### PR TITLE
Prevent fetching health data on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed:
+- No health import on desktop
+
+## [0.8.39] - 2022-06-09
 ### Changed:
 - Ignore foreign messages in IMAP folder
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.39+962
+version: 0.8.40+963
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
Fixes #1035 by preventing the import of health data on desktop platforms, where the native functionality doesn't exist.