### PR TITLE
Fix location on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed:
+- Location on Linux
+
+## [0.8.331] - 2023-04-25
 ### Added:
 - Audio playback on Linux
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.331+2038
+version: 0.9.332+2040
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This commit fixes retrieving geolocation on Linux if enabled. Previously, asking for permission caused an error as that isn't working on Linux.

Resolves #1513. 