### PR TITLE
feat: modal bottom sheet for extended entry actions

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -99,20 +99,20 @@ PODS:
   - sqflite_darwin (0.0.4):
     - Flutter
     - FlutterMacOS
-  - "sqlite3 (3.46.1+1)":
-    - "sqlite3/common (= 3.46.1+1)"
-  - "sqlite3/common (3.46.1+1)"
-  - "sqlite3/dbstatvtab (3.46.1+1)":
+  - sqlite3 (3.47.0):
+    - sqlite3/common (= 3.47.0)
+  - sqlite3/common (3.47.0)
+  - sqlite3/dbstatvtab (3.47.0):
     - sqlite3/common
-  - "sqlite3/fts5 (3.46.1+1)":
+  - sqlite3/fts5 (3.47.0):
     - sqlite3/common
-  - "sqlite3/perf-threadsafe (3.46.1+1)":
+  - sqlite3/perf-threadsafe (3.47.0):
     - sqlite3/common
-  - "sqlite3/rtree (3.46.1+1)":
+  - sqlite3/rtree (3.47.0):
     - sqlite3/common
   - sqlite3_flutter_libs (0.0.1):
     - Flutter
-    - "sqlite3 (~> 3.46.0+1)"
+    - sqlite3 (~> 3.47.0)
     - sqlite3/dbstatvtab
     - sqlite3/fts5
     - sqlite3/perf-threadsafe
@@ -284,8 +284,8 @@ SPEC CHECKSUMS:
   share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   sqflite_darwin: a553b1fd6fe66f53bbb0fe5b4f5bab93f08d7a13
-  sqlite3: 0bb0e6389d824e40296f531b858a2a0b71c0d2fb
-  sqlite3_flutter_libs: c00457ebd31e59fa6bb830380ddba24d44fbcd3b
+  sqlite3: 0aa20658a9b238a3b1ff7175eb7bdd863b0ab4fd
+  sqlite3_flutter_libs: b55ef23cfafea5318ae5081e0bf3fbbce8417c94
   super_native_extensions: 4916b3c627a9c7fffdc48a23a9eca0b1ac228fa7
   url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
   video_player_avfoundation: 7c6c11d8470e1675df7397027218274b6d2360b3

--- a/lib/features/journal/ui/widgets/entry_details/delete_icon_widget.dart
+++ b/lib/features/journal/ui/widgets/entry_details/delete_icon_widget.dart
@@ -5,8 +5,8 @@ import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/widgets/modal/modal_action_sheet.dart';
 import 'package:lotti/widgets/modal/modal_sheet_action.dart';
 
-class DeleteIconWidget extends ConsumerWidget {
-  const DeleteIconWidget({
+class DeleteIconListTile extends ConsumerWidget {
+  const DeleteIconListTile({
     required this.entryId,
     required this.beamBack,
     super.key,
@@ -43,15 +43,15 @@ class DeleteIconWidget extends ConsumerWidget {
       }
     }
 
-    return SizedBox(
-      width: 40,
-      child: IconButton(
-        icon: const Icon(Icons.delete_outline_rounded),
-        splashColor: Colors.transparent,
-        tooltip: context.messages.journalDeleteHint,
-        padding: EdgeInsets.zero,
-        onPressed: onPressed,
-      ),
+    return ListTile(
+      leading: const Icon(Icons.delete_outline_rounded),
+      title: Text(context.messages.journalDeleteHint),
+      onTap: () async {
+        await onPressed();
+        if (context.mounted) {
+          Navigator.of(context).pop();
+        }
+      },
     );
   }
 }

--- a/lib/features/journal/ui/widgets/entry_details/entry_detail_header.dart
+++ b/lib/features/journal/ui/widgets/entry_details/entry_detail_header.dart
@@ -14,7 +14,9 @@ import 'package:lotti/services/link_service.dart';
 import 'package:lotti/themes/colors.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/utils/platform.dart';
+import 'package:lotti/widgets/misc/wolt_modal_config.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
 class EntryDetailHeader extends ConsumerStatefulWidget {
   const EntryDetailHeader({
@@ -39,7 +41,6 @@ class _EntryDetailHeaderState extends ConsumerState<EntryDetailHeader> {
 
   @override
   Widget build(BuildContext context) {
-    final linkService = getIt<LinkService>();
     final provider = entryControllerProvider(id: widget.entryId);
     final notifier = ref.read(provider.notifier);
     final entryState = ref.watch(provider).value;
@@ -80,75 +81,15 @@ class _EntryDetailHeaderState extends ConsumerState<EntryDetailHeader> {
                     journalEntity: entry,
                     linkedFromId: widget.linkedFromId,
                   ),
-                if (!showAllIcons)
-                  SizedBox(
-                    width: 40,
-                    child: IconButton(
-                      icon: const Icon(Icons.more_horiz),
-                      tooltip: context.messages.journalHeaderExpand,
-                      onPressed: () => setState(() => showAllIcons = true),
-                    ),
-                  )
-                else ...[
-                  SwitchIconWidget(
-                    tooltip: context.messages.journalPrivateTooltip,
-                    onPressed: notifier.togglePrivate,
-                    value: entry?.meta.private ?? false,
-                    icon: Icons.shield_outlined,
-                    activeIcon: Icons.shield,
-                    activeColor: context.colorScheme.error,
-                  ),
-                  if (entry?.geolocation != null)
-                    SwitchIconWidget(
-                      tooltip: entryState.showMap
-                          ? context.messages.journalHideMapHint
-                          : context.messages.journalShowMapHint,
-                      onPressed: notifier.toggleMapVisible,
-                      value: entryState.showMap,
-                      icon: Icons.map_outlined,
-                      activeIcon: Icons.map,
-                      activeColor: Theme.of(context).primaryColor,
-                    ),
-                  DeleteIconWidget(
+                IconButton(
+                  icon: const Icon(Icons.more_horiz),
+                  onPressed: () => ExtendedHeaderActions.show(
+                    context: context,
                     entryId: id,
-                    beamBack: !widget.inLinkedEntries,
+                    inLinkedEntries: widget.inLinkedEntries,
+                    unlinkFn: widget.unlinkFn,
                   ),
-                  ShareButtonWidget(entryId: id),
-                  TagAddIconWidget(entryId: id),
-                  SizedBox(
-                    width: 40,
-                    child: IconButton(
-                      icon: const Icon(Icons.add_link),
-                      tooltip: context.messages.journalLinkFromHint,
-                      onPressed: () => linkService.linkFrom(id),
-                    ),
-                  ),
-                  SizedBox(
-                    width: 40,
-                    child: IconButton(
-                      icon: Icon(MdiIcons.target),
-                      tooltip: context.messages.journalLinkToHint,
-                      onPressed: () => linkService.linkTo(id),
-                    ),
-                  ),
-                  if (widget.unlinkFn != null)
-                    SizedBox(
-                      width: 40,
-                      child: IconButton(
-                        icon: Icon(MdiIcons.linkOff),
-                        tooltip: context.messages.journalUnlinkHint,
-                        onPressed: widget.unlinkFn,
-                      ),
-                    ),
-                  SizedBox(
-                    width: 40,
-                    child: IconButton(
-                      icon: const Icon(Icons.more_outlined),
-                      tooltip: context.messages.journalHeaderContract,
-                      onPressed: () => setState(() => showAllIcons = false),
-                    ),
-                  ),
-                ],
+                ),
               ],
             ),
           ),
@@ -203,6 +144,205 @@ class SwitchIconWidget extends StatelessWidget {
               )
             : Icon(icon),
       ),
+    );
+  }
+}
+
+class SwitchListTile extends StatelessWidget {
+  const SwitchListTile({
+    required this.title,
+    required this.onPressed,
+    required this.value,
+    required this.icon,
+    required this.activeIcon,
+    required this.activeColor,
+    super.key,
+  });
+
+  final String title;
+  final void Function() onPressed;
+  final bool value;
+
+  final IconData icon;
+  final IconData activeIcon;
+  final Color activeColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: value
+          ? Icon(
+              activeIcon,
+              color: activeColor,
+            )
+          : Icon(icon),
+      title: Text(title),
+      onTap: onPressed,
+    );
+  }
+}
+
+class ExtendedHeaderActions {
+  static SliverWoltModalSheetPage page1({
+    required BuildContext context,
+    required TextTheme textTheme,
+    required String entryId,
+    required bool inLinkedEntries,
+    required Future<void> Function()? unlinkFn,
+  }) {
+    final linkService = getIt<LinkService>();
+
+    return WoltModalSheetPage(
+      hasSabGradient: false,
+      topBarTitle: Text(
+        context.messages.entryActions,
+        style: textTheme.titleLarge,
+      ),
+      isTopBarLayerAlwaysVisible: true,
+      child: Padding(
+        padding: const EdgeInsets.all(WoltModalConfig.pagePadding).copyWith(
+          top: 0,
+        ),
+        child: Column(
+          children: [
+            TogglePrivateListTile(entryId: entryId),
+            ToggleMapListTile(entryId: entryId),
+            DeleteIconListTile(
+              entryId: entryId,
+              beamBack: !inLinkedEntries,
+            ),
+            ShareButtonListTile(entryId: entryId),
+            TagAddListTile(entryId: entryId),
+            ListTile(
+              leading: const Icon(Icons.add_link),
+              title: Text(context.messages.journalLinkFromHint),
+              onTap: () {
+                linkService.linkFrom(entryId);
+                Navigator.of(context).pop();
+              },
+            ),
+            ListTile(
+              leading: Icon(MdiIcons.target),
+              title: Text(context.messages.journalLinkToHint),
+              onTap: () {
+                linkService.linkTo(entryId);
+                Navigator.of(context).pop();
+              },
+            ),
+            if (unlinkFn != null)
+              ListTile(
+                leading: Icon(MdiIcons.linkOff),
+                title: Text(context.messages.journalUnlinkHint),
+                onTap: () {
+                  unlinkFn();
+                  Navigator.of(context).pop();
+                },
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  static Future<void> show({
+    required BuildContext context,
+    required String entryId,
+    required bool inLinkedEntries,
+    required Future<void> Function()? unlinkFn,
+  }) async {
+    await WoltModalSheet.show<void>(
+      context: context,
+      pageListBuilder: (modalSheetContext) {
+        final textTheme = context.textTheme;
+        return [
+          page1(
+            context: modalSheetContext,
+            textTheme: textTheme,
+            entryId: entryId,
+            inLinkedEntries: inLinkedEntries,
+            unlinkFn: unlinkFn,
+          ),
+        ];
+      },
+      modalTypeBuilder: (context) {
+        final size = MediaQuery.of(context).size.width;
+        if (size < WoltModalConfig.pageBreakpoint) {
+          return WoltModalType.bottomSheet();
+        } else {
+          return WoltModalType.dialog();
+        }
+      },
+      onModalDismissedWithBarrierTap: () {
+        Navigator.of(context).pop();
+      },
+    );
+  }
+}
+
+class TogglePrivateListTile extends ConsumerWidget {
+  const TogglePrivateListTile({
+    required this.entryId,
+    super.key,
+  });
+
+  final String entryId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final provider = entryControllerProvider(id: entryId);
+    final notifier = ref.read(provider.notifier);
+
+    final entryState = ref.watch(provider).value;
+    if (entryState == null) {
+      return const SizedBox.shrink();
+    }
+
+    final entry = entryState.entry;
+
+    return SwitchListTile(
+      title: context.messages.journalPrivateTitle,
+      onPressed: notifier.togglePrivate,
+      value: entry?.meta.private ?? false,
+      icon: Icons.shield_outlined,
+      activeIcon: Icons.shield,
+      activeColor: context.colorScheme.error,
+    );
+  }
+}
+
+class ToggleMapListTile extends ConsumerWidget {
+  const ToggleMapListTile({
+    required this.entryId,
+    super.key,
+  });
+
+  final String entryId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final provider = entryControllerProvider(id: entryId);
+    final notifier = ref.read(provider.notifier);
+
+    final entryState = ref.watch(provider).value;
+    if (entryState == null) {
+      return const SizedBox.shrink();
+    }
+
+    final entry = entryState.entry;
+
+    if (entry?.geolocation == null) {
+      return const SizedBox.shrink();
+    }
+
+    return SwitchListTile(
+      title: entryState.showMap
+          ? context.messages.journalHideMapHint
+          : context.messages.journalShowMapHint,
+      onPressed: notifier.toggleMapVisible,
+      value: entryState.showMap,
+      icon: Icons.map_outlined,
+      activeIcon: Icons.map,
+      activeColor: Theme.of(context).primaryColor,
     );
   }
 }

--- a/lib/features/journal/ui/widgets/tags/tag_add.dart
+++ b/lib/features/journal/ui/widgets/tags/tag_add.dart
@@ -7,8 +7,8 @@ import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/services/tags_service.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
-class TagAddIconWidget extends ConsumerWidget {
-  TagAddIconWidget({
+class TagAddListTile extends ConsumerWidget {
+  TagAddListTile({
     required this.entryId,
     super.key,
   });
@@ -36,14 +36,10 @@ class TagAddIconWidget extends ConsumerWidget {
       );
     }
 
-    return SizedBox(
-      width: 40,
-      child: IconButton(
-        onPressed: onTapAdd,
-        icon: Icon(MdiIcons.tag),
-        splashColor: Colors.transparent,
-        tooltip: context.messages.journalTagPlusHint,
-      ),
+    return ListTile(
+      leading: Icon(MdiIcons.tag),
+      title: Text(context.messages.journalTagPlusHint),
+      onTap: onTapAdd,
     );
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,5 +1,6 @@
 {
   "aiAssistantTitle": "AI Assistant",
+  "entryActions": "Entry Actions",
   "aiAssistantCreateChecklist": "Create checklist items",
   "aiAssistantRunPrompt": "Ask Llama3",
   "addActionAddAudioRecording": "Start Audio Recording",
@@ -118,6 +119,7 @@
   "journalLinkFromHint": "Link from",
   "journalLinkToHint": "Link to",
   "journalPrivateTooltip": "private only",
+  "journalPrivateTitle": "Toggle private mode",
   "journalSearchHint": "Search journal...",
   "journalShareAudioHint": "Share audio",
   "journalSharePhotoHint": "Share photo",

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -62,20 +62,20 @@ PODS:
   - sqflite_darwin (0.0.4):
     - Flutter
     - FlutterMacOS
-  - "sqlite3 (3.46.1+1)":
-    - "sqlite3/common (= 3.46.1+1)"
-  - "sqlite3/common (3.46.1+1)"
-  - "sqlite3/dbstatvtab (3.46.1+1)":
+  - sqlite3 (3.47.0):
+    - sqlite3/common (= 3.47.0)
+  - sqlite3/common (3.47.0)
+  - sqlite3/dbstatvtab (3.47.0):
     - sqlite3/common
-  - "sqlite3/fts5 (3.46.1+1)":
+  - sqlite3/fts5 (3.47.0):
     - sqlite3/common
-  - "sqlite3/perf-threadsafe (3.46.1+1)":
+  - sqlite3/perf-threadsafe (3.47.0):
     - sqlite3/common
-  - "sqlite3/rtree (3.46.1+1)":
+  - sqlite3/rtree (3.47.0):
     - sqlite3/common
   - sqlite3_flutter_libs (0.0.1):
     - FlutterMacOS
-    - "sqlite3 (~> 3.46.0+1)"
+    - sqlite3 (~> 3.47.0)
     - sqlite3/dbstatvtab
     - sqlite3/fts5
     - sqlite3/perf-threadsafe
@@ -199,7 +199,7 @@ SPEC CHECKSUMS:
   ffmpeg_kit_flutter: 5bd75928cf88ec177cea410b027681e4bfe09452
   file_selector_macos: cc3858c981fe6889f364731200d6232dac1d812d
   flutter_image_compress_macos: c26c3c13ea0f28ae6dea4e139b3292e7729f99f1
-  flutter_local_notifications: 3805ca215b2fb7f397d78b66db91f6a747af52e4
+  flutter_local_notifications: 4b427ffabf278fc6ea9484c97505e231166927a5
   flutter_native_timezone: 3a4724189c47dea215bb3e168e555e18308d312c
   flutter_secure_storage_macos: 59459653abe1adb92abbc8ea747d79f8d19866c9
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
@@ -221,8 +221,8 @@ SPEC CHECKSUMS:
   share_plus: fd717ef89a2801d3491e737630112b80c310640e
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   sqflite_darwin: a553b1fd6fe66f53bbb0fe5b4f5bab93f08d7a13
-  sqlite3: 0bb0e6389d824e40296f531b858a2a0b71c0d2fb
-  sqlite3_flutter_libs: 5ca46c1a04eddfbeeb5b16566164aa7ad1616e7b
+  sqlite3: 0aa20658a9b238a3b1ff7175eb7bdd863b0ab4fd
+  sqlite3_flutter_libs: f0b7a85544d8bac7b8bac12eac7d05bcfdd786d0
   super_native_extensions: 85efee3a7495b46b04befcfc86ed12069264ebf3
   url_launcher_macos: c82c93949963e55b228a30115bd219499a6fe404
   video_player_avfoundation: 7c6c11d8470e1675df7397027218274b6d2360b3

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -934,10 +934,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: "49eeef364fddb71515bc78d5a8c51435a68bccd6e4d68e25a942c5e47761ae71"
+      sha256: "674173fd3c9eda9d4c8528da2ce0ea69f161577495a9cc835a2a4ecd7eadeb35"
       url: "https://pub.dev"
     source: hosted
-    version: "17.2.3"
+    version: "17.2.4"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
@@ -971,10 +971,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_markdown
-      sha256: bd9c475d9aae256369edacafc29d1e74c81f78a10cdcdacbbbc9e3c43d009e4a
+      sha256: f0e599ba89c9946c8e051780f0ec99aba4ba15895e0380a7ab68f420046fc44e
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.4+1"
   flutter_native_splash:
     dependency: "direct dev"
     description:
@@ -1019,10 +1019,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_quill
-      sha256: f7ccfb2a97d0117a5f757770a762a2cfe945bacc77fc80ac21287a7096e286bd
+      sha256: "6274834823e61291c0cedee9dd7f73fc7836ea07a12596de8f5fa08598b5eb74"
       url: "https://pub.dev"
     source: hosted
-    version: "10.8.4"
+    version: "10.8.5"
   flutter_quill_delta_from_html:
     dependency: transitive
     description:
@@ -1035,10 +1035,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_quill_extensions
-      sha256: b0b341550eb50ab16459e6a0eeadb6919e1d1d0c3c6ee71c8ec816a7d4d32ff6
+      sha256: e8ff79c2bbdbf57d3248ec07055ec54ef0c35e270659d6058efd42a0e0ae1286
       url: "https://pub.dev"
     source: hosted
-    version: "10.8.4"
+    version: "10.8.5"
   flutter_rating:
     dependency: "direct main"
     description:
@@ -1051,10 +1051,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_riverpod
-      sha256: "6eda4e247774474c715a0805a2fb8e3cd55fbae4ead641e063c95b4bd5f3b317"
+      sha256: "9532ee6db4a943a1ed8383072a2e3eeda041db5657cdf6d2acecf3c21ecbe7e1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.0"
+    version: "2.6.1"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -1403,10 +1403,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: d34e0d9e024e81321b2aeed7b202ec6181cc282e6a1c0c0b4e6ad07ef1065d82
+      sha256: "8faba09ba361d4b246dc0a17cb4289b3324c2b9f6db7b3d457ee69106a86bd32"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.12+16"
+    version: "0.8.12+17"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -1992,10 +1992,10 @@ packages:
     dependency: transitive
     description:
       name: path_parsing
-      sha256: e3e67b1629e6f7e8100b367d3db6ba6af4b1f0bb80f64db18ef1fbabd2fa9ccf
+      sha256: "45f7d6bba1128761de5540f39d5ca000ea8a1f22f06b76b61094a60a2997bd0e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   path_provider:
     dependency: "direct main"
     description:
@@ -2056,10 +2056,10 @@ packages:
     dependency: "direct main"
     description:
       name: photo_manager
-      sha256: "70159eee32203e8162d49d588232f0299ed3f383c63eef1e899cb6b83dee6b26"
+      sha256: "4e156239896c619c9f092ba6d200e4292b1d0084e3ca38c559818053ee483e84"
       url: "https://pub.dev"
     source: hosted
-    version: "3.5.1"
+    version: "3.5.2"
   photo_manager_image_provider:
     dependency: transitive
     description:
@@ -2401,42 +2401,42 @@ packages:
     dependency: transitive
     description:
       name: riverpod
-      sha256: bd6e656a764e3d27f211975626e0c4f9b8d06ab16acf3c7ba7a8061e09744c75
+      sha256: "59062512288d3056b2321804332a13ffdd1bf16df70dcc8e506e411280a72959"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.0"
+    version: "2.6.1"
   riverpod_analyzer_utils:
     dependency: transitive
     description:
       name: riverpod_analyzer_utils
-      sha256: ac28d7bc678471ec986b42d88e5a0893513382ff7542c7ac9634463b044ac72c
+      sha256: "0dcb0af32d561f8fa000c6a6d95633c9fb08ea8a8df46e3f9daca59f11218167"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.4"
+    version: "0.5.6"
   riverpod_annotation:
     dependency: "direct main"
     description:
       name: riverpod_annotation
-      sha256: "1e61f8e7fc360f75e3520bbb35d22213ef542dc0de574cf90d639a358965d743"
+      sha256: e14b0bf45b71326654e2705d462f21b958f987087be850afd60578fcd502d1b8
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.0"
+    version: "2.6.1"
   riverpod_generator:
     dependency: "direct dev"
     description:
       name: riverpod_generator
-      sha256: "63311e361ffc578d655dfc31b48dfa4ed3bc76fd06f9be845e9bf97c5c11a429"
+      sha256: "851aedac7ad52693d12af3bf6d92b1626d516ed6b764eb61bf19e968b5e0b931"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.3"
+    version: "2.6.1"
   riverpod_lint:
     dependency: "direct main"
     description:
       name: riverpod_lint
-      sha256: a35a92f2c2a4b7a5d95671c96c5432b42c20f26bb3e985e83d0b186471b61a85
+      sha256: "0684c21a9a4582c28c897d55c7b611fa59a351579061b43f8c92c005804e63a8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.13"
+    version: "2.6.1"
   rxdart:
     dependency: "direct main"
     description:
@@ -2489,10 +2489,10 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: "334fcdf0ef9c0df0e3b428faebcac9568f35c747d59831474b2fc56e156d244e"
+      sha256: "3af2cda1752e5c24f2fc04b6083b40f013ffe84fb90472f30c6499a9213d5442"
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.0"
+    version: "10.1.1"
   share_plus_platform_interface:
     dependency: transitive
     description:
@@ -2718,18 +2718,18 @@ packages:
     dependency: "direct main"
     description:
       name: sqlite3
-      sha256: "45f168ae2213201b54e09429ed0c593dc2c88c924a1488d6f9c523a255d567cb"
+      sha256: bb174b3ec2527f9c5f680f73a89af8149dd99782fbb56ea88ad0807c5638f2ed
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.6"
+    version: "2.4.7"
   sqlite3_flutter_libs:
     dependency: "direct main"
     description:
       name: sqlite3_flutter_libs
-      sha256: ccd29dd6cf6fb9351fa07cd6f92895809adbf0779c1d986acf5e3d53b3250e33
+      sha256: "7ae52b23366e5295005022e62fa093f64bfe190810223ea0ebf733a4cd140bce"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.25"
+    version: "0.5.26"
   sqlparser:
     dependency: transitive
     description:
@@ -2966,10 +2966,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "8fc3bae0b68c02c47c5c86fa8bfa74471d42687b0eded01b78de87872db745e2"
+      sha256: "0dea215895a4d254401730ca0ba8204b29109a34a99fb06ae559a2b60988d2de"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.12"
+    version: "6.3.13"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -3086,10 +3086,10 @@ packages:
     dependency: transitive
     description:
       name: video_player_android
-      sha256: "2800d68d6d5b4c22da62453568ed68e63c35bea524d4fa42062e53d6bb591433"
+      sha256: "391e092ba4abe2f93b3e625bd6b6a6ec7d7414279462c1c0ee42b5ab8d0a0898"
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.13"
+    version: "2.7.16"
   video_player_avfoundation:
     dependency: transitive
     description:
@@ -3110,10 +3110,10 @@ packages:
     dependency: transitive
     description:
       name: video_player_web
-      sha256: "6dcdd298136523eaf7dfc31abaf0dfba9aa8a8dbc96670e87e9d42b6f2caf774"
+      sha256: "881b375a934d8ebf868c7fb1423b2bfaa393a0a265fa3f733079a86536064a10"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.3.3"
   visibility_detector:
     dependency: "direct main"
     description:
@@ -3222,10 +3222,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "2735daae5150e8b1dfeb3eb0544b4d3af0061e9e82cef063adcd583bdae4306a"
+      sha256: e1d0cc62e65dc2561f5071fcbccecf58ff20c344f8f3dc7d4922df372a11df1f
       url: "https://pub.dev"
     source: hosted
-    version: "5.7.0"
+    version: "5.7.1"
   win32_registry:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.526+2710
+version: 0.9.526+2711
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.525+2709
+version: 0.9.526+2710
 
 msix_config:
   display_name: LottiApp

--- a/test/widgets/journal/entry_details/delete_icon_widget_test.dart
+++ b/test/widgets/journal/entry_details/delete_icon_widget_test.dart
@@ -40,7 +40,7 @@ void main() {
     testWidgets('calls delete in cubit', (WidgetTester tester) async {
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(
-          DeleteIconWidget(
+          DeleteIconListTile(
             entryId: testTextEntry.meta.id,
             beamBack: true,
           ),

--- a/test/widgets/journal/tags/tag_add_test.dart
+++ b/test/widgets/journal/tags/tag_add_test.dart
@@ -67,7 +67,7 @@ void main() {
     testWidgets('Icon tap opens modal', (tester) async {
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(
-          TagAddIconWidget(entryId: testTextEntry.meta.id),
+          TagAddListTile(entryId: testTextEntry.meta.id),
         ),
       );
 


### PR DESCRIPTION
This pull request focuses on refactoring various widgets in the journal UI to use `ListTile` instead of `IconButton`, and introduces a new modal sheet for extended header actions. The key changes include renaming widgets, updating their implementations, and adding new localizations.

### Widget Refactoring:

* [`lib/features/journal/ui/widgets/entry_details/delete_icon_widget.dart`](diffhunk://#diff-0037e6b32746e213e43484c4a39f745c01f6e03f669a761bf6c40de78787ee2aL8-R9): Renamed `DeleteIconWidget` to `DeleteIconListTile` and changed its implementation from `IconButton` to `ListTile`. [[1]](diffhunk://#diff-0037e6b32746e213e43484c4a39f745c01f6e03f669a761bf6c40de78787ee2aL8-R9) [[2]](diffhunk://#diff-0037e6b32746e213e43484c4a39f745c01f6e03f669a761bf6c40de78787ee2aL46-R54)
* [`lib/features/journal/ui/widgets/entry_details/share_button_widget.dart`](diffhunk://#diff-1ab7fa406a39195aaa3c4fbff26c77ef580ec48b4950330687c7d89e6a930bbaL6): Renamed `ShareButtonWidget` to `ShareButtonListTile` and changed its implementation from `IconButton` to `ListTile`. [[1]](diffhunk://#diff-1ab7fa406a39195aaa3c4fbff26c77ef580ec48b4950330687c7d89e6a930bbaL6) [[2]](diffhunk://#diff-1ab7fa406a39195aaa3c4fbff26c77ef580ec48b4950330687c7d89e6a930bbaL64-R125)
* [`lib/features/journal/ui/widgets/tags/tag_add.dart`](diffhunk://#diff-ba1d60b869d5376a4e823065b2f770697323665f08697ae38bed78eb20e398f8L10-R11): Renamed `TagAddIconWidget` to `TagAddListTile` and changed its implementation from `IconButton` to `ListTile`. [[1]](diffhunk://#diff-ba1d60b869d5376a4e823065b2f770697323665f08697ae38bed78eb20e398f8L10-R11) [[2]](diffhunk://#diff-ba1d60b869d5376a4e823065b2f770697323665f08697ae38bed78eb20e398f8L39-R42)

### Extended Header Actions:

* [`lib/features/journal/ui/widgets/entry_details/entry_detail_header.dart`](diffhunk://#diff-5d892f0829b02b37847cc747fec99d35405b2eb1035f1528e1197277e5a20ea6R17-R19): Introduced `ExtendedHeaderActions` class to handle extended header actions using a modal sheet. Refactored the header to use this new modal sheet. [[1]](diffhunk://#diff-5d892f0829b02b37847cc747fec99d35405b2eb1035f1528e1197277e5a20ea6R17-R19) [[2]](diffhunk://#diff-5d892f0829b02b37847cc747fec99d35405b2eb1035f1528e1197277e5a20ea6L42) [[3]](diffhunk://#diff-5d892f0829b02b37847cc747fec99d35405b2eb1035f1528e1197277e5a20ea6L83-L151) [[4]](diffhunk://#diff-5d892f0829b02b37847cc747fec99d35405b2eb1035f1528e1197277e5a20ea6R150-R348)

### Localization Updates:

* [`lib/l10n/app_en.arb`](diffhunk://#diff-9796fde3771f42a3a759ccc941731d83f96037a661e47dde27ce81d3447a69c2R3): Added new localization keys for entry actions and toggle private mode. [[1]](diffhunk://#diff-9796fde3771f42a3a759ccc941731d83f96037a661e47dde27ce81d3447a69c2R3) [[2]](diffhunk://#diff-9796fde3771f42a3a759ccc941731d83f96037a661e47dde27ce81d3447a69c2R122)

### Miscellaneous:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Updated the version of the application.
* [`test/widgets/journal/entry_details/delete_icon_widget_test.dart`](diffhunk://#diff-16c3902769da3c6c7dc43853cef5875bf1f9d0ea543151882a2ff4afcdc0a9a8L43-R43): Updated tests to reflect the renaming of `DeleteIconWidget` to `DeleteIconListTile`.
* [`test/widgets/journal/tags/tag_add_test.dart`](diffhunk://#diff-26be593087fbeec384f690b670999ae9ebd344a139fc53cb761a90ebf5d824c8L70-R70): Updated tests to reflect the renaming of `TagAddIconWidget` to `TagAddListTile`.