### PR TITLE
Fix Sync getting stuck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed:
+- Sync assistant styling
+
+## [0.8.329] - 2023-04-23
+### Changed:
 - Upgrade flutter_quill lib
 
 ## [0.8.328] - 2023-04-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed:
 - Sync assistant styling
+- Upgraded dependencies
 
 ## [0.8.329] - 2023-04-23
 ### Changed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sync assistant styling
 - Upgraded dependencies
 
+### Fixed:
+- Sync getting stuck after generating new sync key and on reading sync message encrypted with old key
+
 ## [0.8.329] - 2023-04-23
 ### Changed:
 - Upgrade flutter_quill lib

--- a/lib/pages/settings/sync/sync_assistant_page.dart
+++ b/lib/pages/settings/sync/sync_assistant_page.dart
@@ -136,9 +136,8 @@ class _SlidingTutorial extends State<SlidingTutorial> {
       pageController: _pageController,
       pageCount: widget.pageCount,
       colors: [
-        styleConfig().secondaryTextColor,
+        styleConfig().cardColor.withOpacity(0.7),
         styleConfig().cardColor,
-        styleConfig().secondaryTextColor,
       ],
       child: Stack(
         children: [

--- a/lib/sync/inbox/process_message.dart
+++ b/lib/sync/inbox/process_message.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:cryptography/cryptography.dart';
 import 'package:enough_mail/enough_mail.dart';
 import 'package:flutter/foundation.dart';
 import 'package:lotti/classes/config.dart';
@@ -114,6 +115,14 @@ Future<void> fetchByUid({
       e,
       domain: 'INBOX_SERVICE',
       subDomain: '_fetchByUid',
+    );
+    rethrow;
+  } on SecretBoxAuthenticationError catch (e) {
+    await setLastReadUid(uid);
+    loggingDb.captureException(
+      e,
+      domain: 'INBOX_SERVICE',
+      subDomain: '_fetchByUid skipping',
     );
     rethrow;
   } catch (e, stackTrace) {

--- a/lib/themes/theme.dart
+++ b/lib/themes/theme.dart
@@ -57,9 +57,7 @@ InputDecoration inputDecoration({
       suffixIcon: suffixIcon,
       label: Text(
         labelText ?? '',
-        style: newLabelStyle().copyWith(
-          color: styleConfig().secondaryTextColor,
-        ),
+        style: newLabelStyle(),
         semanticsLabel: semanticsLabel,
       ),
     );

--- a/lib/themes/theme.dart
+++ b/lib/themes/theme.dart
@@ -170,11 +170,6 @@ TextStyle buttonLabelStyleLarger() => TextStyle(
       fontSize: 20,
     );
 
-TextStyle settingsLabelStyle() => TextStyle(
-      color: styleConfig().primaryTextColor,
-      fontSize: fontSizeMedium,
-    );
-
 TextStyle choiceLabelStyle() => TextStyle(
       color: styleConfig().primaryTextColor,
       fontSize: fontSizeMedium,

--- a/lib/widgets/sync/imap_config_form.dart
+++ b/lib/widgets/sync/imap_config_form.dart
@@ -33,7 +33,7 @@ class _ImapConfigFormState extends State<ImapConfigForm> {
     return BlocBuilder<SyncConfigCubit, SyncConfigState>(
       builder: (context, SyncConfigState state) {
         return SizedBox(
-          height: 300,
+          height: 330,
           child: state.when(
             configured: (cfg, _) => ConfigForm(
               formKey: formKey,
@@ -98,11 +98,11 @@ class ConfigForm extends StatelessWidget {
             validator: FormBuilderValidators.required(),
             style: inputStyle(),
             keyboardAppearance: keyboardAppearance(),
-            decoration: InputDecoration(
+            decoration: inputDecoration(
               labelText: localizations.settingsSyncHostLabel,
-              labelStyle: settingsLabelStyle(),
             ),
           ),
+          const SizedBox(height: 20),
           FormBuilderTextField(
             name: 'imap_userName',
             key: const Key('imap_user_name_form_field'),
@@ -110,11 +110,11 @@ class ConfigForm extends StatelessWidget {
             validator: FormBuilderValidators.required(),
             style: inputStyle(),
             keyboardAppearance: keyboardAppearance(),
-            decoration: InputDecoration(
+            decoration: inputDecoration(
               labelText: localizations.settingsSyncUserLabel,
-              labelStyle: settingsLabelStyle(),
             ),
           ),
+          const SizedBox(height: 20),
           FormBuilderTextField(
             name: 'imap_password',
             key: const Key('imap_password_form_field'),
@@ -123,11 +123,11 @@ class ConfigForm extends StatelessWidget {
             validator: FormBuilderValidators.required(),
             style: inputStyle(),
             keyboardAppearance: keyboardAppearance(),
-            decoration: InputDecoration(
+            decoration: inputDecoration(
               labelText: localizations.settingsSyncPasswordLabel,
-              labelStyle: settingsLabelStyle(),
             ),
           ),
+          const SizedBox(height: 20),
           FormBuilderTextField(
             name: 'imap_port',
             key: const Key('imap_port_form_field'),
@@ -135,9 +135,8 @@ class ConfigForm extends StatelessWidget {
             validator: FormBuilderValidators.integer(),
             style: inputStyle(),
             keyboardAppearance: keyboardAppearance(),
-            decoration: InputDecoration(
+            decoration: inputDecoration(
               labelText: localizations.settingsSyncPortLabel,
-              labelStyle: settingsLabelStyle(),
             ),
           ),
         ],

--- a/lib/widgets/sync/imap_config_status.dart
+++ b/lib/widgets/sync/imap_config_status.dart
@@ -87,16 +87,16 @@ class StatusIndicator extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      height: 24,
-      width: 24,
+      height: 30,
+      width: 30,
       decoration: BoxDecoration(
         color: statusColor,
         shape: BoxShape.circle,
         boxShadow: [
           BoxShadow(
             color: statusColor,
-            blurRadius: 8,
-            spreadRadius: 2,
+            blurRadius: 5,
+            spreadRadius: 1,
           )
         ],
       ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -598,10 +598,10 @@ packages:
     dependency: transitive
     description:
       name: extended_image_library
-      sha256: b1de389378589e4dffb3564d782373238f19064037458092c49b3043b2791b2b
+      sha256: "550743b43ab093aed35ef234500fcc7a304cbac1eca47b0cc991e07e88750758"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.1"
+    version: "3.4.2"
   fake_async:
     dependency: transitive
     description:
@@ -989,10 +989,10 @@ packages:
     dependency: "direct main"
     description:
       name: get_it
-      sha256: "290fde3a86072e4b37dbb03c07bec6126f0ecc28dad403c12ffe2e5a2d751ab7"
+      sha256: f9982979e3d2f286a957c04d2c3a98f55b0f0a06ffd6c5c4abbb96f06937f463
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.0"
+    version: "7.3.0"
   glados:
     dependency: "direct dev"
     description:
@@ -2279,7 +2279,7 @@ packages:
     source: hosted
     version: "3.0.7"
   vector_graphics:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: vector_graphics
       sha256: ea8d3fc7b2e0f35de38a7465063ecfcf03d8217f7962aa2a6717132cb5d43a79

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.329+2027
+version: 0.9.330+2028
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.330+2030
+version: 0.9.330+2032
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.330+2028
+version: 0.9.330+2030
 
 msix_config:
   display_name: LottiApp
@@ -138,6 +138,7 @@ dependencies:
   tuple: ^2.0.0
   url_launcher: ^6.1.2
   uuid: ^3.0.4
+  vector_graphics: 1.1.5
   visibility_detector: ^0.4.0+2
   wechat_assets_picker: ^8.4.1
   week_of_year: ^2.0.0


### PR DESCRIPTION
This PR fixes a condition where sync would get stuck when a participant node would encounter a message that does not match the latest sync key. This would happen when regenerating a new sync key, and then creating another message, e.g. on another device, that was not updated with the latest key.

Resolves #1493.