### PR TITLE
Ignore messages not matching expected subject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed:
+- Ignore foreign messages in IMAP folder
+
+## [0.8.38] - 2022-06-09
 ### Fixed:
 - Romanian language support in forms
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.38+961
+version: 0.8.39+962
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR fixes #1032 by ignoring messages that do not fit the expected subject line of the alphanumeric host ID hash, followed by colon, followed by one or more digits: `[a-z0-9]{40}:[0-9]+`.