### PR TITLE
feat: re-enable enqueuing in sync outbox

### DIFF
--- a/lib/sync/outbox/outbox_service.dart
+++ b/lib/sync/outbox/outbox_service.dart
@@ -42,7 +42,6 @@ class OutboxService {
 
       if (enableMatrix) {
         await getIt<MatrixService>().sendMatrixMsg(syncMessage);
-        return;
       }
 
       final vectorClockService = getIt<VectorClockService>();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -986,6 +986,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: c6b0b4c05c458e1c01ad9bcc14041dd7b1f6783d487be4386f793f47a8a4d03e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.20"
   flutter_quill:
     dependency: "direct main"
     description:
@@ -1278,10 +1286,10 @@ packages:
     dependency: transitive
     description:
       name: html2md
-      sha256: "6f50cec926b0a09816aadb66a59e4cda45c91fd00551e5a8298870069729b508"
+      sha256: "465cf8ffa1b510fe0e97941579bf5b22e2d575f2cecb500a9c0254efe33a8036"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   html_unescape:
     dependency: transitive
     description:
@@ -2880,10 +2888,10 @@ packages:
     dependency: transitive
     description:
       name: video_player_android
-      sha256: "76c3209e47054daaae2cd3636818022c0b1ca3a69ea4b81221ba6c2a43ecb4d2"
+      sha256: "4f77780499ebbdb3a8387f3de7a9d07a7665cfb3a3741177c44a52353fe41d64"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.15"
+    version: "2.4.16"
   video_player_avfoundation:
     dependency: transitive
     description:
@@ -2904,10 +2912,10 @@ packages:
     dependency: transitive
     description:
       name: video_player_web
-      sha256: "41245cef5ef29c4585dbabcbcbe9b209e34376642c7576cabf11b4ad9289d6e4"
+      sha256: ff4d69a6614b03f055397c27a71c9d3ddea2b2a23d71b2ba0164f59ca32b8fe2
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.1"
   visibility_detector:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.469+2539
+version: 0.9.470+2540
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR re-enables the sync outbox. For now, this only enqueues items. In a next PR, the actual send attempt will be started from the outbox, and retried, e.g. when the network is back.