### PR TITLE
feat: improve Habits tab

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -81,14 +81,14 @@ PODS:
   - qr_code_scanner (0.2.0):
     - Flutter
     - MTBBarcodeScanner
-  - ReachabilitySwift (5.0.0)
+  - ReachabilitySwift (5.2.1)
   - record_darwin (1.0.0):
     - Flutter
     - FlutterMacOS
-  - SDWebImage (5.18.10):
-    - SDWebImage/Core (= 5.18.10)
-  - SDWebImage/Core (5.18.10)
-  - SDWebImageWebPCoder (0.14.4):
+  - SDWebImage (5.19.0):
+    - SDWebImage/Core (= 5.19.0)
+  - SDWebImage/Core (5.19.0)
+  - SDWebImageWebPCoder (0.14.5):
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.17)
   - share_plus (0.0.1):
@@ -272,10 +272,10 @@ SPEC CHECKSUMS:
   permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
   photo_manager: 4f6810b7dfc4feb03b461ac1a70dacf91fba7604
   qr_code_scanner: bb67d64904c3b9658ada8c402e8b4d406d5d796e
-  ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
+  ReachabilitySwift: 5ae15e16814b5f9ef568963fb2c87aeb49158c66
   record_darwin: 1f6619f2abac4d1ca91d3eeab038c980d76f1517
-  SDWebImage: fc8f2d48bbfd72ef39d70e981bd24a3f3be53fec
-  SDWebImageWebPCoder: 74cd61d52d8a4b20561f638bb88dda67b00eb5e0
+  SDWebImage: 981fd7e860af070920f249fd092420006014c3eb
+  SDWebImageWebPCoder: c94f09adbca681822edad9e532ac752db713eabf
   share_plus: 8875f4f2500512ea181eef553c3e27dba5135aad
   shared_preferences_foundation: b4c3b4cddf1c21f02770737f147a3f5da9d39695
   sqflite: 673a0e54cc04b7d6dba8d24fb8095b31c3a99eec

--- a/lib/widgets/app_bar/habit_page_app_bar.dart
+++ b/lib/widgets/app_bar/habit_page_app_bar.dart
@@ -20,63 +20,65 @@ class HabitsSliverAppBar extends StatelessWidget {
         final cubit = context.read<HabitsCubit>();
 
         return SliverAppBar(
-          expandedHeight: 250,
           primary: false,
-          title: SingleChildScrollView(
-            scrollDirection: Axis.horizontal,
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                HabitStatusSegmentedControl(
-                  filter: state.displayFilter,
-                  onValueChanged: cubit.setDisplayFilter,
-                ),
-                const SizedBox(width: 10),
-                const HabitsFilter(),
-                IconButton(
-                  onPressed: cubit.toggleShowSearch,
-                  icon: Icon(
-                    Icons.search,
-                    color: state.showSearch
-                        ? Theme.of(context).primaryColor
-                        : Theme.of(context).colorScheme.outline,
-                  ),
-                ),
-                IconButton(
-                  onPressed: cubit.toggleShowTimeSpan,
-                  icon: Icon(
-                    Icons.calendar_month,
-                    color: state.showTimeSpan
-                        ? Theme.of(context).primaryColor
-                        : Theme.of(context).colorScheme.outline,
-                  ),
-                ),
-                SettingsButton(
-                  state.searchString.isNotEmpty
-                      ? '/settings/habits/search/${state.searchString}'
-                      : '/settings/habits',
-                ),
-                if (state.minY > 20)
-                  IconButton(
-                    onPressed: cubit.toggleZeroBased,
-                    icon: Icon(
-                      state.zeroBased
-                          ? MdiIcons.unfoldLessHorizontal
-                          : MdiIcons.unfoldMoreHorizontal,
-                      color: Theme.of(context).colorScheme.outline,
+          toolbarHeight: 240,
+          title: Column(
+            children: [
+              SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    HabitStatusSegmentedControl(
+                      filter: state.displayFilter,
+                      onValueChanged: cubit.setDisplayFilter,
                     ),
-                  ),
-              ],
-            ),
+                    const SizedBox(width: 10),
+                    const HabitsFilter(),
+                    IconButton(
+                      onPressed: cubit.toggleShowSearch,
+                      icon: Icon(
+                        Icons.search,
+                        color: state.showSearch
+                            ? Theme.of(context).primaryColor
+                            : Theme.of(context).colorScheme.outline,
+                      ),
+                    ),
+                    IconButton(
+                      onPressed: cubit.toggleShowTimeSpan,
+                      icon: Icon(
+                        Icons.calendar_month,
+                        color: state.showTimeSpan
+                            ? Theme.of(context).primaryColor
+                            : Theme.of(context).colorScheme.outline,
+                      ),
+                    ),
+                    SettingsButton(
+                      state.searchString.isNotEmpty
+                          ? '/settings/habits/search/${state.searchString}'
+                          : '/settings/habits',
+                    ),
+                    if (state.minY > 20)
+                      IconButton(
+                        onPressed: cubit.toggleZeroBased,
+                        icon: Icon(
+                          state.zeroBased
+                              ? MdiIcons.unfoldLessHorizontal
+                              : MdiIcons.unfoldMoreHorizontal,
+                          color: Theme.of(context).colorScheme.outline,
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+              const Padding(
+                padding: EdgeInsets.only(top: 10),
+                child: HabitCompletionRateChart(),
+              ),
+            ],
           ),
           pinned: true,
           automaticallyImplyLeading: false,
-          flexibleSpace: const FlexibleSpaceBar(
-            background: Padding(
-              padding: EdgeInsets.only(top: 70),
-              child: HabitCompletionRateChart(),
-            ),
-          ),
         );
       },
     );

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -33,7 +33,7 @@ PODS:
     - FlutterMacOS
   - media_kit_native_event_loop (1.0.0):
     - FlutterMacOS
-  - OpenSSL-Universal (3.1.4000)
+  - OpenSSL-Universal (3.1.5000)
   - package_info_plus (0.0.1):
     - FlutterMacOS
   - path_provider_foundation (0.0.1):
@@ -42,7 +42,7 @@ PODS:
   - photo_manager (2.0.0):
     - Flutter
     - FlutterMacOS
-  - ReachabilitySwift (5.0.0)
+  - ReachabilitySwift (5.2.1)
   - record_darwin (1.0.0):
     - Flutter
     - FlutterMacOS
@@ -188,11 +188,11 @@ SPEC CHECKSUMS:
   location: 7cdb0665bd6577d382b0a343acdadbcb7f964775
   media_kit_libs_macos_audio: 3871782a4f3f84c77f04d7666c87800a781c24da
   media_kit_native_event_loop: 7321675377cb9ae8596a29bddf3a3d2b5e8792c5
-  OpenSSL-Universal: 0adf92f748c570f9911fdb3c11fd5f1cf304e8d1
+  OpenSSL-Universal: 7889a99b127116ba40155a555c89c2946362cdaf
   package_info_plus: fa739dd842b393193c5ca93c26798dff6e3d0e0c
   path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
   photo_manager: 4f6810b7dfc4feb03b461ac1a70dacf91fba7604
-  ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
+  ReachabilitySwift: 5ae15e16814b5f9ef568963fb2c87aeb49158c66
   record_darwin: 1f6619f2abac4d1ca91d3eeab038c980d76f1517
   screen_retriever: 59634572a57080243dd1bf715e55b6c54f241a38
   share_plus: 36537c04ce0c3e3f5bd297ce4318b6d5ee5fd6cf

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -133,18 +133,18 @@ packages:
     dependency: "direct main"
     description:
       name: bloc
-      sha256: f53a110e3b48dcd78136c10daa5d51512443cea5e1348c9d80a320095fa2db9e
+      sha256: "106842ad6569f0b60297619e9e0b1885c2fb9bf84812935490e6c5275777804e"
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.3"
+    version: "8.1.4"
   bloc_test:
     dependency: "direct main"
     description:
       name: bloc_test
-      sha256: "55a48f69e0d480717067c5377c8485a3fcd41f1701a820deef72fa0f4ee7215f"
+      sha256: "165a6ec950d9252ebe36dc5335f2e6eb13055f33d56db0eeb7642768849b43d2"
       url: "https://pub.dev"
     source: hosted
-    version: "9.1.6"
+    version: "9.1.7"
   blurhash_dart:
     dependency: transitive
     description:
@@ -699,10 +699,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_bloc
-      sha256: "87325da1ac757fcc4813e6b34ed5dd61169973871fdf181d6c2109dd6935ece1"
+      sha256: f0ecf6e6eb955193ca60af2d5ca39565a86b8a142452c5b24d96fb477428f4d2
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.4"
+    version: "8.1.5"
   flutter_cache_manager:
     dependency: transitive
     description:
@@ -2083,18 +2083,18 @@ packages:
     dependency: "direct main"
     description:
       name: record
-      sha256: "5c8e12c692a4800b33f5f8b6c821ea083b12bfdbd031b36ba9322c40a4eeecc9"
+      sha256: "113b368168c49c78902ab37c2b354dea30a0aec5bdeca434073826b6ea73eca1"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.4"
+    version: "5.0.5"
   record_android:
     dependency: transitive
     description:
       name: record_android
-      sha256: "805ecaa232a671aff2ee9ec4730ef6addb97c548d2db6b1fbd5197f1d4f47a5a"
+      sha256: "0df98e05873b22b443309e289bf1eb3b5b9a60e7779134334e2073eb0763a992"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.1.0"
   record_darwin:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.439+2409
+version: 0.9.440+2410
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.440+2410
+version: 0.9.440+2411
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR adds a quick improvement to the habits tab where the habit completions chart now always stays visible, and only the tab title shrinks and eventually disappears when scrolling down, as opposed to previously when the chart would disappear as well. The reason behind this change is that the gratification from seeing the chart improve when successfully completing a habit was missing when there were more open habits for the day than would fit the screen, and the page was scrolled down so much that the chart had disappeared. That made it even more annoying that so many habits were still open in the first place.

When not scrolled down (similar to before this change):

![image](https://github.com/matthiasn/lotti/assets/1390808/5ba34875-1266-4cb1-89fd-0ea50abb631b)

When scrolled down now:

![image](https://github.com/matthiasn/lotti/assets/1390808/2062c1ce-42a4-4b74-932a-4ed91db20fca)

