### PR TITLE
test: use fresh Matrix persistence directory on every run

### DIFF
--- a/lib/sync/matrix/matrix_service.dart
+++ b/lib/sync/matrix/matrix_service.dart
@@ -23,7 +23,6 @@ import 'package:lotti/utils/file_utils.dart';
 import 'package:lotti/utils/image_utils.dart';
 import 'package:matrix/encryption/utils/key_verification.dart';
 import 'package:matrix/matrix.dart';
-import 'package:path_provider/path_provider.dart';
 
 const configNotFound = 'Could not find Matrix Config';
 const syncMessageType = 'com.lotti.sync.message';
@@ -93,8 +92,8 @@ class MatrixService {
       },
       shareKeysWithUnverifiedDevices: false,
       databaseBuilder: (_) async {
-        final dir = await getApplicationDocumentsDirectory();
-        final path = '${dir.path}/matrix/';
+        final docDir = getIt<Directory>();
+        final path = '${docDir.path}/matrix/';
         final db = HiveCollectionsDatabase(hiveDbName ?? 'lotti_sync', path);
         await db.open();
         return db;


### PR DESCRIPTION
This PR changes the Matrix client persistence directory for the integration test to a temporary directory such that the tests always start with a clean slate. I was running into an issue where tests failed because of some inconsistent state, presumably from a test that I had stopped midway. 