### PR TITLE
Dark keyboard #2

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -90,7 +90,6 @@ class LottiApp extends StatelessWidget {
         ],
         supportedLocales: AppLocalizations.supportedLocales,
         theme: ThemeData(
-          brightness: Brightness.dark,
           primarySwatch: Colors.grey,
         ),
         debugShowCheckedModeBanner: true,

--- a/lib/pages/create/create_measurement_page.dart
+++ b/lib/pages/create/create_measurement_page.dart
@@ -162,6 +162,7 @@ class _CreateMeasurementPageState extends State<CreateMeasurementPage> {
                               labelText: selected!.description,
                               labelStyle: labelStyle,
                             ),
+                            keyboardAppearance: Brightness.dark,
                             style: inputStyle,
                             name: 'value',
                             keyboardType: const TextInputType.numberWithOptions(

--- a/lib/pages/settings/form_text_field.dart
+++ b/lib/pages/settings/form_text_field.dart
@@ -22,6 +22,8 @@ class FormTextField extends StatelessWidget {
       minLines: 1,
       maxLines: 3,
       initialValue: initialValue,
+      textCapitalization: TextCapitalization.sentences,
+      keyboardAppearance: Brightness.dark,
       validator: FormBuilderValidators.required(context),
       style: labelStyle,
       decoration: InputDecoration(

--- a/lib/widgets/sync/imap_config.dart
+++ b/lib/widgets/sync/imap_config.dart
@@ -86,6 +86,7 @@ class _EmailConfigFormState extends State<EmailConfigForm> {
                     ),
                     validator: FormBuilderValidators.required(context),
                     style: inputStyle,
+                    keyboardAppearance: Brightness.dark,
                     decoration: InputDecoration(
                       labelText: localizations.settingsSyncHostLabel,
                       labelStyle: settingsLabelStyle,
@@ -99,6 +100,7 @@ class _EmailConfigFormState extends State<EmailConfigForm> {
                         ) ??
                         'INBOX',
                     validator: FormBuilderValidators.required(context),
+                    keyboardAppearance: Brightness.dark,
                     style: inputStyle,
                     decoration: InputDecoration(
                       labelText: localizations.settingsSyncFolderLabel,
@@ -113,6 +115,7 @@ class _EmailConfigFormState extends State<EmailConfigForm> {
                     ),
                     validator: FormBuilderValidators.required(context),
                     style: inputStyle,
+                    keyboardAppearance: Brightness.dark,
                     decoration: InputDecoration(
                       labelText: localizations.settingsSyncUserLabel,
                       labelStyle: settingsLabelStyle,
@@ -127,6 +130,7 @@ class _EmailConfigFormState extends State<EmailConfigForm> {
                     obscureText: true,
                     validator: FormBuilderValidators.required(context),
                     style: inputStyle,
+                    keyboardAppearance: Brightness.dark,
                     decoration: InputDecoration(
                       labelText: localizations.settingsSyncPasswordLabel,
                       labelStyle: settingsLabelStyle,
@@ -142,6 +146,7 @@ class _EmailConfigFormState extends State<EmailConfigForm> {
                         '993',
                     validator: FormBuilderValidators.integer(context),
                     style: inputStyle,
+                    keyboardAppearance: Brightness.dark,
                     decoration: InputDecoration(
                       labelText: localizations.settingsSyncPortLabel,
                       labelStyle: settingsLabelStyle,

--- a/lib/widgets/tasks/task_form.dart
+++ b/lib/widgets/tasks/task_form.dart
@@ -62,6 +62,8 @@ class _TaskFormState extends State<TaskForm> {
                     labelText: localizations.taskNameLabel,
                     labelStyle: labelStyle,
                   ),
+                  textCapitalization: TextCapitalization.sentences,
+                  keyboardAppearance: Brightness.dark,
                   maxLines: null,
                   style: inputStyle.copyWith(
                     fontFamily: 'Oswald',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.7.31+840
+version: 0.7.31+841
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR is a follow-up to #947, now changing the keyboard color specifically, as the previous approach had the unintended side effect of changing the editor menu color.