### PR TITLE
Show expected habit success when defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed:
+- Show expected habit success when defined
+
+## [0.8.198] - 2022-11-20
 ### Added:
 - Editor display toggle
 

--- a/lib/pages/settings/habits/habit_details_page.dart
+++ b/lib/pages/settings/habits/habit_details_page.dart
@@ -162,6 +162,7 @@ class _HabitDetailsPageState extends State<HabitDetailsPage> {
                               fontSize: 15,
                               fontWeight: FontWeight.w300,
                             ),
+                            initialValue: item.activeFrom,
                             decoration: InputDecoration(
                               labelText: localizations.habitActiveFromLabel,
                               labelStyle: labelStyle(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.198+1581
+version: 0.8.199+1582
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR fixes the display of the expected date from which on success is expected for a particular habit (and show red otherwise). Before, this date could be defined but was not shown again in settings.