### PR TITLE
fix: overlapping bars on small screens

### DIFF
--- a/lib/widgets/charts/time_series/time_series_bar_chart.dart
+++ b/lib/widgets/charts/time_series/time_series_bar_chart.dart
@@ -58,7 +58,8 @@ class TimeSeriesBarChart extends StatelessWidget {
                 : 1;
 
     final screenWidth = MediaQuery.sizeOf(context).width;
-    final barsWidth = (screenWidth - 100 - rangeInDays * 1.3) / rangeInDays;
+    final barsWidth =
+        (screenWidth - 150 - rangeInDays - screenWidth * 0.1) / rangeInDays;
 
     final barGroups = dataWithEmptyDays
         .sortedBy((observation) => observation.dateTime)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.407+2343
+version: 0.9.408+2344
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
Tiny PR for fixing bar widths in time series bar charts on small screen.