### PR TITLE
Fix story assignment on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed:
+- Story assignment on mobile
+
+## [0.8.152] - 2022-09-24
 ### Changed:
 - DefinitionCard design
 - Design: Settings > Tags

--- a/lib/widgets/journal/tags/tag_add.dart
+++ b/lib/widgets/journal/tags/tag_add.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -11,6 +9,7 @@ import 'package:lotti/services/tags_service.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/widgets/journal/tags/tags_modal.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 
 class TagAddIconWidget extends StatelessWidget {
   TagAddIconWidget({super.key});
@@ -43,10 +42,9 @@ class TagAddIconWidget extends StatelessWidget {
             final controller = TextEditingController();
 
             void onTapAdd() {
-              showModalBottomSheet<void>(
+              showCupertinoModalBottomSheet<void>(
                 context: context,
-                isScrollControlled: true,
-                isDismissible: Platform.isMacOS,
+                isDismissible: true,
                 shape: const RoundedRectangleBorder(
                   borderRadius: BorderRadius.vertical(
                     top: Radius.circular(16),

--- a/lib/widgets/journal/tags/tag_add.dart
+++ b/lib/widgets/journal/tags/tag_add.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -44,6 +46,7 @@ class TagAddIconWidget extends StatelessWidget {
               showModalBottomSheet<void>(
                 context: context,
                 isScrollControlled: true,
+                isDismissible: Platform.isMacOS,
                 shape: const RoundedRectangleBorder(
                   borderRadius: BorderRadius.vertical(
                     top: Radius.circular(16),

--- a/lib/widgets/journal/tags/tags_modal.dart
+++ b/lib/widgets/journal/tags/tags_modal.dart
@@ -117,6 +117,7 @@ class _TagsModalState extends State<TagsModal> {
                       controller: _controller,
                       onSubmitted: onSubmitted,
                       onChanged: onChanged,
+                      autofocus: true,
                     ),
                   ),
                   IconButton(

--- a/lib/widgets/settings/settings_card.dart
+++ b/lib/widgets/settings/settings_card.dart
@@ -10,6 +10,10 @@ class SettingsCard extends StatelessWidget {
     this.subtitle,
     this.leading,
     this.trailing,
+    this.contentPadding = const EdgeInsets.symmetric(
+      horizontal: 32,
+      vertical: 8,
+    ),
   });
 
   final String title;
@@ -17,6 +21,7 @@ class SettingsCard extends StatelessWidget {
   final Widget? subtitle;
   final Widget? leading;
   final Widget? trailing;
+  final EdgeInsets contentPadding;
 
   @override
   Widget build(BuildContext context) {
@@ -25,10 +30,7 @@ class SettingsCard extends StatelessWidget {
       elevation: 0,
       color: Colors.transparent,
       child: ListTile(
-        contentPadding: const EdgeInsets.symmetric(
-          horizontal: 32,
-          vertical: 8,
-        ),
+        contentPadding: contentPadding,
         hoverColor: colorConfig().riplight,
         title: Padding(
           padding: const EdgeInsets.symmetric(vertical: 2),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1281,6 +1281,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.3.0"
+  modal_bottom_sheet:
+    dependency: "direct main"
+    description:
+      name: modal_bottom_sheet
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.2"
   msix:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.152+1411
+version: 0.8.153+1412
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.153+1414
+version: 0.8.153+1415
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.153+1412
+version: 0.8.153+1414
 
 msix_config:
   display_name: Lotti
@@ -109,6 +109,7 @@ dependencies:
   lottie: ^1.2.2
   material_design_icons_flutter: ^5.0.6595
   material_floating_search_bar: ^0.3.6
+  modal_bottom_sheet: ^2.1.2
   multi_select_flutter: ^4.0.0
   mutex: ^3.0.0
   package_info_plus: ^1.3.0

--- a/test/widgets/journal/tags/tags_modal_widget_test.dart
+++ b/test/widgets/journal/tags/tags_modal_widget_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/blocs/journal/entry_cubit.dart';
@@ -61,7 +61,7 @@ void main() {
     when(() => mockTagsService.getTagById(testStoryTag1.id))
         .thenAnswer((_) => testStoryTag1);
 
-    when(() => mockTagsService.getMatchingTags('some'))
+    when(() => mockTagsService.getMatchingTags(any()))
         .thenAnswer((_) async => [testTag1]);
 
     when(() => entryCubit.state).thenAnswer(
@@ -124,7 +124,7 @@ void main() {
 
       await tester.pumpAndSettle();
 
-      final searchFieldFinder = find.byType(TextField);
+      final searchFieldFinder = find.byType(CupertinoTextField);
       await tester.enterText(searchFieldFinder, 'some');
       await tester.pumpAndSettle();
 
@@ -176,12 +176,46 @@ void main() {
 
       await tester.pumpAndSettle();
 
-      final searchFieldFinder = find.byType(TextField);
+      final searchFieldFinder = find.byType(CupertinoTextField);
       await tester.enterText(searchFieldFinder, newTag.tag);
       await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.pumpAndSettle(const Duration(seconds: 5));
 
       verify(() => entryCubit.addTagDefinition(newTag.tag)).called(1);
+    });
+
+    testWidgets('remove tag', (tester) async {
+      when(mockTagsService.watchTags).thenAnswer(
+        (_) => Stream<List<TagEntity>>.fromIterable([
+          [
+            testStoryTag1,
+            testPersonTag1,
+            testTag1,
+          ]
+        ]),
+      );
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          BlocProvider<EntryCubit>.value(
+            value: entryCubit,
+            child: TagsModal(
+              controller: controller,
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      final closeIconFinder = find.byIcon(MdiIcons.close);
+      expect(closeIconFinder, findsNWidgets(2));
+
+      when(() => entryCubit.removeTagId(any())).thenAnswer((_) async {});
+
+      await tester.tap(closeIconFinder.first);
+
+      verify(() => entryCubit.removeTagId(any())).called(1);
     });
   });
 }


### PR DESCRIPTION
This PR fixes an issue when assigning stories on mobile where tapping into the search field would lead to the modal being dismissed. For now, behavior on desktop stays as it was, where clicking outside the modal would close it, whereas now on mobile, it needs to be dragged down. Fine for now, this whole interaction is not ideal and likely to change soon.