### PR TITLE
fix: audio recording navigation

### DIFF
--- a/lib/beamer/beamer_app.dart
+++ b/lib/beamer/beamer_app.dart
@@ -59,7 +59,11 @@ class _AppScreenState extends State<AppScreen> {
                   Beamer(routerDelegate: navService.settingsDelegate),
                 ],
               ),
-              const TimeRecordingIndicator(),
+              const Positioned(
+                left: 0,
+                bottom: 0,
+                child: TimeRecordingIndicator(),
+              ),
               const Positioned(
                 right: 100,
                 bottom: 0,

--- a/lib/blocs/audio/player_cubit.dart
+++ b/lib/blocs/audio/player_cubit.dart
@@ -5,7 +5,6 @@ import 'package:lotti/blocs/audio/player_state.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/get_it.dart';
-import 'package:lotti/services/asr_service.dart';
 import 'package:lotti/utils/audio_utils.dart';
 import 'package:media_kit/media_kit.dart';
 
@@ -26,7 +25,6 @@ class AudioPlayerCubit extends Cubit<AudioPlayerState> {
 
   final Player _audioPlayer = Player();
   final LoggingDb _loggingDb = getIt<LoggingDb>();
-  final AsrService _asrService = getIt<AsrService>();
 
   void updateProgress(Duration duration) {
     emit(state.copyWith(progress: duration));
@@ -82,14 +80,6 @@ class AudioPlayerCubit extends Cubit<AudioPlayerState> {
         stackTrace: stackTrace,
       );
     }
-  }
-
-  Future<bool> transcribe() async {
-    if (state.audioNote == null) {
-      return false;
-    }
-
-    return _asrService.enqueue(entry: state.audioNote!);
   }
 
   Future<void> seek(Duration newPosition) async {

--- a/lib/widgets/audio/audio_player.dart
+++ b/lib/widgets/audio/audio_player.dart
@@ -11,6 +11,7 @@ import 'package:lotti/features/journal/state/entry_controller.dart';
 import 'package:lotti/features/journal/util/entry_tools.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/services/asr_service.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/widgets/audio/transcription_progress_modal.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
@@ -110,10 +111,10 @@ class AudioPlayerWidget extends ConsumerWidget {
                     tooltip: 'Transcribe',
                     color: context.colorScheme.outline,
                     onPressed: () async {
-                      await cubit.setAudioNote(journalAudio);
-                      final isQueueEmpty = await cubit.transcribe();
+                      final isQueueEmpty =
+                          getIt<AsrService>().enqueue(entry: journalAudio);
 
-                      if (isQueueEmpty) {
+                      if (await isQueueEmpty) {
                         if (!context.mounted) return;
                         await TranscriptionProgressModal.show(context);
                       }

--- a/lib/widgets/audio/audio_recording_indicator.dart
+++ b/lib/widgets/audio/audio_recording_indicator.dart
@@ -3,8 +3,9 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/blocs/audio/recorder_cubit.dart';
 import 'package:lotti/blocs/audio/recorder_state.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/journal/state/entry_controller.dart';
 import 'package:lotti/features/journal/util/entry_tools.dart';
-import 'package:lotti/get_it.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/themes/theme.dart';
 
@@ -20,8 +21,13 @@ class AudioRecordingIndicator extends ConsumerWidget {
           return const SizedBox.shrink();
         }
         final linkedId = state.linkedId;
+
+        final linkedEntry = linkedId != null
+            ? ref.watch(entryControllerProvider(id: linkedId)).value?.entry
+            : null;
+
         void onTap() {
-          if (getIt<NavService>().tasksTabActive()) {
+          if (linkedEntry is Task) {
             beamToNamed('/tasks/$linkedId/record_audio/$linkedId');
           } else {
             beamToNamed('/journal/$linkedId/record_audio/$linkedId');

--- a/lib/widgets/misc/time_recording_indicator.dart
+++ b/lib/widgets/misc/time_recording_indicator.dart
@@ -7,17 +7,17 @@ import 'package:lotti/services/time_service.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
-class TimeRecordingIndicatorWidget extends StatelessWidget {
-  TimeRecordingIndicatorWidget({
+class TimeRecordingIndicator extends StatelessWidget {
+  const TimeRecordingIndicator({
     super.key,
   });
 
-  final TimeService _timeService = getIt<TimeService>();
-
   @override
   Widget build(BuildContext context) {
+    final timeService = getIt<TimeService>();
+
     return StreamBuilder(
-      stream: _timeService.getStream(),
+      stream: timeService.getStream(),
       builder: (
         _,
         AsyncSnapshot<JournalEntity?> snapshot,
@@ -32,7 +32,7 @@ class TimeRecordingIndicatorWidget extends StatelessWidget {
 
         return GestureDetector(
           onTap: () {
-            final linkedFrom = _timeService.linkedFrom;
+            final linkedFrom = timeService.linkedFrom;
             linkedFrom != null
                 ? linkedFrom is Task
                     ? beamToNamed('/tasks/${linkedFrom.meta.id}')
@@ -73,21 +73,6 @@ class TimeRecordingIndicatorWidget extends StatelessWidget {
           ),
         );
       },
-    );
-  }
-}
-
-class TimeRecordingIndicator extends StatelessWidget {
-  const TimeRecordingIndicator({
-    super.key,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Positioned(
-      left: 0,
-      bottom: 0,
-      child: TimeRecordingIndicatorWidget(),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.512+2680
+version: 0.9.512+2681
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.512+2681
+version: 0.9.512+2682
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR fixes navigation when going back to a running audio recording from the recording indicator at the bottom.

Also improves the start of an audio transcription from the audio player. Previously, starting a transcription would have stopped an ongoing playback. This is not the case any longer.