### PR TITLE
fix: habits chart after end of DST

### DIFF
--- a/lib/blocs/habits/habits_cubit.dart
+++ b/lib/blocs/habits/habits_cubit.dart
@@ -435,9 +435,9 @@ double minY({
 
 List<String> getDays(int timeSpanDays) {
   final now = DateTime.now();
-
-  return daysInRange(
-    rangeStart: now.subtract(Duration(days: timeSpanDays)),
+  final days = daysInRange(
+    rangeStart: now.dayAtMidnight.subtract(Duration(days: timeSpanDays)),
     rangeEnd: now,
   )..sort();
+  return days;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.527+2718
+version: 0.9.527+2719
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This pull request includes a few changes to improve the functionality of the `getDays` method and update the project version.

Improvements to `getDays` method:

* [`lib/blocs/habits/habits_cubit.dart`](diffhunk://#diff-2d1ab1a40de156b2d0cf1c294e16505cc07aa782affd791aa99015de6c792018L438-R442): Modified the `getDays` method to ensure that the `rangeStart` uses `now.dayAtMidnight` for more accurate day calculations.

Project version update:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Updated the project version from `0.9.527+2718` to `0.9.527+2719`.