### PR TITLE
Close datetime modal on save

### DIFF
--- a/lib/widgets/app_bar/task_app_bar.dart
+++ b/lib/widgets/app_bar/task_app_bar.dart
@@ -55,25 +55,7 @@ class TaskAppBar extends StatelessWidget with PreferredSizeWidget {
         } else {
           return AppBar(
             backgroundColor: colorConfig().headerBgColor,
-            title: Stack(
-              children: [
-                Opacity(
-                  opacity: 0.2,
-                  child: LinkedDuration(task: item),
-                ),
-                Positioned(
-                  top: 10,
-                  left: 48,
-                  child: Text(
-                    item.data.title,
-                    style: appBarTextStyle().copyWith(
-                      fontWeight: FontWeight.w300,
-                      fontSize: 16,
-                    ),
-                  ),
-                ),
-              ],
-            ),
+            title: LinkedDuration(task: item),
             centerTitle: true,
             leading: const TestDetectingAutoLeadingButton(),
           );

--- a/lib/widgets/journal/entry_details/entry_datetime_modal.dart
+++ b/lib/widgets/journal/entry_details/entry_datetime_modal.dart
@@ -5,8 +5,6 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lotti/blocs/journal/entry_cubit.dart';
 import 'package:lotti/blocs/journal/entry_state.dart';
 import 'package:lotti/classes/journal_entities.dart';
-import 'package:lotti/get_it.dart';
-import 'package:lotti/routes/router.gr.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/widgets/journal/entry_tools.dart';
 
@@ -66,6 +64,10 @@ class _EntryDateTimeModalState extends State<EntryDateTimeModal> {
     final valid = dateTo.isAfter(dateFrom) || dateTo == dateFrom;
     final changed = dateFrom != widget.item.meta.dateFrom ||
         dateTo != widget.item.meta.dateTo;
+
+    void pop() {
+      Navigator.pop(context);
+    }
 
     return BlocBuilder<EntryCubit, EntryState>(
       builder: (
@@ -195,7 +197,7 @@ class _EntryDateTimeModalState extends State<EntryDateTimeModal> {
                               dateFrom: dateFrom,
                               dateTo: dateTo,
                             );
-                            await getIt<AppRouter>().pop();
+                            pop();
                           },
                           child: Text(
                             localizations.journalDateSaveButton,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.122+1212
+version: 0.8.122+1213
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.122+1213
+version: 0.8.122+1216
 
 msix_config:
   display_name: Lotti

--- a/test/pages/journal/entry_detail_page_test.dart
+++ b/test/pages/journal/entry_detail_page_test.dart
@@ -302,7 +302,7 @@ void main() {
       // test task title is displayed
       expect(
         find.text(testTask.data.title),
-        findsNWidgets(2),
+        findsNWidgets(1),
       );
 
       // task entry duration is rendered

--- a/test/pages/journal/entry_detail_page_test.dart
+++ b/test/pages/journal/entry_detail_page_test.dart
@@ -300,10 +300,7 @@ void main() {
       expect(progressBar.total, const Duration(hours: 3));
 
       // test task title is displayed
-      expect(
-        find.text(testTask.data.title),
-        findsNWidgets(1),
-      );
+      expect(find.text(testTask.data.title), findsOneWidget);
 
       // task entry duration is rendered
       expect(

--- a/test/widgets/journal/entry_details/entry_datetime_widget_test.dart
+++ b/test/widgets/journal/entry_details/entry_datetime_widget_test.dart
@@ -5,7 +5,6 @@ import 'package:lotti/blocs/journal/entry_cubit.dart';
 import 'package:lotti/blocs/journal/entry_state.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
-import 'package:lotti/routes/router.gr.dart';
 import 'package:lotti/services/tags_service.dart';
 import 'package:lotti/themes/themes_service.dart';
 import 'package:lotti/widgets/journal/entry_details/entry_datetime_widget.dart';
@@ -13,7 +12,6 @@ import 'package:lotti/widgets/journal/entry_tools.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../journal_test_data/test_data.dart';
-import '../../../mocks/mocks.dart';
 import '../../../widget_test_utils.dart';
 
 class MockEntryCubit extends MockBloc<EntryCubit, EntryState>
@@ -22,16 +20,12 @@ class MockEntryCubit extends MockBloc<EntryCubit, EntryState>
 void main() {
   group('EntryDetailFooter', () {
     final entryCubit = MockEntryCubit();
-    final mockAppRouter = MockAppRouter();
 
     setUpAll(() {
       getIt
         ..registerSingleton<ThemesService>(ThemesService(watch: false))
         ..registerSingleton<JournalDb>(JournalDb(inMemoryDatabase: true))
-        ..registerSingleton<TagsService>(TagsService())
-        ..registerSingleton<AppRouter>(mockAppRouter);
-
-      when(mockAppRouter.pop).thenAnswer((_) async => true);
+        ..registerSingleton<TagsService>(TagsService());
 
       when(() => entryCubit.state).thenAnswer(
         (_) => EntryState.dirty(
@@ -111,8 +105,6 @@ void main() {
 
       await tester.tap(saveButtonFinder);
       await tester.pumpAndSettle();
-
-      verify(mockAppRouter.pop).called(1);
 
       // updateFromTo called with recent dateTo after tapping now()
       expect(modifiedDateTo?.difference(DateTime.now()).inSeconds, lessThan(2));


### PR DESCRIPTION
Previously, changing either the start or end date of an entry and then saving would close the entry itself, not just the modal. This PR fixes that.