### PR TITLE
test: create Matrix user in test script

### DIFF
--- a/integration_test/matrix_service_test.dart
+++ b/integration_test/matrix_service_test.dart
@@ -35,25 +35,51 @@ void main() {
     test('Create room & join', () async {
       const config = MatrixConfig(
         homeServer: 'http://localhost:8008',
-        user: '@lotti-test:localhost',
-        password: 'Secret123@',
+        user: '@lotti-test2:localhost',
+        password: '?Secret123@!',
       );
-      final matrixService = MatrixService(matrixConfig: config);
-      await matrixService.login();
-
-      final roomId = await matrixService.createRoom();
-      debugPrint('Room created: $roomId');
-
-      final room = matrixService.getRoom(roomId);
-      debugPrint('Room created: $room');
-
-      expect(
-        roomId,
-        isNotEmpty,
+      final matrixService1 = MatrixService(
+        matrixConfig: config,
+        hiveDbName: 'Alice',
+      );
+      await matrixService1.login();
+      debugPrint(
+        'MatrixService 1 - deviceId: ${matrixService1.client.deviceID}',
       );
 
-      final joinRes = await matrixService.joinRoom(roomId);
-      debugPrint('Room joined: $joinRes');
+      final roomId = await matrixService1.createRoom();
+      debugPrint('MatrixService 1 - room created: $roomId');
+
+      expect(roomId, isNotEmpty);
+
+      final joinRes = await matrixService1.joinRoom(roomId);
+      debugPrint('MatrixService 1 - room joined: $joinRes');
+
+      final matrixService2 = MatrixService(
+        matrixConfig: config,
+        hiveDbName: 'Bob',
+      );
+      await matrixService2.login();
+      debugPrint(
+        'MatrixService 2 - deviceId: ${matrixService2.client.deviceID}',
+      );
+
+      final joinRes2 = await matrixService2.joinRoom(roomId);
+      debugPrint('MatrixService 2 - room joined: $joinRes2');
+
+      await Future<void>.delayed(const Duration(seconds: 2));
+
+      final unverified1 = matrixService1.getUnverified();
+      final unverified2 = matrixService2.getUnverified();
+
+      debugPrint('MatrixService 1 - unverified: $unverified1');
+      debugPrint('MatrixService 2 - unverified: $unverified2');
+
+      expect(unverified1.length, 1);
+      expect(unverified2.length, 1);
+
+      await matrixService1.logout();
+      await matrixService2.logout();
     });
   });
 }

--- a/integration_test/matrix_service_test.dart
+++ b/integration_test/matrix_service_test.dart
@@ -32,14 +32,14 @@ void main() {
 
     tearDown(() async {});
 
-    test('Create room', () async {
+    test('Create room & join', () async {
       const config = MatrixConfig(
         homeServer: 'http://localhost:8008',
         user: '@lotti-test:localhost',
         password: 'Secret123@',
       );
       final matrixService = MatrixService(matrixConfig: config);
-      await matrixService.loginAndListen();
+      await matrixService.login();
 
       final roomId = await matrixService.createRoom();
       debugPrint('Room created: $roomId');
@@ -47,7 +47,13 @@ void main() {
       final room = matrixService.getRoom(roomId);
       debugPrint('Room created: $room');
 
-      expect(roomId, isNotEmpty);
+      expect(
+        roomId,
+        isNotEmpty,
+      );
+
+      final joinRes = await matrixService.joinRoom(roomId);
+      debugPrint('Room joined: $joinRes');
     });
   });
 }

--- a/integration_test/matrix_service_test.dart
+++ b/integration_test/matrix_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/config.dart';
@@ -15,6 +17,13 @@ void main() {
   group('MatrixService Tests', () {
     final mockLoggingDb = MockLoggingDb();
     final secureStorageMock = MockSecureStorage();
+    const testUserEnv = 'TEST_USER';
+
+    if (!const bool.hasEnvironment(testUserEnv)) {
+      debugPrint('TEST_USER not defined!!! Run via run_matrix_tests.sh');
+      exit(1);
+    }
+    const testUserName = String.fromEnvironment(testUserEnv);
 
     setUpAll(() async {
       setFakeDocumentsPath();
@@ -35,7 +44,7 @@ void main() {
     test('Create room & join', () async {
       const config = MatrixConfig(
         homeServer: 'http://localhost:8008',
-        user: '@lotti-test2:localhost',
+        user: '@$testUserName:localhost',
         password: '?Secret123@!',
       );
       final matrixService1 = MatrixService(
@@ -67,7 +76,7 @@ void main() {
       final joinRes2 = await matrixService2.joinRoom(roomId);
       debugPrint('MatrixService 2 - room joined: $joinRes2');
 
-      await Future<void>.delayed(const Duration(seconds: 2));
+      await Future<void>.delayed(const Duration(seconds: 1));
 
       final unverified1 = matrixService1.getUnverified();
       final unverified2 = matrixService2.getUnverified();

--- a/integration_test/run_matrix_tests.sh
+++ b/integration_test/run_matrix_tests.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Create user name
+uuid=$(uuidgen)
+TEST_USER=a="$(tr '[:upper:]' '[:lower:]' <<< "$uuid")"
+
+# Go to dendrite docker directory that contains config and keys
+cd ../dendrite/build/docker/config || exit
+
+# Create user using the create-account binary in dendrite build
+../../../bin/create-account -config dendrite.yaml -username "$TEST_USER" -password "?Secret123@!"
+cd - > /dev/null || exit
+
+fvm flutter test integration_test/matrix_service_test.dart --dart-define=TEST_USER="$TEST_USER"

--- a/lib/sync/matrix/matrix_service.dart
+++ b/lib/sync/matrix/matrix_service.dart
@@ -39,10 +39,12 @@ class MatrixStats {
 }
 
 class MatrixService {
-  MatrixService({this.matrixConfig})
-      : _client = createClient(),
-        _keyVerificationController =
+  MatrixService({
+    this.matrixConfig,
+    String? hiveDbName,
+  }) : _keyVerificationController =
             StreamController<KeyVerificationRunner>.broadcast() {
+    _client = createClient(hiveDbName: hiveDbName);
     _incomingKeyVerificationRunnerController =
         StreamController<KeyVerificationRunner>.broadcast(
       onListen: publishIncomingRunnerState,
@@ -57,7 +59,7 @@ class MatrixService {
     incomingKeyVerificationRunner?.publishState();
   }
 
-  Client _client;
+  late final Client _client;
   final LoggingDb _loggingDb = getIt<LoggingDb>();
   MatrixConfig? matrixConfig;
   LoginResponse? _loginResponse;
@@ -78,7 +80,9 @@ class MatrixService {
   final _incomingKeyVerificationController =
       StreamController<KeyVerification>.broadcast();
 
-  static Client createClient() {
+  Client createClient({
+    String? hiveDbName,
+  }) {
     return Client(
       'lotti',
       verificationMethods: {
@@ -88,10 +92,8 @@ class MatrixService {
       shareKeysWithUnverifiedDevices: false,
       databaseBuilder: (_) async {
         final dir = await getApplicationDocumentsDirectory();
-        final db = HiveCollectionsDatabase(
-          'lotti_sync',
-          '${dir.path}/matrix/',
-        );
+        final path = '${dir.path}/matrix/';
+        final db = HiveCollectionsDatabase(hiveDbName ?? 'lotti_sync', path);
         await db.open();
         return db;
       },
@@ -104,9 +106,12 @@ class MatrixService {
     await listen();
   }
 
+  Client get client {
+    return _client;
+  }
+
   Future<void> login() async {
     try {
-      _client = createClient();
       final matrixConfig = this.matrixConfig;
 
       if (matrixConfig == null) {
@@ -135,7 +140,7 @@ class MatrixService {
       );
 
       if (!isLoggedIn()) {
-        final initialDeviceDisplayName = await createDeviceName();
+        final initialDeviceDisplayName = await createMatrixDeviceName();
 
         _loginResponse = await _client.login(
           LoginType.mLoginPassword,
@@ -165,22 +170,7 @@ class MatrixService {
       final roomId = matrixConfig.roomId;
 
       if (roomId != null) {
-        final joinRes = await _client.joinRoom(roomId).onError((
-          error,
-          stackTrace,
-        ) {
-          debugPrint('MatrixService join error $error');
-
-          _loggingDb.captureException(
-            error,
-            domain: 'MATRIX_SERVICE',
-            subDomain: 'login join',
-            stackTrace: stackTrace,
-          );
-
-          return error.toString();
-        });
-        debugPrint('MatrixService joinRes $joinRes');
+        await joinRoom(roomId);
       }
     } catch (e, stackTrace) {
       debugPrint('$e');
@@ -210,7 +200,6 @@ class MatrixService {
 
         return error.toString();
       });
-      debugPrint('MatrixService joinRes $joinRes');
       return joinRes;
     } catch (e, stackTrace) {
       debugPrint('$e');
@@ -627,7 +616,7 @@ class MatrixService {
     await logout();
   }
 
-  Future<String> createDeviceName() async {
+  Future<String> createMatrixDeviceName() async {
     final operatingSystem = Platform.operatingSystem;
     var deviceName = operatingSystem;
 
@@ -646,6 +635,6 @@ class MatrixService {
     }
 
     final dateHhMm = DateTime.now().toIso8601String().substring(0, 16);
-    return '$deviceName $dateHhMm';
+    return '$deviceName $dateHhMm ${uuid.v1().substring(0, 4)}';
   }
 }

--- a/lib/sync/matrix/matrix_service.dart
+++ b/lib/sync/matrix/matrix_service.dart
@@ -193,6 +193,37 @@ class MatrixService {
     }
   }
 
+  Future<String> joinRoom(String roomId) async {
+    try {
+      final joinRes = await _client.joinRoom(roomId).onError((
+        error,
+        stackTrace,
+      ) {
+        debugPrint('MatrixService join error $error');
+
+        _loggingDb.captureException(
+          error,
+          domain: 'MATRIX_SERVICE',
+          subDomain: 'joinRoom',
+          stackTrace: stackTrace,
+        );
+
+        return error.toString();
+      });
+      debugPrint('MatrixService joinRes $joinRes');
+      return joinRes;
+    } catch (e, stackTrace) {
+      debugPrint('$e');
+      _loggingDb.captureException(
+        e,
+        domain: 'MATRIX_SERVICE',
+        subDomain: 'joinRoom',
+        stackTrace: stackTrace,
+      );
+      rethrow;
+    }
+  }
+
   bool isLoggedIn() {
     // TODO(unassigned): find non-deprecated solution
     // ignore: deprecated_member_use

--- a/lib/sync/matrix/matrix_service.dart
+++ b/lib/sync/matrix/matrix_service.dart
@@ -149,17 +149,11 @@ class MatrixService {
           initialDeviceDisplayName: initialDeviceDisplayName,
         );
 
-        debugPrint('MatrixService userId ${_loginResponse?.userId}');
-
         _loggingDb.captureEvent(
           'logged in, userId ${_loginResponse?.userId},'
           ' deviceId  ${_loginResponse?.deviceId}',
           domain: 'MATRIX_SERVICE',
           subDomain: 'login',
-        );
-
-        debugPrint(
-          'MatrixService loginResponse deviceId ${_loginResponse?.deviceId}',
         );
       }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.438+2406
+version: 0.9.438+2407
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR adds creating a new Matrix test user in each run of the Matrix integration test such that the tests don't have to deal with old state such as unverified devices from previous interrupted test runs (when for example the logout was never reached) or also already exiting rooms that a hardcoded test user would have created in previous test runs.
