### PR TITLE
Fix sync client last read UID resetting itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed:
+- Sync resetting its own offset
+
+## [0.8.114] - 2022-07-21
 ### Added:
 - Slideshow for dashboards
 

--- a/lib/blocs/sync/sync_config_cubit.dart
+++ b/lib/blocs/sync/sync_config_cubit.dart
@@ -4,6 +4,7 @@ import 'package:easy_debounce/easy_debounce.dart';
 import 'package:flutter/foundation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:lotti/classes/config.dart';
+import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/sync_config_service.dart';
 import 'package:lotti/sync/inbox/inbox_service.dart';
@@ -97,6 +98,7 @@ class SyncConfigCubit extends Cubit<SyncConfigState> {
   }
 
   Future<void> testConnection() async {
+    final loggingDb = getIt<LoggingDb>();
     resetStatus();
 
     if (imapConfig != null) {
@@ -112,8 +114,18 @@ class SyncConfigCubit extends Cubit<SyncConfigState> {
       if (valid) {
         isAccountValid = true;
         debugPrint('testConnection valid');
+        loggingDb.captureEvent(
+          'connection valid',
+          domain: 'SYNC_CONFIG_CUBIT',
+          subDomain: 'testConnection()',
+        );
       } else {
         debugPrint('testConnection error');
+        loggingDb.captureEvent(
+          'connection error',
+          domain: 'SYNC_CONFIG_CUBIT',
+          subDomain: 'testConnection()',
+        );
         connectionError = 'Error';
       }
     }

--- a/lib/services/sync_config_service.dart
+++ b/lib/services/sync_config_service.dart
@@ -32,7 +32,19 @@ class SyncConfigService {
   Future<void> generateSharedKey() async {
     final key = Key.fromSecureRandom(32);
     final sharedKey = key.base64;
-    await getIt<SecureStorage>().write(key: sharedSecretKey, value: sharedKey);
+    await getIt<SecureStorage>().write(
+      key: sharedSecretKey,
+      value: sharedKey,
+    );
+    final lastReadUid = await getLastReadUid();
+    if (lastReadUid == null) {
+      await setLastReadUid(0);
+    }
+
+    final host = await getIt<VectorClockService>().getHost();
+    if (host == null) {
+      await getIt<VectorClockService>().setNewHost();
+    }
   }
 
   Future<void> setSyncConfig(String configJson) async {
@@ -83,6 +95,7 @@ class SyncConfigService {
 
   Future<void> resetOffset() async {
     await getIt<SecureStorage>().delete(key: lastReadUidKey);
+    await setLastReadUid(0);
     await getIt<VectorClockService>().setNewHost();
   }
 }

--- a/lib/sync/utils.dart
+++ b/lib/sync/utils.dart
@@ -1,6 +1,9 @@
 import 'package:lotti/get_it.dart';
 import 'package:lotti/sync/secure_storage.dart';
 
+const String hostKey = 'VC_HOST';
+const String nextAvailableCounterKey = 'VC_NEXT_AVAILABLE_COUNTER';
+
 const String sharedSecretKey = 'sharedSecret';
 const String imapConfigKey = 'imapConfig';
 const String lastReadUidKey = 'lastReadUid';
@@ -14,9 +17,10 @@ Future<void> setLastReadUid(int? uid) async {
   await getIt<SecureStorage>().write(key: lastReadUidKey, value: '$uid');
 }
 
-Future<int> getLastReadUid() async {
+Future<int?> getLastReadUid() async {
   final lastReadUidValue = await getIt<SecureStorage>().read(
     key: lastReadUidKey,
   );
-  return lastReadUidValue != null ? int.parse(lastReadUidValue) : 0;
+
+  return lastReadUidValue != null ? int.parse(lastReadUidValue) : null;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.115+1180
+version: 0.8.115+1183
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.115+1179
+version: 0.8.115+1180
 
 msix_config:
   display_name: Lotti

--- a/test/blocs/sync/sync_config_cubit_test.dart
+++ b/test/blocs/sync/sync_config_cubit_test.dart
@@ -1,6 +1,7 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/blocs/sync/sync_config_cubit.dart';
+import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/sync_config_service.dart';
 import 'package:lotti/sync/inbox/inbox_service.dart';
@@ -16,6 +17,7 @@ void main() {
   var mock = MockSyncConfigService();
   var mockInboxService = MockSyncInboxService();
   var mockOutboxService = MockOutboxService();
+  final mockLoggingDb = MockLoggingDb();
 
   group('SyncConfigCubit Tests - ', () {
     setUp(() {
@@ -27,6 +29,7 @@ void main() {
 
       getIt
         ..registerSingleton<OutboxService>(mockOutboxService)
+        ..registerSingleton<LoggingDb>(mockLoggingDb)
         ..registerSingleton<InboxService>(mockInboxService);
     });
     tearDown(getIt.reset);

--- a/test/logic/persistence_logic_test.dart
+++ b/test/logic/persistence_logic_test.dart
@@ -17,6 +17,7 @@ import 'package:lotti/sync/connectivity.dart';
 import 'package:lotti/sync/fg_bg.dart';
 import 'package:lotti/sync/outbox_service.dart';
 import 'package:lotti/sync/secure_storage.dart';
+import 'package:lotti/sync/utils.dart';
 import 'package:lotti/themes/themes_service.dart';
 import 'package:lotti/utils/file_utils.dart';
 import 'package:mocktail/mocktail.dart';

--- a/test/mocks/sync_config_test_mocks.dart
+++ b/test/mocks/sync_config_test_mocks.dart
@@ -2,6 +2,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:lotti/blocs/sync/outbox_cubit.dart';
 import 'package:lotti/blocs/sync/outbox_state.dart';
 import 'package:lotti/blocs/sync/sync_config_cubit.dart';
+import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/services/sync_config_service.dart';
 import 'package:lotti/sync/inbox/inbox_service.dart';
@@ -15,6 +16,8 @@ class MockSyncInboxService extends Mock implements InboxService {}
 class MockOutboxService extends Mock implements OutboxService {}
 
 class MockSyncConfigCubit extends Mock implements SyncConfigCubit {}
+
+class MockLoggingDb extends Mock implements LoggingDb {}
 
 MockSyncConfigCubit mockSyncConfigCubitWithState(SyncConfigState state) {
   final mock = MockSyncConfigCubit();

--- a/test/widgets/sync/imap_config_mobile_test.dart
+++ b/test/widgets/sync/imap_config_mobile_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/blocs/sync/sync_config_cubit.dart';
+import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/sync_config_service.dart';
 import 'package:lotti/sync/inbox/inbox_service.dart';
@@ -20,6 +21,7 @@ void main() {
   var mock = MockSyncConfigService();
   var mockInboxService = MockSyncInboxService();
   var mockOutboxService = MockOutboxService();
+  final mockLoggingDb = MockLoggingDb();
 
   group('SyncConfig Mobile Widgets Tests - ', () {
     setUp(() {
@@ -32,6 +34,7 @@ void main() {
       getIt
         ..registerSingleton<OutboxService>(mockOutboxService)
         ..registerSingleton<InboxService>(mockInboxService)
+        ..registerSingleton<LoggingDb>(mockLoggingDb)
         ..registerSingleton<ThemesService>(ThemesService(watch: false));
     });
     tearDown(getIt.reset);


### PR DESCRIPTION
This PR fixes an issue where the last read IMAP UID would reset itself and the sync would start again from the oldest sync message in the mailbox. Thanks to the vector clock variant, this did not cause issues with data integrity, but did cause delays in sync, plus high CPU utilization.