### PR TITLE
feat: logging config flag

### DIFF
--- a/integration_test/matrix_service_test.dart
+++ b/integration_test/matrix_service_test.dart
@@ -19,6 +19,7 @@ import 'package:lotti/features/sync/vector_clock.dart';
 import 'package:lotti/features/user_activity/state/user_activity_service.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/db_notification.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/utils/file_utils.dart';
 import 'package:matrix/encryption/utils/key_verification.dart';
 import 'package:mocktail/mocktail.dart';
@@ -114,6 +115,7 @@ void main() {
       getIt
         ..registerSingleton<Directory>(docDir)
         ..registerSingleton<LoggingDb>(LoggingDb(inMemoryDatabase: true))
+        ..registerSingleton<LoggingService>(LoggingService())
         ..registerSingleton<UpdateNotifications>(mockUpdateNotifications)
         ..registerSingleton<UserActivityService>(UserActivityService())
         ..registerSingleton<JournalDb>(JournalDb(inMemoryDatabase: true))
@@ -140,7 +142,6 @@ void main() {
           dbName: 'Alice',
           deviceDisplayName: 'Alice',
           overriddenJournalDb: aliceDb,
-          overriddenLoggingDb: LoggingDb(inMemoryDatabase: true),
           overriddenSettingsDb: SettingsDb(inMemoryDatabase: true),
         );
 
@@ -167,7 +168,6 @@ void main() {
           dbName: 'Bob',
           deviceDisplayName: 'Bob',
           overriddenJournalDb: bobDb,
-          overriddenLoggingDb: LoggingDb(inMemoryDatabase: true),
           overriddenSettingsDb: SettingsDb(inMemoryDatabase: true),
         );
 

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -11,9 +11,9 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/tag_type_definitions.dart';
 import 'package:lotti/database/common.dart';
 import 'package:lotti/database/conversions.dart';
-import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/features/sync/vector_clock.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/utils/file_utils.dart';
 
 part 'database.g.dart';
@@ -179,7 +179,7 @@ class JournalDb extends _$JournalDb {
           await resolveConflict(existingConflict);
         }
       } else {
-        getIt<LoggingDb>().captureEvent(
+        getIt<LoggingService>().captureEvent(
           EnumToString.convertToString(status),
           domain: 'JOURNAL_DB',
           subDomain: 'Conflict status',

--- a/lib/database/journal_db/config_flags.dart
+++ b/lib/database/journal_db/config_flags.dart
@@ -77,6 +77,13 @@ Future<void> initConfigFlags(
       status: false,
     ),
   );
+  await db.insertFlagIfNotExists(
+    const ConfigFlag(
+      name: enableLoggingFlag,
+      description: 'Enable logging?',
+      status: false,
+    ),
+  );
   if (Platform.isMacOS) {
     await db.insertFlagIfNotExists(
       const ConfigFlag(

--- a/lib/database/logging_db.dart
+++ b/lib/database/logging_db.dart
@@ -1,9 +1,7 @@
 import 'dart:async';
 
 import 'package:drift/drift.dart';
-import 'package:flutter/foundation.dart';
 import 'package:lotti/database/common.dart';
-import 'package:lotti/utils/file_utils.dart';
 
 part 'logging_db.g.dart';
 
@@ -38,91 +36,8 @@ class LoggingDb extends _$LoggingDb {
   @override
   int get schemaVersion => 1;
 
-  Future<int> _logAsync(LogEntry logEntry) async {
+  Future<int> log(LogEntry logEntry) async {
     return into(logEntries).insert(logEntry);
-  }
-
-  void log(LogEntry logEntry) {
-    unawaited(_logAsync(logEntry));
-  }
-
-  Future<void> _captureEventAsync(
-    dynamic event, {
-    required String domain,
-    String? subDomain,
-    InsightLevel level = InsightLevel.info,
-    InsightType type = InsightType.log,
-  }) async {
-    log(
-      LogEntry(
-        id: uuid.v1(),
-        createdAt: DateTime.now().toIso8601String(),
-        domain: domain,
-        subDomain: subDomain,
-        message: event.toString(),
-        level: level.name.toUpperCase(),
-        type: type.name.toUpperCase(),
-      ),
-    );
-  }
-
-  void captureEvent(
-    dynamic event, {
-    required String domain,
-    String? subDomain,
-    InsightLevel level = InsightLevel.info,
-    InsightType type = InsightType.log,
-  }) {
-    unawaited(
-      _captureEventAsync(
-        event,
-        domain: domain,
-        subDomain: subDomain,
-        level: level,
-        type: type,
-      ),
-    );
-  }
-
-  Future<void> _captureExceptionAsync(
-    dynamic exception, {
-    required String domain,
-    String? subDomain,
-    dynamic stackTrace,
-    InsightLevel level = InsightLevel.error,
-    InsightType type = InsightType.exception,
-  }) async {
-    log(
-      LogEntry(
-        id: uuid.v1(),
-        createdAt: DateTime.now().toIso8601String(),
-        domain: domain,
-        subDomain: subDomain,
-        message: exception.toString(),
-        stacktrace: stackTrace.toString(),
-        level: level.name.toUpperCase(),
-        type: type.name.toUpperCase(),
-      ),
-    );
-  }
-
-  void captureException(
-    dynamic exception, {
-    required String domain,
-    String? subDomain,
-    dynamic stackTrace,
-    InsightLevel level = InsightLevel.error,
-    InsightType type = InsightType.exception,
-  }) {
-    debugPrint('EXCEPTION $domain $subDomain $exception $stackTrace');
-    _captureExceptionAsync(
-      exception,
-      domain: domain,
-      subDomain: subDomain,
-      stackTrace: stackTrace,
-      level: level,
-      type: type,
-    );
   }
 
   Stream<List<LogEntry>> watchLogEntryById(String id) {

--- a/lib/database/maintenance.dart
+++ b/lib/database/maintenance.dart
@@ -12,6 +12,7 @@ import 'package:lotti/features/sync/outbox/outbox_service.dart';
 import 'package:lotti/features/tags/repository/tags_repository.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/tags_service.dart';
 
 class Maintenance {
@@ -184,7 +185,7 @@ class Maintenance {
     final file = await getDatabaseFile(fts5DbFileName);
     file.deleteSync();
 
-    getIt<LoggingDb>().captureEvent(
+    getIt<LoggingService>().captureEvent(
       'FTS5 database DELETED',
       domain: 'MAINTENANCE',
       subDomain: 'recreateFts5',
@@ -195,7 +196,7 @@ class Maintenance {
     try {
       await deleteFts5Db();
     } catch (e, stackTrace) {
-      getIt<LoggingDb>().captureException(
+      getIt<LoggingService>().captureException(
         e,
         domain: 'MAINTENANCE',
         subDomain: 'deleteFts5Db',
@@ -229,7 +230,7 @@ class Maintenance {
 
       final progress = entryCount > 0 ? completed / entryCount : 0;
 
-      getIt<LoggingDb>().captureEvent(
+      getIt<LoggingService>().captureEvent(
         'Progress: ${(progress * 100).floor()}%, $completed/$entryCount',
         domain: 'MAINTENANCE',
         subDomain: 'recreateFts5',

--- a/lib/features/dashboards/state/measurables_controller.dart
+++ b/lib/features/dashboards/state/measurables_controller.dart
@@ -5,6 +5,7 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/db_notification.dart';
+import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/utils/cache_extension.dart';
 import 'package:lotti/utils/date_utils_extension.dart';
 import 'package:lotti/utils/measurable_utils.dart';
@@ -29,7 +30,8 @@ class MeasurableDataTypeController extends _$MeasurableDataTypeController {
   }
 
   Future<MeasurableDataType?> _fetch() async {
-    return _journalDb.getMeasurableDataTypeById(id);
+    final dataType = getIt<EntitiesCacheService>().getDataTypeById(id);
+    return dataType ?? await _journalDb.getMeasurableDataTypeById(id);
   }
 }
 

--- a/lib/features/journal/repository/journal_repository.dart
+++ b/lib/features/journal/repository/journal_repository.dart
@@ -7,11 +7,11 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/sync_message.dart';
 import 'package:lotti/database/conversions.dart';
 import 'package:lotti/database/database.dart';
-import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/features/sync/outbox/outbox_service.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/db_notification.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/notification_service.dart';
 import 'package:lotti/services/vector_clock_service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -44,7 +44,7 @@ class JournalRepository {
         ),
       );
     } catch (exception, stackTrace) {
-      getIt<LoggingDb>().captureException(
+      getIt<LoggingService>().captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'updateCategoryId',
@@ -78,7 +78,7 @@ class JournalRepository {
 
       await getIt<NotificationService>().updateBadge();
     } catch (exception, stackTrace) {
-      getIt<LoggingDb>().captureException(
+      getIt<LoggingService>().captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'deleteJournalEntity',
@@ -113,7 +113,7 @@ class JournalRepository {
       );
       await persistenceLogic.updateDbEntity(updated);
     } catch (exception, stackTrace) {
-      getIt<LoggingDb>().captureException(
+      getIt<LoggingService>().captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'updateJournalEntityDate',
@@ -141,7 +141,7 @@ class JournalRepository {
 
       return journalEntity;
     } catch (exception, stackTrace) {
-      getIt<LoggingDb>().captureException(
+      getIt<LoggingService>().captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'createTextEntry',
@@ -175,7 +175,7 @@ class JournalRepository {
       );
       return journalEntity;
     } catch (exception, stackTrace) {
-      getIt<LoggingDb>().captureException(
+      getIt<LoggingService>().captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'createImageEntry',

--- a/lib/features/speech/repository/speech_repository.dart
+++ b/lib/features/speech/repository/speech_repository.dart
@@ -4,10 +4,10 @@ import 'package:lotti/classes/audio_note.dart';
 import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
-import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/features/speech/state/asr_service.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/utils/consts.dart';
 
 class SpeechRepository {
@@ -55,7 +55,7 @@ class SpeechRepository {
 
       return journalEntity;
     } catch (exception, stackTrace) {
-      getIt<LoggingDb>().captureException(
+      getIt<LoggingService>().captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'createAudioEntry',
@@ -84,14 +84,14 @@ class SpeechRepository {
             ),
           );
         },
-        orElse: () async => getIt<LoggingDb>().captureException(
+        orElse: () async => getIt<LoggingService>().captureException(
           'not an audio entry',
           domain: 'persistence_logic',
           subDomain: 'updateLanguage',
         ),
       );
     } catch (exception, stackTrace) {
-      getIt<LoggingDb>().captureException(
+      getIt<LoggingService>().captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'updateLanguage',
@@ -143,14 +143,14 @@ class SpeechRepository {
             ),
           );
         },
-        orElse: () async => getIt<LoggingDb>().captureException(
+        orElse: () async => getIt<LoggingService>().captureException(
           'not an audio entry',
           domain: 'persistence_logic',
           subDomain: 'addAudioTranscript',
         ),
       );
     } catch (exception, stackTrace) {
-      getIt<LoggingDb>().captureException(
+      getIt<LoggingService>().captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'addAudioTranscript',
@@ -190,14 +190,14 @@ class SpeechRepository {
             ),
           );
         },
-        orElse: () async => getIt<LoggingDb>().captureException(
+        orElse: () async => getIt<LoggingService>().captureException(
           'not an audio entry',
           domain: 'persistence_logic',
           subDomain: 'removeAudioTranscript',
         ),
       );
     } catch (exception, stackTrace) {
-      getIt<LoggingDb>().captureException(
+      getIt<LoggingService>().captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'removeAudioTranscript',

--- a/lib/features/speech/state/asr_service.dart
+++ b/lib/features/speech/state/asr_service.dart
@@ -8,10 +8,10 @@ import 'package:ffmpeg_kit_flutter/return_code.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:lotti/classes/journal_entities.dart';
-import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/features/speech/repository/speech_repository.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/utils/audio_utils.dart';
 
 class AsrService {
@@ -96,7 +96,7 @@ class AsrService {
       return;
     }
 
-    getIt<LoggingDb>().captureEvent(
+    getIt<LoggingService>().captureEvent(
       'transcribing $audioFilePath',
       domain: 'ASR',
       subDomain: 'transcribe',
@@ -182,7 +182,7 @@ class AsrService {
     dynamic exception, {
     String subdomain = 'transcribe',
   }) {
-    getIt<LoggingDb>().captureException(
+    getIt<LoggingService>().captureException(
       exception,
       domain: 'ASR',
       subDomain: subdomain,

--- a/lib/features/speech/state/player_cubit.dart
+++ b/lib/features/speech/state/player_cubit.dart
@@ -2,9 +2,9 @@ import 'dart:async';
 
 import 'package:bloc/bloc.dart';
 import 'package:lotti/classes/journal_entities.dart';
-import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/features/speech/state/player_state.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/utils/audio_utils.dart';
 import 'package:media_kit/media_kit.dart';
 
@@ -24,7 +24,7 @@ class AudioPlayerCubit extends Cubit<AudioPlayerState> {
   }
 
   final Player _audioPlayer = Player();
-  final LoggingDb _loggingDb = getIt<LoggingDb>();
+  final LoggingService _loggingService = getIt<LoggingService>();
 
   void updateProgress(Duration duration) {
     emit(state.copyWith(progress: duration));
@@ -51,7 +51,7 @@ class AudioPlayerCubit extends Cubit<AudioPlayerState> {
       final totalDuration = _audioPlayer.state.duration;
       emit(newState.copyWith(totalDuration: totalDuration));
     } catch (exception, stackTrace) {
-      _loggingDb.captureException(
+      _loggingService.captureException(
         exception,
         domain: 'player_cubit',
         stackTrace: stackTrace,
@@ -74,7 +74,7 @@ class AudioPlayerCubit extends Cubit<AudioPlayerState> {
         }
       });
     } catch (exception, stackTrace) {
-      _loggingDb.captureException(
+      _loggingService.captureException(
         exception,
         domain: 'player_cubit',
         stackTrace: stackTrace,
@@ -92,7 +92,7 @@ class AudioPlayerCubit extends Cubit<AudioPlayerState> {
         ),
       );
     } catch (exception, stackTrace) {
-      _loggingDb.captureException(
+      _loggingService.captureException(
         exception,
         domain: 'player_cubit',
         stackTrace: stackTrace,
@@ -105,7 +105,7 @@ class AudioPlayerCubit extends Cubit<AudioPlayerState> {
       await _audioPlayer.setRate(speed);
       emit(state.copyWith(speed: speed));
     } catch (exception, stackTrace) {
-      _loggingDb.captureException(
+      _loggingService.captureException(
         exception,
         domain: 'player_cubit',
         stackTrace: stackTrace,
@@ -127,7 +127,7 @@ class AudioPlayerCubit extends Cubit<AudioPlayerState> {
         ),
       );
     } catch (exception, stackTrace) {
-      _loggingDb.captureException(
+      _loggingService.captureException(
         exception,
         domain: 'player_cubit',
         stackTrace: stackTrace,

--- a/lib/features/speech/state/recorder_cubit.dart
+++ b/lib/features/speech/state/recorder_cubit.dart
@@ -4,11 +4,11 @@ import 'package:bloc/bloc.dart';
 import 'package:flutter/foundation.dart';
 import 'package:intl/intl.dart';
 import 'package:lotti/classes/audio_note.dart';
-import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/features/speech/repository/speech_repository.dart';
 import 'package:lotti/features/speech/state/recorder_state.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/utils/file_utils.dart';
 import 'package:record/record.dart';
 
@@ -40,7 +40,7 @@ class AudioRecorderCubit extends Cubit<AudioRecorderState> {
 
   final _audioRecorder = AudioRecorder();
   StreamSubscription<Amplitude>? _amplitudeSub;
-  final LoggingDb _loggingDb = getIt<LoggingDb>();
+  final LoggingService _loggingService = getIt<LoggingService>();
   final PersistenceLogic persistenceLogic = getIt<PersistenceLogic>();
   String? _linkedId;
   String? _language;
@@ -85,13 +85,13 @@ class AudioRecorderCubit extends Cubit<AudioRecorderState> {
           );
         }
       } else {
-        _loggingDb.captureEvent(
+        _loggingService.captureEvent(
           'no audio recording permission',
           domain: 'recorder_cubit',
         );
       }
     } catch (exception, stackTrace) {
-      _loggingDb.captureException(
+      _loggingService.captureException(
         exception,
         domain: 'recorder_cubit',
         stackTrace: stackTrace,
@@ -116,7 +116,7 @@ class AudioRecorderCubit extends Cubit<AudioRecorderState> {
         return entryId;
       }
     } catch (exception, stackTrace) {
-      _loggingDb.captureException(
+      _loggingService.captureException(
         exception,
         domain: 'recorder_cubit',
         stackTrace: stackTrace,

--- a/lib/features/sync/matrix/client.dart
+++ b/lib/features/sync/matrix/client.dart
@@ -2,9 +2,9 @@ import 'dart:io';
 
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart';
-import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/features/sync/matrix.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/utils/file_utils.dart';
 import 'package:matrix/encryption/utils/key_verification.dart';
 import 'package:matrix/matrix.dart';
@@ -68,13 +68,11 @@ Future<void> matrixConnect({
   required MatrixService service,
   required bool shouldAttemptLogin,
 }) async {
-  final loggingDb = getIt<LoggingDb>();
-
   try {
     final matrixConfig = service.matrixConfig;
 
     if (matrixConfig == null) {
-      loggingDb.captureEvent(
+      getIt<LoggingService>().captureEvent(
         configNotFound,
         domain: 'MATRIX_SERVICE',
         subDomain: 'login',
@@ -87,7 +85,7 @@ Future<void> matrixConnect({
       Uri.parse(matrixConfig.homeServer),
     );
 
-    loggingDb.captureEvent(
+    getIt<LoggingService>().captureEvent(
       'checkHomeserver $homeServerSummary',
       domain: 'MATRIX_SERVICE',
       subDomain: 'login',
@@ -109,7 +107,7 @@ Future<void> matrixConnect({
         initialDeviceDisplayName: initialDeviceDisplayName,
       );
 
-      loggingDb.captureEvent(
+      getIt<LoggingService>().captureEvent(
         'logged in, userId ${service.loginResponse?.userId},'
         ' deviceId  ${service.loginResponse?.deviceId}',
         domain: 'MATRIX_SERVICE',
@@ -124,7 +122,7 @@ Future<void> matrixConnect({
     }
   } catch (e, stackTrace) {
     debugPrint('$e');
-    loggingDb.captureException(
+    getIt<LoggingService>().captureException(
       e,
       domain: 'MATRIX_SERVICE',
       subDomain: 'login',

--- a/lib/features/sync/matrix/key_verification_runner.dart
+++ b/lib/features/sync/matrix/key_verification_runner.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/features/sync/matrix.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:matrix/encryption/utils/key_verification.dart';
 import 'package:matrix/matrix.dart';
 
@@ -80,8 +80,6 @@ class KeyVerificationRunner {
 Future<void> listenForKeyVerificationRequests({
   required MatrixService service,
 }) async {
-  final loggingDb = getIt<LoggingDb>();
-
   try {
     service.client.onKeyVerificationRequest.stream.listen((
       KeyVerification keyVerification,
@@ -97,7 +95,7 @@ Future<void> listenForKeyVerificationRequests({
     });
   } catch (e, stackTrace) {
     debugPrint('$e');
-    loggingDb.captureException(
+    getIt<LoggingService>().captureException(
       e,
       domain: 'MATRIX_SERVICE',
       subDomain: 'listen',

--- a/lib/features/sync/matrix/matrix_service.dart
+++ b/lib/features/sync/matrix/matrix_service.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:lotti/classes/config.dart';
 import 'package:lotti/database/database.dart';
-import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/features/sync/client_runner.dart';
 import 'package:lotti/features/sync/matrix.dart';
@@ -17,7 +16,6 @@ class MatrixService {
     this.deviceDisplayName,
     String? dbName,
     JournalDb? overriddenJournalDb,
-    LoggingDb? overriddenLoggingDb,
     SettingsDb? overriddenSettingsDb,
   })  : keyVerificationController =
             StreamController<KeyVerificationRunner>.broadcast(),
@@ -31,7 +29,6 @@ class MatrixService {
         await processNewTimelineEvents(
           service: this,
           overriddenJournalDb: overriddenJournalDb,
-          overriddenLoggingDb: overriddenLoggingDb,
           overriddenSettingsDb: overriddenSettingsDb,
         );
       },

--- a/lib/features/sync/matrix/process_message.dart
+++ b/lib/features/sync/matrix/process_message.dart
@@ -6,10 +6,10 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/sync_message.dart';
 import 'package:lotti/classes/tag_type_definitions.dart';
 import 'package:lotti/database/database.dart';
-import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/features/sync/matrix.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/db_notification.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/utils/file_utils.dart';
 import 'package:matrix/matrix.dart';
 
@@ -24,7 +24,6 @@ Future<void> processMatrixMessage({
   JournalDb? overriddenJournalDb,
 }) async {
   final journalDb = overriddenJournalDb ?? getIt<JournalDb>();
-  final loggingDb = getIt<LoggingDb>();
   final message = event.text;
   final updateNotifications = getIt<UpdateNotifications>();
 
@@ -35,7 +34,7 @@ Future<void> processMatrixMessage({
       json.decode(decoded) as Map<String, dynamic>,
     );
 
-    loggingDb.captureEvent(
+    getIt<LoggingService>().captureEvent(
       'processing ${event.originServerTs} ${event.eventId}',
       domain: 'MATRIX_SERVICE',
       subDomain: 'processMessage',
@@ -74,7 +73,7 @@ Future<void> processMatrixMessage({
       },
     );
   } catch (e, stackTrace) {
-    loggingDb.captureException(
+    getIt<LoggingService>().captureException(
       e,
       domain: 'MATRIX_SERVICE',
       subDomain: 'processMessage',

--- a/lib/features/sync/matrix/room.dart
+++ b/lib/features/sync/matrix/room.dart
@@ -1,17 +1,15 @@
 import 'package:flutter/foundation.dart';
 import 'package:intl/intl.dart';
-import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/features/sync/matrix.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:matrix/matrix.dart';
 
 Future<String?> joinMatrixRoom({
   required String roomId,
   required MatrixService service,
 }) async {
-  final loggingDb = getIt<LoggingDb>();
-
   try {
     final joinRes = await service.client.joinRoom(roomId).onError((
       error,
@@ -19,7 +17,7 @@ Future<String?> joinMatrixRoom({
     ) {
       debugPrint('MatrixService join error $error');
 
-      loggingDb.captureException(
+      getIt<LoggingService>().captureException(
         error,
         domain: 'MATRIX_SERVICE',
         subDomain: 'joinRoom',
@@ -34,7 +32,7 @@ Future<String?> joinMatrixRoom({
       ..syncRoom = syncRoom
       ..syncRoomId = roomId;
 
-    loggingDb.captureEvent(
+    getIt<LoggingService>().captureEvent(
       'joined $roomId $joinRes',
       domain: 'MATRIX_SERVICE',
       subDomain: 'joinRoom',
@@ -43,7 +41,7 @@ Future<String?> joinMatrixRoom({
     return joinRes;
   } catch (e, stackTrace) {
     debugPrint('$e');
-    loggingDb.captureException(
+    getIt<LoggingService>().captureException(
       e,
       domain: 'MATRIX_SERVICE',
       subDomain: 'joinRoom',

--- a/lib/features/sync/matrix/save_attachment.dart
+++ b/lib/features/sync/matrix/save_attachment.dart
@@ -1,13 +1,12 @@
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
-import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/utils/file_utils.dart';
 import 'package:matrix/matrix.dart';
 
 Future<void> saveAttachment(Event event) async {
-  final loggingDb = getIt<LoggingDb>();
   final attachmentMimetype = event.attachmentMimetype;
 
   if (attachmentMimetype.isNotEmpty) {
@@ -15,7 +14,7 @@ Future<void> saveAttachment(Event event) async {
 
     try {
       if (relativePath != null) {
-        loggingDb.captureEvent(
+        getIt<LoggingService>().captureEvent(
           'downloading $relativePath',
           domain: 'MATRIX_SERVICE',
           subDomain: 'writeToFile',
@@ -24,14 +23,14 @@ Future<void> saveAttachment(Event event) async {
         final matrixFile = await event.downloadAndDecryptAttachment();
         final docDir = getDocumentsDirectory();
         await writeToFile(matrixFile.bytes, '${docDir.path}$relativePath');
-        loggingDb.captureEvent(
+        getIt<LoggingService>().captureEvent(
           'wrote file $relativePath',
           domain: 'MATRIX_SERVICE',
           subDomain: 'saveAttachment',
         );
       }
     } catch (exception, stackTrace) {
-      loggingDb.captureException(
+      getIt<LoggingService>().captureException(
         'failed to save attachment $attachmentMimetype $relativePath',
         domain: 'MATRIX_SERVICE',
         subDomain: 'saveAttachment',
@@ -46,7 +45,7 @@ Future<void> writeToFile(Uint8List? data, String filePath) async {
     await File(filePath).writeAsBytes(data);
   } else {
     debugPrint('No bytes for $filePath');
-    getIt<LoggingDb>().captureEvent(
+    getIt<LoggingService>().captureEvent(
       'No bytes for $filePath',
       domain: 'INBOX',
       subDomain: 'writeToFile',

--- a/lib/features/sync/matrix/send_message.dart
+++ b/lib/features/sync/matrix/send_message.dart
@@ -5,9 +5,9 @@ import 'dart:io';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/sync_message.dart';
 import 'package:lotti/database/database.dart';
-import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/features/sync/matrix.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/utils/audio_utils.dart';
 import 'package:lotti/utils/consts.dart';
 import 'package:lotti/utils/file_utils.dart';
@@ -36,13 +36,13 @@ extension SendExtension on MatrixService {
     SyncMessage syncMessage, {
     String? myRoomId,
   }) async {
-    final loggingDb = getIt<LoggingDb>();
+    final loggingService = getIt<LoggingService>();
 
     final msg = json.encode(syncMessage);
     final roomId = myRoomId ?? syncRoomId;
 
     if (getUnverifiedDevices().isNotEmpty) {
-      loggingDb.captureException(
+      loggingService.captureException(
         'Unverified devices found',
         domain: 'MATRIX_SERVICE',
         subDomain: 'sendMatrixMsg',
@@ -51,14 +51,14 @@ extension SendExtension on MatrixService {
     }
 
     if (roomId == null) {
-      loggingDb.captureEvent(
+      loggingService.captureEvent(
         configNotFound,
         domain: 'MATRIX_SERVICE',
         subDomain: 'sendMatrixMsg',
       );
     }
 
-    loggingDb.captureEvent(
+    loggingService.captureEvent(
       'trying to send text message to $syncRoom',
       domain: 'MATRIX_SERVICE',
       subDomain: 'sendMatrixMsg',
@@ -73,7 +73,7 @@ extension SendExtension on MatrixService {
 
     incrementSentCount();
 
-    loggingDb.captureEvent(
+    loggingService.captureEvent(
       'sent text message to $syncRoom with event ID $eventId',
       domain: 'MATRIX_SERVICE',
       subDomain: 'sendMatrixMsg',
@@ -119,7 +119,7 @@ extension SendExtension on MatrixService {
     required String fullPath,
     required String relativePath,
   }) async {
-    final loggingDb = getIt<LoggingDb>()
+    final loggingDb = getIt<LoggingService>()
       ..captureEvent(
         'trying to send $relativePath file message to $syncRoom',
         domain: 'MATRIX_SERVICE',

--- a/lib/features/sync/matrix/timeline.dart
+++ b/lib/features/sync/matrix/timeline.dart
@@ -2,17 +2,17 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:lotti/database/database.dart';
-import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/features/sync/matrix.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/utils/list_extension.dart';
 import 'package:matrix/matrix.dart';
 
 Future<void> listenToTimelineEvents({
   required MatrixService service,
 }) async {
-  final loggingDb = getIt<LoggingDb>();
+  final loggingDb = getIt<LoggingService>();
 
   try {
     final previousTimeline = service.timeline;
@@ -60,10 +60,10 @@ Future<void> listenToTimelineEvents({
 Future<void> processNewTimelineEvents({
   required MatrixService service,
   JournalDb? overriddenJournalDb,
-  LoggingDb? overriddenLoggingDb,
+  LoggingService? overriddenLoggingService,
   SettingsDb? overriddenSettingsDb,
 }) async {
-  final loggingDb = overriddenLoggingDb ?? getIt<LoggingDb>();
+  final loggingService = overriddenLoggingService ?? getIt<LoggingService>();
 
   try {
     final lastReadEventContextId = service.lastReadEventContextId;
@@ -78,7 +78,7 @@ Future<void> processNewTimelineEvents({
     );
 
     if (timeline == null) {
-      loggingDb.captureEvent(
+      loggingService.captureEvent(
         'Timeline is null',
         domain: 'MATRIX_SERVICE',
         subDomain: 'processNewTimelineEvents',
@@ -121,7 +121,7 @@ Future<void> processNewTimelineEvents({
           }
         }
       } catch (e, stackTrace) {
-        loggingDb.captureException(
+        loggingService.captureException(
           e,
           domain: 'MATRIX_SERVICE',
           subDomain: 'setReadMarker ${service.client.deviceName}',
@@ -130,7 +130,7 @@ Future<void> processNewTimelineEvents({
       }
     }
   } catch (e, stackTrace) {
-    loggingDb.captureException(
+    loggingService.captureException(
       e,
       domain: 'MATRIX_SERVICE',
       subDomain: 'listenToTimelineEvents ${service.client.deviceName}',

--- a/lib/features/tags/repository/tags_repository.dart
+++ b/lib/features/tags/repository/tags_repository.dart
@@ -2,15 +2,14 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/sync_message.dart';
 import 'package:lotti/classes/tag_type_definitions.dart';
 import 'package:lotti/database/database.dart';
-import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/features/sync/outbox/outbox_service.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/tags_service.dart';
 import 'package:lotti/utils/file_utils.dart';
 
 class TagsRepository {
-  static LoggingDb get _loggingDb => getIt<LoggingDb>();
   static JournalDb get _journalDb => getIt<JournalDb>();
   static TagsService get _tagsService => getIt<TagsService>();
   static PersistenceLogic get _persistenceLogic => getIt<PersistenceLogic>();
@@ -35,7 +34,7 @@ class TagsRepository {
         ),
       );
     } catch (exception, stackTrace) {
-      _loggingDb.captureException(
+      getIt<LoggingService>().captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'addTags',
@@ -69,7 +68,7 @@ class TagsRepository {
         );
       }
     } catch (exception, stackTrace) {
-      _loggingDb.captureException(
+      getIt<LoggingService>().captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'addTagsWithLinked',
@@ -100,7 +99,7 @@ class TagsRepository {
         ),
       );
     } catch (exception, stackTrace) {
-      _loggingDb.captureException(
+      getIt<LoggingService>().captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'removeTag',

--- a/lib/features/tasks/repository/checklist_repository.dart
+++ b/lib/features/tasks/repository/checklist_repository.dart
@@ -3,9 +3,9 @@ import 'package:lotti/classes/checklist_data.dart';
 import 'package:lotti/classes/checklist_item_data.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
-import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'checklist_repository.g.dart';
@@ -17,7 +17,7 @@ ChecklistRepository checklistRepository(Ref ref) {
 
 class ChecklistRepository {
   final JournalDb _journalDb = getIt<JournalDb>();
-  final LoggingDb _loggingDb = getIt<LoggingDb>();
+  final LoggingService _loggingService = getIt<LoggingService>();
   final PersistenceLogic _persistenceLogic = getIt<PersistenceLogic>();
 
   Future<JournalEntity?> createChecklist({
@@ -80,7 +80,7 @@ class ChecklistRepository {
 
       return newChecklist;
     } catch (exception, stackTrace) {
-      _loggingDb.captureException(
+      _loggingService.captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'createChecklistEntry',
@@ -108,7 +108,7 @@ class ChecklistRepository {
 
       return newChecklistItem;
     } catch (exception, stackTrace) {
-      _loggingDb.captureException(
+      _loggingService.captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'createChecklistEntry',
@@ -140,14 +140,14 @@ class ChecklistRepository {
 
           await _persistenceLogic.updateDbEntity(updatedChecklist);
         },
-        orElse: () async => _loggingDb.captureException(
+        orElse: () async => _loggingService.captureException(
           'not a checklist',
           domain: 'persistence_logic',
           subDomain: 'updateChecklist',
         ),
       );
     } catch (exception, stackTrace) {
-      _loggingDb.captureException(
+      _loggingService.captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'updateChecklist',
@@ -177,14 +177,14 @@ class ChecklistRepository {
 
           await _persistenceLogic.updateDbEntity(updatedChecklist);
         },
-        orElse: () async => _loggingDb.captureException(
+        orElse: () async => _loggingService.captureException(
           'not a checklist item',
           domain: 'persistence_logic',
           subDomain: 'updateChecklistItem',
         ),
       );
     } catch (exception, stackTrace) {
-      _loggingDb.captureException(
+      _loggingService.captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'updateChecklistItem',

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -18,6 +18,7 @@ import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/editor_state_service.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/services/link_service.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/services/notification_service.dart';
 import 'package:lotti/services/tags_service.dart';
@@ -51,6 +52,7 @@ Future<void> registerSingletons() async {
     ..registerSingleton<NavService>(NavService());
 
   unawaited(getIt<MatrixService>().init());
+  getIt<LoggingService>().listenToConfigFlag();
 
   await initConfigFlags(getIt<JournalDb>(), inMemoryDatabase: false);
 }

--- a/lib/logic/health_import.dart
+++ b/lib/logic/health_import.dart
@@ -10,9 +10,9 @@ import 'package:health/health.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/health.dart';
 import 'package:lotti/database/database.dart';
-import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/utils/platform.dart';
 
 class HealthImport {
@@ -214,7 +214,7 @@ class HealthImport {
           }
         }
       } catch (e) {
-        getIt<LoggingDb>().captureException(
+        getIt<LoggingService>().captureException(
           e,
           domain: 'HEALTH_IMPORT',
           subDomain: 'fetchHealthData',

--- a/lib/logic/persistence_logic.dart
+++ b/lib/logic/persistence_logic.dart
@@ -13,11 +13,11 @@ import 'package:lotti/classes/sync_message.dart';
 import 'package:lotti/classes/task.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/fts5_db.dart';
-import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/features/sync/outbox/outbox_service.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/ai/ai_logic.dart';
 import 'package:lotti/services/db_notification.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/notification_service.dart';
 import 'package:lotti/services/tags_service.dart';
 import 'package:lotti/services/vector_clock_service.dart';
@@ -34,7 +34,7 @@ class PersistenceLogic {
   JournalDb get _journalDb => getIt<JournalDb>();
   VectorClockService get _vectorClockService => getIt<VectorClockService>();
   final UpdateNotifications _updateNotifications = getIt<UpdateNotifications>();
-  LoggingDb get _loggingDb => getIt<LoggingDb>();
+  LoggingService get _loggingService => getIt<LoggingService>();
   final OutboxService outboxService = getIt<OutboxService>();
   final uuid = const Uuid();
   DeviceLocation? location;
@@ -119,7 +119,7 @@ class PersistenceLogic {
       await createDbEntity(journalEntity, shouldAddGeolocation: false);
       return journalEntity;
     } catch (exception, stackTrace) {
-      _loggingDb.captureException(
+      _loggingService.captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'createQuantitativeEntry',
@@ -144,7 +144,7 @@ class PersistenceLogic {
 
       return workout;
     } catch (exception, stackTrace) {
-      _loggingDb.captureException(
+      _loggingService.captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'createWorkoutEntry',
@@ -171,7 +171,7 @@ class PersistenceLogic {
 
       await createDbEntity(journalEntity, linkedId: linkedId);
     } catch (exception, stackTrace) {
-      _loggingDb.captureException(
+      _loggingService.captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'createSurveyEntry',
@@ -214,7 +214,7 @@ class PersistenceLogic {
 
       return measurementEntry;
     } catch (exception, stackTrace) {
-      _loggingDb.captureException(
+      _loggingService.captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'createMeasurementEntry',
@@ -259,7 +259,7 @@ class PersistenceLogic {
 
       return habitCompletionEntry;
     } catch (exception, stackTrace) {
-      _loggingDb.captureException(
+      _loggingService.captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'createMeasurementEntry',
@@ -293,7 +293,7 @@ class PersistenceLogic {
 
       return task;
     } catch (exception, stackTrace) {
-      _loggingDb.captureException(
+      _loggingService.captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'createTaskEntry',
@@ -322,7 +322,7 @@ class PersistenceLogic {
 
       return journalEvent;
     } catch (exception, stackTrace) {
-      _loggingDb.captureException(
+      _loggingService.captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'createEventEntry',
@@ -418,7 +418,7 @@ class PersistenceLogic {
 
       return saved;
     } catch (exception, stackTrace) {
-      _loggingDb.captureException(
+      _loggingService.captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'createDbEntity',
@@ -496,7 +496,7 @@ class PersistenceLogic {
         );
       }
     } catch (exception, stackTrace) {
-      _loggingDb.captureException(
+      _loggingService.captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'updateJournalEntityText',
@@ -529,14 +529,14 @@ class PersistenceLogic {
             ),
           );
         },
-        orElse: () async => _loggingDb.captureException(
+        orElse: () async => _loggingService.captureException(
           'not a task',
           domain: 'persistence_logic',
           subDomain: 'updateTask',
         ),
       );
     } catch (exception, stackTrace) {
-      _loggingDb.captureException(
+      _loggingService.captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'updateTask',
@@ -568,14 +568,14 @@ class PersistenceLogic {
             ),
           );
         },
-        orElse: () async => _loggingDb.captureException(
+        orElse: () async => _loggingService.captureException(
           'not an event',
           domain: 'persistence_logic',
           subDomain: 'updateEvent',
         ),
       );
     } catch (exception, stackTrace) {
-      _loggingDb.captureException(
+      _loggingService.captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'updateEvent',
@@ -606,7 +606,7 @@ class PersistenceLogic {
         );
       }
     } catch (exception, stackTrace) {
-      _loggingDb.captureException(
+      _loggingService.captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'addGeolocation',
@@ -631,7 +631,7 @@ class PersistenceLogic {
         journalEntity.copyWith(meta: await updateMetadata(metadata)),
       );
     } catch (exception, stackTrace) {
-      _loggingDb.captureException(
+      _loggingService.captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'updateJournalEntity',
@@ -674,7 +674,7 @@ class PersistenceLogic {
 
       return true;
     } catch (exception, stackTrace) {
-      _loggingDb.captureException(
+      _loggingService.captureException(
         exception,
         domain: 'persistence_logic',
         subDomain: 'updateDbEntity',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/features/sync/secure_storage.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/window_service.dart';
 import 'package:lotti/utils/file_utils.dart';
 import 'package:lotti/utils/platform.dart';
@@ -20,7 +21,10 @@ import 'package:window_manager/window_manager.dart';
 
 Future<void> main() async {
   await runZonedGuarded(() async {
-    getIt.registerSingleton<LoggingDb>(LoggingDb());
+    getIt
+      ..registerSingleton<LoggingDb>(LoggingDb())
+      ..registerSingleton<LoggingService>(LoggingService());
+
     // ignore: deprecated_member_use
     FlutterQuillExtensions.useSuperClipboardPlugin();
 
@@ -47,7 +51,7 @@ Future<void> main() async {
     await registerSingletons();
 
     FlutterError.onError = (FlutterErrorDetails details) {
-      getIt<LoggingDb>().captureException(
+      getIt<LoggingService>().captureException(
         details.exception,
         domain: 'MAIN',
         subDomain: details.library,
@@ -56,7 +60,7 @@ Future<void> main() async {
 
     runApp(ProviderScope(child: MyBeamerApp()));
   }, (Object error, StackTrace stackTrace) {
-    getIt<LoggingDb>().captureException(
+    getIt<LoggingService>().captureException(
       error,
       domain: 'MAIN',
       subDomain: 'runZonedGuarded',

--- a/lib/pages/create/complete_habit_dialog.dart
+++ b/lib/pages/create/complete_habit_dialog.dart
@@ -5,12 +5,12 @@ import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:flutter_linkify/flutter_linkify.dart';
 import 'package:hotkey_manager/hotkey_manager.dart';
 import 'package:lotti/classes/entity_definitions.dart';
-import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/features/dashboards/ui/widgets/dashboard_widget.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/entities_cache_service.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/themes/colors.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/utils/date_utils_extension.dart';
@@ -321,7 +321,7 @@ class HabitDescription extends StatelessWidget {
       if (uri != null && await canLaunchUrl(uri)) {
         await launchUrl(uri);
       } else {
-        getIt<LoggingDb>().captureEvent(
+        getIt<LoggingService>().captureEvent(
           'Could not launch $uri',
           domain: 'HABIT_COMPLETION',
           subDomain: 'Click Link in Description',

--- a/lib/pages/settings/flags_page.dart
+++ b/lib/pages/settings/flags_page.dart
@@ -28,6 +28,7 @@ class FlagsPage extends StatelessWidget {
           recordLocationFlag,
           allowInvalidCertFlag,
           enableTooltipFlag,
+          enableLoggingFlag,
           releaseHideLinkedEntries,
           enableMatrixFlag,
           resendAttachments,

--- a/lib/services/logging_service.dart
+++ b/lib/services/logging_service.dart
@@ -1,0 +1,102 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/database/logging_db.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/utils/consts.dart';
+import 'package:lotti/utils/file_utils.dart';
+import 'package:lotti/utils/platform.dart';
+
+class LoggingService {
+  bool _enableLogging = !isTestEnv;
+
+  void listenToConfigFlag() {
+    getIt<JournalDb>().watchConfigFlag(enableLoggingFlag).listen((value) {
+      _enableLogging = value;
+    });
+  }
+
+  Future<void> _captureEventAsync(
+    dynamic event, {
+    required String domain,
+    String? subDomain,
+    InsightLevel level = InsightLevel.info,
+    InsightType type = InsightType.log,
+  }) async {
+    await getIt<LoggingDb>().log(
+      LogEntry(
+        id: uuid.v1(),
+        createdAt: DateTime.now().toIso8601String(),
+        domain: domain,
+        subDomain: subDomain,
+        message: event.toString(),
+        level: level.name.toUpperCase(),
+        type: type.name.toUpperCase(),
+      ),
+    );
+  }
+
+  void captureEvent(
+    dynamic event, {
+    required String domain,
+    String? subDomain,
+    InsightLevel level = InsightLevel.info,
+    InsightType type = InsightType.log,
+  }) {
+    if (!_enableLogging) {
+      return;
+    }
+    _captureEventAsync(
+      event,
+      domain: domain,
+      subDomain: subDomain,
+      level: level,
+      type: type,
+    );
+  }
+
+  Future<void> _captureExceptionAsync(
+    dynamic exception, {
+    required String domain,
+    String? subDomain,
+    dynamic stackTrace,
+    InsightLevel level = InsightLevel.error,
+    InsightType type = InsightType.exception,
+  }) async {
+    await getIt<LoggingDb>().log(
+      LogEntry(
+        id: uuid.v1(),
+        createdAt: DateTime.now().toIso8601String(),
+        domain: domain,
+        subDomain: subDomain,
+        message: exception.toString(),
+        stacktrace: stackTrace.toString(),
+        level: level.name.toUpperCase(),
+        type: type.name.toUpperCase(),
+      ),
+    );
+  }
+
+  void captureException(
+    dynamic exception, {
+    required String domain,
+    String? subDomain,
+    dynamic stackTrace,
+    InsightLevel level = InsightLevel.error,
+    InsightType type = InsightType.exception,
+  }) {
+    if (!_enableLogging) {
+      return;
+    }
+    debugPrint('EXCEPTION $domain $subDomain $exception $stackTrace');
+    _captureExceptionAsync(
+      exception,
+      domain: domain,
+      subDomain: subDomain,
+      stackTrace: stackTrace,
+      level: level,
+      type: type,
+    );
+  }
+}

--- a/lib/utils/consts.dart
+++ b/lib/utils/consts.dart
@@ -9,3 +9,4 @@ const enableTooltipFlag = 'enable_tooltip';
 const resendAttachments = 'resend_attachments';
 const attemptEmbedding = 'attempt_embedding';
 const releaseHideLinkedEntries = 'release_hide_linked_entries';
+const enableLoggingFlag = 'enable_logging';

--- a/lib/utils/screenshots.dart
+++ b/lib/utils/screenshots.dart
@@ -3,8 +3,8 @@ import 'dart:io';
 
 import 'package:intl/intl.dart';
 import 'package:lotti/classes/journal_entities.dart';
-import 'package:lotti/database/logging_db.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/utils/file_utils.dart';
 import 'package:window_manager/window_manager.dart';
 
@@ -44,7 +44,7 @@ Future<ImageData> takeScreenshotMac() async {
 
     return imageData;
   } catch (exception, stackTrace) {
-    getIt<LoggingDb>().captureException(
+    getIt<LoggingService>().captureException(
       exception,
       domain: 'SCREENSHOT',
       stackTrace: stackTrace,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.551+2799
+version: 0.9.551+2800
 
 msix_config:
   display_name: LottiApp

--- a/test/blocs/journal/journal_page_cubit_test.dart
+++ b/test/blocs/journal/journal_page_cubit_test.dart
@@ -15,6 +15,7 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/editor_state_service.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/time_service.dart';
 import 'package:lotti/services/vector_clock_service.dart';
 import 'package:mocktail/mocktail.dart';
@@ -57,6 +58,7 @@ void main() {
         ..registerSingleton<SyncDatabase>(SyncDatabase(inMemoryDatabase: true))
         ..registerSingleton<JournalDb>(JournalDb(inMemoryDatabase: true))
         ..registerSingleton<LoggingDb>(LoggingDb(inMemoryDatabase: true))
+        ..registerSingleton<LoggingService>(LoggingService())
         ..registerSingleton<Fts5Db>(Fts5Db(inMemoryDatabase: true))
         ..registerSingleton<SecureStorage>(secureStorageMock)
         ..registerSingleton<OutboxService>(OutboxService())

--- a/test/database/database_test.dart
+++ b/test/database/database_test.dart
@@ -67,6 +67,11 @@ final expectedFlags = <ConfigFlag>{
     description: 'Resend Attachments',
     status: false,
   ),
+  const ConfigFlag(
+    name: enableLoggingFlag,
+    description: 'Enable logging?',
+    status: false,
+  ),
 };
 
 final expectedMacFlags = <ConfigFlag>{

--- a/test/features/journal/state/entry_controller_test.dart
+++ b/test/features/journal/state/entry_controller_test.dart
@@ -19,6 +19,7 @@ import 'package:lotti/logic/ai/ai_logic.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/editor_state_service.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/services/notification_service.dart';
 import 'package:lotti/services/time_service.dart';
@@ -88,6 +89,7 @@ void main() {
         ..registerSingleton<SyncDatabase>(SyncDatabase(inMemoryDatabase: true))
         ..registerSingleton<JournalDb>(mockJournalDb)
         ..registerSingleton<LoggingDb>(LoggingDb(inMemoryDatabase: true))
+        ..registerSingleton<LoggingService>(LoggingService())
         ..registerSingleton<SecureStorage>(secureStorageMock)
         ..registerSingleton<OutboxService>(OutboxService())
         ..registerSingleton<TimeService>(mockTimeService)

--- a/test/logic/persistence_logic_test.dart
+++ b/test/logic/persistence_logic_test.dart
@@ -22,6 +22,7 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/ai/ai_logic.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/db_notification.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/notification_service.dart';
 import 'package:lotti/services/tags_service.dart';
 import 'package:lotti/services/vector_clock_service.dart';
@@ -97,6 +98,7 @@ void main() {
         ..registerSingleton<SyncDatabase>(SyncDatabase(inMemoryDatabase: true))
         ..registerSingleton<JournalDb>(journalDb)
         ..registerSingleton<LoggingDb>(LoggingDb(inMemoryDatabase: true))
+        ..registerSingleton<LoggingService>(LoggingService())
         ..registerSingleton<TagsService>(TagsService())
         ..registerSingleton<OutboxService>(OutboxService())
         ..registerSingleton<SecureStorage>(secureStorageMock)

--- a/test/pages/dashboards/dashboard_page_test.dart
+++ b/test/pages/dashboards/dashboard_page_test.dart
@@ -13,6 +13,7 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/health_import.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/entities_cache_service.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/services/tags_service.dart';
 import 'package:lotti/services/time_service.dart';
@@ -55,6 +56,7 @@ void main() {
 
       getIt
         ..registerSingleton<LoggingDb>(MockLoggingDb())
+        ..registerSingleton<LoggingService>(LoggingService())
         ..registerSingleton<AsrService>(MockAsrService())
         ..registerSingleton<EntitiesCacheService>(mockEntitiesCacheService)
         ..registerSingleton<SettingsDb>(SettingsDb(inMemoryDatabase: true))

--- a/test/pages/journal/infinite_journal_page_test.dart
+++ b/test/pages/journal/infinite_journal_page_test.dart
@@ -19,6 +19,7 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/entities_cache_service.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/tags_service.dart';
 import 'package:lotti/services/time_service.dart';
 import 'package:lotti/themes/colors.dart';
@@ -85,6 +86,7 @@ void main() {
         ..registerSingleton<Directory>(await getApplicationDocumentsDirectory())
         ..registerSingleton<UserActivityService>(UserActivityService())
         ..registerSingleton<LoggingDb>(MockLoggingDb())
+        ..registerSingleton<LoggingService>(LoggingService())
         ..registerSingleton<UpdateNotifications>(mockUpdateNotifications)
         ..registerSingleton<SettingsDb>(mockSettingsDb)
         ..registerSingleton<AsrService>(MockAsrService())

--- a/test/widgets/journal/journal_card_test.dart
+++ b/test/widgets/journal/journal_card_test.dart
@@ -12,6 +12,7 @@ import 'package:lotti/features/speech/state/asr_service.dart';
 import 'package:lotti/features/speech/state/player_cubit.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/db_notification.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/tags_service.dart';
 import 'package:lotti/services/time_service.dart';
 import 'package:mocktail/mocktail.dart';
@@ -50,6 +51,7 @@ void main() {
         ..registerSingleton<Directory>(await getApplicationDocumentsDirectory())
         ..registerSingleton<UpdateNotifications>(mockUpdateNotifications)
         ..registerSingleton<LoggingDb>(MockLoggingDb())
+        ..registerSingleton<LoggingService>(LoggingService())
         ..registerSingleton<AsrService>(MockAsrService())
         ..registerSingleton<TagsService>(mockTagsService)
         ..registerSingleton<TimeService>(mockTimeService)

--- a/test/widgets/journal/tags/tags_modal_widget_test.dart
+++ b/test/widgets/journal/tags/tags_modal_widget_test.dart
@@ -11,6 +11,7 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/editor_state_service.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/tags_service.dart';
 import 'package:lotti/services/vector_clock_service.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
@@ -83,6 +84,7 @@ void main() {
       getIt
         ..registerSingleton<OutboxService>(mockOutboxService)
         ..registerSingleton<LoggingDb>(LoggingDb(inMemoryDatabase: true))
+        ..registerSingleton<LoggingService>(LoggingService())
         ..registerSingleton<TagsService>(mockTagsService)
         ..registerSingleton<UpdateNotifications>(mockUpdateNotifications)
         ..registerSingleton<JournalDb>(mockJournalDb)


### PR DESCRIPTION
This PR add configurability for logging via a config flag. By default, logging is disabled for performance reasons.


From GitHub Copilot:
This pull request includes significant changes to the logging system, replacing the `LoggingDb` class with a new `LoggingService` class, and updating various parts of the codebase to use this new service. Additionally, there are some minor updates to configuration flags and caching mechanisms.

### Logging System Updates:
* Replaced `LoggingDb` with `LoggingService` in various files, such as `database.dart`, `maintenance.dart`, `journal_repository.dart`, `speech_repository.dart`, `asr_service.dart`, and `player_cubit.dart`. This change affects methods like `captureEvent` and `captureException` across these files. [[1]](diffhunk://#diff-58403ca793c79f9cac8520ba22f0b9cb3527232f194f5feefdda0a1089aff2b1L182-R182) [[2]](diffhunk://#diff-3181a930a3fc0b654a42fa7e456f4dfa84a2f85258cc79a07387dca90852cd66L187-R188) [[3]](diffhunk://#diff-001fbe4c939fb8084bdbcd1691a4bbe931c8bc39e39095f375c9b18f24ace751L47-R47) [[4]](diffhunk://#diff-852dcd17bcbf0539057fbef0d1022d9afd02725ac8a677ef1f2884ada5204bfaL58-R58) [[5]](diffhunk://#diff-01cf561c7fcb33e54fbee2be986cd90095156473dfa7cbd8bef074e0b5f9fa85L99-R99) [[6]](diffhunk://#diff-63f90a8302241d9d111820faf4f755c03193f81efd5c7744dac230859bada8f7L54-R54)

### Configuration Flags:
* Added a new configuration flag `enableLoggingFlag` in `config_flags.dart` to enable or disable logging.

### Caching Mechanisms:
* Updated `measurables_controller.dart` to use `EntitiesCacheService` for fetching data types, improving the caching mechanism.

### Code Cleanup:
* Removed unused imports and methods related to `LoggingDb` in `logging_db.dart`. [[1]](diffhunk://#diff-4f7a48a3f79c25138e4eeeb657fe5733f577d8df665259749f44c9a8f786ba6dL4-L6) [[2]](diffhunk://#diff-4f7a48a3f79c25138e4eeeb657fe5733f577d8df665259749f44c9a8f786ba6dL41-L127)

### Integration Tests:
* Removed `overriddenLoggingDb` parameters from integration tests, reflecting the changes in the logging system. [[1]](diffhunk://#diff-e5a55efa9a1b47bf1cfbc486a12993b5ce794be50641fbd1abbda132b7ddbe7fL143) [[2]](diffhunk://#diff-e5a55efa9a1b47bf1cfbc486a12993b5ce794be50641fbd1abbda132b7ddbe7fL170)