### PR TITLE
feat: reorganize tabs

### DIFF
--- a/lib/beamer/beamer_app.dart
+++ b/lib/beamer/beamer_app.dart
@@ -51,11 +51,11 @@ class _AppScreenState extends State<AppScreen> {
               IndexedStack(
                 index: index,
                 children: [
+                  Beamer(routerDelegate: navService.tasksDelegate),
+                  Beamer(routerDelegate: navService.calendarDelegate),
                   Beamer(routerDelegate: navService.habitsDelegate),
                   Beamer(routerDelegate: navService.dashboardsDelegate),
                   Beamer(routerDelegate: navService.journalDelegate),
-                  Beamer(routerDelegate: navService.tasksDelegate),
-                  Beamer(routerDelegate: navService.calendarDelegate),
                   Beamer(routerDelegate: navService.settingsDelegate),
                 ],
               ),
@@ -91,24 +91,6 @@ class _AppScreenState extends State<AppScreen> {
             currentIndex: index,
             items: [
               createNavBarItem(
-                semanticLabel: 'Habits Tab',
-                icon: Icon(MdiIcons.checkboxMultipleMarkedOutline),
-                activeIcon: Icon(MdiIcons.checkboxMultipleMarked),
-                label: context.messages.navTabTitleHabits,
-              ),
-              createNavBarItem(
-                semanticLabel: 'Dashboards Tab',
-                icon: const Icon(Ionicons.bar_chart_outline),
-                activeIcon: const Icon(Ionicons.bar_chart),
-                label: context.messages.navTabTitleInsights,
-              ),
-              createNavBarItem(
-                semanticLabel: 'Logbook Tab',
-                icon: const Icon(Ionicons.book_outline),
-                activeIcon: const Icon(Ionicons.book),
-                label: context.messages.navTabTitleJournal,
-              ),
-              createNavBarItem(
                 semanticLabel: 'Tasks Tab',
                 icon: TasksBadge(
                   child: Icon(MdiIcons.checkboxMarkedCircleOutline),
@@ -125,6 +107,24 @@ class _AppScreenState extends State<AppScreen> {
                   icon: const Icon(Ionicons.calendar),
                 ),
                 label: context.messages.navTabTitleCalendar,
+              ),
+              createNavBarItem(
+                semanticLabel: 'Habits Tab',
+                icon: Icon(MdiIcons.checkboxMultipleMarkedOutline),
+                activeIcon: Icon(MdiIcons.checkboxMultipleMarked),
+                label: context.messages.navTabTitleHabits,
+              ),
+              createNavBarItem(
+                semanticLabel: 'Dashboards Tab',
+                icon: const Icon(Ionicons.bar_chart_outline),
+                activeIcon: const Icon(Ionicons.bar_chart),
+                label: context.messages.navTabTitleInsights,
+              ),
+              createNavBarItem(
+                semanticLabel: 'Logbook Tab',
+                icon: const Icon(Ionicons.book_outline),
+                activeIcon: const Icon(Ionicons.book),
+                label: context.messages.navTabTitleJournal,
               ),
               createNavBarItem(
                 semanticLabel: 'Settings Tab',

--- a/lib/services/nav_service.dart
+++ b/lib/services/nav_service.dart
@@ -8,6 +8,13 @@ import 'package:lotti/get_it.dart';
 
 const String lastRouteKey = 'NAV_LAST_ROUTE';
 
+const tasksIndex = 0;
+const calendarIndex = 1;
+const habitsIndex = 2;
+const dashboardsIndex = 3;
+const journalIndex = 4;
+const settingsIndex = 5;
+
 class NavService {
   NavService() {
     // TODO: fix and bring back
@@ -41,25 +48,24 @@ class NavService {
   void setPath(String path) {
     currentPath = path;
 
+    if (path.startsWith('/tasks')) {
+      setIndex(tasksIndex);
+    }
+    if (path.startsWith('/calendar')) {
+      setIndex(calendarIndex);
+    }
     if (path.startsWith('/habits')) {
-      setIndex(0);
+      setIndex(habitsIndex);
     }
     if (path.startsWith('/dashboards')) {
-      setIndex(1);
+      setIndex(dashboardsIndex);
     }
     if (path.startsWith('/journal')) {
-      setIndex(2);
-    }
-    if (path.startsWith('/tasks')) {
-      setIndex(3);
-    }
-
-    if (path.startsWith('/calendar')) {
-      setIndex(4);
+      setIndex(journalIndex);
     }
 
     if (path.startsWith('/settings')) {
-      setIndex(5);
+      setIndex(settingsIndex);
     }
 
     emitState();
@@ -67,11 +73,11 @@ class NavService {
 
   BeamerDelegate delegateByIndex(int index) {
     final beamerDelegates = <BeamerDelegate>[
+      tasksDelegate,
+      calendarDelegate,
       habitsDelegate,
       dashboardsDelegate,
       journalDelegate,
-      tasksDelegate,
-      calendarDelegate,
       settingsDelegate,
     ];
 
@@ -79,22 +85,22 @@ class NavService {
   }
 
   void setTabRoot(int newIndex) {
-    if (index == 0) {
-      beamToNamed('/habits');
-    }
-    if (index == 1) {
-      beamToNamed('/dashboards');
-    }
-    if (index == 2) {
-      beamToNamed('/journal');
-    }
-    if (index == 3) {
+    if (index == tasksIndex) {
       beamToNamed('/tasks');
     }
-    if (index == 4) {
+    if (index == calendarIndex) {
       beamToNamed('/calendar');
     }
-    if (index == 5) {
+    if (index == habitsIndex) {
+      beamToNamed('/habits');
+    }
+    if (index == dashboardsIndex) {
+      beamToNamed('/dashboards');
+    }
+    if (index == journalIndex) {
+      beamToNamed('/journal');
+    }
+    if (index == settingsIndex) {
       beamToNamed('/settings');
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.515+2693
+version: 0.9.515+2694
 
 msix_config:
   display_name: LottiApp

--- a/test/services/nav_service_test.dart
+++ b/test/services/nav_service_test.dart
@@ -57,49 +57,49 @@ void main() {
       expect(navService.index, 0);
 
       beamToNamed('/settings');
-      expect(navService.index, 5);
+      expect(navService.index, settingsIndex);
       expect(navService.currentPath, '/settings');
 
       beamToNamed('/settings/advanced');
-      expect(navService.index, 5);
+      expect(navService.index, settingsIndex);
       expect(navService.currentPath, '/settings/advanced');
       navService.tapIndex(5);
       expect(navService.currentPath, '/settings');
 
       beamToNamed('/settings/advanced/maintenance');
-      expect(navService.index, 5);
+      expect(navService.index, settingsIndex);
       expect(navService.currentPath, '/settings/advanced/maintenance');
 
       beamToNamed('/journal');
-      expect(navService.index, 2);
+      expect(navService.index, journalIndex);
       expect(navService.currentPath, '/journal');
       beamToNamed('/journal/some-id');
       expect(navService.currentPath, '/journal/some-id');
-      navService.tapIndex(2);
+      navService.tapIndex(journalIndex);
       expect(navService.currentPath, '/journal');
 
       beamToNamed('/tasks');
-      expect(navService.index, 3);
+      expect(navService.index, tasksIndex);
       expect(navService.currentPath, '/tasks');
       beamToNamed('/tasks/some-id');
       expect(navService.currentPath, '/tasks/some-id');
-      navService.tapIndex(3);
+      navService.tapIndex(tasksIndex);
       expect(navService.currentPath, '/tasks');
 
       beamToNamed('/calendar');
-      expect(navService.index, 4);
+      expect(navService.index, calendarIndex);
       expect(navService.currentPath, '/calendar');
 
       beamToNamed('/dashboards');
-      expect(navService.index, 1);
+      expect(navService.index, dashboardsIndex);
       expect(navService.currentPath, '/dashboards');
       beamToNamed('/dashboards/some-id');
       expect(navService.currentPath, '/dashboards/some-id');
-      navService.tapIndex(1);
+      navService.tapIndex(dashboardsIndex);
       expect(navService.currentPath, '/dashboards');
 
       beamToNamed('/habits');
-      expect(navService.index, 0);
+      expect(navService.index, habitsIndex);
       expect(navService.currentPath, '/habits');
     });
   });


### PR DESCRIPTION
This PR reorganizes the tabs to move tasks all the way to the left, and the calendar/time view right next to it.