### PR TITLE
feat: increment retry count when failing

### DIFF
--- a/integration_test/matrix_service_test.dart
+++ b/integration_test/matrix_service_test.dart
@@ -15,6 +15,7 @@ import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/sync/matrix/matrix_service.dart';
+import 'package:lotti/sync/matrix/send_message.dart';
 import 'package:lotti/sync/secure_storage.dart';
 import 'package:lotti/sync/vector_clock.dart';
 import 'package:lotti/utils/file_utils.dart';

--- a/lib/sync/matrix/matrix_service.dart
+++ b/lib/sync/matrix/matrix_service.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:lotti/classes/config.dart';
-import 'package:lotti/classes/sync_message.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/sync/client_runner.dart';
 import 'package:lotti/sync/matrix/client.dart';
@@ -9,7 +8,6 @@ import 'package:lotti/sync/matrix/config.dart';
 import 'package:lotti/sync/matrix/key_verification_runner.dart';
 import 'package:lotti/sync/matrix/last_read.dart';
 import 'package:lotti/sync/matrix/room.dart';
-import 'package:lotti/sync/matrix/send_message.dart';
 import 'package:lotti/sync/matrix/stats.dart';
 import 'package:lotti/sync/matrix/timeline.dart';
 import 'package:matrix/encryption/utils/key_verification.dart';
@@ -177,16 +175,6 @@ class MatrixService {
 
   Future<void> startKeyVerificationListener() =>
       listenForKeyVerificationRequests(service: this);
-
-  Future<bool> sendMatrixMsg(
-    SyncMessage syncMessage, {
-    String? myRoomId,
-  }) async {
-    return sendMessage(
-      syncMessage,
-      myRoomId: myRoomId,
-    );
-  }
 
   Future<void> logout() async {
     if (_client.isLogged()) {

--- a/lib/sync/matrix/matrix_service.dart
+++ b/lib/sync/matrix/matrix_service.dart
@@ -184,7 +184,6 @@ class MatrixService {
   }) async {
     return sendMessage(
       syncMessage,
-      service: this,
       myRoomId: myRoomId,
     );
   }

--- a/lib/sync/matrix/send_message.dart
+++ b/lib/sync/matrix/send_message.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:flutter/foundation.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/sync_message.dart';
 import 'package:lotti/database/database.dart';
@@ -35,103 +34,89 @@ extension SendExtension on MatrixService {
   /// Also updates some stats on sent message counts on the [MatrixService].
   /// The send function will terminate early (and thus refuse to send anything)
   /// when there are users with unverified device in the room.
-  Future<bool> sendMessage(
+  Future<void> sendMatrixMsg(
     SyncMessage syncMessage, {
-    required String? myRoomId,
+    String? myRoomId,
   }) async {
     final loggingDb = getIt<LoggingDb>();
 
-    try {
-      final msg = json.encode(syncMessage);
-      final roomId = myRoomId ?? syncRoomId;
+    final msg = json.encode(syncMessage);
+    final roomId = myRoomId ?? syncRoomId;
 
-      if (getUnverifiedDevices().isNotEmpty) {
-        loggingDb.captureException(
-          'Unverified devices found',
-          domain: 'MATRIX_SERVICE',
-          subDomain: 'sendMatrixMsg',
-        );
-        return false;
-      }
-
-      if (roomId == null) {
-        loggingDb.captureEvent(
-          configNotFound,
-          domain: 'MATRIX_SERVICE',
-          subDomain: 'sendMatrixMsg',
-        );
-        return false;
-      }
-
-      loggingDb.captureEvent(
-        'trying to send text message to $syncRoom',
-        domain: 'MATRIX_SERVICE',
-        subDomain: 'sendMatrixMsg',
-      );
-
-      final eventId = await syncRoom?.sendTextEvent(
-        base64.encode(utf8.encode(msg)),
-        msgtype: syncMessageType,
-        parseCommands: false,
-        parseMarkdown: false,
-      );
-
-      incrementSentCount();
-
-      loggingDb.captureEvent(
-        'sent text message to $syncRoom with event ID $eventId',
-        domain: 'MATRIX_SERVICE',
-        subDomain: 'sendMatrixMsg',
-      );
-
-      final docDir = getDocumentsDirectory();
-
-      if (syncMessage is SyncJournalEntity) {
-        final journalEntity = syncMessage.journalEntity;
-
-        final shouldResendAttachments =
-            await getIt<JournalDb>().getConfigFlag(resendAttachments);
-
-        await journalEntity.maybeMap(
-          journalAudio: (JournalAudio journalAudio) async {
-            if (shouldResendAttachments ||
-                syncMessage.status == SyncEntryStatus.initial) {
-              unawaited(
-                sendFile(
-                  fullPath: AudioUtils.getAudioPath(
-                    journalAudio,
-                    docDir,
-                  ),
-                  relativePath: AudioUtils.getRelativeAudioPath(journalAudio),
-                ),
-              );
-            }
-          },
-          journalImage: (JournalImage journalImage) async {
-            if (shouldResendAttachments ||
-                syncMessage.status == SyncEntryStatus.initial) {
-              unawaited(
-                sendFile(
-                  fullPath: getFullImagePath(journalImage),
-                  relativePath: getRelativeImagePath(journalImage),
-                ),
-              );
-            }
-          },
-          orElse: () {},
-        );
-      }
-      return true;
-    } catch (e, stackTrace) {
-      debugPrint('MATRIX: Error sending message: $e');
+    if (getUnverifiedDevices().isNotEmpty) {
       loggingDb.captureException(
-        e,
+        'Unverified devices found',
         domain: 'MATRIX_SERVICE',
         subDomain: 'sendMatrixMsg',
-        stackTrace: stackTrace,
       );
     }
-    return false;
+
+    if (roomId == null) {
+      loggingDb.captureEvent(
+        configNotFound,
+        domain: 'MATRIX_SERVICE',
+        subDomain: 'sendMatrixMsg',
+      );
+    }
+
+    loggingDb.captureEvent(
+      'trying to send text message to $syncRoom',
+      domain: 'MATRIX_SERVICE',
+      subDomain: 'sendMatrixMsg',
+    );
+
+    final eventId = await syncRoom?.sendTextEvent(
+      base64.encode(utf8.encode(msg)),
+      msgtype: syncMessageType,
+      parseCommands: false,
+      parseMarkdown: false,
+    );
+
+    incrementSentCount();
+
+    loggingDb.captureEvent(
+      'sent text message to $syncRoom with event ID $eventId',
+      domain: 'MATRIX_SERVICE',
+      subDomain: 'sendMatrixMsg',
+    );
+
+    final docDir = getDocumentsDirectory();
+
+    if (syncMessage is SyncJournalEntity) {
+      final journalEntity = syncMessage.journalEntity;
+
+      final shouldResendAttachments =
+          await getIt<JournalDb>().getConfigFlag(resendAttachments);
+
+      await journalEntity.maybeMap(
+        journalAudio: (JournalAudio journalAudio) async {
+          if (shouldResendAttachments ||
+              syncMessage.status == SyncEntryStatus.initial) {
+            unawaited(
+              sendFile(
+                fullPath: AudioUtils.getAudioPath(
+                  journalAudio,
+                  docDir,
+                ),
+                relativePath: AudioUtils.getRelativeAudioPath(journalAudio),
+              ),
+            );
+          }
+        },
+        journalImage: (JournalImage journalImage) async {
+          if (shouldResendAttachments ||
+              syncMessage.status == SyncEntryStatus.initial) {
+            unawaited(
+              sendFile(
+                fullPath: getFullImagePath(journalImage),
+                relativePath: getRelativeImagePath(journalImage),
+              ),
+            );
+          }
+        },
+        orElse: () {},
+      );
+    }
   }
 
   /// Sends a file attachment to the sync room.
@@ -146,32 +131,20 @@ extension SendExtension on MatrixService {
         subDomain: 'sendMatrixMsg',
       );
 
-    try {
-      final eventId = await syncRoom?.sendFileEvent(
-        MatrixFile(
-          bytes: await File(fullPath).readAsBytes(),
-          name: fullPath,
-        ),
-        extraContent: {
-          'relativePath': relativePath,
-        },
-      );
+    final eventId = await syncRoom?.sendFileEvent(
+      MatrixFile(
+        bytes: await File(fullPath).readAsBytes(),
+        name: fullPath,
+      ),
+      extraContent: {'relativePath': relativePath},
+    );
 
-      incrementSentCount();
+    incrementSentCount();
 
-      loggingDb.captureEvent(
-        'sent $relativePath file message to $syncRoom, event ID $eventId',
-        domain: 'MATRIX_SERVICE',
-        subDomain: 'sendMatrixMsg',
-      );
-    } catch (e, stackTrace) {
-      debugPrint('MATRIX: Error sending file: $e');
-      loggingDb.captureException(
-        e,
-        domain: 'MATRIX_SERVICE',
-        subDomain: 'sendFile',
-        stackTrace: stackTrace,
-      );
-    }
+    loggingDb.captureEvent(
+      'sent $relativePath file message to $syncRoom, event ID $eventId',
+      domain: 'MATRIX_SERVICE',
+      subDomain: 'sendMatrixMsg',
+    );
   }
 }

--- a/lib/sync/matrix/send_message.dart
+++ b/lib/sync/matrix/send_message.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -16,157 +17,161 @@ import 'package:lotti/utils/file_utils.dart';
 import 'package:lotti/utils/image_utils.dart';
 import 'package:matrix/matrix.dart';
 
-/// Sends a Matrix message for cross-device state synchronization. Takes a
-/// [SyncMessage] and also requires the system's [MatrixService]. A room can
-/// optionally be specified, e.g. in testing. Otherwise, the service's `syncRoom`
-/// is used.
-/// Also updates some stats on sent message counts on the [service].
-/// The send function will terminate early (and thus refuse to send anything)
-/// when there are users with unverified device in the room.
-Future<bool> sendMessage(
-  SyncMessage syncMessage, {
-  required MatrixService service,
-  required String? myRoomId,
-}) async {
-  final loggingDb = getIt<LoggingDb>();
-
-  try {
-    final msg = json.encode(syncMessage);
-    final syncRoom = service.syncRoom;
-    final roomId = myRoomId ?? service.syncRoomId;
-
-    void incrementSentCount() {
-      service.sentCount = service.sentCount + 1;
-      service.messageCountsController.add(
-        MatrixStats(
-          messageCounts: service.messageCounts,
-          sentCount: service.sentCount,
-        ),
-      );
-    }
-
-    if (service.getUnverifiedDevices().isNotEmpty) {
-      loggingDb.captureException(
-        'Unverified devices found',
-        domain: 'MATRIX_SERVICE',
-        subDomain: 'sendMatrixMsg',
-      );
-      return false;
-    }
-
-    if (roomId == null) {
-      loggingDb.captureEvent(
-        configNotFound,
-        domain: 'MATRIX_SERVICE',
-        subDomain: 'sendMatrixMsg',
-      );
-      return false;
-    }
-
-    loggingDb.captureEvent(
-      'trying to send text message to $syncRoom',
-      domain: 'MATRIX_SERVICE',
-      subDomain: 'sendMatrixMsg',
-    );
-
-    final eventId = await syncRoom?.sendTextEvent(
-      base64.encode(utf8.encode(msg)),
-      msgtype: syncMessageType,
-      parseCommands: false,
-      parseMarkdown: false,
-    );
-
-    incrementSentCount();
-
-    loggingDb.captureEvent(
-      'sent text message to $syncRoom with event ID $eventId',
-      domain: 'MATRIX_SERVICE',
-      subDomain: 'sendMatrixMsg',
-    );
-
-    final docDir = getDocumentsDirectory();
-
-    if (syncMessage is SyncJournalEntity) {
-      final journalEntity = syncMessage.journalEntity;
-
-      final shouldResendAttachments =
-          await getIt<JournalDb>().getConfigFlag(resendAttachments);
-
-      await journalEntity.maybeMap(
-        journalAudio: (JournalAudio journalAudio) async {
-          if (shouldResendAttachments ||
-              syncMessage.status == SyncEntryStatus.initial) {
-            final relativePath = AudioUtils.getRelativeAudioPath(journalAudio);
-            final fullPath = AudioUtils.getAudioPath(journalAudio, docDir);
-            final bytes = await File(fullPath).readAsBytes();
-
-            loggingDb.captureEvent(
-              'trying to send $relativePath file message to $syncRoom',
-              domain: 'MATRIX_SERVICE',
-              subDomain: 'sendMatrixMsg',
-            );
-            final eventId = await syncRoom?.sendFileEvent(
-              MatrixFile(
-                bytes: bytes,
-                name: fullPath,
-              ),
-              extraContent: {
-                'relativePath': relativePath,
-              },
-            );
-            incrementSentCount();
-
-            loggingDb.captureEvent(
-              'sent $relativePath file message to $syncRoom, event ID $eventId',
-              domain: 'MATRIX_SERVICE',
-              subDomain: 'sendMatrixMsg',
-            );
-          }
-        },
-        journalImage: (JournalImage journalImage) async {
-          if (shouldResendAttachments ||
-              syncMessage.status == SyncEntryStatus.initial) {
-            final relativePath = getRelativeImagePath(journalImage);
-            final fullPath = getFullImagePath(journalImage);
-            final bytes = await File(fullPath).readAsBytes();
-
-            loggingDb.captureEvent(
-              'trying to send $relativePath file message to $syncRoom',
-              domain: 'MATRIX_SERVICE',
-              subDomain: 'sendMatrixMsg',
-            );
-
-            final eventId = await syncRoom?.sendFileEvent(
-              MatrixFile(
-                bytes: bytes,
-                name: fullPath,
-              ),
-              extraContent: {
-                'relativePath': relativePath,
-              },
-            );
-
-            incrementSentCount();
-
-            loggingDb.captureEvent(
-              'sent $relativePath file message to $syncRoom, event ID $eventId',
-              domain: 'MATRIX_SERVICE',
-              subDomain: 'sendMatrixMsg',
-            );
-          }
-        },
-        orElse: () {},
-      );
-    }
-    return true;
-  } catch (e, stackTrace) {
-    debugPrint('MATRIX: Error sending message: $e');
-    loggingDb.captureException(
-      e,
-      domain: 'MATRIX_SERVICE',
-      subDomain: 'sendMatrixMsg',
-      stackTrace: stackTrace,
+extension SendExtension on MatrixService {
+  void incrementSentCount() {
+    sentCount = sentCount + 1;
+    messageCountsController.add(
+      MatrixStats(
+        messageCounts: messageCounts,
+        sentCount: sentCount,
+      ),
     );
   }
-  return false;
+
+  /// Sends a Matrix message for cross-device state synchronization. Takes a
+  /// [SyncMessage] and also requires the system's [MatrixService]. A room can
+  /// optionally be specified, e.g. in testing. Otherwise, the service's `syncRoom`
+  /// is used.
+  /// Also updates some stats on sent message counts on the [MatrixService].
+  /// The send function will terminate early (and thus refuse to send anything)
+  /// when there are users with unverified device in the room.
+  Future<bool> sendMessage(
+    SyncMessage syncMessage, {
+    required String? myRoomId,
+  }) async {
+    final loggingDb = getIt<LoggingDb>();
+
+    try {
+      final msg = json.encode(syncMessage);
+      final roomId = myRoomId ?? syncRoomId;
+
+      if (getUnverifiedDevices().isNotEmpty) {
+        loggingDb.captureException(
+          'Unverified devices found',
+          domain: 'MATRIX_SERVICE',
+          subDomain: 'sendMatrixMsg',
+        );
+        return false;
+      }
+
+      if (roomId == null) {
+        loggingDb.captureEvent(
+          configNotFound,
+          domain: 'MATRIX_SERVICE',
+          subDomain: 'sendMatrixMsg',
+        );
+        return false;
+      }
+
+      loggingDb.captureEvent(
+        'trying to send text message to $syncRoom',
+        domain: 'MATRIX_SERVICE',
+        subDomain: 'sendMatrixMsg',
+      );
+
+      final eventId = await syncRoom?.sendTextEvent(
+        base64.encode(utf8.encode(msg)),
+        msgtype: syncMessageType,
+        parseCommands: false,
+        parseMarkdown: false,
+      );
+
+      incrementSentCount();
+
+      loggingDb.captureEvent(
+        'sent text message to $syncRoom with event ID $eventId',
+        domain: 'MATRIX_SERVICE',
+        subDomain: 'sendMatrixMsg',
+      );
+
+      final docDir = getDocumentsDirectory();
+
+      if (syncMessage is SyncJournalEntity) {
+        final journalEntity = syncMessage.journalEntity;
+
+        final shouldResendAttachments =
+            await getIt<JournalDb>().getConfigFlag(resendAttachments);
+
+        await journalEntity.maybeMap(
+          journalAudio: (JournalAudio journalAudio) async {
+            if (shouldResendAttachments ||
+                syncMessage.status == SyncEntryStatus.initial) {
+              unawaited(
+                sendFile(
+                  fullPath: AudioUtils.getAudioPath(
+                    journalAudio,
+                    docDir,
+                  ),
+                  relativePath: AudioUtils.getRelativeAudioPath(journalAudio),
+                ),
+              );
+            }
+          },
+          journalImage: (JournalImage journalImage) async {
+            if (shouldResendAttachments ||
+                syncMessage.status == SyncEntryStatus.initial) {
+              unawaited(
+                sendFile(
+                  fullPath: getFullImagePath(journalImage),
+                  relativePath: getRelativeImagePath(journalImage),
+                ),
+              );
+            }
+          },
+          orElse: () {},
+        );
+      }
+      return true;
+    } catch (e, stackTrace) {
+      debugPrint('MATRIX: Error sending message: $e');
+      loggingDb.captureException(
+        e,
+        domain: 'MATRIX_SERVICE',
+        subDomain: 'sendMatrixMsg',
+        stackTrace: stackTrace,
+      );
+    }
+    return false;
+  }
+
+  /// Sends a file attachment to the sync room.
+  Future<void> sendFile({
+    required String fullPath,
+    required String relativePath,
+  }) async {
+    final loggingDb = getIt<LoggingDb>()
+      ..captureEvent(
+        'trying to send $relativePath file message to $syncRoom',
+        domain: 'MATRIX_SERVICE',
+        subDomain: 'sendMatrixMsg',
+      );
+
+    try {
+      final eventId = await syncRoom?.sendFileEvent(
+        MatrixFile(
+          bytes: await File(fullPath).readAsBytes(),
+          name: fullPath,
+        ),
+        extraContent: {
+          'relativePath': relativePath,
+        },
+      );
+
+      incrementSentCount();
+
+      loggingDb.captureEvent(
+        'sent $relativePath file message to $syncRoom, event ID $eventId',
+        domain: 'MATRIX_SERVICE',
+        subDomain: 'sendMatrixMsg',
+      );
+    } catch (e, stackTrace) {
+      debugPrint('MATRIX: Error sending file: $e');
+      loggingDb.captureException(
+        e,
+        domain: 'MATRIX_SERVICE',
+        subDomain: 'sendFile',
+        stackTrace: stackTrace,
+      );
+    }
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.472+2542
+version: 0.9.473+2543
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR adds incrementing the retries count when sending messages such that a retries are only performed a finite number of times (10x) before continuing with the next sync message. Also include some refactoring to move the sending of messages and files to an extension instead of in a global function.