### PR TITLE
refactor: journal card controller

### DIFF
--- a/lib/features/journal/state/journal_card_controller.dart
+++ b/lib/features/journal/state/journal_card_controller.dart
@@ -1,0 +1,45 @@
+import 'dart:async';
+
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/db_notification.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'journal_card_controller.g.dart';
+
+@riverpod
+class JournalCardController extends _$JournalCardController {
+  JournalCardController() {
+    listen();
+  }
+
+  late final String entryId;
+  StreamSubscription<({DatabaseType type, String id})>? _updateSubscription;
+  final JournalDb _journalDb = getIt<JournalDb>();
+  final UpdateNotifications _updateNotifications = getIt<UpdateNotifications>();
+
+  void listen() {
+    _updateSubscription =
+        _updateNotifications.updateStream.listen((event) async {
+      if (event.id == entryId) {
+        final latest = await _fetch();
+        if (latest != state.value) {
+          state = AsyncData(latest);
+        }
+      }
+    });
+  }
+
+  @override
+  Future<JournalEntity?> build({required String id}) async {
+    entryId = id;
+    ref.onDispose(() => _updateSubscription?.cancel());
+    final entry = await _fetch();
+    return entry;
+  }
+
+  Future<JournalEntity?> _fetch() async {
+    return _journalDb.journalEntityById(entryId);
+  }
+}

--- a/lib/features/journal/state/journal_card_controller.g.dart
+++ b/lib/features/journal/state/journal_card_controller.g.dart
@@ -1,12 +1,13 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'entry_controller.dart';
+part of 'journal_card_controller.dart';
 
 // **************************************************************************
 // RiverpodGenerator
 // **************************************************************************
 
-String _$entryControllerHash() => r'0351cbdbc5f6d55f59be5df11993d0e57e85aa01';
+String _$journalCardControllerHash() =>
+    r'9047001102dd6fafaa529c634ef7cc35339948a3';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -29,36 +30,36 @@ class _SystemHash {
   }
 }
 
-abstract class _$EntryController
-    extends BuildlessAutoDisposeAsyncNotifier<EntryState?> {
+abstract class _$JournalCardController
+    extends BuildlessAutoDisposeAsyncNotifier<JournalEntity?> {
   late final String id;
 
-  FutureOr<EntryState?> build({
+  FutureOr<JournalEntity?> build({
     required String id,
   });
 }
 
-/// See also [EntryController].
-@ProviderFor(EntryController)
-const entryControllerProvider = EntryControllerFamily();
+/// See also [JournalCardController].
+@ProviderFor(JournalCardController)
+const journalCardControllerProvider = JournalCardControllerFamily();
 
-/// See also [EntryController].
-class EntryControllerFamily extends Family<AsyncValue<EntryState?>> {
-  /// See also [EntryController].
-  const EntryControllerFamily();
+/// See also [JournalCardController].
+class JournalCardControllerFamily extends Family<AsyncValue<JournalEntity?>> {
+  /// See also [JournalCardController].
+  const JournalCardControllerFamily();
 
-  /// See also [EntryController].
-  EntryControllerProvider call({
+  /// See also [JournalCardController].
+  JournalCardControllerProvider call({
     required String id,
   }) {
-    return EntryControllerProvider(
+    return JournalCardControllerProvider(
       id: id,
     );
   }
 
   @override
-  EntryControllerProvider getProviderOverride(
-    covariant EntryControllerProvider provider,
+  JournalCardControllerProvider getProviderOverride(
+    covariant JournalCardControllerProvider provider,
   ) {
     return call(
       id: provider.id,
@@ -77,30 +78,31 @@ class EntryControllerFamily extends Family<AsyncValue<EntryState?>> {
       _allTransitiveDependencies;
 
   @override
-  String? get name => r'entryControllerProvider';
+  String? get name => r'journalCardControllerProvider';
 }
 
-/// See also [EntryController].
-class EntryControllerProvider
-    extends AutoDisposeAsyncNotifierProviderImpl<EntryController, EntryState?> {
-  /// See also [EntryController].
-  EntryControllerProvider({
+/// See also [JournalCardController].
+class JournalCardControllerProvider
+    extends AutoDisposeAsyncNotifierProviderImpl<JournalCardController,
+        JournalEntity?> {
+  /// See also [JournalCardController].
+  JournalCardControllerProvider({
     required String id,
   }) : this._internal(
-          () => EntryController()..id = id,
-          from: entryControllerProvider,
-          name: r'entryControllerProvider',
+          () => JournalCardController()..id = id,
+          from: journalCardControllerProvider,
+          name: r'journalCardControllerProvider',
           debugGetCreateSourceHash:
               const bool.fromEnvironment('dart.vm.product')
                   ? null
-                  : _$entryControllerHash,
-          dependencies: EntryControllerFamily._dependencies,
+                  : _$journalCardControllerHash,
+          dependencies: JournalCardControllerFamily._dependencies,
           allTransitiveDependencies:
-              EntryControllerFamily._allTransitiveDependencies,
+              JournalCardControllerFamily._allTransitiveDependencies,
           id: id,
         );
 
-  EntryControllerProvider._internal(
+  JournalCardControllerProvider._internal(
     super._createNotifier, {
     required super.name,
     required super.dependencies,
@@ -113,8 +115,8 @@ class EntryControllerProvider
   final String id;
 
   @override
-  FutureOr<EntryState?> runNotifierBuild(
-    covariant EntryController notifier,
+  FutureOr<JournalEntity?> runNotifierBuild(
+    covariant JournalCardController notifier,
   ) {
     return notifier.build(
       id: id,
@@ -122,10 +124,10 @@ class EntryControllerProvider
   }
 
   @override
-  Override overrideWith(EntryController Function() create) {
+  Override overrideWith(JournalCardController Function() create) {
     return ProviderOverride(
       origin: this,
-      override: EntryControllerProvider._internal(
+      override: JournalCardControllerProvider._internal(
         () => create()..id = id,
         from: from,
         name: null,
@@ -138,14 +140,14 @@ class EntryControllerProvider
   }
 
   @override
-  AutoDisposeAsyncNotifierProviderElement<EntryController, EntryState?>
+  AutoDisposeAsyncNotifierProviderElement<JournalCardController, JournalEntity?>
       createElement() {
-    return _EntryControllerProviderElement(this);
+    return _JournalCardControllerProviderElement(this);
   }
 
   @override
   bool operator ==(Object other) {
-    return other is EntryControllerProvider && other.id == id;
+    return other is JournalCardControllerProvider && other.id == id;
   }
 
   @override
@@ -157,18 +159,19 @@ class EntryControllerProvider
   }
 }
 
-mixin EntryControllerRef on AutoDisposeAsyncNotifierProviderRef<EntryState?> {
+mixin JournalCardControllerRef
+    on AutoDisposeAsyncNotifierProviderRef<JournalEntity?> {
   /// The parameter `id` of this provider.
   String get id;
 }
 
-class _EntryControllerProviderElement
-    extends AutoDisposeAsyncNotifierProviderElement<EntryController,
-        EntryState?> with EntryControllerRef {
-  _EntryControllerProviderElement(super.provider);
+class _JournalCardControllerProviderElement
+    extends AutoDisposeAsyncNotifierProviderElement<JournalCardController,
+        JournalEntity?> with JournalCardControllerRef {
+  _JournalCardControllerProviderElement(super.provider);
 
   @override
-  String get id => (origin as EntryControllerProvider).id;
+  String get id => (origin as JournalCardControllerProvider).id;
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/widgets/journal/editor/editor_widget.dart
+++ b/lib/widgets/journal/editor/editor_widget.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: avoid_dynamic_calls
-
 import 'dart:async';
 
 import 'package:flex_color_scheme/flex_color_scheme.dart';
@@ -9,7 +7,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/journal/state/entry_controller.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/themes/theme.dart';
-import 'package:lotti/utils/platform.dart';
 import 'package:lotti/widgets/journal/editor/editor_styles.dart';
 import 'package:lotti/widgets/journal/editor/editor_toolbar.dart';
 
@@ -40,19 +37,8 @@ class EditorWidget extends ConsumerWidget {
     final controller = notifier.controller;
     final focusNode = notifier.focusNode;
 
-    final isFocused = entryState.value?.isFocused ?? false;
     final shouldShowEditorToolBar =
         entryState.value?.shouldShowEditorToolBar ?? false;
-
-    if (isFocused && isMobile) {
-      Future.microtask(() {
-        Scrollable.ensureVisible(
-          context,
-          duration: const Duration(milliseconds: 400),
-          curve: Curves.easeInOutQuint,
-        );
-      });
-    }
 
     return Card(
       color: Theme.of(context).colorScheme.surface.brighten(),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -173,18 +173,18 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "1414d6d733a85d8ad2f1dfcb3ea7945759e35a123cb99ccfac75d0758f75edfa"
+      sha256: "644dc98a0f179b872f612d3eb627924b578897c629788e858157fa5e704ca0c7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.10"
+    version: "2.4.11"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "4ae8ffe5ac758da294ecf1802f2aff01558d8b1b00616aa7538ea9a8a5d50799"
+      sha256: e3c79f69a64bdfcd8a776a3c28db4eb6e3fb5356d013ae5eb2e52007706d5dbe
       url: "https://pub.dev"
     source: hosted
-    version: "7.3.0"
+    version: "7.3.1"
   built_collection:
     dependency: transitive
     description:
@@ -1899,10 +1899,10 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_apple
-      sha256: e9ad66020b89ff1b63908f247c2c6f931c6e62699b756ef8b3c4569350cd8662
+      sha256: e6f6d73b12438ef13e648c4ae56bd106ec60d17e90a59c4545db6781229082a0
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.4"
+    version: "9.4.5"
   permission_handler_html:
     dependency: transitive
     description:
@@ -2752,10 +2752,10 @@ packages:
     dependency: "direct main"
     description:
       name: url_launcher
-      sha256: "6ce1e04375be4eed30548f10a315826fd933c1e493206eab82eed01f438c8d2e"
+      sha256: "21b704ce5fa560ea9f3b525b43601c678728ba46725bab9b01187b4831377ed3"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.6"
+    version: "6.3.0"
   url_launcher_android:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.476+2554
+version: 0.9.476+2555
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.475+2553
+version: 0.9.476+2554
 
 msix_config:
   display_name: LottiApp

--- a/test/widgets/journal/journal_card_test.dart
+++ b/test/widgets/journal/journal_card_test.dart
@@ -10,6 +10,7 @@ import 'package:lotti/database/database.dart';
 import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/asr_service.dart';
+import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/tags_service.dart';
 import 'package:lotti/services/time_service.dart';
 import 'package:lotti/widgets/journal/journal_card.dart';
@@ -40,8 +41,14 @@ void main() {
       final mockTagsService = mockTagsServiceWithTags([]);
       final mockTimeService = MockTimeService();
 
+      final mockUpdateNotifications = MockUpdateNotifications();
+      when(() => mockUpdateNotifications.updateStream).thenAnswer(
+        (_) => Stream<({DatabaseType type, String id})>.fromIterable([]),
+      );
+
       getIt
         ..registerSingleton<Directory>(await getApplicationDocumentsDirectory())
+        ..registerSingleton<UpdateNotifications>(mockUpdateNotifications)
         ..registerSingleton<LoggingDb>(MockLoggingDb())
         ..registerSingleton<AsrService>(MockAsrService())
         ..registerSingleton<TagsService>(mockTagsService)
@@ -58,11 +65,8 @@ void main() {
     tearDown(getIt.reset);
 
     testWidgets('Render card for text entry', (tester) async {
-      when(
-        () => mockJournalDb.watchEntityById(testTextEntry.meta.id),
-      ).thenAnswer(
-        (_) => Stream<JournalEntity>.fromIterable([testTextEntry]),
-      );
+      when(() => mockJournalDb.journalEntityById(testTextEntry.meta.id))
+          .thenAnswer((_) async => testTextEntry);
 
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(
@@ -81,11 +85,8 @@ void main() {
     });
 
     testWidgets('Render card for image entry', (tester) async {
-      when(
-        () => mockJournalDb.watchEntityById(testImageEntry.meta.id),
-      ).thenAnswer(
-        (_) => Stream<JournalEntity>.fromIterable([testImageEntry]),
-      );
+      when(() => mockJournalDb.journalEntityById(testImageEntry.meta.id))
+          .thenAnswer((_) async => testImageEntry);
 
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(
@@ -104,11 +105,8 @@ void main() {
     });
 
     testWidgets('Render card for audio entry', (tester) async {
-      when(
-        () => mockJournalDb.watchEntityById(testAudioEntry.meta.id),
-      ).thenAnswer(
-        (_) => Stream<JournalEntity>.fromIterable([testAudioEntry]),
-      );
+      when(() => mockJournalDb.journalEntityById(testAudioEntry.meta.id))
+          .thenAnswer((_) async => testAudioEntry);
 
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(


### PR DESCRIPTION
This PR changes the journal cards to listen to changes via a controller vs. via a stream builder that directly listens to database changes (and which was called with updates that weren't changes too often).

Also includes some scrolling on focus behavior on mobile.