### PR TITLE
Postpone obtaining geolocation for faster screenshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed:
+- Faster screenshots when no location in cache
+
+## [0.8.3] - 2022-05-16
+### Changed:
 - Bottom Navigation Bar hidden in entry details
 - Bottom Navigation Bar hidden in sync assistant
 - Bottom Navigation Bar hidden in logging

--- a/lib/logic/persistence_logic.dart
+++ b/lib/logic/persistence_logic.dart
@@ -261,7 +261,7 @@ class PersistenceLogic {
     return true;
   }
 
-  Future<bool> createImageEntry(
+  Future<JournalEntity?> createImageEntry(
     ImageData imageData, {
     JournalEntity? linked,
   }) async {
@@ -297,6 +297,7 @@ class PersistenceLogic {
         enqueueSync: true,
         linkedId: linked?.meta.id,
       );
+      return journalEntity;
     } catch (exception, stackTrace) {
       await _loggingDb.captureException(
         exception,
@@ -307,7 +308,7 @@ class PersistenceLogic {
     }
 
     await transaction.finish();
-    return true;
+    return null;
   }
 
   Future<bool> createAudioEntry(

--- a/lib/widgets/create/add_actions.dart
+++ b/lib/widgets/create/add_actions.dart
@@ -57,10 +57,16 @@ class _RadialAddActionButtonsState extends State<RadialAddActionButtons> {
           backgroundColor: AppColors.actionColor,
           onPressed: () async {
             ImageData imageData = await takeScreenshotMac();
-            await _persistenceLogic.createImageEntry(
+
+            JournalEntity? journalEntity =
+                await _persistenceLogic.createImageEntry(
               imageData,
               linked: widget.linked,
             );
+
+            if (journalEntity != null) {
+              _persistenceLogic.addGeolocation(journalEntity.meta.id);
+            }
           },
         ),
       );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.3+863
+version: 0.8.4+864
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR changes screenshots by postponing fetching a geolocation for the screenshot entry. This much improves screenshot delay when the location is not in the cache.