### PR TITLE
Improve first-time user experience for measurables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed:
+- Improve first-time user experience for measurables
+
+## [0.8.46] - 2022-06-12
+### Changed:
 - Improve layout of health data entry
 - Improve layout of measurable data entry
 

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -6,6 +6,8 @@
   "addActionAddSurvey": "Fragebogen ausfüllen",
   "addActionAddTask": "Aufgabe hinzufügen",
   "addActionAddText": "Texteintrag hinzufügen",
+  "addMeasurementNoneDefined": "Messbaren Datentyp hinzufügen",
+  "addMeasurementTitle": "Messbare Daten erfassen",
   "configFlagEnableNotifications": "Desktop Notifications erlauben?",
   "configFlagGlobalScreenshotHotkey": "Screenshot beim Benutzen des globalen Hotkeys?",
   "configFlagHideForScreenshot": "Lotti bei Screenshots minimieren?",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -7,6 +7,8 @@
   "addActionAddTask": "Add Task",
   "addActionAddText": "Add Text Entry",
   "addActionAddTimeRecording": "Start Time Recording",
+  "addMeasurementNoneDefined": "Add Measurable Data Type",
+  "addMeasurementTitle": "Add Measurement",
   "configFlagEnableNotifications": "Enable desktop notifications?",
   "configFlagGlobalScreenshotHotkey": "Listen to global screenshot hotkey?",
   "configFlagHideForScreenshot": "Hide Lotti when taking screenshots?",

--- a/lib/pages/settings/measurables/measurables_page.dart
+++ b/lib/pages/settings/measurables/measurables_page.dart
@@ -1,11 +1,10 @@
-import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/pages/settings/measurables/measurable_type_card.dart';
-import 'package:lotti/routes/router.gr.dart';
+import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/theme.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:material_floating_search_bar/material_floating_search_bar.dart';
@@ -117,7 +116,7 @@ class _MeasurablesPageState extends State<MeasurablesPage> {
                 child: FloatingActionButton(
                   backgroundColor: AppColors.entryBgColor,
                   onPressed: () {
-                    context.router.push(const CreateMeasurableRoute());
+                    pushNamedRoute('/settings/create_measurable');
                   },
                   child: const Icon(MdiIcons.plus, size: 32),
                 ),

--- a/lib/routes/settings_routes.dart
+++ b/lib/routes/settings_routes.dart
@@ -67,12 +67,12 @@ const AutoRoute settingsRoutes = AutoRoute(
       page: MeasurablesPage,
     ),
     AutoRoute(
-      path: 'measurables/:measurableId',
-      page: EditMeasurablePage,
+      path: 'create_measurable',
+      page: CreateMeasurablePage,
     ),
     AutoRoute(
-      path: 'measurables/create',
-      page: CreateMeasurablePage,
+      path: 'measurables/:measurableId',
+      page: EditMeasurablePage,
     ),
     AutoRoute(
       path: 'outbox_monitor',

--- a/lib/widgets/journal/entry_details/workout_summary.dart
+++ b/lib/widgets/journal/entry_details/workout_summary.dart
@@ -30,8 +30,6 @@ class WorkoutSummary extends StatelessWidget {
       }
     });
 
-    debugPrint(items.toString());
-
     return Padding(
       padding: const EdgeInsets.all(8.0),
       child: Column(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.46+979
+version: 0.8.47+980
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR improves first-time user experience for new measurements when no measurable data types are defined by adding a link to create measurable data type.

Resolves #1023 