### PR TITLE
Smoother scrolling infinite journal page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed:
+- Smoother scrolling infinite journal page
+
+## [0.8.388] - 2023-06-23
+### Changed:
 - Upgraded dependencies
 
 ### Fixed:

--- a/lib/widgets/journal/entry_detail_linked_from.dart
+++ b/lib/widgets/journal/entry_detail_linked_from.dart
@@ -50,6 +50,7 @@ class LinkedFromEntriesWidget extends StatelessWidget {
                       return JournalCard(
                         item: item,
                         key: Key('${item.meta.id}-${item.meta.id}'),
+                        showLinkedDuration: true,
                       );
                     },
                   );

--- a/lib/widgets/journal/entry_details_widget.dart
+++ b/lib/widgets/journal/entry_details_widget.dart
@@ -51,7 +51,10 @@ class EntryDetailWidget extends StatelessWidget {
         final isAudio = item is JournalAudio;
 
         if (isTask && !showTaskDetails) {
-          return JournalCard(item: item);
+          return JournalCard(
+            item: item,
+            showLinkedDuration: true,
+          );
         }
 
         return BlocProvider<EntryCubit>(

--- a/lib/widgets/journal/journal_card.dart
+++ b/lib/widgets/journal/journal_card.dart
@@ -148,12 +148,12 @@ class JournalCardTitle extends StatelessWidget {
   }
 }
 
-class JournalCard extends StatelessWidget {
+class JournalCard extends StatefulWidget {
   const JournalCard({
     required this.item,
     super.key,
     this.maxHeight = 120,
-    this.showLinkedDuration = true,
+    this.showLinkedDuration = false,
   });
 
   final JournalEntity item;
@@ -161,14 +161,19 @@ class JournalCard extends StatelessWidget {
   final bool showLinkedDuration;
 
   @override
+  State<JournalCard> createState() => _JournalCardState();
+}
+
+class _JournalCardState extends State<JournalCard> {
+  @override
   Widget build(BuildContext context) {
     return StreamBuilder<JournalEntity?>(
-      stream: getIt<JournalDb>().watchEntityById(item.meta.id),
+      stream: getIt<JournalDb>().watchEntityById(widget.item.meta.id),
       builder: (
         BuildContext context,
         AsyncSnapshot<JournalEntity?> snapshot,
       ) {
-        final updatedItem = snapshot.data ?? item;
+        final updatedItem = snapshot.data ?? widget.item;
         if (updatedItem.meta.deletedAt != null) {
           return const SizedBox.shrink();
         }
@@ -211,8 +216,8 @@ class JournalCard extends StatelessWidget {
               ),
               title: JournalCardTitle(
                 item: updatedItem,
-                maxHeight: maxHeight,
-                showLinkedDuration: showLinkedDuration,
+                maxHeight: widget.maxHeight,
+                showLinkedDuration: widget.showLinkedDuration,
               ),
               onTap: onTap,
             ),

--- a/lib/widgets/journal/tags/tags_view_widget.dart
+++ b/lib/widgets/journal/tags/tags_view_widget.dart
@@ -6,14 +6,20 @@ import 'package:lotti/services/tags_service.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/themes/utils.dart';
 
-class TagsViewWidget extends StatelessWidget {
-  TagsViewWidget({
+class TagsViewWidget extends StatefulWidget {
+  const TagsViewWidget({
     required this.item,
     super.key,
   });
 
-  final TagsService tagsService = getIt<TagsService>();
   final JournalEntity item;
+
+  @override
+  State<TagsViewWidget> createState() => _TagsViewWidgetState();
+}
+
+class _TagsViewWidgetState extends State<TagsViewWidget> {
+  final TagsService tagsService = getIt<TagsService>();
 
   @override
   Widget build(BuildContext context) {
@@ -26,7 +32,7 @@ class TagsViewWidget extends StatelessWidget {
         // data in the tags service will already have been updated.
         AsyncSnapshot<List<TagEntity>> _,
       ) {
-        final tagIds = item.meta.tagIds ?? [];
+        final tagIds = widget.item.meta.tagIds ?? [];
         final tagsFromTagIds = <TagEntity>[];
 
         for (final tagId in tagIds) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.388+2276
+version: 0.9.389+2277
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR reduces jank on the journal page by removing the display of the cumulated duration of linked entries for tasks when shown on the infinite scrolling page.

Resolves #1628.