### PR TITLE
Fix Android build by removing flutter_health_fit

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -213,53 +213,53 @@ steps:
         soft_fail:
           - exit_status: 24
 
-#  #################
-#
-#  - label: ":android: Bundle "
-#    key: "android_bundle"
-#    depends_on:
-#      - "codegen_test"
-#    command:
-#      - "rsync -ar /tmp/buildkite/${BUILDKITE_COMMIT}/ ./"
-#      - "flutter build appbundle"
-#      - "rsync -ar ./ /tmp/buildkite/${BUILDKITE_COMMIT}/"
-#    agents:
-#      os: "macOS"
-#    soft_fail:
-#      - exit_status: 24
-#
-#  #################
-#
-#  - group: ":android: :github: Release"
-#    key: "android_github_release"
-#    depends_on:
-#      - "android_bundle"
-#    steps:
-#      - label: ":android: Android create APKs "
-#        key: "android_apks"
-#        depends_on:
-#          - "android_bundle"
-#        command:
-#          - "rsync -ar /tmp/buildkite/${BUILDKITE_COMMIT}/ ./"
-#          - "bundletool build-apks --mode universal --bundle build/app/outputs/bundle/release/app-release.aab --output build/android/lotti.apks --overwrite"
-#          - "cp build/android/lotti.apks build/android/lotti.zip"
-#          - "cd build/android && unzip lotti.zip && cd -"
-#          - "rsync -ar --exclude 'build/ios' --exclude 'build/macos' ./ /tmp/buildkite/${BUILDKITE_COMMIT}/"
-#        agents:
-#          os: "macOS"
-#        soft_fail:
-#          - exit_status: 24
-#
-#      - label: ":android: 🚀 publish :github: Prerelease "
-#        key: "android_github_prerelease"
-#        depends_on:
-#          - "create_github_prerelease"
-#          - "android_apks"
-#        command:
-#          - "rsync -ar /tmp/buildkite/${BUILDKITE_COMMIT}/ ./"
-#          - "gh release upload ${BUILDKITE_BRANCH} build/android/universal.apk"
-#          - "gh release upload ${BUILDKITE_BRANCH} build/app/outputs/bundle/release/app-release.aab"
-#        agents:
-#          os: "macOS"
-#        soft_fail:
-#          - exit_status: 24
+  #################
+
+  - label: ":android: Bundle "
+    key: "android_bundle"
+    depends_on:
+      - "codegen_test"
+    command:
+      - "rsync -ar /tmp/buildkite/${BUILDKITE_COMMIT}/ ./"
+      - "flutter build appbundle"
+      - "rsync -ar ./ /tmp/buildkite/${BUILDKITE_COMMIT}/"
+    agents:
+      os: "macOS"
+    soft_fail:
+      - exit_status: 24
+
+  #################
+
+  - group: ":android: :github: Release"
+    key: "android_github_release"
+    depends_on:
+      - "android_bundle"
+    steps:
+      - label: ":android: Android create APKs "
+        key: "android_apks"
+        depends_on:
+          - "android_bundle"
+        command:
+          - "rsync -ar /tmp/buildkite/${BUILDKITE_COMMIT}/ ./"
+          - "bundletool build-apks --mode universal --bundle build/app/outputs/bundle/release/app-release.aab --output build/android/lotti.apks --overwrite"
+          - "cp build/android/lotti.apks build/android/lotti.zip"
+          - "cd build/android && unzip lotti.zip && cd -"
+          - "rsync -ar --exclude 'build/ios' --exclude 'build/macos' ./ /tmp/buildkite/${BUILDKITE_COMMIT}/"
+        agents:
+          os: "macOS"
+        soft_fail:
+          - exit_status: 24
+
+      - label: ":android: 🚀 publish :github: Prerelease "
+        key: "android_github_prerelease"
+        depends_on:
+          - "create_github_prerelease"
+          - "android_apks"
+        command:
+          - "rsync -ar /tmp/buildkite/${BUILDKITE_COMMIT}/ ./"
+          - "gh release upload ${BUILDKITE_BRANCH} build/android/universal.apk"
+          - "gh release upload ${BUILDKITE_BRANCH} build/app/outputs/bundle/release/app-release.aab"
+        agents:
+          os: "macOS"
+        soft_fail:
+          - exit_status: 24

--- a/.github/workflows/flutter-linux-build.yml
+++ b/.github/workflows/flutter-linux-build.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '3.0.0'
+          flutter-version: '3.0.1'
           channel: 'stable'
       - name: Update apt-get
         run: sudo apt-get update

--- a/.github/workflows/flutter-linux-release.yml
+++ b/.github/workflows/flutter-linux-release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '3.0.0'
+          flutter-version: '3.0.1'
           channel: 'stable'
       - name: Update apt-get
         run: sudo apt-get update

--- a/.github/workflows/flutter-test.yml
+++ b/.github/workflows/flutter-test.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '3.0.0'
+          flutter-version: '3.0.1'
           channel: 'stable'
       - name: Run Flutter tests
         run: make clean_test

--- a/.github/workflows/flutter-testflight.yml
+++ b/.github/workflows/flutter-testflight.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '3.0.0'
+          flutter-version: '3.0.1'
           channel: 'stable'
       - name: Fastlane match iOS
         working-directory: lotti/ios

--- a/.github/workflows/flutter-windows-build.yml
+++ b/.github/workflows/flutter-windows-build.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '3.0.0'
+          flutter-version: '3.0.1'
           channel: 'stable'
       - name: Flutter Doctor
         run: make doctor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.8.12] - 2022-05-20
 ### Changed:
 - Disable file sharing on iOS
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -11,8 +11,6 @@ PODS:
     - Flutter
   - flutter_fgbg (0.0.1):
     - Flutter
-  - flutter_health_fit (0.0.1):
-    - Flutter
   - flutter_image_compress (0.0.1):
     - Flutter
     - Mantle
@@ -126,7 +124,6 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_app_badger (from `.symlinks/plugins/flutter_app_badger/ios`)
   - flutter_fgbg (from `.symlinks/plugins/flutter_fgbg/ios`)
-  - flutter_health_fit (from `.symlinks/plugins/flutter_health_fit/ios`)
   - flutter_image_compress (from `.symlinks/plugins/flutter_image_compress/ios`)
   - flutter_inappwebview (from `.symlinks/plugins/flutter_inappwebview/ios`)
   - flutter_keyboard_visibility (from `.symlinks/plugins/flutter_keyboard_visibility/ios`)
@@ -180,8 +177,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_app_badger/ios"
   flutter_fgbg:
     :path: ".symlinks/plugins/flutter_fgbg/ios"
-  flutter_health_fit:
-    :path: ".symlinks/plugins/flutter_health_fit/ios"
   flutter_image_compress:
     :path: ".symlinks/plugins/flutter_image_compress/ios"
   flutter_inappwebview:
@@ -240,7 +235,6 @@ SPEC CHECKSUMS:
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
   flutter_app_badger: b87fc231847b03b92ce1412aa351842e7e97932f
   flutter_fgbg: 31c0d1140a131daea2d342121808f6aa0dcd879d
-  flutter_health_fit: af332b5d7512b9cc8a05e7282cfcee02b056d32e
   flutter_image_compress: fd2b476345226e1a10ea352fa306af95704642c1
   flutter_inappwebview: bfd58618f49dc62f2676de690fc6dcda1d6c3721
   flutter_keyboard_visibility: 0339d06371254c3eb25eeb90ba8d17dca8f9c069

--- a/lib/logic/health_import.dart
+++ b/lib/logic/health_import.dart
@@ -4,10 +4,9 @@ import 'dart:io';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:enum_to_string/enum_to_string.dart';
 import 'package:flutter/widgets.dart';
-import 'package:flutter_health_fit/flutter_health_fit.dart';
-import 'package:flutter_health_fit/workout_sample.dart';
+// import 'package:flutter_health_fit/flutter_health_fit.dart';
+// import 'package:flutter_health_fit/workout_sample.dart';
 import 'package:health/health.dart';
-import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/health.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
@@ -56,18 +55,13 @@ class HealthImport {
     final LoggingDb loggingDb = getIt<LoggingDb>();
     final transaction =
         loggingDb.startTransaction('getActivityHealthData()', 'task');
+    await authorizeHealth(activityTypes);
 
-    final flutterHealthFit = FlutterHealthFit();
-    final bool isAuthorized = await FlutterHealthFit().authorize();
-    final bool isAnyAuth = await flutterHealthFit.isAnyPermissionAuthorized();
-    debugPrint(
-        'flutterHealthFit isAuthorized: $isAuthorized, isAnyAuth: $isAnyAuth');
-
-    Future<void> addEntries(Map<DateTime, int> data, String type) async {
-      List<MapEntry<DateTime, int>> entries = List.from(data.entries);
+    Future<void> addEntries(Map<DateTime, num> data, String type) async {
+      List<MapEntry<DateTime, num>> entries = List.from(data.entries);
       entries.sort((a, b) => a.key.compareTo(b.key));
 
-      for (MapEntry<DateTime, int> dailyStepsEntry in entries) {
+      for (MapEntry<DateTime, num> dailyStepsEntry in entries) {
         DateTime dateFrom = dailyStepsEntry.key;
         DateTime dateTo = dateFrom
             .add(const Duration(days: 1))
@@ -86,15 +80,37 @@ class HealthImport {
       }
     }
 
-    final Map<DateTime, int> stepCounts = await FlutterHealthFit()
-        .getStepsBySegment(dateFrom.millisecondsSinceEpoch,
-            dateToOrNow.millisecondsSinceEpoch, 1, TimeUnit.days);
-    addEntries(stepCounts, 'cumulative_step_count');
+    Map<DateTime, num> stepsByDay = {};
+    Duration range = dateTo.difference(dateFrom);
+    List<DateTime> days = List<DateTime>.generate(range.inDays, (days) {
+      DateTime day = dateFrom.add(Duration(days: days));
+      return DateTime(
+        day.year,
+        day.month,
+        day.day,
+      );
+    });
 
-    final Map<DateTime, int> flights = await FlutterHealthFit()
-        .getFlightsBySegment(dateFrom.millisecondsSinceEpoch,
-            dateToOrNow.millisecondsSinceEpoch, 1, TimeUnit.days);
-    addEntries(flights, 'cumulative_flights_climbed');
+    for (DateTime dateFrom in days) {
+      int? steps = await _healthFactory.getTotalStepsInInterval(
+          dateFrom,
+          DateTime(
+            dateFrom.year,
+            dateFrom.month,
+            dateFrom.day,
+            23,
+            59,
+            59,
+            999,
+          ));
+      stepsByDay[dateFrom] = steps ?? 0;
+    }
+
+    addEntries(stepsByDay, 'cumulative_step_count');
+    debugPrint('getActivityHealthData $stepsByDay');
+
+    // TODO: bring back import of cumulative_flights_climbed
+    // addEntries(flights, 'cumulative_flights_climbed');
     await transaction.finish();
   }
 
@@ -207,30 +223,25 @@ class HealthImport {
     final transaction =
         loggingDb.startTransaction('getActivityHealthData()', 'task');
     debugPrint('getWorkoutsHealthData $dateFrom - $dateTo');
-    final flutterHealthFit = FlutterHealthFit();
-    final bool isAuthorized = await FlutterHealthFit().authorize();
-    final bool isAnyAuth = await flutterHealthFit.isAnyPermissionAuthorized();
-    debugPrint(
-        'getWorkoutsHealthData isAuthorized: $isAuthorized, isAnyAuth: $isAnyAuth');
 
-    List<WorkoutSample>? workouts =
-        await FlutterHealthFit().getWorkoutsBySegment(
-      dateFrom.millisecondsSinceEpoch,
-      dateToOrNow.millisecondsSinceEpoch,
-    );
-
-    workouts?.forEach((WorkoutSample workoutSample) async {
-      WorkoutData workoutData = WorkoutData(
-        dateFrom: workoutSample.start,
-        dateTo: workoutSample.end,
-        distance: workoutSample.distance,
-        energy: workoutSample.energy,
-        source: workoutSample.source,
-        workoutType: workoutSample.type.name,
-        id: workoutSample.id,
-      );
-      await persistenceLogic.createWorkoutEntry(workoutData);
-    });
+    // List<WorkoutSample>? workouts =
+    //     await FlutterHealthFit().getWorkoutsBySegment(
+    //   dateFrom.millisecondsSinceEpoch,
+    //   dateToOrNow.millisecondsSinceEpoch,
+    // );
+    //
+    // workouts?.forEach((WorkoutSample workoutSample) async {
+    //   WorkoutData workoutData = WorkoutData(
+    //     dateFrom: workoutSample.start,
+    //     dateTo: workoutSample.end,
+    //     distance: workoutSample.distance,
+    //     energy: workoutSample.energy,
+    //     source: workoutSample.source,
+    //     workoutType: workoutSample.type.name,
+    //     id: workoutSample.id,
+    //   );
+    //   await persistenceLogic.createWorkoutEntry(workoutData);
+    // });
 
     await transaction.finish();
   }
@@ -268,4 +279,14 @@ List<HealthDataType> bodyMeasurementTypes = [
   HealthDataType.BODY_FAT_PERCENTAGE,
   HealthDataType.BODY_MASS_INDEX,
   HealthDataType.HEIGHT,
+];
+
+List<HealthDataType> workoutTypes = [
+  HealthDataType.EXERCISE_TIME,
+  HealthDataType.WORKOUT,
+];
+
+List<HealthDataType> activityTypes = [
+  HealthDataType.STEPS,
+  HealthDataType.FLIGHTS_CLIMBED,
 ];

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -669,15 +669,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "7.1.1"
-  flutter_health_fit:
-    dependency: "direct main"
-    description:
-      path: "."
-      ref: "30102b6"
-      resolved-ref: "30102b653cdd2af64509edb4643e809e40139e7c"
-      url: "https://github.com/metaflowltd/flutter_health_fit.git"
-    source: git
-    version: "0.1.0"
   flutter_image_compress:
     dependency: "direct main"
     description:
@@ -997,9 +988,11 @@ packages:
   health:
     dependency: "direct main"
     description:
-      name: health
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "packages/health"
+      ref: bfa66d6
+      resolved-ref: bfa66d6027a355eb8b93bfc3dbe9d0c77cd62fb5
+      url: "https://github.com/matthiasn/flutter-plugins"
+    source: git
     version: "3.4.4"
   hexcolor:
     dependency: "direct main"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.12+889
+version: 0.8.13+890
 
 msix_config:
   display_name: Lotti
@@ -23,10 +23,10 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
-  flutter_health_fit:
-    git:
-      url: https://github.com/metaflowltd/flutter_health_fit.git
-      ref: 30102b6
+#  flutter_health_fit:
+#    git:
+#      url: https://github.com/metaflowltd/flutter_health_fit.git
+#      ref: 30102b6
 
   # research_package: ^0.6.7
   research_package:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.13+890
+version: 0.8.13+891
 
 msix_config:
   display_name: Lotti
@@ -27,6 +27,12 @@ dependencies:
 #    git:
 #      url: https://github.com/metaflowltd/flutter_health_fit.git
 #      ref: 30102b6
+
+  health:
+    git:
+      url: https://github.com/matthiasn/flutter-plugins
+      path: packages/health
+      ref: bfa66d6
 
   # research_package: ^0.6.7
   research_package:
@@ -88,7 +94,7 @@ dependencies:
   getwidget: ^2.0.4
   glass: ^1.0.1+1
   google_fonts: 2.2.0
-  health: ^3.4.3
+  # health: ^3.4.3
   hexcolor: ^2.0.6
   hotkey_manager: ^0.1.6
   intl: ^0.17.0


### PR DESCRIPTION
This PR fixes the Android build as reported in #972 by removing the offending library, [`flutter_health_fit`](https://github.com/metaflowltd/flutter_health_fit). The cumulative imports of steps and flights of stairs are replaced with functionality from [`health`](https://pub.dev/packages/health), which is preferable anyway since it's properly released. 

Flights of stairs use a [fork](https://github.com/matthiasn/flutter-plugins) of the library, will create a PR for that later after some deduplication. Cleanup and deduplication should also happen in the imports in a later refactoring.