### PR TITLE
Fix navigation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Changed:
-- Build Android on GitHub Actions
+### Fixed:
+- Navigation pop after changing entry date
+- Navigation pop after adding measurement
 
 ## [0.8.83] - 2022-06-30
 ### Fixed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed:
 - Navigation pop after changing entry date
 - Navigation pop after adding measurement
+- Entry text color in for creating measurable
 
 ## [0.8.83] - 2022-06-30
 ### Fixed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed:
+- FadeIn animation on new measurement page
+
 ### Fixed:
 - Navigation pop after changing entry date
 - Navigation pop after adding measurement

--- a/lib/pages/create/create_measurement_page.dart
+++ b/lib/pages/create/create_measurement_page.dart
@@ -180,7 +180,7 @@ class _CreateMeasurementPageState extends State<CreateMeasurementPage> {
                                           style: titleStyle.copyWith(
                                             decoration:
                                                 TextDecoration.underline,
-                                            color: AppColors.tagColor,
+                                            color: AppColors.entryTextColor,
                                           ),
                                           wrapWords: false,
                                           maxLines: 3,

--- a/lib/pages/create/create_measurement_page.dart
+++ b/lib/pages/create/create_measurement_page.dart
@@ -2,6 +2,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_datetime_picker/flutter_datetime_picker.dart';
+import 'package:flutter_fadein/flutter_fadein.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:form_builder_validators/form_builder_validators.dart';
@@ -137,187 +138,194 @@ class _CreateMeasurementPageState extends State<CreateMeasurementPage> {
             ],
           ),
           backgroundColor: AppColors.bodyBgColor,
-          body: Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              children: [
-                ClipRRect(
-                  borderRadius: BorderRadius.circular(16),
-                  child: Container(
-                    color: AppColors.headerBgColor,
-                    width: MediaQuery.of(context).size.width,
-                    padding: const EdgeInsets.all(32),
-                    child: FormBuilder(
-                      key: _formKey,
-                      autovalidateMode: AutovalidateMode.onUserInteraction,
-                      onChanged: () {
-                        setState(() {
-                          dirty = true;
-                        });
-                      },
-                      child: Column(
-                        children: <Widget>[
-                          if (items.isEmpty)
-                            Row(
-                              children: [
-                                MouseRegion(
-                                  cursor: SystemMouseCursors.click,
-                                  child: GestureDetector(
-                                    onTap: () {
-                                      pushNamedRoute(
-                                        '/settings/create_measurable',
-                                      );
-                                    },
-                                    child: SizedBox(
-                                      width: MediaQuery.of(context).size.width -
-                                          100,
-                                      child: AutoSizeText(
-                                        localizations.addMeasurementNoneDefined,
-                                        style: titleStyle.copyWith(
-                                          decoration: TextDecoration.underline,
-                                          color: AppColors.tagColor,
-                                        ),
-                                        wrapWords: false,
-                                        maxLines: 3,
-                                      ),
-                                    ),
-                                  ),
-                                ),
-                              ],
-                            ),
-                          if (items.isNotEmpty)
-                            Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Row(
-                                  mainAxisAlignment:
-                                      MainAxisAlignment.spaceBetween,
-                                  children: [
-                                    Expanded(
-                                      child: Text(
-                                        selected?.displayName ?? '',
-                                        style: const TextStyle(
-                                          color: AppColors.entryTextColor,
-                                          fontFamily: 'Oswald',
-                                          fontSize: 24,
-                                        ),
-                                      ),
-                                    ),
-                                    IconButton(
-                                      icon: const Icon(Icons.settings_outlined),
-                                      color: AppColors.entryTextColor,
-                                      onPressed: () {
-                                        getIt<AppRouter>().pushNamed(
-                                          '/settings/measurables/${selected?.id}',
+          body: FadeIn(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(16),
+                    child: Container(
+                      color: AppColors.headerBgColor,
+                      width: MediaQuery.of(context).size.width,
+                      padding: const EdgeInsets.all(32),
+                      child: FormBuilder(
+                        key: _formKey,
+                        autovalidateMode: AutovalidateMode.onUserInteraction,
+                        onChanged: () {
+                          setState(() {
+                            dirty = true;
+                          });
+                        },
+                        child: Column(
+                          children: <Widget>[
+                            if (snapshot.hasData && items.isEmpty)
+                              Row(
+                                children: [
+                                  MouseRegion(
+                                    cursor: SystemMouseCursors.click,
+                                    child: GestureDetector(
+                                      onTap: () {
+                                        pushNamedRoute(
+                                          '/settings/create_measurable',
                                         );
                                       },
-                                    ),
-                                  ],
-                                ),
-                                if (selected?.description != null)
-                                  Text(
-                                    selected!.description,
-                                    style: const TextStyle(
-                                      color: AppColors.entryTextColor,
-                                      fontFamily: 'Oswald',
-                                      fontWeight: FontWeight.w300,
-                                      fontSize: 14,
-                                    ),
-                                  ),
-                                if (selected == null)
-                                  FormBuilderDropdown<MeasurableDataType>(
-                                    dropdownColor: AppColors.headerBgColor,
-                                    name: 'type',
-                                    decoration: InputDecoration(
-                                      labelText: 'Type',
-                                      labelStyle: labelStyle,
-                                    ),
-                                    hint: Text(
-                                      'Select Measurement Type',
-                                      style: inputStyle,
-                                    ),
-                                    onChanged: (MeasurableDataType? value) {
-                                      setState(() {
-                                        selected = value;
-                                      });
-                                    },
-                                    validator: FormBuilderValidators.compose(
-                                      [FormBuilderValidators.required()],
-                                    ),
-                                    items: items
-                                        .map(
-                                          (MeasurableDataType item) =>
-                                              DropdownMenuItem(
-                                            value: item,
-                                            child: Text(
-                                              item.displayName,
-                                              style: inputStyle,
-                                            ),
+                                      child: SizedBox(
+                                        width:
+                                            MediaQuery.of(context).size.width -
+                                                100,
+                                        child: AutoSizeText(
+                                          localizations
+                                              .addMeasurementNoneDefined,
+                                          style: titleStyle.copyWith(
+                                            decoration:
+                                                TextDecoration.underline,
+                                            color: AppColors.tagColor,
                                           ),
-                                        )
-                                        .toList(),
-                                  ),
-                                if (selected != null)
-                                  FormBuilderCupertinoDateTimePicker(
-                                    name: 'date',
-                                    alwaysUse24HourFormat: true,
-                                    format: DateFormat(
-                                      "EEEE, MMMM d, yyyy 'at' HH:mm",
-                                    ),
-                                    style: inputStyle,
-                                    decoration: InputDecoration(
-                                      labelText: 'Measurement taken',
-                                      labelStyle: labelStyle,
-                                    ),
-                                    initialValue: DateTime.now(),
-                                    theme: DatePickerTheme(
-                                      headerColor: AppColors.headerBgColor,
-                                      backgroundColor: AppColors.bodyBgColor,
-                                      itemStyle: const TextStyle(
-                                        color: Colors.white,
-                                        fontWeight: FontWeight.bold,
-                                        fontSize: 18,
-                                      ),
-                                      doneStyle: const TextStyle(
-                                        color: Colors.white,
-                                        fontSize: 16,
+                                          wrapWords: false,
+                                          maxLines: 3,
+                                        ),
                                       ),
                                     ),
                                   ),
-                                if (selected != null)
-                                  FormBuilderTextField(
-                                    initialValue: '',
-                                    key: const Key('measurement_value_field'),
-                                    decoration: InputDecoration(
-                                      labelText: '${selected?.displayName} '
-                                          '${'${selected?.unitName}'.isNotEmpty ? '[${selected?.unitName}] ' : ''}',
-                                      labelStyle: labelStyle,
-                                    ),
-                                    keyboardAppearance: Brightness.dark,
-                                    style: inputStyle,
-                                    autofocus: true,
-                                    validator: FormBuilderValidators.required(),
-                                    name: 'value',
-                                    keyboardType:
-                                        const TextInputType.numberWithOptions(
-                                      decimal: true,
-                                    ),
+                                ],
+                              ),
+                            if (items.isNotEmpty)
+                              Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Row(
+                                    mainAxisAlignment:
+                                        MainAxisAlignment.spaceBetween,
+                                    children: [
+                                      Expanded(
+                                        child: Text(
+                                          selected?.displayName ?? '',
+                                          style: const TextStyle(
+                                            color: AppColors.entryTextColor,
+                                            fontFamily: 'Oswald',
+                                            fontSize: 24,
+                                          ),
+                                        ),
+                                      ),
+                                      IconButton(
+                                        icon:
+                                            const Icon(Icons.settings_outlined),
+                                        color: AppColors.entryTextColor,
+                                        onPressed: () {
+                                          getIt<AppRouter>().pushNamed(
+                                            '/settings/measurables/${selected?.id}',
+                                          );
+                                        },
+                                      ),
+                                    ],
                                   ),
-                              ],
-                            ),
-                        ],
+                                  if (selected?.description != null)
+                                    Text(
+                                      selected!.description,
+                                      style: const TextStyle(
+                                        color: AppColors.entryTextColor,
+                                        fontFamily: 'Oswald',
+                                        fontWeight: FontWeight.w300,
+                                        fontSize: 14,
+                                      ),
+                                    ),
+                                  if (selected == null)
+                                    FormBuilderDropdown<MeasurableDataType>(
+                                      dropdownColor: AppColors.headerBgColor,
+                                      name: 'type',
+                                      decoration: InputDecoration(
+                                        labelText: 'Type',
+                                        labelStyle: labelStyle,
+                                      ),
+                                      hint: Text(
+                                        'Select Measurement Type',
+                                        style: inputStyle,
+                                      ),
+                                      onChanged: (MeasurableDataType? value) {
+                                        setState(() {
+                                          selected = value;
+                                        });
+                                      },
+                                      validator: FormBuilderValidators.compose(
+                                        [FormBuilderValidators.required()],
+                                      ),
+                                      items: items
+                                          .map(
+                                            (MeasurableDataType item) =>
+                                                DropdownMenuItem(
+                                              value: item,
+                                              child: Text(
+                                                item.displayName,
+                                                style: inputStyle,
+                                              ),
+                                            ),
+                                          )
+                                          .toList(),
+                                    ),
+                                  if (selected != null)
+                                    FormBuilderCupertinoDateTimePicker(
+                                      name: 'date',
+                                      alwaysUse24HourFormat: true,
+                                      format: DateFormat(
+                                        "EEEE, MMMM d, yyyy 'at' HH:mm",
+                                      ),
+                                      style: inputStyle,
+                                      decoration: InputDecoration(
+                                        labelText: 'Measurement taken',
+                                        labelStyle: labelStyle,
+                                      ),
+                                      initialValue: DateTime.now(),
+                                      theme: DatePickerTheme(
+                                        headerColor: AppColors.headerBgColor,
+                                        backgroundColor: AppColors.bodyBgColor,
+                                        itemStyle: const TextStyle(
+                                          color: Colors.white,
+                                          fontWeight: FontWeight.bold,
+                                          fontSize: 18,
+                                        ),
+                                        doneStyle: const TextStyle(
+                                          color: Colors.white,
+                                          fontSize: 16,
+                                        ),
+                                      ),
+                                    ),
+                                  if (selected != null)
+                                    FormBuilderTextField(
+                                      initialValue: '',
+                                      key: const Key('measurement_value_field'),
+                                      decoration: InputDecoration(
+                                        labelText: '${selected?.displayName} '
+                                            '${'${selected?.unitName}'.isNotEmpty ? '[${selected?.unitName}] ' : ''}',
+                                        labelStyle: labelStyle,
+                                      ),
+                                      keyboardAppearance: Brightness.dark,
+                                      style: inputStyle,
+                                      autofocus: true,
+                                      validator:
+                                          FormBuilderValidators.required(),
+                                      name: 'value',
+                                      keyboardType:
+                                          const TextInputType.numberWithOptions(
+                                        decimal: true,
+                                      ),
+                                    ),
+                                ],
+                              ),
+                          ],
+                        ),
                       ),
                     ),
                   ),
-                ),
-                const SizedBox(height: 16),
-                if (selected != null)
-                  DashboardMeasurablesChart(
-                    measurableDataTypeId: selected!.id,
-                    rangeStart: getRangeStart(context: context),
-                    rangeEnd: getRangeEnd(),
-                  ),
-              ],
+                  const SizedBox(height: 16),
+                  if (selected != null)
+                    DashboardMeasurablesChart(
+                      measurableDataTypeId: selected!.id,
+                      rangeStart: getRangeStart(context: context),
+                      rangeEnd: getRangeEnd(),
+                    ),
+                ],
+              ),
             ),
           ),
         );

--- a/lib/routes/dashboard_routes.dart
+++ b/lib/routes/dashboard_routes.dart
@@ -17,7 +17,7 @@ const AutoRoute dashboardRoutes = AutoRoute(
       page: DashboardPage,
     ),
     AutoRoute(
-      path: 'add_measurement/:selectedId',
+      path: 'measure/:selectedId',
       page: CreateMeasurementWithTypePage,
     ),
   ],

--- a/lib/routes/journal_routes.dart
+++ b/lib/routes/journal_routes.dart
@@ -24,7 +24,7 @@ const AutoRoute journalRoutes = AutoRoute(
       page: CreateTextEntryPage,
     ),
     AutoRoute(
-      path: 'fill_survey_type/:surveyType',
+      path: 'fill_survey/:surveyType',
       page: FillSurveyWithTypePage,
     ),
     AutoRoute(
@@ -36,8 +36,12 @@ const AutoRoute journalRoutes = AutoRoute(
       page: RecordAudioPage,
     ),
     AutoRoute(
-      path: 'create_measurement_linked/:linkedId',
+      path: 'measure_linked/:linkedId',
       page: CreateMeasurementWithLinkedPage,
+    ),
+    AutoRoute(
+      path: 'measure/:selectedId',
+      page: CreateMeasurementWithTypePage,
     ),
   ],
 );

--- a/lib/widgets/charts/dashboard_measurables_chart.dart
+++ b/lib/widgets/charts/dashboard_measurables_chart.dart
@@ -83,11 +83,8 @@ class _DashboardMeasurablesChartState extends State<DashboardMeasurablesChart> {
 
               void onDoubleTap() {
                 if (widget.enableCreate) {
-                  getIt<AppRouter>().push(
-                    CreateMeasurementWithTypeRoute(
-                      selectedId: measurableDataType.id,
-                    ),
-                  );
+                  final id = measurableDataType.id;
+                  getIt<AppRouter>().pushNamed('/dashboards/measure/$id');
                 }
               }
 

--- a/lib/widgets/journal/entry_datetime_modal.dart
+++ b/lib/widgets/journal/entry_datetime_modal.dart
@@ -1,3 +1,4 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_datetime_picker/flutter_datetime_picker.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -5,7 +6,6 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
-import 'package:lotti/routes/router.gr.dart';
 import 'package:lotti/theme.dart';
 import 'package:lotti/widgets/journal/entry_tools.dart';
 
@@ -175,7 +175,7 @@ class _EntryDateTimeModalState extends State<EntryDateTimeModal> {
                               dateFrom: dateFrom,
                               dateTo: dateTo,
                             );
-                            await getIt<AppRouter>().pop();
+                            await context.router.pop();
                           },
                           child: Text(
                             localizations.journalDateSaveButton,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.85+1084
+version: 0.8.85+1085
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.84+1083
+version: 0.8.85+1084
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.85+1085
+version: 0.8.85+1086
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR fixes the navigation when creating a new measurement from the dashboard, where previously saving a measurement would not take the user back to the dashboard but its parent, the dashboard list. Also fixes entry datetime modal where save would also close the entry, not only the modal. The error was introduced by using the router from `getIt` for better testability.