### PR TITLE
Show audio player inline in linked entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed:
+- Show audio player inline in linked entries
+
+## [0.8.327] - 2023-04-22
 ### Fixed:
 - Navigation after delete (not when displayed as a linked entry)
 

--- a/lib/widgets/journal/entry_details_widget.dart
+++ b/lib/widgets/journal/entry_details_widget.dart
@@ -48,9 +48,8 @@ class EntryDetailWidget extends StatelessWidget {
         }
 
         final isTask = item is Task;
-        final isAudio = item is JournalAudio;
 
-        if ((isTask || isAudio) && !showTaskDetails) {
+        if (isTask && !showTaskDetails) {
           return JournalCard(item: item);
         }
 
@@ -82,7 +81,7 @@ class EntryDetailWidget extends StatelessWidget {
                   ),
                   item.map(
                     journalAudio: (JournalAudio audio) {
-                      return const AudioPlayerWidget();
+                      return AudioPlayerWidget(audio);
                     },
                     workout: WorkoutSummary.new,
                     survey: SurveySummary.new,

--- a/lib/widgets/journal/journal_card.dart
+++ b/lib/widgets/journal/journal_card.dart
@@ -1,7 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:lotti/blocs/audio/player_cubit.dart';
-import 'package:lotti/blocs/audio/player_state.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
@@ -176,48 +173,37 @@ class JournalCard extends StatelessWidget {
         if (updatedItem.meta.deletedAt != null) {
           return const SizedBox.shrink();
         }
+        void onTap() {
+          beamToNamed('/journal/${updatedItem.meta.id}');
+        }
 
-        return BlocBuilder<AudioPlayerCubit, AudioPlayerState>(
-          builder: (BuildContext context, AudioPlayerState state) {
-            void onTap() {
-              updatedItem.mapOrNull(
-                journalAudio: (JournalAudio audioNote) {
-                  context.read<AudioPlayerCubit>().setAudioNote(audioNote);
-                },
-              );
-
-              beamToNamed('/journal/${updatedItem.meta.id}');
-            }
-
-            return Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 5),
-              child: Card(
-                child: ListTile(
-                  leading: updatedItem.maybeMap(
-                    journalAudio: (_) => const LeadingIcon(Icons.mic),
-                    journalEntry: (_) => const LeadingIcon(Icons.article),
-                    quantitative: (_) => const LeadingIcon(MdiIcons.heart),
-                    measurement: (_) => const LeadingIcon(MdiIcons.numeric),
-                    task: (task) => LeadingIcon(
-                      task.data.status.maybeMap(
-                        done: (_) => MdiIcons.checkboxMarkedOutline,
-                        orElse: () => MdiIcons.checkboxBlankOutline,
-                      ),
-                    ),
-                    habitCompletion: (habitCompletion) =>
-                        HabitCompletionColorIcon(habitCompletion.data.habitId),
-                    orElse: () => null,
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 5),
+          child: Card(
+            child: ListTile(
+              leading: updatedItem.maybeMap(
+                journalAudio: (_) => const LeadingIcon(Icons.mic),
+                journalEntry: (_) => const LeadingIcon(Icons.article),
+                quantitative: (_) => const LeadingIcon(MdiIcons.heart),
+                measurement: (_) => const LeadingIcon(MdiIcons.numeric),
+                task: (task) => LeadingIcon(
+                  task.data.status.maybeMap(
+                    done: (_) => MdiIcons.checkboxMarkedOutline,
+                    orElse: () => MdiIcons.checkboxBlankOutline,
                   ),
-                  title: JournalCardTitle(
-                    item: updatedItem,
-                    maxHeight: maxHeight,
-                    showLinkedDuration: showLinkedDuration,
-                  ),
-                  onTap: onTap,
                 ),
+                habitCompletion: (habitCompletion) =>
+                    HabitCompletionColorIcon(habitCompletion.data.habitId),
+                orElse: () => null,
               ),
-            );
-          },
+              title: JournalCardTitle(
+                item: updatedItem,
+                maxHeight: maxHeight,
+                showLinkedDuration: showLinkedDuration,
+              ),
+              onTap: onTap,
+            ),
+          ),
         );
       },
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.327+2025
+version: 0.9.328+2026
 
 msix_config:
   display_name: LottiApp

--- a/test/mocks/mocks.dart
+++ b/test/mocks/mocks.dart
@@ -141,6 +141,8 @@ class FakeTaskData extends Fake implements TaskData {}
 
 class FakeJournalEntity extends Fake implements JournalEntity {}
 
+class FakeJournalAudio extends Fake implements JournalAudio {}
+
 class FakeMeasurementData extends Fake implements MeasurementData {}
 
 class FakeHabitCompletionData extends Fake implements HabitCompletionData {}

--- a/test/widgets/audio/audio_player_test.dart
+++ b/test/widgets/audio/audio_player_test.dart
@@ -9,10 +9,12 @@ import 'package:lotti/widgets/audio/audio_player.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../mocks/mocks.dart';
+import '../../test_data/test_data.dart';
 import '../../widget_test_utils.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+  registerFallbackValue(FakeJournalAudio());
 
   group('AudioPlayerWidget Widget Tests - ', () {
     setUp(() {
@@ -28,6 +30,7 @@ void main() {
       totalDuration: const Duration(minutes: 1),
       pausedAt: Duration.zero,
       speed: 1,
+      audioNote: testAudioEntry,
     );
 
     testWidgets('controls are are displayed, paused state', (tester) async {
@@ -38,6 +41,9 @@ void main() {
       when(() => mockAudioPlayerCubit.state).thenAnswer(
         (_) => pausedState,
       );
+
+      when(() => mockAudioPlayerCubit.setAudioNote(any()))
+          .thenAnswer((_) async {});
 
       when(mockAudioPlayerCubit.play).thenAnswer((_) async {});
 
@@ -52,7 +58,7 @@ void main() {
           BlocProvider<AudioPlayerCubit>(
             create: (_) => mockAudioPlayerCubit,
             lazy: false,
-            child: const AudioPlayerWidget(),
+            child: AudioPlayerWidget(pausedState.audioNote!),
           ),
         ),
       );
@@ -91,6 +97,7 @@ void main() {
         totalDuration: const Duration(minutes: 1),
         pausedAt: Duration.zero,
         speed: 1,
+        audioNote: testAudioEntry,
       );
 
       when(() => mockAudioPlayerCubit.stream).thenAnswer(
@@ -100,6 +107,9 @@ void main() {
       when(() => mockAudioPlayerCubit.state).thenAnswer(
         (_) => playingState,
       );
+
+      when(() => mockAudioPlayerCubit.setAudioNote(any()))
+          .thenAnswer((_) async {});
 
       when(mockAudioPlayerCubit.close).thenAnswer((_) async {});
       when(mockAudioPlayerCubit.stopPlay).thenAnswer((_) async {});
@@ -112,7 +122,7 @@ void main() {
           BlocProvider<AudioPlayerCubit>(
             create: (_) => mockAudioPlayerCubit,
             lazy: false,
-            child: const AudioPlayerWidget(),
+            child: AudioPlayerWidget(playingState.audioNote!),
           ),
         ),
       );


### PR DESCRIPTION
This PR changes the navigation to the audio player(s). Previously, when trying to play audio in the list of linked entries, e.g. on a task, required navigation to a new details page for the audio entry. This was cumbersome and annoying. Now instead, the audio player is shown inline.