### PR TITLE
feat: display response stream from LLM prompt

### DIFF
--- a/lib/features/ai/state/ollama_prompt.dart
+++ b/lib/features/ai/state/ollama_prompt.dart
@@ -1,6 +1,5 @@
-import 'dart:async';
-
 import 'package:delta_markdown/delta_markdown.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:langchain/langchain.dart';
 import 'package:langchain_ollama/langchain_ollama.dart';
 import 'package:lotti/classes/entry_text.dart';
@@ -9,13 +8,19 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/utils/file_utils.dart';
 
-class AiService {
-  AiService();
+final aiResponseProvider = NotifierProvider<AiResponse, String>(AiResponse.new);
+
+class AiResponse extends Notifier<String> {
+  @override
+  String build() {
+    return '';
+  }
 
   Future<void> prompt(
     JournalEntity? journalEntity, {
     String? linkedFromId,
   }) async {
+    state = '';
     final promptText = journalEntity?.entryText?.plainText;
 
     if (promptText == null || journalEntity == null) {
@@ -29,14 +34,16 @@ class AiService {
     );
 
     final prompt = PromptValue.string(promptText);
-    final result = await llm.invoke(prompt);
-    final plainText = result.firstOutputAsString;
+
+    await llm.stream(prompt).forEach((res) {
+      state += res.firstOutputAsString;
+    });
 
     await getIt<PersistenceLogic>().createTextEntry(
       EntryText(
-        plainText: plainText,
-        markdown: plainText,
-        quill: markdownToDelta(plainText),
+        plainText: state,
+        markdown: state,
+        quill: markdownToDelta(state),
       ),
       id: uuid.v1(),
       linkedId: linkedFromId ?? journalEntity.meta.id,

--- a/lib/features/ai/ui/ai_prompt_icon_widget.dart
+++ b/lib/features/ai/ui/ai_prompt_icon_widget.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/ai/state/ollama_prompt.dart';
+import 'package:lotti/features/ai/ui/ai_response_preview.dart';
+
+class AiPromptIconWidget extends ConsumerWidget {
+  const AiPromptIconWidget({
+    required this.journalEntity,
+    this.linkedFromId,
+    super.key,
+  });
+
+  final JournalEntity journalEntity;
+  final String? linkedFromId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return IconButton(
+      icon: const Icon(Icons.assistant_rounded),
+      tooltip: 'Prompt',
+      onPressed: () {
+        ref.read(aiResponseProvider.notifier).prompt(
+              journalEntity,
+              linkedFromId: linkedFromId,
+            );
+        showModalBottomSheet<void>(
+          context: context,
+          isScrollControlled: true,
+          builder: (BuildContext context) => const AiResponsePreview(),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/ai/ui/ai_response_preview.dart
+++ b/lib/features/ai/ui/ai_response_preview.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/features/ai/state/ollama_prompt.dart';
+
+class AiResponsePreview extends ConsumerWidget {
+  const AiResponsePreview({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final responseText = ref.watch(aiResponseProvider);
+
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(minWidth: 600),
+          child: MarkdownBody(data: responseText),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -10,7 +10,6 @@ import 'package:lotti/database/maintenance.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/logic/health_import.dart';
 import 'package:lotti/logic/persistence_logic.dart';
-import 'package:lotti/services/ai_service.dart';
 import 'package:lotti/services/asr_service.dart';
 import 'package:lotti/services/editor_state_service.dart';
 import 'package:lotti/services/entities_cache_service.dart';
@@ -57,7 +56,6 @@ Future<void> registerSingletons() async {
     ..registerSingleton<SyncDatabase>(getSyncDatabase())
     ..registerSingleton<ImapClientManager>(ImapClientManager())
     ..registerSingleton<AsrService>(AsrService())
-    ..registerSingleton<AiService>(AiService())
     ..registerSingleton<VectorClockService>(VectorClockService())
     ..registerSingleton<SyncConfigService>(SyncConfigService())
     ..registerSingleton<TimeService>(TimeService())

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:drift/isolate.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hotkey_manager/hotkey_manager.dart';
 import 'package:lotti/beamer/beamer_app.dart';
 import 'package:lotti/database/common.dart';
@@ -56,7 +57,7 @@ Future<void> main() async {
       );
     };
 
-    runApp(MyBeamerApp());
+    runApp(ProviderScope(child: MyBeamerApp()));
   }, (Object error, StackTrace stackTrace) {
     getIt<LoggingDb>().captureException(
       error,

--- a/lib/widgets/journal/entry_details/entry_detail_header.dart
+++ b/lib/widgets/journal/entry_details/entry_detail_header.dart
@@ -2,11 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/blocs/journal/entry_cubit.dart';
 import 'package:lotti/blocs/journal/entry_state.dart';
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/ai/ui/ai_prompt_icon_widget.dart';
 import 'package:lotti/get_it.dart';
-import 'package:lotti/services/ai_service.dart';
 import 'package:lotti/services/link_service.dart';
 import 'package:lotti/themes/colors.dart';
 import 'package:lotti/utils/platform.dart';
@@ -16,7 +17,7 @@ import 'package:lotti/widgets/journal/entry_details/share_button_widget.dart';
 import 'package:lotti/widgets/journal/tags/tag_add.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
-class EntryDetailHeader extends StatefulWidget {
+class EntryDetailHeader extends ConsumerStatefulWidget {
   const EntryDetailHeader({
     this.inLinkedEntries = false,
     super.key,
@@ -29,10 +30,10 @@ class EntryDetailHeader extends StatefulWidget {
   final String? linkedFromId;
 
   @override
-  State<EntryDetailHeader> createState() => _EntryDetailHeaderState();
+  ConsumerState<EntryDetailHeader> createState() => _EntryDetailHeaderState();
 }
 
-class _EntryDetailHeaderState extends State<EntryDetailHeader> {
+class _EntryDetailHeaderState extends ConsumerState<EntryDetailHeader> {
   bool showAllIcons = false;
 
   @override
@@ -143,13 +144,9 @@ class _EntryDetailHeaderState extends State<EntryDetailHeader> {
                       if (isDesktop)
                         SizedBox(
                           width: 40,
-                          child: IconButton(
-                            icon: const Icon(Icons.assistant_rounded),
-                            tooltip: 'Prompt',
-                            onPressed: () => getIt<AiService>().prompt(
-                              item,
-                              linkedFromId: widget.linkedFromId,
-                            ),
+                          child: AiPromptIconWidget(
+                            journalEntity: item,
+                            linkedFromId: widget.linkedFromId,
                           ),
                         ),
                     ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -882,6 +882,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
+  flutter_markdown:
+    dependency: "direct main"
+    description:
+      name: flutter_markdown
+      sha256: "30088ce826b5b9cfbf9e8bece34c716c8a59fa54461dcae1e4ac01a94639e762"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.18+3"
   flutter_native_splash:
     dependency: "direct dev"
     description:
@@ -906,6 +914,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.2.2"
+  flutter_riverpod:
+    dependency: "direct main"
+    description:
+      name: flutter_riverpod
+      sha256: da9591d1f8d5881628ccd5c25c40e74fc3eef50ba45e40c3905a06e1712412d5
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.9"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -1951,6 +1967,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
+  riverpod:
+    dependency: transitive
+    description:
+      name: riverpod
+      sha256: "942999ee48b899f8a46a860f1e13cee36f2f77609eb54c5b7a669bb20d550b11"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.9"
   rxdart:
     dependency: "direct main"
     description:
@@ -2204,6 +2228,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.11.1"
+  state_notifier:
+    dependency: transitive
+    description:
+      name: state_notifier
+      sha256: b8677376aa54f2d7c58280d5a007f9e8774f1968d1fb1c096adcb4792fba29bb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   stream_channel:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.406+2342
+version: 0.9.407+2343
 
 msix_config:
   display_name: LottiApp
@@ -74,8 +74,10 @@ dependencies:
     sdk: flutter
 
   flutter_map: ^6.1.0
+  flutter_markdown: ^0.6.18+3
   flutter_native_timezone: ^2.0.0
   flutter_quill: ^9.2.1
+  flutter_riverpod: ^2.4.9
   flutter_secure_storage: ^9.0.0
   flutter_sliding_tutorial: ^2.0.0
   flutter_svg: ^2.0.7


### PR DESCRIPTION
This PR introduces streaming responses from the large language model so that when tapping the prompt I do not have to wait for 10-20 seconds but rather I get to see the results streaming it immediately which makes for a much more interesting user experience.

Also in this PR I'm introducing [riverpod](https://pub.dev/packages/riverpod) which will be the state management solution going forward in this project.

This is how it looks like:

![image](https://github.com/matthiasn/lotti/assets/1390808/229e2685-0024-44d7-8943-a1bb1291154b)
