### PR TITLE
Add link from new measurement to measurable type definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added:
+- Link from new measurement page to respective measurable definition
+
+## [0.8.71] - 2022-06-23
 ### Fixed:
 - Line wrap for long title and description in dashboard definition card
 - Line wrap for long description in dashboard page

--- a/lib/pages/create/create_measurement_page.dart
+++ b/lib/pages/create/create_measurement_page.dart
@@ -166,14 +166,30 @@ class _CreateMeasurementPageState extends State<CreateMeasurementPage> {
                             ),
                           if (items.isNotEmpty)
                             Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
-                                Text(
-                                  selected?.displayName ?? '',
-                                  style: TextStyle(
-                                    color: AppColors.entryTextColor,
-                                    fontFamily: 'Oswald',
-                                    fontSize: 20,
-                                  ),
+                                Row(
+                                  mainAxisAlignment:
+                                      MainAxisAlignment.spaceBetween,
+                                  children: [
+                                    Text(
+                                      selected?.displayName ?? '',
+                                      style: TextStyle(
+                                        color: AppColors.entryTextColor,
+                                        fontFamily: 'Oswald',
+                                        fontSize: 24,
+                                      ),
+                                    ),
+                                    IconButton(
+                                      icon: const Icon(Icons.settings_outlined),
+                                      color: AppColors.entryTextColor,
+                                      onPressed: () {
+                                        context.router.pushNamed(
+                                          '/settings/measurables/${selected?.id}',
+                                        );
+                                      },
+                                    ),
+                                  ],
                                 ),
                                 if (selected?.description != null)
                                   Text(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.71+1049
+version: 0.8.72+1050
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR adds a link from new measurements to the respective measurable type definition.