### PR TITLE
Show dashboard directly instead of list if only one is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed:
+- Show single dashboard directly without dashboards list page
+
+## [0.8.99] - 2022-07-10
+### Changed:
 - Show bottom navigation bar in dashboard page
 
 ## [0.8.98] - 2022-07-10

--- a/lib/pages/dashboards/dashboard_page.dart
+++ b/lib/pages/dashboards/dashboard_page.dart
@@ -22,9 +22,11 @@ class DashboardPage extends StatefulWidget {
   const DashboardPage({
     super.key,
     @PathParam() required this.dashboardId,
+    this.showBackIcon = true,
   });
 
   final String dashboardId;
+  final bool showBackIcon;
 
   @override
   State<DashboardPage> createState() => _DashboardPageState();
@@ -106,7 +108,10 @@ class _DashboardPageState extends State<DashboardPage> {
 
           return Scaffold(
             backgroundColor: colorConfig().bodyBgColor,
-            appBar: DashboardAppBar(dashboard),
+            appBar: DashboardAppBar(
+              dashboard,
+              showBackIcon: widget.showBackIcon,
+            ),
             body: SingleChildScrollView(
               child: Padding(
                 padding: const EdgeInsets.all(8),

--- a/lib/pages/dashboards/dashboards_list_page.dart
+++ b/lib/pages/dashboards/dashboards_list_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/pages/dashboards/dashboard_page.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/utils/sort.dart';
@@ -27,27 +28,33 @@ class _DashboardsListPageState extends State<DashboardsListPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: colorConfig().bodyBgColor,
-      appBar: const DashboardsAppBar(),
-      body: StreamBuilder<List<DashboardDefinition>>(
-        stream: stream,
-        builder: (
-          BuildContext context,
-          AsyncSnapshot<List<DashboardDefinition>> snapshot,
-        ) {
-          if (snapshot.data == null) {
-            return const LoadingDashboards();
-          }
+    return StreamBuilder<List<DashboardDefinition>>(
+      stream: stream,
+      builder: (
+        BuildContext context,
+        AsyncSnapshot<List<DashboardDefinition>> snapshot,
+      ) {
+        if (snapshot.data == null) {
+          return const LoadingDashboards();
+        }
 
-          final dashboards =
-              filteredSortedDashboards(snapshot.data ?? [], match);
+        final dashboards = filteredSortedDashboards(snapshot.data ?? [], match);
 
-          if (dashboards.isEmpty) {
-            return const EmptyDashboards();
-          }
+        if (dashboards.isEmpty) {
+          return const EmptyDashboards();
+        }
 
-          return ListView(
+        if (dashboards.length == 1) {
+          return DashboardPage(
+            dashboardId: dashboards[0].id,
+            showBackIcon: false,
+          );
+        }
+
+        return Scaffold(
+          backgroundColor: colorConfig().bodyBgColor,
+          appBar: const DashboardsAppBar(),
+          body: ListView(
             shrinkWrap: true,
             padding: const EdgeInsets.all(8),
             children: List.generate(
@@ -59,9 +66,9 @@ class _DashboardsListPageState extends State<DashboardsListPage> {
                 );
               },
             ),
-          );
-        },
-      ),
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/widgets/app_bar/dashboard_app_bar.dart
+++ b/lib/widgets/app_bar/dashboard_app_bar.dart
@@ -6,10 +6,12 @@ import 'package:lotti/widgets/app_bar/auto_leading_button.dart';
 class DashboardAppBar extends StatelessWidget with PreferredSizeWidget {
   const DashboardAppBar(
     this.dashboard, {
+    required this.showBackIcon,
     super.key,
   });
 
   final DashboardDefinition dashboard;
+  final bool showBackIcon;
 
   @override
   Size get preferredSize => const Size.fromHeight(kToolbarHeight);
@@ -23,7 +25,7 @@ class DashboardAppBar extends StatelessWidget with PreferredSizeWidget {
         style: appBarTextStyle(),
       ),
       centerTitle: true,
-      leading: const TestDetectingAutoLeadingButton(),
+      leading: showBackIcon ? const TestDetectingAutoLeadingButton() : null,
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.99+1143
+version: 0.8.100+1145
 
 msix_config:
   display_name: Lotti

--- a/test/journal_test_data/test_data.dart
+++ b/test/journal_test_data/test_data.dart
@@ -102,6 +102,20 @@ final testDashboardConfig = DashboardDefinition(
   id: '',
 );
 
+final emptyTestDashboardConfig = DashboardDefinition(
+  items: [],
+  name: 'Test Dashboard #2 - empty',
+  description: 'testDashboardDescription #2',
+  createdAt: testEpochDateTime,
+  updatedAt: testEpochDateTime,
+  vectorClock: null,
+  private: false,
+  version: '',
+  lastReviewed: testEpochDateTime,
+  active: true,
+  id: '',
+);
+
 final testStoryTagReading = StoryTag(
   id: '27bbabc6-f323-11ec-b939-0242ac120002',
   tag: 'Reading',

--- a/test/pages/settings/dashboards/dashboard_definition_page_test.dart
+++ b/test/pages/settings/dashboards/dashboard_definition_page_test.dart
@@ -462,11 +462,14 @@ void main() {
       expect(find.text(testDashboardDescription), findsOneWidget);
     });
 
-    testWidgets('dashboard list page is displayed with one test item',
+    testWidgets('dashboard list page is displayed with two test dashboard',
         (tester) async {
       when(mockJournalDb.watchDashboards).thenAnswer(
         (_) => Stream<List<DashboardDefinition>>.fromIterable([
-          [testDashboardConfig],
+          [
+            testDashboardConfig,
+            emptyTestDashboardConfig,
+          ],
         ]),
       );
 
@@ -489,6 +492,43 @@ void main() {
       // finds text in dashboard card
       expect(find.text(testDashboardName), findsOneWidget);
       expect(find.text(testDashboardDescription), findsOneWidget);
+    });
+
+    testWidgets(
+        'dashboard page is displayed directly when there is only one '
+        'dashboard defined', (tester) async {
+      when(mockJournalDb.watchDashboards).thenAnswer(
+        (_) => Stream<List<DashboardDefinition>>.fromIterable([
+          [emptyTestDashboardConfig],
+        ]),
+      );
+
+      when(() => mockJournalDb.watchDashboardById(emptyTestDashboardConfig.id))
+          .thenAnswer(
+        (_) => Stream<List<DashboardDefinition>>.fromIterable([
+          [emptyTestDashboardConfig],
+        ]),
+      );
+
+      await tester.pumpWidget(
+        makeTestableWidget(
+          ConstrainedBox(
+            constraints: const BoxConstraints(
+              maxHeight: 1000,
+              maxWidth: 1000,
+            ),
+            child: const DashboardsListPage(),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      verify(mockJournalDb.watchDashboards).called(1);
+
+      // finds text in dashboard card
+      expect(find.text(emptyTestDashboardConfig.name), findsOneWidget);
+      expect(find.text(emptyTestDashboardConfig.description), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
This PR changes the behavior of the dashboards tab when there is only a single defined dashboard. In that case, that dashboard will be shown, instead of the dashboards list with a single entry. 