### PR TITLE
feat: automatically assign new task category when only one selected

### DIFF
--- a/lib/pages/journal/infinite_journal_page.dart
+++ b/lib/pages/journal/infinite_journal_page.dart
@@ -34,14 +34,24 @@ class InfiniteJournalPage extends StatelessWidget {
       create: (BuildContext context) => JournalPageCubit(showTasks: showTasks),
       child: Scaffold(
         floatingActionButton: showTasks
-            ? FloatingAddIcon(
-                createFn: () async {
-                  final task = await createTask();
-                  if (task != null) {
-                    getIt<NavService>().beamToNamed('/tasks/${task.meta.id}');
-                  }
+            ? BlocBuilder<JournalPageCubit, JournalPageState>(
+                builder: (context, snapshot) {
+                  return FloatingAddIcon(
+                    createFn: () async {
+                      final selectedCategoryIds = snapshot.selectedCategoryIds;
+                      final task = await createTask(
+                        categoryId: selectedCategoryIds.length == 1
+                            ? selectedCategoryIds.first
+                            : null,
+                      );
+                      if (task != null) {
+                        getIt<NavService>()
+                            .beamToNamed('/tasks/${task.meta.id}');
+                      }
+                    },
+                    semanticLabel: context.messages.addActionAddTask,
+                  );
                 },
-                semanticLabel: context.messages.addActionAddTask,
               )
             : RadialAddActionButtons(
                 radius: isMobile ? 180 : 120,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.487+2606
+version: 0.9.488+2607
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR adds automatic assignment of a task's category when only a single category is selected in the tasks filter.