### PR TITLE
Bring back index creation in journal database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed:
+- Bring back index creation in journal database
+
+## [0.8.176] - 2022-10-16
+### Fixed:
 - "Task not found" when task still loading
 - Spacing between habit success indicators
 

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:collection/collection.dart';
 import 'package:drift/drift.dart';
@@ -14,9 +13,7 @@ import 'package:lotti/database/common.dart';
 import 'package:lotti/database/conversions.dart';
 import 'package:lotti/database/stream_helpers.dart';
 import 'package:lotti/sync/vector_clock.dart';
-import 'package:lotti/utils/consts.dart';
 import 'package:lotti/utils/file_utils.dart';
-import 'package:lotti/utils/platform.dart';
 import 'package:lotti/widgets/journal/entry_tools.dart';
 
 part 'database.g.dart';
@@ -53,7 +50,7 @@ class JournalDb extends _$JournalDb {
       beforeOpen: (details) async {
         await customStatement('PRAGMA foreign_keys = ON');
       },
-      onCreate: (Migrator m) {
+      onCreate: (Migrator m) async {
         return m.createAll();
       },
       onUpgrade: (Migrator m, int from, int to) async {
@@ -62,17 +59,17 @@ class JournalDb extends _$JournalDb {
         await () async {
           debugPrint('Creating habit_definitions table and indices');
           await m.createTable(habitDefinitions);
-          // await m.createIndex(idxHabitDefinitionsId);
-          // await m.createIndex(idxHabitDefinitionsName);
-          // await m.createIndex(idxHabitDefinitionsPrivate);
+          await m.createIndex(idxHabitDefinitionsId);
+          await m.createIndex(idxHabitDefinitionsName);
+          await m.createIndex(idxHabitDefinitionsPrivate);
         }();
 
         await () async {
           debugPrint('Creating dashboard_definitions table and indices');
           await m.createTable(dashboardDefinitions);
-          // await m.createIndex(idxDashboardDefinitionsId);
-          // await m.createIndex(idxDashboardDefinitionsName);
-          // await m.createIndex(idxDashboardDefinitionsPrivate);
+          await m.createIndex(idxDashboardDefinitionsId);
+          await m.createIndex(idxDashboardDefinitionsName);
+          await m.createIndex(idxDashboardDefinitionsPrivate);
         }();
 
         await () async {
@@ -86,34 +83,34 @@ class JournalDb extends _$JournalDb {
         await () async {
           debugPrint('Creating tagged table and indices');
           await m.createTable(tagged);
-          // await m.createIndex(idxTaggedJournalId);
-          // await m.createIndex(idxTaggedTagEntityId);
+          await m.createIndex(idxTaggedJournalId);
+          await m.createIndex(idxTaggedTagEntityId);
         }();
 
         await () async {
           debugPrint('Creating task columns and indices');
           await m.addColumn(journal, journal.taskStatus);
-          //await m.createIndex(idxJournalTaskStatus);
+          await m.createIndex(idxJournalTaskStatus);
           await m.addColumn(journal, journal.task);
-          //await m.createIndex(idxJournalTask);
+          await m.createIndex(idxJournalTask);
         }();
 
         await () async {
           debugPrint('Creating linked entries table and indices');
           await m.createTable(linkedEntries);
-          // await m.createIndex(idxLinkedEntriesFromId);
-          // await m.createIndex(idxLinkedEntriesToId);
-          // await m.createIndex(idxLinkedEntriesType);
+          await m.createIndex(idxLinkedEntriesFromId);
+          await m.createIndex(idxLinkedEntriesToId);
+          await m.createIndex(idxLinkedEntriesType);
         }();
 
         await () async {
           debugPrint('Creating tag_entities table and indices');
           await m.createTable(tagEntities);
-          // await m.createIndex(idxTagEntitiesId);
-          // await m.createIndex(idxTagEntitiesTag);
-          // await m.createIndex(idxTagEntitiesType);
-          // await m.createIndex(idxTagEntitiesInactive);
-          // await m.createIndex(idxTagEntitiesPrivate);
+          await m.createIndex(idxTagEntitiesId);
+          await m.createIndex(idxTagEntitiesTag);
+          await m.createIndex(idxTagEntitiesType);
+          await m.createIndex(idxTagEntitiesInactive);
+          await m.createIndex(idxTagEntitiesPrivate);
         }();
 
         await () async {
@@ -513,97 +510,6 @@ class JournalDb extends _$JournalDb {
 
     if (existing == null) {
       await into(configFlags).insert(configFlag);
-    }
-  }
-
-  Future<void> initConfigFlags() async {
-    await insertFlagIfNotExists(
-      const ConfigFlag(
-        name: privateFlag,
-        description: 'Show private entries?',
-        status: true,
-      ),
-    );
-    await insertFlagIfNotExists(
-      const ConfigFlag(
-        name: notifyExceptionsFlag,
-        description: 'Notify when exceptions occur?',
-        status: false,
-      ),
-    );
-    await insertFlagIfNotExists(
-      const ConfigFlag(
-        name: hideForScreenshotFlag,
-        description: 'Hide Lotti when taking screenshots?',
-        status: true,
-      ),
-    );
-    await insertFlagIfNotExists(
-      const ConfigFlag(
-        name: showTasksTabFlag,
-        description: 'Show Tasks tab?',
-        status: false,
-      ),
-    );
-    await insertFlagIfNotExists(
-      const ConfigFlag(
-        name: showBrightSchemeFlag,
-        description: 'Show Bright ☀️ scheme?',
-        status: false,
-      ),
-    );
-    await insertFlagIfNotExists(
-      const ConfigFlag(
-        name: allowInvalidCertFlag,
-        description: 'Allow invalid certificate? (not recommended)',
-        status: false,
-      ),
-    );
-    await insertFlagIfNotExists(
-      const ConfigFlag(
-        name: enableSyncInboxFlag,
-        description: 'Enable sync inbox? (requires restart)',
-        status: true,
-      ),
-    );
-    await insertFlagIfNotExists(
-      const ConfigFlag(
-        name: enableSyncOutboxFlag,
-        description: 'Enable sync outbox? (requires restart)',
-        status: true,
-      ),
-    );
-    await insertFlagIfNotExists(
-      const ConfigFlag(
-        name: enableBeamerNavFlag,
-        description: 'Show new navigation (in progress)',
-        status: false,
-      ),
-    );
-    if (Platform.isMacOS) {
-      await insertFlagIfNotExists(
-        const ConfigFlag(
-          name: listenToScreenshotHotkeyFlag,
-          description: 'Listen to global screenshot hotkey?',
-          status: true,
-        ),
-      );
-      await insertFlagIfNotExists(
-        const ConfigFlag(
-          name: enableNotificationsFlag,
-          description: 'Enable desktop notifications?',
-          status: false,
-        ),
-      );
-    }
-    if (isDesktop) {
-      await insertFlagIfNotExists(
-        const ConfigFlag(
-          name: showThemeConfigFlag,
-          description: 'Show Theme Config UI?',
-          status: false,
-        ),
-      );
     }
   }
 

--- a/lib/database/database.drift
+++ b/lib/database/database.drift
@@ -22,20 +22,20 @@ CREATE TABLE journal (
   PRIMARY KEY (id)
 ) as JournalDbEntity;
 
--- CREATE INDEX idx_journal_created_at ON journal (created_at);
--- CREATE INDEX idx_journal_updated_at ON journal (updated_at);
--- CREATE INDEX idx_journal_date_from ON journal (date_from);
--- CREATE INDEX idx_journal_date_to ON journal (date_to);
--- CREATE INDEX idx_journal_deleted ON journal (deleted);
--- CREATE INDEX idx_journal_starred ON journal (starred);
--- CREATE INDEX idx_journal_private ON journal (private);
--- CREATE INDEX idx_journal_task ON journal (task);
--- CREATE INDEX idx_journal_task_status ON journal (task_status);
--- CREATE INDEX idx_journal_flag ON journal (flag);
--- CREATE INDEX idx_journal_type ON journal (type);
--- CREATE INDEX idx_journal_subtype ON journal (subtype);
--- CREATE INDEX idx_journal_geohash_string ON journal (geohash_string);
--- CREATE INDEX idx_journal_geohash_int ON journal (geohash_int);
+CREATE INDEX idx_journal_created_at ON journal (created_at);
+CREATE INDEX idx_journal_updated_at ON journal (updated_at);
+CREATE INDEX idx_journal_date_from ON journal (date_from);
+CREATE INDEX idx_journal_date_to ON journal (date_to);
+CREATE INDEX idx_journal_deleted ON journal (deleted);
+CREATE INDEX idx_journal_starred ON journal (starred);
+CREATE INDEX idx_journal_private ON journal (private);
+CREATE INDEX idx_journal_task ON journal (task);
+CREATE INDEX idx_journal_task_status ON journal (task_status);
+CREATE INDEX idx_journal_flag ON journal (flag);
+CREATE INDEX idx_journal_type ON journal (type);
+CREATE INDEX idx_journal_subtype ON journal (subtype);
+CREATE INDEX idx_journal_geohash_string ON journal (geohash_string);
+CREATE INDEX idx_journal_geohash_int ON journal (geohash_int);
 
 CREATE TABLE conflicts (
   id TEXT NOT NULL,
@@ -72,9 +72,9 @@ CREATE TABLE habit_definitions (
   PRIMARY KEY (id)
 ) as HabitDefinitionDbEntity;
 
--- CREATE INDEX idx_habit_definitions_id ON habit_definitions (id);
--- CREATE INDEX idx_habit_definitions_name ON habit_definitions (name);
--- CREATE INDEX idx_habit_definitions_private ON habit_definitions (private);
+CREATE INDEX idx_habit_definitions_id ON habit_definitions (id);
+CREATE INDEX idx_habit_definitions_name ON habit_definitions (name);
+CREATE INDEX idx_habit_definitions_private ON habit_definitions (private);
 
 CREATE TABLE dashboard_definitions (
   id TEXT NOT NULL,
@@ -89,9 +89,9 @@ CREATE TABLE dashboard_definitions (
   PRIMARY KEY (id)
 ) as DashboardDefinitionDbEntity;
 
--- CREATE INDEX idx_dashboard_definitions_id ON dashboard_definitions (id);
--- CREATE INDEX idx_dashboard_definitions_name ON dashboard_definitions (name);
--- CREATE INDEX idx_dashboard_definitions_private ON dashboard_definitions (private);
+CREATE INDEX idx_dashboard_definitions_id ON dashboard_definitions (id);
+CREATE INDEX idx_dashboard_definitions_name ON dashboard_definitions (name);
+CREATE INDEX idx_dashboard_definitions_private ON dashboard_definitions (private);
 
 CREATE TABLE config_flags (
   name TEXT NOT NULL UNIQUE,
@@ -114,11 +114,11 @@ CREATE TABLE tag_entities (
   UNIQUE(tag, type)
 ) as TagDbEntity;
 
--- CREATE INDEX idx_tag_entities_id ON tag_entities (id);
--- CREATE INDEX idx_tag_entities_tag ON tag_entities (tag);
--- CREATE INDEX idx_tag_entities_type ON tag_entities (type);
--- CREATE INDEX idx_tag_entities_private ON tag_entities (private);
--- CREATE INDEX idx_tag_entities_inactive ON tag_entities (inactive);
+CREATE INDEX idx_tag_entities_id ON tag_entities (id);
+CREATE INDEX idx_tag_entities_tag ON tag_entities (tag);
+CREATE INDEX idx_tag_entities_type ON tag_entities (type);
+CREATE INDEX idx_tag_entities_private ON tag_entities (private);
+CREATE INDEX idx_tag_entities_inactive ON tag_entities (inactive);
 
 CREATE TABLE tagged (
   id TEXT NOT NULL UNIQUE,
@@ -130,8 +130,8 @@ CREATE TABLE tagged (
   UNIQUE(journal_id, tag_entity_id)
 ) as TaggedWith;
 
--- CREATE INDEX idx_tagged_journal_id ON tagged (journal_id);
--- CREATE INDEX idx_tagged_tag_entity_id ON tagged (tag_entity_id);
+CREATE INDEX idx_tagged_journal_id ON tagged (journal_id);
+CREATE INDEX idx_tagged_tag_entity_id ON tagged (tag_entity_id);
 
 CREATE TABLE linked_entries (
   id TEXT NOT NULL UNIQUE,
@@ -143,9 +143,9 @@ CREATE TABLE linked_entries (
   UNIQUE(from_id, to_id, type)
 ) as LinkedDbEntry;
 
--- CREATE INDEX idx_linked_entries_from_id ON linked_entries (from_id);
--- CREATE INDEX idx_linked_entries_to_id ON linked_entries (to_id);
--- CREATE INDEX idx_linked_entries_type ON linked_entries (type);
+CREATE INDEX idx_linked_entries_from_id ON linked_entries (from_id);
+CREATE INDEX idx_linked_entries_to_id ON linked_entries (to_id);
+CREATE INDEX idx_linked_entries_type ON linked_entries (type);
 
 /* Queries ----------------------------------------------------- */
 listConfigFlags:

--- a/lib/database/journal_db/config_flags.dart
+++ b/lib/database/journal_db/config_flags.dart
@@ -1,0 +1,96 @@
+import 'dart:io';
+
+import 'package:lotti/database/database.dart';
+import 'package:lotti/utils/consts.dart';
+import 'package:lotti/utils/platform.dart';
+
+Future<void> initConfigFlags(JournalDb db) async {
+  await db.insertFlagIfNotExists(
+    const ConfigFlag(
+      name: privateFlag,
+      description: 'Show private entries?',
+      status: true,
+    ),
+  );
+  await db.insertFlagIfNotExists(
+    const ConfigFlag(
+      name: notifyExceptionsFlag,
+      description: 'Notify when exceptions occur?',
+      status: false,
+    ),
+  );
+  await db.insertFlagIfNotExists(
+    const ConfigFlag(
+      name: hideForScreenshotFlag,
+      description: 'Hide Lotti when taking screenshots?',
+      status: true,
+    ),
+  );
+  await db.insertFlagIfNotExists(
+    const ConfigFlag(
+      name: showTasksTabFlag,
+      description: 'Show Tasks tab?',
+      status: false,
+    ),
+  );
+  await db.insertFlagIfNotExists(
+    const ConfigFlag(
+      name: showBrightSchemeFlag,
+      description: 'Show Bright ☀️ scheme?',
+      status: false,
+    ),
+  );
+  await db.insertFlagIfNotExists(
+    const ConfigFlag(
+      name: allowInvalidCertFlag,
+      description: 'Allow invalid certificate? (not recommended)',
+      status: false,
+    ),
+  );
+  await db.insertFlagIfNotExists(
+    const ConfigFlag(
+      name: enableSyncInboxFlag,
+      description: 'Enable sync inbox? (requires restart)',
+      status: true,
+    ),
+  );
+  await db.insertFlagIfNotExists(
+    const ConfigFlag(
+      name: enableSyncOutboxFlag,
+      description: 'Enable sync outbox? (requires restart)',
+      status: true,
+    ),
+  );
+  await db.insertFlagIfNotExists(
+    const ConfigFlag(
+      name: enableBeamerNavFlag,
+      description: 'Show new navigation (in progress)',
+      status: false,
+    ),
+  );
+  if (Platform.isMacOS) {
+    await db.insertFlagIfNotExists(
+      const ConfigFlag(
+        name: listenToScreenshotHotkeyFlag,
+        description: 'Listen to global screenshot hotkey?',
+        status: true,
+      ),
+    );
+    await db.insertFlagIfNotExists(
+      const ConfigFlag(
+        name: enableNotificationsFlag,
+        description: 'Enable desktop notifications?',
+        status: false,
+      ),
+    );
+  }
+  if (isDesktop) {
+    await db.insertFlagIfNotExists(
+      const ConfigFlag(
+        name: showThemeConfigFlag,
+        description: 'Show Theme Config UI?',
+        status: false,
+      ),
+    );
+  }
+}

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -3,6 +3,7 @@ import 'package:get_it/get_it.dart';
 import 'package:lotti/database/common.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/editor_db.dart';
+import 'package:lotti/database/journal_db/config_flags.dart';
 import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/database/maintenance.dart';
 import 'package:lotti/database/sync_db.dart';
@@ -59,5 +60,5 @@ void registerSingletons() {
     ..registerSingleton<Maintenance>(Maintenance())
     ..registerSingleton<NavService>(NavService());
 
-  getIt<JournalDb>().initConfigFlags();
+  initConfigFlags(getIt<JournalDb>());
 }

--- a/lib/widgets/charts/dashboard_habits_chart.dart
+++ b/lib/widgets/charts/dashboard_habits_chart.dart
@@ -167,9 +167,6 @@ List<HabitResult> habitResultsByDay(
             : completionType == HabitCompletionType.skip
                 ? skipColor
                 : successColor;
-        if (completionType != null) {
-          debugPrint('completion $dayString $completionType $hexColor');
-        }
 
         return hexColor;
       },

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.176+1497
+version: 0.8.177+1498
 
 msix_config:
   display_name: Lotti

--- a/test/database/database_test.dart
+++ b/test/database/database_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/database/journal_db/config_flags.dart';
 import 'package:lotti/utils/consts.dart';
 
 final expectedActiveFlagNames = Platform.isMacOS
@@ -91,7 +92,7 @@ void main() {
   group('Database Tests - ', () {
     setUp(() async {
       db = JournalDb(inMemoryDatabase: true);
-      await db?.initConfigFlags();
+      await initConfigFlags(db!);
     });
     tearDown(() async {
       await db?.close();

--- a/test/logic/persistence_logic_test.dart
+++ b/test/logic/persistence_logic_test.dart
@@ -5,6 +5,7 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/tag_type_definitions.dart';
 import 'package:lotti/classes/task.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/database/journal_db/config_flags.dart';
 import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/get_it.dart';
@@ -49,7 +50,7 @@ void main() {
 
     setUpAll(() async {
       final journalDb = JournalDb(inMemoryDatabase: true);
-      await journalDb.initConfigFlags();
+      await initConfigFlags(journalDb);
 
       final syncConfigMock = MockSyncConfigService();
       when(syncConfigMock.getSyncConfig)


### PR DESCRIPTION
This PR brings back the creation of indices by changing the `onCreate` of the migration strategy to run async. Follow up to #1235 