### PR TITLE
Add make task for tag from version in pubspec.yaml and push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.8.24] - 2022-05-31
 ### Changed:
 - Improve Search Header in Tasks
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ IOS_ARCHIVE_PATH = ./build/ios/archive/Runner.xcarchive
 IOS_EXPORT_PATH = ./build/ios/export
 MACOS_ARCHIVE_PATH = ./build/macos/archive/Runner.xcarchive
 MACOS_EXPORT_PATH = ./build/macos/export
+LOTTI_VERSION := $(shell yq '.version' pubspec.yaml |  tr -d '"')
 
 .PHONY: test
 test:
@@ -182,6 +183,11 @@ linux: clean_test linux_build
 .PHONY: windows
 windows: clean_test
 	flutter build windows
+
+.PHONY: tag_push
+tag_push:
+	git tag ${LOTTI_VERSION}
+	git push origin ${LOTTI_VERSION}
 
 .PHONY: all
 all: ios macos

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.24+920
+version: 0.8.25+922
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR adds a make task for tagging and pushing using the version from `pubspec.yaml`.