### PR TITLE
test: add config ENVs for TEST_SERVER, TEST_PASSWORD, SLOW_NETWORK

### DIFF
--- a/integration_test/matrix_service_test.dart
+++ b/integration_test/matrix_service_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/config.dart';
 import 'package:lotti/database/logging_db.dart';
@@ -21,12 +22,29 @@ void main() {
     final mockLoggingDb = MockLoggingDb();
     final secureStorageMock = MockSecureStorage();
     const testUserEnv = 'TEST_USER';
+    const testServerEnv = 'TEST_SERVER';
+    const testPasswordEnv = 'TEST_PASSWORD';
+    const testSlowNetworkEnv = 'SLOW_NETWORK';
 
     if (!const bool.hasEnvironment(testUserEnv)) {
       debugPrint('TEST_USER not defined!!! Run via run_matrix_tests.sh');
       exit(1);
     }
     const testUserName = String.fromEnvironment(testUserEnv);
+    const testHomeServer = bool.hasEnvironment(testServerEnv)
+        ? String.fromEnvironment(testServerEnv)
+        : 'http://localhost:8008';
+    const testPassword = bool.hasEnvironment(testPasswordEnv)
+        ? String.fromEnvironment(testPasswordEnv)
+        : '?Secret123@!';
+
+    const config = MatrixConfig(
+      homeServer: testHomeServer,
+      user: testUserName,
+      password: testPassword,
+    );
+
+    const delayFactor = bool.hasEnvironment(testSlowNetworkEnv) ? 10 : 1;
 
     setUpAll(() async {
       setFakeDocumentsPath();
@@ -44,127 +62,131 @@ void main() {
 
     tearDown(() async {});
 
-    test('Create room & join', () async {
-      const config = MatrixConfig(
-        homeServer: 'http://localhost:8008',
-        user: '@$testUserName:localhost',
-        password: '?Secret123@!',
-      );
-      debugPrint('\n--- AliceDevice goes live');
-      final aliceDevice = MatrixService(
-        matrixConfig: config,
-        hiveDbName: 'AliceDevice',
-        deviceDisplayName: 'AliceDevice',
-      );
+    test(
+      'Create room & join',
+      () async {
+        debugPrint('\n--- AliceDevice goes live');
+        final aliceDevice = MatrixService(
+          matrixConfig: config,
+          hiveDbName: 'AliceDevice',
+          deviceDisplayName: 'AliceDevice',
+        );
 
-      await aliceDevice.login();
-      await aliceDevice.listen();
+        await aliceDevice.login();
+        await aliceDevice.listen();
 
-      debugPrint(
-        'AliceDevice - deviceId: ${aliceDevice.client.deviceID}',
-      );
+        debugPrint(
+          'AliceDevice - deviceId: ${aliceDevice.client.deviceID}',
+        );
 
-      final roomId = await aliceDevice.createRoom();
-      debugPrint('AliceDevice - room created: $roomId');
+        final roomId = await aliceDevice.createRoom();
+        debugPrint('AliceDevice - room created: $roomId');
 
-      expect(roomId, isNotEmpty);
+        expect(roomId, isNotEmpty);
 
-      await Future<void>.delayed(const Duration(seconds: 1));
+        await Future<void>.delayed(const Duration(seconds: 1 * delayFactor));
 
-      final joinRes = await aliceDevice.joinRoom(roomId);
-      debugPrint('AliceDevice - room joined: $joinRes');
+        final joinRes = await aliceDevice.joinRoom(roomId);
+        debugPrint('AliceDevice - room joined: $joinRes');
 
-      await Future<void>.delayed(const Duration(seconds: 1));
+        await Future<void>.delayed(const Duration(seconds: 1 * delayFactor));
 
-      debugPrint('\n--- BobDevice goes live');
-      final bobDevice = MatrixService(
-        matrixConfig: config,
-        hiveDbName: 'BobDevice',
-        deviceDisplayName: 'BobDevice',
-      );
+        debugPrint('\n--- BobDevice goes live');
+        final bobDevice = MatrixService(
+          matrixConfig: config,
+          hiveDbName: 'BobDevice',
+          deviceDisplayName: 'BobDevice',
+        );
 
-      await bobDevice.login();
-      await bobDevice.listen();
-      debugPrint('BobDevice - deviceId: ${bobDevice.client.deviceID}');
+        await bobDevice.login();
+        await bobDevice.listen();
+        debugPrint('BobDevice - deviceId: ${bobDevice.client.deviceID}');
 
-      final joinRes2 = await bobDevice.joinRoom(roomId);
-      debugPrint('BobDevice - room joined: $joinRes2');
+        final joinRes2 = await bobDevice.joinRoom(roomId);
+        debugPrint('BobDevice - room joined: $joinRes2');
 
-      await Future<void>.delayed(const Duration(seconds: 1));
+        await Future<void>.delayed(const Duration(seconds: 1 * delayFactor));
 
-      final unverifiedAlice = aliceDevice.getUnverified();
-      final unverifiedBob = bobDevice.getUnverified();
+        final unverifiedAlice = aliceDevice.getUnverified();
+        final unverifiedBob = bobDevice.getUnverified();
 
-      debugPrint('AliceDevice - unverified: $unverifiedAlice');
-      debugPrint('BobDevice - unverified: $unverifiedBob');
+        debugPrint('AliceDevice - unverified: $unverifiedAlice');
+        debugPrint('BobDevice - unverified: $unverifiedBob');
 
-      expect(unverifiedAlice.length, 1);
-      expect(unverifiedBob.length, 1);
+        expect(unverifiedAlice.length, 1);
+        expect(unverifiedBob.length, 1);
 
-      final outgoingKeyVerificationStream = aliceDevice.keyVerificationStream;
-      final incomingKeyVerificationRunnerStream =
-          bobDevice.incomingKeyVerificationRunnerStream;
+        final outgoingKeyVerificationStream = aliceDevice.keyVerificationStream;
+        final incomingKeyVerificationRunnerStream =
+            bobDevice.incomingKeyVerificationRunnerStream;
 
-      debugPrint('\n--- AliceDevice verifies BobDevice');
-      await aliceDevice.verifyDevice(unverifiedAlice.first);
+        debugPrint('\n--- AliceDevice verifies BobDevice');
+        await aliceDevice.verifyDevice(unverifiedAlice.first);
 
-      var emojisFromBob = '';
-      var emojisFromAlice = '';
+        var emojisFromBob = '';
+        var emojisFromAlice = '';
 
-      unawaited(
-        incomingKeyVerificationRunnerStream.forEach((runner) async {
-          debugPrint(
-            'BobDevice - incoming verification runner step: ${runner.lastStep}',
-          );
-          if (runner.lastStep == 'm.key.verification.request') {
-            await runner.acceptVerification();
-          }
-          if (runner.lastStep == 'm.key.verification.key') {
-            emojisFromAlice = extractEmojiString(runner.emojis);
-            debugPrint('BobDevice received emojis: $emojisFromAlice');
-
-            await Future<void>.delayed(const Duration(seconds: 1));
-            if (emojisFromAlice == emojisFromBob &&
-                emojisFromAlice.isNotEmpty) {
-              await runner.acceptEmojiVerification();
+        unawaited(
+          incomingKeyVerificationRunnerStream.forEach((runner) async {
+            debugPrint(
+              'BobDevice - incoming verification runner step: ${runner.lastStep}',
+            );
+            if (runner.lastStep == 'm.key.verification.request') {
+              await runner.acceptVerification();
             }
-          }
-        }),
-      );
+            if (runner.lastStep == 'm.key.verification.key') {
+              emojisFromAlice = extractEmojiString(runner.emojis);
+              debugPrint('BobDevice received emojis: $emojisFromAlice');
 
-      unawaited(
-        outgoingKeyVerificationStream.forEach((runner) async {
-          debugPrint(
-            'AliceDevice - outgoing verification step: ${runner.lastStep}',
-          );
-          if (runner.lastStep == 'm.key.verification.key') {
-            emojisFromBob = extractEmojiString(runner.emojis);
-            debugPrint('AliceDevice received emojis: $emojisFromBob');
-
-            await Future<void>.delayed(const Duration(seconds: 1));
-            if (emojisFromAlice == emojisFromBob && emojisFromBob.isNotEmpty) {
-              await runner.acceptEmojiVerification();
+              await Future<void>.delayed(
+                const Duration(seconds: 1 * delayFactor),
+              );
+              if (emojisFromAlice == emojisFromBob &&
+                  emojisFromAlice.isNotEmpty) {
+                await runner.acceptEmojiVerification();
+              }
             }
-          }
-        }),
-      );
+          }),
+        );
 
-      await Future<void>.delayed(const Duration(seconds: 5));
+        unawaited(
+          outgoingKeyVerificationStream.forEach((runner) async {
+            debugPrint(
+              'AliceDevice - outgoing verification step: ${runner.lastStep}',
+            );
+            if (runner.lastStep == 'm.key.verification.key') {
+              emojisFromBob = extractEmojiString(runner.emojis);
+              debugPrint('AliceDevice received emojis: $emojisFromBob');
 
-      expect(emojisFromAlice, isNotEmpty);
-      expect(emojisFromBob, isNotEmpty);
-      expect(emojisFromAlice, emojisFromAlice);
+              await Future<void>.delayed(
+                const Duration(seconds: 1 * delayFactor),
+              );
+              if (emojisFromAlice == emojisFromBob &&
+                  emojisFromBob.isNotEmpty) {
+                await runner.acceptEmojiVerification();
+              }
+            }
+          }),
+        );
 
-      debugPrint(
-        '\n--- AliceDevice and BobDevice both have no unverified devices',
-      );
-      expect(aliceDevice.getUnverified(), isEmpty);
-      expect(bobDevice.getUnverified(), isEmpty);
+        await Future<void>.delayed(const Duration(seconds: 5 * delayFactor));
 
-      debugPrint('\n--- Logging out AliceDevice and BobDevice');
-      await aliceDevice.logout();
-      await bobDevice.logout();
-    });
+        expect(emojisFromAlice, isNotEmpty);
+        expect(emojisFromBob, isNotEmpty);
+        expect(emojisFromAlice, emojisFromAlice);
+
+        debugPrint(
+          '\n--- AliceDevice and BobDevice both have no unverified devices',
+        );
+        expect(aliceDevice.getUnverified(), isEmpty);
+        expect(bobDevice.getUnverified(), isEmpty);
+
+        debugPrint('\n--- Logging out AliceDevice and BobDevice');
+        await aliceDevice.logout();
+        await bobDevice.logout();
+      },
+      timeout: const Timeout(Duration(minutes: 10)),
+    );
   });
 }
 

--- a/integration_test/run_matrix_tests.sh
+++ b/integration_test/run_matrix_tests.sh
@@ -11,4 +11,4 @@ cd ../dendrite/build/docker/config || exit
 ../../../bin/create-account -config dendrite.yaml -username "$TEST_USER" -admin -password "?Secret123@!"
 cd - > /dev/null || exit
 
-fvm flutter test integration_test/matrix_service_test.dart --dart-define=TEST_USER="$TEST_USER"
+fvm flutter test integration_test/matrix_service_test.dart --dart-define=TEST_USER="@$TEST_USER:localhost"


### PR DESCRIPTION
This PR adds configuration to the integration tests as environment variables:

- `TEST_SERVER`
- `TEST_PASSWORD`
- `SLOW_NETWORK`

This allows connecting to a remote server instead of a locally running dendrite instance, and then also simulating bad network. For that case, e.g. when using Apple's [Network Link Conditioner](https://nshipster.com/network-link-conditioner/), `SLOW_NETWORK=true` can be specified which increases delays in the test by a factor of 10.

I tested with the probably worst predefined profile **Edge** and the test for client verification are still passing, just taking longer at almost four minutes:

![image](https://github.com/matthiasn/lotti/assets/1390808/baa4e4cb-e342-4de6-9dd5-93fbe9f22e0a)

