### PR TITLE
Create audio metadata file from sync

### DIFF
--- a/wisely/lib/blocs/audio_recorder_cubit.dart
+++ b/wisely/lib/blocs/audio_recorder_cubit.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:bloc/bloc.dart';
@@ -137,10 +136,7 @@ class AudioRecorderCubit extends Cubit<AudioRecorderState> {
     if (_audioNote != null) {
       _audioNote!.updatedAt = DateTime.now();
       assignVectorClock();
-      String json = jsonEncode(_audioNote);
-      File file =
-          File('${await AudioUtils.getFullAudioPath(_audioNote!)}.json');
-      await file.writeAsString(json);
+      String json = await AudioUtils.saveAudioNoteJson(_audioNote!);
       saveEncryptedImapPoC('subject', json);
       _audioNotesCubit.save(_audioNote!);
     }

--- a/wisely/lib/sync/imap.dart
+++ b/wisely/lib/sync/imap.dart
@@ -120,6 +120,7 @@ class ImapSyncClient {
         print('saveAttachment $filePath');
         writeToFile(bytes, encrypted.path);
         decryptFile(encrypted, File(filePath), b64Secret);
+        await AudioUtils.saveAudioNoteJson(audioNote);
       }
     }
   }

--- a/wisely/lib/utils/audio_utils.dart
+++ b/wisely/lib/utils/audio_utils.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:path_provider/path_provider.dart';
@@ -15,6 +16,13 @@ class AudioUtils {
     if (file.existsSync()) {
       return file;
     }
+  }
+
+  static Future<String> saveAudioNoteJson(AudioNote audioNote) async {
+    String json = jsonEncode(audioNote);
+    File file = File('${await AudioUtils.getFullAudioPath(audioNote)}.json');
+    await file.writeAsString(json);
+    return json;
   }
 
   static Future<String> createAudioDirectory(String relativePath) async {

--- a/wisely/pubspec.yaml
+++ b/wisely/pubspec.yaml
@@ -12,7 +12,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.1.12+13
+version: 0.1.13+14
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR adds saving the audio metadata JSON file from sync on desktop. Thus, audio can be recorded in mobile app, and then imported into meins. 