### PR TITLE
Audio playback speed toggle instead of individual icon button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed:
+- Audio playback speed toggle instead of individual icon button
+
+## [0.8.192] - 2022-11-07
 ### Changed: 
 - Upgraded dependencies
 - Error handling in editor

--- a/lib/widgets/audio/audio_player.dart
+++ b/lib/widgets/audio/audio_player.dart
@@ -10,6 +10,26 @@ class AudioPlayerWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final speedToggleMap = <double, double>{
+      0.5: 0.75,
+      0.75: 1,
+      1: 1.25,
+      1.25: 1.5,
+      1.5: 1.75,
+      1.75: 2,
+      2: 0.5,
+    };
+
+    final speedLabelMap = <double, String>{
+      0.5: '0.5x',
+      0.75: '0.75x',
+      1: '1x',
+      1.25: '1.25x',
+      1.5: '1.5x',
+      1.75: '1.75x',
+      2: '2x',
+    };
+
     return BlocBuilder<AudioPlayerCubit, AudioPlayerState>(
       builder: (BuildContext context, AudioPlayerState state) {
         return Column(
@@ -58,32 +78,20 @@ class AudioPlayerWidget extends StatelessWidget {
                 ),
                 IconButton(
                   icon: Text(
-                    '1x',
+                    speedLabelMap[state.speed] ?? '1x',
                     style: TextStyle(
                       fontFamily: 'Oswald',
                       fontWeight: FontWeight.bold,
-                      color: (state.speed == 1)
+                      color: (state.speed != 1)
                           ? styleConfig().activeAudioControl
                           : styleConfig().secondaryTextColor,
                     ),
                   ),
-                  tooltip: 'Normal speed',
-                  onPressed: () => context.read<AudioPlayerCubit>().setSpeed(1),
-                ),
-                IconButton(
-                  icon: Text(
-                    '1.5x',
-                    style: TextStyle(
-                      fontFamily: 'Oswald',
-                      fontWeight: FontWeight.bold,
-                      color: (state.speed == 1.5)
-                          ? styleConfig().activeAudioControl
-                          : styleConfig().secondaryTextColor,
-                    ),
-                  ),
-                  tooltip: '1.5x speed',
-                  onPressed: () =>
-                      context.read<AudioPlayerCubit>().setSpeed(1.5),
+                  iconSize: 32,
+                  tooltip: 'Toggle speed',
+                  onPressed: () => context
+                      .read<AudioPlayerCubit>()
+                      .setSpeed(speedToggleMap[state.speed] ?? 1),
                 ),
               ],
             ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.193+1568
+version: 0.8.194+1569
 
 msix_config:
   display_name: Lotti

--- a/test/widgets/audio/audio_player_test.dart
+++ b/test/widgets/audio/audio_player_test.dart
@@ -66,16 +66,13 @@ void main() {
       final fwdIconFinder = find.byIcon(Icons.fast_forward);
 
       final normalSpeedIcon = find.text('1x');
-      final fastSpeedIcon = find.text('1.5x');
 
       expect(stopIconFinder, findsOneWidget);
       expect(playIconFinder, findsOneWidget);
       expect(pauseIconFinder, findsOneWidget);
       expect(rewindIconFinder, findsOneWidget);
       expect(fwdIconFinder, findsOneWidget);
-
       expect(normalSpeedIcon, findsOneWidget);
-      expect(fastSpeedIcon, findsOneWidget);
 
       await tester.tap(playIconFinder);
       verify(mockAudioPlayerCubit.play).called(1);
@@ -106,70 +103,10 @@ void main() {
 
       when(mockAudioPlayerCubit.close).thenAnswer((_) async {});
       when(mockAudioPlayerCubit.stopPlay).thenAnswer((_) async {});
-
-      when(() => mockAudioPlayerCubit.setSpeed(1.5)).thenAnswer((_) async {});
-
-      await tester.pumpWidget(
-        makeTestableWidgetWithScaffold(
-          BlocProvider<AudioPlayerCubit>(
-            create: (_) => mockAudioPlayerCubit,
-            lazy: false,
-            child: const AudioPlayerWidget(),
-          ),
-        ),
-      );
-
-      await tester.pumpAndSettle();
-
-      final stopIconFinder = find.byIcon(Icons.stop);
-      final playIconFinder = find.byIcon(Icons.play_arrow);
-      final rewindIconFinder = find.byIcon(Icons.fast_rewind);
-      final pauseIconFinder = find.byIcon(Icons.pause);
-      final fwdIconFinder = find.byIcon(Icons.fast_forward);
-
-      final normalSpeedIcon = find.text('1x');
-      final fastSpeedIcon = find.text('1.5x');
-
-      expect(stopIconFinder, findsOneWidget);
-      expect(playIconFinder, findsOneWidget);
-      expect(pauseIconFinder, findsOneWidget);
-      expect(rewindIconFinder, findsOneWidget);
-      expect(fwdIconFinder, findsOneWidget);
-
-      expect(normalSpeedIcon, findsOneWidget);
-      expect(fastSpeedIcon, findsOneWidget);
-
-      await tester.tap(fastSpeedIcon);
-      verify(() => mockAudioPlayerCubit.setSpeed(1.5)).called(1);
-
-      await tester.tap(stopIconFinder);
-      verify(mockAudioPlayerCubit.stopPlay).called(1);
-    });
-
-    testWidgets('controls are are displayed, playing state (1.5x)',
-        (tester) async {
-      final playingState = AudioPlayerState(
-        status: AudioPlayerStatus.playing,
-        progress: const Duration(seconds: 15),
-        totalDuration: const Duration(minutes: 1),
-        pausedAt: Duration.zero,
-        speed: 1.5,
-      );
-
-      when(() => mockAudioPlayerCubit.stream).thenAnswer(
-        (_) => Stream<AudioPlayerState>.fromIterable([playingState]),
-      );
-
-      when(() => mockAudioPlayerCubit.state).thenAnswer(
-        (_) => playingState,
-      );
-
-      when(() => mockAudioPlayerCubit.setSpeed(1)).thenAnswer((_) async {});
-
-      when(mockAudioPlayerCubit.close).thenAnswer((_) async {});
-
       when(mockAudioPlayerCubit.pause).thenAnswer((_) async {});
 
+      when(() => mockAudioPlayerCubit.setSpeed(1.25)).thenAnswer((_) async {});
+
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(
           BlocProvider<AudioPlayerCubit>(
@@ -189,7 +126,7 @@ void main() {
       final fwdIconFinder = find.byIcon(Icons.fast_forward);
 
       final normalSpeedIcon = find.text('1x');
-      final fastSpeedIcon = find.text('1.5x');
+      final fasterSpeedIcon = find.text('1.25x');
 
       expect(stopIconFinder, findsOneWidget);
       expect(playIconFinder, findsOneWidget);
@@ -198,13 +135,19 @@ void main() {
       expect(fwdIconFinder, findsOneWidget);
 
       expect(normalSpeedIcon, findsOneWidget);
-      expect(fastSpeedIcon, findsOneWidget);
+      expect(fasterSpeedIcon, findsNothing);
 
       await tester.tap(normalSpeedIcon);
-      verify(() => mockAudioPlayerCubit.setSpeed(1)).called(1);
+
+      verify(() => mockAudioPlayerCubit.setSpeed(1.25)).called(1);
+
+      await tester.pumpAndSettle();
 
       await tester.tap(pauseIconFinder);
       verify(mockAudioPlayerCubit.pause).called(1);
+
+      await tester.tap(playIconFinder);
+      verify(mockAudioPlayerCubit.play).called(1);
 
       await tester.tap(stopIconFinder);
       verify(mockAudioPlayerCubit.stopPlay).called(1);


### PR DESCRIPTION
This PR improves the audio playback widget by allowing to toggle through different speeds instead of requiring multiple buttons.