### PR TITLE
Sort dashboards alphabetically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed:
 - Sync of entities without vector clock
+- Dashboards sorted alphabetically
 
 ### Added:
 - Maintenance task for reprocessing messages

--- a/lib/pages/dashboards/dashboards_list_page.dart
+++ b/lib/pages/dashboards/dashboards_list_page.dart
@@ -4,6 +4,7 @@ import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/theme.dart';
+import 'package:lotti/utils/sort.dart';
 import 'package:lotti/widgets/charts/empty_dashboards_widget.dart';
 
 class DashboardsListPage extends StatefulWidget {
@@ -31,14 +32,10 @@ class _DashboardsListPageState extends State<DashboardsListPage> {
         BuildContext context,
         AsyncSnapshot<List<DashboardDefinition>> snapshot,
       ) {
-        List<DashboardDefinition> items = snapshot.data ?? [];
-        List<DashboardDefinition> filtered = items
-            .where((DashboardDefinition dashboard) =>
-                dashboard.name.toLowerCase().contains(match) &&
-                dashboard.active)
-            .toList();
+        List<DashboardDefinition> dashboards =
+            filteredSortedDashboards(snapshot.data ?? [], match);
 
-        if (items.isEmpty) {
+        if (dashboards.isEmpty) {
           return const EmptyDashboards();
         }
 
@@ -46,10 +43,10 @@ class _DashboardsListPageState extends State<DashboardsListPage> {
           shrinkWrap: true,
           padding: const EdgeInsets.all(8.0),
           children: List.generate(
-            filtered.length,
+            dashboards.length,
             (int index) {
               return DashboardCard(
-                dashboard: filtered.elementAt(index),
+                dashboard: dashboards.elementAt(index),
                 index: index,
               );
             },

--- a/lib/pages/settings/dashboards/dashboards_page.dart
+++ b/lib/pages/settings/dashboards/dashboards_page.dart
@@ -7,6 +7,7 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/routes/router.gr.dart';
 import 'package:lotti/theme.dart';
+import 'package:lotti/utils/sort.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:material_floating_search_bar/material_floating_search_bar.dart';
 
@@ -79,11 +80,8 @@ class _DashboardSettingsPageState extends State<DashboardSettingsPage> {
         BuildContext context,
         AsyncSnapshot<List<DashboardDefinition>> snapshot,
       ) {
-        List<DashboardDefinition> items = snapshot.data ?? [];
-        List<DashboardDefinition> filtered = items
-            .where((DashboardDefinition dashboard) =>
-                dashboard.name.toLowerCase().contains(match))
-            .toList();
+        List<DashboardDefinition> dashboards =
+            filteredSortedDashboards(snapshot.data ?? [], match);
 
         return Stack(
           children: [
@@ -96,10 +94,10 @@ class _DashboardSettingsPageState extends State<DashboardSettingsPage> {
                 top: 64,
               ),
               children: List.generate(
-                filtered.length,
+                dashboards.length,
                 (int index) {
                   return DashboardCard(
-                    dashboard: filtered.elementAt(index),
+                    dashboard: dashboards.elementAt(index),
                     index: index,
                   );
                 },

--- a/lib/utils/sort.dart
+++ b/lib/utils/sort.dart
@@ -1,0 +1,12 @@
+import 'package:collection/collection.dart';
+import 'package:lotti/classes/entity_definitions.dart';
+
+List<DashboardDefinition> filteredSortedDashboards(
+    List<DashboardDefinition> items, String match) {
+  return items
+      .where((DashboardDefinition dashboard) =>
+          dashboard.name.toLowerCase().contains(match) && dashboard.active)
+      .sorted((DashboardDefinition a, DashboardDefinition b) =>
+          a.name.toLowerCase().compareTo(b.name.toLowerCase()))
+      .toList();
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.45+970
+version: 0.8.45+971
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR fixes sorting dashboards alphabetically. Previously, the sort order was determined by the name field in the database.