### PR TITLE
Unlink icon in editor toolbar instead of using Dismissable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed:
+- Unlink icon in editor toolbar instead of using Dismissable
+
+## [0.8.206] - 2022-12-11
 ### Added:
 - Tooltips for habit completions, showing date
 
 ### Changed:
 - Show habit streaks count at bottom of habits page, with labels
 - Extract habit streak lists & use adaptive header
-
-## [0.8.206] - 2022-12-10
-### Changed:
 - Remove autofocus on measurement value field
 - Unify segmented time span controls on dashboard and habit pages
 - Increase analyzed habit completion time span to 90 days

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -94,6 +94,7 @@
   "journalLinkedFromLabel": "Linked from:",
   "journalLinkFromHint": "Link from",
   "journalLinkToHint": "Link to",
+  "journalUnlinkHint": "Unlink",
   "journalPrivateTooltip": "Private",
   "journalSearchHint": "Search journal...",
   "journalShareAudioHint": "Share audio",

--- a/lib/widgets/journal/editor/editor_toolbar.dart
+++ b/lib/widgets/journal/editor/editor_toolbar.dart
@@ -13,12 +13,14 @@ class ToolbarWidget extends StatelessWidget {
     super.key,
     this.toolbarIconSize = 20,
     this.iconTheme,
+    this.unlinkFn,
   });
 
   final LinkService linkService = getIt<LinkService>();
   final double toolbarIconSize;
   final WrapAlignment toolbarIconAlignment = WrapAlignment.start;
   final QuillIconTheme? iconTheme;
+  final Future<void> Function()? unlinkFn;
 
   @override
   Widget build(BuildContext context) {
@@ -118,6 +120,13 @@ class ToolbarWidget extends StatelessWidget {
               tooltip: localizations.journalLinkToHint,
               onPressed: () => linkService.linkTo(id),
             ),
+            if (unlinkFn != null)
+              IconButton(
+                icon: const Icon(MdiIcons.closeCircleOutline),
+                iconSize: toolbarIconSize,
+                tooltip: localizations.journalUnlinkHint,
+                onPressed: unlinkFn,
+              ),
           ],
         );
       },

--- a/lib/widgets/journal/editor/editor_widget.dart
+++ b/lib/widgets/journal/editor/editor_widget.dart
@@ -16,12 +16,14 @@ class EditorWidget extends StatelessWidget {
     this.maxHeight = double.maxFinite,
     this.padding = 16,
     this.autoFocus = false,
+    this.unlinkFn,
   });
 
   final double maxHeight;
   final double minHeight;
   final bool autoFocus;
   final double padding;
+  final Future<void> Function()? unlinkFn;
 
   @override
   Widget build(BuildContext context) {
@@ -77,7 +79,7 @@ class EditorWidget extends StatelessWidget {
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  ToolbarWidget(),
+                  ToolbarWidget(unlinkFn: unlinkFn),
                   Flexible(
                     child: Padding(
                       padding: EdgeInsets.symmetric(horizontal: padding),

--- a/lib/widgets/journal/entry_detail_linked.dart
+++ b/lib/widgets/journal/entry_detail_linked.dart
@@ -56,14 +56,7 @@ class _LinkedEntriesWidgetState extends State<LinkedEntriesWidget> {
                 (int index) {
                   final itemId = itemIds.elementAt(index);
 
-                  Future<void> onDismissed(DismissDirection _) async {
-                    await _db.removeLink(
-                      fromId: widget.itemId,
-                      toId: itemId,
-                    );
-                  }
-
-                  Future<bool> confirmDismiss(DismissDirection _) async {
+                  Future<void> unlink() async {
                     const unlinkKey = 'unlinkKey';
                     final result = await showModalActionSheet<String>(
                       context: context,
@@ -79,45 +72,18 @@ class _LinkedEntriesWidgetState extends State<LinkedEntriesWidget> {
                       ],
                     );
 
-                    return result == unlinkKey;
+                    if (result == unlinkKey) {
+                      await _db.removeLink(
+                        fromId: widget.itemId,
+                        toId: itemId,
+                      );
+                    }
                   }
 
-                  return Dismissible(
-                    key: ValueKey('Dismissible-$itemId'),
-                    onDismissed: onDismissed,
-                    confirmDismiss: confirmDismiss,
-                    background: ColoredBox(
-                      color: styleConfig().alarm,
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.end,
-                        children: [
-                          Padding(
-                            padding: const EdgeInsets.only(bottom: 6),
-                            child: Text(
-                              localizations.journalUnlinkText,
-                              style: TextStyle(
-                                color: styleConfig().secondaryTextColor,
-                                fontFamily: 'Oswald',
-                                fontWeight: FontWeight.w300,
-                                fontSize: 24,
-                              ),
-                            ),
-                          ),
-                          Padding(
-                            padding: const EdgeInsets.all(8),
-                            child: Icon(
-                              Icons.link_off,
-                              size: 32,
-                              color: styleConfig().secondaryTextColor,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                    child: EntryDetailWidget(
-                      itemId: itemId,
-                      popOnDelete: false,
-                    ),
+                  return EntryDetailWidget(
+                    itemId: itemId,
+                    popOnDelete: false,
+                    unlinkFn: unlink,
                   );
                 },
               )

--- a/lib/widgets/journal/entry_details_widget.dart
+++ b/lib/widgets/journal/entry_details_widget.dart
@@ -24,11 +24,13 @@ class EntryDetailWidget extends StatelessWidget {
     required this.itemId,
     required this.popOnDelete,
     this.showTaskDetails = false,
+    this.unlinkFn,
   });
 
   final String itemId;
   final bool popOnDelete;
   final bool showTaskDetails;
+  final Future<void> Function()? unlinkFn;
 
   @override
   Widget build(BuildContext context) {
@@ -85,7 +87,7 @@ class EntryDetailWidget extends StatelessWidget {
                       quantitative: (_) => const SizedBox.shrink(),
                       workout: (_) => const SizedBox.shrink(),
                       orElse: () {
-                        return const EditorWidget();
+                        return EditorWidget(unlinkFn: unlinkFn);
                       },
                     ),
                     Padding(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.206+1607
+version: 0.8.207+1608
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR improves the UX when unlinking entries, e.g. from a task. Before, a Dismissible was used but that interfered with text selection on mobile. Now, an icon in the editor toolbar is used instead, next to link-to and link-from icons. The whole UX around entry linking needs more thought, but this removes the biggest annoyance at the moment.