### PR TITLE
feat: animate the editor toolbar vertical size on entry

### DIFF
--- a/lib/widgets/journal/editor/editor_toolbar.dart
+++ b/lib/widgets/journal/editor/editor_toolbar.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 
 class ToolbarWidget extends StatelessWidget {
@@ -8,12 +9,16 @@ class ToolbarWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    const duration = Duration(milliseconds: 800);
+    const curve = Curves.easeInOutQuint;
+    const height = 44.0;
+
     return Material(
       elevation: 1,
       child: QuillToolbar(
         key: key,
         configurations: const QuillToolbarConfigurations(
-          toolbarSize: 44,
+          toolbarSize: height,
           toolbarSectionSpacing: 0,
           toolbarIconAlignment: WrapAlignment.start,
           multiRowsDisplay: false,
@@ -25,7 +30,28 @@ class ToolbarWidget extends StatelessWidget {
           showIndent: false,
           showFontSize: false,
         ),
-      ),
+      )
+          .animate()
+          .scaleY(
+            duration: duration,
+            curve: curve,
+            begin: 0,
+            end: 1,
+          )
+          .fadeIn(
+            duration: duration,
+            curve: curve,
+          )
+          .custom(
+            duration: duration,
+            curve: curve,
+            builder: (context, value, child) {
+              return SizedBox(
+                height: height * value,
+                child: child, // child is the Text widget being animated
+              );
+            },
+          ),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.398+2315
+version: 0.9.398+2316
 
 msix_config:
   display_name: LottiApp

--- a/test/widgets/journal/editor/editor_widget_test.dart
+++ b/test/widgets/journal/editor/editor_widget_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -43,6 +45,8 @@ void main() {
         (WidgetTester tester) async {
       when(entryCubit.togglePrivate).thenAnswer((_) async => true);
 
+      const key = ValueKey('editor');
+
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(
           BlocProvider<EntryCubit>.value(
@@ -52,10 +56,14 @@ void main() {
             ),
             child: const EditorWidget(
               autoFocus: true,
+              key: key,
             ),
           ),
         ),
       );
+
+      final editorFinder = find.byKey(key);
+      await tester.tap(editorFinder);
       await tester.pumpAndSettle();
 
       final boldIconFinder = find.byIcon(Icons.format_bold);


### PR DESCRIPTION
This PR reduces the jumpiness of abruptly displaying the editor toolbar on focus. Instead, the vertical size, scale, and opacity are animated to full height and opacity over the course of 800ms.