### PR TITLE
Bump package:media_kit_libs_android_audio

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -103,7 +103,7 @@ dependencies:
   lottie: ^2.2.0
   material_design_icons_flutter: ^6.0.7096
   media_kit: ^0.0.7
-  media_kit_libs_android_audio: ^1.0.2
+  media_kit_libs_android_audio: ^1.0.3
   media_kit_libs_ios_audio: ^1.0.4
   media_kit_libs_linux: ^1.0.2
   media_kit_libs_macos_audio: ^1.0.5


### PR DESCRIPTION
Resolves #1524.

<hr>

I apologize for the inconvenience. Most of our focus has been on video libraries & audio libraries got less attention & testing.

Now I've resolved it. Aiming to address every corner before 1.0.0.

**Off-Topic:** My own personal [project uses package:media_kit (for audio)](https://harmonoid.com/) on Windows & GNU/Linux. I need to find some time & update it to use media_kit on Android too. package:media_kit started from desktop platforms first.