### PR TITLE
Workaround for multiple audio player in linked entries list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added:
--
+### Fixed:
+- Audio playback for multiple recordings in list of linked entries was not 
+  working previously
 
 ## [0.7.22] - 2022-04-28
 ### Added:

--- a/lib/widgets/journal/entry_details_widget.dart
+++ b/lib/widgets/journal/entry_details_widget.dart
@@ -84,8 +84,9 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
         }
 
         bool isTask = item is Task;
+        bool isAudio = item is JournalAudio;
 
-        if (isTask && !widget.showTaskDetails) {
+        if ((isTask || isAudio) && !widget.showTaskDetails) {
           return JournalCard(item: item);
         }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.7.27+832
+version: 0.7.28+833
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR adds a workaround for #939 by showing audio recordings as journal cards that navigate to a detail page from which the audio can be played. This is not ideal but at least it works at all. 