### PR TITLE
Improved Tags Modal

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -105,6 +105,7 @@ steps:
         retry:
           automatic:
             - exit_status: 24
+            - exit_status: 2
 
       - label: "📱🚀 iOS fastlane TestFlight "
         key: "ios_fastlane_testflight"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed:
+- Refactor: use showModalBottomSheet for managing tags
+
+## [0.8.274] - 2023-02-26
+### Changed:
 - More consistent app bar
 - Reduce clutter in tasks header by moving count stats
 - Upgraded dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed:
 - Refactor: use showModalBottomSheet for managing tags
+- CI: retry on exit status 2
 
 ## [0.8.274] - 2023-02-26
 ### Changed:

--- a/lib/beamer/locations/journal_location.dart
+++ b/lib/beamer/locations/journal_location.dart
@@ -1,16 +1,11 @@
 import 'package:beamer/beamer.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:lotti/beamer/beamer_delegates.dart';
-import 'package:lotti/blocs/journal/entry_cubit.dart';
 import 'package:lotti/pages/create/create_measurement_page.dart';
 import 'package:lotti/pages/create/fill_survey_page.dart';
 import 'package:lotti/pages/create/record_audio_page.dart';
 import 'package:lotti/pages/journal/entry_details_page.dart';
 import 'package:lotti/pages/journal/infinite_journal_page.dart';
-import 'package:lotti/themes/theme.dart';
 import 'package:lotti/utils/uuid.dart';
-import 'package:lotti/widgets/journal/tags/tags_modal.dart';
 
 class JournalLocation extends BeamLocation<BeamState> {
   JournalLocation(RouteInformation super.routeInformation);
@@ -18,7 +13,6 @@ class JournalLocation extends BeamLocation<BeamState> {
   @override
   List<String> get pathPatterns => [
         '/journal/:entryId',
-        '/journal/:entryId/manage_tags',
         '/journal/:entryId/record_audio/:linkedId',
         '/journal/fill_survey/:surveyType',
         '/journal/fill_survey_linked/:linkedId',
@@ -73,38 +67,6 @@ class JournalLocation extends BeamLocation<BeamState> {
         BeamPage(
           key: ValueKey('journal-measure-$selectedId'),
           child: CreateMeasurementPage(selectedId: selectedId),
-        ),
-      if (pathContains('/manage_tags'))
-        BeamPage(
-          routeBuilder: (
-            BuildContext context,
-            RouteSettings settings,
-            Widget child,
-          ) {
-            return ModalBottomSheetRoute<void>(
-              isScrollControlled: true,
-              builder: (context) {
-                final data = context.currentBeamLocation.data;
-
-                if (data == null) {
-                  return const SizedBox.shrink();
-                }
-
-                return BlocProvider.value(
-                  value: data as EntryCubit,
-                  child: child,
-                );
-              },
-              settings: settings,
-              modalBarrierColor: styleConfig().negspace.withOpacity(0.54),
-            );
-          },
-          key: ValueKey('journal-manage-tags-$entryId'),
-          child: const TagsModal(),
-          onPopPage: (context, delegate, _, page) {
-            journalBeamerDelegate.beamBack();
-            return false;
-          },
         ),
     ];
   }

--- a/lib/pages/settings/dashboards/dashboard_item_card.dart
+++ b/lib/pages/settings/dashboards/dashboard_item_card.dart
@@ -118,11 +118,6 @@ class MeasurableItemCard extends StatelessWidget {
           onTap: () {
             showModalBottomSheet<void>(
               context: context,
-              shape: const RoundedRectangleBorder(
-                borderRadius: BorderRadius.vertical(
-                  top: Radius.circular(16),
-                ),
-              ),
               clipBehavior: Clip.antiAliasWithSaveLayer,
               builder: (BuildContext context) {
                 return DashboardItemModal(

--- a/lib/surveys/run_surveys.dart
+++ b/lib/surveys/run_surveys.dart
@@ -13,11 +13,6 @@ Future<void> runSurvey({
 }) async {
   await showModalBottomSheet<void>(
     context: context,
-    shape: const RoundedRectangleBorder(
-      borderRadius: BorderRadius.vertical(
-        top: Radius.circular(16),
-      ),
-    ),
     backgroundColor: styleConfig().cardColor,
     clipBehavior: Clip.antiAliasWithSaveLayer,
     useRootNavigator: true,

--- a/lib/widgets/journal/entry_details/entry_datetime_widget.dart
+++ b/lib/widgets/journal/entry_details/entry_datetime_widget.dart
@@ -27,11 +27,6 @@ class EntryDatetimeWidget extends StatelessWidget {
             onPressed: () {
               showModalBottomSheet<void>(
                 context: context,
-                shape: const RoundedRectangleBorder(
-                  borderRadius: BorderRadius.vertical(
-                    top: Radius.circular(16),
-                  ),
-                ),
                 clipBehavior: Clip.antiAliasWithSaveLayer,
                 builder: (BuildContext _) {
                   return BlocProvider.value(

--- a/lib/widgets/journal/tags/tag_add.dart
+++ b/lib/widgets/journal/tags/tag_add.dart
@@ -5,9 +5,9 @@ import 'package:flutter_svg/svg.dart';
 import 'package:lotti/blocs/journal/entry_cubit.dart';
 import 'package:lotti/blocs/journal/entry_state.dart';
 import 'package:lotti/get_it.dart';
-import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/services/tags_service.dart';
 import 'package:lotti/themes/theme.dart';
+import 'package:lotti/widgets/journal/tags/tags_modal.dart';
 
 class TagAddIconWidget extends StatelessWidget {
   TagAddIconWidget({super.key});
@@ -28,10 +28,18 @@ class TagAddIconWidget extends StatelessWidget {
           return const SizedBox.shrink();
         }
 
-        void onTapAdd() => beamToNamed(
-              '/journal/${state.entryId}/manage_tags',
-              data: context.read<EntryCubit>(),
-            );
+        void onTapAdd() {
+          showModalBottomSheet<void>(
+            context: context,
+            clipBehavior: Clip.antiAliasWithSaveLayer,
+            builder: (BuildContext _) {
+              return BlocProvider.value(
+                value: BlocProvider.of<EntryCubit>(context),
+                child: const TagsModal(),
+              );
+            },
+          );
+        }
 
         return SizedBox(
           width: 40,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.275+1803
+version: 0.8.275+1804
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.274+1802
+version: 0.8.275+1803
 
 msix_config:
   display_name: Lotti

--- a/test/widgets/journal/tags/tag_add_test.dart
+++ b/test/widgets/journal/tags/tag_add_test.dart
@@ -73,13 +73,6 @@ void main() {
 
       await tester.tap(tagAddIconFinder);
       await tester.pumpAndSettle();
-
-      verify(
-        () => mockNavService.beamToNamed(
-          '/journal/32ea936e-dfc6-43bd-8722-d816c35eb489/manage_tags',
-          data: any(named: 'data'),
-        ),
-      ).called(1);
     });
   });
 }


### PR DESCRIPTION
This PR refactors the tags modal to use the default modal implementation, which feels very natural to use, throughout the codebase, and removes the use of a separate beamer page for this particular modal, which turned out to be way more complicated than necessary.

Resolves #1394.