### PR TITLE
fix: disable auto scroll when keyboard appears until better solution

### DIFF
--- a/lib/widgets/journal/entry_details_widget.dart
+++ b/lib/widgets/journal/entry_details_widget.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/journal/state/entry_controller.dart';
-import 'package:lotti/utils/platform.dart';
 import 'package:lotti/widgets/audio/audio_player.dart';
 import 'package:lotti/widgets/events/event_form.dart';
 import 'package:lotti/widgets/journal/editor/editor_widget.dart';
@@ -111,8 +110,7 @@ class EntryDetailsContent extends ConsumerWidget {
       return const SizedBox.shrink();
     }
 
-    final isFocused = entryState?.isFocused ?? false;
-
+    /*  final isFocused = entryState?.isFocused ?? false;
     if (isFocused && isMobile) {
       Future.microtask(() {
         Scrollable.ensureVisible(
@@ -121,7 +119,7 @@ class EntryDetailsContent extends ConsumerWidget {
           curve: Curves.easeInOutQuint,
         );
       });
-    }
+    }*/
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.481+2572
+version: 0.9.481+2573
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR disables automatically scrolling to an entry in focus when the keyboard appears since that lead to annoying behavior on mobile. Behavior will likely come back when I find a better solution.