### PR TITLE
fix: time recording progress indicator

### DIFF
--- a/lib/features/tasks/state/task_progress_controller.dart
+++ b/lib/features/tasks/state/task_progress_controller.dart
@@ -37,6 +37,10 @@ class TaskProgressController extends _$TaskProgressController {
 
     _timeServiceSubscription = _timeService.getStream().listen((journalEntity) {
       if (journalEntity != null) {
+        if (_timeService.linkedFrom?.id != entryId) {
+          return;
+        }
+
         final duration = entryDuration(journalEntity);
         _durations[journalEntity.meta.id] = duration;
         state = AsyncData(_getProgress());

--- a/lib/features/tasks/ui/linked_duration.dart
+++ b/lib/features/tasks/ui/linked_duration.dart
@@ -3,7 +3,6 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/journal/util/entry_tools.dart';
-import 'package:lotti/features/tasks/model/task_progress_state.dart';
 import 'package:lotti/features/tasks/state/task_progress_controller.dart';
 import 'package:lotti/themes/colors.dart';
 import 'package:lotti/themes/theme.dart';
@@ -20,11 +19,11 @@ class LinkedDuration extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final state =
-        ref.watch(taskProgressControllerProvider(id: taskId)).valueOrNull ??
-            const TaskProgressState(
-              progress: Duration.zero,
-              estimate: Duration.zero,
-            );
+        ref.watch(taskProgressControllerProvider(id: taskId)).valueOrNull;
+
+    if (state == null || state.estimate == Duration.zero) {
+      return const SizedBox.shrink();
+    }
 
     final progress = state.progress;
     final estimate = state.estimate;

--- a/lib/services/time_service.dart
+++ b/lib/services/time_service.dart
@@ -30,8 +30,7 @@ class TimeService {
 
     _periodicStream = Stream<int>.periodic(interval, callback);
     if (_periodicStream != null) {
-      // ignore: unused_local_variable
-      await for (final int i in _periodicStream!) {
+      await for (final int _i in _periodicStream!) {
         if (_current != null) {
           _controller.add(
             _current!.copyWith(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.541+2764
+version: 0.9.542+2765
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and performance of the task progress feature, as well as some minor cleanup and version update.

### Task Progress Improvements:

* [`lib/features/tasks/state/task_progress_controller.dart`](diffhunk://#diff-2da69635ef99953c40fad916edf5865f880d5a5b80daea2e9a39a637aa1e6e4bR40-R43): Added a check to ensure that the `_timeService.linkedFrom` ID matches the `entryId` before processing the `journalEntity` in the `_timeServiceSubscription` listener.
* [`lib/features/tasks/ui/linked_duration.dart`](diffhunk://#diff-c891b98fa54e4a178b12f6c86b356b29d038dec83db935cb0a50678b9b59ad8eL23-R26): Modified the `LinkedDuration` widget to return an empty `SizedBox` if the state is `null` or the `estimate` is zero, preventing unnecessary UI updates.

### Code Cleanup:

* [`lib/features/tasks/ui/linked_duration.dart`](diffhunk://#diff-c891b98fa54e4a178b12f6c86b356b29d038dec83db935cb0a50678b9b59ad8eL6): Removed an unused import for `task_progress_state.dart`.
* [`lib/services/time_service.dart`](diffhunk://#diff-632f1a0ddc52baa45cab7ddd3960c98a20b54109ab0ed83c3bd99b026f22ca9fL33-R33): Removed an unnecessary comment and renamed a variable from `i` to `_i` in the `TimeService` class to adhere to naming conventions.

### Version Update:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Updated the version number from `0.9.541+2764` to `0.9.542+2765`.