### PR TITLE
Hide bottom nav on dashboard detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed:
+- Bottom Navigation Bar hidden in dashboards
+- Dashboard title moved to app bar
+
+## [0.8.1] - 2022-05-15
+### Changed: 
 - Upgrade to Flutter 3.0.0
 
 ## [0.7.38] - 2022-05-12

--- a/lib/pages/dashboards/dashboard_page.dart
+++ b/lib/pages/dashboards/dashboard_page.dart
@@ -93,10 +93,6 @@ class _DashboardPageState extends State<DashboardPage> {
               padding: const EdgeInsets.all(8.0),
               child: Column(
                 children: [
-                  Padding(
-                    padding: const EdgeInsets.only(bottom: 8.0),
-                    child: Text(dashboard.name, style: formLabelStyle),
-                  ),
                   ...dashboard.items.map((DashboardItem dashboardItem) {
                     return dashboardItem.map(
                       measurement: (DashboardMeasurementItem measurement) {

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -56,6 +56,13 @@ class HomePage extends StatelessWidget {
         //TutorialRouter(),
       ],
       bottomNavigationBuilder: (_, TabsRouter tabsRouter) {
+        final topRoute = tabsRouter.topRoute.name;
+        final hideBottomNav = topRoute == DashboardRoute.name;
+
+        if (hideBottomNav) {
+          return const SizedBox.shrink();
+        }
+
         return Container(
           decoration: const BoxDecoration(
             boxShadow: <BoxShadow>[

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -9,6 +9,7 @@ import 'package:lotti/widgets/audio/audio_recording_indicator.dart';
 import 'package:lotti/widgets/bottom_nav/flagged_badge_icon.dart';
 import 'package:lotti/widgets/bottom_nav/tasks_badge_icon.dart';
 import 'package:lotti/widgets/misc/app_bar_version.dart';
+import 'package:lotti/widgets/misc/dashboard_app_bar.dart';
 import 'package:lotti/widgets/misc/time_recording_indicator.dart';
 
 class HomePage extends StatelessWidget {
@@ -23,14 +24,19 @@ class HomePage extends StatelessWidget {
     return AutoTabsScaffold(
       lazyLoad: false,
       animationDuration: const Duration(milliseconds: 500),
-      appBarBuilder: (context, tabsRouter) => AppBar(
-        backgroundColor: AppColors.headerBgColor,
-        title: const VersionAppBar(title: 'Lotti'),
-        centerTitle: true,
-        leading: AutoBackButton(
-          color: AppColors.entryTextColor,
-        ),
-      ),
+      appBarBuilder: (context, TabsRouter tabsRouter) {
+        final String topRouteName = tabsRouter.topRoute.name;
+        final bool dashboardAppBar = topRouteName == DashboardRoute.name;
+
+        if (dashboardAppBar) {
+          return DashboardAppBar(
+            dashboardId:
+                tabsRouter.topRoute.pathParams.getString('dashboardId'),
+          );
+        }
+
+        return const VersionAppBar(title: 'Lotti');
+      },
       builder: (context, child, _) {
         return Container(
           color: AppColors.bodyBgColor,

--- a/lib/widgets/misc/app_bar_version.dart
+++ b/lib/widgets/misc/app_bar_version.dart
@@ -1,3 +1,4 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
@@ -52,22 +53,29 @@ class _VersionAppBarState extends State<VersionAppBar> {
           if (snapshot.data == null) {
             return const SizedBox.shrink();
           } else {
-            return Column(
-              children: [
-                Text(
-                  widget.title,
-                  style: appBarTextStyle,
-                ),
-                Text(
-                  'v$version ($buildNumber), n = ${snapshot.data}',
-                  style: TextStyle(
-                    color: AppColors.headerFontColor2,
-                    fontFamily: 'Oswald',
-                    fontSize: 10.0,
-                    fontWeight: FontWeight.w300,
+            return AppBar(
+              backgroundColor: AppColors.headerBgColor,
+              title: Column(
+                children: [
+                  Text(
+                    widget.title,
+                    style: appBarTextStyle,
                   ),
-                ),
-              ],
+                  Text(
+                    'v$version ($buildNumber), n = ${snapshot.data}',
+                    style: TextStyle(
+                      color: AppColors.headerFontColor2,
+                      fontFamily: 'Oswald',
+                      fontSize: 10.0,
+                      fontWeight: FontWeight.w300,
+                    ),
+                  ),
+                ],
+              ),
+              centerTitle: true,
+              leading: AutoBackButton(
+                color: AppColors.entryTextColor,
+              ),
             );
           }
         });

--- a/lib/widgets/misc/dashboard_app_bar.dart
+++ b/lib/widgets/misc/dashboard_app_bar.dart
@@ -1,0 +1,64 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/theme.dart';
+
+class DashboardAppBar extends StatefulWidget with PreferredSizeWidget {
+  final String dashboardId;
+
+  const DashboardAppBar({
+    Key? key,
+    required this.dashboardId,
+  }) : super(key: key);
+
+  @override
+  _DashboardAppBarState createState() => _DashboardAppBarState();
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+}
+
+class _DashboardAppBarState extends State<DashboardAppBar> {
+  final JournalDb _db = getIt<JournalDb>();
+  late Stream<List<DashboardDefinition>> stream;
+
+  @override
+  void initState() {
+    super.initState();
+    stream = _db.watchDashboardById(widget.dashboardId);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<List<DashboardDefinition>>(
+        stream: stream,
+        builder: (
+          BuildContext context,
+          AsyncSnapshot<List<DashboardDefinition>> snapshot,
+        ) {
+          DashboardDefinition? dashboard;
+          var data = snapshot.data ?? [];
+          if (data.isNotEmpty) {
+            dashboard = data.first;
+          }
+
+          if (dashboard == null) {
+            return const SizedBox.shrink();
+          } else {
+            return AppBar(
+              backgroundColor: AppColors.headerBgColor,
+              title: Text(
+                dashboard.name,
+                style: appBarTextStyle,
+              ),
+              centerTitle: true,
+              leading: AutoBackButton(
+                color: AppColors.entryTextColor,
+              ),
+            );
+          }
+        });
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -885,7 +885,7 @@ packages:
       name: flutter_typeahead
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.5"
+    version: "3.2.7"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -2171,7 +2171,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.0"
+    version: "2.6.1"
   window_manager:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.1+858
+version: 0.8.2+859
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.2+859
+version: 0.8.2+860
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.2+860
+version: 0.8.2+861
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR adds hiding the bottom navigation bar on dashboard detail pages so that more data can be shown at the same time, and moves the dashboard title into the app bar.