### PR TITLE
feat: improve sync restart on reconnect

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.403+2335
+version: 0.9.404+2336
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
Instead of restarting after network reconnect inside the outbox isolate, if there's a disconnect of the network, kill the isolate altogether, and then restart it on next reconnect.