### PR TITLE
Buildkite: smaller steps

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,8 +3,7 @@ steps:
     key: "ios_build"
     command:
     - "make ios_build"
-    - "mkdir -p /tmp/buildkite/$$BUILDKITE_COMMIT/build"
-    - "rsync -ar build/ios /tmp/buildkite/$$BUILDKITE_COMMIT/build"
+    - "rsync -ar ./ /tmp/buildkite/$$BUILDKITE_COMMIT/"
     artifact_paths:
       - "missing_translations.txt"
 
@@ -13,24 +12,22 @@ steps:
     depends_on:
       - "ios_build"
     command:
-    - "mkdir -p build"
-    - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/build/ios build/"
+    - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/ ./"
     - "make ios_fastlane_build"
-    - "rsync -ar ios /tmp/buildkite/$$BUILDKITE_COMMIT/"
+    - "rsync -ar ./ /tmp/buildkite/$$BUILDKITE_COMMIT/"
 
   - label: "📱 iOS fastlane TestFlight upload 🚀 "
     key: "ios_fastlane_testflight"
     depends_on:
       - "ios_fastlane_build"
     command:
-    - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/ios/Runner.ipa ios/"
+    - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/ ./"
     - "make ios_fastlane_upload"
 
   - label: "💻 macOS Build 🏭 "
     key: "macos_build"
     command:
       - "make macos_build"
-      - "mkdir -p /tmp/buildkite/$$BUILDKITE_COMMIT/build"
       - "rsync -ar ./ /tmp/buildkite/$$BUILDKITE_COMMIT/"
     artifact_paths:
       - "missing_translations.txt"
@@ -40,7 +37,6 @@ steps:
     depends_on:
       - "macos_build"
     command:
-      - "mkdir -p build"
       - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/ ./"
       - "make macos_fastlane_build"
       - "rsync -ar ./ /tmp/buildkite/$$BUILDKITE_COMMIT/"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@ steps:
     command:
     - "make ios_build"
     - "mkdir -p /tmp/buildkite/$$BUILDKITE_COMMIT"
-    - "rsync -ar build/ /tmp/buildkite/$$BUILDKITE_COMMIT"
+    - "rsync -ar build /tmp/buildkite/$$BUILDKITE_COMMIT/"
     artifact_paths:
       - "missing_translations.txt"
 
@@ -13,17 +13,17 @@ steps:
     depends_on:
       - "ios_build"
     command:
-    - "mkdir -p build/ios"
-    - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/ios build/ios"
+    - "mkdir -p build"
+    - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/build/ios build/"
     - "make ios_fastlane_build"
-    - "rsync -ar ios/Runner.ipa /tmp/buildkite/$$BUILDKITE_COMMIT/Runner.ipa"
+    - "rsync -ar ios /tmp/buildkite/$$BUILDKITE_COMMIT/"
 
   - label: "📱 iOS fastlane TestFlight upload 🚀 "
     key: "ios_fastlane_testflight"
     depends_on:
       - "ios_fastlane_build"
     command:
-    - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/Runner.ipa ios/Runner.ipa"
+    - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/ios/Runner.ipa ios/"
     - "make ios_fastlane_upload"
 
 #  - label: "💻 macOS TestFlight 💻"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,12 +1,26 @@
 steps:
-  - label: "📱 iOS TestFlight 📱"
-    command: "make ios"
+  - label: "📱 iOS Build 🏭"
+    key: "ios_build"
+    command:
+    - "make ios_build"
     artifact_paths:
       - "build/ios/archive/**/*"
-  - label: "💻 macOS TestFlight 💻"
+
+  - label: "📱 iOS TestFlight 🚀"
+    key: "ios_fastlane"
+    depends_on:
+      - "ios_build"
     command:
-    - "make macos_build"
-    - "make macos_fastlane_build"
-    - "make macos_fastlane_upload"
+    - "buildkite-agent artifact download build/ios/archive/* build/ios/archive/"
+    - "make ios_fastlane_build"
+    - "make ios_fastlane_upload"
     artifact_paths:
-      - "build/macos/Build/**/*"
+      - "build/ios/archive/**/*"
+
+#  - label: "💻 macOS TestFlight 💻"
+#    command:
+#    - "make macos_build"
+#    - "make macos_fastlane_build"
+#    - "make macos_fastlane_upload"
+#    artifact_paths:
+#      - "build/macos/Build/Products/**/*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,26 +1,34 @@
 steps:
-  - label: "📱 iOS Build 🏭"
+  - label: "📱 iOS Build 🏭 "
     key: "ios_build"
     command:
     - "make ios_build"
     artifact_paths:
       - "build/ios/archive/**/*"
 
-  - label: "📱 iOS TestFlight 🚀"
-    key: "ios_fastlane"
+  - label: "📱 iOS fastlane build 👟 "
+    key: "ios_fastlane_build"
     depends_on:
       - "ios_build"
     command:
+    - "mkdir -p build/ios/archive"
     - "buildkite-agent artifact download build/ios/archive/* build/ios/archive/"
     - "make ios_fastlane_build"
-    - "make ios_fastlane_upload"
     artifact_paths:
-      - "build/ios/archive/**/*"
+      - "ios/Runner.ipa"
 
-#  - label: "💻 macOS TestFlight 💻"
-#    command:
-#    - "make macos_build"
-#    - "make macos_fastlane_build"
-#    - "make macos_fastlane_upload"
-#    artifact_paths:
-#      - "build/macos/Build/Products/**/*"
+  - label: "📱 iOS fastlane TestFlight upload 🚀 "
+    key: "ios_fastlane_testflight"
+    depends_on:
+      - "ios_fastlane_build"
+    command:
+    - "buildkite-agent artifact download ios/Runner.ipa ios/Runner.ipa"
+    - "make ios_fastlane_upload"
+
+  - label: "💻 macOS TestFlight 💻"
+    command:
+    - "make macos_build"
+    - "make macos_fastlane_build"
+    - "make macos_fastlane_upload"
+    artifact_paths:
+      - "build/macos/Build/Products/**/*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,8 +1,17 @@
 steps:
+  - label: "🧽 Clean 🧽, 🛠 build 🛠, 🔬 test 🔬 "
+    key: "clean_test"
+    command:
+    - "make clean_test"
+    - "rsync -ar ./ /tmp/buildkite/$$BUILDKITE_COMMIT/"
+
   - label: "📱 iOS Build 🏭 "
     key: "ios_build"
+    depends_on:
+      - "clean_test"
     command:
-    - "make ios_build"
+    - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/ ./"
+    - "make ios_build_ipa"
     - "rsync -ar ./ /tmp/buildkite/$$BUILDKITE_COMMIT/"
     artifact_paths:
       - "missing_translations.txt"
@@ -26,8 +35,11 @@ steps:
 
   - label: "💻 macOS Build 🏭 "
     key: "macos_build"
+    depends_on:
+      - "clean_test"
     command:
-      - "make macos_build"
+      - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/ ./"
+      - "make macos_build_flutter"
       - "rsync -ar ./ /tmp/buildkite/$$BUILDKITE_COMMIT/"
     artifact_paths:
       - "missing_translations.txt"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,32 +3,33 @@ steps:
     key: "ios_build"
     command:
     - "make ios_build"
+    - "mkdir -p /tmp/buildkite/$$BUILDKITE_COMMIT"
+    - "rsync -ar build/ /tmp/buildkite/$$BUILDKITE_COMMIT"
     artifact_paths:
-      - "build/ios/archive/**/*"
+      - "missing_translations.txt"
 
   - label: "📱 iOS fastlane build 👟 "
     key: "ios_fastlane_build"
     depends_on:
       - "ios_build"
     command:
-    - "mkdir -p build/ios/archive"
-    - "buildkite-agent artifact download build/ios/archive/* build/ios/archive/"
+    - "mkdir -p build/ios"
+    - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/ios build/ios"
     - "make ios_fastlane_build"
-    artifact_paths:
-      - "ios/Runner.ipa"
+    - "rsync -ar ios/Runner.ipa /tmp/buildkite/$$BUILDKITE_COMMIT/Runner.ipa"
 
   - label: "📱 iOS fastlane TestFlight upload 🚀 "
     key: "ios_fastlane_testflight"
     depends_on:
       - "ios_fastlane_build"
     command:
-    - "buildkite-agent artifact download ios/Runner.ipa ios/Runner.ipa"
+    - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/Runner.ipa ios/Runner.ipa"
     - "make ios_fastlane_upload"
 
-  - label: "💻 macOS TestFlight 💻"
-    command:
-    - "make macos_build"
-    - "make macos_fastlane_build"
-    - "make macos_fastlane_upload"
-    artifact_paths:
-      - "build/macos/Build/Products/**/*"
+#  - label: "💻 macOS TestFlight 💻"
+#    command:
+#    - "make macos_build"
+#    - "make macos_fastlane_build"
+#    - "make macos_fastlane_upload"
+#    artifact_paths:
+#      - "build/macos/Build/Products/**/*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,8 +31,7 @@ steps:
     command:
       - "make macos_build"
       - "mkdir -p /tmp/buildkite/$$BUILDKITE_COMMIT/build"
-      - "rsync -ar build/ /tmp/buildkite/$$BUILDKITE_COMMIT/build/"
-      - "rsync -ar macos/ /tmp/buildkite/$$BUILDKITE_COMMIT/macos/"
+      - "rsync -ar ./ /tmp/buildkite/$$BUILDKITE_COMMIT/"
     artifact_paths:
       - "missing_translations.txt"
 
@@ -42,15 +41,14 @@ steps:
       - "macos_build"
     command:
       - "mkdir -p build"
-      - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/build/ build/"
-      - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/macos/ macos/"
+      - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/ ./"
       - "make macos_fastlane_build"
-      - "rsync -ar macos /tmp/buildkite/$$BUILDKITE_COMMIT/"
+      - "rsync -ar ./ /tmp/buildkite/$$BUILDKITE_COMMIT/"
 
   - label: "💻 macOS fastlane TestFlight upload 🚀 "
     key: "macos_fastlane_testflight"
     depends_on:
       - "macos_fastlane_build"
     command:
-      - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/macos/ macos/"
+      - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/ ./"
       - "make macos_fastlane_upload"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,8 +1,12 @@
 steps:
-  - command: "make ios"
-    label: ":iOS:"
-  - command:
+  - label: "📱 iOS TestFlight 📱"
+    command: "make ios"
+    artifact_paths:
+      - "build/ios/archive/**/*"
+  - label: "💻 macOS TestFlight 💻"
+    command:
     - "make macos_build"
     - "make macos_fastlane_build"
     - "make macos_fastlane_upload"
-    label: ":macOS:"
+    artifact_paths:
+      - "build/macos/Build/**/*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,8 +3,8 @@ steps:
     key: "ios_build"
     command:
     - "make ios_build"
-    - "mkdir -p /tmp/buildkite/$$BUILDKITE_COMMIT"
-    - "rsync -ar build /tmp/buildkite/$$BUILDKITE_COMMIT/"
+    - "mkdir -p /tmp/buildkite/$$BUILDKITE_COMMIT/build"
+    - "rsync -ar build/ios /tmp/buildkite/$$BUILDKITE_COMMIT/build"
     artifact_paths:
       - "missing_translations.txt"
 
@@ -26,10 +26,31 @@ steps:
     - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/ios/Runner.ipa ios/"
     - "make ios_fastlane_upload"
 
-#  - label: "💻 macOS TestFlight 💻"
-#    command:
-#    - "make macos_build"
-#    - "make macos_fastlane_build"
-#    - "make macos_fastlane_upload"
-#    artifact_paths:
-#      - "build/macos/Build/Products/**/*"
+  - label: "💻 macOS Build 🏭 "
+    key: "macos_build"
+    command:
+      - "make macos_build"
+      - "mkdir -p /tmp/buildkite/$$BUILDKITE_COMMIT/build"
+      - "rsync -ar build/ /tmp/buildkite/$$BUILDKITE_COMMIT/build/"
+      - "rsync -ar macos/ /tmp/buildkite/$$BUILDKITE_COMMIT/macos/"
+    artifact_paths:
+      - "missing_translations.txt"
+
+  - label: "💻 macOS fastlane build 👟 "
+    key: "macos_fastlane_build"
+    depends_on:
+      - "macos_build"
+    command:
+      - "mkdir -p build"
+      - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/build/ build/"
+      - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/macos/ macos/"
+      - "make macos_fastlane_build"
+      - "rsync -ar macos /tmp/buildkite/$$BUILDKITE_COMMIT/"
+
+  - label: "💻 macOS fastlane TestFlight upload 🚀 "
+    key: "macos_fastlane_testflight"
+    depends_on:
+      - "macos_fastlane_build"
+    command:
+      - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/macos/ macos/"
+      - "make macos_fastlane_upload"

--- a/Makefile
+++ b/Makefile
@@ -69,9 +69,12 @@ bundle:
 
 #######################################
 
-.PHONY: ios_build
-ios_build: clean_test
+.PHONY: ios_build_ipa
+ios_build_ipa:
 	flutter build ipa
+
+.PHONY: ios_build
+ios_build: clean_test ios_build_ipa
 
 .PHONY: ios_fastlane_beta
 ios_fastlane_beta:
@@ -108,9 +111,12 @@ ios_upload:
 .PHONY: ios
 ios: ios_build ios_fastlane_build ios_fastlane_upload
 
-.PHONY: macos_build
-macos_build: clean_test
+.PHONY: macos_build_flutter
+macos_build_flutter:
 	flutter build macos
+
+.PHONY: macos_build
+macos_build: clean_test macos_build_flutter
 
 .PHONY: macos_archive
 macos_archive:

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -3,6 +3,7 @@ $upload_retry=0
 
 platform :ios do
   desc "Push a new beta build to TestFlight"
+
   lane :do_build do
     build_app(
       skip_build_archive: true,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.7.23+776
+version: 0.7.23+777
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.7.23+770
+version: 0.7.23+771
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.7.23+764
+version: 0.7.23+766
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.7.23+766
+version: 0.7.23+767
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.7.23+763
+version: 0.7.23+764
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.7.23+778
+version: 0.7.23+779
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.7.23+777
+version: 0.7.23+778
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.7.23+771
+version: 0.7.23+776
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.7.23+767
+version: 0.7.23+770
 
 environment:
   sdk: ">=2.16.0 <3.0.0"


### PR DESCRIPTION
This PR splits the previous all encompassing make tasks into smaller steps for better visibility into where time is spent, plus only running the initial `clean, build runner, l10n, test` step only once.