### PR TITLE
Remove leading insights icon in measurement card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed:
+- Leading insights icon in measurement card removed
+
+## [0.8.67] - 2022-06-23
+### Changed:
 - Outbox monitor layout
 - Outbox badge now displays larger counts
 

--- a/lib/widgets/journal/journal_card.dart
+++ b/lib/widgets/journal/journal_card.dart
@@ -177,7 +177,6 @@ class JournalCard extends StatelessWidget {
               journalAudio: (_) => const LeadingIcon(Icons.mic),
               journalEntry: (_) => const LeadingIcon(Icons.article),
               quantitative: (_) => const LeadingIcon(MdiIcons.heart),
-              measurement: (_) => const LeadingIcon(Icons.insights),
               orElse: () => null,
             ),
             title: JournalCardTitle(item: item),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.67+1043
+version: 0.8.68+1044
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR removes the useless leading insight icon in measurement cards.