### PR TITLE
feat: hide habit completion cards when page invisible

### DIFF
--- a/lib/pages/habits/habits_page.dart
+++ b/lib/pages/habits/habits_page.dart
@@ -100,7 +100,7 @@ class HabitsTabPage extends StatelessWidget {
                                 style: chartTitleStyle,
                               ),
                             ),
-                          if (showOpenNow)
+                          if (showOpenNow && state.isVisible)
                             ...openNow.map((habitDefinition) {
                               return HabitCompletionCard(
                                 habitDefinition: habitDefinition,
@@ -118,7 +118,7 @@ class HabitsTabPage extends StatelessWidget {
                                 style: chartTitleStyle,
                               ),
                             ),
-                          if (showPendingLater)
+                          if (showPendingLater && state.isVisible)
                             ...pendingLater.map((habitDefinition) {
                               return HabitCompletionCard(
                                 habitDefinition: habitDefinition,
@@ -136,7 +136,7 @@ class HabitsTabPage extends StatelessWidget {
                                 style: chartTitleStyle,
                               ),
                             ),
-                          if (showCompleted)
+                          if (showCompleted && state.isVisible)
                             ...completed.map((habitDefinition) {
                               return HabitCompletionCard(
                                 habitDefinition: habitDefinition,

--- a/lib/pages/settings/advanced/logging_page.dart
+++ b/lib/pages/settings/advanced/logging_page.dart
@@ -9,44 +9,65 @@ import 'package:lotti/themes/theme.dart';
 import 'package:lotti/widgets/app_bar/sliver_title_bar.dart';
 import 'package:lotti/widgets/app_bar/title_app_bar.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:visibility_detector/visibility_detector.dart';
 
-class LoggingPage extends StatelessWidget {
+class LoggingPage extends StatefulWidget {
   const LoggingPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return StreamBuilder<List<LogEntry>>(
-      stream: getIt<LoggingDb>().watchLogEntries(),
-      builder: (
-        BuildContext context,
-        AsyncSnapshot<List<LogEntry>> snapshot,
-      ) {
-        final logEntries = snapshot.data ?? [];
+  State<LoggingPage> createState() => _LoggingPageState();
+}
 
-        return CustomScrollView(
-          slivers: <Widget>[
-            SliverTitleBar(
-              context.messages.settingsLogsTitle,
-              pinned: true,
-              showBackButton: true,
-            ),
-            SliverList(
-              delegate: SliverChildBuilderDelegate(
-                (
-                  BuildContext context,
-                  int index,
-                ) {
-                  return LogLineCard(
-                    logEntry: logEntries.elementAt(index),
-                    index: index,
-                  );
-                },
-                childCount: logEntries.length,
-              ),
-            ),
-          ],
-        );
+class _LoggingPageState extends State<LoggingPage> {
+  bool _isVisible = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return VisibilityDetector(
+      onVisibilityChanged: (info) {
+        final isVisible = info.visibleBounds.size.width > 0;
+        if (_isVisible != isVisible && mounted) {
+          setState(() {
+            _isVisible = isVisible;
+          });
+        }
       },
+      key: const Key('logging_page'),
+      child: _isVisible
+          ? StreamBuilder<List<LogEntry>>(
+              stream: getIt<LoggingDb>().watchLogEntries(),
+              builder: (
+                BuildContext context,
+                AsyncSnapshot<List<LogEntry>> snapshot,
+              ) {
+                final logEntries = snapshot.data ?? [];
+
+                return CustomScrollView(
+                  slivers: <Widget>[
+                    SliverTitleBar(
+                      context.messages.settingsLogsTitle,
+                      pinned: true,
+                      showBackButton: true,
+                    ),
+                    SliverList(
+                      delegate: SliverChildBuilderDelegate(
+                        (
+                          BuildContext context,
+                          int index,
+                        ) {
+                          return LogLineCard(
+                            logEntry: logEntries.elementAt(index),
+                            index: index,
+                          );
+                        },
+                        childCount: logEntries.length,
+                      ),
+                    ),
+                  ],
+                );
+              },
+            )
+          : const SizedBox.shrink(),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.484+2583
+version: 0.9.485+2584
 
 msix_config:
   display_name: LottiApp

--- a/test/pages/settings/logging_page_test.dart
+++ b/test/pages/settings/logging_page_test.dart
@@ -6,6 +6,7 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/pages/settings/advanced/logging_page.dart';
 import 'package:lotti/utils/file_utils.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:visibility_detector/visibility_detector.dart';
 
 import '../../mocks/mocks.dart';
 import '../../widget_test_utils.dart';
@@ -20,6 +21,11 @@ void main() {
         ..registerSingleton<LoggingDb>(MockLoggingDb())
         ..registerSingleton<JournalDb>(mockJournalDb);
     });
+
+    setUpAll(() {
+      VisibilityDetectorController.instance.updateInterval = Duration.zero;
+    });
+
     tearDown(getIt.reset);
 
     testWidgets('empty logging page is displayed', (tester) async {


### PR DESCRIPTION
This PR adds hiding the habit completion cards when the habits page is invisible. The problem was that the `StreamBuilder` used in `HabitCompletionCard` stays alive even when invisible and thus causing expensive re-renders even when the habits page is not visible. For example, when processing sync messages, in one sample it took 33 seconds to process 10 messages prior to this change, and less than 4 seconds after this change. The whole area of when to re-render anything when there's a change in the database, e.g. when receiving messages from sync, still needs more thought, but at least this is already a good improvement.