### PR TITLE
Fix updating habit completion sort order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed:
 - Upgraded dependencies
 
+### Fixed:
+- Fix updating habit completion type
+
 ## [0.8.247] - 2023-01-20
 ### Changed:
 - Audio recording lib replaced

--- a/lib/database/database.drift
+++ b/lib/database/database.drift
@@ -300,7 +300,7 @@ SELECT * FROM journal
   AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'))
   AND date_from >= :rangeStart
   AND deleted = false
-  ORDER BY date_from DESC;
+  ORDER BY created_at ASC;
 
 quantitativeByType:
 SELECT * FROM journal

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.248+1733
+version: 0.8.248+1734
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR changes the sort order of habit completions to `created_at` in ascending order, which fixes the reported habit completion percentages in the completion rate chart, such that LAST ONE WINS as expected.

Resolves #1342.