### PR TITLE
Improve search header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed:
+- Long press on entry type filter to select only one type
+
 ### Fixed:
 - Add missing habit completion summary in entry detail view
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed:
 - Long press on entry type filter to select only one type
+- Select all entry types toggle button
 
 ### Fixed:
 - Add missing habit completion summary in entry detail view

--- a/lib/blocs/journal/journal_page_cubit.dart
+++ b/lib/blocs/journal/journal_page_cubit.dart
@@ -128,6 +128,16 @@ class JournalPageCubit extends Cubit<JournalPageState> {
     refreshQuery();
   }
 
+  void selectAllEntryTypes() {
+    _selectedEntryTypes = entryTypes.toSet();
+    refreshQuery();
+  }
+
+  void clearSelectedEntryTypes() {
+    _selectedEntryTypes = {};
+    refreshQuery();
+  }
+
   void toggleFlaggedEntriesOnly() {
     _flaggedEntriesOnly = !_flaggedEntriesOnly;
     refreshQuery();

--- a/lib/blocs/journal/journal_page_cubit.dart
+++ b/lib/blocs/journal/journal_page_cubit.dart
@@ -123,6 +123,11 @@ class JournalPageCubit extends Cubit<JournalPageState> {
     refreshQuery();
   }
 
+  void setSingleEntryType(String entryType) {
+    _selectedEntryTypes = {entryType};
+    refreshQuery();
+  }
+
   void toggleFlaggedEntriesOnly() {
     _flaggedEntriesOnly = !_flaggedEntriesOnly;
     refreshQuery();

--- a/lib/widgets/search/entry_type_filter.dart
+++ b/lib/widgets/search/entry_type_filter.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lotti/blocs/journal/journal_page_cubit.dart';
 import 'package:lotti/blocs/journal/journal_page_state.dart';
 import 'package:lotti/themes/theme.dart';
+import 'package:quiver/collection.dart';
 
 class EntryTypeFilter extends StatelessWidget {
   const EntryTypeFilter({super.key});
@@ -21,6 +22,7 @@ class EntryTypeFilter extends StatelessWidget {
             lineSpacing: 5,
             children: [
               ...entryTypes.map(EntryTypeChip.new),
+              const EntryTypeAllChip(),
             ],
           ),
         );
@@ -42,6 +44,7 @@ class EntryTypeChip extends StatelessWidget {
     return BlocBuilder<JournalPageCubit, JournalPageState>(
       builder: (context, snapshot) {
         final cubit = context.read<JournalPageCubit>();
+        final isSelected = snapshot.selectedEntryTypes.contains(entryType);
 
         return GestureDetector(
           onTap: () {
@@ -57,7 +60,7 @@ class EntryTypeChip extends StatelessWidget {
             child: ClipRRect(
               borderRadius: BorderRadius.circular(8),
               child: ColoredBox(
-                color: snapshot.selectedEntryTypes.contains(entryType)
+                color: isSelected
                     ? styleConfig().selectedChoiceChipColor
                     : styleConfig().unselectedChoiceChipColor.withOpacity(0.7),
                 child: Padding(
@@ -71,7 +74,61 @@ class EntryTypeChip extends StatelessWidget {
                       fontFamily: 'Oswald',
                       fontSize: fontSizeMedium,
                       fontWeight: FontWeight.w300,
-                      color: snapshot.selectedEntryTypes.contains(entryType)
+                      color: isSelected
+                          ? styleConfig().selectedChoiceChipTextColor
+                          : styleConfig().unselectedChoiceChipTextColor,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class EntryTypeAllChip extends StatelessWidget {
+  const EntryTypeAllChip({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<JournalPageCubit, JournalPageState>(
+      builder: (context, snapshot) {
+        final cubit = context.read<JournalPageCubit>();
+        final isSelected =
+            setsEqual(snapshot.selectedEntryTypes.toSet(), entryTypes.toSet());
+
+        return GestureDetector(
+          onTap: () {
+            if (isSelected) {
+              cubit.clearSelectedEntryTypes();
+            } else {
+              cubit.selectAllEntryTypes();
+            }
+            HapticFeedback.heavyImpact();
+          },
+          child: MouseRegion(
+            cursor: SystemMouseCursors.click,
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(8),
+              child: ColoredBox(
+                color: isSelected
+                    ? styleConfig().selectedChoiceChipColor
+                    : styleConfig().unselectedChoiceChipColor.withOpacity(0.7),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    vertical: 5,
+                    horizontal: 15,
+                  ),
+                  child: Text(
+                    'All',
+                    style: TextStyle(
+                      fontFamily: 'Oswald',
+                      fontSize: fontSizeMedium,
+                      fontWeight: FontWeight.w300,
+                      color: isSelected
                           ? styleConfig().selectedChoiceChipTextColor
                           : styleConfig().unselectedChoiceChipTextColor,
                     ),

--- a/lib/widgets/search/entry_type_filter.dart
+++ b/lib/widgets/search/entry_type_filter.dart
@@ -48,6 +48,10 @@ class EntryTypeChip extends StatelessWidget {
             cubit.toggleSelectedEntryTypes(entryType);
             HapticFeedback.heavyImpact();
           },
+          onLongPress: () {
+            cubit.setSingleEntryType(entryType);
+            HapticFeedback.heavyImpact();
+          },
           child: MouseRegion(
             cursor: SystemMouseCursors.click,
             child: ClipRRect(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.239+1711
+version: 0.8.239+1712
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR adds an all button in the entry type filter, which will select all types unless all are selected already, in which case it will clear the selection. Also adds a long press gesture on the individual choice chips which will clear the selection except for the long pressed item.

Resolves #1324.