### PR TITLE
Indicate unsaved changes for dashboards, measurables, tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed:
 - Indicate unsaved changes on tag edit page
 - Indicate unsaved changes on measurable data type edit page
+- Indicate unsaved changes on dashboard edit page
 
 ## [0.8.49] - 2022-06-13
 ### Fixed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.8.49] - 2022-06-13
 ### Fixed:
 - Timezone name on Linux
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed:
 - Indicate unsaved changes on tag edit page
+- Indicate unsaved changes on measurable data type edit page
 
 ## [0.8.49] - 2022-06-13
 ### Fixed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed:
+- Indicate unsaved changes on tag edit page
 
 ## [0.8.49] - 2022-06-13
 ### Fixed:

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -134,7 +134,7 @@
   "settingsTagsDeleteTooltip": "Delete tag",
   "settingsTagsHideLabel": "Hide from suggestions:",
   "settingsTagsPrivateLabel": "Private:",
-  "settingsTagsSaveLabel": "Save tag",
+  "settingsTagsSaveLabel": "Save",
   "settingsTagsSearchHint": "Search Tags...",
   "settingsTagsTagName": "Tag:",
   "settingsTagsTitle": "Tags",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -38,7 +38,7 @@
   "dashboardNotFound": "Dashboard not found",
   "dashboardPrivateLabel": "Private:",
   "dashboardReviewTimeLabel": "Daily Review Time:",
-  "dashboardSaveLabel": "Save & Close",
+  "dashboardSaveLabel": "Save",
   "dashboardsEmptyHint": "Nothing to see here yet, please create a new Dashboard in Settings, Dashboard Management. \n\nThe cogs button above will take you there directly.",
   "journalDateFromLabel": "Date from:",
   "journalDateInvalid": "Invalid Date Range",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -92,7 +92,7 @@
   "settingsConflictsTitle": "Sync Conflicts",
   "settingsDashboardsSearchHint": "Search...",
   "settingsDashboardsTitle": "Dashboard Management",
-  "settingsFlagsTitle": "Flags",
+  "settingsFlagsTitle": "Config Flags",
   "settingsHealthImportTitle": "Health Import",
   "settingsLogsTitle": "Logs",
   "settingsMaintenanceTitle": "Maintenance",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -36,7 +36,7 @@
   "dashboardNotFound": "Tableau de bord non trouvé",
   "dashboardPrivateLabel": "Privé :",
   "dashboardReviewTimeLabel": "Temps d’examen quotidien :",
-  "dashboardSaveLabel": "Enregistrer et fermer",
+  "dashboardSaveLabel": "Enregistrer",
   "dashboardsEmptyHint": "Il n’y encore rien ici, veuillez créer un nouveau Tableau de bord dans Paramètres > Gestion du tableau de bord.\n\nLe bouton va vous y amener directement.",
   "journalDateFromLabel": "Date de début :",
   "journalDateInvalid": "Plage de dates invalide",

--- a/lib/pages/create/create_measurement_page.dart
+++ b/lib/pages/create/create_measurement_page.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:auto_route/auto_route.dart';
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';

--- a/lib/pages/dashboards/dashboard_page.dart
+++ b/lib/pages/dashboards/dashboard_page.dart
@@ -6,6 +6,7 @@ import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/theme.dart';
+import 'package:lotti/widgets/app_bar/dashboard_app_bar.dart';
 import 'package:lotti/widgets/charts/dashboard_health_chart.dart';
 import 'package:lotti/widgets/charts/dashboard_measurables_chart.dart';
 import 'package:lotti/widgets/charts/dashboard_story_chart.dart';
@@ -88,73 +89,79 @@ class _DashboardPageState extends State<DashboardPage> {
             return const SizedBox.shrink();
           }
 
-          return SingleChildScrollView(
-            child: Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: Column(
-                children: [
-                  ...dashboard.items.map((DashboardItem dashboardItem) {
-                    return dashboardItem.map(
-                      measurement: (DashboardMeasurementItem measurement) {
-                        return DashboardMeasurablesChart(
-                          measurableDataTypeId: measurement.id,
-                          aggregationType: measurement.aggregationType,
-                          rangeStart: rangeStart,
-                          rangeEnd: rangeEnd,
-                          enableCreate: true,
-                        );
-                      },
-                      healthChart: (DashboardHealthItem healthChart) {
-                        return DashboardHealthChart(
-                          chartConfig: healthChart,
-                          rangeStart: rangeStart,
-                          rangeEnd: rangeEnd,
-                        );
-                      },
-                      workoutChart: (DashboardWorkoutItem workoutChart) {
-                        return DashboardWorkoutChart(
-                          chartConfig: workoutChart,
-                          rangeStart: rangeStart,
-                          rangeEnd: rangeEnd,
-                        );
-                      },
-                      storyTimeChart: (DashboardStoryTimeItem storyChart) {
-                        return DashboardStoryChart(
-                          chartConfig: storyChart,
-                          rangeStart: rangeStart,
-                          rangeEnd: rangeEnd,
-                        );
-                      },
-                      surveyChart: (DashboardSurveyItem surveyChart) {
-                        return DashboardSurveyChart(
-                          chartConfig: surveyChart,
-                          rangeStart: rangeStart,
-                          rangeEnd: rangeEnd,
-                        );
-                      },
-                    );
-                  }),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Padding(
-                        padding: const EdgeInsets.only(left: 8.0),
-                        child: Text(
-                          dashboard.description,
-                          style: formLabelStyle,
-                        ),
-                      ),
-                      IconButton(
-                        icon: const Icon(Icons.dashboard_customize_outlined),
-                        color: AppColors.entryTextColor,
-                        onPressed: () {
-                          context.router.pushNamed(
-                              '/settings/dashboards/${widget.dashboardId}');
+          return Scaffold(
+            backgroundColor: AppColors.bodyBgColor,
+            appBar: DashboardAppBar(
+              dashboardId: dashboard.id,
+            ),
+            body: SingleChildScrollView(
+              child: Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Column(
+                  children: [
+                    ...dashboard.items.map((DashboardItem dashboardItem) {
+                      return dashboardItem.map(
+                        measurement: (DashboardMeasurementItem measurement) {
+                          return DashboardMeasurablesChart(
+                            measurableDataTypeId: measurement.id,
+                            aggregationType: measurement.aggregationType,
+                            rangeStart: rangeStart,
+                            rangeEnd: rangeEnd,
+                            enableCreate: true,
+                          );
                         },
-                      ),
-                    ],
-                  ),
-                ],
+                        healthChart: (DashboardHealthItem healthChart) {
+                          return DashboardHealthChart(
+                            chartConfig: healthChart,
+                            rangeStart: rangeStart,
+                            rangeEnd: rangeEnd,
+                          );
+                        },
+                        workoutChart: (DashboardWorkoutItem workoutChart) {
+                          return DashboardWorkoutChart(
+                            chartConfig: workoutChart,
+                            rangeStart: rangeStart,
+                            rangeEnd: rangeEnd,
+                          );
+                        },
+                        storyTimeChart: (DashboardStoryTimeItem storyChart) {
+                          return DashboardStoryChart(
+                            chartConfig: storyChart,
+                            rangeStart: rangeStart,
+                            rangeEnd: rangeEnd,
+                          );
+                        },
+                        surveyChart: (DashboardSurveyItem surveyChart) {
+                          return DashboardSurveyChart(
+                            chartConfig: surveyChart,
+                            rangeStart: rangeStart,
+                            rangeEnd: rangeEnd,
+                          );
+                        },
+                      );
+                    }),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Padding(
+                          padding: const EdgeInsets.only(left: 8.0),
+                          child: Text(
+                            dashboard.description,
+                            style: formLabelStyle,
+                          ),
+                        ),
+                        IconButton(
+                          icon: const Icon(Icons.dashboard_customize_outlined),
+                          color: AppColors.entryTextColor,
+                          onPressed: () {
+                            context.router.pushNamed(
+                                '/settings/dashboards/${widget.dashboardId}');
+                          },
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
               ),
             ),
           );

--- a/lib/pages/dashboards/dashboards_list_page.dart
+++ b/lib/pages/dashboards/dashboards_list_page.dart
@@ -5,6 +5,7 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/theme.dart';
 import 'package:lotti/utils/sort.dart';
+import 'package:lotti/widgets/app_bar/dashboards_app_bar.dart';
 import 'package:lotti/widgets/charts/empty_dashboards_widget.dart';
 
 class DashboardsListPage extends StatefulWidget {
@@ -26,33 +27,37 @@ class _DashboardsListPageState extends State<DashboardsListPage> {
 
   @override
   Widget build(BuildContext context) {
-    return StreamBuilder<List<DashboardDefinition>>(
-      stream: stream,
-      builder: (
-        BuildContext context,
-        AsyncSnapshot<List<DashboardDefinition>> snapshot,
-      ) {
-        List<DashboardDefinition> dashboards =
-            filteredSortedDashboards(snapshot.data ?? [], match);
+    return Scaffold(
+      backgroundColor: AppColors.bodyBgColor,
+      appBar: const DashboardsAppBar(),
+      body: StreamBuilder<List<DashboardDefinition>>(
+        stream: stream,
+        builder: (
+          BuildContext context,
+          AsyncSnapshot<List<DashboardDefinition>> snapshot,
+        ) {
+          List<DashboardDefinition> dashboards =
+              filteredSortedDashboards(snapshot.data ?? [], match);
 
-        if (dashboards.isEmpty) {
-          return const EmptyDashboards();
-        }
+          if (dashboards.isEmpty) {
+            return const EmptyDashboards();
+          }
 
-        return ListView(
-          shrinkWrap: true,
-          padding: const EdgeInsets.all(8.0),
-          children: List.generate(
-            dashboards.length,
-            (int index) {
-              return DashboardCard(
-                dashboard: dashboards.elementAt(index),
-                index: index,
-              );
-            },
-          ),
-        );
-      },
+          return ListView(
+            shrinkWrap: true,
+            padding: const EdgeInsets.all(8.0),
+            children: List.generate(
+              dashboards.length,
+              (int index) {
+                return DashboardCard(
+                  dashboard: dashboards.elementAt(index),
+                  index: index,
+                );
+              },
+            ),
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -8,12 +8,6 @@ import 'package:lotti/routes/observer.dart';
 import 'package:lotti/routes/router.gr.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/theme.dart';
-import 'package:lotti/widgets/app_bar/app_bar_version.dart';
-import 'package:lotti/widgets/app_bar/dashboard_app_bar.dart';
-import 'package:lotti/widgets/app_bar/dashboards_app_bar.dart';
-import 'package:lotti/widgets/app_bar/empty_app_bar.dart';
-import 'package:lotti/widgets/app_bar/task_app_bar.dart';
-import 'package:lotti/widgets/app_bar/title_app_bar.dart';
 import 'package:lotti/widgets/audio/audio_recording_indicator.dart';
 import 'package:lotti/widgets/bottom_nav/flagged_badge_icon.dart';
 import 'package:lotti/widgets/bottom_nav/tasks_badge_icon.dart';
@@ -30,8 +24,6 @@ class HomePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    AppLocalizations localizations = AppLocalizations.of(context)!;
-
     return StreamBuilder<bool>(
         stream: _db.watchConfigFlag('show_tasks_tab'),
         builder: (context, snapshot) {
@@ -44,46 +36,6 @@ class HomePage extends StatelessWidget {
           return AutoTabsScaffold(
             lazyLoad: false,
             animationDuration: const Duration(milliseconds: 500),
-            appBarBuilder: (context, TabsRouter tabsRouter) {
-              final String topRouteName = tabsRouter.topRoute.name;
-
-              if (topRouteName == DashboardRoute.name) {
-                return DashboardAppBar(
-                  dashboardId:
-                      tabsRouter.topRoute.pathParams.getString('dashboardId'),
-                );
-              }
-
-              if (topRouteName == DashboardsListRoute.name) {
-                return const DashboardsAppBar();
-              }
-
-              if (topRouteName == DashboardSettingsRoute.name) {
-                return TitleAppBar(
-                    title: localizations.settingsDashboardsTitle);
-              }
-
-              if (topRouteName == MeasurablesRoute.name) {
-                return TitleAppBar(
-                    title: localizations.settingsMeasurablesTitle);
-              }
-
-              if (topRouteName == EntryDetailRoute.name) {
-                return TaskAppBar(
-                  itemId: tabsRouter.topRoute.pathParams.getString('itemId'),
-                );
-              }
-
-              if (topRouteName == SettingsRoute.name) {
-                return VersionAppBar(title: localizations.navTabTitleSettings);
-              }
-
-              if ({TasksRoute.name, JournalRoute.name}.contains(topRouteName)) {
-                return EmptyAppBar();
-              }
-
-              return const VersionAppBar(title: 'Lotti');
-            },
             builder: (context, child, _) {
               return Container(
                 color: AppColors.bodyBgColor,

--- a/lib/pages/journal/entry_details_page.dart
+++ b/lib/pages/journal/entry_details_page.dart
@@ -71,36 +71,26 @@ class _EntryDetailPageState extends State<EntryDetailPage> {
         return Scaffold(
           appBar: TaskAppBar(itemId: item.meta.id),
           backgroundColor: AppColors.bodyBgColor,
-          body: Stack(
-            children: [
-              SingleChildScrollView(
-                physics: const ClampingScrollPhysics(),
-                padding: const EdgeInsets.only(top: 8, bottom: 96),
-                reverse: false,
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: <Widget>[
-                    EntryDetailWidget(
-                      itemId: widget.itemId,
-                      popOnDelete: true,
-                      showTaskDetails: true,
-                    ),
-                    LinkedEntriesWidget(itemId: widget.itemId),
-                    LinkedFromEntriesWidget(item: item),
-                  ],
+          floatingActionButton: RadialAddActionButtons(
+            linked: item,
+            radius: isMobile ? 180 : 120,
+          ),
+          body: SingleChildScrollView(
+            physics: const ClampingScrollPhysics(),
+            padding: const EdgeInsets.only(top: 8, bottom: 96),
+            reverse: false,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: <Widget>[
+                EntryDetailWidget(
+                  itemId: widget.itemId,
+                  popOnDelete: true,
+                  showTaskDetails: true,
                 ),
-              ),
-              Align(
-                alignment: Alignment.bottomRight,
-                child: Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: RadialAddActionButtons(
-                    linked: item,
-                    radius: isMobile ? 180 : 120,
-                  ),
-                ),
-              )
-            ],
+                LinkedEntriesWidget(itemId: widget.itemId),
+                LinkedFromEntriesWidget(item: item),
+              ],
+            ),
           ),
         );
       },

--- a/lib/pages/journal/entry_details_page.dart
+++ b/lib/pages/journal/entry_details_page.dart
@@ -7,7 +7,9 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/theme.dart';
 import 'package:lotti/utils/platform.dart';
+import 'package:lotti/widgets/app_bar/task_app_bar.dart';
 import 'package:lotti/widgets/create/add_actions.dart';
 import 'package:lotti/widgets/journal/entry_detail_linked.dart';
 import 'package:lotti/widgets/journal/entry_detail_linked_from.dart';
@@ -66,36 +68,40 @@ class _EntryDetailPageState extends State<EntryDetailPage> {
           return const SizedBox.shrink();
         }
 
-        return Stack(
-          children: [
-            SingleChildScrollView(
-              physics: const ClampingScrollPhysics(),
-              padding: const EdgeInsets.only(top: 8, bottom: 96),
-              reverse: false,
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.end,
-                children: <Widget>[
-                  EntryDetailWidget(
-                    itemId: widget.itemId,
-                    popOnDelete: true,
-                    showTaskDetails: true,
-                  ),
-                  LinkedEntriesWidget(itemId: widget.itemId),
-                  LinkedFromEntriesWidget(item: item),
-                ],
-              ),
-            ),
-            Align(
-              alignment: Alignment.bottomRight,
-              child: Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: RadialAddActionButtons(
-                  linked: item,
-                  radius: isMobile ? 180 : 120,
+        return Scaffold(
+          appBar: TaskAppBar(itemId: item.meta.id),
+          backgroundColor: AppColors.bodyBgColor,
+          body: Stack(
+            children: [
+              SingleChildScrollView(
+                physics: const ClampingScrollPhysics(),
+                padding: const EdgeInsets.only(top: 8, bottom: 96),
+                reverse: false,
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: <Widget>[
+                    EntryDetailWidget(
+                      itemId: widget.itemId,
+                      popOnDelete: true,
+                      showTaskDetails: true,
+                    ),
+                    LinkedEntriesWidget(itemId: widget.itemId),
+                    LinkedFromEntriesWidget(item: item),
+                  ],
                 ),
               ),
-            )
-          ],
+              Align(
+                alignment: Alignment.bottomRight,
+                child: Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: RadialAddActionButtons(
+                    linked: item,
+                    radius: isMobile ? 180 : 120,
+                  ),
+                ),
+              )
+            ],
+          ),
         );
       },
     );

--- a/lib/pages/settings/advanced_settings_page.dart
+++ b/lib/pages/settings/advanced_settings_page.dart
@@ -4,6 +4,8 @@ import 'package:lotti/pages/settings/outbox_badge.dart';
 import 'package:lotti/pages/settings/settings_card.dart';
 import 'package:lotti/pages/settings/settings_icon.dart';
 import 'package:lotti/services/nav_service.dart';
+import 'package:lotti/theme.dart';
+import 'package:lotti/widgets/app_bar/title_app_bar.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
 class AdvancedSettingsPage extends StatelessWidget {
@@ -15,58 +17,62 @@ class AdvancedSettingsPage extends StatelessWidget {
   Widget build(BuildContext context) {
     AppLocalizations localizations = AppLocalizations.of(context)!;
 
-    return Container(
-      margin: const EdgeInsets.symmetric(
-        vertical: 8.0,
-        horizontal: 8.0,
-      ),
-      child: ListView(
-        children: [
-          SettingsCard(
-            icon: const SettingsIcon(Icons.sync),
-            title: localizations.settingsSyncCfgTitle,
-            onTap: () {
-              pushNamedRoute('/settings/sync_settings');
-            },
-          ),
-          SettingsCard(
-            icon: OutboxBadgeIcon(
-              icon: const SettingsIcon(MdiIcons.mailboxOutline),
+    return Scaffold(
+      backgroundColor: AppColors.bodyBgColor,
+      appBar: TitleAppBar(title: localizations.settingsAdvancedTitle),
+      body: Container(
+        margin: const EdgeInsets.symmetric(
+          vertical: 8.0,
+          horizontal: 8.0,
+        ),
+        child: ListView(
+          children: [
+            SettingsCard(
+              icon: const SettingsIcon(Icons.sync),
+              title: localizations.settingsSyncCfgTitle,
+              onTap: () {
+                pushNamedRoute('/settings/sync_settings');
+              },
             ),
-            title: localizations.settingsSyncOutboxTitle,
-            onTap: () {
-              pushNamedRoute('/settings/outbox_monitor');
-            },
-          ),
-          SettingsCard(
-            icon: const SettingsIcon(MdiIcons.emoticonConfusedOutline),
-            title: localizations.settingsConflictsTitle,
-            onTap: () {
-              pushNamedRoute('/settings/conflicts');
-            },
-          ),
-          SettingsCard(
-            icon: const SettingsIcon(MdiIcons.informationOutline),
-            title: localizations.settingsLogsTitle,
-            onTap: () {
-              pushNamedRoute('/settings/logging');
-            },
-          ),
-          SettingsCard(
-            icon: const SettingsIcon(MdiIcons.broom),
-            title: localizations.settingsMaintenanceTitle,
-            onTap: () {
-              pushNamedRoute('/settings/maintenance');
-            },
-          ),
-          SettingsCard(
-            icon: const SettingsIcon(MdiIcons.slide),
-            title: localizations.settingsPlaygroundTitle,
-            onTap: () {
-              pushNamedRoute('/settings/playground');
-            },
-          ),
-        ],
+            SettingsCard(
+              icon: OutboxBadgeIcon(
+                icon: const SettingsIcon(MdiIcons.mailboxOutline),
+              ),
+              title: localizations.settingsSyncOutboxTitle,
+              onTap: () {
+                pushNamedRoute('/settings/outbox_monitor');
+              },
+            ),
+            SettingsCard(
+              icon: const SettingsIcon(MdiIcons.emoticonConfusedOutline),
+              title: localizations.settingsConflictsTitle,
+              onTap: () {
+                pushNamedRoute('/settings/conflicts');
+              },
+            ),
+            SettingsCard(
+              icon: const SettingsIcon(MdiIcons.informationOutline),
+              title: localizations.settingsLogsTitle,
+              onTap: () {
+                pushNamedRoute('/settings/logging');
+              },
+            ),
+            SettingsCard(
+              icon: const SettingsIcon(MdiIcons.broom),
+              title: localizations.settingsMaintenanceTitle,
+              onTap: () {
+                pushNamedRoute('/settings/maintenance');
+              },
+            ),
+            SettingsCard(
+              icon: const SettingsIcon(MdiIcons.slide),
+              title: localizations.settingsPlaygroundTitle,
+              onTap: () {
+                pushNamedRoute('/settings/playground');
+              },
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/pages/settings/conflicts.dart
+++ b/lib/pages/settings/conflicts.dart
@@ -9,6 +9,7 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/pages/journal/entry_details_page.dart';
 import 'package:lotti/sync/vector_clock.dart';
 import 'package:lotti/theme.dart';
+import 'package:lotti/widgets/app_bar/title_app_bar.dart';
 import 'package:lotti/widgets/journal/entry_tools.dart';
 
 class ConflictsPage extends StatefulWidget {
@@ -43,60 +44,64 @@ class _ConflictsPageState extends State<ConflictsPage> {
       ) {
         List<Conflict> items = snapshot.data ?? [];
 
-        return SingleChildScrollView(
-          child: Column(
-            children: [
-              CupertinoSegmentedControl(
-                selectedColor: AppColors.entryBgColor,
-                unselectedColor: AppColors.headerBgColor,
-                borderColor: AppColors.entryBgColor,
-                groupValue: _selectedValue,
-                onValueChanged: (String value) {
-                  setState(() {
-                    _selectedValue = value;
-                    if (_selectedValue == 'unresolved') {
-                      stream = _db.watchConflicts(ConflictStatus.unresolved);
-                    }
-                    if (_selectedValue == 'resolved') {
-                      stream = _db.watchConflicts(ConflictStatus.resolved);
-                    }
-                  });
-                },
-                children: {
-                  'unresolved': SizedBox(
-                    width: 64,
-                    height: 32,
-                    child: Center(
-                      child: Text(
-                        localizations.conflictsUnresolved,
-                        style: segmentItemStyle,
+        return Scaffold(
+          backgroundColor: AppColors.bodyBgColor,
+          appBar: TitleAppBar(title: localizations.settingsConflictsTitle),
+          body: SingleChildScrollView(
+            child: Column(
+              children: [
+                CupertinoSegmentedControl(
+                  selectedColor: AppColors.entryBgColor,
+                  unselectedColor: AppColors.headerBgColor,
+                  borderColor: AppColors.entryBgColor,
+                  groupValue: _selectedValue,
+                  onValueChanged: (String value) {
+                    setState(() {
+                      _selectedValue = value;
+                      if (_selectedValue == 'unresolved') {
+                        stream = _db.watchConflicts(ConflictStatus.unresolved);
+                      }
+                      if (_selectedValue == 'resolved') {
+                        stream = _db.watchConflicts(ConflictStatus.resolved);
+                      }
+                    });
+                  },
+                  children: {
+                    'unresolved': SizedBox(
+                      width: 64,
+                      height: 32,
+                      child: Center(
+                        child: Text(
+                          localizations.conflictsUnresolved,
+                          style: segmentItemStyle,
+                        ),
                       ),
                     ),
-                  ),
-                  'resolved': SizedBox(
-                    child: Center(
-                      child: Text(
-                        localizations.conflictsResolved,
-                        style: segmentItemStyle,
+                    'resolved': SizedBox(
+                      child: Center(
+                        child: Text(
+                          localizations.conflictsResolved,
+                          style: segmentItemStyle,
+                        ),
                       ),
                     ),
-                  ),
-                },
-              ),
-              ListView(
-                shrinkWrap: true,
-                padding: const EdgeInsets.all(8.0),
-                children: List.generate(
-                  items.length,
-                  (int index) {
-                    return ConflictCard(
-                      conflict: items.elementAt(index),
-                      index: index,
-                    );
                   },
                 ),
-              ),
-            ],
+                ListView(
+                  shrinkWrap: true,
+                  padding: const EdgeInsets.all(8.0),
+                  children: List.generate(
+                    items.length,
+                    (int index) {
+                      return ConflictCard(
+                        conflict: items.elementAt(index),
+                        index: index,
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
           ),
         );
       },

--- a/lib/pages/settings/dashboards/dashboard_details_page.dart
+++ b/lib/pages/settings/dashboards/dashboard_details_page.dart
@@ -43,6 +43,7 @@ class _DashboardDetailPageState extends State<DashboardDetailPage> {
   final JournalDb _db = getIt<JournalDb>();
   final PersistenceLogic persistenceLogic = getIt<PersistenceLogic>();
   final _formKey = GlobalKey<FormBuilderState>();
+  bool dirty = false;
 
   late final Stream<List<MeasurableDataType>> stream =
       _db.watchMeasurableDataTypes();
@@ -204,6 +205,9 @@ class _DashboardDetailPageState extends State<DashboardDetailPage> {
 
         Future<void> saveDashboardPress() async {
           await saveDashboard();
+          setState(() {
+            dirty = false;
+          });
           context.router.pop();
         }
 
@@ -232,7 +236,23 @@ class _DashboardDetailPageState extends State<DashboardDetailPage> {
 
         return Scaffold(
           backgroundColor: AppColors.bodyBgColor,
-          appBar: TitleAppBar(title: localizations.settingsDashboardsTitle),
+          appBar: TitleAppBar(
+            title: localizations.settingsDashboardsTitle,
+            actions: [
+              if (dirty)
+                TextButton(
+                  key: const Key('dashboard_save'),
+                  onPressed: saveDashboardPress,
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                    child: Text(
+                      localizations.dashboardSaveLabel,
+                      style: saveButtonStyle,
+                    ),
+                  ),
+                ),
+            ],
+          ),
           body: SingleChildScrollView(
             child: Padding(
               padding: const EdgeInsets.all(16.0),
@@ -249,6 +269,11 @@ class _DashboardDetailPageState extends State<DashboardDetailPage> {
                             key: _formKey,
                             autovalidateMode:
                                 AutovalidateMode.onUserInteraction,
+                            onChanged: () {
+                              setState(() {
+                                dirty = true;
+                              });
+                            },
                             child: Column(
                               children: <Widget>[
                                 FormTextField(
@@ -404,14 +429,7 @@ class _DashboardDetailPageState extends State<DashboardDetailPage> {
                             child: Row(
                               mainAxisAlignment: MainAxisAlignment.spaceBetween,
                               children: [
-                                TextButton(
-                                  key: const Key('dashboard_save'),
-                                  onPressed: saveDashboardPress,
-                                  child: Text(
-                                    localizations.dashboardSaveLabel,
-                                    style: saveButtonStyle,
-                                  ),
-                                ),
+                                const Spacer(),
                                 const SizedBox(width: 8),
                                 Row(
                                   children: [

--- a/lib/pages/settings/dashboards/dashboard_details_page.dart
+++ b/lib/pages/settings/dashboards/dashboard_details_page.dart
@@ -18,6 +18,7 @@ import 'package:lotti/pages/settings/dashboards/dashboard_item_card.dart';
 import 'package:lotti/pages/settings/form_text_field.dart';
 import 'package:lotti/services/tags_service.dart';
 import 'package:lotti/theme.dart';
+import 'package:lotti/widgets/app_bar/title_app_bar.dart';
 import 'package:lotti/widgets/charts/dashboard_health_config.dart';
 import 'package:lotti/widgets/charts/dashboard_survey_data.dart';
 import 'package:lotti/widgets/charts/dashboard_workout_config.dart';
@@ -229,239 +230,246 @@ class _DashboardDetailPageState extends State<DashboardDetailPage> {
               ClipboardData(text: json.encode(entityDefinitions)));
         }
 
-        return SingleChildScrollView(
-          child: Padding(
-            padding: const EdgeInsets.all(16.0),
-            child: Column(
-              children: [
-                ClipRRect(
-                  borderRadius: BorderRadius.circular(16),
-                  child: Container(
-                    color: AppColors.headerBgColor,
-                    padding: const EdgeInsets.all(24.0),
-                    child: Column(
-                      children: [
-                        FormBuilder(
-                          key: _formKey,
-                          autovalidateMode: AutovalidateMode.onUserInteraction,
-                          child: Column(
-                            children: <Widget>[
-                              FormTextField(
-                                initialValue: widget.dashboard.name,
-                                labelText: localizations.dashboardNameLabel,
-                                name: 'name',
-                                key: const Key('dashboard_name_field'),
-                              ),
-                              FormTextField(
-                                initialValue: widget.dashboard.description,
-                                labelText:
-                                    localizations.dashboardDescriptionLabel,
-                                name: 'description',
-                                fieldRequired: false,
-                                key: const Key('dashboard_description_field'),
-                              ),
-                              FormBuilderSwitch(
-                                name: 'private',
-                                initialValue: widget.dashboard.private,
-                                title: Text(
-                                  localizations.dashboardPrivateLabel,
-                                  style: formLabelStyle,
+        return Scaffold(
+          backgroundColor: AppColors.bodyBgColor,
+          appBar: TitleAppBar(title: localizations.settingsDashboardsTitle),
+          body: SingleChildScrollView(
+            child: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Column(
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(16),
+                    child: Container(
+                      color: AppColors.headerBgColor,
+                      padding: const EdgeInsets.all(24.0),
+                      child: Column(
+                        children: [
+                          FormBuilder(
+                            key: _formKey,
+                            autovalidateMode:
+                                AutovalidateMode.onUserInteraction,
+                            child: Column(
+                              children: <Widget>[
+                                FormTextField(
+                                  initialValue: widget.dashboard.name,
+                                  labelText: localizations.dashboardNameLabel,
+                                  name: 'name',
+                                  key: const Key('dashboard_name_field'),
                                 ),
-                                activeColor: AppColors.private,
-                              ),
-                              FormBuilderSwitch(
-                                name: 'active',
-                                initialValue: widget.dashboard.active,
-                                title: Text(
-                                  localizations.dashboardActiveLabel,
-                                  style: formLabelStyle,
-                                ),
-                                activeColor: AppColors.starredGold,
-                              ),
-                              FormBuilderCupertinoDateTimePicker(
-                                name: 'review_at',
-                                alwaysUse24HourFormat: true,
-                                format: DateFormat('HH:mm'),
-                                inputType:
-                                    CupertinoDateTimePickerInputType.time,
-                                style: inputStyle.copyWith(
-                                  fontSize: 18,
-                                  fontWeight: FontWeight.w300,
-                                  fontFamily: 'Oswald',
-                                ),
-                                initialValue: widget.dashboard.reviewAt,
-                                decoration: InputDecoration(
+                                FormTextField(
+                                  initialValue: widget.dashboard.description,
                                   labelText:
-                                      localizations.dashboardReviewTimeLabel,
-                                  labelStyle: labelStyle,
+                                      localizations.dashboardDescriptionLabel,
+                                  name: 'description',
+                                  fieldRequired: false,
+                                  key: const Key('dashboard_description_field'),
                                 ),
-                                theme: DatePickerTheme(
-                                  headerColor: AppColors.headerBgColor,
-                                  backgroundColor: AppColors.bodyBgColor,
-                                  itemStyle: const TextStyle(
-                                    color: Colors.white,
-                                    fontWeight: FontWeight.bold,
+                                FormBuilderSwitch(
+                                  name: 'private',
+                                  initialValue: widget.dashboard.private,
+                                  title: Text(
+                                    localizations.dashboardPrivateLabel,
+                                    style: formLabelStyle,
+                                  ),
+                                  activeColor: AppColors.private,
+                                ),
+                                FormBuilderSwitch(
+                                  name: 'active',
+                                  initialValue: widget.dashboard.active,
+                                  title: Text(
+                                    localizations.dashboardActiveLabel,
+                                    style: formLabelStyle,
+                                  ),
+                                  activeColor: AppColors.starredGold,
+                                ),
+                                FormBuilderCupertinoDateTimePicker(
+                                  name: 'review_at',
+                                  alwaysUse24HourFormat: true,
+                                  format: DateFormat('HH:mm'),
+                                  inputType:
+                                      CupertinoDateTimePickerInputType.time,
+                                  style: inputStyle.copyWith(
                                     fontSize: 18,
+                                    fontWeight: FontWeight.w300,
+                                    fontFamily: 'Oswald',
                                   ),
-                                  doneStyle: const TextStyle(
-                                    color: Colors.white,
-                                    fontSize: 16,
+                                  initialValue: widget.dashboard.reviewAt,
+                                  decoration: InputDecoration(
+                                    labelText:
+                                        localizations.dashboardReviewTimeLabel,
+                                    labelStyle: labelStyle,
+                                  ),
+                                  theme: DatePickerTheme(
+                                    headerColor: AppColors.headerBgColor,
+                                    backgroundColor: AppColors.bodyBgColor,
+                                    itemStyle: const TextStyle(
+                                      color: Colors.white,
+                                      fontWeight: FontWeight.bold,
+                                      fontSize: 18,
+                                    ),
+                                    doneStyle: const TextStyle(
+                                      color: Colors.white,
+                                      fontSize: 16,
+                                    ),
                                   ),
                                 ),
-                              ),
-                            ],
-                          ),
-                        ),
-                        const SizedBox(height: 24),
-                        Theme(
-                          data: ThemeData(canvasColor: Colors.transparent),
-                          child: ReorderableListView(
-                            shrinkWrap: true,
-                            physics: const NeverScrollableScrollPhysics(),
-                            onReorder: (int oldIndex, int newIndex) {
-                              setState(() {
-                                dashboardItems = dashboardItems;
-                                final movedItem =
-                                    dashboardItems.removeAt(oldIndex);
-                                final insertionIndex = newIndex > oldIndex
-                                    ? newIndex - 1
-                                    : newIndex;
-                                dashboardItems.insert(
-                                    insertionIndex, movedItem);
-                              });
-                            },
-                            children: List.generate(
-                              (dashboardItems).length,
-                              (int index) {
-                                List<DashboardItem> items = dashboardItems;
-                                DashboardItem item = items.elementAt(index);
-
-                                return Dismissible(
-                                  onDismissed: (_) {
-                                    dismissItem(index);
-                                  },
-                                  key: Key(
-                                      'dashboard-item-${item.hashCode}-$index'),
-                                  child: DashboardItemCard(
-                                    item: item,
-                                    index: index,
-                                    updateItemFn: updateItem,
-                                    measurableTypes: measurableDataTypes,
-                                  ),
-                                );
-                              },
+                              ],
                             ),
                           ),
-                        ),
-                        Text(
-                          localizations.dashboardAddChartsTitle,
-                          style: formLabelStyle,
-                        ),
-                        if (measurableSelectItems.isNotEmpty)
-                          ChartMultiSelect<MeasurableDataType>(
-                            multiSelectItems: measurableSelectItems,
-                            onConfirm: onConfirmAddMeasurement,
-                            title: localizations.dashboardAddMeasurementTitle,
-                            buttonText:
-                                localizations.dashboardAddMeasurementButton,
-                            iconData: Icons.insights,
-                          ),
-                        ChartMultiSelect<HealthTypeConfig>(
-                          multiSelectItems: healthSelectItems,
-                          onConfirm: onConfirmAddHealthType,
-                          title: localizations.dashboardAddHealthTitle,
-                          buttonText: localizations.dashboardAddHealthButton,
-                          iconData: MdiIcons.stethoscope,
-                        ),
-                        ChartMultiSelect<DashboardSurveyItem>(
-                          multiSelectItems: surveySelectItems,
-                          onConfirm: onConfirmAddSurveyType,
-                          title: localizations.dashboardAddSurveyTitle,
-                          buttonText: localizations.dashboardAddSurveyButton,
-                          iconData: MdiIcons.clipboardOutline,
-                        ),
-                        ChartMultiSelect<DashboardWorkoutItem>(
-                          multiSelectItems: workoutSelectItems,
-                          onConfirm: onConfirmAddWorkoutType,
-                          title: localizations.dashboardAddWorkoutTitle,
-                          buttonText: localizations.dashboardAddWorkoutButton,
-                          iconData: Icons.sports_gymnastics,
-                        ),
-                        ChartMultiSelect<DashboardStoryTimeItem>(
-                          multiSelectItems: storySelectItems,
-                          onConfirm: onConfirmAddStoryTimeType,
-                          title: localizations.dashboardAddStoryTitle,
-                          buttonText: localizations.dashboardAddStoryButton,
-                          iconData: MdiIcons.watch,
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.only(top: 16.0),
-                          child: Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              TextButton(
-                                key: const Key('dashboard_save'),
-                                onPressed: saveDashboardPress,
-                                child: Text(
-                                  localizations.dashboardSaveLabel,
-                                  style: saveButtonStyle,
-                                ),
-                              ),
-                              const SizedBox(width: 8),
-                              Row(
-                                children: [
-                                  IconButton(
-                                    icon: const Icon(Icons.copy),
-                                    iconSize: 24,
-                                    tooltip: localizations.dashboardCopyHint,
-                                    color: AppColors.appBarFgColor,
-                                    onPressed: copyDashboard,
-                                  ),
-                                  IconButton(
-                                    icon: const Icon(MdiIcons.trashCanOutline),
-                                    iconSize: 24,
-                                    tooltip: localizations.dashboardDeleteHint,
-                                    color: AppColors.appBarFgColor,
-                                    onPressed: () async {
-                                      const deleteKey = 'deleteKey';
-                                      final result =
-                                          await showModalActionSheet<String>(
-                                        context: context,
-                                        title: localizations
-                                            .dashboardDeleteQuestion,
-                                        actions: [
-                                          SheetAction(
-                                            icon: Icons.warning,
-                                            label: localizations
-                                                .dashboardDeleteConfirm,
-                                            key: deleteKey,
-                                            isDestructiveAction: true,
-                                            isDefaultAction: true,
-                                          ),
-                                        ],
-                                      );
+                          const SizedBox(height: 24),
+                          Theme(
+                            data: ThemeData(canvasColor: Colors.transparent),
+                            child: ReorderableListView(
+                              shrinkWrap: true,
+                              physics: const NeverScrollableScrollPhysics(),
+                              onReorder: (int oldIndex, int newIndex) {
+                                setState(() {
+                                  dashboardItems = dashboardItems;
+                                  final movedItem =
+                                      dashboardItems.removeAt(oldIndex);
+                                  final insertionIndex = newIndex > oldIndex
+                                      ? newIndex - 1
+                                      : newIndex;
+                                  dashboardItems.insert(
+                                      insertionIndex, movedItem);
+                                });
+                              },
+                              children: List.generate(
+                                (dashboardItems).length,
+                                (int index) {
+                                  List<DashboardItem> items = dashboardItems;
+                                  DashboardItem item = items.elementAt(index);
 
-                                      if (result == deleteKey) {
-                                        persistenceLogic
-                                            .upsertDashboardDefinition(
-                                          widget.dashboard.copyWith(
-                                            deletedAt: DateTime.now(),
-                                          ),
-                                        );
-                                        context.router.pop();
-                                      }
+                                  return Dismissible(
+                                    onDismissed: (_) {
+                                      dismissItem(index);
                                     },
-                                  ),
-                                ],
+                                    key: Key(
+                                        'dashboard-item-${item.hashCode}-$index'),
+                                    child: DashboardItemCard(
+                                      item: item,
+                                      index: index,
+                                      updateItemFn: updateItem,
+                                      measurableTypes: measurableDataTypes,
+                                    ),
+                                  );
+                                },
                               ),
-                            ],
+                            ),
                           ),
-                        ),
-                      ],
+                          Text(
+                            localizations.dashboardAddChartsTitle,
+                            style: formLabelStyle,
+                          ),
+                          if (measurableSelectItems.isNotEmpty)
+                            ChartMultiSelect<MeasurableDataType>(
+                              multiSelectItems: measurableSelectItems,
+                              onConfirm: onConfirmAddMeasurement,
+                              title: localizations.dashboardAddMeasurementTitle,
+                              buttonText:
+                                  localizations.dashboardAddMeasurementButton,
+                              iconData: Icons.insights,
+                            ),
+                          ChartMultiSelect<HealthTypeConfig>(
+                            multiSelectItems: healthSelectItems,
+                            onConfirm: onConfirmAddHealthType,
+                            title: localizations.dashboardAddHealthTitle,
+                            buttonText: localizations.dashboardAddHealthButton,
+                            iconData: MdiIcons.stethoscope,
+                          ),
+                          ChartMultiSelect<DashboardSurveyItem>(
+                            multiSelectItems: surveySelectItems,
+                            onConfirm: onConfirmAddSurveyType,
+                            title: localizations.dashboardAddSurveyTitle,
+                            buttonText: localizations.dashboardAddSurveyButton,
+                            iconData: MdiIcons.clipboardOutline,
+                          ),
+                          ChartMultiSelect<DashboardWorkoutItem>(
+                            multiSelectItems: workoutSelectItems,
+                            onConfirm: onConfirmAddWorkoutType,
+                            title: localizations.dashboardAddWorkoutTitle,
+                            buttonText: localizations.dashboardAddWorkoutButton,
+                            iconData: Icons.sports_gymnastics,
+                          ),
+                          ChartMultiSelect<DashboardStoryTimeItem>(
+                            multiSelectItems: storySelectItems,
+                            onConfirm: onConfirmAddStoryTimeType,
+                            title: localizations.dashboardAddStoryTitle,
+                            buttonText: localizations.dashboardAddStoryButton,
+                            iconData: MdiIcons.watch,
+                          ),
+                          Padding(
+                            padding: const EdgeInsets.only(top: 16.0),
+                            child: Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                              children: [
+                                TextButton(
+                                  key: const Key('dashboard_save'),
+                                  onPressed: saveDashboardPress,
+                                  child: Text(
+                                    localizations.dashboardSaveLabel,
+                                    style: saveButtonStyle,
+                                  ),
+                                ),
+                                const SizedBox(width: 8),
+                                Row(
+                                  children: [
+                                    IconButton(
+                                      icon: const Icon(Icons.copy),
+                                      iconSize: 24,
+                                      tooltip: localizations.dashboardCopyHint,
+                                      color: AppColors.appBarFgColor,
+                                      onPressed: copyDashboard,
+                                    ),
+                                    IconButton(
+                                      icon:
+                                          const Icon(MdiIcons.trashCanOutline),
+                                      iconSize: 24,
+                                      tooltip:
+                                          localizations.dashboardDeleteHint,
+                                      color: AppColors.appBarFgColor,
+                                      onPressed: () async {
+                                        const deleteKey = 'deleteKey';
+                                        final result =
+                                            await showModalActionSheet<String>(
+                                          context: context,
+                                          title: localizations
+                                              .dashboardDeleteQuestion,
+                                          actions: [
+                                            SheetAction(
+                                              icon: Icons.warning,
+                                              label: localizations
+                                                  .dashboardDeleteConfirm,
+                                              key: deleteKey,
+                                              isDestructiveAction: true,
+                                              isDefaultAction: true,
+                                            ),
+                                          ],
+                                        );
+
+                                        if (result == deleteKey) {
+                                          persistenceLogic
+                                              .upsertDashboardDefinition(
+                                            widget.dashboard.copyWith(
+                                              deletedAt: DateTime.now(),
+                                            ),
+                                          );
+                                          context.router.pop();
+                                        }
+                                      },
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
                     ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         );

--- a/lib/pages/settings/dashboards/dashboards_page.dart
+++ b/lib/pages/settings/dashboards/dashboards_page.dart
@@ -8,6 +8,7 @@ import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/routes/router.gr.dart';
 import 'package:lotti/theme.dart';
 import 'package:lotti/utils/sort.dart';
+import 'package:lotti/widgets/app_bar/title_app_bar.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:material_floating_search_bar/material_floating_search_bar.dart';
 
@@ -74,52 +75,52 @@ class _DashboardSettingsPageState extends State<DashboardSettingsPage> {
 
   @override
   Widget build(BuildContext context) {
-    return StreamBuilder<List<DashboardDefinition>>(
-      stream: stream,
-      builder: (
-        BuildContext context,
-        AsyncSnapshot<List<DashboardDefinition>> snapshot,
-      ) {
-        List<DashboardDefinition> dashboards =
-            filteredSortedDashboards(snapshot.data ?? [], match);
+    AppLocalizations localizations = AppLocalizations.of(context)!;
 
-        return Stack(
-          children: [
-            ListView(
-              shrinkWrap: true,
-              padding: const EdgeInsets.only(
-                left: 8.0,
-                right: 8.0,
-                bottom: 8,
-                top: 64,
-              ),
-              children: List.generate(
-                dashboards.length,
-                (int index) {
-                  return DashboardCard(
-                    dashboard: dashboards.elementAt(index),
-                    index: index,
-                  );
-                },
-              ),
-            ),
-            buildFloatingSearchBar(),
-            Align(
-              alignment: Alignment.bottomRight,
-              child: Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: FloatingActionButton(
-                  backgroundColor: AppColors.entryBgColor,
-                  onPressed: () {
-                    context.router.push(const CreateDashboardRoute());
+    return Scaffold(
+      backgroundColor: AppColors.bodyBgColor,
+      appBar: TitleAppBar(title: localizations.settingsDashboardsTitle),
+      floatingActionButton: FloatingActionButton(
+        backgroundColor: AppColors.entryBgColor,
+        onPressed: () {
+          context.router.push(const CreateDashboardRoute());
+        },
+        child: const Icon(MdiIcons.plus, size: 32),
+      ),
+      body: StreamBuilder<List<DashboardDefinition>>(
+        stream: stream,
+        builder: (
+          BuildContext context,
+          AsyncSnapshot<List<DashboardDefinition>> snapshot,
+        ) {
+          List<DashboardDefinition> dashboards =
+              filteredSortedDashboards(snapshot.data ?? [], match);
+
+          return Stack(
+            children: [
+              ListView(
+                shrinkWrap: true,
+                padding: const EdgeInsets.only(
+                  left: 8.0,
+                  right: 8.0,
+                  bottom: 8,
+                  top: 64,
+                ),
+                children: List.generate(
+                  dashboards.length,
+                  (int index) {
+                    return DashboardCard(
+                      dashboard: dashboards.elementAt(index),
+                      index: index,
+                    );
                   },
-                  child: const Icon(MdiIcons.plus, size: 32),
                 ),
               ),
-            ),
-          ],
-        );
-      },
+              buildFloatingSearchBar(),
+            ],
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/pages/settings/dev_playground_page.dart
+++ b/lib/pages/settings/dev_playground_page.dart
@@ -3,6 +3,8 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lotti/pages/settings/settings_card.dart';
 import 'package:lotti/pages/settings/settings_icon.dart';
 import 'package:lotti/services/nav_service.dart';
+import 'package:lotti/theme.dart';
+import 'package:lotti/widgets/app_bar/title_app_bar.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
 class DevPlaygroundPage extends StatelessWidget {
@@ -14,21 +16,25 @@ class DevPlaygroundPage extends StatelessWidget {
   Widget build(BuildContext context) {
     AppLocalizations localizations = AppLocalizations.of(context)!;
 
-    return Container(
-      margin: const EdgeInsets.symmetric(
-        vertical: 8.0,
-        horizontal: 8.0,
-      ),
-      child: ListView(
-        children: [
-          SettingsCard(
-            icon: const SettingsIcon(MdiIcons.slide),
-            title: localizations.settingsPlaygroundTutorialTitle,
-            onTap: () {
-              pushNamedRoute('/settings/tutorial');
-            },
-          ),
-        ],
+    return Scaffold(
+      backgroundColor: AppColors.bodyBgColor,
+      appBar: TitleAppBar(title: localizations.settingsPlaygroundTitle),
+      body: Container(
+        margin: const EdgeInsets.symmetric(
+          vertical: 8.0,
+          horizontal: 8.0,
+        ),
+        child: ListView(
+          children: [
+            SettingsCard(
+              icon: const SettingsIcon(MdiIcons.slide),
+              title: localizations.settingsPlaygroundTutorialTitle,
+              onTap: () {
+                pushNamedRoute('/settings/tutorial');
+              },
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/pages/settings/flags_page.dart
+++ b/lib/pages/settings/flags_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/theme.dart';
+import 'package:lotti/widgets/app_bar/title_app_bar.dart';
 
 class FlagsPage extends StatefulWidget {
   const FlagsPage({Key? key}) : super(key: key);
@@ -24,29 +25,35 @@ class _FlagsPageState extends State<FlagsPage> {
 
   @override
   Widget build(BuildContext context) {
-    return StreamBuilder<List<ConfigFlag>>(
-      stream: stream,
-      builder: (
-        BuildContext context,
-        AsyncSnapshot<List<ConfigFlag>> snapshot,
-      ) {
-        List<ConfigFlag> items = snapshot.data ?? [];
-        debugPrint('$items');
+    AppLocalizations localizations = AppLocalizations.of(context)!;
 
-        return ListView(
-          shrinkWrap: true,
-          padding: const EdgeInsets.all(8.0),
-          children: List.generate(
-            items.length,
-            (int index) {
-              return ConfigFlagCard(
-                item: items.elementAt(index),
-                index: index,
-              );
-            },
-          ),
-        );
-      },
+    return Scaffold(
+      appBar: TitleAppBar(title: localizations.settingsFlagsTitle),
+      backgroundColor: AppColors.bodyBgColor,
+      body: StreamBuilder<List<ConfigFlag>>(
+        stream: stream,
+        builder: (
+          BuildContext context,
+          AsyncSnapshot<List<ConfigFlag>> snapshot,
+        ) {
+          List<ConfigFlag> items = snapshot.data ?? [];
+          debugPrint('$items');
+
+          return ListView(
+            shrinkWrap: true,
+            padding: const EdgeInsets.all(8.0),
+            children: List.generate(
+              items.length,
+              (int index) {
+                return ConfigFlagCard(
+                  item: items.elementAt(index),
+                  index: index,
+                );
+              },
+            ),
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/pages/settings/health_import_page.dart
+++ b/lib/pages/settings/health_import_page.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/health_import.dart';
+import 'package:lotti/theme.dart';
+import 'package:lotti/widgets/app_bar/title_app_bar.dart';
 import 'package:lotti/widgets/misc/buttons.dart';
 import 'package:syncfusion_flutter_datepicker/datepicker.dart';
 
@@ -33,77 +36,85 @@ class _HealthImportPageState extends State<HealthImportPage> {
 
   @override
   Widget build(BuildContext context) {
-    return SingleChildScrollView(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: <Widget>[
-          SfDateRangePicker(
-            backgroundColor: Colors.white,
-            onSelectionChanged: _onSelectionChanged,
-            enableMultiView: true,
-            selectionMode: DateRangePickerSelectionMode.range,
-            initialSelectedRange: PickerDateRange(
-              _dateFrom,
-              _dateTo,
+    AppLocalizations localizations = AppLocalizations.of(context)!;
+
+    return Scaffold(
+      backgroundColor: AppColors.bodyBgColor,
+      appBar: TitleAppBar(
+        title: localizations.settingsHealthImportTitle,
+      ),
+      body: SingleChildScrollView(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            SfDateRangePicker(
+              backgroundColor: Colors.white,
+              onSelectionChanged: _onSelectionChanged,
+              enableMultiView: true,
+              selectionMode: DateRangePickerSelectionMode.range,
+              initialSelectedRange: PickerDateRange(
+                _dateFrom,
+                _dateTo,
+              ),
             ),
-          ),
-          Button(
-            'Import Activity Data',
-            onPressed: () {
-              _healthImport.getActivityHealthData(
-                  dateFrom: _dateFrom, dateTo: _dateTo);
-            },
-          ),
-          Button(
-            'Import Sleep Data',
-            onPressed: () {
-              _healthImport.fetchHealthData(
-                dateFrom: _dateFrom,
-                dateTo: _dateTo,
-                types: sleepTypes,
-              );
-            },
-          ),
-          Button(
-            'Import Heart Rate Data',
-            onPressed: () {
-              _healthImport.fetchHealthData(
-                dateFrom: _dateFrom,
-                dateTo: _dateTo,
-                types: heartRateTypes,
-              );
-            },
-          ),
-          Button(
-            'Import Blood Pressure Data',
-            onPressed: () {
-              _healthImport.fetchHealthData(
-                dateFrom: _dateFrom,
-                dateTo: _dateTo,
-                types: bpTypes,
-              );
-            },
-          ),
-          Button(
-            'Import Body Measurement Data',
-            onPressed: () {
-              _healthImport.fetchHealthData(
-                dateFrom: _dateFrom,
-                dateTo: _dateTo,
-                types: bodyMeasurementTypes,
-              );
-            },
-          ),
-          Button(
-            'Import Workout Data',
-            onPressed: () {
-              _healthImport.getWorkoutsHealthData(
-                dateFrom: _dateFrom,
-                dateTo: _dateTo,
-              );
-            },
-          ),
-        ],
+            Button(
+              'Import Activity Data',
+              onPressed: () {
+                _healthImport.getActivityHealthData(
+                    dateFrom: _dateFrom, dateTo: _dateTo);
+              },
+            ),
+            Button(
+              'Import Sleep Data',
+              onPressed: () {
+                _healthImport.fetchHealthData(
+                  dateFrom: _dateFrom,
+                  dateTo: _dateTo,
+                  types: sleepTypes,
+                );
+              },
+            ),
+            Button(
+              'Import Heart Rate Data',
+              onPressed: () {
+                _healthImport.fetchHealthData(
+                  dateFrom: _dateFrom,
+                  dateTo: _dateTo,
+                  types: heartRateTypes,
+                );
+              },
+            ),
+            Button(
+              'Import Blood Pressure Data',
+              onPressed: () {
+                _healthImport.fetchHealthData(
+                  dateFrom: _dateFrom,
+                  dateTo: _dateTo,
+                  types: bpTypes,
+                );
+              },
+            ),
+            Button(
+              'Import Body Measurement Data',
+              onPressed: () {
+                _healthImport.fetchHealthData(
+                  dateFrom: _dateFrom,
+                  dateTo: _dateTo,
+                  types: bodyMeasurementTypes,
+                );
+              },
+            ),
+            Button(
+              'Import Workout Data',
+              onPressed: () {
+                _healthImport.getWorkoutsHealthData(
+                  dateFrom: _dateFrom,
+                  dateTo: _dateTo,
+                );
+              },
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/pages/settings/logging_page.dart
+++ b/lib/pages/settings/logging_page.dart
@@ -1,10 +1,12 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/theme.dart';
+import 'package:lotti/widgets/app_bar/title_app_bar.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
 class LoggingPage extends StatefulWidget {
@@ -25,28 +27,34 @@ class _LoggingPageState extends State<LoggingPage> {
 
   @override
   Widget build(BuildContext context) {
-    return StreamBuilder<List<LogEntry>>(
-      stream: stream,
-      builder: (
-        BuildContext context,
-        AsyncSnapshot<List<LogEntry>> snapshot,
-      ) {
-        List<LogEntry> logEntries = snapshot.data ?? [];
+    AppLocalizations localizations = AppLocalizations.of(context)!;
 
-        return ListView(
-          shrinkWrap: true,
-          padding: const EdgeInsets.all(8.0),
-          children: List.generate(
-            logEntries.length,
-            (int index) {
-              return LogLineCard(
-                logEntry: logEntries.elementAt(index),
-                index: index,
-              );
-            },
-          ),
-        );
-      },
+    return Scaffold(
+      backgroundColor: AppColors.bodyBgColor,
+      appBar: TitleAppBar(title: localizations.settingsLogsTitle),
+      body: StreamBuilder<List<LogEntry>>(
+        stream: stream,
+        builder: (
+          BuildContext context,
+          AsyncSnapshot<List<LogEntry>> snapshot,
+        ) {
+          List<LogEntry> logEntries = snapshot.data ?? [];
+
+          return ListView(
+            shrinkWrap: true,
+            padding: const EdgeInsets.all(8.0),
+            children: List.generate(
+              logEntries.length,
+              (int index) {
+                return LogLineCard(
+                  logEntry: logEntries.elementAt(index),
+                  index: index,
+                );
+              },
+            ),
+          );
+        },
+      ),
     );
   }
 }
@@ -101,81 +109,87 @@ class LogDetailPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return StreamBuilder(
-      stream: _db.watchLogEntryById(logEntryId),
-      builder: (
-        BuildContext context,
-        AsyncSnapshot<List<LogEntry>> snapshot,
-      ) {
-        LogEntry? logEntry;
-        var data = snapshot.data ?? [];
-        if (data.isNotEmpty) {
-          logEntry = data.first;
-        }
+    AppLocalizations localizations = AppLocalizations.of(context)!;
 
-        if (logEntry == null) {
-          return const SizedBox.shrink();
-        }
+    return Scaffold(
+      backgroundColor: AppColors.bodyBgColor,
+      appBar: TitleAppBar(title: localizations.settingsLogsTitle),
+      body: StreamBuilder(
+        stream: _db.watchLogEntryById(logEntryId),
+        builder: (
+          BuildContext context,
+          AsyncSnapshot<List<LogEntry>> snapshot,
+        ) {
+          LogEntry? logEntry;
+          var data = snapshot.data ?? [];
+          if (data.isNotEmpty) {
+            logEntry = data.first;
+          }
 
-        String timestamp = logEntry.createdAt.substring(0, 23);
-        String domain = logEntry.domain;
-        String level = logEntry.level;
-        String? subDomain = logEntry.subDomain;
-        String message = logEntry.message;
-        String? stacktrace = logEntry.stacktrace;
+          if (logEntry == null) {
+            return const SizedBox.shrink();
+          }
 
-        String clipboardText =
-            '$timestamp $level $domain $subDomain\n\n$message\n\n$stacktrace';
+          String timestamp = logEntry.createdAt.substring(0, 23);
+          String domain = logEntry.domain;
+          String level = logEntry.level;
+          String? subDomain = logEntry.subDomain;
+          String message = logEntry.message;
+          String? stacktrace = logEntry.stacktrace;
 
-        TextStyle headerStyle = level == 'ERROR'
-            ? logDetailStyle.copyWith(
-                color: AppColors.error,
-                fontWeight: FontWeight.bold,
-                fontSize: 20,
-              )
-            : logDetailStyle.copyWith(fontSize: 20);
+          String clipboardText =
+              '$timestamp $level $domain $subDomain\n\n$message\n\n$stacktrace';
 
-        return SingleChildScrollView(
-          padding: const EdgeInsets.all(8.0),
-          child: Column(
-            children: [
-              Wrap(
-                children: [
-                  Text(timestamp, style: headerStyle),
-                  const SizedBox(width: 10),
-                  Text(level, style: headerStyle),
-                  const SizedBox(width: 10),
-                  Text(domain, style: headerStyle),
-                  if (subDomain != null) ...[
+          TextStyle headerStyle = level == 'ERROR'
+              ? logDetailStyle.copyWith(
+                  color: AppColors.error,
+                  fontWeight: FontWeight.bold,
+                  fontSize: 20,
+                )
+              : logDetailStyle.copyWith(fontSize: 20);
+
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(8.0),
+            child: Column(
+              children: [
+                Wrap(
+                  children: [
+                    Text(timestamp, style: headerStyle),
                     const SizedBox(width: 10),
-                    Text(subDomain, style: headerStyle),
+                    Text(level, style: headerStyle),
+                    const SizedBox(width: 10),
+                    Text(domain, style: headerStyle),
+                    if (subDomain != null) ...[
+                      const SizedBox(width: 10),
+                      Text(subDomain, style: headerStyle),
+                    ],
                   ],
-                ],
-              ),
-              Padding(
-                padding: const EdgeInsets.only(top: 16.0),
-                child: Text('Message:', style: formLabelStyle),
-              ),
-              SelectableText(message, style: logDetailStyle),
-              if (stacktrace != null) ...[
+                ),
                 Padding(
                   padding: const EdgeInsets.only(top: 16.0),
-                  child: Text('Stack Trace:', style: formLabelStyle),
+                  child: Text('Message:', style: formLabelStyle),
                 ),
-                SelectableText(stacktrace, style: logDetailStyle),
+                SelectableText(message, style: logDetailStyle),
+                if (stacktrace != null) ...[
+                  Padding(
+                    padding: const EdgeInsets.only(top: 16.0),
+                    child: Text('Stack Trace:', style: formLabelStyle),
+                  ),
+                  SelectableText(stacktrace, style: logDetailStyle),
+                ],
+                IconButton(
+                  icon: const Icon(MdiIcons.clipboardOutline),
+                  iconSize: 48,
+                  color: AppColors.entryTextColor,
+                  onPressed: () {
+                    Clipboard.setData(ClipboardData(text: clipboardText));
+                  },
+                ),
               ],
-              IconButton(
-                icon: const Icon(MdiIcons.clipboardOutline),
-                iconSize: 48,
-                color: AppColors.entryTextColor,
-                onPressed: () {
-                  Clipboard.setData(ClipboardData(text: clipboardText));
-                },
-              ),
-            ],
-          ),
-        );
-      },
+            ),
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/pages/settings/maintenance_page.dart
+++ b/lib/pages/settings/maintenance_page.dart
@@ -5,6 +5,7 @@ import 'package:lotti/database/maintenance.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/sync_config_service.dart';
 import 'package:lotti/theme.dart';
+import 'package:lotti/widgets/app_bar/title_app_bar.dart';
 
 class MaintenancePage extends StatefulWidget {
   const MaintenancePage({Key? key}) : super(key: key);
@@ -28,58 +29,62 @@ class _MaintenancePageState extends State<MaintenancePage> {
   Widget build(BuildContext context) {
     AppLocalizations localizations = AppLocalizations.of(context)!;
 
-    return StreamBuilder<List<ConfigFlag>>(
-      stream: stream,
-      builder: (
-        BuildContext context,
-        AsyncSnapshot<List<ConfigFlag>> snapshot,
-      ) {
-        List<ConfigFlag> items = snapshot.data ?? [];
-        debugPrint('$items');
-        return StreamBuilder<int>(
-          stream: _db.watchTaggedCount(),
-          builder: (
-            BuildContext context,
-            AsyncSnapshot<int> snapshot,
-          ) {
-            return ListView(
-              shrinkWrap: true,
-              padding: const EdgeInsets.all(8.0),
-              children: [
-                MaintenanceCard(
-                  title:
-                      '${localizations.maintenanceDeleteTagged}, n = ${snapshot.data}',
-                  onTap: () => _maintenance.deleteTaggedLinks(),
-                ),
-                MaintenanceCard(
-                  title: localizations.maintenanceDeleteEditorDb,
-                  onTap: () => _maintenance.deleteEditorDb(),
-                ),
-                MaintenanceCard(
-                  title: localizations.maintenanceDeleteLoggingDb,
-                  onTap: () => _maintenance.deleteLoggingDb(),
-                ),
-                MaintenanceCard(
-                  title: localizations.maintenanceRecreateTagged,
-                  onTap: () => _maintenance.recreateTaggedLinks(),
-                ),
-                MaintenanceCard(
-                  title: localizations.maintenanceStories,
-                  onTap: () => _maintenance.recreateStoryAssignment(),
-                ),
-                MaintenanceCard(
-                  title: localizations.maintenancePurgeDeleted,
-                  onTap: () => _db.purgeDeleted(),
-                ),
-                MaintenanceCard(
-                  title: localizations.maintenanceReprocessSync,
-                  onTap: () => getIt<SyncConfigService>().resetOffset(),
-                ),
-              ],
-            );
-          },
-        );
-      },
+    return Scaffold(
+      backgroundColor: AppColors.bodyBgColor,
+      appBar: TitleAppBar(title: localizations.settingsMaintenanceTitle),
+      body: StreamBuilder<List<ConfigFlag>>(
+        stream: stream,
+        builder: (
+          BuildContext context,
+          AsyncSnapshot<List<ConfigFlag>> snapshot,
+        ) {
+          List<ConfigFlag> items = snapshot.data ?? [];
+          debugPrint('$items');
+          return StreamBuilder<int>(
+            stream: _db.watchTaggedCount(),
+            builder: (
+              BuildContext context,
+              AsyncSnapshot<int> snapshot,
+            ) {
+              return ListView(
+                shrinkWrap: true,
+                padding: const EdgeInsets.all(8.0),
+                children: [
+                  MaintenanceCard(
+                    title:
+                        '${localizations.maintenanceDeleteTagged}, n = ${snapshot.data}',
+                    onTap: () => _maintenance.deleteTaggedLinks(),
+                  ),
+                  MaintenanceCard(
+                    title: localizations.maintenanceDeleteEditorDb,
+                    onTap: () => _maintenance.deleteEditorDb(),
+                  ),
+                  MaintenanceCard(
+                    title: localizations.maintenanceDeleteLoggingDb,
+                    onTap: () => _maintenance.deleteLoggingDb(),
+                  ),
+                  MaintenanceCard(
+                    title: localizations.maintenanceRecreateTagged,
+                    onTap: () => _maintenance.recreateTaggedLinks(),
+                  ),
+                  MaintenanceCard(
+                    title: localizations.maintenanceStories,
+                    onTap: () => _maintenance.recreateStoryAssignment(),
+                  ),
+                  MaintenanceCard(
+                    title: localizations.maintenancePurgeDeleted,
+                    onTap: () => _db.purgeDeleted(),
+                  ),
+                  MaintenanceCard(
+                    title: localizations.maintenanceReprocessSync,
+                    onTap: () => getIt<SyncConfigService>().resetOffset(),
+                  ),
+                ],
+              );
+            },
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/pages/settings/measurables/measurable_details_page.dart
+++ b/lib/pages/settings/measurables/measurable_details_page.dart
@@ -69,14 +69,10 @@ class _MeasurableDetailsPageState extends State<MeasurableDetailsPage> {
             TextButton(
               onPressed: onSavePressed,
               child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 24.0),
+                padding: const EdgeInsets.symmetric(horizontal: 12.0),
                 child: Text(
                   AppLocalizations.of(context)!.settingsMeasurableSaveLabel,
-                  style: TextStyle(
-                    fontSize: 20,
-                    fontFamily: 'Oswald',
-                    color: AppColors.error,
-                  ),
+                  style: saveButtonStyle,
                 ),
               ),
             )

--- a/lib/pages/settings/measurables/measurable_details_page.dart
+++ b/lib/pages/settings/measurables/measurable_details_page.dart
@@ -9,6 +9,7 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/pages/settings/form_text_field.dart';
 import 'package:lotti/theme.dart';
+import 'package:lotti/widgets/app_bar/title_app_bar.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
 const double iconSize = 24.0;
@@ -33,169 +34,175 @@ class _MeasurableDetailsPageState extends State<MeasurableDetailsPage> {
 
   @override
   Widget build(BuildContext context) {
+    AppLocalizations localizations = AppLocalizations.of(context)!;
     final MeasurableDataType item = widget.dataType;
 
-    return SingleChildScrollView(
-      child: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          children: [
-            ClipRRect(
-              borderRadius: BorderRadius.circular(16),
-              child: Container(
-                color: AppColors.headerBgColor,
-                padding: const EdgeInsets.all(24.0),
-                child: Column(
-                  children: [
-                    FormBuilder(
-                      key: _formKey,
-                      autovalidateMode: AutovalidateMode.onUserInteraction,
-                      child: Column(
-                        children: <Widget>[
-                          FormTextField(
-                            initialValue: item.displayName,
-                            labelText: AppLocalizations.of(context)!
-                                .settingsMeasurableNameLabel,
-                            name: 'displayName',
-                          ),
-                          FormTextField(
-                            initialValue: item.description,
-                            labelText: AppLocalizations.of(context)!
-                                .settingsMeasurableDescriptionLabel,
-                            fieldRequired: false,
-                            name: 'description',
-                          ),
-                          FormTextField(
-                            initialValue: item.unitName,
-                            labelText: AppLocalizations.of(context)!
-                                .settingsMeasurableUnitLabel,
-                            fieldRequired: false,
-                            name: 'unitName',
-                          ),
-                          FormBuilderSwitch(
-                            name: 'private',
-                            initialValue: item.private,
-                            title: Text(
-                              AppLocalizations.of(context)!
-                                  .settingsMeasurablePrivateLabel,
-                              style: formLabelStyle,
-                            ),
-                            activeColor: AppColors.private,
-                          ),
-                          FormBuilderSwitch(
-                            name: 'favorite',
-                            initialValue: item.favorite,
-                            title: Text(
-                              AppLocalizations.of(context)!
-                                  .settingsMeasurableFavoriteLabel,
-                              style: formLabelStyle,
-                            ),
-                            activeColor: AppColors.starredGold,
-                          ),
-                          FormBuilderDropdown(
-                            name: 'aggregationType',
-                            initialValue: item.aggregationType,
-                            decoration: InputDecoration(
+    return Scaffold(
+      backgroundColor: AppColors.bodyBgColor,
+      appBar: TitleAppBar(title: localizations.settingsMeasurablesTitle),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            children: [
+              ClipRRect(
+                borderRadius: BorderRadius.circular(16),
+                child: Container(
+                  color: AppColors.headerBgColor,
+                  padding: const EdgeInsets.all(24.0),
+                  child: Column(
+                    children: [
+                      FormBuilder(
+                        key: _formKey,
+                        autovalidateMode: AutovalidateMode.onUserInteraction,
+                        child: Column(
+                          children: <Widget>[
+                            FormTextField(
+                              initialValue: item.displayName,
                               labelText: AppLocalizations.of(context)!
-                                  .settingsMeasurableAggregationLabel,
-                              labelStyle: formLabelStyle,
+                                  .settingsMeasurableNameLabel,
+                              name: 'displayName',
                             ),
-                            iconEnabledColor: AppColors.entryTextColor,
-                            clearIcon: Padding(
-                              padding: const EdgeInsets.only(right: 8.0),
-                              child: Icon(
-                                Icons.close,
-                                color: AppColors.entryTextColor,
+                            FormTextField(
+                              initialValue: item.description,
+                              labelText: AppLocalizations.of(context)!
+                                  .settingsMeasurableDescriptionLabel,
+                              fieldRequired: false,
+                              name: 'description',
+                            ),
+                            FormTextField(
+                              initialValue: item.unitName,
+                              labelText: AppLocalizations.of(context)!
+                                  .settingsMeasurableUnitLabel,
+                              fieldRequired: false,
+                              name: 'unitName',
+                            ),
+                            FormBuilderSwitch(
+                              name: 'private',
+                              initialValue: item.private,
+                              title: Text(
+                                AppLocalizations.of(context)!
+                                    .settingsMeasurablePrivateLabel,
+                                style: formLabelStyle,
                               ),
+                              activeColor: AppColors.private,
                             ),
-                            style: const TextStyle(fontSize: 40),
-                            allowClear: true,
-                            dropdownColor: AppColors.headerBgColor,
-                            items:
-                                AggregationType.values.map((aggregationType) {
-                              return DropdownMenuItem(
-                                value: aggregationType,
-                                child: Padding(
-                                  padding: const EdgeInsets.all(8.0),
-                                  child: Text(
-                                    EnumToString.convertToString(
-                                        aggregationType),
-                                    style: TextStyle(
-                                      fontSize: 16,
-                                      color: AppColors.entryTextColor,
+                            FormBuilderSwitch(
+                              name: 'favorite',
+                              initialValue: item.favorite,
+                              title: Text(
+                                AppLocalizations.of(context)!
+                                    .settingsMeasurableFavoriteLabel,
+                                style: formLabelStyle,
+                              ),
+                              activeColor: AppColors.starredGold,
+                            ),
+                            FormBuilderDropdown(
+                              name: 'aggregationType',
+                              initialValue: item.aggregationType,
+                              decoration: InputDecoration(
+                                labelText: AppLocalizations.of(context)!
+                                    .settingsMeasurableAggregationLabel,
+                                labelStyle: formLabelStyle,
+                              ),
+                              iconEnabledColor: AppColors.entryTextColor,
+                              clearIcon: Padding(
+                                padding: const EdgeInsets.only(right: 8.0),
+                                child: Icon(
+                                  Icons.close,
+                                  color: AppColors.entryTextColor,
+                                ),
+                              ),
+                              style: const TextStyle(fontSize: 40),
+                              allowClear: true,
+                              dropdownColor: AppColors.headerBgColor,
+                              items:
+                                  AggregationType.values.map((aggregationType) {
+                                return DropdownMenuItem(
+                                  value: aggregationType,
+                                  child: Padding(
+                                    padding: const EdgeInsets.all(8.0),
+                                    child: Text(
+                                      EnumToString.convertToString(
+                                          aggregationType),
+                                      style: TextStyle(
+                                        fontSize: 16,
+                                        color: AppColors.entryTextColor,
+                                      ),
                                     ),
                                   ),
-                                ),
-                              );
-                            }).toList(),
-                          ),
-                        ],
-                      ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.only(top: 16.0),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          TextButton(
-                            onPressed: () async {
-                              _formKey.currentState!.save();
-                              if (_formKey.currentState!.validate()) {
-                                final formData = _formKey.currentState?.value;
-                                debugPrint('$formData');
-                                MeasurableDataType dataType = item.copyWith(
-                                  description:
-                                      '${formData!['description']}'.trim(),
-                                  unitName: '${formData['unitName']}'.trim(),
-                                  displayName:
-                                      '${formData['displayName']}'.trim(),
-                                  private: formData['private'],
-                                  favorite: formData['favorite'],
-                                  aggregationType: formData['aggregationType'],
                                 );
+                              }).toList(),
+                            ),
+                          ],
+                        ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.only(top: 16.0),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            TextButton(
+                              onPressed: () async {
+                                _formKey.currentState!.save();
+                                if (_formKey.currentState!.validate()) {
+                                  final formData = _formKey.currentState?.value;
+                                  debugPrint('$formData');
+                                  MeasurableDataType dataType = item.copyWith(
+                                    description:
+                                        '${formData!['description']}'.trim(),
+                                    unitName: '${formData['unitName']}'.trim(),
+                                    displayName:
+                                        '${formData['displayName']}'.trim(),
+                                    private: formData['private'],
+                                    favorite: formData['favorite'],
+                                    aggregationType:
+                                        formData['aggregationType'],
+                                  );
 
-                                persistenceLogic
-                                    .upsertEntityDefinition(dataType);
-                                context.router.pop();
-                              }
-                            },
-                            child: Padding(
-                              padding:
-                                  const EdgeInsets.symmetric(horizontal: 24.0),
-                              child: Text(
-                                AppLocalizations.of(context)!
-                                    .settingsMeasurableSaveLabel,
-                                style: const TextStyle(
-                                  fontSize: 20,
-                                  fontFamily: 'Oswald',
-                                  fontWeight: FontWeight.bold,
+                                  persistenceLogic
+                                      .upsertEntityDefinition(dataType);
+                                  context.router.pop();
+                                }
+                              },
+                              child: Padding(
+                                padding: const EdgeInsets.symmetric(
+                                    horizontal: 24.0),
+                                child: Text(
+                                  AppLocalizations.of(context)!
+                                      .settingsMeasurableSaveLabel,
+                                  style: const TextStyle(
+                                    fontSize: 20,
+                                    fontFamily: 'Oswald',
+                                    fontWeight: FontWeight.bold,
+                                  ),
                                 ),
                               ),
                             ),
-                          ),
-                          IconButton(
-                            icon: const Icon(MdiIcons.trashCanOutline),
-                            iconSize: 24,
-                            tooltip: AppLocalizations.of(context)!
-                                .settingsMeasurableDeleteTooltip,
-                            color: AppColors.appBarFgColor,
-                            onPressed: () {
-                              persistenceLogic.upsertEntityDefinition(
-                                item.copyWith(
-                                  deletedAt: DateTime.now(),
-                                ),
-                              );
-                              context.router.pop();
-                            },
-                          ),
-                        ],
+                            IconButton(
+                              icon: const Icon(MdiIcons.trashCanOutline),
+                              iconSize: 24,
+                              tooltip: AppLocalizations.of(context)!
+                                  .settingsMeasurableDeleteTooltip,
+                              color: AppColors.appBarFgColor,
+                              onPressed: () {
+                                persistenceLogic.upsertEntityDefinition(
+                                  item.copyWith(
+                                    deletedAt: DateTime.now(),
+                                  ),
+                                );
+                                context.router.pop();
+                              },
+                            ),
+                          ],
+                        ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/pages/settings/measurables/measurables_page.dart
+++ b/lib/pages/settings/measurables/measurables_page.dart
@@ -6,6 +6,7 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/pages/settings/measurables/measurable_type_card.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/theme.dart';
+import 'package:lotti/widgets/app_bar/title_app_bar.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:material_floating_search_bar/material_floating_search_bar.dart';
 
@@ -76,6 +77,8 @@ class _MeasurablesPageState extends State<MeasurablesPage> {
 
   @override
   Widget build(BuildContext context) {
+    AppLocalizations localizations = AppLocalizations.of(context)!;
+
     return StreamBuilder<List<MeasurableDataType>>(
       stream: stream,
       builder: (
@@ -88,41 +91,39 @@ class _MeasurablesPageState extends State<MeasurablesPage> {
                 dataType.displayName.toLowerCase().contains(match))
             .toList();
 
-        return Stack(
-          children: [
-            ListView(
-              shrinkWrap: true,
-              padding: const EdgeInsets.only(
-                left: 8,
-                right: 8,
-                bottom: 8,
-                top: 64,
-              ),
-              children: List.generate(
-                filtered.length,
-                (int index) {
-                  return MeasurableTypeCard(
-                    item: filtered.elementAt(index),
-                    index: index,
-                  );
-                },
-              ),
-            ),
-            buildFloatingSearchBar(),
-            Align(
-              alignment: Alignment.bottomRight,
-              child: Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: FloatingActionButton(
-                  backgroundColor: AppColors.entryBgColor,
-                  onPressed: () {
-                    pushNamedRoute('/settings/create_measurable');
+        return Scaffold(
+          appBar: TitleAppBar(title: localizations.settingsMeasurablesTitle),
+          backgroundColor: AppColors.bodyBgColor,
+          floatingActionButton: FloatingActionButton(
+            backgroundColor: AppColors.entryBgColor,
+            onPressed: () {
+              pushNamedRoute('/settings/create_measurable');
+            },
+            child: const Icon(MdiIcons.plus, size: 32),
+          ),
+          body: Stack(
+            children: [
+              ListView(
+                shrinkWrap: true,
+                padding: const EdgeInsets.only(
+                  left: 8,
+                  right: 8,
+                  bottom: 8,
+                  top: 64,
+                ),
+                children: List.generate(
+                  filtered.length,
+                  (int index) {
+                    return MeasurableTypeCard(
+                      item: filtered.elementAt(index),
+                      index: index,
+                    );
                   },
-                  child: const Icon(MdiIcons.plus, size: 32),
                 ),
               ),
-            )
-          ],
+              buildFloatingSearchBar(),
+            ],
+          ),
         );
       },
     );

--- a/lib/pages/settings/outbox_monitor.dart
+++ b/lib/pages/settings/outbox_monitor.dart
@@ -8,6 +8,7 @@ import 'package:lotti/blocs/sync/outbox_state.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/theme.dart';
+import 'package:lotti/widgets/app_bar/title_app_bar.dart';
 import 'package:lotti/widgets/journal/entry_tools.dart';
 
 class OutboxMonitorPage extends StatefulWidget {
@@ -43,94 +44,97 @@ class _OutboxMonitorPageState extends State<OutboxMonitorPage> {
             List<OutboxItem> items = snapshot.data ?? [];
             bool onlineStatus = state is! OutboxDisabled;
 
-            return SingleChildScrollView(
-              child: Column(
-                children: [
-                  const SizedBox(height: 8),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Text(localizations.outboxMonitorSwitchLabel,
-                        style: labelStyleLarger
-                      ),
-                      CupertinoSwitch(
-                        value: onlineStatus,
-                        onChanged: (_) {
-                          context.read<OutboxCubit>().toggleStatus();
-                        },
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 8),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      CupertinoSegmentedControl(
-                        selectedColor: AppColors.entryBgColor,
-                        unselectedColor: AppColors.headerBgColor,
-                        borderColor: AppColors.entryBgColor,
-                        groupValue: _selectedValue,
-                        onValueChanged: (String value) {
-                          setState(() {
-                            _selectedValue = value;
-                            if (_selectedValue == 'all') {
-                              stream = _db.watchOutboxItems();
-                            }
-                            if (_selectedValue == 'pending') {
-                              stream = _db.watchOutboxItems(
-                                  statuses: [OutboxStatus.pending]);
-                            }
-                            if (_selectedValue == 'error') {
-                              stream = _db.watchOutboxItems(
-                                  statuses: [OutboxStatus.error]);
-                            }
-                          });
-                        },
-                        children: {
-                          'pending': SizedBox(
-                            width: 64,
-                            height: 32,
-                            child: Center(
-                              child: Text(
-                                localizations.outboxMonitorLabelPending,
-                                style: segmentItemStyle,
-                              ),
-                            ),
-                          ),
-                          'error': SizedBox(
-                            child: Center(
-                              child: Text(
-                                localizations.outboxMonitorLabelError,
-                                style: segmentItemStyle,
-                              ),
-                            ),
-                          ),
-                          'all': SizedBox(
-                            child: Center(
-                              child: Text(
-                                localizations.outboxMonitorLabelAll,
-                                style: segmentItemStyle,
-                              ),
-                            ),
-                          ),
-                        },
-                      ),
-                    ],
-                  ),
-                  ListView(
-                    shrinkWrap: true,
-                    padding: const EdgeInsets.all(8.0),
-                    children: List.generate(
-                      items.length,
-                      (int index) {
-                        return OutboxItemCard(
-                          item: items.elementAt(index),
-                          index: index,
-                        );
-                      },
+            return Scaffold(
+              backgroundColor: AppColors.bodyBgColor,
+              appBar: TitleAppBar(title: localizations.settingsSyncOutboxTitle),
+              body: SingleChildScrollView(
+                child: Column(
+                  children: [
+                    const SizedBox(height: 8),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(localizations.outboxMonitorSwitchLabel,
+                            style: labelStyleLarger),
+                        CupertinoSwitch(
+                          value: onlineStatus,
+                          onChanged: (_) {
+                            context.read<OutboxCubit>().toggleStatus();
+                          },
+                        ),
+                      ],
                     ),
-                  ),
-                ],
+                    const SizedBox(height: 8),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        CupertinoSegmentedControl(
+                          selectedColor: AppColors.entryBgColor,
+                          unselectedColor: AppColors.headerBgColor,
+                          borderColor: AppColors.entryBgColor,
+                          groupValue: _selectedValue,
+                          onValueChanged: (String value) {
+                            setState(() {
+                              _selectedValue = value;
+                              if (_selectedValue == 'all') {
+                                stream = _db.watchOutboxItems();
+                              }
+                              if (_selectedValue == 'pending') {
+                                stream = _db.watchOutboxItems(
+                                    statuses: [OutboxStatus.pending]);
+                              }
+                              if (_selectedValue == 'error') {
+                                stream = _db.watchOutboxItems(
+                                    statuses: [OutboxStatus.error]);
+                              }
+                            });
+                          },
+                          children: {
+                            'pending': SizedBox(
+                              width: 64,
+                              height: 32,
+                              child: Center(
+                                child: Text(
+                                  localizations.outboxMonitorLabelPending,
+                                  style: segmentItemStyle,
+                                ),
+                              ),
+                            ),
+                            'error': SizedBox(
+                              child: Center(
+                                child: Text(
+                                  localizations.outboxMonitorLabelError,
+                                  style: segmentItemStyle,
+                                ),
+                              ),
+                            ),
+                            'all': SizedBox(
+                              child: Center(
+                                child: Text(
+                                  localizations.outboxMonitorLabelAll,
+                                  style: segmentItemStyle,
+                                ),
+                              ),
+                            ),
+                          },
+                        ),
+                      ],
+                    ),
+                    ListView(
+                      shrinkWrap: true,
+                      padding: const EdgeInsets.all(8.0),
+                      children: List.generate(
+                        items.length,
+                        (int index) {
+                          return OutboxItemCard(
+                            item: items.elementAt(index),
+                            index: index,
+                          );
+                        },
+                      ),
+                    ),
+                  ],
+                ),
               ),
             );
           },

--- a/lib/pages/settings/settings_page.dart
+++ b/lib/pages/settings/settings_page.dart
@@ -3,6 +3,8 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lotti/pages/settings/settings_card.dart';
 import 'package:lotti/pages/settings/settings_icon.dart';
 import 'package:lotti/services/nav_service.dart';
+import 'package:lotti/theme.dart';
+import 'package:lotti/widgets/app_bar/app_bar_version.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
 class SettingsPage extends StatefulWidget {
@@ -27,56 +29,60 @@ class _SettingsPageState extends State<SettingsPage> {
   Widget build(BuildContext context) {
     AppLocalizations localizations = AppLocalizations.of(context)!;
 
-    return Container(
-      margin: const EdgeInsets.symmetric(
-        vertical: 8.0,
-        horizontal: 8.0,
-      ),
-      child: ListView(
-        children: [
-          SettingsCard(
-            icon: const SettingsIcon(MdiIcons.tagOutline),
-            title: localizations.settingsTagsTitle,
-            onTap: () {
-              pushNamedRoute('/settings/tags');
-            },
-          ),
-          SettingsCard(
-            icon: const SettingsIcon(Icons.dashboard_customize_outlined),
-            title: localizations.settingsDashboardsTitle,
-            onTap: () {
-              pushNamedRoute('/settings/dashboards');
-            },
-          ),
-          SettingsCard(
-            icon: const SettingsIcon(Icons.insights),
-            title: localizations.settingsMeasurablesTitle,
-            onTap: () {
-              pushNamedRoute('/settings/measurables');
-            },
-          ),
-          SettingsCard(
-            icon: const SettingsIcon(MdiIcons.heartOutline),
-            title: localizations.settingsHealthImportTitle,
-            onTap: () {
-              pushNamedRoute('/settings/health_import');
-            },
-          ),
-          SettingsCard(
-            icon: const SettingsIcon(MdiIcons.flagOutline),
-            title: localizations.settingsFlagsTitle,
-            onTap: () {
-              pushNamedRoute('/settings/flags');
-            },
-          ),
-          SettingsCard(
-            icon: const SettingsIcon(MdiIcons.alertRhombusOutline),
-            title: localizations.settingsAdvancedTitle,
-            onTap: () {
-              pushNamedRoute('/settings/advanced');
-            },
-          ),
-        ],
+    return Scaffold(
+      backgroundColor: AppColors.bodyBgColor,
+      appBar: VersionAppBar(title: localizations.navTabTitleSettings),
+      body: Container(
+        margin: const EdgeInsets.symmetric(
+          vertical: 8.0,
+          horizontal: 8.0,
+        ),
+        child: ListView(
+          children: [
+            SettingsCard(
+              icon: const SettingsIcon(MdiIcons.tagOutline),
+              title: localizations.settingsTagsTitle,
+              onTap: () {
+                pushNamedRoute('/settings/tags');
+              },
+            ),
+            SettingsCard(
+              icon: const SettingsIcon(Icons.dashboard_customize_outlined),
+              title: localizations.settingsDashboardsTitle,
+              onTap: () {
+                pushNamedRoute('/settings/dashboards');
+              },
+            ),
+            SettingsCard(
+              icon: const SettingsIcon(Icons.insights),
+              title: localizations.settingsMeasurablesTitle,
+              onTap: () {
+                pushNamedRoute('/settings/measurables');
+              },
+            ),
+            SettingsCard(
+              icon: const SettingsIcon(MdiIcons.heartOutline),
+              title: localizations.settingsHealthImportTitle,
+              onTap: () {
+                pushNamedRoute('/settings/health_import');
+              },
+            ),
+            SettingsCard(
+              icon: const SettingsIcon(MdiIcons.flagOutline),
+              title: localizations.settingsFlagsTitle,
+              onTap: () {
+                pushNamedRoute('/settings/flags');
+              },
+            ),
+            SettingsCard(
+              icon: const SettingsIcon(MdiIcons.alertRhombusOutline),
+              title: localizations.settingsAdvancedTitle,
+              onTap: () {
+                pushNamedRoute('/settings/advanced');
+              },
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/pages/settings/sync/sync_assistant_page.dart
+++ b/lib/pages/settings/sync/sync_assistant_page.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_sliding_tutorial/flutter_sliding_tutorial.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:lotti/pages/settings/sync/sync_assistant_slide_config.dart';
@@ -10,6 +11,7 @@ import 'package:lotti/pages/settings/sync/sync_assistant_slide_intro_3.dart';
 import 'package:lotti/pages/settings/sync/sync_assistant_slide_qr_code.dart';
 import 'package:lotti/pages/settings/sync/sync_assistant_slide_success.dart';
 import 'package:lotti/theme.dart';
+import 'package:lotti/widgets/app_bar/title_app_bar.dart';
 
 class SyncAssistantPage extends StatefulWidget {
   const SyncAssistantPage({
@@ -35,75 +37,81 @@ class _SyncAssistantPageState extends State<SyncAssistantPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-        child: Stack(
-      children: <Widget>[
-        SlidingTutorial(
-          controller: _pageCtrl,
-          pageCount: pageCount,
-          notifier: notifier,
-        ),
+    AppLocalizations localizations = AppLocalizations.of(context)!;
 
-        /// Separator.
-        Align(
-          alignment: const Alignment(0, 0.85),
-          child: Container(
-            width: double.infinity,
-            height: 0.5,
-            color: Colors.white,
-          ),
-        ),
-        Align(
-          alignment: Alignment.centerLeft,
-          child: IconButton(
-            icon: const Icon(
-              Icons.arrow_back_ios_rounded,
-              color: Colors.white,
-            ),
-            onPressed: () {
-              _pageCtrl.previousPage(
-                duration: const Duration(milliseconds: 600),
-                curve: Curves.linear,
-              );
-            },
-          ),
-        ),
-        Align(
-          alignment: Alignment.centerRight,
-          child: IconButton(
-            icon: const Icon(
-              Icons.arrow_back_ios_rounded,
-              color: Colors.white,
-              textDirection: TextDirection.rtl,
-            ),
-            onPressed: () {
-              _pageCtrl.nextPage(
-                duration: const Duration(milliseconds: 600),
-                curve: Curves.linear,
-              );
-            },
-          ),
-        ),
-
-        Align(
-          alignment: const Alignment(0, 0.94),
-          child: SlidingIndicator(
-            indicatorCount: pageCount,
+    return Scaffold(
+      backgroundColor: AppColors.bodyBgColor,
+      appBar: TitleAppBar(title: localizations.settingsSyncCfgTitle),
+      body: Center(
+          child: Stack(
+        children: <Widget>[
+          SlidingTutorial(
+            controller: _pageCtrl,
+            pageCount: pageCount,
             notifier: notifier,
-            activeIndicator: const Icon(
-              Icons.check_circle,
-              color: Color(0xFF29B6F6),
-            ),
-            inActiveIndicator: SvgPicture.asset(
-              'assets/images/tutorial/hollow_circle.svg',
-            ),
-            margin: 8,
-            inactiveIndicatorSize: 14,
-            activeIndicatorSize: 14,
           ),
-        )
-      ],
-    ));
+
+          /// Separator.
+          Align(
+            alignment: const Alignment(0, 0.85),
+            child: Container(
+              width: double.infinity,
+              height: 0.5,
+              color: Colors.white,
+            ),
+          ),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: IconButton(
+              icon: const Icon(
+                Icons.arrow_back_ios_rounded,
+                color: Colors.white,
+              ),
+              onPressed: () {
+                _pageCtrl.previousPage(
+                  duration: const Duration(milliseconds: 600),
+                  curve: Curves.linear,
+                );
+              },
+            ),
+          ),
+          Align(
+            alignment: Alignment.centerRight,
+            child: IconButton(
+              icon: const Icon(
+                Icons.arrow_back_ios_rounded,
+                color: Colors.white,
+                textDirection: TextDirection.rtl,
+              ),
+              onPressed: () {
+                _pageCtrl.nextPage(
+                  duration: const Duration(milliseconds: 600),
+                  curve: Curves.linear,
+                );
+              },
+            ),
+          ),
+
+          Align(
+            alignment: const Alignment(0, 0.94),
+            child: SlidingIndicator(
+              indicatorCount: pageCount,
+              notifier: notifier,
+              activeIndicator: const Icon(
+                Icons.check_circle,
+                color: Color(0xFF29B6F6),
+              ),
+              inActiveIndicator: SvgPicture.asset(
+                'assets/images/tutorial/hollow_circle.svg',
+              ),
+              margin: 8,
+              inactiveIndicatorSize: 14,
+              activeIndicatorSize: 14,
+            ),
+          )
+        ],
+      )),
+    );
   }
 }
 

--- a/lib/pages/settings/tags/tag_edit_page.dart
+++ b/lib/pages/settings/tags/tag_edit_page.dart
@@ -101,14 +101,10 @@ class _TagEditPageState extends State<TagEditPage> {
               key: const Key('tag_save'),
               onPressed: onSavePressed,
               child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 24.0),
+                padding: const EdgeInsets.symmetric(horizontal: 12.0),
                 child: Text(
                   localizations.settingsTagsSaveLabel,
-                  style: TextStyle(
-                    fontSize: 20,
-                    fontFamily: 'Oswald',
-                    color: AppColors.error,
-                  ),
+                  style: saveButtonStyle,
                 ),
               ),
             ),

--- a/lib/pages/settings/tags/tag_edit_page.dart
+++ b/lib/pages/settings/tags/tag_edit_page.dart
@@ -8,6 +8,7 @@ import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/pages/settings/form_text_field.dart';
 import 'package:lotti/services/tags_service.dart';
 import 'package:lotti/theme.dart';
+import 'package:lotti/widgets/app_bar/title_app_bar.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
 class TagEditPage extends StatefulWidget {
@@ -32,198 +33,202 @@ class _TagEditPageState extends State<TagEditPage> {
   Widget build(BuildContext context) {
     AppLocalizations localizations = AppLocalizations.of(context)!;
 
-    return Padding(
-      padding: const EdgeInsets.all(16.0),
-      child: Column(
-        children: [
-          ClipRRect(
-            borderRadius: BorderRadius.circular(16),
-            child: Container(
-              color: AppColors.entryCardColor,
-              padding: const EdgeInsets.all(24.0),
-              child: Column(
-                children: [
-                  FormBuilder(
-                    key: _formKey,
-                    autovalidateMode: AutovalidateMode.onUserInteraction,
-                    child: Column(
-                      children: <Widget>[
-                        FormTextField(
-                          initialValue: widget.tagEntity.tag,
-                          labelText: localizations.settingsTagsTagName,
-                          name: 'tag',
-                          key: const Key('tag_name_field'),
-                        ),
-                        FormBuilderSwitch(
-                          name: 'private',
-                          initialValue: widget.tagEntity.private,
-                          title: Text(
-                            localizations.settingsTagsPrivateLabel,
-                            style: formLabelStyle,
+    return Scaffold(
+      appBar: TitleAppBar(title: localizations.settingsTagsTitle),
+      backgroundColor: AppColors.bodyBgColor,
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            ClipRRect(
+              borderRadius: BorderRadius.circular(16),
+              child: Container(
+                color: AppColors.entryCardColor,
+                padding: const EdgeInsets.all(24.0),
+                child: Column(
+                  children: [
+                    FormBuilder(
+                      key: _formKey,
+                      autovalidateMode: AutovalidateMode.onUserInteraction,
+                      child: Column(
+                        children: <Widget>[
+                          FormTextField(
+                            initialValue: widget.tagEntity.tag,
+                            labelText: localizations.settingsTagsTagName,
+                            name: 'tag',
+                            key: const Key('tag_name_field'),
                           ),
-                          activeColor: AppColors.private,
-                        ),
-                        FormBuilderSwitch(
-                          name: 'inactive',
-                          initialValue: widget.tagEntity.inactive,
-                          title: Text(
-                            localizations.settingsTagsHideLabel,
-                            style: formLabelStyle,
+                          FormBuilderSwitch(
+                            name: 'private',
+                            initialValue: widget.tagEntity.private,
+                            title: Text(
+                              localizations.settingsTagsPrivateLabel,
+                              style: formLabelStyle,
+                            ),
+                            activeColor: AppColors.private,
                           ),
-                          activeColor: AppColors.private,
-                        ),
-                        FormBuilderChoiceChip(
-                          name: 'type',
-                          initialValue: widget.tagEntity.map(
-                            genericTag: (_) =>
-                                localizations.settingsTagsTypeTag,
-                            personTag: (_) =>
-                                localizations.settingsTagsTypePerson,
-                            storyTag: (_) =>
-                                localizations.settingsTagsTypeStory, // 'STORY',
+                          FormBuilderSwitch(
+                            name: 'inactive',
+                            initialValue: widget.tagEntity.inactive,
+                            title: Text(
+                              localizations.settingsTagsHideLabel,
+                              style: formLabelStyle,
+                            ),
+                            activeColor: AppColors.private,
                           ),
-                          decoration: InputDecoration(
-                            labelText: localizations.settingsTagsTypeLabel,
-                            labelStyle: labelStyle.copyWith(
-                              height: 0.6,
+                          FormBuilderChoiceChip(
+                            name: 'type',
+                            initialValue: widget.tagEntity.map(
+                              genericTag: (_) =>
+                                  localizations.settingsTagsTypeTag,
+                              personTag: (_) =>
+                                  localizations.settingsTagsTypePerson,
+                              storyTag: (_) => localizations
+                                  .settingsTagsTypeStory, // 'STORY',
+                            ),
+                            decoration: InputDecoration(
+                              labelText: localizations.settingsTagsTypeLabel,
+                              labelStyle: labelStyle.copyWith(
+                                height: 0.6,
+                                fontFamily: 'Oswald',
+                              ),
+                            ),
+                            selectedColor: widget.tagEntity.map(
+                              genericTag: (tag) => getTagColor(tag),
+                              personTag: (tag) => getTagColor(tag),
+                              storyTag: (tag) => getTagColor(tag),
+                            ),
+                            runSpacing: 4,
+                            spacing: 4,
+                            labelStyle: const TextStyle(
+                              fontSize: 14,
+                              fontWeight: FontWeight.w300,
                               fontFamily: 'Oswald',
                             ),
-                          ),
-                          selectedColor: widget.tagEntity.map(
-                            genericTag: (tag) => getTagColor(tag),
-                            personTag: (tag) => getTagColor(tag),
-                            storyTag: (tag) => getTagColor(tag),
-                          ),
-                          runSpacing: 4,
-                          spacing: 4,
-                          labelStyle: const TextStyle(
-                            fontSize: 14,
-                            fontWeight: FontWeight.w300,
-                            fontFamily: 'Oswald',
-                          ),
-                          options: [
-                            FormBuilderFieldOption(
-                              value: 'TAG',
-                              child: Text(
-                                localizations.settingsTagsTypeTag,
-                                style: const TextStyle(color: Colors.black87),
+                            options: [
+                              FormBuilderFieldOption(
+                                value: 'TAG',
+                                child: Text(
+                                  localizations.settingsTagsTypeTag,
+                                  style: const TextStyle(color: Colors.black87),
+                                ),
                               ),
-                            ),
-                            FormBuilderFieldOption(
-                              value: 'PERSON',
-                              child: Text(
-                                localizations.settingsTagsTypePerson,
-                                style: const TextStyle(color: Colors.black87),
+                              FormBuilderFieldOption(
+                                value: 'PERSON',
+                                child: Text(
+                                  localizations.settingsTagsTypePerson,
+                                  style: const TextStyle(color: Colors.black87),
+                                ),
                               ),
-                            ),
-                            FormBuilderFieldOption(
-                              value: 'STORY',
-                              child: Text(
-                                localizations.settingsTagsTypeStory,
-                                style: const TextStyle(color: Colors.black87),
+                              FormBuilderFieldOption(
+                                value: 'STORY',
+                                child: Text(
+                                  localizations.settingsTagsTypeStory,
+                                  style: const TextStyle(color: Colors.black87),
+                                ),
                               ),
-                            ),
-                          ],
-                        ),
-                      ],
+                            ],
+                          ),
+                        ],
+                      ),
                     ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.only(top: 16.0),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        TextButton(
-                          key: const Key('tag_save'),
-                          onPressed: () async {
-                            _formKey.currentState!.save();
-                            if (_formKey.currentState!.validate()) {
-                              final formData = _formKey.currentState?.value;
-                              TagEntity newTagEntity =
-                                  widget.tagEntity.copyWith(
-                                tag: '${formData!['tag']}'.trim(),
-                                private: formData['private'],
-                                inactive: formData['inactive'],
-                                updatedAt: DateTime.now(),
+                    Padding(
+                      padding: const EdgeInsets.only(top: 16.0),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          TextButton(
+                            key: const Key('tag_save'),
+                            onPressed: () async {
+                              _formKey.currentState!.save();
+                              if (_formKey.currentState!.validate()) {
+                                final formData = _formKey.currentState?.value;
+                                TagEntity newTagEntity =
+                                    widget.tagEntity.copyWith(
+                                  tag: '${formData!['tag']}'.trim(),
+                                  private: formData['private'],
+                                  inactive: formData['inactive'],
+                                  updatedAt: DateTime.now(),
+                                );
+
+                                String type = formData['type'];
+
+                                if (type == 'PERSON') {
+                                  newTagEntity = TagEntity.personTag(
+                                    tag: newTagEntity.tag,
+                                    vectorClock: newTagEntity.vectorClock,
+                                    updatedAt: newTagEntity.updatedAt,
+                                    createdAt: newTagEntity.createdAt,
+                                    private: newTagEntity.private,
+                                    inactive: newTagEntity.inactive,
+                                    id: newTagEntity.id,
+                                  );
+                                }
+
+                                if (type == 'STORY') {
+                                  newTagEntity = TagEntity.storyTag(
+                                    tag: newTagEntity.tag,
+                                    vectorClock: newTagEntity.vectorClock,
+                                    updatedAt: newTagEntity.updatedAt,
+                                    createdAt: newTagEntity.createdAt,
+                                    private: newTagEntity.private,
+                                    inactive: newTagEntity.inactive,
+                                    id: newTagEntity.id,
+                                  );
+                                }
+
+                                if (type == 'TAG') {
+                                  newTagEntity = TagEntity.genericTag(
+                                    tag: newTagEntity.tag,
+                                    vectorClock: newTagEntity.vectorClock,
+                                    updatedAt: newTagEntity.updatedAt,
+                                    createdAt: newTagEntity.createdAt,
+                                    private: newTagEntity.private,
+                                    inactive: newTagEntity.inactive,
+                                    id: newTagEntity.id,
+                                  );
+                                }
+
+                                persistenceLogic.upsertTagEntity(newTagEntity);
+                                context.router.pop();
+                              }
+                            },
+                            child: Padding(
+                              padding:
+                                  const EdgeInsets.symmetric(horizontal: 24.0),
+                              child: Text(
+                                localizations.settingsTagsSaveLabel,
+                                style: const TextStyle(
+                                  fontSize: 20,
+                                  fontFamily: 'Oswald',
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                            ),
+                          ),
+                          IconButton(
+                            icon: const Icon(MdiIcons.trashCanOutline),
+                            iconSize: 24,
+                            tooltip: localizations.settingsTagsDeleteTooltip,
+                            color: AppColors.appBarFgColor,
+                            onPressed: () {
+                              persistenceLogic.upsertTagEntity(
+                                widget.tagEntity.copyWith(
+                                  deletedAt: DateTime.now(),
+                                ),
                               );
-
-                              String type = formData['type'];
-
-                              if (type == 'PERSON') {
-                                newTagEntity = TagEntity.personTag(
-                                  tag: newTagEntity.tag,
-                                  vectorClock: newTagEntity.vectorClock,
-                                  updatedAt: newTagEntity.updatedAt,
-                                  createdAt: newTagEntity.createdAt,
-                                  private: newTagEntity.private,
-                                  inactive: newTagEntity.inactive,
-                                  id: newTagEntity.id,
-                                );
-                              }
-
-                              if (type == 'STORY') {
-                                newTagEntity = TagEntity.storyTag(
-                                  tag: newTagEntity.tag,
-                                  vectorClock: newTagEntity.vectorClock,
-                                  updatedAt: newTagEntity.updatedAt,
-                                  createdAt: newTagEntity.createdAt,
-                                  private: newTagEntity.private,
-                                  inactive: newTagEntity.inactive,
-                                  id: newTagEntity.id,
-                                );
-                              }
-
-                              if (type == 'TAG') {
-                                newTagEntity = TagEntity.genericTag(
-                                  tag: newTagEntity.tag,
-                                  vectorClock: newTagEntity.vectorClock,
-                                  updatedAt: newTagEntity.updatedAt,
-                                  createdAt: newTagEntity.createdAt,
-                                  private: newTagEntity.private,
-                                  inactive: newTagEntity.inactive,
-                                  id: newTagEntity.id,
-                                );
-                              }
-
-                              persistenceLogic.upsertTagEntity(newTagEntity);
                               context.router.pop();
-                            }
-                          },
-                          child: Padding(
-                            padding:
-                                const EdgeInsets.symmetric(horizontal: 24.0),
-                            child: Text(
-                              localizations.settingsTagsSaveLabel,
-                              style: const TextStyle(
-                                fontSize: 20,
-                                fontFamily: 'Oswald',
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
+                            },
                           ),
-                        ),
-                        IconButton(
-                          icon: const Icon(MdiIcons.trashCanOutline),
-                          iconSize: 24,
-                          tooltip: localizations.settingsTagsDeleteTooltip,
-                          color: AppColors.appBarFgColor,
-                          onPressed: () {
-                            persistenceLogic.upsertTagEntity(
-                              widget.tagEntity.copyWith(
-                                deletedAt: DateTime.now(),
-                              ),
-                            );
-                            context.router.pop();
-                          },
-                        ),
-                      ],
+                        ],
+                      ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/pages/settings/tags/tag_edit_page.dart
+++ b/lib/pages/settings/tags/tag_edit_page.dart
@@ -93,7 +93,27 @@ class _TagEditPageState extends State<TagEditPage> {
     }
 
     return Scaffold(
-      appBar: TitleAppBar(title: localizations.settingsTagsTitle),
+      appBar: TitleAppBar(
+        title: localizations.settingsTagsTitle,
+        actions: [
+          if (dirty)
+            TextButton(
+              key: const Key('tag_save'),
+              onPressed: onSavePressed,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 24.0),
+                child: Text(
+                  localizations.settingsTagsSaveLabel,
+                  style: TextStyle(
+                    fontSize: 20,
+                    fontFamily: 'Oswald',
+                    color: AppColors.error,
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
       backgroundColor: AppColors.bodyBgColor,
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16.0),
@@ -201,25 +221,7 @@ class _TagEditPageState extends State<TagEditPage> {
                       child: Row(
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
-                          TextButton(
-                            key: const Key('tag_save'),
-                            onPressed: onSavePressed,
-                            child: Padding(
-                              padding:
-                                  const EdgeInsets.symmetric(horizontal: 24.0),
-                              child: Text(
-                                localizations.settingsTagsSaveLabel,
-                                style: TextStyle(
-                                  fontSize: 20,
-                                  fontFamily: 'Oswald',
-                                  fontWeight: FontWeight.bold,
-                                  color: dirty
-                                      ? AppColors.error
-                                      : AppColors.entryTextColor,
-                                ),
-                              ),
-                            ),
-                          ),
+                          const Spacer(),
                           IconButton(
                             icon: const Icon(MdiIcons.trashCanOutline),
                             iconSize: 24,

--- a/lib/pages/settings/tags/tags_page.dart
+++ b/lib/pages/settings/tags/tags_page.dart
@@ -8,6 +8,7 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/routes/router.gr.dart';
 import 'package:lotti/theme.dart';
+import 'package:lotti/widgets/app_bar/title_app_bar.dart';
 import 'package:lotti/widgets/create/add_tag_actions.dart';
 import 'package:material_floating_search_bar/material_floating_search_bar.dart';
 
@@ -74,49 +75,49 @@ class _TagsPageState extends State<TagsPage> {
 
   @override
   Widget build(BuildContext context) {
-    return StreamBuilder<List<TagEntity>>(
-      stream: stream,
-      builder: (
-        BuildContext context,
-        AsyncSnapshot<List<TagEntity>> snapshot,
-      ) {
-        List<TagEntity> items = snapshot.data ?? [];
-        List<TagEntity> filtered = items
-            .where(
-                (TagEntity entity) => entity.tag.toLowerCase().contains(match))
-            .toList();
+    AppLocalizations localizations = AppLocalizations.of(context)!;
 
-        return Stack(
-          children: [
-            ListView(
-              shrinkWrap: true,
-              padding: const EdgeInsets.only(
-                left: 8.0,
-                right: 8.0,
-                bottom: 8,
-                top: 64,
+    return Scaffold(
+      appBar: TitleAppBar(title: localizations.settingsTagsTitle),
+      backgroundColor: AppColors.bodyBgColor,
+      floatingActionButton: const RadialAddTagButtons(),
+      body: StreamBuilder<List<TagEntity>>(
+        stream: stream,
+        builder: (
+          BuildContext context,
+          AsyncSnapshot<List<TagEntity>> snapshot,
+        ) {
+          List<TagEntity> items = snapshot.data ?? [];
+          List<TagEntity> filtered = items
+              .where((TagEntity entity) =>
+                  entity.tag.toLowerCase().contains(match))
+              .toList();
+
+          return Stack(
+            children: [
+              ListView(
+                shrinkWrap: true,
+                padding: const EdgeInsets.only(
+                  left: 8.0,
+                  right: 8.0,
+                  bottom: 8,
+                  top: 64,
+                ),
+                children: List.generate(
+                  filtered.length,
+                  (int index) {
+                    return TagCard(
+                      tagEntity: filtered.elementAt(index),
+                      index: index,
+                    );
+                  },
+                ),
               ),
-              children: List.generate(
-                filtered.length,
-                (int index) {
-                  return TagCard(
-                    tagEntity: filtered.elementAt(index),
-                    index: index,
-                  );
-                },
-              ),
-            ),
-            buildFloatingSearchBar(),
-            const Align(
-              alignment: Alignment.bottomRight,
-              child: Padding(
-                padding: EdgeInsets.all(16.0),
-                child: RadialAddTagButtons(),
-              ),
-            )
-          ],
-        );
-      },
+              buildFloatingSearchBar(),
+            ],
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -216,10 +216,10 @@ TextStyle chartTitleStyle = TextStyle(
 
 const taskFormFieldStyle = TextStyle(color: Colors.black87);
 
-const saveButtonStyle = TextStyle(
+ TextStyle saveButtonStyle = TextStyle(
   fontSize: 20,
   fontFamily: 'Oswald',
-  fontWeight: FontWeight.bold,
+  color: AppColors.error,
 );
 
 const segmentItemStyle = TextStyle(

--- a/lib/widgets/app_bar/title_app_bar.dart
+++ b/lib/widgets/app_bar/title_app_bar.dart
@@ -6,9 +6,11 @@ class TitleAppBar extends StatelessWidget with PreferredSizeWidget {
   const TitleAppBar({
     Key? key,
     required this.title,
+    this.actions,
   }) : super(key: key);
 
   final String title;
+  final List<Widget>? actions;
 
   @override
   Size get preferredSize => const Size.fromHeight(kToolbarHeight);
@@ -16,6 +18,7 @@ class TitleAppBar extends StatelessWidget with PreferredSizeWidget {
   @override
   Widget build(BuildContext context) {
     return AppBar(
+      actions: actions,
       backgroundColor: AppColors.headerBgColor,
       title: Text(title, style: appBarTextStyle),
       centerTitle: true,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.50+984
+version: 0.8.50+985
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.49+983
+version: 0.8.50+984
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.50+987
+version: 0.8.50+988
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.50+985
+version: 0.8.50+986
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.50+986
+version: 0.8.50+987
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR adds indicating unsaved changes in dashboards, measurables, tags by moving the save button to the actions section in the app bar, and only displaying it (in red) when there are unsaved changes.

Huge PR because of requiring to move the app bars into individual scaffolds, which wrap large widgets.

Resolves #1009 