### PR TITLE
ci: run Matrix test with simulated bad network

### DIFF
--- a/.github/workflows/flutter-matrix-test.yml
+++ b/.github/workflows/flutter-matrix-test.yml
@@ -26,6 +26,10 @@ jobs:
           cwd: "integration_test/docker"
       - name: Run Matrix integration test
         uses: GabrielBB/xvfb-action@v1.6
+        env:
+          SLOW_NETWORK: true
         with:
           working-directory: ./integration_test
-          run: ./run_matrix_tests.sh
+          run: |
+            ./setup_toxiproxy_docker.sh
+            ./run_matrix_tests.sh

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -39,7 +39,7 @@ Run the test script against `toxiproxy`;
     $ SLOW_NETWORK=true ./run_matrix_tests.sh
 ````
 
-With the simulated bad network (with added 1000 ms latency and throttled to 100 KB/s), the tests 
+With the simulated bad network (with added 500 ms latency and throttled to 100 KB/s), the tests 
 should still complete successfully, it'll just take a bit longer. For example on an M1 Max, it
 typically takes around 1m 25s with the bad network simulation, and around 50s with non-degraded
 network.

--- a/integration_test/matrix_service_test.dart
+++ b/integration_test/matrix_service_test.dart
@@ -29,6 +29,10 @@ void main() {
 
     const testSlowNetwork = bool.fromEnvironment(testSlowNetworkEnv);
 
+    if (testSlowNetwork) {
+      debugPrint('Testing with degraded network.');
+    }
+
     if (!const bool.hasEnvironment(testUserEnv1)) {
       debugPrint('TEST_USER1 not defined!!! Run via run_matrix_tests.sh');
       exit(1);
@@ -63,7 +67,7 @@ void main() {
       password: testPassword,
     );
 
-    const delayFactor = bool.hasEnvironment(testSlowNetworkEnv) ? 5 : 1;
+    const delayFactor = testSlowNetwork ? 5 : 1;
 
     setUpAll(() async {
       setFakeDocumentsPath();

--- a/integration_test/setup_toxiproxy_docker.sh
+++ b/integration_test/setup_toxiproxy_docker.sh
@@ -4,6 +4,6 @@ cd "$(dirname "$0")" || exit
 
 cd docker || exit
 docker compose exec toxiproxy /toxiproxy-cli create -l toxiproxy:18008 -u dendrite:8008 dendrite-proxy
-docker compose exec toxiproxy /toxiproxy-cli toxic add -t latency -a latency=1000 dendrite-proxy
+docker compose exec toxiproxy /toxiproxy-cli toxic add -t latency -a latency=500 dendrite-proxy
 docker compose exec toxiproxy /toxiproxy-cli toxic add -t bandwidth -a rate=100 dendrite-proxy
 cd ..


### PR DESCRIPTION
This PR adds running the Matrix integration test with simulated bas network.