### PR TITLE
feat: auto assign category & filter for tasks with unassigned category

### DIFF
--- a/lib/blocs/journal/journal_page_cubit.dart
+++ b/lib/blocs/journal/journal_page_cubit.dart
@@ -132,7 +132,7 @@ class JournalPageCubit extends Cubit<JournalPageState> {
   bool _showPrivateEntries = false;
   bool showTasks = false;
   bool taskAsListView = true;
-  Set<String> _selectedCategoryIds = {};
+  Set<String?> _selectedCategoryIds = {};
 
   Set<String> _fullTextMatches = {};
   Set<String> _lastIds = {};
@@ -182,10 +182,9 @@ class JournalPageCubit extends Cubit<JournalPageState> {
     persistTaskStatuses();
   }
 
-  void toggleSelectedCategoryIds(String categoryId) {
+  void toggleSelectedCategoryIds(String? categoryId) {
     if (_selectedCategoryIds.contains(categoryId)) {
-      _selectedCategoryIds =
-          _selectedCategoryIds.difference(<String>{categoryId});
+      _selectedCategoryIds = _selectedCategoryIds.difference({categoryId});
     } else {
       _selectedCategoryIds = _selectedCategoryIds.union({categoryId});
     }

--- a/lib/blocs/journal/journal_page_state.dart
+++ b/lib/blocs/journal/journal_page_state.dart
@@ -24,6 +24,6 @@ class JournalPageState with _$JournalPageState {
     required PagingController<int, JournalEntity> pagingController,
     required List<String> taskStatuses,
     required Set<String> selectedTaskStatuses,
-    required Set<String> selectedCategoryIds,
+    required Set<String?> selectedCategoryIds,
   }) = _JournalPageState;
 }

--- a/lib/blocs/journal/journal_page_state.freezed.dart
+++ b/lib/blocs/journal/journal_page_state.freezed.dart
@@ -28,7 +28,7 @@ mixin _$JournalPageState {
       throw _privateConstructorUsedError;
   List<String> get taskStatuses => throw _privateConstructorUsedError;
   Set<String> get selectedTaskStatuses => throw _privateConstructorUsedError;
-  Set<String> get selectedCategoryIds => throw _privateConstructorUsedError;
+  Set<String?> get selectedCategoryIds => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
   $JournalPageStateCopyWith<JournalPageState> get copyWith =>
@@ -53,7 +53,7 @@ abstract class $JournalPageStateCopyWith<$Res> {
       PagingController<int, JournalEntity> pagingController,
       List<String> taskStatuses,
       Set<String> selectedTaskStatuses,
-      Set<String> selectedCategoryIds});
+      Set<String?> selectedCategoryIds});
 }
 
 /// @nodoc
@@ -130,7 +130,7 @@ class _$JournalPageStateCopyWithImpl<$Res, $Val extends JournalPageState>
       selectedCategoryIds: null == selectedCategoryIds
           ? _value.selectedCategoryIds
           : selectedCategoryIds // ignore: cast_nullable_to_non_nullable
-              as Set<String>,
+              as Set<String?>,
     ) as $Val);
   }
 }
@@ -155,7 +155,7 @@ abstract class _$$JournalPageStateImplCopyWith<$Res>
       PagingController<int, JournalEntity> pagingController,
       List<String> taskStatuses,
       Set<String> selectedTaskStatuses,
-      Set<String> selectedCategoryIds});
+      Set<String?> selectedCategoryIds});
 }
 
 /// @nodoc
@@ -230,7 +230,7 @@ class __$$JournalPageStateImplCopyWithImpl<$Res>
       selectedCategoryIds: null == selectedCategoryIds
           ? _value._selectedCategoryIds
           : selectedCategoryIds // ignore: cast_nullable_to_non_nullable
-              as Set<String>,
+              as Set<String?>,
     ));
   }
 }
@@ -250,7 +250,7 @@ class _$JournalPageStateImpl implements _JournalPageState {
       required this.pagingController,
       required final List<String> taskStatuses,
       required final Set<String> selectedTaskStatuses,
-      required final Set<String> selectedCategoryIds})
+      required final Set<String?> selectedCategoryIds})
       : _tagIds = tagIds,
         _filters = filters,
         _selectedEntryTypes = selectedEntryTypes,
@@ -319,9 +319,9 @@ class _$JournalPageStateImpl implements _JournalPageState {
     return EqualUnmodifiableSetView(_selectedTaskStatuses);
   }
 
-  final Set<String> _selectedCategoryIds;
+  final Set<String?> _selectedCategoryIds;
   @override
-  Set<String> get selectedCategoryIds {
+  Set<String?> get selectedCategoryIds {
     if (_selectedCategoryIds is EqualUnmodifiableSetView)
       return _selectedCategoryIds;
     // ignore: implicit_dynamic_type
@@ -387,18 +387,19 @@ class _$JournalPageStateImpl implements _JournalPageState {
 
 abstract class _JournalPageState implements JournalPageState {
   factory _JournalPageState(
-      {required final String match,
-      required final Set<String> tagIds,
-      required final Set<DisplayFilter> filters,
-      required final bool showPrivateEntries,
-      required final bool showTasks,
-      required final bool taskAsListView,
-      required final List<String> selectedEntryTypes,
-      required final Set<String> fullTextMatches,
-      required final PagingController<int, JournalEntity> pagingController,
-      required final List<String> taskStatuses,
-      required final Set<String> selectedTaskStatuses,
-      required final Set<String> selectedCategoryIds}) = _$JournalPageStateImpl;
+          {required final String match,
+          required final Set<String> tagIds,
+          required final Set<DisplayFilter> filters,
+          required final bool showPrivateEntries,
+          required final bool showTasks,
+          required final bool taskAsListView,
+          required final List<String> selectedEntryTypes,
+          required final Set<String> fullTextMatches,
+          required final PagingController<int, JournalEntity> pagingController,
+          required final List<String> taskStatuses,
+          required final Set<String> selectedTaskStatuses,
+          required final Set<String?> selectedCategoryIds}) =
+      _$JournalPageStateImpl;
 
   @override
   String get match;
@@ -423,7 +424,7 @@ abstract class _JournalPageState implements JournalPageState {
   @override
   Set<String> get selectedTaskStatuses;
   @override
-  Set<String> get selectedCategoryIds;
+  Set<String?> get selectedCategoryIds;
   @override
   @JsonKey(ignore: true)
   _$$JournalPageStateImplCopyWith<_$JournalPageStateImpl> get copyWith =>

--- a/lib/logic/create/create_entry.dart
+++ b/lib/logic/create/create_entry.dart
@@ -34,7 +34,7 @@ Future<JournalEntity?> createTimerEntry({String? linkedId}) async {
   return timerItem;
 }
 
-Future<Task?> createTask({String? linkedId}) async {
+Future<Task?> createTask({String? linkedId, String? categoryId}) async {
   final now = DateTime.now();
 
   final task = await getIt<PersistenceLogic>().createTaskEntry(
@@ -48,6 +48,7 @@ Future<Task?> createTask({String? linkedId}) async {
     ),
     entryText: const EntryText(plainText: ''),
     linkedId: linkedId,
+    categoryId: categoryId,
   );
 
   return task;

--- a/lib/logic/persistence_logic.dart
+++ b/lib/logic/persistence_logic.dart
@@ -272,6 +272,7 @@ class PersistenceLogic {
     required TaskData data,
     required EntryText entryText,
     String? linkedId,
+    String? categoryId,
   }) async {
     try {
       final now = DateTime.now();
@@ -287,6 +288,7 @@ class PersistenceLogic {
           dateFrom: data.dateFrom,
           dateTo: data.dateTo,
           id: id,
+          categoryId: categoryId,
           vectorClock: vc,
           timezone: await getLocalTimezone(),
           utcOffset: now.timeZoneOffset.inMinutes,

--- a/lib/widgets/create/add_actions.dart
+++ b/lib/widgets/create/add_actions.dart
@@ -141,7 +141,10 @@ class _RadialAddActionButtonsState extends State<RadialAddActionButtons> {
           onPressed: () async {
             rebuild();
             final linkedId = widget.linked?.meta.id;
-            final task = await createTask(linkedId: linkedId);
+            final task = await createTask(
+              linkedId: linkedId,
+              categoryId: widget.linked?.meta.categoryId,
+            );
 
             if (task != null) {
               beamToNamed('/journal/${task.meta.id}');

--- a/lib/widgets/search/task_status_filter.dart
+++ b/lib/widgets/search/task_status_filter.dart
@@ -104,6 +104,21 @@ class TaskCategoryFilter extends StatelessWidget {
                     ),
                   );
                 }),
+                Opacity(
+                  opacity: state.selectedCategoryIds.contains(null) ? 1 : 0.4,
+                  child: ActionChip(
+                    onPressed: () => cubit.toggleSelectedCategoryIds(null),
+                    label: const Text(
+                      'unassigned',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: fontSizeMedium,
+                        fontWeight: FontWeight.w300,
+                      ),
+                    ),
+                    backgroundColor: Colors.grey,
+                  ),
+                ),
               ],
             ),
           ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.481+2573
+version: 0.9.482+2574
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.482+2574
+version: 0.9.482+2575
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR adds:

- auto assigning existing category when creating a new task linked to an existing task
- filter chip specifically for tasks with unassigned category