### PR TITLE
Disable file browsing on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed:
+- Disable file sharing on iOS
+
+## [0.8.11] - 2022-05-19
 ### Added:
 - Persistence of editor drafts
 

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -69,8 +69,6 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>UISupportsDocumentBrowser</key>
-	<true/>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 	<key>io.flutter.embedded_views_preview</key>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.11+886
+version: 0.8.12+889
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR disables file browsing on iOS so that files no longer show up in the Files app.