### PR TITLE
fix: flickering task or event form

### DIFF
--- a/lib/logic/create/create_entry.dart
+++ b/lib/logic/create/create_entry.dart
@@ -24,11 +24,11 @@ Future<JournalEntity?> createTextEntry({String? linkedId}) async {
   return entry;
 }
 
-Future<JournalEntity?> createTimerEntry({String? linkedId}) async {
-  final timerItem = await createTextEntry(linkedId: linkedId);
-  if (linkedId != null) {
+Future<JournalEntity?> createTimerEntry({JournalEntity? linked}) async {
+  final timerItem = await createTextEntry(linkedId: linked?.meta.id);
+  if (linked != null) {
     if (timerItem != null) {
-      await getIt<TimeService>().start(timerItem);
+      await getIt<TimeService>().start(timerItem, linked);
     }
   }
   return timerItem;

--- a/lib/services/time_service.dart
+++ b/lib/services/time_service.dart
@@ -11,14 +11,16 @@ class TimeService {
 
   late final StreamController<JournalEntity?> _controller;
   JournalEntity? _current;
+  JournalEntity? linkedFrom;
   Stream<int>? _periodicStream;
 
-  Future<void> start(JournalEntity journalEntity) async {
+  Future<void> start(JournalEntity journalEntity, JournalEntity? linked) async {
     if (_current != null) {
       await stop();
     }
 
     _current = journalEntity;
+    linkedFrom = linked;
 
     const interval = Duration(seconds: 1);
 

--- a/lib/widgets/create/add_actions.dart
+++ b/lib/widgets/create/add_actions.dart
@@ -107,8 +107,7 @@ class _RadialAddActionButtonsState extends State<RadialAddActionButtons> {
           tooltip: context.messages.addActionAddTimeRecording,
           onPressed: () async {
             rebuild();
-            final linkedId = widget.linked?.meta.id;
-            await createTimerEntry(linkedId: linkedId);
+            await createTimerEntry(linked: widget.linked);
           },
           child: Icon(
             MdiIcons.timerOutline,

--- a/lib/widgets/journal/entry_detail_linked.dart
+++ b/lib/widgets/journal/entry_detail_linked.dart
@@ -71,7 +71,7 @@ class LinkedEntriesWidget extends StatelessWidget {
                     popOnDelete: false,
                     unlinkFn: unlink,
                     parentTags: item.meta.tagIds?.toSet(),
-                    linkedFromId: item.meta.id,
+                    linkedFrom: item,
                   );
                 },
               ),

--- a/lib/widgets/journal/entry_details/duration_widget.dart
+++ b/lib/widgets/journal/entry_details/duration_widget.dart
@@ -13,12 +13,15 @@ import 'package:material_design_icons_flutter/material_design_icons_flutter.dart
 class DurationWidget extends ConsumerWidget {
   DurationWidget({
     required this.item,
+    required this.linkedFrom,
     super.key,
     this.style,
   });
 
   final TimeService _timeService = getIt<TimeService>();
   final JournalEntity item;
+  final JournalEntity? linkedFrom;
+
   final TextStyle? style;
 
   @override
@@ -80,7 +83,7 @@ class DurationWidget extends ConsumerWidget {
                         tooltip: 'Record',
                         color: context.colorScheme.error,
                         onPressed: () {
-                          _timeService.start(item);
+                          _timeService.start(item, linkedFrom);
                         },
                       ),
                     ),

--- a/lib/widgets/journal/entry_details/entry_detail_footer.dart
+++ b/lib/widgets/journal/entry_details/entry_detail_footer.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/journal/state/entry_controller.dart';
 import 'package:lotti/widgets/journal/entry_details/duration_widget.dart';
 import 'package:lotti/widgets/journal/entry_details/entry_datetime_widget.dart';
@@ -8,10 +9,12 @@ import 'package:lotti/widgets/misc/map_widget.dart';
 class EntryDetailFooter extends ConsumerWidget {
   const EntryDetailFooter({
     required this.entryId,
+    required this.linkedFrom,
     super.key,
   });
 
   final String entryId;
+  final JournalEntity? linkedFrom;
 
   @override
   Widget build(
@@ -32,7 +35,10 @@ class EntryDetailFooter extends ConsumerWidget {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             EntryDatetimeWidget(entryId: entry.meta.id),
-            DurationWidget(item: entry),
+            DurationWidget(
+              item: entry,
+              linkedFrom: linkedFrom,
+            ),
           ],
         ),
         Visibility(

--- a/lib/widgets/journal/entry_details_widget.dart
+++ b/lib/widgets/journal/entry_details_widget.dart
@@ -25,14 +25,14 @@ class EntryDetailWidget extends ConsumerWidget {
     this.showTaskDetails = false,
     this.unlinkFn,
     this.parentTags,
-    this.linkedFromId,
+    this.linkedFrom,
   });
 
   final String itemId;
   final bool popOnDelete;
   final bool showTaskDetails;
   final Future<void> Function()? unlinkFn;
-  final String? linkedFromId;
+  final JournalEntity? linkedFrom;
   final Set<String>? parentTags;
 
   @override
@@ -73,7 +73,7 @@ class EntryDetailWidget extends ConsumerWidget {
             EntryDetailsContent(
               itemId,
               unlinkFn: unlinkFn,
-              linkedFromId: linkedFromId,
+              linkedFrom: linkedFrom,
               parentTags: parentTags,
             ),
           ],
@@ -87,14 +87,14 @@ class EntryDetailsContent extends ConsumerWidget {
   const EntryDetailsContent(
     this.itemId, {
     this.unlinkFn,
-    this.linkedFromId,
+    this.linkedFrom,
     this.parentTags,
     super.key,
   });
 
   final String itemId;
   final Future<void> Function()? unlinkFn;
-  final String? linkedFromId;
+  final JournalEntity? linkedFrom;
   final Set<String>? parentTags;
 
   @override
@@ -127,7 +127,7 @@ class EntryDetailsContent extends ConsumerWidget {
         EntryDetailHeader(
           entryId: itemId,
           inLinkedEntries: unlinkFn != null,
-          linkedFromId: linkedFromId,
+          linkedFromId: linkedFrom?.meta.id,
           unlinkFn: unlinkFn,
         ),
         TagsListWidget(entryId: itemId, parentTags: parentTags),
@@ -165,7 +165,10 @@ class EntryDetailsContent extends ConsumerWidget {
           checklist: (_) => const SizedBox.shrink(),
           checklistItem: (_) => const SizedBox.shrink(),
         ),
-        EntryDetailFooter(entryId: itemId),
+        EntryDetailFooter(
+          entryId: itemId,
+          linkedFrom: linkedFrom,
+        ),
       ],
     );
   }

--- a/lib/widgets/journal/journal_card.dart
+++ b/lib/widgets/journal/journal_card.dart
@@ -5,7 +5,6 @@ import 'package:flutter_rating/flutter_rating.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/journal/state/journal_card_controller.dart';
-import 'package:lotti/get_it.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/themes/colors.dart';
 import 'package:lotti/themes/theme.dart';
@@ -222,7 +221,7 @@ class _JournalCardState extends ConsumerState<JournalCard> {
       return const SizedBox.shrink();
     }
     void onTap() {
-      if (getIt<NavService>().tasksTabActive()) {
+      if (updatedItem is Task) {
         beamToNamed('/tasks/${updatedItem.meta.id}');
       } else {
         beamToNamed('/journal/${updatedItem.meta.id}');

--- a/lib/widgets/misc/time_recording_indicator.dart
+++ b/lib/widgets/misc/time_recording_indicator.dart
@@ -31,7 +31,14 @@ class TimeRecordingIndicatorWidget extends StatelessWidget {
         final durationString = formatDuration(entryDuration(current));
 
         return GestureDetector(
-          onTap: () => beamToNamed('/journal/${current.meta.id}'),
+          onTap: () {
+            final linkedFrom = _timeService.linkedFrom;
+            linkedFrom != null
+                ? linkedFrom is Task
+                    ? beamToNamed('/tasks/${linkedFrom.meta.id}')
+                    : beamToNamed('/journal/${linkedFrom.meta.id}')
+                : beamToNamed('/journal/${current.meta.id}');
+          },
           child: MouseRegion(
             cursor: SystemMouseCursors.click,
             child: ClipRRect(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.495+2640
+version: 0.9.496+2641
 
 msix_config:
   display_name: LottiApp

--- a/test/widgets/create/add_actions_test.dart
+++ b/test/widgets/create/add_actions_test.dart
@@ -218,7 +218,8 @@ void main() {
           ),
         );
 
-        when(() => mockTimeService.start(any())).thenAnswer((_) async {});
+        when(() => mockTimeService.start(any(), any()))
+            .thenAnswer((_) async {});
 
         await tester.pumpAndSettle();
 
@@ -235,7 +236,7 @@ void main() {
         await tester.tap(addTimerIconFinder);
         await tester.pumpAndSettle();
 
-        verify(() => mockTimeService.start(any())).called(1);
+        verify(() => mockTimeService.start(any(), any())).called(1);
         verifyNever(() => mockNavService.beamToNamed(any()));
       },
     );

--- a/test/widgets/journal/entry_details/entry_detail_footer_test.dart
+++ b/test/widgets/journal/entry_details/entry_detail_footer_test.dart
@@ -95,7 +95,10 @@ void main() {
     testWidgets('entry date is visible', (WidgetTester tester) async {
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(
-          EntryDetailFooter(entryId: testTextEntry.meta.id),
+          EntryDetailFooter(
+            entryId: testTextEntry.meta.id,
+            linkedFrom: null,
+          ),
         ),
       );
       await tester.pumpAndSettle();
@@ -109,7 +112,10 @@ void main() {
         (WidgetTester tester) async {
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(
-          EntryDetailFooter(entryId: testTextEntry.meta.id),
+          EntryDetailFooter(
+            entryId: testTextEntry.meta.id,
+            linkedFrom: null,
+          ),
         ),
       );
       await tester.pumpAndSettle();
@@ -124,7 +130,10 @@ void main() {
 
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(
-          EntryDetailFooter(entryId: testTextEntry.meta.id),
+          EntryDetailFooter(
+            entryId: testTextEntry.meta.id,
+            linkedFrom: null,
+          ),
         ),
       );
       await tester.pumpAndSettle();
@@ -149,12 +158,15 @@ void main() {
       when(() => mockJournalDb.journalEntityById(testTextEntry.meta.id))
           .thenAnswer((_) async => testEntry);
 
-      Future<void> mockStartTimer() => mockTimeService.start(testEntry);
+      Future<void> mockStartTimer() => mockTimeService.start(testEntry, null);
       when(mockStartTimer).thenAnswer((_) async {});
 
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(
-          EntryDetailFooter(entryId: testTextEntry.meta.id),
+          EntryDetailFooter(
+            entryId: testTextEntry.meta.id,
+            linkedFrom: null,
+          ),
         ),
       );
       await tester.pumpAndSettle();
@@ -195,7 +207,10 @@ void main() {
 
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(
-          EntryDetailFooter(entryId: testTextEntry.meta.id),
+          EntryDetailFooter(
+            entryId: testTextEntry.meta.id,
+            linkedFrom: null,
+          ),
         ),
       );
       await tester.pumpAndSettle();


### PR DESCRIPTION
This PR fixes a rather annoying issue where occasionally, the task or event forms would flicker when typing. Turns out the problem was instances of `GlobalKey` used in multiple places. The solution is proper routing to a singlet instance for each of the respective widgets.