### PR TITLE
Task improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed:
+- More consistent app bar
+
+## [0.8.273] - 2023-02-24
+### Changed:
 - Upgraded dependencies
 - Progress bar height and opacity
 - Remove entry duration in journal card

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed:
 - More consistent app bar
+- Reduce clutter in tasks header by moving count stats
 
 ## [0.8.273] - 2023-02-24
 ### Changed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - More consistent app bar
 - Reduce clutter in tasks header by moving count stats
 - Upgraded dependencies
+- Improved styling of about page
 
 ## [0.8.273] - 2023-02-24
 ### Changed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed:
 - More consistent app bar
 - Reduce clutter in tasks header by moving count stats
+- Upgraded dependencies
 
 ## [0.8.273] - 2023-02-24
 ### Changed:

--- a/lib/pages/empty_scaffold.dart
+++ b/lib/pages/empty_scaffold.dart
@@ -19,9 +19,7 @@ class EmptyScaffoldWithTitle extends StatelessWidget {
       duration: const Duration(seconds: 2),
       child: Scaffold(
         backgroundColor: styleConfig().negspace,
-        appBar: TitleAppBar(
-          title: title,
-        ),
+        appBar: TitleAppBar(title: title),
         body: body,
       ),
     );

--- a/lib/pages/settings/about_page.dart
+++ b/lib/pages/settings/about_page.dart
@@ -5,9 +5,8 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/utils/platform.dart';
 import 'package:lotti/widgets/app_bar/title_app_bar.dart';
+import 'package:lotti/widgets/misc/tasks_counts.dart';
 import 'package:package_info_plus/package_info_plus.dart';
-
-import '../../widgets/misc/tasks_counts.dart';
 
 class AboutPage extends StatefulWidget {
   const AboutPage({super.key});

--- a/lib/pages/settings/about_page.dart
+++ b/lib/pages/settings/about_page.dart
@@ -43,12 +43,6 @@ class _AboutPageState extends State<AboutPage> {
   Widget build(BuildContext context) {
     final localizations = AppLocalizations.of(context)!;
 
-    final style = TextStyle(
-      color: styleConfig().primaryTextColor,
-      fontSize: 25,
-      fontWeight: FontWeight.w300,
-    );
-
     return Scaffold(
       backgroundColor: styleConfig().negspace,
       appBar: TitleAppBar(title: localizations.settingsAboutTitle),
@@ -61,17 +55,17 @@ class _AboutPageState extends State<AboutPage> {
           return Padding(
             padding: const EdgeInsets.all(16),
             child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
                   'Version: $version ($buildNumber)',
-                  style: style,
+                  style: searchLabelStyle(),
                 ),
-                const SizedBox(height: 8),
+                const SizedBox(height: 10),
                 Text(
-                  'Entries count: ${snapshot.data}',
-                  style: style,
+                  'Entries: ${snapshot.data}',
+                  style: searchLabelStyle(),
                 ),
+                const SizedBox(height: 10),
                 const TaskCounts(),
               ],
             ),

--- a/lib/pages/settings/about_page.dart
+++ b/lib/pages/settings/about_page.dart
@@ -7,6 +7,8 @@ import 'package:lotti/utils/platform.dart';
 import 'package:lotti/widgets/app_bar/title_app_bar.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
+import '../../widgets/misc/tasks_counts.dart';
+
 class AboutPage extends StatefulWidget {
   const AboutPage({super.key});
 
@@ -71,6 +73,7 @@ class _AboutPageState extends State<AboutPage> {
                   'Entries count: ${snapshot.data}',
                   style: style,
                 ),
+                const TaskCounts(),
               ],
             ),
           );

--- a/lib/widgets/app_bar/journal_sliver_appbar.dart
+++ b/lib/widgets/app_bar/journal_sliver_appbar.dart
@@ -8,7 +8,6 @@ import 'package:lotti/themes/theme.dart';
 import 'package:lotti/utils/platform.dart';
 import 'package:lotti/widgets/badges/flagged_badge.dart';
 import 'package:lotti/widgets/badges/tasks_badge_icon.dart';
-import 'package:lotti/widgets/misc/tasks_counts.dart';
 import 'package:lotti/widgets/search/entry_type_filter.dart';
 import 'package:lotti/widgets/search/search_widget.dart';
 import 'package:lotti/widgets/search/task_status_filter.dart';
@@ -29,12 +28,11 @@ class JournalSliverAppBar extends StatelessWidget {
 
         return SliverAppBar(
           backgroundColor: styleConfig().negspace,
-          expandedHeight: 290,
+          expandedHeight: 280,
           flexibleSpace: FlexibleSpaceBar(
             background: Padding(
               padding: EdgeInsets.only(top: isIOS ? 30 : 0),
               child: Column(
-                mainAxisSize: MainAxisSize.min,
                 children: [
                   SearchWidget(
                     margin: const EdgeInsets.symmetric(
@@ -52,7 +50,7 @@ class JournalSliverAppBar extends StatelessWidget {
                       runAlignment: WrapAlignment.center,
                       crossAxisAlignment: WrapCrossAlignment.center,
                       spacing: 5,
-                      runSpacing: 2,
+                      runSpacing: 4,
                       children: [
                         TasksBadge(
                           child: TasksSegmentedControl(
@@ -123,7 +121,6 @@ class JournalSliverAppBar extends StatelessWidget {
                         ),
                         if (!snapshot.showTasks) const EntryTypeFilter(),
                         if (snapshot.showTasks) const TaskStatusFilter(),
-                        if (snapshot.showTasks) const TaskCounts(),
                       ],
                     ),
                   ),

--- a/lib/widgets/app_bar/task_app_bar.dart
+++ b/lib/widgets/app_bar/task_app_bar.dart
@@ -29,10 +29,7 @@ class TaskAppBar extends StatelessWidget with PreferredSizeWidget {
       ) {
         final item = snapshot.data;
         if (item == null || item.meta.deletedAt != null) {
-          return AppBar(
-            backgroundColor: styleConfig().cardColor,
-            centerTitle: true,
-          );
+          return const TitleAppBar(title: '');
         }
 
         final isTask = item is Task;

--- a/lib/widgets/app_bar/task_app_bar.dart
+++ b/lib/widgets/app_bar/task_app_bar.dart
@@ -29,7 +29,7 @@ class TaskAppBar extends StatelessWidget with PreferredSizeWidget {
       ) {
         final item = snapshot.data;
         if (item == null || item.meta.deletedAt != null) {
-          return const TitleAppBar(title: '');
+          return const TitleAppBar(title: 'Lotti');
         }
 
         final isTask = item is Task;

--- a/lib/widgets/misc/tasks_counts.dart
+++ b/lib/widgets/misc/tasks_counts.dart
@@ -11,12 +11,16 @@ class TaskCounts extends StatelessWidget {
   Widget build(BuildContext context) {
     final localizations = AppLocalizations.of(context)!;
 
-    return Container(
-      padding: const EdgeInsets.only(top: 4),
+    return SizedBox(
       width: MediaQuery.of(context).size.width,
       child: Wrap(
         alignment: WrapAlignment.center,
+        spacing: 5,
         children: [
+          Text(
+            'Tasks:',
+            style: searchLabelStyle(),
+          ),
           TasksCountWidget(
             status: 'OPEN',
             label: localizations.taskStatusOpen,
@@ -68,7 +72,7 @@ class TasksCountWidget extends StatelessWidget {
           return Padding(
             padding: const EdgeInsets.symmetric(horizontal: 4),
             child: Text(
-              '$label: ${snapshot.data}',
+              '${snapshot.data} $label',
               style: searchLabelStyle(),
             ),
           );

--- a/lib/widgets/search/entry_type_filter.dart
+++ b/lib/widgets/search/entry_type_filter.dart
@@ -14,17 +14,14 @@ class EntryTypeFilter extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<JournalPageCubit, JournalPageState>(
       builder: (context, snapshot) {
-        return Padding(
-          padding: const EdgeInsets.only(top: 10),
-          child: WrapSuper(
-            alignment: WrapSuperAlignment.center,
-            spacing: 5,
-            lineSpacing: 5,
-            children: [
-              ...entryTypes.map(EntryTypeChip.new),
-              const EntryTypeAllChip(),
-            ],
-          ),
+        return WrapSuper(
+          alignment: WrapSuperAlignment.center,
+          spacing: 5,
+          lineSpacing: 5,
+          children: [
+            ...entryTypes.map(EntryTypeChip.new),
+            const EntryTypeAllChip(),
+          ],
         );
       },
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -421,10 +421,10 @@ packages:
     dependency: transitive
     description:
       name: dart_code_metrics_presets
-      sha256: "9c51724f836aebc4465228954cb5757e5a99737af26a452b5dec0a2d5d0b4d66"
+      sha256: "09cba116b99202b95cacd1e32817dbb1cbfb28e3896f5f60de59b09c63c74078"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   dart_geohash:
     dependency: "direct main"
     description:
@@ -2018,10 +2018,10 @@ packages:
     dependency: "direct main"
     description:
       name: sqflite
-      sha256: "78324387dc81df14f78df06019175a86a2ee0437624166c382e145d0a7fd9a4f"
+      sha256: "851d5040552cf911f4cabda08d003eca76b27da3ed0002978272e27c8fbf8ecc"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.4+1"
+    version: "2.2.5"
   sqflite_common:
     dependency: transitive
     description:
@@ -2442,10 +2442,10 @@ packages:
     dependency: "direct main"
     description:
       name: window_manager
-      sha256: "5bdd29dc5f1f3185fc90696373a571d77968e03e5e820fb1ecdbdade3f5d8fff"
+      sha256: "492806c69879f0d28e95472bbe5e8d5940ac8c6e99cc07052fe14946974555ba"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.1"
   wkt_parser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.274+1801
+version: 0.8.274+1802
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.274+1800
+version: 0.8.274+1801
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.273+1798
+version: 0.8.274+1799
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.274+1799
+version: 0.8.274+1800
 
 msix_config:
   display_name: Lotti

--- a/test/pages/settings/about_page_test.dart
+++ b/test/pages/settings/about_page_test.dart
@@ -48,7 +48,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('About Lotti'), findsOneWidget);
-      expect(find.text('Entries count: 111'), findsOneWidget);
+      expect(find.text('Entries: 111'), findsOneWidget);
     });
   });
 }

--- a/test/pages/settings/about_page_test.dart
+++ b/test/pages/settings/about_page_test.dart
@@ -23,6 +23,12 @@ void main() {
       getIt
         ..registerSingleton<JournalDb>(mockJournalDb)
         ..registerSingleton<ThemesService>(ThemesService(watch: false));
+
+      when(
+        () => mockJournalDb.watchTaskCount(any()),
+      ).thenAnswer(
+        (_) => Stream<int>.fromIterable([10]),
+      );
     });
     tearDown(getIt.reset);
 


### PR DESCRIPTION
This PR declutters the task search header by removing task stats to the about page. The stats are occasionally useful but do not need to be seen all the time. 