### PR TITLE
Fix entry location on Linux

### DIFF
--- a/.github/workflows/flutter-linux-build.yml
+++ b/.github/workflows/flutter-linux-build.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '3.0.1'
+          flutter-version: '3.0.2'
           channel: 'stable'
       - name: Update apt-get
         run: sudo apt-get update

--- a/.github/workflows/flutter-linux-release.yml
+++ b/.github/workflows/flutter-linux-release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '3.0.1'
+          flutter-version: '3.0.2'
           channel: 'stable'
       - name: Update apt-get
         run: sudo apt-get update

--- a/.github/workflows/flutter-test.yml
+++ b/.github/workflows/flutter-test.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '3.0.1'
+          flutter-version: '3.0.2'
           channel: 'stable'
       - name: Run Flutter tests
         run: make clean_test

--- a/.github/workflows/flutter-testflight.yml
+++ b/.github/workflows/flutter-testflight.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '3.0.1'
+          flutter-version: '3.0.2'
           channel: 'stable'
       - name: Fastlane match iOS
         working-directory: lotti/ios

--- a/.github/workflows/flutter-windows-build.yml
+++ b/.github/workflows/flutter-windows-build.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '3.0.1'
+          flutter-version: '3.0.2'
           channel: 'stable'
       - name: Flutter Doctor
         run: make doctor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed:
+- Location on Linux
+
+## [0.8.47] - 2022-06-12
 ### Changed:
 - Improve first-time user experience for measurables
 

--- a/lib/logic/persistence_logic.dart
+++ b/lib/logic/persistence_logic.dart
@@ -40,7 +40,7 @@ class PersistenceLogic {
   }
 
   Future<void> init() async {
-    if (!Platform.isLinux && !Platform.isWindows) {
+    if (!Platform.isWindows) {
       location = DeviceLocation();
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.48+981
+version: 0.8.48+982
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.47+980
+version: 0.8.48+981
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR fixes retrieving the geolocation for an entry on Linux using `GeoClueManager` and `GeoClueClient`, adapted from this [example](https://github.com/canonical/geoclue.dart/blob/main/example/client.dart).

Resolves #664 