### PR TITLE
chore: upgrade Flutter dependencies & WhisperKit

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -255,7 +255,7 @@ SPEC CHECKSUMS:
   flutter_image_compress_common: ec1d45c362c9d30a3f6a0426c297f47c52007e3e
   flutter_keyboard_visibility_temp_fork: 8a8809c4129e31d25fca77446e0f3fd548122ced
   flutter_local_notifications: df98d66e515e1ca797af436137b4459b160ad8c9
-  flutter_native_splash: e8a1e01082d97a8099d973f919f57904c925008a
+  flutter_native_splash: f71420956eb811e6d310720fee915f1d42852e7a
   flutter_native_timezone: 5f05b2de06c9776b4cc70e1839f03de178394d22
   flutter_olm: 7154e02866bd06d91e400e94f66d5e2a955de0b1
   flutter_openssl_crypto: 636ad25f56fbe0f45b9e13b8589540b341a486a1

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -613,7 +613,7 @@
 			repositoryURL = "https://github.com/argmaxinc/whisperkit";
 			requirement = {
 				kind = exactVersion;
-				version = 0.9.4;
+				version = 0.10.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/argmaxinc/whisperkit",
       "state" : {
-        "revision" : "defefaefe33dc6dbb45005958abaea1c0f8293ff",
-        "version" : "0.9.4"
+        "revision" : "63d955bc99e4dce9ba3e733f2f8815b9a9f53eee",
+        "version" : "0.10.1"
       }
     }
   ],

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -708,7 +708,7 @@
 			repositoryURL = "https://github.com/argmaxinc/whisperkit";
 			requirement = {
 				kind = exactVersion;
-				version = 0.9.4;
+				version = 0.10.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/argmaxinc/whisperkit",
       "state" : {
-        "revision" : "defefaefe33dc6dbb45005958abaea1c0f8293ff",
-        "version" : "0.9.4"
+        "revision" : "63d955bc99e4dce9ba3e733f2f8815b9a9f53eee",
+        "version" : "0.10.1"
       }
     }
   ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -739,18 +739,18 @@ packages:
     dependency: "direct main"
     description:
       name: flex_color_scheme
-      sha256: "90f4fe67b9561ae8a4af117df65a8ce9988624025667c54e6d304e65cff77d52"
+      sha256: "09bea5d776f694c5a67f2229f2aa500cc7cce369322dc6500ab01cf9ad1b4e1a"
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.2"
+    version: "8.1.0"
   flex_seed_scheme:
     dependency: transitive
     description:
       name: flex_seed_scheme
-      sha256: "7639d2c86268eff84a909026eb169f008064af0fb3696a651b24b0fa24a40334"
+      sha256: d3ba3c5c92d2d79d45e94b4c6c71d01fac3c15017da1545880c53864da5dfeb0
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.1"
+    version: "3.5.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -813,10 +813,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_form_builder
-      sha256: "39aee5a2548df0b3979a83eea38468116a888341fbca8a92c4be18a486a7bb57"
+      sha256: "375da52998c72f80dec9187bd93afa7ab202b89d5d066699368ff96d39fd4876"
       url: "https://pub.dev"
     source: hosted
-    version: "9.6.0"
+    version: "9.7.0"
   flutter_health_fit:
     dependency: "direct main"
     description:
@@ -987,10 +987,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_native_splash
-      sha256: "1152ab0067ca5a2ebeb862fe0a762057202cceb22b7e62692dcbabf6483891bb"
+      sha256: "7062602e0dbd29141fb8eb19220b5871ca650be5197ab9c1f193a28b17537bc7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.3"
+    version: "2.4.4"
   flutter_native_timezone:
     dependency: "direct main"
     description:
@@ -3262,10 +3262,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "8b338d4486ab3fbc0ba0db9f9b4f5239b6697fcee427939a40e720cbb9ee0a69"
+      sha256: "154360849a56b7b67331c21f09a386562d88903f90a1099c5987afc1912e1f29"
       url: "https://pub.dev"
     source: hosted
-    version: "5.9.0"
+    version: "5.10.0"
   win32_registry:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.551+2797
+version: 0.9.551+2798
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This pull request includes updates to version numbers and dependencies for both iOS and macOS projects, as well as a minor version update for the `pubspec.yaml` file. The most important changes include updating the `whisperkit` package version and its corresponding revision.

Dependency updates:

* [`ios/Runner.xcodeproj/project.pbxproj`](diffhunk://#diff-413fd2395fd4377132c8c1135c9bc9ab215c6f97322d27717a487223bd03e2c7L616-R616): Updated `whisperkit` package version from `0.9.4` to `0.10.1`.
* [`ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved`](diffhunk://#diff-6dd9bba242a295a8b13064d176cb756ffb0b74a544fe2ef58341f6a0e3290e9aL27-R28): Updated `whisperkit` package version from `0.9.4` to `0.10.1` and its revision to `63d955bc99e4dce9ba3e733f2f8815b9a9f53eee`.
* [`macos/Runner.xcodeproj/project.pbxproj`](diffhunk://#diff-ec40d5406d2e5b54c265f64285bf1f073febb06b92a906239f8905a6244e68efL711-R711): Updated `whisperkit` package version from `0.9.4` to `0.10.1`.
* [`macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved`](diffhunk://#diff-6dd9bba242a295a8b13064d176cb756ffb0b74a544fe2ef58341f6a0e3290e9aL27-R28): Updated `whisperkit` package version from `0.9.4` to `0.10.1` and its revision to `63d955bc99e4dce9ba3e733f2f8815b9a9f53eee`.

Version update:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Incremented the version from `0.9.551+2797` to `0.9.551+2798`.