### PR TITLE
feat: retry binary file sync

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -18,7 +18,7 @@ PODS:
     - Mantle
     - SDWebImage
     - SDWebImageWebPCoder
-  - flutter_keyboard_visibility (0.0.1):
+  - flutter_keyboard_visibility_temp_fork (0.0.1):
     - Flutter
   - flutter_local_notifications (0.0.1):
     - Flutter
@@ -68,7 +68,7 @@ PODS:
   - media_kit_native_event_loop (1.0.0):
     - Flutter
   - MTBBarcodeScanner (5.0.11)
-  - OpenSSL-Universal (3.3.1000)
+  - OpenSSL-Universal (3.3.2000)
   - package_info_plus (0.4.5):
     - Flutter
   - path_provider_foundation (0.0.1):
@@ -132,7 +132,7 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_health_fit (from `.symlinks/plugins/flutter_health_fit/ios`)
   - flutter_image_compress_common (from `.symlinks/plugins/flutter_image_compress_common/ios`)
-  - flutter_keyboard_visibility (from `.symlinks/plugins/flutter_keyboard_visibility/ios`)
+  - flutter_keyboard_visibility_temp_fork (from `.symlinks/plugins/flutter_keyboard_visibility_temp_fork/ios`)
   - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
   - flutter_native_timezone (from `.symlinks/plugins/flutter_native_timezone/ios`)
@@ -186,8 +186,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_health_fit/ios"
   flutter_image_compress_common:
     :path: ".symlinks/plugins/flutter_image_compress_common/ios"
-  flutter_keyboard_visibility:
-    :path: ".symlinks/plugins/flutter_keyboard_visibility/ios"
+  flutter_keyboard_visibility_temp_fork:
+    :path: ".symlinks/plugins/flutter_keyboard_visibility_temp_fork/ios"
   flutter_local_notifications:
     :path: ".symlinks/plugins/flutter_local_notifications/ios"
   flutter_native_splash:
@@ -253,7 +253,7 @@ SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_health_fit: af332b5d7512b9cc8a05e7282cfcee02b056d32e
   flutter_image_compress_common: ec1d45c362c9d30a3f6a0426c297f47c52007e3e
-  flutter_keyboard_visibility: 0339d06371254c3eb25eeb90ba8d17dca8f9c069
+  flutter_keyboard_visibility_temp_fork: 442dadca3b81868a225cd6a2f605bffff1215844
   flutter_local_notifications: 4cde75091f6327eb8517fa068a0a5950212d2086
   flutter_native_splash: edf599c81f74d093a4daf8e17bd7a018854bc778
   flutter_native_timezone: 5f05b2de06c9776b4cc70e1839f03de178394d22
@@ -272,7 +272,7 @@ SPEC CHECKSUMS:
   media_kit_libs_ios_audio: 8f39d96a9c630685dfb844c289bd1d114c486fb3
   media_kit_native_event_loop: 99111eded5acbdc9c2738021ea6550dd36ca8837
   MTBBarcodeScanner: f453b33c4b7dfe545d8c6484ed744d55671788cb
-  OpenSSL-Universal: 57f92a826947ee3183556bf5e22d7dff8d55f834
+  OpenSSL-Universal: b60a3702c9fea8b3145549d421fdb018e53ab7b4
   package_info_plus: 58f0028419748fad15bf008b270aaa8e54380b1c
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   photo_manager: ff695c7a1dd5bc379974953a2b5c0a293f7c4c8a

--- a/lib/features/sync/matrix/send_message.dart
+++ b/lib/features/sync/matrix/send_message.dart
@@ -90,25 +90,21 @@ extension SendExtension on MatrixService {
         journalAudio: (JournalAudio journalAudio) async {
           if (shouldResendAttachments ||
               syncMessage.status == SyncEntryStatus.initial) {
-            unawaited(
-              sendFile(
-                fullPath: AudioUtils.getAudioPath(
-                  journalAudio,
-                  docDir,
-                ),
-                relativePath: AudioUtils.getRelativeAudioPath(journalAudio),
+            await sendFile(
+              fullPath: AudioUtils.getAudioPath(
+                journalAudio,
+                docDir,
               ),
+              relativePath: AudioUtils.getRelativeAudioPath(journalAudio),
             );
           }
         },
         journalImage: (JournalImage journalImage) async {
           if (shouldResendAttachments ||
               syncMessage.status == SyncEntryStatus.initial) {
-            unawaited(
-              sendFile(
-                fullPath: getFullImagePath(journalImage),
-                relativePath: getRelativeImagePath(journalImage),
-              ),
+            await sendFile(
+              fullPath: getFullImagePath(journalImage),
+              relativePath: getRelativeImagePath(journalImage),
             );
           }
         },

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -38,7 +38,7 @@ PODS:
     - FlutterMacOS
   - media_kit_native_event_loop (1.0.0):
     - FlutterMacOS
-  - OpenSSL-Universal (3.3.1000)
+  - OpenSSL-Universal (3.3.2000)
   - package_info_plus (0.0.1):
     - FlutterMacOS
   - path_provider_foundation (0.0.1):
@@ -206,7 +206,7 @@ SPEC CHECKSUMS:
   location: 7cdb0665bd6577d382b0a343acdadbcb7f964775
   media_kit_libs_macos_audio: 3871782a4f3f84c77f04d7666c87800a781c24da
   media_kit_native_event_loop: 7321675377cb9ae8596a29bddf3a3d2b5e8792c5
-  OpenSSL-Universal: 57f92a826947ee3183556bf5e22d7dff8d55f834
+  OpenSSL-Universal: b60a3702c9fea8b3145549d421fdb018e53ab7b4
   package_info_plus: fa739dd842b393193c5ca93c26798dff6e3d0e0c
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   photo_manager: ff695c7a1dd5bc379974953a2b5c0a293f7c4c8a

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -458,10 +458,10 @@ packages:
     dependency: transitive
     description:
       name: dart_quill_delta
-      sha256: ad51d0953e5b1c80200a8db0fab635c491d2f86e620f00c49fa0589d60bec8fe
+      sha256: a3552d7dfe4904ab344ccc7bf6453fd2d966b7ef64a945e364ae18dd486b9569
       url: "https://pub.dev"
     source: hosted
-    version: "10.8.0"
+    version: "10.8.1"
   dart_style:
     dependency: "direct dev"
     description:
@@ -890,14 +890,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.4+1"
-  flutter_keyboard_visibility:
-    dependency: transitive
-    description:
-      name: flutter_keyboard_visibility
-      sha256: "98664be7be0e3ffca00de50f7f6a287ab62c763fc8c762e0a21584584a3ff4f8"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.0.0"
   flutter_keyboard_visibility_linux:
     dependency: transitive
     description:
@@ -922,14 +914,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
-  flutter_keyboard_visibility_web:
+  flutter_keyboard_visibility_temp_fork:
     dependency: transitive
     description:
-      name: flutter_keyboard_visibility_web
-      sha256: d3771a2e752880c79203f8d80658401d0c998e4183edca05a149f5098ce6e3d1
+      name: flutter_keyboard_visibility_temp_fork
+      sha256: e342172aaa6173a661e822c85a005f8c5d0a04a1d263e00cb9f9155adab9cb7c
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "0.1.1"
   flutter_keyboard_visibility_windows:
     dependency: transitive
     description:
@@ -1003,10 +995,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_markdown
-      sha256: a23c41ee57573e62fc2190a1f36a0480c4d90bde3a8a8d7126e5d5992fb53fb7
+      sha256: e17575ca576a34b46c58c91f9948891117a1bd97815d2e661813c7f90c647a78
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3+1"
+    version: "0.7.3+2"
   flutter_native_splash:
     dependency: "direct dev"
     description:
@@ -1051,10 +1043,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_quill
-      sha256: "8cefede1dd4bf52d65b37bbcb78f94f76b5b0ede4d5439c52dbe1f5535efbb87"
+      sha256: "27afdee8ea3b7bf5cb3b36f4c195468b24bcaad80036d4daa423bf948e8b5a97"
       url: "https://pub.dev"
     source: hosted
-    version: "10.8.0"
+    version: "10.8.1"
   flutter_quill_delta_from_html:
     dependency: transitive
     description:
@@ -1067,10 +1059,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_quill_extensions
-      sha256: fae541303a35c415a90d53e3372db6d1732e14a2b92a781e79cecb367f863a05
+      sha256: b397f786f122a3ce7a58ba1288e7c24656298709315719deeec22fa4aec7bf8b
       url: "https://pub.dev"
     source: hosted
-    version: "10.8.0"
+    version: "10.8.1"
   flutter_rating:
     dependency: "direct main"
     description:
@@ -1226,10 +1218,10 @@ packages:
     dependency: transitive
     description:
       name: gal_linux
-      sha256: cbff918888aaa7b86d5a992764ad94d217347d63912e008e8449605b1cc0b38a
+      sha256: "0040d61843134cc5a93e4597080a86f2ba073217957e28b2a684b4d8b050873c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.0"
+    version: "0.1.2"
   geoclue:
     dependency: "direct main"
     description:
@@ -2645,26 +2637,26 @@ packages:
     dependency: "direct main"
     description:
       name: sqflite
-      sha256: a43e5a27235518c03ca238e7b4732cf35eabe863a369ceba6cbefa537a66f16d
+      sha256: ff5a2436ef8ebdfda748fbfe957f9981524cb5ff11e7bafa8c42771840e8a788
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3+1"
+    version: "2.3.3+2"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "4058172e418eb7e7f2058dcb7657d451a8fc264afa0dea4dbd0f304a57131611"
+      sha256: "2d8e607db72e9cb7748c9c6e739e2c9618320a5517de693d5a24609c4671b1a4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4+3"
+    version: "2.5.4+4"
   sqflite_common_ffi:
     dependency: "direct main"
     description:
       name: sqflite_common_ffi
-      sha256: "4d6137c29e930d6e4a8ff373989dd9de7bac12e3bc87bce950f6e844e8ad3bb5"
+      sha256: a6057d4c87e9260ba1ec436ebac24760a110589b9c0a859e128842eb69a7ef04
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "2.3.3+1"
   sqlite3:
     dependency: "direct main"
     description:
@@ -2773,10 +2765,10 @@ packages:
     dependency: transitive
     description:
       name: synchronized
-      sha256: "51b08572b9f091f8c3eb4d9d4be253f196ff0075d5ec9b10a884026d5b55d7bc"
+      sha256: "69fe30f3a8b04a0be0c15ae6490fc859a78ef4c43ae2dd5e8a623d45bfcf9225"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0+2"
+    version: "3.3.0+3"
   system_info2:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.510+2677
+version: 0.9.511+2678
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.511+2678
+version: 0.9.511+2679
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR adds awaiting the sending of binary files (audio files and images). Previously, sending files would silently fail when there was an issue (such as bad connectivity) and only sending the entry itself would be repeated. However, sending the entry itself was much less likely to fail in the first place, being at most single kilobytes, whereas binary files can be much larger. With this change, sending binary files will now be retried up to ten times as well.