### PR TITLE
feat: show tasks as list with only title and status by default

### DIFF
--- a/ios/Flutter/AppFrameworkInfo.plist
+++ b/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>11.0</string>
+  <string>12.0</string>
 </dict>
 </plist>

--- a/lib/blocs/journal/journal_page_cubit.dart
+++ b/lib/blocs/journal/journal_page_cubit.dart
@@ -19,6 +19,7 @@ class JournalPageCubit extends Cubit<JournalPageState> {
             selectedEntryTypes: entryTypes,
             fullTextMatches: {},
             showTasks: showTasks,
+            taskAsListView: true,
             pagingController: PagingController(firstPageKey: 0),
             taskStatuses: [
               'OPEN',
@@ -70,6 +71,7 @@ class JournalPageCubit extends Cubit<JournalPageState> {
   String _query = '';
   bool _showPrivateEntries = false;
   bool showTasks = false;
+  bool taskAsListView = true;
 
   Set<String> _fullTextMatches = {};
 
@@ -85,6 +87,7 @@ class JournalPageCubit extends Cubit<JournalPageState> {
         match: _query,
         tagIds: <String>{},
         filters: _filters,
+        taskAsListView: taskAsListView,
         showPrivateEntries: _showPrivateEntries,
         showTasks: showTasks,
         selectedEntryTypes: _selectedEntryTypes.toList(),
@@ -115,6 +118,11 @@ class JournalPageCubit extends Cubit<JournalPageState> {
     }
 
     refreshQuery();
+  }
+
+  void toggleTaskAsListView() {
+    taskAsListView = !taskAsListView;
+    emitState();
   }
 
   void toggleSelectedEntryTypes(String entryType) {

--- a/lib/blocs/journal/journal_page_state.dart
+++ b/lib/blocs/journal/journal_page_state.dart
@@ -18,6 +18,7 @@ class JournalPageState with _$JournalPageState {
     required Set<DisplayFilter> filters,
     required bool showPrivateEntries,
     required bool showTasks,
+    required bool taskAsListView,
     required List<String> selectedEntryTypes,
     required Set<String> fullTextMatches,
     required PagingController<int, JournalEntity> pagingController,

--- a/lib/blocs/journal/journal_page_state.freezed.dart
+++ b/lib/blocs/journal/journal_page_state.freezed.dart
@@ -21,6 +21,7 @@ mixin _$JournalPageState {
   Set<DisplayFilter> get filters => throw _privateConstructorUsedError;
   bool get showPrivateEntries => throw _privateConstructorUsedError;
   bool get showTasks => throw _privateConstructorUsedError;
+  bool get taskAsListView => throw _privateConstructorUsedError;
   List<String> get selectedEntryTypes => throw _privateConstructorUsedError;
   Set<String> get fullTextMatches => throw _privateConstructorUsedError;
   PagingController<int, JournalEntity> get pagingController =>
@@ -45,6 +46,7 @@ abstract class $JournalPageStateCopyWith<$Res> {
       Set<DisplayFilter> filters,
       bool showPrivateEntries,
       bool showTasks,
+      bool taskAsListView,
       List<String> selectedEntryTypes,
       Set<String> fullTextMatches,
       PagingController<int, JournalEntity> pagingController,
@@ -70,6 +72,7 @@ class _$JournalPageStateCopyWithImpl<$Res, $Val extends JournalPageState>
     Object? filters = null,
     Object? showPrivateEntries = null,
     Object? showTasks = null,
+    Object? taskAsListView = null,
     Object? selectedEntryTypes = null,
     Object? fullTextMatches = null,
     Object? pagingController = null,
@@ -96,6 +99,10 @@ class _$JournalPageStateCopyWithImpl<$Res, $Val extends JournalPageState>
       showTasks: null == showTasks
           ? _value.showTasks
           : showTasks // ignore: cast_nullable_to_non_nullable
+              as bool,
+      taskAsListView: null == taskAsListView
+          ? _value.taskAsListView
+          : taskAsListView // ignore: cast_nullable_to_non_nullable
               as bool,
       selectedEntryTypes: null == selectedEntryTypes
           ? _value.selectedEntryTypes
@@ -135,6 +142,7 @@ abstract class _$$JournalPageStateImplCopyWith<$Res>
       Set<DisplayFilter> filters,
       bool showPrivateEntries,
       bool showTasks,
+      bool taskAsListView,
       List<String> selectedEntryTypes,
       Set<String> fullTextMatches,
       PagingController<int, JournalEntity> pagingController,
@@ -158,6 +166,7 @@ class __$$JournalPageStateImplCopyWithImpl<$Res>
     Object? filters = null,
     Object? showPrivateEntries = null,
     Object? showTasks = null,
+    Object? taskAsListView = null,
     Object? selectedEntryTypes = null,
     Object? fullTextMatches = null,
     Object? pagingController = null,
@@ -184,6 +193,10 @@ class __$$JournalPageStateImplCopyWithImpl<$Res>
       showTasks: null == showTasks
           ? _value.showTasks
           : showTasks // ignore: cast_nullable_to_non_nullable
+              as bool,
+      taskAsListView: null == taskAsListView
+          ? _value.taskAsListView
+          : taskAsListView // ignore: cast_nullable_to_non_nullable
               as bool,
       selectedEntryTypes: null == selectedEntryTypes
           ? _value._selectedEntryTypes
@@ -218,6 +231,7 @@ class _$JournalPageStateImpl implements _JournalPageState {
       required final Set<DisplayFilter> filters,
       required this.showPrivateEntries,
       required this.showTasks,
+      required this.taskAsListView,
       required final List<String> selectedEntryTypes,
       required final Set<String> fullTextMatches,
       required this.pagingController,
@@ -252,6 +266,8 @@ class _$JournalPageStateImpl implements _JournalPageState {
   final bool showPrivateEntries;
   @override
   final bool showTasks;
+  @override
+  final bool taskAsListView;
   final List<String> _selectedEntryTypes;
   @override
   List<String> get selectedEntryTypes {
@@ -290,7 +306,7 @@ class _$JournalPageStateImpl implements _JournalPageState {
 
   @override
   String toString() {
-    return 'JournalPageState(match: $match, tagIds: $tagIds, filters: $filters, showPrivateEntries: $showPrivateEntries, showTasks: $showTasks, selectedEntryTypes: $selectedEntryTypes, fullTextMatches: $fullTextMatches, pagingController: $pagingController, taskStatuses: $taskStatuses, selectedTaskStatuses: $selectedTaskStatuses)';
+    return 'JournalPageState(match: $match, tagIds: $tagIds, filters: $filters, showPrivateEntries: $showPrivateEntries, showTasks: $showTasks, taskAsListView: $taskAsListView, selectedEntryTypes: $selectedEntryTypes, fullTextMatches: $fullTextMatches, pagingController: $pagingController, taskStatuses: $taskStatuses, selectedTaskStatuses: $selectedTaskStatuses)';
   }
 
   @override
@@ -305,6 +321,8 @@ class _$JournalPageStateImpl implements _JournalPageState {
                 other.showPrivateEntries == showPrivateEntries) &&
             (identical(other.showTasks, showTasks) ||
                 other.showTasks == showTasks) &&
+            (identical(other.taskAsListView, taskAsListView) ||
+                other.taskAsListView == taskAsListView) &&
             const DeepCollectionEquality()
                 .equals(other._selectedEntryTypes, _selectedEntryTypes) &&
             const DeepCollectionEquality()
@@ -325,6 +343,7 @@ class _$JournalPageStateImpl implements _JournalPageState {
       const DeepCollectionEquality().hash(_filters),
       showPrivateEntries,
       showTasks,
+      taskAsListView,
       const DeepCollectionEquality().hash(_selectedEntryTypes),
       const DeepCollectionEquality().hash(_fullTextMatches),
       pagingController,
@@ -346,6 +365,7 @@ abstract class _JournalPageState implements JournalPageState {
           required final Set<DisplayFilter> filters,
           required final bool showPrivateEntries,
           required final bool showTasks,
+          required final bool taskAsListView,
           required final List<String> selectedEntryTypes,
           required final Set<String> fullTextMatches,
           required final PagingController<int, JournalEntity> pagingController,
@@ -363,6 +383,8 @@ abstract class _JournalPageState implements JournalPageState {
   bool get showPrivateEntries;
   @override
   bool get showTasks;
+  @override
+  bool get taskAsListView;
   @override
   List<String> get selectedEntryTypes;
   @override

--- a/lib/pages/journal/infinite_journal_page.dart
+++ b/lib/pages/journal/infinite_journal_page.dart
@@ -82,6 +82,16 @@ class InfiniteJournalPageBody extends StatelessWidget {
                     return item.maybeMap(
                       journalImage: (JournalImage image) =>
                           JournalImageCard(item: image, key: valueKey),
+                      task: (Task task) {
+                        if (snapshot.taskAsListView) {
+                          return TaskListCard(
+                            task: task,
+                            key: valueKey,
+                          );
+                        } else {
+                          return JournalCard(item: item, key: valueKey);
+                        }
+                      },
                       orElse: () => JournalCard(item: item, key: valueKey),
                     );
                   },

--- a/lib/widgets/app_bar/journal_sliver_appbar.dart
+++ b/lib/widgets/app_bar/journal_sliver_appbar.dart
@@ -34,7 +34,13 @@ class JournalSliverAppBar extends StatelessWidget {
                     text: snapshot.match,
                     onChanged: cubit.setSearchString,
                   ),
-                  const JournalFilter(),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      const JournalFilter(),
+                      if (snapshot.showTasks) const TaskListToggle(),
+                    ],
+                  ),
                   const SizedBox(height: 10),
                   if (!snapshot.showTasks) const EntryTypeFilter(),
                   if (snapshot.showTasks) const TaskStatusFilter(),

--- a/lib/widgets/journal/journal_card.dart
+++ b/lib/widgets/journal/journal_card.dart
@@ -1,7 +1,6 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_animate/flutter_animate.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
@@ -217,7 +216,7 @@ class _JournalCardState extends State<JournalCard> {
               ),
               onTap: onTap,
             ),
-          ).animate().fadeIn(duration: const Duration(milliseconds: 100)),
+          ),
         );
       },
     );
@@ -299,8 +298,35 @@ class JournalImageCard extends StatelessWidget {
               ],
             ),
           ),
-        ).animate().fadeIn(duration: const Duration(milliseconds: 100));
+        );
       },
+    );
+  }
+}
+
+class TaskListCard extends StatelessWidget {
+  const TaskListCard({
+    required this.task,
+    super.key,
+  });
+
+  final Task task;
+
+  @override
+  Widget build(BuildContext context) {
+    void onTap() => beamToNamed('/tasks/${task.meta.id}');
+
+    return Card(
+      child: ListTile(
+        onTap: onTap,
+        trailing: TaskStatusWidget(task),
+        title: Text(
+          task.data.title,
+          style: const TextStyle(
+            fontSize: fontSizeMediumLarge,
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/widgets/search/task_status_filter.dart
+++ b/lib/widgets/search/task_status_filter.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -26,6 +26,51 @@ class TaskStatusFilter extends StatelessWidget {
               const SizedBox(width: 5),
             ],
           ),
+        );
+      },
+    );
+  }
+}
+
+class TaskListToggle extends StatelessWidget {
+  const TaskListToggle({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<JournalPageCubit, JournalPageState>(
+      builder: (context, snapshot) {
+        final cubit = context.read<JournalPageCubit>();
+        final iconColor = Theme.of(context).textTheme.titleLarge?.color;
+        final inactiveIconColor = iconColor?.withOpacity(0.5);
+        final taskAsListView = snapshot.taskAsListView;
+
+        return Row(
+          children: [
+            const SizedBox(width: 15),
+            SegmentedButton<bool>(
+              showSelectedIcon: false,
+              onSelectionChanged: (selection) {
+                cubit.toggleTaskAsListView();
+              },
+              segments: [
+                ButtonSegment<bool>(
+                  value: true,
+                  label: Icon(
+                    Icons.density_small_rounded,
+                    color: taskAsListView ? iconColor : inactiveIconColor,
+                  ),
+                ),
+                ButtonSegment<bool>(
+                  value: false,
+                  label: Icon(
+                    Icons.density_medium_rounded,
+                    color: taskAsListView ? inactiveIconColor : iconColor,
+                  ),
+                ),
+              ],
+              selected: {taskAsListView},
+            ),
+          ],
         );
       },
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.411+2347
+version: 0.9.412+2349
 
 msix_config:
   display_name: LottiApp

--- a/test/pages/journal/infinite_journal_page_test.dart
+++ b/test/pages/journal/infinite_journal_page_test.dart
@@ -237,22 +237,10 @@ void main() {
 
       await tester.pumpAndSettle();
 
-      // task entry displays expected date
-      expect(
-        find.text(dfShorter.format(testTask.meta.dateFrom)),
-        findsOneWidget,
-      );
-
       // test task title is displayed
       expect(
         find.text(testTask.data.title),
         findsOneWidget,
-      );
-
-      // test task is starred
-      expect(
-        (tester.firstWidget(find.byIcon(MdiIcons.star)) as Icon).color,
-        starredGold,
       );
     });
 
@@ -290,22 +278,10 @@ void main() {
 
       await tester.pumpAndSettle();
 
-      // task entry displays expected date
-      expect(
-        find.text(dfShorter.format(testTask.meta.dateFrom)),
-        findsOneWidget,
-      );
-
       // test task title is displayed
       expect(
         find.text(testTask.data.title),
         findsOneWidget,
-      );
-
-      // test task is starred
-      expect(
-        (tester.firstWidget(find.byIcon(MdiIcons.star)) as Icon).color,
-        starredGold,
       );
     });
 


### PR DESCRIPTION
This PR adds a narrower list view for tasks that is shown by default, only showing the task title and status, and a segmented button in the task page header for toggling between those views. 

The idea here is that previously, too much scrolling was needed to go through tasks, and that most of the displayed information wasn't helpful in a list representation.