### PR TITLE
Fix save button not appering in dashboard config - fixes #1135

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed:
+- Dashboard save button not appearing after reordering items
+
+## [0.8.97] - 2022-07-10
 ### Changed:
 - Simplified & cleaner Outbox Service
 

--- a/lib/pages/settings/dashboards/dashboard_definition_page.dart
+++ b/lib/pages/settings/dashboards/dashboard_definition_page.dart
@@ -372,6 +372,7 @@ class _DashboardDefinitionPageState extends State<DashboardDefinitionPage> {
                               physics: const NeverScrollableScrollPhysics(),
                               onReorder: (int oldIndex, int newIndex) {
                                 setState(() {
+                                  dirty = true;
                                   dashboardItems = dashboardItems;
                                   final movedItem =
                                       dashboardItems.removeAt(oldIndex);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.97+1141
+version: 0.8.98+1142
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR fixes a glitch where dashboards could not be saved after only reordering charts but nothing else.

Fixes #1135 