### PR TITLE
Cancel notifications for deleted dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed:
+- Remove notifications for deleted dashboards
+
+## [0.8.82] - 2022-06-29
 ### Added:
 - Bright ☀️ color scheme with config flag
 - Change️ color scheme from menu on desktop

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -75,6 +75,7 @@
   "journalTagsRemoveHint": "Remove tag",
   "journalToolbarSaveHint": "Save entry",
   "journalUnlinkText": "Unlink entry",
+  "maintenanceCancelNotifications": "Cancel all notifications",
   "maintenanceDeleteEditorDb": "Delete editor drafts database",
   "maintenanceDeleteLoggingDb": "Delete logging database",
   "maintenanceDeleteTagged": "Delete tagged",

--- a/lib/logic/persistence_logic.dart
+++ b/lib/logic/persistence_logic.dart
@@ -943,7 +943,7 @@ class PersistenceLogic {
       ),
     );
 
-    if (dashboard.reviewAt != null) {
+    if (dashboard.reviewAt != null && dashboard.deletedAt != null) {
       await getIt<NotificationService>().scheduleNotification(
         title: 'Time for a Dashboard Review!',
         body: dashboard.name,
@@ -952,6 +952,19 @@ class PersistenceLogic {
         deepLink: '/dashboards/${dashboard.id}',
       );
     }
+
+    return linesAffected;
+  }
+
+  Future<int> deleteDashboardDefinition(DashboardDefinition dashboard) async {
+    final linesAffected = await upsertDashboardDefinition(
+      dashboard.copyWith(
+        deletedAt: DateTime.now(),
+      ),
+    );
+
+    await getIt<NotificationService>()
+        .cancelNotification(dashboard.id.hashCode);
 
     return linesAffected;
   }

--- a/lib/pages/settings/dashboards/dashboard_definition_page.dart
+++ b/lib/pages/settings/dashboards/dashboard_definition_page.dart
@@ -493,10 +493,8 @@ class _DashboardDefinitionPageState extends State<DashboardDefinitionPage> {
 
                                         if (result == deleteKey) {
                                           await persistenceLogic
-                                              .upsertDashboardDefinition(
-                                            widget.dashboard.copyWith(
-                                              deletedAt: DateTime.now(),
-                                            ),
+                                              .deleteDashboardDefinition(
+                                            widget.dashboard,
                                           );
 
                                           await getIt<AppRouter>().pop();

--- a/lib/pages/settings/maintenance_page.dart
+++ b/lib/pages/settings/maintenance_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/maintenance.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/notification_service.dart';
 import 'package:lotti/services/sync_config_service.dart';
 import 'package:lotti/theme.dart';
 import 'package:lotti/widgets/app_bar/title_app_bar.dart';
@@ -78,6 +79,10 @@ class _MaintenancePageState extends State<MaintenancePage> {
                   MaintenanceCard(
                     title: localizations.maintenanceReprocessSync,
                     onTap: () => getIt<SyncConfigService>().resetOffset(),
+                  ),
+                  MaintenanceCard(
+                    title: localizations.maintenanceCancelNotifications,
+                    onTap: () => getIt<NotificationService>().cancelAll(),
                   ),
                 ],
               );

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -177,6 +177,22 @@ class NotificationService {
     );
   }
 
+  Future<void> cancelNotification(int notificationId) async {
+    if (Platform.isWindows || Platform.isLinux) {
+      return;
+    }
+
+    await flutterLocalNotificationsPlugin.cancel(notificationId);
+  }
+
+  Future<void> cancelAll() async {
+    if (Platform.isWindows || Platform.isLinux) {
+      return;
+    }
+
+    await flutterLocalNotificationsPlugin.cancelAll();
+  }
+
   Future<void> showNotification({
     required String title,
     required String body,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.82+1081
+version: 0.8.83+1082
 
 msix_config:
   display_name: Lotti

--- a/test/pages/settings/dashboards/dashboard_definition_page_test.dart
+++ b/test/pages/settings/dashboards/dashboard_definition_page_test.dart
@@ -230,7 +230,7 @@ void main() {
         'then tapping delete', (tester) async {
       final formKey = GlobalKey<FormBuilderState>();
 
-      when(() => mockPersistenceLogic.upsertDashboardDefinition(any()))
+      when(() => mockPersistenceLogic.deleteDashboardDefinition(any()))
           .thenAnswer((_) async => 1);
 
       when(
@@ -309,7 +309,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // delete button calls mocked function
-      verify(() => mockPersistenceLogic.upsertDashboardDefinition(any()))
+      verify(() => mockPersistenceLogic.deleteDashboardDefinition(any()))
           .called(1);
     });
 


### PR DESCRIPTION
This PR adds the cancellation of notifications for deleted dashboards. Also, a maintenance action is added for cancelling all notifications, after which dashboards need to be saved again for notifications to take effect.

Notifications need more work, both on the code level and on the functionality side.

Fixes #1105 