### PR TITLE
Stacked habit success chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added:
+- Stacked habit success chart
+
+## [0.8.213] - 2022-12-23
+### Added:
 - Throttle habits success scoring
 - Habit completions via click on habits success indicator
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added:
-- Stacked habit success chart
+- Stacked habit success chart, with success, skipped, explicitly failed, implicitly failed
 
 ## [0.8.213] - 2022-12-23
 ### Added:

--- a/lib/blocs/habits/habits_cubit.dart
+++ b/lib/blocs/habits/habits_cubit.dart
@@ -25,6 +25,7 @@ class HabitsCubit extends Cubit<HabitsState> {
             successfulToday: <String>{},
             successfulByDay: <String, Set<String>>{},
             skippedByDay: <String, Set<String>>{},
+            failedByDay: <String, Set<String>>{},
             shortStreakCount: 0,
             longStreakCount: 0,
             timeSpanDays: 14,
@@ -75,6 +76,7 @@ class HabitsCubit extends Cubit<HabitsState> {
     _successfulToday = <String>{};
     _successfulByDay = <String, Set<String>>{};
     _skippedByDay = <String, Set<String>>{};
+    _failedByDay = <String, Set<String>>{};
 
     final today = ymd(DateTime.now());
 
@@ -109,6 +111,13 @@ class HabitsCubit extends Cubit<HabitsState> {
           if (day == today) {
             _successfulToday.add(item.data.habitId);
           }
+        }
+
+        if (completionType == HabitCompletionType.fail) {
+          final failedForDay = _failedByDay[day] ?? <String>{}
+            ..add(item.data.habitId);
+
+          _failedByDay[day] = failedForDay;
         }
       }
     }
@@ -182,6 +191,7 @@ class HabitsCubit extends Cubit<HabitsState> {
   var _successfulToday = <String>{};
   var _successfulByDay = <String, Set<String>>{};
   var _skippedByDay = <String, Set<String>>{};
+  var _failedByDay = <String, Set<String>>{};
 
   var _shortStreakCount = 0;
   var _longStreakCount = 0;
@@ -212,6 +222,7 @@ class HabitsCubit extends Cubit<HabitsState> {
         completed: _completed,
         successfulToday: _successfulToday,
         successfulByDay: _successfulByDay,
+        failedByDay: _failedByDay,
         skippedByDay: _skippedByDay,
         shortStreakCount: _shortStreakCount,
         longStreakCount: _longStreakCount,

--- a/lib/blocs/habits/habits_state.dart
+++ b/lib/blocs/habits/habits_state.dart
@@ -17,6 +17,7 @@ class HabitsState with _$HabitsState {
     required Set<String> successfulToday,
     required Map<String, Set<String>> successfulByDay,
     required Map<String, Set<String>> skippedByDay,
+    required Map<String, Set<String>> failedByDay,
     required int shortStreakCount,
     required int longStreakCount,
     required int timeSpanDays,

--- a/lib/pages/habits/habits_page.dart
+++ b/lib/pages/habits/habits_page.dart
@@ -5,7 +5,6 @@ import 'package:lotti/blocs/habits/habits_cubit.dart';
 import 'package:lotti/blocs/habits/habits_state.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/widgets/charts/habits/dashboard_habits_chart.dart';
-import 'package:lotti/widgets/charts/habits/habit_completion_rate_chart.dart';
 import 'package:lotti/widgets/charts/utils.dart';
 import 'package:lotti/widgets/habits/habit_page_app_bar.dart';
 import 'package:lotti/widgets/habits/habit_streaks.dart';
@@ -112,30 +111,6 @@ class HabitsTabPage extends StatelessWidget {
                   ),
                   const SizedBox(height: 20),
                   const HabitStreaksCounter(),
-                  Padding(
-                    padding: const EdgeInsets.only(top: 50, bottom: 20),
-                    child: Text(
-                      'Successful and skipped habits',
-                      style: chartTitleStyle(),
-                    ),
-                  ),
-                  const HabitCompletionRateChart(),
-                  // Padding(
-                  //   padding: const EdgeInsets.only(top: 20, bottom: 5),
-                  //   child: Text(
-                  //     'Successful',
-                  //     style: chartTitleStyle(),
-                  //   ),
-                  // ),
-                  // const HabitCompletionRateChart(showSkipped: false),
-                  // Padding(
-                  //   padding: const EdgeInsets.only(top: 20, bottom: 5),
-                  //   child: Text(
-                  //     'Skipped',
-                  //     style: chartTitleStyle(),
-                  //   ),
-                  // ),
-                  // const HabitCompletionRateChart(showSuccessful: false),
                 ],
               ),
             ),

--- a/lib/pages/habits/habits_page.dart
+++ b/lib/pages/habits/habits_page.dart
@@ -113,29 +113,29 @@ class HabitsTabPage extends StatelessWidget {
                   const SizedBox(height: 20),
                   const HabitStreaksCounter(),
                   Padding(
-                    padding: const EdgeInsets.only(top: 20, bottom: 5),
+                    padding: const EdgeInsets.only(top: 50, bottom: 20),
                     child: Text(
-                      'Checked off',
+                      'Successful and skipped habits',
                       style: chartTitleStyle(),
                     ),
                   ),
                   const HabitCompletionRateChart(),
-                  Padding(
-                    padding: const EdgeInsets.only(top: 20, bottom: 5),
-                    child: Text(
-                      'Successful',
-                      style: chartTitleStyle(),
-                    ),
-                  ),
-                  const HabitCompletionRateChart(showSkipped: false),
-                  Padding(
-                    padding: const EdgeInsets.only(top: 20, bottom: 5),
-                    child: Text(
-                      'Skipped',
-                      style: chartTitleStyle(),
-                    ),
-                  ),
-                  const HabitCompletionRateChart(showSuccessful: false),
+                  // Padding(
+                  //   padding: const EdgeInsets.only(top: 20, bottom: 5),
+                  //   child: Text(
+                  //     'Successful',
+                  //     style: chartTitleStyle(),
+                  //   ),
+                  // ),
+                  // const HabitCompletionRateChart(showSkipped: false),
+                  // Padding(
+                  //   padding: const EdgeInsets.only(top: 20, bottom: 5),
+                  //   child: Text(
+                  //     'Skipped',
+                  //     style: chartTitleStyle(),
+                  //   ),
+                  // ),
+                  // const HabitCompletionRateChart(showSuccessful: false),
                 ],
               ),
             ),

--- a/lib/themes/theme.dart
+++ b/lib/themes/theme.dart
@@ -58,7 +58,7 @@ TextStyle chartTooltipStyle() => const TextStyle(
     );
 
 TextStyle chartTooltipStyleBold() => const TextStyle(
-      fontSize: fontSizeMedium,
+      fontSize: fontSizeSmall,
       fontFamily: mainFont,
       fontWeight: FontWeight.bold,
     );

--- a/lib/widgets/charts/habits/habit_completion_rate_chart.dart
+++ b/lib/widgets/charts/habits/habit_completion_rate_chart.dart
@@ -148,13 +148,31 @@ class HabitCompletionRateChart extends StatelessWidget {
                 minY: 0,
                 maxY: 100,
                 lineBarsData: [
+                  // barData(
+                  //   days: days,
+                  //   successfulByDay: state.successfulByDay,
+                  //   skippedByDay: state.skippedByDay,
+                  //   showSkipped: showSkipped,
+                  //   showSuccessful: showSuccessful,
+                  //   habitCount: state.habitCount,
+                  // ),
                   barData(
                     days: days,
                     successfulByDay: state.successfulByDay,
                     skippedByDay: state.skippedByDay,
-                    showSkipped: showSkipped,
-                    showSuccessful: showSuccessful,
+                    showSkipped: true,
+                    showSuccessful: true,
                     habitCount: state.habitCount,
+                    color: styleConfig().primaryColorLight,
+                  ),
+                  barData(
+                    days: days,
+                    successfulByDay: state.successfulByDay,
+                    skippedByDay: state.skippedByDay,
+                    showSkipped: false,
+                    showSuccessful: true,
+                    habitCount: state.habitCount,
+                    color: styleConfig().primaryColor,
                   ),
                 ],
               ),
@@ -174,6 +192,7 @@ LineChartBarData barData({
   required Map<String, Set<String>> skippedByDay,
   required bool showSuccessful,
   required bool showSkipped,
+  required Color color,
 }) {
   final spots = days.mapIndexed((idx, day) {
     final successCount = successfulByDay[day]?.length ?? 0;
@@ -198,15 +217,17 @@ LineChartBarData barData({
   return LineChartBarData(
     spots: spots,
     isCurved: true,
-    gradient: LinearGradient(colors: gradientColors),
-    barWidth: 2,
+    //gradient: LinearGradient(colors: gradientColors),
+    color: color,
+    barWidth: 1,
     isStrokeCapRound: true,
     dotData: FlDotData(show: false),
     belowBarData: BarAreaData(
       show: true,
-      gradient: LinearGradient(
-        colors: gradientColors.map((color) => color.withOpacity(0.3)).toList(),
-      ),
+      color: color.withOpacity(0.5),
+      // gradient: LinearGradient(
+      //   colors: gradientColors.map((color) => color.withOpacity(0.3)).toList(),
+      // ),
     ),
   );
 }

--- a/lib/widgets/charts/habits/habit_completion_rate_chart.dart
+++ b/lib/widgets/charts/habits/habit_completion_rate_chart.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:collection/collection.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
@@ -5,14 +7,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lotti/blocs/habits/habits_cubit.dart';
 import 'package:lotti/blocs/habits/habits_state.dart';
 import 'package:lotti/themes/theme.dart';
-import 'package:lotti/utils/platform.dart';
 import 'package:lotti/widgets/charts/utils.dart';
 import 'package:tinycolor2/tinycolor2.dart';
-
-List<Color> gradientColors = [
-  styleConfig().primaryColorLight,
-  styleConfig().primaryColor,
-];
 
 final gridLine = FlLine(
   color: styleConfig().chartTextColor.withOpacity(gridOpacity),
@@ -60,6 +56,10 @@ class HabitCompletionRateChart extends StatelessWidget {
           );
         }
 
+        final skipColor = styleConfig()
+            .primaryColorLight
+            .mix(styleConfig().alarm.complement());
+
         return SizedBox(
           height: 110,
           width: MediaQuery.of(context).size.width,
@@ -72,15 +72,15 @@ class HabitCompletionRateChart extends StatelessWidget {
               LineChartData(
                 lineTouchData: LineTouchData(
                   touchTooltipData: LineTouchTooltipData(
-                    tooltipMargin: isMobile ? 24 : 16,
+                    tooltipMargin: -150,
                     tooltipPadding: const EdgeInsets.symmetric(
                       horizontal: 8,
                       vertical: 3,
                     ),
-                    tooltipBgColor: styleConfig().primaryColor.desaturate(),
+                    tooltipBgColor: styleConfig().primaryColor,
                     tooltipRoundedRadius: 8,
                     getTooltipItems: (List<LineBarSpot> spots) {
-                      return spots.map((spot) {
+                      return spots.mapIndexed((index, spot) {
                         return LineTooltipItem(
                           '',
                           const TextStyle(
@@ -89,12 +89,22 @@ class HabitCompletionRateChart extends StatelessWidget {
                             fontWeight: FontWeight.w300,
                           ),
                           children: [
+                            if (index == 0)
+                              TextSpan(
+                                text:
+                                    '${chartDateFormatter(days[spot.x.toInt()])}\n\n',
+                                style: chartTooltipStyleBold(),
+                              ),
                             TextSpan(
-                              text: '${spot.y.toInt()} %\n',
+                              text: '${min(spot.y.toInt(), 100)} % ',
                               style: chartTooltipStyleBold(),
                             ),
                             TextSpan(
-                              text: chartDateFormatter(days[spot.x.toInt()]),
+                              text: index == 0
+                                  ? 'tracked'
+                                  : index == 1
+                                      ? 'with skipped'
+                                      : 'successful',
                               style: chartTooltipStyle(),
                             ),
                           ],
@@ -148,29 +158,37 @@ class HabitCompletionRateChart extends StatelessWidget {
                 minY: 0,
                 maxY: 100,
                 lineBarsData: [
-                  // barData(
-                  //   days: days,
-                  //   successfulByDay: state.successfulByDay,
-                  //   skippedByDay: state.skippedByDay,
-                  //   showSkipped: showSkipped,
-                  //   showSuccessful: showSuccessful,
-                  //   habitCount: state.habitCount,
-                  // ),
                   barData(
                     days: days,
                     successfulByDay: state.successfulByDay,
                     skippedByDay: state.skippedByDay,
+                    failedByDay: state.failedByDay,
                     showSkipped: true,
                     showSuccessful: true,
+                    showFailed: true,
                     habitCount: state.habitCount,
-                    color: styleConfig().primaryColorLight,
+                    color: styleConfig().alarm.lighten().desaturate(),
+                    aboveColor: styleConfig().alarm.withOpacity(0.5),
                   ),
                   barData(
                     days: days,
                     successfulByDay: state.successfulByDay,
                     skippedByDay: state.skippedByDay,
+                    failedByDay: state.failedByDay,
+                    showSkipped: true,
+                    showSuccessful: true,
+                    showFailed: false,
+                    habitCount: state.habitCount,
+                    color: skipColor,
+                  ),
+                  barData(
+                    days: days,
+                    successfulByDay: state.successfulByDay,
+                    skippedByDay: state.skippedByDay,
+                    failedByDay: state.failedByDay,
                     showSkipped: false,
                     showSuccessful: true,
+                    showFailed: false,
                     habitCount: state.habitCount,
                     color: styleConfig().primaryColor,
                   ),
@@ -190,13 +208,17 @@ LineChartBarData barData({
   required int habitCount,
   required Map<String, Set<String>> successfulByDay,
   required Map<String, Set<String>> skippedByDay,
+  required Map<String, Set<String>> failedByDay,
   required bool showSuccessful,
   required bool showSkipped,
+  required bool showFailed,
   required Color color,
+  Color? aboveColor,
 }) {
   final spots = days.mapIndexed((idx, day) {
     final successCount = successfulByDay[day]?.length ?? 0;
     final skippedCount = skippedByDay[day]?.length ?? 0;
+    final failedCount = failedByDay[day]?.length ?? 0;
 
     var value = 0;
 
@@ -208,16 +230,24 @@ LineChartBarData barData({
       value = value + skippedCount;
     }
 
+    if (showFailed) {
+      value = value + failedCount;
+    }
+
     return FlSpot(
       idx.toDouble(),
-      habitCount > 0 ? value * 100 / habitCount : 0,
+      min(
+        habitCount > 0 ? value * 100 / habitCount : 0,
+        100,
+      ),
     );
   }).toList();
 
   return LineChartBarData(
     spots: spots,
     isCurved: true,
-    //gradient: LinearGradient(colors: gradientColors),
+    preventCurveOverShooting: true,
+    preventCurveOvershootingThreshold: 0,
     color: color,
     barWidth: 1,
     isStrokeCapRound: true,
@@ -225,10 +255,13 @@ LineChartBarData barData({
     belowBarData: BarAreaData(
       show: true,
       color: color.withOpacity(0.5),
-      // gradient: LinearGradient(
-      //   colors: gradientColors.map((color) => color.withOpacity(0.3)).toList(),
-      // ),
     ),
+    aboveBarData: aboveColor != null
+        ? BarAreaData(
+            show: true,
+            color: aboveColor,
+          )
+        : null,
   );
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.214+1628
+version: 0.8.214+1629
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.213+1627
+version: 0.8.214+1628
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR introduces a stacked representation of habit success, skipped, and failed. The red line represents the total of tracked habits (success, skipped, and fail) whereas the area above up to 100% represents the habits that failed implicitly, by not being tracked at all. Tracked failures are preferable to implicit habits because from a behavioural perspective, they at least acknowledge failure, presenting a chance to form implementation intentions (should be tracked). Code needs refactoring at some point, this was the easiest to transform from single line chart per completion type. But for experimenting with improving overall success rate, this will do.

An alternative could be using individual line charts as described [here](https://everydayanalytics.ca/2014/08/stacked-area-graphs-are-not-your-friend.html). Watch this space.

![image](https://user-images.githubusercontent.com/1390808/209452582-8999bf05-b921-4d81-9753-934023727306.png)
