### PR TITLE
Show bottom navigation bar on dashboard page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed:
+- Show bottom navigation bar in dashboard page
+
+## [0.8.98] - 2022-07-10
 ### Fixed:
 - Dashboard save button not appearing after reordering items
 

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -68,7 +68,6 @@ class HomePage extends StatelessWidget {
           ],
           bottomNavigationBuilder: (_, TabsRouter tabsRouter) {
             final hideBottomNavRoutes = <String>{
-              DashboardRoute.name,
               EntryDetailRoute.name,
               LoggingRoute.name,
               LogDetailRoute.name,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.98+1142
+version: 0.8.99+1143
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR changes the bottom navigation bar to be visible on the dashboard details page.


Resolves #1133.