### PR TITLE
Use salomon_bottom_bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed:
+- Navbar changed to Salomon style
+
 ### Fixed:
 - Navigation glitch where the bottom nav bar was moving
 - Error handling when page does not exist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed:
+- Navigation glitch where the bottom nav bar was moving
+- Error handling when page does not exist
+
+## [0.8.126] - 2022-08-08
 ### Changed:
 - Updated dependencies
 - Inline code style in editor

--- a/lib/logic/create/create_entry.dart
+++ b/lib/logic/create/create_entry.dart
@@ -17,7 +17,7 @@ Future<JournalEntity?> createTextEntry({String? linkedId}) async {
   );
 
   if (linkedId == null) {
-    pushNamedRoute('/journal/${entry?.meta.id}');
+    navigateNamedRoute('/journal/${entry?.meta.id}');
   }
   return entry;
 }
@@ -48,7 +48,7 @@ Future<Task?> createTask({String? linkedId}) async {
     linkedId: linkedId,
   );
 
-  pushNamedRoute('/journal/${task?.meta.id}');
+  navigateNamedRoute('/tasks/${task?.meta.id}');
   return task;
 }
 

--- a/lib/pages/create/create_measurement_page.dart
+++ b/lib/pages/create/create_measurement_page.dart
@@ -166,7 +166,7 @@ class _CreateMeasurementPageState extends State<CreateMeasurementPage> {
                                     cursor: SystemMouseCursors.click,
                                     child: GestureDetector(
                                       onTap: () {
-                                        pushNamedRoute(
+                                        navigateNamedRoute(
                                           '/settings/create_measurable',
                                         );
                                       },
@@ -213,7 +213,7 @@ class _CreateMeasurementPageState extends State<CreateMeasurementPage> {
                                             const Icon(Icons.settings_outlined),
                                         color: colorConfig().entryTextColor,
                                         onPressed: () {
-                                          pushNamedRoute(
+                                          navigateNamedRoute(
                                             '/settings/measurables/${selected?.id}',
                                           );
                                         },

--- a/lib/pages/dashboards/dashboard_page.dart
+++ b/lib/pages/dashboards/dashboard_page.dart
@@ -102,6 +102,7 @@ class _DashboardPageState extends State<DashboardPage> {
           }
 
           if (dashboard == null) {
+            navigateNamedRoute('/dashboards');
             return EmptyScaffoldWithTitle(
               localizations.dashboardNotFound,
             );
@@ -227,7 +228,7 @@ class DashboardWidget extends StatelessWidget {
                   icon: const Icon(Icons.dashboard_customize_outlined),
                   color: colorConfig().entryTextColor,
                   onPressed: () {
-                    pushNamedRoute(
+                    navigateNamedRoute(
                       '/settings/dashboards/$dashboardId',
                     );
                   },

--- a/lib/pages/dashboards/dashboards_list_page.dart
+++ b/lib/pages/dashboards/dashboards_list_page.dart
@@ -116,7 +116,7 @@ class DashboardCard extends StatelessWidget {
           ),
         ),
         onTap: () {
-          pushNamedRoute(
+          navigateNamedRoute(
             '/dashboards/dashboard/${dashboard.id}',
           );
         },

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -67,13 +67,6 @@ class HomePage extends StatelessWidget {
             //TutorialRouter(),
           ],
           bottomNavigationBuilder: (_, TabsRouter tabsRouter) {
-            final hideBottomNavRoutes = <String>{
-              EntryDetailRoute.name,
-              LoggingRoute.name,
-              LogDetailRoute.name,
-              SyncAssistantRoute.name,
-            };
-
             final navService = getIt<NavService>();
 
             final routesByIndex = <String>[
@@ -92,10 +85,6 @@ class HomePage extends StatelessWidget {
               tabsRouter.setActiveIndex(index);
               navService.bottomNavRouteTap(index);
               HapticFeedback.lightImpact();
-            }
-
-            if (hideBottomNavRoutes.contains(tabsRouter.topRoute.name)) {
-              return const SizedBox.shrink();
             }
 
             return DecoratedBox(

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -15,6 +15,7 @@ import 'package:lotti/widgets/audio/audio_recording_indicator.dart';
 import 'package:lotti/widgets/bottom_nav/flagged_badge_icon.dart';
 import 'package:lotti/widgets/bottom_nav/tasks_badge_icon.dart';
 import 'package:lotti/widgets/misc/time_recording_indicator.dart';
+import 'package:salomon_bottom_bar/salomon_bottom_bar.dart';
 
 class HomePage extends StatelessWidget {
   HomePage({super.key});
@@ -31,6 +32,8 @@ class HomePage extends StatelessWidget {
     return StreamBuilder<Set<String>>(
       stream: _db.watchActiveConfigFlagNames(),
       builder: (context, snapshot) {
+        final localizations = AppLocalizations.of(context)!;
+
         final showTasks = snapshot.data?.contains(showTasksTabFlag);
 
         if (showTasks == null) {
@@ -87,57 +90,50 @@ class HomePage extends StatelessWidget {
               HapticFeedback.lightImpact();
             }
 
-            return DecoratedBox(
-              decoration: const BoxDecoration(
-                boxShadow: <BoxShadow>[
-                  BoxShadow(
-                    color: Colors.black54,
-                    blurRadius: 8,
-                    offset: Offset(0, 0.75),
-                  )
-                ],
-              ),
-              child: BottomNavigationBar(
-                type: BottomNavigationBarType.fixed,
-                backgroundColor: colorConfig().bottomNavBackground,
-                unselectedItemColor: colorConfig().bottomNavIconUnselected,
-                selectedItemColor: colorConfig().bottomNavIconSelected,
-                currentIndex: tabsRouter.activeIndex,
-                selectedLabelStyle: bottomNavLabelStyle.copyWith(
-                  fontWeight: FontWeight.normal,
+            return SalomonBottomBar(
+              unselectedItemColor: colorConfig().bottomNavIconUnselected,
+              selectedItemColor: colorConfig().bottomNavIconSelected,
+              currentIndex: tabsRouter.activeIndex,
+              onTap: onTap,
+              items: [
+                SalomonBottomBarItem(
+                  icon: const Icon(Icons.dashboard_outlined),
+                  title: NavTitle(localizations.navTabTitleInsights),
                 ),
-                unselectedLabelStyle: bottomNavLabelStyle,
-                onTap: onTap,
-                enableFeedback: true,
-                selectedFontSize: 18,
-                unselectedFontSize: 16,
-                items: [
-                  BottomNavigationBarItem(
-                    icon: const Icon(Icons.dashboard_outlined),
-                    label: AppLocalizations.of(context)!.navTabTitleInsights,
+                SalomonBottomBarItem(
+                  icon: FlaggedBadgeIcon(),
+                  title: NavTitle(localizations.navTabTitleJournal),
+                ),
+                if (showTasks)
+                  SalomonBottomBarItem(
+                    icon: TasksBadgeIcon(),
+                    title: NavTitle(localizations.navTabTitleTasks),
                   ),
-                  BottomNavigationBarItem(
-                    icon: FlaggedBadgeIcon(),
-                    label: AppLocalizations.of(context)!.navTabTitleJournal,
+                SalomonBottomBarItem(
+                  icon: OutboxBadgeIcon(
+                    icon: const Icon(Icons.settings_outlined),
                   ),
-                  if (showTasks)
-                    BottomNavigationBarItem(
-                      icon: TasksBadgeIcon(),
-                      label: AppLocalizations.of(context)!.navTabTitleTasks,
-                    ),
-                  BottomNavigationBarItem(
-                    icon: OutboxBadgeIcon(
-                      icon: const Icon(Icons.settings_outlined),
-                    ),
-                    label: AppLocalizations.of(context)!.navTabTitleSettings,
-                  ),
-                ],
-              ),
+                  title: NavTitle(localizations.navTabTitleSettings),
+                ),
+              ],
             );
           },
           navigatorObservers: () => [NavObserver()],
         );
       },
+    );
+  }
+}
+
+class NavTitle extends StatelessWidget {
+  const NavTitle(this.title, {super.key});
+
+  final String title;
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 4),
+      child: Text(title),
     );
   }
 }

--- a/lib/pages/journal/entry_details_page.dart
+++ b/lib/pages/journal/entry_details_page.dart
@@ -70,7 +70,7 @@ class _EntryDetailPageState extends State<EntryDetailPage> {
       ) {
         final item = snapshot.data;
         if (item == null) {
-          return EmptyScaffoldWithTitle(localizations.dashboardNotFound);
+          return EmptyScaffoldWithTitle(localizations.entryNotFound);
         }
 
         return Scaffold(

--- a/lib/pages/settings/advanced_settings_page.dart
+++ b/lib/pages/settings/advanced_settings_page.dart
@@ -21,7 +21,7 @@ class AdvancedSettingsPage extends StatelessWidget {
       body: Container(
         margin: const EdgeInsets.symmetric(
           vertical: 8,
-          horizontal: 8,
+          horizontal: 4,
         ),
         child: ListView(
           children: [

--- a/lib/pages/settings/advanced_settings_page.dart
+++ b/lib/pages/settings/advanced_settings_page.dart
@@ -29,7 +29,7 @@ class AdvancedSettingsPage extends StatelessWidget {
               icon: const SettingsIcon(Icons.sync),
               title: localizations.settingsSyncCfgTitle,
               onTap: () {
-                pushNamedRoute('/settings/sync_settings');
+                navigateNamedRoute('/settings/sync_settings');
               },
             ),
             SettingsCard(
@@ -38,28 +38,28 @@ class AdvancedSettingsPage extends StatelessWidget {
               ),
               title: localizations.settingsSyncOutboxTitle,
               onTap: () {
-                pushNamedRoute('/settings/outbox_monitor');
+                navigateNamedRoute('/settings/outbox_monitor');
               },
             ),
             SettingsCard(
               icon: const SettingsIcon(MdiIcons.emoticonConfusedOutline),
               title: localizations.settingsConflictsTitle,
               onTap: () {
-                pushNamedRoute('/settings/conflicts');
+                navigateNamedRoute('/settings/conflicts');
               },
             ),
             SettingsCard(
               icon: const SettingsIcon(MdiIcons.informationOutline),
               title: localizations.settingsLogsTitle,
               onTap: () {
-                pushNamedRoute('/settings/logging');
+                navigateNamedRoute('/settings/logging');
               },
             ),
             SettingsCard(
               icon: const SettingsIcon(MdiIcons.broom),
               title: localizations.settingsMaintenanceTitle,
               onTap: () {
-                pushNamedRoute('/settings/maintenance');
+                navigateNamedRoute('/settings/maintenance');
               },
             ),
           ],

--- a/lib/pages/settings/flags_page.dart
+++ b/lib/pages/settings/flags_page.dart
@@ -42,7 +42,7 @@ class _FlagsPageState extends State<FlagsPage> {
 
           return ListView(
             shrinkWrap: true,
-            padding: const EdgeInsets.all(8),
+            padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
             children: List.generate(
               items.length,
               (int index) {

--- a/lib/pages/settings/logging_page.dart
+++ b/lib/pages/settings/logging_page.dart
@@ -81,7 +81,7 @@ class LogLineCard extends StatelessWidget {
 
     return GestureDetector(
       onTap: () {
-        pushNamedRoute('/settings/logging/${logEntry.id}');
+        navigateNamedRoute('/settings/logging/${logEntry.id}');
       },
       child: Padding(
         padding: const EdgeInsets.all(2),

--- a/lib/pages/settings/measurables/measurables_page.dart
+++ b/lib/pages/settings/measurables/measurables_page.dart
@@ -99,7 +99,7 @@ class _MeasurablesPageState extends State<MeasurablesPage> {
           floatingActionButton: FloatingActionButton(
             backgroundColor: colorConfig().entryBgColor,
             onPressed: () {
-              pushNamedRoute('/settings/create_measurable');
+              navigateNamedRoute('/settings/create_measurable');
             },
             child: const Icon(MdiIcons.plus, size: 32),
           ),

--- a/lib/pages/settings/settings_page.dart
+++ b/lib/pages/settings/settings_page.dart
@@ -35,7 +35,7 @@ class _SettingsPageState extends State<SettingsPage> {
       body: Container(
         margin: const EdgeInsets.symmetric(
           vertical: 8,
-          horizontal: 8,
+          horizontal: 4,
         ),
         child: ListView(
           children: [

--- a/lib/pages/settings/settings_page.dart
+++ b/lib/pages/settings/settings_page.dart
@@ -43,42 +43,42 @@ class _SettingsPageState extends State<SettingsPage> {
               icon: const SettingsIcon(MdiIcons.tagOutline),
               title: localizations.settingsTagsTitle,
               onTap: () {
-                pushNamedRoute('/settings/tags');
+                navigateNamedRoute('/settings/tags');
               },
             ),
             SettingsCard(
               icon: const SettingsIcon(Icons.dashboard_customize_outlined),
               title: localizations.settingsDashboardsTitle,
               onTap: () {
-                pushNamedRoute('/settings/dashboards');
+                navigateNamedRoute('/settings/dashboards');
               },
             ),
             SettingsCard(
               icon: const SettingsIcon(Icons.insights),
               title: localizations.settingsMeasurablesTitle,
               onTap: () {
-                pushNamedRoute('/settings/measurables');
+                navigateNamedRoute('/settings/measurables');
               },
             ),
             SettingsCard(
               icon: const SettingsIcon(MdiIcons.heartOutline),
               title: localizations.settingsHealthImportTitle,
               onTap: () {
-                pushNamedRoute('/settings/health_import');
+                navigateNamedRoute('/settings/health_import');
               },
             ),
             SettingsCard(
               icon: const SettingsIcon(MdiIcons.flagOutline),
               title: localizations.settingsFlagsTitle,
               onTap: () {
-                pushNamedRoute('/settings/flags');
+                navigateNamedRoute('/settings/flags');
               },
             ),
             SettingsCard(
               icon: const SettingsIcon(MdiIcons.alertRhombusOutline),
               title: localizations.settingsAdvancedTitle,
               onTap: () {
-                pushNamedRoute('/settings/advanced');
+                navigateNamedRoute('/settings/advanced');
               },
             ),
           ],

--- a/lib/pages/tasks/tasks_page.dart
+++ b/lib/pages/tasks/tasks_page.dart
@@ -315,7 +315,7 @@ class _TasksPageState extends State<TasksPage> {
                       Scaffold(
                         backgroundColor: colorConfig().bodyBgColor,
                         body: Container(
-                          margin: const EdgeInsets.symmetric(horizontal: 8),
+                          margin: const EdgeInsets.symmetric(horizontal: 4),
                           child: ListView(
                             children: [
                               SizedBox(height: searchHeaderHeight),

--- a/lib/services/nav_service.dart
+++ b/lib/services/nav_service.dart
@@ -63,6 +63,7 @@ void navigateNamedRoute(String route) {
   persistNamedRoute(route);
   getIt<AppRouter>().navigateNamed(
     route,
+    includePrefixMatches: true,
     onFailure: (_) => getIt<AppRouter>().navigateNamed('/'),
   );
 }

--- a/lib/services/nav_service.dart
+++ b/lib/services/nav_service.dart
@@ -23,7 +23,7 @@ class NavService {
 
     if (route != null) {
       Timer(const Duration(milliseconds: 1), () {
-        pushNamedRoute(route);
+        navigateNamedRoute(route);
         debugPrint('restoreRoute: $route');
       });
     }
@@ -58,8 +58,11 @@ void persistNamedRoute(String route) {
   getIt<NavService>().currentRoute = route;
 }
 
-void pushNamedRoute(String route) {
-  debugPrint('pushNamedRoute: $route');
+void navigateNamedRoute(String route) {
+  debugPrint('navigateNamedRoute: $route');
   persistNamedRoute(route);
-  getIt<AppRouter>().pushNamed(route);
+  getIt<AppRouter>().navigateNamed(
+    route,
+    onFailure: (_) => getIt<AppRouter>().navigateNamed('/'),
+  );
 }

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -36,14 +36,14 @@ class NotificationService {
 
   Future<void> onSelectNotification(String? payload) async {
     if (payload != null) {
-      pushNamedRoute(payload);
+      navigateNamedRoute(payload);
     }
 
     final details =
         await flutterLocalNotificationsPlugin.getNotificationAppLaunchDetails();
 
     if (details?.payload != null) {
-      pushNamedRoute('${details?.payload}');
+      navigateNamedRoute('${details?.payload}');
     }
   }
 

--- a/lib/widgets/app_bar/dashboards_app_bar.dart
+++ b/lib/widgets/app_bar/dashboards_app_bar.dart
@@ -47,7 +47,7 @@ class DashboardsAppBar extends StatelessWidget with PreferredSizeWidget {
                     );
 
                     Future<void>.delayed(const Duration(milliseconds: 50)).then(
-                      (value) => pushNamedRoute('/dashboards/carousel'),
+                      (value) => navigateNamedRoute('/dashboards/carousel'),
                     );
                   },
                 ),
@@ -68,7 +68,7 @@ class DashboardsAppBar extends StatelessWidget with PreferredSizeWidget {
                   );
 
                   Future<void>.delayed(const Duration(milliseconds: 50)).then(
-                    (value) => pushNamedRoute('/settings/dashboards/'),
+                    (value) => navigateNamedRoute('/settings/dashboards/'),
                   );
                 },
               ),

--- a/lib/widgets/charts/dashboard_measurables_chart.dart
+++ b/lib/widgets/charts/dashboard_measurables_chart.dart
@@ -85,7 +85,7 @@ class _DashboardMeasurablesChartState extends State<DashboardMeasurablesChart> {
               void onDoubleTap() {
                 if (widget.enableCreate) {
                   final id = measurableDataType.id;
-                  pushNamedRoute('/dashboards/measure/$id');
+                  navigateNamedRoute('/dashboards/measure/$id');
                 }
               }
 

--- a/lib/widgets/create/add_actions.dart
+++ b/lib/widgets/create/add_actions.dart
@@ -99,7 +99,7 @@ class _RadialAddActionButtonsState extends State<RadialAddActionButtons> {
             rebuild();
 
             final linkedId = widget.linked?.meta.id;
-            pushNamedRoute('/journal/fill_survey_linked/$linkedId');
+            navigateNamedRoute('/journal/fill_survey_linked/$linkedId');
           },
           child: const Icon(
             MdiIcons.clipboardOutline,
@@ -170,7 +170,7 @@ class _RadialAddActionButtonsState extends State<RadialAddActionButtons> {
             rebuild();
 
             final linkedId = widget.linked?.meta.id;
-            pushNamedRoute('/journal/record_audio/$linkedId');
+            navigateNamedRoute('/journal/record_audio/$linkedId');
 
             context.read<AudioRecorderCubit>().record(
                   linkedId: widget.linked?.meta.id,

--- a/lib/widgets/journal/journal_card.dart
+++ b/lib/widgets/journal/journal_card.dart
@@ -182,7 +182,12 @@ class JournalCard extends StatelessWidget {
                 },
               );
 
-              pushNamedRoute('/journal/${item.meta.id}');
+              final path = item.maybeMap(
+                task: (_) => '/tasks',
+                orElse: () => '/journal',
+              );
+
+              navigateNamedRoute('$path/${item.meta.id}');
             },
           ),
         );
@@ -243,7 +248,7 @@ class JournalImageCard extends StatelessWidget {
             child: JournalCardTitle(item: item),
           ),
           onTap: () {
-            pushNamedRoute('/journal/${item.meta.id}');
+            navigateNamedRoute('/journal/${item.meta.id}');
           },
         ),
       ),

--- a/lib/widgets/journal/tags/tag_widget.dart
+++ b/lib/widgets/journal/tags/tag_widget.dart
@@ -30,7 +30,7 @@ class TagWidget extends StatelessWidget {
           children: [
             GestureDetector(
               onDoubleTap: () {
-                pushNamedRoute('/settings/tags/${tagEntity.id}');
+                navigateNamedRoute('/settings/tags/${tagEntity.id}');
               },
               child: Padding(
                 padding: const EdgeInsets.only(bottom: 2),

--- a/lib/widgets/misc/time_recording_indicator.dart
+++ b/lib/widgets/misc/time_recording_indicator.dart
@@ -33,7 +33,7 @@ class TimeRecordingIndicatorWidget extends StatelessWidget {
         return GestureDetector(
           onTap: () {
             final itemId = current.meta.id;
-            pushNamedRoute('/journal/$itemId');
+            navigateNamedRoute('/journal/$itemId');
           },
           child: MouseRegion(
             cursor: SystemMouseCursors.click,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1756,6 +1756,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.27.5"
+  salomon_bottom_bar:
+    dependency: "direct main"
+    description:
+      name: salomon_bottom_bar
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.3.1"
   screen_retriever:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.126+1228
+version: 0.8.127+1229
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.127+1230
+version: 0.8.127+1231
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.127+1229
+version: 0.8.127+1230
 
 msix_config:
   display_name: Lotti
@@ -133,6 +133,7 @@ dependencies:
   research_package:
     git: https://github.com/matthiasn/research.package.git
 
+  salomon_bottom_bar: ^3.3.1
   share_plus: ^4.0.4
   sqflite: ^2.0.1
   sqlite3_flutter_libs: ^0.5.2

--- a/test/widgets/charts/dashboard_measurables_test.dart
+++ b/test/widgets/charts/dashboard_measurables_test.dart
@@ -175,8 +175,11 @@ void main() {
           mockSecureStorage.writeValue(any(), expectedRoute);
       when(mockWriteValue).thenAnswer((_) async {});
 
-      Future<void> mockNavigateNamed() => mockAppRouter
-          .navigateNamed(expectedRoute, onFailure: any(named: 'onFailure'));
+      Future<void> mockNavigateNamed() => mockAppRouter.navigateNamed(
+            expectedRoute,
+            includePrefixMatches: true,
+            onFailure: any(named: 'onFailure'),
+          );
       when(mockNavigateNamed).thenAnswer((_) async {});
 
       final chartTappableFinder = find.byType(GestureDetector).first;

--- a/test/widgets/charts/dashboard_measurables_test.dart
+++ b/test/widgets/charts/dashboard_measurables_test.dart
@@ -175,8 +175,9 @@ void main() {
           mockSecureStorage.writeValue(any(), expectedRoute);
       when(mockWriteValue).thenAnswer((_) async {});
 
-      Future<void> mockPushNamed() => mockAppRouter.pushNamed(expectedRoute);
-      when(mockPushNamed).thenAnswer((_) async {});
+      Future<void> mockNavigateNamed() => mockAppRouter
+          .navigateNamed(expectedRoute, onFailure: any(named: 'onFailure'));
+      when(mockNavigateNamed).thenAnswer((_) async {});
 
       final chartTappableFinder = find.byType(GestureDetector).first;
       await tester.tap(chartTappableFinder);
@@ -185,7 +186,7 @@ void main() {
 
       await tester.pumpAndSettle();
       verify(mockWriteValue).called(1);
-      verify(mockPushNamed).called(1);
+      verify(mockNavigateNamed).called(1);
     });
   });
 }


### PR DESCRIPTION
This PR changes the bottom navigation bar to use [`salomon_bottom_bar`](https://pub.dev/packages/salomon_bottom_bar) which looks more modern and takes up less vertical space. The PR also fixes the transition between pages by using `navigateNamed` instead of `pushNamed`. Previously, the bottom bar would slide in and out of the page with the subpage, whereas now, it stays in place as expected.