### PR TITLE
test: Matrix device verification

### DIFF
--- a/integration_test/matrix_service_test.dart
+++ b/integration_test/matrix_service_test.dart
@@ -16,6 +16,7 @@ import '../test/mocks/mocks.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  // description and how to run in https://github.com/matthiasn/lotti/pull/1695
   group('MatrixService Tests', () {
     final mockLoggingDb = MockLoggingDb();
     final secureStorageMock = MockSecureStorage();

--- a/integration_test/run_matrix_tests.sh
+++ b/integration_test/run_matrix_tests.sh
@@ -2,7 +2,7 @@
 
 # Create user name
 uuid=$(uuidgen)
-TEST_USER=a="$(tr '[:upper:]' '[:lower:]' <<< "$uuid")"
+TEST_USER="$(tr '[:upper:]' '[:lower:]' <<< "$uuid")"
 
 # Go to dendrite docker directory that contains config and keys
 cd ../dendrite/build/docker/config || exit

--- a/integration_test/run_matrix_tests.sh
+++ b/integration_test/run_matrix_tests.sh
@@ -8,7 +8,7 @@ TEST_USER="$(tr '[:upper:]' '[:lower:]' <<< "$uuid")"
 cd ../dendrite/build/docker/config || exit
 
 # Create user using the create-account binary in dendrite build
-../../../bin/create-account -config dendrite.yaml -username "$TEST_USER" -password "?Secret123@!"
+../../../bin/create-account -config dendrite.yaml -username "$TEST_USER" -admin -password "?Secret123@!"
 cd - > /dev/null || exit
 
 fvm flutter test integration_test/matrix_service_test.dart --dart-define=TEST_USER="$TEST_USER"

--- a/lib/services/sync_config_service.dart
+++ b/lib/services/sync_config_service.dart
@@ -73,7 +73,10 @@ class SyncConfigService {
 
   Future<void> setImapConfig(ImapConfig imapConfig) async {
     final json = jsonEncode(imapConfig);
-    await getIt<SecureStorage>().write(key: imapConfigKey, value: json);
+    await getIt<SecureStorage>().write(
+      key: imapConfigKey,
+      value: json,
+    );
   }
 
   Future<bool> testConnection(SyncConfig syncConfig) async {

--- a/lib/sync/matrix/key_verification_runner.dart
+++ b/lib/sync/matrix/key_verification_runner.dart
@@ -12,7 +12,6 @@ class KeyVerificationRunner {
   }) {
     lastStep = keyVerification.lastStep ?? '';
     startedVerification = keyVerification.startedVerification;
-    lastStepHistory.add(lastStep);
     publishState();
 
     _timer = Timer.periodic(
@@ -21,7 +20,6 @@ class KeyVerificationRunner {
         final newLastStep = keyVerification.lastStep;
         if (newLastStep != null && newLastStep != lastStep) {
           lastStep = newLastStep;
-          lastStepHistory.add(newLastStep);
           debugPrint('$name newLastStep: $newLastStep');
 
           if (lastStep == 'm.key.verification.key') {
@@ -45,7 +43,6 @@ class KeyVerificationRunner {
   String name;
   String lastStep = '';
   bool? startedVerification;
-  List<String> lastStepHistory = [];
   List<KeyVerificationEmoji>? emojis;
   KeyVerification keyVerification;
   StreamController<KeyVerificationRunner> controller;

--- a/lib/sync/matrix/key_verification_runner.dart
+++ b/lib/sync/matrix/key_verification_runner.dart
@@ -22,7 +22,7 @@ class KeyVerificationRunner {
         if (newLastStep != null && newLastStep != lastStep) {
           lastStep = newLastStep;
           lastStepHistory.add(newLastStep);
-          debugPrint('$name newLastStep: $newLastStep ');
+          debugPrint('$name newLastStep: $newLastStep');
 
           if (lastStep == 'm.key.verification.key') {
             readEmojis();
@@ -30,10 +30,6 @@ class KeyVerificationRunner {
 
           if (lastStep == EventTypes.KeyVerificationDone) {
             stopTimer();
-          }
-
-          if (lastStep == 'm.key.verification.mac') {
-            //keyVerification.acceptVerification();
           }
 
           if (lastStep == 'm.key.verification.cancel') {
@@ -63,11 +59,8 @@ class KeyVerificationRunner {
     await keyVerification.acceptVerification();
   }
 
-  Future<List<KeyVerificationEmoji>?> acceptEmojiVerification() async {
+  Future<void> acceptEmojiVerification() async {
     await keyVerification.acceptSas();
-    emojis = keyVerification.sasEmojis;
-    publishState();
-    return emojis;
   }
 
   void readEmojis() {

--- a/lib/sync/matrix/key_verification_runner.dart
+++ b/lib/sync/matrix/key_verification_runner.dart
@@ -8,6 +8,7 @@ class KeyVerificationRunner {
   KeyVerificationRunner(
     this.keyVerification, {
     required this.controller,
+    required this.name,
   }) {
     lastStep = keyVerification.lastStep ?? '';
     startedVerification = keyVerification.startedVerification;
@@ -18,15 +19,12 @@ class KeyVerificationRunner {
       const Duration(milliseconds: 100),
       (timer) {
         final newLastStep = keyVerification.lastStep;
-        // debugPrint('KeyVerificationRunner newLastStep: $newLastStep ');
         if (newLastStep != null && newLastStep != lastStep) {
           lastStep = newLastStep;
           lastStepHistory.add(newLastStep);
-          debugPrint('KeyVerificationRunner newLastStep: $newLastStep ');
-          publishState();
+          debugPrint('$name newLastStep: $newLastStep ');
 
           if (lastStep == 'm.key.verification.key') {
-            //acceptEmojiVerification();
             readEmojis();
           }
 
@@ -41,11 +39,14 @@ class KeyVerificationRunner {
           if (lastStep == 'm.key.verification.cancel') {
             stopTimer();
           }
+
+          publishState();
         }
       },
     );
   }
 
+  String name;
   String lastStep = '';
   bool? startedVerification;
   List<String> lastStepHistory = [];
@@ -69,10 +70,8 @@ class KeyVerificationRunner {
     return emojis;
   }
 
-  Future<List<KeyVerificationEmoji>?> readEmojis() async {
+  void readEmojis() {
     emojis = keyVerification.sasEmojis;
-    publishState();
-    return emojis;
   }
 
   void publishState() {

--- a/lib/sync/matrix/matrix_service.dart
+++ b/lib/sync/matrix/matrix_service.dart
@@ -597,14 +597,11 @@ class MatrixService {
   }
 
   Future<void> setMatrixConfig(MatrixConfig config) async {
+    matrixConfig = config;
     await getIt<SecureStorage>().write(
       key: matrixConfigKey,
-      value: jsonEncode(matrixConfig),
+      value: jsonEncode(config),
     );
-    matrixConfig = config;
-
-    await logout();
-    await login();
   }
 
   Future<void> deleteMatrixConfig() async {

--- a/lib/sync/matrix/matrix_service.dart
+++ b/lib/sync/matrix/matrix_service.dart
@@ -41,6 +41,7 @@ class MatrixStats {
 class MatrixService {
   MatrixService({
     this.matrixConfig,
+    this.deviceDisplayName,
     String? hiveDbName,
   }) : _keyVerificationController =
             StreamController<KeyVerificationRunner>.broadcast() {
@@ -51,7 +52,7 @@ class MatrixService {
     );
 
     keyVerificationStream = _keyVerificationController.stream;
-    incomingKeyVerificationStream =
+    incomingKeyVerificationRunnerStream =
         _incomingKeyVerificationRunnerController.stream;
   }
 
@@ -59,6 +60,7 @@ class MatrixService {
     incomingKeyVerificationRunner?.publishState();
   }
 
+  final String? deviceDisplayName;
   late final Client _client;
   final LoggingDb _loggingDb = getIt<LoggingDb>();
   MatrixConfig? matrixConfig;
@@ -75,7 +77,7 @@ class MatrixService {
   late final StreamController<KeyVerificationRunner>
       _incomingKeyVerificationRunnerController;
   late final Stream<KeyVerificationRunner> keyVerificationStream;
-  late final Stream<KeyVerificationRunner> incomingKeyVerificationStream;
+  late final Stream<KeyVerificationRunner> incomingKeyVerificationRunnerStream;
 
   final _incomingKeyVerificationController =
       StreamController<KeyVerification>.broadcast();
@@ -140,7 +142,8 @@ class MatrixService {
       );
 
       if (!isLoggedIn()) {
-        final initialDeviceDisplayName = await createMatrixDeviceName();
+        final initialDeviceDisplayName =
+            deviceDisplayName ?? await createMatrixDeviceName();
 
         _loginResponse = await _client.login(
           LoginType.mLoginPassword,
@@ -245,6 +248,7 @@ class MatrixService {
     keyVerificationRunner = KeyVerificationRunner(
       keyVerification,
       controller: _keyVerificationController,
+      name: 'Outgoing KeyVerificationRunner',
     );
   }
 
@@ -255,11 +259,11 @@ class MatrixService {
     }
   }
 
-  String? getDeviceId() {
+  String? get deviceId {
     return _client.deviceID;
   }
 
-  String? getDeviceName() {
+  String? get deviceName {
     return _client.deviceName;
   }
 
@@ -279,6 +283,7 @@ class MatrixService {
         incomingKeyVerificationRunner = KeyVerificationRunner(
           keyVerification,
           controller: _incomingKeyVerificationRunnerController,
+          name: 'Incoming KeyVerificationRunner',
         );
 
         debugPrint('Key Verification Request from ${keyVerification.deviceId}');

--- a/lib/sync/secure_storage.dart
+++ b/lib/sync/secure_storage.dart
@@ -1,6 +1,9 @@
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 class SecureStorage {
+  SecureStorage();
+
   final _storage = const FlutterSecureStorage();
   final _state = <String, String>{};
 
@@ -8,7 +11,16 @@ class SecureStorage {
     final exists = _state[key] != null;
 
     if (!exists) {
-      final fromSecureStorage = await _storage.read(key: key);
+      final info = await PackageInfo.fromPlatform();
+      final fromSecureStorage = await _storage.read(
+        key: key,
+        iOptions: IOSOptions(
+          accountName: info.packageName,
+        ),
+        mOptions: MacOsOptions(
+          accountName: info.packageName,
+        ),
+      );
       if (fromSecureStorage != null) {
         _state[key] = fromSecureStorage;
       }
@@ -24,10 +36,18 @@ class SecureStorage {
   Future<void> writeValue(String key, String value) async {
     await delete(key: key);
     _state[key] = value;
+
+    final info = await PackageInfo.fromPlatform();
+
     await _storage.write(
       key: key,
-      value: _state[key],
-      iOptions: IOSOptions.defaultOptions,
+      value: value,
+      iOptions: IOSOptions(
+        accountName: info.packageName,
+      ),
+      mOptions: MacOsOptions(
+        accountName: info.packageName,
+      ),
     );
   }
 
@@ -39,7 +59,16 @@ class SecureStorage {
   }
 
   Future<void> delete({required String key}) async {
-    await _storage.delete(key: key);
     _state.remove(key);
+    final info = await PackageInfo.fromPlatform();
+    await _storage.delete(
+      key: key,
+      iOptions: IOSOptions(
+        accountName: info.packageName,
+      ),
+      mOptions: MacOsOptions(
+        accountName: info.packageName,
+      ),
+    );
   }
 }

--- a/lib/widgets/sync/matrix/incoming_verification_modal.dart
+++ b/lib/widgets/sync/matrix/incoming_verification_modal.dart
@@ -44,7 +44,7 @@ class _IncomingVerificationModalState extends State<IncomingVerificationModal> {
         'device name not found';
 
     return StreamBuilder<KeyVerificationRunner>(
-      stream: _matrixService.incomingKeyVerificationStream,
+      stream: _matrixService.incomingKeyVerificationRunnerStream,
       builder: (context, snapshot) {
         final runner = snapshot.data;
         final lastStep = runner?.lastStep;

--- a/lib/widgets/sync/matrix/incoming_verification_modal.dart
+++ b/lib/widgets/sync/matrix/incoming_verification_modal.dart
@@ -60,14 +60,6 @@ class _IncomingVerificationModalState extends State<IncomingVerificationModal> {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                ...?runner?.lastStepHistory.map(
-                  (step) => Text(
-                    step,
-                    style: Theme.of(context).textTheme.bodySmall,
-                  ),
-                ),
-                const SizedBox(height: 10),
-                const Divider(),
                 Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [

--- a/lib/widgets/sync/matrix/matrix_settings.dart
+++ b/lib/widgets/sync/matrix/matrix_settings.dart
@@ -211,8 +211,8 @@ class _MatrixSettingsWidgetState extends ConsumerState<MatrixSettingsWidget> {
                 ),
               ),
             const SizedBox(height: 40),
-            Text('Device ID: ${_matrixService.getDeviceId()}'),
-            Text('Device Name: ${_matrixService.getDeviceName()}'),
+            Text('Device ID: ${_matrixService.deviceId}'),
+            Text('Device Name: ${_matrixService.deviceName}'),
             const SizedBox(height: 40),
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/lib/widgets/sync/matrix/verification_modal.dart
+++ b/lib/widgets/sync/matrix/verification_modal.dart
@@ -73,14 +73,6 @@ class _VerificationModalState extends State<VerificationModal> {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                ...?runner?.lastStepHistory.map(
-                  (step) => Text(
-                    step,
-                    style: Theme.of(context).textTheme.bodySmall,
-                  ),
-                ),
-                const SizedBox(height: 10),
-                const Divider(),
                 Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.439+2408
+version: 0.9.439+2409
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR adds an integration test for [Matrix](https://spec.matrix.org/v1.10/) device verification, and some refactoring to enable that. In order to run it, you need to do the following:

1. clone [dendrite](https://github.com/matrix-org/dendrite) and build it, see top level README there.
2. Copy `./integration_test/dendrite` from here into `./build/docker` in `dendrite` and start the Docker Compose setup according to the respective docs using the copied `docker-compose.yml`. Feel free to change the shared secret in `dendrite.yaml` as you see fit.
3. Run `./integration_test/run_matrix_tests.sh` from project root here, which will [create a user](https://matrix-org.github.io/dendrite/administration/createusers) in the locally running dendrite instance, and then run the integration test against it.

The integration test will then do the following:

1. `AliceDevice` logs in.
2. `AliceDevice` creates room.
4. `BobDevice` logs in.
5. `BobDevice` joins room.
6. `AliceDevice` verifies unverified client/device, which happens to be `BobDevice`.
7. `BobDevice` accepts.
8. They negotiate to verify using [Short Authentication String (SAS) verification](https://spec.matrix.org/v1.10/client-server-api/#short-authentication-string-sas-verification), more specifically [SAS method: emoji](https://spec.matrix.org/v1.10/client-server-api/#sas-method-emoji).
9. They exchange sequences with seven emojis, which normally two users would show (or read to) each other, where trust is established if both sequences are identical. `AliceDevice` and `BobDevice` compare and conclude that the sequence is indeed the same and change the device status to verified. This is important as Lotti will only send any messages into a sync room when there are no unverified devices present.
10. The test ends successfully.

The verification of devices participating in sync enables the main goal here, which is synchronizing data between instances of an app using zero-trust infrastructure. Ideally, I as a user should not have to trust my data to anyone, ever, and this approach will allow that when the server has no way of intercepting any communication because [End-to-end encryption (E2EE)](https://en.wikipedia.org/wiki/End-to-end_encryption) is in place between devices that explicitly trust each other.

Test output:

<img width="986" alt="image" src="https://github.com/matthiasn/lotti/assets/1390808/1cbd4bb4-e55c-4176-84e3-390110158ad9">
