### PR TITLE
Add desktop menu for macOS

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,7 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/routes/router.gr.dart';
 import 'package:lotti/services/window_service.dart';
 import 'package:lotti/utils/screenshots.dart';
+import 'package:lotti/widgets/misc/desktop_menu.dart';
 import 'package:timezone/data/latest.dart' as tz;
 import 'package:window_manager/window_manager.dart';
 
@@ -80,23 +81,25 @@ class LottiApp extends StatelessWidget {
           create: (BuildContext context) => AudioPlayerCubit(),
         ),
       ],
-      child: MaterialApp.router(
-        localizationsDelegates: const [
-          AppLocalizations.delegate,
-          FormBuilderLocalizations.delegate,
-          GlobalMaterialLocalizations.delegate,
-          GlobalWidgetsLocalizations.delegate,
-          GlobalCupertinoLocalizations.delegate,
-        ],
-        supportedLocales: AppLocalizations.supportedLocales,
-        theme: ThemeData(
-          primarySwatch: Colors.grey,
+      child: DesktopMenuWrapper(
+        MaterialApp.router(
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            FormBuilderLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          theme: ThemeData(
+            primarySwatch: Colors.grey,
+          ),
+          debugShowCheckedModeBanner: true,
+          routerDelegate: router.delegate(
+            navigatorObservers: () => [],
+          ),
+          routeInformationParser: router.defaultRouteParser(),
         ),
-        debugShowCheckedModeBanner: true,
-        routerDelegate: router.delegate(
-          navigatorObservers: () => [],
-        ),
-        routeInformationParser: router.defaultRouteParser(),
       ),
     );
   }

--- a/lib/services/nav_service.dart
+++ b/lib/services/nav_service.dart
@@ -13,7 +13,7 @@ class NavService {
   }
 
   void restoreRoute() async {
-    String? route = await SecureStorage.readValue(lastRouteKey);
+    String? route = await getSavedRoute();
     if (route != null) {
       Timer(const Duration(milliseconds: 100), () {
         getIt<AppRouter>().pushNamed(route);
@@ -21,6 +21,20 @@ class NavService {
       });
     }
   }
+}
+
+Future<String?> getSavedRoute() async {
+  return await SecureStorage.readValue(lastRouteKey);
+}
+
+Future<String?> getIdFromSavedRoute() async {
+  RegExp regExp = RegExp(
+    r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}',
+    caseSensitive: false,
+    multiLine: false,
+  );
+  String? route = await getSavedRoute();
+  return regExp.firstMatch('$route')?.group(0);
 }
 
 void persistNamedRoute(String route) {

--- a/lib/widgets/misc/desktop_menu.dart
+++ b/lib/widgets/misc/desktop_menu.dart
@@ -1,0 +1,118 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:lotti/services/nav_service.dart';
+
+class DesktopMenuWrapper extends StatelessWidget {
+  final Widget body;
+
+  const DesktopMenuWrapper(
+    this.body, {
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    if (!Platform.isMacOS) {
+      return body;
+    }
+
+    return PlatformMenuBar(
+      body: body,
+      menus: <MenuItem>[
+        const PlatformMenu(
+          label: 'Lotti',
+          menus: [
+            PlatformProvidedMenuItem(
+              type: PlatformProvidedMenuItemType.about,
+            ),
+            PlatformMenuItemGroup(
+              members: [
+                PlatformProvidedMenuItem(
+                  type: PlatformProvidedMenuItemType.servicesSubmenu,
+                ),
+              ],
+            ),
+            PlatformMenuItemGroup(
+              members: [
+                PlatformProvidedMenuItem(
+                  type: PlatformProvidedMenuItemType.hide,
+                ),
+              ],
+            ),
+            PlatformProvidedMenuItem(
+              type: PlatformProvidedMenuItemType.quit,
+            ),
+          ],
+        ),
+        PlatformMenu(
+          label: 'File',
+          menus: [
+            PlatformMenuItem(
+              label: 'New Entry',
+              onSelected: () {
+                pushNamedRoute('/journal/create/${null}');
+              },
+              shortcut: const SingleActivator(
+                LogicalKeyboardKey.keyN,
+                meta: true,
+              ),
+            ),
+            PlatformMenu(
+              label: 'New ...',
+              menus: [
+                PlatformMenuItem(
+                  label: 'Task',
+                  shortcut: const SingleActivator(
+                    LogicalKeyboardKey.keyT,
+                    meta: true,
+                  ),
+                  onSelected: () {
+                    pushNamedRoute('/tasks/create/${null}');
+                  },
+                ),
+              ],
+            ),
+          ],
+        ),
+        PlatformMenu(
+          label: 'Edit',
+          menus: [
+            PlatformMenuItem(
+              label: 'Cut',
+              shortcut: const SingleActivator(
+                LogicalKeyboardKey.keyX,
+                meta: true,
+              ),
+              onSelected: () {
+                debugPrint('Cut');
+              },
+            ),
+            PlatformMenuItem(
+              label: 'Copy',
+              shortcut: const SingleActivator(
+                LogicalKeyboardKey.keyC,
+                meta: true,
+              ),
+              onSelected: () {
+                debugPrint('Copy');
+              },
+            ),
+          ],
+        ),
+        const PlatformMenu(
+          label: 'View',
+          menus: [
+            PlatformProvidedMenuItem(
+              type: PlatformProvidedMenuItemType.toggleFullScreen,
+            ),
+            PlatformProvidedMenuItem(
+              type: PlatformProvidedMenuItemType.zoomWindow,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/misc/desktop_menu.dart
+++ b/lib/widgets/misc/desktop_menu.dart
@@ -2,12 +2,16 @@ import 'dart:io';
 
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
+import 'package:lotti/classes/entry_text.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/nav_service.dart';
 
 class DesktopMenuWrapper extends StatelessWidget {
+  final PersistenceLogic _persistenceLogic = getIt<PersistenceLogic>();
   final Widget body;
 
-  const DesktopMenuWrapper(
+  DesktopMenuWrapper(
     this.body, {
     Key? key,
   }) : super(key: key);
@@ -51,8 +55,17 @@ class DesktopMenuWrapper extends StatelessWidget {
           menus: [
             PlatformMenuItem(
               label: 'New Entry',
-              onSelected: () {
-                pushNamedRoute('/journal/create/${null}');
+              onSelected: () async {
+                String? linkedId = await getIdFromSavedRoute();
+                if (linkedId != null) {
+                  _persistenceLogic.createTextEntry(
+                    EntryText(plainText: ''),
+                    linkedId: linkedId,
+                    started: DateTime.now(),
+                  );
+                } else {
+                  pushNamedRoute('/journal/create/$linkedId');
+                }
               },
               shortcut: const SingleActivator(
                 LogicalKeyboardKey.keyN,
@@ -68,38 +81,18 @@ class DesktopMenuWrapper extends StatelessWidget {
                     LogicalKeyboardKey.keyT,
                     meta: true,
                   ),
-                  onSelected: () {
-                    pushNamedRoute('/tasks/create/${null}');
+                  onSelected: () async {
+                    String? linkedId = await getIdFromSavedRoute();
+                    pushNamedRoute('/tasks/create/$linkedId');
                   },
                 ),
               ],
             ),
           ],
         ),
-        PlatformMenu(
+        const PlatformMenu(
           label: 'Edit',
-          menus: [
-            PlatformMenuItem(
-              label: 'Cut',
-              shortcut: const SingleActivator(
-                LogicalKeyboardKey.keyX,
-                meta: true,
-              ),
-              onSelected: () {
-                debugPrint('Cut');
-              },
-            ),
-            PlatformMenuItem(
-              label: 'Copy',
-              shortcut: const SingleActivator(
-                LogicalKeyboardKey.keyC,
-                meta: true,
-              ),
-              onSelected: () {
-                debugPrint('Copy');
-              },
-            ),
-          ],
+          menus: [],
         ),
         const PlatformMenu(
           label: 'View',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.6+867
+version: 0.8.6+869
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.5+866
+version: 0.8.6+867
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR adds a basic menu on macOS, for now allowing to create new tasks and entries via the menu, and via key shortcuts `CMD-N` for a new entry and `CMD-T` for a new task.