### PR TITLE
feat: show all tasks when no category is selected

### DIFF
--- a/lib/blocs/journal/journal_page_cubit.dart
+++ b/lib/blocs/journal/journal_page_cubit.dart
@@ -13,6 +13,7 @@ import 'package:lotti/database/fts5_db.dart';
 import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/db_notification.dart';
+import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/utils/platform.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:visibility_detector/visibility_detector.dart';
@@ -325,11 +326,19 @@ class JournalPageCubit extends Cubit<JournalPageState> {
         _filters.contains(DisplayFilter.flaggedEntriesOnly);
 
     if (showTasks) {
+      final allCategoryIds = getIt<EntitiesCacheService>()
+          .sortedCategories
+          .map((e) => e.id)
+          .toSet();
+
+      final categoryIds =
+          _selectedCategoryIds.isEmpty ? allCategoryIds : _selectedCategoryIds;
+
       final res = await _db.getTasks(
         ids: ids,
         starredStatuses: starredEntriesOnly ? [true] : [true, false],
         taskStatuses: _selectedTaskStatuses.toList(),
-        categoryIds: _selectedCategoryIds.toList(),
+        categoryIds: categoryIds.toList(),
         limit: _pageSize,
         offset: pageKey,
       );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.497+2642
+version: 0.9.498+2643
 
 msix_config:
   display_name: LottiApp

--- a/test/pages/journal/infinite_journal_page_test.dart
+++ b/test/pages/journal/infinite_journal_page_test.dart
@@ -236,13 +236,10 @@ void main() {
       );
     });
 
-    testWidgets('page is rendered with task entry', (tester) async {
-      Future<MeasurementEntry?> mockCreateMeasurementEntry() {
-        return mockPersistenceLogic.createMeasurementEntry(
-          data: any(named: 'data'),
-          private: false,
-        );
-      }
+    testWidgets('tasks page is rendered with task entry', (tester) async {
+      when(
+        () => mockEntitiesCacheService.sortedCategories,
+      ).thenAnswer((_) => []);
 
       when(
         () => mockJournalDb.getTasks(
@@ -255,8 +252,6 @@ void main() {
 
       when(() => mockJournalDb.journalEntityById(testTask.meta.id))
           .thenAnswer((_) async => testTask);
-
-      when(mockCreateMeasurementEntry).thenAnswer((_) async => null);
 
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(


### PR DESCRIPTION
This PR improves the tasks filter modal by showing all tasks for any category when no category is selected, which is much more useful than showing no tasks at all when the category selection is empty. Otherwise, one would have to select every single category one by one to see tasks of any category.