### PR TITLE
feat: no image resizing

### DIFF
--- a/lib/utils/image_utils.dart
+++ b/lib/utils/image_utils.dart
@@ -9,6 +9,8 @@ Future<XFile?> compressAndSave(File file, String targetPath) async {
   final result = await FlutterImageCompress.compressAndGetFile(
     sourcePath,
     targetPath,
+    minHeight: 10000,
+    minWidth: 10000,
     quality: 90,
     keepExif: true,
   );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.446+2446
+version: 0.9.447+2447
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR disables image resizing on import. The API of [`flutter_image_compress`](https://pub.dev/packages/flutter_image_compress) is rather confusing here. Apparently, setting min dimensions larger than the source image disables resizing 🤷 