### PR TITLE
feat: add flag for enabling/disabling ASR per device

### DIFF
--- a/lib/database/journal_db/config_flags.dart
+++ b/lib/database/journal_db/config_flags.dart
@@ -31,6 +31,13 @@ Future<void> initConfigFlags(
   );
   await db.insertFlagIfNotExists(
     const ConfigFlag(
+      name: autoTranscribeFlag,
+      description: 'Automatically transcribe audio',
+      status: false,
+    ),
+  );
+  await db.insertFlagIfNotExists(
+    const ConfigFlag(
       name: enableTaskManagement,
       description: 'Enable task management?',
       status: false,

--- a/lib/pages/settings/flags_page.dart
+++ b/lib/pages/settings/flags_page.dart
@@ -25,6 +25,7 @@ class FlagsPage extends StatelessWidget {
         const displayedItems = {
           privateFlag,
           enableNotificationsFlag,
+          autoTranscribeFlag,
           recordLocationFlag,
           enableSyncFlag,
           enableTaskManagement,

--- a/lib/services/asr_service.dart
+++ b/lib/services/asr_service.dart
@@ -6,11 +6,13 @@ import 'package:ffmpeg_kit_flutter/return_code.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/database/database.dart';
 import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/utils/audio_utils.dart';
+import 'package:lotti/utils/consts.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
@@ -113,9 +115,15 @@ class AsrService {
   }
 
   Future<void> enqueue({required JournalAudio entry}) async {
-    queue.add(entry);
-    if (!running) {
-      unawaited(_start());
+    final autoTranscribe = await getIt<JournalDb>().getConfigFlag(
+      autoTranscribeFlag,
+    );
+
+    if (autoTranscribe) {
+      queue.add(entry);
+      if (!running) {
+        unawaited(_start());
+      }
     }
   }
 }

--- a/lib/utils/consts.dart
+++ b/lib/utils/consts.dart
@@ -4,3 +4,4 @@ const allowInvalidCertFlag = 'allow_invalid_cert';
 const enableSyncFlag = 'enable_sync';
 const enableTaskManagement = 'enable_task_management';
 const recordLocationFlag = 'record_location';
+const autoTranscribeFlag = 'auto_transcribe';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.410+2346
+version: 0.9.411+2347
 
 msix_config:
   display_name: LottiApp

--- a/test/database/database_test.dart
+++ b/test/database/database_test.dart
@@ -17,6 +17,11 @@ final expectedFlags = <ConfigFlag>{
     status: true,
   ),
   const ConfigFlag(
+    name: autoTranscribeFlag,
+    description: 'Automatically transcribe audio',
+    status: false,
+  ),
+  const ConfigFlag(
     name: recordLocationFlag,
     description: 'Record geolocation?',
     status: false,


### PR DESCRIPTION
This PR adds a config flag for enabling/disabling automatic transcription of audio recordings (after finishing the recording). The reason for that is that I prefer running the whisper medium model which in my experience (and for my voice) is far superior than the smaller variants. However, while it works on mobile, it takes too long and uses too much battery, so I'd rather postpone the transcription and run it on the desktop later.
