### PR TITLE
Windows: app-specific data folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show config flag for invalid cert
 - App documents folder on Windows
 
+### Fixed:
+- App ID on Windows and Linux
+
 ### Added:
 - Save and restore window position on Windows and Linux
 - HotKey support on Windows and Linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed:
 - Updated dependencies
 - Show config flag for invalid cert
+- App documents folder on Windows
 
 ### Added:
 - Save and restore window position on Windows and Linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed:
-- Updated dependencies
+- Upgraded dependencies
 - Show config flag for invalid cert
 - App documents folder on Windows
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,9 +11,9 @@ import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/window_service.dart';
 import 'package:lotti/sync/secure_storage.dart';
+import 'package:lotti/utils/file_utils.dart';
 import 'package:lotti/utils/platform.dart';
 import 'package:media_kit/media_kit.dart';
-import 'package:path_provider/path_provider.dart';
 import 'package:timezone/data/latest.dart' as tz;
 import 'package:window_manager/window_manager.dart';
 
@@ -26,7 +26,7 @@ Future<void> main() async {
     await hotKeyManager.unregisterAll();
   }
 
-  final docDir = await getApplicationDocumentsDirectory();
+  final docDir = await findDocumentsDirectory();
 
   getIt
     ..registerSingleton<SecureStorage>(SecureStorage())

--- a/lib/utils/file_utils.dart
+++ b/lib/utils/file_utils.dart
@@ -1,11 +1,13 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:intl/intl.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/utils/audio_utils.dart';
 import 'package:lotti/utils/image_utils.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:uuid/uuid.dart';
 
 Uuid uuid = const Uuid();
@@ -76,4 +78,16 @@ Future<String> createAssetDirectory(String relativePath) async {
 
 Directory getDocumentsDirectory() {
   return getIt<Directory>();
+}
+
+Future<Directory> findDocumentsDirectory() async {
+  final docDir = await getApplicationDocumentsDirectory();
+  final appSupportDir = await getApplicationSupportDirectory();
+  debugPrint('appSupportDir $appSupportDir');
+
+  if (Platform.isWindows) {
+    return appSupportDir;
+  } else {
+    return docDir;
+  }
 }

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 project(runner LANGUAGES CXX)
 
 set(BINARY_NAME "lotti")
-set(APPLICATION_ID "com.example.lotti")
+set(APPLICATION_ID "com.matthiasnehlsen.lotti")
 
 cmake_policy(SET CMP0063 NEW)
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -854,10 +854,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_quill
-      sha256: b6e48dd5e0e40ee740ac926338f8ab36a038a4c3037429c2a8491b603c250bc1
+      sha256: "803d39a210f5aaa7b9d1a999ef1dac5fef4931916483f23a196fcc6e5cd75ee1"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.13"
+    version: "7.1.14"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -1259,10 +1259,10 @@ packages:
     dependency: transitive
     description:
       name: markdown
-      sha256: d95a9d12954aafc97f984ca29baaa7690ed4d9ec4140a23ad40580bcdb6c87f5
+      sha256: "8e332924094383133cee218b676871f42db2514f1f6ac617b6cf6152a7faab8e"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.2"
+    version: "7.1.0"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.341+2058
+version: 0.9.341+2059
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.341+2057
+version: 0.9.341+2058
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.341+2056
+version: 0.9.341+2057
 
 msix_config:
   display_name: LottiApp

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -89,13 +89,13 @@ BEGIN
     BEGIN
         BLOCK "040904e4"
         BEGIN
-            VALUE "CompanyName", "com.example" "\0"
-            VALUE "FileDescription", "A new Flutter project." "\0"
+            VALUE "CompanyName", "com.matthiasnehlsen" "\0"
+            VALUE "FileDescription", "Achieve your goals and keep your data private with Lotti." "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
-            VALUE "InternalName", "lotti" "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2022 com.example. All rights reserved." "\0"
+            VALUE "InternalName", "Lotti" "\0"
+            VALUE "LegalCopyright", "Copyright (C) 2022 Matthias Nehlsen. All rights reserved." "\0"
             VALUE "OriginalFilename", "lotti.exe" "\0"
-            VALUE "ProductName", "lotti" "\0"
+            VALUE "ProductName", "Lotti" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END


### PR DESCRIPTION
This PR changes app data storage on Windows from the general `Documents` folder to an app-specific folder.

Existing data needs to be moved after installing the latest version.

Resolves #1534.