### PR TITLE
Fix crashes when attempting simultaneous transcriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed:
+- Crashes when attempting simultaneous transcriptions
+
+## [0.8.357] - 2023-05-22
 ### Changed:
 - Upgraded dependencies
 - Larger map with interaction

--- a/lib/blocs/audio/player_cubit.dart
+++ b/lib/blocs/audio/player_cubit.dart
@@ -78,7 +78,7 @@ class AudioPlayerCubit extends Cubit<AudioPlayerState> {
       return;
     }
 
-    await _asrService.transcribe(entry: state.audioNote!);
+    await _asrService.enqueue(entry: state.audioNote!);
   }
 
   Future<void> stopPlay() async {

--- a/lib/blocs/audio/recorder_cubit.dart
+++ b/lib/blocs/audio/recorder_cubit.dart
@@ -106,7 +106,7 @@ class AudioRecorderCubit extends Cubit<AudioRecorderState> {
         _linkedId = null;
 
         getIt<NavService>().beamBack();
-        await getIt<AsrService>().transcribe(entry: entry!);
+        await getIt<AsrService>().enqueue(entry: entry!);
       }
     } catch (exception, stackTrace) {
       _loggingDb.captureException(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.357+2161
+version: 0.9.358+2162
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
Resolves #1564 by only allowing one transcript at a time, and enqueuing transcription jobs in an in-memory queue.