### PR TITLE
refactor: extract persistence logic

### DIFF
--- a/lib/features/ai/state/ollama_prompt.dart
+++ b/lib/features/ai/state/ollama_prompt.dart
@@ -4,8 +4,7 @@ import 'package:langchain/langchain.dart';
 import 'package:langchain_ollama/langchain_ollama.dart';
 import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/journal_entities.dart';
-import 'package:lotti/get_it.dart';
-import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/features/journal/repository/journal_repository.dart';
 import 'package:lotti/utils/file_utils.dart';
 
 final aiResponseProvider = NotifierProvider<AiResponse, String>(AiResponse.new);
@@ -39,7 +38,7 @@ class AiResponse extends Notifier<String> {
       state += res.outputAsString;
     });
 
-    await getIt<PersistenceLogic>().createTextEntry(
+    await JournalRepository.createTextEntry(
       EntryText(
         plainText: state,
         markdown: state,

--- a/lib/features/journal/repository/journal_repository.dart
+++ b/lib/features/journal/repository/journal_repository.dart
@@ -1,0 +1,179 @@
+import 'dart:convert';
+
+import 'package:lotti/classes/entry_text.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/database/logging_db.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/services/notification_service.dart';
+
+class JournalRepository {
+  JournalRepository();
+
+  static Future<bool> updateCategoryId(
+    String journalEntityId, {
+    required String? categoryId,
+  }) async {
+    try {
+      final persistenceLogic = getIt<PersistenceLogic>();
+
+      final journalEntity =
+          await getIt<JournalDb>().journalEntityById(journalEntityId);
+
+      if (journalEntity == null) {
+        return false;
+      }
+
+      await persistenceLogic.updateDbEntity(
+        journalEntity.copyWith(
+          meta: await persistenceLogic.updateMetadata(
+            journalEntity.meta,
+            categoryId: categoryId,
+          ),
+        ),
+      );
+    } catch (exception, stackTrace) {
+      getIt<LoggingDb>().captureException(
+        exception,
+        domain: 'persistence_logic',
+        subDomain: 'updateCategoryId',
+        stackTrace: stackTrace,
+      );
+    }
+    return true;
+  }
+
+  static Future<bool> deleteJournalEntity(
+    String journalEntityId,
+  ) async {
+    try {
+      final persistenceLogic = getIt<PersistenceLogic>();
+
+      final journalEntity =
+          await getIt<JournalDb>().journalEntityById(journalEntityId);
+
+      if (journalEntity == null) {
+        return false;
+      }
+
+      await persistenceLogic.updateDbEntity(
+        journalEntity.copyWith(
+          meta: await persistenceLogic.updateMetadata(
+            journalEntity.meta,
+            deletedAt: DateTime.now(),
+          ),
+        ),
+      );
+
+      await getIt<NotificationService>().updateBadge();
+    } catch (exception, stackTrace) {
+      getIt<LoggingDb>().captureException(
+        exception,
+        domain: 'persistence_logic',
+        subDomain: 'deleteJournalEntity',
+        stackTrace: stackTrace,
+      );
+    }
+
+    return true;
+  }
+
+  static Future<bool> updateJournalEntityDate(
+    String journalEntityId, {
+    required DateTime dateFrom,
+    required DateTime dateTo,
+  }) async {
+    try {
+      final persistenceLogic = getIt<PersistenceLogic>();
+
+      final journalEntity =
+          await getIt<JournalDb>().journalEntityById(journalEntityId);
+
+      if (journalEntity == null) {
+        return false;
+      }
+
+      await persistenceLogic.updateDbEntity(
+        journalEntity.copyWith(
+          meta: await persistenceLogic.updateMetadata(
+            journalEntity.meta,
+            dateFrom: dateFrom,
+            dateTo: dateTo,
+          ),
+        ),
+      );
+    } catch (exception, stackTrace) {
+      getIt<LoggingDb>().captureException(
+        exception,
+        domain: 'persistence_logic',
+        subDomain: 'updateJournalEntityDate',
+        stackTrace: stackTrace,
+      );
+    }
+    return true;
+  }
+
+  static Future<JournalEntity?> createTextEntry(
+    EntryText entryText, {
+    required DateTime started,
+    required String id,
+    String? linkedId,
+  }) async {
+    try {
+      final persistenceLogic = getIt<PersistenceLogic>();
+
+      final journalEntity = JournalEntity.journalEntry(
+        entryText: entryText,
+        meta: await persistenceLogic.createMetadata(dateFrom: started),
+      );
+
+      await persistenceLogic.createDbEntity(journalEntity, linkedId: linkedId);
+
+      return journalEntity;
+    } catch (exception, stackTrace) {
+      getIt<LoggingDb>().captureException(
+        exception,
+        domain: 'persistence_logic',
+        subDomain: 'createTextEntry',
+        stackTrace: stackTrace,
+      );
+      return null;
+    }
+  }
+
+  static Future<JournalEntity?> createImageEntry(
+    ImageData imageData, {
+    String? linkedId,
+  }) async {
+    try {
+      final persistenceLogic = getIt<PersistenceLogic>();
+
+      final journalEntity = JournalEntity.journalImage(
+        data: imageData,
+        meta: await persistenceLogic.createMetadata(
+          dateFrom: imageData.capturedAt,
+          dateTo: imageData.capturedAt,
+          uuidV5Input: json.encode(imageData),
+          flag: EntryFlag.import,
+        ),
+        geolocation: imageData.geolocation,
+      );
+      await persistenceLogic.createDbEntity(
+        journalEntity,
+        linkedId: linkedId,
+        shouldAddGeolocation: false,
+      );
+      return journalEntity;
+    } catch (exception, stackTrace) {
+      getIt<LoggingDb>().captureException(
+        exception,
+        domain: 'persistence_logic',
+        subDomain: 'createImageEntry',
+        stackTrace: stackTrace,
+      );
+    }
+
+    return null;
+  }
+}

--- a/lib/features/journal/state/entry_controller.dart
+++ b/lib/features/journal/state/entry_controller.dart
@@ -12,6 +12,7 @@ import 'package:lotti/classes/task.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/features/journal/model/entry_state.dart';
 import 'package:lotti/features/journal/ui/widgets/editor/editor_tools.dart';
+import 'package:lotti/features/speech/repository/speech_repository.dart';
 import 'package:lotti/features/tags/repository/tags_repository.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
@@ -365,7 +366,7 @@ class EntryController extends _$EntryController {
   }
 
   Future<void> setLanguage(String language) async {
-    return _persistenceLogic.updateLanguage(
+    return SpeechRepository.updateLanguage(
       journalEntityId: entryId,
       language: language,
     );

--- a/lib/features/journal/state/entry_controller.dart
+++ b/lib/features/journal/state/entry_controller.dart
@@ -11,6 +11,7 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/features/journal/model/entry_state.dart';
+import 'package:lotti/features/journal/repository/journal_repository.dart';
 import 'package:lotti/features/journal/ui/widgets/editor/editor_tools.dart';
 import 'package:lotti/features/speech/repository/speech_repository.dart';
 import 'package:lotti/features/tags/repository/tags_repository.dart';
@@ -138,7 +139,7 @@ class EntryController extends _$EntryController {
     required DateTime dateFrom,
     required DateTime dateTo,
   }) async {
-    return _persistenceLogic.updateJournalEntityDate(
+    return JournalRepository.updateJournalEntityDate(
       entryId,
       dateFrom: dateFrom,
       dateTo: dateTo,
@@ -146,7 +147,7 @@ class EntryController extends _$EntryController {
   }
 
   Future<bool> updateCategoryId(String? categoryId) async {
-    return _persistenceLogic.updateCategoryId(
+    return JournalRepository.updateCategoryId(
       entryId,
       categoryId: categoryId,
     );
@@ -229,7 +230,7 @@ class EntryController extends _$EntryController {
   Future<bool> delete({
     required bool beamBack,
   }) async {
-    final res = await _persistenceLogic.deleteJournalEntity(entryId);
+    final res = await JournalRepository.deleteJournalEntity(entryId);
     if (beamBack) {
       getIt<NavService>().beamBack();
     }

--- a/lib/features/speech/repository/speech_repository.dart
+++ b/lib/features/speech/repository/speech_repository.dart
@@ -1,0 +1,209 @@
+import 'dart:convert';
+
+import 'package:lotti/classes/audio_note.dart';
+import 'package:lotti/classes/entry_text.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/database/logging_db.dart';
+import 'package:lotti/features/speech/state/asr_service.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/utils/consts.dart';
+
+class SpeechRepository {
+  SpeechRepository();
+
+  static Future<JournalAudio?> createAudioEntry(
+    AudioNote audioNote, {
+    required String? language,
+    String? linkedId,
+  }) async {
+    try {
+      final persistenceLogic = getIt<PersistenceLogic>();
+
+      final autoTranscribe = await getIt<JournalDb>().getConfigFlag(
+        autoTranscribeFlag,
+      );
+
+      final audioData = AudioData(
+        audioDirectory: audioNote.audioDirectory,
+        duration: audioNote.duration,
+        audioFile: audioNote.audioFile,
+        dateTo: audioNote.createdAt.add(audioNote.duration),
+        dateFrom: audioNote.createdAt,
+        autoTranscribeWasActive: autoTranscribe,
+        language: language,
+      );
+
+      final dateFrom = audioData.dateFrom;
+      final dateTo = audioData.dateTo;
+
+      final journalEntity = JournalAudio(
+        data: audioData,
+        meta: await persistenceLogic.createMetadata(
+          dateFrom: dateFrom,
+          dateTo: dateTo,
+          uuidV5Input: json.encode(audioData),
+          flag: EntryFlag.import,
+        ),
+      );
+      await persistenceLogic.createDbEntity(journalEntity, linkedId: linkedId);
+
+      if (autoTranscribe) {
+        await getIt<AsrService>().enqueue(entry: journalEntity);
+      }
+
+      return journalEntity;
+    } catch (exception, stackTrace) {
+      getIt<LoggingDb>().captureException(
+        exception,
+        domain: 'persistence_logic',
+        subDomain: 'createAudioEntry',
+        stackTrace: stackTrace,
+      );
+    }
+
+    return null;
+  }
+
+  static Future<void> updateLanguage({
+    required String journalEntityId,
+    required String language,
+  }) async {
+    try {
+      final persistenceLogic = getIt<PersistenceLogic>();
+      final journalEntity =
+          await getIt<JournalDb>().journalEntityById(journalEntityId);
+
+      await journalEntity?.maybeMap(
+        journalAudio: (JournalAudio item) async {
+          await persistenceLogic.updateDbEntity(
+            item.copyWith(
+              meta: await persistenceLogic.updateMetadata(journalEntity.meta),
+              data: item.data.copyWith(language: language),
+            ),
+          );
+        },
+        orElse: () async => getIt<LoggingDb>().captureException(
+          'not an audio entry',
+          domain: 'persistence_logic',
+          subDomain: 'updateLanguage',
+        ),
+      );
+    } catch (exception, stackTrace) {
+      getIt<LoggingDb>().captureException(
+        exception,
+        domain: 'persistence_logic',
+        subDomain: 'updateLanguage',
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  static Future<bool> addAudioTranscript({
+    required String journalEntityId,
+    required AudioTranscript transcript,
+  }) async {
+    try {
+      final persistenceLogic = getIt<PersistenceLogic>();
+
+      final journalEntity =
+          await getIt<JournalDb>().journalEntityById(journalEntityId);
+
+      if (journalEntity == null) {
+        return false;
+      }
+
+      await journalEntity.maybeMap(
+        journalAudio: (JournalAudio journalAudio) async {
+          final data = journalAudio.data;
+          final updatedData = journalAudio.data.copyWith(
+            transcripts: [
+              ...?data.transcripts,
+              transcript,
+            ],
+          );
+
+          final entryText = journalAudio.entryText;
+
+          final newEntryText = EntryText(
+            plainText: transcript.transcript,
+            markdown: transcript.transcript,
+          );
+
+          final replaceEntryText = entryText == null ||
+              entryText.plainText.isEmpty ||
+              '${entryText.markdown}'.trim().isEmpty;
+
+          await persistenceLogic.updateDbEntity(
+            journalAudio.copyWith(
+              meta: await persistenceLogic.updateMetadata(journalEntity.meta),
+              entryText: replaceEntryText ? newEntryText : entryText,
+              data: updatedData,
+            ),
+          );
+        },
+        orElse: () async => getIt<LoggingDb>().captureException(
+          'not an audio entry',
+          domain: 'persistence_logic',
+          subDomain: 'addAudioTranscript',
+        ),
+      );
+    } catch (exception, stackTrace) {
+      getIt<LoggingDb>().captureException(
+        exception,
+        domain: 'persistence_logic',
+        subDomain: 'addAudioTranscript',
+        stackTrace: stackTrace,
+      );
+    }
+    return true;
+  }
+
+  static Future<bool> removeAudioTranscript({
+    required String journalEntityId,
+    required AudioTranscript transcript,
+  }) async {
+    try {
+      final persistenceLogic = getIt<PersistenceLogic>();
+
+      final journalEntity =
+          await getIt<JournalDb>().journalEntityById(journalEntityId);
+
+      if (journalEntity == null) {
+        return false;
+      }
+
+      await journalEntity.maybeMap(
+        journalAudio: (JournalAudio journalAudio) async {
+          final data = journalAudio.data;
+          final updatedData = journalAudio.data.copyWith(
+            transcripts: data.transcripts
+                ?.where((element) => element.created != transcript.created)
+                .toList(),
+          );
+
+          await persistenceLogic.updateDbEntity(
+            journalAudio.copyWith(
+              meta: await persistenceLogic.updateMetadata(journalEntity.meta),
+              data: updatedData,
+            ),
+          );
+        },
+        orElse: () async => getIt<LoggingDb>().captureException(
+          'not an audio entry',
+          domain: 'persistence_logic',
+          subDomain: 'removeAudioTranscript',
+        ),
+      );
+    } catch (exception, stackTrace) {
+      getIt<LoggingDb>().captureException(
+        exception,
+        domain: 'persistence_logic',
+        subDomain: 'removeAudioTranscript',
+        stackTrace: stackTrace,
+      );
+    }
+    return true;
+  }
+}

--- a/lib/features/speech/state/asr_service.dart
+++ b/lib/features/speech/state/asr_service.dart
@@ -10,8 +10,8 @@ import 'package:flutter/services.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/database/settings_db.dart';
+import 'package:lotti/features/speech/repository/speech_repository.dart';
 import 'package:lotti/get_it.dart';
-import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/utils/audio_utils.dart';
 
 class AsrService {
@@ -139,7 +139,7 @@ class AsrService {
               processingTime: finish.difference(start),
             );
 
-            await getIt<PersistenceLogic>().addAudioTranscript(
+            await SpeechRepository.addAudioTranscript(
               journalEntityId: entry.meta.id,
               transcript: transcript,
             );

--- a/lib/features/speech/state/recorder_cubit.dart
+++ b/lib/features/speech/state/recorder_cubit.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:intl/intl.dart';
 import 'package:lotti/classes/audio_note.dart';
 import 'package:lotti/database/logging_db.dart';
+import 'package:lotti/features/speech/repository/speech_repository.dart';
 import 'package:lotti/features/speech/state/recorder_state.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
@@ -105,7 +106,7 @@ class AudioRecorderCubit extends Cubit<AudioRecorderState> {
       _audioNote = _audioNote?.copyWith(duration: state.progress);
       emit(initialState.copyWith(status: AudioRecorderStatus.stopped));
       if (_audioNote != null) {
-        final journalAudio = await persistenceLogic.createAudioEntry(
+        final journalAudio = await SpeechRepository.createAudioEntry(
           _audioNote!,
           language: _language,
           linkedId: _linkedId,

--- a/lib/features/speech/ui/widgets/speech_modal/transcripts_list_item.dart
+++ b/lib/features/speech/ui/widgets/speech_modal/transcripts_list_item.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/journal/util/entry_tools.dart';
-import 'package:lotti/get_it.dart';
-import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/features/speech/repository/speech_repository.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/widgets/charts/utils.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
@@ -61,7 +60,7 @@ class _TranscriptListItemState extends State<TranscriptListItem> {
             opacity: show ? 1 : 0,
             child: IconButton(
               onPressed: () {
-                getIt<PersistenceLogic>().removeAudioTranscript(
+                SpeechRepository.removeAudioTranscript(
                   journalEntityId: widget.entryId,
                   transcript: widget.transcript,
                 );

--- a/lib/features/tasks/state/checklist_controller.dart
+++ b/lib/features/tasks/state/checklist_controller.dart
@@ -2,10 +2,10 @@ import 'dart:async';
 
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/features/journal/repository/journal_repository.dart';
 import 'package:lotti/features/tasks/repository/checklist_repository.dart';
 import 'package:lotti/features/tasks/state/checklist_item_controller.dart';
 import 'package:lotti/get_it.dart';
-import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/db_notification.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -19,7 +19,6 @@ class ChecklistController extends _$ChecklistController {
   late final String entryId;
   final subscribedIds = <String>{};
   StreamSubscription<Set<String>>? _updateSubscription;
-  final _persistenceLogic = getIt<PersistenceLogic>();
 
   void listen() {
     _updateSubscription =
@@ -58,7 +57,7 @@ class ChecklistController extends _$ChecklistController {
   }
 
   Future<bool> delete() async {
-    final res = await _persistenceLogic.deleteJournalEntity(entryId);
+    final res = await JournalRepository.deleteJournalEntity(entryId);
     state = const AsyncData(null);
     return res;
   }

--- a/lib/features/tasks/state/checklist_item_controller.dart
+++ b/lib/features/tasks/state/checklist_item_controller.dart
@@ -2,9 +2,9 @@ import 'dart:async';
 
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/features/journal/repository/journal_repository.dart';
 import 'package:lotti/features/tasks/repository/checklist_repository.dart';
 import 'package:lotti/get_it.dart';
-import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/db_notification.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -47,7 +47,7 @@ class ChecklistItemController extends _$ChecklistItemController {
   }
 
   Future<bool> delete() async {
-    final res = await getIt<PersistenceLogic>().deleteJournalEntity(entryId);
+    final res = await JournalRepository.deleteJournalEntity(entryId);
     state = const AsyncData(null);
     return res;
   }

--- a/lib/logic/create/create_entry.dart
+++ b/lib/logic/create/create_entry.dart
@@ -4,6 +4,7 @@ import 'package:lotti/classes/event_data.dart';
 import 'package:lotti/classes/event_status.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
+import 'package:lotti/features/journal/repository/journal_repository.dart';
 import 'package:lotti/features/tasks/repository/checklist_repository.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
@@ -13,7 +14,7 @@ import 'package:lotti/utils/file_utils.dart';
 import 'package:lotti/utils/screenshots.dart';
 
 Future<JournalEntity?> createTextEntry({String? linkedId}) async {
-  final entry = await getIt<PersistenceLogic>().createTextEntry(
+  final entry = await JournalRepository.createTextEntry(
     const EntryText(plainText: ''),
     id: uuid.v1(),
     linkedId: linkedId,
@@ -81,7 +82,7 @@ Future<JournalEvent?> createEvent({String? linkedId}) =>
 Future<JournalEntity?> createScreenshot({String? linkedId}) async {
   final persistenceLogic = getIt<PersistenceLogic>();
   final imageData = await takeScreenshotMac();
-  final entry = await persistenceLogic.createImageEntry(
+  final entry = await JournalRepository.createImageEntry(
     imageData,
     linkedId: linkedId,
   );

--- a/lib/logic/image_import.dart
+++ b/lib/logic/image_import.dart
@@ -4,8 +4,7 @@ import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';
 import 'package:lotti/classes/geolocation.dart';
 import 'package:lotti/classes/journal_entities.dart';
-import 'package:lotti/get_it.dart';
-import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/features/journal/repository/journal_repository.dart';
 import 'package:lotti/utils/file_utils.dart';
 import 'package:lotti/utils/image_utils.dart';
 import 'package:lotti/utils/location.dart';
@@ -15,8 +14,6 @@ Future<void> importImageAssets(
   BuildContext context, {
   String? linkedId,
 }) async {
-  final persistenceLogic = getIt<PersistenceLogic>();
-
   final assets = await AssetPicker.pickAssets(
     context,
     pickerConfig: const AssetPickerConfig(
@@ -78,7 +75,7 @@ Future<void> importImageAssets(
           geolocation: geolocation,
         );
 
-        await persistenceLogic.createImageEntry(
+        await JournalRepository.createImageEntry(
           imageData,
           linkedId: linkedId,
         );

--- a/lib/logic/persistence_logic.dart
+++ b/lib/logic/persistence_logic.dart
@@ -331,67 +331,6 @@ class PersistenceLogic {
     return null;
   }
 
-  Future<JournalEntity?> createImageEntry(
-    ImageData imageData, {
-    String? linkedId,
-  }) async {
-    try {
-      final journalEntity = JournalEntity.journalImage(
-        data: imageData,
-        meta: await createMetadata(
-          dateFrom: imageData.capturedAt,
-          dateTo: imageData.capturedAt,
-          uuidV5Input: json.encode(imageData),
-          flag: EntryFlag.import,
-        ),
-        geolocation: imageData.geolocation,
-      );
-      await createDbEntity(
-        journalEntity,
-        linkedId: linkedId,
-        shouldAddGeolocation: false,
-      );
-      return journalEntity;
-    } catch (exception, stackTrace) {
-      _loggingDb.captureException(
-        exception,
-        domain: 'persistence_logic',
-        subDomain: 'createImageEntry',
-        stackTrace: stackTrace,
-      );
-    }
-
-    return null;
-  }
-
-  Future<JournalEntity?> createTextEntry(
-    EntryText entryText, {
-    required DateTime started,
-    required String id,
-    String? linkedId,
-  }) async {
-    try {
-      final journalEntity = JournalEntity.journalEntry(
-        entryText: entryText,
-        meta: await createMetadata(
-          dateFrom: started,
-        ),
-      );
-
-      await createDbEntity(journalEntity, linkedId: linkedId);
-
-      return journalEntity;
-    } catch (exception, stackTrace) {
-      _loggingDb.captureException(
-        exception,
-        domain: 'persistence_logic',
-        subDomain: 'createTextEntry',
-        stackTrace: stackTrace,
-      );
-      return null;
-    }
-  }
-
   Future<bool> createLink({
     required String fromId,
     required String toId,
@@ -685,68 +624,6 @@ class PersistenceLogic {
     unawaited(addGeolocationAsync(journalEntityId));
   }
 
-  Future<bool> updateJournalEntityDate(
-    String journalEntityId, {
-    required DateTime dateFrom,
-    required DateTime dateTo,
-  }) async {
-    try {
-      final journalEntity = await _journalDb.journalEntityById(journalEntityId);
-
-      if (journalEntity == null) {
-        return false;
-      }
-
-      await updateDbEntity(
-        journalEntity.copyWith(
-          meta: await updateMetadata(
-            journalEntity.meta,
-            dateFrom: dateFrom,
-            dateTo: dateTo,
-          ),
-        ),
-      );
-    } catch (exception, stackTrace) {
-      _loggingDb.captureException(
-        exception,
-        domain: 'persistence_logic',
-        subDomain: 'updateJournalEntityDate',
-        stackTrace: stackTrace,
-      );
-    }
-    return true;
-  }
-
-  Future<bool> updateCategoryId(
-    String journalEntityId, {
-    required String? categoryId,
-  }) async {
-    try {
-      final journalEntity = await _journalDb.journalEntityById(journalEntityId);
-
-      if (journalEntity == null) {
-        return false;
-      }
-
-      await updateDbEntity(
-        journalEntity.copyWith(
-          meta: await updateMetadata(
-            journalEntity.meta,
-            categoryId: categoryId,
-          ),
-        ),
-      );
-    } catch (exception, stackTrace) {
-      _loggingDb.captureException(
-        exception,
-        domain: 'persistence_logic',
-        subDomain: 'updateCategoryId',
-        stackTrace: stackTrace,
-      );
-    }
-    return true;
-  }
-
   Future<bool> updateJournalEntity(
     JournalEntity journalEntity,
     Metadata metadata,
@@ -763,38 +640,6 @@ class PersistenceLogic {
         exception,
         domain: 'persistence_logic',
         subDomain: 'updateJournalEntity',
-        stackTrace: stackTrace,
-      );
-    }
-
-    return true;
-  }
-
-  Future<bool> deleteJournalEntity(
-    String journalEntityId,
-  ) async {
-    try {
-      final journalEntity = await _journalDb.journalEntityById(journalEntityId);
-
-      if (journalEntity == null) {
-        return false;
-      }
-
-      await updateDbEntity(
-        journalEntity.copyWith(
-          meta: await updateMetadata(
-            journalEntity.meta,
-            deletedAt: DateTime.now(),
-          ),
-        ),
-      );
-
-      await getIt<NotificationService>().updateBadge();
-    } catch (exception, stackTrace) {
-      _loggingDb.captureException(
-        exception,
-        domain: 'persistence_logic',
-        subDomain: 'deleteJournalEntity',
         stackTrace: stackTrace,
       );
     }

--- a/lib/logic/persistence_logic.dart
+++ b/lib/logic/persistence_logic.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
-import 'package:lotti/classes/audio_note.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/entry_links.dart';
 import 'package:lotti/classes/entry_text.dart';
@@ -15,7 +14,6 @@ import 'package:lotti/classes/task.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/fts5_db.dart';
 import 'package:lotti/database/logging_db.dart';
-import 'package:lotti/features/speech/state/asr_service.dart';
 import 'package:lotti/features/sync/outbox/outbox_service.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/ai/ai_logic.dart';
@@ -23,7 +21,6 @@ import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/notification_service.dart';
 import 'package:lotti/services/tags_service.dart';
 import 'package:lotti/services/vector_clock_service.dart';
-import 'package:lotti/utils/consts.dart';
 import 'package:lotti/utils/entry_utils.dart';
 import 'package:lotti/utils/location.dart';
 import 'package:lotti/utils/timezone.dart';
@@ -367,57 +364,6 @@ class PersistenceLogic {
     return null;
   }
 
-  Future<JournalAudio?> createAudioEntry(
-    AudioNote audioNote, {
-    required String? language,
-    String? linkedId,
-  }) async {
-    try {
-      final autoTranscribe = await getIt<JournalDb>().getConfigFlag(
-        autoTranscribeFlag,
-      );
-
-      final audioData = AudioData(
-        audioDirectory: audioNote.audioDirectory,
-        duration: audioNote.duration,
-        audioFile: audioNote.audioFile,
-        dateTo: audioNote.createdAt.add(audioNote.duration),
-        dateFrom: audioNote.createdAt,
-        autoTranscribeWasActive: autoTranscribe,
-        language: language,
-      );
-
-      final dateFrom = audioData.dateFrom;
-      final dateTo = audioData.dateTo;
-
-      final journalEntity = JournalAudio(
-        data: audioData,
-        meta: await createMetadata(
-          dateFrom: dateFrom,
-          dateTo: dateTo,
-          uuidV5Input: json.encode(audioData),
-          flag: EntryFlag.import,
-        ),
-      );
-      await createDbEntity(journalEntity, linkedId: linkedId);
-
-      if (autoTranscribe) {
-        await getIt<AsrService>().enqueue(entry: journalEntity);
-      }
-
-      return journalEntity;
-    } catch (exception, stackTrace) {
-      _loggingDb.captureException(
-        exception,
-        domain: 'persistence_logic',
-        subDomain: 'createAudioEntry',
-        stackTrace: stackTrace,
-      );
-    }
-
-    return null;
-  }
-
   Future<JournalEntity?> createTextEntry(
     EntryText entryText, {
     required DateTime started,
@@ -699,139 +645,6 @@ class PersistenceLogic {
         exception,
         domain: 'persistence_logic',
         subDomain: 'updateEvent',
-        stackTrace: stackTrace,
-      );
-    }
-    return true;
-  }
-
-  Future<void> updateLanguage({
-    required String journalEntityId,
-    required String language,
-  }) async {
-    try {
-      final journalEntity = await _journalDb.journalEntityById(journalEntityId);
-
-      await journalEntity?.maybeMap(
-        journalAudio: (JournalAudio item) async {
-          await updateDbEntity(
-            item.copyWith(
-              meta: await updateMetadata(journalEntity.meta),
-              data: item.data.copyWith(language: language),
-            ),
-          );
-        },
-        orElse: () async => _loggingDb.captureException(
-          'not an audio entry',
-          domain: 'persistence_logic',
-          subDomain: 'updateLanguage',
-        ),
-      );
-    } catch (exception, stackTrace) {
-      _loggingDb.captureException(
-        exception,
-        domain: 'persistence_logic',
-        subDomain: 'updateLanguage',
-        stackTrace: stackTrace,
-      );
-    }
-  }
-
-  Future<bool> addAudioTranscript({
-    required String journalEntityId,
-    required AudioTranscript transcript,
-  }) async {
-    try {
-      final journalEntity = await _journalDb.journalEntityById(journalEntityId);
-
-      if (journalEntity == null) {
-        return false;
-      }
-
-      await journalEntity.maybeMap(
-        journalAudio: (JournalAudio journalAudio) async {
-          final data = journalAudio.data;
-          final updatedData = journalAudio.data.copyWith(
-            transcripts: [
-              ...?data.transcripts,
-              transcript,
-            ],
-          );
-
-          final entryText = journalAudio.entryText;
-
-          final newEntryText = EntryText(
-            plainText: transcript.transcript,
-            markdown: transcript.transcript,
-          );
-
-          final replaceEntryText = entryText == null ||
-              entryText.plainText.isEmpty ||
-              '${entryText.markdown}'.trim().isEmpty;
-
-          await updateDbEntity(
-            journalAudio.copyWith(
-              meta: await updateMetadata(journalEntity.meta),
-              entryText: replaceEntryText ? newEntryText : entryText,
-              data: updatedData,
-            ),
-          );
-        },
-        orElse: () async => _loggingDb.captureException(
-          'not an audio entry',
-          domain: 'persistence_logic',
-          subDomain: 'addAudioTranscript',
-        ),
-      );
-    } catch (exception, stackTrace) {
-      _loggingDb.captureException(
-        exception,
-        domain: 'persistence_logic',
-        subDomain: 'addAudioTranscript',
-        stackTrace: stackTrace,
-      );
-    }
-    return true;
-  }
-
-  Future<bool> removeAudioTranscript({
-    required String journalEntityId,
-    required AudioTranscript transcript,
-  }) async {
-    try {
-      final journalEntity = await _journalDb.journalEntityById(journalEntityId);
-
-      if (journalEntity == null) {
-        return false;
-      }
-
-      await journalEntity.maybeMap(
-        journalAudio: (JournalAudio journalAudio) async {
-          final data = journalAudio.data;
-          final updatedData = journalAudio.data.copyWith(
-            transcripts: data.transcripts
-                ?.where((element) => element.created != transcript.created)
-                .toList(),
-          );
-
-          await updateDbEntity(
-            journalAudio.copyWith(
-              meta: await updateMetadata(journalEntity.meta),
-              data: updatedData,
-            ),
-          );
-        },
-        orElse: () async => _loggingDb.captureException(
-          'not an audio entry',
-          domain: 'persistence_logic',
-          subDomain: 'removeAudioTranscript',
-        ),
-      );
-    } catch (exception, stackTrace) {
-      _loggingDb.captureException(
-        exception,
-        domain: 'persistence_logic',
-        subDomain: 'removeAudioTranscript',
         stackTrace: stackTrace,
       );
     }

--- a/lib/services/time_service.dart
+++ b/lib/services/time_service.dart
@@ -1,8 +1,7 @@
 import 'dart:async';
 
 import 'package:lotti/classes/journal_entities.dart';
-import 'package:lotti/get_it.dart';
-import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/features/journal/repository/journal_repository.dart';
 
 class TimeService {
   TimeService() {
@@ -50,10 +49,8 @@ class TimeService {
   }
 
   Future<void> stop() async {
-    final persistenceLogic = getIt<PersistenceLogic>();
-
     if (_current != null) {
-      await persistenceLogic.updateJournalEntityDate(
+      await JournalRepository.updateJournalEntityDate(
         _current!.meta.id,
         dateFrom: _current!.meta.dateFrom,
         dateTo: DateTime.now(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.545+2778
+version: 0.9.545+2779
 
 msix_config:
   display_name: LottiApp

--- a/test/logic/persistence_logic_test.dart
+++ b/test/logic/persistence_logic_test.dart
@@ -12,6 +12,7 @@ import 'package:lotti/database/journal_db/config_flags.dart';
 import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/database/sync_db.dart';
+import 'package:lotti/features/journal/repository/journal_repository.dart';
 import 'package:lotti/features/sync/outbox/outbox_service.dart';
 import 'package:lotti/features/sync/secure_storage.dart';
 import 'package:lotti/features/sync/utils.dart';
@@ -120,7 +121,7 @@ void main() {
         const updatedTestText = 'updated test text';
 
         // create test entry
-        final textEntry = await getIt<PersistenceLogic>().createTextEntry(
+        final textEntry = await JournalRepository.createTextEntry(
           const EntryText(plainText: testText),
           id: uuid.v1(),
           started: now,
@@ -322,7 +323,7 @@ void main() {
       // create linked comment entry
       const testText = 'test comment for task';
       const updatedTestText = 'updated test comment for task';
-      final comment = await getIt<PersistenceLogic>().createTextEntry(
+      final comment = await JournalRepository.createTextEntry(
         const EntryText(plainText: testText),
         id: uuid.v1(),
         started: now,
@@ -434,7 +435,7 @@ void main() {
       );
 
       // delete task and expect counts to be updated
-      await getIt<PersistenceLogic>().deleteJournalEntity(task.meta.id);
+      await JournalRepository.deleteJournalEntity(task.meta.id);
       expect(await getIt<JournalDb>().watchJournalCount().first, 2);
       expect(await getIt<JournalDb>().getJournalCount(), 2);
       expect(await getIt<JournalDb>().watchTaskCount('OPEN').first, 0);


### PR DESCRIPTION
This pull request introduces significant changes to the codebase, primarily focusing on the refactoring of persistence logic by moving it into dedicated repository classes. The changes improve the organization and maintainability of the code. The most important changes include the creation of the `JournalRepository` and `SpeechRepository` classes, and the refactoring of various classes to use these new repositories instead of directly using `PersistenceLogic`.

Repository creation and refactoring:

* Created `JournalRepository` class to handle journal-related database operations, including methods for creating, updating, and deleting journal entries. (`lib/features/journal/repository/journal_repository.dart`)
* Created `SpeechRepository` class to handle speech-related database operations, including methods for creating audio entries and managing audio transcripts. (`lib/features/speech/repository/speech_repository.dart`)

Refactoring to use repositories:

* Updated `AiResponse` class to use `JournalRepository` for creating text entries instead of `PersistenceLogic`. (`lib/features/ai/state/ollama_prompt.dart`)
* Updated `EntryController` class to use `JournalRepository` for various journal operations and `SpeechRepository` for updating language. (`lib/features/journal/state/entry_controller.dart`) [[1]](diffhunk://#diff-073fb67f5d87a4ca641101e845ee4b45cc2cdb2ee4a6cd4698bb94093921c235L140-R150) [[2]](diffhunk://#diff-073fb67f5d87a4ca641101e845ee4b45cc2cdb2ee4a6cd4698bb94093921c235L368-R370)
* Updated `AsrService` and `AudioRecorderCubit` classes to use `SpeechRepository` for managing audio transcripts and creating audio entries. (`lib/features/speech/state/asr_service.dart`) [[1]](diffhunk://#diff-01cf561c7fcb33e54fbee2be986cd90095156473dfa7cbd8bef074e0b5f9fa85L142-R142) (`lib/features/speech/state/recorder_cubit.dart`) [[2]](diffhunk://#diff-bf7a2bda8bfa84addb4e44d121b2831a6554ce2a8b7cce94c364da29985acbe7L108-R109)

These changes enhance the modularity and clarity of the code by separating concerns and encapsulating database operations within specific repositories.