### PR TITLE
Remove useless entry text toggle icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed:
+- Remove useless entry text toggle icon
+
+## [0.8.211] - 2022-12-18
+### Changed:
 - Header position on image entries
 
 ### Fixed:

--- a/lib/blocs/journal/entry_cubit.dart
+++ b/lib/blocs/journal/entry_cubit.dart
@@ -18,20 +18,6 @@ import 'package:lotti/utils/platform.dart';
 import 'package:lotti/widgets/journal/editor/editor_tools.dart';
 import 'package:tuple/tuple.dart';
 
-bool showEditorByDefault(JournalEntity entry) {
-  return entry.map(
-    journalEntry: (_) => true,
-    task: (_) => true,
-    journalImage: (entry) => entry.entryText != null,
-    quantitative: (entry) => entry.entryText != null,
-    survey: (entry) => entry.entryText != null,
-    measurement: (entry) => entry.entryText != null,
-    workout: (entry) => entry.entryText != null,
-    journalAudio: (_) => true,
-    habitCompletion: (_) => true,
-  );
-}
-
 class EntryCubit extends Cubit<EntryState> {
   EntryCubit({
     required this.entryId,
@@ -41,11 +27,9 @@ class EntryCubit extends Cubit<EntryState> {
             entryId: entryId,
             entry: entry,
             showMap: false,
-            showEditor: showEditorByDefault(entry),
           ),
         ) {
     final lastSaved = entry.meta.updatedAt;
-    showEditor = showEditorByDefault(entry);
 
     _editorStateService
         .getUnsavedStream(entryId, lastSaved)
@@ -97,7 +81,6 @@ class EntryCubit extends Cubit<EntryState> {
   JournalEntity entry;
   bool dirty = false;
   bool showMap = false;
-  bool showEditor = false;
 
   late final QuillController controller;
   late final GlobalKey<FormBuilderState>? formKey;
@@ -153,7 +136,6 @@ class EntryCubit extends Cubit<EntryState> {
           entryId: entryId,
           entry: entry,
           showMap: showMap,
-          showEditor: showEditor,
         ),
       );
     } else {
@@ -162,7 +144,6 @@ class EntryCubit extends Cubit<EntryState> {
           entryId: entryId,
           entry: entry,
           showMap: showMap,
-          showEditor: showEditor,
         ),
       );
     }
@@ -191,11 +172,6 @@ class EntryCubit extends Cubit<EntryState> {
       showMap = !showMap;
       emitState();
     }
-  }
-
-  void toggleShowEditor() {
-    showEditor = !showEditor;
-    emitState();
   }
 
   Future<void> togglePrivate() async {

--- a/lib/blocs/journal/entry_state.dart
+++ b/lib/blocs/journal/entry_state.dart
@@ -9,13 +9,11 @@ class EntryState with _$EntryState {
     required String entryId,
     required JournalEntity? entry,
     required bool showMap,
-    required bool showEditor,
   }) = _EntryStateSaved;
 
   factory EntryState.dirty({
     required String entryId,
     required JournalEntity? entry,
     required bool showMap,
-    required bool showEditor,
   }) = EntryStateDirty;
 }

--- a/lib/widgets/journal/editor/editor_widget.dart
+++ b/lib/widgets/journal/editor/editor_widget.dart
@@ -59,10 +59,6 @@ class EditorWidget extends StatelessWidget {
           }
         }
 
-        if (!snapshot.showEditor) {
-          return const SizedBox.shrink();
-        }
-
         return RawKeyboardListener(
           focusNode: FocusNode(),
           onKey: (RawKeyEvent event) {

--- a/lib/widgets/journal/entry_details/entry_detail_header.dart
+++ b/lib/widgets/journal/entry_details/entry_detail_header.dart
@@ -58,13 +58,6 @@ class EntryDetailHeader extends StatelessWidget {
                       icon: styleConfig().cardFlagIcon,
                       activeIcon: styleConfig().cardFlagIconActive,
                     ),
-                    SwitchIconWidget(
-                      tooltip: localizations.journalFlaggedTooltip,
-                      onPressed: cubit.toggleShowEditor,
-                      value: state.showEditor,
-                      icon: styleConfig().cardEditorIcon,
-                      activeIcon: styleConfig().cardEditorIconActive,
-                    ),
                     if (state.entry?.geolocation != null)
                       SwitchIconWidget(
                         tooltip: state.showMap

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.211+1620
+version: 0.8.212+1621
 
 msix_config:
   display_name: Lotti

--- a/test/blocs/journal/entry_cubit_test.dart
+++ b/test/blocs/journal/entry_cubit_test.dart
@@ -95,13 +95,11 @@ void main() {
           entry: testTextEntry,
           entryId: testTextEntry.meta.id,
           showMap: false,
-          showEditor: true,
         ),
         EntryState.saved(
           entry: testTextEntry,
           entryId: testTextEntry.meta.id,
           showMap: false,
-          showEditor: true,
         ),
       ],
       verify: (c) {},
@@ -124,13 +122,11 @@ void main() {
           entry: testTask,
           entryId: testTask.meta.id,
           showMap: false,
-          showEditor: true,
         ),
         EntryState.saved(
           entry: testTask,
           entryId: testTask.meta.id,
           showMap: false,
-          showEditor: true,
         ),
       ],
       verify: (c) {},
@@ -153,13 +149,11 @@ void main() {
           entry: testTask,
           entryId: testTask.meta.id,
           showMap: false,
-          showEditor: true,
         ),
         EntryState.dirty(
           entry: testTask,
           entryId: testTask.meta.id,
           showMap: false,
-          showEditor: true,
         ),
       ],
       verify: (c) {},
@@ -181,7 +175,6 @@ void main() {
           entry: testTask,
           entryId: testTask.meta.id,
           showMap: false,
-          showEditor: true,
         ),
       ],
     );
@@ -202,49 +195,6 @@ void main() {
           entry: testTextEntry,
           entryId: testTextEntry.meta.id,
           showMap: true,
-          showEditor: true,
-        ),
-      ],
-    );
-
-    blocTest<EntryCubit, EntryState>(
-      'toggle editor hides editor for text entry',
-      build: () => EntryCubit(
-        entry: testTextEntry,
-        entryId: testTextEntry.meta.id,
-      ),
-      setUp: () {},
-      act: (c) {
-        c.toggleShowEditor();
-      },
-      wait: defaultWait,
-      expect: () => <EntryState>[
-        EntryState.saved(
-          entry: testTextEntry,
-          entryId: testTextEntry.meta.id,
-          showMap: false,
-          showEditor: false,
-        ),
-      ],
-    );
-
-    blocTest<EntryCubit, EntryState>(
-      'toggle editor show editor for measurement entry',
-      build: () => EntryCubit(
-        entry: testMeasuredPullUpsEntry,
-        entryId: testMeasuredPullUpsEntry.meta.id,
-      ),
-      setUp: () {},
-      act: (c) {
-        c.toggleShowEditor();
-      },
-      wait: defaultWait,
-      expect: () => <EntryState>[
-        EntryState.saved(
-          entry: testMeasuredPullUpsEntry,
-          entryId: testMeasuredPullUpsEntry.meta.id,
-          showMap: false,
-          showEditor: true,
         ),
       ],
     );
@@ -269,19 +219,16 @@ void main() {
           entry: testTextEntry,
           entryId: testTextEntry.meta.id,
           showMap: false,
-          showEditor: true,
         ),
         EntryState.dirty(
           entry: testTextEntry,
           entryId: testTextEntry.meta.id,
           showMap: false,
-          showEditor: true,
         ),
         EntryState.saved(
           entry: testTextEntry,
           entryId: testTextEntry.meta.id,
           showMap: false,
-          showEditor: true,
         ),
       ],
       verify: (c) {},

--- a/test/widgets/journal/entry_details/delete_icon_widget_test.dart
+++ b/test/widgets/journal/entry_details/delete_icon_widget_test.dart
@@ -27,7 +27,6 @@ void main() {
           entryId: testTextEntry.meta.id,
           entry: testTextEntry,
           showMap: false,
-          showEditor: true,
         ),
       );
 

--- a/test/widgets/journal/entry_details/entry_datetime_widget_test.dart
+++ b/test/widgets/journal/entry_details/entry_datetime_widget_test.dart
@@ -29,7 +29,6 @@ void main() {
           entryId: testTextEntry.meta.id,
           entry: testTextEntry,
           showMap: false,
-          showEditor: true,
         ),
       );
     });

--- a/test/widgets/journal/entry_details/entry_detail_footer_test.dart
+++ b/test/widgets/journal/entry_details/entry_detail_footer_test.dart
@@ -40,7 +40,6 @@ void main() {
           entryId: testTextEntry.meta.id,
           entry: testTextEntry,
           showMap: false,
-          showEditor: true,
         ),
       );
     });
@@ -137,7 +136,6 @@ void main() {
           entryId: testEntry.meta.id,
           entry: testEntry,
           showMap: false,
-          showEditor: true,
         ),
       );
       Future<void> mockStartTimer() => mockTimeService.start(testEntry);
@@ -186,7 +184,6 @@ void main() {
           entryId: testEntry.meta.id,
           entry: testEntry,
           showMap: false,
-          showEditor: true,
         ),
       );
 

--- a/test/widgets/journal/entry_details/entry_detail_header_test.dart
+++ b/test/widgets/journal/entry_details/entry_detail_header_test.dart
@@ -33,7 +33,6 @@ void main() {
           entryId: testTextEntry.meta.id,
           entry: testTextEntry,
           showMap: false,
-          showEditor: true,
         ),
       );
     });
@@ -110,7 +109,6 @@ void main() {
           entryId: testTextEntry.meta.id,
           entry: testTextEntry,
           showMap: false,
-          showEditor: true,
         ),
       );
 
@@ -135,7 +133,6 @@ void main() {
           entryId: testTextEntry.meta.id,
           entry: testTextEntry,
           showMap: false,
-          showEditor: true,
         ),
       );
 
@@ -167,7 +164,6 @@ void main() {
           entryId: testTextEntry.meta.id,
           entry: testTextEntry.copyWith(geolocation: null),
           showMap: false,
-          showEditor: true,
         ),
       );
 
@@ -194,7 +190,6 @@ void main() {
           entryId: testTextEntry.meta.id,
           entry: testTextEntry,
           showMap: false,
-          showEditor: true,
         ),
       );
 

--- a/test/widgets/journal/entry_details/share_button_widget_test.dart
+++ b/test/widgets/journal/entry_details/share_button_widget_test.dart
@@ -38,7 +38,6 @@ void main() {
           entryId: testImageEntry.meta.id,
           entry: testImageEntry,
           showMap: false,
-          showEditor: true,
         ),
       );
 
@@ -64,7 +63,6 @@ void main() {
           entryId: testAudioEntry.meta.id,
           entry: testAudioEntry,
           showMap: false,
-          showEditor: true,
         ),
       );
 

--- a/test/widgets/journal/tags/tag_add_test.dart
+++ b/test/widgets/journal/tags/tag_add_test.dart
@@ -49,7 +49,6 @@ void main() {
           entryId: testTextEntry.meta.id,
           entry: testTextEntry,
           showMap: false,
-          showEditor: true,
         ),
       );
 

--- a/test/widgets/journal/tags/tags_modal_widget_test.dart
+++ b/test/widgets/journal/tags/tags_modal_widget_test.dart
@@ -68,7 +68,6 @@ void main() {
         entryId: testTextEntryWithTags.meta.id,
         entry: testTextEntryWithTags,
         showMap: false,
-        showEditor: true,
       ),
     );
 


### PR DESCRIPTION
This PR removes the useless text editor show/hide toggle icon, which turned out to be not useful, and if anything annoying and/or confusing.