### PR TITLE
feat: maintenance task for skipping sync message

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -137,6 +137,7 @@
   "maintenanceRecreateFts5": "Recreate full-text index",
   "maintenanceRecreateTagged": "Recreate tagged",
   "maintenanceReprocessSync": "Reprocess sync messages",
+  "maintenanceSyncSkip": "Skip sync message",
   "maintenanceResetHostId": "Reset Host ID",
   "maintenanceStories": "Assign stories from parent entries",
   "maintenanceSyncDefinitions": "Sync tags, measurables, dashboards, habits",

--- a/lib/pages/settings/advanced/maintenance_page.dart
+++ b/lib/pages/settings/advanced/maintenance_page.dart
@@ -63,6 +63,10 @@ class MaintenancePage extends StatelessWidget {
                 onTap: () => getIt<SyncConfigService>().resetOffset(),
               ),
               SettingsCard(
+                title: localizations.maintenanceSyncSkip,
+                onTap: () => getIt<SyncConfigService>().resetOffset(),
+              ),
+              SettingsCard(
                 title: localizations.maintenanceResetHostId,
                 onTap: () => getIt<SyncConfigService>().resetHostId(),
               ),

--- a/lib/services/sync_config_service.dart
+++ b/lib/services/sync_config_service.dart
@@ -106,4 +106,11 @@ class SyncConfigService {
     await setLastReadUid(0);
     await resetHostId();
   }
+
+  Future<void> skipMessage() async {
+    final lastReadUid = await getLastReadUid();
+    if (lastReadUid != null) {
+      await setLastReadUid(lastReadUid + 1);
+    }
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.401+2333
+version: 0.9.402+2334
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR adds a maintenance task for skipping e.g. corrupted sync messages.