### PR TITLE
feat: improve entry preview in journal cards

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -50,9 +50,9 @@ Future<void> main() async {
 
     FlutterError.onError = (FlutterErrorDetails details) {
       getIt<LoggingDb>().captureException(
-        details,
+        details.exception,
         domain: 'MAIN',
-        subDomain: 'onError',
+        subDomain: details.library,
       );
     };
 

--- a/lib/pages/empty_scaffold.dart
+++ b/lib/pages/empty_scaffold.dart
@@ -15,7 +15,7 @@ class EmptyScaffoldWithTitle extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return FadeIn(
-      duration: const Duration(seconds: 2),
+      duration: const Duration(seconds: 1),
       child: Scaffold(
         appBar: TitleAppBar(title: title),
         body: body,

--- a/lib/services/editor_state_service.dart
+++ b/lib/services/editor_state_service.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:easy_debounce/easy_debounce.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:lotti/database/database.dart';
@@ -75,7 +74,6 @@ class EditorStateService {
     required DateTime lastSaved,
     required String json,
   }) {
-    debugPrint('saveTempState $id');
     editorStateById[id] = json;
     selectionById.remove(id);
 

--- a/lib/widgets/journal/editor/editor_styles.dart
+++ b/lib/widgets/journal/editor/editor_styles.dart
@@ -4,9 +4,11 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:lotti/themes/theme.dart';
 
 DefaultStyles customEditorStyles({
-  required Color textColor,
-  required Color codeBlockBackground,
+  required ThemeData themeData,
 }) {
+  final textColor = themeData.textTheme.bodyLarge?.color;
+  final codeBlockBackground = themeData.primaryColorLight;
+
   return DefaultStyles(
     h1: DefaultTextBlockStyle(
       GoogleFonts.plusJakartaSans(

--- a/lib/widgets/journal/editor/editor_widget.dart
+++ b/lib/widgets/journal/editor/editor_widget.dart
@@ -107,11 +107,7 @@ class EditorWidget extends StatelessWidget {
                           ),
                           keyboardAppearance: Theme.of(context).brightness,
                           customStyles: customEditorStyles(
-                            textColor:
-                                Theme.of(context).textTheme.bodyLarge?.color ??
-                                    Colors.grey,
-                            codeBlockBackground:
-                                Theme.of(context).primaryColorLight,
+                            themeData: Theme.of(context),
                           ),
                         ),
                       ),

--- a/lib/widgets/journal/journal_card.dart
+++ b/lib/widgets/journal/journal_card.dart
@@ -126,7 +126,6 @@ class JournalCardTitle extends StatelessWidget {
                         fontSize: fontSizeLarge,
                       ),
                     ),
-                    const SizedBox(height: 8),
                     if (showLinkedDuration) LinkedDuration(task: task),
                     TextViewerWidget(
                       entryText: task.entryText,

--- a/lib/widgets/journal/journal_card.dart
+++ b/lib/widgets/journal/journal_card.dart
@@ -39,7 +39,11 @@ class JournalCardTitle extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 8),
+      padding: const EdgeInsets.only(
+        top: 8,
+        bottom: 8,
+        left: 8,
+      ),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -200,15 +204,8 @@ class _JournalCardState extends State<JournalCard> {
                         : errorColor.withOpacity(0.4),
                   );
                 },
-                journalEntry: (_) => const LeadingIcon(Icons.article),
                 quantitative: (_) => LeadingIcon(MdiIcons.heart),
                 measurement: (_) => LeadingIcon(MdiIcons.numeric),
-                task: (task) => LeadingIcon(
-                  task.data.status.maybeMap(
-                    done: (_) => MdiIcons.checkboxMarkedOutline,
-                    orElse: () => MdiIcons.checkboxBlankOutline,
-                  ),
-                ),
                 habitCompletion: (habitCompletion) =>
                     HabitCompletionColorIcon(habitCompletion.data.habitId),
                 orElse: () => null,

--- a/lib/widgets/journal/text_viewer_widget.dart
+++ b/lib/widgets/journal/text_viewer_widget.dart
@@ -25,21 +25,13 @@ class TextViewerWidget extends StatelessWidget {
     return LimitedBox(
       maxHeight: maxHeight,
       child: QuillProvider(
-        configurations: QuillConfigurations(
-          controller: controller,
-        ),
-        child: Flexible(
-          child: QuillEditor(
-            scrollController: ScrollController(),
-            focusNode: FocusNode(),
-            configurations: QuillEditorConfigurations(
-              readOnly: true,
-              customStyles: customEditorStyles(
-                textColor:
-                    Theme.of(context).textTheme.bodyLarge?.color ?? Colors.grey,
-                codeBlockBackground: Theme.of(context).primaryColorLight,
-              ),
-            ),
+        configurations: QuillConfigurations(controller: controller),
+        child: QuillEditor(
+          scrollController: ScrollController(),
+          focusNode: FocusNode(),
+          configurations: QuillEditorConfigurations(
+            readOnly: true,
+            customStyles: customEditorStyles(themeData: Theme.of(context)),
           ),
         ),
       ),

--- a/lib/widgets/journal/text_viewer_widget.dart
+++ b/lib/widgets/journal/text_viewer_widget.dart
@@ -1,7 +1,9 @@
-import 'package:flutter/cupertino.dart';
-import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:delta_markdown/delta_markdown.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_quill/flutter_quill.dart';
 import 'package:lotti/classes/entry_text.dart';
-import 'package:lotti/themes/theme.dart';
+import 'package:lotti/widgets/journal/editor/editor_styles.dart';
+import 'package:lotti/widgets/journal/editor/editor_tools.dart';
 
 class TextViewerWidget extends StatelessWidget {
   const TextViewerWidget({
@@ -15,17 +17,27 @@ class TextViewerWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final serializedQuill = entryText?.quill;
+    final markdown = entryText?.markdown ?? entryText?.plainText ?? '';
+    final quill = serializedQuill ?? markdownToDelta(markdown);
+    final controller = makeController(serializedQuill: quill);
+
     return LimitedBox(
       maxHeight: maxHeight,
-      child: Markdown(
-        data: entryText?.markdown ?? '',
-        shrinkWrap: true,
-        padding: const EdgeInsets.only(top: 10),
-        styleSheet: MarkdownStyleSheet.fromCupertinoTheme(
-          const CupertinoThemeData(
-            textTheme: CupertinoTextThemeData(
-              textStyle: TextStyle(
-                fontSize: fontSizeMedium,
+      child: QuillProvider(
+        configurations: QuillConfigurations(
+          controller: controller,
+        ),
+        child: Flexible(
+          child: QuillEditor(
+            scrollController: ScrollController(),
+            focusNode: FocusNode(),
+            configurations: QuillEditorConfigurations(
+              readOnly: true,
+              customStyles: customEditorStyles(
+                textColor:
+                    Theme.of(context).textTheme.bodyLarge?.color ?? Colors.grey,
+                codeBlockBackground: Theme.of(context).primaryColorLight,
               ),
             ),
           ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -874,14 +874,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
-  flutter_markdown:
-    dependency: "direct main"
-    description:
-      name: flutter_markdown
-      sha256: "35108526a233cc0755664d445f8a6b4b61e6f8fe993b3658b80b4a26827fc196"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.18+2"
   flutter_native_splash:
     dependency: "direct dev"
     description:
@@ -1303,14 +1295,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.7.0"
-  markdown:
-    dependency: transitive
-    description:
-      name: markdown
-      sha256: acf35edccc0463a9d7384e437c015a3535772e09714cf60e07eeef3a15870dcd
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.1.1"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.397+232
+version: 0.9.397+2313
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.398+2314
+version: 0.9.398+2315
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.397+2313
+version: 0.9.398+2314
 
 msix_config:
   display_name: LottiApp
@@ -75,7 +75,6 @@ dependencies:
     sdk: flutter
 
   flutter_map: ^6.1.0
-  flutter_markdown: ^0.6.9+1
   flutter_native_timezone: ^2.0.0
   flutter_quill: 8.6.4
   flutter_secure_storage: ^9.0.0


### PR DESCRIPTION
This PR improves the entry text preview in journal cards by using the same quill editor widget for rendering the preview, only in read-only mode.