### PR TITLE
Fix recording audio note as comment to other entry types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed:
+- Record audio note as comment to other entry types
+
+## [0.8.240] - 2023-01-14
+### Fixed:
 - Text color for entry duration when timer running
 - Fix possibility of accidentally overwriting task title, estimate, and status
 

--- a/lib/beamer/locations/journal_location.dart
+++ b/lib/beamer/locations/journal_location.dart
@@ -62,7 +62,7 @@ class JournalLocation extends BeamLocation<BeamState> {
         ),
       if (pathContains('record_audio/'))
         BeamPage(
-          key: ValueKey('journal-$linkedId'),
+          key: ValueKey('record_audio-$linkedId'),
           child: RecordAudioPage(linkedId: linkedId),
         ),
       if (pathContains('measure_linked/'))

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.240+1716
+version: 0.8.241+1717
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This one-liner PR fixes a routing issue where audio notes could only be taken at top level but not as comments to other entries because the unique page key requirement was violated and a new page with a similar ID could not be created.

Fixes #1329. 