### PR TITLE
feat: move tasks filter into modal sheet

### DIFF
--- a/lib/widgets/app_bar/journal_sliver_appbar.dart
+++ b/lib/widgets/app_bar/journal_sliver_appbar.dart
@@ -3,7 +3,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:lotti/blocs/journal/journal_page_cubit.dart';
 import 'package:lotti/blocs/journal/journal_page_state.dart';
-import 'package:lotti/utils/platform.dart';
 import 'package:lotti/widgets/search/entry_type_filter.dart';
 import 'package:lotti/widgets/search/search_widget.dart';
 import 'package:lotti/widgets/search/task_status_filter.dart';
@@ -18,35 +17,34 @@ class JournalSliverAppBar extends StatelessWidget {
     return BlocBuilder<JournalPageCubit, JournalPageState>(
       builder: (context, snapshot) {
         final cubit = context.read<JournalPageCubit>();
+        final showTasks = snapshot.showTasks;
 
         return SliverAppBar(
-          expandedHeight: 200,
-          flexibleSpace: FlexibleSpaceBar(
-            background: Padding(
-              padding: EdgeInsets.only(top: isIOS ? 30 : 0),
-              child: Column(
+          expandedHeight: showTasks ? null : 230,
+          pinned: true,
+          toolbarHeight: showTasks ? 100 : 200,
+          title: Column(
+            children: [
+              const SizedBox(height: 10),
+              Row(
                 children: [
-                  SearchWidget(
-                    margin: const EdgeInsets.symmetric(
-                      vertical: 20,
-                      horizontal: 40,
+                  Flexible(
+                    child: SearchWidget(
+                      margin: const EdgeInsets.symmetric(
+                        vertical: 20,
+                        horizontal: 40,
+                      ),
+                      text: snapshot.match,
+                      onChanged: cubit.setSearchString,
                     ),
-                    text: snapshot.match,
-                    onChanged: cubit.setSearchString,
                   ),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      const JournalFilter(),
-                      if (snapshot.showTasks) const TaskListToggle(),
-                    ],
-                  ),
-                  const SizedBox(height: 10),
-                  if (!snapshot.showTasks) const EntryTypeFilter(),
-                  if (snapshot.showTasks) const TaskStatusFilter(),
+                  if (showTasks) const TaskFilterIcon(),
                 ],
               ),
-            ),
+              if (!showTasks) const JournalFilter(),
+              const SizedBox(height: 10),
+              if (!showTasks) const EntryTypeFilter(),
+            ],
           ),
         );
       },

--- a/lib/widgets/search/filter_choice_chip.dart
+++ b/lib/widgets/search/filter_choice_chip.dart
@@ -8,12 +8,14 @@ class FilterChoiceChip extends StatelessWidget {
     required this.label,
     required this.isSelected,
     required this.onTap,
+    this.selectedColor,
     this.onLongPress,
     super.key,
   });
 
   final String label;
   final bool isSelected;
+  final Color? selectedColor;
   final void Function() onTap;
   final void Function()? onLongPress;
 
@@ -29,9 +31,11 @@ class FilterChoiceChip extends StatelessWidget {
             horizontal: horizontalChipMargin,
           ),
           child: Chip(
-            side: isSelected
-                ? BorderSide.none
-                : BorderSide(color: Theme.of(context).colorScheme.secondary),
+            side: BorderSide(
+              color: isSelected
+                  ? selectedColor ?? Colors.grey
+                  : Theme.of(context).colorScheme.secondary,
+            ),
             label: Text(
               label,
               style: choiceChipTextStyle(
@@ -40,8 +44,9 @@ class FilterChoiceChip extends StatelessWidget {
               ),
             ),
             visualDensity: VisualDensity.compact,
-            backgroundColor:
-                isSelected ? Theme.of(context).colorScheme.secondary : null,
+            backgroundColor: isSelected
+                ? selectedColor ?? Theme.of(context).colorScheme.secondary
+                : null,
           ),
         ),
       ),

--- a/lib/widgets/search/search_widget.dart
+++ b/lib/widgets/search/search_widget.dart
@@ -36,7 +36,7 @@ class _SearchWidgetState extends State<SearchWidget> {
       child: Container(
         margin: widget.margin,
         height: 53,
-        padding: const EdgeInsets.symmetric(horizontal: 10),
+        padding: const EdgeInsets.only(left: 10),
         child: SearchBar(
           controller: controller,
           hintText: widget.hintText ?? localizations.searchHint,

--- a/lib/widgets/settings/settings_card.dart
+++ b/lib/widgets/settings/settings_card.dart
@@ -30,13 +30,10 @@ class SettingsCard extends StatelessWidget {
     return Card(
       child: ListTile(
         contentPadding: contentPadding,
-        title: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 2),
-          child: Text(
-            title,
-            style: settingsCardTextStyle,
-            semanticsLabel: semanticsLabel,
-          ),
+        title: Text(
+          title,
+          style: settingsCardTextStyle,
+          semanticsLabel: semanticsLabel,
         ),
         subtitle: subtitle,
         leading: leading,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2884,6 +2884,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  wolt_modal_sheet:
+    dependency: "direct main"
+    description:
+      name: wolt_modal_sheet
+      sha256: e5f08db4927bd97ec57fdf6f995d4bd6f17459c5511cbb07f4c94c82c6a2cfcd
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.440+2411
+version: 0.9.441+2413
 
 msix_config:
   display_name: LottiApp
@@ -149,6 +149,7 @@ dependencies:
   wechat_assets_picker: ^9.0.0
   week_of_year: ^2.0.0
   window_manager: ^0.3.0
+  wolt_modal_sheet: ^0.5.0
 
 dependency_overrides:
   device_info_plus: ^9.0.0


### PR DESCRIPTION
This PR moves the filtering in the tasks tab to a modal sheet. For the sheet, the neat [wolt_modal_sheet](https://pub.dev/packages/wolt_modal_sheet) library is used, which promises to make building appealing bottom sheets much easier than with Flutter's built-in API. Being a Wolt user, I also quite enjoy the design, has been the most visually pleasing app of its kind for me for quite some time. Not much of its functionality is used here yet, but I plan on making good use of especially the multi-page functionality and the smooth transitions between them.

What especially stood out for me was the really well done [Figma file](https://www.figma.com/file/jRQUhvi44bkUxRxSWGhSXO/Wolt-Modal-Sheet-Specs?type=design&node-id=1-3&mode=design&t=52EssN7MlQlyqQOv-0) for collaborating with designers. This should be the norm & benchmark.