### PR TITLE
feat: add maintenance task for resyncing categories

### DIFF
--- a/lib/database/maintenance.dart
+++ b/lib/database/maintenance.dart
@@ -145,6 +145,20 @@ class Maintenance {
     }
   }
 
+  Future<void> syncCategories() async {
+    final outboxService = getIt<OutboxService>();
+    final categories = await _db.watchCategories().first;
+
+    for (final category in categories) {
+      await outboxService.enqueueMessage(
+        SyncMessage.entityDefinition(
+          entityDefinition: category,
+          status: SyncEntryStatus.update,
+        ),
+      );
+    }
+  }
+
   Future<void> deleteTaggedLinks() async {
     await createDbBackup(journalDbFileName);
     await _db.deleteTagged();

--- a/lib/features/tasks/state/checklist_controller.g.dart
+++ b/lib/features/tasks/state/checklist_controller.g.dart
@@ -7,7 +7,7 @@ part of 'checklist_controller.dart';
 // **************************************************************************
 
 String _$checklistControllerHash() =>
-    r'7484a3e7f406e25b55c944337e08257efb2082cb';
+    r'f2f64aaf386fcb76fa5ef2c281ffe6ec5afbf62f';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -176,7 +176,7 @@ class _ChecklistControllerProviderElement
 }
 
 String _$checklistCompletionControllerHash() =>
-    r'5a77b1e2f4430530570968cae7eeea098ea9aaf7';
+    r'eba25442a2767af0e8a5ace1889ed6233baf1535';
 
 abstract class _$ChecklistCompletionController
     extends BuildlessAutoDisposeAsyncNotifier<double> {

--- a/lib/features/tasks/state/checklist_item_controller.g.dart
+++ b/lib/features/tasks/state/checklist_item_controller.g.dart
@@ -7,7 +7,7 @@ part of 'checklist_item_controller.dart';
 // **************************************************************************
 
 String _$checklistItemControllerHash() =>
-    r'5be1b06249350cb526c6a4b91676da1c3d967df3';
+    r'5202e51beaca56c4f445b35b7c29659f3e257a54';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -156,6 +156,7 @@
   "maintenanceResetHostId": "Reset Host ID",
   "maintenanceStories": "Assign stories from parent entries",
   "maintenanceSyncDefinitions": "Sync tags, measurables, dashboards, habits",
+  "maintenanceSyncCategories": "Sync categories",
   "maintenanceSyncSkip": "Skip sync message",
   "manualLinkText": "Check out the manual for more information",
   "measurableDeleteConfirm": "YES, DELETE THIS MEASURABLE",

--- a/lib/pages/settings/advanced/maintenance_page.dart
+++ b/lib/pages/settings/advanced/maintenance_page.dart
@@ -57,6 +57,10 @@ class MaintenancePage extends StatelessWidget {
                 onTap: maintenance.syncDefinitions,
               ),
               SettingsCard(
+                title: context.messages.maintenanceSyncCategories,
+                onTap: maintenance.syncCategories,
+              ),
+              SettingsCard(
                 title: context.messages.maintenancePurgeDeleted,
                 onTap: db.purgeDeleted,
               ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -563,18 +563,18 @@ packages:
     dependency: "direct main"
     description:
       name: drift
-      sha256: df027d168a2985a2e9da900adeba2ab0136f0d84436592cf3cd5135f82c8579c
+      sha256: "530d6c5a79723dff418c49c0bb498360fd77c965ea234587e345826cb63ecdd2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.21.0"
+    version: "2.22.0"
   drift_dev:
     dependency: "direct dev"
     description:
       name: drift_dev
-      sha256: "623649abe932fc17bd32e578e7e05f7ac5e7dd0b33e6c8669a0634105d1389bf"
+      sha256: "488263d85d027333fc602eb7714125de317e8c7db064aa6c2f208a8f79139e7b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.21.2"
+    version: "2.22.0"
   easy_debounce:
     dependency: "direct main"
     description:
@@ -979,10 +979,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_markdown
-      sha256: "999a4e3cb3e1532a971c86d6c73a480264f6a687959d4887cb4e2990821827e4"
+      sha256: "255b00afa1a7bad19727da6a7780cf3db6c3c12e68d302d85e0ff1fdf173db9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4+2"
+    version: "0.7.4+3"
   flutter_native_splash:
     dependency: "direct dev"
     description:
@@ -1131,10 +1131,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_svg
-      sha256: "936d9c1c010d3e234d1672574636f3352b4941ca3decaddd3cafaeb9ad49c471"
+      sha256: "54900a1a1243f3c4a5506d853a2b5c2dbc38d5f27e52a52618a8054401431123"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.15"
+    version: "2.0.16"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -1411,10 +1411,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: "8faba09ba361d4b246dc0a17cb4289b3324c2b9f6db7b3d457ee69106a86bd32"
+      sha256: fa8141602fde3f7e2f81dbf043613eb44dfa325fa0bcf93c0f142c9f7a2c193e
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.12+17"
+    version: "0.8.12+18"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -2766,10 +2766,10 @@ packages:
     dependency: transitive
     description:
       name: sqlparser
-      sha256: d77749237609784e337ec36c979d41f6f38a7b279df98622ae23929c8eb954a4
+      sha256: "4cad4b2c5f63dc9ea1a8dcffb58cf762322bea5dd8836870164a65e913bdae41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.39.2"
+    version: "0.40.0"
   stack_trace:
     dependency: transitive
     description:
@@ -3254,10 +3254,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "84ba388638ed7a8cb3445a320c8273136ab2631cd5f2c57888335504ddab1bc2"
+      sha256: "8b338d4486ab3fbc0ba0db9f9b4f5239b6697fcee427939a40e720cbb9ee0a69"
       url: "https://pub.dev"
     source: hosted
-    version: "5.8.0"
+    version: "5.9.0"
   win32_registry:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.536+2754
+version: 0.9.536+2755
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.535+2753
+version: 0.9.536+2754
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This pull request introduces a new feature to sync categories in the maintenance section of the application. The changes include adding a new method to handle the synchronization process, updating the localization file, and modifying the settings page to include this new feature.

### New Feature: Sync Categories

* [`lib/database/maintenance.dart`](diffhunk://#diff-3181a930a3fc0b654a42fa7e456f4dfa84a2f85258cc79a07387dca90852cd66R148-R161): Added a new method `syncCategories` to the `Maintenance` class to handle the synchronization of categories. This method retrieves categories from the database and enqueues sync messages for each category.

### Localization Update

* [`lib/l10n/app_en.arb`](diffhunk://#diff-9796fde3771f42a3a759ccc941731d83f96037a661e47dde27ce81d3447a69c2R159): Added a new localization string `maintenanceSyncCategories` for the sync categories feature.

### UI Update

* [`lib/pages/settings/advanced/maintenance_page.dart`](diffhunk://#diff-9629a2a007ae47f07a96d05d0ee0e3dfb0800201a7ae590bbdc1e4dd6a24d205R59-R62): Added a new `SettingsCard` to the `MaintenancePage` to trigger the `syncCategories` method when tapped.

### Version Update

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Updated the version number from `0.9.535+2753` to `0.9.536+2754`.