### PR TITLE
Improve search header for tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed:
 - Long press on entry type filter to select only one type
 - Select all entry types toggle button
+- Long press on task status filter to select only one status
+- Select all task statuses toggle button
 
 ### Fixed:
 - Add missing habit completion summary in entry detail view

--- a/lib/blocs/journal/journal_page_cubit.dart
+++ b/lib/blocs/journal/journal_page_cubit.dart
@@ -123,7 +123,7 @@ class JournalPageCubit extends Cubit<JournalPageState> {
     refreshQuery();
   }
 
-  void setSingleEntryType(String entryType) {
+  void selectSingleEntryType(String entryType) {
     _selectedEntryTypes = {entryType};
     refreshQuery();
   }
@@ -135,6 +135,21 @@ class JournalPageCubit extends Cubit<JournalPageState> {
 
   void clearSelectedEntryTypes() {
     _selectedEntryTypes = {};
+    refreshQuery();
+  }
+
+  void selectSingleTaskStatus(String taskStatus) {
+    _selectedTaskStatuses = {taskStatus};
+    refreshQuery();
+  }
+
+  void selectAllTaskStatuses() {
+    _selectedTaskStatuses = state.taskStatuses.toSet();
+    refreshQuery();
+  }
+
+  void clearSelectedTaskStatuses() {
+    _selectedTaskStatuses = {};
     refreshQuery();
   }
 

--- a/lib/themes/theme.dart
+++ b/lib/themes/theme.dart
@@ -51,6 +51,15 @@ TextStyle textStyle() => TextStyle(
       fontSize: fontSizeMedium,
     );
 
+TextStyle choiceChipTextStyle({required bool isSelected}) => TextStyle(
+      fontFamily: 'Oswald',
+      fontSize: fontSizeMedium,
+      fontWeight: FontWeight.w300,
+      color: isSelected
+          ? styleConfig().selectedChoiceChipTextColor
+          : styleConfig().unselectedChoiceChipTextColor,
+    );
+
 TextStyle chartTooltipStyle() => const TextStyle(
       fontSize: fontSizeSmall,
       fontFamily: mainFont,

--- a/lib/widgets/search/entry_type_filter.dart
+++ b/lib/widgets/search/entry_type_filter.dart
@@ -53,7 +53,7 @@ class EntryTypeChip extends StatelessWidget {
         }
 
         void onLongPress() {
-          cubit.setSingleEntryType(entryType);
+          cubit.selectSingleEntryType(entryType);
           HapticFeedback.heavyImpact();
         }
 

--- a/lib/widgets/search/entry_type_filter.dart
+++ b/lib/widgets/search/entry_type_filter.dart
@@ -4,7 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lotti/blocs/journal/journal_page_cubit.dart';
 import 'package:lotti/blocs/journal/journal_page_state.dart';
-import 'package:lotti/themes/theme.dart';
+import 'package:lotti/widgets/search/filter_choice_chip.dart';
 import 'package:quiver/collection.dart';
 
 class EntryTypeFilter extends StatelessWidget {
@@ -44,45 +44,24 @@ class EntryTypeChip extends StatelessWidget {
     return BlocBuilder<JournalPageCubit, JournalPageState>(
       builder: (context, snapshot) {
         final cubit = context.read<JournalPageCubit>();
+
         final isSelected = snapshot.selectedEntryTypes.contains(entryType);
 
-        return GestureDetector(
-          onTap: () {
-            cubit.toggleSelectedEntryTypes(entryType);
-            HapticFeedback.heavyImpact();
-          },
-          onLongPress: () {
-            cubit.setSingleEntryType(entryType);
-            HapticFeedback.heavyImpact();
-          },
-          child: MouseRegion(
-            cursor: SystemMouseCursors.click,
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(8),
-              child: ColoredBox(
-                color: isSelected
-                    ? styleConfig().selectedChoiceChipColor
-                    : styleConfig().unselectedChoiceChipColor.withOpacity(0.7),
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(
-                    vertical: 5,
-                    horizontal: 15,
-                  ),
-                  child: Text(
-                    entryTypeDisplayNames[entryType] ?? '',
-                    style: TextStyle(
-                      fontFamily: 'Oswald',
-                      fontSize: fontSizeMedium,
-                      fontWeight: FontWeight.w300,
-                      color: isSelected
-                          ? styleConfig().selectedChoiceChipTextColor
-                          : styleConfig().unselectedChoiceChipTextColor,
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ),
+        void onTap() {
+          cubit.toggleSelectedEntryTypes(entryType);
+          HapticFeedback.heavyImpact();
+        }
+
+        void onLongPress() {
+          cubit.setSingleEntryType(entryType);
+          HapticFeedback.heavyImpact();
+        }
+
+        return FilterChoiceChip(
+          label: entryTypeDisplayNames[entryType] ?? '',
+          isSelected: isSelected,
+          onTap: onTap,
+          onLongPress: onLongPress,
         );
       },
     );
@@ -97,46 +76,25 @@ class EntryTypeAllChip extends StatelessWidget {
     return BlocBuilder<JournalPageCubit, JournalPageState>(
       builder: (context, snapshot) {
         final cubit = context.read<JournalPageCubit>();
-        final isSelected =
-            setsEqual(snapshot.selectedEntryTypes.toSet(), entryTypes.toSet());
 
-        return GestureDetector(
-          onTap: () {
-            if (isSelected) {
-              cubit.clearSelectedEntryTypes();
-            } else {
-              cubit.selectAllEntryTypes();
-            }
-            HapticFeedback.heavyImpact();
-          },
-          child: MouseRegion(
-            cursor: SystemMouseCursors.click,
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(8),
-              child: ColoredBox(
-                color: isSelected
-                    ? styleConfig().selectedChoiceChipColor
-                    : styleConfig().unselectedChoiceChipColor.withOpacity(0.7),
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(
-                    vertical: 5,
-                    horizontal: 15,
-                  ),
-                  child: Text(
-                    'All',
-                    style: TextStyle(
-                      fontFamily: 'Oswald',
-                      fontSize: fontSizeMedium,
-                      fontWeight: FontWeight.w300,
-                      color: isSelected
-                          ? styleConfig().selectedChoiceChipTextColor
-                          : styleConfig().unselectedChoiceChipTextColor,
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ),
+        final isSelected = setsEqual(
+          snapshot.selectedEntryTypes.toSet(),
+          entryTypes.toSet(),
+        );
+
+        void onTap() {
+          if (isSelected) {
+            cubit.clearSelectedEntryTypes();
+          } else {
+            cubit.selectAllEntryTypes();
+          }
+          HapticFeedback.heavyImpact();
+        }
+
+        return FilterChoiceChip(
+          label: 'All',
+          isSelected: isSelected,
+          onTap: onTap,
         );
       },
     );

--- a/lib/widgets/search/filter_choice_chip.dart
+++ b/lib/widgets/search/filter_choice_chip.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/themes/theme.dart';
+
+class FilterChoiceChip extends StatelessWidget {
+  const FilterChoiceChip({
+    super.key,
+    required this.label,
+    required this.isSelected,
+    required this.onTap,
+    this.onLongPress,
+  });
+
+  final String label;
+  final bool isSelected;
+  final void Function() onTap;
+  final void Function()? onLongPress;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      onLongPress: onLongPress,
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(8),
+          child: ColoredBox(
+            color: isSelected
+                ? styleConfig().selectedChoiceChipColor
+                : styleConfig().unselectedChoiceChipColor.withOpacity(0.7),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                vertical: 5,
+                horizontal: 15,
+              ),
+              child: Text(
+                label,
+                style: choiceChipTextStyle(isSelected: isSelected),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/search/task_status_filter.dart
+++ b/lib/widgets/search/task_status_filter.dart
@@ -5,8 +5,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lotti/blocs/journal/journal_page_cubit.dart';
 import 'package:lotti/blocs/journal/journal_page_state.dart';
-
-import 'filter_choice_chip.dart';
+import 'package:lotti/widgets/search/filter_choice_chip.dart';
+import 'package:quiver/collection.dart';
 
 class TaskStatusFilter extends StatefulWidget {
   const TaskStatusFilter({super.key});
@@ -28,6 +28,7 @@ class _TaskStatusFilterState extends State<TaskStatusFilter> {
             lineSpacing: 5,
             children: [
               ...snapshot.taskStatuses.map(TaskStatusChip.new),
+              const TaskStatusAllChip(),
             ],
           ),
         );
@@ -60,14 +61,55 @@ class TaskStatusChip extends StatelessWidget {
 
     return BlocBuilder<JournalPageCubit, JournalPageState>(
       builder: (context, snapshot) {
+        final cubit = context.read<JournalPageCubit>();
+
         void onTap() {
-          context.read<JournalPageCubit>().toggleSelectedTaskStatus(status);
+          cubit.toggleSelectedTaskStatus(status);
+          HapticFeedback.heavyImpact();
+        }
+
+        void onLongPress() {
+          cubit.selectSingleTaskStatus(status);
           HapticFeedback.heavyImpact();
         }
 
         return FilterChoiceChip(
           label: '${localizationLookup[status]}',
           isSelected: snapshot.selectedTaskStatuses.contains(status),
+          onTap: onTap,
+          onLongPress: onLongPress,
+        );
+      },
+    );
+  }
+}
+
+class TaskStatusAllChip extends StatelessWidget {
+  const TaskStatusAllChip({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<JournalPageCubit, JournalPageState>(
+      builder: (context, snapshot) {
+        final cubit = context.read<JournalPageCubit>();
+
+        final isSelected = setsEqual(
+          snapshot.selectedTaskStatuses,
+          snapshot.taskStatuses.toSet(),
+        );
+
+        void onTap() {
+          if (isSelected) {
+            cubit.clearSelectedTaskStatuses();
+          } else {
+            cubit.selectAllTaskStatuses();
+          }
+          HapticFeedback.heavyImpact();
+        }
+
+        return FilterChoiceChip(
+          label: 'ALL',
+          isSelected: isSelected,
           onTap: onTap,
         );
       },

--- a/lib/widgets/search/task_status_filter.dart
+++ b/lib/widgets/search/task_status_filter.dart
@@ -5,7 +5,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lotti/blocs/journal/journal_page_cubit.dart';
 import 'package:lotti/blocs/journal/journal_page_state.dart';
-import 'package:lotti/themes/theme.dart';
+
+import 'filter_choice_chip.dart';
 
 class TaskStatusFilter extends StatefulWidget {
   const TaskStatusFilter({super.key});
@@ -59,41 +60,15 @@ class TaskStatusChip extends StatelessWidget {
 
     return BlocBuilder<JournalPageCubit, JournalPageState>(
       builder: (context, snapshot) {
-        final cubit = context.read<JournalPageCubit>();
+        void onTap() {
+          context.read<JournalPageCubit>().toggleSelectedTaskStatus(status);
+          HapticFeedback.heavyImpact();
+        }
 
-        return GestureDetector(
-          onTap: () {
-            cubit.toggleSelectedTaskStatus(status);
-            HapticFeedback.heavyImpact();
-          },
-          child: MouseRegion(
-            cursor: SystemMouseCursors.click,
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(8),
-              child: ColoredBox(
-                color: snapshot.selectedTaskStatuses.contains(status)
-                    ? styleConfig().selectedChoiceChipColor
-                    : styleConfig().unselectedChoiceChipColor.withOpacity(0.7),
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(
-                    vertical: 5,
-                    horizontal: 15,
-                  ),
-                  child: Text(
-                    '${localizationLookup[status]}',
-                    style: TextStyle(
-                      fontFamily: 'Oswald',
-                      fontSize: fontSizeMedium,
-                      fontWeight: FontWeight.w300,
-                      color: snapshot.selectedTaskStatuses.contains(status)
-                          ? styleConfig().selectedChoiceChipTextColor
-                          : styleConfig().unselectedChoiceChipTextColor,
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ),
+        return FilterChoiceChip(
+          label: '${localizationLookup[status]}',
+          isSelected: snapshot.selectedTaskStatuses.contains(status),
+          onTap: onTap,
         );
       },
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.239+1712
+version: 0.8.239+1713
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.239+1713
+version: 0.8.239+1714
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR adapts the task filter to offer the same functionality of the entry types filter as introduced in #1325, plus extracts code that is reusable in both.