### PR TITLE
fix: much faster time visualization database query

### DIFF
--- a/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/argmaxinc/whisperkit",
       "state" : {
-        "revision" : "aa4bb901c8a09c8b5320ff4bb9fe64a095614d4e",
-        "version" : "0.7.2"
+        "revision" : "02763ca430f7190fc80d003b51a2e4510c35f9cc",
+        "version" : "0.8.0"
       }
     }
   ],

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -233,6 +233,13 @@ class JournalDb extends _$JournalDb {
     return res.map(fromDbEntity).toList();
   }
 
+  Future<List<JournalEntity>> getJournalEntitiesForIds(
+    Set<String> ids,
+  ) async {
+    final res = await entriesForIds(ids.toList()).get();
+    return res.map(fromDbEntity).toList();
+  }
+
   Future<List<String>> getJournalEntityIds({
     required List<String> types,
     required List<bool> starredStatuses,
@@ -841,6 +848,10 @@ class JournalDb extends _$JournalDb {
 
   Future<List<String>> linksForEntryId(String entryId) {
     return linkedEntriesFor(entryId).get();
+  }
+
+  Future<List<LinkedDbEntry>> linksForEntryIds(Set<String> ids) async {
+    return linksForIds(ids.toList()).get();
   }
 
   Future<int> upsertEntryLink(EntryLink link) async {

--- a/lib/database/database.drift
+++ b/lib/database/database.drift
@@ -550,6 +550,14 @@ SELECT * FROM journal
   AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'))
   ORDER BY date_from DESC;
 
+linksForIds:
+SELECT * FROM linked_entries
+  WHERE from_id IN :from_ids;
+
+entriesForIds:
+SELECT * FROM journal
+  WHERE id IN :ids;
+
 journalEntitiesByIds:
 SELECT * FROM journal
   WHERE deleted = false

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -5367,6 +5367,33 @@ abstract class _$JournalDb extends GeneratedDatabase {
         }).asyncMap(journal.mapFromRow);
   }
 
+  Selectable<LinkedDbEntry> linksForIds(List<String> fromIds) {
+    var $arrayStartIndex = 1;
+    final expandedfromIds = $expandVar($arrayStartIndex, fromIds.length);
+    $arrayStartIndex += fromIds.length;
+    return customSelect(
+        'SELECT * FROM linked_entries WHERE from_id IN ($expandedfromIds)',
+        variables: [
+          for (var $ in fromIds) Variable<String>($)
+        ],
+        readsFrom: {
+          linkedEntries,
+        }).asyncMap(linkedEntries.mapFromRow);
+  }
+
+  Selectable<JournalDbEntity> entriesForIds(List<String> ids) {
+    var $arrayStartIndex = 1;
+    final expandedids = $expandVar($arrayStartIndex, ids.length);
+    $arrayStartIndex += ids.length;
+    return customSelect('SELECT * FROM journal WHERE id IN ($expandedids)',
+        variables: [
+          for (var $ in ids) Variable<String>($)
+        ],
+        readsFrom: {
+          journal,
+        }).asyncMap(journal.mapFromRow);
+  }
+
   Selectable<JournalDbEntity> journalEntitiesByIds(List<String> ids) {
     var $arrayStartIndex = 1;
     final expandedids = $expandVar($arrayStartIndex, ids.length);

--- a/lib/features/tasks/state/time_by_category_controller.g.dart
+++ b/lib/features/tasks/state/time_by_category_controller.g.dart
@@ -24,7 +24,7 @@ final timeByDayChartProvider =
 typedef TimeByDayChartRef
     = AutoDisposeFutureProviderRef<List<TimeByDayAndCategory>>;
 String _$timeByCategoryControllerHash() =>
-    r'028feca67380c004afb04877200549f4b47edcf5';
+    r'76b4fd2aaa6092f2143fb3c7cb49a1346ada169a';
 
 /// See also [TimeByCategoryController].
 @ProviderFor(TimeByCategoryController)

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -5,7 +5,6 @@ import 'package:lotti/database/database.dart';
 import 'package:lotti/database/editor_db.dart';
 import 'package:lotti/database/fts5_db.dart';
 import 'package:lotti/database/journal_db/config_flags.dart';
-import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/database/maintenance.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/logic/ai/ai_logic.dart';
@@ -29,7 +28,6 @@ final getIt = GetIt.instance;
 Future<void> registerSingletons() async {
   getIt
     ..registerSingleton<Fts5Db>(Fts5Db())
-    ..registerSingleton<LoggingDb>(LoggingDb())
     ..registerSingleton<UpdateNotifications>(UpdateNotifications())
     ..registerSingleton<JournalDb>(JournalDb())
     ..registerSingleton<EditorDb>(EditorDb())

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,6 +19,8 @@ import 'package:window_manager/window_manager.dart';
 
 Future<void> main() async {
   await runZonedGuarded(() async {
+    getIt.registerSingleton<LoggingDb>(LoggingDb());
+
     WidgetsFlutterBinding.ensureInitialized();
     MediaKit.ensureInitialized();
     Animate.restartOnHotReload = true;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.487+2596
+version: 0.9.487+2599
 
 msix_config:
   display_name: LottiApp

--- a/test/pages/settings/about_page_test.dart
+++ b/test/pages/settings/about_page_test.dart
@@ -17,58 +17,58 @@ void main() {
   final mockJournalDb = MockJournalDb();
   final mockUpdateNotifications = MockUpdateNotifications();
 
-  group(
-    'SettingsPage Widget Tests - ',
-    () {
-      setUpAll(() {
-        when(mockJournalDb.watchJournalCount)
-            .thenAnswer((_) => Stream<int>.fromIterable([n]));
+  group('SettingsPage Widget Tests - ', () {
+    setUpAll(() {
+      when(mockJournalDb.watchJournalCount)
+          .thenAnswer((_) => Stream<int>.fromIterable([n]));
 
-        when(mockJournalDb.watchCountImportFlagEntries)
-            .thenAnswer((_) => Stream<int>.fromIterable([0]));
+      when(mockJournalDb.watchCountImportFlagEntries)
+          .thenAnswer((_) => Stream<int>.fromIterable([0]));
 
-        when(
-          () => mockJournalDb.sortedJournalEntities(
-            rangeStart: any(named: 'rangeStart'),
-            rangeEnd: any(named: 'rangeEnd'),
-          ),
-        ).thenAnswer((_) async => <JournalEntity>[]);
+      when(
+        () => mockJournalDb.sortedJournalEntities(
+          rangeStart: any(named: 'rangeStart'),
+          rangeEnd: any(named: 'rangeEnd'),
+        ),
+      ).thenAnswer((_) async => <JournalEntity>[]);
 
-        when(() => mockUpdateNotifications.updateStream).thenAnswer(
-          (_) => Stream<Set<String>>.fromIterable([]),
-        );
+      when(
+        () => mockJournalDb.linksForEntryIds(any()),
+      ).thenAnswer((_) async => <LinkedDbEntry>[]);
 
-        getIt
-          ..registerSingleton<UpdateNotifications>(mockUpdateNotifications)
-          ..registerSingleton<JournalDb>(mockJournalDb);
+      when(() => mockUpdateNotifications.updateStream).thenAnswer(
+        (_) => Stream<Set<String>>.fromIterable([]),
+      );
 
-        when(
-          () => mockJournalDb.watchTaskCount(any()),
-        ).thenAnswer(
-          (_) => Stream<int>.fromIterable([10]),
-        );
-      });
-      tearDown(getIt.reset);
+      getIt
+        ..registerSingleton<UpdateNotifications>(mockUpdateNotifications)
+        ..registerSingleton<JournalDb>(mockJournalDb);
 
-      testWidgets('main page is displayed', (tester) async {
-        await tester.pumpWidget(
-          makeTestableWidgetWithScaffold(
-            ConstrainedBox(
-              constraints: const BoxConstraints(
-                maxHeight: 1000,
-                maxWidth: 1000,
-              ),
-              child: const AboutPage(),
+      when(
+        () => mockJournalDb.watchTaskCount(any()),
+      ).thenAnswer(
+        (_) => Stream<int>.fromIterable([10]),
+      );
+    });
+    tearDown(getIt.reset);
+
+    testWidgets('main page is displayed', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          ConstrainedBox(
+            constraints: const BoxConstraints(
+              maxHeight: 1000,
+              maxWidth: 1000,
             ),
+            child: const AboutPage(),
           ),
-        );
+        ),
+      );
 
-        await tester.pumpAndSettle();
+      await tester.pumpAndSettle();
 
-        expect(find.text('About Lotti'), findsOneWidget);
-        expect(find.text('Entries: 111, '), findsOneWidget);
-      });
-    },
-    skip: true,
-  );
+      expect(find.text('About Lotti'), findsOneWidget);
+      expect(find.text('Entries: 111, '), findsOneWidget);
+    });
+  });
 }


### PR DESCRIPTION
This PR fixes the previously slow database queries by improving query and data processing time until display by a factor of roughly 30x.

There was an `n+1` problem where each entry would individually fetch linked entries to determine its category. Typically, a time tracking entry would not have a set category but the task it is linked from does, so this related task would be fetched individually. In my case of fetching 30 days worth of time, there would have been over 1K database queries for this reason. Instead, with this change, all related ids are collected and all the links fetched at once, creating a lookup table, and similarly for the targeted tasks. This results in 3 queries in total, instead of over 1K. This approach reduces the total time until chart display from 15 seconds to around 500 ms. Still not very cheap, with room for improvement by caching data, but good enough for a decent UX when displaying only 30 days.