### PR TITLE
test: add timeout in matrix test

### DIFF
--- a/integration_test/matrix_service_test.dart
+++ b/integration_test/matrix_service_test.dart
@@ -53,10 +53,6 @@ void main() {
       () => mockUpdateNotifications.notify(any()),
     ).thenAnswer((_) {});
 
-    getIt
-      ..registerSingleton<UpdateNotifications>(mockUpdateNotifications)
-      ..registerSingleton<UserActivityService>(UserActivityService());
-
     final aliceDb = JournalDb(
       overriddenFilename: 'alice_db.sqlite',
       inMemoryDatabase: true,
@@ -115,18 +111,16 @@ void main() {
         ..createSync(recursive: true);
       debugPrint('Created temporary docDir ${docDir.path}');
 
-      final mockSettingsDb = MockSettingsDb();
-
       getIt
         ..registerSingleton<Directory>(docDir)
         ..registerSingleton<LoggingDb>(LoggingDb(inMemoryDatabase: true))
+        ..registerSingleton<UpdateNotifications>(mockUpdateNotifications)
+        ..registerSingleton<UserActivityService>(UserActivityService())
         ..registerSingleton<JournalDb>(JournalDb(inMemoryDatabase: true))
         ..registerSingleton<SettingsDb>(SettingsDb(inMemoryDatabase: true))
         ..registerSingleton<SecureStorage>(secureStorageMock);
 
-      when(() => mockSettingsDb.itemByKey(any())).thenAnswer((_) async => null);
-      when(() => mockSettingsDb.saveSettingsItem(any(), any()))
-          .thenAnswer((_) async => 0);
+      await Future<void>.delayed(const Duration(seconds: 5));
     });
 
     setUp(() {});
@@ -146,6 +140,8 @@ void main() {
           dbName: 'Alice',
           deviceDisplayName: 'Alice',
           overriddenJournalDb: aliceDb,
+          overriddenLoggingDb: LoggingDb(inMemoryDatabase: true),
+          overriddenSettingsDb: SettingsDb(inMemoryDatabase: true),
         );
 
         await alice.login();
@@ -171,6 +167,8 @@ void main() {
           dbName: 'Bob',
           deviceDisplayName: 'Bob',
           overriddenJournalDb: bobDb,
+          overriddenLoggingDb: LoggingDb(inMemoryDatabase: true),
+          overriddenSettingsDb: SettingsDb(inMemoryDatabase: true),
         );
 
         await bob.login();

--- a/lib/features/sync/matrix/last_read.dart
+++ b/lib/features/sync/matrix/last_read.dart
@@ -2,11 +2,15 @@ import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/features/sync/matrix.dart';
 import 'package:lotti/get_it.dart';
 
-Future<void> setLastReadMatrixEventId(String eventId) =>
-    getIt<SettingsDb>().saveSettingsItem(
+Future<void> setLastReadMatrixEventId(
+  String eventId,
+  SettingsDb? overriddenSettingsDb,
+) =>
+    (overriddenSettingsDb ?? getIt<SettingsDb>()).saveSettingsItem(
       lastReadMatrixEventId,
       eventId,
     );
 
-Future<String?> getLastReadMatrixEventId() =>
-    getIt<SettingsDb>().itemByKey(lastReadMatrixEventId);
+Future<String?> getLastReadMatrixEventId(SettingsDb? overriddenSettingsDb) =>
+    (overriddenSettingsDb ?? getIt<SettingsDb>())
+        .itemByKey(lastReadMatrixEventId);

--- a/lib/features/sync/matrix/matrix_service.dart
+++ b/lib/features/sync/matrix/matrix_service.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import 'package:lotti/classes/config.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/database/logging_db.dart';
+import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/features/sync/client_runner.dart';
 import 'package:lotti/features/sync/matrix.dart';
 import 'package:lotti/features/user_activity/state/user_activity_service.dart';
@@ -15,6 +17,8 @@ class MatrixService {
     this.deviceDisplayName,
     String? dbName,
     JournalDb? overriddenJournalDb,
+    LoggingDb? overriddenLoggingDb,
+    SettingsDb? overriddenSettingsDb,
   })  : keyVerificationController =
             StreamController<KeyVerificationRunner>.broadcast(),
         _client = createMatrixClient(dbName: dbName) {
@@ -27,11 +31,13 @@ class MatrixService {
         await processNewTimelineEvents(
           service: this,
           overriddenJournalDb: overriddenJournalDb,
+          overriddenLoggingDb: overriddenLoggingDb,
+          overriddenSettingsDb: overriddenSettingsDb,
         );
       },
     );
 
-    getLastReadMatrixEventId().then(
+    getLastReadMatrixEventId(overriddenSettingsDb).then(
       (value) => lastReadEventContextId = value,
     );
 

--- a/lib/features/sync/matrix/timeline.dart
+++ b/lib/features/sync/matrix/timeline.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/logging_db.dart';
+import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/features/sync/matrix.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/utils/list_extension.dart';
@@ -59,8 +60,10 @@ Future<void> listenToTimelineEvents({
 Future<void> processNewTimelineEvents({
   required MatrixService service,
   JournalDb? overriddenJournalDb,
+  LoggingDb? overriddenLoggingDb,
+  SettingsDb? overriddenSettingsDb,
 }) async {
-  final loggingDb = getIt<LoggingDb>();
+  final loggingDb = overriddenLoggingDb ?? getIt<LoggingDb>();
 
   try {
     final lastReadEventContextId = service.lastReadEventContextId;
@@ -111,7 +114,7 @@ Future<void> processNewTimelineEvents({
       try {
         if (eventId.startsWith(r'$')) {
           service.lastReadEventContextId = eventId;
-          await setLastReadMatrixEventId(eventId);
+          await setLastReadMatrixEventId(eventId, overriddenSettingsDb);
           final loginState = service.client.onLoginStateChanged.value;
           if (loginState == LoginState.loggedIn) {
             await timeline.setReadMarker(eventId: eventId);


### PR DESCRIPTION
This pull request includes several changes to the `integration_test/matrix_service_test.dart`, `lib/features/sync/matrix/last_read.dart`, `lib/features/sync/matrix/matrix_service.dart`, and `lib/features/sync/matrix/timeline.dart` files. The changes primarily focus on improving dependency injection and adding support for overridden databases in various components.

Improvements to dependency injection and support for overridden databases:

* [`integration_test/matrix_service_test.dart`](diffhunk://#diff-e5a55efa9a1b47bf1cfbc486a12993b5ce794be50641fbd1abbda132b7ddbe7fL56-L59): Removed redundant singleton registrations and added delayed initialization for `UpdateNotifications` and `UserActivityService`. [[1]](diffhunk://#diff-e5a55efa9a1b47bf1cfbc486a12993b5ce794be50641fbd1abbda132b7ddbe7fL56-L59) [[2]](diffhunk://#diff-e5a55efa9a1b47bf1cfbc486a12993b5ce794be50641fbd1abbda132b7ddbe7fL118-R123)
* [`integration_test/matrix_service_test.dart`](diffhunk://#diff-e5a55efa9a1b47bf1cfbc486a12993b5ce794be50641fbd1abbda132b7ddbe7fR143-R144): Added support for `overriddenLoggingDb` and `overriddenSettingsDb` in the test setup for `Alice` and `Bob` instances. [[1]](diffhunk://#diff-e5a55efa9a1b47bf1cfbc486a12993b5ce794be50641fbd1abbda132b7ddbe7fR143-R144) [[2]](diffhunk://#diff-e5a55efa9a1b47bf1cfbc486a12993b5ce794be50641fbd1abbda132b7ddbe7fR170-R171)
* [`lib/features/sync/matrix/last_read.dart`](diffhunk://#diff-29e01754be1d2cf1444133dac400ac30949879edc393231aae7d760694d13550L5-R16): Modified `setLastReadMatrixEventId` and `getLastReadMatrixEventId` to accept an optional `overriddenSettingsDb` parameter.
* [`lib/features/sync/matrix/matrix_service.dart`](diffhunk://#diff-b2562ebc9d3428cc2fbbe7bd13441c53eb853840e84b9e1f4b99c96e73d91a66R5-R6): Added `LoggingDb` and `SettingsDb` as optional parameters in `MatrixService` and updated method calls to use these parameters. [[1]](diffhunk://#diff-b2562ebc9d3428cc2fbbe7bd13441c53eb853840e84b9e1f4b99c96e73d91a66R5-R6) [[2]](diffhunk://#diff-b2562ebc9d3428cc2fbbe7bd13441c53eb853840e84b9e1f4b99c96e73d91a66R20-R21) [[3]](diffhunk://#diff-b2562ebc9d3428cc2fbbe7bd13441c53eb853840e84b9e1f4b99c96e73d91a66R34-R40)
* [`lib/features/sync/matrix/timeline.dart`](diffhunk://#diff-38469ae86ca9de9ad7c38045ab4f362a04d8575cabfd112dc3c83eec55cf7dc5R6): Updated `processNewTimelineEvents` to accept optional `overriddenLoggingDb` and `overriddenSettingsDb` parameters and use them if provided. [[1]](diffhunk://#diff-38469ae86ca9de9ad7c38045ab4f362a04d8575cabfd112dc3c83eec55cf7dc5R6) [[2]](diffhunk://#diff-38469ae86ca9de9ad7c38045ab4f362a04d8575cabfd112dc3c83eec55cf7dc5R63-R66) [[3]](diffhunk://#diff-38469ae86ca9de9ad7c38045ab4f362a04d8575cabfd112dc3c83eec55cf7dc5L114-R117)