### PR TITLE
Fetch every 15 seconds in all cases

### DIFF
--- a/lib/sync/inbox/inbox_service.dart
+++ b/lib/sync/inbox/inbox_service.dart
@@ -69,13 +69,15 @@ class InboxService {
     });
 
     enqueueNextFetchRequest();
+
     Timer.periodic(
       const Duration(seconds: 15),
       (timer) async {
-        final isObserving = _observingClient?.isPolling() ?? false;
-        if (!isObserving) {
-          enqueueNextFetchRequest();
-        }
+        // final isObserving = _observingClient?.isPolling() ?? false;
+        // if (!isObserving) {
+        //   enqueueNextFetchRequest();
+        // }
+        enqueueNextFetchRequest();
       },
     );
 
@@ -110,8 +112,10 @@ class InboxService {
       final hostHash = await _vectorClockService.getHostHash();
 
       if (imapClient != null && hostHash != null) {
-        final fetchResult =
-            await imapClient!.uidFetchMessages(sequence, 'ENVELOPE');
+        final fetchResult = await imapClient!.uidFetchMessages(
+          sequence,
+          'ENVELOPE',
+        );
 
         for (final msg in fetchResult.messages.take(1)) {
           final lastReadUid = await getLastReadUid();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.115+1183
+version: 0.8.115+1184
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR changes the Sync inbox to fetch every 15 seconds in any case, even when the observing client believes it is still online to fix sync messages not being picked up after resuming the app. Workaround, needs further investigation.