### PR TITLE
Fix recreating deleted dashboard with same name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed:
+- Allow dashboards with the same name
+
+## [0.8.42] - 2022-06-11
+### Changed:
 - Auto-sizing text in Sync Assistant
 
 ## [0.8.41] - 2022-06-10

--- a/lib/database/conversions.dart
+++ b/lib/database/conversions.dart
@@ -166,7 +166,7 @@ DashboardDefinitionDbEntity dashboardDefinitionDbEntity(
     private: dashboard.private,
     deleted: dashboard.deletedAt != null,
     active: dashboard.active,
-    name: dashboard.name,
+    name: dashboard.id,
   );
 }
 

--- a/lib/database/database.drift
+++ b/lib/database/database.drift
@@ -110,7 +110,7 @@ ON habit_definitions (private);
 
 CREATE TABLE dashboard_definitions (
   id TEXT NOT NULL,
-  name TEXT NOT NULL UNIQUE,
+  name TEXT NOT NULL,
   created_at DATETIME NOT NULL,
   updated_at DATETIME NOT NULL,
   last_reviewed DATETIME NOT NULL,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.42+965
+version: 0.8.43+966
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR fixes an issue where previously, dashboard items, once deleted, could not be created again, as the name column has a unique constraint. The field is not used anyway, so just using the ID here, and not setting the constraint on new databases.
