### PR TITLE
chore: upgrade WhisperKit

### DIFF
--- a/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/argmaxinc/whisperkit",
       "state" : {
-        "revision" : "defefaefe33dc6dbb45005958abaea1c0f8293ff",
-        "version" : "0.9.4"
+        "revision" : "63d955bc99e4dce9ba3e733f2f8815b9a9f53eee",
+        "version" : "0.10.1"
       }
     }
   ],

--- a/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/argmaxinc/whisperkit",
       "state" : {
-        "revision" : "defefaefe33dc6dbb45005958abaea1c0f8293ff",
-        "version" : "0.9.4"
+        "revision" : "63d955bc99e4dce9ba3e733f2f8815b9a9f53eee",
+        "version" : "0.10.1"
       }
     }
   ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.551+2798
+version: 0.9.551+2799
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This pull request includes updates to the `whisperkit` package versions for both iOS and macOS, as well as a minor version bump in the `pubspec.yaml` file.

Package version updates:

* [`ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`](diffhunk://#diff-2bbba4945556820d8d37758665ea4779d8016b7020a2601d0ee9cfcadc97ecb4L27-R28): Updated `whisperkit` package version from `0.9.4` to `0.10.1` and its revision.
* [`macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`](diffhunk://#diff-2bbba4945556820d8d37758665ea4779d8016b7020a2601d0ee9cfcadc97ecb4L27-R28): Updated `whisperkit` package version from `0.9.4` to `0.10.1` and its revision.

Version bump:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Incremented the build version from `0.9.551+2798` to `0.9.551+2799`.