### PR TITLE
Add surveys with plus icon in dashboard, not double tap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed:
+- Plus icon for adding measurement from dashboard instead of double tab
+- Plus icon for filling survey from dashboard instead of double tab
+
+## [0.8.130] - 2022-08-23
 ### Added:
 - New navigation using beamer (in progress, available via config flag)
 - Navigation in Settings > Tags using beamer

--- a/lib/surveys/run_surveys.dart
+++ b/lib/surveys/run_surveys.dart
@@ -19,6 +19,7 @@ Future<void> runSurvey({
       ),
     ),
     clipBehavior: Clip.antiAliasWithSaveLayer,
+    useRootNavigator: true,
     builder: (BuildContext context) {
       return SurveyWidget(task, resultCallback);
     },

--- a/lib/widgets/charts/dashboard_health_bmi_chart.dart
+++ b/lib/widgets/charts/dashboard_health_bmi_chart.dart
@@ -136,7 +136,7 @@ class _DashboardHealthBmiChartState extends State<DashboardHealthBmiChart> {
                     key: Key('${widget.chartConfig.hashCode}'),
                     color: Colors.white,
                     height: 320,
-                    padding: const EdgeInsets.symmetric(horizontal: 4),
+                    padding: const EdgeInsets.symmetric(horizontal: 12),
                     child: Stack(
                       children: [
                         charts.TimeSeriesChart(

--- a/lib/widgets/charts/dashboard_health_bp_chart.dart
+++ b/lib/widgets/charts/dashboard_health_bp_chart.dart
@@ -118,7 +118,7 @@ class _DashboardHealthBpChartState extends State<DashboardHealthBpChart> {
                 key: Key('${widget.chartConfig.hashCode}'),
                 color: Colors.white,
                 height: 200,
-                padding: const EdgeInsets.symmetric(horizontal: 4),
+                padding: const EdgeInsets.symmetric(horizontal: 12),
                 child: Stack(
                   children: [
                     charts.TimeSeriesChart(

--- a/lib/widgets/charts/dashboard_health_chart.dart
+++ b/lib/widgets/charts/dashboard_health_chart.dart
@@ -125,7 +125,7 @@ class _DashboardHealthChartState extends State<DashboardHealthChart> {
                 key: Key('${widget.chartConfig.hashCode}'),
                 color: Colors.white,
                 height: 120,
-                padding: const EdgeInsets.symmetric(horizontal: 4),
+                padding: const EdgeInsets.symmetric(horizontal: 12),
                 child: Stack(
                   children: [
                     charts.TimeSeriesChart(

--- a/lib/widgets/charts/dashboard_measurables_chart.dart
+++ b/lib/widgets/charts/dashboard_measurables_chart.dart
@@ -199,14 +199,15 @@ class _DashboardMeasurablesChartState extends State<DashboardMeasurablesChart> {
                           top: 0,
                           child: IconButton(
                             padding: const EdgeInsets.only(
-                              right: 4,
-                              top: 4,
+                              right: 6,
+                              top: 48,
                               left: 16,
-                              bottom: 16,
+                              bottom: 48,
                             ),
                             onPressed: onTapAdd,
                             icon: const Icon(
                               Icons.add_circle_outline,
+                              size: 28,
                               color: Color.fromRGBO(0, 0, 0, 0.7),
                             ),
                           ),

--- a/lib/widgets/charts/dashboard_survey_chart.dart
+++ b/lib/widgets/charts/dashboard_survey_chart.dart
@@ -43,7 +43,7 @@ class DashboardSurveyChart extends StatelessWidget {
       ) {
         final items = snapshot.data ?? [];
 
-        Future<void> onDoubleTap() async {
+        void onTapAdd() {
           if (chartConfig.surveyType == 'cfq11SurveyTask') {
             runCfq11(context: context);
           }
@@ -52,21 +52,19 @@ class DashboardSurveyChart extends StatelessWidget {
           }
         }
 
-        return GestureDetector(
-          onDoubleTap: onDoubleTap,
-          onLongPress: onDoubleTap,
-          child: Padding(
-            padding: const EdgeInsets.only(bottom: 8),
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(16),
-              child: Container(
-                key: Key('${chartConfig.hashCode}'),
-                color: Colors.white,
-                height: 120,
-                padding: const EdgeInsets.symmetric(horizontal: 4),
-                child: Stack(
-                  children: [
-                    charts.TimeSeriesChart(
+        return Padding(
+          padding: const EdgeInsets.only(bottom: 8),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(16),
+            child: Container(
+              key: Key('${chartConfig.hashCode}'),
+              color: Colors.white,
+              height: 120,
+              child: Stack(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 12),
+                    child: charts.TimeSeriesChart(
                       surveySeries(
                         entities: items,
                         dashboardSurveyItem: chartConfig,
@@ -84,24 +82,42 @@ class DashboardSurveyChart extends StatelessWidget {
                         ),
                       ),
                     ),
-                    Positioned(
-                      top: 0,
-                      left: MediaQuery.of(context).size.width / 4,
-                      child: SizedBox(
-                        width: MediaQuery.of(context).size.width / 2,
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            Text(
-                              chartConfig.surveyName,
-                              style: chartTitleStyle(),
-                            ),
-                          ],
-                        ),
+                  ),
+                  Positioned(
+                    top: 0,
+                    left: MediaQuery.of(context).size.width / 4,
+                    child: SizedBox(
+                      width: MediaQuery.of(context).size.width / 2,
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Text(
+                            chartConfig.surveyName,
+                            style: chartTitleStyle(),
+                          ),
+                        ],
                       ),
                     ),
-                  ],
-                ),
+                  ),
+                  Positioned(
+                    right: 0,
+                    top: 0,
+                    child: IconButton(
+                      padding: const EdgeInsets.only(
+                        right: 6,
+                        top: 48,
+                        left: 16,
+                        bottom: 48,
+                      ),
+                      onPressed: onTapAdd,
+                      icon: const Icon(
+                        Icons.add_circle_outline,
+                        size: 28,
+                        color: Color.fromRGBO(0, 0, 0, 0.7),
+                      ),
+                    ),
+                  ),
+                ],
               ),
             ),
           ),

--- a/lib/widgets/charts/dashboard_workout_chart.dart
+++ b/lib/widgets/charts/dashboard_workout_chart.dart
@@ -97,7 +97,7 @@ class _DashboardWorkoutChartState extends State<DashboardWorkoutChart> {
                 key: Key('${widget.chartConfig.hashCode}'),
                 color: Colors.white,
                 height: 120,
-                padding: const EdgeInsets.symmetric(horizontal: 4),
+                padding: const EdgeInsets.symmetric(horizontal: 12),
                 child: Stack(
                   children: [
                     charts.TimeSeriesChart(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -749,7 +749,7 @@ packages:
       name: flutter_launcher_icons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.3"
+    version: "0.10.0"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.130+1293
+version: 0.8.131+1294
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.131+1294
+version: 0.8.131+1295
 
 msix_config:
   display_name: Lotti
@@ -162,7 +162,7 @@ dev_dependencies:
   build_runner: ^2.2.0
   dart_code_metrics: ^4.8.1
   drift_dev: ^2.0.2
-  flutter_launcher_icons: ^0.9.2
+  flutter_launcher_icons: ^0.10.0
   flutter_lints: ^2.0.1
   flutter_native_splash: ^2.1.3+1
   flutter_test:


### PR DESCRIPTION
This PR makes filling surveys more intuitive by adding a more obvious plus icon in the dashboard, instead of having to double tab.