### PR TITLE
feat: replace deprecated Matrix database

### DIFF
--- a/integration_test/matrix_service_test.dart
+++ b/integration_test/matrix_service_test.dart
@@ -118,7 +118,7 @@ void main() {
         debugPrint('\n--- Alice goes live');
         final alice = MatrixService(
           matrixConfig: config1,
-          hiveDbName: 'Alice',
+          dbName: 'Alice',
           deviceDisplayName: 'Alice',
           overriddenJournalDb: aliceDb,
         );
@@ -143,7 +143,7 @@ void main() {
         debugPrint('\n--- Bob goes live');
         final bob = MatrixService(
           matrixConfig: config2,
-          hiveDbName: 'Bob',
+          dbName: 'Bob',
           deviceDisplayName: 'Bob',
           overriddenJournalDb: bobDb,
         );

--- a/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/argmaxinc/whisperkit",
       "state" : {
-        "revision" : "61df12a322aa9ff840a46f78115ad0ad93873e2e",
-        "version" : "0.5.0"
+        "revision" : "076b6709f3a3af98e0a611c5bfed7401eac90be1",
+        "version" : "0.6.0"
       }
     }
   ],

--- a/lib/pages/settings/flags_page.dart
+++ b/lib/pages/settings/flags_page.dart
@@ -27,6 +27,7 @@ class FlagsPage extends StatelessWidget {
           recordLocationFlag,
           allowInvalidCertFlag,
           enableMatrixFlag,
+          resendAttachments,
         };
 
         final filteredItems =

--- a/lib/sync/matrix/matrix_service.dart
+++ b/lib/sync/matrix/matrix_service.dart
@@ -19,11 +19,11 @@ class MatrixService {
   MatrixService({
     this.matrixConfig,
     this.deviceDisplayName,
-    String? hiveDbName,
+    String? dbName,
     JournalDb? overriddenJournalDb,
   })  : keyVerificationController =
             StreamController<KeyVerificationRunner>.broadcast(),
-        _client = createMatrixClient(hiveDbName: hiveDbName) {
+        _client = createMatrixClient(dbName: dbName) {
     clientRunner = ClientRunner<void>(
       callback: (event) async {
         await processNewTimelineEvents(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2532,6 +2532,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.5.4"
+  sqflite_common_ffi:
+    dependency: "direct main"
+    description:
+      name: sqflite_common_ffi
+      sha256: "4d6137c29e930d6e4a8ff373989dd9de7bac12e3bc87bce950f6e844e8ad3bb5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.3"
   sqlite3:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.452+2470
+version: 0.9.452+2471
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.452+2471
+version: 0.9.452+2472
 
 msix_config:
   display_name: LottiApp
@@ -141,6 +141,7 @@ dependencies:
   rxdart: ^0.27.7
   share_plus: ^8.0.2
   sqflite: ^2.0.1
+  sqflite_common_ffi: ^2.3.3
   sqlite3_flutter_libs: ^0.5.15
   timezone: ^0.9.1
   tinycolor2: ^3.0.0


### PR DESCRIPTION
This PR replaces the deprecated `HiveCollectionsDatabase` with the new `MatrixSdkDatabase` which uses SQLite under the hood.