### PR TITLE
Remove index creation from Drift file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed:
+- Removed index creation in JournalDb for now
+
+## [0.8.173] - 2022-10-16
+### Changed:
 - Improved photo view
 
 ## [0.8.172] - 2022-10-16

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -62,17 +62,17 @@ class JournalDb extends _$JournalDb {
         await () async {
           debugPrint('Creating habit_definitions table and indices');
           await m.createTable(habitDefinitions);
-          await m.createIndex(idxHabitDefinitionsId);
-          await m.createIndex(idxHabitDefinitionsName);
-          await m.createIndex(idxHabitDefinitionsPrivate);
+          // await m.createIndex(idxHabitDefinitionsId);
+          // await m.createIndex(idxHabitDefinitionsName);
+          // await m.createIndex(idxHabitDefinitionsPrivate);
         }();
 
         await () async {
           debugPrint('Creating dashboard_definitions table and indices');
           await m.createTable(dashboardDefinitions);
-          await m.createIndex(idxDashboardDefinitionsId);
-          await m.createIndex(idxDashboardDefinitionsName);
-          await m.createIndex(idxDashboardDefinitionsPrivate);
+          // await m.createIndex(idxDashboardDefinitionsId);
+          // await m.createIndex(idxDashboardDefinitionsName);
+          // await m.createIndex(idxDashboardDefinitionsPrivate);
         }();
 
         await () async {
@@ -86,34 +86,34 @@ class JournalDb extends _$JournalDb {
         await () async {
           debugPrint('Creating tagged table and indices');
           await m.createTable(tagged);
-          await m.createIndex(idxTaggedJournalId);
-          await m.createIndex(idxTaggedTagEntityId);
+          // await m.createIndex(idxTaggedJournalId);
+          // await m.createIndex(idxTaggedTagEntityId);
         }();
 
         await () async {
           debugPrint('Creating task columns and indices');
           await m.addColumn(journal, journal.taskStatus);
-          await m.createIndex(idxJournalTaskStatus);
+          //await m.createIndex(idxJournalTaskStatus);
           await m.addColumn(journal, journal.task);
-          await m.createIndex(idxJournalTask);
+          //await m.createIndex(idxJournalTask);
         }();
 
         await () async {
           debugPrint('Creating linked entries table and indices');
           await m.createTable(linkedEntries);
-          await m.createIndex(idxLinkedEntriesFromId);
-          await m.createIndex(idxLinkedEntriesToId);
-          await m.createIndex(idxLinkedEntriesType);
+          // await m.createIndex(idxLinkedEntriesFromId);
+          // await m.createIndex(idxLinkedEntriesToId);
+          // await m.createIndex(idxLinkedEntriesType);
         }();
 
         await () async {
           debugPrint('Creating tag_entities table and indices');
           await m.createTable(tagEntities);
-          await m.createIndex(idxTagEntitiesId);
-          await m.createIndex(idxTagEntitiesTag);
-          await m.createIndex(idxTagEntitiesType);
-          await m.createIndex(idxTagEntitiesInactive);
-          await m.createIndex(idxTagEntitiesPrivate);
+          // await m.createIndex(idxTagEntitiesId);
+          // await m.createIndex(idxTagEntitiesTag);
+          // await m.createIndex(idxTagEntitiesType);
+          // await m.createIndex(idxTagEntitiesInactive);
+          // await m.createIndex(idxTagEntitiesPrivate);
         }();
 
         await () async {

--- a/lib/database/database.drift
+++ b/lib/database/database.drift
@@ -22,20 +22,20 @@ CREATE TABLE journal (
   PRIMARY KEY (id)
 ) as JournalDbEntity;
 
-CREATE INDEX idx_journal_created_at ON journal (created_at);
-CREATE INDEX idx_journal_updated_at ON journal (updated_at);
-CREATE INDEX idx_journal_date_from ON journal (date_from);
-CREATE INDEX idx_journal_date_to ON journal (date_to);
-CREATE INDEX idx_journal_deleted ON journal (deleted);
-CREATE INDEX idx_journal_starred ON journal (starred);
-CREATE INDEX idx_journal_private ON journal (private);
-CREATE INDEX idx_journal_task ON journal (task);
-CREATE INDEX idx_journal_task_status ON journal (task_status);
-CREATE INDEX idx_journal_flag ON journal (flag);
-CREATE INDEX idx_journal_type ON journal (type);
-CREATE INDEX idx_journal_subtype ON journal (subtype);
-CREATE INDEX idx_journal_geohash_string ON journal (geohash_string);
-CREATE INDEX idx_journal_geohash_int ON journal (geohash_int);
+-- CREATE INDEX idx_journal_created_at ON journal (created_at);
+-- CREATE INDEX idx_journal_updated_at ON journal (updated_at);
+-- CREATE INDEX idx_journal_date_from ON journal (date_from);
+-- CREATE INDEX idx_journal_date_to ON journal (date_to);
+-- CREATE INDEX idx_journal_deleted ON journal (deleted);
+-- CREATE INDEX idx_journal_starred ON journal (starred);
+-- CREATE INDEX idx_journal_private ON journal (private);
+-- CREATE INDEX idx_journal_task ON journal (task);
+-- CREATE INDEX idx_journal_task_status ON journal (task_status);
+-- CREATE INDEX idx_journal_flag ON journal (flag);
+-- CREATE INDEX idx_journal_type ON journal (type);
+-- CREATE INDEX idx_journal_subtype ON journal (subtype);
+-- CREATE INDEX idx_journal_geohash_string ON journal (geohash_string);
+-- CREATE INDEX idx_journal_geohash_int ON journal (geohash_int);
 
 CREATE TABLE conflicts (
   id TEXT NOT NULL,
@@ -72,9 +72,9 @@ CREATE TABLE habit_definitions (
   PRIMARY KEY (id)
 ) as HabitDefinitionDbEntity;
 
-CREATE INDEX idx_habit_definitions_id ON habit_definitions (id);
-CREATE INDEX idx_habit_definitions_name ON habit_definitions (name);
-CREATE INDEX idx_habit_definitions_private ON habit_definitions (private);
+-- CREATE INDEX idx_habit_definitions_id ON habit_definitions (id);
+-- CREATE INDEX idx_habit_definitions_name ON habit_definitions (name);
+-- CREATE INDEX idx_habit_definitions_private ON habit_definitions (private);
 
 CREATE TABLE dashboard_definitions (
   id TEXT NOT NULL,
@@ -89,9 +89,9 @@ CREATE TABLE dashboard_definitions (
   PRIMARY KEY (id)
 ) as DashboardDefinitionDbEntity;
 
-CREATE INDEX idx_dashboard_definitions_id ON dashboard_definitions (id);
-CREATE INDEX idx_dashboard_definitions_name ON dashboard_definitions (name);
-CREATE INDEX idx_dashboard_definitions_private ON dashboard_definitions (private);
+-- CREATE INDEX idx_dashboard_definitions_id ON dashboard_definitions (id);
+-- CREATE INDEX idx_dashboard_definitions_name ON dashboard_definitions (name);
+-- CREATE INDEX idx_dashboard_definitions_private ON dashboard_definitions (private);
 
 CREATE TABLE config_flags (
   name TEXT NOT NULL UNIQUE,
@@ -114,11 +114,11 @@ CREATE TABLE tag_entities (
   UNIQUE(tag, type)
 ) as TagDbEntity;
 
-CREATE INDEX idx_tag_entities_id ON tag_entities (id);
-CREATE INDEX idx_tag_entities_tag ON tag_entities (tag);
-CREATE INDEX idx_tag_entities_type ON tag_entities (type);
-CREATE INDEX idx_tag_entities_private ON tag_entities (private);
-CREATE INDEX idx_tag_entities_inactive ON tag_entities (inactive);
+-- CREATE INDEX idx_tag_entities_id ON tag_entities (id);
+-- CREATE INDEX idx_tag_entities_tag ON tag_entities (tag);
+-- CREATE INDEX idx_tag_entities_type ON tag_entities (type);
+-- CREATE INDEX idx_tag_entities_private ON tag_entities (private);
+-- CREATE INDEX idx_tag_entities_inactive ON tag_entities (inactive);
 
 CREATE TABLE tagged (
   id TEXT NOT NULL UNIQUE,
@@ -130,8 +130,8 @@ CREATE TABLE tagged (
   UNIQUE(journal_id, tag_entity_id)
 ) as TaggedWith;
 
-CREATE INDEX idx_tagged_journal_id ON tagged (journal_id);
-CREATE INDEX idx_tagged_tag_entity_id ON tagged (tag_entity_id);
+-- CREATE INDEX idx_tagged_journal_id ON tagged (journal_id);
+-- CREATE INDEX idx_tagged_tag_entity_id ON tagged (tag_entity_id);
 
 CREATE TABLE linked_entries (
   id TEXT NOT NULL UNIQUE,
@@ -143,9 +143,9 @@ CREATE TABLE linked_entries (
   UNIQUE(from_id, to_id, type)
 ) as LinkedDbEntry;
 
-CREATE INDEX idx_linked_entries_from_id ON linked_entries (from_id);
-CREATE INDEX idx_linked_entries_to_id ON linked_entries (to_id);
-CREATE INDEX idx_linked_entries_type ON linked_entries (type);
+-- CREATE INDEX idx_linked_entries_from_id ON linked_entries (from_id);
+-- CREATE INDEX idx_linked_entries_to_id ON linked_entries (to_id);
+-- CREATE INDEX idx_linked_entries_type ON linked_entries (type);
 
 /* Queries ----------------------------------------------------- */
 listConfigFlags:

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -26,7 +26,6 @@ final getIt = GetIt.instance;
 
 void registerSingletons() {
   getIt
-//    ..registerSingleton<JournalDb>(JournalDb())
     ..registerSingleton<Future<DriftIsolate>>(
       createDriftIsolate(journalDbFileName),
       instanceName: journalDbFileName,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.173+1492
+version: 0.8.174+1494
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
For some reason the app startup only fails on desktop with an error the first index, idx_journal_created_at, exists already. Not a problem on mobile, or with new database files.