### PR TITLE
Improve task search header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed:
+- Improve Search Header in Tasks
+
+## [0.8.23] - 2022-05-31
+### Changed:
 - Improve Search Header in Journal
 
 ## [0.8.22] - 2022-05-31

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -11,6 +11,8 @@ PODS:
     - Flutter
   - flutter_fgbg (0.0.1):
     - Flutter
+  - flutter_health_fit (0.0.1):
+    - Flutter
   - flutter_image_compress (0.0.1):
     - Flutter
     - Mantle
@@ -124,6 +126,7 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_app_badger (from `.symlinks/plugins/flutter_app_badger/ios`)
   - flutter_fgbg (from `.symlinks/plugins/flutter_fgbg/ios`)
+  - flutter_health_fit (from `.symlinks/plugins/flutter_health_fit/ios`)
   - flutter_image_compress (from `.symlinks/plugins/flutter_image_compress/ios`)
   - flutter_inappwebview (from `.symlinks/plugins/flutter_inappwebview/ios`)
   - flutter_keyboard_visibility (from `.symlinks/plugins/flutter_keyboard_visibility/ios`)
@@ -177,6 +180,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_app_badger/ios"
   flutter_fgbg:
     :path: ".symlinks/plugins/flutter_fgbg/ios"
+  flutter_health_fit:
+    :path: ".symlinks/plugins/flutter_health_fit/ios"
   flutter_image_compress:
     :path: ".symlinks/plugins/flutter_image_compress/ios"
   flutter_inappwebview:
@@ -235,6 +240,7 @@ SPEC CHECKSUMS:
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
   flutter_app_badger: b87fc231847b03b92ce1412aa351842e7e97932f
   flutter_fgbg: 31c0d1140a131daea2d342121808f6aa0dcd879d
+  flutter_health_fit: af332b5d7512b9cc8a05e7282cfcee02b056d32e
   flutter_image_compress: fd2b476345226e1a10ea352fa306af95704642c1
   flutter_inappwebview: bfd58618f49dc62f2676de690fc6dcda1d6c3721
   flutter_keyboard_visibility: 0339d06371254c3eb25eeb90ba8d17dca8f9c069

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -9,7 +9,6 @@ import 'package:lotti/widgets/app_bar/app_bar_version.dart';
 import 'package:lotti/widgets/app_bar/dashboard_app_bar.dart';
 import 'package:lotti/widgets/app_bar/empty_app_bar.dart';
 import 'package:lotti/widgets/app_bar/task_app_bar.dart';
-import 'package:lotti/widgets/app_bar/tasks_app_bar.dart';
 import 'package:lotti/widgets/audio/audio_recording_indicator.dart';
 import 'package:lotti/widgets/bottom_nav/flagged_badge_icon.dart';
 import 'package:lotti/widgets/bottom_nav/tasks_badge_icon.dart';
@@ -43,11 +42,7 @@ class HomePage extends StatelessWidget {
           );
         }
 
-        if (topRouteName == TasksRoute.name) {
-          return TasksAppBar();
-        }
-
-        if (topRouteName == JournalRoute.name) {
+        if ({TasksRoute.name, JournalRoute.name}.contains(topRouteName)) {
           return EmptyAppBar();
         }
 

--- a/lib/services/editor_state_service.dart
+++ b/lib/services/editor_state_service.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:easy_debounce/easy_debounce.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:lotti/classes/entry_text.dart';

--- a/lib/widgets/misc/tasks_counts.dart
+++ b/lib/widgets/misc/tasks_counts.dart
@@ -1,60 +1,45 @@
-import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/theme.dart';
 
-class TasksAppBar extends StatelessWidget with PreferredSizeWidget {
-  TasksAppBar({
+class TaskCounts extends StatelessWidget {
+  const TaskCounts({
     Key? key,
   }) : super(key: key);
-
-  @override
-  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
 
   @override
   Widget build(BuildContext context) {
     AppLocalizations localizations = AppLocalizations.of(context)!;
 
-    return AppBar(
-      backgroundColor: AppColors.headerBgColor,
-      title: Column(
+    return Container(
+      padding: const EdgeInsets.only(bottom: 4),
+      width: MediaQuery.of(context).size.width,
+      child: Wrap(
+        alignment: WrapAlignment.center,
         children: [
-          Text(
-            'Tasks',
-            style: appBarTextStyle.copyWith(fontWeight: FontWeight.w300),
+          TasksCountWidget(
+            status: 'OPEN',
+            label: localizations.taskStatusOpen,
           ),
-          Wrap(
-            alignment: WrapAlignment.center,
-            children: [
-              TasksCountWidget(
-                status: 'OPEN',
-                label: localizations.taskStatusOpen,
-              ),
-              TasksCountWidget(
-                status: 'IN PROGRESS',
-                label: localizations.taskStatusInProgress,
-              ),
-              TasksCountWidget(
-                status: 'ON HOLD',
-                label: localizations.taskStatusOnHold,
-              ),
-              TasksCountWidget(
-                status: 'BLOCKED',
-                label: localizations.taskStatusBlocked,
-              ),
-              TasksCountWidget(
-                status: 'DONE',
-                label: localizations.taskStatusDone,
-              ),
-            ],
+          TasksCountWidget(
+            status: 'IN PROGRESS',
+            label: localizations.taskStatusInProgress,
+          ),
+          TasksCountWidget(
+            status: 'ON HOLD',
+            label: localizations.taskStatusOnHold,
+          ),
+          TasksCountWidget(
+            status: 'BLOCKED',
+            label: localizations.taskStatusBlocked,
+          ),
+          TasksCountWidget(
+            status: 'DONE',
+            label: localizations.taskStatusDone,
           ),
         ],
-      ),
-      centerTitle: true,
-      leading: AutoLeadingButton(
-        color: AppColors.entryTextColor,
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.23+919
+version: 0.8.24+920
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR improves the Tasks page by removing the unnecessary AppBar (there's nothing to navigate back to anyway) and moving the stats and status selectors to the search header.