### PR TITLE
fix: keyboard listener issue

### DIFF
--- a/lib/blocs/journal/entry_cubit.dart
+++ b/lib/blocs/journal/entry_cubit.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:flutter_quill/flutter_quill.dart';
+import 'package:hotkey_manager/hotkey_manager.dart';
 import 'package:lotti/blocs/journal/entry_state.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
@@ -45,9 +46,34 @@ class EntryCubit extends Cubit<EntryState> {
       formKey = GlobalKey<FormBuilderState>();
     }
 
+    final saveHotKey = HotKey(
+      key: LogicalKeyboardKey.keyS,
+      modifiers: [HotKeyModifier.meta],
+      scope: HotKeyScope.inapp,
+    );
+
     focusNode.addListener(() {
-      _isFocused = true;
+      _isFocused = focusNode.hasFocus;
+      if (_isFocused) {
+        hotKeyManager.register(
+          saveHotKey,
+          keyDownHandler: (hotKey) => save(),
+        );
+      } else {
+        hotKeyManager.unregister(saveHotKey);
+      }
       emitState();
+    });
+
+    taskTitleFocusNode.addListener(() {
+      if (taskTitleFocusNode.hasFocus) {
+        hotKeyManager.register(
+          saveHotKey,
+          keyDownHandler: (hotKey) => save(),
+        );
+      } else {
+        hotKeyManager.unregister(saveHotKey);
+      }
     });
 
     try {
@@ -107,6 +133,7 @@ class EntryCubit extends Cubit<EntryState> {
   late final Stream<JournalEntity?> _entryStream;
   late final StreamSubscription<JournalEntity?> _entryStreamSubscription;
   final FocusNode focusNode = FocusNode();
+  final FocusNode taskTitleFocusNode = FocusNode();
   final EditorStateService _editorStateService = getIt<EditorStateService>();
   final JournalDb _journalDb = getIt<JournalDb>();
   final PersistenceLogic _persistenceLogic = getIt<PersistenceLogic>();

--- a/lib/widgets/journal/editor/editor_widget.dart
+++ b/lib/widgets/journal/editor/editor_widget.dart
@@ -42,42 +42,6 @@ class EditorWidget extends StatelessWidget {
         final controller = context.read<EntryCubit>().controller;
         final focusNode = context.read<EntryCubit>().focusNode;
 
-        void keyFormatter<T>(
-          // ignore: deprecated_member_use
-          RawKeyEvent event,
-          String char,
-          Attribute<T> attribute,
-        ) {
-          // ignore: deprecated_member_use
-          if (event.data.isMetaPressed && event.character == char) {
-            final attributes = controller.getSelectionStyle().attributes;
-            final alreadySet = attributes.keys.toSet().contains(attribute.key);
-            final selection = controller.selection;
-
-            if (alreadySet) {
-              controller.formatText(
-                selection.baseOffset,
-                selection.extentOffset - selection.baseOffset,
-                Attribute.clone(attribute, null),
-              );
-            } else {
-              controller.formatText(
-                selection.baseOffset,
-                selection.extentOffset - selection.baseOffset,
-                attribute,
-              );
-            }
-          }
-        }
-
-        // ignore: deprecated_member_use
-        void saveViaKeyboard(RawKeyEvent event) {
-          // ignore: deprecated_member_use
-          if (event.data.isMetaPressed && event.character == 's') {
-            context.read<EntryCubit>().save();
-          }
-        }
-
         if (snapshot.isFocused && isMobile) {
           Timer(const Duration(milliseconds: 300), () {
             Scrollable.ensureVisible(
@@ -87,59 +51,48 @@ class EditorWidget extends StatelessWidget {
           });
         }
 
-        // ignore: deprecated_member_use
-        return RawKeyboardListener(
-          focusNode: FocusNode(),
-          // ignore: deprecated_member_use
-          onKey: (RawKeyEvent event) {
-            keyFormatter(event, 'b', Attribute.bold);
-            keyFormatter(event, 'i', Attribute.italic);
-            saveViaKeyboard(event);
-          },
-          child: Card(
-            color: Theme.of(context).colorScheme.surface.brighten(),
-            elevation: 0,
-            clipBehavior: Clip.hardEdge,
-            shape: const RoundedRectangleBorder(
-              borderRadius:
-                  BorderRadius.all(Radius.circular(inputBorderRadius)),
-              side: BorderSide(),
+        return Card(
+          color: Theme.of(context).colorScheme.surface.brighten(),
+          elevation: 0,
+          clipBehavior: Clip.hardEdge,
+          shape: const RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(inputBorderRadius)),
+            side: BorderSide(),
+          ),
+          child: ConstrainedBox(
+            constraints: BoxConstraints(
+              maxHeight: maxHeight,
             ),
-            child: ConstrainedBox(
-              constraints: BoxConstraints(
-                maxHeight: maxHeight,
-              ),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  if (snapshot.isFocused)
-                    ToolbarWidget(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (snapshot.isFocused)
+                  ToolbarWidget(
+                    controller: controller,
+                  ),
+                Flexible(
+                  child: QuillEditor(
+                    scrollController: ScrollController(),
+                    focusNode: focusNode,
+                    configurations: QuillEditorConfigurations(
+                      autoFocus: autoFocus,
+                      minHeight: minHeight,
+                      placeholder: localizations.editorPlaceholder,
+                      padding: EdgeInsets.only(
+                        top: 8,
+                        bottom: 16,
+                        left: padding,
+                        right: padding,
+                      ),
+                      keyboardAppearance: Theme.of(context).brightness,
+                      customStyles: customEditorStyles(
+                        themeData: Theme.of(context),
+                      ),
                       controller: controller,
                     ),
-                  Flexible(
-                    child: QuillEditor(
-                      scrollController: ScrollController(),
-                      focusNode: focusNode,
-                      configurations: QuillEditorConfigurations(
-                        autoFocus: autoFocus,
-                        minHeight: minHeight,
-                        placeholder: localizations.editorPlaceholder,
-                        padding: EdgeInsets.only(
-                          top: 8,
-                          bottom: 16,
-                          left: padding,
-                          right: padding,
-                        ),
-                        keyboardAppearance: Theme.of(context).brightness,
-                        customStyles: customEditorStyles(
-                          themeData: Theme.of(context),
-                        ),
-                        controller: controller,
-                      ),
-                    ),
                   ),
-                ],
-              ),
+                ),
+              ],
             ),
           ),
         );

--- a/lib/widgets/tasks/task_form.dart
+++ b/lib/widgets/tasks/task_form.dart
@@ -53,33 +53,22 @@ class _TaskFormState extends State<TaskForm> {
                 child: Column(
                   children: <Widget>[
                     const SizedBox(height: 10),
-                    // ignore: deprecated_member_use
-                    RawKeyboardListener(
-                      focusNode: FocusNode(),
-                      // ignore: deprecated_member_use
-                      onKey: (RawKeyEvent event) {
-                        // ignore: deprecated_member_use
-                        if (event.data.isMetaPressed &&
-                            event.character == 's') {
-                          save();
-                        }
-                      },
-                      child: FormBuilderTextField(
-                        autofocus: widget.focusOnTitle,
-                        initialValue: widget.data?.title ?? '',
-                        decoration: inputDecoration(
-                          labelText: '${widget.data?.title}'.isEmpty
-                              ? localizations.taskNameLabel
-                              : '',
-                          themeData: Theme.of(context),
-                        ),
-                        textCapitalization: TextCapitalization.sentences,
-                        keyboardAppearance: Theme.of(context).brightness,
-                        maxLines: null,
-                        style: const TextStyle(fontSize: fontSizeLarge),
-                        name: 'title',
-                        onChanged: context.read<EntryCubit>().setDirty,
+                    FormBuilderTextField(
+                      autofocus: widget.focusOnTitle,
+                      focusNode: context.read<EntryCubit>().taskTitleFocusNode,
+                      initialValue: widget.data?.title ?? '',
+                      decoration: inputDecoration(
+                        labelText: '${widget.data?.title}'.isEmpty
+                            ? localizations.taskNameLabel
+                            : '',
+                        themeData: Theme.of(context),
                       ),
+                      textCapitalization: TextCapitalization.sentences,
+                      keyboardAppearance: Theme.of(context).brightness,
+                      maxLines: null,
+                      style: const TextStyle(fontSize: fontSizeLarge),
+                      name: 'title',
+                      onChanged: context.read<EntryCubit>().setDirty,
                     ),
                     inputSpacer,
                     Row(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -117,10 +117,10 @@ packages:
     dependency: "direct main"
     description:
       name: beamer
-      sha256: "88e3e47aceebbc4cb781949493acb99ec4af7043ae6fab6739a4708c24270fee"
+      sha256: c32c5dea11c178fca271f2cce8f3bce4bc0ad761a2b69978573c4e75e991abf9
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.0"
+    version: "1.6.1"
   beautiful_soup_dart:
     dependency: transitive
     description:
@@ -769,42 +769,50 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_image_compress
-      sha256: f159d2e8c4ed04b8e36994124fd4a5017a0f01e831ae3358c74095c340e9ae5e
+      sha256: "4edadb0ca2f957b85190e9c3aa728569b91b64b6e06e0eec5b622d47a8692ab2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   flutter_image_compress_common:
     dependency: transitive
     description:
       name: flutter_image_compress_common
-      sha256: "0756440ddc647696ebc56f393be8c1055e81ef1c1f58986fb1f078af393637d8"
+      sha256: "7f79bc6c8a363063620b4e372fa86bc691e1cb28e58048cd38e030692fbd99ee"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   flutter_image_compress_macos:
     dependency: transitive
     description:
       name: flutter_image_compress_macos
-      sha256: fea1e3d71150d03373916b832c49b5c2f56c3e7e13da82a929274a2c6f88251e
+      sha256: "26df6385512e92b3789dc76b613b54b55c457a7f1532e59078b04bf189782d47"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
+  flutter_image_compress_ohos:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_ohos
+      sha256: "70360371698be994786e5dd2e364a6525b1c5a4f843bff8af9b8a2fbe808d8d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.2"
   flutter_image_compress_platform_interface:
     dependency: transitive
     description:
       name: flutter_image_compress_platform_interface
-      sha256: "87d0964ae72ccab1cdfbc32f825ce6b57bf87fd3576a2842bf38189d392163b8"
+      sha256: "579cb3947fd4309103afe6442a01ca01e1e6f93dc53bb4cbd090e8ce34a41889"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   flutter_image_compress_web:
     dependency: transitive
     description:
       name: flutter_image_compress_web
-      sha256: "1c8cd505be95cb2e0573cdd9d236ac0ba39c166b8df06ef1823f2a17b60e1253"
+      sha256: f02fe352b17f82b72f481de45add240db062a2585850bea1667e82cc4cd6c311
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.4+1"
   flutter_keyboard_visibility:
     dependency: transitive
     description:
@@ -966,10 +974,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_riverpod
-      sha256: "4bce556b7ecbfea26109638d5237684538d4abc509d253e6c5c4c5733b360098"
+      sha256: "0f1974eff5bbe774bf1d870e406fc6f29e3d6f1c46bd9c58e7172ff68a785d7d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.10"
+    version: "2.5.1"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -1133,10 +1141,10 @@ packages:
     dependency: "direct main"
     description:
       name: google_fonts
-      sha256: "5b1726fee554d1cc9db1baef8061b126567ff0a1140a03ed7de936e62f2ab98b"
+      sha256: b1ac0fe2832c9cc95e5e88b57d627c5e68c223b9657f4b96e1487aa9098c7b82
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.0"
+    version: "6.2.1"
   graphs:
     dependency: transitive
     description:
@@ -1555,10 +1563,10 @@ packages:
     dependency: "direct main"
     description:
       name: matrix
-      sha256: aa9a7c641c5f99e7839c62c0461b279e5e9a3e803d400e57110f158ac28763d9
+      sha256: f829dd542f354e5073e3b43aaed3adc2829e762a9ec50a3f186ffd7dddc36d5e
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.0"
+    version: "0.26.1"
   matrix_api_lite:
     dependency: transitive
     description:
@@ -2139,10 +2147,10 @@ packages:
     dependency: transitive
     description:
       name: riverpod
-      sha256: "548e2192eb7aeb826eb89387f814edb76594f3363e2c0bb99dd733d795ba3589"
+      sha256: f21b32ffd26a36555e501b04f4a5dca43ed59e16343f1a30c13632b2351dfa4d
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.0"
+    version: "2.5.1"
   rxdart:
     dependency: "direct main"
     description:
@@ -2448,18 +2456,18 @@ packages:
     dependency: transitive
     description:
       name: super_clipboard
-      sha256: "15d25eb88df8e904e0c2ef77378c6010cc57bbfc0b6f91f2416d08fad5fcca92"
+      sha256: ea683cedf63d7d92731b53891a6baabf7d7e5b38ef10ab7a2ed145bd16af159c
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.5"
+    version: "0.8.9"
   super_native_extensions:
     dependency: transitive
     description:
       name: super_native_extensions
-      sha256: f96db6b137a0b135e43034289bb55ca6447b65225076036e81f97ebb6381ffeb
+      sha256: "9ebae48891159d3365d342d6d43abeb5b702758ed30d2b0cc6c125fa0ad577e3"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.5"
+    version: "0.8.9"
   sync_http:
     dependency: transitive
     description:
@@ -2902,4 +2910,4 @@ packages:
     version: "3.1.2"
 sdks:
   dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.19.0"
+  flutter: ">=3.19.2"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1174,10 +1174,10 @@ packages:
     dependency: "direct main"
     description:
       name: hotkey_manager
-      sha256: a3950a87ae011c190ba6bf3775e3b53c0f7cbd26dc032e648e7a0e2fd9363ab5
+      sha256: fb4b976ce7f4240bf75c2be807d2e4bf9e1d73ad379187db2c96a11219efe707
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.1"
   hotkey_manager_linux:
     dependency: transitive
     description:
@@ -2123,10 +2123,10 @@ packages:
     dependency: "direct main"
     description:
       name: research_package
-      sha256: "4c72da3d88937c9e29d770bf75fa721b60c21731c15c8b7ab704ed208568015b"
+      sha256: "979674019091ee2728a5b5565ef99afd9ac652c95cc97472e5da4c3c0514d228"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.2"
   retry:
     dependency: "direct main"
     description:
@@ -2832,10 +2832,10 @@ packages:
     dependency: "direct main"
     description:
       name: wechat_assets_picker
-      sha256: "6e52853f7dbc6f7aec10675d0064167eb7fc65f636ed22e55c38c450f5b75918"
+      sha256: "3d5cfcebbcbe21d6a4f91927423d437d3c8b441b0d9cc5318bc2632b05c1cddf"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.1"
+    version: "9.0.2"
   wechat_picker_library:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.433+2396
+version: 0.9.434+2397
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.434+2397
+version: 0.9.434+2398
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR fixes a keyboard lister issue where the registered `CMD-r` for refreshing the journal list page would also be triggered when just typing `r`, and thus swallowing the keypress event such that no `r` could be typed in any text input. This bug must have recently been introduced in `hotkey_manager` as reported [here](https://github.com/leanflutter/hotkey_manager/issues/52) and is fixed in `v0.2.1`, so the update alone fixes the problem.

This PR also does other dependency upgrades, and some refactoring around event handling.