### PR TITLE
Publish macOS prerelease on GitHub Releases via Buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -68,5 +68,14 @@ steps:
     command:
       - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/ ./"
       - "make macos_fastlane_export"
+      - "rsync -ar ./ /tmp/buildkite/$$BUILDKITE_COMMIT/"
     artifact_paths:
       - "build/export/Lotti.app"
+
+  - label: "💻 macOS publish GitHub prerelease 🚀 "
+    key: "macos_github_prerelease"
+    depends_on:
+      - "macos_fastlane_export"
+    command:
+      - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/ ./"
+      - "gh release create -p -d --generate-notes --target $$BUILDKITE_COMMIT $$BUILDKITE_BRANCH build/export/Lotti.app"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -79,6 +79,5 @@ steps:
     command:
       - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/ ./"
       - "mkdir build/export/macOS"
-      - "cp -r build/export/Lotti.app build/export/macOS/"
-      - "create-dmg build/export/Lotti.dmg build/export/macOS"
-      - "gh release create -p -d --generate-notes --target $$BUILDKITE_COMMIT $$BUILDKITE_BRANCH build/export/Lotti.dmg"
+      - "npx create-dmg build/export/Lotti.app build/export/macOS/"
+      - "gh release create -p -d --generate-notes --target $$BUILDKITE_COMMIT $$BUILDKITE_BRANCH build/export/macOS/*.dmg"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -78,5 +78,7 @@ steps:
       - "macos_fastlane_export"
     command:
       - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/ ./"
-      - "zip -r -q build/export/Lotti.zip build/export/Lotti.app"
-      - "gh release create -p -d --generate-notes --target $$BUILDKITE_COMMIT $$BUILDKITE_BRANCH build/export/Lotti.zip"
+      - "mkdir build/export/macOS"
+      - "cp -r build/export/Lotti.app build/export/macOS/"
+      - "create-dmg build/export/Lotti.dmg build/export/macOS"
+      - "gh release create -p -d --generate-notes --target $$BUILDKITE_COMMIT $$BUILDKITE_BRANCH build/export/Lotti.dmg"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -72,12 +72,27 @@ steps:
     artifact_paths:
       - "build/export/Lotti.app"
 
-  - label: "💻 macOS publish GitHub prerelease 🚀 "
-    key: "macos_github_prerelease"
+  - label: "💻 macOS create DMG file 💾 "
+    key: "macos_dmg"
     depends_on:
       - "macos_fastlane_export"
     command:
       - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/ ./"
       - "npx create-dmg build/export/Lotti.app build/export/"
+      - "rsync -ar ./ /tmp/buildkite/$$BUILDKITE_COMMIT/"
+
+  - label: "💻 macOS notarize DMG file ⚖️ "
+    key: "macos_notarize"
+    depends_on:
+      - "macos_dmg"
+    command:
+      - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/ ./"
       - "xcrun altool --notarize-app -f build/export/*.dmg --primary-bundle-id com.matthiasnehlsen.lotti -u $$APPLEID -p $$APPLEIDPASS"
+
+  - label: "💻 macOS publish GitHub prerelease 🚀 "
+    key: "macos_github_prerelease"
+    depends_on:
+      - "macos_notarize"
+    command:
+      - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/ ./"
       - "gh release create -p -d --generate-notes --target $$BUILDKITE_COMMIT $$BUILDKITE_BRANCH build/export/*.dmg"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -78,6 +78,5 @@ steps:
       - "macos_fastlane_export"
     command:
       - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/ ./"
-      - "mkdir build/export/macOS"
-      - "npx create-dmg build/export/Lotti.app build/export/macOS/"
-      - "gh release create -p -d --generate-notes --target $$BUILDKITE_COMMIT $$BUILDKITE_BRANCH build/export/macOS/*.dmg"
+      - "npx create-dmg build/export/Lotti.app build/export/"
+      - "gh release create -p -d --generate-notes --target $$BUILDKITE_COMMIT $$BUILDKITE_BRANCH build/export/*.dmg"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -79,4 +79,5 @@ steps:
     command:
       - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/ ./"
       - "npx create-dmg build/export/Lotti.app build/export/"
+      - "xcrun altool --notarize-app -f build/export/*.dmg --primary-bundle-id com.matthiasnehlsen.lotti -u $$APPLEID -p $$APPLEIDPASS"
       - "gh release create -p -d --generate-notes --target $$BUILDKITE_COMMIT $$BUILDKITE_BRANCH build/export/*.dmg"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -78,4 +78,5 @@ steps:
       - "macos_fastlane_export"
     command:
       - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/ ./"
-      - "gh release create -p -d --generate-notes --target $$BUILDKITE_COMMIT $$BUILDKITE_BRANCH build/export/Lotti.app"
+      - "zip -r -q build/export/Lotti.zip build/export/Lotti.app"
+      - "gh release create -p -d --generate-notes --target $$BUILDKITE_COMMIT $$BUILDKITE_BRANCH build/export/Lotti.zip"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -64,7 +64,7 @@ steps:
   - label: "💻 macOS fastlane Export 🚀 "
     key: "macos_fastlane_export"
     depends_on:
-      - "macos_fastlane_build"
+      - "macos_build"
     command:
       - "rsync -ar /tmp/buildkite/$$BUILDKITE_COMMIT/ ./"
       - "make macos_fastlane_export"

--- a/README.md
+++ b/README.md
@@ -53,6 +53,22 @@ resuming: `$ sudo dhclient ens33`
 Please create a PR with instructions for Windows if you find anything that is
 required.
 
+
+## Continuous Integration
+
+This project uses Buildkite for releasing to TestFlight on iOS and macOS, 
+plus publishing to GitHub releases. The following steps are necessary for 
+setting up a new runner:
+
+1) Install [Buildkite agent for macOS](https://buildkite.
+   com/docs/agent/v3/macos)
+2) Install [create-dmg](https://github.com/create-dmg/create-dmg) for 
+   bundling the DMG file for GitHub releases
+
+HELP WANTED: Linux and Windows versions are not yet published on HitHub 
+releases. Please consider helping out with the pipelines if you can.
+
+
 ## Contributions
 
 Contributions to this project are very welcome. How can you help?

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ setting up a new runner:
 
 1) Install [Buildkite agent for macOS](https://buildkite.
    com/docs/agent/v3/macos)
-2) Install [create-dmg](https://github.com/create-dmg/create-dmg) for 
+2) Install [create-dmg](https://github.com/sindresorhus/create-dmg) for 
    bundling the DMG file for GitHub releases
 
 HELP WANTED: Linux and Windows versions are not yet published on HitHub 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.7.23+783
+version: 0.7.23+784
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.7.23+784
+version: 0.7.23+785
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.7.23+786
+version: 0.7.23+787
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.7.23+787
+version: 0.7.23+788
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.7.23+785
+version: 0.7.23+786
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.7.23+780
+version: 0.7.23+782
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.7.23+782
+version: 0.7.23+783
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.7.23+788
+version: 0.7.23+789
 
 environment:
   sdk: ">=2.16.0 <3.0.0"


### PR DESCRIPTION
This PR adds the publication of prereleases of the macOS desktop version on GitHub Releases.