### PR TITLE
Improve filtering on Journal and Task pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed:
 - Show open, groomed & in-progress tasks by default
+- Remove AppBar in Journal
 
 ## [0.8.20] - 2022-05-28
 ### Fixed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed:
+- Show open, groomed & in-progress tasks by default
+
+## [0.8.20] - 2022-05-28
 ### Fixed:
 - Bring back workout import
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed:
 - Show open, groomed & in-progress tasks by default
 - Remove AppBar in Journal
+- Show all types in Journal by default
 
 ## [0.8.20] - 2022-05-28
 ### Fixed:

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -7,6 +7,7 @@ import 'package:lotti/routes/router.gr.dart';
 import 'package:lotti/theme.dart';
 import 'package:lotti/widgets/app_bar/app_bar_version.dart';
 import 'package:lotti/widgets/app_bar/dashboard_app_bar.dart';
+import 'package:lotti/widgets/app_bar/empty_app_bar.dart';
 import 'package:lotti/widgets/app_bar/task_app_bar.dart';
 import 'package:lotti/widgets/app_bar/tasks_app_bar.dart';
 import 'package:lotti/widgets/audio/audio_recording_indicator.dart';
@@ -44,6 +45,10 @@ class HomePage extends StatelessWidget {
 
         if (topRouteName == TasksRoute.name) {
           return TasksAppBar();
+        }
+
+        if (topRouteName == JournalRoute.name) {
+          return EmptyAppBar();
         }
 
         return const VersionAppBar(title: 'Lotti');

--- a/lib/pages/journal_page.dart
+++ b/lib/pages/journal_page.dart
@@ -67,6 +67,9 @@ class _JournalPageState extends State<JournalPage> {
     'JournalImage',
     'SurveyEntry',
     'Task',
+    'QuantitativeEntry',
+    'MeasurementEntry',
+    'WorkoutEntry',
   ];
   late Set<String> types;
   Set<String> tagIds = {};

--- a/lib/pages/tasks_page.dart
+++ b/lib/pages/tasks_page.dart
@@ -44,6 +44,8 @@ class _TasksPageState extends State<TasksPage> {
   ];
 
   Set<String> selectedStatuses = {
+    'OPEN',
+    'GROOMED',
     'IN PROGRESS',
   };
 

--- a/lib/widgets/app_bar/empty_app_bar.dart
+++ b/lib/widgets/app_bar/empty_app_bar.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class EmptyAppBar extends StatelessWidget with PreferredSizeWidget {
+  EmptyAppBar({Key? key}) : super(key: key);
+
+  @override
+  Size get preferredSize => const Size.fromHeight(0);
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox.shrink();
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -301,14 +301,14 @@ packages:
       name: connectivity_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.1"
   connectivity_plus_linux:
     dependency: transitive
     description:
       name: connectivity_plus_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   connectivity_plus_macos:
     dependency: transitive
     description:
@@ -322,14 +322,14 @@ packages:
       name: connectivity_plus_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   connectivity_plus_web:
     dependency: transitive
     description:
       name: connectivity_plus_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   connectivity_plus_windows:
     dependency: transitive
     description:
@@ -343,7 +343,7 @@ packages:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   coverage:
     dependency: transitive
     description:
@@ -773,7 +773,7 @@ packages:
       name: flutter_native_splash
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "2.2.2"
   flutter_native_timezone:
     dependency: "direct main"
     description:
@@ -794,7 +794,7 @@ packages:
       name: flutter_quill
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.2"
+    version: "5.0.3"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -956,7 +956,7 @@ packages:
       name: getwidget
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.1.0"
   glados:
     dependency: "direct dev"
     description:
@@ -1544,14 +1544,14 @@ packages:
       name: photo_manager
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   photo_view:
     dependency: "direct main"
     description:
       name: photo_view
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.0"
+    version: "0.14.0"
   pigment:
     dependency: transitive
     description:
@@ -1690,14 +1690,14 @@ packages:
       name: rxdart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.27.3"
+    version: "0.27.4"
   share_plus:
     dependency: "direct main"
     description:
       name: share_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.4"
+    version: "4.0.5"
   share_plus_linux:
     dependency: transitive
     description:
@@ -1711,28 +1711,28 @@ packages:
       name: share_plus_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   share_plus_web:
     dependency: transitive
     description:
       name: share_plus_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   share_plus_windows:
     dependency: transitive
     description:
       name: share_plus_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   shelf:
     dependency: transitive
     description:
@@ -1905,21 +1905,21 @@ packages:
       name: syncfusion_flutter_calendar
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "20.1.57"
+    version: "20.1.58"
   syncfusion_flutter_core:
     dependency: transitive
     description:
       name: syncfusion_flutter_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "20.1.57"
+    version: "20.1.58"
   syncfusion_flutter_datepicker:
     dependency: "direct main"
     description:
       name: syncfusion_flutter_datepicker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "20.1.57"
+    version: "20.1.58"
   synchronized:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.22+914
+version: 0.8.22+915
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.22+916
+version: 0.8.22+917
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.22+917
+version: 0.8.22+918
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.22+915
+version: 0.8.22+916
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.21+913
+version: 0.8.22+914
 
 msix_config:
   display_name: Lotti
@@ -76,7 +76,7 @@ dependencies:
   flutter_local_notifications: ^9.2.0
   flutter_map: ^0.14.0
   flutter_native_timezone: ^2.0.0
-  flutter_quill: ^5.0.1
+  flutter_quill: ^5.0.3
   flutter_secure_storage: ^5.0.0
   flutter_sliding_tutorial: ^1.1.3+3
   flutter_sound: ^8.3.12
@@ -107,7 +107,7 @@ dependencies:
   path: ^1.8.0
   path_provider: ^2.0.8
   permission_handler: ^9.2.0
-  photo_view: ^0.13.0
+  photo_view: ^0.14.0
 
 #  qr_code_scanner: ^0.7.0
   qr_code_scanner:
@@ -134,7 +134,7 @@ dependencies:
 dependency_overrides:
   collection: ^1.16.0
   crypto: ^3.0.2
-  flutter_quill: ^5.0.1
+  flutter_quill: ^5.0.3
   xml: ^5.3.1
 
 dev_dependencies:


### PR DESCRIPTION
This PR improves the filtering on the Journal and Tasks pages. On the Tasks page, now open, groomed, and in-progress tasks are shown by default, since otherwise newly created tasks didn't show up, which from feedback was unintuitive. In a subsequent PR, the search bar should permanently show the choice chips to make the possible interactions more obvious.

In the Journal page, all entries are now shown by default, and the useless and space-consuming header is removed. In a subsequent PR, the search bar widget can be made bigger to permanently show the choice chips, for similar reasons as for the tasks.