### PR TITLE
Read timezone name from /etc/timezone on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed:
+- Timezone name on Linux
+
+## [0.8.48] - 2022-06-13
+### Fixed:
 - Location on Linux
 
 ## [0.8.47] - 2022-06-12

--- a/lib/utils/timezone.dart
+++ b/lib/utils/timezone.dart
@@ -5,7 +5,14 @@ import 'package:flutter_native_timezone/flutter_native_timezone.dart';
 Future<String> getLocalTimezone() async {
   DateTime now = DateTime.now();
 
-  return (!Platform.isWindows && !Platform.isLinux)
-      ? await FlutterNativeTimezone.getLocalTimezone()
-      : now.timeZoneName;
+  if (Platform.isLinux) {
+    String timezone = await File('/etc/timezone').readAsString();
+    return timezone.trim();
+  }
+
+  if (!Platform.isWindows && !Platform.isLinux) {
+    return FlutterNativeTimezone.getLocalTimezone();
+  }
+
+  return now.timeZoneName;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.48+982
+version: 0.8.49+983
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR fixes #665 by reading the timezone name from `/etc/timezone` on Linux.