### PR TITLE
Fix font weight in search hints for Romanian, see #995

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added:
-- Use Romanian localization
+- Romanian localization
 
 ## [0.8.17] - 2022-05-22
 ### Fixed:

--- a/lib/pages/journal_page.dart
+++ b/lib/pages/journal_page.dart
@@ -149,12 +149,10 @@ class _JournalPageState extends State<JournalPage> {
       queryStyle: const TextStyle(
         fontFamily: 'Lato',
         fontSize: 24,
-        fontWeight: FontWeight.w300,
       ),
       hintStyle: const TextStyle(
         fontFamily: 'Lato',
         fontSize: 24,
-        fontWeight: FontWeight.w300,
       ),
       physics: const BouncingScrollPhysics(),
       borderRadius: BorderRadius.circular(8.0),

--- a/lib/pages/settings/dashboards/dashboards_page.dart
+++ b/lib/pages/settings/dashboards/dashboards_page.dart
@@ -45,12 +45,10 @@ class _DashboardSettingsPageState extends State<DashboardSettingsPage> {
       queryStyle: const TextStyle(
         fontFamily: 'Lato',
         fontSize: 20,
-        fontWeight: FontWeight.w300,
       ),
       hintStyle: const TextStyle(
         fontFamily: 'Lato',
         fontSize: 20,
-        fontWeight: FontWeight.w300,
       ),
       physics: const BouncingScrollPhysics(),
       borderRadius: BorderRadius.circular(8.0),

--- a/lib/pages/settings/measurables/measurables_page.dart
+++ b/lib/pages/settings/measurables/measurables_page.dart
@@ -76,12 +76,10 @@ class _MeasurablesPageState extends State<MeasurablesPage> {
       queryStyle: const TextStyle(
         fontFamily: 'Lato',
         fontSize: 20,
-        fontWeight: FontWeight.w300,
       ),
       hintStyle: const TextStyle(
         fontFamily: 'Lato',
         fontSize: 20,
-        fontWeight: FontWeight.w300,
       ),
       physics: const BouncingScrollPhysics(),
       borderRadius: BorderRadius.circular(8.0),

--- a/lib/pages/settings/tags/tags_page.dart
+++ b/lib/pages/settings/tags/tags_page.dart
@@ -46,12 +46,10 @@ class _TagsPageState extends State<TagsPage> {
       queryStyle: const TextStyle(
         fontFamily: 'Lato',
         fontSize: 20,
-        fontWeight: FontWeight.w300,
       ),
       hintStyle: const TextStyle(
         fontFamily: 'Lato',
         fontSize: 20,
-        fontWeight: FontWeight.w300,
       ),
       physics: const BouncingScrollPhysics(),
       borderRadius: BorderRadius.circular(8.0),

--- a/lib/pages/tasks_page.dart
+++ b/lib/pages/tasks_page.dart
@@ -111,12 +111,10 @@ class _TasksPageState extends State<TasksPage> {
       queryStyle: const TextStyle(
         fontFamily: 'Lato',
         fontSize: 24,
-        fontWeight: FontWeight.w300,
       ),
       hintStyle: const TextStyle(
         fontFamily: 'Lato',
         fontSize: 24,
-        fontWeight: FontWeight.w300,
       ),
       physics: const BouncingScrollPhysics(),
       borderRadius: BorderRadius.circular(8.0),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.19+904
+version: 0.8.19+905
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR fixes #995 by setting the search hints to normal font weight, as apparently, the used font does not contain glyphs for the `ă` character in weight `w300`.

![image](https://user-images.githubusercontent.com/1390808/170316993-411b514a-8d35-441e-bf8e-f6ffc9972987.png)
