### PR TITLE
chore: revert drift update & update dependencies

### DIFF
--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -5561,6 +5561,119 @@ typedef $JournalUpdateCompanionBuilder = JournalCompanion Function({
   Value<int> rowid,
 });
 
+class $JournalTableManager extends RootTableManager<
+    _$JournalDb,
+    Journal,
+    JournalDbEntity,
+    $JournalFilterComposer,
+    $JournalOrderingComposer,
+    $JournalCreateCompanionBuilder,
+    $JournalUpdateCompanionBuilder> {
+  $JournalTableManager(_$JournalDb db, Journal table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer: $JournalFilterComposer(ComposerState(db, table)),
+          orderingComposer: $JournalOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<String> id = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime> updatedAt = const Value.absent(),
+            Value<DateTime> dateFrom = const Value.absent(),
+            Value<DateTime> dateTo = const Value.absent(),
+            Value<bool> deleted = const Value.absent(),
+            Value<bool> starred = const Value.absent(),
+            Value<bool> private = const Value.absent(),
+            Value<bool> task = const Value.absent(),
+            Value<String?> taskStatus = const Value.absent(),
+            Value<int> flag = const Value.absent(),
+            Value<String> type = const Value.absent(),
+            Value<String?> subtype = const Value.absent(),
+            Value<String> serialized = const Value.absent(),
+            Value<int> schemaVersion = const Value.absent(),
+            Value<String?> plainText = const Value.absent(),
+            Value<double?> latitude = const Value.absent(),
+            Value<double?> longitude = const Value.absent(),
+            Value<String?> geohashString = const Value.absent(),
+            Value<int?> geohashInt = const Value.absent(),
+            Value<String> category = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              JournalCompanion(
+            id: id,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            dateFrom: dateFrom,
+            dateTo: dateTo,
+            deleted: deleted,
+            starred: starred,
+            private: private,
+            task: task,
+            taskStatus: taskStatus,
+            flag: flag,
+            type: type,
+            subtype: subtype,
+            serialized: serialized,
+            schemaVersion: schemaVersion,
+            plainText: plainText,
+            latitude: latitude,
+            longitude: longitude,
+            geohashString: geohashString,
+            geohashInt: geohashInt,
+            category: category,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required String id,
+            required DateTime createdAt,
+            required DateTime updatedAt,
+            required DateTime dateFrom,
+            required DateTime dateTo,
+            Value<bool> deleted = const Value.absent(),
+            Value<bool> starred = const Value.absent(),
+            Value<bool> private = const Value.absent(),
+            Value<bool> task = const Value.absent(),
+            Value<String?> taskStatus = const Value.absent(),
+            Value<int> flag = const Value.absent(),
+            required String type,
+            Value<String?> subtype = const Value.absent(),
+            required String serialized,
+            Value<int> schemaVersion = const Value.absent(),
+            Value<String?> plainText = const Value.absent(),
+            Value<double?> latitude = const Value.absent(),
+            Value<double?> longitude = const Value.absent(),
+            Value<String?> geohashString = const Value.absent(),
+            Value<int?> geohashInt = const Value.absent(),
+            Value<String> category = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              JournalCompanion.insert(
+            id: id,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            dateFrom: dateFrom,
+            dateTo: dateTo,
+            deleted: deleted,
+            starred: starred,
+            private: private,
+            task: task,
+            taskStatus: taskStatus,
+            flag: flag,
+            type: type,
+            subtype: subtype,
+            serialized: serialized,
+            schemaVersion: schemaVersion,
+            plainText: plainText,
+            latitude: latitude,
+            longitude: longitude,
+            geohashString: geohashString,
+            geohashInt: geohashInt,
+            category: category,
+            rowid: rowid,
+          ),
+        ));
+}
+
 class $JournalFilterComposer extends FilterComposer<_$JournalDb, Journal> {
   $JournalFilterComposer(super.$state);
   ColumnFilters<String> get id => $state.composableBuilder(
@@ -5777,137 +5890,6 @@ class $JournalOrderingComposer extends OrderingComposer<_$JournalDb, Journal> {
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $JournalTableManager extends RootTableManager<
-    _$JournalDb,
-    Journal,
-    JournalDbEntity,
-    $JournalFilterComposer,
-    $JournalOrderingComposer,
-    $JournalCreateCompanionBuilder,
-    $JournalUpdateCompanionBuilder,
-    (JournalDbEntity, BaseReferences<_$JournalDb, Journal, JournalDbEntity>),
-    JournalDbEntity,
-    PrefetchHooks Function()> {
-  $JournalTableManager(_$JournalDb db, Journal table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer: $JournalFilterComposer(ComposerState(db, table)),
-          orderingComposer: $JournalOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<String> id = const Value.absent(),
-            Value<DateTime> createdAt = const Value.absent(),
-            Value<DateTime> updatedAt = const Value.absent(),
-            Value<DateTime> dateFrom = const Value.absent(),
-            Value<DateTime> dateTo = const Value.absent(),
-            Value<bool> deleted = const Value.absent(),
-            Value<bool> starred = const Value.absent(),
-            Value<bool> private = const Value.absent(),
-            Value<bool> task = const Value.absent(),
-            Value<String?> taskStatus = const Value.absent(),
-            Value<int> flag = const Value.absent(),
-            Value<String> type = const Value.absent(),
-            Value<String?> subtype = const Value.absent(),
-            Value<String> serialized = const Value.absent(),
-            Value<int> schemaVersion = const Value.absent(),
-            Value<String?> plainText = const Value.absent(),
-            Value<double?> latitude = const Value.absent(),
-            Value<double?> longitude = const Value.absent(),
-            Value<String?> geohashString = const Value.absent(),
-            Value<int?> geohashInt = const Value.absent(),
-            Value<String> category = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              JournalCompanion(
-            id: id,
-            createdAt: createdAt,
-            updatedAt: updatedAt,
-            dateFrom: dateFrom,
-            dateTo: dateTo,
-            deleted: deleted,
-            starred: starred,
-            private: private,
-            task: task,
-            taskStatus: taskStatus,
-            flag: flag,
-            type: type,
-            subtype: subtype,
-            serialized: serialized,
-            schemaVersion: schemaVersion,
-            plainText: plainText,
-            latitude: latitude,
-            longitude: longitude,
-            geohashString: geohashString,
-            geohashInt: geohashInt,
-            category: category,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required String id,
-            required DateTime createdAt,
-            required DateTime updatedAt,
-            required DateTime dateFrom,
-            required DateTime dateTo,
-            Value<bool> deleted = const Value.absent(),
-            Value<bool> starred = const Value.absent(),
-            Value<bool> private = const Value.absent(),
-            Value<bool> task = const Value.absent(),
-            Value<String?> taskStatus = const Value.absent(),
-            Value<int> flag = const Value.absent(),
-            required String type,
-            Value<String?> subtype = const Value.absent(),
-            required String serialized,
-            Value<int> schemaVersion = const Value.absent(),
-            Value<String?> plainText = const Value.absent(),
-            Value<double?> latitude = const Value.absent(),
-            Value<double?> longitude = const Value.absent(),
-            Value<String?> geohashString = const Value.absent(),
-            Value<int?> geohashInt = const Value.absent(),
-            Value<String> category = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              JournalCompanion.insert(
-            id: id,
-            createdAt: createdAt,
-            updatedAt: updatedAt,
-            dateFrom: dateFrom,
-            dateTo: dateTo,
-            deleted: deleted,
-            starred: starred,
-            private: private,
-            task: task,
-            taskStatus: taskStatus,
-            flag: flag,
-            type: type,
-            subtype: subtype,
-            serialized: serialized,
-            schemaVersion: schemaVersion,
-            plainText: plainText,
-            latitude: latitude,
-            longitude: longitude,
-            geohashString: geohashString,
-            geohashInt: geohashInt,
-            category: category,
-            rowid: rowid,
-          ),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
-              .toList(),
-          prefetchHooksCallback: null,
-        ));
-}
-
-typedef $JournalProcessedTableManager = ProcessedTableManager<
-    _$JournalDb,
-    Journal,
-    JournalDbEntity,
-    $JournalFilterComposer,
-    $JournalOrderingComposer,
-    $JournalCreateCompanionBuilder,
-    $JournalUpdateCompanionBuilder,
-    (JournalDbEntity, BaseReferences<_$JournalDb, Journal, JournalDbEntity>),
-    JournalDbEntity,
-    PrefetchHooks Function()>;
 typedef $ConflictsCreateCompanionBuilder = ConflictsCompanion Function({
   required String id,
   required DateTime createdAt,
@@ -5926,6 +5908,60 @@ typedef $ConflictsUpdateCompanionBuilder = ConflictsCompanion Function({
   Value<int> status,
   Value<int> rowid,
 });
+
+class $ConflictsTableManager extends RootTableManager<
+    _$JournalDb,
+    Conflicts,
+    Conflict,
+    $ConflictsFilterComposer,
+    $ConflictsOrderingComposer,
+    $ConflictsCreateCompanionBuilder,
+    $ConflictsUpdateCompanionBuilder> {
+  $ConflictsTableManager(_$JournalDb db, Conflicts table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer: $ConflictsFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $ConflictsOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<String> id = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime> updatedAt = const Value.absent(),
+            Value<String> serialized = const Value.absent(),
+            Value<int> schemaVersion = const Value.absent(),
+            Value<int> status = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              ConflictsCompanion(
+            id: id,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            serialized: serialized,
+            schemaVersion: schemaVersion,
+            status: status,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required String id,
+            required DateTime createdAt,
+            required DateTime updatedAt,
+            required String serialized,
+            Value<int> schemaVersion = const Value.absent(),
+            required int status,
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              ConflictsCompanion.insert(
+            id: id,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            serialized: serialized,
+            schemaVersion: schemaVersion,
+            status: status,
+            rowid: rowid,
+          ),
+        ));
+}
 
 class $ConflictsFilterComposer extends FilterComposer<_$JournalDb, Conflicts> {
   $ConflictsFilterComposer(super.$state);
@@ -5994,78 +6030,6 @@ class $ConflictsOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $ConflictsTableManager extends RootTableManager<
-    _$JournalDb,
-    Conflicts,
-    Conflict,
-    $ConflictsFilterComposer,
-    $ConflictsOrderingComposer,
-    $ConflictsCreateCompanionBuilder,
-    $ConflictsUpdateCompanionBuilder,
-    (Conflict, BaseReferences<_$JournalDb, Conflicts, Conflict>),
-    Conflict,
-    PrefetchHooks Function()> {
-  $ConflictsTableManager(_$JournalDb db, Conflicts table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer: $ConflictsFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $ConflictsOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<String> id = const Value.absent(),
-            Value<DateTime> createdAt = const Value.absent(),
-            Value<DateTime> updatedAt = const Value.absent(),
-            Value<String> serialized = const Value.absent(),
-            Value<int> schemaVersion = const Value.absent(),
-            Value<int> status = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              ConflictsCompanion(
-            id: id,
-            createdAt: createdAt,
-            updatedAt: updatedAt,
-            serialized: serialized,
-            schemaVersion: schemaVersion,
-            status: status,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required String id,
-            required DateTime createdAt,
-            required DateTime updatedAt,
-            required String serialized,
-            Value<int> schemaVersion = const Value.absent(),
-            required int status,
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              ConflictsCompanion.insert(
-            id: id,
-            createdAt: createdAt,
-            updatedAt: updatedAt,
-            serialized: serialized,
-            schemaVersion: schemaVersion,
-            status: status,
-            rowid: rowid,
-          ),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
-              .toList(),
-          prefetchHooksCallback: null,
-        ));
-}
-
-typedef $ConflictsProcessedTableManager = ProcessedTableManager<
-    _$JournalDb,
-    Conflicts,
-    Conflict,
-    $ConflictsFilterComposer,
-    $ConflictsOrderingComposer,
-    $ConflictsCreateCompanionBuilder,
-    $ConflictsUpdateCompanionBuilder,
-    (Conflict, BaseReferences<_$JournalDb, Conflicts, Conflict>),
-    Conflict,
-    PrefetchHooks Function()>;
 typedef $MeasurableTypesCreateCompanionBuilder = MeasurableTypesCompanion
     Function({
   required String id,
@@ -6092,6 +6056,73 @@ typedef $MeasurableTypesUpdateCompanionBuilder = MeasurableTypesCompanion
   Value<int> status,
   Value<int> rowid,
 });
+
+class $MeasurableTypesTableManager extends RootTableManager<
+    _$JournalDb,
+    MeasurableTypes,
+    MeasurableDbEntity,
+    $MeasurableTypesFilterComposer,
+    $MeasurableTypesOrderingComposer,
+    $MeasurableTypesCreateCompanionBuilder,
+    $MeasurableTypesUpdateCompanionBuilder> {
+  $MeasurableTypesTableManager(_$JournalDb db, MeasurableTypes table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $MeasurableTypesFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $MeasurableTypesOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<String> id = const Value.absent(),
+            Value<String> uniqueName = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime> updatedAt = const Value.absent(),
+            Value<bool> deleted = const Value.absent(),
+            Value<bool> private = const Value.absent(),
+            Value<String> serialized = const Value.absent(),
+            Value<int> version = const Value.absent(),
+            Value<int> status = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              MeasurableTypesCompanion(
+            id: id,
+            uniqueName: uniqueName,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            deleted: deleted,
+            private: private,
+            serialized: serialized,
+            version: version,
+            status: status,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required String id,
+            required String uniqueName,
+            required DateTime createdAt,
+            required DateTime updatedAt,
+            Value<bool> deleted = const Value.absent(),
+            Value<bool> private = const Value.absent(),
+            required String serialized,
+            Value<int> version = const Value.absent(),
+            required int status,
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              MeasurableTypesCompanion.insert(
+            id: id,
+            uniqueName: uniqueName,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            deleted: deleted,
+            private: private,
+            serialized: serialized,
+            version: version,
+            status: status,
+            rowid: rowid,
+          ),
+        ));
+}
 
 class $MeasurableTypesFilterComposer
     extends FilterComposer<_$JournalDb, MeasurableTypes> {
@@ -6191,97 +6222,6 @@ class $MeasurableTypesOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $MeasurableTypesTableManager extends RootTableManager<
-    _$JournalDb,
-    MeasurableTypes,
-    MeasurableDbEntity,
-    $MeasurableTypesFilterComposer,
-    $MeasurableTypesOrderingComposer,
-    $MeasurableTypesCreateCompanionBuilder,
-    $MeasurableTypesUpdateCompanionBuilder,
-    (
-      MeasurableDbEntity,
-      BaseReferences<_$JournalDb, MeasurableTypes, MeasurableDbEntity>
-    ),
-    MeasurableDbEntity,
-    PrefetchHooks Function()> {
-  $MeasurableTypesTableManager(_$JournalDb db, MeasurableTypes table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $MeasurableTypesFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $MeasurableTypesOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<String> id = const Value.absent(),
-            Value<String> uniqueName = const Value.absent(),
-            Value<DateTime> createdAt = const Value.absent(),
-            Value<DateTime> updatedAt = const Value.absent(),
-            Value<bool> deleted = const Value.absent(),
-            Value<bool> private = const Value.absent(),
-            Value<String> serialized = const Value.absent(),
-            Value<int> version = const Value.absent(),
-            Value<int> status = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              MeasurableTypesCompanion(
-            id: id,
-            uniqueName: uniqueName,
-            createdAt: createdAt,
-            updatedAt: updatedAt,
-            deleted: deleted,
-            private: private,
-            serialized: serialized,
-            version: version,
-            status: status,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required String id,
-            required String uniqueName,
-            required DateTime createdAt,
-            required DateTime updatedAt,
-            Value<bool> deleted = const Value.absent(),
-            Value<bool> private = const Value.absent(),
-            required String serialized,
-            Value<int> version = const Value.absent(),
-            required int status,
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              MeasurableTypesCompanion.insert(
-            id: id,
-            uniqueName: uniqueName,
-            createdAt: createdAt,
-            updatedAt: updatedAt,
-            deleted: deleted,
-            private: private,
-            serialized: serialized,
-            version: version,
-            status: status,
-            rowid: rowid,
-          ),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
-              .toList(),
-          prefetchHooksCallback: null,
-        ));
-}
-
-typedef $MeasurableTypesProcessedTableManager = ProcessedTableManager<
-    _$JournalDb,
-    MeasurableTypes,
-    MeasurableDbEntity,
-    $MeasurableTypesFilterComposer,
-    $MeasurableTypesOrderingComposer,
-    $MeasurableTypesCreateCompanionBuilder,
-    $MeasurableTypesUpdateCompanionBuilder,
-    (
-      MeasurableDbEntity,
-      BaseReferences<_$JournalDb, MeasurableTypes, MeasurableDbEntity>
-    ),
-    MeasurableDbEntity,
-    PrefetchHooks Function()>;
 typedef $HabitDefinitionsCreateCompanionBuilder = HabitDefinitionsCompanion
     Function({
   required String id,
@@ -6306,6 +6246,69 @@ typedef $HabitDefinitionsUpdateCompanionBuilder = HabitDefinitionsCompanion
   Value<bool> active,
   Value<int> rowid,
 });
+
+class $HabitDefinitionsTableManager extends RootTableManager<
+    _$JournalDb,
+    HabitDefinitions,
+    HabitDefinitionDbEntity,
+    $HabitDefinitionsFilterComposer,
+    $HabitDefinitionsOrderingComposer,
+    $HabitDefinitionsCreateCompanionBuilder,
+    $HabitDefinitionsUpdateCompanionBuilder> {
+  $HabitDefinitionsTableManager(_$JournalDb db, HabitDefinitions table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $HabitDefinitionsFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $HabitDefinitionsOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<String> id = const Value.absent(),
+            Value<String> name = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime> updatedAt = const Value.absent(),
+            Value<bool> deleted = const Value.absent(),
+            Value<bool> private = const Value.absent(),
+            Value<String> serialized = const Value.absent(),
+            Value<bool> active = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              HabitDefinitionsCompanion(
+            id: id,
+            name: name,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            deleted: deleted,
+            private: private,
+            serialized: serialized,
+            active: active,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required String id,
+            required String name,
+            required DateTime createdAt,
+            required DateTime updatedAt,
+            Value<bool> deleted = const Value.absent(),
+            Value<bool> private = const Value.absent(),
+            required String serialized,
+            required bool active,
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              HabitDefinitionsCompanion.insert(
+            id: id,
+            name: name,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            deleted: deleted,
+            private: private,
+            serialized: serialized,
+            active: active,
+            rowid: rowid,
+          ),
+        ));
+}
 
 class $HabitDefinitionsFilterComposer
     extends FilterComposer<_$JournalDb, HabitDefinitions> {
@@ -6395,93 +6398,6 @@ class $HabitDefinitionsOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $HabitDefinitionsTableManager extends RootTableManager<
-    _$JournalDb,
-    HabitDefinitions,
-    HabitDefinitionDbEntity,
-    $HabitDefinitionsFilterComposer,
-    $HabitDefinitionsOrderingComposer,
-    $HabitDefinitionsCreateCompanionBuilder,
-    $HabitDefinitionsUpdateCompanionBuilder,
-    (
-      HabitDefinitionDbEntity,
-      BaseReferences<_$JournalDb, HabitDefinitions, HabitDefinitionDbEntity>
-    ),
-    HabitDefinitionDbEntity,
-    PrefetchHooks Function()> {
-  $HabitDefinitionsTableManager(_$JournalDb db, HabitDefinitions table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $HabitDefinitionsFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $HabitDefinitionsOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<String> id = const Value.absent(),
-            Value<String> name = const Value.absent(),
-            Value<DateTime> createdAt = const Value.absent(),
-            Value<DateTime> updatedAt = const Value.absent(),
-            Value<bool> deleted = const Value.absent(),
-            Value<bool> private = const Value.absent(),
-            Value<String> serialized = const Value.absent(),
-            Value<bool> active = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              HabitDefinitionsCompanion(
-            id: id,
-            name: name,
-            createdAt: createdAt,
-            updatedAt: updatedAt,
-            deleted: deleted,
-            private: private,
-            serialized: serialized,
-            active: active,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required String id,
-            required String name,
-            required DateTime createdAt,
-            required DateTime updatedAt,
-            Value<bool> deleted = const Value.absent(),
-            Value<bool> private = const Value.absent(),
-            required String serialized,
-            required bool active,
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              HabitDefinitionsCompanion.insert(
-            id: id,
-            name: name,
-            createdAt: createdAt,
-            updatedAt: updatedAt,
-            deleted: deleted,
-            private: private,
-            serialized: serialized,
-            active: active,
-            rowid: rowid,
-          ),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
-              .toList(),
-          prefetchHooksCallback: null,
-        ));
-}
-
-typedef $HabitDefinitionsProcessedTableManager = ProcessedTableManager<
-    _$JournalDb,
-    HabitDefinitions,
-    HabitDefinitionDbEntity,
-    $HabitDefinitionsFilterComposer,
-    $HabitDefinitionsOrderingComposer,
-    $HabitDefinitionsCreateCompanionBuilder,
-    $HabitDefinitionsUpdateCompanionBuilder,
-    (
-      HabitDefinitionDbEntity,
-      BaseReferences<_$JournalDb, HabitDefinitions, HabitDefinitionDbEntity>
-    ),
-    HabitDefinitionDbEntity,
-    PrefetchHooks Function()>;
 typedef $CategoryDefinitionsCreateCompanionBuilder
     = CategoryDefinitionsCompanion Function({
   required String id,
@@ -6506,6 +6422,69 @@ typedef $CategoryDefinitionsUpdateCompanionBuilder
   Value<bool> active,
   Value<int> rowid,
 });
+
+class $CategoryDefinitionsTableManager extends RootTableManager<
+    _$JournalDb,
+    CategoryDefinitions,
+    CategoryDefinitionDbEntity,
+    $CategoryDefinitionsFilterComposer,
+    $CategoryDefinitionsOrderingComposer,
+    $CategoryDefinitionsCreateCompanionBuilder,
+    $CategoryDefinitionsUpdateCompanionBuilder> {
+  $CategoryDefinitionsTableManager(_$JournalDb db, CategoryDefinitions table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $CategoryDefinitionsFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $CategoryDefinitionsOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<String> id = const Value.absent(),
+            Value<String> name = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime> updatedAt = const Value.absent(),
+            Value<bool> deleted = const Value.absent(),
+            Value<bool> private = const Value.absent(),
+            Value<String> serialized = const Value.absent(),
+            Value<bool> active = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              CategoryDefinitionsCompanion(
+            id: id,
+            name: name,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            deleted: deleted,
+            private: private,
+            serialized: serialized,
+            active: active,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required String id,
+            required String name,
+            required DateTime createdAt,
+            required DateTime updatedAt,
+            Value<bool> deleted = const Value.absent(),
+            Value<bool> private = const Value.absent(),
+            required String serialized,
+            required bool active,
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              CategoryDefinitionsCompanion.insert(
+            id: id,
+            name: name,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            deleted: deleted,
+            private: private,
+            serialized: serialized,
+            active: active,
+            rowid: rowid,
+          ),
+        ));
+}
 
 class $CategoryDefinitionsFilterComposer
     extends FilterComposer<_$JournalDb, CategoryDefinitions> {
@@ -6595,95 +6574,6 @@ class $CategoryDefinitionsOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $CategoryDefinitionsTableManager extends RootTableManager<
-    _$JournalDb,
-    CategoryDefinitions,
-    CategoryDefinitionDbEntity,
-    $CategoryDefinitionsFilterComposer,
-    $CategoryDefinitionsOrderingComposer,
-    $CategoryDefinitionsCreateCompanionBuilder,
-    $CategoryDefinitionsUpdateCompanionBuilder,
-    (
-      CategoryDefinitionDbEntity,
-      BaseReferences<_$JournalDb, CategoryDefinitions,
-          CategoryDefinitionDbEntity>
-    ),
-    CategoryDefinitionDbEntity,
-    PrefetchHooks Function()> {
-  $CategoryDefinitionsTableManager(_$JournalDb db, CategoryDefinitions table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $CategoryDefinitionsFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $CategoryDefinitionsOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<String> id = const Value.absent(),
-            Value<String> name = const Value.absent(),
-            Value<DateTime> createdAt = const Value.absent(),
-            Value<DateTime> updatedAt = const Value.absent(),
-            Value<bool> deleted = const Value.absent(),
-            Value<bool> private = const Value.absent(),
-            Value<String> serialized = const Value.absent(),
-            Value<bool> active = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              CategoryDefinitionsCompanion(
-            id: id,
-            name: name,
-            createdAt: createdAt,
-            updatedAt: updatedAt,
-            deleted: deleted,
-            private: private,
-            serialized: serialized,
-            active: active,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required String id,
-            required String name,
-            required DateTime createdAt,
-            required DateTime updatedAt,
-            Value<bool> deleted = const Value.absent(),
-            Value<bool> private = const Value.absent(),
-            required String serialized,
-            required bool active,
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              CategoryDefinitionsCompanion.insert(
-            id: id,
-            name: name,
-            createdAt: createdAt,
-            updatedAt: updatedAt,
-            deleted: deleted,
-            private: private,
-            serialized: serialized,
-            active: active,
-            rowid: rowid,
-          ),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
-              .toList(),
-          prefetchHooksCallback: null,
-        ));
-}
-
-typedef $CategoryDefinitionsProcessedTableManager = ProcessedTableManager<
-    _$JournalDb,
-    CategoryDefinitions,
-    CategoryDefinitionDbEntity,
-    $CategoryDefinitionsFilterComposer,
-    $CategoryDefinitionsOrderingComposer,
-    $CategoryDefinitionsCreateCompanionBuilder,
-    $CategoryDefinitionsUpdateCompanionBuilder,
-    (
-      CategoryDefinitionDbEntity,
-      BaseReferences<_$JournalDb, CategoryDefinitions,
-          CategoryDefinitionDbEntity>
-    ),
-    CategoryDefinitionDbEntity,
-    PrefetchHooks Function()>;
 typedef $DashboardDefinitionsCreateCompanionBuilder
     = DashboardDefinitionsCompanion Function({
   required String id,
@@ -6710,6 +6600,73 @@ typedef $DashboardDefinitionsUpdateCompanionBuilder
   Value<bool> active,
   Value<int> rowid,
 });
+
+class $DashboardDefinitionsTableManager extends RootTableManager<
+    _$JournalDb,
+    DashboardDefinitions,
+    DashboardDefinitionDbEntity,
+    $DashboardDefinitionsFilterComposer,
+    $DashboardDefinitionsOrderingComposer,
+    $DashboardDefinitionsCreateCompanionBuilder,
+    $DashboardDefinitionsUpdateCompanionBuilder> {
+  $DashboardDefinitionsTableManager(_$JournalDb db, DashboardDefinitions table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $DashboardDefinitionsFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $DashboardDefinitionsOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<String> id = const Value.absent(),
+            Value<String> name = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime> updatedAt = const Value.absent(),
+            Value<DateTime> lastReviewed = const Value.absent(),
+            Value<bool> deleted = const Value.absent(),
+            Value<bool> private = const Value.absent(),
+            Value<String> serialized = const Value.absent(),
+            Value<bool> active = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              DashboardDefinitionsCompanion(
+            id: id,
+            name: name,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            lastReviewed: lastReviewed,
+            deleted: deleted,
+            private: private,
+            serialized: serialized,
+            active: active,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required String id,
+            required String name,
+            required DateTime createdAt,
+            required DateTime updatedAt,
+            required DateTime lastReviewed,
+            Value<bool> deleted = const Value.absent(),
+            Value<bool> private = const Value.absent(),
+            required String serialized,
+            required bool active,
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              DashboardDefinitionsCompanion.insert(
+            id: id,
+            name: name,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            lastReviewed: lastReviewed,
+            deleted: deleted,
+            private: private,
+            serialized: serialized,
+            active: active,
+            rowid: rowid,
+          ),
+        ));
+}
 
 class $DashboardDefinitionsFilterComposer
     extends FilterComposer<_$JournalDb, DashboardDefinitions> {
@@ -6809,99 +6766,6 @@ class $DashboardDefinitionsOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $DashboardDefinitionsTableManager extends RootTableManager<
-    _$JournalDb,
-    DashboardDefinitions,
-    DashboardDefinitionDbEntity,
-    $DashboardDefinitionsFilterComposer,
-    $DashboardDefinitionsOrderingComposer,
-    $DashboardDefinitionsCreateCompanionBuilder,
-    $DashboardDefinitionsUpdateCompanionBuilder,
-    (
-      DashboardDefinitionDbEntity,
-      BaseReferences<_$JournalDb, DashboardDefinitions,
-          DashboardDefinitionDbEntity>
-    ),
-    DashboardDefinitionDbEntity,
-    PrefetchHooks Function()> {
-  $DashboardDefinitionsTableManager(_$JournalDb db, DashboardDefinitions table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $DashboardDefinitionsFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $DashboardDefinitionsOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<String> id = const Value.absent(),
-            Value<String> name = const Value.absent(),
-            Value<DateTime> createdAt = const Value.absent(),
-            Value<DateTime> updatedAt = const Value.absent(),
-            Value<DateTime> lastReviewed = const Value.absent(),
-            Value<bool> deleted = const Value.absent(),
-            Value<bool> private = const Value.absent(),
-            Value<String> serialized = const Value.absent(),
-            Value<bool> active = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              DashboardDefinitionsCompanion(
-            id: id,
-            name: name,
-            createdAt: createdAt,
-            updatedAt: updatedAt,
-            lastReviewed: lastReviewed,
-            deleted: deleted,
-            private: private,
-            serialized: serialized,
-            active: active,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required String id,
-            required String name,
-            required DateTime createdAt,
-            required DateTime updatedAt,
-            required DateTime lastReviewed,
-            Value<bool> deleted = const Value.absent(),
-            Value<bool> private = const Value.absent(),
-            required String serialized,
-            required bool active,
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              DashboardDefinitionsCompanion.insert(
-            id: id,
-            name: name,
-            createdAt: createdAt,
-            updatedAt: updatedAt,
-            lastReviewed: lastReviewed,
-            deleted: deleted,
-            private: private,
-            serialized: serialized,
-            active: active,
-            rowid: rowid,
-          ),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
-              .toList(),
-          prefetchHooksCallback: null,
-        ));
-}
-
-typedef $DashboardDefinitionsProcessedTableManager = ProcessedTableManager<
-    _$JournalDb,
-    DashboardDefinitions,
-    DashboardDefinitionDbEntity,
-    $DashboardDefinitionsFilterComposer,
-    $DashboardDefinitionsOrderingComposer,
-    $DashboardDefinitionsCreateCompanionBuilder,
-    $DashboardDefinitionsUpdateCompanionBuilder,
-    (
-      DashboardDefinitionDbEntity,
-      BaseReferences<_$JournalDb, DashboardDefinitions,
-          DashboardDefinitionDbEntity>
-    ),
-    DashboardDefinitionDbEntity,
-    PrefetchHooks Function()>;
 typedef $ConfigFlagsCreateCompanionBuilder = ConfigFlagsCompanion Function({
   required String name,
   required String description,
@@ -6914,6 +6778,49 @@ typedef $ConfigFlagsUpdateCompanionBuilder = ConfigFlagsCompanion Function({
   Value<bool> status,
   Value<int> rowid,
 });
+
+class $ConfigFlagsTableManager extends RootTableManager<
+    _$JournalDb,
+    ConfigFlags,
+    ConfigFlag,
+    $ConfigFlagsFilterComposer,
+    $ConfigFlagsOrderingComposer,
+    $ConfigFlagsCreateCompanionBuilder,
+    $ConfigFlagsUpdateCompanionBuilder> {
+  $ConfigFlagsTableManager(_$JournalDb db, ConfigFlags table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $ConfigFlagsFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $ConfigFlagsOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<String> name = const Value.absent(),
+            Value<String> description = const Value.absent(),
+            Value<bool> status = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              ConfigFlagsCompanion(
+            name: name,
+            description: description,
+            status: status,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required String name,
+            required String description,
+            Value<bool> status = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              ConfigFlagsCompanion.insert(
+            name: name,
+            description: description,
+            status: status,
+            rowid: rowid,
+          ),
+        ));
+}
 
 class $ConfigFlagsFilterComposer
     extends FilterComposer<_$JournalDb, ConfigFlags> {
@@ -6953,67 +6860,6 @@ class $ConfigFlagsOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $ConfigFlagsTableManager extends RootTableManager<
-    _$JournalDb,
-    ConfigFlags,
-    ConfigFlag,
-    $ConfigFlagsFilterComposer,
-    $ConfigFlagsOrderingComposer,
-    $ConfigFlagsCreateCompanionBuilder,
-    $ConfigFlagsUpdateCompanionBuilder,
-    (ConfigFlag, BaseReferences<_$JournalDb, ConfigFlags, ConfigFlag>),
-    ConfigFlag,
-    PrefetchHooks Function()> {
-  $ConfigFlagsTableManager(_$JournalDb db, ConfigFlags table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $ConfigFlagsFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $ConfigFlagsOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<String> name = const Value.absent(),
-            Value<String> description = const Value.absent(),
-            Value<bool> status = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              ConfigFlagsCompanion(
-            name: name,
-            description: description,
-            status: status,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required String name,
-            required String description,
-            Value<bool> status = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              ConfigFlagsCompanion.insert(
-            name: name,
-            description: description,
-            status: status,
-            rowid: rowid,
-          ),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
-              .toList(),
-          prefetchHooksCallback: null,
-        ));
-}
-
-typedef $ConfigFlagsProcessedTableManager = ProcessedTableManager<
-    _$JournalDb,
-    ConfigFlags,
-    ConfigFlag,
-    $ConfigFlagsFilterComposer,
-    $ConfigFlagsOrderingComposer,
-    $ConfigFlagsCreateCompanionBuilder,
-    $ConfigFlagsUpdateCompanionBuilder,
-    (ConfigFlag, BaseReferences<_$JournalDb, ConfigFlags, ConfigFlag>),
-    ConfigFlag,
-    PrefetchHooks Function()>;
 typedef $TagEntitiesCreateCompanionBuilder = TagEntitiesCompanion Function({
   required String id,
   required String tag,
@@ -7038,6 +6884,73 @@ typedef $TagEntitiesUpdateCompanionBuilder = TagEntitiesCompanion Function({
   Value<String> serialized,
   Value<int> rowid,
 });
+
+class $TagEntitiesTableManager extends RootTableManager<
+    _$JournalDb,
+    TagEntities,
+    TagDbEntity,
+    $TagEntitiesFilterComposer,
+    $TagEntitiesOrderingComposer,
+    $TagEntitiesCreateCompanionBuilder,
+    $TagEntitiesUpdateCompanionBuilder> {
+  $TagEntitiesTableManager(_$JournalDb db, TagEntities table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $TagEntitiesFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $TagEntitiesOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<String> id = const Value.absent(),
+            Value<String> tag = const Value.absent(),
+            Value<String> type = const Value.absent(),
+            Value<bool?> inactive = const Value.absent(),
+            Value<bool> private = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime> updatedAt = const Value.absent(),
+            Value<bool?> deleted = const Value.absent(),
+            Value<String> serialized = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              TagEntitiesCompanion(
+            id: id,
+            tag: tag,
+            type: type,
+            inactive: inactive,
+            private: private,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            deleted: deleted,
+            serialized: serialized,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required String id,
+            required String tag,
+            required String type,
+            Value<bool?> inactive = const Value.absent(),
+            Value<bool> private = const Value.absent(),
+            required DateTime createdAt,
+            required DateTime updatedAt,
+            Value<bool?> deleted = const Value.absent(),
+            required String serialized,
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              TagEntitiesCompanion.insert(
+            id: id,
+            tag: tag,
+            type: type,
+            inactive: inactive,
+            private: private,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            deleted: deleted,
+            serialized: serialized,
+            rowid: rowid,
+          ),
+        ));
+}
 
 class $TagEntitiesFilterComposer
     extends FilterComposer<_$JournalDb, TagEntities> {
@@ -7137,91 +7050,6 @@ class $TagEntitiesOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $TagEntitiesTableManager extends RootTableManager<
-    _$JournalDb,
-    TagEntities,
-    TagDbEntity,
-    $TagEntitiesFilterComposer,
-    $TagEntitiesOrderingComposer,
-    $TagEntitiesCreateCompanionBuilder,
-    $TagEntitiesUpdateCompanionBuilder,
-    (TagDbEntity, BaseReferences<_$JournalDb, TagEntities, TagDbEntity>),
-    TagDbEntity,
-    PrefetchHooks Function()> {
-  $TagEntitiesTableManager(_$JournalDb db, TagEntities table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $TagEntitiesFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $TagEntitiesOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<String> id = const Value.absent(),
-            Value<String> tag = const Value.absent(),
-            Value<String> type = const Value.absent(),
-            Value<bool?> inactive = const Value.absent(),
-            Value<bool> private = const Value.absent(),
-            Value<DateTime> createdAt = const Value.absent(),
-            Value<DateTime> updatedAt = const Value.absent(),
-            Value<bool?> deleted = const Value.absent(),
-            Value<String> serialized = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              TagEntitiesCompanion(
-            id: id,
-            tag: tag,
-            type: type,
-            inactive: inactive,
-            private: private,
-            createdAt: createdAt,
-            updatedAt: updatedAt,
-            deleted: deleted,
-            serialized: serialized,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required String id,
-            required String tag,
-            required String type,
-            Value<bool?> inactive = const Value.absent(),
-            Value<bool> private = const Value.absent(),
-            required DateTime createdAt,
-            required DateTime updatedAt,
-            Value<bool?> deleted = const Value.absent(),
-            required String serialized,
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              TagEntitiesCompanion.insert(
-            id: id,
-            tag: tag,
-            type: type,
-            inactive: inactive,
-            private: private,
-            createdAt: createdAt,
-            updatedAt: updatedAt,
-            deleted: deleted,
-            serialized: serialized,
-            rowid: rowid,
-          ),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
-              .toList(),
-          prefetchHooksCallback: null,
-        ));
-}
-
-typedef $TagEntitiesProcessedTableManager = ProcessedTableManager<
-    _$JournalDb,
-    TagEntities,
-    TagDbEntity,
-    $TagEntitiesFilterComposer,
-    $TagEntitiesOrderingComposer,
-    $TagEntitiesCreateCompanionBuilder,
-    $TagEntitiesUpdateCompanionBuilder,
-    (TagDbEntity, BaseReferences<_$JournalDb, TagEntities, TagDbEntity>),
-    TagDbEntity,
-    PrefetchHooks Function()>;
 typedef $TaggedCreateCompanionBuilder = TaggedCompanion Function({
   required String id,
   required String journalId,
@@ -7234,6 +7062,47 @@ typedef $TaggedUpdateCompanionBuilder = TaggedCompanion Function({
   Value<String> tagEntityId,
   Value<int> rowid,
 });
+
+class $TaggedTableManager extends RootTableManager<
+    _$JournalDb,
+    Tagged,
+    TaggedWith,
+    $TaggedFilterComposer,
+    $TaggedOrderingComposer,
+    $TaggedCreateCompanionBuilder,
+    $TaggedUpdateCompanionBuilder> {
+  $TaggedTableManager(_$JournalDb db, Tagged table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer: $TaggedFilterComposer(ComposerState(db, table)),
+          orderingComposer: $TaggedOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<String> id = const Value.absent(),
+            Value<String> journalId = const Value.absent(),
+            Value<String> tagEntityId = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              TaggedCompanion(
+            id: id,
+            journalId: journalId,
+            tagEntityId: tagEntityId,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required String id,
+            required String journalId,
+            required String tagEntityId,
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              TaggedCompanion.insert(
+            id: id,
+            journalId: journalId,
+            tagEntityId: tagEntityId,
+            rowid: rowid,
+          ),
+        ));
+}
 
 class $TaggedFilterComposer extends FilterComposer<_$JournalDb, Tagged> {
   $TaggedFilterComposer(super.$state);
@@ -7271,65 +7140,6 @@ class $TaggedOrderingComposer extends OrderingComposer<_$JournalDb, Tagged> {
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $TaggedTableManager extends RootTableManager<
-    _$JournalDb,
-    Tagged,
-    TaggedWith,
-    $TaggedFilterComposer,
-    $TaggedOrderingComposer,
-    $TaggedCreateCompanionBuilder,
-    $TaggedUpdateCompanionBuilder,
-    (TaggedWith, BaseReferences<_$JournalDb, Tagged, TaggedWith>),
-    TaggedWith,
-    PrefetchHooks Function()> {
-  $TaggedTableManager(_$JournalDb db, Tagged table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer: $TaggedFilterComposer(ComposerState(db, table)),
-          orderingComposer: $TaggedOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<String> id = const Value.absent(),
-            Value<String> journalId = const Value.absent(),
-            Value<String> tagEntityId = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              TaggedCompanion(
-            id: id,
-            journalId: journalId,
-            tagEntityId: tagEntityId,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required String id,
-            required String journalId,
-            required String tagEntityId,
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              TaggedCompanion.insert(
-            id: id,
-            journalId: journalId,
-            tagEntityId: tagEntityId,
-            rowid: rowid,
-          ),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
-              .toList(),
-          prefetchHooksCallback: null,
-        ));
-}
-
-typedef $TaggedProcessedTableManager = ProcessedTableManager<
-    _$JournalDb,
-    Tagged,
-    TaggedWith,
-    $TaggedFilterComposer,
-    $TaggedOrderingComposer,
-    $TaggedCreateCompanionBuilder,
-    $TaggedUpdateCompanionBuilder,
-    (TaggedWith, BaseReferences<_$JournalDb, Tagged, TaggedWith>),
-    TaggedWith,
-    PrefetchHooks Function()>;
 typedef $LinkedEntriesCreateCompanionBuilder = LinkedEntriesCompanion Function({
   required String id,
   required String fromId,
@@ -7346,6 +7156,57 @@ typedef $LinkedEntriesUpdateCompanionBuilder = LinkedEntriesCompanion Function({
   Value<String> serialized,
   Value<int> rowid,
 });
+
+class $LinkedEntriesTableManager extends RootTableManager<
+    _$JournalDb,
+    LinkedEntries,
+    LinkedDbEntry,
+    $LinkedEntriesFilterComposer,
+    $LinkedEntriesOrderingComposer,
+    $LinkedEntriesCreateCompanionBuilder,
+    $LinkedEntriesUpdateCompanionBuilder> {
+  $LinkedEntriesTableManager(_$JournalDb db, LinkedEntries table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $LinkedEntriesFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $LinkedEntriesOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<String> id = const Value.absent(),
+            Value<String> fromId = const Value.absent(),
+            Value<String> toId = const Value.absent(),
+            Value<String> type = const Value.absent(),
+            Value<String> serialized = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              LinkedEntriesCompanion(
+            id: id,
+            fromId: fromId,
+            toId: toId,
+            type: type,
+            serialized: serialized,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required String id,
+            required String fromId,
+            required String toId,
+            required String type,
+            required String serialized,
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              LinkedEntriesCompanion.insert(
+            id: id,
+            fromId: fromId,
+            toId: toId,
+            type: type,
+            serialized: serialized,
+            rowid: rowid,
+          ),
+        ));
+}
 
 class $LinkedEntriesFilterComposer
     extends FilterComposer<_$JournalDb, LinkedEntries> {
@@ -7404,76 +7265,6 @@ class $LinkedEntriesOrderingComposer
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
-
-class $LinkedEntriesTableManager extends RootTableManager<
-    _$JournalDb,
-    LinkedEntries,
-    LinkedDbEntry,
-    $LinkedEntriesFilterComposer,
-    $LinkedEntriesOrderingComposer,
-    $LinkedEntriesCreateCompanionBuilder,
-    $LinkedEntriesUpdateCompanionBuilder,
-    (LinkedDbEntry, BaseReferences<_$JournalDb, LinkedEntries, LinkedDbEntry>),
-    LinkedDbEntry,
-    PrefetchHooks Function()> {
-  $LinkedEntriesTableManager(_$JournalDb db, LinkedEntries table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $LinkedEntriesFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $LinkedEntriesOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<String> id = const Value.absent(),
-            Value<String> fromId = const Value.absent(),
-            Value<String> toId = const Value.absent(),
-            Value<String> type = const Value.absent(),
-            Value<String> serialized = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              LinkedEntriesCompanion(
-            id: id,
-            fromId: fromId,
-            toId: toId,
-            type: type,
-            serialized: serialized,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required String id,
-            required String fromId,
-            required String toId,
-            required String type,
-            required String serialized,
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              LinkedEntriesCompanion.insert(
-            id: id,
-            fromId: fromId,
-            toId: toId,
-            type: type,
-            serialized: serialized,
-            rowid: rowid,
-          ),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
-              .toList(),
-          prefetchHooksCallback: null,
-        ));
-}
-
-typedef $LinkedEntriesProcessedTableManager = ProcessedTableManager<
-    _$JournalDb,
-    LinkedEntries,
-    LinkedDbEntry,
-    $LinkedEntriesFilterComposer,
-    $LinkedEntriesOrderingComposer,
-    $LinkedEntriesCreateCompanionBuilder,
-    $LinkedEntriesUpdateCompanionBuilder,
-    (LinkedDbEntry, BaseReferences<_$JournalDb, LinkedEntries, LinkedDbEntry>),
-    LinkedDbEntry,
-    PrefetchHooks Function()>;
 
 class $JournalDbManager {
   final _$JournalDb _db;

--- a/lib/database/editor_db.g.dart
+++ b/lib/database/editor_db.g.dart
@@ -426,6 +426,61 @@ typedef $EditorDraftsUpdateCompanionBuilder = EditorDraftsCompanion Function({
   Value<int> rowid,
 });
 
+class $EditorDraftsTableManager extends RootTableManager<
+    _$EditorDb,
+    EditorDrafts,
+    EditorDraftState,
+    $EditorDraftsFilterComposer,
+    $EditorDraftsOrderingComposer,
+    $EditorDraftsCreateCompanionBuilder,
+    $EditorDraftsUpdateCompanionBuilder> {
+  $EditorDraftsTableManager(_$EditorDb db, EditorDrafts table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $EditorDraftsFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $EditorDraftsOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<String> id = const Value.absent(),
+            Value<String> entryId = const Value.absent(),
+            Value<String> status = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime> lastSaved = const Value.absent(),
+            Value<String> delta = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              EditorDraftsCompanion(
+            id: id,
+            entryId: entryId,
+            status: status,
+            createdAt: createdAt,
+            lastSaved: lastSaved,
+            delta: delta,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required String id,
+            required String entryId,
+            required String status,
+            required DateTime createdAt,
+            required DateTime lastSaved,
+            required String delta,
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              EditorDraftsCompanion.insert(
+            id: id,
+            entryId: entryId,
+            status: status,
+            createdAt: createdAt,
+            lastSaved: lastSaved,
+            delta: delta,
+            rowid: rowid,
+          ),
+        ));
+}
+
 class $EditorDraftsFilterComposer
     extends FilterComposer<_$EditorDb, EditorDrafts> {
   $EditorDraftsFilterComposer(super.$state);
@@ -493,86 +548,6 @@ class $EditorDraftsOrderingComposer
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
-
-class $EditorDraftsTableManager extends RootTableManager<
-    _$EditorDb,
-    EditorDrafts,
-    EditorDraftState,
-    $EditorDraftsFilterComposer,
-    $EditorDraftsOrderingComposer,
-    $EditorDraftsCreateCompanionBuilder,
-    $EditorDraftsUpdateCompanionBuilder,
-    (
-      EditorDraftState,
-      BaseReferences<_$EditorDb, EditorDrafts, EditorDraftState>
-    ),
-    EditorDraftState,
-    PrefetchHooks Function()> {
-  $EditorDraftsTableManager(_$EditorDb db, EditorDrafts table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $EditorDraftsFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $EditorDraftsOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<String> id = const Value.absent(),
-            Value<String> entryId = const Value.absent(),
-            Value<String> status = const Value.absent(),
-            Value<DateTime> createdAt = const Value.absent(),
-            Value<DateTime> lastSaved = const Value.absent(),
-            Value<String> delta = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              EditorDraftsCompanion(
-            id: id,
-            entryId: entryId,
-            status: status,
-            createdAt: createdAt,
-            lastSaved: lastSaved,
-            delta: delta,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required String id,
-            required String entryId,
-            required String status,
-            required DateTime createdAt,
-            required DateTime lastSaved,
-            required String delta,
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              EditorDraftsCompanion.insert(
-            id: id,
-            entryId: entryId,
-            status: status,
-            createdAt: createdAt,
-            lastSaved: lastSaved,
-            delta: delta,
-            rowid: rowid,
-          ),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
-              .toList(),
-          prefetchHooksCallback: null,
-        ));
-}
-
-typedef $EditorDraftsProcessedTableManager = ProcessedTableManager<
-    _$EditorDb,
-    EditorDrafts,
-    EditorDraftState,
-    $EditorDraftsFilterComposer,
-    $EditorDraftsOrderingComposer,
-    $EditorDraftsCreateCompanionBuilder,
-    $EditorDraftsUpdateCompanionBuilder,
-    (
-      EditorDraftState,
-      BaseReferences<_$EditorDb, EditorDrafts, EditorDraftState>
-    ),
-    EditorDraftState,
-    PrefetchHooks Function()>;
 
 class $EditorDbManager {
   final _$EditorDb _db;

--- a/lib/database/fts5_db.g.dart
+++ b/lib/database/fts5_db.g.dart
@@ -386,6 +386,57 @@ typedef $JournalFtsUpdateCompanionBuilder = JournalFtsCompanion Function({
   Value<int> rowid,
 });
 
+class $JournalFtsTableManager extends RootTableManager<
+    _$Fts5Db,
+    JournalFts,
+    JournalFt,
+    $JournalFtsFilterComposer,
+    $JournalFtsOrderingComposer,
+    $JournalFtsCreateCompanionBuilder,
+    $JournalFtsUpdateCompanionBuilder> {
+  $JournalFtsTableManager(_$Fts5Db db, JournalFts table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $JournalFtsFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $JournalFtsOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<String> plainText = const Value.absent(),
+            Value<String> title = const Value.absent(),
+            Value<String> summary = const Value.absent(),
+            Value<String> tags = const Value.absent(),
+            Value<String> uuid = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              JournalFtsCompanion(
+            plainText: plainText,
+            title: title,
+            summary: summary,
+            tags: tags,
+            uuid: uuid,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required String plainText,
+            required String title,
+            required String summary,
+            required String tags,
+            required String uuid,
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              JournalFtsCompanion.insert(
+            plainText: plainText,
+            title: title,
+            summary: summary,
+            tags: tags,
+            uuid: uuid,
+            rowid: rowid,
+          ),
+        ));
+}
+
 class $JournalFtsFilterComposer extends FilterComposer<_$Fts5Db, JournalFts> {
   $JournalFtsFilterComposer(super.$state);
   ColumnFilters<String> get plainText => $state.composableBuilder(
@@ -442,76 +493,6 @@ class $JournalFtsOrderingComposer
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
-
-class $JournalFtsTableManager extends RootTableManager<
-    _$Fts5Db,
-    JournalFts,
-    JournalFt,
-    $JournalFtsFilterComposer,
-    $JournalFtsOrderingComposer,
-    $JournalFtsCreateCompanionBuilder,
-    $JournalFtsUpdateCompanionBuilder,
-    (JournalFt, BaseReferences<_$Fts5Db, JournalFts, JournalFt>),
-    JournalFt,
-    PrefetchHooks Function()> {
-  $JournalFtsTableManager(_$Fts5Db db, JournalFts table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $JournalFtsFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $JournalFtsOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<String> plainText = const Value.absent(),
-            Value<String> title = const Value.absent(),
-            Value<String> summary = const Value.absent(),
-            Value<String> tags = const Value.absent(),
-            Value<String> uuid = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              JournalFtsCompanion(
-            plainText: plainText,
-            title: title,
-            summary: summary,
-            tags: tags,
-            uuid: uuid,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required String plainText,
-            required String title,
-            required String summary,
-            required String tags,
-            required String uuid,
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              JournalFtsCompanion.insert(
-            plainText: plainText,
-            title: title,
-            summary: summary,
-            tags: tags,
-            uuid: uuid,
-            rowid: rowid,
-          ),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
-              .toList(),
-          prefetchHooksCallback: null,
-        ));
-}
-
-typedef $JournalFtsProcessedTableManager = ProcessedTableManager<
-    _$Fts5Db,
-    JournalFts,
-    JournalFt,
-    $JournalFtsFilterComposer,
-    $JournalFtsOrderingComposer,
-    $JournalFtsCreateCompanionBuilder,
-    $JournalFtsUpdateCompanionBuilder,
-    (JournalFt, BaseReferences<_$Fts5Db, JournalFts, JournalFt>),
-    JournalFt,
-    PrefetchHooks Function()>;
 
 class $Fts5DbManager {
   final _$Fts5Db _db;

--- a/lib/database/logging_db.g.dart
+++ b/lib/database/logging_db.g.dart
@@ -568,6 +568,73 @@ typedef $LogEntriesUpdateCompanionBuilder = LogEntriesCompanion Function({
   Value<int> rowid,
 });
 
+class $LogEntriesTableManager extends RootTableManager<
+    _$LoggingDb,
+    LogEntries,
+    LogEntry,
+    $LogEntriesFilterComposer,
+    $LogEntriesOrderingComposer,
+    $LogEntriesCreateCompanionBuilder,
+    $LogEntriesUpdateCompanionBuilder> {
+  $LogEntriesTableManager(_$LoggingDb db, LogEntries table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $LogEntriesFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $LogEntriesOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<String> id = const Value.absent(),
+            Value<String> createdAt = const Value.absent(),
+            Value<String> domain = const Value.absent(),
+            Value<String?> subDomain = const Value.absent(),
+            Value<String> type = const Value.absent(),
+            Value<String> level = const Value.absent(),
+            Value<String> message = const Value.absent(),
+            Value<String?> stacktrace = const Value.absent(),
+            Value<String?> data = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              LogEntriesCompanion(
+            id: id,
+            createdAt: createdAt,
+            domain: domain,
+            subDomain: subDomain,
+            type: type,
+            level: level,
+            message: message,
+            stacktrace: stacktrace,
+            data: data,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required String id,
+            required String createdAt,
+            required String domain,
+            Value<String?> subDomain = const Value.absent(),
+            required String type,
+            required String level,
+            required String message,
+            Value<String?> stacktrace = const Value.absent(),
+            Value<String?> data = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              LogEntriesCompanion.insert(
+            id: id,
+            createdAt: createdAt,
+            domain: domain,
+            subDomain: subDomain,
+            type: type,
+            level: level,
+            message: message,
+            stacktrace: stacktrace,
+            data: data,
+            rowid: rowid,
+          ),
+        ));
+}
+
 class $LogEntriesFilterComposer
     extends FilterComposer<_$LoggingDb, LogEntries> {
   $LogEntriesFilterComposer(super.$state);
@@ -665,92 +732,6 @@ class $LogEntriesOrderingComposer
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
-
-class $LogEntriesTableManager extends RootTableManager<
-    _$LoggingDb,
-    LogEntries,
-    LogEntry,
-    $LogEntriesFilterComposer,
-    $LogEntriesOrderingComposer,
-    $LogEntriesCreateCompanionBuilder,
-    $LogEntriesUpdateCompanionBuilder,
-    (LogEntry, BaseReferences<_$LoggingDb, LogEntries, LogEntry>),
-    LogEntry,
-    PrefetchHooks Function()> {
-  $LogEntriesTableManager(_$LoggingDb db, LogEntries table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $LogEntriesFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $LogEntriesOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<String> id = const Value.absent(),
-            Value<String> createdAt = const Value.absent(),
-            Value<String> domain = const Value.absent(),
-            Value<String?> subDomain = const Value.absent(),
-            Value<String> type = const Value.absent(),
-            Value<String> level = const Value.absent(),
-            Value<String> message = const Value.absent(),
-            Value<String?> stacktrace = const Value.absent(),
-            Value<String?> data = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              LogEntriesCompanion(
-            id: id,
-            createdAt: createdAt,
-            domain: domain,
-            subDomain: subDomain,
-            type: type,
-            level: level,
-            message: message,
-            stacktrace: stacktrace,
-            data: data,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required String id,
-            required String createdAt,
-            required String domain,
-            Value<String?> subDomain = const Value.absent(),
-            required String type,
-            required String level,
-            required String message,
-            Value<String?> stacktrace = const Value.absent(),
-            Value<String?> data = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              LogEntriesCompanion.insert(
-            id: id,
-            createdAt: createdAt,
-            domain: domain,
-            subDomain: subDomain,
-            type: type,
-            level: level,
-            message: message,
-            stacktrace: stacktrace,
-            data: data,
-            rowid: rowid,
-          ),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
-              .toList(),
-          prefetchHooksCallback: null,
-        ));
-}
-
-typedef $LogEntriesProcessedTableManager = ProcessedTableManager<
-    _$LoggingDb,
-    LogEntries,
-    LogEntry,
-    $LogEntriesFilterComposer,
-    $LogEntriesOrderingComposer,
-    $LogEntriesCreateCompanionBuilder,
-    $LogEntriesUpdateCompanionBuilder,
-    (LogEntry, BaseReferences<_$LoggingDb, LogEntries, LogEntry>),
-    LogEntry,
-    PrefetchHooks Function()>;
 
 class $LoggingDbManager {
   final _$LoggingDb _db;

--- a/lib/database/settings_db.g.dart
+++ b/lib/database/settings_db.g.dart
@@ -276,6 +276,47 @@ typedef $SettingsUpdateCompanionBuilder = SettingsCompanion Function({
   Value<int> rowid,
 });
 
+class $SettingsTableManager extends RootTableManager<
+    _$SettingsDb,
+    Settings,
+    SettingsItem,
+    $SettingsFilterComposer,
+    $SettingsOrderingComposer,
+    $SettingsCreateCompanionBuilder,
+    $SettingsUpdateCompanionBuilder> {
+  $SettingsTableManager(_$SettingsDb db, Settings table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer: $SettingsFilterComposer(ComposerState(db, table)),
+          orderingComposer: $SettingsOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<String> configKey = const Value.absent(),
+            Value<String> value = const Value.absent(),
+            Value<DateTime> updatedAt = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              SettingsCompanion(
+            configKey: configKey,
+            value: value,
+            updatedAt: updatedAt,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required String configKey,
+            required String value,
+            required DateTime updatedAt,
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              SettingsCompanion.insert(
+            configKey: configKey,
+            value: value,
+            updatedAt: updatedAt,
+            rowid: rowid,
+          ),
+        ));
+}
+
 class $SettingsFilterComposer extends FilterComposer<_$SettingsDb, Settings> {
   $SettingsFilterComposer(super.$state);
   ColumnFilters<String> get configKey => $state.composableBuilder(
@@ -312,66 +353,6 @@ class $SettingsOrderingComposer
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
-
-class $SettingsTableManager extends RootTableManager<
-    _$SettingsDb,
-    Settings,
-    SettingsItem,
-    $SettingsFilterComposer,
-    $SettingsOrderingComposer,
-    $SettingsCreateCompanionBuilder,
-    $SettingsUpdateCompanionBuilder,
-    (SettingsItem, BaseReferences<_$SettingsDb, Settings, SettingsItem>),
-    SettingsItem,
-    PrefetchHooks Function()> {
-  $SettingsTableManager(_$SettingsDb db, Settings table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer: $SettingsFilterComposer(ComposerState(db, table)),
-          orderingComposer: $SettingsOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<String> configKey = const Value.absent(),
-            Value<String> value = const Value.absent(),
-            Value<DateTime> updatedAt = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              SettingsCompanion(
-            configKey: configKey,
-            value: value,
-            updatedAt: updatedAt,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required String configKey,
-            required String value,
-            required DateTime updatedAt,
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              SettingsCompanion.insert(
-            configKey: configKey,
-            value: value,
-            updatedAt: updatedAt,
-            rowid: rowid,
-          ),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
-              .toList(),
-          prefetchHooksCallback: null,
-        ));
-}
-
-typedef $SettingsProcessedTableManager = ProcessedTableManager<
-    _$SettingsDb,
-    Settings,
-    SettingsItem,
-    $SettingsFilterComposer,
-    $SettingsOrderingComposer,
-    $SettingsCreateCompanionBuilder,
-    $SettingsUpdateCompanionBuilder,
-    (SettingsItem, BaseReferences<_$SettingsDb, Settings, SettingsItem>),
-    SettingsItem,
-    PrefetchHooks Function()>;
 
 class $SettingsDbManager {
   final _$SettingsDb _db;

--- a/lib/database/sync_db.g.dart
+++ b/lib/database/sync_db.g.dart
@@ -442,6 +442,65 @@ typedef $$OutboxTableUpdateCompanionBuilder = OutboxCompanion Function({
   Value<String?> filePath,
 });
 
+class $$OutboxTableTableManager extends RootTableManager<
+    _$SyncDatabase,
+    $OutboxTable,
+    OutboxItem,
+    $$OutboxTableFilterComposer,
+    $$OutboxTableOrderingComposer,
+    $$OutboxTableCreateCompanionBuilder,
+    $$OutboxTableUpdateCompanionBuilder> {
+  $$OutboxTableTableManager(_$SyncDatabase db, $OutboxTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$OutboxTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$OutboxTableOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime> updatedAt = const Value.absent(),
+            Value<int> status = const Value.absent(),
+            Value<int> retries = const Value.absent(),
+            Value<String> message = const Value.absent(),
+            Value<String> subject = const Value.absent(),
+            Value<String?> filePath = const Value.absent(),
+          }) =>
+              OutboxCompanion(
+            id: id,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            status: status,
+            retries: retries,
+            message: message,
+            subject: subject,
+            filePath: filePath,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime> updatedAt = const Value.absent(),
+            Value<int> status = const Value.absent(),
+            Value<int> retries = const Value.absent(),
+            required String message,
+            required String subject,
+            Value<String?> filePath = const Value.absent(),
+          }) =>
+              OutboxCompanion.insert(
+            id: id,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            status: status,
+            retries: retries,
+            message: message,
+            subject: subject,
+            filePath: filePath,
+          ),
+        ));
+}
+
 class $$OutboxTableFilterComposer
     extends FilterComposer<_$SyncDatabase, $OutboxTable> {
   $$OutboxTableFilterComposer(super.$state);
@@ -529,84 +588,6 @@ class $$OutboxTableOrderingComposer
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
-
-class $$OutboxTableTableManager extends RootTableManager<
-    _$SyncDatabase,
-    $OutboxTable,
-    OutboxItem,
-    $$OutboxTableFilterComposer,
-    $$OutboxTableOrderingComposer,
-    $$OutboxTableCreateCompanionBuilder,
-    $$OutboxTableUpdateCompanionBuilder,
-    (OutboxItem, BaseReferences<_$SyncDatabase, $OutboxTable, OutboxItem>),
-    OutboxItem,
-    PrefetchHooks Function()> {
-  $$OutboxTableTableManager(_$SyncDatabase db, $OutboxTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$OutboxTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$OutboxTableOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<DateTime> createdAt = const Value.absent(),
-            Value<DateTime> updatedAt = const Value.absent(),
-            Value<int> status = const Value.absent(),
-            Value<int> retries = const Value.absent(),
-            Value<String> message = const Value.absent(),
-            Value<String> subject = const Value.absent(),
-            Value<String?> filePath = const Value.absent(),
-          }) =>
-              OutboxCompanion(
-            id: id,
-            createdAt: createdAt,
-            updatedAt: updatedAt,
-            status: status,
-            retries: retries,
-            message: message,
-            subject: subject,
-            filePath: filePath,
-          ),
-          createCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<DateTime> createdAt = const Value.absent(),
-            Value<DateTime> updatedAt = const Value.absent(),
-            Value<int> status = const Value.absent(),
-            Value<int> retries = const Value.absent(),
-            required String message,
-            required String subject,
-            Value<String?> filePath = const Value.absent(),
-          }) =>
-              OutboxCompanion.insert(
-            id: id,
-            createdAt: createdAt,
-            updatedAt: updatedAt,
-            status: status,
-            retries: retries,
-            message: message,
-            subject: subject,
-            filePath: filePath,
-          ),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
-              .toList(),
-          prefetchHooksCallback: null,
-        ));
-}
-
-typedef $$OutboxTableProcessedTableManager = ProcessedTableManager<
-    _$SyncDatabase,
-    $OutboxTable,
-    OutboxItem,
-    $$OutboxTableFilterComposer,
-    $$OutboxTableOrderingComposer,
-    $$OutboxTableCreateCompanionBuilder,
-    $$OutboxTableUpdateCompanionBuilder,
-    (OutboxItem, BaseReferences<_$SyncDatabase, $OutboxTable, OutboxItem>),
-    OutboxItem,
-    PrefetchHooks Function()>;
 
 class $SyncDatabaseManager {
   final _$SyncDatabase _db;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -218,10 +218,10 @@ packages:
     dependency: "direct main"
     description:
       name: cached_network_image
-      sha256: "7c1183e361e5c8b0a0f21a28401eecdbde252441106a9816400dd4c2b2424916"
+      sha256: "4a5d8d2c728b0f3d0245f69f921d7be90cae4c2fd5288f773088672c0893f819"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.1"
+    version: "3.4.0"
   cached_network_image_platform_interface:
     dependency: transitive
     description:
@@ -234,10 +234,10 @@ packages:
     dependency: transitive
     description:
       name: cached_network_image_web
-      sha256: "980842f4e8e2535b8dbd3d5ca0b1f0ba66bf61d14cc3a17a9b4788a3685ba062"
+      sha256: "6322dde7a5ad92202e64df659241104a43db20ed594c41ca18de1014598d7996"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.0"
   calendar_view:
     dependency: "direct main"
     description:
@@ -571,18 +571,18 @@ packages:
     dependency: "direct main"
     description:
       name: drift
-      sha256: "15b51e0ee1970455c0c3f7e560f3ac02ecb9c04711a9657586e470b234659dba"
+      sha256: "4e0ffee40d23f0b809e6cff1ad202886f51d629649073ed42d9cd1d194ea943e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.20.0"
+    version: "2.19.1+1"
   drift_dev:
     dependency: "direct dev"
     description:
       name: drift_dev
-      sha256: b9ec6159a731288e805a44225ccbebad507dd84d52ab71352c52584f13199d2d
+      sha256: ac7647c6cedca99724ca300cff9181f6dd799428f8ed71f94159ed0528eaec26
       url: "https://pub.dev"
     source: hosted
-    version: "2.20.1"
+    version: "2.19.1"
   easy_debounce:
     dependency: "direct main"
     description:
@@ -2320,10 +2320,10 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: "468c43f285207c84bcabf5737f33b914ceb8eb38398b91e5e3ad1698d1b72a52"
+      sha256: "59dfd53f497340a0c3a81909b220cfdb9b8973a91055c4e5ab9b9b9ad7c513c0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.2"
+    version: "10.0.0"
   share_plus_platform_interface:
     dependency: transitive
     description:
@@ -2525,10 +2525,10 @@ packages:
     dependency: "direct main"
     description:
       name: sqlite3
-      sha256: "45f168ae2213201b54e09429ed0c593dc2c88c924a1488d6f9c523a255d567cb"
+      sha256: fde692580bee3379374af1f624eb3e113ab2865ecb161dbe2d8ac2de9735dbdb
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.6"
+    version: "2.4.5"
   sqlite3_flutter_libs:
     dependency: "direct main"
     description:
@@ -2922,13 +2922,13 @@ packages:
     source: hosted
     version: "1.1.0"
   web:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: web
-      sha256: d43c1d6b787bf0afad444700ae7f4db8827f701bc61c255ac8d328c6f4d52062
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "0.5.1"
   web_socket:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -410,18 +410,18 @@ packages:
     dependency: transitive
     description:
       name: custom_lint
-      sha256: "4939d89e580c36215e48a7de8fd92f22c79dcc3eb11fda84f3402b3b45aec663"
+      sha256: "6e1ec47427ca968f22bce734d00028ae7084361999b41673291138945c5baca0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   custom_lint_builder:
     dependency: transitive
     description:
       name: custom_lint_builder
-      sha256: d9e5bb63ed52c1d006f5a1828992ba6de124c27a531e8fba0a31afffa81621b3
+      sha256: ba2f90fff4eff71d202d097eb14b14f87087eaaef742e956208c0eb9d3a40a21
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   custom_lint_core:
     dependency: transitive
     description:
@@ -458,10 +458,10 @@ packages:
     dependency: transitive
     description:
       name: dart_quill_delta
-      sha256: "98058901330038c32710183c9c919511fcb2859ec2244aefd2e0337b4d7cb9f7"
+      sha256: e001f64695c0830551f4ff5729625599d5e338fd5b3f4db42109d0ca37fc1252
       url: "https://pub.dev"
     source: hosted
-    version: "10.5.8"
+    version: "10.5.9"
   dart_style:
     dependency: "direct dev"
     description:
@@ -1011,10 +1011,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_quill
-      sha256: "659c9b1cee4f4c0fe24fa478b57cb37af25f0b5d5a96640efdb8f3407b1557c1"
+      sha256: "3d47d5e8d838c9d2fb54654df3bb0bd5f2e10e2d1329909401d797757c0f1b51"
       url: "https://pub.dev"
     source: hosted
-    version: "10.5.8"
+    version: "10.5.9"
   flutter_quill_delta_from_html:
     dependency: transitive
     description:
@@ -2408,10 +2408,10 @@ packages:
     dependency: transitive
     description:
       name: shelf_static
-      sha256: a41d3f53c4adf0f57480578c1d61d90342cd617de7fc8077b1304643c2d85c1e
+      sha256: c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   shelf_web_socket:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.509+2671
+version: 0.9.509+2670
 
 msix_config:
   display_name: LottiApp
@@ -37,11 +37,12 @@ dependencies:
       ref: ce9a6b6
 
   device_info_plus: ^10.0.1
-  drift: ^2.20.0
+  drift: ^2.16.0
   easy_debounce: ^2.0.2+1
   enum_to_string: ^2.0.1
   equatable: ^2.0.3
   exif: ^3.0.1
+
   ffmpeg_kit_flutter: ^6.0.3
   fl_chart: ^0.69.0
   flex_color_scheme: ^7.1.2
@@ -150,14 +151,13 @@ dependency_overrides:
   device_info_plus: ^10.0.1
   intl: ^0.19.0
   rxdart: ^0.28.0
-  web: ^1.0.0
 
 dev_dependencies:
   analyzer: ^6.4.1
   archive: ^3.3.0
   build_runner: ^2.3.0
   dart_style: ^2.3.6
-  drift_dev: ^2.20.1
+  drift_dev: ^2.16.0
   flutter_launcher_icons: ^0.13.1
   flutter_lints: ^4.0.0
   flutter_native_splash: ^2.2.16

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.509+2670
+version: 0.9.509+2672
 
 msix_config:
   display_name: LottiApp
@@ -37,7 +37,7 @@ dependencies:
       ref: ce9a6b6
 
   device_info_plus: ^10.0.1
-  drift: ^2.16.0
+  drift: 2.19.1+1
   easy_debounce: ^2.0.2+1
   enum_to_string: ^2.0.1
   equatable: ^2.0.3


### PR DESCRIPTION
This PR reverts #1819 because of so far inexplicable and annoying freezes in the mobile app, which never happened before. The only way to get out was to kill the app and restart. Installing an older version from TestFlight immediately fixed the issue.