### PR TITLE
CI: move analyze step to separate GitHub Action

### DIFF
--- a/.buildkite/test_only_pipeline.yml
+++ b/.buildkite/test_only_pipeline.yml
@@ -5,7 +5,6 @@ steps:
       - "flutter clean"
       - "flutter pub get"
       - "flutter pub run build_runner build --delete-conflicting-outputs"
-      - "make analyze"
       - "make junit"
     agents:
       os: "macOS"

--- a/.github/workflows/flutter-analyze.yml
+++ b/.github/workflows/flutter-analyze.yml
@@ -1,4 +1,4 @@
-name: Flutter Test
+name: Flutter Analyze
 
 on:
   push:
@@ -17,7 +17,5 @@ jobs:
         with:
           flutter-version: '3.0.2'
           channel: 'stable'
-      - name: Run Flutter tests
-        run: make clean_test
-      - name: Run Flutter bundle
-        run: make bundle
+      - name: Run Flutter Analyze
+        run: make clean_build_analyze

--- a/Makefile
+++ b/Makefile
@@ -234,7 +234,10 @@ viz:
 	open classes.viz.png
 
 .PHONY: clean_test
-clean_test: clean deps l10n build_runner test analyze
+clean_test: clean deps l10n build_runner test
+
+.PHONY: clean_build_analyze
+clean_build_analyze: clean deps l10n build_runner analyze
 
 .PHONY: clean_integration_test
 clean_integration_test: clean deps build_runner integration_test


### PR DESCRIPTION
This PR moves the `flutter analyze` step into a separate GitHb Actions for better parallelization. 