### PR TITLE
Enable symlinks in Windows GitHub Action

### DIFF
--- a/.github/workflows/flutter-windows-build.yml
+++ b/.github/workflows/flutter-windows-build.yml
@@ -10,6 +10,9 @@ jobs:
     name: Flutter Build on Windows
     runs-on: windows-2019
     steps:
+      - name: core.symlinks
+        run: |
+          git config --global core.symlinks true
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
         with:


### PR DESCRIPTION
This PR fixes builds on Windows GitHub Actions, following the instructions from https://github.com/actions/virtual-environments/issues/1177.