### PR TITLE
Add Romanian localization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added:
+- Use Romanian localization
+
+## [0.8.17] - 2022-05-22
 ### Fixed:
 - Intra-day steps import
 

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -17,6 +17,7 @@
 		<string>en</string>
 		<string>de</string>
 		<string>fr</string>
+		<string>ro</string>
 	</array>
 	<key>CFBundleName</key>
 	<string>$(APP_NAME)</string>

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -17,6 +17,7 @@
 		<string>en</string>
 		<string>de</string>
 		<string>fr</string>
+		<string>ro</string>
 	</array>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -35,7 +35,7 @@ packages:
       name: animations
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   ansicolor:
     dependency: transitive
     description:
@@ -196,7 +196,7 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.3.0"
+    version: "8.3.2"
   cached_network_image:
     dependency: "direct main"
     description:
@@ -357,7 +357,7 @@ packages:
       name: cross_file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.3"
+    version: "0.3.3+1"
   crypto:
     dependency: "direct main"
     description:
@@ -785,7 +785,7 @@ packages:
       name: flutter_quill
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.1"
+    version: "5.0.2"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -862,7 +862,7 @@ packages:
       name: flutter_svg
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.1.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -1054,7 +1054,7 @@ packages:
       name: i18n_extension
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.1"
+    version: "5.0.0"
   image:
     dependency: transitive
     description:
@@ -1896,21 +1896,21 @@ packages:
       name: syncfusion_flutter_calendar
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "20.1.56"
+    version: "20.1.57"
   syncfusion_flutter_core:
     dependency: transitive
     description:
       name: syncfusion_flutter_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "20.1.56"
+    version: "20.1.57"
   syncfusion_flutter_datepicker:
     dependency: "direct main"
     description:
       name: syncfusion_flutter_datepicker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "20.1.56"
+    version: "20.1.57"
   synchronized:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.18+902
+version: 0.8.19+903
 
 msix_config:
   display_name: Lotti
@@ -9,7 +9,7 @@ msix_config:
   publisher: CN=Matthias Nehlsen, O=Matthias Nehlsen, C=DE
   identity_name: com.matthiasnehlsen.lotti
   capabilities: internetClient, location, microphone, webcam
-  languages: en-us, de-de
+  languages: en-us, de-de, ro-ro
   install_certificate: false
   sign_msix: false
   #logo_path: C:\lotti\logo.png


### PR DESCRIPTION
This PR adds configuration on iOS, macOS and Windows for using the Romanian localization contributed in #993, thanks @ixici 🇷🇴 

The changes follow the instructions in the official [Internationalizing Flutter apps](https://docs.flutter.dev/development/accessibility-and-localization/internationalization) guide. Not exactly sure what these steps change, however, since the Romanian translation was also available in a simulator set to Romanian prior to this change:

![image](https://user-images.githubusercontent.com/1390808/170308652-0a0e166e-4bcf-4fbc-bd81-690a17486a95.png)

Does anyone know what is actually affected by the changes in these two `Info.plist` files?

