### PR TITLE
Show popular values in capture dialog for past dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed:
+- Show popular values in capture dialog for past dates
+
+## [0.8.228] - 2023-01-10
 ### Added:
 - Full-text search database using FTS5
 - Wire full-text database search (no refresh yet)

--- a/lib/pages/create/create_measurement_dialog.dart
+++ b/lib/pages/create/create_measurement_dialog.dart
@@ -43,7 +43,7 @@ class _MeasurementDialogState extends State<MeasurementDialog> {
 
   final beamBack = dashboardsBeamerDelegate.beamBack;
 
-  Future<void> saveMeasurement() async {
+  Future<void> saveMeasurement({num? value}) async {
     _formKey.currentState!.save();
     if (validate()) {
       final formData = _formKey.currentState?.value;
@@ -63,7 +63,7 @@ class _MeasurementDialogState extends State<MeasurementDialog> {
         dataTypeId: selected!.id,
         dateTo: formData!['date'] as DateTime,
         dateFrom: formData['date'] as DateTime,
-        value: nf.parse('${formData['value']}'.replaceAll(',', '.')),
+        value: value ?? nf.parse('${formData['value']}'.replaceAll(',', '.')),
       );
 
       await persistenceLogic.createMeasurementEntry(
@@ -238,8 +238,11 @@ class _MeasurementDialogState extends State<MeasurementDialog> {
                         name: 'comment',
                       ),
                       const SizedBox(height: 20),
-                      if (selected != null && dirty == false)
-                        MeasurementSuggestions(measurableDataType: selected!),
+                      if (selected != null)
+                        MeasurementSuggestions(
+                          measurableDataType: selected!,
+                          saveMeasurement: saveMeasurement,
+                        ),
                     ],
                   ),
                 ),

--- a/lib/widgets/create/suggest_measurement.dart
+++ b/lib/widgets/create/suggest_measurement.dart
@@ -1,20 +1,20 @@
 import 'package:flutter/material.dart';
-import 'package:lotti/beamer/beamer_delegates.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
-import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/utils/measurable_utils.dart';
 
 class MeasurementSuggestions extends StatelessWidget {
   const MeasurementSuggestions({
     required this.measurableDataType,
+    required this.saveMeasurement,
     super.key,
   });
 
   final MeasurableDataType measurableDataType;
+  final Future<void> Function({num? value}) saveMeasurement;
 
   @override
   Widget build(BuildContext context) {
@@ -40,19 +40,7 @@ class MeasurementSuggestions extends StatelessWidget {
             final label = value.toDouble().toString().replaceAll(regex, '');
             final unit = measurableDataType.unitName;
 
-            void onTap() {
-              final now = DateTime.now();
-              getIt<PersistenceLogic>().createMeasurementEntry(
-                data: MeasurementData(
-                  dataTypeId: measurableDataType.id,
-                  dateTo: now,
-                  dateFrom: now,
-                  value: value,
-                ),
-                private: measurableDataType.private ?? false,
-              );
-              dashboardsBeamerDelegate.beamBack();
-            }
+            void onTap() => saveMeasurement(value: value);
 
             return MouseRegion(
               cursor: SystemMouseCursors.click,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.228+1681
+version: 0.8.229+1683
 
 msix_config:
   display_name: Lotti

--- a/test/widgets/create/measurement_suggestions_test.dart
+++ b/test/widgets/create/measurement_suggestions_test.dart
@@ -12,9 +12,14 @@ import '../../test_data/test_data.dart';
 import '../../utils/measurable_utils_test.dart';
 import '../../widget_test_utils.dart';
 
+class MeasurementMock extends Mock {
+  Future<void> saveMeasurement({num? value});
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   registerFallbackValue(FakeMeasurementData());
+  final mock = MeasurementMock();
 
   group(' - ', () {
     final mockJournalDb = MockJournalDb();
@@ -34,15 +39,8 @@ void main() {
       ]),
     );
 
-    Future<MeasurementEntry?> mockCreateMeasurementEntry() {
-      return mockPersistenceLogic.createMeasurementEntry(
-        data: any(named: 'data'),
-        comment: any(named: 'comment'),
-        private: false,
-      );
-    }
-
-    when(mockCreateMeasurementEntry).thenAnswer((_) async => null);
+    Future<void> mockSaveMeasurement() => mock.saveMeasurement(value: 500);
+    when(mockSaveMeasurement).thenAnswer((_) async => true);
 
     setUp(() async {
       getIt
@@ -59,6 +57,7 @@ void main() {
           makeTestableWidgetWithScaffold(
             MeasurementSuggestions(
               measurableDataType: measurableWater,
+              saveMeasurement: mock.saveMeasurement,
             ),
           ),
         );
@@ -72,7 +71,7 @@ void main() {
         await tester.tap(find.text('500 ml'));
         await tester.pumpAndSettle();
 
-        verify(mockCreateMeasurementEntry).called(1);
+        verify(mockSaveMeasurement).called(1);
       },
     );
   });


### PR DESCRIPTION
This PR improves the capture dialog by showing suggested popular values in the dialog also when selecting a different date. Before, the suggestions would disappear when selecting a different date or comment, for no good reason.