### PR TITLE
fix: idle CPU load 

### DIFF
--- a/lib/pages/habits/habits_page.dart
+++ b/lib/pages/habits/habits_page.dart
@@ -26,10 +26,6 @@ class HabitsTabPage extends StatelessWidget {
       onVisibilityChanged: cubit.updateVisibility,
       child: BlocBuilder<HabitsCubit, HabitsState>(
         builder: (context, HabitsState state) {
-          if (!state.isVisible) {
-            return const Center(child: CircularProgressIndicator());
-          }
-
           final timeSpanDays = state.timeSpanDays;
 
           final rangeStart = getStartOfDay(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.464+2517
+version: 0.9.465+2518
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR fixes an issue with unexpectedly high CPU utilization around `20%` when the app was doing nothing at all (noticed on macOS desktop). The issue was that a `CircularProgressIndicator` was shown on the habits tab when that wasn't actually visible. Removing that results in idle CPU load under `1%`, as one should expect.