### PR TITLE
CI: soft fail on exit code 24

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,9 +1,3 @@
-# Workaround for rsync warning about vanished files,
-# which is inconsequential here but returns exit code
-# 24 and is therefore interpreted as a failure
-soft_fail:
-  - exit_status: 24
-
 steps:
   - group: "Codegen & Test"
     key: "codegen_test"
@@ -25,6 +19,11 @@ steps:
           - "rsync -ar ./ /tmp/buildkite/${BUILDKITE_COMMIT}/"
         agents:
           os: "macOS"
+        # Workaround for rsync warning about vanished files,
+        # which is inconsequential here but returns exit code
+        # 24 and is therefore interpreted as a failure
+        soft_fail:
+          - exit_status: 24
 
       - label: "🛠 Codegen "
         key: "apple_codegen"
@@ -38,6 +37,8 @@ steps:
           os: "macOS"
         artifact_paths:
           - "missing_translations.txt"
+        soft_fail:
+          - exit_status: 24
 
       - label: "🔬 Test "
         key: "apple_test"
@@ -48,6 +49,8 @@ steps:
           - "flutter test"
         agents:
           os: "macOS"
+        soft_fail:
+          - exit_status: 24
 
   #################
 
@@ -61,6 +64,8 @@ steps:
       - "rsync -ar ./ /tmp/buildkite/${BUILDKITE_COMMIT}/"
     agents:
       os: "macOS"
+    soft_fail:
+      - exit_status: 24
 
   #################
 
@@ -79,6 +84,8 @@ steps:
           - "rsync -ar ./ /tmp/buildkite/${BUILDKITE_COMMIT}/"
         agents:
           os: "macOS"
+        soft_fail:
+          - exit_status: 24
 
       - label: "📱🚀 iOS fastlane TestFlight "
         key: "ios_fastlane_testflight"
@@ -89,6 +96,8 @@ steps:
           - "make ios_fastlane_upload"
         agents:
           os: "macOS"
+        soft_fail:
+          - exit_status: 24
 
   #################
 
@@ -102,6 +111,8 @@ steps:
       - "rsync -ar ./ /tmp/buildkite/${BUILDKITE_COMMIT}/"
     agents:
       os: "macOS"
+    soft_fail:
+      - exit_status: 24
 
   #################
 
@@ -120,6 +131,8 @@ steps:
           - "rsync -ar ./ /tmp/buildkite/${BUILDKITE_COMMIT}/"
         agents:
           os: "macOS"
+        soft_fail:
+          - exit_status: 24
 
       - label: ":mac: 🚀 fastlane TestFlight "
         key: "macos_fastlane_testflight"
@@ -130,6 +143,8 @@ steps:
           - "make macos_fastlane_upload"
         agents:
           os: "macOS"
+        soft_fail:
+          - exit_status: 24
 
   #################
 
@@ -157,6 +172,8 @@ steps:
           - "build/export/Lotti.app"
         agents:
           os: "macOS"
+        soft_fail:
+          - exit_status: 24
 
       - label: ":mac: 💾 create DMG "
         key: "macos_dmg"
@@ -168,6 +185,8 @@ steps:
           - "rsync -ar ./ /tmp/buildkite/${BUILDKITE_COMMIT}/"
         agents:
           os: "macOS"
+        soft_fail:
+          - exit_status: 24
 
       - label: "⚖️ :mac: notarize DMG file "
         key: "macos_notarize"
@@ -178,6 +197,8 @@ steps:
           - "xcrun altool --notarize-app -f build/export/*.dmg --primary-bundle-id com.matthiasnehlsen.lotti -u $$APPLEID -p $$APPLEIDPASS"
         agents:
           os: "macOS"
+        soft_fail:
+          - exit_status: 24
 
       - label: ":mac: publish :github: Prerelease 🚀 "
         key: "macos_github_prerelease"
@@ -189,6 +210,8 @@ steps:
           - "gh release upload ${BUILDKITE_BRANCH} build/export/*.dmg"
         agents:
           os: "macOS"
+        soft_fail:
+          - exit_status: 24
 
   #################
 
@@ -202,6 +225,8 @@ steps:
       - "rsync -ar ./ /tmp/buildkite/${BUILDKITE_COMMIT}/"
     agents:
       os: "macOS"
+    soft_fail:
+      - exit_status: 24
 
   #################
 
@@ -222,6 +247,8 @@ steps:
           - "rsync -ar --exclude 'build/ios' --exclude 'build/macos' ./ /tmp/buildkite/${BUILDKITE_COMMIT}/"
         agents:
           os: "macOS"
+        soft_fail:
+          - exit_status: 24
 
       - label: ":android: 🚀 publish :github: Prerelease "
         key: "android_github_prerelease"
@@ -234,3 +261,5 @@ steps:
           - "gh release upload ${BUILDKITE_BRANCH} build/app/outputs/bundle/release/app-release.aab"
         agents:
           os: "macOS"
+        soft_fail:
+          - exit_status: 24

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -26,6 +26,8 @@ PODS:
     - FlutterMacOS
   - location (0.0.1):
     - FlutterMacOS
+  - macos_ui (0.1.0):
+    - FlutterMacOS
   - package_info_plus_macos (0.0.1):
     - FlutterMacOS
   - path_provider_macos (0.0.1):
@@ -74,6 +76,7 @@ DEPENDENCIES:
   - hotkey_manager (from `Flutter/ephemeral/.symlinks/plugins/hotkey_manager/macos`)
   - just_audio (from `Flutter/ephemeral/.symlinks/plugins/just_audio/macos`)
   - location (from `Flutter/ephemeral/.symlinks/plugins/location/macos`)
+  - macos_ui (from `Flutter/ephemeral/.symlinks/plugins/macos_ui/macos`)
   - package_info_plus_macos (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus_macos/macos`)
   - path_provider_macos (from `Flutter/ephemeral/.symlinks/plugins/path_provider_macos/macos`)
   - photo_manager (from `Flutter/ephemeral/.symlinks/plugins/photo_manager/macos`)
@@ -113,6 +116,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/just_audio/macos
   location:
     :path: Flutter/ephemeral/.symlinks/plugins/location/macos
+  macos_ui:
+    :path: Flutter/ephemeral/.symlinks/plugins/macos_ui/macos
   package_info_plus_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus_macos/macos
   path_provider_macos:
@@ -144,6 +149,7 @@ SPEC CHECKSUMS:
   hotkey_manager: ad673457691f4d39e481be04a61da2ae07d81c62
   just_audio: 9b67ca7b97c61cfc9784ea23cd8cc55eb226d489
   location: 7cdb0665bd6577d382b0a343acdadbcb7f964775
+  macos_ui: 125c911559d646194386d84c017ad6819122e2db
   package_info_plus_macos: f010621b07802a241d96d01876d6705f15e77c1c
   path_provider_macos: 160cab0d5461f0c0e02995469a98f24bdb9a3f1f
   photo_manager: 4f6810b7dfc4feb03b461ac1a70dacf91fba7604

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.7.27+830
+version: 0.7.27+832
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR adds a workaround for an `Rsync` warning about vanished files, which is inconsequential here but returns exit code **`24`** and is therefore interpreted as a failure.