### PR TITLE
feat: integrate Ollama for interacting with a locally running LLM

### DIFF
--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -10,6 +10,7 @@ import 'package:lotti/database/maintenance.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/logic/health_import.dart';
 import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/services/ai_service.dart';
 import 'package:lotti/services/asr_service.dart';
 import 'package:lotti/services/editor_state_service.dart';
 import 'package:lotti/services/entities_cache_service.dart';
@@ -56,6 +57,7 @@ Future<void> registerSingletons() async {
     ..registerSingleton<SyncDatabase>(getSyncDatabase())
     ..registerSingleton<ImapClientManager>(ImapClientManager())
     ..registerSingleton<AsrService>(AsrService())
+    ..registerSingleton<AiService>(AiService())
     ..registerSingleton<VectorClockService>(VectorClockService())
     ..registerSingleton<SyncConfigService>(SyncConfigService())
     ..registerSingleton<TimeService>(TimeService())

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -113,6 +113,7 @@
   "journalLinkedEntriesLabel": "Linked:",
   "journalLinkedFromLabel": "Linked from:",
   "journalLinkFromHint": "Link from",
+  "journalHeaderExpand": "Show all",
   "journalLinkToHint": "Link to",
   "journalUnlinkHint": "Unlink",
   "journalPrivateTooltip": "private only",

--- a/lib/services/ai_service.dart
+++ b/lib/services/ai_service.dart
@@ -1,0 +1,43 @@
+import 'dart:async';
+
+import 'package:delta_markdown/delta_markdown.dart';
+import 'package:langchain/langchain.dart';
+import 'package:langchain_ollama/langchain_ollama.dart';
+import 'package:lotti/classes/entry_text.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/utils/file_utils.dart';
+
+class AiService {
+  AiService();
+
+  Future<void> prompt(JournalEntity? journalEntity) async {
+    final promptText = journalEntity?.entryText?.plainText;
+
+    if (promptText == null || journalEntity == null) {
+      return;
+    }
+    final llm = Ollama(
+      defaultOptions: const OllamaOptions(
+        model: 'llama2:13b',
+        temperature: 1,
+      ),
+    );
+
+    final prompt = PromptValue.string(promptText);
+    final result = await llm.invoke(prompt);
+    final plainText = result.firstOutputAsString;
+
+    await getIt<PersistenceLogic>().createTextEntry(
+      EntryText(
+        plainText: plainText,
+        markdown: plainText,
+        quill: markdownToDelta(plainText),
+      ),
+      id: uuid.v1(),
+      linkedId: journalEntity.meta.id,
+      started: DateTime.now(),
+    );
+  }
+}

--- a/lib/services/ai_service.dart
+++ b/lib/services/ai_service.dart
@@ -12,7 +12,10 @@ import 'package:lotti/utils/file_utils.dart';
 class AiService {
   AiService();
 
-  Future<void> prompt(JournalEntity? journalEntity) async {
+  Future<void> prompt(
+    JournalEntity? journalEntity, {
+    String? linkedFromId,
+  }) async {
     final promptText = journalEntity?.entryText?.plainText;
 
     if (promptText == null || journalEntity == null) {
@@ -36,7 +39,7 @@ class AiService {
         quill: markdownToDelta(plainText),
       ),
       id: uuid.v1(),
-      linkedId: journalEntity.meta.id,
+      linkedId: linkedFromId ?? journalEntity.meta.id,
       started: DateTime.now(),
     );
   }

--- a/lib/widgets/journal/entry_detail_linked.dart
+++ b/lib/widgets/journal/entry_detail_linked.dart
@@ -71,6 +71,7 @@ class LinkedEntriesWidget extends StatelessWidget {
                     popOnDelete: false,
                     unlinkFn: unlink,
                     parentTags: item.meta.tagIds?.toSet(),
+                    linkedFromId: item.meta.id,
                   );
                 },
               ),

--- a/lib/widgets/journal/entry_details/entry_detail_header.dart
+++ b/lib/widgets/journal/entry_details/entry_detail_header.dart
@@ -22,10 +22,12 @@ class EntryDetailHeader extends StatefulWidget {
     this.inLinkedEntries = false,
     super.key,
     this.unlinkFn,
+    this.linkedFromId,
   });
 
   final bool inLinkedEntries;
   final Future<void> Function()? unlinkFn;
+  final String? linkedFromId;
 
   @override
   State<EntryDetailHeader> createState() => _EntryDetailHeaderState();
@@ -145,7 +147,10 @@ class _EntryDetailHeaderState extends State<EntryDetailHeader> {
                           child: IconButton(
                             icon: const Icon(Icons.assistant_rounded),
                             tooltip: 'Prompt',
-                            onPressed: () => getIt<AiService>().prompt(item),
+                            onPressed: () => getIt<AiService>().prompt(
+                              item,
+                              linkedFromId: widget.linkedFromId,
+                            ),
                           ),
                         ),
                     ],

--- a/lib/widgets/journal/entry_details/entry_detail_header.dart
+++ b/lib/widgets/journal/entry_details/entry_detail_header.dart
@@ -81,7 +81,7 @@ class _EntryDetailHeaderState extends State<EntryDetailHeader> {
                         width: 40,
                         child: IconButton(
                           icon: const Icon(Icons.more_horiz),
-                          tooltip: localizations.journalLinkFromHint,
+                          tooltip: localizations.journalHeaderExpand,
                           onPressed: () => setState(() => showAllIcons = true),
                         ),
                       )

--- a/lib/widgets/journal/entry_details/entry_detail_header.dart
+++ b/lib/widgets/journal/entry_details/entry_detail_header.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -11,6 +9,7 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/services/ai_service.dart';
 import 'package:lotti/services/link_service.dart';
 import 'package:lotti/themes/colors.dart';
+import 'package:lotti/utils/platform.dart';
 import 'package:lotti/widgets/journal/entry_details/delete_icon_widget.dart';
 import 'package:lotti/widgets/journal/entry_details/save_button.dart';
 import 'package:lotti/widgets/journal/entry_details/share_button_widget.dart';
@@ -141,7 +140,7 @@ class _EntryDetailHeaderState extends State<EntryDetailHeader> {
                           onPressed: () => setState(() => showAllIcons = false),
                         ),
                       ),
-                      if (Platform.isMacOS)
+                      if (isDesktop)
                         SizedBox(
                           width: 40,
                           child: IconButton(

--- a/lib/widgets/journal/entry_details/entry_detail_header.dart
+++ b/lib/widgets/journal/entry_details/entry_detail_header.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -6,6 +8,7 @@ import 'package:lotti/blocs/journal/entry_cubit.dart';
 import 'package:lotti/blocs/journal/entry_state.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/ai_service.dart';
 import 'package:lotti/services/link_service.dart';
 import 'package:lotti/themes/colors.dart';
 import 'package:lotti/widgets/journal/entry_details/delete_icon_widget.dart';
@@ -136,6 +139,15 @@ class _EntryDetailHeaderState extends State<EntryDetailHeader> {
                           onPressed: () => setState(() => showAllIcons = false),
                         ),
                       ),
+                      if (Platform.isMacOS)
+                        SizedBox(
+                          width: 40,
+                          child: IconButton(
+                            icon: const Icon(Icons.assistant_rounded),
+                            tooltip: 'Prompt',
+                            onPressed: () => getIt<AiService>().prompt(item),
+                          ),
+                        ),
                     ],
                   ],
                 ),

--- a/lib/widgets/journal/entry_details_widget.dart
+++ b/lib/widgets/journal/entry_details_widget.dart
@@ -26,12 +26,14 @@ class EntryDetailWidget extends StatelessWidget {
     this.showTaskDetails = false,
     this.unlinkFn,
     this.parentTags,
+    this.linkedFromId,
   });
 
   final String itemId;
   final bool popOnDelete;
   final bool showTaskDetails;
   final Future<void> Function()? unlinkFn;
+  final String? linkedFromId;
   final Set<String>? parentTags;
 
   @override
@@ -76,6 +78,7 @@ class EntryDetailWidget extends StatelessWidget {
                   ),
                   EntryDetailHeader(
                     inLinkedEntries: unlinkFn != null,
+                    linkedFromId: linkedFromId,
                     unlinkFn: unlinkFn,
                   ),
                   TagsListWidget(parentTags: parentTags),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -113,6 +113,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.6"
+  beautiful_soup_dart:
+    dependency: transitive
+    description:
+      name: beautiful_soup_dart
+      sha256: "57e23946c85776dd9515a4e9a14263fff37dbedbd559bc4412bf565886e12b10"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
   bloc:
     dependency: "direct main"
     description:
@@ -369,6 +377,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  csv:
+    dependency: transitive
+    description:
+      name: csv
+      sha256: "63ed2871dd6471193dffc52c0e6c76fb86269c00244d244297abbb355c84a86e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.1"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -554,6 +570,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  fetch_api:
+    dependency: transitive
+    description:
+      name: fetch_api
+      sha256: "74a1e426d41ed9c89353703b2d80400c5d0ecfa144b2d8a7bd8882fbc9e48787"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
+  fetch_client:
+    dependency: transitive
+    description:
+      name: fetch_client
+      sha256: "83c07b07a63526a43630572c72715707ca113a8aa3459efbc7b2d366b79402af"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   ffi:
     dependency: transitive
     description:
@@ -1167,6 +1199,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
+  iregexp:
+    dependency: transitive
+    description:
+      name: iregexp
+      sha256: "143859dcaeecf6f683102786762d70a47ef8441a0d2287a158172d32d38799cf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
   irondash_engine_context:
     dependency: transitive
     description:
@@ -1207,6 +1247,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.1"
+  json_path:
+    dependency: transitive
+    description:
+      name: json_path
+      sha256: "93f2cb012eb37112e62d3b5e5eb535431beb4c2566a9c1987b079b13b308763b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.6"
   json_serializable:
     dependency: "direct dev"
     description:
@@ -1215,6 +1263,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.7.1"
+  langchain:
+    dependency: "direct main"
+    description:
+      name: langchain
+      sha256: "7c8c9a0c9591a57fd38d3bc6f9356d86d0fea9f1856d53729eb119fa3ec9b018"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1+1"
+  langchain_ollama:
+    dependency: "direct main"
+    description:
+      name: langchain_ollama
+      sha256: b4b77ecdc67debc2be5b5e883f862c96d20019f6fa1426871cc64f166c061fdd
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.2+1"
   latlong2:
     dependency: "direct main"
     description:
@@ -1327,6 +1391,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.7296"
+  math_expressions:
+    dependency: transitive
+    description:
+      name: math_expressions
+      sha256: "3576593617c3870d75728a751f6ec6e606706d44e363f088ac394b5a28a98064"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
+  maybe_just_nothing:
+    dependency: transitive
+    description:
+      name: maybe_just_nothing
+      sha256: "0c06326e26d08f6ed43247404376366dc4d756cef23a4f1db765f546224c35e0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.3"
   media_kit:
     dependency: "direct main"
     description:
@@ -1463,6 +1543,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  ollama_dart:
+    dependency: transitive
+    description:
+      name: ollama_dart
+      sha256: "6e669c713f567c5ed1d2ec0db8bcd8457d5b01884a810c403f5fce1147d2cebf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.2"
   package_config:
     dependency: transitive
     description:
@@ -1855,6 +1943,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  rfc_6901:
+    dependency: transitive
+    description:
+      name: rfc_6901
+      sha256: df1bbfa3d023009598f19636d6114c6ac1e0b7bb7bf6a260f0e6e6ce91416820
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   rxdart:
     dependency: "direct main"
     description:
@@ -2212,6 +2308,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.9"
+  tiktoken:
+    dependency: transitive
+    description:
+      name: tiktoken
+      sha256: a100ca6e387e18be7b711478c8d18627e0753536846600a5961a83631ce5c586
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
   timezone:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.405+2338
+version: 0.9.406+2339
 
 msix_config:
   display_name: LottiApp
@@ -98,6 +98,8 @@ dependencies:
   intl: ^0.18.0
   jiffy: ^6.1.0
   json_annotation: ^4.8.1
+  langchain: ^0.3.1+1
+  langchain_ollama: ^0.0.2+1
   latlong2: ^0.9.0
   location: ^5.0.0
   lottie: ^2.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.406+2340
+version: 0.9.406+2341
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.406+2339
+version: 0.9.406+2340
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.406+2341
+version: 0.9.406+2342
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
I was working on habit tracking, in particular for grouping habits, and then got a bit side-tracked, in a good way. I wanted to check out [Ollama](https://ollama.ai) anyway and thought, why not quickly (2 minutes, first try) dictate my feature idea, have Lotti transcribe the audio, and then prompt a capable [llama:13b](https://ollama.ai/library/llama2) model running locally in [Ollama](https://ollama.ai). The result blew me away:

```
a) Acceptance Criteria for Defining Habit Groups:

1. The user should be able to define a subset of habits as a "habit group" for the purpose of tracking success rate.
2. The habit group should be defined by selecting a specific set of habits from the full list of habits.
3. The user should be able to name the habit group and see it listed in the app's overview.
4. The user should be able to remove habits from the group at any time, but not add new ones.
5. The user should be able to switch between different habit groups in the app's overview.

b) Acceptance Criteria for Displaying Success Rate of Habit Groups:

1. The app should display a chart showing the success rate of each habit group.
2. The chart should be interactive, allowing the user to hover over each bar to see the exact success rate for that habit.
3. The chart should be grouped by habit group, with each group represented by a separate bar on the chart.
4. The app should default to showing only the habit groups that are currently selected for tracking.
5. The user should be able to toggle between seeing all habits or only the selected habit groups in the overview.
6. The success rate of each habit group should be calculated based on the number of days the user completed the habits in that group.
7. The app should display a "goal" percentage for each habit group, showing the user what percentage of days they need to complete in order to reach their
goal for that group.
8. The app should display a "current streak" count for each habit group, showing the user how many days in a row they have completed habits in that group.
```

This is what I was waiting for, for use in Lotti. With all the recent developments around large language models, of course it would be super useful to use AI to help with tasks, summarize text, find information or whatnot, but not at the expense of privacy. When I last looked at the potential for AI in Lotti, I decided to wait until capable LLMs can be run locally. That time seems to have arrived now.

---

This PR integrates a locally running Ollama instance in the simplest possible way, where I can now use any entry that contains text (e.g. a transcribed audio recording), tap an icon in the entry header, and a short while later get a response from a `llama:13b` model. The model is currently hardcoded, configurability will come later (also for example for system messages). For now it's a one-time prompt with a single response. Multi-prompt, chat-style interactions will follow in due course, likely soon.

Let me give you an example, given this transcription of an unedited audio note I recorded earlier, I can tap the `Prompt` icon and like half a minute later, I get the a totally useful response which I find is a more than decent start into defining relevant acceptance criteria, potentially saving me a lot of time, and all that without sharing even the tiniest bit of information with anyone, since all this was possible on my M1 Max MacBook Pro.

<img width="1459" alt="image" src="https://github.com/matthiasn/lotti/assets/1390808/9fb9bf03-ff76-4120-ab97-466de5e8a31e">

<img width="1459" alt="image" src="https://github.com/matthiasn/lotti/assets/1390808/0478ca47-5dbf-49a2-a1a8-3c3c3273904e">

Some refinement would surely still help, this unedited checklist is already better than a lot of acceptance criteria that I've seen in the past year.

<img width="1459" alt="image" src="https://github.com/matthiasn/lotti/assets/1390808/e18a8a52-09df-4637-bb4d-6959d07033cd">
