### PR TITLE
Change header position for image entries

### DIFF
--- a/.github/workflows/flutter-analyze.yml
+++ b/.github/workflows/flutter-analyze.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '3.3.9'
+          flutter-version: '3.3.10'
           channel: 'stable'
       - name: Run Flutter Analyze
         run: make clean_build_analyze

--- a/.github/workflows/flutter-linux-build.yml
+++ b/.github/workflows/flutter-linux-build.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '3.3.9'
+          flutter-version: '3.3.10'
           channel: 'stable'
       - name: Update apt-get
         run: sudo apt-get update

--- a/.github/workflows/flutter-linux-release.yml
+++ b/.github/workflows/flutter-linux-release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '3.3.9'
+          flutter-version: '3.3.10'
           channel: 'stable'
       - name: Update apt-get
         run: sudo apt-get update

--- a/.github/workflows/flutter-test.yml
+++ b/.github/workflows/flutter-test.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '3.3.9'
+          flutter-version: '3.3.10'
           channel: 'stable'
       - name: Run Flutter tests
         run: make clean_test

--- a/.github/workflows/flutter-testflight.yml
+++ b/.github/workflows/flutter-testflight.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '3.3.9'
+          flutter-version: '3.3.10'
           channel: 'stable'
       - name: Fastlane match iOS
         working-directory: lotti/ios

--- a/.github/workflows/flutter-windows-build.yml
+++ b/.github/workflows/flutter-windows-build.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '3.3.9'
+          flutter-version: '3.3.10'
           channel: 'stable'
       - name: Flutter Doctor
         run: make doctor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed:
+- Header position on image entries
+
 ### Fixed:
 - Duplicate display issue
 - Tag display issue in JournalCard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed:
 - Duplicate display issue
+- Tag display issue in JournalCard
 
 ## [0.8.210] - 2022-12-17
 ### Changed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed:
+- Duplicate display issue
+
+## [0.8.210] - 2022-12-17
 ### Changed:
 - Improve line charts by using fl_chart library
 - Improve blood pressure chart by using fl_chart library

--- a/lib/themes/theme.dart
+++ b/lib/themes/theme.dart
@@ -21,7 +21,7 @@ const double chipBorderRadius = 8;
 const mainFont = 'PlusJakartaSans';
 
 const chipPadding = EdgeInsets.symmetric(
-  vertical: 2,
+  vertical: 3,
   horizontal: 8,
 );
 

--- a/lib/widgets/journal/entry_detail_linked.dart
+++ b/lib/widgets/journal/entry_detail_linked.dart
@@ -6,36 +6,21 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/widgets/journal/entry_details_widget.dart';
 
-class LinkedEntriesWidget extends StatefulWidget {
+class LinkedEntriesWidget extends StatelessWidget {
   const LinkedEntriesWidget({
     super.key,
-    this.navigatorKey,
     required this.itemId,
   });
 
-  final GlobalKey? navigatorKey;
   final String itemId;
 
   @override
-  State<LinkedEntriesWidget> createState() => _LinkedEntriesWidgetState();
-}
-
-class _LinkedEntriesWidgetState extends State<LinkedEntriesWidget> {
-  final JournalDb _db = getIt<JournalDb>();
-  late Stream<List<String>> stream;
-
-  @override
-  void initState() {
-    super.initState();
-    stream = _db.watchLinkedEntityIds(widget.itemId);
-  }
-
-  @override
   Widget build(BuildContext context) {
+    final db = getIt<JournalDb>();
     final localizations = AppLocalizations.of(context)!;
 
     return StreamBuilder<List<String>>(
-      stream: stream,
+      stream: db.watchLinkedEntityIds(itemId),
       builder: (context, itemsSnapshot) {
         if (itemsSnapshot.data == null || itemsSnapshot.data!.isEmpty) {
           return Container();
@@ -73,14 +58,15 @@ class _LinkedEntriesWidgetState extends State<LinkedEntriesWidget> {
                     );
 
                     if (result == unlinkKey) {
-                      await _db.removeLink(
-                        fromId: widget.itemId,
+                      await db.removeLink(
+                        fromId: itemId,
                         toId: itemId,
                       );
                     }
                   }
 
                   return EntryDetailWidget(
+                    key: Key('$itemId-$itemId'),
                     itemId: itemId,
                     popOnDelete: false,
                     unlinkFn: unlink,

--- a/lib/widgets/journal/entry_detail_linked_from.dart
+++ b/lib/widgets/journal/entry_detail_linked_from.dart
@@ -6,37 +6,20 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/widgets/journal/journal_card.dart';
 
-class LinkedFromEntriesWidget extends StatefulWidget {
+class LinkedFromEntriesWidget extends StatelessWidget {
   const LinkedFromEntriesWidget({
     super.key,
-    this.navigatorKey,
     required this.item,
   });
 
-  final GlobalKey? navigatorKey;
   final JournalEntity item;
-
-  @override
-  State<LinkedFromEntriesWidget> createState() =>
-      _LinkedFromEntriesWidgetState();
-}
-
-class _LinkedFromEntriesWidgetState extends State<LinkedFromEntriesWidget> {
-  final JournalDb _db = getIt<JournalDb>();
-  late Stream<List<JournalEntity>> stream;
-
-  @override
-  void initState() {
-    super.initState();
-    stream = _db.watchLinkedToEntities(linkedTo: widget.item.meta.id);
-  }
 
   @override
   Widget build(BuildContext context) {
     final localizations = AppLocalizations.of(context)!;
 
     return StreamBuilder<List<JournalEntity>>(
-      stream: stream,
+      stream: getIt<JournalDb>().watchLinkedToEntities(linkedTo: item.meta.id),
       builder: (
         BuildContext context,
         AsyncSnapshot<List<JournalEntity>> snapshot,
@@ -62,10 +45,16 @@ class _LinkedFromEntriesWidgetState extends State<LinkedFromEntriesWidget> {
                     final item = items.elementAt(index);
                     return item.maybeMap(
                       journalImage: (JournalImage image) {
-                        return JournalImageCard(item: image);
+                        return JournalImageCard(
+                          item: image,
+                          key: Key('${item.meta.id}-${item.meta.id}'),
+                        );
                       },
                       orElse: () {
-                        return JournalCard(item: item);
+                        return JournalCard(
+                          item: item,
+                          key: Key('${item.meta.id}-${item.meta.id}'),
+                        );
                       },
                     );
                   },

--- a/lib/widgets/journal/entry_details/entry_detail_header.dart
+++ b/lib/widgets/journal/entry_details/entry_detail_header.dart
@@ -12,20 +12,10 @@ import 'package:lotti/widgets/journal/entry_details/save_button.dart';
 import 'package:lotti/widgets/journal/entry_details/share_button_widget.dart';
 import 'package:lotti/widgets/journal/tags/tag_add.dart';
 
-class EntryDetailHeader extends StatefulWidget {
+class EntryDetailHeader extends StatelessWidget {
   const EntryDetailHeader({
     super.key,
   });
-
-  @override
-  State<EntryDetailHeader> createState() => _EntryDetailHeaderState();
-}
-
-class _EntryDetailHeaderState extends State<EntryDetailHeader> {
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/journal/entry_details_widget.dart
+++ b/lib/widgets/journal/entry_details_widget.dart
@@ -76,12 +76,12 @@ class EntryDetailWidget extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    const EntryDetailHeader(),
-                    TagsListWidget(),
                     item.maybeMap(
                       journalImage: EntryImageWidget.new,
                       orElse: () => const SizedBox.shrink(),
                     ),
+                    const EntryDetailHeader(),
+                    TagsListWidget(),
                     item.maybeMap(
                       task: (_) => const SizedBox.shrink(),
                       quantitative: (_) => const SizedBox.shrink(),

--- a/lib/widgets/journal/tags/tags_view_widget.dart
+++ b/lib/widgets/journal/tags/tags_view_widget.dart
@@ -43,7 +43,8 @@ class TagsViewWidget extends StatelessWidget {
               Wrap(
                 spacing: 4,
                 runSpacing: 4,
-                children: tagsFromTagIds.map(TagChip.new).toList(),
+                // ignore: unnecessary_lambdas
+                children: tagsFromTagIds.map((tag) => TagChip(tag)).toList(),
               ),
             ],
           ),
@@ -73,8 +74,8 @@ class TagChip extends StatelessWidget {
           child: Text(
             tagEntity.tag,
             style: const TextStyle(
-              fontSize: 12,
-              fontFamily: 'Oswald',
+              fontSize: 11,
+              fontFamily: mainFont,
             ),
           ),
         ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2138,35 +2138,35 @@ packages:
       name: video_player
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.9"
+    version: "2.4.10"
   video_player_android:
     dependency: transitive
     description:
       name: video_player_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.9"
+    version: "2.3.10"
   video_player_avfoundation:
     dependency: transitive
     description:
       name: video_player_avfoundation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.7"
+    version: "2.3.8"
   video_player_platform_interface:
     dependency: transitive
     description:
       name: video_player_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.1.4"
+    version: "6.0.1"
   video_player_web:
     dependency: transitive
     description:
       name: video_player_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.12"
+    version: "2.0.13"
   visibility_detector:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.211+1617
+version: 0.8.211+1618
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.211+1616
+version: 0.8.211+1617
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.211+1618
+version: 0.8.211+1619
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.210+1615
+version: 0.8.211+1616
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.211+1619
+version: 0.8.211+1620
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR moves the header down below images in image entries so that the SAVE button stays within the visible field of view. Also fixes some bugs.