### PR TITLE
refactor: replace StreamBuilder

### DIFF
--- a/lib/features/journal/repository/journal_repository.dart
+++ b/lib/features/journal/repository/journal_repository.dart
@@ -213,6 +213,14 @@ class JournalRepository {
     return res;
   }
 
+  Future<List<JournalEntity>> getLinkedToEntities({
+    required String linkedTo,
+  }) async {
+    final items =
+        await getIt<JournalDb>().linkedToJournalEntities(linkedTo).get();
+    return items.map(fromDbEntity).toList();
+  }
+
   Future<List<EntryLink>> getLinksFromId(
     String linkedFrom, {
     bool includeHidden = false,

--- a/lib/features/journal/state/linked_from_entries_controller.dart
+++ b/lib/features/journal/state/linked_from_entries_controller.dart
@@ -1,0 +1,48 @@
+import 'dart:async';
+
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/journal/repository/journal_repository.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/db_notification.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'linked_from_entries_controller.g.dart';
+
+@riverpod
+class LinkedFromEntriesController extends _$LinkedFromEntriesController {
+  StreamSubscription<Set<String>>? _updateSubscription;
+  final UpdateNotifications _updateNotifications = getIt<UpdateNotifications>();
+  final watchedIds = <String>{};
+
+  void listen() {
+    _updateSubscription =
+        _updateNotifications.updateStream.listen((affectedIds) {
+      if (affectedIds.intersection(watchedIds).isNotEmpty) {
+        _fetch().then((latest) {
+          if (latest != state.value) {
+            state = AsyncData(latest);
+          }
+        });
+      }
+    });
+  }
+
+  @override
+  Future<List<JournalEntity>> build({
+    required String id,
+  }) async {
+    ref.onDispose(() => _updateSubscription?.cancel());
+    final res = await _fetch();
+    watchedIds.add(id);
+    listen();
+    return res;
+  }
+
+  Future<List<JournalEntity>> _fetch() async {
+    final res = await ref.read(journalRepositoryProvider).getLinkedToEntities(
+          linkedTo: id,
+        );
+    watchedIds.addAll(res.map((item) => item.id));
+    return res;
+  }
+}

--- a/lib/features/journal/state/linked_from_entries_controller.g.dart
+++ b/lib/features/journal/state/linked_from_entries_controller.g.dart
@@ -1,0 +1,180 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'linked_from_entries_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$linkedFromEntriesControllerHash() =>
+    r'da38ecc6b51947a559336ed804272bddf78d8e9b';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+abstract class _$LinkedFromEntriesController
+    extends BuildlessAutoDisposeAsyncNotifier<List<JournalEntity>> {
+  late final String id;
+
+  FutureOr<List<JournalEntity>> build({
+    required String id,
+  });
+}
+
+/// See also [LinkedFromEntriesController].
+@ProviderFor(LinkedFromEntriesController)
+const linkedFromEntriesControllerProvider = LinkedFromEntriesControllerFamily();
+
+/// See also [LinkedFromEntriesController].
+class LinkedFromEntriesControllerFamily
+    extends Family<AsyncValue<List<JournalEntity>>> {
+  /// See also [LinkedFromEntriesController].
+  const LinkedFromEntriesControllerFamily();
+
+  /// See also [LinkedFromEntriesController].
+  LinkedFromEntriesControllerProvider call({
+    required String id,
+  }) {
+    return LinkedFromEntriesControllerProvider(
+      id: id,
+    );
+  }
+
+  @override
+  LinkedFromEntriesControllerProvider getProviderOverride(
+    covariant LinkedFromEntriesControllerProvider provider,
+  ) {
+    return call(
+      id: provider.id,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'linkedFromEntriesControllerProvider';
+}
+
+/// See also [LinkedFromEntriesController].
+class LinkedFromEntriesControllerProvider
+    extends AutoDisposeAsyncNotifierProviderImpl<LinkedFromEntriesController,
+        List<JournalEntity>> {
+  /// See also [LinkedFromEntriesController].
+  LinkedFromEntriesControllerProvider({
+    required String id,
+  }) : this._internal(
+          () => LinkedFromEntriesController()..id = id,
+          from: linkedFromEntriesControllerProvider,
+          name: r'linkedFromEntriesControllerProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$linkedFromEntriesControllerHash,
+          dependencies: LinkedFromEntriesControllerFamily._dependencies,
+          allTransitiveDependencies:
+              LinkedFromEntriesControllerFamily._allTransitiveDependencies,
+          id: id,
+        );
+
+  LinkedFromEntriesControllerProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.id,
+  }) : super.internal();
+
+  final String id;
+
+  @override
+  FutureOr<List<JournalEntity>> runNotifierBuild(
+    covariant LinkedFromEntriesController notifier,
+  ) {
+    return notifier.build(
+      id: id,
+    );
+  }
+
+  @override
+  Override overrideWith(LinkedFromEntriesController Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: LinkedFromEntriesControllerProvider._internal(
+        () => create()..id = id,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        id: id,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeAsyncNotifierProviderElement<LinkedFromEntriesController,
+      List<JournalEntity>> createElement() {
+    return _LinkedFromEntriesControllerProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is LinkedFromEntriesControllerProvider && other.id == id;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, id.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+mixin LinkedFromEntriesControllerRef
+    on AutoDisposeAsyncNotifierProviderRef<List<JournalEntity>> {
+  /// The parameter `id` of this provider.
+  String get id;
+}
+
+class _LinkedFromEntriesControllerProviderElement
+    extends AutoDisposeAsyncNotifierProviderElement<LinkedFromEntriesController,
+        List<JournalEntity>> with LinkedFromEntriesControllerRef {
+  _LinkedFromEntriesControllerProviderElement(super.provider);
+
+  @override
+  String get id => (origin as LinkedFromEntriesControllerProvider).id;
+}
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/journal/ui/pages/entry_details_page.dart
+++ b/lib/features/journal/ui/pages/entry_details_page.dart
@@ -79,7 +79,7 @@ class _EntryDetailPageState extends ConsumerState<EntryDetailPage> {
                     showTaskDetails: true,
                   ),
                   LinkedEntriesWidget(item),
-                  LinkedFromEntriesWidget(item: item),
+                  LinkedFromEntriesWidget(item),
                 ],
               ).animate().fadeIn(
                     duration: const Duration(

--- a/lib/features/journal/ui/widgets/entry_detail_linked_from.dart
+++ b/lib/features/journal/ui/widgets/entry_detail_linked_from.dart
@@ -1,64 +1,61 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
-import 'package:lotti/database/database.dart';
+import 'package:lotti/features/journal/state/linked_from_entries_controller.dart';
 import 'package:lotti/features/journal/ui/widgets/journal_card.dart';
-import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/themes/theme.dart';
 
-class LinkedFromEntriesWidget extends StatelessWidget {
-  const LinkedFromEntriesWidget({
-    required this.item,
+class LinkedFromEntriesWidget extends ConsumerWidget {
+  const LinkedFromEntriesWidget(
+    this.item, {
     super.key,
   });
 
   final JournalEntity item;
 
   @override
-  Widget build(BuildContext context) {
-    return StreamBuilder<List<JournalEntity>>(
-      stream: getIt<JournalDb>().watchLinkedToEntities(linkedTo: item.meta.id),
-      builder: (
-        BuildContext context,
-        AsyncSnapshot<List<JournalEntity>> snapshot,
-      ) {
-        if (snapshot.data == null || snapshot.data!.isEmpty) {
-          return Container();
-        } else {
-          final items = snapshot.data!;
-          return Column(
-            children: [
-              Text(
-                context.messages.journalLinkedFromLabel,
-                style: TextStyle(
-                  color: context.colorScheme.outline,
-                ),
-              ),
-              ...List.generate(
-                items.length,
-                (int index) {
-                  final item = items.elementAt(index);
-                  return item.maybeMap(
-                    journalImage: (JournalImage image) {
-                      return JournalImageCard(
-                        item: image,
-                        key: Key('${item.meta.id}-${item.meta.id}'),
-                      );
-                    },
-                    orElse: () {
-                      return JournalCard(
-                        item: item,
-                        key: Key('${item.meta.id}-${item.meta.id}'),
-                        showLinkedDuration: true,
-                      );
-                    },
-                  );
-                },
-              ),
-            ],
-          );
-        }
-      },
+  Widget build(
+    BuildContext context,
+    WidgetRef ref,
+  ) {
+    final provider = linkedFromEntriesControllerProvider(id: item.id);
+    final items = ref.watch(provider).valueOrNull ?? [];
+
+    if (items.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Column(
+      children: [
+        Text(
+          context.messages.journalLinkedFromLabel,
+          style: TextStyle(
+            color: context.colorScheme.outline,
+          ),
+        ),
+        ...List.generate(
+          items.length,
+          (int index) {
+            final item = items.elementAt(index);
+            return item.maybeMap(
+              journalImage: (JournalImage image) {
+                return JournalImageCard(
+                  item: image,
+                  key: Key('${item.meta.id}-${item.meta.id}'),
+                );
+              },
+              orElse: () {
+                return JournalCard(
+                  item: item,
+                  key: Key('${item.meta.id}-${item.meta.id}'),
+                  showLinkedDuration: true,
+                );
+              },
+            );
+          },
+        ),
+      ],
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.547+2785
+version: 0.9.547+2786
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This pull request introduces improvements to the journal module. The most significant changes include the addition of a new method in the `JournalRepository`, the creation of a new `LinkedFromEntriesController` class, and updates to the `LinkedFromEntriesWidget` to use Riverpod for state management.

### Key Changes:

#### New Features:
* [`lib/features/journal/repository/journal_repository.dart`](diffhunk://#diff-001fbe4c939fb8084bdbcd1691a4bbe931c8bc39e39095f375c9b18f24ace751R216-R223): Added a new method `getLinkedToEntities` to fetch journal entities linked to a specific entity.
* [`lib/features/journal/state/linked_from_entries_controller.dart`](diffhunk://#diff-a7809f3531f4a2c829e6ed85da8618e4fc97e59994746458d1b40176f20c08f6R1-R48): Introduced a new `LinkedFromEntriesController` class to manage state and handle updates for linked journal entries.
* [`lib/features/journal/state/linked_from_entries_controller.g.dart`](diffhunk://#diff-1ada2dc8510537e89d13723aab39f4dca1d5ca17e9eb0b9f1ede503bd62952b7R1-R180): Added generated code for the `LinkedFromEntriesController` using Riverpod.

#### UI Updates:
* [`lib/features/journal/ui/pages/entry_details_page.dart`](diffhunk://#diff-d32e1aafdc3cba360a85b50733ac339715c6ef74ce58fa1d92f58306ea903f72L82-R82): Updated the `LinkedFromEntriesWidget` instantiation to match the new constructor signature.
* [`lib/features/journal/ui/widgets/entry_detail_linked_from.dart`](diffhunk://#diff-21b7fb6475a891c47ebb336dd0c0c8ebbe3d5b4d52cd50fad843a0dbcfd6154eR2-R28): Refactored `LinkedFromEntriesWidget` to extend `ConsumerWidget` and use Riverpod for state management, replacing the previous `StreamBuilder` approach. [[1]](diffhunk://#diff-21b7fb6475a891c47ebb336dd0c0c8ebbe3d5b4d52cd50fad843a0dbcfd6154eR2-R28) [[2]](diffhunk://#diff-21b7fb6475a891c47ebb336dd0c0c8ebbe3d5b4d52cd50fad843a0dbcfd6154eL61-L63)

#### Miscellaneous:
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Incremented the version number.