### PR TITLE
Fix issue where task title could disappear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed:
+- Text color for entry duration when timer running
+
+## [0.8.239] - 2023-01-14
 ### Changed:
 - Long press on entry type filter to select only one type
 - Select all entry types toggle button

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed:
 - Text color for entry duration when timer running
+- Fix possibility of accidentally overwriting task title, estimate, and status
 
 ## [0.8.239] - 2023-01-14
 ### Changed:

--- a/lib/blocs/journal/entry_cubit.dart
+++ b/lib/blocs/journal/entry_cubit.dart
@@ -114,9 +114,12 @@ class EntryCubit extends Cubit<EntryState> {
         entryText: entryTextFromController(controller),
         journalEntityId: entryId,
         taskData: task.data.copyWith(
-          title: title ?? '',
-          estimate: Duration(hours: dt?.hour ?? 0, minutes: dt?.minute ?? 0),
-          status: taskStatusFromString(status ?? ''),
+          title: title ?? task.data.title,
+          estimate: dt != null
+              ? Duration(hours: dt.hour, minutes: dt.minute)
+              : task.data.estimate,
+          status:
+              status != null ? taskStatusFromString(status) : task.data.status,
         ),
       );
     } else {

--- a/lib/widgets/journal/entry_details/duration_widget.dart
+++ b/lib/widgets/journal/entry_details/duration_widget.dart
@@ -60,7 +60,6 @@ class DurationWidget extends StatelessWidget {
                   FormattedTime(
                     labelColor: labelColor,
                     displayed: displayed,
-                    style: style,
                   ),
                   Visibility(
                     visible: isRecent && showRecordIcon,
@@ -112,12 +111,10 @@ class DurationViewWidget extends StatelessWidget {
   DurationViewWidget({
     super.key,
     required this.item,
-    this.style,
   });
 
   final TimeService _timeService = getIt<TimeService>();
   final JournalEntity item;
-  final TextStyle? style;
 
   @override
   Widget build(BuildContext context) {
@@ -136,14 +133,14 @@ class DurationViewWidget extends StatelessWidget {
           isRecording = true;
         }
 
-        final labelColor = isRecording ? styleConfig().alarm : style?.color;
+        final labelColor =
+            isRecording ? styleConfig().alarm : styleConfig().primaryTextColor;
 
         return Visibility(
           visible: entryDuration(displayed).inMilliseconds > 0,
           child: FormattedTime(
             labelColor: labelColor,
             displayed: displayed,
-            style: style,
           ),
         );
       },
@@ -156,12 +153,10 @@ class FormattedTime extends StatelessWidget {
     super.key,
     required this.labelColor,
     required this.displayed,
-    required this.style,
   });
 
   final Color? labelColor;
   final JournalEntity displayed;
-  final TextStyle? style;
 
   @override
   Widget build(BuildContext context) {
@@ -171,13 +166,13 @@ class FormattedTime extends StatelessWidget {
           padding: const EdgeInsets.only(right: 4),
           child: Icon(
             MdiIcons.timerOutline,
-            color: styleConfig().primaryTextColor,
+            color: labelColor,
             size: 15,
           ),
         ),
         Text(
           formatDuration(entryDuration(displayed)),
-          style: monospaceTextStyle(),
+          style: monospaceTextStyle().copyWith(color: labelColor),
         ),
       ],
     );

--- a/lib/widgets/journal/journal_card.dart
+++ b/lib/widgets/journal/journal_card.dart
@@ -154,11 +154,6 @@ class JournalCardTitle extends StatelessWidget {
             task: (_) => const SizedBox.shrink(),
             orElse: () => DurationViewWidget(
               item: item,
-              style: TextStyle(
-                color: styleConfig().primaryTextColor,
-                fontSize: 15,
-                fontWeight: FontWeight.w300,
-              ),
             ),
           ),
         ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.239+1714
+version: 0.8.240+1715
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.240+1715
+version: 0.8.240+1716
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR fixes an issue where occasionally, the task title would be cleared accidentally, which as a user was really painful and annoying.

The solution and learning is to stop carelessly (or recklessly) overwriting form field values with empty defaults when form field access could return null value, no matter how rarely that happens (usually, the form would be fully initialized). The type system was pretty clear here.

Resolves #1327. 