### PR TITLE
Fix DMG signing in pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -203,7 +203,7 @@ steps:
           - "macos_dmg"
         commands:
           - "rsync -ar /tmp/buildkite/${BUILDKITE_COMMIT}/ ./"
-          - "xcrun altool --notarize-app -f build/export/*.dmg --primary-bundle-id com.matthiasnehlsen.lotti -u $$APPLEID -p $$APPLEIDPASS"
+          - "xcrun altool --notarize-app -f build/export/*.dmg --primary-bundle-id com.matthiasnehlsen.lotti -u $$APPLEID -p $$APPLEIDPASS --asc-provider $$APPLE_DEV_PROVIDER"
         agents:
           os: "macOS"
         soft_fail:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.87+1090
+version: 0.8.87+1093
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR adds `--asc-provider` in the call to `altool`, now required because of multiple teams.