### PR TITLE
Add upload retry for macOS build for iTMSTransporter failures

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,8 @@
 steps:
   - command: "make ios"
     label: ":iOS:"
-  - command: "make macos"
+  - command:
+    - "make macos_build"
+    - "make macos_fastlane_build"
+    - "make macos_fastlane_upload"
     label: ":macOS:"

--- a/Makefile
+++ b/Makefile
@@ -126,9 +126,13 @@ macos_upload:
 macos_open: macos_build macos_archive
 	open $(MACOS_ARCHIVE_PATH)
 
-.PHONY: macos_fastlane_beta
-macos_fastlane_beta:
-	cd macos && fastlane beta && cd ..
+.PHONY: macos_fastlane_build
+macos_fastlane_build:
+	cd macos && fastlane do_build && cd ..
+
+.PHONY: macos_fastlane_upload
+macos_fastlane_upload:
+	cd macos && fastlane do_upload && cd ..
 
 .PHONY: macos_fastlane_match
 macos_fastlane_match:
@@ -136,10 +140,10 @@ macos_fastlane_match:
 
 .PHONY: macos_fastlane_export
 macos_fastlane_export:
-	cd macos && fastlane package && cd ..
+	cd macos && fastlane do_package && cd ..
 
 .PHONY: macos
-macos: macos_build macos_fastlane_beta macos_fastlane_export
+macos: macos_build macos_fastlane_build macos_fastlane_upload macos_fastlane_export
 
 .PHONY: macos_export
 macos_export: macos_build macos_fastlane_export

--- a/macos/fastlane/Fastfile
+++ b/macos/fastlane/Fastfile
@@ -1,21 +1,35 @@
 default_platform(:mac)
+$upload_retry=0
 
 platform :mac do
   desc "Push a new beta build to TestFlight"
-  lane :beta do
-    changelog = read_changelog(changelog_path: '../CHANGELOG.md')
+  lane :do_build do
     build_mac_app(
       workspace: "Runner.xcworkspace",
       scheme: "Runner",
       export_method: "app-store"
     )
-    upload_to_testflight(
-      skip_waiting_for_build_processing: true,
-      changelog: changelog,
-    )
   end
 
-  lane :package do
+  lane :do_upload do
+    changelog = read_changelog(changelog_path: '../CHANGELOG.md')
+
+    begin
+      upload_to_testflight(
+        skip_waiting_for_build_processing: true,
+        changelog: changelog,
+      )
+    rescue => ex
+         $upload_retry +=1
+         if $upload_retry <= 3
+           do_upload
+         else
+           raise ex
+         end
+     end
+  end
+
+  lane :do_package do
     changelog = read_changelog(changelog_path: '../CHANGELOG.md')
     build_mac_app(
       workspace: "Runner.xcworkspace",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.7.21+760
+version: 0.7.21+761
 
 environment:
   sdk: ">=2.16.0 <3.0.0"


### PR DESCRIPTION
This PR adds a retry mechanism for the fastlane upload for macOS, as that has failed multiple times before because apparently, `iTMSTransporter` cannot handle concurrent uploads to TestFlight.