### PR TITLE
feat: use Matrix user per device and add invites

### DIFF
--- a/integration_test/matrix_service_test.dart
+++ b/integration_test/matrix_service_test.dart
@@ -297,7 +297,7 @@ void main() {
                   vectorClock: VectorClock({deviceName: index}),
                 ),
                 entryText: EntryText(
-                  plainText: 'Test $deviceName #$index - $now',
+                  plainText: 'Test from $deviceName #$index - $now',
                 ),
               ),
               status: SyncEntryStatus.initial,
@@ -327,19 +327,19 @@ void main() {
         }
 
         await waitUntilAsync(
-          () async => await aliceDb.getJournalCount() == 2 * n,
+          () async => await aliceDb.getJournalCount() == n,
         );
         debugPrint('\n--- AliceDevice finished receiving messages');
         final aliceEntriesCount = await aliceDb.getJournalCount();
-        expect(aliceEntriesCount, 2 * n);
+        expect(aliceEntriesCount, n);
         debugPrint('AliceDevice persisted entries: $aliceEntriesCount');
 
         await waitUntilAsync(
-          () async => await bobDb.getJournalCount() == 2 * n,
+          () async => await bobDb.getJournalCount() == n,
         );
         debugPrint('\n--- BobDevice finished receiving messages');
         final bobEntriesCount = await bobDb.getJournalCount();
-        expect(bobEntriesCount, 2 * n);
+        expect(bobEntriesCount, n);
         debugPrint('BobDevice persisted entries: $bobEntriesCount');
 
         debugPrint('\n--- Logging out AliceDevice and BobDevice');

--- a/integration_test/matrix_service_test.dart
+++ b/integration_test/matrix_service_test.dart
@@ -127,9 +127,7 @@ void main() {
         await aliceDevice.startKeyVerificationListener();
         debugPrint('AliceDevice - deviceId: ${aliceDevice.client.deviceID}');
 
-        final roomId = await aliceDevice.createRoom(
-            //invite: [bobUserName],
-            );
+        final roomId = await aliceDevice.createRoom();
 
         debugPrint('AliceDevice - room created: $roomId');
 
@@ -188,11 +186,11 @@ void main() {
           });
         }
 
-        await waitUntil(() => aliceDevice.findUnverified() != null);
-        await waitUntil(() => bobDevice.findUnverified() != null);
+        await waitUntil(() => aliceDevice.getUnverifiedDevices().isNotEmpty);
+        await waitUntil(() => bobDevice.getUnverifiedDevices().isNotEmpty);
 
-        final unverifiedAlice = aliceDevice.findUnverified();
-        final unverifiedBob = bobDevice.findUnverified();
+        final unverifiedAlice = aliceDevice.getUnverifiedDevices();
+        final unverifiedBob = bobDevice.getUnverifiedDevices();
 
         debugPrint('\nAliceDevice - unverified: $unverifiedAlice');
         debugPrint('\nBobDevice - unverified: $unverifiedBob');
@@ -255,7 +253,7 @@ void main() {
         await waitSeconds(defaultDelay * delayFactor);
 
         debugPrint('\n--- AliceDevice verifies BobDevice');
-        await aliceDevice.verifyDevice(unverifiedAlice!);
+        await aliceDevice.verifyDevice(unverifiedAlice.first);
 
         await waitUntil(() => emojisFromAlice.isNotEmpty);
         await waitUntil(() => emojisFromBob.isNotEmpty);
@@ -268,11 +266,11 @@ void main() {
           '\n--- AliceDevice and BobDevice both have no unverified devices',
         );
 
-        await waitUntil(() => aliceDevice.findUnverified() == null);
-        await waitUntil(() => bobDevice.findUnverified() == null);
+        await waitUntil(() => aliceDevice.getUnverifiedDevices().isEmpty);
+        await waitUntil(() => bobDevice.getUnverifiedDevices().isEmpty);
 
-        expect(aliceDevice.findUnverified(), isNull);
-        expect(bobDevice.findUnverified(), isNull);
+        expect(aliceDevice.getUnverifiedDevices(), isEmpty);
+        expect(bobDevice.getUnverifiedDevices(), isEmpty);
 
         await waitSeconds(defaultDelay * delayFactor);
 

--- a/lib/sync/matrix/matrix_service.dart
+++ b/lib/sync/matrix/matrix_service.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:collection/collection.dart';
 import 'package:lotti/classes/config.dart';
 import 'package:lotti/classes/sync_message.dart';
 import 'package:lotti/database/database.dart';
@@ -117,17 +116,19 @@ class MatrixService {
         userId: userId,
       );
 
-  DeviceKeys? findUnverified() {
-    return client.userDeviceKeys.values
-        .firstWhereOrNull(
-          (item) => item.deviceKeys.values.firstOrNull?.verified == false,
-        )
-        ?.deviceKeys
-        .values
-        .firstOrNull;
-  }
+  List<DeviceKeys> getUnverifiedDevices() {
+    final unverifiedDevices = <DeviceKeys>[];
 
-  List<DeviceKeys> getUnverified() => _client.unverifiedDevices;
+    for (final deviceKeysList in client.userDeviceKeys.values) {
+      for (final deviceKeys in deviceKeysList.deviceKeys.values) {
+        if (!deviceKeys.verified) {
+          unverifiedDevices.add(deviceKeys);
+        }
+      }
+    }
+
+    return unverifiedDevices;
+  }
 
   Future<void> verifyDevice(DeviceKeys deviceKeys) => verifyMatrixDevice(
         deviceKeys: deviceKeys,

--- a/lib/sync/matrix/matrix_service.dart
+++ b/lib/sync/matrix/matrix_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:collection/collection.dart';
 import 'package:lotti/classes/config.dart';
 import 'package:lotti/classes/sync_message.dart';
 import 'package:lotti/database/database.dart';
@@ -100,7 +101,31 @@ class MatrixService {
     await listenToTimelineEvents(service: this);
   }
 
-  Future<String> createRoom() => createMatrixRoom(client: _client);
+  Future<String> createRoom({
+    List<String>? invite,
+  }) =>
+      createMatrixRoom(
+        client: _client,
+        invite: invite,
+      );
+
+  Future<void> inviteToSyncRoom({
+    required String userId,
+  }) =>
+      inviteToMatrixRoom(
+        service: this,
+        userId: userId,
+      );
+
+  DeviceKeys? findUnverified() {
+    return client.userDeviceKeys.values
+        .firstWhereOrNull(
+          (item) => item.deviceKeys.values.firstOrNull?.verified == false,
+        )
+        ?.deviceKeys
+        .values
+        .firstOrNull;
+  }
 
   List<DeviceKeys> getUnverified() => _client.unverifiedDevices;
 

--- a/lib/sync/matrix/process_message.dart
+++ b/lib/sync/matrix/process_message.dart
@@ -8,11 +8,18 @@ import 'package:lotti/classes/tag_type_definitions.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/sync/matrix/matrix_service.dart';
 import 'package:lotti/utils/file_utils.dart';
 import 'package:matrix/matrix.dart';
 
-Future<void> processMatrixMessage(
-  Event event, {
+/// Process a sync message from the room that the client has joined.
+/// Takes decrypted [Event] and tries to insert into the local database
+/// if not already contained, or in conflict with an existing entry.
+/// The conflicts are checked as part of the call to JournalDb.
+
+Future<void> processMatrixMessage({
+  required Event event,
+  required MatrixService service,
   JournalDb? overriddenJournalDb,
 }) async {
   final journalDb = overriddenJournalDb ?? getIt<JournalDb>();

--- a/lib/sync/matrix/room.dart
+++ b/lib/sync/matrix/room.dart
@@ -48,21 +48,23 @@ Future<String?> joinMatrixRoom({
 
 Future<String> createMatrixRoom({
   required Client client,
+  List<String>? invite,
 }) async {
   final name = DateFormat('yyyy-MM-dd_HH-mm-ss').format(DateTime.now());
   final roomId = await client.createRoom(
     visibility: Visibility.private,
     name: name,
+    invite: invite,
+    preset: CreateRoomPreset.trustedPrivateChat,
   );
   final room = client.getRoomById(roomId);
   await room?.enableEncryption();
   return roomId;
 }
 
-Future<Uri?> invite({
+Future<void> inviteToMatrixRoom({
   required MatrixService service,
+  required String userId,
 }) async {
-  final inviteLink = await service.syncRoom?.matrixToInviteLink();
-  debugPrint('inviteLink $inviteLink');
-  return inviteLink;
+  await service.syncRoom?.invite(userId);
 }

--- a/lib/sync/matrix/send_message.dart
+++ b/lib/sync/matrix/send_message.dart
@@ -14,6 +14,13 @@ import 'package:lotti/utils/file_utils.dart';
 import 'package:lotti/utils/image_utils.dart';
 import 'package:matrix/matrix.dart';
 
+/// Sends a Matrix message for cross-device state synchronization. Takes a
+/// [SyncMessage] and also requires the system's [MatrixService]. A room can
+/// optionally be specified, e.g. in testing. Otherwise, the service's `syncRoom`
+/// is used.
+/// Also updates some stats on sent message counts on the [service].
+/// The send function will terminate early (and thus refuse to send anything)
+/// when there are users with unverified device in the room.
 Future<void> sendMessage(
   SyncMessage syncMessage, {
   required MatrixService service,

--- a/lib/sync/matrix/send_message.dart
+++ b/lib/sync/matrix/send_message.dart
@@ -37,7 +37,7 @@ Future<void> sendMessage(
       );
     }
 
-    if (service.client.unverifiedDevices.isNotEmpty) {
+    if (service.findUnverified() != null) {
       loggingDb.captureException(
         'Unverified devices found',
         domain: 'MATRIX_SERVICE',

--- a/lib/sync/matrix/send_message.dart
+++ b/lib/sync/matrix/send_message.dart
@@ -44,7 +44,7 @@ Future<void> sendMessage(
       );
     }
 
-    if (service.findUnverified() != null) {
+    if (service.getUnverifiedDevices().isNotEmpty) {
       loggingDb.captureException(
         'Unverified devices found',
         domain: 'MATRIX_SERVICE',

--- a/lib/sync/matrix/timeline.dart
+++ b/lib/sync/matrix/timeline.dart
@@ -84,14 +84,20 @@ Future<void> processNewTimelineEvents({
       await service.client.sync();
       final eventId = event.eventId;
 
-      if (event.messageType == syncMessageType) {
-        await processMatrixMessage(
-          event,
-          overriddenJournalDb: overriddenJournalDb,
-        );
-      }
+      // Terminates early when the message was emitted by the device itself,
+      // as it would be a waste of battery to try to ingest what the device
+      // already knows.
+      if (event.senderId != service.client.userID) {
+        if (event.messageType == syncMessageType) {
+          await processMatrixMessage(
+            event: event,
+            service: service,
+            overriddenJournalDb: overriddenJournalDb,
+          );
+        }
 
-      await saveAttachment(event);
+        await saveAttachment(event);
+      }
 
       try {
         if (eventId.startsWith(r'$')) {

--- a/lib/widgets/sync/matrix/incoming_verification_modal.dart
+++ b/lib/widgets/sync/matrix/incoming_verification_modal.dart
@@ -34,7 +34,7 @@ class _IncomingVerificationModalState extends State<IncomingVerificationModal> {
       Navigator.of(context).pop();
     }
 
-    final unverifiedDevices = _matrixService.getUnverified();
+    final unverifiedDevices = _matrixService.getUnverifiedDevices();
     final requestingDevice = unverifiedDevices.firstWhereOrNull(
       (deviceKeys) => deviceKeys.deviceId == widget.keyVerification.deviceId,
     );

--- a/lib/widgets/sync/matrix/unverified_devices.dart
+++ b/lib/widgets/sync/matrix/unverified_devices.dart
@@ -22,13 +22,13 @@ class _UnverifiedDevicesState extends State<UnverifiedDevices> {
   void initState() {
     super.initState();
     setState(() {
-      _unverifiedDevices = _matrixService.getUnverified();
+      _unverifiedDevices = _matrixService.getUnverifiedDevices();
     });
   }
 
   void refreshList() {
     setState(() {
-      _unverifiedDevices = _matrixService.getUnverified();
+      _unverifiedDevices = _matrixService.getUnverifiedDevices();
     });
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.445+2443
+version: 0.9.446+2444
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.446+2444
+version: 0.9.446+2445
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.446+2445
+version: 0.9.446+2446
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR changes the Matrix setup in the integration test to utilizing a user per device involved in synchronization between Lotti instances (e.g. on my desktop and on my mobile device, plus maybe tablet or whatever other device). The reason for that is that this makes it easier to listen for new messages, as in unread for that user. I also like the idea of users being a throwaway concept in a zero trust environment.