### PR TITLE
Bright theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added:
+- Bright ☀️ color scheme with config flag
+
+## [0.8.80] - 2022-06-27
 ### Changed:
 - Use AppRouter mock in tests (no UI changes)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added:
 - Bright ☀️ color scheme with config flag
+- Change️ color scheme from menu on desktop
 
 ## [0.8.80] - 2022-06-27
 ### Changed:

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -508,6 +508,13 @@ class JournalDb extends _$JournalDb {
         status: false,
       ),
     );
+    await insertFlagIfNotExists(
+      ConfigFlag(
+        name: 'show_bright_scheme',
+        description: 'Show Bright ☀️ scheme?',
+        status: false,
+      ),
+    );
     if (Platform.isMacOS) {
       await insertFlagIfNotExists(
         ConfigFlag(

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -15,6 +15,7 @@ import 'package:lotti/classes/tag_type_definitions.dart';
 import 'package:lotti/database/conversions.dart';
 import 'package:lotti/database/stream_helpers.dart';
 import 'package:lotti/sync/vector_clock.dart';
+import 'package:lotti/utils/consts.dart';
 import 'package:lotti/utils/file_utils.dart';
 import 'package:lotti/widgets/journal/entry_tools.dart';
 import 'package:path/path.dart' as p;
@@ -510,7 +511,7 @@ class JournalDb extends _$JournalDb {
     );
     await insertFlagIfNotExists(
       ConfigFlag(
-        name: 'show_bright_scheme',
+        name: showBrightSchemeFlagName,
         description: 'Show Bright ☀️ scheme?',
         status: false,
       ),
@@ -535,6 +536,14 @@ class JournalDb extends _$JournalDb {
 
   Future<int> upsertConfigFlag(ConfigFlag configFlag) async {
     return into(configFlags).insertOnConflictUpdate(configFlag);
+  }
+
+  Future<void> toggleConfigFlag(String flagName) async {
+    final configFlag = await getConfigFlagByName(flagName);
+
+    if (configFlag != null) {
+      await upsertConfigFlag(configFlag.copyWith(status: !configFlag.status));
+    }
   }
 
   Future<int> getCountImportFlagEntries() async {

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -17,12 +17,14 @@ import 'package:lotti/services/time_service.dart';
 import 'package:lotti/services/vector_clock_service.dart';
 import 'package:lotti/sync/inbox_service.dart';
 import 'package:lotti/sync/outbox.dart';
+import 'package:lotti/theme.dart';
 
 final getIt = GetIt.instance;
 
 void registerSingletons() {
   getIt
     ..registerSingleton<JournalDb>(JournalDb())
+    ..registerSingleton<ThemeService>(ThemeService())
     ..registerSingleton<EditorDb>(EditorDb())
     ..registerSingleton<TagsService>(TagsService())
     ..registerSingleton<SyncDatabase>(SyncDatabase())

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -89,8 +89,8 @@ class LottiApp extends StatelessWidget {
       child: StreamBuilder<Themes>(
         stream: getIt<ThemeService>().getStream(),
         builder: (context, snapshot) {
-          debugPrint('${snapshot.data}');
           return DesktopMenuWrapper(
+            key: Key('theme-${snapshot.data}'),
             MaterialApp.router(
               localizationsDelegates: const [
                 AppLocalizations.delegate,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -91,30 +91,28 @@ class LottiApp extends StatelessWidget {
         stream: getIt<ThemeService>().getStream(),
         builder: (context, snapshot) {
           return DesktopMenuWrapper(
-            ColoredBox(
-              color: AppColors.bodyBgColor,
+            FadeIn(
               key: Key('theme-${snapshot.data}'),
-              child: FadeIn(
-                duration: const Duration(milliseconds: 1000),
-                child: MaterialApp.router(
-                  localizationsDelegates: const [
-                    AppLocalizations.delegate,
-                    FormBuilderLocalizations.delegate,
-                    GlobalMaterialLocalizations.delegate,
-                    GlobalWidgetsLocalizations.delegate,
-                    GlobalCupertinoLocalizations.delegate,
-                  ],
-                  color: AppColors.bodyBgColor,
-                  supportedLocales: AppLocalizations.supportedLocales,
-                  theme: ThemeData(
-                    primarySwatch: Colors.grey,
-                  ),
-                  debugShowCheckedModeBanner: false,
-                  routerDelegate: router.delegate(
-                    navigatorObservers: () => [],
-                  ),
-                  routeInformationParser: router.defaultRouteParser(),
+              duration: const Duration(milliseconds: 500),
+              child: MaterialApp.router(
+                localizationsDelegates: const [
+                  AppLocalizations.delegate,
+                  FormBuilderLocalizations.delegate,
+                  GlobalMaterialLocalizations.delegate,
+                  GlobalWidgetsLocalizations.delegate,
+                  GlobalCupertinoLocalizations.delegate,
+                ],
+                color: AppColors.bodyBgColor,
+                supportedLocales: AppLocalizations.supportedLocales,
+                theme: ThemeData(
+                  primarySwatch: Colors.grey,
+                  scaffoldBackgroundColor: AppColors.bodyBgColor,
                 ),
+                debugShowCheckedModeBanner: false,
+                routerDelegate: router.delegate(
+                  navigatorObservers: () => [],
+                ),
+                routeInformationParser: router.defaultRouteParser(),
               ),
             ),
           );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,7 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/routes/router.gr.dart';
 import 'package:lotti/services/window_service.dart';
 import 'package:lotti/sync/secure_storage.dart';
+import 'package:lotti/theme.dart';
 import 'package:lotti/utils/screenshots.dart';
 import 'package:lotti/widgets/misc/desktop_menu.dart';
 import 'package:timezone/data/latest.dart' as tz;
@@ -85,25 +86,31 @@ class LottiApp extends StatelessWidget {
           create: (BuildContext context) => AudioPlayerCubit(),
         ),
       ],
-      child: DesktopMenuWrapper(
-        MaterialApp.router(
-          localizationsDelegates: const [
-            AppLocalizations.delegate,
-            FormBuilderLocalizations.delegate,
-            GlobalMaterialLocalizations.delegate,
-            GlobalWidgetsLocalizations.delegate,
-            GlobalCupertinoLocalizations.delegate,
-          ],
-          supportedLocales: AppLocalizations.supportedLocales,
-          theme: ThemeData(
-            primarySwatch: Colors.grey,
-          ),
-          debugShowCheckedModeBanner: false,
-          routerDelegate: router.delegate(
-            navigatorObservers: () => [],
-          ),
-          routeInformationParser: router.defaultRouteParser(),
-        ),
+      child: StreamBuilder<Themes>(
+        stream: getIt<ThemeService>().getStream(),
+        builder: (context, snapshot) {
+          debugPrint('${snapshot.data}');
+          return DesktopMenuWrapper(
+            MaterialApp.router(
+              localizationsDelegates: const [
+                AppLocalizations.delegate,
+                FormBuilderLocalizations.delegate,
+                GlobalMaterialLocalizations.delegate,
+                GlobalWidgetsLocalizations.delegate,
+                GlobalCupertinoLocalizations.delegate,
+              ],
+              supportedLocales: AppLocalizations.supportedLocales,
+              theme: ThemeData(
+                primarySwatch: Colors.grey,
+              ),
+              debugShowCheckedModeBanner: false,
+              routerDelegate: router.delegate(
+                navigatorObservers: () => [],
+              ),
+              routeInformationParser: router.defaultRouteParser(),
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -95,7 +95,7 @@ class LottiApp extends StatelessWidget {
               color: AppColors.bodyBgColor,
               key: Key('theme-${snapshot.data}'),
               child: FadeIn(
-                duration: const Duration(milliseconds: 500),
+                duration: const Duration(milliseconds: 1000),
                 child: MaterialApp.router(
                   localizationsDelegates: const [
                     AppLocalizations.delegate,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_fadein/flutter_fadein.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:form_builder_validators/localization/l10n.dart';
@@ -90,24 +91,31 @@ class LottiApp extends StatelessWidget {
         stream: getIt<ThemeService>().getStream(),
         builder: (context, snapshot) {
           return DesktopMenuWrapper(
-            key: Key('theme-${snapshot.data}'),
-            MaterialApp.router(
-              localizationsDelegates: const [
-                AppLocalizations.delegate,
-                FormBuilderLocalizations.delegate,
-                GlobalMaterialLocalizations.delegate,
-                GlobalWidgetsLocalizations.delegate,
-                GlobalCupertinoLocalizations.delegate,
-              ],
-              supportedLocales: AppLocalizations.supportedLocales,
-              theme: ThemeData(
-                primarySwatch: Colors.grey,
+            ColoredBox(
+              color: AppColors.bodyBgColor,
+              key: Key('theme-${snapshot.data}'),
+              child: FadeIn(
+                duration: const Duration(milliseconds: 500),
+                child: MaterialApp.router(
+                  localizationsDelegates: const [
+                    AppLocalizations.delegate,
+                    FormBuilderLocalizations.delegate,
+                    GlobalMaterialLocalizations.delegate,
+                    GlobalWidgetsLocalizations.delegate,
+                    GlobalCupertinoLocalizations.delegate,
+                  ],
+                  color: AppColors.bodyBgColor,
+                  supportedLocales: AppLocalizations.supportedLocales,
+                  theme: ThemeData(
+                    primarySwatch: Colors.grey,
+                  ),
+                  debugShowCheckedModeBanner: false,
+                  routerDelegate: router.delegate(
+                    navigatorObservers: () => [],
+                  ),
+                  routeInformationParser: router.defaultRouteParser(),
+                ),
               ),
-              debugShowCheckedModeBanner: false,
-              routerDelegate: router.delegate(
-                navigatorObservers: () => [],
-              ),
-              routeInformationParser: router.defaultRouteParser(),
             ),
           );
         },

--- a/lib/pages/create/create_measurement_page.dart
+++ b/lib/pages/create/create_measurement_page.dart
@@ -196,7 +196,7 @@ class _CreateMeasurementPageState extends State<CreateMeasurementPage> {
                                     Expanded(
                                       child: Text(
                                         selected?.displayName ?? '',
-                                        style: TextStyle(
+                                        style: const TextStyle(
                                           color: AppColors.entryTextColor,
                                           fontFamily: 'Oswald',
                                           fontSize: 24,
@@ -217,7 +217,7 @@ class _CreateMeasurementPageState extends State<CreateMeasurementPage> {
                                 if (selected?.description != null)
                                   Text(
                                     selected!.description,
-                                    style: TextStyle(
+                                    style: const TextStyle(
                                       color: AppColors.entryTextColor,
                                       fontFamily: 'Oswald',
                                       fontWeight: FontWeight.w300,

--- a/lib/pages/create/create_task_page.dart
+++ b/lib/pages/create/create_task_page.dart
@@ -97,8 +97,8 @@ class _CreateTaskPageState extends State<CreateTaskPage> {
               ),
               TextButton(
                 onPressed: _save,
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 24),
+                child: const Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 24),
                   child: Text(
                     'Save',
                     style: TextStyle(

--- a/lib/pages/dashboards/dashboards_list_page.dart
+++ b/lib/pages/dashboards/dashboards_list_page.dart
@@ -85,7 +85,7 @@ class DashboardCard extends StatelessWidget {
             const EdgeInsets.only(left: 16, top: 8, bottom: 20, right: 16),
         title: Text(
           dashboard.name,
-          style: TextStyle(
+          style: const TextStyle(
             color: AppColors.entryTextColor,
             fontFamily: 'Oswald',
             fontSize: 24,
@@ -94,7 +94,7 @@ class DashboardCard extends StatelessWidget {
         ),
         subtitle: Text(
           dashboard.description,
-          style: TextStyle(
+          style: const TextStyle(
             color: AppColors.entryTextColor,
             fontFamily: 'Oswald',
             fontSize: 16,

--- a/lib/pages/journal_page.dart
+++ b/lib/pages/journal_page.dart
@@ -257,7 +257,9 @@ class _JournalPageState extends State<JournalPage> {
                         children: [
                           Text(
                             localizations.journalPrivateTooltip,
-                            style: TextStyle(color: AppColors.entryTextColor),
+                            style: const TextStyle(
+                              color: AppColors.entryTextColor,
+                            ),
                           ),
                           CupertinoSwitch(
                             value: privateEntriesOnly,
@@ -274,7 +276,7 @@ class _JournalPageState extends State<JournalPage> {
                     ),
                     Text(
                       localizations.journalFavoriteTooltip,
-                      style: TextStyle(color: AppColors.entryTextColor),
+                      style: const TextStyle(color: AppColors.entryTextColor),
                     ),
                     CupertinoSwitch(
                       value: starredEntriesOnly,
@@ -288,7 +290,7 @@ class _JournalPageState extends State<JournalPage> {
                     ),
                     Text(
                       localizations.journalFlaggedTooltip,
-                      style: TextStyle(color: AppColors.entryTextColor),
+                      style: const TextStyle(color: AppColors.entryTextColor),
                     ),
                     CupertinoSwitch(
                       value: flaggedEntriesOnly,
@@ -445,7 +447,7 @@ class _JournalPageState extends State<JournalPage> {
                                 resetStream();
                               });
                             },
-                            icon: Icon(
+                            icon: const Icon(
                               Icons.close,
                               color: AppColors.bottomNavIconUnselected,
                             ),

--- a/lib/pages/settings/conflicts.dart
+++ b/lib/pages/settings/conflicts.dart
@@ -137,7 +137,7 @@ class ConflictCard extends StatelessWidget {
           contentPadding: const EdgeInsets.only(left: 24, right: 24),
           title: Text(
             '${df.format(conflict.createdAt)} - ${statusString(conflict)}',
-            style: TextStyle(
+            style: const TextStyle(
               color: AppColors.entryTextColor,
               fontFamily: 'Oswald',
               fontSize: 16,
@@ -145,7 +145,7 @@ class ConflictCard extends StatelessWidget {
           ),
           subtitle: Text(
             '${fromSerialized(conflict.serialized).meta.vectorClock}',
-            style: TextStyle(
+            style: const TextStyle(
               color: AppColors.entryTextColor,
               fontFamily: 'Oswald',
               fontWeight: FontWeight.w200,
@@ -199,7 +199,7 @@ class DetailRoute extends StatelessWidget {
       appBar: AppBar(
         title: Text(
           df.format(local.meta.dateFrom),
-          style: TextStyle(
+          style: const TextStyle(
             color: AppColors.entryBgColor,
             fontFamily: 'Oswald',
           ),

--- a/lib/pages/settings/dashboards/chart_multi_select.dart
+++ b/lib/pages/settings/dashboards/chart_multi_select.dart
@@ -49,7 +49,7 @@ class ChartMultiSelect<T> extends StatelessWidget {
           fontWeight: FontWeight.normal,
         ),
         unselectedColor: AppColors.entryTextColor,
-        searchIcon: Icon(
+        searchIcon: const Icon(
           Icons.search,
           size: 32,
           color: AppColors.entryTextColor,
@@ -62,7 +62,7 @@ class ChartMultiSelect<T> extends StatelessWidget {
         ),
         buttonText: Text(
           buttonText,
-          style: TextStyle(
+          style: const TextStyle(
             color: AppColors.entryTextColor,
             fontSize: 16,
           ),

--- a/lib/pages/settings/dashboards/dashboard_item_card.dart
+++ b/lib/pages/settings/dashboards/dashboard_item_card.dart
@@ -89,27 +89,27 @@ class DashboardItemCard extends StatelessWidget {
           horizontal: 16,
         ),
         leading: item.map(
-          measurement: (_) => Icon(
+          measurement: (_) => const Icon(
             Icons.insights,
             size: 32,
             color: AppColors.entryTextColor,
           ),
-          healthChart: (_) => Icon(
+          healthChart: (_) => const Icon(
             MdiIcons.stethoscope,
             size: 32,
             color: AppColors.entryTextColor,
           ),
-          workoutChart: (_) => Icon(
+          workoutChart: (_) => const Icon(
             Icons.sports_gymnastics,
             size: 32,
             color: AppColors.entryTextColor,
           ),
-          surveyChart: (_) => Icon(
+          surveyChart: (_) => const Icon(
             MdiIcons.clipboardOutline,
             size: 32,
             color: AppColors.entryTextColor,
           ),
-          storyTimeChart: (_) => Icon(
+          storyTimeChart: (_) => const Icon(
             MdiIcons.bookOutline,
             size: 32,
             color: AppColors.entryTextColor,
@@ -117,7 +117,7 @@ class DashboardItemCard extends StatelessWidget {
         ),
         title: Text(
           itemName,
-          style: TextStyle(
+          style: const TextStyle(
             color: AppColors.entryTextColor,
             fontFamily: 'Oswald',
             fontSize: 20,

--- a/lib/pages/settings/flags_page.dart
+++ b/lib/pages/settings/flags_page.dart
@@ -105,7 +105,7 @@ class ConfigFlagCard extends StatelessWidget {
             children: [
               Text(
                 getLocalizedDescription(item),
-                style: TextStyle(
+                style: const TextStyle(
                   color: AppColors.entryTextColor,
                   fontFamily: 'Oswald',
                   fontSize: 20,

--- a/lib/pages/settings/maintenance_page.dart
+++ b/lib/pages/settings/maintenance_page.dart
@@ -115,7 +115,7 @@ class MaintenanceCard extends StatelessWidget {
           children: [
             Text(
               title,
-              style: TextStyle(
+              style: const TextStyle(
                 color: AppColors.entryTextColor,
                 fontFamily: 'Oswald',
                 fontSize: 20,

--- a/lib/pages/settings/measurables/measurable_details_page.dart
+++ b/lib/pages/settings/measurables/measurable_details_page.dart
@@ -155,8 +155,8 @@ class _MeasurableDetailsPageState extends State<MeasurableDetailsPage> {
                                 labelStyle: formLabelStyle,
                               ),
                               iconEnabledColor: AppColors.entryTextColor,
-                              clearIcon: Padding(
-                                padding: const EdgeInsets.only(right: 8),
+                              clearIcon: const Padding(
+                                padding: EdgeInsets.only(right: 8),
                                 child: Icon(
                                   Icons.close,
                                   color: AppColors.entryTextColor,
@@ -175,7 +175,7 @@ class _MeasurableDetailsPageState extends State<MeasurableDetailsPage> {
                                       EnumToString.convertToString(
                                         aggregationType,
                                       ),
-                                      style: TextStyle(
+                                      style: const TextStyle(
                                         fontSize: 16,
                                         color: AppColors.entryTextColor,
                                       ),

--- a/lib/pages/settings/outbox/outbox_monitor.dart
+++ b/lib/pages/settings/outbox/outbox_monitor.dart
@@ -150,7 +150,7 @@ class OutboxItemCard extends StatelessWidget {
           contentPadding: const EdgeInsets.only(left: 24, right: 24),
           title: Text(
             '${df.format(item.createdAt)} - $status',
-            style: TextStyle(
+            style: const TextStyle(
               color: AppColors.entryTextColor,
               fontFamily: 'Oswald',
               fontSize: 16,
@@ -159,7 +159,7 @@ class OutboxItemCard extends StatelessWidget {
           subtitle: Text(
             '${item.retries} $retriesText - '
             '${item.filePath ?? localizations.outboxMonitorNoAttachment}',
-            style: TextStyle(
+            style: const TextStyle(
               color: AppColors.entryTextColor,
               fontFamily: 'Oswald',
               fontWeight: FontWeight.w200,

--- a/lib/pages/settings/settings_card.dart
+++ b/lib/pages/settings/settings_card.dart
@@ -26,7 +26,7 @@ class SettingsCard extends StatelessWidget {
         leading: icon,
         title: Text(
           title,
-          style: TextStyle(
+          style: const TextStyle(
             color: AppColors.entryTextColor,
             fontFamily: 'Oswald',
             fontSize: 22,

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -1,8 +1,11 @@
 // ignore_for_file: equal_keys_in_map
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:lotti/classes/tag_type_definitions.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/utils/consts.dart';
 import 'package:themed/themed.dart';
 import 'package:tinycolor2/tinycolor2.dart';
 
@@ -167,16 +170,28 @@ Map<ThemeRef, Object> brightTheme = {
   AppColors.unselectedChoiceChipTextColor: const Color.fromRGBO(51, 77, 118, 1),
 };
 
+enum Themes {
+  dark,
+  bright,
+}
+
 class ThemeService {
   ThemeService() {
+    _controller = StreamController<Themes>.broadcast();
     Themed.defaultTheme = darkTheme;
 
-    _db.watchConfigFlag('show_bright_scheme').listen((bright) {
+    _db.watchConfigFlag(showBrightSchemeFlagName).listen((bright) {
       Themed.currentTheme = bright ? brightTheme : darkTheme;
+      _controller.add(bright ? Themes.bright : Themes.dark);
     });
   }
 
+  late final StreamController<Themes> _controller;
   final _db = getIt<JournalDb>();
+
+  Stream<Themes> getStream() {
+    return _controller.stream;
+  }
 }
 
 const double chipBorderRadius = 8;

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:lotti/classes/tag_type_definitions.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/utils/consts.dart';
 import 'package:themed/themed.dart';
 import 'package:tinycolor2/tinycolor2.dart';
@@ -183,6 +184,7 @@ class ThemeService {
     _db.watchConfigFlag(showBrightSchemeFlagName).listen((bright) {
       Themed.currentTheme = bright ? brightTheme : darkTheme;
       _controller.add(bright ? Themes.bright : Themes.dark);
+      getIt<NavService>().restoreRoute();
     });
   }
 

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -1,5 +1,8 @@
+// ignore_for_file: equal_keys_in_map
 import 'package:flutter/material.dart';
 import 'package:lotti/classes/tag_type_definitions.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/get_it.dart';
 import 'package:themed/themed.dart';
 import 'package:tinycolor2/tinycolor2.dart';
 
@@ -15,54 +18,56 @@ Color getTagColor(TagEntity tagEntity) {
   );
 }
 
+const defaultBaseColor = Color.fromRGBO(51, 77, 118, 1);
+
 class AppColors {
-  static Color entryBgColor = const ColorRef(Color.fromRGBO(155, 200, 245, 1));
-  static Color actionColor = const ColorRef(Color.fromRGBO(155, 200, 245, 1));
-  static Color tagColor = const ColorRef(Color.fromRGBO(155, 200, 245, 1));
-  static Color tagTextColor = ColorRef(editorTextColor);
-  static Color personTagColor = const ColorRef(Color.fromRGBO(55, 201, 154, 1));
-  static Color storyTagColor = const ColorRef(Color.fromRGBO(200, 120, 0, 1));
-  static Color privateTagColor = const ColorRef(Colors.red);
-  static Color bottomNavIconUnselected = ColorRef(entryTextColor);
-  static Color bottomNavIconSelected =
-      const ColorRef(Color.fromRGBO(252, 147, 76, 1));
-  static Color editorTextColor = const ColorRef(Color.fromRGBO(51, 51, 51, 1));
-  static Color starredGold = const ColorRef(Color.fromRGBO(255, 215, 0, 1));
-  static Color editorBgColor = const ColorRef(Colors.white);
+  static const entryBgColor = ColorRef(Color.fromRGBO(155, 200, 245, 1));
+  static const actionColor = ColorRef(Color.fromRGBO(155, 200, 245, 1));
+  static const tagColor = ColorRef(Color.fromRGBO(155, 200, 245, 1));
+  static const tagTextColor = ColorRef(editorTextColor);
+  static const personTagColor = ColorRef(Color.fromRGBO(55, 201, 154, 1));
+  static const storyTagColor = ColorRef(Color.fromRGBO(200, 120, 0, 1));
+  static const privateTagColor = ColorRef(Colors.red);
+  static const bottomNavIconUnselected = ColorRef(entryTextColor);
+  static const bottomNavIconSelected =
+      ColorRef(Color.fromRGBO(252, 147, 76, 1));
+  static const editorTextColor = ColorRef(Color.fromRGBO(51, 51, 51, 1));
+  static const starredGold = ColorRef(Color.fromRGBO(255, 215, 0, 1));
+  static const editorBgColor = ColorRef(Colors.white);
 
-  static Color baseColor = const ColorRef(Color.fromRGBO(51, 77, 118, 1));
+  static const baseColor = ColorRef(Color.fromRGBO(51, 77, 118, 1));
 
-  static Color bodyBgColor = ColorRef(darken(baseColor, 20));
-  static Color headerBgColor = ColorRef(darken(baseColor, 10));
-  static Color entryCardColor = ColorRef(baseColor);
-  static Color entryTextColor =
-      const ColorRef(Color.fromRGBO(200, 195, 190, 1));
+  static final bodyBgColor = ColorRef(darken(baseColor, 20));
+  static final headerBgColor = ColorRef(darken(baseColor, 10));
+  static const entryCardColor = ColorRef(baseColor);
+  static const entryTextColor = ColorRef(Color.fromRGBO(200, 195, 190, 1));
 
-  static Color searchBgColor = const ColorRef(Color.fromRGBO(68, 68, 85, 0.3));
-  static Color appBarFgColor = const ColorRef(Color.fromRGBO(180, 190, 200, 1));
-  static Color codeBlockBackground =
-      const ColorRef(Color.fromRGBO(228, 232, 240, 1));
+  static const searchBgColor = ColorRef(Color.fromRGBO(68, 68, 85, 0.3));
+  static const appBarFgColor = ColorRef(Color.fromRGBO(180, 190, 200, 1));
+  static const codeBlockBackground = ColorRef(Color.fromRGBO(228, 232, 240, 1));
 
-  static Color timeRecording = const ColorRef(Color.fromRGBO(255, 22, 22, 1));
-  static Color timeRecordingBg =
-      const ColorRef(Color.fromRGBO(255, 44, 44, 0.95));
+  static const timeRecording = ColorRef(Color.fromRGBO(255, 22, 22, 1));
+  static const timeRecordingBg = ColorRef(Color.fromRGBO(255, 44, 44, 0.95));
 
-  static Color outboxSuccessColor =
-      const ColorRef(Color.fromRGBO(50, 120, 50, 1));
-  static Color outboxPendingColor =
-      const ColorRef(Color.fromRGBO(200, 120, 0, 1));
-  static Color outboxErrorColor =
-      const ColorRef(Color.fromRGBO(120, 50, 50, 1));
-  static Color headerFontColor = ColorRef(entryBgColor);
-  static Color activeAudioControl = const ColorRef(Colors.red);
-  static Color audioMeterBar = const ColorRef(Colors.blue);
-  static Color audioMeterTooHotBar = const ColorRef(Colors.orange);
-  static Color audioMeterPeakedBar = const ColorRef(Colors.red);
-  static Color error = const ColorRef(Colors.red);
-  static Color private = const ColorRef(Colors.red);
-  static Color audioMeterBarBackground = ColorRef(lighten(headerBgColor, 40));
-  static Color inactiveAudioControl =
-      const ColorRef(Color.fromRGBO(155, 155, 177, 1));
+  static const outboxSuccessColor = ColorRef(Color.fromRGBO(50, 120, 50, 1));
+  static const outboxPendingColor = ColorRef(Color.fromRGBO(200, 120, 0, 1));
+  static const outboxErrorColor = ColorRef(Color.fromRGBO(120, 50, 50, 1));
+  static const headerFontColor = ColorRef(entryBgColor);
+  static const activeAudioControl = ColorRef(Colors.red);
+  static const audioMeterBar = ColorRef(Colors.blue);
+  static const audioMeterTooHotBar = ColorRef(Colors.orange);
+  static const audioMeterPeakedBar = ColorRef(Colors.red);
+  static const error = ColorRef(Colors.red);
+  static const private = ColorRef(Colors.red);
+  static final audioMeterBarBackground = ColorRef(lighten(headerBgColor, 40));
+  static const inactiveAudioControl =
+      ColorRef(Color.fromRGBO(155, 155, 177, 1));
+
+  static const unselectedChoiceChipColor =
+      ColorRef(Color.fromRGBO(200, 195, 190, 1));
+
+  static const unselectedChoiceChipTextColor =
+      ColorRef(Color.fromRGBO(51, 77, 118, 1));
 }
 
 Color darken(Color color, int value) {
@@ -81,6 +86,99 @@ class AppTheme {
   );
 }
 
+Map<ThemeRef, Object> darkTheme = {
+  AppColors.entryBgColor: Colors.white,
+  AppColors.unselectedChoiceChipColor: const Color.fromRGBO(200, 195, 190, 1),
+  AppColors.actionColor: const Color.fromRGBO(155, 200, 245, 1),
+  AppColors.tagColor: const Color.fromRGBO(155, 200, 245, 1),
+  AppColors.tagTextColor: const Color.fromRGBO(51, 51, 51, 1),
+  AppColors.personTagColor: const Color.fromRGBO(55, 201, 154, 1),
+  AppColors.storyTagColor: const Color.fromRGBO(200, 120, 0, 1),
+  AppColors.privateTagColor: Colors.red,
+  AppColors.bottomNavIconUnselected: const Color.fromRGBO(200, 195, 190, 1),
+  AppColors.bottomNavIconSelected: const Color.fromRGBO(252, 147, 76, 1),
+  AppColors.editorTextColor: const Color.fromRGBO(51, 51, 51, 1),
+  AppColors.starredGold: const Color.fromRGBO(255, 215, 0, 1),
+  AppColors.editorBgColor: Colors.white,
+  AppColors.baseColor: const Color.fromRGBO(51, 77, 118, 1),
+  AppColors.bodyBgColor: darken(defaultBaseColor, 20),
+  AppColors.headerBgColor: darken(defaultBaseColor, 10),
+  AppColors.entryCardColor: defaultBaseColor,
+  AppColors.entryTextColor: const Color.fromRGBO(200, 195, 190, 1),
+  AppColors.searchBgColor: const Color.fromRGBO(68, 68, 85, 0.3),
+  AppColors.appBarFgColor: const Color.fromRGBO(180, 190, 200, 1),
+  AppColors.codeBlockBackground: const Color.fromRGBO(228, 232, 240, 1),
+  AppColors.timeRecording: const Color.fromRGBO(255, 22, 22, 1),
+  AppColors.timeRecordingBg: const Color.fromRGBO(255, 44, 44, 0.95),
+  AppColors.outboxSuccessColor: const Color.fromRGBO(50, 120, 50, 1),
+  AppColors.outboxPendingColor: const Color.fromRGBO(200, 120, 0, 1),
+  AppColors.outboxErrorColor: const Color.fromRGBO(120, 50, 50, 1),
+  AppColors.headerFontColor: const Color.fromRGBO(155, 200, 245, 1),
+  AppColors.activeAudioControl: Colors.red,
+  AppColors.audioMeterBar: Colors.blue,
+  AppColors.audioMeterTooHotBar: Colors.orange,
+  AppColors.audioMeterPeakedBar: Colors.red,
+  AppColors.error: Colors.red,
+  AppColors.private: Colors.red,
+  AppColors.audioMeterBarBackground:
+      TinyColor.fromColor(defaultBaseColor).lighten(30).color,
+  AppColors.inactiveAudioControl: const Color.fromRGBO(155, 155, 177, 1),
+  AppColors.unselectedChoiceChipTextColor: const Color.fromRGBO(51, 77, 118, 1),
+};
+const brightBaseColor = Color.fromRGBO(244, 187, 41, 1);
+
+Map<ThemeRef, Object> brightTheme = {
+  AppColors.entryBgColor: Colors.white,
+  AppColors.unselectedChoiceChipColor: const Color.fromRGBO(200, 195, 190, 1),
+  AppColors.actionColor: const Color.fromRGBO(155, 200, 245, 1),
+  AppColors.tagColor: const Color.fromRGBO(155, 200, 245, 1),
+  AppColors.tagTextColor: const Color.fromRGBO(51, 51, 51, 1),
+  AppColors.personTagColor: const Color.fromRGBO(55, 201, 154, 1),
+  AppColors.storyTagColor: const Color.fromRGBO(200, 120, 0, 1),
+  AppColors.privateTagColor: Colors.red,
+  AppColors.bottomNavIconUnselected: const Color.fromRGBO(30, 50, 90, 1),
+  AppColors.bottomNavIconSelected: Colors.white,
+  AppColors.editorTextColor: const Color.fromRGBO(51, 51, 51, 1),
+  AppColors.starredGold: const Color.fromRGBO(255, 215, 0, 1),
+  AppColors.editorBgColor: Colors.white,
+  AppColors.baseColor: const Color.fromRGBO(244, 187, 41, 1),
+  AppColors.bodyBgColor: darken(brightBaseColor, 20),
+  AppColors.headerBgColor: darken(brightBaseColor, 10),
+  AppColors.entryCardColor: brightBaseColor,
+  AppColors.entryTextColor: const Color.fromRGBO(30, 50, 90, 1),
+  AppColors.searchBgColor: const Color.fromRGBO(68, 68, 85, 0.3),
+  AppColors.appBarFgColor: const Color.fromRGBO(180, 190, 200, 1),
+  AppColors.codeBlockBackground: const Color.fromRGBO(228, 232, 240, 1),
+  AppColors.timeRecording: const Color.fromRGBO(255, 22, 22, 1),
+  AppColors.timeRecordingBg: const Color.fromRGBO(255, 44, 44, 0.95),
+  AppColors.outboxSuccessColor: const Color.fromRGBO(50, 120, 50, 1),
+  AppColors.outboxPendingColor: const Color.fromRGBO(200, 120, 0, 1),
+  AppColors.outboxErrorColor: const Color.fromRGBO(120, 50, 50, 1),
+  AppColors.headerFontColor: const Color.fromRGBO(40, 60, 100, 1),
+  AppColors.activeAudioControl: Colors.red,
+  AppColors.audioMeterBar: Colors.blue,
+  AppColors.audioMeterTooHotBar: Colors.orange,
+  AppColors.audioMeterPeakedBar: Colors.red,
+  AppColors.error: Colors.red,
+  AppColors.private: Colors.red,
+  AppColors.audioMeterBarBackground:
+      TinyColor.fromColor(defaultBaseColor).lighten(30).color,
+  AppColors.inactiveAudioControl: const Color.fromRGBO(155, 155, 177, 1),
+  AppColors.unselectedChoiceChipTextColor: const Color.fromRGBO(51, 77, 118, 1),
+};
+
+class ThemeService {
+  ThemeService() {
+    Themed.defaultTheme = darkTheme;
+
+    _db.watchConfigFlag('show_bright_scheme').listen((bright) {
+      Themed.currentTheme = bright ? brightTheme : darkTheme;
+    });
+  }
+
+  final _db = getIt<JournalDb>();
+}
+
 const double chipBorderRadius = 8;
 
 const chipPadding = EdgeInsets.symmetric(
@@ -95,14 +193,14 @@ const chipPaddingClosable = EdgeInsets.only(
   right: 4,
 );
 
-TextStyle inputStyle = TextStyle(
+TextStyle inputStyle = const TextStyle(
   color: AppColors.entryTextColor,
   fontWeight: FontWeight.bold,
   fontFamily: 'Lato',
   fontSize: 18,
 );
 
-TextStyle textStyle = TextStyle(
+TextStyle textStyle = const TextStyle(
   color: AppColors.entryTextColor,
   fontFamily: 'Oswald',
   fontWeight: FontWeight.w400,
@@ -119,62 +217,62 @@ TextStyle labelStyleLarger = textStyleLarger.copyWith(
   fontWeight: FontWeight.w300,
 );
 
-TextStyle labelStyle = TextStyle(
+TextStyle labelStyle = const TextStyle(
   color: AppColors.entryTextColor,
   fontWeight: FontWeight.w500,
   fontSize: 18,
 );
 
-TextStyle formLabelStyle = TextStyle(
+TextStyle formLabelStyle = const TextStyle(
   color: AppColors.entryTextColor,
   fontFamily: 'Oswald',
   fontSize: 16,
 );
 
-TextStyle buttonLabelStyle = TextStyle(
+TextStyle buttonLabelStyle = const TextStyle(
   color: AppColors.entryTextColor,
   fontFamily: 'Oswald',
   fontSize: 16,
 );
 
-TextStyle settingsLabelStyle = TextStyle(
+TextStyle settingsLabelStyle = const TextStyle(
   color: AppColors.entryTextColor,
   fontFamily: 'Oswald',
   fontSize: 16,
 );
 
-TextStyle choiceLabelStyle = TextStyle(
+TextStyle choiceLabelStyle = const TextStyle(
   color: AppColors.entryTextColor,
   fontFamily: 'Oswald',
   fontSize: 16,
 );
 
-TextStyle logDetailStyle = TextStyle(
+TextStyle logDetailStyle = const TextStyle(
   color: AppColors.entryTextColor,
   fontFamily: 'ShareTechMono',
   fontSize: 10,
 );
 
-TextStyle appBarTextStyle = TextStyle(
+TextStyle appBarTextStyle = const TextStyle(
   color: AppColors.entryTextColor,
   fontFamily: 'Oswald',
   fontSize: 20,
 );
 
-TextStyle titleStyle = TextStyle(
+TextStyle titleStyle = const TextStyle(
   color: AppColors.entryTextColor,
   fontFamily: 'Oswald',
   fontSize: 32,
   fontWeight: FontWeight.w300,
 );
 
-TextStyle taskTitleStyle = TextStyle(
+TextStyle taskTitleStyle = const TextStyle(
   color: AppColors.entryTextColor,
   fontFamily: 'Oswald',
   fontSize: 24,
 );
 
-TextStyle multiSelectStyle = TextStyle(
+TextStyle multiSelectStyle = const TextStyle(
   color: AppColors.entryTextColor,
   fontFamily: 'Oswald',
   fontWeight: FontWeight.w100,
@@ -190,7 +288,7 @@ TextStyle chartTitleStyle = TextStyle(
 
 const taskFormFieldStyle = TextStyle(color: Colors.black87);
 
-TextStyle saveButtonStyle = TextStyle(
+TextStyle saveButtonStyle = const TextStyle(
   fontSize: 20,
   fontFamily: 'Oswald',
   color: AppColors.error,
@@ -212,14 +310,14 @@ const bottomNavLabelStyle = TextStyle(
   fontWeight: FontWeight.w300,
 );
 
-final definitionCardTitleStyle = TextStyle(
+const definitionCardTitleStyle = TextStyle(
   color: AppColors.entryTextColor,
   fontFamily: 'Oswald',
   fontSize: 24,
   height: 1.2,
 );
 
-final definitionCardSubtitleStyle = TextStyle(
+const definitionCardSubtitleStyle = TextStyle(
   color: AppColors.entryTextColor,
   fontFamily: 'Oswald',
   fontWeight: FontWeight.w200,

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:lotti/classes/tag_type_definitions.dart';
+import 'package:themed/themed.dart';
 import 'package:tinycolor2/tinycolor2.dart';
 
 Color getTagColor(TagEntity tagEntity) {
@@ -15,52 +16,53 @@ Color getTagColor(TagEntity tagEntity) {
 }
 
 class AppColors {
-  static Color entryBgColor = const Color.fromRGBO(155, 200, 245, 1);
-  static Color actionColor = const Color.fromRGBO(155, 200, 245, 1);
-  static Color tagColor = const Color.fromRGBO(155, 200, 245, 1);
-  static Color tagTextColor = editorTextColor;
-  static Color personTagColor = const Color.fromRGBO(55, 201, 154, 1);
-  static Color storyTagColor = const Color.fromRGBO(200, 120, 0, 1);
-  static Color privateTagColor = Colors.red;
-  static Color bottomNavIconUnselected = entryTextColor;
-  static Color bottomNavIconSelected = const Color.fromRGBO(252, 147, 76, 1);
-  static Color editorTextColor = const Color.fromRGBO(51, 51, 51, 1);
-  static Color starredGold = const Color.fromRGBO(255, 215, 0, 1);
-  static Color yolk = const Color.fromRGBO(244, 187, 41, 1);
-  static Color recordingTextColor = const Color.fromRGBO(224, 224, 224, 0.8);
-  static Color editorBgColor = Colors.white;
+  static Color entryBgColor = const ColorRef(Color.fromRGBO(155, 200, 245, 1));
+  static Color actionColor = const ColorRef(Color.fromRGBO(155, 200, 245, 1));
+  static Color tagColor = const ColorRef(Color.fromRGBO(155, 200, 245, 1));
+  static Color tagTextColor = ColorRef(editorTextColor);
+  static Color personTagColor = const ColorRef(Color.fromRGBO(55, 201, 154, 1));
+  static Color storyTagColor = const ColorRef(Color.fromRGBO(200, 120, 0, 1));
+  static Color privateTagColor = const ColorRef(Colors.red);
+  static Color bottomNavIconUnselected = ColorRef(entryTextColor);
+  static Color bottomNavIconSelected =
+      const ColorRef(Color.fromRGBO(252, 147, 76, 1));
+  static Color editorTextColor = const ColorRef(Color.fromRGBO(51, 51, 51, 1));
+  static Color starredGold = const ColorRef(Color.fromRGBO(255, 215, 0, 1));
+  static Color editorBgColor = const ColorRef(Colors.white);
 
-  static Color baseColor = const Color.fromRGBO(51, 77, 118, 1);
+  static Color baseColor = const ColorRef(Color.fromRGBO(51, 77, 118, 1));
 
-  static Color bodyBgColor = darken(baseColor, 20);
-  static Color headerBgColor = darken(baseColor, 10);
-  static Color entryCardColor = baseColor;
-  static Color entryTextColor = const Color.fromRGBO(200, 195, 190, 1);
+  static Color bodyBgColor = ColorRef(darken(baseColor, 20));
+  static Color headerBgColor = ColorRef(darken(baseColor, 10));
+  static Color entryCardColor = ColorRef(baseColor);
+  static Color entryTextColor =
+      const ColorRef(Color.fromRGBO(200, 195, 190, 1));
 
-  static Color vuBgColor = headerBgColor;
-  static Color searchBgColor = const Color.fromRGBO(68, 68, 85, 0.3);
-  static Color searchBgHoverColor = const Color.fromRGBO(68, 68, 85, 0.6);
-  static Color appBarFgColor = const Color.fromRGBO(180, 190, 200, 1);
-  static Color codeBlockBackground = const Color.fromRGBO(228, 232, 240, 1);
+  static Color searchBgColor = const ColorRef(Color.fromRGBO(68, 68, 85, 0.3));
+  static Color appBarFgColor = const ColorRef(Color.fromRGBO(180, 190, 200, 1));
+  static Color codeBlockBackground =
+      const ColorRef(Color.fromRGBO(228, 232, 240, 1));
 
-  static Color timeRecording = const Color.fromRGBO(255, 22, 22, 1);
-  static Color timeRecordingBg = const Color.fromRGBO(255, 44, 44, 0.95);
+  static Color timeRecording = const ColorRef(Color.fromRGBO(255, 22, 22, 1));
+  static Color timeRecordingBg =
+      const ColorRef(Color.fromRGBO(255, 44, 44, 0.95));
 
-  static Color outboxSuccessColor = const Color.fromRGBO(50, 120, 50, 1);
-  static Color outboxPendingColor = const Color.fromRGBO(200, 120, 0, 1);
-  static Color outboxErrorColor = const Color.fromRGBO(120, 50, 50, 1);
-  static Color headerFontColor = Colors.white;
-  static Color headerFontColor2 = entryBgColor;
-  static Color activeAudioControl = Colors.red;
-  static Color audioMeterBar = Colors.blue;
-  static Color audioMeterTooHotBar = Colors.orange;
-  static Color audioMeterPeakedBar = Colors.red;
-  static Color error = Colors.red;
-  static Color private = Colors.red;
-  static Color audioMeterBarBackground =
-      TinyColor.fromColor(headerBgColor).lighten(40).color;
-  static Color inactiveAudioControl = const Color.fromRGBO(155, 155, 177, 1);
-  static Color listItemText = bodyBgColor;
+  static Color outboxSuccessColor =
+      const ColorRef(Color.fromRGBO(50, 120, 50, 1));
+  static Color outboxPendingColor =
+      const ColorRef(Color.fromRGBO(200, 120, 0, 1));
+  static Color outboxErrorColor =
+      const ColorRef(Color.fromRGBO(120, 50, 50, 1));
+  static Color headerFontColor = ColorRef(entryBgColor);
+  static Color activeAudioControl = const ColorRef(Colors.red);
+  static Color audioMeterBar = const ColorRef(Colors.blue);
+  static Color audioMeterTooHotBar = const ColorRef(Colors.orange);
+  static Color audioMeterPeakedBar = const ColorRef(Colors.red);
+  static Color error = const ColorRef(Colors.red);
+  static Color private = const ColorRef(Colors.red);
+  static Color audioMeterBarBackground = ColorRef(lighten(headerBgColor, 40));
+  static Color inactiveAudioControl =
+      const ColorRef(Color.fromRGBO(155, 155, 177, 1));
 }
 
 Color darken(Color color, int value) {
@@ -69,50 +71,6 @@ Color darken(Color color, int value) {
 
 Color lighten(Color color, int value) {
   return TinyColor.fromColor(color).lighten(value).color;
-}
-
-class AppColors2 {
-  static Color bodyBgColor = const Color.fromRGBO(47, 47, 59, 1);
-  static Color entryBgColor = const Color.fromRGBO(155, 200, 245, 1);
-  static Color actionColor = const Color.fromRGBO(155, 200, 245, 1);
-  static Color tagColor = const Color.fromRGBO(155, 200, 245, 1);
-  static Color tagTextColor = editorTextColor;
-  static Color personTagColor = const Color.fromRGBO(55, 201, 154, 1);
-  static Color storyTagColor = const Color.fromRGBO(200, 120, 0, 1);
-  static Color privateTagColor = Colors.red;
-  static Color entryTextColor = const Color.fromRGBO(158, 158, 158, 1);
-  static Color bottomNavIconUnselected = entryTextColor;
-  static Color bottomNavIconSelected = const Color.fromRGBO(200, 120, 0, 1);
-  static Color editorTextColor = const Color.fromRGBO(51, 51, 51, 1);
-  static Color starredGold = const Color.fromRGBO(255, 215, 0, 1);
-  static Color recordingTextColor = const Color.fromRGBO(224, 224, 224, 0.8);
-  static Color editorBgColor = Colors.white;
-
-  static Color headerBgColor = const Color.fromRGBO(68, 68, 85, 1);
-  static Color vuBgColor = headerBgColor;
-  static Color searchBgColor = const Color.fromRGBO(68, 68, 85, 0.3);
-  static Color searchBgHoverColor = const Color.fromRGBO(68, 68, 85, 0.6);
-  static Color appBarFgColor = const Color.fromRGBO(180, 190, 200, 1);
-  static Color codeBlockBackground = const Color.fromRGBO(228, 232, 240, 1);
-
-  static Color timeRecording = const Color.fromRGBO(255, 22, 22, 1);
-  static Color timeRecordingBg = const Color.fromRGBO(255, 44, 44, 0.95);
-
-  static Color outboxSuccessColor = const Color.fromRGBO(50, 120, 50, 1);
-  static Color outboxPendingColor = const Color.fromRGBO(200, 120, 0, 1);
-  static Color outboxErrorColor = const Color.fromRGBO(120, 50, 50, 1);
-  static Color headerFontColor = Colors.white;
-  static Color headerFontColor2 = entryBgColor;
-  static Color activeAudioControl = Colors.red;
-  static Color audioMeterBar = Colors.blue;
-  static Color audioMeterTooHotBar = Colors.orange;
-  static Color audioMeterPeakedBar = Colors.red;
-  static Color error = Colors.red;
-  static Color private = Colors.red;
-  static Color audioMeterBarBackground =
-      TinyColor.fromColor(headerBgColor).lighten(40).color;
-  static Color inactiveAudioControl = const Color.fromRGBO(155, 155, 177, 1);
-  static Color listItemText = bodyBgColor;
 }
 
 class AppTheme {

--- a/lib/utils/consts.dart
+++ b/lib/utils/consts.dart
@@ -1,0 +1,1 @@
+const showBrightSchemeFlagName = 'show_bright_scheme';

--- a/lib/widgets/app_bar/app_bar_version.dart
+++ b/lib/widgets/app_bar/app_bar_version.dart
@@ -66,7 +66,7 @@ class _VersionAppBarState extends State<VersionAppBar> {
                 ),
                 Text(
                   'v$version ($buildNumber), n = ${snapshot.data}',
-                  style: TextStyle(
+                  style: const TextStyle(
                     color: AppColors.headerFontColor,
                     fontFamily: 'Oswald',
                     fontSize: 10,

--- a/lib/widgets/app_bar/app_bar_version.dart
+++ b/lib/widgets/app_bar/app_bar_version.dart
@@ -53,17 +53,15 @@ class _VersionAppBarState extends State<VersionAppBar> {
         BuildContext context,
         AsyncSnapshot<int> snapshot,
       ) {
-        if (snapshot.data == null) {
-          return const SizedBox.shrink();
-        } else {
-          return AppBar(
-            backgroundColor: AppColors.headerBgColor,
-            title: Column(
-              children: [
-                Text(
-                  widget.title,
-                  style: appBarTextStyle,
-                ),
+        return AppBar(
+          backgroundColor: AppColors.headerBgColor,
+          title: Column(
+            children: [
+              Text(
+                widget.title,
+                style: appBarTextStyle,
+              ),
+              if (snapshot.data != null)
                 Text(
                   'v$version ($buildNumber), n = ${snapshot.data}',
                   style: const TextStyle(
@@ -73,12 +71,11 @@ class _VersionAppBarState extends State<VersionAppBar> {
                     fontWeight: FontWeight.w300,
                   ),
                 ),
-              ],
-            ),
-            centerTitle: true,
-            leading: const TestDetectingAutoLeadingButton(),
-          );
-        }
+            ],
+          ),
+          centerTitle: true,
+          leading: const TestDetectingAutoLeadingButton(),
+        );
       },
     );
   }

--- a/lib/widgets/app_bar/app_bar_version.dart
+++ b/lib/widgets/app_bar/app_bar_version.dart
@@ -67,7 +67,7 @@ class _VersionAppBarState extends State<VersionAppBar> {
                 Text(
                   'v$version ($buildNumber), n = ${snapshot.data}',
                   style: TextStyle(
-                    color: AppColors.headerFontColor2,
+                    color: AppColors.headerFontColor,
                     fontFamily: 'Oswald',
                     fontSize: 10,
                     fontWeight: FontWeight.w300,

--- a/lib/widgets/app_bar/title_app_bar.dart
+++ b/lib/widgets/app_bar/title_app_bar.dart
@@ -20,7 +20,12 @@ class TitleAppBar extends StatelessWidget with PreferredSizeWidget {
     return AppBar(
       actions: actions,
       backgroundColor: AppColors.headerBgColor,
-      title: Text(title, style: appBarTextStyle),
+      title: Text(
+        title,
+        style: appBarTextStyle.copyWith(
+          color: AppColors.entryTextColor,
+        ),
+      ),
       centerTitle: true,
       leading: const TestDetectingAutoLeadingButton(),
     );

--- a/lib/widgets/audio/audio_recorder.dart
+++ b/lib/widgets/audio/audio_recorder.dart
@@ -58,7 +58,7 @@ class AudioRecorderWidget extends StatelessWidget {
                   padding: const EdgeInsets.all(8),
                   child: Text(
                     formatDuration(state.progress.toString()),
-                    style: TextStyle(
+                    style: const TextStyle(
                       fontFamily: 'ShareTechMono',
                       fontSize: 32,
                       color: AppColors.inactiveAudioControl,
@@ -72,7 +72,7 @@ class AudioRecorderWidget extends StatelessWidget {
               padding: const EdgeInsets.all(8),
               child: Text(
                 formatDecibels(state.decibels),
-                style: TextStyle(
+                style: const TextStyle(
                   fontFamily: 'ShareTechMono',
                   fontSize: 20,
                   color: AppColors.inactiveAudioControl,

--- a/lib/widgets/audio/audio_recording_indicator.dart
+++ b/lib/widgets/audio/audio_recording_indicator.dart
@@ -41,7 +41,7 @@ class AudioRecordingIndicator extends StatelessWidget {
                       Row(
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: <Widget>[
-                          Icon(
+                          const Icon(
                             Icons.mic,
                             size: 24,
                             color: AppColors.editorTextColor,
@@ -50,7 +50,7 @@ class AudioRecordingIndicator extends StatelessWidget {
                             padding: const EdgeInsets.only(left: 4),
                             child: Text(
                               formatDuration(state.progress),
-                              style: TextStyle(
+                              style: const TextStyle(
                                 fontFamily: 'ShareTechMono',
                                 fontSize: 18,
                                 color: AppColors.editorTextColor,

--- a/lib/widgets/journal/entry_detail_linked.dart
+++ b/lib/widgets/journal/entry_detail_linked.dart
@@ -45,7 +45,7 @@ class _LinkedEntriesWidgetState extends State<LinkedEntriesWidget> {
             children: [
               Text(
                 localizations.journalLinkedEntriesLabel,
-                style: TextStyle(
+                style: const TextStyle(
                   color: AppColors.entryTextColor,
                   fontFamily: 'Oswald',
                 ),

--- a/lib/widgets/journal/entry_detail_linked_from.dart
+++ b/lib/widgets/journal/entry_detail_linked_from.dart
@@ -51,7 +51,7 @@ class _LinkedFromEntriesWidgetState extends State<LinkedFromEntriesWidget> {
               children: [
                 Text(
                   localizations.journalLinkedFromLabel,
-                  style: TextStyle(
+                  style: const TextStyle(
                     color: AppColors.entryTextColor,
                     fontFamily: 'Oswald',
                   ),

--- a/lib/widgets/journal/entry_details/survey_summary.dart
+++ b/lib/widgets/journal/entry_details/survey_summary.dart
@@ -33,7 +33,7 @@ class SurveySummary extends StatelessWidget {
                   children: [
                     Text(
                       '${mapEntry.key}: ',
-                      style: TextStyle(
+                      style: const TextStyle(
                         fontWeight: FontWeight.w900,
                         fontFamily: 'Lato',
                         color: AppColors.entryTextColor,
@@ -42,7 +42,7 @@ class SurveySummary extends StatelessWidget {
                     ),
                     Text(
                       mapEntry.value.toString(),
-                      style: TextStyle(
+                      style: const TextStyle(
                         fontWeight: FontWeight.w400,
                         fontSize: 16,
                         color: AppColors.entryTextColor,

--- a/lib/widgets/journal/entry_tools.dart
+++ b/lib/widgets/journal/entry_tools.dart
@@ -63,7 +63,7 @@ class InfoText extends StatelessWidget {
     return Text(
       text,
       maxLines: maxLines,
-      style: TextStyle(
+      style: const TextStyle(
         fontFamily: 'ShareTechMono',
         fontSize: 14,
         color: AppColors.entryTextColor,

--- a/lib/widgets/journal/helpers.dart
+++ b/lib/widgets/journal/helpers.dart
@@ -20,7 +20,7 @@ class EntryTextWidget extends StatelessWidget {
       child: Text(
         text,
         maxLines: maxLines,
-        style: TextStyle(
+        style: const TextStyle(
           fontFamily: 'ShareTechMono',
           color: AppColors.entryTextColor,
           fontWeight: FontWeight.w300,

--- a/lib/widgets/journal/journal_card.dart
+++ b/lib/widgets/journal/journal_card.dart
@@ -40,7 +40,7 @@ class JournalCardTitle extends StatelessWidget {
             children: [
               Text(
                 df.format(item.meta.dateFrom),
-                style: TextStyle(
+                style: const TextStyle(
                   color: AppColors.entryTextColor,
                   fontSize: 14,
                   fontWeight: FontWeight.w300,
@@ -52,7 +52,7 @@ class JournalCardTitle extends StatelessWidget {
                 children: [
                   Visibility(
                     visible: fromNullableBool(item.meta.private),
-                    child: Icon(
+                    child: const Icon(
                       MdiIcons.security,
                       color: AppColors.error,
                       size: iconSize,
@@ -60,8 +60,8 @@ class JournalCardTitle extends StatelessWidget {
                   ),
                   Visibility(
                     visible: fromNullableBool(item.meta.starred),
-                    child: Padding(
-                      padding: const EdgeInsets.only(left: 4),
+                    child: const Padding(
+                      padding: EdgeInsets.only(left: 4),
                       child: Icon(
                         MdiIcons.star,
                         color: AppColors.starredGold,
@@ -71,8 +71,8 @@ class JournalCardTitle extends StatelessWidget {
                   ),
                   Visibility(
                     visible: item.meta.flag == EntryFlag.import,
-                    child: Padding(
-                      padding: const EdgeInsets.only(left: 4),
+                    child: const Padding(
+                      padding: EdgeInsets.only(left: 4),
                       child: Icon(
                         MdiIcons.flag,
                         color: AppColors.error,
@@ -108,7 +108,7 @@ class JournalCardTitle extends StatelessWidget {
                   children: [
                     Text(
                       data.title,
-                      style: TextStyle(
+                      style: const TextStyle(
                         fontFamily: 'Oswald',
                         color: AppColors.entryTextColor,
                         fontWeight: FontWeight.normal,
@@ -129,7 +129,7 @@ class JournalCardTitle extends StatelessWidget {
             task: (_) => const SizedBox.shrink(),
             orElse: () => DurationWidget(
               item: item,
-              style: TextStyle(
+              style: const TextStyle(
                 color: AppColors.entryTextColor,
                 fontSize: 14,
                 fontWeight: FontWeight.w300,

--- a/lib/widgets/journal/tags_widget.dart
+++ b/lib/widgets/journal/tags_widget.dart
@@ -172,7 +172,7 @@ class TagAddIconWidget extends StatelessWidget {
                                   top: 16,
                                   bottom: 16,
                                 ),
-                                icon: Icon(
+                                icon: const Icon(
                                   MdiIcons.contentCopy,
                                   color: AppColors.entryTextColor,
                                 ),
@@ -185,7 +185,7 @@ class TagAddIconWidget extends StatelessWidget {
                                   top: 16,
                                   bottom: 16,
                                 ),
-                                icon: Icon(
+                                icon: const Icon(
                                   MdiIcons.contentPaste,
                                   color: AppColors.entryTextColor,
                                 ),
@@ -203,7 +203,7 @@ class TagAddIconWidget extends StatelessWidget {
 
             return IconButton(
               onPressed: onTapAdd,
-              icon: Icon(
+              icon: const Icon(
                 MdiIcons.tagPlusOutline,
                 size: 24,
                 color: AppColors.entryTextColor,
@@ -321,7 +321,7 @@ class TagWidget extends StatelessWidget {
                 padding: const EdgeInsets.only(bottom: 2),
                 child: Text(
                   tagEntity.tag,
-                  style: TextStyle(
+                  style: const TextStyle(
                     fontSize: 14,
                     fontFamily: 'Oswald',
                     color: AppColors.tagTextColor,
@@ -332,7 +332,7 @@ class TagWidget extends StatelessWidget {
                 onPressed: onTapRemove,
                 padding: const EdgeInsets.only(left: 4),
                 constraints: const BoxConstraints(maxHeight: 16, maxWidth: 20),
-                icon: Icon(
+                icon: const Icon(
                   MdiIcons.close,
                   size: 16,
                   color: AppColors.tagTextColor,

--- a/lib/widgets/misc/desktop_menu.dart
+++ b/lib/widgets/misc/desktop_menu.dart
@@ -3,9 +3,11 @@ import 'dart:io';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:lotti/classes/entry_text.dart';
+import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/nav_service.dart';
+import 'package:lotti/utils/consts.dart';
 import 'package:lotti/utils/screenshots.dart';
 
 class DesktopMenuWrapper extends StatelessWidget {
@@ -15,6 +17,7 @@ class DesktopMenuWrapper extends StatelessWidget {
   });
 
   final PersistenceLogic _persistenceLogic = getIt<PersistenceLogic>();
+  final JournalDb _db = getIt<JournalDb>();
   final Widget body;
 
   @override
@@ -23,101 +26,124 @@ class DesktopMenuWrapper extends StatelessWidget {
       return body;
     }
 
-    return PlatformMenuBar(
-      body: body,
-      menus: <MenuItem>[
-        const PlatformMenu(
-          label: 'Lotti',
-          menus: [
-            PlatformProvidedMenuItem(
-              type: PlatformProvidedMenuItemType.about,
-            ),
-            PlatformMenuItemGroup(
-              members: [
+    return StreamBuilder<bool>(
+      //stream: getIt<ThemeService>().getStream(),
+      stream: _db.watchConfigFlag(showBrightSchemeFlagName),
+      builder: (context, snapshot) {
+        return PlatformMenuBar(
+          body: body,
+          menus: <MenuItem>[
+            const PlatformMenu(
+              label: 'Lotti',
+              menus: [
                 PlatformProvidedMenuItem(
-                  type: PlatformProvidedMenuItemType.servicesSubmenu,
+                  type: PlatformProvidedMenuItemType.about,
+                ),
+                PlatformMenuItemGroup(
+                  members: [
+                    PlatformProvidedMenuItem(
+                      type: PlatformProvidedMenuItemType.servicesSubmenu,
+                    ),
+                  ],
+                ),
+                PlatformMenuItemGroup(
+                  members: [
+                    PlatformProvidedMenuItem(
+                      type: PlatformProvidedMenuItemType.hide,
+                    ),
+                  ],
+                ),
+                PlatformProvidedMenuItem(
+                  type: PlatformProvidedMenuItemType.quit,
                 ),
               ],
-            ),
-            PlatformMenuItemGroup(
-              members: [
-                PlatformProvidedMenuItem(
-                  type: PlatformProvidedMenuItemType.hide,
-                ),
-              ],
-            ),
-            PlatformProvidedMenuItem(
-              type: PlatformProvidedMenuItemType.quit,
-            ),
-          ],
-        ),
-        PlatformMenu(
-          label: 'File',
-          menus: [
-            PlatformMenuItem(
-              label: 'New Entry',
-              onSelected: () async {
-                final linkedId = await getIdFromSavedRoute();
-                if (linkedId != null) {
-                  await _persistenceLogic.createTextEntry(
-                    EntryText(plainText: ''),
-                    linkedId: linkedId,
-                    started: DateTime.now(),
-                  );
-                } else {
-                  pushNamedRoute('/journal/create/$linkedId');
-                }
-              },
-              shortcut: const SingleActivator(
-                LogicalKeyboardKey.keyN,
-                meta: true,
-              ),
             ),
             PlatformMenu(
-              label: 'New ...',
+              label: 'File',
               menus: [
                 PlatformMenuItem(
-                  label: 'Task',
-                  shortcut: const SingleActivator(
-                    LogicalKeyboardKey.keyT,
-                    meta: true,
-                  ),
+                  label: 'New Entry',
                   onSelected: () async {
                     final linkedId = await getIdFromSavedRoute();
-                    pushNamedRoute('/tasks/create/$linkedId');
+                    if (linkedId != null) {
+                      await _persistenceLogic.createTextEntry(
+                        EntryText(plainText: ''),
+                        linkedId: linkedId,
+                        started: DateTime.now(),
+                      );
+                    } else {
+                      pushNamedRoute('/journal/create/$linkedId');
+                    }
                   },
-                ),
-                PlatformMenuItem(
-                  label: 'Screenshot',
                   shortcut: const SingleActivator(
-                    LogicalKeyboardKey.keyS,
+                    LogicalKeyboardKey.keyN,
                     meta: true,
-                    alt: true,
                   ),
-                  onSelected: () async {
-                    await takeScreenshotWithLinked();
-                  },
+                ),
+                PlatformMenu(
+                  label: 'New ...',
+                  menus: [
+                    PlatformMenuItem(
+                      label: 'Task',
+                      shortcut: const SingleActivator(
+                        LogicalKeyboardKey.keyT,
+                        meta: true,
+                      ),
+                      onSelected: () async {
+                        final linkedId = await getIdFromSavedRoute();
+                        pushNamedRoute('/tasks/create/$linkedId');
+                      },
+                    ),
+                    PlatformMenuItem(
+                      label: 'Screenshot',
+                      shortcut: const SingleActivator(
+                        LogicalKeyboardKey.keyS,
+                        meta: true,
+                        alt: true,
+                      ),
+                      onSelected: () async {
+                        await takeScreenshotWithLinked();
+                      },
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            const PlatformMenu(
+              label: 'Edit',
+              menus: [],
+            ),
+            PlatformMenu(
+              label: 'View',
+              menus: [
+                const PlatformProvidedMenuItem(
+                  type: PlatformProvidedMenuItemType.toggleFullScreen,
+                ),
+                const PlatformProvidedMenuItem(
+                  type: PlatformProvidedMenuItemType.zoomWindow,
+                ),
+                PlatformMenuItemGroup(
+                  members: [
+                    PlatformMenuItem(
+                      label: snapshot.data ?? false
+                          ? 'Disable Bright Theme'
+                          : 'Enable Bright theme',
+                      shortcut: const SingleActivator(
+                        LogicalKeyboardKey.keyS,
+                        meta: true,
+                        alt: true,
+                      ),
+                      onSelected: () async {
+                        await _db.toggleConfigFlag(showBrightSchemeFlagName);
+                      },
+                    ),
+                  ],
                 ),
               ],
             ),
           ],
-        ),
-        const PlatformMenu(
-          label: 'Edit',
-          menus: [],
-        ),
-        const PlatformMenu(
-          label: 'View',
-          menus: [
-            PlatformProvidedMenuItem(
-              type: PlatformProvidedMenuItemType.toggleFullScreen,
-            ),
-            PlatformProvidedMenuItem(
-              type: PlatformProvidedMenuItemType.zoomWindow,
-            ),
-          ],
-        ),
-      ],
+        );
+      },
     );
   }
 }

--- a/lib/widgets/misc/tasks_counts.dart
+++ b/lib/widgets/misc/tasks_counts.dart
@@ -69,7 +69,7 @@ class TasksCountWidget extends StatelessWidget {
             padding: const EdgeInsets.symmetric(horizontal: 4),
             child: Text(
               '$label: ${snapshot.data}',
-              style: TextStyle(
+              style: const TextStyle(
                 color: AppColors.headerFontColor,
                 fontFamily: 'Oswald',
                 fontSize: 12,

--- a/lib/widgets/misc/tasks_counts.dart
+++ b/lib/widgets/misc/tasks_counts.dart
@@ -70,7 +70,7 @@ class TasksCountWidget extends StatelessWidget {
             child: Text(
               '$label: ${snapshot.data}',
               style: TextStyle(
-                color: AppColors.headerFontColor2,
+                color: AppColors.headerFontColor,
                 fontFamily: 'Oswald',
                 fontSize: 12,
                 fontWeight: FontWeight.w100,

--- a/lib/widgets/misc/time_recording_indicator.dart
+++ b/lib/widgets/misc/time_recording_indicator.dart
@@ -48,7 +48,7 @@ class TimeRecordingIndicatorWidget extends StatelessWidget {
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    Icon(
+                    const Icon(
                       MdiIcons.timerOutline,
                       color: AppColors.editorTextColor,
                       size: 16,
@@ -57,7 +57,7 @@ class TimeRecordingIndicatorWidget extends StatelessWidget {
                       padding: const EdgeInsets.only(left: 4),
                       child: Text(
                         durationString,
-                        style: TextStyle(
+                        style: const TextStyle(
                           fontFamily: 'ShareTechMono',
                           fontSize: 18,
                           color: AppColors.editorTextColor,

--- a/lib/widgets/settings/dashboards/dashboard_definition_card.dart
+++ b/lib/widgets/settings/dashboards/dashboard_definition_card.dart
@@ -44,7 +44,7 @@ class DashboardDefinitionCard extends StatelessWidget {
               const Spacer(),
               Visibility(
                 visible: dashboard.private,
-                child: Icon(
+                child: const Icon(
                   MdiIcons.security,
                   color: AppColors.error,
                   size: settingsIconSize,

--- a/lib/widgets/settings/measurables/measurable_type_card.dart
+++ b/lib/widgets/settings/measurables/measurable_type_card.dart
@@ -59,7 +59,7 @@ class MeasurableTypeCard extends StatelessWidget {
                     children: [
                       Visibility(
                         visible: fromNullableBool(item.private),
-                        child: Icon(
+                        child: const Icon(
                           MdiIcons.security,
                           color: AppColors.error,
                           size: settingsIconSize,
@@ -67,8 +67,8 @@ class MeasurableTypeCard extends StatelessWidget {
                       ),
                       Visibility(
                         visible: fromNullableBool(item.favorite),
-                        child: Padding(
-                          padding: const EdgeInsets.only(left: 4),
+                        child: const Padding(
+                          padding: EdgeInsets.only(left: 4),
                           child: Icon(
                             MdiIcons.star,
                             color: AppColors.starredGold,

--- a/lib/widgets/sync/imap_config_status.dart
+++ b/lib/widgets/sync/imap_config_status.dart
@@ -40,12 +40,14 @@ class ImapConfigStatus extends StatelessWidget {
                 ),
               state.when(
                 configured: (_, __) =>
-                    StatusIndicator(AppColors.outboxSuccessColor),
-                imapValid: (_) => StatusIndicator(AppColors.outboxSuccessColor),
-                imapSaved: (_) => StatusIndicator(AppColors.outboxSuccessColor),
+                    const StatusIndicator(AppColors.outboxSuccessColor),
+                imapValid: (_) =>
+                    const StatusIndicator(AppColors.outboxSuccessColor),
+                imapSaved: (_) =>
+                    const StatusIndicator(AppColors.outboxSuccessColor),
                 imapTesting: (_) =>
-                    StatusIndicator(AppColors.outboxPendingColor),
-                imapInvalid: (_, __) => StatusIndicator(AppColors.error),
+                    const StatusIndicator(AppColors.outboxPendingColor),
+                imapInvalid: (_, __) => const StatusIndicator(AppColors.error),
                 loading: () => const StatusIndicator(Colors.grey),
                 generating: () => const StatusIndicator(Colors.grey),
                 empty: () => const StatusIndicator(Colors.grey),

--- a/lib/widgets/sync/qr_widget.dart
+++ b/lib/widgets/sync/qr_widget.dart
@@ -232,7 +232,7 @@ class StatusTextWidget extends StatelessWidget {
       padding: const EdgeInsets.all(8),
       child: Text(
         label,
-        style: TextStyle(
+        style: const TextStyle(
           fontFamily: 'ShareTechMono',
           color: AppColors.entryTextColor,
         ),

--- a/lib/widgets/tasks/linked_duration.dart
+++ b/lib/widgets/tasks/linked_duration.dart
@@ -60,7 +60,7 @@ class LinkedDuration extends StatelessWidget {
                         barHeight: 4,
                         thumbRadius: 6,
                         onSeek: (newPosition) {},
-                        timeLabelTextStyle: TextStyle(
+                        timeLabelTextStyle: const TextStyle(
                           fontFamily: 'Oswald',
                           color: AppColors.entryTextColor,
                           fontWeight: FontWeight.normal,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1983,6 +1983,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.13"
+  themed:
+    dependency: "direct main"
+    description:
+      name: themed
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.2"
   timezone:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.82+1075
+version: 0.8.82+1076
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.82+1073
+version: 0.8.82+1074
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.82+1074
+version: 0.8.82+1075
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.82+1076
+version: 0.8.82+1077
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.82+1071
+version: 0.8.82+1073
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -131,6 +131,7 @@ dependencies:
   sqlite3_flutter_libs: ^0.5.2
   syncfusion_flutter_calendar: ^20.1.47
   syncfusion_flutter_datepicker: ^20.1.47
+  themed: ^3.0.2
   timezone: ^0.8.0
   tinycolor2: ^2.0.0
   tuple: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.81+1068
+version: 0.8.82+1071
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR adds changing the colors in the app during runtime, currently implemented as a config flag for toggling between a dark and a bright theme. The latter needs work, only a few colors have been changed so far, leading to poor contrast in some areas (to be tackled in a subsequent PR). Toggling between themes can be done in either `Settings > Config Flags` or via the menu on desktop. Competent design input would be helpful.

Further down the line, color themes need to become serializable to allow a catalog of themes to pick from, and potentially also themes as (shareable?) user-generated content.