### PR TITLE
Habit active toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed:
-- Allow setting active until field in habits
+- Allow setting habit active or inactive
 
 ## [0.8.190] - 2022-11-04
 - Flutter upgrade

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed:
+- Allow setting active until field in habits
+
+## [0.8.190] - 2022-11-04
 - Flutter upgrade
 - Upgraded dependencies
 

--- a/lib/blocs/habits/habits_cubit.dart
+++ b/lib/blocs/habits/habits_cubit.dart
@@ -27,15 +27,10 @@ class HabitsCubit extends Cubit<HabitsState> {
           ),
         ) {
     _definitionsStream = _journalDb.watchHabitDefinitions();
+
     _definitionsSubscription = _definitionsStream.listen((habitDefinitions) {
-      final now = DateTime.now();
-      _habitDefinitions = habitDefinitions
-          .where(
-            (habit) =>
-                (habit.activeFrom == null || habit.activeFrom!.isBefore(now)) &&
-                (habit.activeUntil == null || habit.activeUntil!.isAfter(now)),
-          )
-          .toList();
+      _habitDefinitions =
+          habitDefinitions.where((habit) => habit.active).toList();
       determineHabitSuccessByDays();
     });
 

--- a/lib/blocs/habits/habits_cubit.dart
+++ b/lib/blocs/habits/habits_cubit.dart
@@ -28,8 +28,15 @@ class HabitsCubit extends Cubit<HabitsState> {
         ) {
     _definitionsStream = _journalDb.watchHabitDefinitions();
     _definitionsSubscription = _definitionsStream.listen((habitDefinitions) {
-      _habitDefinitions = habitDefinitions;
-      emitState();
+      final now = DateTime.now();
+      _habitDefinitions = habitDefinitions
+          .where(
+            (habit) =>
+                (habit.activeFrom == null || habit.activeFrom!.isBefore(now)) &&
+                (habit.activeUntil == null || habit.activeUntil!.isAfter(now)),
+          )
+          .toList();
+      determineHabitSuccessByDays();
     });
 
     _completionsStream = _journalDb.watchHabitCompletionsInRange(
@@ -40,74 +47,77 @@ class HabitsCubit extends Cubit<HabitsState> {
 
     _completionsSubscription = _completionsStream.listen((habitCompletions) {
       _habitCompletions = habitCompletions;
-
-      _completedToday = <String>{};
-
-      final today = ymd(DateTime.now());
-
-      for (final item in _habitCompletions) {
-        final day = ymd(item.meta.dateFrom);
-
-        if (item is HabitCompletionEntry && day == today) {
-          _completedToday.add(item.data.habitId);
-        }
-      }
-
-      _openHabits = _habitDefinitions
-          .where((item) => !_completedToday.contains(item.id))
-          .sorted(habitSorter);
-
-      _openNow = _openHabits.where(showHabit).toList();
-      _pendingLater = _openHabits.where((item) => !showHabit(item)).toList();
-
-      _completed = _habitDefinitions
-          .where((item) => _completedToday.contains(item.id))
-          .sorted(habitSorter);
-
-      final now = DateTime.now();
-
-      final shortStreakDays = daysInRange(
-        rangeStart: now.subtract(const Duration(days: 3)),
-        rangeEnd: getEndOfToday(),
-      );
-
-      final longStreakDays = daysInRange(
-        rangeStart: now.subtract(const Duration(days: 7)),
-        rangeEnd: getEndOfToday(),
-      );
-
-      final habitSuccessDays = <String, Set<String>>{};
-
-      for (final item in _habitCompletions) {
-        if (item is HabitCompletionEntry &&
-            (item.data.completionType == HabitCompletionType.success ||
-                item.data.completionType == HabitCompletionType.skip ||
-                item.data.completionType == null)) {
-          final day = ymd(item.meta.dateFrom);
-          final successDays = habitSuccessDays[item.data.habitId] ?? <String>{}
-            ..add(day);
-          habitSuccessDays[item.data.habitId] = successDays;
-        }
-      }
-
-      var shortStreakCount = 0;
-      var longStreakCount = 0;
-
-      habitSuccessDays.forEach((habitId, days) {
-        if (days.containsAll(shortStreakDays)) {
-          shortStreakCount++;
-        }
-
-        if (days.containsAll(longStreakDays)) {
-          longStreakCount++;
-        }
-      });
-
-      _shortStreakCount = shortStreakCount;
-      _longStreakCount = longStreakCount;
-
-      emitState();
+      determineHabitSuccessByDays();
     });
+  }
+
+  void determineHabitSuccessByDays() {
+    _completedToday = <String>{};
+
+    final today = ymd(DateTime.now());
+
+    for (final item in _habitCompletions) {
+      final day = ymd(item.meta.dateFrom);
+
+      if (item is HabitCompletionEntry && day == today) {
+        _completedToday.add(item.data.habitId);
+      }
+    }
+
+    _openHabits = _habitDefinitions
+        .where((item) => !_completedToday.contains(item.id))
+        .sorted(habitSorter);
+
+    _openNow = _openHabits.where(showHabit).toList();
+    _pendingLater = _openHabits.where((item) => !showHabit(item)).toList();
+
+    _completed = _habitDefinitions
+        .where((item) => _completedToday.contains(item.id))
+        .sorted(habitSorter);
+
+    final now = DateTime.now();
+
+    final shortStreakDays = daysInRange(
+      rangeStart: now.subtract(const Duration(days: 3)),
+      rangeEnd: getEndOfToday(),
+    );
+
+    final longStreakDays = daysInRange(
+      rangeStart: now.subtract(const Duration(days: 7)),
+      rangeEnd: getEndOfToday(),
+    );
+
+    final habitSuccessDays = <String, Set<String>>{};
+
+    for (final item in _habitCompletions) {
+      if (item is HabitCompletionEntry &&
+          (item.data.completionType == HabitCompletionType.success ||
+              item.data.completionType == HabitCompletionType.skip ||
+              item.data.completionType == null)) {
+        final day = ymd(item.meta.dateFrom);
+        final successDays = habitSuccessDays[item.data.habitId] ?? <String>{}
+          ..add(day);
+        habitSuccessDays[item.data.habitId] = successDays;
+      }
+    }
+
+    var shortStreakCount = 0;
+    var longStreakCount = 0;
+
+    habitSuccessDays.forEach((habitId, days) {
+      if (days.containsAll(shortStreakDays)) {
+        shortStreakCount++;
+      }
+
+      if (days.containsAll(longStreakDays)) {
+        longStreakCount++;
+      }
+    });
+
+    _shortStreakCount = shortStreakCount;
+    _longStreakCount = longStreakCount;
+
+    emitState();
   }
 
   List<HabitDefinition> _habitDefinitions = [];

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -48,6 +48,7 @@
   "fileMenuNewTask": "Aufgabe",
   "fileMenuTitle": "Datei",
   "habitActiveFromLabel": "Aktiv ab",
+  "habitActiveUntilLabel": "Aktiv bis",
   "habitNotFound": "Habit nicht gefunden",
   "habitDeleteConfirm": "JA, HABIT löschen",
   "habitDeleteQuestion": "Habit wirklich löschen?",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -65,6 +65,7 @@
   "fileMenuNewTask": "Task",
   "fileMenuTitle": "File",
   "habitActiveFromLabel": "Active from",
+  "habitActiveUntilLabel": "Active until",
   "habitNotFound": "Habit not found",
   "habitDeleteConfirm": "YES, DELETE THIS HABIT",
   "habitDeleteQuestion": "Do you want to delete this habit?",

--- a/lib/pages/settings/habits/habit_details_page.dart
+++ b/lib/pages/settings/habits/habit_details_page.dart
@@ -44,16 +44,14 @@ class _HabitDetailsPageState extends State<HabitDetailsPage> {
       if (_formKey.currentState!.validate()) {
         final formData = _formKey.currentState?.value;
         final private = formData?['private'] as bool? ?? false;
-        final activeFrom = formData?['active_from'] as DateTime;
-        final activeUntil = formData?['active_until'] as DateTime?;
+        final active = formData?['active'] as bool? ?? false;
         final showFrom = formData?['show_from'] as DateTime?;
 
         final dataType = item.copyWith(
           name: '${formData!['name']}'.trim(),
           description: '${formData['description']}'.trim(),
           private: private,
-          activeFrom: activeFrom,
-          activeUntil: activeUntil,
+          active: active,
           habitSchedule: HabitSchedule.daily(
             requiredCompletions: 1,
             showFrom: showFrom,
@@ -134,37 +132,15 @@ class _HabitDetailsPageState extends State<HabitDetailsPage> {
                         ),
                         activeColor: styleConfig().private,
                       ),
-                      FormBuilderCupertinoDateTimePicker(
-                        key: const Key('active_from'),
-                        name: 'active_from',
-                        alwaysUse24HourFormat: true,
-                        inputType: CupertinoDateTimePickerInputType.date,
-                        style: inputStyle().copyWith(
-                          fontSize: 15,
-                          fontWeight: FontWeight.w300,
+                      FormBuilderSwitch(
+                        name: 'active',
+                        key: const Key('habit_active'),
+                        initialValue: widget.habitDefinition.active,
+                        title: Text(
+                          localizations.dashboardActiveLabel,
+                          style: formLabelStyle(),
                         ),
-                        decoration: InputDecoration(
-                          labelText: localizations.habitActiveFromLabel,
-                          labelStyle: labelStyle(),
-                        ),
-                        initialValue: item.activeFrom ?? DateTime.now(),
-                        theme: datePickerTheme(),
-                      ),
-                      FormBuilderCupertinoDateTimePicker(
-                        key: const Key('active_until'),
-                        name: 'active_until',
-                        alwaysUse24HourFormat: true,
-                        inputType: CupertinoDateTimePickerInputType.date,
-                        style: inputStyle().copyWith(
-                          fontSize: 15,
-                          fontWeight: FontWeight.w300,
-                        ),
-                        decoration: InputDecoration(
-                          labelText: localizations.habitActiveUntilLabel,
-                          labelStyle: labelStyle(),
-                        ),
-                        initialValue: item.activeUntil,
-                        theme: datePickerTheme(),
+                        activeColor: styleConfig().starredGold,
                       ),
                       if (isDaily)
                         FormBuilderCupertinoDateTimePicker(

--- a/lib/pages/settings/habits/habit_details_page.dart
+++ b/lib/pages/settings/habits/habit_details_page.dart
@@ -45,6 +45,7 @@ class _HabitDetailsPageState extends State<HabitDetailsPage> {
         final formData = _formKey.currentState?.value;
         final private = formData?['private'] as bool? ?? false;
         final activeFrom = formData?['active_from'] as DateTime;
+        final activeUntil = formData?['active_until'] as DateTime?;
         final showFrom = formData?['show_from'] as DateTime?;
 
         final dataType = item.copyWith(
@@ -52,6 +53,7 @@ class _HabitDetailsPageState extends State<HabitDetailsPage> {
           description: '${formData['description']}'.trim(),
           private: private,
           activeFrom: activeFrom,
+          activeUntil: activeUntil,
           habitSchedule: HabitSchedule.daily(
             requiredCompletions: 1,
             showFrom: showFrom,
@@ -146,6 +148,22 @@ class _HabitDetailsPageState extends State<HabitDetailsPage> {
                           labelStyle: labelStyle(),
                         ),
                         initialValue: item.activeFrom ?? DateTime.now(),
+                        theme: datePickerTheme(),
+                      ),
+                      FormBuilderCupertinoDateTimePicker(
+                        key: const Key('active_until'),
+                        name: 'active_until',
+                        alwaysUse24HourFormat: true,
+                        inputType: CupertinoDateTimePickerInputType.date,
+                        style: inputStyle().copyWith(
+                          fontSize: 15,
+                          fontWeight: FontWeight.w300,
+                        ),
+                        decoration: InputDecoration(
+                          labelText: localizations.habitActiveUntilLabel,
+                          labelStyle: labelStyle(),
+                        ),
+                        initialValue: item.activeUntil,
                         theme: datePickerTheme(),
                       ),
                       if (isDaily)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.191+1562
+version: 0.8.191+1563
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.190+1561
+version: 0.8.191+1562
 
 msix_config:
   display_name: Lotti

--- a/test/pages/settings/habits/habit_details_page_test.dart
+++ b/test/pages/settings/habits/habit_details_page_test.dart
@@ -190,7 +190,7 @@ void main() {
 
       await tester.pumpAndSettle();
 
-      final activeFromFieldFinder = find.byKey(const Key('active_from'));
+      final activeFromFieldFinder = find.byKey(const Key('habit_active'));
 
       final saveButtonFinder = find.byKey(const Key('habit_save'));
 


### PR DESCRIPTION
This PR simplifies enabling and disabling habits. A habit starts out as active, and can be set inactive by toggling a switch, and vice versa. Previously, a date range in which the habit was active needed to be defined, with at least the `activeFrom` field required, which proved to complicated without adding benefits.