### PR TITLE
feat: Llama3 generated checklists preview

### DIFF
--- a/lib/features/ai/state/ollama_prompt.dart
+++ b/lib/features/ai/state/ollama_prompt.dart
@@ -28,7 +28,7 @@ class AiResponse extends Notifier<String> {
     }
     final llm = Ollama(
       defaultOptions: const OllamaOptions(
-        model: 'llama2:13b',
+        model: 'llama3:8b',
         temperature: 1,
       ),
     );

--- a/lib/features/ai/state/ollama_prompt_checklist.dart
+++ b/lib/features/ai/state/ollama_prompt_checklist.dart
@@ -1,0 +1,73 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:langchain/langchain.dart';
+import 'package:langchain_ollama/langchain_ollama.dart';
+import 'package:lotti/classes/checklist_item_data.dart';
+import 'package:lotti/classes/journal_entities.dart';
+
+final aiChecklistResponseProvider =
+    NotifierProvider<AiChecklistResponse, List<ChecklistItemData>>(
+  AiChecklistResponse.new,
+);
+
+class AiChecklistResponse extends Notifier<List<ChecklistItemData>> {
+  @override
+  List<ChecklistItemData> build() {
+    return [];
+  }
+
+  Future<void> createChecklistItems(
+    JournalEntity? journalEntity, {
+    String? linkedFromId,
+  }) async {
+    state = [];
+    final promptText = journalEntity?.entryText?.plainText;
+
+    if (promptText == null || journalEntity == null) {
+      return;
+    }
+
+    var response = '';
+
+    final llm = Ollama(
+      defaultOptions: const OllamaOptions(
+        model: 'llama3:8b',
+        temperature: 3,
+        system:
+            'Assume that the input is describing a task that needs to be completed. '
+            'Create a checklist for that task, in the best order to complete it. '
+            'The checklist should be a list of items, in JSON format, as an array '
+            'of objects, with each checklist item having a short title, which '
+            'goes in the "title" field. '
+            'Come up with up to 10 checklist items.',
+      ),
+    );
+
+    final prompt = PromptValue.string(promptText);
+
+    await llm.stream(prompt).forEach((res) {
+      response += res.outputAsString;
+    });
+
+    final exp = RegExp(
+      r'(\[[^[]*\])',
+      multiLine: true,
+    );
+
+    debugPrint(response);
+
+    final match = exp.firstMatch(response);
+    final responseList = json.decode(match?.group(0) ?? '[]') as List<dynamic>;
+
+    state = responseList
+        .map((e) => ChecklistItemData(
+              title: e['title'] as String,
+              isChecked: false,
+            ))
+        .toList();
+
+    debugPrint(responseList.toString());
+  }
+}

--- a/lib/features/ai/state/ollama_prompt_checklist.dart
+++ b/lib/features/ai/state/ollama_prompt_checklist.dart
@@ -62,10 +62,13 @@ class AiChecklistResponse extends Notifier<List<ChecklistItemData>> {
     final responseList = json.decode(match?.group(0) ?? '[]') as List<dynamic>;
 
     state = responseList
-        .map((e) => ChecklistItemData(
-              title: e['title'] as String,
-              isChecked: false,
-            ))
+        .map(
+          (e) => ChecklistItemData(
+            // ignore: avoid_dynamic_calls
+            title: e['title'] as String,
+            isChecked: false,
+          ),
+        )
         .toList();
 
     debugPrint(responseList.toString());

--- a/lib/features/ai/ui/ai_prompt_icon_widget.dart
+++ b/lib/features/ai/ui/ai_prompt_icon_widget.dart
@@ -5,6 +5,50 @@ import 'package:lotti/features/ai/state/ollama_prompt.dart';
 import 'package:lotti/features/ai/state/ollama_prompt_checklist.dart';
 import 'package:lotti/features/ai/ui/ai_response_preview.dart';
 
+class AiPopUpMenu extends StatelessWidget {
+  const AiPopUpMenu({
+    required this.journalEntity,
+    required this.linkedFromId,
+    super.key,
+  });
+
+  final JournalEntity? journalEntity;
+  final String? linkedFromId;
+
+  @override
+  Widget build(BuildContext context) {
+    return PopupMenuButton(
+      child: const Icon(Icons.more_vert_rounded),
+      itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
+        PopupMenuItem(
+          value: 'prompt',
+          child: Row(
+            children: [
+              AiPromptIconWidget(
+                journalEntity: journalEntity,
+                linkedFromId: linkedFromId,
+              ),
+              const Text('Prompt'),
+            ],
+          ),
+        ),
+        PopupMenuItem(
+          value: 'checklist',
+          child: Row(
+            children: [
+              AiChecklistIconWidget(
+                journalEntity: journalEntity,
+                linkedFromId: linkedFromId,
+              ),
+              const Text('Create checklist'),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
 class AiPromptIconWidget extends ConsumerWidget {
   const AiPromptIconWidget({
     required this.journalEntity,

--- a/lib/features/ai/ui/ai_prompt_icon_widget.dart
+++ b/lib/features/ai/ui/ai_prompt_icon_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/ai/state/ollama_prompt.dart';
+import 'package:lotti/features/ai/state/ollama_prompt_checklist.dart';
 import 'package:lotti/features/ai/ui/ai_response_preview.dart';
 
 class AiPromptIconWidget extends ConsumerWidget {
@@ -28,6 +29,36 @@ class AiPromptIconWidget extends ConsumerWidget {
           context: context,
           isScrollControlled: true,
           builder: (BuildContext context) => const AiResponsePreview(),
+        );
+      },
+    );
+  }
+}
+
+class AiChecklistIconWidget extends ConsumerWidget {
+  const AiChecklistIconWidget({
+    required this.journalEntity,
+    this.linkedFromId,
+    super.key,
+  });
+
+  final JournalEntity? journalEntity;
+  final String? linkedFromId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return IconButton(
+      icon: const Icon(Icons.checklist_rounded),
+      tooltip: 'Create checklist items',
+      onPressed: () {
+        ref.read(aiChecklistResponseProvider.notifier).createChecklistItems(
+              journalEntity,
+              linkedFromId: linkedFromId,
+            );
+        showModalBottomSheet<void>(
+          context: context,
+          isScrollControlled: true,
+          builder: (BuildContext context) => const AiChecklistResponsePreview(),
         );
       },
     );

--- a/lib/features/ai/ui/ai_response_preview.dart
+++ b/lib/features/ai/ui/ai_response_preview.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/ai/state/ollama_prompt.dart';
+import 'package:lotti/features/ai/state/ollama_prompt_checklist.dart';
+
+import '../../tasks/ui/checkbox_item_widget.dart';
 
 class AiResponsePreview extends ConsumerWidget {
   const AiResponsePreview({super.key});
@@ -16,6 +19,34 @@ class AiResponsePreview extends ConsumerWidget {
         child: ConstrainedBox(
           constraints: const BoxConstraints(minWidth: 600),
           child: MarkdownBody(data: responseText),
+        ),
+      ),
+    );
+  }
+}
+
+class AiChecklistResponsePreview extends ConsumerWidget {
+  const AiChecklistResponsePreview({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final items = ref.watch(aiChecklistResponseProvider);
+
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(minWidth: 600),
+          child: Column(
+            children: [
+              for (final item in items)
+                CheckboxItemWidget(
+                  title: item.title,
+                  isChecked: false,
+                  onChanged: (checked) {},
+                ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/ai/ui/ai_response_preview.dart
+++ b/lib/features/ai/ui/ai_response_preview.dart
@@ -3,8 +3,7 @@ import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/ai/state/ollama_prompt.dart';
 import 'package:lotti/features/ai/state/ollama_prompt_checklist.dart';
-
-import '../../tasks/ui/checkbox_item_widget.dart';
+import 'package:lotti/features/tasks/ui/checkbox_item_widget.dart';
 
 class AiResponsePreview extends ConsumerWidget {
   const AiResponsePreview({super.key});

--- a/lib/features/journal/ui/widgets/entry_details/entry_detail_header.dart
+++ b/lib/features/journal/ui/widgets/entry_details/entry_detail_header.dart
@@ -144,6 +144,11 @@ class _EntryDetailHeaderState extends ConsumerState<EntryDetailHeader> {
                     ),
                   ),
                   if (isDesktop)
+                    AiPopUpMenu(
+                      journalEntity: entry,
+                      linkedFromId: widget.linkedFromId,
+                    ),
+                  if (isDesktop)
                     SizedBox(
                       width: 40,
                       child: AiPromptIconWidget(

--- a/lib/features/journal/ui/widgets/entry_details/entry_detail_header.dart
+++ b/lib/features/journal/ui/widgets/entry_details/entry_detail_header.dart
@@ -151,6 +151,14 @@ class _EntryDetailHeaderState extends ConsumerState<EntryDetailHeader> {
                         linkedFromId: widget.linkedFromId,
                       ),
                     ),
+                  if (isDesktop)
+                    SizedBox(
+                      width: 40,
+                      child: AiChecklistIconWidget(
+                        journalEntity: entry,
+                        linkedFromId: widget.linkedFromId,
+                      ),
+                    ),
                 ],
               ],
             ),

--- a/lib/features/journal/ui/widgets/entry_details/entry_detail_header.dart
+++ b/lib/features/journal/ui/widgets/entry_details/entry_detail_header.dart
@@ -75,6 +75,11 @@ class _EntryDetailHeaderState extends ConsumerState<EntryDetailHeader> {
                   activeIcon: Icons.flag,
                   activeColor: context.colorScheme.error,
                 ),
+                if (isDesktop)
+                  AiPopUpMenu(
+                    journalEntity: entry,
+                    linkedFromId: widget.linkedFromId,
+                  ),
                 if (!showAllIcons)
                   SizedBox(
                     width: 40,
@@ -143,27 +148,6 @@ class _EntryDetailHeaderState extends ConsumerState<EntryDetailHeader> {
                       onPressed: () => setState(() => showAllIcons = false),
                     ),
                   ),
-                  if (isDesktop)
-                    AiPopUpMenu(
-                      journalEntity: entry,
-                      linkedFromId: widget.linkedFromId,
-                    ),
-                  if (isDesktop)
-                    SizedBox(
-                      width: 40,
-                      child: AiPromptIconWidget(
-                        journalEntity: entry,
-                        linkedFromId: widget.linkedFromId,
-                      ),
-                    ),
-                  if (isDesktop)
-                    SizedBox(
-                      width: 40,
-                      child: AiChecklistIconWidget(
-                        journalEntity: entry,
-                        linkedFromId: widget.linkedFromId,
-                      ),
-                    ),
                 ],
               ],
             ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,4 +1,7 @@
 {
+  "aiAssistantTitle": "AI Assistant",
+  "aiAssistantCreateChecklist": "Create checklist items",
+  "aiAssistantRunPrompt": "Ask Llama3",
   "addActionAddAudioRecording": "Start Audio Recording",
   "addActionAddMeasurable": "Add Measurable",
   "addActionAddPhotos": "Add Photo(s)",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.517+2697
+version: 0.9.518+2698
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR adds an experimental feature for creating checklist from any freeform text (such as transcribed audio recordings) which Llama3 is prompted with, together with a system message that tells it to assume the text describes a task, something that needs to get done, and then to create JSON output with matching checklist items. 

The results look promising:

Text: "I need to update the dependencies of a mobile app and for that first identify which dependencies to upgrade, run an automatic upgrade, then release macOS, release iOS and create a pull request."

<img width="744" alt="image" src="https://github.com/user-attachments/assets/fdc3033c-6cec-4f48-bbf3-1de467b6833c">

Text: "Okay, so I want to bake a cake and it should be some cake with fruit of the season. The season is fall and for example there are apples and plums available."

<img width="744" alt="image" src="https://github.com/user-attachments/assets/d9ecbb53-0349-4762-b1aa-1c1a20a81dd7">

Note that this is a preview. Checklists are not actually created yet, that will happen in a subsequent PR that will also bring the UI integration of checklist and checklist item entities. To test this, you will need to run Lotti on macOS and have [Ollama](https://ollama.com) running in the background. Also, you will need to have model `llama3:8b` installed locally. You can install this model by running the following in the terminal

```
    $ ollama pull llama3:8b
```