### PR TITLE
Add maintenance task for purging deleted items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed:
 - Allow dashboards with the same name
+- Add maintenance task for purging deleted items
 
 ## [0.8.42] - 2022-06-11
 ### Changed:

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -438,6 +438,14 @@ class JournalDb extends _$JournalDb {
     return flag;
   }
 
+  Future<void> purgeDeleted() async {
+    await createDbBackup();
+    await purgeDeletedDashboards();
+    await purgeDeletedMeasurables();
+    await purgeDeletedTagEntities();
+    await purgeDeletedJournalEntities();
+  }
+
   Future<bool> getConfigFlag(String flagName) async {
     List<ConfigFlag> flags = await listConfigFlags().get();
     return findConfigFlag(flagName, flags);

--- a/lib/database/database.drift
+++ b/lib/database/database.drift
@@ -398,6 +398,22 @@ deleteTaggedForId:
 DELETE FROM tagged
   WHERE journal_id = :id;
 
+purgeDeletedDashboards:
+DELETE FROM dashboard_definitions
+  WHERE deleted = TRUE;
+
+purgeDeletedMeasurables:
+DELETE FROM measurable_types
+  WHERE deleted = TRUE;
+
+purgeDeletedTagEntities:
+DELETE FROM tag_entities
+  WHERE deleted = TRUE;
+
+purgeDeletedJournalEntities:
+DELETE FROM journal
+  WHERE deleted = TRUE;
+
 deleteTagged:
 DELETE FROM tagged;
 

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -66,6 +66,7 @@
   "maintenanceDeleteEditorDb": "Textentwürfedatenbank löschen",
   "maintenanceDeleteLoggingDb": "Loggingdatenbank löschen",
   "maintenanceDeleteTagged": "Tag Links löschen",
+  "maintenancePurgeDeleted": "Papierkorb leeren",
   "maintenanceRecreateTagged": "Tag Links wiederherstellen",
   "maintenanceStories": "Stories von verlinkten Einträgen zuweisen",
   "navTabTitleFlagged": "Markiert",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -69,6 +69,7 @@
   "maintenanceDeleteEditorDb": "Delete editor drafts database",
   "maintenanceDeleteLoggingDb": "Delete logging database",
   "maintenanceDeleteTagged": "Delete tagged",
+  "maintenancePurgeDeleted": "Purge deleted items",
   "maintenanceRecreateTagged": "Recreate tagged",
   "maintenanceStories": "Assign stories from parent entries",
   "manualLinkText": "Check out the manual for more information",

--- a/lib/pages/settings/maintenance_page.dart
+++ b/lib/pages/settings/maintenance_page.dart
@@ -66,6 +66,10 @@ class _MaintenancePageState extends State<MaintenancePage> {
                   title: localizations.maintenanceStories,
                   onTap: () => _maintenance.recreateStoryAssignment(),
                 ),
+                MaintenanceCard(
+                  title: localizations.maintenancePurgeDeleted,
+                  onTap: () => _db.purgeDeleted(),
+                ),
               ],
             );
           },

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.43+966
+version: 0.8.43+967
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR adds a maintenance task for purging previously deleted items of all kinds (dashboards, tags, measurables, journal entries).