### PR TITLE
feat: navigate back from tag settings page to task/entry

### DIFF
--- a/lib/widgets/journal/tags/tag_widget.dart
+++ b/lib/widgets/journal/tags/tag_widget.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:lotti/classes/tag_type_definitions.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
-import 'package:lotti/services/nav_service.dart';
+import 'package:lotti/pages/settings/tags/tag_edit_page.dart';
 import 'package:lotti/themes/colors.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/themes/utils.dart';
@@ -23,7 +23,15 @@ class TagWidget extends StatelessWidget {
 
     return Chip(
       label: GestureDetector(
-        onDoubleTap: () => beamToNamed('/settings/tags/${tagEntity.id}'),
+        onDoubleTap: () {
+          Navigator.of(context).push(
+            MaterialPageRoute<void>(
+              builder: (context) => EditExistingTagPage(
+                tagEntityId: tagEntity.id,
+              ),
+            ),
+          );
+        },
         child: Text(
           tagEntity.tag,
           style: TextStyle(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.461+2512
+version: 0.9.462+2513
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR improves navigation back to a task or entry when double tapping a tag to navigate to the tag settings page. Previously, when saving the tag, the app would navigate to the tags list page.