### PR TITLE
Add upload retry for iOS build for iTMSTransporter failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added:
+-
+
+## [0.7.22] - 2022-04-28
+### Added:
 - Haptic feedback for setting/unsetting starred/private/flagged statuses
 
 ## [0.7.19] - 2022-04-28

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,14 @@ ios_build: clean_test
 ios_fastlane_beta:
 	cd ios && fastlane beta && cd ..
 
+.PHONY: ios_fastlane_build
+ios_fastlane_build:
+	cd ios && fastlane do_build && cd ..
+
+.PHONY: ios_fastlane_upload
+ios_fastlane_upload:
+	cd ios && fastlane do_upload && cd ..
+
 .PHONY: ios_fastlane_match
 ios_fastlane_match:
 	cd ios && fastlane match --generate_apple_certs false && cd ..
@@ -98,7 +106,7 @@ ios_upload:
                   -u $(APPLEID) -p $(LOTTI_APPSTORE_CONNECT)
 
 .PHONY: ios
-ios: ios_build ios_fastlane_beta
+ios: ios_build ios_fastlane_build ios_fastlane_upload
 
 .PHONY: macos_build
 macos_build: clean_test

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -1,16 +1,30 @@
 default_platform(:ios)
+$upload_retry=0
 
 platform :ios do
   desc "Push a new beta build to TestFlight"
-  lane :beta do
-    changelog = read_changelog(changelog_path: '../CHANGELOG.md')
+  lane :do_build do
     build_app(
       skip_build_archive: true,
       archive_path: "../build/ios/archive/Runner.xcarchive",
     )
-    upload_to_testflight(
-      skip_waiting_for_build_processing: true,
-      changelog: changelog,
-    )
+  end
+
+  lane :do_upload do
+    changelog = read_changelog(changelog_path: '../CHANGELOG.md')
+
+    begin
+      upload_to_testflight(
+        skip_waiting_for_build_processing: true,
+        changelog: changelog,
+      )
+    rescue => ex
+         $upload_retry +=1
+         if $upload_retry <= 3
+           do_upload
+         else
+           raise ex
+         end
+     end
   end
 end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.7.22+762
+version: 0.7.23+763
 
 environment:
   sdk: ">=2.16.0 <3.0.0"


### PR DESCRIPTION
This PR adds TestFlight upload retries for the iOS build, similar to #922 for macOS.