### PR TITLE
Fix build by removing sort_arb_files task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fix:
+- Build errors
+
+## [0.8.115] - 2022-07-25
 ### Fixed:
 - Sync resetting its own offset
+- Polling
 
 ## [0.8.114] - 2022-07-21
 ### Added:

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ sort_arb_files: enable_arb_tools
 	find lib/l10n/ -type f -exec dart pub global run arb_utils:sort -i {} \;
 
 .PHONY: l10n
-l10n: sort_arb_files
+l10n: #sort_arb_files
 	flutter gen-l10n
 	@echo "Missing translations:"
 	@cat missing_translations.txt

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "42.0.0"
+    version: "43.0.0"
   adaptive_dialog:
     dependency: "direct main"
     description:
@@ -21,7 +21,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.3.0"
+    version: "4.3.1"
   analyzer_plugin:
     dependency: transitive
     description:
@@ -126,7 +126,7 @@ packages:
       name: basic_utils
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.4.1"
+    version: "4.4.2"
   bloc:
     dependency: "direct main"
     description:
@@ -406,7 +406,7 @@ packages:
       name: dart_code_metrics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.16.0"
+    version: "4.17.0"
   dart_console:
     dependency: transitive
     description:
@@ -722,13 +722,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.2"
-  flutter_inappwebview:
+  flutter_inappwebview_quill:
     dependency: transitive
     description:
-      name: flutter_inappwebview
+      name: flutter_inappwebview_quill
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.4.3+7"
+    version: "5.4.6"
   flutter_keyboard_visibility:
     dependency: transitive
     description:
@@ -803,7 +803,7 @@ packages:
       name: flutter_native_splash
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.5"
+    version: "2.2.6"
   flutter_native_timezone:
     dependency: "direct main"
     description:
@@ -824,7 +824,7 @@ packages:
       name: flutter_quill
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.1"
+    version: "5.2.10"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -1065,7 +1065,7 @@ packages:
       name: http_client_helper
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   http_multi_server:
     dependency: transitive
     description:
@@ -1231,7 +1231,7 @@ packages:
       name: lint
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.10.0"
   lints:
     dependency: transitive
     description:
@@ -1949,21 +1949,21 @@ packages:
       name: syncfusion_flutter_calendar
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "20.2.39"
+    version: "20.2.40"
   syncfusion_flutter_core:
     dependency: transitive
     description:
       name: syncfusion_flutter_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "20.2.39"
+    version: "20.2.40"
   syncfusion_flutter_datepicker:
     dependency: "direct main"
     description:
       name: syncfusion_flutter_datepicker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "20.2.39"
+    version: "20.2.40"
   synchronized:
     dependency: transitive
     description:
@@ -2258,13 +2258,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.1"
-  youtube_player_flutter:
+  youtube_player_flutter_quill:
     dependency: transitive
     description:
-      name: youtube_player_flutter
+      name: youtube_player_flutter_quill
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.1.0"
+    version: "8.2.2"
 sdks:
   dart: ">=2.17.0 <3.0.0"
   flutter: ">=3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.115+1184
+version: 0.8.116+1186
 
 msix_config:
   display_name: Lotti
@@ -162,7 +162,7 @@ dependency_overrides:
 dev_dependencies:
   archive: ^3.1.6
   auto_route_generator: ^4.0.0
-  build_runner: ^2.1.4
+  build_runner: ^2.2.0
   dart_code_metrics: ^4.8.1
   drift_dev: ^1.7.0
   flutter_launcher_icons: ^0.9.2


### PR DESCRIPTION
This PR fixes mysterious errors in the build such as

```
/usr/local/Caskroom/flutter/3.0.5/flutter/packages/flutter/lib/src/semantics/semantics.dart:3768:11: Error: 'VoidCallback' isn't a type.
    final VoidCallback? callback = _customSemanticsActions[action];
          ^^^^^^^^^^^^
/usr/local/Caskroom/flutter/3.0.5/flutter/packages/flutter/lib/src/semantics/semantics.dart:4017:36: Error: The getter 'SemanticsFlag' isn't defined for the class 'SemanticsConfiguration'.
 - 'SemanticsConfiguration' is from 'package:flutter/src/semantics/semantics.dart' ('/usr/local/Caskroom/flutter/3.0.5/flutter/packages/flutter/lib/src/semantics/semantics.dart').
Try correcting the name to the name of an existing getter, or defining a getter or field named 'SemanticsFlag'.
  bool get scopesRoute => _hasFlag(SemanticsFlag.scopesRoute);
                                   ^^^^^^^^^^^^^
/usr/local/Caskroom/flutter/3.0.5/flutter/packages/flutter/lib/src/semantics/semantics.dart:4019:14: Error: The getter 'SemanticsFlag' isn't defined for the class 'SemanticsConfiguration'.
 - 'SemanticsConfiguration' is from 'package:flutter/src/semantics/semantics.dart' ('/usr/local/Caskroom/flutter/3.0.5/flutter/packages/flutter/lib/src/semantics/semantics.dart').
Try correcting the name to the name of an existing getter, or defining a getter or field named 'SemanticsFlag'.
    _setFlag(SemanticsFlag.scopesRoute, value);
             ^^^^^^^^^^^^^
```