### PR TITLE
Time chart fix

### DIFF
--- a/lib/widgets/charts/utils.dart
+++ b/lib/widgets/charts/utils.dart
@@ -157,7 +157,7 @@ DateTime getRangeStart({
 
 DateTime getRangeEnd({int shiftDays = 0}) {
   final now = DateTime.now();
-  return DateTime(now.year, now.month, now.day, 23, 59, 59)
+  return DateTime(now.year, now.month, now.day + 1)
       .subtract(Duration(days: shiftDays));
 }
 

--- a/lib/widgets/journal/duration_widget.dart
+++ b/lib/widgets/journal/duration_widget.dart
@@ -79,10 +79,10 @@ class DurationWidget extends StatelessWidget {
                       visible: !isRecording,
                       child: IconButton(
                         padding: const EdgeInsets.only(right: 8),
-                        icon: const Icon(Icons.play_arrow),
+                        icon: const Icon(Icons.fiber_manual_record_sharp),
                         iconSize: 20,
                         tooltip: 'Record',
-                        color: style?.color,
+                        color: colorConfig().timeRecording,
                         onPressed: () {
                           _timeService.start(item);
                         },

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -126,7 +126,7 @@ packages:
       name: basic_utils
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.3.0"
+    version: "4.4.1"
   bloc:
     dependency: "direct main"
     description:
@@ -569,7 +569,7 @@ packages:
       name: exif
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
   extended_image:
     dependency: transitive
     description:
@@ -2138,7 +2138,7 @@ packages:
       name: video_player_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.7"
+    version: "2.3.8"
   video_player_avfoundation:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.113+1175
+version: 0.8.113+1176
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.113+1174
+version: 0.8.113+1175
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.113+1176
+version: 0.8.113+1177
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR fixes the time chart to include entries of today by setting end of range to beginning of tomorrow, instead of end of today.