### PR TITLE
Add habit progress bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added:
+- Progress bar for habit progress for the current day
+
+## [0.8.203] - 2022-12-05
+### Added:
 - Suggest last used value in measurable
 - Upgrade dependencies
 - More responsiveness in measurement creation

--- a/lib/blocs/habits/habits_cubit.dart
+++ b/lib/blocs/habits/habits_cubit.dart
@@ -21,6 +21,7 @@ class HabitsCubit extends Cubit<HabitsState> {
             openNow: [],
             pendingLater: [],
             completed: [],
+            successfulToday: <String>{},
             shortStreakCount: 0,
             longStreakCount: 0,
             timeSpanDays: 30,
@@ -48,6 +49,7 @@ class HabitsCubit extends Cubit<HabitsState> {
 
   void determineHabitSuccessByDays() {
     _completedToday = <String>{};
+    _successfulToday = <String>{};
 
     final today = ymd(DateTime.now());
 
@@ -56,6 +58,11 @@ class HabitsCubit extends Cubit<HabitsState> {
 
       if (item is HabitCompletionEntry && day == today) {
         _completedToday.add(item.data.habitId);
+        final completionType = item.data.completionType;
+        if (completionType == HabitCompletionType.success ||
+            completionType == HabitCompletionType.skip) {
+          _successfulToday.add(item.data.habitId);
+        }
       }
     }
 
@@ -124,6 +131,7 @@ class HabitsCubit extends Cubit<HabitsState> {
 
   List<JournalEntity> _habitCompletions = [];
   var _completedToday = <String>{};
+  var _successfulToday = <String>{};
 
   var _shortStreakCount = 0;
   var _longStreakCount = 0;
@@ -152,6 +160,7 @@ class HabitsCubit extends Cubit<HabitsState> {
         openNow: _openNow,
         pendingLater: _pendingLater,
         completed: _completed,
+        successfulToday: _successfulToday,
         shortStreakCount: _shortStreakCount,
         longStreakCount: _longStreakCount,
         timeSpanDays: _timeSpanDays,

--- a/lib/blocs/habits/habits_state.dart
+++ b/lib/blocs/habits/habits_state.dart
@@ -14,6 +14,7 @@ class HabitsState with _$HabitsState {
     required List<HabitDefinition> completed,
     required List<JournalEntity> habitCompletions,
     required Set<String> completedToday,
+    required Set<String> successfulToday,
     required int shortStreakCount,
     required int longStreakCount,
     required int timeSpanDays,

--- a/lib/pages/habits/habits_page.dart
+++ b/lib/pages/habits/habits_page.dart
@@ -161,7 +161,7 @@ class HabitsPageAppBar extends StatelessWidget with PreferredSizeWidget {
   HabitsPageAppBar({super.key});
 
   @override
-  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight + 40);
 
   @override
   Widget build(BuildContext context) {
@@ -176,9 +176,87 @@ class HabitsPageAppBar extends StatelessWidget with PreferredSizeWidget {
         final habitCounters =
             '($total / $todayCount / ${state.shortStreakCount} / ${state.longStreakCount})';
 
-        return TitleAppBar(
-          title: '$title $habitCounters',
-          showBackButton: false,
+        return Column(
+          children: [
+            TitleAppBar(title: '$title $habitCounters', showBackButton: false),
+            const HabitsPageProgressBar(),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class HabitsPageProgressBar extends StatelessWidget {
+  const HabitsPageProgressBar({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<HabitsCubit, HabitsState>(
+      builder: (context, HabitsState state) {
+        final width = MediaQuery.of(context).size.width - 200;
+        const height = 20.0;
+        final total = state.habitDefinitions.length;
+
+        if (total == 0) {
+          return const SizedBox.shrink();
+        }
+
+        final successfulToday = state.successfulToday.length;
+        final done = successfulToday / total;
+        final percentage = (done * 100).toInt();
+
+        final greenWidth = done * width;
+        final redWidth = width - greenWidth - 1;
+
+        return Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Opacity(
+              opacity: 0,
+              child: Padding(
+                padding: const EdgeInsets.only(left: 20),
+                child: Text(
+                  '$percentage %',
+                  style: chartTitleStyle().copyWith(
+                    color: styleConfig().primaryColor,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(height),
+              child: Row(
+                children: [
+                  Container(
+                    width: greenWidth,
+                    height: height,
+                    color: styleConfig().primaryColor,
+                  ),
+                  const SizedBox(width: 1),
+                  Opacity(
+                    opacity: 0.5,
+                    child: Container(
+                      width: redWidth,
+                      height: height,
+                      color: styleConfig().alarm,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.only(left: 20),
+              child: Text(
+                '$percentage %',
+                style: chartTitleStyle().copyWith(
+                  color: styleConfig().primaryColor,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+          ],
         );
       },
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.203+1594
+version: 0.8.204+1596
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR adds a progress bar on the habits page showing the percentage of habits to checked off today, where both success and skip constitute a completion. The idea behind skip is that I skip a habit when outside circumstances do not allow me to complete a habit. Example: let's say I want to establish a habit of playing ping pong. When I could have done it but didn't, it's a **fail**. But when outside circumstances didn't allow it, maybe because I couldn't find someone to play with, or there's too much snow on the ping pong table, it's a **skip** that doesn't break a habit chain.