### PR TITLE
feat: re-enable sync outbox

### DIFF
--- a/lib/services/window_service.dart
+++ b/lib/services/window_service.dart
@@ -2,7 +2,6 @@ import 'dart:ui';
 
 import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/get_it.dart';
-import 'package:lotti/sync/outbox/outbox_service.dart';
 import 'package:lotti/utils/platform.dart';
 import 'package:window_manager/window_manager.dart';
 
@@ -50,7 +49,7 @@ class WindowService implements WindowListener {
 
   @override
   void onWindowFocus() {
-    getIt<OutboxService>().restartRunner();
+    //getIt<OutboxService>().restartRunner();
   }
 
   @override

--- a/lib/sync/matrix/matrix_service.dart
+++ b/lib/sync/matrix/matrix_service.dart
@@ -178,15 +178,16 @@ class MatrixService {
   Future<void> startKeyVerificationListener() =>
       listenForKeyVerificationRequests(service: this);
 
-  Future<void> sendMatrixMsg(
+  Future<bool> sendMatrixMsg(
     SyncMessage syncMessage, {
     String? myRoomId,
-  }) =>
-      sendMessage(
-        syncMessage,
-        service: this,
-        myRoomId: myRoomId,
-      );
+  }) async {
+    return sendMessage(
+      syncMessage,
+      service: this,
+      myRoomId: myRoomId,
+    );
+  }
 
   Future<void> logout() async {
     if (_client.isLogged()) {

--- a/lib/sync/matrix/send_message.dart
+++ b/lib/sync/matrix/send_message.dart
@@ -23,7 +23,7 @@ import 'package:matrix/matrix.dart';
 /// Also updates some stats on sent message counts on the [service].
 /// The send function will terminate early (and thus refuse to send anything)
 /// when there are users with unverified device in the room.
-Future<void> sendMessage(
+Future<bool> sendMessage(
   SyncMessage syncMessage, {
   required MatrixService service,
   required String? myRoomId,
@@ -51,7 +51,7 @@ Future<void> sendMessage(
         domain: 'MATRIX_SERVICE',
         subDomain: 'sendMatrixMsg',
       );
-      return;
+      return false;
     }
 
     if (roomId == null) {
@@ -60,7 +60,7 @@ Future<void> sendMessage(
         domain: 'MATRIX_SERVICE',
         subDomain: 'sendMatrixMsg',
       );
-      return;
+      return false;
     }
 
     loggingDb.captureEvent(
@@ -158,6 +158,7 @@ Future<void> sendMessage(
         orElse: () {},
       );
     }
+    return true;
   } catch (e, stackTrace) {
     debugPrint('MATRIX: Error sending message: $e');
     loggingDb.captureException(
@@ -167,4 +168,5 @@ Future<void> sendMessage(
       stackTrace: stackTrace,
     );
   }
+  return false;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.470+2540
+version: 0.9.471+2541
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR re-enables the sync outbox, such that outgoing messages are perished in the sync database, and then sent later when possible, such as when the network is back. The detection of the network being back is still pending and will be added back in a later PR.