### PR TITLE
Save screenshots on desktop as JPG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed:
 - Save screenshots on desktop as JPG
+- Improved icons
 
 ## [0.8.34] - 2022-06-08
 ### Added:

--- a/lib/utils/screenshots.dart
+++ b/lib/utils/screenshots.dart
@@ -15,7 +15,7 @@ Future<ImageData> takeScreenshotMac() async {
   bool hide = await db.getConfigFlag('hide_for_screenshot');
 
   String id = uuid.v1();
-  String filename = '$id.screenshot.png';
+  String filename = '$id.screenshot.jpg';
   DateTime created = DateTime.now();
   String day = DateFormat('yyyy-MM-dd').format(created);
   String relativePath = '/images/$day/';
@@ -27,7 +27,7 @@ Future<ImageData> takeScreenshotMac() async {
 
   Process process = await Process.start(
     'screencapture',
-    [filename],
+    ['-tjpg', filename],
     runInShell: true,
     workingDirectory: directory,
   );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.35+957
+version: 0.8.35+958
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR changes the image file format for screenshots to JPG since PNG files can become very large on high resolution screens.