### PR TITLE
Fix dashboard sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed:
+- Sync of entities without vector clock
+
+## [0.8.44] - 2022-06-12
 ### Changed:
 - Layout improvements in empty dashboards page
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed:
 - Sync of entities without vector clock
 
+### Added:
+- Maintenance task for reprocessing messages
+
 ## [0.8.44] - 2022-06-12
 ### Changed:
 - Layout improvements in empty dashboards page

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -71,6 +71,7 @@
   "maintenanceDeleteTagged": "Delete tagged",
   "maintenancePurgeDeleted": "Purge deleted items",
   "maintenanceRecreateTagged": "Recreate tagged",
+  "maintenanceReprocessSync": "Reprocess sync messages",
   "maintenanceStories": "Assign stories from parent entries",
   "manualLinkText": "Check out the manual for more information",
   "navTabTitleFlagged": "Flagged",

--- a/lib/pages/settings/maintenance_page.dart
+++ b/lib/pages/settings/maintenance_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/maintenance.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/sync_config_service.dart';
 import 'package:lotti/theme.dart';
 
 class MaintenancePage extends StatefulWidget {
@@ -69,6 +70,10 @@ class _MaintenancePageState extends State<MaintenancePage> {
                 MaintenanceCard(
                   title: localizations.maintenancePurgeDeleted,
                   onTap: () => _db.purgeDeleted(),
+                ),
+                MaintenanceCard(
+                  title: localizations.maintenanceReprocessSync,
+                  onTap: () => getIt<SyncConfigService>().resetOffset(),
                 ),
               ],
             );

--- a/lib/services/sync_config_service.dart
+++ b/lib/services/sync_config_service.dart
@@ -3,6 +3,9 @@ import 'dart:convert';
 import 'package:encrypt/encrypt.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:lotti/classes/config.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/vector_clock_service.dart';
+import 'package:lotti/sync/inbox_service.dart';
 
 class SyncConfigService {
   final _storage = const FlutterSecureStorage();
@@ -52,5 +55,10 @@ class SyncConfigService {
   Future<void> setImapConfig(ImapConfig imapConfig) async {
     String json = jsonEncode(imapConfig);
     await _storage.write(key: imapConfigKey, value: json);
+  }
+
+  Future<void> resetOffset() async {
+    await _storage.delete(key: lastReadUidKey);
+    await getIt<VectorClockService>().setNewHost();
   }
 }

--- a/lib/sync/inbox_service.dart
+++ b/lib/sync/inbox_service.dart
@@ -379,9 +379,4 @@ class SyncInboxService {
       );
     }
   }
-
-  Future<void> resetOffset() async {
-    await _storage.delete(key: lastReadUidKey);
-    await _vectorClockService.setNewHost();
-  }
 }

--- a/lib/sync/inbox_service.dart
+++ b/lib/sync/inbox_service.dart
@@ -176,7 +176,7 @@ class SyncInboxService {
   }
 
   bool validSubject(String subject) {
-    RegExp validSubject = RegExp(r'[a-z0-9]{40}:[0-9]+');
+    RegExp validSubject = RegExp(r'[a-z0-9]{40}:[a-z0-9]+');
     return validSubject.hasMatch(subject);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.45+969
+version: 0.8.45+970
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.44+968
+version: 0.8.45+969
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR fixes processing of valid sync messages. Previously, the criteria for detecting valid sync messages were too strict and ignored sync of entity definitions since they currently don't have a vector clock for detecting concurrent edits, which arguably is not as important as for text entries. Also adds a maintenance task for reprocessing previously ignored sync messages. This maintenance task is available under `Settings > Advanced Settings > Maintenance > Reprocess sync messages`