### PR TITLE
Dashboard not found header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added:
+- Dashboard not found header, this becomes relevant after deleting a dashboard
+
+## [0.8.15] - 2022-05-21
 ### Changed:
 - Activity imports up to now
 

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -131,6 +131,7 @@
   "taskEditHint": "Aufgabe bearbeiten",
   "taskEstimateLabel": "Geschätzter Zeitbedarf:",
   "taskNameLabel": "Aufgabe:",
+  "taskNotFound": "Aufgabe nicht gefunden",
   "tasksSearchHint": "Suche nach Tasks...",
   "taskStatusBlocked": "BLOCKIERT",
   "taskStatusDone": "FERTIG",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -24,6 +24,7 @@
   "dashboardDeleteQuestion": "Dashboard wirklich löschen?",
   "dashboardDescriptionLabel": "Beschreibung:",
   "dashboardNameLabel": "Name des Dashboards:",
+  "dashboardNotFound": "Dashboard nicht gefunden",
   "dashboardPrivateLabel": "Privat:",
   "dashboardReviewTimeLabel": "Täglich erinnern um:",
   "dashboardSaveLabel": "Speichern",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -137,6 +137,7 @@
   "taskEditHint": "Edit Task",
   "taskEstimateLabel": "Estimated time:",
   "taskNameLabel": "Task:",
+  "taskNotFound": "Task not found",
   "tasksSearchHint": "Search tasks...",
   "taskStatusBlocked": "BLOCKED",
   "taskStatusDone": "DONE",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -24,6 +24,7 @@
   "dashboardDeleteQuestion": "Do you want to delete this dashboard?",
   "dashboardDescriptionLabel": "Description:",
   "dashboardNameLabel": "Dashboard name:",
+  "dashboardNotFound": "Dashboard not found",
   "dashboardPrivateLabel": "Private:",
   "dashboardReviewTimeLabel": "Daily Review Time:",
   "dashboardSaveLabel": "Save & Close",

--- a/lib/pages/settings/dashboards/dashboard_details_page.dart
+++ b/lib/pages/settings/dashboards/dashboard_details_page.dart
@@ -241,7 +241,7 @@ class _DashboardDetailPageState extends State<DashboardDetailPage> {
               active: formData['active'],
               reviewAt: formData['review_at'],
               updatedAt: DateTime.now(),
-              items: dashboardItems ?? widget.dashboard.items,
+              items: dashboardItems,
             );
 
             await persistenceLogic.upsertDashboardDefinition(dashboard);
@@ -373,22 +373,20 @@ class _DashboardDetailPageState extends State<DashboardDetailPage> {
                             physics: const NeverScrollableScrollPhysics(),
                             onReorder: (int oldIndex, int newIndex) {
                               setState(() {
-                                dashboardItems =
-                                    dashboardItems ?? widget.dashboard.items;
+                                dashboardItems = dashboardItems;
                                 final movedItem =
-                                    dashboardItems!.removeAt(oldIndex);
+                                    dashboardItems.removeAt(oldIndex);
                                 final insertionIndex = newIndex > oldIndex
                                     ? newIndex - 1
                                     : newIndex;
-                                dashboardItems!
-                                    .insert(insertionIndex, movedItem);
+                                dashboardItems.insert(
+                                    insertionIndex, movedItem);
                               });
                             },
                             children: List.generate(
-                              (dashboardItems ?? widget.dashboard.items).length,
+                              (dashboardItems).length,
                               (int index) {
-                                List<DashboardItem> items =
-                                    dashboardItems ?? widget.dashboard.items;
+                                List<DashboardItem> items = dashboardItems;
                                 DashboardItem item = items.elementAt(index);
 
                                 return Dismissible(

--- a/lib/widgets/app_bar/dashboard_app_bar.dart
+++ b/lib/widgets/app_bar/dashboard_app_bar.dart
@@ -1,5 +1,6 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
@@ -32,6 +33,8 @@ class _DashboardAppBarState extends State<DashboardAppBar> {
 
   @override
   Widget build(BuildContext context) {
+    AppLocalizations localizations = AppLocalizations.of(context)!;
+
     return StreamBuilder<List<DashboardDefinition>>(
         stream: stream,
         builder: (
@@ -44,21 +47,19 @@ class _DashboardAppBarState extends State<DashboardAppBar> {
             dashboard = data.first;
           }
 
-          if (dashboard == null) {
-            return const SizedBox.shrink();
-          } else {
-            return AppBar(
-              backgroundColor: AppColors.headerBgColor,
-              title: Text(
-                dashboard.name,
-                style: appBarTextStyle,
-              ),
-              centerTitle: true,
-              leading: AutoLeadingButton(
-                color: AppColors.entryTextColor,
-              ),
-            );
-          }
+          return AppBar(
+            backgroundColor: AppColors.headerBgColor,
+            title: Text(
+              dashboard == null
+                  ? localizations.dashboardNotFound
+                  : dashboard.name,
+              style: appBarTextStyle,
+            ),
+            centerTitle: true,
+            leading: AutoLeadingButton(
+              color: AppColors.entryTextColor,
+            ),
+          );
         });
   }
 }

--- a/lib/widgets/app_bar/task_app_bar.dart
+++ b/lib/widgets/app_bar/task_app_bar.dart
@@ -1,5 +1,6 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
@@ -22,6 +23,8 @@ class TaskAppBar extends StatelessWidget with PreferredSizeWidget {
 
   @override
   Widget build(BuildContext context) {
+    AppLocalizations localizations = AppLocalizations.of(context)!;
+
     return StreamBuilder<JournalEntity?>(
         stream: _db.watchEntityById(itemId),
         builder: (
@@ -30,7 +33,17 @@ class TaskAppBar extends StatelessWidget with PreferredSizeWidget {
         ) {
           JournalEntity? item = snapshot.data;
           if (item == null || item.meta.deletedAt != null) {
-            return const SizedBox.shrink();
+            return AppBar(
+              backgroundColor: AppColors.headerBgColor,
+              title: Text(
+                localizations.taskNotFound,
+                style: appBarTextStyle,
+              ),
+              centerTitle: true,
+              leading: AutoLeadingButton(
+                color: AppColors.entryTextColor,
+              ),
+            );
           }
 
           bool isTask = item is Task;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.16+897
+version: 0.8.16+899
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.15+895
+version: 0.8.16+896
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.16+896
+version: 0.8.16+897
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR adapts dashboard and task headers to still render a modified app bar when the underlying item had been deleted so that the user can still navigate elsewhere instead of being stuck when the app tries to restore the last active route.