### PR TITLE
Open habits visualisation by category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed:
 - Delete category question and confirmation label
+- Scroll in category bottom sheet
 
 ## [0.8.287] - 2023-03-22
 ### Changed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added:
 - Visualization for categories of open habits
+- Category name validation checking for duplicates
 
 ### Changed:
 - Upgraded dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed:
 - Delete category question and confirmation label
 - Scroll in category bottom sheet
+- Prevent duplicate categories
 
 ## [0.8.287] - 2023-03-22
 ### Changed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed:
 - Upgraded dependencies
 
+### Fixed:
+- Delete category question and confirmation label
+
 ## [0.8.287] - 2023-03-22
 ### Changed:
 - Habit completion card layout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added:
+- Visualization for categories of open habits
+
 ### Changed:
 - Upgraded dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed:
+- Upgraded dependencies
+
+## [0.8.287] - 2023-03-22
+### Changed:
 - Habit completion card layout
 
 ## [0.8.286] - 2023-03-21

--- a/lib/database/conversions.dart
+++ b/lib/database/conversions.dart
@@ -175,7 +175,7 @@ CategoryDefinitionDbEntity categoryDefinitionDbEntity(
     serialized: jsonEncode(category),
     private: category.private,
     active: category.active,
-    name: category.id,
+    name: category.name,
     deleted: category.deletedAt != null,
   );
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -115,6 +115,7 @@
   "settingsDashboardsTitle": "Konfiguration Dashboards",
   "settingsFlagsTitle": "Konfigurations-Flags",
   "settingsCategoriesTitle": "Kategorien",
+  "settingsCategoriesDuplicateError": "Kategorie existiert bereits",
   "settingsHealthImportTitle": "Import aus Health",
   "settingsLogsTitle": "Aktivitäts- und Fehlerprotokoll",
   "settingsMaintenanceTitle": "Wartung",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -11,6 +11,8 @@
   "addMeasurementNoneDefined": "Messbaren Datentyp hinzufügen",
   "addMeasurementSaveButton": "Speichern",
   "addMeasurementTitle": "Messbare Daten erfassen",
+  "categoryDeleteConfirm": "JA, KATEGORIE LÖSCHEN",
+  "categoryDeleteQuestion": "Kategorie wirklich löschen?",
   "configFlagEnableNotifications": "Desktop Notifications erlauben?",
   "configFlagPrivate": "Private Einträge anzeigen?",
   "conflictsResolved": "gelöst",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -23,6 +23,8 @@
   "appBarBack": "Back",
   "addSurveyTitle": "Fill Survey",
   "addTaskTitle": "Add Task",
+  "categoryDeleteConfirm": "YES, DELETE THIS CATEGORY",
+  "categoryDeleteQuestion": "Do you want to delete this category?",
   "configFlagEnableNotifications": "Enable desktop notifications?",
   "configInvalidCert": "Allow invalid SSL certificate?",
   "configFlagPrivate": "Show private entries?",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -159,6 +159,7 @@
   "settingsFlagsTitle": "Config Flags",
   "settingsCategoriesTitle": "Categories",
   "settingsCategoriesNameLabel": "Category name:",
+  "settingsCategoriesDuplicateError": "Category exists already",
   "settingsHabitsTitle": "Habits",
   "settingsHabitsDeleteTooltip": "Delete Habit",
   "settingsHabitsDescriptionLabel": "Description (optional):",

--- a/lib/pages/habits/habits_page.dart
+++ b/lib/pages/habits/habits_page.dart
@@ -11,6 +11,7 @@ import 'package:lotti/widgets/charts/utils.dart';
 import 'package:lotti/widgets/habits/habit_completion_card.dart';
 import 'package:lotti/widgets/habits/habit_page_app_bar.dart';
 import 'package:lotti/widgets/habits/habit_streaks.dart';
+import 'package:lotti/widgets/habits/habits_filter.dart';
 import 'package:lotti/widgets/habits/status_segmented_control.dart';
 import 'package:lotti/widgets/misc/timespan_segmented_control.dart';
 
@@ -98,23 +99,29 @@ class HabitsTabPage extends StatelessWidget {
                             filter: state.displayFilter,
                             onValueChanged: cubit.setDisplayFilter,
                           ),
-                          IconButton(
-                            onPressed: cubit.toggleShowSearch,
-                            icon: Icon(
-                              Icons.search,
-                              color: state.showSearch
-                                  ? styleConfig().primaryColor
-                                  : styleConfig().secondaryTextColor,
-                            ),
-                          ),
-                          IconButton(
-                            onPressed: cubit.toggleShowTimeSpan,
-                            icon: Icon(
-                              Icons.calendar_month,
-                              color: state.showTimeSpan
-                                  ? styleConfig().primaryColor
-                                  : styleConfig().secondaryTextColor,
-                            ),
+                          Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              IconButton(
+                                onPressed: cubit.toggleShowSearch,
+                                icon: Icon(
+                                  Icons.search,
+                                  color: state.showSearch
+                                      ? styleConfig().primaryColor
+                                      : styleConfig().secondaryTextColor,
+                                ),
+                              ),
+                              IconButton(
+                                onPressed: cubit.toggleShowTimeSpan,
+                                icon: Icon(
+                                  Icons.calendar_month,
+                                  color: state.showTimeSpan
+                                      ? styleConfig().primaryColor
+                                      : styleConfig().secondaryTextColor,
+                                ),
+                              ),
+                              const HabitsFilter(),
+                            ],
                           ),
                         ],
                       ),

--- a/lib/pages/settings/categories/category_details_page.dart
+++ b/lib/pages/settings/categories/category_details_page.dart
@@ -111,11 +111,12 @@ class CategoryDetailsPage extends StatelessWidget {
                                 final result =
                                     await showModalActionSheet<String>(
                                   context: context,
-                                  title: localizations.habitDeleteQuestion,
+                                  title: localizations.categoryDeleteQuestion,
                                   actions: [
                                     SheetAction(
                                       icon: Icons.warning,
-                                      label: localizations.habitDeleteConfirm,
+                                      label:
+                                          localizations.categoryDeleteConfirm,
                                       key: deleteKey,
                                       isDestructiveAction: true,
                                       isDefaultAction: true,

--- a/lib/pages/settings/categories/category_details_page.dart
+++ b/lib/pages/settings/categories/category_details_page.dart
@@ -4,13 +4,13 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_colorpicker/flutter_colorpicker.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:form_builder_validators/form_builder_validators.dart';
 import 'package:lotti/blocs/settings/categories/category_settings_cubit.dart';
 import 'package:lotti/blocs/settings/categories/category_settings_state.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/pages/empty_scaffold.dart';
-import 'package:lotti/pages/settings/form_text_field.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/utils/color.dart';
 import 'package:lotti/widgets/app_bar/title_app_bar.dart';
@@ -24,121 +24,156 @@ class CategoryDetailsPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final localizations = AppLocalizations.of(context)!;
 
-    return BlocBuilder<CategorySettingsCubit, CategorySettingsState>(
-      builder: (context, CategorySettingsState state) {
-        final item = state.categoryDefinition;
-        final cubit = context.read<CategorySettingsCubit>();
+    return StreamBuilder<List<CategoryDefinition>>(
+      stream: getIt<JournalDb>().watchCategories(),
+      builder: (context, snapshot) {
+        final categories = snapshot.data ?? <CategoryDefinition>[];
+        final categoryNames = <String>{};
 
-        final pickerColor = colorFromCssHex(state.categoryDefinition.color);
+        for (final category in categories) {
+          categoryNames.add(category.name.toLowerCase());
+        }
 
-        return Scaffold(
-          backgroundColor: styleConfig().negspace,
-          appBar: TitleAppBar(
-            title: state.categoryDefinition.name,
-            actions: [
-              if (state.dirty)
-                TextButton(
-                  key: const Key('habit_save'),
-                  onPressed: cubit.onSavePressed,
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 12),
-                    child: Text(
-                      AppLocalizations.of(context)!.settingsHabitsSaveLabel,
-                      style: saveButtonStyle(),
-                    ),
-                  ),
-                )
-            ],
-          ),
-          body: SingleChildScrollView(
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: Card(
+        return BlocBuilder<CategorySettingsCubit, CategorySettingsState>(
+          builder: (context, CategorySettingsState state) {
+            final item = state.categoryDefinition;
+            final cubit = context.read<CategorySettingsCubit>();
+
+            final pickerColor = colorFromCssHex(state.categoryDefinition.color);
+
+            return Scaffold(
+              backgroundColor: styleConfig().negspace,
+              appBar: TitleAppBar(
+                title: state.categoryDefinition.name,
+                actions: [
+                  if (state.dirty)
+                    TextButton(
+                      key: const Key('habit_save'),
+                      onPressed: cubit.onSavePressed,
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 12),
+                        child: Text(
+                          AppLocalizations.of(context)!.settingsHabitsSaveLabel,
+                          style: saveButtonStyle(),
+                        ),
+                      ),
+                    )
+                ],
+              ),
+              body: SingleChildScrollView(
                 child: Padding(
-                  padding: const EdgeInsets.all(20),
-                  child: Column(
-                    children: [
-                      FormBuilder(
-                        key: state.formKey,
-                        autovalidateMode: AutovalidateMode.onUserInteraction,
-                        onChanged: cubit.setDirty,
-                        child: Column(
-                          children: <Widget>[
-                            FormTextField(
-                              key: const Key('category_name_field'),
-                              initialValue: item.name,
-                              labelText: AppLocalizations.of(context)!
-                                  .settingsCategoriesNameLabel,
-                              name: 'name',
+                  padding: const EdgeInsets.all(16),
+                  child: Card(
+                    child: Padding(
+                      padding: const EdgeInsets.all(20),
+                      child: Column(
+                        children: [
+                          FormBuilder(
+                            key: state.formKey,
+                            autovalidateMode:
+                                AutovalidateMode.onUserInteraction,
+                            onChanged: cubit.setDirty,
+                            child: Column(
+                              children: <Widget>[
+                                FormBuilderTextField(
+                                  key: const Key('category_name_field1'),
+                                  name: 'name',
+                                  minLines: 1,
+                                  maxLines: 3,
+                                  initialValue: item.name,
+                                  textCapitalization:
+                                      TextCapitalization.sentences,
+                                  keyboardAppearance: keyboardAppearance(),
+                                  validator: FormBuilderValidators.compose([
+                                    FormBuilderValidators.required(),
+                                    (categoryName) {
+                                      if (categoryNames.contains(
+                                        categoryName?.toLowerCase(),
+                                      )) {
+                                        return localizations
+                                            .settingsCategoriesDuplicateError;
+                                      }
+                                      return null;
+                                    }
+                                  ]),
+                                  style: labelStyle(),
+                                  decoration: inputDecoration(
+                                    labelText: AppLocalizations.of(context)!
+                                        .settingsCategoriesNameLabel,
+                                  ),
+                                ),
+                                inputSpacer,
+                                FormSwitch(
+                                  name: 'private',
+                                  initialValue: item.private,
+                                  title:
+                                      localizations.settingsHabitsPrivateLabel,
+                                  activeColor: styleConfig().private,
+                                ),
+                                FormSwitch(
+                                  name: 'active',
+                                  key: const Key('habit_active'),
+                                  initialValue: state.categoryDefinition.active,
+                                  title: localizations.dashboardActiveLabel,
+                                  activeColor: styleConfig().starredGold,
+                                ),
+                                ColorPicker(
+                                  pickerColor: pickerColor,
+                                  enableAlpha: false,
+                                  labelTypes: const [],
+                                  onColorChanged: cubit.setColor,
+                                )
+                              ],
                             ),
-                            inputSpacer,
-                            FormSwitch(
-                              name: 'private',
-                              initialValue: item.private,
-                              title: localizations.settingsHabitsPrivateLabel,
-                              activeColor: styleConfig().private,
-                            ),
-                            FormSwitch(
-                              name: 'active',
-                              key: const Key('habit_active'),
-                              initialValue: state.categoryDefinition.active,
-                              title: localizations.dashboardActiveLabel,
-                              activeColor: styleConfig().starredGold,
-                            ),
-                            ColorPicker(
-                              pickerColor: pickerColor,
-                              enableAlpha: false,
-                              labelTypes: const [],
-                              onColorChanged: cubit.setColor,
-                            )
-                          ],
-                        ),
-                      ),
+                          ),
 
-                      Padding(
-                        padding: const EdgeInsets.only(top: 16),
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.end,
-                          children: [
-                            IconButton(
-                              icon: const Icon(MdiIcons.trashCanOutline),
-                              iconSize: settingsIconSize,
-                              tooltip: AppLocalizations.of(context)!
-                                  .settingsHabitsDeleteTooltip,
-                              color: styleConfig().secondaryTextColor,
-                              onPressed: () async {
-                                const deleteKey = 'deleteKey';
-                                final result =
-                                    await showModalActionSheet<String>(
-                                  context: context,
-                                  title: localizations.categoryDeleteQuestion,
-                                  actions: [
-                                    SheetAction(
-                                      icon: Icons.warning,
-                                      label:
-                                          localizations.categoryDeleteConfirm,
-                                      key: deleteKey,
-                                      isDestructiveAction: true,
-                                      isDefaultAction: true,
-                                    ),
-                                  ],
-                                );
+                          Padding(
+                            padding: const EdgeInsets.only(top: 16),
+                            child: Row(
+                              mainAxisAlignment: MainAxisAlignment.end,
+                              children: [
+                                IconButton(
+                                  icon: const Icon(MdiIcons.trashCanOutline),
+                                  iconSize: settingsIconSize,
+                                  tooltip: AppLocalizations.of(context)!
+                                      .settingsHabitsDeleteTooltip,
+                                  color: styleConfig().secondaryTextColor,
+                                  onPressed: () async {
+                                    const deleteKey = 'deleteKey';
+                                    final result =
+                                        await showModalActionSheet<String>(
+                                      context: context,
+                                      title:
+                                          localizations.categoryDeleteQuestion,
+                                      actions: [
+                                        SheetAction(
+                                          icon: Icons.warning,
+                                          label: localizations
+                                              .categoryDeleteConfirm,
+                                          key: deleteKey,
+                                          isDestructiveAction: true,
+                                          isDefaultAction: true,
+                                        ),
+                                      ],
+                                    );
 
-                                if (result == deleteKey) {
-                                  await cubit.delete();
-                                }
-                              },
+                                    if (result == deleteKey) {
+                                      await cubit.delete();
+                                    }
+                                  },
+                                ),
+                              ],
                             ),
-                          ],
-                        ),
+                          ),
+                          // const HabitAutocompleteWrapper(),
+                        ],
                       ),
-                      // const HabitAutocompleteWrapper(),
-                    ],
+                    ),
                   ),
                 ),
               ),
-            ),
-          ),
+            );
+          },
         );
       },
     );

--- a/lib/widgets/habits/habit_category.dart
+++ b/lib/widgets/habits/habit_category.dart
@@ -51,28 +51,33 @@ class SelectCategoryWidget extends StatelessWidget {
                   return BlocProvider.value(
                     value: BlocProvider.of<HabitSettingsCubit>(context),
                     child: Container(
+                      constraints: BoxConstraints(
+                        maxHeight: MediaQuery.of(context).size.height * 0.8,
+                      ),
                       padding: const EdgeInsets.symmetric(
                         horizontal: 10,
                         vertical: 20,
                       ),
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          ...categories.map(
-                            (category) => SettingsCard(
-                              onTap: () {
-                                context
-                                    .read<HabitSettingsCubit>()
-                                    .setCategory(category.id);
-                                Navigator.pop(context);
-                              },
-                              title: category.name,
-                              leading: CategoryColorIcon(
-                                colorFromCssHex(category.color),
+                      child: SingleChildScrollView(
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            ...categories.map(
+                              (category) => SettingsCard(
+                                onTap: () {
+                                  context
+                                      .read<HabitSettingsCubit>()
+                                      .setCategory(category.id);
+                                  Navigator.pop(context);
+                                },
+                                title: category.name,
+                                leading: CategoryColorIcon(
+                                  colorFromCssHex(category.color),
+                                ),
                               ),
-                            ),
-                          )
-                        ],
+                            )
+                          ],
+                        ),
                       ),
                     ),
                   );

--- a/lib/widgets/habits/habits_filter.dart
+++ b/lib/widgets/habits/habits_filter.dart
@@ -41,7 +41,7 @@ class HabitsFilter extends StatelessWidget {
             }).toList();
 
             if (dataMap.isEmpty) {
-              return SizedBox.shrink();
+              return const SizedBox.shrink();
             }
 
             return Padding(

--- a/lib/widgets/habits/habits_filter.dart
+++ b/lib/widgets/habits/habits_filter.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:lotti/blocs/habits/habits_cubit.dart';
+import 'package:lotti/blocs/habits/habits_state.dart';
+import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/utils/color.dart';
+import 'package:pie_chart/pie_chart.dart';
+
+class HabitsFilter extends StatelessWidget {
+  const HabitsFilter({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<List<CategoryDefinition>>(
+      stream: getIt<JournalDb>().watchCategories(),
+      builder: (context, snapshot) {
+        final categories = snapshot.data ?? <CategoryDefinition>[];
+        final categoriesById = <String, CategoryDefinition>{};
+
+        for (final category in categories) {
+          categoriesById[category.id] = category;
+        }
+
+        return BlocBuilder<HabitsCubit, HabitsState>(
+          builder: (context, HabitsState state) {
+            final dataMap = <String, double>{};
+
+            for (final habit in state.openNow) {
+              final categoryId = habit.categoryId ?? 'undefined';
+              dataMap[categoryId] = (dataMap[categoryId] ?? 0) + 1;
+            }
+
+            final colorList = dataMap.keys.map((categoryId) {
+              final category = categoriesById[categoryId];
+
+              return category != null
+                  ? colorFromCssHex(category.color)
+                  : Colors.grey;
+            }).toList();
+
+            if (dataMap.isEmpty) {
+              return SizedBox.shrink();
+            }
+
+            return Padding(
+              padding: const EdgeInsets.all(5),
+              child: PieChart(
+                dataMap: dataMap,
+                animationDuration: const Duration(milliseconds: 800),
+                chartRadius: 25,
+                colorList: colorList,
+                initialAngleInDegree: 0,
+                chartType: ChartType.ring,
+                ringStrokeWidth: 10,
+                legendOptions: const LegendOptions(showLegends: false),
+                chartValuesOptions: const ChartValuesOptions(
+                  showChartValueBackground: false,
+                  showChartValues: false,
+                ),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1591,6 +1591,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.14.0"
+  pie_chart:
+    dependency: "direct main"
+    description:
+      name: pie_chart
+      sha256: "5dba6d0eb4718e8ed00a9079361cd8947c3f84ac5a5d76f05a27f4ec5e27589e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.3.2"
   pigment:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1579,10 +1579,10 @@ packages:
     dependency: transitive
     description:
       name: photo_manager
-      sha256: "55d50ad1b8f984c57fa7c4bd4980f4760e80d3d9355263cf72624a6ff1bf2b5b"
+      sha256: bdc4ab1fa9fb064d8ccfea6ab44119f55b220293d7ce2e19eb5a5f998db86c88
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.2"
+    version: "2.6.0"
   photo_view:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "0c80aeab9bc807ab10022cd3b2f4cf2ecdf231949dc1ddd9442406a003f19201"
+      sha256: "503361166f4a100e0d7eb7fb5a62c6f0322512f2bcb48d6922caf98f24b0ab90"
       url: "https://pub.dev"
     source: hosted
-    version: "52.0.0"
+    version: "56.0.0"
   adaptive_dialog:
     dependency: "direct main"
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: "direct main"
     description:
       name: analyzer
-      sha256: cd8ee83568a77f3ae6b913a36093a1c9b1264e7cb7f834d9ddd2311dade9c1f4
+      sha256: "93fcd81a6716e69864516750590cf1e699420615046bda19100238aa7b429785"
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.0"
+    version: "5.8.0"
   analyzer_plugin:
     dependency: transitive
     description:
@@ -109,10 +109,10 @@ packages:
     dependency: "direct main"
     description:
       name: audio_video_progress_bar
-      sha256: "38d8efe20cd0ff2bfad648396ae3d4ba6f8058b7d8b6ee6cb26e3245eda58ddd"
+      sha256: "67f3a5ea70d48b48caaf29f5a0606284a6aa3a393736daf9e82bec985d2f9b70"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   auto_size_text:
     dependency: "direct main"
     description:
@@ -413,18 +413,18 @@ packages:
     dependency: "direct dev"
     description:
       name: dart_code_metrics
-      sha256: "026e28da197a03caeccccc0b174ec98ef03da3c81c4543314d7add121aab4375"
+      sha256: "728b1835a8c5b994ae8111148b427236f2f89954eebcb62baf4c476909b3d02d"
       url: "https://pub.dev"
     source: hosted
-    version: "5.6.0"
+    version: "5.7.0"
   dart_code_metrics_presets:
     dependency: transitive
     description:
       name: dart_code_metrics_presets
-      sha256: d3c36f97470f478c8432cee163058750db3d167c0a7af9bf291f48dd86c75086
+      sha256: "1b841b3ab3e7b942683a706cfbcef55fe9f38e7d01b690dbcd2e9f3c8e268525"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.5.0"
   dart_geohash:
     dependency: "direct main"
     description:
@@ -437,10 +437,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "5be16bf1707658e4c03078d4a9b90208ded217fb02c163e207d334082412f2fb"
+      sha256: "6d691edde054969f0e0f26abb1b30834b5138b963793e56f69d3a9a4435e6352"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.5"
+    version: "2.3.0"
   dbus:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.288+1874
+version: 0.8.288+1875
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.287+1869
+version: 0.8.288+1870
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.288+1872
+version: 0.8.288+1873
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.288+1870
+version: 0.8.288+1872
 
 msix_config:
   display_name: Lotti
@@ -111,6 +111,7 @@ dependencies:
   path_provider: ^2.0.12
   permission_handler: ^10.0.0
   photo_view: ^0.14.0
+  pie_chart: ^5.3.2
   qr_code_scanner: ^1.0.1
   qr_flutter: ^4.0.0
   quiver: ^3.2.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.288+1875
+version: 0.8.288+1876
 
 msix_config:
   display_name: Lotti

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: A Smart Journal.
 publish_to: 'none'
-version: 0.8.288+1873
+version: 0.8.288+1874
 
 msix_config:
   display_name: Lotti


### PR DESCRIPTION
This PR adds a small visualisation with a donut chart showing the distribution of open habits by category. In the next step, this small chart can be used as a button for opening a filter of habit categories to limit what is shown and make the list of open habits less intimidating.

Also adds some fixes around categories, such as preventing the creation of duplicate habits, and enabling scrolling in the category selection bottom sheet (toaster).