### PR TITLE
Split APKs by architecture to reduce APK size

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -200,56 +200,20 @@ steps:
 
 #  #################
 
-  - label: ":android: Bundle "
-    key: "android_bundle"
+  - label: ":android: Bundle & Release"
+    key: "android_bundle_release"
     depends_on:
       - "codegen_test"
     command:
       - "rsync -ar /tmp/buildkite/${BUILDKITE_COMMIT}/ ./"
       - "flutter build appbundle"
-      - "rsync -ar ./ /tmp/buildkite/${BUILDKITE_COMMIT}/"
+      - "flutter build apk --split-per-abi"
+      - "gh release upload ${BUILDKITE_BRANCH} build/app/outputs/bundle/release/app-release.aab"
+      - "gh release upload ${BUILDKITE_BRANCH} build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk"
+      - "gh release upload ${BUILDKITE_BRANCH} build/app/outputs/flutter-apk/app-arm64-v8a-release.apk"
+      - "gh release upload ${BUILDKITE_BRANCH} build/app/outputs/flutter-apk/app-x86_64-release.apk"
     agents:
       os: "macOS"
     retry:
       automatic:
         - exit_status: 24
-
-#  #################
-
-  - group: ":android: :github: Release"
-    key: "android_github_release"
-    depends_on:
-      - "android_bundle"
-    steps:
-      - label: ":android: Android create APKs "
-        key: "android_apks"
-        depends_on:
-          - "android_bundle"
-        command:
-          - "rsync -ar /tmp/buildkite/${BUILDKITE_COMMIT}/ ./"
-          - "bundletool build-apks --mode universal --bundle build/app/outputs/bundle/release/app-release.aab --output build/android/lotti.apks --overwrite"
-          - "cp build/android/lotti.apks build/android/lotti.zip"
-          - "cd build/android && unzip lotti.zip && cd -"
-          - "rsync -ar --exclude 'build/ios' --exclude 'build/macos' ./ /tmp/buildkite/${BUILDKITE_COMMIT}/"
-        agents:
-          os: "macOS"
-        retry:
-          automatic:
-            - exit_status: 24
-
-      - label: ":android: 🚀 publish :github: Prerelease "
-        key: "android_github_prerelease"
-        depends_on:
-          - "create_github_prerelease"
-          - "android_apks"
-        command:
-          - "rsync -ar /tmp/buildkite/${BUILDKITE_COMMIT}/ ./"
-          - "cp build/android/universal.apk build/android/lotti.apk"
-          - "gh release upload ${BUILDKITE_BRANCH} build/android/lotti.apk"
-          - "cp build/app/outputs/bundle/release/app-release.aab build/android/lotti.aab"
-          - "gh release upload ${BUILDKITE_BRANCH} build/android/lotti.aab"
-        agents:
-          os: "macOS"
-        retry:
-          automatic:
-            - exit_status: 24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed:
+- Reduced APK size
+
+## [0.8.332] - 2023-04-26
 ### Fixed:
 - Location on Linux
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.332+2040
+version: 0.9.333+2041
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
Thanks to @alexmercerind, this PR results in reasonably sized APKs by architecture instead of one large 130 MB APK for all platforms:

![image](https://user-images.githubusercontent.com/1390808/234664461-aa0d2f3e-4114-42b3-b523-3cf2c0d661b8.png)

Resolves #1515.