### PR TITLE
test: degraded network support instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ whisper.cpp/whisper.cpp-*/
 .fvm/
 
 integration_test/dendrite/config/jetstream/
+integration_test/dendrite/config/logs/

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -23,10 +23,22 @@ successfully. Also see [PR #1695](https://github.com/matthiasn/lotti/pull/1695) 
 
 ## Testing with simulated bad network
 
-Install [comcast](https://github.com/tylertreat/Comcast), e.g.:
+Install [toxiproxy](https://github.com/Shopify/toxiproxy) and run server:
 
 ````shell
-    $ GOBIN=~/bin/ go install github.com/tylertreat/comcast@latest
+    $ toxiproxy-server
 ````
 
- To be continued.
+In separate shell:
+
+````shell
+    $ toxiproxy-cli create -l localhost:18008 -u localhost:8008 dendrite-proxy
+    $ toxiproxy-cli toxic add -t latency -a latency=1000 dendrite-proxy
+    $ toxiproxy-cli toxic add -t bandwidth -a rate=100 dendrite-proxy
+````
+
+Run the test script against `toxiproxy`;
+
+````shell
+    $ SLOW_NETWORK=true ./integration_test/run_matrix_tests.sh
+````

--- a/integration_test/matrix_service_test.dart
+++ b/integration_test/matrix_service_test.dart
@@ -27,6 +27,8 @@ void main() {
     const testPasswordEnv = 'TEST_PASSWORD';
     const testSlowNetworkEnv = 'SLOW_NETWORK';
 
+    const testSlowNetwork = bool.fromEnvironment(testSlowNetworkEnv);
+
     if (!const bool.hasEnvironment(testUserEnv1)) {
       debugPrint('TEST_USER1 not defined!!! Run via run_matrix_tests.sh');
       exit(1);
@@ -42,7 +44,9 @@ void main() {
 
     const testHomeServer = bool.hasEnvironment(testServerEnv)
         ? String.fromEnvironment(testServerEnv)
-        : 'http://localhost:8008';
+        : testSlowNetwork
+            ? 'http://localhost:18008'
+            : 'http://localhost:8008';
     const testPassword = bool.hasEnvironment(testPasswordEnv)
         ? String.fromEnvironment(testPasswordEnv)
         : '?Secret123@!';
@@ -59,7 +63,7 @@ void main() {
       password: testPassword,
     );
 
-    const delayFactor = bool.hasEnvironment(testSlowNetworkEnv) ? 10 : 1;
+    const delayFactor = bool.hasEnvironment(testSlowNetworkEnv) ? 5 : 1;
 
     setUpAll(() async {
       setFakeDocumentsPath();

--- a/integration_test/run_matrix_tests.sh
+++ b/integration_test/run_matrix_tests.sh
@@ -15,5 +15,7 @@ cd ../dendrite/build/docker/config || exit
 cd - > /dev/null || exit
 
 fvm flutter test integration_test/matrix_service_test.dart \
-    --dart-define=TEST_USER1="@$TEST_USER1:localhost" \
-    --dart-define=TEST_USER2="@$TEST_USER2:localhost"
+--dart-define=TEST_USER1="@$TEST_USER1:localhost" \
+--dart-define=TEST_USER2="@$TEST_USER2:localhost" \
+--dart-define=SLOW_NETWORK="$SLOW_NETWORK"
+


### PR DESCRIPTION
This PR adds instructions for running the Matrix integration test under adverse networking conditions, here with a delay of `1000 ms` and a slow connection of `100 KB/s`.
