### PR TITLE
feat: favorite categories

### DIFF
--- a/lib/blocs/settings/categories/category_settings_cubit.dart
+++ b/lib/blocs/settings/categories/category_settings_cubit.dart
@@ -52,11 +52,13 @@ class CategorySettingsCubit extends Cubit<CategorySettingsState> {
       final formData = state.formKey.currentState?.value;
       final private = formData?['private'] as bool? ?? false;
       final active = formData?['active'] as bool? ?? false;
+      final favorite = formData?['favorite'] as bool? ?? false;
 
       final dataType = categoryDefinition.copyWith(
         name: '${formData!['name']}'.trim(),
         private: private,
         active: active,
+        favorite: favorite,
       );
 
       await persistenceLogic.upsertEntityDefinition(dataType);

--- a/lib/classes/entity_definitions.dart
+++ b/lib/classes/entity_definitions.dart
@@ -101,6 +101,7 @@ class EntityDefinition with _$EntityDefinition {
     required VectorClock? vectorClock,
     required bool private,
     required bool active,
+    bool? favorite,
     String? color,
     String? categoryId,
     DateTime? deletedAt,

--- a/lib/classes/entity_definitions.freezed.dart
+++ b/lib/classes/entity_definitions.freezed.dart
@@ -2603,6 +2603,7 @@ mixin _$EntityDefinition {
             VectorClock? vectorClock,
             bool private,
             bool active,
+            bool? favorite,
             String? color,
             String? categoryId,
             DateTime? deletedAt)
@@ -2671,6 +2672,7 @@ mixin _$EntityDefinition {
             VectorClock? vectorClock,
             bool private,
             bool active,
+            bool? favorite,
             String? color,
             String? categoryId,
             DateTime? deletedAt)?
@@ -2739,6 +2741,7 @@ mixin _$EntityDefinition {
             VectorClock? vectorClock,
             bool private,
             bool active,
+            bool? favorite,
             String? color,
             String? categoryId,
             DateTime? deletedAt)?
@@ -3140,6 +3143,7 @@ class _$MeasurableDataTypeImpl implements MeasurableDataType {
             VectorClock? vectorClock,
             bool private,
             bool active,
+            bool? favorite,
             String? color,
             String? categoryId,
             DateTime? deletedAt)
@@ -3224,6 +3228,7 @@ class _$MeasurableDataTypeImpl implements MeasurableDataType {
             VectorClock? vectorClock,
             bool private,
             bool active,
+            bool? favorite,
             String? color,
             String? categoryId,
             DateTime? deletedAt)?
@@ -3308,6 +3313,7 @@ class _$MeasurableDataTypeImpl implements MeasurableDataType {
             VectorClock? vectorClock,
             bool private,
             bool active,
+            bool? favorite,
             String? color,
             String? categoryId,
             DateTime? deletedAt)?
@@ -3479,6 +3485,7 @@ abstract class _$$CategoryDefinitionImplCopyWith<$Res>
       VectorClock? vectorClock,
       bool private,
       bool active,
+      bool? favorite,
       String? color,
       String? categoryId,
       DateTime? deletedAt});
@@ -3504,6 +3511,7 @@ class __$$CategoryDefinitionImplCopyWithImpl<$Res>
     Object? vectorClock = freezed,
     Object? private = null,
     Object? active = null,
+    Object? favorite = freezed,
     Object? color = freezed,
     Object? categoryId = freezed,
     Object? deletedAt = freezed,
@@ -3537,6 +3545,10 @@ class __$$CategoryDefinitionImplCopyWithImpl<$Res>
           ? _value.active
           : active // ignore: cast_nullable_to_non_nullable
               as bool,
+      favorite: freezed == favorite
+          ? _value.favorite
+          : favorite // ignore: cast_nullable_to_non_nullable
+              as bool?,
       color: freezed == color
           ? _value.color
           : color // ignore: cast_nullable_to_non_nullable
@@ -3564,6 +3576,7 @@ class _$CategoryDefinitionImpl implements CategoryDefinition {
       required this.vectorClock,
       required this.private,
       required this.active,
+      this.favorite,
       this.color,
       this.categoryId,
       this.deletedAt,
@@ -3588,6 +3601,8 @@ class _$CategoryDefinitionImpl implements CategoryDefinition {
   @override
   final bool active;
   @override
+  final bool? favorite;
+  @override
   final String? color;
   @override
   final String? categoryId;
@@ -3599,7 +3614,7 @@ class _$CategoryDefinitionImpl implements CategoryDefinition {
 
   @override
   String toString() {
-    return 'EntityDefinition.categoryDefinition(id: $id, createdAt: $createdAt, updatedAt: $updatedAt, name: $name, vectorClock: $vectorClock, private: $private, active: $active, color: $color, categoryId: $categoryId, deletedAt: $deletedAt)';
+    return 'EntityDefinition.categoryDefinition(id: $id, createdAt: $createdAt, updatedAt: $updatedAt, name: $name, vectorClock: $vectorClock, private: $private, active: $active, favorite: $favorite, color: $color, categoryId: $categoryId, deletedAt: $deletedAt)';
   }
 
   @override
@@ -3617,6 +3632,8 @@ class _$CategoryDefinitionImpl implements CategoryDefinition {
                 other.vectorClock == vectorClock) &&
             (identical(other.private, private) || other.private == private) &&
             (identical(other.active, active) || other.active == active) &&
+            (identical(other.favorite, favorite) ||
+                other.favorite == favorite) &&
             (identical(other.color, color) || other.color == color) &&
             (identical(other.categoryId, categoryId) ||
                 other.categoryId == categoryId) &&
@@ -3627,7 +3644,7 @@ class _$CategoryDefinitionImpl implements CategoryDefinition {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, id, createdAt, updatedAt, name,
-      vectorClock, private, active, color, categoryId, deletedAt);
+      vectorClock, private, active, favorite, color, categoryId, deletedAt);
 
   /// Create a copy of EntityDefinition
   /// with the given fields replaced by the non-null parameter values.
@@ -3664,6 +3681,7 @@ class _$CategoryDefinitionImpl implements CategoryDefinition {
             VectorClock? vectorClock,
             bool private,
             bool active,
+            bool? favorite,
             String? color,
             String? categoryId,
             DateTime? deletedAt)
@@ -3707,7 +3725,7 @@ class _$CategoryDefinitionImpl implements CategoryDefinition {
         dashboard,
   }) {
     return categoryDefinition(id, createdAt, updatedAt, name, vectorClock,
-        private, active, color, categoryId, deletedAt);
+        private, active, favorite, color, categoryId, deletedAt);
   }
 
   @override
@@ -3736,6 +3754,7 @@ class _$CategoryDefinitionImpl implements CategoryDefinition {
             VectorClock? vectorClock,
             bool private,
             bool active,
+            bool? favorite,
             String? color,
             String? categoryId,
             DateTime? deletedAt)?
@@ -3779,7 +3798,7 @@ class _$CategoryDefinitionImpl implements CategoryDefinition {
         dashboard,
   }) {
     return categoryDefinition?.call(id, createdAt, updatedAt, name, vectorClock,
-        private, active, color, categoryId, deletedAt);
+        private, active, favorite, color, categoryId, deletedAt);
   }
 
   @override
@@ -3808,6 +3827,7 @@ class _$CategoryDefinitionImpl implements CategoryDefinition {
             VectorClock? vectorClock,
             bool private,
             bool active,
+            bool? favorite,
             String? color,
             String? categoryId,
             DateTime? deletedAt)?
@@ -3853,7 +3873,7 @@ class _$CategoryDefinitionImpl implements CategoryDefinition {
   }) {
     if (categoryDefinition != null) {
       return categoryDefinition(id, createdAt, updatedAt, name, vectorClock,
-          private, active, color, categoryId, deletedAt);
+          private, active, favorite, color, categoryId, deletedAt);
     }
     return orElse();
   }
@@ -3912,6 +3932,7 @@ abstract class CategoryDefinition implements EntityDefinition {
       required final VectorClock? vectorClock,
       required final bool private,
       required final bool active,
+      final bool? favorite,
       final String? color,
       final String? categoryId,
       final DateTime? deletedAt}) = _$CategoryDefinitionImpl;
@@ -3931,6 +3952,7 @@ abstract class CategoryDefinition implements EntityDefinition {
   @override
   bool get private;
   bool get active;
+  bool? get favorite;
   String? get color;
   @override
   String? get categoryId;
@@ -4279,6 +4301,7 @@ class _$HabitDefinitionImpl implements HabitDefinition {
             VectorClock? vectorClock,
             bool private,
             bool active,
+            bool? favorite,
             String? color,
             String? categoryId,
             DateTime? deletedAt)
@@ -4368,6 +4391,7 @@ class _$HabitDefinitionImpl implements HabitDefinition {
             VectorClock? vectorClock,
             bool private,
             bool active,
+            bool? favorite,
             String? color,
             String? categoryId,
             DateTime? deletedAt)?
@@ -4457,6 +4481,7 @@ class _$HabitDefinitionImpl implements HabitDefinition {
             VectorClock? vectorClock,
             bool private,
             bool active,
+            bool? favorite,
             String? color,
             String? categoryId,
             DateTime? deletedAt)?
@@ -4904,6 +4929,7 @@ class _$DashboardDefinitionImpl implements DashboardDefinition {
             VectorClock? vectorClock,
             bool private,
             bool active,
+            bool? favorite,
             String? color,
             String? categoryId,
             DateTime? deletedAt)
@@ -4990,6 +5016,7 @@ class _$DashboardDefinitionImpl implements DashboardDefinition {
             VectorClock? vectorClock,
             bool private,
             bool active,
+            bool? favorite,
             String? color,
             String? categoryId,
             DateTime? deletedAt)?
@@ -5076,6 +5103,7 @@ class _$DashboardDefinitionImpl implements DashboardDefinition {
             VectorClock? vectorClock,
             bool private,
             bool active,
+            bool? favorite,
             String? color,
             String? categoryId,
             DateTime? deletedAt)?

--- a/lib/classes/entity_definitions.g.dart
+++ b/lib/classes/entity_definitions.g.dart
@@ -247,6 +247,7 @@ _$CategoryDefinitionImpl _$$CategoryDefinitionImplFromJson(
           : VectorClock.fromJson(json['vectorClock'] as Map<String, dynamic>),
       private: json['private'] as bool,
       active: json['active'] as bool,
+      favorite: json['favorite'] as bool?,
       color: json['color'] as String?,
       categoryId: json['categoryId'] as String?,
       deletedAt: json['deletedAt'] == null
@@ -265,6 +266,7 @@ Map<String, dynamic> _$$CategoryDefinitionImplToJson(
       'vectorClock': instance.vectorClock,
       'private': instance.private,
       'active': instance.active,
+      'favorite': instance.favorite,
       'color': instance.color,
       'categoryId': instance.categoryId,
       'deletedAt': instance.deletedAt?.toIso8601String(),

--- a/lib/pages/settings/categories/category_details_page.dart
+++ b/lib/pages/settings/categories/category_details_page.dart
@@ -112,6 +112,14 @@ class CategoryDetailsPage extends StatelessWidget {
                             title: context.messages.dashboardActiveLabel,
                             activeColor: starredGold,
                           ),
+                          FormSwitch(
+                            name: 'favorite',
+                            key: const Key('category_favorite'),
+                            initialValue: state.categoryDefinition.favorite,
+                            title: context
+                                .messages.settingsMeasurableFavoriteLabel,
+                            activeColor: starredGold,
+                          ),
                           inputSpacer,
                           SelectColorField(
                             hexColor: state.categoryDefinition.color,

--- a/lib/services/entities_cache_service.dart
+++ b/lib/services/entities_cache_service.dart
@@ -48,7 +48,7 @@ class EntitiesCacheService {
   Map<String, DashboardDefinition> dashboardsById = {};
 
   List<CategoryDefinition> get sortedCategories {
-    final res = categoriesById.values.toList()
+    final res = categoriesById.values.where((e) => e.active).toList()
       ..sortBy((category) => category.name);
     return res;
   }

--- a/lib/widgets/search/task_category_filter.dart
+++ b/lib/widgets/search/task_category_filter.dart
@@ -9,14 +9,25 @@ import 'package:lotti/themes/theme.dart';
 import 'package:lotti/utils/color.dart';
 import 'package:lotti/widgets/search/filter_choice_chip.dart';
 
-class TaskCategoryFilter extends StatelessWidget {
+class TaskCategoryFilter extends StatefulWidget {
   const TaskCategoryFilter({super.key});
+
+  @override
+  State<TaskCategoryFilter> createState() => _TaskCategoryFilterState();
+}
+
+class _TaskCategoryFilterState extends State<TaskCategoryFilter> {
+  bool _showAll = false;
 
   @override
   Widget build(BuildContext context) {
     final categories = getIt<EntitiesCacheService>().sortedCategories;
 
-    if (categories.isEmpty) {
+    final filteredCategories = _showAll
+        ? categories
+        : categories.where((category) => category.favorite ?? false).toList();
+
+    if (filteredCategories.isEmpty) {
       return const SizedBox.shrink();
     }
 
@@ -37,7 +48,7 @@ class TaskCategoryFilter extends StatelessWidget {
               spacing: 8,
               runSpacing: 8,
               children: [
-                ...categories.map((category) {
+                ...filteredCategories.map((category) {
                   final isSelected =
                       state.selectedCategoryIds.contains(category.id);
                   final color = colorFromCssHex(category.color);
@@ -56,6 +67,15 @@ class TaskCategoryFilter extends StatelessWidget {
                   selectedColor: Colors.grey,
                   isSelected: state.selectedCategoryIds.contains(''),
                 ),
+                if (!_showAll)
+                  FilterChoiceChip(
+                    onTap: () => setState(() {
+                      _showAll = !_showAll;
+                    }),
+                    label: '...',
+                    selectedColor: Colors.grey,
+                    isSelected: _showAll,
+                  ),
               ],
             ),
           ],

--- a/lib/widgets/settings/categories/categories_type_card.dart
+++ b/lib/widgets/settings/categories/categories_type_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/entities_cache_service.dart';
+import 'package:lotti/themes/colors.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/utils/color.dart';
 import 'package:lotti/widgets/journal/entry_tools.dart';
@@ -32,6 +33,16 @@ class CategoriesTypeCard extends StatelessWidget {
             child: Icon(
               MdiIcons.security,
               color: context.colorScheme.error,
+              size: settingsIconSize,
+            ),
+          ),
+          Visibility(
+            visible: fromNullableBool(
+              categoryDefinition.favorite ?? false,
+            ),
+            child: Icon(
+              MdiIcons.star,
+              color: starredGold,
               size: settingsIconSize,
             ),
           ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -410,26 +410,26 @@ packages:
     dependency: transitive
     description:
       name: custom_lint
-      sha256: "7c0aec12df22f9082146c354692056677f1e70bc43471644d1fdb36c6fdda799"
+      sha256: "4939d89e580c36215e48a7de8fd92f22c79dcc3eb11fda84f3402b3b45aec663"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.5"
   custom_lint_builder:
     dependency: transitive
     description:
       name: custom_lint_builder
-      sha256: d7dc41e709dde223806660268678be7993559e523eb3164e2a1425fd6f7615a9
+      sha256: d9e5bb63ed52c1d006f5a1828992ba6de124c27a531e8fba0a31afffa81621b3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.5"
   custom_lint_core:
     dependency: transitive
     description:
       name: custom_lint_core
-      sha256: a85e8f78f4c52f6c63cdaf8c872eb573db0231dcdf3c3a5906d493c1f8bc20e6
+      sha256: "4ddbbdaa774265de44c97054dcec058a83d9081d071785ece601e348c18c267d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.5"
   dart_console:
     dependency: transitive
     description:
@@ -458,10 +458,10 @@ packages:
     dependency: transitive
     description:
       name: dart_quill_delta
-      sha256: "06f69b160456b8cce3c7dfc1120299f502751734ce19b5303514089d4776629c"
+      sha256: "2c971507ae2e235d7afbfcd0c25ce831bf6865685923cb19f8cb2581d682c5fb"
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.10"
+    version: "10.2.0"
   dart_style:
     dependency: "direct dev"
     description:
@@ -635,10 +635,10 @@ packages:
     dependency: transitive
     description:
       name: extended_image_library
-      sha256: c9caee8fe9b6547bd41c960c4f2d1ef8e34321804de6a1777f1d614a24247ad6
+      sha256: "9a94ec9314aa206cfa35f16145c3cd6e2c924badcc670eaaca8a3a8063a68cd7"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.4"
+    version: "4.0.5"
   fake_async:
     dependency: transitive
     description:
@@ -1011,10 +1011,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_quill
-      sha256: "848a554c10e084de303037781b3670d2a145c2017b2d52ff198389d6d9cd5576"
+      sha256: d92ce023a84f92b4ca5cceb6bbfe73c87232092282570f3dc29a22edd54cb46d
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.10"
+    version: "10.2.0"
   flutter_quill_delta_from_html:
     dependency: transitive
     description:
@@ -1776,10 +1776,10 @@ packages:
     dependency: "direct dev"
     description:
       name: msix
-      sha256: "519b183d15dc9f9c594f247e2d2339d855cf0eaacc30e19b128e14f3ecc62047"
+      sha256: c50d6bd1aafe0d071a3c1e5a5ccb056404502935cb0a549e3178c4aae16caf33
       url: "https://pub.dev"
     source: hosted
-    version: "3.16.7"
+    version: "3.16.8"
   multi_select_flutter:
     dependency: "direct main"
     description:
@@ -2973,10 +2973,10 @@ packages:
     dependency: "direct main"
     description:
       name: wechat_assets_picker
-      sha256: dc44a6f0c8493cf0a53f7bffc92ae3403e22a063dc109bc486bfefa137b60a20
+      sha256: "04b695235aba08aafc1eda255d65582d555c1515fd46d1766a6df063aa5c047a"
       url: "https://pub.dev"
     source: hosted
-    version: "9.2.0"
+    version: "9.2.1"
   wechat_picker_library:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.501+2647
+version: 0.9.501+2648
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.500+2646
+version: 0.9.501+2647
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR adds a favorite flag in category definitions, which is then used to only show favorite categories by default when filtering tasks. A `...` button is also added which allows expanding the categories to choose from in the filter to all active categories.