### PR TITLE
Habit autocomplete definition data structure and visualization

### DIFF
--- a/.github/workflows/flutter-analyze.yml
+++ b/.github/workflows/flutter-analyze.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '3.3.6'
+          flutter-version: '3.3.8'
           channel: 'stable'
       - name: Run Flutter Analyze
         run: make clean_build_analyze

--- a/.github/workflows/flutter-linux-build.yml
+++ b/.github/workflows/flutter-linux-build.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '3.3.6'
+          flutter-version: '3.3.8'
           channel: 'stable'
       - name: Update apt-get
         run: sudo apt-get update

--- a/.github/workflows/flutter-linux-release.yml
+++ b/.github/workflows/flutter-linux-release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '3.3.6'
+          flutter-version: '3.3.8'
           channel: 'stable'
       - name: Update apt-get
         run: sudo apt-get update

--- a/.github/workflows/flutter-test.yml
+++ b/.github/workflows/flutter-test.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '3.3.6'
+          flutter-version: '3.3.8'
           channel: 'stable'
       - name: Run Flutter tests
         run: make clean_test

--- a/.github/workflows/flutter-testflight.yml
+++ b/.github/workflows/flutter-testflight.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '3.3.6'
+          flutter-version: '3.3.8'
           channel: 'stable'
       - name: Fastlane match iOS
         working-directory: lotti/ios

--- a/.github/workflows/flutter-windows-build.yml
+++ b/.github/workflows/flutter-windows-build.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '3.3.6'
+          flutter-version: '3.3.8'
           channel: 'stable'
       - name: Flutter Doctor
         run: make doctor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added:
+- Habit autocomplete definition refinements
+
+### Changed:
+- New Flutter version & dependencies
+
+## [0.8.196] - 2022-11-10
 ### Changed:
 - Define default story for habit completion entry
 

--- a/lib/classes/entity_definitions.dart
+++ b/lib/classes/entity_definitions.dart
@@ -28,31 +28,40 @@ class HabitSchedule with _$HabitSchedule {
 }
 
 @freezed
-class HabitAutoComplete with _$HabitAutoComplete {
-  factory HabitAutoComplete.health({
+class AutoCompleteRule with _$AutoCompleteRule {
+  factory AutoCompleteRule.health({
     required String dataType,
     num? minimum,
     num? maximum,
-  }) = HabitAutoCompleteHealth;
+  }) = AutoCompleteRuleHealth;
 
-  factory HabitAutoComplete.measurable({
+  factory AutoCompleteRule.workout({
+    required String dataType,
+    num? minimum,
+    num? maximum,
+  }) = AutoCompleteRuleWorkout;
+
+  factory AutoCompleteRule.measurable({
     required String dataTypeId,
     num? minimum,
     num? maximum,
-  }) = HabitAutoCompleteMeasurable;
+  }) = AutoCompleteRuleMeasurable;
 
-  factory HabitAutoComplete.and({
-    required HabitAutoComplete a,
-    required HabitAutoComplete b,
-  }) = HabitAutoCompleteAnd;
+  factory AutoCompleteRule.and({
+    required List<AutoCompleteRule> rules,
+  }) = AutoCompleteRuleAnd;
 
-  factory HabitAutoComplete.or({
-    required HabitAutoComplete a,
-    required HabitAutoComplete b,
-  }) = HabitAutoCompleteOr;
+  factory AutoCompleteRule.or({
+    required List<AutoCompleteRule> rules,
+  }) = AutoCompleteRuleOr;
 
-  factory HabitAutoComplete.fromJson(Map<String, dynamic> json) =>
-      _$HabitAutoCompleteFromJson(json);
+  factory AutoCompleteRule.multiple({
+    required List<AutoCompleteRule> rules,
+    required int successes,
+  }) = AutoCompleteRuleMultiple;
+
+  factory AutoCompleteRule.fromJson(Map<String, dynamic> json) =>
+      _$AutoCompleteRuleFromJson(json);
 }
 
 @freezed
@@ -79,7 +88,7 @@ class EntityDefinition with _$EntityDefinition {
     required String name,
     required String description,
     required HabitSchedule habitSchedule,
-    HabitAutoComplete? autoComplete,
+    AutoCompleteRule? autoCompleteRule,
     String? version,
     required VectorClock? vectorClock,
     required bool active,

--- a/lib/pages/settings/habits/habit_details_page.dart
+++ b/lib/pages/settings/habits/habit_details_page.dart
@@ -226,7 +226,7 @@ class _HabitDetailsPageState extends State<HabitDetailsPage> {
                                 );
                               }).toList(),
                             ),
-                          HabitAutocompleteWidget(sleepAutoComplete),
+                          HabitAutocompleteWidget(testAutoComplete),
                         ],
                       ),
                     ),

--- a/lib/pages/settings/habits/habit_details_page.dart
+++ b/lib/pages/settings/habits/habit_details_page.dart
@@ -14,7 +14,6 @@ import 'package:lotti/themes/theme.dart';
 import 'package:lotti/widgets/app_bar/title_app_bar.dart';
 import 'package:lotti/widgets/form_builder/cupertino_datepicker.dart';
 import 'package:lotti/widgets/journal/entry_tools.dart';
-import 'package:lotti/widgets/settings/habits/habit_autocomplete_widget.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
 class HabitDetailsPage extends StatefulWidget {
@@ -226,7 +225,7 @@ class _HabitDetailsPageState extends State<HabitDetailsPage> {
                                 );
                               }).toList(),
                             ),
-                          HabitAutocompleteWidget(testAutoComplete),
+                          //HabitAutocompleteWidget(testAutoComplete),
                         ],
                       ),
                     ),

--- a/lib/pages/settings/habits/habit_details_page.dart
+++ b/lib/pages/settings/habits/habit_details_page.dart
@@ -14,6 +14,7 @@ import 'package:lotti/themes/theme.dart';
 import 'package:lotti/widgets/app_bar/title_app_bar.dart';
 import 'package:lotti/widgets/form_builder/cupertino_datepicker.dart';
 import 'package:lotti/widgets/journal/entry_tools.dart';
+import 'package:lotti/widgets/settings/habits/habit_autocomplete_widget.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
 class HabitDetailsPage extends StatefulWidget {
@@ -225,6 +226,7 @@ class _HabitDetailsPageState extends State<HabitDetailsPage> {
                                 );
                               }).toList(),
                             ),
+                          HabitAutocompleteWidget(sleepAutoComplete),
                         ],
                       ),
                     ),

--- a/lib/widgets/settings/habits/habit_autocomplete_widget.dart
+++ b/lib/widgets/settings/habits/habit_autocomplete_widget.dart
@@ -1,27 +1,78 @@
 import 'package:flutter/material.dart';
+import 'package:intersperse/intersperse.dart';
 import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/themes/theme.dart';
 
-final sleepAutoComplete = HabitAutoCompleteOr(
-  a: HabitAutoComplete.and(
-    a: HabitAutoCompleteHealth(
-      dataType: 'HealthDataType.SLEEP_ASLEEP_CORE',
-      minimum: 360,
+final testAutoComplete = AutoCompleteRule.and(
+  rules: [
+    AutoCompleteRule.or(
+      rules: [
+        AutoCompleteRule.multiple(
+          successes: 5,
+          rules: [
+            AutoCompleteRule.measurable(
+              dataTypeId: 'push-ups',
+              minimum: 25,
+            ),
+            AutoCompleteRule.measurable(
+              dataTypeId: 'pull-ups',
+              minimum: 10,
+            ),
+            AutoCompleteRule.measurable(
+              dataTypeId: 'sit-ups',
+              minimum: 70,
+            ),
+            AutoCompleteRule.measurable(
+              dataTypeId: 'lunges',
+              minimum: 30,
+            ),
+            AutoCompleteRule.measurable(
+              dataTypeId: 'plank',
+              minimum: 70,
+            ),
+            AutoCompleteRule.measurable(
+              dataTypeId: 'squats',
+              minimum: 10,
+            ),
+          ],
+        ),
+        AutoCompleteRule.workout(
+          dataType: 'functionalStrengthTraining.duration',
+          minimum: 30,
+        ),
+      ],
     ),
-    b: HabitAutoComplete.measurable(
-      dataTypeId: 'dataTypeId',
+    AutoCompleteRule.or(
+      rules: [
+        AutoCompleteRule.health(
+          dataType: 'cumulative_step_count',
+          minimum: 10000,
+        ),
+        AutoCompleteRule.workout(
+          dataType: 'walking.duration',
+          minimum: 60,
+        ),
+        AutoCompleteRule.workout(
+          dataType: 'swimming.duration',
+          minimum: 20,
+        ),
+        AutoCompleteRule.workout(
+          dataType: 'cycling.duration',
+          minimum: 120,
+        ),
+      ],
+    ),
+    AutoCompleteRule.measurable(
+      dataTypeId: 'water',
       minimum: 2000,
     ),
-  ),
-  b: HabitAutoCompleteHealth(
-    dataType: 'HealthDataType.SLEEP_ASLEEP_REM',
-    minimum: 60,
-  ),
+  ],
 );
 
 class HabitAutocompleteWidget extends StatefulWidget {
-  const HabitAutocompleteWidget(this.habitAutoComplete, {super.key});
+  const HabitAutocompleteWidget(this.autoCompleteRule, {super.key});
 
-  final HabitAutoComplete? habitAutoComplete;
+  final AutoCompleteRule? autoCompleteRule;
 
   @override
   State<HabitAutocompleteWidget> createState() =>
@@ -31,21 +82,34 @@ class HabitAutocompleteWidget extends StatefulWidget {
 class _HabitAutocompleteWidgetState extends State<HabitAutocompleteWidget> {
   @override
   Widget build(BuildContext context) {
-    const spacer = SizedBox(height: 8, width: 8);
+    const spacer = SizedBox(height: 10, width: 15);
 
     return ClipRRect(
       borderRadius: BorderRadius.circular(8),
       child: ColoredBox(
         color: Colors.grey.withOpacity(0.6),
-        child: widget.habitAutoComplete?.map(
+        child: widget.autoCompleteRule?.map(
           health: (health) {
             return Container(
               color: Colors.blue.withOpacity(0.5),
               padding: const EdgeInsets.all(8),
               child: Text(
-                '${health.dataType.substring(15)} '
-                ' ${health.minimum != null ? 'min: ${health.minimum}' : ''}'
-                ' ${health.maximum != null ? 'max: ${health.maximum}' : ''}',
+                '${health.dataType}'
+                '${health.minimum != null ? ', min: ${health.minimum}' : ''}'
+                '${health.maximum != null ? ', max: ${health.maximum}' : ''}',
+                style: monospaceTextStyle(),
+              ),
+            );
+          },
+          workout: (workout) {
+            return Container(
+              color: Colors.blue.withOpacity(0.5),
+              padding: const EdgeInsets.all(8),
+              child: Text(
+                '${workout.dataType}'
+                '${workout.minimum != null ? ', min: ${workout.minimum}' : ''}'
+                '${workout.maximum != null ? ', max: ${workout.maximum}' : ''}',
+                style: monospaceTextStyle(),
               ),
             );
           },
@@ -53,22 +117,33 @@ class _HabitAutocompleteWidgetState extends State<HabitAutocompleteWidget> {
             return Container(
               color: Colors.green.withOpacity(0.5),
               padding: const EdgeInsets.all(8),
-              child: Text('Measurable $measurable'),
+              child: Text(
+                '${measurable.dataTypeId}'
+                '${measurable.minimum != null ? ', min: ${measurable.minimum}' : ''}'
+                '${measurable.maximum != null ? ', max: ${measurable.maximum}' : ''}',
+                style: monospaceTextStyle(),
+              ),
             );
           },
           and: (and) {
             return Row(
               children: [
-                const Padding(
-                  padding: EdgeInsets.all(8),
-                  child: Text('AND'),
+                Padding(
+                  padding: const EdgeInsets.all(8),
+                  child: Text(
+                    'AND',
+                    style: monospaceTextStyle()
+                        .copyWith(fontWeight: FontWeight.bold),
+                  ),
                 ),
                 Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     spacer,
-                    HabitAutocompleteWidget(and.a),
-                    spacer,
-                    HabitAutocompleteWidget(and.b),
+                    ...intersperse(
+                      spacer,
+                      and.rules.map(HabitAutocompleteWidget.new),
+                    ),
                     spacer,
                   ],
                 ),
@@ -79,19 +154,54 @@ class _HabitAutocompleteWidgetState extends State<HabitAutocompleteWidget> {
           or: (or) {
             return Row(
               children: [
-                const Padding(
-                  padding: EdgeInsets.all(8),
-                  child: Text('OR'),
+                Padding(
+                  padding: const EdgeInsets.all(8),
+                  child: Text(
+                    'OR',
+                    style: monospaceTextStyle()
+                        .copyWith(fontWeight: FontWeight.bold),
+                  ),
                 ),
                 Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     spacer,
-                    HabitAutocompleteWidget(or.a),
-                    spacer,
-                    HabitAutocompleteWidget(or.b),
+                    ...intersperse(
+                      spacer,
+                      or.rules.map(HabitAutocompleteWidget.new),
+                    ),
                     spacer,
                   ],
                 ),
+                spacer,
+              ],
+            );
+          },
+          multiple: (multiple) {
+            final n = multiple.rules.length;
+
+            return Row(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.all(8),
+                  child: Text(
+                    '${multiple.successes}/$n',
+                    style: monospaceTextStyle()
+                        .copyWith(fontWeight: FontWeight.bold),
+                  ),
+                ),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    spacer,
+                    ...intersperse(
+                      spacer,
+                      multiple.rules.map(HabitAutocompleteWidget.new),
+                    ),
+                    spacer,
+                  ],
+                ),
+                spacer,
               ],
             );
           },

--- a/lib/widgets/settings/habits/habit_autocomplete_widget.dart
+++ b/lib/widgets/settings/habits/habit_autocomplete_widget.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/classes/entity_definitions.dart';
+
+final sleepAutoComplete = HabitAutoCompleteOr(
+  a: HabitAutoComplete.and(
+    a: HabitAutoCompleteHealth(
+      dataType: 'HealthDataType.SLEEP_ASLEEP_CORE',
+      minimum: 360,
+    ),
+    b: HabitAutoComplete.measurable(
+      dataTypeId: 'dataTypeId',
+      minimum: 2000,
+    ),
+  ),
+  b: HabitAutoCompleteHealth(
+    dataType: 'HealthDataType.SLEEP_ASLEEP_REM',
+    minimum: 60,
+  ),
+);
+
+class HabitAutocompleteWidget extends StatefulWidget {
+  const HabitAutocompleteWidget(this.habitAutoComplete, {super.key});
+
+  final HabitAutoComplete? habitAutoComplete;
+
+  @override
+  State<HabitAutocompleteWidget> createState() =>
+      _HabitAutocompleteWidgetState();
+}
+
+class _HabitAutocompleteWidgetState extends State<HabitAutocompleteWidget> {
+  @override
+  Widget build(BuildContext context) {
+    const spacer = SizedBox(height: 8, width: 8);
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(8),
+      child: ColoredBox(
+        color: Colors.grey.withOpacity(0.6),
+        child: widget.habitAutoComplete?.map(
+          health: (health) {
+            return Container(
+              color: Colors.blue.withOpacity(0.5),
+              padding: const EdgeInsets.all(8),
+              child: Text(
+                '${health.dataType.substring(15)} '
+                ' ${health.minimum != null ? 'min: ${health.minimum}' : ''}'
+                ' ${health.maximum != null ? 'max: ${health.maximum}' : ''}',
+              ),
+            );
+          },
+          measurable: (measurable) {
+            return Container(
+              color: Colors.green.withOpacity(0.5),
+              padding: const EdgeInsets.all(8),
+              child: Text('Measurable $measurable'),
+            );
+          },
+          and: (and) {
+            return Row(
+              children: [
+                const Padding(
+                  padding: EdgeInsets.all(8),
+                  child: Text('AND'),
+                ),
+                Column(
+                  children: [
+                    spacer,
+                    HabitAutocompleteWidget(and.a),
+                    spacer,
+                    HabitAutocompleteWidget(and.b),
+                    spacer,
+                  ],
+                ),
+                spacer,
+              ],
+            );
+          },
+          or: (or) {
+            return Row(
+              children: [
+                const Padding(
+                  padding: EdgeInsets.all(8),
+                  child: Text('OR'),
+                ),
+                Column(
+                  children: [
+                    spacer,
+                    HabitAutocompleteWidget(or.a),
+                    spacer,
+                    HabitAutocompleteWidget(or.b),
+                    spacer,
+                  ],
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -541,14 +541,14 @@ packages:
       name: extended_image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.3.1"
+    version: "6.3.2"
   extended_image_library:
     dependency: transitive
     description:
       name: extended_image_library
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.4.0"
+    version: "3.4.1"
   fake_async:
     dependency: transitive
     description:
@@ -686,7 +686,7 @@ packages:
       name: flutter_isolate
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   flutter_keyboard_visibility:
     dependency: transitive
     description:
@@ -796,7 +796,7 @@ packages:
       name: flutter_quill
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.4"
+    version: "6.1.5"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -1567,7 +1567,7 @@ packages:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   pub_updater:
     dependency: transitive
     description:
@@ -1657,7 +1657,7 @@ packages:
       name: rxdart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.27.5"
+    version: "0.27.6"
   salomon_bottom_bar:
     dependency: "direct main"
     description:
@@ -1886,7 +1886,7 @@ packages:
       name: sqlite3_flutter_libs
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.11"
+    version: "0.5.11+1"
   sqlparser:
     dependency: transitive
     description:
@@ -2096,7 +2096,7 @@ packages:
       name: uuid
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.6"
+    version: "3.0.7"
   vector_math:
     dependency: transitive
     description:
@@ -2236,7 +2236,7 @@ packages:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.2.0"
+    version: "6.2.2"
   yaml:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.196+1573
+version: 0.8.197+1574
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.197+1574
+version: 0.8.197+1575
 
 msix_config:
   display_name: Lotti

--- a/test/classes/entity_definitions_test.dart
+++ b/test/classes/entity_definitions_test.dart
@@ -6,25 +6,29 @@ import 'package:lotti/classes/entity_definitions.dart';
 void main() {
   group('Entity definitions tests', () {
     test('Recursive autocomplete can be serialized and deserialized', () {
-      final sleepAutoComplete = HabitAutoCompleteOr(
-        a: HabitAutoComplete.and(
-          a: HabitAutoCompleteHealth(
-            dataType: 'HealthDataType.SLEEP_ASLEEP_CORE',
-            minimum: 360,
+      final sleepAutoComplete = AutoCompleteRuleOr(
+        rules: [
+          AutoCompleteRule.and(
+            rules: [
+              AutoCompleteRuleHealth(
+                dataType: 'HealthDataType.SLEEP_ASLEEP_CORE',
+                minimum: 360,
+              ),
+              AutoCompleteRule.measurable(
+                dataTypeId: 'dataTypeId',
+                minimum: 2000,
+              ),
+            ],
           ),
-          b: HabitAutoComplete.measurable(
-            dataTypeId: 'dataTypeId',
-            minimum: 2000,
+          AutoCompleteRuleHealth(
+            dataType: 'HealthDataType.SLEEP_ASLEEP_REM',
+            minimum: 60,
           ),
-        ),
-        b: HabitAutoCompleteHealth(
-          dataType: 'HealthDataType.SLEEP_ASLEEP_REM',
-          minimum: 60,
-        ),
+        ],
       );
 
       final json = jsonEncode(sleepAutoComplete);
-      final fromJson = HabitAutoComplete.fromJson(
+      final fromJson = AutoCompleteRule.fromJson(
         jsonDecode(json) as Map<String, dynamic>,
       );
 


### PR DESCRIPTION
This PR refines the data structure for defining habit autocomplete rules by allowing multiple child rules within rules with multiple children such as AND and OR, effectively using them like a prefix notation as used in a LISP. 

Also starts a UI component for visualizing habit auto completion rules, which will be used in a next step.