### PR TITLE
Fix unlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed:
+- Unlinking entries
+
+## [0.8.235] - 2023-01-13
 ### Added:
 - Remove habit streaks section - not useful, streaks are apparent without
 - Chore: upgraded dependencies

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,3 +3,4 @@ coverage:
     project:
       default:
         threshold: 0.2%
+    patch: off

--- a/lib/widgets/journal/entry_detail_linked.dart
+++ b/lib/widgets/journal/entry_detail_linked.dart
@@ -60,7 +60,7 @@ class LinkedEntriesWidget extends StatelessWidget {
 
                     if (result == unlinkKey) {
                       await db.removeLink(
-                        fromId: itemId,
+                        fromId: item.meta.id,
                         toId: itemId,
                       );
                     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1450,12 +1450,12 @@ packages:
     source: hosted
     version: "2.1.7"
   path_provider_macos:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.7"
+    version: "2.0.6"
   path_provider_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.235+1706
+version: 0.8.236+1707
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -122,6 +122,7 @@ dependencies:
   package_info_plus: ^3.0.1
   path: ^1.8.1
   path_provider: ^2.0.8
+  path_provider_macos: 2.0.6
   permission_handler: ^10.0.0
   photo_view: ^0.14.0
 


### PR DESCRIPTION
This PR fixes unlinking entries, e.g. for linking a time recording entry to a separate task when realizing that the time log belongs elsewhere. Example: I work on a feature but end up fixing CI. Then I'd want to associate a log entry where I describe the fix with its own task.