### PR TITLE
Rearrange entry details layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed:
+- Entry details layout
+
+## [0.8.120] - 2022-08-02
 ### Fixed
 - Crash in tags modal due to wrong context
 

--- a/lib/widgets/journal/entry_details/delete_icon_widget.dart
+++ b/lib/widgets/journal/entry_details/delete_icon_widget.dart
@@ -52,11 +52,7 @@ class DeleteIconWidget extends StatelessWidget {
           icon: const Icon(MdiIcons.trashCanOutline),
           iconSize: 24,
           tooltip: localizations.journalDeleteHint,
-          padding: const EdgeInsets.only(
-            left: 16,
-            top: 8,
-            bottom: 8,
-          ),
+          padding: EdgeInsets.zero,
           color: colorConfig().entryTextColor,
           onPressed: onPressed,
         );

--- a/lib/widgets/journal/entry_details/entry_datetime_widget.dart
+++ b/lib/widgets/journal/entry_details/entry_datetime_widget.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:lotti/blocs/journal/entry_cubit.dart';
+import 'package:lotti/blocs/journal/entry_state.dart';
+import 'package:lotti/themes/theme.dart';
+import 'package:lotti/widgets/journal/entry_details/entry_datetime_modal.dart';
+import 'package:lotti/widgets/journal/entry_tools.dart';
+
+class EntryDatetimeWidget extends StatelessWidget {
+  const EntryDatetimeWidget({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<EntryCubit, EntryState>(
+      builder: (context, EntryState state) {
+        final item = state.entry;
+
+        if (item == null) {
+          return const SizedBox.shrink();
+        }
+
+        return Padding(
+          padding: const EdgeInsets.all(8),
+          child: TextButton(
+            onPressed: () {
+              showModalBottomSheet<void>(
+                context: context,
+                isScrollControlled: true,
+                shape: const RoundedRectangleBorder(
+                  borderRadius: BorderRadius.vertical(
+                    top: Radius.circular(16),
+                  ),
+                ),
+                clipBehavior: Clip.antiAliasWithSaveLayer,
+                builder: (BuildContext _) {
+                  return BlocProvider.value(
+                    value: BlocProvider.of<EntryCubit>(context),
+                    child: EntryDateTimeModal(item: item),
+                  );
+                },
+              );
+            },
+            child: Text(
+              df.format(item.meta.dateFrom),
+              style: textStyle(),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/widgets/journal/entry_details/entry_detail_footer.dart
+++ b/lib/widgets/journal/entry_details/entry_detail_footer.dart
@@ -3,19 +3,15 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lotti/blocs/journal/entry_cubit.dart';
 import 'package:lotti/blocs/journal/entry_state.dart';
 import 'package:lotti/themes/theme.dart';
-import 'package:lotti/widgets/journal/entry_details/delete_icon_widget.dart';
 import 'package:lotti/widgets/journal/entry_details/duration_widget.dart';
-import 'package:lotti/widgets/journal/entry_details/share_button_widget.dart';
+import 'package:lotti/widgets/journal/entry_details/entry_datetime_widget.dart';
 import 'package:lotti/widgets/journal/entry_tools.dart';
 import 'package:lotti/widgets/misc/map_widget.dart';
 
 class EntryDetailFooter extends StatefulWidget {
   const EntryDetailFooter({
     super.key,
-    required this.itemId,
   });
-
-  final String itemId;
 
   @override
   State<EntryDetailFooter> createState() => _EntryDetailFooterState();
@@ -42,44 +38,35 @@ class _EntryDetailFooterState extends State<EntryDetailFooter> {
 
         return Column(
           children: [
-            Padding(
-              padding: const EdgeInsets.only(left: 8, right: 4),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  DurationWidget(
-                    item: item,
-                    style: textStyle(),
-                  ),
-                  Visibility(
-                    visible: loc != null && loc.longitude != 0,
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 4),
-                      child: Row(
-                        children: [
-                          TextButton(
-                            onPressed: () => setState(() {
-                              mapVisible = !mapVisible;
-                            }),
-                            child: Text(
-                              '📍 ${formatLatLon(loc?.latitude)}, '
-                              '${formatLatLon(loc?.longitude)}',
-                              style: textStyle(),
-                            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const EntryDatetimeWidget(),
+                DurationWidget(
+                  item: item,
+                  style: textStyle(),
+                ),
+                Visibility(
+                  visible: loc != null && loc.longitude != 0,
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 4),
+                    child: Row(
+                      children: [
+                        TextButton(
+                          onPressed: () => setState(() {
+                            mapVisible = !mapVisible;
+                          }),
+                          child: Text(
+                            '📍 ${formatLatLon(loc?.latitude)}, '
+                            '${formatLatLon(loc?.longitude)}',
+                            style: textStyle(),
                           ),
-                        ],
-                      ),
+                        ),
+                      ],
                     ),
                   ),
-                  Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: const [
-                      DeleteIconWidget(),
-                      ShareButtonWidget(),
-                    ],
-                  ),
-                ],
-              ),
+                ),
+              ],
             ),
             Visibility(
               visible: mapVisible,

--- a/lib/widgets/journal/entry_details/entry_detail_header.dart
+++ b/lib/widgets/journal/entry_details/entry_detail_header.dart
@@ -6,19 +6,17 @@ import 'package:lotti/blocs/journal/entry_cubit.dart';
 import 'package:lotti/blocs/journal/entry_state.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/themes/theme.dart';
-import 'package:lotti/widgets/journal/entry_details/entry_datetime_modal.dart';
+import 'package:lotti/widgets/journal/entry_details/delete_icon_widget.dart';
 import 'package:lotti/widgets/journal/entry_details/save_button.dart';
-import 'package:lotti/widgets/journal/entry_tools.dart';
+import 'package:lotti/widgets/journal/entry_details/share_button_widget.dart';
 import 'package:lotti/widgets/journal/tags/tag_add.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
 class EntryDetailHeader extends StatefulWidget {
   const EntryDetailHeader({
     super.key,
-    required this.itemId,
   });
 
-  final String itemId;
 
   @override
   State<EntryDetailHeader> createState() => _EntryDetailHeaderState();
@@ -46,30 +44,6 @@ class _EntryDetailHeaderState extends State<EntryDetailHeader> {
         return Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            TextButton(
-              onPressed: () {
-                showModalBottomSheet<void>(
-                  context: context,
-                  isScrollControlled: true,
-                  shape: const RoundedRectangleBorder(
-                    borderRadius: BorderRadius.vertical(
-                      top: Radius.circular(16),
-                    ),
-                  ),
-                  clipBehavior: Clip.antiAliasWithSaveLayer,
-                  builder: (BuildContext _) {
-                    return BlocProvider.value(
-                      value: BlocProvider.of<EntryCubit>(context),
-                      child: EntryDateTimeModal(item: item),
-                    );
-                  },
-                );
-              },
-              child: Text(
-                df.format(item.meta.dateFrom),
-                style: textStyle(),
-              ),
-            ),
             Row(
               children: [
                 SwitchIconWidget(
@@ -93,6 +67,8 @@ class _EntryDetailHeaderState extends State<EntryDetailHeader> {
                   value: item.meta.flag == EntryFlag.import,
                   iconData: MdiIcons.flag,
                 ),
+                const DeleteIconWidget(),
+                const ShareButtonWidget(),
                 TagAddIconWidget(),
               ],
             ),
@@ -123,7 +99,7 @@ class SwitchIconWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return IconButton(
-      padding: const EdgeInsets.symmetric(horizontal: 4),
+      padding: EdgeInsets.zero,
       tooltip: tooltip,
       onPressed: () {
         if (value) {

--- a/lib/widgets/journal/entry_details/share_button_widget.dart
+++ b/lib/widgets/journal/entry_details/share_button_widget.dart
@@ -55,11 +55,7 @@ class ShareButtonWidget extends StatelessWidget {
           icon: const Icon(MdiIcons.shareOutline),
           iconSize: 24,
           tooltip: tooltip,
-          padding: const EdgeInsets.only(
-            left: 12,
-            top: 8,
-            bottom: 8,
-          ),
+          padding: EdgeInsets.zero,
           color: colorConfig().entryTextColor,
           onPressed: onPressed,
         );

--- a/lib/widgets/journal/entry_details_widget.dart
+++ b/lib/widgets/journal/entry_details_widget.dart
@@ -102,7 +102,7 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
                       },
                       orElse: () => const SizedBox.shrink(),
                     ),
-                    EntryDetailHeader(itemId: widget.itemId),
+                    const EntryDetailHeader(),
                     Padding(
                       padding: EdgeInsets.only(
                         left: 8,
@@ -139,9 +139,7 @@ class _EntryDetailWidgetState extends State<EntryDetailWidget> {
                       journalEntry: (_) => const SizedBox.shrink(),
                       journalImage: (_) => const SizedBox.shrink(),
                     ),
-                    EntryDetailFooter(
-                      itemId: widget.itemId,
-                    ),
+                    const EntryDetailFooter(),
                   ],
                 ),
               ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.121+1211
+version: 0.8.122+1212
 
 msix_config:
   display_name: Lotti

--- a/test/widgets/journal/entry_details/entry_datetime_widget_test.dart
+++ b/test/widgets/journal/entry_details/entry_datetime_widget_test.dart
@@ -1,0 +1,121 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/blocs/journal/entry_cubit.dart';
+import 'package:lotti/blocs/journal/entry_state.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/routes/router.gr.dart';
+import 'package:lotti/services/tags_service.dart';
+import 'package:lotti/themes/themes_service.dart';
+import 'package:lotti/widgets/journal/entry_details/entry_datetime_widget.dart';
+import 'package:lotti/widgets/journal/entry_tools.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../journal_test_data/test_data.dart';
+import '../../../mocks/mocks.dart';
+import '../../../widget_test_utils.dart';
+
+class MockEntryCubit extends MockBloc<EntryCubit, EntryState>
+    implements EntryCubit {}
+
+void main() {
+  group('EntryDetailFooter', () {
+    final entryCubit = MockEntryCubit();
+    final mockAppRouter = MockAppRouter();
+
+    setUpAll(() {
+      getIt
+        ..registerSingleton<ThemesService>(ThemesService(watch: false))
+        ..registerSingleton<JournalDb>(JournalDb(inMemoryDatabase: true))
+        ..registerSingleton<TagsService>(TagsService())
+        ..registerSingleton<AppRouter>(mockAppRouter);
+
+      when(mockAppRouter.pop).thenAnswer((_) async => true);
+
+      when(() => entryCubit.state).thenAnswer(
+        (_) => EntryState.dirty(
+          entryId: testTextEntry.meta.id,
+          entry: testTextEntry,
+        ),
+      );
+    });
+
+    testWidgets('tap entry date', (WidgetTester tester) async {
+      when(entryCubit.togglePrivate).thenAnswer((_) async => true);
+
+      DateTime? modifiedDateTo;
+
+      when(
+        () => entryCubit.updateFromTo(
+          dateFrom: testTextEntry.meta.dateFrom,
+          dateTo: any(named: 'dateTo'),
+        ),
+      ).thenAnswer((Invocation i) async {
+        const dateTo = Symbol('dateTo');
+        modifiedDateTo = i.namedArguments[dateTo] as DateTime;
+        return true;
+      });
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          BlocProvider<EntryCubit>.value(
+            value: entryCubit,
+            child: const EntryDatetimeWidget(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final entryDateFromFinder =
+          find.text(df.format(testTextEntry.meta.dateFrom));
+      expect(entryDateFromFinder, findsOneWidget);
+
+      await tester.tap(entryDateFromFinder);
+      await tester.pumpAndSettle();
+
+      // entry date displayed in modal, too
+      expect(entryDateFromFinder, findsNWidgets(2));
+
+      // open and close dateTo selection
+      final entryDateToFinder = find.text(df.format(testTextEntry.meta.dateTo));
+      expect(entryDateToFinder, findsOneWidget);
+
+      await tester.tap(entryDateToFinder);
+      await tester.pumpAndSettle();
+
+      final doneButtonFinder = find.text('Done');
+      expect(doneButtonFinder, findsOneWidget);
+
+      await tester.tap(doneButtonFinder);
+      await tester.pumpAndSettle();
+
+      // open and close dateFrom selection
+      await tester.tap(entryDateFromFinder.last);
+      await tester.pumpAndSettle();
+
+      expect(doneButtonFinder, findsOneWidget);
+
+      await tester.tap(doneButtonFinder);
+      await tester.pumpAndSettle();
+
+      // set dateTo to now() and save
+      final nowButtonFinder = find.text('now');
+      expect(nowButtonFinder, findsOneWidget);
+
+      await tester.tap(nowButtonFinder);
+      await tester.pumpAndSettle();
+
+      final saveButtonFinder = find.text('SAVE');
+      expect(saveButtonFinder, findsOneWidget);
+
+      await tester.tap(saveButtonFinder);
+      await tester.pumpAndSettle();
+
+      verify(mockAppRouter.pop).called(1);
+
+      // updateFromTo called with recent dateTo after tapping now()
+      expect(modifiedDateTo?.difference(DateTime.now()).inSeconds, lessThan(2));
+    });
+  });
+}

--- a/test/widgets/journal/entry_details/entry_detail_footer_test.dart
+++ b/test/widgets/journal/entry_details/entry_detail_footer_test.dart
@@ -13,6 +13,7 @@ import 'package:lotti/services/tags_service.dart';
 import 'package:lotti/services/time_service.dart';
 import 'package:lotti/themes/themes_service.dart';
 import 'package:lotti/widgets/journal/entry_details/entry_detail_footer.dart';
+import 'package:lotti/widgets/journal/entry_tools.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../journal_test_data/test_data.dart';
@@ -38,6 +39,9 @@ void main() {
 
       when(mockAppRouter.pop).thenAnswer((_) async => true);
 
+      when(mockTimeService.getStream)
+          .thenAnswer((_) => Stream<JournalEntity>.fromIterable([]));
+
       when(() => entryCubit.state).thenAnswer(
         (_) => EntryState.dirty(
           entryId: testTextEntry.meta.id,
@@ -46,18 +50,31 @@ void main() {
       );
     });
 
-    testWidgets('tap map icon toggles map display',
-        (WidgetTester tester) async {
-      when(mockTimeService.getStream)
-          .thenAnswer((_) => Stream<JournalEntity>.fromIterable([]));
+    testWidgets('entry date is visible', (WidgetTester tester) async {
+      when(entryCubit.togglePrivate).thenAnswer((_) async => true);
 
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(
           BlocProvider<EntryCubit>.value(
             value: entryCubit,
-            child: EntryDetailFooter(
-              itemId: testTextEntry.meta.id,
-            ),
+            child: const EntryDetailFooter(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final entryDateFromFinder =
+          find.text(df.format(testTextEntry.meta.dateFrom));
+      expect(entryDateFromFinder, findsOneWidget);
+    });
+
+    testWidgets('tap map icon toggles map display',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          BlocProvider<EntryCubit>.value(
+            value: entryCubit,
+            child: const EntryDetailFooter(),
           ),
         ),
       );
@@ -83,9 +100,7 @@ void main() {
         makeTestableWidgetWithScaffold(
           BlocProvider<EntryCubit>.value(
             value: entryCubit,
-            child: EntryDetailFooter(
-              itemId: testTextEntry.meta.id,
-            ),
+            child: const EntryDetailFooter(),
           ),
         ),
       );
@@ -124,9 +139,7 @@ void main() {
         makeTestableWidgetWithScaffold(
           BlocProvider<EntryCubit>.value(
             value: entryCubit,
-            child: EntryDetailFooter(
-              itemId: testTextEntry.meta.id,
-            ),
+            child: const EntryDetailFooter(),
           ),
         ),
       );
@@ -176,9 +189,7 @@ void main() {
         makeTestableWidgetWithScaffold(
           BlocProvider<EntryCubit>.value(
             value: entryCubit,
-            child: EntryDetailFooter(
-              itemId: testTextEntry.meta.id,
-            ),
+            child: const EntryDetailFooter(),
           ),
         ),
       );

--- a/test/widgets/journal/entry_details/entry_detail_header_test.dart
+++ b/test/widgets/journal/entry_details/entry_detail_header_test.dart
@@ -9,7 +9,6 @@ import 'package:lotti/routes/router.gr.dart';
 import 'package:lotti/services/tags_service.dart';
 import 'package:lotti/themes/themes_service.dart';
 import 'package:lotti/widgets/journal/entry_details/entry_detail_header.dart';
-import 'package:lotti/widgets/journal/entry_tools.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -49,7 +48,7 @@ void main() {
         makeTestableWidgetWithScaffold(
           BlocProvider<EntryCubit>.value(
             value: entryCubit,
-            child: EntryDetailHeader(itemId: testTextEntry.meta.id),
+            child: const EntryDetailHeader(),
           ),
         ),
       );
@@ -70,7 +69,7 @@ void main() {
         makeTestableWidgetWithScaffold(
           BlocProvider<EntryCubit>.value(
             value: entryCubit,
-            child: EntryDetailHeader(itemId: testTextEntry.meta.id),
+            child: const EntryDetailHeader(),
           ),
         ),
       );
@@ -91,7 +90,7 @@ void main() {
         makeTestableWidgetWithScaffold(
           BlocProvider<EntryCubit>.value(
             value: entryCubit,
-            child: EntryDetailHeader(itemId: testTextEntry.meta.id),
+            child: const EntryDetailHeader(),
           ),
         ),
       );
@@ -103,83 +102,6 @@ void main() {
       await tester.pumpAndSettle();
 
       verify(entryCubit.togglePrivate).called(1);
-    });
-
-    testWidgets('tap entry date', (WidgetTester tester) async {
-      when(entryCubit.togglePrivate).thenAnswer((_) async => true);
-
-      DateTime? modifiedDateTo;
-
-      when(
-        () => entryCubit.updateFromTo(
-          dateFrom: testTextEntry.meta.dateFrom,
-          dateTo: any(named: 'dateTo'),
-        ),
-      ).thenAnswer((Invocation i) async {
-        const dateTo = Symbol('dateTo');
-        modifiedDateTo = i.namedArguments[dateTo] as DateTime;
-        return true;
-      });
-
-      await tester.pumpWidget(
-        makeTestableWidgetWithScaffold(
-          BlocProvider<EntryCubit>.value(
-            value: entryCubit,
-            child: EntryDetailHeader(itemId: testTextEntry.meta.id),
-          ),
-        ),
-      );
-      await tester.pumpAndSettle();
-
-      final entryDateFromFinder =
-          find.text(df.format(testTextEntry.meta.dateFrom));
-      expect(entryDateFromFinder, findsOneWidget);
-
-      await tester.tap(entryDateFromFinder);
-      await tester.pumpAndSettle();
-
-      // entry date displayed in modal, too
-      expect(entryDateFromFinder, findsNWidgets(2));
-
-      // open and close dateTo selection
-      final entryDateToFinder = find.text(df.format(testTextEntry.meta.dateTo));
-      expect(entryDateToFinder, findsOneWidget);
-
-      await tester.tap(entryDateToFinder);
-      await tester.pumpAndSettle();
-
-      final doneButtonFinder = find.text('Done');
-      expect(doneButtonFinder, findsOneWidget);
-
-      await tester.tap(doneButtonFinder);
-      await tester.pumpAndSettle();
-
-      // open and close dateFrom selection
-      await tester.tap(entryDateFromFinder.last);
-      await tester.pumpAndSettle();
-
-      expect(doneButtonFinder, findsOneWidget);
-
-      await tester.tap(doneButtonFinder);
-      await tester.pumpAndSettle();
-
-      // set dateTo to now() and save
-      final nowButtonFinder = find.text('now');
-      expect(nowButtonFinder, findsOneWidget);
-
-      await tester.tap(nowButtonFinder);
-      await tester.pumpAndSettle();
-
-      final saveButtonFinder = find.text('SAVE');
-      expect(saveButtonFinder, findsOneWidget);
-
-      await tester.tap(saveButtonFinder);
-      await tester.pumpAndSettle();
-
-      verify(mockAppRouter.pop).called(1);
-
-      // updateFromTo called with recent dateTo after tapping now()
-      expect(modifiedDateTo?.difference(DateTime.now()).inSeconds, lessThan(2));
     });
 
     testWidgets('save button invisible when saved/clean',
@@ -195,7 +117,7 @@ void main() {
         makeTestableWidgetWithScaffold(
           BlocProvider<EntryCubit>.value(
             value: entryCubit,
-            child: EntryDetailHeader(itemId: testTextEntry.meta.id),
+            child: const EntryDetailHeader(),
           ),
         ),
       );
@@ -220,7 +142,7 @@ void main() {
         makeTestableWidgetWithScaffold(
           BlocProvider<EntryCubit>.value(
             value: entryCubit,
-            child: EntryDetailHeader(itemId: testTextEntry.meta.id),
+            child: const EntryDetailHeader(),
           ),
         ),
       );


### PR DESCRIPTION
This PR improves the layout of entry details by moving the entry date to the footer so that there is enough space in the header for the save button even on small screens. Delete and share icons move to the other icons at the top.