### PR TITLE
refactor: database updates via stream

### DIFF
--- a/integration_test/matrix_service_test.dart
+++ b/integration_test/matrix_service_test.dart
@@ -13,6 +13,7 @@ import 'package:lotti/database/database.dart';
 import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/sync/matrix/matrix_service.dart';
 import 'package:lotti/sync/secure_storage.dart';
 import 'package:lotti/sync/vector_clock.dart';
@@ -39,6 +40,18 @@ void main() {
 
     // create separate databases for each simulated device & suppress warning
     drift.driftRuntimeOptions.dontWarnAboutMultipleDatabases = true;
+
+    final mockUpdateNotifications = MockUpdateNotifications();
+
+    when(() => mockUpdateNotifications.updateStream).thenAnswer(
+      (_) => Stream<DatabaseType>.fromIterable([]),
+    );
+
+    when(() => mockUpdateNotifications.notifyUpdate(DatabaseType.journal))
+        .thenAnswer((_) {});
+
+    getIt.registerSingleton<UpdateNotifications>(mockUpdateNotifications);
+
     final aliceDb = JournalDb(overriddenFilename: 'alice_db.sqlite');
     final bobDb = JournalDb(overriddenFilename: 'bob_db.sqlite');
 

--- a/lib/database/journal_db/config_flags.dart
+++ b/lib/database/journal_db/config_flags.dart
@@ -14,7 +14,13 @@ Future<void> initConfigFlags(
       status: true,
     ),
   );
-
+  await db.insertFlagIfNotExists(
+    const ConfigFlag(
+      name: attemptEmbedding,
+      description: 'Create LLM embedding',
+      status: false,
+    ),
+  );
   await db.insertFlagIfNotExists(
     const ConfigFlag(
       name: allowInvalidCertFlag,

--- a/lib/database/logging_db.dart
+++ b/lib/database/logging_db.dart
@@ -135,7 +135,3 @@ class LoggingDb extends _$LoggingDb {
     return allLogEntries(limit).watch();
   }
 }
-
-LoggingDb getLoggingDb() {
-  return LoggingDb.connect(getDatabaseConnection(loggingDbFileName));
-}

--- a/lib/database/settings_db.dart
+++ b/lib/database/settings_db.dart
@@ -55,7 +55,3 @@ class SettingsDb extends _$SettingsDb {
     }
   }
 }
-
-SettingsDb getSettingsDb() {
-  return SettingsDb.connect(getDatabaseConnection(settingsDbFileName));
-}

--- a/lib/database/sync_db.dart
+++ b/lib/database/sync_db.dart
@@ -97,7 +97,3 @@ class SyncDatabase extends _$SyncDatabase {
   @override
   int get schemaVersion => 1;
 }
-
-SyncDatabase getSyncDatabase() {
-  return SyncDatabase.connect(getDatabaseConnection(syncDbFileName));
-}

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -1,8 +1,6 @@
 import 'dart:async';
 
-import 'package:drift/isolate.dart';
 import 'package:get_it/get_it.dart';
-import 'package:lotti/database/common.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/editor_db.dart';
 import 'package:lotti/database/fts5_db.dart';
@@ -14,7 +12,6 @@ import 'package:lotti/logic/ai/ai_logic.dart';
 import 'package:lotti/logic/health_import.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/asr_service.dart';
-import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/editor_state_service.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/services/link_service.dart';
@@ -29,32 +26,17 @@ import 'package:lotti/sync/outbox/outbox_service.dart';
 final getIt = GetIt.instance;
 
 Future<void> registerSingletons() async {
-  await getIt.registerSingleton<Future<DriftIsolate>>(
-    createDriftIsolate(journalDbFileName),
-    instanceName: journalDbFileName,
-  );
-
-  await getIt.registerSingleton<Future<DriftIsolate>>(
-    createDriftIsolate(loggingDbFileName),
-    instanceName: loggingDbFileName,
-  );
-
-  await getIt.registerSingleton<Future<DriftIsolate>>(
-    createDriftIsolate(syncDbFileName),
-    instanceName: syncDbFileName,
-  );
-
   getIt
     ..registerSingleton<Fts5Db>(Fts5Db())
-    ..registerSingleton<LoggingDb>(getLoggingDb())
-    ..registerSingleton<JournalDb>(getJournalDb())
-    ..registerSingleton<DatabaseUpdateNotifications>(
-      DatabaseUpdateNotifications(),
-    )
+    ..registerSingleton<LoggingDb>(LoggingDb())
+    ..registerSingleton<JournalDb>(JournalDb())
+    // ..registerSingleton<DatabaseUpdateNotifications>(
+    //   DatabaseUpdateNotifications(),
+    // )
     ..registerSingleton<EditorDb>(EditorDb())
     ..registerSingleton<TagsService>(TagsService())
     ..registerSingleton<EntitiesCacheService>(EntitiesCacheService())
-    ..registerSingleton<SyncDatabase>(getSyncDatabase())
+    ..registerSingleton<SyncDatabase>(SyncDatabase())
     ..registerSingleton<AsrService>(AsrService())
     ..registerSingleton<VectorClockService>(VectorClockService())
     ..registerSingleton<TimeService>(TimeService())

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -12,6 +12,7 @@ import 'package:lotti/logic/ai/ai_logic.dart';
 import 'package:lotti/logic/health_import.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/asr_service.dart';
+import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/editor_state_service.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/services/link_service.dart';
@@ -29,10 +30,8 @@ Future<void> registerSingletons() async {
   getIt
     ..registerSingleton<Fts5Db>(Fts5Db())
     ..registerSingleton<LoggingDb>(LoggingDb())
+    ..registerSingleton<UpdateNotifications>(UpdateNotifications())
     ..registerSingleton<JournalDb>(JournalDb())
-    // ..registerSingleton<DatabaseUpdateNotifications>(
-    //   DatabaseUpdateNotifications(),
-    // )
     ..registerSingleton<EditorDb>(EditorDb())
     ..registerSingleton<TagsService>(TagsService())
     ..registerSingleton<EntitiesCacheService>(EntitiesCacheService())

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -14,6 +14,7 @@ import 'package:lotti/logic/ai/ai_logic.dart';
 import 'package:lotti/logic/health_import.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/asr_service.dart';
+import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/editor_state_service.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/services/link_service.dart';
@@ -47,6 +48,9 @@ Future<void> registerSingletons() async {
     ..registerSingleton<Fts5Db>(Fts5Db())
     ..registerSingleton<LoggingDb>(getLoggingDb())
     ..registerSingleton<JournalDb>(getJournalDb())
+    ..registerSingleton<DatabaseUpdateNotifications>(
+      DatabaseUpdateNotifications(),
+    )
     ..registerSingleton<EditorDb>(EditorDb())
     ..registerSingleton<TagsService>(TagsService())
     ..registerSingleton<EntitiesCacheService>(EntitiesCacheService())

--- a/lib/logic/ai/ai_logic.dart
+++ b/lib/logic/ai/ai_logic.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/foundation.dart';
 import 'package:langchain/langchain.dart';
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/utils/consts.dart';
 import 'package:lotti/utils/platform.dart';
 import 'package:ollama_dart/ollama_dart.dart';
 
@@ -13,6 +16,13 @@ class AiLogic {
     JournalEntity? journalEntity, {
     String? linkedFromId,
   }) async {
+    final shouldAttemptEmbedding = await getIt<JournalDb>().getConfigFlag(
+      attemptEmbedding,
+    );
+    if (!shouldAttemptEmbedding) {
+      return;
+    }
+
     final markdown = journalEntity?.entryText?.markdown;
     final headline = switch (journalEntity) {
       Task() => journalEntity.data.title,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,13 +1,11 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:drift/isolate.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hotkey_manager/hotkey_manager.dart';
 import 'package:lotti/beamer/beamer_app.dart';
-import 'package:lotti/database/common.dart';
 import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/get_it.dart';
@@ -34,14 +32,8 @@ Future<void> main() async {
 
     getIt
       ..registerSingleton<SecureStorage>(SecureStorage())
-      ..registerSingleton<Directory>(docDir);
-
-    await getIt.registerSingleton<Future<DriftIsolate>>(
-      createDriftIsolate(settingsDbFileName),
-      instanceName: settingsDbFileName,
-    );
-    getIt
-      ..registerSingleton<SettingsDb>(getSettingsDb())
+      ..registerSingleton<Directory>(docDir)
+      ..registerSingleton<SettingsDb>(SettingsDb())
       ..registerSingleton<WindowService>(WindowService());
 
     await getIt<WindowService>().restore();

--- a/lib/pages/settings/flags_page.dart
+++ b/lib/pages/settings/flags_page.dart
@@ -22,6 +22,7 @@ class FlagsPage extends StatelessWidget {
 
         const displayedItems = {
           privateFlag,
+          attemptEmbedding,
           enableNotificationsFlag,
           autoTranscribeFlag,
           recordLocationFlag,

--- a/lib/services/db_notification.dart
+++ b/lib/services/db_notification.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/foundation.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/get_it.dart';
+
+class DatabaseUpdateNotifications {
+  DatabaseUpdateNotifications() {
+    listen();
+  }
+
+  final JournalDb _journalDb = getIt<JournalDb>();
+
+  void listen() {
+    _journalDb.countJournalEntries().watch().listen((event) async {
+      final start = DateTime.now();
+      final count = await _journalDb.countJournalEntries().getSingle();
+      final end = DateTime.now();
+      final duration = end.difference(start).inMicroseconds / 1000;
+      debugPrint('DatabaseUpdateNotifications $count - $duration ms');
+    });
+  }
+}

--- a/lib/services/db_notification.dart
+++ b/lib/services/db_notification.dart
@@ -1,21 +1,20 @@
-import 'package:flutter/foundation.dart';
-import 'package:lotti/database/database.dart';
-import 'package:lotti/get_it.dart';
+import 'dart:async';
 
-class DatabaseUpdateNotifications {
-  DatabaseUpdateNotifications() {
-    listen();
-  }
+enum DatabaseType {
+  journal,
+  setting,
+  sync,
+  logging,
+}
 
-  final JournalDb _journalDb = getIt<JournalDb>();
+class UpdateNotifications {
+  UpdateNotifications();
 
-  void listen() {
-    _journalDb.countJournalEntries().watch().listen((event) async {
-      final start = DateTime.now();
-      final count = await _journalDb.countJournalEntries().getSingle();
-      final end = DateTime.now();
-      final duration = end.difference(start).inMicroseconds / 1000;
-      debugPrint('DatabaseUpdateNotifications $count - $duration ms');
-    });
+  final _updateStreamController = StreamController<DatabaseType>.broadcast();
+
+  Stream<DatabaseType> get updateStream => _updateStreamController.stream;
+
+  void notifyUpdate(DatabaseType databaseType) {
+    _updateStreamController.add(databaseType);
   }
 }

--- a/lib/utils/consts.dart
+++ b/lib/utils/consts.dart
@@ -6,3 +6,4 @@ const recordLocationFlag = 'record_location';
 const autoTranscribeFlag = 'auto_transcribe';
 const enableMatrixFlag = 'enable_matrix';
 const resendAttachments = 'resend_attachments';
+const attemptEmbedding = 'attempt_embedding';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2501,7 +2501,7 @@ packages:
     source: hosted
     version: "2.3.3"
   sqlite3:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: sqlite3
       sha256: "1abbeb84bf2b1a10e5e1138c913123c8aa9d83cd64e5f9a0dd847b3c83063202"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.458+2493
+version: 0.9.459+2494
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.459+2494
+version: 0.9.459+2496
 
 msix_config:
   display_name: LottiApp
@@ -138,6 +138,7 @@ dependencies:
   share_plus: ^9.0.0
   sqflite: ^2.0.1
   sqflite_common_ffi: ^2.3.3
+  sqlite3: ^2.4.2
   sqlite3_flutter_libs: ^0.5.15
   timezone: ^0.9.1
   tinycolor2: ^3.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.459+2496
+version: 0.9.459+2498
 
 msix_config:
   display_name: LottiApp

--- a/test/blocs/journal/entry_cubit_test.dart
+++ b/test/blocs/journal/entry_cubit_test.dart
@@ -9,6 +9,7 @@ import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/editor_state_service.dart';
 import 'package:lotti/services/time_service.dart';
 import 'package:lotti/services/vector_clock_service.dart';
@@ -28,6 +29,12 @@ void main() {
     var vcMockNext = '1';
 
     setUpAll(() {
+      final mockUpdateNotifications = MockUpdateNotifications();
+      when(() => mockUpdateNotifications.updateStream).thenAnswer(
+        (_) => Stream<DatabaseType>.fromIterable([]),
+      );
+      getIt.registerSingleton<UpdateNotifications>(mockUpdateNotifications);
+
       final secureStorageMock = MockSecureStorage();
       final settingsDb = SettingsDb(inMemoryDatabase: true);
       final mockTimeService = MockTimeService();

--- a/test/blocs/journal/journal_page_cubit_test.dart
+++ b/test/blocs/journal/journal_page_cubit_test.dart
@@ -10,6 +10,7 @@ import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/editor_state_service.dart';
 import 'package:lotti/services/time_service.dart';
 import 'package:lotti/services/vector_clock_service.dart';
@@ -23,6 +24,7 @@ import '../../test_data/sync_config_test_data.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+  final mockUpdateNotifications = MockUpdateNotifications();
 
   group('JournalPageCubit Tests - ', () {
     var vcMockNext = '1';
@@ -31,6 +33,10 @@ void main() {
       final secureStorageMock = MockSecureStorage();
       final settingsDb = SettingsDb(inMemoryDatabase: true);
       final mockTimeService = MockTimeService();
+
+      when(() => mockUpdateNotifications.updateStream).thenAnswer(
+        (_) => Stream<DatabaseType>.fromIterable([]),
+      );
 
       when(() => secureStorageMock.readValue(hostKey))
           .thenAnswer((_) async => 'some_host');
@@ -46,6 +52,7 @@ void main() {
       });
 
       getIt
+        ..registerSingleton<UpdateNotifications>(mockUpdateNotifications)
         ..registerSingleton<SettingsDb>(settingsDb)
         ..registerSingleton<SyncDatabase>(SyncDatabase(inMemoryDatabase: true))
         ..registerSingleton<JournalDb>(JournalDb(inMemoryDatabase: true))

--- a/test/database/database_test.dart
+++ b/test/database/database_test.dart
@@ -3,7 +3,12 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/journal_db/config_flags.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/utils/consts.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../mocks/mocks.dart';
 
 final expectedActiveFlagNames = {
   privateFlag,
@@ -63,14 +68,22 @@ final expectedMacFlags = <ConfigFlag>{
 
 void main() {
   JournalDb? db;
+  final mockUpdateNotifications = MockUpdateNotifications();
 
   group('Database Tests - ', () {
     setUp(() async {
+      getIt.registerSingleton<UpdateNotifications>(mockUpdateNotifications);
+
       db = JournalDb(inMemoryDatabase: true);
       await initConfigFlags(db!, inMemoryDatabase: true);
+
+      when(() => mockUpdateNotifications.updateStream).thenAnswer(
+        (_) => Stream<DatabaseType>.fromIterable([]),
+      );
     });
     tearDown(() async {
       await db?.close();
+      getIt.unregister<UpdateNotifications>();
     });
 
     test(

--- a/test/database/database_test.dart
+++ b/test/database/database_test.dart
@@ -17,6 +17,11 @@ final expectedFlags = <ConfigFlag>{
     status: true,
   ),
   const ConfigFlag(
+    name: attemptEmbedding,
+    description: 'Create LLM embedding',
+    status: false,
+  ),
+  const ConfigFlag(
     name: autoTranscribeFlag,
     description: 'Automatically transcribe audio',
     status: false,

--- a/test/logic/persistence_logic_test.dart
+++ b/test/logic/persistence_logic_test.dart
@@ -15,6 +15,7 @@ import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/ai/ai_logic.dart';
 import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/notification_service.dart';
 import 'package:lotti/services/tags_service.dart';
 import 'package:lotti/services/vector_clock_service.dart';
@@ -36,6 +37,7 @@ void main() {
   registerFallbackValue(FakeJournalEntity());
 
   final mockNotificationService = MockNotificationService();
+  final mockUpdateNotifications = MockUpdateNotifications();
   final mockAiLogic = MockAiLogic();
   final mockFts5Db = MockFts5Db();
 
@@ -48,6 +50,8 @@ void main() {
 
     setUpAll(() async {
       setFakeDocumentsPath();
+
+      getIt.registerSingleton<UpdateNotifications>(mockUpdateNotifications);
 
       final settingsDb = SettingsDb(inMemoryDatabase: true);
       final journalDb = JournalDb(inMemoryDatabase: true);
@@ -65,6 +69,10 @@ void main() {
       });
 
       when(mockNotificationService.updateBadge).thenAnswer((_) async {});
+
+      when(() => mockUpdateNotifications.updateStream).thenAnswer(
+        (_) => Stream<DatabaseType>.fromIterable([]),
+      );
 
       when(() => mockFts5Db.insertText(any())).thenAnswer((_) async {});
 

--- a/test/mocks/mocks.dart
+++ b/test/mocks/mocks.dart
@@ -19,6 +19,7 @@ import 'package:lotti/logic/ai/ai_logic.dart';
 import 'package:lotti/logic/health_import.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/asr_service.dart';
+import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/editor_state_service.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/services/link_service.dart';
@@ -114,6 +115,8 @@ class MockDownloadManager extends Mock implements DownloadManager {}
 class MockEditorStateService extends Mock implements EditorStateService {}
 
 class MockLinkService extends Mock implements LinkService {}
+
+class MockUpdateNotifications extends Mock implements UpdateNotifications {}
 
 class MockEntryCubit extends MockBloc<EntryCubit, EntryState>
     implements EntryCubit {}

--- a/test/pages/journal/infinite_journal_page_test.dart
+++ b/test/pages/journal/infinite_journal_page_test.dart
@@ -15,6 +15,7 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/pages/journal/infinite_journal_page.dart';
 import 'package:lotti/services/asr_service.dart';
+import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/services/tags_service.dart';
 import 'package:lotti/services/time_service.dart';
@@ -39,6 +40,7 @@ void main() {
   final mockSettingsDb = MockSettingsDb();
   var mockPersistenceLogic = MockPersistenceLogic();
   final mockEntitiesCacheService = MockEntitiesCacheService();
+  final mockUpdateNotifications = MockUpdateNotifications();
 
   final entryTypeStrings = entryTypes.toList();
 
@@ -100,6 +102,7 @@ void main() {
       getIt
         ..registerSingleton<Directory>(await getApplicationDocumentsDirectory())
         ..registerSingleton<LoggingDb>(MockLoggingDb())
+        ..registerSingleton<UpdateNotifications>(mockUpdateNotifications)
         ..registerSingleton<SettingsDb>(mockSettingsDb)
         ..registerSingleton<AsrService>(MockAsrService())
         ..registerSingleton<TagsService>(mockTagsService)
@@ -113,6 +116,10 @@ void main() {
 
       when(mockTagsService.watchTags).thenAnswer(
         (_) => Stream<List<TagEntity>>.fromIterable([[]]),
+      );
+
+      when(() => mockUpdateNotifications.updateStream).thenAnswer(
+        (_) => Stream<DatabaseType>.fromIterable([]),
       );
 
       when(mockJournalDb.watchConfigFlags).thenAnswer(

--- a/test/themes/themes_service_test.dart
+++ b/test/themes/themes_service_test.dart
@@ -1,15 +1,24 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/db_notification.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../mocks/mocks.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('ThemesService test -', () {
     setUpAll(() {
-      final db = JournalDb(inMemoryDatabase: true);
+      final mockUpdateNotifications = MockUpdateNotifications();
+      when(() => mockUpdateNotifications.updateStream).thenAnswer(
+        (_) => Stream<DatabaseType>.fromIterable([]),
+      );
 
-      getIt.registerSingleton<JournalDb>(db);
+      getIt
+        ..registerSingleton<UpdateNotifications>(mockUpdateNotifications)
+        ..registerSingleton<JournalDb>(JournalDb(inMemoryDatabase: true));
     });
     tearDownAll(() async {
       await getIt.reset();

--- a/test/themes/utils_test.dart
+++ b/test/themes/utils_test.dart
@@ -2,8 +2,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/tag_type_definitions.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/themes/colors.dart';
 import 'package:lotti/themes/utils.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../mocks/mocks.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -11,9 +15,14 @@ void main() {
 
   group('Theme Utils test -', () {
     setUpAll(() {
-      final db = JournalDb(inMemoryDatabase: true);
+      final mockUpdateNotifications = MockUpdateNotifications();
+      when(() => mockUpdateNotifications.updateStream).thenAnswer(
+        (_) => Stream<DatabaseType>.fromIterable([]),
+      );
 
-      getIt.registerSingleton<JournalDb>(db);
+      getIt
+        ..registerSingleton<UpdateNotifications>(mockUpdateNotifications)
+        ..registerSingleton<JournalDb>(JournalDb(inMemoryDatabase: true));
     });
     tearDownAll(() async {
       await getIt.reset();

--- a/test/widgets/journal/editor/editor_widget_test.dart
+++ b/test/widgets/journal/editor/editor_widget_test.dart
@@ -10,6 +10,7 @@ import 'package:lotti/database/editor_db.dart';
 import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/editor_state_service.dart';
 import 'package:lotti/services/tags_service.dart';
 import 'package:lotti/services/time_service.dart';
@@ -27,7 +28,13 @@ void main() {
     final mockTimeService = MockTimeService();
 
     setUpAll(() {
+      final mockUpdateNotifications = MockUpdateNotifications();
+      when(() => mockUpdateNotifications.updateStream).thenAnswer(
+        (_) => Stream<DatabaseType>.fromIterable([]),
+      );
+
       getIt
+        ..registerSingleton<UpdateNotifications>(mockUpdateNotifications)
         ..registerSingleton<LoggingDb>(LoggingDb(inMemoryDatabase: true))
         ..registerSingleton<VectorClockService>(MockVectorClockService())
         ..registerSingleton<JournalDb>(JournalDb(inMemoryDatabase: true))

--- a/test/widgets/journal/entry_details/entry_datetime_widget_test.dart
+++ b/test/widgets/journal/entry_details/entry_datetime_widget_test.dart
@@ -4,6 +4,7 @@ import 'package:lotti/blocs/journal/entry_cubit.dart';
 import 'package:lotti/blocs/journal/entry_state.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/tags_service.dart';
 import 'package:lotti/widgets/journal/entry_details/entry_datetime_widget.dart';
 import 'package:lotti/widgets/journal/entry_tools.dart';
@@ -18,7 +19,13 @@ void main() {
     final entryCubit = MockEntryCubit();
 
     setUpAll(() {
+      final mockUpdateNotifications = MockUpdateNotifications();
+      when(() => mockUpdateNotifications.updateStream).thenAnswer(
+        (_) => Stream<DatabaseType>.fromIterable([]),
+      );
+
       getIt
+        ..registerSingleton<UpdateNotifications>(mockUpdateNotifications)
         ..registerSingleton<JournalDb>(JournalDb(inMemoryDatabase: true))
         ..registerSingleton<TagsService>(TagsService());
 

--- a/test/widgets/journal/entry_details/entry_detail_footer_test.dart
+++ b/test/widgets/journal/entry_details/entry_detail_footer_test.dart
@@ -7,6 +7,7 @@ import 'package:lotti/blocs/journal/entry_state.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/tags_service.dart';
 import 'package:lotti/services/time_service.dart';
 import 'package:lotti/widgets/journal/entry_details/entry_detail_footer.dart';
@@ -23,7 +24,13 @@ void main() {
     final mockTimeService = MockTimeService();
 
     setUpAll(() {
+      final mockUpdateNotifications = MockUpdateNotifications();
+      when(() => mockUpdateNotifications.updateStream).thenAnswer(
+        (_) => Stream<DatabaseType>.fromIterable([]),
+      );
+
       getIt
+        ..registerSingleton<UpdateNotifications>(mockUpdateNotifications)
         ..registerSingleton<JournalDb>(JournalDb(inMemoryDatabase: true))
         ..registerSingleton<TagsService>(TagsService())
         ..registerSingleton<TimeService>(mockTimeService);

--- a/test/widgets/journal/entry_details/entry_detail_header_test.dart
+++ b/test/widgets/journal/entry_details/entry_detail_header_test.dart
@@ -5,6 +5,7 @@ import 'package:lotti/blocs/journal/entry_cubit.dart';
 import 'package:lotti/blocs/journal/entry_state.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/link_service.dart';
 import 'package:lotti/services/tags_service.dart';
 import 'package:lotti/widgets/journal/entry_details/entry_detail_header.dart';
@@ -20,7 +21,13 @@ void main() {
     final entryCubit = MockEntryCubit();
 
     setUpAll(() {
+      final mockUpdateNotifications = MockUpdateNotifications();
+      when(() => mockUpdateNotifications.updateStream).thenAnswer(
+        (_) => Stream<DatabaseType>.fromIterable([]),
+      );
+
       getIt
+        ..registerSingleton<UpdateNotifications>(mockUpdateNotifications)
         ..registerSingleton<JournalDb>(JournalDb(inMemoryDatabase: true))
         ..registerSingleton<LinkService>(MockLinkService())
         ..registerSingleton<TagsService>(TagsService());

--- a/test/widgets/journal/entry_details/share_button_widget_test.dart
+++ b/test/widgets/journal/entry_details/share_button_widget_test.dart
@@ -6,6 +6,7 @@ import 'package:lotti/blocs/journal/entry_cubit.dart';
 import 'package:lotti/blocs/journal/entry_state.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/tags_service.dart';
 import 'package:lotti/widgets/journal/entry_details/share_button_widget.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
@@ -24,7 +25,13 @@ void main() {
     setUpAll(() async {
       setFakeDocumentsPath();
 
+      final mockUpdateNotifications = MockUpdateNotifications();
+      when(() => mockUpdateNotifications.updateStream).thenAnswer(
+        (_) => Stream<DatabaseType>.fromIterable([]),
+      );
+
       getIt
+        ..registerSingleton<UpdateNotifications>(mockUpdateNotifications)
         ..registerSingleton<Directory>(await getApplicationDocumentsDirectory())
         ..registerSingleton<JournalDb>(JournalDb(inMemoryDatabase: true))
         ..registerSingleton<TagsService>(TagsService());


### PR DESCRIPTION
This PR removes the previous setup for running `drift` in isolates. Also, it adds a notification service for database updates, with a stream that can then be listened to by widgets, BloCs or providers for changes to the database. Unlike listening to a stream for a potentially expensive query, which then runs automatically when using drift subscriptions, it then allows listeners to re-fetch at their own leisure.