### PR TITLE
Assign story to comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed:
+- Upgraded dependencies
+
+## [0.8.141] - 2022-09-12
+### Changed:
 - Flutter version upgrade
 - Upgraded dependencies
 - Sync reliability improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed:
 - Upgraded dependencies
+- Assign story tag to comment entries as well
 
 ## [0.8.141] - 2022-09-12
 ### Changed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded dependencies
 - Assign story tag to comment entries as well
 
+### Added:
+- More tests for persistence logic
+
 ## [0.8.141] - 2022-09-12
 ### Changed:
 - Flutter version upgrade

--- a/lib/blocs/journal/entry_cubit.dart
+++ b/lib/blocs/journal/entry_cubit.dart
@@ -211,7 +211,7 @@ class EntryCubit extends Cubit<EntryState> {
   }
 
   Future<void> addTagIds(List<String> addedTagIds) async {
-    await _persistenceLogic.addTags(
+    await _persistenceLogic.addTagsWithLinked(
       journalEntityId: entryId,
       addedTagIds: addedTagIds,
     );

--- a/lib/logic/persistence_logic.dart
+++ b/lib/logic/persistence_logic.dart
@@ -755,6 +755,41 @@ class PersistenceLogic {
     return true;
   }
 
+  Future<bool?> addTagsWithLinked({
+    required String journalEntityId,
+    required List<String> addedTagIds,
+  }) async {
+    try {
+      await addTags(
+        journalEntityId: journalEntityId,
+        addedTagIds: addedTagIds,
+      );
+
+      final tagsService = getIt<TagsService>();
+      final storyTags = tagsService.getFilteredStoryTagIds(addedTagIds);
+
+      final linkedEntities = await _journalDb.getLinkedEntities(
+        journalEntityId,
+      );
+
+      for (final linked in linkedEntities) {
+        await addTags(
+          journalEntityId: linked.meta.id,
+          addedTagIds: storyTags,
+        );
+      }
+    } catch (exception, stackTrace) {
+      _loggingDb.captureException(
+        exception,
+        domain: 'persistence_logic',
+        subDomain: 'addTagsWithLinked',
+        stackTrace: stackTrace,
+      );
+    }
+
+    return true;
+  }
+
   Future<bool?> removeTag({
     required String journalEntityId,
     required String tagId,

--- a/lib/logic/persistence_logic.dart
+++ b/lib/logic/persistence_logic.dart
@@ -43,7 +43,9 @@ class PersistenceLogic {
     }
   }
 
-  Future<bool> createQuantitativeEntry(QuantitativeData data) async {
+  Future<QuantitativeEntry?> createQuantitativeEntry(
+    QuantitativeData data,
+  ) async {
     try {
       final now = DateTime.now();
       final vc = await _vectorClockService.getNextVectorClock();
@@ -54,7 +56,7 @@ class PersistenceLogic {
       final dateFrom = data.dateFrom;
       final dateTo = data.dateTo;
 
-      final journalEntity = JournalEntity.quantitative(
+      final journalEntity = QuantitativeEntry(
         data: data,
         meta: Metadata(
           createdAt: now,
@@ -68,6 +70,7 @@ class PersistenceLogic {
         ),
       );
       await createDbEntity(journalEntity, enqueueSync: true);
+      return journalEntity;
     } catch (exception, stackTrace) {
       _loggingDb.captureException(
         exception,
@@ -77,7 +80,7 @@ class PersistenceLogic {
       );
     }
 
-    return true;
+    return null;
   }
 
   Future<WorkoutEntry?> createWorkoutEntry(WorkoutData data) async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "46.0.0"
+    version: "47.0.0"
   adaptive_dialog:
     dependency: "direct main"
     description:
@@ -21,7 +21,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.6.0"
+    version: "4.7.0"
   analyzer_plugin:
     dependency: transitive
     description:
@@ -392,7 +392,7 @@ packages:
       name: dart_code_metrics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.18.0-dev.2"
+    version: "4.18.0"
   dart_console:
     dependency: transitive
     description:
@@ -796,7 +796,7 @@ packages:
       name: flutter_quill
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.0"
+    version: "6.0.2"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -873,7 +873,7 @@ packages:
       name: flutter_svg
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.4"
+    version: "1.1.5"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -2061,7 +2061,7 @@ packages:
       name: very_good_analysis
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   video_player:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.142+1335
+version: 0.8.142+1336
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.141+1332
+version: 0.8.142+1333
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.142+1333
+version: 0.8.142+1334
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.142+1334
+version: 0.8.142+1335
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.142+1336
+version: 0.8.142+1337
 
 msix_config:
   display_name: Lotti

--- a/test/logic/persistence_logic_test.dart
+++ b/test/logic/persistence_logic_test.dart
@@ -579,5 +579,30 @@ void main() {
 
       expect(createdTag.tag, testTag);
     });
+
+    test('create, retrieve and delete dashboard', () async {
+      await getIt<PersistenceLogic>()
+          .upsertDashboardDefinition(testDashboardConfig);
+
+      final created = (await getIt<JournalDb>()
+              .watchDashboardById(testDashboardConfig.id)
+              .first)
+          .first;
+
+      expect(created, testDashboardConfig);
+
+      when(() => mockNotificationService.cancelNotification(any()))
+          .thenAnswer((_) async {});
+
+      await getIt<PersistenceLogic>()
+          .deleteDashboardDefinition(testDashboardConfig);
+
+      final count = (await getIt<JournalDb>()
+              .watchDashboardById(testDashboardConfig.id)
+              .first)
+          .length;
+
+      expect(count, 0);
+    });
   });
 }

--- a/test/logic/persistence_logic_test.dart
+++ b/test/logic/persistence_logic_test.dart
@@ -462,6 +462,35 @@ void main() {
       );
     });
 
+    test('create and retrieve QuantitativeEntry', () async {
+      final entry = await getIt<PersistenceLogic>().createQuantitativeEntry(
+        testWeightEntry.data,
+      );
+      expect(entry?.data, testWeightEntry.data);
+
+      // workout is retrieved as latest workout
+      expect(
+        (await getIt<JournalDb>()
+                .latestQuantitativeByType('HealthDataType.WEIGHT'))
+            ?.data,
+        testWeightEntry.data,
+      );
+
+      // workout is retrieved on workout watch stream
+      expect(
+        ((await getIt<JournalDb>()
+                    .watchQuantitativeByType(
+                      rangeStart: DateTime(0),
+                      rangeEnd: DateTime(2100),
+                      type: 'HealthDataType.WEIGHT',
+                    )
+                    .first)
+                .first as QuantitativeEntry)
+            .data,
+        testWeightEntry.data,
+      );
+    });
+
     test('create and retrieve measurement entry', () async {
       // create test data types
       await getIt<JournalDb>().upsertMeasurableDataType(measurableWater);

--- a/test/logic/persistence_logic_test.dart
+++ b/test/logic/persistence_logic_test.dart
@@ -569,5 +569,15 @@ void main() {
         {measurableWater},
       );
     });
+
+    test('create and retrieve tag', () async {
+      const testTag = 'test-tag';
+      await getIt<PersistenceLogic>().addTagDefinition(testTag);
+
+      final createdTag =
+          (await getIt<JournalDb>().getMatchingTags(testTag)).first;
+
+      expect(createdTag.tag, testTag);
+    });
   });
 }


### PR DESCRIPTION
This PR changes assigning a story tag to assign the story to linked comments as well, e.g. for having a story assigned to a task assigned to time recordings on that task, too.