### PR TITLE
chore: revert photo_manager to 3.0.0

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -260,7 +260,7 @@ SPEC CHECKSUMS:
   package_info_plus: 58f0028419748fad15bf008b270aaa8e54380b1c
   path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
   permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
-  photo_manager: ff695c7a1dd5bc379974953a2b5c0a293f7c4c8a
+  photo_manager: 4f6810b7dfc4feb03b461ac1a70dacf91fba7604
   qr_code_scanner: bb67d64904c3b9658ada8c402e8b4d406d5d796e
   record_darwin: 1f6619f2abac4d1ca91d3eeab038c980d76f1517
   SDWebImage: 40b0b4053e36c660a764958bff99eed16610acbb

--- a/lib/features/journal/state/entry_controller.dart
+++ b/lib/features/journal/state/entry_controller.dart
@@ -23,7 +23,7 @@ class EntryController extends _$EntryController {
     _updateSubscription =
         _updateNotifications.updateStream.listen((event) async {
       if (event.id == _entryId) {
-        final latest = await fetch();
+        final latest = await _fetch();
         if (latest != state.value) {
           state = AsyncData(latest);
         }
@@ -35,10 +35,10 @@ class EntryController extends _$EntryController {
   Future<JournalEntity?> build({required String id}) async {
     _entryId = id;
     ref.onDispose(() => _updateSubscription?.cancel());
-    return fetch();
+    return _fetch();
   }
 
-  Future<JournalEntity?> fetch() async {
+  Future<JournalEntity?> _fetch() async {
     if (_entryId == null) {
       return null;
     }

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -193,7 +193,7 @@ SPEC CHECKSUMS:
   OpenSSL-Universal: 045ed3c22ef3f38a428ab3d3708f82ac25b8740c
   package_info_plus: fa739dd842b393193c5ca93c26798dff6e3d0e0c
   path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
-  photo_manager: ff695c7a1dd5bc379974953a2b5c0a293f7c4c8a
+  photo_manager: 4f6810b7dfc4feb03b461ac1a70dacf91fba7604
   record_darwin: 1f6619f2abac4d1ca91d3eeab038c980d76f1517
   screen_retriever: 59634572a57080243dd1bf715e55b6c54f241a38
   share_plus: 36537c04ce0c3e3f5bd297ce4318b6d5ee5fd6cf

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1923,10 +1923,10 @@ packages:
     dependency: "direct main"
     description:
       name: photo_manager
-      sha256: aec3fb848e4bf3f0e36630de90d1bcafff57a059b39f429009fe561fdf9acb74
+      sha256: df594f989f0c31cdb3ed48f3d49cb9ffadf11cc3700d2c3460b1912c93432621
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.0.0"
   photo_manager_image_provider:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.459+2506
+version: 0.9.460+2507
 
 msix_config:
   display_name: LottiApp
@@ -120,6 +120,7 @@ dependencies:
   path: ^1.8.1
   path_provider: ^2.0.12
   permission_handler: ^11.0.1
+  photo_manager: 3.0.0
   photo_view: ^0.15.0
   pie_chart: ^5.3.2
   qr_code_scanner: ^1.0.1


### PR DESCRIPTION
Upgrading `photo_manager` to `3.1.0` broke image import, where no new photos would be available for selection. This PR downgrades to `0.3.0` again, which fixes the issue.

Also reported here: https://github.com/fluttercandies/flutter_photo_manager/issues/1125