### PR TITLE
Upgrade enough_mail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.7.37] - 2022-05-11
 ### Added:
 - Disable panning while zoom is ongoing
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -119,7 +119,7 @@ packages:
       name: basic_utils
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.9.4"
+    version: "4.2.1"
   bloc:
     dependency: "direct main"
     description:
@@ -289,12 +289,12 @@ packages:
     source: hosted
     version: "4.1.0"
   collection:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   connectivity_plus:
     dependency: "direct main"
     description:
@@ -364,7 +364,7 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   cryptography:
     dependency: "direct main"
     description:
@@ -515,12 +515,10 @@ packages:
   enough_mail:
     dependency: "direct main"
     description:
-      path: "."
-      ref: "80c8900"
-      resolved-ref: "80c89005e2544df622dc5da5c1222e080a90d3bd"
-      url: "https://github.com/Enough-Software/enough_mail"
-    source: git
-    version: "1.3.6"
+      name: enough_mail
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   enough_serialization:
     dependency: transitive
     description:
@@ -562,14 +560,14 @@ packages:
       name: extended_image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.3"
+    version: "6.1.0"
   extended_image_library:
     dependency: transitive
     description:
       name: extended_image_library
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.4"
+    version: "3.2.0"
   fake_async:
     dependency: transitive
     description:
@@ -1544,7 +1542,7 @@ packages:
       name: photo_manager
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.0.9"
   photo_view:
     dependency: "direct main"
     description:
@@ -2192,7 +2190,7 @@ packages:
     source: hosted
     version: "0.2.0+1"
   xml:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: xml
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,17 +29,11 @@ dependencies:
   research_package:
     git: https://github.com/matthiasn/research.package.git
 
-  enough_mail:
-    git:
-      url: https://github.com/Enough-Software/enough_mail
-      ref: 80c8900
-
   radial_button:
     git:
       url: https://github.com/matthiasn/radial_button
       ref: 3137f03
 
-  # enough_mail: ^1.3.6
   adaptive_dialog: ^1.3.0
   arb_utils: ^0.2.0
   audio_video_progress_bar: ^0.10.0
@@ -58,6 +52,7 @@ dependencies:
   device_info_plus: ^3.1.0
   drift: ^1.1.0
   easy_debounce: ^2.0.2+1
+  enough_mail: ^2.0.0
   enum_to_string: ^2.0.1
   equatable: ^2.0.3
   exif: ^3.0.1
@@ -117,6 +112,11 @@ dependencies:
   wechat_assets_picker: ^7.0.1
   window_manager: ^0.2.0
   yaml: ^3.1.0
+
+dependency_overrides:
+  collection: ^1.16.0
+  crypto: ^3.0.2
+  xml: ^5.3.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR upgrades the `enough_mail` library after the release of https://github.com/Enough-Software/enough_mail/pull/181 so that it is no longer required to use a fork. This involves overrides for the time being, probably until the next Flutter version.