### PR TITLE
Move non-secrets from SecretStorage to SQLite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed:
 - Locking issue in sync
 
+### Added:
+- Settings DB
+
+### Changed:
+- Window manager persistence moved to settings database
+
 ## [0.8.255] - 2023-02-02
 ### Changed:
 - Upgrade dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed:
 - Window manager persistence moved to settings database
+- Routing persistence moved to settings database
 
 ## [0.8.255] - 2023-02-02
 ### Changed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed:
+- Locking issue in sync
+
+## [0.8.255] - 2023-02-02
 ### Changed:
 - Upgrade dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed:
 - Window manager persistence moved to settings database
 - Routing persistence moved to settings database
+- Last read UID persistence moved to settings database
 
 ## [0.8.255] - 2023-02-02
 ### Changed:

--- a/lib/database/settings_db.dart
+++ b/lib/database/settings_db.dart
@@ -1,0 +1,36 @@
+import 'package:drift/drift.dart';
+import 'package:lotti/database/common.dart';
+
+part 'settings_db.g.dart';
+
+const settingsDbFileName = 'settings.sqlite';
+
+@DriftDatabase(include: {'settings_db.drift'})
+class SettingsDb extends _$SettingsDb {
+  SettingsDb({this.inMemoryDatabase = false})
+      : super(
+          openDbConnection(
+            settingsDbFileName,
+            inMemoryDatabase: inMemoryDatabase,
+          ),
+        );
+
+  SettingsDb.connect(super.connection) : super.connect();
+
+  bool inMemoryDatabase = false;
+
+  @override
+  int get schemaVersion => 1;
+
+  Future<int> saveSettingsItem(SettingsItem settingsItem) async {
+    return into(settings).insertOnConflictUpdate(settingsItem);
+  }
+
+  Stream<List<SettingsItem>> watchSettingsItemByKey(String configKey) {
+    return settingsItemByKey(configKey).watch();
+  }
+}
+
+SettingsDb getSettingsDb() {
+  return SettingsDb.connect(getDatabaseConnection(settingsDbFileName));
+}

--- a/lib/database/settings_db.dart
+++ b/lib/database/settings_db.dart
@@ -22,12 +22,28 @@ class SettingsDb extends _$SettingsDb {
   @override
   int get schemaVersion => 1;
 
-  Future<int> saveSettingsItem(SettingsItem settingsItem) async {
+  Future<int> saveSettingsItem(String configKey, String value) async {
+    final settingsItem = SettingsItem(
+      configKey: configKey,
+      value: value,
+      updatedAt: DateTime.now(),
+    );
+
     return into(settings).insertOnConflictUpdate(settingsItem);
   }
 
   Stream<List<SettingsItem>> watchSettingsItemByKey(String configKey) {
     return settingsItemByKey(configKey).watch();
+  }
+
+  Future<String?> itemByKey(String configKey) async {
+    final existing = await watchSettingsItemByKey(configKey).first;
+
+    if (existing.isNotEmpty) {
+      return existing.first.value;
+    } else {
+      return null;
+    }
   }
 }
 

--- a/lib/database/settings_db.drift
+++ b/lib/database/settings_db.drift
@@ -1,0 +1,11 @@
+CREATE TABLE settings (
+  config_key TEXT NOT NULL UNIQUE,
+  value TEXT NOT NULL,
+  updated_at DATETIME NOT NULL,
+  PRIMARY KEY (config_key)
+) as SettingsItem;
+
+/* Queries ----------------------------------------------------- */
+settingsItemByKey:
+SELECT * FROM settings
+  WHERE config_key = :config_key;

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:drift/isolate.dart';
 import 'package:get_it/get_it.dart';
 import 'package:lotti/database/common.dart';
@@ -9,7 +7,6 @@ import 'package:lotti/database/fts5_db.dart';
 import 'package:lotti/database/journal_db/config_flags.dart';
 import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/database/maintenance.dart';
-import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/logic/health_import.dart';
 import 'package:lotti/logic/persistence_logic.dart';
@@ -28,24 +25,15 @@ import 'package:lotti/sync/imap_client.dart';
 import 'package:lotti/sync/inbox/inbox_service.dart';
 import 'package:lotti/sync/outbox/outbox_service.dart';
 import 'package:lotti/themes/themes_service.dart';
-import 'package:path_provider/path_provider.dart';
 
 final getIt = GetIt.instance;
 
 Future<void> registerSingletons() async {
-  final docDir = await getApplicationDocumentsDirectory();
-
   getIt
-    ..registerSingleton<Directory>(docDir)
     ..registerSingleton<Future<DriftIsolate>>(
       createDriftIsolate(journalDbFileName),
       instanceName: journalDbFileName,
     )
-    ..registerSingleton<Future<DriftIsolate>>(
-      createDriftIsolate(settingsDbFileName),
-      instanceName: settingsDbFileName,
-    )
-    ..registerSingleton<SettingsDb>(getSettingsDb())
     ..registerSingleton<Fts5Db>(Fts5Db())
     ..registerSingleton<JournalDb>(getJournalDb())
     ..registerSingleton<ConnectivityService>(ConnectivityService())

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -9,6 +9,7 @@ import 'package:lotti/database/fts5_db.dart';
 import 'package:lotti/database/journal_db/config_flags.dart';
 import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/database/maintenance.dart';
+import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/logic/health_import.dart';
 import 'package:lotti/logic/persistence_logic.dart';
@@ -40,6 +41,11 @@ Future<void> registerSingletons() async {
       createDriftIsolate(journalDbFileName),
       instanceName: journalDbFileName,
     )
+    ..registerSingleton<Future<DriftIsolate>>(
+      createDriftIsolate(settingsDbFileName),
+      instanceName: settingsDbFileName,
+    )
+    ..registerSingleton<SettingsDb>(getSettingsDb())
     ..registerSingleton<Fts5Db>(Fts5Db())
     ..registerSingleton<JournalDb>(getJournalDb())
     ..registerSingleton<ConnectivityService>(ConnectivityService())

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -115,6 +115,7 @@
   "maintenanceRecreateFts5": "Recreate full-text index",
   "maintenanceRecreateTagged": "Recreate tagged",
   "maintenanceReprocessSync": "Reprocess sync messages",
+  "maintenanceResetHostId": "Reset Host ID",
   "maintenanceStories": "Assign stories from parent entries",
   "maintenanceSyncDefinitions": "Sync tags, measurables, dashboards, habits",
   "manualLinkText": "Check out the manual for more information",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,13 +1,17 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:drift/isolate.dart';
 import 'package:flutter/material.dart';
 import 'package:hotkey_manager/hotkey_manager.dart';
 import 'package:lotti/beamer/beamer_app.dart';
+import 'package:lotti/database/common.dart';
 import 'package:lotti/database/logging_db.dart';
+import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/window_service.dart';
 import 'package:lotti/sync/secure_storage.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:timezone/data/latest.dart' as tz;
 import 'package:window_manager/window_manager.dart';
 
@@ -18,9 +22,16 @@ Future<void> main() async {
     await windowManager.ensureInitialized();
     await hotKeyManager.unregisterAll();
   }
+  final docDir = await getApplicationDocumentsDirectory();
 
   getIt
     ..registerSingleton<SecureStorage>(SecureStorage())
+    ..registerSingleton<Directory>(docDir)
+    ..registerSingleton<Future<DriftIsolate>>(
+      createDriftIsolate(settingsDbFileName),
+      instanceName: settingsDbFileName,
+    )
+    ..registerSingleton<SettingsDb>(getSettingsDb())
     ..registerSingleton<WindowService>(WindowService());
 
   await getIt<WindowService>().restore();

--- a/lib/pages/settings/maintenance_page.dart
+++ b/lib/pages/settings/maintenance_page.dart
@@ -94,6 +94,11 @@ class _MaintenancePageState extends State<MaintenancePage> {
                     ),
                     const SettingsDivider(),
                     SettingsCard(
+                      title: localizations.maintenanceResetHostId,
+                      onTap: () => getIt<SyncConfigService>().resetHostId(),
+                    ),
+                    const SettingsDivider(),
+                    SettingsCard(
                       title: localizations.maintenanceCancelNotifications,
                       onTap: () => getIt<NotificationService>().cancelAll(),
                     ),

--- a/lib/services/nav_service.dart
+++ b/lib/services/nav_service.dart
@@ -3,10 +3,10 @@ import 'dart:async';
 import 'package:beamer/beamer.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:lotti/beamer/beamer_delegates.dart';
+import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/get_it.dart';
-import 'package:lotti/sync/secure_storage.dart';
 
-const String lastRouteKey = 'LAST_ROUTE_KEY';
+const String lastRouteKey = 'NAV_LAST_ROUTE';
 
 class NavService {
   NavService() {
@@ -105,7 +105,7 @@ class NavService {
 }
 
 Future<String?> getSavedRoute() async {
-  return await getIt<SecureStorage>().readValue(lastRouteKey);
+  return getIt<SettingsDb>().itemByKey(lastRouteKey);
 }
 
 Future<String?> getIdFromSavedRoute() async {
@@ -117,8 +117,8 @@ Future<String?> getIdFromSavedRoute() async {
   return regExp.firstMatch('$route')?.group(0);
 }
 
-void persistNamedRoute(String route) {
-  getIt<SecureStorage>().writeValue(lastRouteKey, route);
+Future<void> persistNamedRoute(String route) async {
+  await getIt<SettingsDb>().saveSettingsItem(lastRouteKey, route);
   getIt<NavService>().currentPath = route;
 }
 

--- a/lib/services/sync_config_service.dart
+++ b/lib/services/sync_config_service.dart
@@ -99,9 +99,13 @@ class SyncConfigService {
     return imapConfig;
   }
 
+  Future<void> resetHostId() async {
+    await getIt<VectorClockService>().setNewHost();
+  }
+
   Future<void> resetOffset() async {
     await getIt<SecureStorage>().delete(key: lastReadUidKey);
     await setLastReadUid(0);
-    await getIt<VectorClockService>().setNewHost();
+    await resetHostId();
   }
 }

--- a/lib/services/vector_clock_service.dart
+++ b/lib/services/vector_clock_service.dart
@@ -27,14 +27,7 @@ class VectorClockService {
   Future<String> setNewHost() async {
     final host = uuid.v4();
 
-    await getIt<SettingsDb>().saveSettingsItem(
-      SettingsItem(
-        configKey: hostKey,
-        value: host,
-        updatedAt: DateTime.now(),
-      ),
-    );
-
+    await getIt<SettingsDb>().saveSettingsItem(hostKey, host);
     await setNextAvailableCounter(0);
 
     _host = host;
@@ -42,14 +35,7 @@ class VectorClockService {
   }
 
   Future<String?> _getHost() async {
-    final existing =
-        await getIt<SettingsDb>().watchSettingsItemByKey(hostKey).first;
-
-    if (existing.isNotEmpty) {
-      return existing.first.value;
-    }
-
-    return null;
+    return getIt<SettingsDb>().itemByKey(hostKey);
   }
 
   Future<String?> getHost() async {
@@ -60,11 +46,8 @@ class VectorClockService {
     _nextAvailableCounter = nextAvailableCounter;
 
     await getIt<SettingsDb>().saveSettingsItem(
-      SettingsItem(
-        configKey: nextAvailableCounterKey,
-        value: nextAvailableCounter.toString(),
-        updatedAt: DateTime.now(),
-      ),
+      nextAvailableCounterKey,
+      nextAvailableCounter.toString(),
     );
   }
 

--- a/lib/services/vector_clock_service.dart
+++ b/lib/services/vector_clock_service.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
 
 import 'package:crypto/crypto.dart';
+import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/get_it.dart';
-import 'package:lotti/sync/secure_storage.dart';
 import 'package:lotti/sync/utils.dart';
 import 'package:lotti/sync/vector_clock.dart';
 import 'package:lotti/utils/file_utils.dart';
@@ -15,8 +15,8 @@ class VectorClockService {
   late String _host;
 
   Future<void> init() async {
-    _host = await getHost() ?? await setNewHost();
-    _nextAvailableCounter = await _getNextAvailableCounter();
+    _host = await _getHost() ?? await setNewHost();
+    await _getNextAvailableCounter();
   }
 
   Future<void> increment() async {
@@ -26,34 +26,58 @@ class VectorClockService {
 
   Future<String> setNewHost() async {
     final host = uuid.v4();
-    await getIt<SecureStorage>().writeValue(hostKey, host);
+
+    await getIt<SettingsDb>().saveSettingsItem(
+      SettingsItem(
+        configKey: hostKey,
+        value: host,
+        updatedAt: DateTime.now(),
+      ),
+    );
+
+    await setNextAvailableCounter(0);
+
+    _host = host;
     return host;
   }
 
+  Future<String?> _getHost() async {
+    final existing =
+        await getIt<SettingsDb>().watchSettingsItemByKey(hostKey).first;
+
+    if (existing.isNotEmpty) {
+      return existing.first.value;
+    }
+
+    return null;
+  }
+
   Future<String?> getHost() async {
-    return getIt<SecureStorage>().readValue(hostKey);
+    return _host;
   }
 
   Future<void> setNextAvailableCounter(int nextAvailableCounter) async {
-    await getIt<SecureStorage>().writeValue(
-      nextAvailableCounterKey,
-      nextAvailableCounter.toString(),
-    );
     _nextAvailableCounter = nextAvailableCounter;
+
+    await getIt<SettingsDb>().saveSettingsItem(
+      SettingsItem(
+        configKey: nextAvailableCounterKey,
+        value: nextAvailableCounter.toString(),
+        updatedAt: DateTime.now(),
+      ),
+    );
   }
 
-  Future<int> _getNextAvailableCounter() async {
-    int? nextAvailableCounter;
-    final nextAvailableCounterString =
-        await getIt<SecureStorage>().readValue(nextAvailableCounterKey);
+  Future<void> _getNextAvailableCounter() async {
+    final existing = await getIt<SettingsDb>()
+        .watchSettingsItemByKey(nextAvailableCounterKey)
+        .first;
 
-    if (nextAvailableCounterString != null) {
-      nextAvailableCounter = int.parse(nextAvailableCounterString);
+    if (existing.isNotEmpty) {
+      _nextAvailableCounter = int.parse(existing.first.value);
     } else {
-      nextAvailableCounter = 0;
-      await setNextAvailableCounter(nextAvailableCounter);
+      await setNextAvailableCounter(0);
     }
-    return nextAvailableCounter;
   }
 
   Future<int> getNextAvailableCounter() async {

--- a/lib/services/window_service.dart
+++ b/lib/services/window_service.dart
@@ -1,9 +1,9 @@
 import 'dart:ui';
 
+import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/sync/inbox/inbox_service.dart';
 import 'package:lotti/sync/outbox/outbox_service.dart';
-import 'package:lotti/sync/secure_storage.dart';
 import 'package:window_manager/window_manager.dart';
 
 class WindowService implements WindowListener {
@@ -11,8 +11,8 @@ class WindowService implements WindowListener {
     windowManager.addListener(this);
   }
 
-  final sizeKey = 'sizeKey';
-  final offsetKey = 'offsetKey';
+  final sizeKey = 'WINDOW_SIZE';
+  final offsetKey = 'WINDOW_OFFSET';
 
   Future<void> restore() async {
     await restoreSize();
@@ -20,7 +20,7 @@ class WindowService implements WindowListener {
   }
 
   Future<void> restoreSize() async {
-    final sizeString = await getIt<SecureStorage>().readValue(sizeKey);
+    final sizeString = await getIt<SettingsDb>().itemByKey(sizeKey);
     final values = sizeString?.split(',').map(double.parse).toList();
     final width = values?.first;
     final height = values?.last;
@@ -30,7 +30,7 @@ class WindowService implements WindowListener {
   }
 
   Future<void> restoreOffset() async {
-    final offsetString = await getIt<SecureStorage>().readValue(offsetKey);
+    final offsetString = await getIt<SettingsDb>().itemByKey(offsetKey);
     final values = offsetString?.split(',').map(double.parse).toList();
     final dx = values?.first;
     final dy = values?.last;
@@ -63,19 +63,27 @@ class WindowService implements WindowListener {
   @override
   void onWindowMinimize() {}
 
-  @override
-  Future<void> onWindowMove() async {
+  Future<void> _onMoved() async {
     final offset = await windowManager.getPosition();
-    await getIt<SecureStorage>()
-        .writeValue(offsetKey, '${offset.dx},${offset.dy}');
+    await getIt<SettingsDb>().saveSettingsItem(
+      offsetKey,
+      '${offset.dx},${offset.dy}',
+    );
+  }
+
+  Future<void> _onResized() async {
+    final size = await windowManager.getSize();
+    await getIt<SettingsDb>().saveSettingsItem(
+      sizeKey,
+      '${size.width},${size.height}',
+    );
   }
 
   @override
-  Future<void> onWindowResize() async {
-    final size = await windowManager.getSize();
-    await getIt<SecureStorage>()
-        .writeValue(sizeKey, '${size.width},${size.height}');
-  }
+  Future<void> onWindowMove() async {}
+
+  @override
+  Future<void> onWindowResize() async {}
 
   @override
   void onWindowRestore() {}
@@ -87,8 +95,12 @@ class WindowService implements WindowListener {
   void onWindowClose() {}
 
   @override
-  void onWindowMoved() {}
+  void onWindowMoved() {
+    _onMoved();
+  }
 
   @override
-  void onWindowResized() {}
+  void onWindowResized() {
+    _onResized();
+  }
 }

--- a/lib/sync/inbox/inbox_service.dart
+++ b/lib/sync/inbox/inbox_service.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_fgbg/flutter_fgbg.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/logging_db.dart';
+import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/sync_config_service.dart';
@@ -94,6 +95,10 @@ class InboxService {
       instanceName: journalDbFileName,
     );
 
+    final settingsDbIsolate = await getIt<Future<DriftIsolate>>(
+      instanceName: settingsDbFileName,
+    );
+
     final allowInvalidCert =
         await getIt<JournalDb>().getConfigFlag(allowInvalidCertFlag);
 
@@ -107,6 +112,7 @@ class InboxService {
           loggingDbConnectPort: loggingDbIsolate.connectPort,
           allowInvalidCert: allowInvalidCert,
           journalDbConnectPort: journalDbIsolate.connectPort,
+          settingsDbConnectPort: settingsDbIsolate.connectPort,
           hostHash: hostHash,
           docDir: getDocumentsDirectory(),
           lastReadUid: lastReadUid,

--- a/lib/sync/inbox/inbox_service_isolate.dart
+++ b/lib/sync/inbox/inbox_service_isolate.dart
@@ -10,6 +10,7 @@ import 'package:lotti/classes/config.dart';
 import 'package:lotti/database/common.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/logging_db.dart';
+import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/sync/client_runner.dart';
 import 'package:lotti/sync/imap_client.dart';
@@ -39,8 +40,15 @@ Future<void> entryPoint(SendPort sendPort) async {
             ),
           );
 
+          final settingsDb = SettingsDb.connect(
+            getDbConnFromIsolate(
+              DriftIsolate.fromConnectPort(initMsg.settingsDbConnectPort),
+            ),
+          );
+
           getIt
             ..registerSingleton<Directory>(initMsg.docDir)
+            ..registerSingleton<SettingsDb>(settingsDb)
             ..registerSingleton<ImapClientManager>(ImapClientManager())
             ..registerSingleton<LoggingDb>(loggingDb)
             ..registerSingleton<JournalDb>(journalDb);

--- a/lib/sync/inbox/messages.dart
+++ b/lib/sync/inbox/messages.dart
@@ -12,6 +12,7 @@ class InboxIsolateMessage with _$InboxIsolateMessage {
     required SyncConfig syncConfig,
     required SendPort loggingDbConnectPort,
     required SendPort journalDbConnectPort,
+    required SendPort settingsDbConnectPort,
     required bool allowInvalidCert,
     required String? hostHash,
     required Directory docDir,

--- a/lib/sync/outbox/messages.dart
+++ b/lib/sync/outbox/messages.dart
@@ -12,6 +12,7 @@ class OutboxIsolateMessage with _$OutboxIsolateMessage {
     required SyncConfig syncConfig,
     required SendPort syncDbConnectPort,
     required SendPort loggingDbConnectPort,
+    required SendPort settingsDbConnectPort,
     required bool allowInvalidCert,
     required Directory docDir,
   }) = OutboxIsolateInitMessage;

--- a/lib/sync/outbox/outbox_service.dart
+++ b/lib/sync/outbox/outbox_service.dart
@@ -12,6 +12,7 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/sync_message.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/logging_db.dart';
+import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/sync_config_service.dart';
@@ -60,9 +61,15 @@ class OutboxService {
     final syncDbIsolate = await getIt<Future<DriftIsolate>>(
       instanceName: syncDbFileName,
     );
+
     final loggingDbIsolate = await getIt<Future<DriftIsolate>>(
       instanceName: loggingDbFileName,
     );
+
+    final settingsDbIsolate = await getIt<Future<DriftIsolate>>(
+      instanceName: settingsDbFileName,
+    );
+
     final allowInvalidCert =
         await getIt<JournalDb>().getConfigFlag(allowInvalidCertFlag);
 
@@ -72,6 +79,7 @@ class OutboxService {
           syncConfig: syncConfig,
           syncDbConnectPort: syncDbIsolate.connectPort,
           loggingDbConnectPort: loggingDbIsolate.connectPort,
+          settingsDbConnectPort: settingsDbIsolate.connectPort,
           allowInvalidCert: allowInvalidCert,
           docDir: getDocumentsDirectory(),
         ),

--- a/lib/sync/outbox/outbox_service_isolate.dart
+++ b/lib/sync/outbox/outbox_service_isolate.dart
@@ -8,6 +8,7 @@ import 'package:lotti/blocs/sync/outbox_state.dart';
 import 'package:lotti/classes/config.dart';
 import 'package:lotti/database/common.dart';
 import 'package:lotti/database/logging_db.dart';
+import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/sync/client_runner.dart';
@@ -37,8 +38,15 @@ Future<void> entryPoint(SendPort sendPort) async {
             ),
           );
 
+          final settingsDb = SettingsDb.connect(
+            getDbConnFromIsolate(
+              DriftIsolate.fromConnectPort(initMsg.settingsDbConnectPort),
+            ),
+          );
+
           getIt
             ..registerSingleton<Directory>(initMsg.docDir)
+            ..registerSingleton<SettingsDb>(settingsDb)
             ..registerSingleton<ImapClientManager>(ImapClientManager())
             ..registerSingleton<SyncDatabase>(syncDb)
             ..registerSingleton<LoggingDb>(loggingDb);

--- a/lib/sync/utils.dart
+++ b/lib/sync/utils.dart
@@ -1,26 +1,23 @@
+import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/get_it.dart';
-import 'package:lotti/sync/secure_storage.dart';
 
 const String hostKey = 'VC_HOST';
 const String nextAvailableCounterKey = 'VC_NEXT_AVAILABLE_COUNTER';
 
 const String sharedSecretKey = 'sharedSecret';
 const String imapConfigKey = 'imapConfig';
-const String lastReadUidKey = 'lastReadUid';
+const String lastReadUidKey = 'LAST_READ_UID';
 
 bool validSubject(String subject) {
   final validSubject = RegExp('[a-z0-9]{40}:[a-z0-9]+');
   return validSubject.hasMatch(subject);
 }
 
-Future<void> setLastReadUid(int? uid) async {
-  await getIt<SecureStorage>().write(key: lastReadUidKey, value: '$uid');
+Future<void> setLastReadUid(int uid) async {
+  await getIt<SettingsDb>().saveSettingsItem(lastReadUidKey, '$uid');
 }
 
 Future<int?> getLastReadUid() async {
-  final lastReadUidValue = await getIt<SecureStorage>().read(
-    key: lastReadUidKey,
-  );
-
+  final lastReadUidValue = await getIt<SettingsDb>().itemByKey(lastReadUidKey);
   return lastReadUidValue != null ? int.parse(lastReadUidValue) : null;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.257+1758
+version: 0.8.257+1761
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.257+1756
+version: 0.8.257+1757
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.256+1754
+version: 0.8.257+1756
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.257+1757
+version: 0.8.257+1758
 
 msix_config:
   display_name: Lotti

--- a/test/blocs/journal/entry_cubit_test.dart
+++ b/test/blocs/journal/entry_cubit_test.dart
@@ -5,6 +5,7 @@ import 'package:lotti/blocs/journal/entry_state.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/editor_db.dart';
 import 'package:lotti/database/logging_db.dart';
+import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
@@ -32,6 +33,7 @@ void main() {
 
     setUpAll(() {
       final secureStorageMock = MockSecureStorage();
+      final settingsDb = SettingsDb(inMemoryDatabase: true);
       final mockConnectivityService = MockConnectivityService();
       final mockFgBgService = MockFgBgService();
       final mockTimeService = MockTimeService();
@@ -63,6 +65,7 @@ void main() {
 
       getIt
         ..registerSingleton<ConnectivityService>(mockConnectivityService)
+        ..registerSingleton<SettingsDb>(settingsDb)
         ..registerSingleton<FgBgService>(mockFgBgService)
         ..registerSingleton<SyncConfigService>(syncConfigMock)
         ..registerSingleton<SyncDatabase>(SyncDatabase(inMemoryDatabase: true))

--- a/test/blocs/journal/journal_page_cubit_test.dart
+++ b/test/blocs/journal/journal_page_cubit_test.dart
@@ -6,6 +6,7 @@ import 'package:lotti/database/database.dart';
 import 'package:lotti/database/editor_db.dart';
 import 'package:lotti/database/fts5_db.dart';
 import 'package:lotti/database/logging_db.dart';
+import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
@@ -32,6 +33,7 @@ void main() {
 
     setUpAll(() {
       final secureStorageMock = MockSecureStorage();
+      final settingsDb = SettingsDb(inMemoryDatabase: true);
       final mockConnectivityService = MockConnectivityService();
       final mockFgBgService = MockFgBgService();
       final mockTimeService = MockTimeService();
@@ -63,6 +65,7 @@ void main() {
 
       getIt
         ..registerSingleton<ConnectivityService>(mockConnectivityService)
+        ..registerSingleton<SettingsDb>(settingsDb)
         ..registerSingleton<FgBgService>(mockFgBgService)
         ..registerSingleton<SyncConfigService>(syncConfigMock)
         ..registerSingleton<SyncDatabase>(SyncDatabase(inMemoryDatabase: true))

--- a/test/logic/persistence_logic_test.dart
+++ b/test/logic/persistence_logic_test.dart
@@ -10,6 +10,7 @@ import 'package:lotti/database/database.dart';
 import 'package:lotti/database/fts5_db.dart';
 import 'package:lotti/database/journal_db/config_flags.dart';
 import 'package:lotti/database/logging_db.dart';
+import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
@@ -58,6 +59,7 @@ void main() {
     setUpAll(() async {
       setFakeDocumentsPath();
 
+      final settingsDb = SettingsDb(inMemoryDatabase: true);
       final journalDb = JournalDb(inMemoryDatabase: true);
       await initConfigFlags(journalDb);
 
@@ -91,6 +93,7 @@ void main() {
 
       getIt
         ..registerSingleton<Directory>(await getApplicationDocumentsDirectory())
+        ..registerSingleton<SettingsDb>(settingsDb)
         ..registerSingleton<ConnectivityService>(mockConnectivityService)
         ..registerSingleton<Fts5Db>(mockFts5Db)
         ..registerSingleton<FgBgService>(mockFgBgService)

--- a/test/pages/settings/tags/tags_page_test.dart
+++ b/test/pages/settings/tags/tags_page_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/tag_type_definitions.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/pages/settings/tags/tags_page.dart';
@@ -27,11 +28,12 @@ void main() {
       final mockTagsService = mockTagsServiceWithTags([]);
       final mockJournalDb = mockJournalDbWithMeasurableTypes([]);
       final mockPersistenceLogic = MockPersistenceLogic();
-
+      final settingsDb = SettingsDb(inMemoryDatabase: true);
       final secureStorageMock = MockSecureStorage();
 
       getIt
         ..registerSingleton<SecureStorage>(secureStorageMock)
+        ..registerSingleton<SettingsDb>(settingsDb)
         ..registerSingleton<NavService>(NavService())
         ..registerSingleton<TagsService>(mockTagsService)
         ..registerSingleton<JournalDb>(mockJournalDb)

--- a/test/services/nav_service_test.dart
+++ b/test/services/nav_service_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/sync/secure_storage.dart';
@@ -12,6 +13,7 @@ void main() {
   group('NavService Tests', () {
     setUpAll(() {
       final secureStorageMock = MockSecureStorage();
+      final settingsDb = SettingsDb(inMemoryDatabase: true);
 
       when(() => secureStorageMock.readValue(lastRouteKey))
           .thenAnswer((_) async => '/settings');
@@ -21,6 +23,7 @@ void main() {
 
       getIt
         ..registerSingleton<SecureStorage>(secureStorageMock)
+        ..registerSingleton<SettingsDb>(settingsDb)
         ..registerSingleton<NavService>(NavService());
     });
 

--- a/test/sync/inbox/inbox_service_test.dart
+++ b/test/sync/inbox/inbox_service_test.dart
@@ -6,6 +6,7 @@ import 'package:lotti/database/common.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/journal_db/config_flags.dart';
 import 'package:lotti/database/logging_db.dart';
+import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/sync_config_service.dart';
@@ -64,6 +65,11 @@ void main() {
 
       getIt
         ..registerSingleton<Directory>(await getApplicationDocumentsDirectory())
+        ..registerSingleton<Future<DriftIsolate>>(
+          createDriftIsolate(settingsDbFileName, inMemory: true),
+          instanceName: settingsDbFileName,
+        )
+        ..registerSingleton<SettingsDb>(getSettingsDb())
         ..registerSingleton<SecureStorage>(secureStorageMock)
         ..registerSingleton<SyncConfigService>(syncConfigMock)
         ..registerSingleton<ConnectivityService>(mockConnectivityService)

--- a/test/sync/outbox/outbox_service_test.dart
+++ b/test/sync/outbox/outbox_service_test.dart
@@ -8,6 +8,7 @@ import 'package:lotti/classes/sync_message.dart';
 import 'package:lotti/database/common.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/logging_db.dart';
+import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/sync_config_service.dart';
@@ -56,6 +57,11 @@ void main() {
 
       getIt
         ..registerSingleton<Directory>(await getApplicationDocumentsDirectory())
+        ..registerSingleton<Future<DriftIsolate>>(
+          createDriftIsolate(settingsDbFileName, inMemory: true),
+          instanceName: settingsDbFileName,
+        )
+        ..registerSingleton<SettingsDb>(getSettingsDb())
         ..registerSingleton<Future<DriftIsolate>>(
           createDriftIsolate(syncDbFileName, inMemory: true),
           instanceName: syncDbFileName,


### PR DESCRIPTION
This PR moves all config items that were previously stored in SecureStorage but that are not actually secrets to SQLite to fix a mysterious locking issue.

Resolves #1362 