### PR TITLE
Add sleep types CORE, DEEP, REM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed:
+- Sleep import on iOS
+
+## [0.8.159] - 2022-09-29
 ### Added:
 - Aggregation by hour in measurables charts
 

--- a/lib/pages/settings/health_import_page.dart
+++ b/lib/pages/settings/health_import_page.dart
@@ -52,7 +52,7 @@ class _HealthImportPageState extends State<HealthImportPage> {
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             SfDateRangePicker(
-              backgroundColor: Colors.transparent,
+              backgroundColor: styleConfig().cardColor,
               onSelectionChanged: _onSelectionChanged,
               enableMultiView: true,
               selectionMode: DateRangePickerSelectionMode.range,

--- a/lib/widgets/charts/dashboard_health_config.dart
+++ b/lib/widgets/charts/dashboard_health_config.dart
@@ -123,6 +123,27 @@ Map<String, HealthTypeConfig> healthTypes = {
     aggregationType: HealthAggregationType.dailyTimeSum,
     hoursMinutes: true,
   ),
+  'HealthDataType.SLEEP_ASLEEP_CORE': HealthTypeConfig(
+    displayName: 'Asleep - core',
+    healthType: 'HealthDataType.SLEEP_ASLEEP_CORE',
+    chartType: HealthChartType.barChart,
+    aggregationType: HealthAggregationType.dailyTimeSum,
+    hoursMinutes: true,
+  ),
+  'HealthDataType.SLEEP_ASLEEP_DEEP': HealthTypeConfig(
+    displayName: 'Asleep - deep',
+    healthType: 'HealthDataType.SLEEP_ASLEEP_DEEP',
+    chartType: HealthChartType.barChart,
+    aggregationType: HealthAggregationType.dailyTimeSum,
+    hoursMinutes: true,
+  ),
+  'HealthDataType.SLEEP_ASLEEP_REM': HealthTypeConfig(
+    displayName: 'Asleep - REM',
+    healthType: 'HealthDataType.SLEEP_ASLEEP_REM',
+    chartType: HealthChartType.barChart,
+    aggregationType: HealthAggregationType.dailyTimeSum,
+    hoursMinutes: true,
+  ),
   'HealthDataType.SLEEP_IN_BED': HealthTypeConfig(
     displayName: 'In bed',
     healthType: 'HealthDataType.SLEEP_IN_BED',

--- a/lib/widgets/charts/dashboard_health_data.dart
+++ b/lib/widgets/charts/dashboard_health_data.dart
@@ -107,6 +107,7 @@ List<Observation> aggregateDailySum(List<JournalEntity?> entities) {
   final aggregated = <Observation>[];
   for (final dayString in sumsByDay.keys) {
     final day = DateTime.parse(dayString);
+    // final midDay = day.add(const Duration(hours: 12));
     aggregated.add(Observation(day, sumsByDay[dayString] ?? 0));
   }
 

--- a/lib/widgets/charts/dashboard_measurables_chart.dart
+++ b/lib/widgets/charts/dashboard_measurables_chart.dart
@@ -152,9 +152,10 @@ class _DashboardMeasurablesChartState extends State<DashboardMeasurablesChart> {
                     )
                   ],
                   behaviors: [
-                    measurablesChartRangeAnnotation(
-                      aggregationType,
-                      widget.rangeStart,
+                    chartRangeAnnotation(
+                      aggregationType == AggregationType.hourlySum
+                          ? widget.rangeStart.subtract(const Duration(days: 1))
+                          : widget.rangeStart,
                       widget.rangeEnd,
                     )
                   ],

--- a/lib/widgets/charts/utils.dart
+++ b/lib/widgets/charts/utils.dart
@@ -46,7 +46,7 @@ List<MeasuredObservation> aggregateSumByDay(
   final sumsByDay = <String, num>{};
   final range = rangeEnd.difference(rangeStart);
   final dayStrings = List<String>.generate(range.inDays, (days) {
-    final day = rangeStart.add(Duration(days: days + 1));
+    final day = rangeStart.add(Duration(days: days));
     return ymd(day);
   });
 
@@ -64,8 +64,9 @@ List<MeasuredObservation> aggregateSumByDay(
 
   final aggregated = <MeasuredObservation>[];
   for (final dayString in sumsByDay.keys) {
-    final midDay = DateTime.parse(dayString).add(const Duration(hours: 12));
-    aggregated.add(MeasuredObservation(midDay, sumsByDay[dayString] ?? 0));
+    final day = DateTime.parse(dayString);
+    // final midDay = day.add(const Duration(hours: 12));
+    aggregated.add(MeasuredObservation(day, sumsByDay[dayString] ?? 0));
   }
 
   return aggregated;
@@ -166,8 +167,8 @@ RangeAnnotation<DateTime> chartRangeAnnotation(
 ) {
   return RangeAnnotation([
     RangeAnnotationSegment(
-      rangeStart,
-      rangeEnd,
+      rangeStart.add(const Duration(days: 1)),
+      rangeEnd.subtract(const Duration(days: 1)),
       RangeAnnotationAxisType.domain,
       color: Color.transparent,
     )

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -991,8 +991,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/health"
-      ref: bfa66d6
-      resolved-ref: bfa66d6027a355eb8b93bfc3dbe9d0c77cd62fb5
+      ref: "8fa7374"
+      resolved-ref: "8fa7374d08edb7485407fc26204e5ead533dec00"
       url: "https://github.com/matthiasn/flutter-plugins"
     source: git
     version: "3.4.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.159+1444
+version: 0.8.160+1445
 
 msix_config:
   display_name: Lotti
@@ -95,7 +95,7 @@ dependencies:
     git:
       url: https://github.com/matthiasn/flutter-plugins
       path: packages/health
-      ref: bfa66d6
+      ref: 8fa7374
 
   hotkey_manager: ^0.1.6
   intersperse: ^2.0.0


### PR DESCRIPTION
This PR fixes sleep import by adding additional sleep types `CORE`, `DEEP`, and `REM`. Sleep import broke after upgrading to iOS 16 in combination with watchOS 9, or rather the now deprecated generic type `ASLEEP` is not retrieved any longer. In addition to recording the specific sleep type, the generic type is recorded as well for backwards comparability.