### PR TITLE
Improved habit chart info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed:
 - Improved habit chart info on tap
-- Clear habit chart info within 5 seconds of mouse exit on desktop
+- Clear habit chart info within 15 seconds
 
 ## [0.8.214] - 2022-12-24
 ### Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed:
 - Improved habit chart info on tap
+- Clear habit chart info within 5 seconds of mouse exit on desktop
 
 ## [0.8.214] - 2022-12-24
 ### Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed:
+- Improved habit chart info on tap
+
+## [0.8.214] - 2022-12-24
 ### Added:
 - Stacked habit success chart, with success, skipped, explicitly failed, implicitly failed
 

--- a/lib/blocs/habits/habits_cubit.dart
+++ b/lib/blocs/habits/habits_cubit.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:bloc/bloc.dart';
 import 'package:collection/collection.dart';
+import 'package:easy_debounce/easy_debounce.dart';
 import 'package:lotti/blocs/habits/habits_state.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/journal_entities.dart';
@@ -207,6 +208,12 @@ class HabitsCubit extends Cubit<HabitsState> {
   void setInfoYmd(String ymd) {
     _selectedInfoYmd = ymd;
     emitState();
+
+    EasyDebounce.debounce(
+      'clearInfoYmd',
+      const Duration(seconds: 15),
+      () => setInfoYmd(''),
+    );
   }
 
   final JournalDb _journalDb = getIt<JournalDb>();

--- a/lib/blocs/habits/habits_cubit.dart
+++ b/lib/blocs/habits/habits_cubit.dart
@@ -26,6 +26,7 @@ class HabitsCubit extends Cubit<HabitsState> {
             successfulByDay: <String, Set<String>>{},
             skippedByDay: <String, Set<String>>{},
             failedByDay: <String, Set<String>>{},
+            selectedInfoYmd: '',
             shortStreakCount: 0,
             longStreakCount: 0,
             timeSpanDays: 14,
@@ -196,9 +197,15 @@ class HabitsCubit extends Cubit<HabitsState> {
   var _shortStreakCount = 0;
   var _longStreakCount = 0;
   var _timeSpanDays = isDesktop ? 14 : 7;
+  var _selectedInfoYmd = '';
 
   void setTimeSpan(int timeSpanDays) {
     _timeSpanDays = timeSpanDays;
+    emitState();
+  }
+
+  void setInfoYmd(String ymd) {
+    _selectedInfoYmd = ymd;
     emitState();
   }
 
@@ -223,6 +230,7 @@ class HabitsCubit extends Cubit<HabitsState> {
         successfulToday: _successfulToday,
         successfulByDay: _successfulByDay,
         failedByDay: _failedByDay,
+        selectedInfoYmd: _selectedInfoYmd,
         skippedByDay: _skippedByDay,
         shortStreakCount: _shortStreakCount,
         longStreakCount: _longStreakCount,

--- a/lib/blocs/habits/habits_state.dart
+++ b/lib/blocs/habits/habits_state.dart
@@ -18,6 +18,7 @@ class HabitsState with _$HabitsState {
     required Map<String, Set<String>> successfulByDay,
     required Map<String, Set<String>> skippedByDay,
     required Map<String, Set<String>> failedByDay,
+    required String selectedInfoYmd,
     required int shortStreakCount,
     required int longStreakCount,
     required int timeSpanDays,

--- a/lib/widgets/charts/habits/habit_completion_rate_chart.dart
+++ b/lib/widgets/charts/habits/habit_completion_rate_chart.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:math';
 
 import 'package:collection/collection.dart';
@@ -94,120 +93,115 @@ class HabitCompletionRateChart extends StatelessWidget {
                     )
                   : null,
             ),
-            MouseRegion(
-              onExit: (_) {
-                Timer(const Duration(seconds: 5), () => cubit.setInfoYmd(''));
-              },
-              child: SizedBox(
-                height: 110,
-                width: MediaQuery.of(context).size.width,
-                child: Padding(
-                  padding: const EdgeInsets.only(
-                    right: 25,
-                    left: 20,
-                  ),
-                  child: LineChart(
-                    LineChartData(
-                      lineTouchData: LineTouchData(
-                        touchTooltipData: LineTouchTooltipData(
-                          tooltipMargin: -150,
-                          tooltipPadding: const EdgeInsets.symmetric(
-                            horizontal: 8,
-                            vertical: 3,
-                          ),
-                          tooltipBgColor: styleConfig().primaryColor,
-                          tooltipRoundedRadius: 8,
-                          getTooltipItems: (List<LineBarSpot> spots) {
-                            final ymd = days[spots.first.x.toInt()];
-                            cubit.setInfoYmd(ymd);
-                            return [];
-                          },
+            SizedBox(
+              height: 110,
+              width: MediaQuery.of(context).size.width,
+              child: Padding(
+                padding: const EdgeInsets.only(
+                  right: 25,
+                  left: 20,
+                ),
+                child: LineChart(
+                  LineChartData(
+                    lineTouchData: LineTouchData(
+                      touchTooltipData: LineTouchTooltipData(
+                        tooltipMargin: -150,
+                        tooltipPadding: const EdgeInsets.symmetric(
+                          horizontal: 8,
+                          vertical: 3,
                         ),
+                        tooltipBgColor: styleConfig().primaryColor,
+                        tooltipRoundedRadius: 8,
+                        getTooltipItems: (List<LineBarSpot> spots) {
+                          final ymd = days[spots.first.x.toInt()];
+                          cubit.setInfoYmd(ymd);
+                          return [];
+                        },
                       ),
-                      gridData: FlGridData(
-                        show: true,
-                        drawVerticalLine: true,
-                        horizontalInterval: 12.5,
-                        verticalInterval: 1,
-                        getDrawingHorizontalLine: (value) => gridLine,
-                        getDrawingVerticalLine: (value) => gridLine,
-                      ),
-                      titlesData: FlTitlesData(
-                        show: true,
-                        rightTitles: AxisTitles(
-                          sideTitles: SideTitles(showTitles: false),
-                        ),
-                        topTitles: AxisTitles(
-                          sideTitles: SideTitles(showTitles: false),
-                        ),
-                        bottomTitles: AxisTitles(
-                          sideTitles: SideTitles(
-                            showTitles: true,
-                            reservedSize: 30,
-                            interval: 1,
-                            getTitlesWidget: bottomTitleWidgets,
-                          ),
-                        ),
-                        leftTitles: AxisTitles(
-                          sideTitles: SideTitles(
-                            showTitles: true,
-                            interval: 12.5,
-                            getTitlesWidget: leftTitleWidgets,
-                            reservedSize: 35,
-                          ),
-                        ),
-                      ),
-                      borderData: FlBorderData(
-                        show: true,
-                        border: Border.all(
-                          color: styleConfig()
-                              .chartTextColor
-                              .withOpacity(labelOpacity),
-                        ),
-                      ),
-                      minX: 0,
-                      maxX: timeSpanDays.toDouble(),
-                      minY: 0,
-                      maxY: 100,
-                      lineBarsData: [
-                        barData(
-                          days: days,
-                          successfulByDay: state.successfulByDay,
-                          skippedByDay: state.skippedByDay,
-                          failedByDay: state.failedByDay,
-                          showSkipped: true,
-                          showSuccessful: true,
-                          showFailed: true,
-                          habitCount: state.habitCount,
-                          color: styleConfig().alarm.lighten().desaturate(),
-                          aboveColor: styleConfig().alarm.withOpacity(0.5),
-                        ),
-                        barData(
-                          days: days,
-                          successfulByDay: state.successfulByDay,
-                          skippedByDay: state.skippedByDay,
-                          failedByDay: state.failedByDay,
-                          showSkipped: true,
-                          showSuccessful: true,
-                          showFailed: false,
-                          habitCount: state.habitCount,
-                          color: skipColor,
-                        ),
-                        barData(
-                          days: days,
-                          successfulByDay: state.successfulByDay,
-                          skippedByDay: state.skippedByDay,
-                          failedByDay: state.failedByDay,
-                          showSkipped: false,
-                          showSuccessful: true,
-                          showFailed: false,
-                          habitCount: state.habitCount,
-                          color: styleConfig().primaryColor,
-                        ),
-                      ],
                     ),
-                    swapAnimationCurve: Curves.bounceInOut,
+                    gridData: FlGridData(
+                      show: true,
+                      drawVerticalLine: true,
+                      horizontalInterval: 12.5,
+                      verticalInterval: 1,
+                      getDrawingHorizontalLine: (value) => gridLine,
+                      getDrawingVerticalLine: (value) => gridLine,
+                    ),
+                    titlesData: FlTitlesData(
+                      show: true,
+                      rightTitles: AxisTitles(
+                        sideTitles: SideTitles(showTitles: false),
+                      ),
+                      topTitles: AxisTitles(
+                        sideTitles: SideTitles(showTitles: false),
+                      ),
+                      bottomTitles: AxisTitles(
+                        sideTitles: SideTitles(
+                          showTitles: true,
+                          reservedSize: 30,
+                          interval: 1,
+                          getTitlesWidget: bottomTitleWidgets,
+                        ),
+                      ),
+                      leftTitles: AxisTitles(
+                        sideTitles: SideTitles(
+                          showTitles: true,
+                          interval: 12.5,
+                          getTitlesWidget: leftTitleWidgets,
+                          reservedSize: 35,
+                        ),
+                      ),
+                    ),
+                    borderData: FlBorderData(
+                      show: true,
+                      border: Border.all(
+                        color: styleConfig()
+                            .chartTextColor
+                            .withOpacity(labelOpacity),
+                      ),
+                    ),
+                    minX: 0,
+                    maxX: timeSpanDays.toDouble(),
+                    minY: 0,
+                    maxY: 100,
+                    lineBarsData: [
+                      barData(
+                        days: days,
+                        successfulByDay: state.successfulByDay,
+                        skippedByDay: state.skippedByDay,
+                        failedByDay: state.failedByDay,
+                        showSkipped: true,
+                        showSuccessful: true,
+                        showFailed: true,
+                        habitCount: state.habitCount,
+                        color: styleConfig().alarm.lighten().desaturate(),
+                        aboveColor: styleConfig().alarm.withOpacity(0.5),
+                      ),
+                      barData(
+                        days: days,
+                        successfulByDay: state.successfulByDay,
+                        skippedByDay: state.skippedByDay,
+                        failedByDay: state.failedByDay,
+                        showSkipped: true,
+                        showSuccessful: true,
+                        showFailed: false,
+                        habitCount: state.habitCount,
+                        color: skipColor,
+                      ),
+                      barData(
+                        days: days,
+                        successfulByDay: state.successfulByDay,
+                        skippedByDay: state.skippedByDay,
+                        failedByDay: state.failedByDay,
+                        showSkipped: false,
+                        showSuccessful: true,
+                        showFailed: false,
+                        habitCount: state.habitCount,
+                        color: styleConfig().primaryColor,
+                      ),
+                    ],
                   ),
+                  swapAnimationCurve: Curves.bounceInOut,
                 ),
               ),
             ),

--- a/lib/widgets/charts/habits/habit_completion_rate_chart.dart
+++ b/lib/widgets/charts/habits/habit_completion_rate_chart.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 
 import 'package:collection/collection.dart';
@@ -93,115 +94,120 @@ class HabitCompletionRateChart extends StatelessWidget {
                     )
                   : null,
             ),
-            SizedBox(
-              height: 110,
-              width: MediaQuery.of(context).size.width,
-              child: Padding(
-                padding: const EdgeInsets.only(
-                  right: 25,
-                  left: 20,
-                ),
-                child: LineChart(
-                  LineChartData(
-                    lineTouchData: LineTouchData(
-                      touchTooltipData: LineTouchTooltipData(
-                        tooltipMargin: -150,
-                        tooltipPadding: const EdgeInsets.symmetric(
-                          horizontal: 8,
-                          vertical: 3,
-                        ),
-                        tooltipBgColor: styleConfig().primaryColor,
-                        tooltipRoundedRadius: 8,
-                        getTooltipItems: (List<LineBarSpot> spots) {
-                          final ymd = days[spots.first.x.toInt()];
-                          cubit.setInfoYmd(ymd);
-                          return [];
-                        },
-                      ),
-                    ),
-                    gridData: FlGridData(
-                      show: true,
-                      drawVerticalLine: true,
-                      horizontalInterval: 12.5,
-                      verticalInterval: 1,
-                      getDrawingHorizontalLine: (value) => gridLine,
-                      getDrawingVerticalLine: (value) => gridLine,
-                    ),
-                    titlesData: FlTitlesData(
-                      show: true,
-                      rightTitles: AxisTitles(
-                        sideTitles: SideTitles(showTitles: false),
-                      ),
-                      topTitles: AxisTitles(
-                        sideTitles: SideTitles(showTitles: false),
-                      ),
-                      bottomTitles: AxisTitles(
-                        sideTitles: SideTitles(
-                          showTitles: true,
-                          reservedSize: 30,
-                          interval: 1,
-                          getTitlesWidget: bottomTitleWidgets,
-                        ),
-                      ),
-                      leftTitles: AxisTitles(
-                        sideTitles: SideTitles(
-                          showTitles: true,
-                          interval: 12.5,
-                          getTitlesWidget: leftTitleWidgets,
-                          reservedSize: 35,
-                        ),
-                      ),
-                    ),
-                    borderData: FlBorderData(
-                      show: true,
-                      border: Border.all(
-                        color: styleConfig()
-                            .chartTextColor
-                            .withOpacity(labelOpacity),
-                      ),
-                    ),
-                    minX: 0,
-                    maxX: timeSpanDays.toDouble(),
-                    minY: 0,
-                    maxY: 100,
-                    lineBarsData: [
-                      barData(
-                        days: days,
-                        successfulByDay: state.successfulByDay,
-                        skippedByDay: state.skippedByDay,
-                        failedByDay: state.failedByDay,
-                        showSkipped: true,
-                        showSuccessful: true,
-                        showFailed: true,
-                        habitCount: state.habitCount,
-                        color: styleConfig().alarm.lighten().desaturate(),
-                        aboveColor: styleConfig().alarm.withOpacity(0.5),
-                      ),
-                      barData(
-                        days: days,
-                        successfulByDay: state.successfulByDay,
-                        skippedByDay: state.skippedByDay,
-                        failedByDay: state.failedByDay,
-                        showSkipped: true,
-                        showSuccessful: true,
-                        showFailed: false,
-                        habitCount: state.habitCount,
-                        color: skipColor,
-                      ),
-                      barData(
-                        days: days,
-                        successfulByDay: state.successfulByDay,
-                        skippedByDay: state.skippedByDay,
-                        failedByDay: state.failedByDay,
-                        showSkipped: false,
-                        showSuccessful: true,
-                        showFailed: false,
-                        habitCount: state.habitCount,
-                        color: styleConfig().primaryColor,
-                      ),
-                    ],
+            MouseRegion(
+              onExit: (_) {
+                Timer(const Duration(seconds: 5), () => cubit.setInfoYmd(''));
+              },
+              child: SizedBox(
+                height: 110,
+                width: MediaQuery.of(context).size.width,
+                child: Padding(
+                  padding: const EdgeInsets.only(
+                    right: 25,
+                    left: 20,
                   ),
-                  swapAnimationCurve: Curves.bounceInOut,
+                  child: LineChart(
+                    LineChartData(
+                      lineTouchData: LineTouchData(
+                        touchTooltipData: LineTouchTooltipData(
+                          tooltipMargin: -150,
+                          tooltipPadding: const EdgeInsets.symmetric(
+                            horizontal: 8,
+                            vertical: 3,
+                          ),
+                          tooltipBgColor: styleConfig().primaryColor,
+                          tooltipRoundedRadius: 8,
+                          getTooltipItems: (List<LineBarSpot> spots) {
+                            final ymd = days[spots.first.x.toInt()];
+                            cubit.setInfoYmd(ymd);
+                            return [];
+                          },
+                        ),
+                      ),
+                      gridData: FlGridData(
+                        show: true,
+                        drawVerticalLine: true,
+                        horizontalInterval: 12.5,
+                        verticalInterval: 1,
+                        getDrawingHorizontalLine: (value) => gridLine,
+                        getDrawingVerticalLine: (value) => gridLine,
+                      ),
+                      titlesData: FlTitlesData(
+                        show: true,
+                        rightTitles: AxisTitles(
+                          sideTitles: SideTitles(showTitles: false),
+                        ),
+                        topTitles: AxisTitles(
+                          sideTitles: SideTitles(showTitles: false),
+                        ),
+                        bottomTitles: AxisTitles(
+                          sideTitles: SideTitles(
+                            showTitles: true,
+                            reservedSize: 30,
+                            interval: 1,
+                            getTitlesWidget: bottomTitleWidgets,
+                          ),
+                        ),
+                        leftTitles: AxisTitles(
+                          sideTitles: SideTitles(
+                            showTitles: true,
+                            interval: 12.5,
+                            getTitlesWidget: leftTitleWidgets,
+                            reservedSize: 35,
+                          ),
+                        ),
+                      ),
+                      borderData: FlBorderData(
+                        show: true,
+                        border: Border.all(
+                          color: styleConfig()
+                              .chartTextColor
+                              .withOpacity(labelOpacity),
+                        ),
+                      ),
+                      minX: 0,
+                      maxX: timeSpanDays.toDouble(),
+                      minY: 0,
+                      maxY: 100,
+                      lineBarsData: [
+                        barData(
+                          days: days,
+                          successfulByDay: state.successfulByDay,
+                          skippedByDay: state.skippedByDay,
+                          failedByDay: state.failedByDay,
+                          showSkipped: true,
+                          showSuccessful: true,
+                          showFailed: true,
+                          habitCount: state.habitCount,
+                          color: styleConfig().alarm.lighten().desaturate(),
+                          aboveColor: styleConfig().alarm.withOpacity(0.5),
+                        ),
+                        barData(
+                          days: days,
+                          successfulByDay: state.successfulByDay,
+                          skippedByDay: state.skippedByDay,
+                          failedByDay: state.failedByDay,
+                          showSkipped: true,
+                          showSuccessful: true,
+                          showFailed: false,
+                          habitCount: state.habitCount,
+                          color: skipColor,
+                        ),
+                        barData(
+                          days: days,
+                          successfulByDay: state.successfulByDay,
+                          skippedByDay: state.skippedByDay,
+                          failedByDay: state.failedByDay,
+                          showSkipped: false,
+                          showSuccessful: true,
+                          showFailed: false,
+                          habitCount: state.habitCount,
+                          color: styleConfig().primaryColor,
+                        ),
+                      ],
+                    ),
+                    swapAnimationCurve: Curves.bounceInOut,
+                  ),
                 ),
               ),
             ),

--- a/lib/widgets/habits/habit_page_app_bar.dart
+++ b/lib/widgets/habits/habit_page_app_bar.dart
@@ -7,7 +7,7 @@ class HabitsPageAppBar extends StatelessWidget with PreferredSizeWidget {
   HabitsPageAppBar({super.key});
 
   @override
-  Size get preferredSize => const Size.fromHeight(kToolbarHeight + 110);
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight + 130);
 
   @override
   Widget build(BuildContext context) {
@@ -17,7 +17,6 @@ class HabitsPageAppBar extends StatelessWidget with PreferredSizeWidget {
     return Column(
       children: [
         TitleAppBar(title: title, showBackButton: false),
-        //const HabitsPageProgressBar(),
         const HabitCompletionRateChart(),
       ],
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -287,7 +287,7 @@ packages:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.3.0"
+    version: "4.4.0"
   collection:
     dependency: "direct main"
     description:
@@ -1504,7 +1504,7 @@ packages:
       name: photo_manager
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.1+1"
+    version: "2.5.2"
   photo_view:
     dependency: "direct main"
     description:
@@ -1632,7 +1632,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "3.2.1"
   radial_button:
     dependency: "direct main"
     description:
@@ -1963,14 +1963,14 @@ packages:
       name: syncfusion_flutter_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "20.3.61"
+    version: "20.4.38"
   syncfusion_flutter_datepicker:
     dependency: "direct main"
     description:
       name: syncfusion_flutter_datepicker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "20.3.61"
+    version: "20.4.38"
   synchronized:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.215+1632
+version: 0.8.215+1633
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.215+1631
+version: 0.8.215+1632
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.214+1629
+version: 0.8.215+1630
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.215+1630
+version: 0.8.215+1631
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR improves the habits chart by rendering the info for a selected day (tap/horizontal drag on mobile, hover on desktop) at the top of the chart, as the previous approach with the tooltip was pretty useless on mobile.

<img width="448" alt="image" src="https://user-images.githubusercontent.com/1390808/209481524-d36de6be-2734-475e-80af-8d5feea13f35.png">
