### PR TITLE
fix: left icon navigation icon in day view not working

### DIFF
--- a/lib/features/calendar/ui/pages/day_view_page.dart
+++ b/lib/features/calendar/ui/pages/day_view_page.dart
@@ -127,24 +127,6 @@ class _DayViewWidgetState extends ConsumerState<DayViewWidget> {
                 headerTextStyle: chartTitleStyleMonospace.copyWith(
                   fontWeight: FontWeight.w400,
                 ),
-                leftIconConfig: IconDataConfig(
-                  icon: (_) => const Padding(
-                    padding: EdgeInsets.only(left: 30, top: 10, bottom: 10),
-                    child: Icon(
-                      Icons.arrow_back,
-                      size: 24,
-                    ),
-                  ),
-                ),
-                rightIconConfig: IconDataConfig(
-                  icon: (_) => const Padding(
-                    padding: EdgeInsets.only(right: 30, top: 10, bottom: 10),
-                    child: Icon(
-                      Icons.arrow_forward,
-                      size: 24,
-                    ),
-                  ),
-                ),
                 decoration: BoxDecoration(
                   color: context.colorScheme.primaryContainer,
                 ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.545+2779
+version: 0.9.546+2780
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This pull request includes changes to the `lib/features/calendar/ui/pages/day_view_page.dart` and `pubspec.yaml` files. The changes involve removing icon configurations from the day view widget, which does seem to fix the previously non-functional and differently styled left navigation button.

Changes to `day_view_page.dart`:

* Removed `leftIconConfig` and `rightIconConfig` from the `_DayViewWidgetState` class.

Changes to `pubspec.yaml`:

* Updated the project version from `0.9.545+2779` to `0.9.546+2780`.