### PR TITLE
Fix empty text rendered as grey box in release mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed:
+- Grey boxes in flagged entries that do not have text yet
+
+## [0.8.58] - 2022-06-16
+### Fixed:
 - App bar when creating new entries
 
 ## [0.8.55] - 2022-06-16

--- a/lib/widgets/journal/journal_card.dart
+++ b/lib/widgets/journal/journal_card.dart
@@ -96,8 +96,8 @@ class JournalCardTitle extends StatelessWidget {
               journalEntry: (JournalEntry journalEntry) => TextViewerWidget(
                 entryText: journalEntry.entryText,
               ),
-              journalImage: (JournalImage journalImage) => Expanded(
-                child: TextViewerWidget(entryText: journalImage.entryText),
+              journalImage: (JournalImage journalImage) => TextViewerWidget(
+                entryText: journalImage.entryText,
               ),
               survey: SurveySummary.new,
               measurement: MeasurementSummary.new,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.56+1012
+version: 0.8.57+1013
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR fixes empty text in image entries rendered as a grey box in release mode. The underlying cause was using an `Expanded` widget in the wrong place.