### PR TITLE
feat: fetch same health data type at most once every 10 min

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.478+2565
+version: 0.9.479+2566
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR adds preventing fetching health data too often. For example, when a dashboard includes step count, and other cumulative data, those would be fetched every single time a dashboard with that data opens. That would for example be the case when a dashboard is shown as part of a habit completion. In my case, every completion of a habit that includes a bigger dashboard with health data would create 10 pointless entries that would still need to be persisted and synced.