### PR TITLE
Adapt journal page to use CustomScrollView & replace search header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed:
+- New search header in journal
+- Upgraded dependencies
+
+## [0.8.226] - 2023-01-07
+### Changed:
 - Declutter task form
 - Simplified editor toolbar
 - Unified searchable list
 - Hide task title label when task defined
 - Floating search bar replaced in settings
 - Floating search bar replaced in journal
-- New search header in journal
 
 ## [0.8.225] - 2023-01-06
 ### Changed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hide task title label when task defined
 - Floating search bar replaced in settings
 - Floating search bar replaced in journal
+- New search header in journal
 
 ## [0.8.225] - 2023-01-06
 ### Changed:

--- a/lib/beamer/locations/journal_location.dart
+++ b/lib/beamer/locations/journal_location.dart
@@ -41,8 +41,7 @@ class JournalLocation extends BeamLocation<BeamState> {
         key: ValueKey('journal'),
         title: 'Journal',
         type: BeamPageType.noTransition,
-        //child: JournalPage(),
-        child: InfiniteJournalPage(),
+        child: JournalPageWrapper(),
       ),
       if (isUuid(entryId))
         BeamPage(

--- a/lib/blocs/journal/journal_page_cubit.dart
+++ b/lib/blocs/journal/journal_page_cubit.dart
@@ -1,0 +1,107 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:lotti/blocs/journal/journal_page_state.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/get_it.dart';
+
+class FilterBy {
+  FilterBy({
+    required this.typeName,
+    required this.name,
+  });
+
+  final String typeName;
+  final String name;
+}
+
+final List<FilterBy> entryTypes = [
+  FilterBy(typeName: 'Task', name: 'Task'),
+  FilterBy(typeName: 'JournalEntry', name: 'Text'),
+  FilterBy(typeName: 'JournalAudio', name: 'Audio'),
+  FilterBy(typeName: 'JournalImage', name: 'Photo'),
+  FilterBy(typeName: 'MeasurementEntry', name: 'Measured'),
+  FilterBy(typeName: 'SurveyEntry', name: 'Survey'),
+  FilterBy(typeName: 'WorkoutEntry', name: 'Workout'),
+  FilterBy(typeName: 'HabitCompletionEntry', name: 'Habit'),
+  FilterBy(typeName: 'QuantitativeEntry', name: 'Quant'),
+];
+
+final List<FilterBy> defaultTypes = [
+  FilterBy(typeName: 'Task', name: 'Task'),
+  FilterBy(typeName: 'JournalEntry', name: 'Text'),
+  FilterBy(typeName: 'JournalAudio', name: 'Audio'),
+  FilterBy(typeName: 'JournalImage', name: 'Photo'),
+];
+
+class JournalPageCubit extends Cubit<JournalPageState> {
+  JournalPageCubit()
+      : super(
+          JournalPageState(
+            match: '',
+            tagIds: <String>{},
+            starredEntriesOnly: false,
+            flaggedEntriesOnly: false,
+            privateEntriesOnly: false,
+            showPrivateEntries: false,
+            selectedEntryTypes: defaultTypes,
+          ),
+        ) {
+    getIt<JournalDb>().watchConfigFlag('private').listen((showPrivate) {
+      _showPrivateEntries = showPrivate;
+      emitState();
+    });
+  }
+
+  List<FilterBy?> _selectedEntryTypes = <FilterBy?>[];
+
+  String _match = '';
+  bool _starredEntriesOnly = false;
+  bool _flaggedEntriesOnly = false;
+  bool _privateEntriesOnly = false;
+  bool _showPrivateEntries = false;
+
+  void emitState() {
+    emit(
+      JournalPageState(
+        match: _match,
+        tagIds: <String>{},
+        starredEntriesOnly: _starredEntriesOnly,
+        flaggedEntriesOnly: _flaggedEntriesOnly,
+        privateEntriesOnly: _privateEntriesOnly,
+        showPrivateEntries: _showPrivateEntries,
+        selectedEntryTypes: _selectedEntryTypes,
+      ),
+    );
+  }
+
+  void setSelectedTypes(List<FilterBy?> selected) {
+    _selectedEntryTypes = selected;
+    emitState();
+  }
+
+  void toggleStarredEntriesOnly() {
+    _starredEntriesOnly = !_starredEntriesOnly;
+    emitState();
+  }
+
+  void toggleFlaggedEntriesOnly() {
+    _flaggedEntriesOnly = !_flaggedEntriesOnly;
+    emitState();
+  }
+
+  void togglePrivateEntriesOnly() {
+    _privateEntriesOnly = !_privateEntriesOnly;
+    emitState();
+  }
+
+  void setSearchString(String match) {
+    _match = match;
+    emitState();
+  }
+
+  @override
+  Future<void> close() async {
+    await super.close();
+  }
+}

--- a/lib/blocs/journal/journal_page_state.dart
+++ b/lib/blocs/journal/journal_page_state.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:lotti/blocs/journal/journal_page_cubit.dart';
+
+part 'journal_page_state.freezed.dart';
+
+@freezed
+class JournalPageState with _$JournalPageState {
+  factory JournalPageState({
+    required String match,
+    required Set<String> tagIds,
+    required bool starredEntriesOnly,
+    required bool flaggedEntriesOnly,
+    required bool privateEntriesOnly,
+    required bool showPrivateEntries,
+    required List<FilterBy?> selectedEntryTypes,
+  }) = _JournalPageState;
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -64,7 +64,7 @@
   "journalDeleteHint": "Eintrag löschen",
   "journalDeleteQuestion": "Eintrag wirklich löschen?",
   "journalFavoriteTooltip": "Favorit",
-  "journalFlaggedTooltip": "Wiedervorlage",
+  "journalFlaggedTooltip": "Flag",
   "journalHideMapHint": "Karte verstecken",
   "journalLinkedEntriesLabel": "Verlinkte Einträge:",
   "journalLinkedFromLabel": "Verlinkt von:",

--- a/lib/pages/journal/infinite_journal_page.dart
+++ b/lib/pages/journal/infinite_journal_page.dart
@@ -1,55 +1,45 @@
 import 'dart:async';
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
+import 'package:lotti/blocs/journal/journal_page_cubit.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/tag_type_definitions.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/utils/platform.dart';
+import 'package:lotti/widgets/app_bar/journal_sliver_appbar.dart';
 import 'package:lotti/widgets/create/add_actions.dart';
 import 'package:lotti/widgets/journal/journal_card.dart';
-import 'package:lotti/widgets/journal/tags/selected_tags_widget.dart';
-import 'package:lotti/widgets/misc/search_widget.dart';
-import 'package:multi_select_flutter/util/multi_select_item.dart';
 
-class FilterBy {
-  FilterBy({
-    required this.typeName,
-    required this.name,
+class JournalPageWrapper extends StatelessWidget {
+  const JournalPageWrapper({
+    super.key,
+    this.navigatorKey,
   });
 
-  final String typeName;
-  final String name;
+  final GlobalKey? navigatorKey;
+
+  @override
+  Widget build(BuildContext context) {
+    return Navigator(
+      key: navigatorKey,
+      onGenerateRoute: (RouteSettings settings) {
+        return MaterialPageRoute(
+          settings: settings,
+          builder: (BuildContext context) {
+            return BlocProvider<JournalPageCubit>(
+              create: (BuildContext context) => JournalPageCubit(),
+              child: const InfiniteJournalPage(),
+            );
+          },
+        );
+      },
+    );
+  }
 }
-
-final List<String> defaultTypes = [
-  'JournalEntry',
-  'JournalAudio',
-  'JournalImage',
-  'SurveyEntry',
-  'Task',
-  // 'QuantitativeEntry',
-  'MeasurementEntry',
-  'WorkoutEntry',
-  // 'HabitCompletionEntry',
-];
-
-final List<FilterBy> _entryTypes = [
-  FilterBy(typeName: 'Task', name: 'Task'),
-  FilterBy(typeName: 'JournalEntry', name: 'Text'),
-  FilterBy(typeName: 'JournalAudio', name: 'Audio'),
-  FilterBy(typeName: 'JournalImage', name: 'Photo'),
-  FilterBy(typeName: 'MeasurementEntry', name: 'Measured'),
-  FilterBy(typeName: 'SurveyEntry', name: 'Survey'),
-  FilterBy(typeName: 'WorkoutEntry', name: 'Workout'),
-  FilterBy(typeName: 'HabitCompletionEntry', name: 'Habit'),
-  FilterBy(typeName: 'QuantitativeEntry', name: 'Quant'),
-];
 
 class InfiniteJournalPage extends StatefulWidget {
   const InfiniteJournalPage({
@@ -66,21 +56,10 @@ class InfiniteJournalPage extends StatefulWidget {
 class _InfiniteJournalPageState extends State<InfiniteJournalPage> {
   final JournalDb _db = getIt<JournalDb>();
 
-  late Set<String> types;
-
   StreamController<List<TagEntity>> matchingTagsController =
       StreamController<List<TagEntity>>();
 
-  final List<MultiSelectItem<FilterBy?>> _items = _entryTypes
-      .map((entryType) => MultiSelectItem<FilterBy?>(entryType, entryType.name))
-      .toList();
-
   Set<String> tagIds = {};
-  bool starredEntriesOnly = false;
-  bool flaggedEntriesOnly = false;
-  bool privateEntriesOnly = false;
-  bool showPrivateEntriesSwitch = false;
-
   static const _pageSize = 50;
 
   final PagingController<int, JournalEntity> _pagingController =
@@ -89,13 +68,12 @@ class _InfiniteJournalPageState extends State<InfiniteJournalPage> {
   @override
   void initState() {
     _pagingController.addPageRequestListener(_fetchPage);
-
-    types = defaultTypes.toSet();
-
     super.initState();
   }
 
   Future<void> _fetchPage(int pageKey) async {
+    final cubit = context.read<JournalPageCubit>();
+
     try {
       Set<String>? entryIds;
       for (final tagId in tagIds) {
@@ -107,19 +85,24 @@ class _InfiniteJournalPageState extends State<InfiniteJournalPage> {
         }
       }
 
+      final types = cubit.state.selectedEntryTypes
+          .map((e) => e?.typeName)
+          .whereType<String>()
+          .toList();
+
       final newItems = await _db
           .watchJournalEntities(
-            types: types.toList(),
+            types: types,
             ids: entryIds?.toList(),
-            starredStatuses: starredEntriesOnly ? [true] : [true, false],
-            privateStatuses: privateEntriesOnly ? [true] : [true, false],
-            flaggedStatuses: flaggedEntriesOnly ? [1] : [1, 0],
+            starredStatuses:
+                cubit.state.starredEntriesOnly ? [true] : [true, false],
+            privateStatuses:
+                cubit.state.privateEntriesOnly ? [true] : [true, false],
+            flaggedStatuses: cubit.state.flaggedEntriesOnly ? [1] : [1, 0],
             limit: _pageSize,
             offset: pageKey,
           )
           .first;
-
-      //final newItems = await RemoteApi.getCharacterList(pageKey, _pageSize);
 
       final isLastPage = newItems.length < _pageSize;
       if (isLastPage) {
@@ -151,185 +134,47 @@ class _InfiniteJournalPageState extends State<InfiniteJournalPage> {
     });
   }
 
-  Widget searchRow() {
-    final localizations = AppLocalizations.of(context)!;
-
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Column(
-          children: [
-            Wrap(
-              spacing: 4,
-              runSpacing: 4,
-              children: [
-                ..._items.map(
-                  (MultiSelectItem<FilterBy?> item) => GestureDetector(
-                    onTap: () {
-                      setState(() {
-                        final typeName = item.value?.typeName;
-                        if (typeName != null) {
-                          if (types.contains(typeName)) {
-                            types.remove(typeName);
-                          } else {
-                            types.add(typeName);
-                          }
-                          resetQuery();
-                          HapticFeedback.heavyImpact();
-                        }
-                      });
-                    },
-                    child: MouseRegion(
-                      cursor: SystemMouseCursors.click,
-                      child: ClipRRect(
-                        borderRadius: BorderRadius.circular(4),
-                        child: ColoredBox(
-                          color: types.contains(item.value?.typeName)
-                              ? styleConfig().selectedChoiceChipColor
-                              : styleConfig().unselectedChoiceChipColor,
-                          child: Padding(
-                            padding: const EdgeInsets.symmetric(
-                              vertical: 1,
-                              horizontal: 8,
-                            ),
-                            child: Text(
-                              item.label,
-                              style: TextStyle(
-                                fontFamily: 'Oswald',
-                                fontSize: 14,
-                                color: types.contains(item.value?.typeName)
-                                    ? styleConfig().selectedChoiceChipTextColor
-                                    : styleConfig()
-                                        .unselectedChoiceChipTextColor,
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-              ],
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceAround,
-                children: [
-                  Visibility(
-                    visible: showPrivateEntriesSwitch,
-                    child: Row(
-                      children: [
-                        Text(
-                          localizations.journalPrivateTooltip,
-                          style: TextStyle(
-                            color: styleConfig().primaryTextColor,
-                          ),
-                        ),
-                        CupertinoSwitch(
-                          value: privateEntriesOnly,
-                          activeColor: styleConfig().private,
-                          onChanged: (bool value) {
-                            setState(() {
-                              privateEntriesOnly = value;
-                              resetQuery();
-                            });
-                          },
-                        ),
-                      ],
-                    ),
-                  ),
-                  Text(
-                    localizations.journalFavoriteTooltip,
-                    style: TextStyle(color: styleConfig().primaryTextColor),
-                  ),
-                  CupertinoSwitch(
-                    value: starredEntriesOnly,
-                    activeColor: styleConfig().starredGold,
-                    onChanged: (bool value) {
-                      setState(() {
-                        starredEntriesOnly = value;
-                        resetQuery();
-                      });
-                    },
-                  ),
-                  Text(
-                    localizations.journalFlaggedTooltip,
-                    style: TextStyle(color: styleConfig().primaryTextColor),
-                  ),
-                  CupertinoSwitch(
-                    value: flaggedEntriesOnly,
-                    activeColor: styleConfig().starredGold,
-                    onChanged: (bool value) {
-                      setState(() {
-                        flaggedEntriesOnly = value;
-                        resetQuery();
-                      });
-                    },
-                  ),
-                ],
-              ),
-            ),
-            SelectedTagsWidget(
-              removeTag: removeTag,
-              tagIds: tagIds.toList(),
-            ),
-          ],
-        )
-      ],
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
-    return Navigator(
-      key: widget.navigatorKey,
-      onGenerateRoute: (RouteSettings settings) {
-        return MaterialPageRoute(
-          settings: settings,
-          builder: (BuildContext context) {
-            return Scaffold(
-              backgroundColor: styleConfig().negspace,
-              appBar: JournalPageAppBar(
-                title: 'Journal',
-                match: '',
-                onQueryChanged: (text) {},
-                searchRow: searchRow(),
-              ),
-              body: RefreshIndicator(
-                onRefresh: () => Future.sync(_pagingController.refresh),
-                child: PagedListView<int, JournalEntity>(
-                  pagingController: _pagingController,
-                  builderDelegate: PagedChildBuilderDelegate<JournalEntity>(
-                    itemBuilder: (context, item, index) {
-                      return item.maybeMap(
-                        journalImage: (JournalImage image) {
-                          return JournalImageCard(
-                            item: image,
-                            key: ValueKey(item.meta.id),
-                          );
-                        },
-                        orElse: () {
-                          return JournalCard(
-                            item: item,
-                            key: ValueKey(item.meta.id),
-                          );
-                        },
+    return Scaffold(
+      backgroundColor: styleConfig().negspace,
+      floatingActionButton: RadialAddActionButtons(
+        radius: isMobile ? 180 : 120,
+        isMacOS: isMacOS,
+        isIOS: isIOS,
+        isAndroid: isAndroid,
+      ),
+      body: RefreshIndicator(
+        onRefresh: () => Future.sync(_pagingController.refresh),
+        child: CustomScrollView(
+          slivers: <Widget>[
+            JournalSliverAppBar(
+              resetQuery: resetQuery,
+            ),
+            PagedSliverList<int, JournalEntity>(
+              pagingController: _pagingController,
+              builderDelegate: PagedChildBuilderDelegate<JournalEntity>(
+                itemBuilder: (context, item, index) {
+                  return item.maybeMap(
+                    journalImage: (JournalImage image) {
+                      return JournalImageCard(
+                        item: image,
+                        key: ValueKey(item.meta.id),
                       );
                     },
-                  ),
-                ),
+                    orElse: () {
+                      return JournalCard(
+                        item: item,
+                        key: ValueKey(item.meta.id),
+                      );
+                    },
+                  );
+                },
               ),
-              floatingActionButton: RadialAddActionButtons(
-                radius: isMobile ? 180 : 120,
-                isMacOS: isMacOS,
-                isIOS: isIOS,
-                isAndroid: isAndroid,
-              ),
-            );
-          },
-        );
-      },
+            ),
+          ],
+        ),
+      ),
     );
   }
 
@@ -337,39 +182,5 @@ class _InfiniteJournalPageState extends State<InfiniteJournalPage> {
   void dispose() {
     _pagingController.dispose();
     super.dispose();
-  }
-}
-
-class JournalPageAppBar extends StatelessWidget with PreferredSizeWidget {
-  const JournalPageAppBar({
-    super.key,
-    required this.title,
-    required this.match,
-    required this.onQueryChanged,
-    required this.searchRow,
-  });
-
-  final String title;
-  final String match;
-  final void Function(String) onQueryChanged;
-  final Widget searchRow;
-
-  @override
-  Size get preferredSize => const Size.fromHeight(kToolbarHeight * 3);
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [
-        const SizedBox(height: 5),
-        SearchWidget(
-          text: match,
-          onChanged: onQueryChanged,
-          hintText: 'Search $title...',
-        ),
-        searchRow,
-      ],
-    );
   }
 }

--- a/lib/themes/theme.dart
+++ b/lib/themes/theme.dart
@@ -167,6 +167,10 @@ TextStyle searchFieldStyle() => TextStyle(
       fontWeight: FontWeight.w100,
     );
 
+TextStyle searchFieldHintStyle() => searchFieldStyle().copyWith(
+      color: styleConfig().secondaryTextColor,
+    );
+
 TextStyle settingsCardTextStyle() => TextStyle(
       //color: colorConfig().entryTextColor,
       color: styleConfig().primaryTextColor,

--- a/lib/widgets/app_bar/journal_sliver_appbar.dart
+++ b/lib/widgets/app_bar/journal_sliver_appbar.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:lotti/blocs/journal/journal_page_cubit.dart';
+import 'package:lotti/blocs/journal/journal_page_state.dart';
+import 'package:lotti/themes/theme.dart';
+import 'package:lotti/utils/platform.dart';
+import 'package:lotti/widgets/misc/multi_select.dart';
+import 'package:lotti/widgets/misc/search_widget.dart';
+import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:multi_select_flutter/multi_select_flutter.dart';
+
+class JournalSliverAppBar extends StatelessWidget {
+  const JournalSliverAppBar({
+    super.key,
+    required this.resetQuery,
+  });
+
+  final void Function() resetQuery;
+
+  @override
+  Widget build(BuildContext context) {
+    final localizations = AppLocalizations.of(context)!;
+
+    final items = entryTypes
+        .map(
+          (entryType) => MultiSelectItem<FilterBy?>(entryType, entryType.name),
+        )
+        .toList();
+
+    return BlocBuilder<JournalPageCubit, JournalPageState>(
+      builder: (context, snapshot) {
+        final cubit = context.read<JournalPageCubit>();
+
+        return SliverAppBar(
+          backgroundColor: styleConfig().negspace,
+          expandedHeight: isIOS ? 230 : 210,
+          flexibleSpace: FlexibleSpaceBar(
+            background: Padding(
+              padding: EdgeInsets.only(top: isIOS ? 30 : 0),
+              child: Wrap(
+                alignment: WrapAlignment.center,
+                runAlignment: WrapAlignment.center,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                spacing: 10,
+                runSpacing: 10,
+                children: [
+                  SizedBox(
+                    width: 321,
+                    child: SearchWidget(
+                      margin: EdgeInsets.zero,
+                      text: snapshot.match,
+                      onChanged: cubit.setSearchString,
+                      hintText: 'Search Journal...',
+                    ),
+                  ),
+                  MultiSelect<FilterBy?>(
+                    multiSelectItems: items,
+                    initialValue: snapshot.selectedEntryTypes,
+                    onConfirm: (selected) {
+                      cubit.setSelectedTypes(selected);
+                      resetQuery();
+                      HapticFeedback.heavyImpact();
+                    },
+                    title: 'Entry types',
+                    buttonText: 'Entry types',
+                    iconData: MdiIcons.filter,
+                  ),
+                  const SizedBox(width: 10),
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Visibility(
+                        visible: snapshot.showPrivateEntries,
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              localizations.journalPrivateTooltip,
+                              style: TextStyle(
+                                color: styleConfig().secondaryTextColor,
+                              ),
+                            ),
+                            CupertinoSwitch(
+                              value: snapshot.privateEntriesOnly,
+                              activeColor: styleConfig().private,
+                              onChanged: (bool value) {
+                                cubit.togglePrivateEntriesOnly();
+                                resetQuery();
+                              },
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(width: 10),
+                      Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(
+                            localizations.journalFavoriteTooltip,
+                            style: TextStyle(
+                              color: styleConfig().secondaryTextColor,
+                            ),
+                          ),
+                          CupertinoSwitch(
+                            value: snapshot.starredEntriesOnly,
+                            activeColor: styleConfig().starredGold,
+                            onChanged: (bool value) {
+                              cubit.toggleStarredEntriesOnly();
+                              resetQuery();
+                            },
+                          ),
+                        ],
+                      ),
+                      const SizedBox(width: 10),
+                      Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(
+                            localizations.journalFlaggedTooltip,
+                            style: TextStyle(
+                              color: styleConfig().secondaryTextColor,
+                            ),
+                          ),
+                          CupertinoSwitch(
+                            value: snapshot.flaggedEntriesOnly,
+                            activeColor: styleConfig().starredGold,
+                            onChanged: (bool value) {
+                              cubit.toggleFlaggedEntriesOnly();
+                              resetQuery();
+                            },
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/widgets/misc/multi_select.dart
+++ b/lib/widgets/misc/multi_select.dart
@@ -1,15 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:lotti/themes/theme.dart';
-import 'package:multi_select_flutter/multi_select_flutter.dart';
+import 'package:multi_select_flutter/bottom_sheet/multi_select_bottom_sheet_field.dart';
+import 'package:multi_select_flutter/util/multi_select_item.dart';
 
-class ChartMultiSelect<T> extends StatelessWidget {
-  const ChartMultiSelect({
+class MultiSelect<T> extends StatelessWidget {
+  const MultiSelect({
     super.key,
     required this.multiSelectItems,
     required this.onConfirm,
     required this.title,
     required this.buttonText,
     required this.iconData,
+    required this.initialValue,
   });
 
   final List<MultiSelectItem<T?>> multiSelectItems;
@@ -17,16 +19,17 @@ class ChartMultiSelect<T> extends StatelessWidget {
   final String title;
   final String buttonText;
   final IconData iconData;
+  final List<T> initialValue;
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.all(16),
+    return SizedBox(
+      width: 321,
       child: MultiSelectBottomSheetField<T?>(
-        searchable: true,
         backgroundColor: styleConfig().cardColor,
         items: multiSelectItems,
-        initialValue: const [],
+        initialChildSize: 0.8,
+        maxChildSize: 0.8,
         title: Text(
           title,
           style: titleStyle(),
@@ -34,13 +37,9 @@ class ChartMultiSelect<T> extends StatelessWidget {
         checkColor: styleConfig().primaryTextColor,
         selectedColor: styleConfig().primaryColor,
         decoration: BoxDecoration(
-          color: Colors.blue.withOpacity(0.1),
-          borderRadius: const BorderRadius.all(
-            Radius.circular(40),
-          ),
-          border: Border.all(
-            color: styleConfig().secondaryTextColor,
-          ),
+          borderRadius: BorderRadius.circular(12),
+          color: Colors.white.withOpacity(0.2),
+          border: Border.all(color: Colors.black26),
         ),
         itemsTextStyle: multiSelectStyle(),
         selectedItemsTextStyle: multiSelectStyle().copyWith(
@@ -56,15 +55,9 @@ class ChartMultiSelect<T> extends StatelessWidget {
         searchHintStyle: formLabelStyle(),
         buttonIcon: Icon(
           iconData,
-          color: styleConfig().primaryTextColor,
+          color: styleConfig().secondaryTextColor,
         ),
-        buttonText: Text(
-          buttonText,
-          style: TextStyle(
-            color: styleConfig().primaryTextColor,
-            fontSize: fontSizeMedium,
-          ),
-        ),
+        buttonText: Text(buttonText, style: searchFieldHintStyle()),
         onConfirm: onConfirm,
       ),
     );

--- a/lib/widgets/misc/search_widget.dart
+++ b/lib/widgets/misc/search_widget.dart
@@ -8,11 +8,13 @@ class SearchWidget extends StatefulWidget with PreferredSizeWidget {
     required this.text,
     required this.onChanged,
     required this.hintText,
+    this.margin = const EdgeInsets.all(20),
   });
 
   final String text;
   final ValueChanged<String> onChanged;
   final String hintText;
+  final EdgeInsets margin;
 
   @override
   Size get preferredSize => const Size.fromHeight(kToolbarHeight);
@@ -27,17 +29,16 @@ class _SearchWidgetState extends State<SearchWidget> {
   @override
   Widget build(BuildContext context) {
     final styleActive = searchFieldStyle();
-    final styleHint = styleActive.copyWith(
-      color: styleActive.color?.withOpacity(0.5),
-    );
+    final styleHint = searchFieldHintStyle();
+
     final style = widget.text.isEmpty ? styleHint : styleActive;
 
     return Container(
-      height: 42,
-      margin: const EdgeInsets.fromLTRB(16, 16, 16, 16),
+      margin: widget.margin,
+      height: 53,
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(12),
-        color: Colors.white.withOpacity(0.3),
+        color: Colors.white.withOpacity(0.2),
         border: Border.all(color: Colors.black26),
       ),
       padding: const EdgeInsets.symmetric(horizontal: 8),

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -175,7 +175,7 @@ SPEC CHECKSUMS:
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
   screen_retriever: 59634572a57080243dd1bf715e55b6c54f241a38
   share_plus_macos: 853ee48e7dce06b633998ca0735d482dd671ade4
-  shared_preferences_macos: a64dc611287ed6cbe28fd1297898db1336975727
+  shared_preferences_macos: 8b221d457159a85f478c0b9d2f19aeae9feff475
   sqflite: a5789cceda41d54d23f31d6de539d65bb14100ea
   sqlite3: 88dd99ef4ac3945f5a15facdd752933c52fd93bf
   sqlite3_flutter_libs: 7523e007b12584944a26feaa9975ea741eab136f

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1610,6 +1610,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.1"
+  pull_to_refresh:
+    dependency: "direct main"
+    description:
+      name: pull_to_refresh
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   qr:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "51.0.0"
+    version: "52.0.0"
   adaptive_dialog:
     dependency: "direct main"
     description:
@@ -21,7 +21,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.3.1"
+    version: "5.4.0"
   analyzer_plugin:
     dependency: transitive
     description:
@@ -478,7 +478,7 @@ packages:
       name: easy_debounce
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2+1"
+    version: "2.0.3"
   encrypt:
     dependency: "direct main"
     description:
@@ -1783,7 +1783,7 @@ packages:
       name: shared_preferences_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.5"
   shared_preferences_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.226+1658
+version: 0.8.226+1662
 
 msix_config:
   display_name: Lotti
@@ -125,6 +125,7 @@ dependencies:
   photo_view: ^0.14.0
 
 #  qr_code_scanner: ^0.7.0
+  pull_to_refresh: ^2.0.0
   qr_code_scanner:
     git:
       url: https://github.com/xeinebiu/qr_code_scanner.git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.226+1662
+version: 0.8.227+1663
 
 msix_config:
   display_name: Lotti

--- a/test/pages/journal/infinite_journal_page_test.dart
+++ b/test/pages/journal/infinite_journal_page_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/blocs/audio/player_cubit.dart';
+import 'package:lotti/blocs/journal/journal_page_cubit.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/tag_type_definitions.dart';
@@ -16,6 +17,7 @@ import 'package:lotti/services/tags_service.dart';
 import 'package:lotti/services/time_service.dart';
 import 'package:lotti/themes/themes.dart';
 import 'package:lotti/themes/themes_service.dart';
+import 'package:lotti/utils/consts.dart';
 import 'package:lotti/widgets/journal/entry_tools.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:mocktail/mocktail.dart';
@@ -31,6 +33,9 @@ void main() {
 
   var mockJournalDb = MockJournalDb();
   var mockPersistenceLogic = MockPersistenceLogic();
+
+  final entryTypes =
+      defaultTypes.map((e) => e.typeName).whereType<String>().toList();
 
   group('JournalPage Widget Tests - ', () {
     setUpAll(() {
@@ -48,6 +53,10 @@ void main() {
 
       final mockTagsService = mockTagsServiceWithTags([]);
       final mockTimeService = MockTimeService();
+
+      when(() => mockJournalDb.watchConfigFlag(privateFlag)).thenAnswer(
+        (_) => Stream<bool>.fromIterable([true]),
+      );
 
       getIt
         ..registerSingleton<Directory>(await getApplicationDocumentsDirectory())
@@ -110,7 +119,7 @@ void main() {
 
       when(
         () => mockJournalDb.watchJournalEntities(
-          types: defaultTypes.toList(),
+          types: entryTypes,
           starredStatuses: [true, false],
           privateStatuses: [true, false],
           flaggedStatuses: [1, 0],
@@ -128,7 +137,7 @@ void main() {
           BlocProvider<AudioPlayerCubit>(
             create: (BuildContext context) => AudioPlayerCubit(),
             lazy: false,
-            child: const InfiniteJournalPage(),
+            child: const JournalPageWrapper(),
           ),
         ),
       );
@@ -166,7 +175,7 @@ void main() {
 
       when(
         () => mockJournalDb.watchJournalEntities(
-          types: defaultTypes.toList(),
+          types: entryTypes,
           starredStatuses: [true, false],
           privateStatuses: [true, false],
           flaggedStatuses: [1, 0],
@@ -186,7 +195,7 @@ void main() {
           BlocProvider<AudioPlayerCubit>(
             create: (BuildContext context) => AudioPlayerCubit(),
             lazy: false,
-            child: const InfiniteJournalPage(),
+            child: const JournalPageWrapper(),
           ),
         ),
       );
@@ -222,7 +231,7 @@ void main() {
 
       when(
         () => mockJournalDb.watchJournalEntities(
-          types: defaultTypes.toList(),
+          types: entryTypes,
           starredStatuses: [true, false],
           privateStatuses: [true, false],
           flaggedStatuses: [1, 0],
@@ -242,7 +251,7 @@ void main() {
           BlocProvider<AudioPlayerCubit>(
             create: (BuildContext context) => AudioPlayerCubit(),
             lazy: false,
-            child: const InfiniteJournalPage(),
+            child: const JournalPageWrapper(),
           ),
         ),
       );
@@ -302,7 +311,7 @@ void main() {
 
       when(
         () => mockJournalDb.watchJournalEntities(
-          types: defaultTypes.toList(),
+          types: entryTypes,
           starredStatuses: [true, false],
           privateStatuses: [true, false],
           flaggedStatuses: [1, 0],
@@ -332,7 +341,7 @@ void main() {
           BlocProvider<AudioPlayerCubit>(
             create: (BuildContext context) => AudioPlayerCubit(),
             lazy: false,
-            child: const InfiniteJournalPage(),
+            child: const JournalPageWrapper(),
           ),
         ),
       );
@@ -394,7 +403,7 @@ void main() {
 
       when(
         () => mockJournalDb.watchJournalEntities(
-          types: defaultTypes.toList(),
+          types: entryTypes,
           starredStatuses: [true, false],
           privateStatuses: [true, false],
           flaggedStatuses: [1, 0],
@@ -422,7 +431,7 @@ void main() {
           BlocProvider<AudioPlayerCubit>(
             create: (BuildContext context) => AudioPlayerCubit(),
             lazy: false,
-            child: const InfiniteJournalPage(),
+            child: const JournalPageWrapper(),
           ),
         ),
       );


### PR DESCRIPTION
This PR adapts the journal page to use a CustomScrollView so that the header can be animated when scrolling up. Also remove this floating search bar for which the author must have deleted the GitHub project... 🤦 

Also, the journal page widget is reduced in complexity by moving logic into `JournalPageCubit`. This needs to be completed by moving all the fetch logic into the cubit.