### PR TITLE
feat: entry provider & improved reload

### DIFF
--- a/integration_test/matrix_service_test.dart
+++ b/integration_test/matrix_service_test.dart
@@ -44,11 +44,12 @@ void main() {
     final mockUpdateNotifications = MockUpdateNotifications();
 
     when(() => mockUpdateNotifications.updateStream).thenAnswer(
-      (_) => Stream<DatabaseType>.fromIterable([]),
+      (_) => Stream<({DatabaseType type, String id})>.fromIterable([]),
     );
 
-    when(() => mockUpdateNotifications.notifyUpdate(DatabaseType.journal))
-        .thenAnswer((_) {});
+    when(
+      () => mockUpdateNotifications.notifyUpdate(DatabaseType.journal, any()),
+    ).thenAnswer((_) {});
 
     getIt.registerSingleton<UpdateNotifications>(mockUpdateNotifications);
 

--- a/lib/blocs/journal/journal_page_cubit.dart
+++ b/lib/blocs/journal/journal_page_cubit.dart
@@ -286,26 +286,22 @@ class JournalPageCubit extends Cubit<JournalPageState> {
           _filters.contains(DisplayFilter.flaggedEntriesOnly);
 
       final newItems = showTasks
-          ? await _db
-              .watchTasks(
-                ids: ids,
-                starredStatuses: starredEntriesOnly ? [true] : [true, false],
-                taskStatuses: _selectedTaskStatuses.toList(),
-                limit: _pageSize,
-                offset: pageKey,
-              )
-              .first
-          : await _db
-              .watchJournalEntities(
-                types: types,
-                ids: ids,
-                starredStatuses: starredEntriesOnly ? [true] : [true, false],
-                privateStatuses: privateEntriesOnly ? [true] : [true, false],
-                flaggedStatuses: flaggedEntriesOnly ? [1] : [1, 0],
-                limit: _pageSize,
-                offset: pageKey,
-              )
-              .first;
+          ? await _db.getTasks(
+              ids: ids,
+              starredStatuses: starredEntriesOnly ? [true] : [true, false],
+              taskStatuses: _selectedTaskStatuses.toList(),
+              limit: _pageSize,
+              offset: pageKey,
+            )
+          : await _db.getJournalEntities(
+              types: types,
+              ids: ids,
+              starredStatuses: starredEntriesOnly ? [true] : [true, false],
+              privateStatuses: privateEntriesOnly ? [true] : [true, false],
+              flaggedStatuses: flaggedEntriesOnly ? [1] : [1, 0],
+              limit: _pageSize,
+              offset: pageKey,
+            );
 
       final isLastPage = newItems.length < _pageSize;
 
@@ -315,10 +311,9 @@ class JournalPageCubit extends Cubit<JournalPageState> {
         final nextPageKey = pageKey + newItems.length;
         state.pagingController.appendPage(newItems, nextPageKey);
       }
-      final finished = DateTime.now();
-      final duration = finished.difference(start).inMicroseconds / 1000;
+      final duration2 = DateTime.now().difference(start).inMicroseconds / 1000;
       debugPrint(
-        '_fetchPage ${showTasks ? 'TASK' : 'JOURNAL'} duration $duration ms',
+        '_fetchPage ${showTasks ? 'TASK' : 'JOURNAL'} duration $duration2 ms',
       );
     } catch (error) {
       state.pagingController.error = error;

--- a/lib/blocs/journal/journal_page_cubit.dart
+++ b/lib/blocs/journal/journal_page_cubit.dart
@@ -98,7 +98,7 @@ class JournalPageCubit extends Cubit<JournalPageState> {
           .where(makeDuplicateFilter())
           .listen((_) {
             if (_isVisible) {
-              refreshQuery();
+              //refreshQuery();
             }
           });
     } else {

--- a/lib/blocs/journal/journal_page_cubit.dart
+++ b/lib/blocs/journal/journal_page_cubit.dart
@@ -29,7 +29,7 @@ class JournalPageCubit extends Cubit<JournalPageState> {
             fullTextMatches: {},
             showTasks: showTasks,
             taskAsListView: true,
-            pagingController: PagingController(firstPageKey: 0),
+            pagingController: PagingController<int, String>(firstPageKey: 0),
             taskStatuses: [
               'OPEN',
               'GROOMED',
@@ -286,14 +286,14 @@ class JournalPageCubit extends Cubit<JournalPageState> {
           _filters.contains(DisplayFilter.flaggedEntriesOnly);
 
       final newItems = showTasks
-          ? await _db.getTasks(
+          ? await _db.getTasksIds(
               ids: ids,
               starredStatuses: starredEntriesOnly ? [true] : [true, false],
               taskStatuses: _selectedTaskStatuses.toList(),
               limit: _pageSize,
               offset: pageKey,
             )
-          : await _db.getJournalEntities(
+          : await _db.getJournalEntityIds(
               types: types,
               ids: ids,
               starredStatuses: starredEntriesOnly ? [true] : [true, false],

--- a/lib/blocs/journal/journal_page_state.dart
+++ b/lib/blocs/journal/journal_page_state.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
+import 'package:lotti/classes/journal_entities.dart';
 
 part 'journal_page_state.freezed.dart';
 
@@ -20,7 +21,7 @@ class JournalPageState with _$JournalPageState {
     required bool taskAsListView,
     required List<String> selectedEntryTypes,
     required Set<String> fullTextMatches,
-    required PagingController<int, String> pagingController,
+    required PagingController<int, JournalEntity> pagingController,
     required List<String> taskStatuses,
     required Set<String> selectedTaskStatuses,
   }) = _JournalPageState;

--- a/lib/blocs/journal/journal_page_state.dart
+++ b/lib/blocs/journal/journal_page_state.dart
@@ -1,6 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
-import 'package:lotti/classes/journal_entities.dart';
 
 part 'journal_page_state.freezed.dart';
 
@@ -21,7 +20,7 @@ class JournalPageState with _$JournalPageState {
     required bool taskAsListView,
     required List<String> selectedEntryTypes,
     required Set<String> fullTextMatches,
-    required PagingController<int, JournalEntity> pagingController,
+    required PagingController<int, String> pagingController,
     required List<String> taskStatuses,
     required Set<String> selectedTaskStatuses,
   }) = _JournalPageState;

--- a/lib/blocs/journal/journal_page_state.freezed.dart
+++ b/lib/blocs/journal/journal_page_state.freezed.dart
@@ -24,7 +24,7 @@ mixin _$JournalPageState {
   bool get taskAsListView => throw _privateConstructorUsedError;
   List<String> get selectedEntryTypes => throw _privateConstructorUsedError;
   Set<String> get fullTextMatches => throw _privateConstructorUsedError;
-  PagingController<int, String> get pagingController =>
+  PagingController<int, JournalEntity> get pagingController =>
       throw _privateConstructorUsedError;
   List<String> get taskStatuses => throw _privateConstructorUsedError;
   Set<String> get selectedTaskStatuses => throw _privateConstructorUsedError;
@@ -49,7 +49,7 @@ abstract class $JournalPageStateCopyWith<$Res> {
       bool taskAsListView,
       List<String> selectedEntryTypes,
       Set<String> fullTextMatches,
-      PagingController<int, String> pagingController,
+      PagingController<int, JournalEntity> pagingController,
       List<String> taskStatuses,
       Set<String> selectedTaskStatuses});
 }
@@ -115,7 +115,7 @@ class _$JournalPageStateCopyWithImpl<$Res, $Val extends JournalPageState>
       pagingController: null == pagingController
           ? _value.pagingController
           : pagingController // ignore: cast_nullable_to_non_nullable
-              as PagingController<int, String>,
+              as PagingController<int, JournalEntity>,
       taskStatuses: null == taskStatuses
           ? _value.taskStatuses
           : taskStatuses // ignore: cast_nullable_to_non_nullable
@@ -145,7 +145,7 @@ abstract class _$$JournalPageStateImplCopyWith<$Res>
       bool taskAsListView,
       List<String> selectedEntryTypes,
       Set<String> fullTextMatches,
-      PagingController<int, String> pagingController,
+      PagingController<int, JournalEntity> pagingController,
       List<String> taskStatuses,
       Set<String> selectedTaskStatuses});
 }
@@ -209,7 +209,7 @@ class __$$JournalPageStateImplCopyWithImpl<$Res>
       pagingController: null == pagingController
           ? _value.pagingController
           : pagingController // ignore: cast_nullable_to_non_nullable
-              as PagingController<int, String>,
+              as PagingController<int, JournalEntity>,
       taskStatuses: null == taskStatuses
           ? _value._taskStatuses
           : taskStatuses // ignore: cast_nullable_to_non_nullable
@@ -286,7 +286,7 @@ class _$JournalPageStateImpl implements _JournalPageState {
   }
 
   @override
-  final PagingController<int, String> pagingController;
+  final PagingController<int, JournalEntity> pagingController;
   final List<String> _taskStatuses;
   @override
   List<String> get taskStatuses {
@@ -368,7 +368,7 @@ abstract class _JournalPageState implements JournalPageState {
           required final bool taskAsListView,
           required final List<String> selectedEntryTypes,
           required final Set<String> fullTextMatches,
-          required final PagingController<int, String> pagingController,
+          required final PagingController<int, JournalEntity> pagingController,
           required final List<String> taskStatuses,
           required final Set<String> selectedTaskStatuses}) =
       _$JournalPageStateImpl;
@@ -390,7 +390,7 @@ abstract class _JournalPageState implements JournalPageState {
   @override
   Set<String> get fullTextMatches;
   @override
-  PagingController<int, String> get pagingController;
+  PagingController<int, JournalEntity> get pagingController;
   @override
   List<String> get taskStatuses;
   @override

--- a/lib/blocs/journal/journal_page_state.freezed.dart
+++ b/lib/blocs/journal/journal_page_state.freezed.dart
@@ -24,7 +24,7 @@ mixin _$JournalPageState {
   bool get taskAsListView => throw _privateConstructorUsedError;
   List<String> get selectedEntryTypes => throw _privateConstructorUsedError;
   Set<String> get fullTextMatches => throw _privateConstructorUsedError;
-  PagingController<int, JournalEntity> get pagingController =>
+  PagingController<int, String> get pagingController =>
       throw _privateConstructorUsedError;
   List<String> get taskStatuses => throw _privateConstructorUsedError;
   Set<String> get selectedTaskStatuses => throw _privateConstructorUsedError;
@@ -49,7 +49,7 @@ abstract class $JournalPageStateCopyWith<$Res> {
       bool taskAsListView,
       List<String> selectedEntryTypes,
       Set<String> fullTextMatches,
-      PagingController<int, JournalEntity> pagingController,
+      PagingController<int, String> pagingController,
       List<String> taskStatuses,
       Set<String> selectedTaskStatuses});
 }
@@ -115,7 +115,7 @@ class _$JournalPageStateCopyWithImpl<$Res, $Val extends JournalPageState>
       pagingController: null == pagingController
           ? _value.pagingController
           : pagingController // ignore: cast_nullable_to_non_nullable
-              as PagingController<int, JournalEntity>,
+              as PagingController<int, String>,
       taskStatuses: null == taskStatuses
           ? _value.taskStatuses
           : taskStatuses // ignore: cast_nullable_to_non_nullable
@@ -145,7 +145,7 @@ abstract class _$$JournalPageStateImplCopyWith<$Res>
       bool taskAsListView,
       List<String> selectedEntryTypes,
       Set<String> fullTextMatches,
-      PagingController<int, JournalEntity> pagingController,
+      PagingController<int, String> pagingController,
       List<String> taskStatuses,
       Set<String> selectedTaskStatuses});
 }
@@ -209,7 +209,7 @@ class __$$JournalPageStateImplCopyWithImpl<$Res>
       pagingController: null == pagingController
           ? _value.pagingController
           : pagingController // ignore: cast_nullable_to_non_nullable
-              as PagingController<int, JournalEntity>,
+              as PagingController<int, String>,
       taskStatuses: null == taskStatuses
           ? _value._taskStatuses
           : taskStatuses // ignore: cast_nullable_to_non_nullable
@@ -286,7 +286,7 @@ class _$JournalPageStateImpl implements _JournalPageState {
   }
 
   @override
-  final PagingController<int, JournalEntity> pagingController;
+  final PagingController<int, String> pagingController;
   final List<String> _taskStatuses;
   @override
   List<String> get taskStatuses {
@@ -368,7 +368,7 @@ abstract class _JournalPageState implements JournalPageState {
           required final bool taskAsListView,
           required final List<String> selectedEntryTypes,
           required final Set<String> fullTextMatches,
-          required final PagingController<int, JournalEntity> pagingController,
+          required final PagingController<int, String> pagingController,
           required final List<String> taskStatuses,
           required final Set<String> selectedTaskStatuses}) =
       _$JournalPageStateImpl;
@@ -390,7 +390,7 @@ abstract class _JournalPageState implements JournalPageState {
   @override
   Set<String> get fullTextMatches;
   @override
-  PagingController<int, JournalEntity> get pagingController;
+  PagingController<int, String> get pagingController;
   @override
   List<String> get taskStatuses;
   @override

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -270,7 +270,7 @@ class JournalDb extends _$JournalDb {
     int limit = 500,
     int offset = 0,
   }) async {
-    final res = await _selectJournalEntities(
+    return _selectJournalEntityIds(
       types: types,
       starredStatuses: starredStatuses,
       privateStatuses: privateStatuses,
@@ -279,7 +279,6 @@ class JournalDb extends _$JournalDb {
       limit: limit,
       offset: offset,
     ).get();
-    return res.map((e) => e.id).toList();
   }
 
   Selectable<JournalDbEntity> _selectJournalEntities({
@@ -303,6 +302,37 @@ class JournalDb extends _$JournalDb {
       );
     } else {
       return filteredJournal(
+        types,
+        starredStatuses,
+        privateStatuses,
+        flaggedStatuses,
+        limit,
+        offset,
+      );
+    }
+  }
+
+  Selectable<String> _selectJournalEntityIds({
+    required List<String> types,
+    required List<bool> starredStatuses,
+    required List<bool> privateStatuses,
+    required List<int> flaggedStatuses,
+    required List<String>? ids,
+    int limit = 500,
+    int offset = 0,
+  }) {
+    if (ids != null) {
+      return filteredJournalIds2(
+        types,
+        ids,
+        starredStatuses,
+        privateStatuses,
+        flaggedStatuses,
+        limit,
+        offset,
+      );
+    } else {
+      return filteredJournalIds(
         types,
         starredStatuses,
         privateStatuses,
@@ -362,31 +392,13 @@ class JournalDb extends _$JournalDb {
     int limit = 500,
     int offset = 0,
   }) async {
-    final res = await _selectTasks(
+    return _selectTaskIds(
       starredStatuses: starredStatuses,
       taskStatuses: taskStatuses,
       ids: ids,
       limit: limit,
       offset: offset,
     ).get();
-    return res.map((e) => e.id).toList();
-  }
-
-  Future<List<JournalEntity>> getTasks({
-    required List<bool> starredStatuses,
-    required List<String> taskStatuses,
-    List<String>? ids,
-    int limit = 500,
-    int offset = 0,
-  }) async {
-    final res = await _selectTasks(
-      starredStatuses: starredStatuses,
-      taskStatuses: taskStatuses,
-      ids: ids,
-      limit: limit,
-      offset: offset,
-    ).get();
-    return res.map(fromDbEntity).toList();
   }
 
   Selectable<JournalDbEntity> _selectTasks({
@@ -398,7 +410,7 @@ class JournalDb extends _$JournalDb {
   }) {
     final types = <String>['Task'];
     if (ids != null) {
-      return filteredTasksByTag(
+      return filteredTasks2(
         types,
         ids,
         starredStatuses,
@@ -408,6 +420,34 @@ class JournalDb extends _$JournalDb {
       );
     } else {
       return filteredTasks(
+        types,
+        starredStatuses,
+        taskStatuses,
+        limit,
+        offset,
+      );
+    }
+  }
+
+  Selectable<String> _selectTaskIds({
+    required List<bool> starredStatuses,
+    required List<String> taskStatuses,
+    List<String>? ids,
+    int limit = 500,
+    int offset = 0,
+  }) {
+    final types = <String>['Task'];
+    if (ids != null) {
+      return filteredTaskIds2(
+        types,
+        ids,
+        starredStatuses,
+        taskStatuses,
+        limit,
+        offset,
+      );
+    } else {
+      return filteredTaskIds(
         types,
         starredStatuses,
         taskStatuses,

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -71,7 +71,14 @@ class JournalDb extends _$JournalDb {
   }
 
   Future<int> upsertJournalDbEntity(JournalDbEntity entry) async {
-    return into(journal).insertOnConflictUpdate(entry);
+    final res = into(journal).insertOnConflictUpdate(entry);
+
+    _updateNotifications.notifyUpdate(
+      DatabaseType.journal,
+      entry.id,
+    );
+
+    return res;
   }
 
   Future<int> addConflict(Conflict conflict) async {
@@ -182,10 +189,7 @@ class JournalDb extends _$JournalDb {
 
   Future<JournalDbEntity?> entityById(String id) async {
     final res = await (select(journal)..where((t) => t.id.equals(id))).get();
-    if (res.isNotEmpty) {
-      return res.first;
-    }
-    return null;
+    return res.firstOrNull;
   }
 
   Stream<JournalEntity?> watchEntityById(String id) {
@@ -723,7 +727,10 @@ class JournalDb extends _$JournalDb {
       dashboard: upsertDashboardDefinition,
       categoryDefinition: upsertCategoryDefinition,
     );
-    _updateNotifications.notifyUpdate(DatabaseType.journal);
+    _updateNotifications.notifyUpdate(
+      DatabaseType.entity,
+      entityDefinition.id,
+    );
     return linesAffected;
   }
 }

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -229,6 +229,68 @@ class JournalDb extends _$JournalDb {
     int limit = 500,
     int offset = 0,
   }) {
+    return _selectJournalEntities(
+      types: types,
+      starredStatuses: starredStatuses,
+      privateStatuses: privateStatuses,
+      flaggedStatuses: flaggedStatuses,
+      ids: ids,
+      limit: limit,
+      offset: offset,
+    ).watch().map(entityStreamMapper);
+  }
+
+  Future<List<JournalEntity>> getJournalEntities({
+    required List<String> types,
+    required List<bool> starredStatuses,
+    required List<bool> privateStatuses,
+    required List<int> flaggedStatuses,
+    required List<String>? ids,
+    int limit = 500,
+    int offset = 0,
+  }) async {
+    final res = await _selectJournalEntities(
+      types: types,
+      starredStatuses: starredStatuses,
+      privateStatuses: privateStatuses,
+      flaggedStatuses: flaggedStatuses,
+      ids: ids,
+      limit: limit,
+      offset: offset,
+    ).get();
+    return res.map(fromDbEntity).toList();
+  }
+
+  Future<List<String>> getJournalEntityIds({
+    required List<String> types,
+    required List<bool> starredStatuses,
+    required List<bool> privateStatuses,
+    required List<int> flaggedStatuses,
+    required List<String>? ids,
+    int limit = 500,
+    int offset = 0,
+  }) async {
+    final res = await _selectJournalEntities(
+      types: types,
+      starredStatuses: starredStatuses,
+      privateStatuses: privateStatuses,
+      flaggedStatuses: flaggedStatuses,
+      ids: ids,
+      limit: limit,
+      offset: offset,
+    ).get();
+    return res.map((e) => e.id).toList();
+  }
+
+  Selectable<JournalDbEntity> _selectJournalEntities({
+    required List<String> types,
+    required List<bool> starredStatuses,
+    required List<bool> privateStatuses,
+    required List<int> flaggedStatuses,
+    required List<String>? ids,
+    int limit = 500,
+    int offset = 0,
+  }) {
     if (ids != null) {
       return filteredByTagJournal(
         types,
@@ -238,7 +300,7 @@ class JournalDb extends _$JournalDb {
         flaggedStatuses,
         limit,
         offset,
-      ).watch().map(entityStreamMapper);
+      );
     } else {
       return filteredJournal(
         types,
@@ -247,7 +309,7 @@ class JournalDb extends _$JournalDb {
         flaggedStatuses,
         limit,
         offset,
-      ).watch().map(entityStreamMapper);
+      );
     }
   }
 
@@ -284,6 +346,56 @@ class JournalDb extends _$JournalDb {
     int limit = 500,
     int offset = 0,
   }) {
+    return _selectTasks(
+      starredStatuses: starredStatuses,
+      taskStatuses: taskStatuses,
+      ids: ids,
+      limit: limit,
+      offset: offset,
+    ).watch().map(entityStreamMapper);
+  }
+
+  Future<List<String>> getTasksIds({
+    required List<bool> starredStatuses,
+    required List<String> taskStatuses,
+    List<String>? ids,
+    int limit = 500,
+    int offset = 0,
+  }) async {
+    final res = await _selectTasks(
+      starredStatuses: starredStatuses,
+      taskStatuses: taskStatuses,
+      ids: ids,
+      limit: limit,
+      offset: offset,
+    ).get();
+    return res.map((e) => e.id).toList();
+  }
+
+  Future<List<JournalEntity>> getTasks({
+    required List<bool> starredStatuses,
+    required List<String> taskStatuses,
+    List<String>? ids,
+    int limit = 500,
+    int offset = 0,
+  }) async {
+    final res = await _selectTasks(
+      starredStatuses: starredStatuses,
+      taskStatuses: taskStatuses,
+      ids: ids,
+      limit: limit,
+      offset: offset,
+    ).get();
+    return res.map(fromDbEntity).toList();
+  }
+
+  Selectable<JournalDbEntity> _selectTasks({
+    required List<bool> starredStatuses,
+    required List<String> taskStatuses,
+    List<String>? ids,
+    int limit = 500,
+    int offset = 0,
+  }) {
     final types = <String>['Task'];
     if (ids != null) {
       return filteredTasksByTag(
@@ -293,7 +405,7 @@ class JournalDb extends _$JournalDb {
         taskStatuses,
         limit,
         offset,
-      ).watch().map(entityStreamMapper);
+      );
     } else {
       return filteredTasks(
         types,
@@ -301,7 +413,7 @@ class JournalDb extends _$JournalDb {
         taskStatuses,
         limit,
         offset,
-      ).watch().map(entityStreamMapper);
+      );
     }
   }
 

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -385,6 +385,24 @@ class JournalDb extends _$JournalDb {
     ).watch().map(entityStreamMapper);
   }
 
+  Future<List<JournalEntity>> getTasks({
+    required List<bool> starredStatuses,
+    required List<String> taskStatuses,
+    List<String>? ids,
+    int limit = 500,
+    int offset = 0,
+  }) async {
+    final res = await _selectTasks(
+      starredStatuses: starredStatuses,
+      taskStatuses: taskStatuses,
+      ids: ids,
+      limit: limit,
+      offset: offset,
+    ).get();
+
+    return res.map(fromDbEntity).toList();
+  }
+
   Future<List<String>> getTasksIds({
     required List<bool> starredStatuses,
     required List<String> taskStatuses,

--- a/lib/database/database.drift
+++ b/lib/database/database.drift
@@ -24,7 +24,7 @@ CREATE TABLE journal (
 
 CREATE INDEX idx_journal_created_at ON journal (created_at);
 CREATE INDEX idx_journal_updated_at ON journal (updated_at);
-CREATE INDEX idx_journal_date_from ON journal (date_from);
+CREATE INDEX idx_journal_date_from ON journal (date_from DESC);
 CREATE INDEX idx_journal_date_to ON journal (date_to);
 CREATE INDEX idx_journal_deleted ON journal (deleted);
 CREATE INDEX idx_journal_starred ON journal (starred);
@@ -185,6 +185,31 @@ SELECT * FROM journal
   LIMIT :limit
   OFFSET :offset;
 
+filteredJournalIds:
+SELECT id FROM journal
+  WHERE type IN :types
+  AND deleted = false
+  AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'))
+  AND starred IN :starredStatuses
+  AND private IN :privateStatuses
+  AND flag IN :flaggedStatuses
+  ORDER BY date_from DESC
+  LIMIT :limit
+  OFFSET :offset;
+
+filteredJournalIds2:
+SELECT id FROM journal
+  WHERE type IN :types
+  AND deleted = false
+  AND id IN :ids
+  AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'))
+  AND starred IN :starredStatuses
+  AND private IN :privateStatuses
+  AND flag IN :flaggedStatuses
+  ORDER BY date_from DESC
+  LIMIT :limit
+  OFFSET :offset;
+
 filteredByTagJournal:
 SELECT * FROM journal
   WHERE type IN :types
@@ -244,8 +269,33 @@ SELECT * FROM journal
   LIMIT :limit
   OFFSET :offset;
 
-filteredTasksByTag:
+filteredTasks2:
 SELECT * FROM journal
+  WHERE type IN :types
+  AND deleted = false
+  AND id IN :ids
+  AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'))
+  AND starred IN :starredStatuses
+  AND task = 1
+  AND task_status IN :taskStatuses
+  ORDER BY date_from DESC
+  LIMIT :limit
+  OFFSET :offset;
+
+filteredTaskIds:
+SELECT id FROM journal
+  WHERE type IN :types
+  AND deleted = false
+  AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'))
+  AND starred IN :starredStatuses
+  AND task = 1
+  AND task_status IN :taskStatuses
+  ORDER BY date_from DESC
+  LIMIT :limit
+  OFFSET :offset;
+
+filteredTaskIds2:
+SELECT id FROM journal
   WHERE type IN :types
   AND deleted = false
   AND id IN :ids

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -4291,7 +4291,7 @@ abstract class _$JournalDb extends GeneratedDatabase {
   late final Index idxJournalUpdatedAt = Index('idx_journal_updated_at',
       'CREATE INDEX idx_journal_updated_at ON journal (updated_at)');
   late final Index idxJournalDateFrom = Index('idx_journal_date_from',
-      'CREATE INDEX idx_journal_date_from ON journal (date_from)');
+      'CREATE INDEX idx_journal_date_from ON journal (date_from DESC)');
   late final Index idxJournalDateTo = Index('idx_journal_date_to',
       'CREATE INDEX idx_journal_date_to ON journal (date_to)');
   late final Index idxJournalDeleted = Index('idx_journal_deleted',
@@ -4423,6 +4423,80 @@ abstract class _$JournalDb extends GeneratedDatabase {
         }).asyncMap(journal.mapFromRow);
   }
 
+  Selectable<String> filteredJournalIds(
+      List<String> types,
+      List<bool> starredStatuses,
+      List<bool> privateStatuses,
+      List<int> flaggedStatuses,
+      int limit,
+      int offset) {
+    var $arrayStartIndex = 3;
+    final expandedtypes = $expandVar($arrayStartIndex, types.length);
+    $arrayStartIndex += types.length;
+    final expandedstarredStatuses =
+        $expandVar($arrayStartIndex, starredStatuses.length);
+    $arrayStartIndex += starredStatuses.length;
+    final expandedprivateStatuses =
+        $expandVar($arrayStartIndex, privateStatuses.length);
+    $arrayStartIndex += privateStatuses.length;
+    final expandedflaggedStatuses =
+        $expandVar($arrayStartIndex, flaggedStatuses.length);
+    $arrayStartIndex += flaggedStatuses.length;
+    return customSelect(
+        'SELECT id FROM journal WHERE type IN ($expandedtypes) AND deleted = FALSE AND private IN (0, (SELECT status FROM config_flags WHERE name = \'private\')) AND starred IN ($expandedstarredStatuses) AND private IN ($expandedprivateStatuses) AND flag IN ($expandedflaggedStatuses) ORDER BY date_from DESC LIMIT ?1 OFFSET ?2',
+        variables: [
+          Variable<int>(limit),
+          Variable<int>(offset),
+          for (var $ in types) Variable<String>($),
+          for (var $ in starredStatuses) Variable<bool>($),
+          for (var $ in privateStatuses) Variable<bool>($),
+          for (var $ in flaggedStatuses) Variable<int>($)
+        ],
+        readsFrom: {
+          journal,
+          configFlags,
+        }).map((QueryRow row) => row.read<String>('id'));
+  }
+
+  Selectable<String> filteredJournalIds2(
+      List<String> types,
+      List<String> ids,
+      List<bool> starredStatuses,
+      List<bool> privateStatuses,
+      List<int> flaggedStatuses,
+      int limit,
+      int offset) {
+    var $arrayStartIndex = 3;
+    final expandedtypes = $expandVar($arrayStartIndex, types.length);
+    $arrayStartIndex += types.length;
+    final expandedids = $expandVar($arrayStartIndex, ids.length);
+    $arrayStartIndex += ids.length;
+    final expandedstarredStatuses =
+        $expandVar($arrayStartIndex, starredStatuses.length);
+    $arrayStartIndex += starredStatuses.length;
+    final expandedprivateStatuses =
+        $expandVar($arrayStartIndex, privateStatuses.length);
+    $arrayStartIndex += privateStatuses.length;
+    final expandedflaggedStatuses =
+        $expandVar($arrayStartIndex, flaggedStatuses.length);
+    $arrayStartIndex += flaggedStatuses.length;
+    return customSelect(
+        'SELECT id FROM journal WHERE type IN ($expandedtypes) AND deleted = FALSE AND id IN ($expandedids) AND private IN (0, (SELECT status FROM config_flags WHERE name = \'private\')) AND starred IN ($expandedstarredStatuses) AND private IN ($expandedprivateStatuses) AND flag IN ($expandedflaggedStatuses) ORDER BY date_from DESC LIMIT ?1 OFFSET ?2',
+        variables: [
+          Variable<int>(limit),
+          Variable<int>(offset),
+          for (var $ in types) Variable<String>($),
+          for (var $ in ids) Variable<String>($),
+          for (var $ in starredStatuses) Variable<bool>($),
+          for (var $ in privateStatuses) Variable<bool>($),
+          for (var $ in flaggedStatuses) Variable<int>($)
+        ],
+        readsFrom: {
+          journal,
+          configFlags,
+        }).map((QueryRow row) => row.read<String>('id'));
+  }
+
   Selectable<JournalDbEntity> filteredByTagJournal(
       List<String> types,
       List<String> ids,
@@ -4546,7 +4620,7 @@ abstract class _$JournalDb extends GeneratedDatabase {
         }).asyncMap(journal.mapFromRow);
   }
 
-  Selectable<JournalDbEntity> filteredTasksByTag(
+  Selectable<JournalDbEntity> filteredTasks2(
       List<String> types,
       List<String> ids,
       List<bool> starredStatuses,
@@ -4578,6 +4652,70 @@ abstract class _$JournalDb extends GeneratedDatabase {
           journal,
           configFlags,
         }).asyncMap(journal.mapFromRow);
+  }
+
+  Selectable<String> filteredTaskIds(
+      List<String> types,
+      List<bool> starredStatuses,
+      List<String?> taskStatuses,
+      int limit,
+      int offset) {
+    var $arrayStartIndex = 3;
+    final expandedtypes = $expandVar($arrayStartIndex, types.length);
+    $arrayStartIndex += types.length;
+    final expandedstarredStatuses =
+        $expandVar($arrayStartIndex, starredStatuses.length);
+    $arrayStartIndex += starredStatuses.length;
+    final expandedtaskStatuses =
+        $expandVar($arrayStartIndex, taskStatuses.length);
+    $arrayStartIndex += taskStatuses.length;
+    return customSelect(
+        'SELECT id FROM journal WHERE type IN ($expandedtypes) AND deleted = FALSE AND private IN (0, (SELECT status FROM config_flags WHERE name = \'private\')) AND starred IN ($expandedstarredStatuses) AND task = 1 AND task_status IN ($expandedtaskStatuses) ORDER BY date_from DESC LIMIT ?1 OFFSET ?2',
+        variables: [
+          Variable<int>(limit),
+          Variable<int>(offset),
+          for (var $ in types) Variable<String>($),
+          for (var $ in starredStatuses) Variable<bool>($),
+          for (var $ in taskStatuses) Variable<String>($)
+        ],
+        readsFrom: {
+          journal,
+          configFlags,
+        }).map((QueryRow row) => row.read<String>('id'));
+  }
+
+  Selectable<String> filteredTaskIds2(
+      List<String> types,
+      List<String> ids,
+      List<bool> starredStatuses,
+      List<String?> taskStatuses,
+      int limit,
+      int offset) {
+    var $arrayStartIndex = 3;
+    final expandedtypes = $expandVar($arrayStartIndex, types.length);
+    $arrayStartIndex += types.length;
+    final expandedids = $expandVar($arrayStartIndex, ids.length);
+    $arrayStartIndex += ids.length;
+    final expandedstarredStatuses =
+        $expandVar($arrayStartIndex, starredStatuses.length);
+    $arrayStartIndex += starredStatuses.length;
+    final expandedtaskStatuses =
+        $expandVar($arrayStartIndex, taskStatuses.length);
+    $arrayStartIndex += taskStatuses.length;
+    return customSelect(
+        'SELECT id FROM journal WHERE type IN ($expandedtypes) AND deleted = FALSE AND id IN ($expandedids) AND private IN (0, (SELECT status FROM config_flags WHERE name = \'private\')) AND starred IN ($expandedstarredStatuses) AND task = 1 AND task_status IN ($expandedtaskStatuses) ORDER BY date_from DESC LIMIT ?1 OFFSET ?2',
+        variables: [
+          Variable<int>(limit),
+          Variable<int>(offset),
+          for (var $ in types) Variable<String>($),
+          for (var $ in ids) Variable<String>($),
+          for (var $ in starredStatuses) Variable<bool>($),
+          for (var $ in taskStatuses) Variable<String>($)
+        ],
+        readsFrom: {
+          journal,
+          configFlags,
+        }).map((QueryRow row) => row.read<String>('id'));
   }
 
   Selectable<JournalDbEntity> orderedJournal(int limit, int offset) {

--- a/lib/features/journal/state/entry_controller.dart
+++ b/lib/features/journal/state/entry_controller.dart
@@ -1,0 +1,47 @@
+import 'dart:async';
+
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/db_notification.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'entry_controller.g.dart';
+
+@riverpod
+class EntryController extends _$EntryController {
+  EntryController() {
+    listen();
+  }
+  String? _entryId;
+  StreamSubscription<({DatabaseType type, String id})>? _updateSubscription;
+
+  final JournalDb _journalDb = getIt<JournalDb>();
+  final UpdateNotifications _updateNotifications = getIt<UpdateNotifications>();
+
+  void listen() {
+    _updateSubscription =
+        _updateNotifications.updateStream.listen((event) async {
+      if (event.id == _entryId) {
+        final latest = await fetch();
+        if (latest != state.value) {
+          state = AsyncData(latest);
+        }
+      }
+    });
+  }
+
+  @override
+  Future<JournalEntity?> build({required String id}) async {
+    _entryId = id;
+    ref.onDispose(() => _updateSubscription?.cancel());
+    return fetch();
+  }
+
+  Future<JournalEntity?> fetch() async {
+    if (_entryId == null) {
+      return null;
+    }
+    return _journalDb.journalEntityById(_entryId!);
+  }
+}

--- a/lib/features/journal/state/entry_controller.g.dart
+++ b/lib/features/journal/state/entry_controller.g.dart
@@ -1,0 +1,175 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'entry_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$entryControllerHash() => r'42529c555e9cbfc17581021e2a872f8cb5633db9';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+abstract class _$EntryController
+    extends BuildlessAutoDisposeAsyncNotifier<JournalEntity?> {
+  late final String id;
+
+  FutureOr<JournalEntity?> build({
+    required String id,
+  });
+}
+
+/// See also [EntryController].
+@ProviderFor(EntryController)
+const entryControllerProvider = EntryControllerFamily();
+
+/// See also [EntryController].
+class EntryControllerFamily extends Family<AsyncValue<JournalEntity?>> {
+  /// See also [EntryController].
+  const EntryControllerFamily();
+
+  /// See also [EntryController].
+  EntryControllerProvider call({
+    required String id,
+  }) {
+    return EntryControllerProvider(
+      id: id,
+    );
+  }
+
+  @override
+  EntryControllerProvider getProviderOverride(
+    covariant EntryControllerProvider provider,
+  ) {
+    return call(
+      id: provider.id,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'entryControllerProvider';
+}
+
+/// See also [EntryController].
+class EntryControllerProvider extends AutoDisposeAsyncNotifierProviderImpl<
+    EntryController, JournalEntity?> {
+  /// See also [EntryController].
+  EntryControllerProvider({
+    required String id,
+  }) : this._internal(
+          () => EntryController()..id = id,
+          from: entryControllerProvider,
+          name: r'entryControllerProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$entryControllerHash,
+          dependencies: EntryControllerFamily._dependencies,
+          allTransitiveDependencies:
+              EntryControllerFamily._allTransitiveDependencies,
+          id: id,
+        );
+
+  EntryControllerProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.id,
+  }) : super.internal();
+
+  final String id;
+
+  @override
+  FutureOr<JournalEntity?> runNotifierBuild(
+    covariant EntryController notifier,
+  ) {
+    return notifier.build(
+      id: id,
+    );
+  }
+
+  @override
+  Override overrideWith(EntryController Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: EntryControllerProvider._internal(
+        () => create()..id = id,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        id: id,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeAsyncNotifierProviderElement<EntryController, JournalEntity?>
+      createElement() {
+    return _EntryControllerProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is EntryControllerProvider && other.id == id;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, id.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+mixin EntryControllerRef
+    on AutoDisposeAsyncNotifierProviderRef<JournalEntity?> {
+  /// The parameter `id` of this provider.
+  String get id;
+}
+
+class _EntryControllerProviderElement
+    extends AutoDisposeAsyncNotifierProviderElement<EntryController,
+        JournalEntity?> with EntryControllerRef {
+  _EntryControllerProviderElement(super.provider);
+
+  @override
+  String get id => (origin as EntryControllerProvider).id;
+}
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/pages/journal/infinite_journal_page.dart
+++ b/lib/pages/journal/infinite_journal_page.dart
@@ -88,8 +88,8 @@ class InfiniteJournalPageBody extends StatelessWidget {
                             JournalImageCard(item: image, key: valueKey),
                         task: (Task task) {
                           if (snapshot.taskAsListView) {
-                            return TaskListCard(
-                              task: task,
+                            return TaskListCard2(
+                              id: task.meta.id,
                               key: valueKey,
                             );
                           } else {

--- a/lib/pages/journal/infinite_journal_page.dart
+++ b/lib/pages/journal/infinite_journal_page.dart
@@ -5,7 +5,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
 import 'package:lotti/blocs/journal/journal_page_cubit.dart';
 import 'package:lotti/blocs/journal/journal_page_state.dart';
-import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/logic/create/create_entry.dart';
@@ -78,14 +77,14 @@ class InfiniteJournalPageBody extends StatelessWidget {
             child: CustomScrollView(
               slivers: <Widget>[
                 const JournalSliverAppBar(),
-                PagedSliverList<int, JournalEntity>(
+                PagedSliverList<int, String>(
                   pagingController: snapshot.pagingController,
-                  builderDelegate: PagedChildBuilderDelegate<JournalEntity>(
-                    itemBuilder: (context, item, index) {
+                  builderDelegate: PagedChildBuilderDelegate<String>(
+                    itemBuilder: (context, id, index) {
                       return EntryWrapperWidget(
-                        id: item.meta.id,
+                        id: id,
                         taskAsListView: snapshot.taskAsListView,
-                        key: ValueKey(item.meta.id),
+                        key: ValueKey(id),
                       );
                     },
                   ),

--- a/lib/pages/journal/infinite_journal_page.dart
+++ b/lib/pages/journal/infinite_journal_page.dart
@@ -82,21 +82,10 @@ class InfiniteJournalPageBody extends StatelessWidget {
                   pagingController: snapshot.pagingController,
                   builderDelegate: PagedChildBuilderDelegate<JournalEntity>(
                     itemBuilder: (context, item, index) {
-                      final valueKey = ValueKey(item.meta.id);
-                      return item.maybeMap(
-                        journalImage: (JournalImage image) =>
-                            JournalImageCard(item: image, key: valueKey),
-                        task: (Task task) {
-                          if (snapshot.taskAsListView) {
-                            return TaskListCard2(
-                              id: task.meta.id,
-                              key: valueKey,
-                            );
-                          } else {
-                            return JournalCard(item: item, key: valueKey);
-                          }
-                        },
-                        orElse: () => JournalCard(item: item, key: valueKey),
+                      return EntryWrapperWidget(
+                        id: item.meta.id,
+                        taskAsListView: snapshot.taskAsListView,
+                        key: ValueKey(item.meta.id),
                       );
                     },
                   ),

--- a/lib/pages/journal/infinite_journal_page.dart
+++ b/lib/pages/journal/infinite_journal_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
 import 'package:lotti/blocs/journal/journal_page_cubit.dart';
 import 'package:lotti/blocs/journal/journal_page_state.dart';
+import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/logic/create/create_entry.dart';
@@ -77,14 +78,15 @@ class InfiniteJournalPageBody extends StatelessWidget {
             child: CustomScrollView(
               slivers: <Widget>[
                 const JournalSliverAppBar(),
-                PagedSliverList<int, String>(
+                PagedSliverList<int, JournalEntity>(
                   pagingController: snapshot.pagingController,
-                  builderDelegate: PagedChildBuilderDelegate<String>(
-                    itemBuilder: (context, id, index) {
+                  builderDelegate: PagedChildBuilderDelegate<JournalEntity>(
+                    animateTransitions: true,
+                    itemBuilder: (context, item, index) {
                       return EntryWrapperWidget(
-                        id: id,
+                        item: item,
                         taskAsListView: snapshot.taskAsListView,
-                        key: ValueKey(id),
+                        key: ValueKey(item.meta.id),
                       );
                     },
                   ),

--- a/lib/services/db_notification.dart
+++ b/lib/services/db_notification.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 enum DatabaseType {
   journal,
+  entity,
   setting,
   sync,
   logging,
@@ -10,11 +11,13 @@ enum DatabaseType {
 class UpdateNotifications {
   UpdateNotifications();
 
-  final _updateStreamController = StreamController<DatabaseType>.broadcast();
+  final _updateStreamController =
+      StreamController<({DatabaseType type, String id})>.broadcast();
 
-  Stream<DatabaseType> get updateStream => _updateStreamController.stream;
+  Stream<({DatabaseType type, String id})> get updateStream =>
+      _updateStreamController.stream;
 
-  void notifyUpdate(DatabaseType databaseType) {
-    _updateStreamController.add(databaseType);
+  void notifyUpdate(DatabaseType databaseType, String id) {
+    _updateStreamController.add((type: databaseType, id: id));
   }
 }

--- a/lib/widgets/journal/journal_card.dart
+++ b/lib/widgets/journal/journal_card.dart
@@ -333,13 +333,15 @@ class TaskListCard extends StatelessWidget {
   }
 }
 
-class TaskListCard2 extends ConsumerWidget {
-  const TaskListCard2({
+class EntryWrapperWidget extends ConsumerWidget {
+  const EntryWrapperWidget({
     required this.id,
+    required this.taskAsListView,
     super.key,
   });
 
   final String id;
+  final bool taskAsListView;
 
   void onTap() => beamToNamed('/tasks/$id');
 
@@ -348,22 +350,21 @@ class TaskListCard2 extends ConsumerWidget {
     BuildContext context,
     WidgetRef ref,
   ) {
-    final task = ref.watch(entryControllerProvider(id: id)).value;
-
-    if (task is Task) {
-      return Card(
-        child: ListTile(
-          onTap: onTap,
-          trailing: TaskStatusWidget(task),
-          title: Text(
-            task.data.title,
-            style: const TextStyle(
-              fontSize: fontSizeMediumLarge,
-            ),
-          ),
-        ),
-      );
+    final entry = ref.watch(entryControllerProvider(id: id)).value;
+    if (entry == null) {
+      return const SizedBox.shrink();
     }
-    return const SizedBox.shrink();
+
+    return entry.maybeMap(
+      journalImage: (JournalImage image) => JournalImageCard(item: image),
+      task: (Task task) {
+        if (taskAsListView) {
+          return TaskListCard(task: task);
+        } else {
+          return JournalCard(item: entry);
+        }
+      },
+      orElse: () => JournalCard(item: entry),
+    );
   }
 }

--- a/lib/widgets/journal/journal_card.dart
+++ b/lib/widgets/journal/journal_card.dart
@@ -1,8 +1,10 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/features/journal/state/entry_controller.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/themes/colors.dart';
@@ -328,5 +330,40 @@ class TaskListCard extends StatelessWidget {
         ),
       ),
     );
+  }
+}
+
+class TaskListCard2 extends ConsumerWidget {
+  const TaskListCard2({
+    required this.id,
+    super.key,
+  });
+
+  final String id;
+
+  void onTap() => beamToNamed('/tasks/$id');
+
+  @override
+  Widget build(
+    BuildContext context,
+    WidgetRef ref,
+  ) {
+    final task = ref.watch(entryControllerProvider(id: id)).value;
+
+    if (task is Task) {
+      return Card(
+        child: ListTile(
+          onTap: onTap,
+          trailing: TaskStatusWidget(task),
+          title: Text(
+            task.data.title,
+            style: const TextStyle(
+              fontSize: fontSizeMediumLarge,
+            ),
+          ),
+        ),
+      );
+    }
+    return const SizedBox.shrink();
   }
 }

--- a/lib/widgets/journal/journal_card.dart
+++ b/lib/widgets/journal/journal_card.dart
@@ -333,8 +333,34 @@ class TaskListCard extends StatelessWidget {
   }
 }
 
-class EntryWrapperWidget extends ConsumerWidget {
+class EntryWrapperWidget extends StatelessWidget {
   const EntryWrapperWidget({
+    required this.item,
+    required this.taskAsListView,
+    super.key,
+  });
+
+  final JournalEntity item;
+  final bool taskAsListView;
+
+  @override
+  Widget build(BuildContext context) {
+    return item.maybeMap(
+      journalImage: (JournalImage image) => JournalImageCard(item: image),
+      task: (Task task) {
+        if (taskAsListView) {
+          return TaskListCard(task: task);
+        } else {
+          return JournalCard(item: task);
+        }
+      },
+      orElse: () => JournalCard(item: item),
+    );
+  }
+}
+
+class EntryWrapperConsumerWidget extends ConsumerWidget {
+  const EntryWrapperConsumerWidget({
     required this.id,
     required this.taskAsListView,
     super.key,
@@ -342,8 +368,6 @@ class EntryWrapperWidget extends ConsumerWidget {
 
   final String id;
   final bool taskAsListView;
-
-  void onTap() => beamToNamed('/tasks/$id');
 
   @override
   Widget build(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.459+2504
+version: 0.9.459+2506
 
 msix_config:
   display_name: LottiApp
@@ -120,7 +120,6 @@ dependencies:
   path: ^1.8.1
   path_provider: ^2.0.12
   permission_handler: ^11.0.1
-  photo_manager: ^3.0.0
   photo_view: ^0.15.0
   pie_chart: ^5.3.2
   qr_code_scanner: ^1.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.459+2498
+version: 0.9.459+2499
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.459+2499
+version: 0.9.459+2500
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.459+2501
+version: 0.9.459+2502
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.459+2500
+version: 0.9.459+2501
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.459+2503
+version: 0.9.459+2504
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.459+2502
+version: 0.9.459+2503
 
 msix_config:
   display_name: LottiApp

--- a/test/blocs/journal/entry_cubit_test.dart
+++ b/test/blocs/journal/entry_cubit_test.dart
@@ -31,7 +31,7 @@ void main() {
     setUpAll(() {
       final mockUpdateNotifications = MockUpdateNotifications();
       when(() => mockUpdateNotifications.updateStream).thenAnswer(
-        (_) => Stream<DatabaseType>.fromIterable([]),
+        (_) => Stream<({DatabaseType type, String id})>.fromIterable([]),
       );
       getIt.registerSingleton<UpdateNotifications>(mockUpdateNotifications);
 

--- a/test/blocs/journal/journal_page_cubit_test.dart
+++ b/test/blocs/journal/journal_page_cubit_test.dart
@@ -35,7 +35,7 @@ void main() {
       final mockTimeService = MockTimeService();
 
       when(() => mockUpdateNotifications.updateStream).thenAnswer(
-        (_) => Stream<DatabaseType>.fromIterable([]),
+        (_) => Stream<({DatabaseType type, String id})>.fromIterable([]),
       );
 
       when(() => secureStorageMock.readValue(hostKey))

--- a/test/database/database_test.dart
+++ b/test/database/database_test.dart
@@ -78,7 +78,7 @@ void main() {
       await initConfigFlags(db!, inMemoryDatabase: true);
 
       when(() => mockUpdateNotifications.updateStream).thenAnswer(
-        (_) => Stream<DatabaseType>.fromIterable([]),
+        (_) => Stream<({DatabaseType type, String id})>.fromIterable([]),
       );
     });
     tearDown(() async {

--- a/test/logic/persistence_logic_test.dart
+++ b/test/logic/persistence_logic_test.dart
@@ -71,7 +71,7 @@ void main() {
       when(mockNotificationService.updateBadge).thenAnswer((_) async {});
 
       when(() => mockUpdateNotifications.updateStream).thenAnswer(
-        (_) => Stream<DatabaseType>.fromIterable([]),
+        (_) => Stream<({DatabaseType type, String id})>.fromIterable([]),
       );
 
       when(() => mockFts5Db.insertText(any())).thenAnswer((_) async {});

--- a/test/logic/persistence_logic_test.dart
+++ b/test/logic/persistence_logic_test.dart
@@ -246,13 +246,13 @@ void main() {
 
       // expect task in journal entities stream by type
       expect(
-        (await getIt<JournalDb>().watchJournalEntities(
+        (await getIt<JournalDb>().getJournalEntities(
           starredStatuses: [true, false],
           privateStatuses: [true, false],
           flaggedStatuses: [1, 0],
           types: ['Task'],
           ids: null,
-        ).first)
+        ))
             .length,
         1,
       );

--- a/test/pages/journal/infinite_journal_page_test.dart
+++ b/test/pages/journal/infinite_journal_page_test.dart
@@ -186,6 +186,9 @@ void main() {
         (_) => Stream<JournalEntity>.fromIterable([testTextEntry]),
       );
 
+      when(() => mockJournalDb.journalEntityById(testTextEntry.meta.id))
+          .thenAnswer((_) async => testTextEntry);
+
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(
           BlocProvider<AudioPlayerCubit>(
@@ -236,6 +239,9 @@ void main() {
         ]),
       );
 
+      when(() => mockJournalDb.journalEntityById(testTask.meta.id))
+          .thenAnswer((_) async => testTask);
+
       when(mockCreateMeasurementEntry).thenAnswer((_) async => null);
 
       await tester.pumpWidget(
@@ -276,6 +282,9 @@ void main() {
           [testTask],
         ]),
       );
+
+      when(() => mockJournalDb.journalEntityById(testTask.meta.id))
+          .thenAnswer((_) async => testTask);
 
       when(mockCreateMeasurementEntry).thenAnswer((_) async => null);
 
@@ -328,6 +337,9 @@ void main() {
       );
 
       when(mockCreateMeasurementEntry).thenAnswer((_) async => null);
+
+      when(() => mockJournalDb.journalEntityById(testWeightEntry.meta.id))
+          .thenAnswer((_) async => testWeightEntry);
 
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(
@@ -432,6 +444,11 @@ void main() {
         ]),
       );
 
+      when(
+        () => mockJournalDb
+            .journalEntityById(testMeasurementChocolateEntry.meta.id),
+      ).thenAnswer((_) async => testMeasurementChocolateEntry);
+
       when(mockCreateMeasurementEntry).thenAnswer((_) async => null);
 
       await tester.pumpWidget(
@@ -533,6 +550,11 @@ void main() {
           measurableCoverage,
         ]),
       );
+
+      when(
+        () =>
+            mockJournalDb.journalEntityById(testMeasuredCoverageEntry.meta.id),
+      ).thenAnswer((_) async => testMeasuredCoverageEntry);
 
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(

--- a/test/pages/journal/infinite_journal_page_test.dart
+++ b/test/pages/journal/infinite_journal_page_test.dart
@@ -119,7 +119,7 @@ void main() {
       );
 
       when(() => mockUpdateNotifications.updateStream).thenAnswer(
-        (_) => Stream<DatabaseType>.fromIterable([]),
+        (_) => Stream<({DatabaseType type, String id})>.fromIterable([]),
       );
 
       when(mockJournalDb.watchConfigFlags).thenAnswer(

--- a/test/pages/journal/infinite_journal_page_test.dart
+++ b/test/pages/journal/infinite_journal_page_test.dart
@@ -166,7 +166,7 @@ void main() {
       when(mockCreateMeasurementEntry).thenAnswer((_) async => null);
 
       when(
-        () => mockJournalDb.watchJournalEntities(
+        () => mockJournalDb.getJournalEntities(
           types: entryTypeStrings,
           starredStatuses: [true, false],
           privateStatuses: [true, false],
@@ -174,11 +174,7 @@ void main() {
           ids: null,
           limit: 50,
         ),
-      ).thenAnswer(
-        (_) => Stream<List<JournalEntity>>.fromIterable([
-          [testTextEntry],
-        ]),
-      );
+      ).thenAnswer((_) async => [testTextEntry]);
 
       when(
         () => mockJournalDb.watchEntityById(testTextEntry.meta.id),
@@ -225,7 +221,7 @@ void main() {
       }
 
       when(
-        () => mockJournalDb.watchJournalEntities(
+        () => mockJournalDb.getJournalEntities(
           types: entryTypeStrings,
           starredStatuses: [true, false],
           privateStatuses: [true, false],
@@ -233,11 +229,7 @@ void main() {
           ids: null,
           limit: 50,
         ),
-      ).thenAnswer(
-        (_) => Stream<List<JournalEntity>>.fromIterable([
-          [testTask],
-        ]),
-      );
+      ).thenAnswer((_) async => [testTask]);
 
       when(() => mockJournalDb.journalEntityById(testTask.meta.id))
           .thenAnswer((_) async => testTask);
@@ -272,16 +264,12 @@ void main() {
       }
 
       when(
-        () => mockJournalDb.watchTasks(
+        () => mockJournalDb.getTasks(
           starredStatuses: [true, false],
           limit: 50,
           taskStatuses: ['OPEN', 'GROOMED', 'IN PROGRESS'],
         ),
-      ).thenAnswer(
-        (_) => Stream<List<JournalEntity>>.fromIterable([
-          [testTask],
-        ]),
-      );
+      ).thenAnswer((_) async => [testTask]);
 
       when(() => mockJournalDb.journalEntityById(testTask.meta.id))
           .thenAnswer((_) async => testTask);
@@ -316,7 +304,7 @@ void main() {
       }
 
       when(
-        () => mockJournalDb.watchJournalEntities(
+        () => mockJournalDb.getJournalEntities(
           types: entryTypeStrings,
           starredStatuses: [true, false],
           privateStatuses: [true, false],
@@ -324,11 +312,7 @@ void main() {
           ids: null,
           limit: 50,
         ),
-      ).thenAnswer(
-        (_) => Stream<List<JournalEntity>>.fromIterable([
-          [testWeightEntry],
-        ]),
-      );
+      ).thenAnswer((_) async => [testWeightEntry]);
 
       when(
         () => mockJournalDb.watchEntityById(testWeightEntry.meta.id),
@@ -420,7 +404,7 @@ void main() {
       ).thenAnswer((_) async => measurableChocolate);
 
       when(
-        () => mockJournalDb.watchJournalEntities(
+        () => mockJournalDb.getJournalEntities(
           types: entryTypeStrings,
           starredStatuses: [true, false],
           privateStatuses: [true, false],
@@ -428,11 +412,7 @@ void main() {
           ids: null,
           limit: 50,
         ),
-      ).thenAnswer(
-        (_) => Stream<List<JournalEntity>>.fromIterable([
-          [testMeasurementChocolateEntry],
-        ]),
-      );
+      ).thenAnswer((_) async => [testMeasurementChocolateEntry]);
 
       when(
         () => mockJournalDb.watchMeasurableDataTypeById(
@@ -527,7 +507,7 @@ void main() {
       ).thenAnswer((_) async => measurableCoverage);
 
       when(
-        () => mockJournalDb.watchJournalEntities(
+        () => mockJournalDb.getJournalEntities(
           types: entryTypeStrings,
           starredStatuses: [true, false],
           privateStatuses: [true, false],
@@ -535,11 +515,7 @@ void main() {
           ids: null,
           limit: 50,
         ),
-      ).thenAnswer(
-        (_) => Stream<List<JournalEntity>>.fromIterable([
-          [testMeasuredCoverageEntry],
-        ]),
-      );
+      ).thenAnswer((_) async => [testMeasuredCoverageEntry]);
 
       when(
         () => mockJournalDb.watchMeasurableDataTypeById(

--- a/test/themes/themes_service_test.dart
+++ b/test/themes/themes_service_test.dart
@@ -13,7 +13,7 @@ void main() {
     setUpAll(() {
       final mockUpdateNotifications = MockUpdateNotifications();
       when(() => mockUpdateNotifications.updateStream).thenAnswer(
-        (_) => Stream<DatabaseType>.fromIterable([]),
+        (_) => Stream<({DatabaseType type, String id})>.fromIterable([]),
       );
 
       getIt

--- a/test/themes/utils_test.dart
+++ b/test/themes/utils_test.dart
@@ -17,7 +17,7 @@ void main() {
     setUpAll(() {
       final mockUpdateNotifications = MockUpdateNotifications();
       when(() => mockUpdateNotifications.updateStream).thenAnswer(
-        (_) => Stream<DatabaseType>.fromIterable([]),
+        (_) => Stream<({DatabaseType type, String id})>.fromIterable([]),
       );
 
       getIt

--- a/test/widget_test_utils.dart
+++ b/test/widget_test_utils.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:form_builder_validators/localization/l10n.dart';
 
 Widget makeTestableWidget(Widget child) {
@@ -38,25 +39,27 @@ Widget makeTestableWidget2(Widget child) {
 }
 
 Widget makeTestableWidgetWithScaffold(Widget child) {
-  return MediaQuery(
-    data: const MediaQueryData(),
-    child: MaterialApp(
-      localizationsDelegates: const [
-        AppLocalizations.delegate,
-        FormBuilderLocalizations.delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-      ],
-      supportedLocales: AppLocalizations.supportedLocales,
-      home: Scaffold(
-        body: SingleChildScrollView(
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(
-              maxHeight: 800,
-              maxWidth: 800,
+  return ProviderScope(
+    child: MediaQuery(
+      data: const MediaQueryData(),
+      child: MaterialApp(
+        localizationsDelegates: const [
+          AppLocalizations.delegate,
+          FormBuilderLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(
+                maxHeight: 800,
+                maxWidth: 800,
+              ),
+              child: child,
             ),
-            child: child,
           ),
         ),
       ),

--- a/test/widgets/journal/editor/editor_widget_test.dart
+++ b/test/widgets/journal/editor/editor_widget_test.dart
@@ -30,7 +30,7 @@ void main() {
     setUpAll(() {
       final mockUpdateNotifications = MockUpdateNotifications();
       when(() => mockUpdateNotifications.updateStream).thenAnswer(
-        (_) => Stream<DatabaseType>.fromIterable([]),
+        (_) => Stream<({DatabaseType type, String id})>.fromIterable([]),
       );
 
       getIt

--- a/test/widgets/journal/entry_details/entry_datetime_widget_test.dart
+++ b/test/widgets/journal/entry_details/entry_datetime_widget_test.dart
@@ -21,7 +21,7 @@ void main() {
     setUpAll(() {
       final mockUpdateNotifications = MockUpdateNotifications();
       when(() => mockUpdateNotifications.updateStream).thenAnswer(
-        (_) => Stream<DatabaseType>.fromIterable([]),
+        (_) => Stream<({DatabaseType type, String id})>.fromIterable([]),
       );
 
       getIt

--- a/test/widgets/journal/entry_details/entry_detail_footer_test.dart
+++ b/test/widgets/journal/entry_details/entry_detail_footer_test.dart
@@ -26,7 +26,7 @@ void main() {
     setUpAll(() {
       final mockUpdateNotifications = MockUpdateNotifications();
       when(() => mockUpdateNotifications.updateStream).thenAnswer(
-        (_) => Stream<DatabaseType>.fromIterable([]),
+        (_) => Stream<({DatabaseType type, String id})>.fromIterable([]),
       );
 
       getIt

--- a/test/widgets/journal/entry_details/entry_detail_header_test.dart
+++ b/test/widgets/journal/entry_details/entry_detail_header_test.dart
@@ -23,7 +23,7 @@ void main() {
     setUpAll(() {
       final mockUpdateNotifications = MockUpdateNotifications();
       when(() => mockUpdateNotifications.updateStream).thenAnswer(
-        (_) => Stream<DatabaseType>.fromIterable([]),
+        (_) => Stream<({DatabaseType type, String id})>.fromIterable([]),
       );
 
       getIt

--- a/test/widgets/journal/entry_details/share_button_widget_test.dart
+++ b/test/widgets/journal/entry_details/share_button_widget_test.dart
@@ -27,7 +27,7 @@ void main() {
 
       final mockUpdateNotifications = MockUpdateNotifications();
       when(() => mockUpdateNotifications.updateStream).thenAnswer(
-        (_) => Stream<DatabaseType>.fromIterable([]),
+        (_) => Stream<({DatabaseType type, String id})>.fromIterable([]),
       );
 
       getIt


### PR DESCRIPTION
This PR adds a Riverpod provider for entries. The initial idea here was to use this for display in the infinite scroll pages, but that's actually not feasible because it results in yank, which is quite unpleasant. But this will still be usable or useful when going on to entry detail pages. Also, this PR adds improved reloading behavior when there are incoming messages from sync.