### PR TITLE
Prevent activity import for dateFrom in the future

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed:
+- Activity imports up to now
+
+## [0.8.14] - 2022-05-21
+### Fixed:
+- Dashboard creation
 
 ## [0.8.12] - 2022-05-20
 ### Changed:

--- a/lib/logic/health_import.dart
+++ b/lib/logic/health_import.dart
@@ -18,7 +18,7 @@ class HealthImport {
   final PersistenceLogic persistenceLogic = getIt<PersistenceLogic>();
   final JournalDb _db = getIt<JournalDb>();
   final HealthFactory _healthFactory = HealthFactory();
-  Duration defaultFetchDuration = const Duration(days: 30);
+  Duration defaultFetchDuration = const Duration(days: 90);
 
   late final String platform;
   String? deviceType;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.15+894
+version: 0.8.15+895
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.14+893
+version: 0.8.15+894
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR changes activity imports so that only start dates up until the query time take place.