### PR TITLE
feat: add delays for less lag

### DIFF
--- a/lib/features/sync/outbox/outbox_service.dart
+++ b/lib/features/sync/outbox/outbox_service.dart
@@ -45,6 +45,7 @@ class OutboxService {
 
   Future<void> enqueueMessage(SyncMessage syncMessage) async {
     try {
+      await Future<void>.delayed(const Duration(milliseconds: 200));
       final vectorClockService = getIt<VectorClockService>();
       final hostHash = await vectorClockService.getHostHash();
       final host = await vectorClockService.getHost();

--- a/lib/widgets/charts/dashboard_health_chart.dart
+++ b/lib/widgets/charts/dashboard_health_chart.dart
@@ -40,7 +40,9 @@ class _DashboardHealthChartState extends State<DashboardHealthChart> {
   @override
   void initState() {
     super.initState();
-    _healthImport.fetchHealthDataDelta(widget.chartConfig.healthType);
+    Future.delayed(Duration(milliseconds: 200 + Random().nextInt(100)), () {
+      _healthImport.fetchHealthDataDelta(widget.chartConfig.healthType);
+    });
   }
 
   @override

--- a/lib/widgets/charts/dashboard_health_chart.dart
+++ b/lib/widgets/charts/dashboard_health_chart.dart
@@ -1,4 +1,5 @@
 import 'dart:core';
+import 'dart:io';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
@@ -40,6 +41,10 @@ class _DashboardHealthChartState extends State<DashboardHealthChart> {
   @override
   void initState() {
     super.initState();
+    if (Platform.environment.containsKey('FLUTTER_TEST')) {
+      return;
+    }
+
     Future.delayed(Duration(milliseconds: 200 + Random().nextInt(100)), () {
       _healthImport.fetchHealthDataDelta(widget.chartConfig.healthType);
     });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.549+2790
+version: 0.9.550+2791
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.550+2791
+version: 0.9.550+2792
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR adds small delays of non-critical functionality to improve rendering performance.


From GitHub Copilot:
This pull request includes several changes to improve the functionality and performance of the `lotti` application. The most important changes include adding a delay in the `OutboxService`, modifying the initialization of the `DashboardHealthChart` to account for test environments, and updating the application version.

Performance improvements:

* [`lib/features/sync/outbox/outbox_service.dart`](diffhunk://#diff-faf3f488a7f4fded6bcc246677a38fa8ff54b6133ce00418a05ee11ed1f6ac6cR48): Added a 200-millisecond delay in the `enqueueMessage` method to improve synchronization timing.

Test environment handling:

* [`lib/widgets/charts/dashboard_health_chart.dart`](diffhunk://#diff-213b9ff416a62d1d872700ba58c2fac6629587eff1e32e8a879651581d4af1ccR2): Imported the `dart:io` library and added a check in the `initState` method to bypass fetching health data if the `FLUTTER_TEST` environment variable is set. [[1]](diffhunk://#diff-213b9ff416a62d1d872700ba58c2fac6629587eff1e32e8a879651581d4af1ccR2) [[2]](diffhunk://#diff-213b9ff416a62d1d872700ba58c2fac6629587eff1e32e8a879651581d4af1ccR44-R50)

Version update:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Updated the application version from `0.9.549+2790` to `0.9.550+2792`.