### PR TITLE
feat: only publish sporadic update notifications from sync

### DIFF
--- a/lib/features/ai/ui/ai_prompt_icon_widget.dart
+++ b/lib/features/ai/ui/ai_prompt_icon_widget.dart
@@ -5,6 +5,7 @@ import 'package:lotti/features/ai/state/ollama_prompt.dart';
 import 'package:lotti/features/ai/state/ollama_prompt_checklist.dart';
 import 'package:lotti/features/ai/ui/ai_response_preview.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/themes/theme.dart';
 import 'package:lotti/utils/modals.dart';
 
 class AiPopUpMenu extends StatelessWidget {
@@ -34,7 +35,7 @@ class AiPopUpMenu extends StatelessWidget {
               journalEntity: journalEntity,
               linkedFromId: linkedFromId,
             ),
-            const SizedBox(height: 40),
+            verticalModalSpacer,
           ],
         ),
       ),

--- a/lib/features/journal/ui/widgets/create/create_entry_action_modal.dart
+++ b/lib/features/journal/ui/widgets/create/create_entry_action_modal.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:lotti/features/journal/ui/widgets/create/create_entry_action_list_tiles.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/themes/theme.dart';
 import 'package:lotti/utils/modals.dart';
 import 'package:lotti/utils/platform.dart';
 
@@ -22,6 +23,7 @@ class CreateEntryModal {
           CreateTextEntryListTile(linkedFromId),
           ImportImageAssetsListTile(linkedFromId),
           if (isMacOS) CreateScreenshotListTile(linkedFromId),
+          verticalModalSpacer,
         ],
       ),
     );

--- a/lib/features/journal/ui/widgets/entry_details/header/extended_header_modal.dart
+++ b/lib/features/journal/ui/widgets/entry_details/header/extended_header_modal.dart
@@ -8,6 +8,7 @@ import 'package:lotti/features/speech/ui/widgets/speech_modal/speech_modal.dart'
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/services/link_service.dart';
+import 'package:lotti/themes/theme.dart';
 import 'package:lotti/utils/modals.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
@@ -61,6 +62,7 @@ class ExtendedHeaderModal {
               entryId: entryId,
               link: link,
             ),
+          verticalModalSpacer,
         ],
       ),
     );

--- a/lib/features/journal/ui/widgets/tags/tags_modal.dart
+++ b/lib/features/journal/ui/widgets/tags/tags_modal.dart
@@ -153,6 +153,7 @@ class _TagsModalState extends ConsumerState<TagsModal> {
               constraints: const BoxConstraints(minHeight: 25),
               child: TagsListWidget(entryId: widget.entryId),
             ),
+            verticalModalSpacer,
           ],
         ),
       ),

--- a/lib/features/sync/matrix/process_message.dart
+++ b/lib/features/sync/matrix/process_message.dart
@@ -48,11 +48,17 @@ Future<void> processMatrixMessage({
       ) async {
         await saveJournalEntityJson(journalEntity);
         await journalDb.updateJournalEntity(journalEntity);
-        updateNotifications.notify(journalEntity.affectedIds);
+        updateNotifications.notify(
+          journalEntity.affectedIds,
+          fromSync: true,
+        );
       },
       entryLink: (EntryLink entryLink, SyncEntryStatus _) {
         journalDb.upsertEntryLink(entryLink);
-        updateNotifications.notify({entryLink.fromId, entryLink.toId});
+        updateNotifications.notify(
+          {entryLink.fromId, entryLink.toId},
+          fromSync: true,
+        );
       },
       entityDefinition: (
         EntityDefinition entityDefinition,

--- a/lib/services/db_notification.dart
+++ b/lib/services/db_notification.dart
@@ -5,19 +5,32 @@ class UpdateNotifications {
 
   final _controller = StreamController<Set<String>>.broadcast();
   final _affectedIds = <String>{};
+  final _affectedIdsFromSync = <String>{};
   Timer? _timer;
+  Timer? _fromSyncTimer;
 
   Stream<Set<String>> get updateStream => _controller.stream;
 
-  void notify(Set<String> affectedIds) {
-    _affectedIds.addAll(affectedIds);
+  void notify(Set<String> affectedIds, {bool fromSync = false}) {
+    if (fromSync) {
+      _affectedIdsFromSync.addAll(affectedIds);
+      _fromSyncTimer ??= Timer(const Duration(seconds: 5), () {
+        if (_affectedIdsFromSync.isNotEmpty) {
+          _controller.add({..._affectedIdsFromSync});
+          _affectedIdsFromSync.clear();
+        }
+        _fromSyncTimer = null;
+      });
+    } else {
+      _affectedIds.addAll(affectedIds);
 
-    _timer ??= Timer(const Duration(milliseconds: 50), () {
-      if (_affectedIds.isNotEmpty) {
-        _controller.add({..._affectedIds});
-        _affectedIds.clear();
-      }
-      _timer = null;
-    });
+      _timer ??= Timer(const Duration(milliseconds: 50), () {
+        if (_affectedIds.isNotEmpty) {
+          _controller.add({..._affectedIds});
+          _affectedIds.clear();
+        }
+        _timer = null;
+      });
+    }
   }
 }

--- a/lib/themes/theme.dart
+++ b/lib/themes/theme.dart
@@ -18,6 +18,8 @@ class AppTheme {
 const double inputBorderRadius = 10;
 const mainFont = 'PlusJakartaSans';
 
+const verticalModalSpacer = SizedBox(height: 30);
+
 InputDecoration inputDecoration({
   required ThemeData themeData,
   String? labelText,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.548+2787
+version: 0.9.549+2788
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.549+2788
+version: 0.9.549+2789
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This pull request includes updates to the notification system to handle synchronization events separately, as well as a version bump for the project.

### Notification System Updates:
* [`lib/features/sync/matrix/process_message.dart`](diffhunk://#diff-516296985799d96f1a86244d20a4ac6ba3b90d268b1ee528cc1f8f6d62fd38bcL51-R61): Updated `processMatrixMessage` and `entryLink` methods to include a `fromSync` parameter when calling `updateNotifications.notify`.
* [`lib/services/db_notification.dart`](diffhunk://#diff-72c616bb37b79ef3dad4470d8ea99adc0acbca2db53e8c727c04c6ffa7579bcbR8-R24): Modified the `UpdateNotifications` class to handle a separate set of affected IDs for sync events and introduced a new timer for these events. [[1]](diffhunk://#diff-72c616bb37b79ef3dad4470d8ea99adc0acbca2db53e8c727c04c6ffa7579bcbR8-R24) [[2]](diffhunk://#diff-72c616bb37b79ef3dad4470d8ea99adc0acbca2db53e8c727c04c6ffa7579bcbR36)

### Version Update:
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Bumped the project version from `0.9.548+2787` to `0.9.549+2788`.