### PR TITLE
Fix navigate back after entry deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed:
+- Navigate back after entry deletion
+
+## [0.8.236] - 2023-01-14
+### Fixed:
 - Unlinking entries
 
 ## [0.8.235] - 2023-01-13

--- a/lib/blocs/journal/entry_cubit.dart
+++ b/lib/blocs/journal/entry_cubit.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:flutter_quill/flutter_quill.dart';
+import 'package:lotti/beamer/beamer_delegates.dart';
 import 'package:lotti/blocs/journal/entry_state.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
@@ -213,7 +214,9 @@ class EntryCubit extends Cubit<EntryState> {
   }
 
   Future<bool> delete() async {
-    return _persistenceLogic.deleteJournalEntity(entryId);
+    final res = await _persistenceLogic.deleteJournalEntity(entryId);
+    journalBeamerDelegate.beamBack();
+    return res;
   }
 
   Future<bool> updateFromTo({

--- a/lib/widgets/journal/entry_details/delete_icon_widget.dart
+++ b/lib/widgets/journal/entry_details/delete_icon_widget.dart
@@ -15,7 +15,6 @@ class DeleteIconWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final localizations = AppLocalizations.of(context)!;
-    void maybePop() => Navigator.of(context).maybePop();
 
     return BlocBuilder<EntryCubit, EntryState>(
       builder: (
@@ -42,7 +41,6 @@ class DeleteIconWidget extends StatelessWidget {
 
           if (result == deleteKey) {
             await cubit.delete();
-            maybePop();
           }
         }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.236+1707
+version: 0.8.237+1708
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR fixes navigating back when deleting an entry. Solution was pretty simple, just call `beamBack` on the beamer delegate:

`journalBeamerDelegate.beamBack();`

Resolves #1318