### PR TITLE
fix: duplicate days in charts on day DST ends

### DIFF
--- a/lib/widgets/charts/utils.dart
+++ b/lib/widgets/charts/utils.dart
@@ -1,3 +1,4 @@
+import 'dart:collection';
 import 'dart:core';
 import 'dart:math';
 
@@ -128,7 +129,9 @@ List<String> daysInRange({
   required DateTime rangeEnd,
 }) {
   final range = rangeEnd.difference(rangeStart);
-  return getDayStrings(range.inDays + 1, rangeStart);
+  return LinkedHashSet<String>.from(
+    getDayStrings(range.inDays + 1, rangeStart),
+  ).toList();
 }
 
 List<Observation> aggregateMaxByDay(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.526+2714
+version: 0.9.526+2715
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This pull request includes several changes to the `lib/widgets/charts/utils.dart` file and a version update in `pubspec.yaml`. The most important changes include the addition of a new import statement and a modification to the `daysInRange` function to ensure unique day strings.

Changes to `lib/widgets/charts/utils.dart`:

* Added `dart:collection` import to the file. (`lib/widgets/charts/utils.dart`)
* Modified the `daysInRange` function to return a list of unique day strings using `LinkedHashSet`. (`lib/widgets/charts/utils.dart`)

Version update:

* Incremented the version number in `pubspec.yaml` from `0.9.526+2714` to `0.9.526+2715`. (`pubspec.yaml`)