### PR TITLE
Add stream for watching active config flags

### DIFF
--- a/lib/database/common.dart
+++ b/lib/database/common.dart
@@ -1,0 +1,38 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter/foundation.dart';
+import 'package:intl/intl.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+Future<File> getDatabaseFile(String dbFileName) async {
+  final dbFolder = await getApplicationDocumentsDirectory();
+  return File(p.join(dbFolder.path, dbFileName));
+}
+
+Future<void> createDbBackup(String fileName) async {
+  final file = await getDatabaseFile(fileName);
+  final ts = DateFormat('yyyy-MM-dd_HH-mm-ss-S').format(DateTime.now());
+  final backupDir =
+      await Directory('${file.parent.path}/backup').create(recursive: true);
+  await file.copy('${backupDir.path}/db.$ts.sqlite');
+}
+
+LazyDatabase openDbConnection(
+  String fileName, {
+  bool inMemoryDatabase = false,
+}) {
+  return LazyDatabase(() async {
+    if (inMemoryDatabase) {
+      return NativeDatabase.memory();
+    }
+
+    final file = await getDatabaseFile('db.sqlite');
+    debugPrint('DB LazyDatabase ${file.path}');
+
+    return NativeDatabase(file);
+  });
+}

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -425,6 +425,18 @@ class JournalDb extends _$JournalDb {
     return listConfigFlags().watch().where(makeDuplicateFilter());
   }
 
+  Stream<Set<String>> watchActiveConfigFlagNames() {
+    return watchConfigFlags().map((configFlags) {
+      final activeFlags = <String>{};
+      for (final flag in configFlags) {
+        if (flag.status) {
+          activeFlags.add(flag.name);
+        }
+      }
+      return activeFlags;
+    });
+  }
+
   Future<List<ConfigFlag>> getConfigFlags() {
     return listConfigFlags().get();
   }

--- a/lib/database/maintenance.dart
+++ b/lib/database/maintenance.dart
@@ -1,3 +1,4 @@
+import 'package:lotti/database/common.dart';
 import 'package:lotti/database/conversions.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/editor_db.dart';
@@ -12,7 +13,7 @@ class Maintenance {
   final PersistenceLogic persistenceLogic = getIt<PersistenceLogic>();
 
   Future<void> recreateTaggedLinks() async {
-    await createDbBackup();
+    await createDbBackup(journalDbFileName);
 
     final count = await _db.getJournalCount();
     const pageSize = 100;
@@ -30,7 +31,7 @@ class Maintenance {
   }
 
   Future<void> recreateStoryAssignment() async {
-    await createDbBackup();
+    await createDbBackup(journalDbFileName);
 
     final count = await _db.getJournalCount();
     const pageSize = 100;
@@ -59,7 +60,7 @@ class Maintenance {
   }
 
   Future<void> deleteTaggedLinks() async {
-    await createDbBackup();
+    await createDbBackup(journalDbFileName);
     await _db.deleteTagged();
   }
 

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -26,10 +26,10 @@ class HomePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return StreamBuilder<bool>(
-      stream: _db.watchConfigFlag('show_tasks_tab'),
+    return StreamBuilder<Set<String>>(
+      stream: _db.watchActiveConfigFlagNames(),
       builder: (context, snapshot) {
-        final showTasks = snapshot.data;
+        final showTasks = snapshot.data?.contains('show_tasks_tab');
 
         if (showTasks == null) {
           return const CircularProgressIndicator();

--- a/lib/pages/journal_page.dart
+++ b/lib/pages/journal_page.dart
@@ -57,7 +57,7 @@ class _JournalPageState extends State<JournalPage> {
   ];
 
   late Stream<List<JournalEntity>> stream;
-  late Stream<List<ConfigFlag>> configFlagsStream;
+  late Stream<Set<ConfigFlag>> configFlagsStream;
 
   final List<MultiSelectItem<FilterBy?>> _items = _entryTypes
       .map((entryType) => MultiSelectItem<FilterBy?>(entryType, entryType.name))
@@ -88,7 +88,7 @@ class _JournalPageState extends State<JournalPage> {
     super.initState();
     types = defaultTypes.toSet();
     configFlagsStream = _db.watchConfigFlags();
-    configFlagsStream.listen((List<ConfigFlag> configFlags) {
+    configFlagsStream.listen((Set<ConfigFlag> configFlags) {
       setState(() {
         for (final flag in configFlags) {
           if (flag.name == 'private') {

--- a/lib/pages/settings/flags_page.dart
+++ b/lib/pages/settings/flags_page.dart
@@ -16,7 +16,7 @@ class FlagsPage extends StatefulWidget {
 class _FlagsPageState extends State<FlagsPage> {
   final JournalDb _db = getIt<JournalDb>();
 
-  late final Stream<List<ConfigFlag>> stream = _db.watchConfigFlags();
+  late final Stream<Set<ConfigFlag>> stream = _db.watchConfigFlags();
 
   @override
   void initState() {
@@ -30,13 +30,13 @@ class _FlagsPageState extends State<FlagsPage> {
     return Scaffold(
       appBar: TitleAppBar(title: localizations.settingsFlagsTitle),
       backgroundColor: colorConfig().bodyBgColor,
-      body: StreamBuilder<List<ConfigFlag>>(
+      body: StreamBuilder<Set<ConfigFlag>>(
         stream: stream,
         builder: (
           BuildContext context,
-          AsyncSnapshot<List<ConfigFlag>> snapshot,
+          AsyncSnapshot<Set<ConfigFlag>> snapshot,
         ) {
-          final items = snapshot.data ?? [];
+          final items = snapshot.data?.toList() ?? [];
           debugPrint('$items');
 
           return ListView(
@@ -105,7 +105,7 @@ class ConfigFlagCard extends StatelessWidget {
             children: [
               Text(
                 getLocalizedDescription(item),
-                style:  TextStyle(
+                style: TextStyle(
                   color: colorConfig().entryTextColor,
                   fontFamily: 'Oswald',
                   fontSize: 20,

--- a/lib/pages/settings/maintenance_page.dart
+++ b/lib/pages/settings/maintenance_page.dart
@@ -19,7 +19,7 @@ class _MaintenancePageState extends State<MaintenancePage> {
   final JournalDb _db = getIt<JournalDb>();
   final Maintenance _maintenance = getIt<Maintenance>();
 
-  late final Stream<List<ConfigFlag>> stream = _db.watchConfigFlags();
+  late final Stream<Set<ConfigFlag>> stream = _db.watchConfigFlags();
 
   @override
   void initState() {
@@ -33,13 +33,13 @@ class _MaintenancePageState extends State<MaintenancePage> {
     return Scaffold(
       backgroundColor: colorConfig().bodyBgColor,
       appBar: TitleAppBar(title: localizations.settingsMaintenanceTitle),
-      body: StreamBuilder<List<ConfigFlag>>(
+      body: StreamBuilder<Set<ConfigFlag>>(
         stream: stream,
         builder: (
           BuildContext context,
-          AsyncSnapshot<List<ConfigFlag>> snapshot,
+          AsyncSnapshot<Set<ConfigFlag>> snapshot,
         ) {
-          final items = snapshot.data ?? [];
+          final items = snapshot.data?.toList() ?? [];
           debugPrint('$items');
           return StreamBuilder<int>(
             stream: _db.watchTaggedCount(),

--- a/lib/pages/tasks_page.dart
+++ b/lib/pages/tasks_page.dart
@@ -33,7 +33,7 @@ class TasksPage extends StatefulWidget {
 class _TasksPageState extends State<TasksPage> {
   final JournalDb _db = getIt<JournalDb>();
   late Stream<List<JournalEntity>> stream;
-  late Stream<List<ConfigFlag>> configFlagsStream;
+  late Stream<Set<ConfigFlag>> configFlagsStream;
 
   final List<String> taskStatuses = [
     'OPEN',
@@ -61,7 +61,7 @@ class _TasksPageState extends State<TasksPage> {
     super.initState();
 
     configFlagsStream = _db.watchConfigFlags();
-    configFlagsStream.listen((List<ConfigFlag> configFlags) {
+    configFlagsStream.listen((Set<ConfigFlag> configFlags) {
       resetStream();
     });
     resetStream();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.89+1099
+version: 0.8.89+1100
 
 msix_config:
   display_name: Lotti

--- a/test/database/database_test.dart
+++ b/test/database/database_test.dart
@@ -1,0 +1,161 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/utils/consts.dart';
+
+final expectedActiveFlagNames = Platform.isMacOS
+    ? {
+        'private',
+        'hide_for_screenshot',
+        'listen_to_global_screenshot_hotkey',
+      }
+    : {
+        'private',
+        'hide_for_screenshot',
+      };
+
+final expectedFlags = <ConfigFlag>{
+  ConfigFlag(
+    name: 'private',
+    description: 'Show private entries?',
+    status: true,
+  ),
+  ConfigFlag(
+    name: 'notify_exceptions',
+    description: 'Notify when exceptions occur?',
+    status: false,
+  ),
+  ConfigFlag(
+    name: 'hide_for_screenshot',
+    description: 'Hide Lotti when taking screenshots?',
+    status: true,
+  ),
+  ConfigFlag(
+    name: 'show_tasks_tab',
+    description: 'Show Tasks tab?',
+    status: false,
+  ),
+  ConfigFlag(
+    name: 'show_bright_scheme',
+    description: 'Show Bright ☀️ scheme?',
+    status: false,
+  ),
+};
+
+final expectedMacFlags = <ConfigFlag>{
+  ConfigFlag(
+    name: 'listen_to_global_screenshot_hotkey',
+    description: 'Listen to global screenshot hotkey?',
+    status: true,
+  ),
+  ConfigFlag(
+    name: 'enable_notifications',
+    description: 'Enable desktop notifications?',
+    status: false,
+  ),
+};
+
+void main() {
+  JournalDb? db;
+
+  group('Database Tests - ', () {
+    setUp(() async {
+      db = JournalDb(inMemoryDatabase: true);
+      await db?.initConfigFlags();
+    });
+    tearDown(() async {
+      await db?.close();
+    });
+
+    test(
+      'Config flags are initialized as expected',
+      () async {
+        final flags = await db?.watchConfigFlags().first;
+
+        if (Platform.isMacOS) {
+          expect(flags, expectedFlags.union(expectedMacFlags));
+        } else {
+          expect(flags, expectedFlags);
+        }
+      },
+    );
+
+    test(
+      'Active config flag names are shown as expected',
+      () async {
+        final flags = await db?.watchActiveConfigFlagNames().first;
+        expect(flags, expectedActiveFlagNames);
+      },
+    );
+
+    test(
+      'Toggle config flag works',
+      () async {
+        expect(
+          await db?.watchActiveConfigFlagNames().first,
+          expectedActiveFlagNames,
+        );
+
+        await db?.toggleConfigFlag(showBrightSchemeFlagName);
+
+        expect(
+          await db?.getConfigFlagByName(showBrightSchemeFlagName),
+          ConfigFlag(
+            name: 'show_bright_scheme',
+            description: 'Show Bright ☀️ scheme?',
+            status: true,
+          ),
+        );
+
+        expect(
+          await db?.watchActiveConfigFlagNames().first,
+          expectedActiveFlagNames.union({showBrightSchemeFlagName}),
+        );
+
+        await db?.toggleConfigFlag(showBrightSchemeFlagName);
+
+        expect(
+          await db?.getConfigFlagByName(showBrightSchemeFlagName),
+          ConfigFlag(
+            name: 'show_bright_scheme',
+            description: 'Show Bright ☀️ scheme?',
+            status: false,
+          ),
+        );
+
+        expect(
+          await db?.watchActiveConfigFlagNames().first,
+          expectedActiveFlagNames,
+        );
+      },
+    );
+
+    test(
+      'ConfigFlag can be retrieved by name',
+      () async {
+        expect(
+          await db?.getConfigFlagByName(showBrightSchemeFlagName),
+          ConfigFlag(
+            name: 'show_bright_scheme',
+            description: 'Show Bright ☀️ scheme?',
+            status: false,
+          ),
+        );
+
+        await db?.toggleConfigFlag(showBrightSchemeFlagName);
+
+        expect(
+          await db?.getConfigFlagByName(showBrightSchemeFlagName),
+          ConfigFlag(
+            name: 'show_bright_scheme',
+            description: 'Show Bright ☀️ scheme?',
+            status: true,
+          ),
+        );
+
+        expect(await db?.getConfigFlagByName('invalid'), null);
+      },
+    );
+  });
+}


### PR DESCRIPTION
This PR adds a new stream function for watching active config flags, which makes it easier to use multiple flags in any one page. Previously, nested StreamControllers would have been required to achieve the same.