### PR TITLE
chore: upgrade WhisperKit

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -631,7 +631,7 @@
 			repositoryURL = "https://github.com/argmaxinc/whisperkit";
 			requirement = {
 				kind = exactVersion;
-				version = 0.5.0;
+				version = 0.6.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/argmaxinc/whisperkit",
       "state" : {
-        "revision" : "61df12a322aa9ff840a46f78115ad0ad93873e2e",
-        "version" : "0.5.0"
+        "revision" : "076b6709f3a3af98e0a611c5bfed7401eac90be1",
+        "version" : "0.6.0"
       }
     }
   ],

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -708,7 +708,7 @@
 			repositoryURL = "https://github.com/argmaxinc/whisperkit";
 			requirement = {
 				kind = exactVersion;
-				version = 0.5.0;
+				version = 0.6.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/argmaxinc/whisperkit",
       "state" : {
-        "revision" : "61df12a322aa9ff840a46f78115ad0ad93873e2e",
-        "version" : "0.5.0"
+        "revision" : "076b6709f3a3af98e0a611c5bfed7401eac90be1",
+        "version" : "0.6.0"
       }
     }
   ],

--- a/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/argmaxinc/whisperkit",
       "state" : {
-        "revision" : "61df12a322aa9ff840a46f78115ad0ad93873e2e",
-        "version" : "0.5.0"
+        "revision" : "076b6709f3a3af98e0a611c5bfed7401eac90be1",
+        "version" : "0.6.0"
       }
     }
   ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.451+2469
+version: 0.9.452+2470
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR upgrades WhisperKit to the latest version [`0.6.0`](https://github.com/argmaxinc/WhisperKit/releases/tag/v0.6.0).