### PR TITLE
Audio recording on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed:
+- Audio recording lib replaced
+
+### Added:
+- Audio recording on macOS
+
+## [0.8.246] - 2023-01-19
+### Changed:
 - Chore: redundant dependencies removed
 - Chore: upgraded dependencies
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -71,6 +71,8 @@ PODS:
     - Flutter
     - MTBBarcodeScanner
   - ReachabilitySwift (5.0.0)
+  - record (0.0.1):
+    - Flutter
   - SDWebImage (5.14.2):
     - SDWebImage/Core (= 5.14.2)
   - SDWebImage/Core (5.14.2)
@@ -129,6 +131,7 @@ DEPENDENCIES:
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - photo_manager (from `.symlinks/plugins/photo_manager/ios`)
   - qr_code_scanner (from `.symlinks/plugins/qr_code_scanner/ios`)
+  - record (from `.symlinks/plugins/record/ios`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/ios`)
   - sqflite (from `.symlinks/plugins/sqflite/ios`)
@@ -196,6 +199,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/photo_manager/ios"
   qr_code_scanner:
     :path: ".symlinks/plugins/qr_code_scanner/ios"
+  record:
+    :path: ".symlinks/plugins/record/ios"
   share_plus:
     :path: ".symlinks/plugins/share_plus/ios"
   shared_preferences_foundation:
@@ -240,6 +245,7 @@ SPEC CHECKSUMS:
   photo_manager: 4f6810b7dfc4feb03b461ac1a70dacf91fba7604
   qr_code_scanner: bb67d64904c3b9658ada8c402e8b4d406d5d796e
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
+  record: cae05d8dd3cdb1dea3511b20e5a5811a1ae00d0d
   SDWebImage: b9a731e1d6307f44ca703b3976d18c24ca561e84
   SDWebImageWebPCoder: 18503de6621dd2c420d680e33d46bf8e1d5169b0
   share_plus: 056a1e8ac890df3e33cb503afffaf1e9b4fbae68

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -26,11 +26,6 @@ PODS:
     - Flutter
   - flutter_secure_storage (6.0.0):
     - Flutter
-  - flutter_sound (8.5.0):
-    - Flutter
-    - flutter_sound_core (= 8.5.0)
-    - mobile-ffmpeg-audio (= 4.4.LTS)
-  - flutter_sound_core (8.5.0)
   - FMDB (2.7.5):
     - FMDB/standard (= 2.7.5)
   - FMDB/standard (2.7.5)
@@ -54,7 +49,6 @@ PODS:
   - Mantle (2.2.0):
     - Mantle/extobjc (= 2.2.0)
   - Mantle/extobjc (2.2.0)
-  - mobile-ffmpeg-audio (4.4.LTS)
   - MTBBarcodeScanner (5.0.11)
   - package_info_plus (0.4.5):
     - Flutter
@@ -120,7 +114,6 @@ DEPENDENCIES:
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
   - flutter_native_timezone (from `.symlinks/plugins/flutter_native_timezone/ios`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
-  - flutter_sound (from `.symlinks/plugins/flutter_sound/ios`)
   - health (from `.symlinks/plugins/health/ios`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - just_audio (from `.symlinks/plugins/just_audio/ios`)
@@ -141,11 +134,9 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - flutter_sound_core
     - FMDB
     - libwebp
     - Mantle
-    - mobile-ffmpeg-audio
     - MTBBarcodeScanner
     - ReachabilitySwift
     - SDWebImage
@@ -177,8 +168,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_native_timezone/ios"
   flutter_secure_storage:
     :path: ".symlinks/plugins/flutter_secure_storage/ios"
-  flutter_sound:
-    :path: ".symlinks/plugins/flutter_sound/ios"
   health:
     :path: ".symlinks/plugins/health/ios"
   integration_test:
@@ -227,8 +216,6 @@ SPEC CHECKSUMS:
   flutter_native_splash: 52501b97d1c0a5f898d687f1646226c1f93c56ef
   flutter_native_timezone: 5f05b2de06c9776b4cc70e1839f03de178394d22
   flutter_secure_storage: 23fc622d89d073675f2eaa109381aefbcf5a49be
-  flutter_sound: ba7daf658dea78e9f18b79657338bfc222489f4f
-  flutter_sound_core: d9396f10752a0df9aa3197f4c431d62d934918cc
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
   health: e7a5807e45ec58fe6b89a730c97abc6caafe94a0
   integration_test: a1e7d09bd98eca2fc37aefd79d4f41ad37bdbbe5
@@ -236,7 +223,6 @@ SPEC CHECKSUMS:
   libwebp: f62cb61d0a484ba548448a4bd52aabf150ff6eef
   location: 3a2eed4dd2fab25e7b7baf2a9efefe82b512d740
   Mantle: c5aa8794a29a022dfbbfc9799af95f477a69b62d
-  mobile-ffmpeg-audio: 1e0a053f8a6de57114e50ff48b3a85ff1c60f902
   MTBBarcodeScanner: f453b33c4b7dfe545d8c6484ed744d55671788cb
   package_info_plus: 6c92f08e1f853dc01228d6f553146438dafcd14e
   pasteboard: 982969ebaa7c78af3e6cc7761e8f5e77565d9ce0

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -48,7 +48,7 @@
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>Obtain location for journal entries</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Record audio and video</string>
+	<string>Record audio notes</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Import photos and videos</string>
 	<key>UIBackgroundModes</key>

--- a/lib/widgets/create/add_actions.dart
+++ b/lib/widgets/create/add_actions.dart
@@ -8,6 +8,8 @@ import 'package:lotti/themes/theme.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:radial_button/widget/circle_floating_button.dart';
 
+const actionIconSize = 32.0;
+
 class RadialAddActionButtons extends StatefulWidget {
   const RadialAddActionButtons({
     super.key,
@@ -61,7 +63,7 @@ class _RadialAddActionButtonsState extends State<RadialAddActionButtons> {
           },
           child: const Icon(
             MdiIcons.monitorScreenshot,
-            size: 32,
+            size: actionIconSize,
           ),
         ),
       );
@@ -80,7 +82,7 @@ class _RadialAddActionButtonsState extends State<RadialAddActionButtons> {
           },
           child: const Icon(
             Icons.insights,
-            size: 32,
+            size: actionIconSize,
           ),
         ),
       )
@@ -96,7 +98,7 @@ class _RadialAddActionButtonsState extends State<RadialAddActionButtons> {
           },
           child: const Icon(
             MdiIcons.clipboardOutline,
-            size: 32,
+            size: actionIconSize,
           ),
         ),
       )
@@ -115,7 +117,7 @@ class _RadialAddActionButtonsState extends State<RadialAddActionButtons> {
           },
           child: const Icon(
             Icons.add_a_photo_outlined,
-            size: 32,
+            size: actionIconSize,
           ),
         ),
       )
@@ -131,7 +133,7 @@ class _RadialAddActionButtonsState extends State<RadialAddActionButtons> {
           },
           child: const Icon(
             MdiIcons.textLong,
-            size: 32,
+            size: actionIconSize,
           ),
         ),
       );
@@ -149,14 +151,14 @@ class _RadialAddActionButtonsState extends State<RadialAddActionButtons> {
           },
           child: const Icon(
             MdiIcons.timerOutline,
-            size: 32,
+            size: actionIconSize,
           ),
         ),
       );
     }
 
-    if (widget.isIOS || widget.isAndroid) {
-      items.add(
+    items
+      ..add(
         FloatingActionButton(
           heroTag: 'audio',
           tooltip: localizations.addActionAddAudioRecording,
@@ -168,32 +170,30 @@ class _RadialAddActionButtonsState extends State<RadialAddActionButtons> {
           },
           child: const Icon(
             MdiIcons.microphone,
-            size: 32,
+            size: actionIconSize,
+          ),
+        ),
+      )
+      ..add(
+        FloatingActionButton(
+          heroTag: 'task',
+          tooltip: localizations.addActionAddTask,
+          backgroundColor: styleConfig().primaryColor,
+          onPressed: () async {
+            rebuild();
+            final linkedId = widget.linked?.meta.id;
+            final task = await createTask(linkedId: linkedId);
+
+            if (task != null) {
+              beamToNamed('/journal/${task.meta.id}');
+            }
+          },
+          child: const Icon(
+            Icons.task_outlined,
+            size: actionIconSize,
           ),
         ),
       );
-    }
-
-    items.add(
-      FloatingActionButton(
-        heroTag: 'task',
-        tooltip: localizations.addActionAddTask,
-        backgroundColor: styleConfig().primaryColor,
-        onPressed: () async {
-          rebuild();
-          final linkedId = widget.linked?.meta.id;
-          final task = await createTask(linkedId: linkedId);
-
-          if (task != null) {
-            beamToNamed('/journal/${task.meta.id}');
-          }
-        },
-        child: const Icon(
-          Icons.task_outlined,
-          size: 32,
-        ),
-      ),
-    );
 
     return CircleFloatingButton.floatingActionButton(
       radius: items.length * 32,

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -10,6 +10,7 @@
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <hotkey_manager/hotkey_manager_plugin.h>
 #include <pasteboard/pasteboard_plugin.h>
+#include <record_linux/record_linux_plugin.h>
 #include <screen_retriever/screen_retriever_plugin.h>
 #include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
@@ -28,6 +29,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) pasteboard_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "PasteboardPlugin");
   pasteboard_plugin_register_with_registrar(pasteboard_registrar);
+  g_autoptr(FlPluginRegistrar) record_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "RecordLinuxPlugin");
+  record_linux_plugin_register_with_registrar(record_linux_registrar);
   g_autoptr(FlPluginRegistrar) screen_retriever_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverPlugin");
   screen_retriever_plugin_register_with_registrar(screen_retriever_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -7,6 +7,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_linux
   hotkey_manager
   pasteboard
+  record_linux
   screen_retriever
   sqlite3_flutter_libs
   url_launcher_linux

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -20,6 +20,7 @@ import package_info_plus
 import pasteboard
 import path_provider_macos
 import photo_manager
+import record_macos
 import screen_retriever
 import share_plus_macos
 import shared_preferences_foundation
@@ -44,6 +45,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PasteboardPlugin.register(with: registry.registrar(forPlugin: "PasteboardPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   PhotoManagerPlugin.register(with: registry.registrar(forPlugin: "PhotoManagerPlugin"))
+  RecordMacosPlugin.register(with: registry.registrar(forPlugin: "RecordMacosPlugin"))
   ScreenRetrieverPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -38,6 +38,8 @@ PODS:
     - Flutter
     - FlutterMacOS
   - ReachabilitySwift (5.0.0)
+  - record_macos (0.2.0):
+    - FlutterMacOS
   - screen_retriever (0.0.1):
     - FlutterMacOS
   - share_plus_macos (0.0.1):
@@ -85,6 +87,7 @@ DEPENDENCIES:
   - pasteboard (from `Flutter/ephemeral/.symlinks/plugins/pasteboard/macos`)
   - path_provider_macos (from `Flutter/ephemeral/.symlinks/plugins/path_provider_macos/macos`)
   - photo_manager (from `Flutter/ephemeral/.symlinks/plugins/photo_manager/macos`)
+  - record_macos (from `Flutter/ephemeral/.symlinks/plugins/record_macos/macos`)
   - screen_retriever (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever/macos`)
   - share_plus_macos (from `Flutter/ephemeral/.symlinks/plugins/share_plus_macos/macos`)
   - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/macos`)
@@ -133,6 +136,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/path_provider_macos/macos
   photo_manager:
     :path: Flutter/ephemeral/.symlinks/plugins/photo_manager/macos
+  record_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/record_macos/macos
   screen_retriever:
     :path: Flutter/ephemeral/.symlinks/plugins/screen_retriever/macos
   share_plus_macos:
@@ -168,6 +173,7 @@ SPEC CHECKSUMS:
   path_provider_macos: 3c0c3b4b0d4a76d2bf989a913c2de869c5641a19
   photo_manager: 4f6810b7dfc4feb03b461ac1a70dacf91fba7604
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
+  record_macos: 937889e0f2a7a12b6fc14e97a3678e5a18943de6
   screen_retriever: 59634572a57080243dd1bf715e55b6c54f241a38
   share_plus_macos: 853ee48e7dce06b633998ca0735d482dd671ade4
   shared_preferences_foundation: 297b3ebca31b34ec92be11acd7fb0ba932c822ca

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -427,6 +427,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.matthiasnehlsen.lotti.profile;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -557,6 +558,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.matthiasn.lotti.dev;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -581,6 +583,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.matthiasnehlsen.lotti;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -8,6 +8,8 @@
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -47,5 +47,7 @@
 	<string>Import photos and videos</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSMicrophoneUsageDescription</key>
+    <string>Record audio notes</string>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -6,6 +6,8 @@
 	<true/>
 	<key>com.apple.security.assets.pictures.read-only</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.personal-information.location</key>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -839,27 +839,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0+1"
-  flutter_sound:
-    dependency: "direct main"
-    description:
-      name: flutter_sound
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "8.5.0"
-  flutter_sound_platform_interface:
-    dependency: transitive
-    description:
-      name: flutter_sound_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "8.5.0"
-  flutter_sound_web:
-    dependency: transitive
-    description:
-      name: flutter_sound_web
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "8.5.0"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -1183,13 +1162,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.1"
-  logger:
-    dependency: transitive
-    description:
-      name: logger
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.0"
   logging:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1628,6 +1628,48 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.1.0"
+  record:
+    dependency: "direct main"
+    description:
+      name: record
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.4.4"
+  record_linux:
+    dependency: transitive
+    description:
+      name: record_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.1"
+  record_macos:
+    dependency: transitive
+    description:
+      name: record_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.2"
+  record_platform_interface:
+    dependency: transitive
+    description:
+      name: record_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.0"
+  record_web:
+    dependency: transitive
+    description:
+      name: record_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.0"
+  record_windows:
+    dependency: transitive
+    description:
+      name: record_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.7.1"
   research_package:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ msix_config:
   publisher_display_name: Matthias Nehlsen
   publisher: CN=Matthias Nehlsen, O=Matthias Nehlsen, C=DE
   identity_name: com.matthiasnehlsen.lotti
-  capabilities: internetClient, location, microphone, webcam
+  capabilities: internetClient, location, microphone
   languages: en-us, de-de, ro-ro
   install_certificate: false
   sign_msix: false
@@ -135,6 +135,7 @@ dependencies:
 
   # research_package: ^0.6.7
   random_password_generator: ^0.2.1
+  record: ^4.4.4
   research_package:
     git:
       url: https://github.com/matthiasn/research.package.git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.247+1730
+version: 0.8.247+1732
 
 msix_config:
   display_name: Lotti
@@ -81,7 +81,6 @@ dependencies:
   flutter_quill: ^6.1.0
   flutter_secure_storage: ^6.0.0
   flutter_sliding_tutorial: ^2.0.0
-  flutter_sound: ^8.3.12
   flutter_svg: ^1.0.3
   form_builder_validators: ^8.1.1
   freezed_annotation: ^2.0.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.246+1729
+version: 0.8.247+1730
 
 msix_config:
   display_name: Lotti

--- a/test/widgets/create/add_actions_test.dart
+++ b/test/widgets/create/add_actions_test.dart
@@ -471,7 +471,7 @@ void main() {
     );
 
     testWidgets(
-      'add audio icon is not shown when not on mobile',
+      'add audio icon is shown',
       (tester) async {
         await tester.pumpWidget(
           makeTestableWidgetWithScaffold(
@@ -489,7 +489,7 @@ void main() {
         await tester.tap(addIconFinder);
         await tester.pumpAndSettle();
 
-        expect(addAudioIconFinder, findsNothing);
+        expect(addAudioIconFinder, findsOneWidget);
       },
     );
 

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -12,6 +12,7 @@
 #include <hotkey_manager/hotkey_manager_plugin.h>
 #include <pasteboard/pasteboard_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
+#include <record_windows/record_windows_plugin_c_api.h>
 #include <screen_retriever/screen_retriever_plugin.h>
 #include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
@@ -30,6 +31,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("PasteboardPlugin"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
+  RecordWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("RecordWindowsPluginCApi"));
   ScreenRetrieverPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ScreenRetrieverPlugin"));
   Sqlite3FlutterLibsPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -9,6 +9,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   hotkey_manager
   pasteboard
   permission_handler_windows
+  record_windows
   screen_retriever
   sqlite3_flutter_libs
   url_launcher_windows


### PR DESCRIPTION
This PR replaces [`flutter_sound`](https://pub.dev/packages/flutter_sound) with the [`record`](https://pub.dev/packages/record) library. This solves both the outdated library issue where the upgrade did not work, and also the missing support on desktop platforms.

Resolves #976.
Resolves #1339.