### PR TITLE
Remove `adaptive_dialog` library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed:
+- Remove `adaptive_dialog` library
+
+## [0.8.347] - 2023-05-13
 ### Added:
 - Settings page for downloading and activating whisper models
 - Download whisper.cpp models from Hugging Face

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed:
 - Remove `adaptive_dialog` library
 
+### Fixed:
+- Flutter 3.10 warnings
+
 ## [0.8.347] - 2023-05-13
 ### Added:
 - Settings page for downloading and activating whisper models

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed:
 - Remove `adaptive_dialog` library
+- Upgraded dependencies & removing unused
 
 ### Fixed:
 - Flutter 3.10 warnings

--- a/lib/database/sync_db.dart
+++ b/lib/database/sync_db.dart
@@ -91,7 +91,7 @@ class SyncDatabase extends _$SyncDatabase {
   }
 
   Future<int> deleteOutboxItems() {
-    return (delete(outbox)).go();
+    return delete(outbox).go();
   }
 
   @override

--- a/lib/pages/settings/categories/category_details_page.dart
+++ b/lib/pages/settings/categories/category_details_page.dart
@@ -1,4 +1,3 @@
-import 'package:adaptive_dialog/adaptive_dialog.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
@@ -13,6 +12,8 @@ import 'package:lotti/pages/empty_scaffold.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/widgets/app_bar/title_app_bar.dart';
 import 'package:lotti/widgets/categories/select_color_field.dart';
+import 'package:lotti/widgets/modal/modal_action_sheet.dart';
+import 'package:lotti/widgets/modal/modal_sheet_action.dart';
 import 'package:lotti/widgets/settings/form/form_switch.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
@@ -140,7 +141,7 @@ class CategoryDetailsPage extends StatelessWidget {
                                     context: context,
                                     title: localizations.categoryDeleteQuestion,
                                     actions: [
-                                      SheetAction(
+                                      ModalSheetAction(
                                         icon: Icons.warning,
                                         label:
                                             localizations.categoryDeleteConfirm,

--- a/lib/pages/settings/conflicts_page.dart
+++ b/lib/pages/settings/conflicts_page.dart
@@ -255,7 +255,7 @@ class ConflictDetailRoute extends StatelessWidget {
                           onPressed: () {
                             Clipboard.setData(
                               ClipboardData(
-                                text: fromSync.entryText?.plainText,
+                                text: fromSync.entryText?.plainText ?? '',
                               ),
                             );
                           },

--- a/lib/pages/settings/dashboards/dashboard_definition_page.dart
+++ b/lib/pages/settings/dashboards/dashboard_definition_page.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 
-import 'package:adaptive_dialog/adaptive_dialog.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
@@ -19,6 +18,8 @@ import 'package:lotti/widgets/app_bar/title_app_bar.dart';
 import 'package:lotti/widgets/charts/dashboard_health_config.dart';
 import 'package:lotti/widgets/charts/dashboard_survey_data.dart';
 import 'package:lotti/widgets/charts/dashboard_workout_config.dart';
+import 'package:lotti/widgets/modal/modal_action_sheet.dart';
+import 'package:lotti/widgets/modal/modal_sheet_action.dart';
 import 'package:lotti/widgets/settings/dashboards/dashboard_category.dart';
 import 'package:lotti/widgets/settings/form/form_switch.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
@@ -565,7 +566,7 @@ class _DashboardDefinitionPageState extends State<DashboardDefinitionPage> {
                                           title: localizations
                                               .dashboardDeleteQuestion,
                                           actions: [
-                                            SheetAction(
+                                            ModalSheetAction(
                                               icon: Icons.warning,
                                               label: localizations
                                                   .dashboardDeleteConfirm,

--- a/lib/pages/settings/habits/habit_details_page.dart
+++ b/lib/pages/settings/habits/habit_details_page.dart
@@ -1,4 +1,3 @@
-import 'package:adaptive_dialog/adaptive_dialog.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -16,6 +15,8 @@ import 'package:lotti/widgets/app_bar/title_app_bar.dart';
 import 'package:lotti/widgets/date_time/datetime_field.dart';
 import 'package:lotti/widgets/habits/habit_category.dart';
 import 'package:lotti/widgets/habits/habit_dashboard.dart';
+import 'package:lotti/widgets/modal/modal_action_sheet.dart';
+import 'package:lotti/widgets/modal/modal_sheet_action.dart';
 import 'package:lotti/widgets/settings/form/form_switch.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
@@ -147,7 +148,7 @@ class HabitDetailsPage extends StatelessWidget {
                                   context: context,
                                   title: localizations.habitDeleteQuestion,
                                   actions: [
-                                    SheetAction(
+                                    ModalSheetAction(
                                       icon: Icons.warning,
                                       label: localizations.habitDeleteConfirm,
                                       key: deleteKey,

--- a/lib/pages/settings/measurables/measurable_details_page.dart
+++ b/lib/pages/settings/measurables/measurable_details_page.dart
@@ -1,4 +1,3 @@
-import 'package:adaptive_dialog/adaptive_dialog.dart';
 import 'package:enum_to_string/enum_to_string.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
@@ -11,6 +10,8 @@ import 'package:lotti/pages/empty_scaffold.dart';
 import 'package:lotti/pages/settings/form_text_field.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/widgets/app_bar/title_app_bar.dart';
+import 'package:lotti/widgets/modal/modal_action_sheet.dart';
+import 'package:lotti/widgets/modal/modal_sheet_action.dart';
 import 'package:lotti/widgets/settings/form/form_switch.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
@@ -190,7 +191,7 @@ class _MeasurableDetailsPageState extends State<MeasurableDetailsPage> {
                               context: context,
                               title: localizations.measurableDeleteQuestion,
                               actions: [
-                                SheetAction(
+                                ModalSheetAction(
                                   icon: Icons.warning,
                                   label: localizations.measurableDeleteConfirm,
                                   key: deleteKey,

--- a/lib/surveys/calculate.dart
+++ b/lib/surveys/calculate.dart
@@ -15,8 +15,8 @@ Map<String, int> calculateScores({
     var score = 0;
 
     for (final questionId in scoreDefinition.value) {
-      final stepResult = results[questionId] as RPStepResult;
-      final choice = stepResult.results['answer'] as RPImageChoice;
+      final stepResult = results[questionId] as RPStepResult?;
+      final choice = stepResult?.results['answer'] as RPImageChoice;
       final value = choice.value as int;
       score = score + value;
     }

--- a/lib/widgets/journal/entry_detail_linked.dart
+++ b/lib/widgets/journal/entry_detail_linked.dart
@@ -1,4 +1,3 @@
-import 'package:adaptive_dialog/adaptive_dialog.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lotti/classes/journal_entities.dart';
@@ -6,6 +5,8 @@ import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/widgets/journal/entry_details_widget.dart';
+import 'package:lotti/widgets/modal/modal_action_sheet.dart';
+import 'package:lotti/widgets/modal/modal_sheet_action.dart';
 
 class LinkedEntriesWidget extends StatelessWidget {
   const LinkedEntriesWidget({
@@ -47,7 +48,7 @@ class LinkedEntriesWidget extends StatelessWidget {
                       context: context,
                       title: localizations.journalUnlinkQuestion,
                       actions: [
-                        SheetAction(
+                        ModalSheetAction(
                           icon: Icons.warning,
                           label: localizations.journalUnlinkConfirm,
                           key: unlinkKey,

--- a/lib/widgets/journal/entry_details/delete_icon_widget.dart
+++ b/lib/widgets/journal/entry_details/delete_icon_widget.dart
@@ -1,10 +1,11 @@
-import 'package:adaptive_dialog/adaptive_dialog.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lotti/blocs/journal/entry_cubit.dart';
 import 'package:lotti/blocs/journal/entry_state.dart';
 import 'package:lotti/themes/theme.dart';
+import 'package:lotti/widgets/modal/modal_action_sheet.dart';
+import 'package:lotti/widgets/modal/modal_sheet_action.dart';
 
 class DeleteIconWidget extends StatelessWidget {
   const DeleteIconWidget({
@@ -31,7 +32,7 @@ class DeleteIconWidget extends StatelessWidget {
             context: context,
             title: localizations.journalDeleteQuestion,
             actions: [
-              SheetAction(
+              ModalSheetAction(
                 icon: Icons.warning,
                 label: localizations.journalDeleteConfirm,
                 key: deleteKey,

--- a/lib/widgets/modal/modal_action_sheet.dart
+++ b/lib/widgets/modal/modal_action_sheet.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/themes/theme.dart';
+import 'package:lotti/widgets/modal/modal_sheet_action.dart';
+import 'package:meta/meta.dart';
+
+@useResult
+Future<T?> showModalActionSheet<T>({
+  required BuildContext context,
+  String? title,
+  String? message,
+  List<ModalSheetAction<T>> actions = const [],
+  String? cancelLabel,
+  bool isDismissible = true,
+  bool useRootNavigator = true,
+}) {
+  return showModalBottomSheet(
+    constraints: const BoxConstraints(maxHeight: 150),
+    context: context,
+    isScrollControlled: false,
+    isDismissible: isDismissible,
+    useRootNavigator: useRootNavigator,
+    builder: (context) {
+      return ColoredBox(
+        color: styleConfig().cardColor,
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(20),
+              child: Text(
+                title ?? '',
+                style:
+                    settingsCardTextStyle().copyWith(fontSize: fontSizeMedium),
+              ),
+            ),
+            ...actions.map((action) {
+              final color = action.isDestructiveAction
+                  ? styleConfig().alarm
+                  : styleConfig().primaryColor;
+
+              void pop() {
+                Navigator.pop<T>(context, action.key);
+              }
+
+              return Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 10),
+                child: TextButton(
+                  onPressed: pop,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(
+                        action.icon,
+                        color: color,
+                      ),
+                      const SizedBox(width: 10),
+                      Text(
+                        action.label,
+                        style: settingsCardTextStyle().copyWith(color: color),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            }),
+          ],
+        ),
+      );
+    },
+  );
+}

--- a/lib/widgets/modal/modal_sheet_action.dart
+++ b/lib/widgets/modal/modal_sheet_action.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/widgets.dart';
+
+@immutable
+class ModalSheetAction<T> {
+  const ModalSheetAction({
+    required this.label,
+    this.key,
+    this.icon,
+    this.isDefaultAction = false,
+    this.isDestructiveAction = false,
+  });
+
+  final String label;
+
+  /// Only works for Material Style
+  final IconData? icon;
+
+  /// Used for checking selection result
+  final T? key;
+
+  /// Make font weight to bold(Only works for CupertinoStyle).
+  final bool isDefaultAction;
+
+  /// Make font color to destructive/error color(red).
+  final bool isDestructiveAction;
+}

--- a/lib/widgets/search/tasks_segmented_control.dart
+++ b/lib/widgets/search/tasks_segmented_control.dart
@@ -10,6 +10,8 @@ class TasksSegmentedControl extends StatelessWidget {
   });
 
   final bool showTasks;
+
+  // ignore: avoid_positional_boolean_parameters
   final void Function(bool) onValueChanged;
 
   @override

--- a/lib/widgets/sync/qr_widget.dart
+++ b/lib/widgets/sync/qr_widget.dart
@@ -142,7 +142,7 @@ class EncryptionQrWidget extends StatelessWidget {
                               ),
                             );
                           },
-                          child: QrImage(
+                          child: QrImageView(
                             data: syncCfgJson,
                             size: 280,
                             key: const Key('QrImage'),

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,7 +6,6 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <dynamic_color/dynamic_color_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <hotkey_manager/hotkey_manager_plugin.h>
 #include <media_kit_libs_linux/media_kit_libs_linux_plugin.h>
@@ -18,9 +17,6 @@
 #include <window_manager/window_manager_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
-  g_autoptr(FlPluginRegistrar) dynamic_color_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "DynamicColorPlugin");
-  dynamic_color_plugin_register_with_registrar(dynamic_color_registrar);
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,7 +3,6 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
-  dynamic_color
   flutter_secure_storage_linux
   hotkey_manager
   media_kit_libs_linux

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,14 +7,12 @@ import Foundation
 
 import connectivity_plus
 import device_info_plus
-import dynamic_color
 import ffmpeg_kit_flutter
 import flutter_local_notifications
 import flutter_native_timezone
 import flutter_secure_storage_macos
 import hotkey_manager
 import location
-import macos_ui
 import media_kit_libs_macos_audio
 import package_info_plus
 import pasteboard
@@ -32,14 +30,12 @@ import window_manager
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   ConnectivityPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
-  DynamicColorPlugin.register(with: registry.registrar(forPlugin: "DynamicColorPlugin"))
   FFmpegKitFlutterPlugin.register(with: registry.registrar(forPlugin: "FFmpegKitFlutterPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterNativeTimezonePlugin.register(with: registry.registrar(forPlugin: "FlutterNativeTimezonePlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   HotkeyManagerPlugin.register(with: registry.registrar(forPlugin: "HotkeyManagerPlugin"))
   LocationPlugin.register(with: registry.registrar(forPlugin: "LocationPlugin"))
-  MacOSUiPlugin.register(with: registry.registrar(forPlugin: "MacOSUiPlugin"))
   MediaKitLibsMacosAudioPlugin.register(with: registry.registrar(forPlugin: "MediaKitLibsMacosAudioPlugin"))
   FLTPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FLTPackageInfoPlusPlugin"))
   PasteboardPlugin.register(with: registry.registrar(forPlugin: "PasteboardPlugin"))

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -4,8 +4,6 @@ PODS:
     - ReachabilitySwift
   - device_info_plus (0.0.1):
     - FlutterMacOS
-  - dynamic_color (0.0.2):
-    - FlutterMacOS
   - ffmpeg-kit-macos-https (5.1)
   - ffmpeg_kit_flutter (5.1.0):
     - ffmpeg_kit_flutter/https (= 5.1.0)
@@ -28,8 +26,6 @@ PODS:
     - FlutterMacOS
     - HotKey
   - location (0.0.1):
-    - FlutterMacOS
-  - macos_ui (0.1.0):
     - FlutterMacOS
   - media_kit_libs_macos_audio (1.0.4):
     - FlutterMacOS
@@ -81,7 +77,6 @@ PODS:
 DEPENDENCIES:
   - connectivity_plus (from `Flutter/ephemeral/.symlinks/plugins/connectivity_plus/macos`)
   - device_info_plus (from `Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos`)
-  - dynamic_color (from `Flutter/ephemeral/.symlinks/plugins/dynamic_color/macos`)
   - ffmpeg_kit_flutter (from `Flutter/ephemeral/.symlinks/plugins/ffmpeg_kit_flutter/macos`)
   - flutter_local_notifications (from `Flutter/ephemeral/.symlinks/plugins/flutter_local_notifications/macos`)
   - flutter_native_timezone (from `Flutter/ephemeral/.symlinks/plugins/flutter_native_timezone/macos`)
@@ -89,7 +84,6 @@ DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
   - hotkey_manager (from `Flutter/ephemeral/.symlinks/plugins/hotkey_manager/macos`)
   - location (from `Flutter/ephemeral/.symlinks/plugins/location/macos`)
-  - macos_ui (from `Flutter/ephemeral/.symlinks/plugins/macos_ui/macos`)
   - media_kit_libs_macos_audio (from `Flutter/ephemeral/.symlinks/plugins/media_kit_libs_macos_audio/macos`)
   - media_kit_native_event_loop (from `Flutter/ephemeral/.symlinks/plugins/media_kit_native_event_loop/macos`)
   - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
@@ -118,8 +112,6 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/connectivity_plus/macos
   device_info_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos
-  dynamic_color:
-    :path: Flutter/ephemeral/.symlinks/plugins/dynamic_color/macos
   ffmpeg_kit_flutter:
     :path: Flutter/ephemeral/.symlinks/plugins/ffmpeg_kit_flutter/macos
   flutter_local_notifications:
@@ -134,8 +126,6 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/hotkey_manager/macos
   location:
     :path: Flutter/ephemeral/.symlinks/plugins/location/macos
-  macos_ui:
-    :path: Flutter/ephemeral/.symlinks/plugins/macos_ui/macos
   media_kit_libs_macos_audio:
     :path: Flutter/ephemeral/.symlinks/plugins/media_kit_libs_macos_audio/macos
   media_kit_native_event_loop:
@@ -168,7 +158,6 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   connectivity_plus: 18d3c32514c886e046de60e9c13895109866c747
   device_info_plus: 5401765fde0b8d062a2f8eb65510fb17e77cf07f
-  dynamic_color: 2eaa27267de1ca20d879fbd6e01259773fb1670f
   ffmpeg-kit-macos-https: ff9c8479ed36b20a4e07b265e1bddd36d62a7d7b
   ffmpeg_kit_flutter: de6ad9df446c3b70c34033f49a163d05313eea61
   flutter_local_notifications: 3805ca215b2fb7f397d78b66db91f6a747af52e4
@@ -179,7 +168,6 @@ SPEC CHECKSUMS:
   HotKey: ad59450195936c10992438c4210f673de5aee43e
   hotkey_manager: ad673457691f4d39e481be04a61da2ae07d81c62
   location: 7cdb0665bd6577d382b0a343acdadbcb7f964775
-  macos_ui: 6229a8922cd97bafb7d9636c8eb8dfb0744183ca
   media_kit_libs_macos_audio: 1c2b0099843763fefd0939bae1f6a2ada534f58f
   media_kit_native_event_loop: 81f3d1888a9bd283e5416276fd5716aa331d1751
   package_info_plus: 02d7a575e80f194102bef286361c6c326e4c29ce

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -9,14 +9,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "60.0.0"
-  adaptive_dialog:
-    dependency: "direct main"
-    description:
-      name: adaptive_dialog
-      sha256: "665e90c9eecdbf0aa953a9e1fce5da6c8db3d3357c450262b9c534a54e939119"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.8.3"
   analyzer:
     dependency: "direct dev"
     description:
@@ -33,14 +25,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.11.2"
-  animations:
-    dependency: transitive
-    description:
-      name: animations
-      sha256: fe8a6bdca435f718bb1dc8a11661b2c22504c6da40ef934cee8327ed77934164
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.7"
   ansicolor:
     dependency: transitive
     description:
@@ -506,14 +490,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.8.0"
-  dynamic_color:
-    dependency: transitive
-    description:
-      name: dynamic_color
-      sha256: bbebb1b7ebed819e0ec83d4abdc2a8482d934f6a85289ffc1c6acf7589fa2aad
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.6.3"
   easy_debounce:
     dependency: "direct main"
     description:
@@ -1279,14 +1255,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
-  macos_ui:
-    dependency: transitive
-    description:
-      name: macos_ui
-      sha256: "57208eec8180656acd379e1c754e9b6d8830f32a020b94571ae2188f8112075b"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.12.2"
   markdown:
     dependency: transitive
     description:
@@ -1384,7 +1352,7 @@ packages:
     source: hosted
     version: "1.0.3"
   meta:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: meta
       sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -65,14 +65,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
-  assorted_layout_widgets:
-    dependency: "direct main"
-    description:
-      name: assorted_layout_widgets
-      sha256: "5ffa446e84acb0352f2dd16847c2d0ff364e1aa1df628023ac43b8cbd6fc7c01"
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.0.1"
   async:
     dependency: transitive
     description:
@@ -1287,14 +1279,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.7096"
-  matrix4_transform:
-    dependency: transitive
-    description:
-      name: matrix4_transform
-      sha256: "6ddeaa2c0e1f5c3f3a197f552377570b3e54fa0b8bf48507728a216fc0fd78a6"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
   media_kit:
     dependency: "direct main"
     description:
@@ -1715,10 +1699,10 @@ packages:
     dependency: transitive
     description:
       name: qr
-      sha256: "5c4208b4dc0d55c3184d10d83ee0ded6212dc2b5e2ba17c5a0c0aab279128d21"
+      sha256: "64957a3930367bf97cc211a5af99551d630f2f4625e38af10edd6b19131b64b3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "3.0.1"
   qr_code_scanner:
     dependency: "direct main"
     description:
@@ -1731,10 +1715,10 @@ packages:
     dependency: "direct main"
     description:
       name: qr_flutter
-      sha256: c5c121c54cb6dd837b9b9d57eb7bc7ec6df4aee741032060c8833a678c80b87e
+      sha256: "5095f0fc6e3f71d08adef8feccc8cea4f12eec18a2e31c2e8d82cb6019f4b097"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "4.1.0"
   quiver:
     dependency: "direct main"
     description:
@@ -2511,5 +2495,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">2.19.0 <3.0.0"
+  dart: ">=2.19.6 <3.0.0"
   flutter: ">=3.7.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.347+2112
+version: 0.9.348+2113
 
 msix_config:
   display_name: LottiApp
@@ -18,7 +18,6 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  adaptive_dialog: ^1.3.0
   arb_utils: ^0.3.0
   assorted_layout_widgets: ^7.0.0
   audio_video_progress_bar: ^1.0.0
@@ -111,6 +110,7 @@ dependencies:
   media_kit_libs_macos_audio: ^1.0.5
   media_kit_libs_windows_audio: ^1.0.3
   media_kit_native_event_loop: ^1.0.3
+  meta: ^1.8.0
   multi_select_flutter: ^4.0.0
   package_info_plus: ^3.1.0
   path: ^1.8.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.348+2113
+version: 0.9.348+2114
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.348+2114
+version: 0.9.348+2115
 
 msix_config:
   display_name: LottiApp
@@ -19,7 +19,6 @@ environment:
 
 dependencies:
   arb_utils: ^0.3.0
-  assorted_layout_widgets: ^7.0.0
   audio_video_progress_bar: ^1.0.0
   auto_size_text: ^3.0.0
   beamer: ^1.5.2

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,7 +7,6 @@
 #include "generated_plugin_registrant.h"
 
 #include <connectivity_plus/connectivity_plus_windows_plugin.h>
-#include <dynamic_color/dynamic_color_plugin_c_api.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <hotkey_manager/hotkey_manager_plugin.h>
 #include <media_kit_libs_windows_audio/media_kit_libs_windows_audio_plugin_c_api.h>
@@ -23,8 +22,6 @@
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   ConnectivityPlusWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
-  DynamicColorPluginCApiRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("DynamicColorPluginCApi"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   HotkeyManagerPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,7 +4,6 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   connectivity_plus
-  dynamic_color
   flutter_secure_storage_windows
   hotkey_manager
   media_kit_libs_windows_audio


### PR DESCRIPTION
This PR removes the `adaptive_dialog` library, which was causing problems in the attempt to upgrade to Flutter 3.10.