### PR TITLE
Refactor: decouple widgets from persistence logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.8.117] - 2022-07-28
 ### Changed:
 - Show unsaved state after changing task title
 - Save entries when navigating away

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed:
+- Decoupling of PersistenceLogic and widgets
 
 ## [0.8.117] - 2022-07-28
 ### Changed:

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -18,11 +18,11 @@ PODS:
     - Mantle
     - SDWebImage
     - SDWebImageWebPCoder
-  - flutter_inappwebview (0.0.1):
+  - flutter_inappwebview_quill (0.0.1):
     - Flutter
-    - flutter_inappwebview/Core (= 0.0.1)
+    - flutter_inappwebview_quill/Core (= 0.0.1)
     - OrderedSet (~> 5.0)
-  - flutter_inappwebview/Core (0.0.1):
+  - flutter_inappwebview_quill/Core (0.0.1):
     - Flutter
     - OrderedSet (~> 5.0)
   - flutter_keyboard_visibility (0.0.1):
@@ -126,7 +126,7 @@ DEPENDENCIES:
   - flutter_fgbg (from `.symlinks/plugins/flutter_fgbg/ios`)
   - flutter_health_fit (from `.symlinks/plugins/flutter_health_fit/ios`)
   - flutter_image_compress (from `.symlinks/plugins/flutter_image_compress/ios`)
-  - flutter_inappwebview (from `.symlinks/plugins/flutter_inappwebview/ios`)
+  - flutter_inappwebview_quill (from `.symlinks/plugins/flutter_inappwebview_quill/ios`)
   - flutter_keyboard_visibility (from `.symlinks/plugins/flutter_keyboard_visibility/ios`)
   - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
@@ -181,8 +181,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_health_fit/ios"
   flutter_image_compress:
     :path: ".symlinks/plugins/flutter_image_compress/ios"
-  flutter_inappwebview:
-    :path: ".symlinks/plugins/flutter_inappwebview/ios"
+  flutter_inappwebview_quill:
+    :path: ".symlinks/plugins/flutter_inappwebview_quill/ios"
   flutter_keyboard_visibility:
     :path: ".symlinks/plugins/flutter_keyboard_visibility/ios"
   flutter_local_notifications:
@@ -237,7 +237,7 @@ SPEC CHECKSUMS:
   flutter_fgbg: 31c0d1140a131daea2d342121808f6aa0dcd879d
   flutter_health_fit: af332b5d7512b9cc8a05e7282cfcee02b056d32e
   flutter_image_compress: fd2b476345226e1a10ea352fa306af95704642c1
-  flutter_inappwebview: bfd58618f49dc62f2676de690fc6dcda1d6c3721
+  flutter_inappwebview_quill: eb69bfa35fdde431e273476cf359a3686427b8da
   flutter_keyboard_visibility: 0339d06371254c3eb25eeb90ba8d17dca8f9c069
   flutter_local_notifications: 0c0b1ae97e741e1521e4c1629a459d04b9aec743
   flutter_native_splash: 52501b97d1c0a5f898d687f1646226c1f93c56ef

--- a/lib/widgets/journal/duration_widget.dart
+++ b/lib/widgets/journal/duration_widget.dart
@@ -6,7 +6,6 @@ import 'package:lotti/blocs/journal/entry_cubit.dart';
 import 'package:lotti/blocs/journal/entry_state.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/get_it.dart';
-import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/time_service.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/widgets/journal/entry_tools.dart';
@@ -20,7 +19,6 @@ class DurationWidget extends StatelessWidget {
   });
 
   final TimeService _timeService = getIt<TimeService>();
-  final PersistenceLogic persistenceLogic = getIt<PersistenceLogic>();
   final JournalEntity item;
   final TextStyle? style;
 
@@ -116,7 +114,6 @@ class DurationViewWidget extends StatelessWidget {
   });
 
   final TimeService _timeService = getIt<TimeService>();
-  final PersistenceLogic persistenceLogic = getIt<PersistenceLogic>();
   final JournalEntity item;
   final TextStyle? style;
 

--- a/lib/widgets/journal/entry_details/delete_icon_widget.dart
+++ b/lib/widgets/journal/entry_details/delete_icon_widget.dart
@@ -1,63 +1,71 @@
 import 'package:adaptive_dialog/adaptive_dialog.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:lotti/blocs/journal/entry_cubit.dart';
+import 'package:lotti/blocs/journal/entry_state.dart';
 import 'package:lotti/get_it.dart';
-import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/routes/router.gr.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
 class DeleteIconWidget extends StatelessWidget {
-  DeleteIconWidget({
+  const DeleteIconWidget({
     super.key,
-    required this.entityId,
     required this.popOnDelete,
   });
 
-  final PersistenceLogic persistenceLogic = getIt<PersistenceLogic>();
-  final String entityId;
   final bool popOnDelete;
 
   @override
   Widget build(BuildContext context) {
     final localizations = AppLocalizations.of(context)!;
 
-    Future<void> onPressed() async {
-      const deleteKey = 'deleteKey';
-      final result = await showModalActionSheet<String>(
-        context: context,
-        title: localizations.journalDeleteQuestion,
-        actions: [
-          SheetAction(
-            icon: Icons.warning,
-            label: localizations.journalDeleteConfirm,
-            key: deleteKey,
-            isDestructiveAction: true,
-            isDefaultAction: true,
-          ),
-        ],
-      );
+    return BlocBuilder<EntryCubit, EntryState>(
+      builder: (
+        context,
+        EntryState state,
+      ) {
+        final cubit = context.read<EntryCubit>();
 
-      if (result == deleteKey) {
-        await persistenceLogic.deleteJournalEntity(entityId);
+        Future<void> onPressed() async {
+          const deleteKey = 'deleteKey';
+          final result = await showModalActionSheet<String>(
+            context: context,
+            title: localizations.journalDeleteQuestion,
+            actions: [
+              SheetAction(
+                icon: Icons.warning,
+                label: localizations.journalDeleteConfirm,
+                key: deleteKey,
+                isDestructiveAction: true,
+                isDefaultAction: true,
+              ),
+            ],
+          );
 
-        if (popOnDelete) {
-          await getIt<AppRouter>().pop();
+          if (result == deleteKey) {
+            await cubit.delete();
+
+            if (popOnDelete) {
+              await getIt<AppRouter>().pop();
+            }
+          }
         }
-      }
-    }
 
-    return IconButton(
-      icon: const Icon(MdiIcons.trashCanOutline),
-      iconSize: 24,
-      tooltip: localizations.journalDeleteHint,
-      padding: const EdgeInsets.only(
-        left: 16,
-        top: 8,
-        bottom: 8,
-      ),
-      color: colorConfig().entryTextColor,
-      onPressed: onPressed,
+        return IconButton(
+          icon: const Icon(MdiIcons.trashCanOutline),
+          iconSize: 24,
+          tooltip: localizations.journalDeleteHint,
+          padding: const EdgeInsets.only(
+            left: 16,
+            top: 8,
+            bottom: 8,
+          ),
+          color: colorConfig().entryTextColor,
+          onPressed: onPressed,
+        );
+      },
     );
   }
 }

--- a/lib/widgets/journal/entry_details/entry_detail_footer.dart
+++ b/lib/widgets/journal/entry_details/entry_detail_footer.dart
@@ -84,7 +84,6 @@ class _EntryDetailFooterState extends State<EntryDetailFooter> {
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       DeleteIconWidget(
-                        entityId: widget.itemId,
                         popOnDelete: widget.popOnDelete,
                       ),
                       ShareButtonWidget(entityId: widget.itemId),

--- a/lib/widgets/misc/desktop_menu.dart
+++ b/lib/widgets/misc/desktop_menu.dart
@@ -3,14 +3,11 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/create/create_entry.dart';
-import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/utils/consts.dart';
-import 'package:lotti/utils/file_utils.dart';
 
 class DesktopMenuWrapper extends StatelessWidget {
   DesktopMenuWrapper(
@@ -18,7 +15,6 @@ class DesktopMenuWrapper extends StatelessWidget {
     super.key,
   });
 
-  final PersistenceLogic _persistenceLogic = getIt<PersistenceLogic>();
   final JournalDb _db = getIt<JournalDb>();
   final Widget body;
 
@@ -71,17 +67,7 @@ class DesktopMenuWrapper extends StatelessWidget {
                     label: localizations.fileMenuNewEntry,
                     onSelected: () async {
                       final linkedId = await getIdFromSavedRoute();
-
-                      if (linkedId != null) {
-                        await _persistenceLogic.createTextEntry(
-                          EntryText(plainText: ''),
-                          id: uuid.v1(),
-                          linkedId: linkedId,
-                          started: DateTime.now(),
-                        );
-                      } else {
-                        pushNamedRoute('/journal/create/$linkedId');
-                      }
+                      await createTextEntry(linkedId: linkedId);
                     },
                     shortcut: const SingleActivator(
                       LogicalKeyboardKey.keyN,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: adaptive_dialog
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.4+2"
+    version: "1.7.0"
   analyzer:
     dependency: "direct overridden"
     description:
@@ -126,7 +126,7 @@ packages:
       name: basic_utils
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.4.2"
+    version: "4.4.3"
   bloc:
     dependency: "direct main"
     description:
@@ -301,7 +301,7 @@ packages:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "4.2.0"
   collection:
     dependency: "direct main"
     description:
@@ -698,7 +698,7 @@ packages:
       name: flutter_form_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.4.0"
+    version: "7.5.0"
   flutter_health_fit:
     dependency: "direct main"
     description:
@@ -824,7 +824,7 @@ packages:
       name: flutter_quill
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.10"
+    version: "5.2.11"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -1128,7 +1128,7 @@ packages:
       name: image_picker_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.0"
   integration_test:
     dependency: "direct dev"
     description: flutter
@@ -1287,14 +1287,14 @@ packages:
       name: lottie
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   macos_ui:
     dependency: transitive
     description:
       name: macos_ui
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.7.1"
   matcher:
     dependency: transitive
     description:
@@ -1483,14 +1483,14 @@ packages:
       name: path_provider_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.16"
+    version: "2.0.17"
   path_provider_ios:
     dependency: transitive
     description:
       name: path_provider_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.10"
+    version: "2.0.11"
   path_provider_linux:
     dependency: transitive
     description:
@@ -1893,7 +1893,7 @@ packages:
       name: sqlite3_flutter_libs
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.8"
+    version: "0.5.9"
   sqlparser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.118+1199
+version: 0.8.118+1200
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.118+1200
+version: 0.8.118+1201
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.117+1198
+version: 0.8.118+1199
 
 msix_config:
   display_name: Lotti

--- a/test/blocs/journal/entry_cubit_test.dart
+++ b/test/blocs/journal/entry_cubit_test.dart
@@ -149,5 +149,37 @@ void main() {
       ],
       verify: (c) {},
     );
+
+    blocTest<EntryCubit, EntryState>(
+      'toggle',
+      build: () => EntryCubit(
+        entry: testTextEntry,
+        entryId: testTextEntry.meta.id,
+      ),
+      setUp: () {},
+      act: (c) async {
+        c.controller.document.insert(0, 'foo');
+        await c.save();
+        await c.toggleStarred();
+        await c.toggleFlagged();
+        await c.togglePrivate();
+      },
+      wait: defaultWait,
+      expect: () => <EntryState>[
+        EntryState.saved(
+          entry: testTextEntry,
+          entryId: testTextEntry.meta.id,
+        ),
+        EntryState.dirty(
+          entry: testTextEntry,
+          entryId: testTextEntry.meta.id,
+        ),
+        EntryState.saved(
+          entry: testTextEntry,
+          entryId: testTextEntry.meta.id,
+        ),
+      ],
+      verify: (c) {},
+    );
   });
 }

--- a/test/widgets/journal/entry_details/workout_summary_test.dart
+++ b/test/widgets/journal/entry_details/workout_summary_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/logic/health_import.dart';
+import 'package:lotti/themes/themes_service.dart';
+import 'package:lotti/widgets/journal/entry_details/workout_summary.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../journal_test_data/test_data.dart';
+import '../../../mocks/mocks.dart';
+import '../../../widget_test_utils.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  var mockJournalDb = MockJournalDb();
+  final mockHealthImport = MockHealthImport();
+
+  group('WorkoutSummary Widget Tests - ', () {
+    setUp(() {
+      mockJournalDb = MockJournalDb();
+
+      getIt
+        ..registerSingleton<ThemesService>(ThemesService(watch: false))
+        ..registerSingleton<JournalDb>(mockJournalDb)
+        ..registerSingleton<HealthImport>(mockHealthImport);
+    });
+    tearDown(getIt.reset);
+
+    testWidgets('summary with workout chart for running distance is rendered',
+        (tester) async {
+      when(
+        () => mockJournalDb.watchWorkouts(
+          rangeEnd: any(named: 'rangeEnd'),
+          rangeStart: any(named: 'rangeStart'),
+        ),
+      ).thenAnswer(
+        (_) => Stream<List<JournalEntity>>.fromIterable([
+          [testWorkoutRunning]
+        ]),
+      );
+
+      when(mockHealthImport.getWorkoutsHealthDataDelta)
+          .thenAnswer((_) async {});
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          WorkoutSummary(testWorkoutRunning),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // charts display expected titles
+      expect(find.text('Running time'), findsOneWidget);
+      expect(find.text('Running calories'), findsOneWidget);
+      expect(find.text('Running distance/m'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
This PR decouples widgets and persistence logic. Any interactions with the latter now go through `EntryCubit`.