### PR TITLE
feat: use controller in health charts & chart improvements

### DIFF
--- a/lib/classes/journal_entities.dart
+++ b/lib/classes/journal_entities.dart
@@ -219,6 +219,11 @@ extension JournalEntityExtension on JournalEntity {
       ids.add(checklistItem.data.dataTypeId);
     }
 
+    if (this is QuantitativeEntry) {
+      final checklistItem = this as QuantitativeEntry;
+      ids.add(checklistItem.data.dataType);
+    }
+
     return ids;
   }
 }

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -159,6 +159,7 @@ class JournalDb extends _$JournalDb {
   Future<int> updateJournalEntity(
     JournalEntity updated, {
     bool overrideComparison = false,
+    bool overwrite = true,
   }) async {
     var rowsAffected = 0;
     final dbEntity = toDbEntity(updated).copyWith(
@@ -166,6 +167,11 @@ class JournalDb extends _$JournalDb {
     );
 
     final existingDbEntity = await entityById(dbEntity.id);
+
+    if (existingDbEntity != null && !overwrite) {
+      return rowsAffected;
+    }
+
     if (existingDbEntity != null) {
       final existing = fromDbEntity(existingDbEntity);
       final status = await detectConflict(existing, updated);
@@ -694,6 +700,16 @@ class JournalDb extends _$JournalDb {
     return quantitativeByType(type, rangeStart, rangeEnd)
         .watch()
         .map(entityStreamMapper);
+  }
+
+  Future<List<JournalEntity>> getQuantitativeByType({
+    required String type,
+    required DateTime rangeStart,
+    required DateTime rangeEnd,
+  }) async {
+    final res = await quantitativeByType(type, rangeStart, rangeEnd).get();
+
+    return res.map(fromDbEntity).toList();
   }
 
   Future<QuantitativeEntry?> latestQuantitativeByType(String type) async {

--- a/lib/features/calendar/ui/time_by_category_chart_card.dart
+++ b/lib/features/calendar/ui/time_by_category_chart_card.dart
@@ -27,7 +27,7 @@ class TimeByCategoryChartCard extends ConsumerWidget {
               ),
               hasTopBarLayer: true,
               trailingNavBarWidget: IconButton(
-                padding: const EdgeInsets.all(WoltModalConfig.pagePadding),
+                padding: WoltModalConfig.pagePadding,
                 icon: const Icon(Icons.close),
                 onPressed: Navigator.of(modalSheetContext).pop,
               ),

--- a/lib/features/dashboards/state/health_chart_controller.dart
+++ b/lib/features/dashboards/state/health_chart_controller.dart
@@ -1,0 +1,93 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/logic/health_import.dart';
+import 'package:lotti/services/db_notification.dart';
+import 'package:lotti/utils/cache_extension.dart';
+import 'package:lotti/widgets/charts/dashboard_health_data.dart';
+import 'package:lotti/widgets/charts/utils.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'health_chart_controller.g.dart';
+
+@riverpod
+class HealthChartDataController extends _$HealthChartDataController {
+  final JournalDb _journalDb = getIt<JournalDb>();
+
+  StreamSubscription<Set<String>>? _updateSubscription;
+  final UpdateNotifications _updateNotifications = getIt<UpdateNotifications>();
+
+  void listen() {
+    _updateSubscription =
+        _updateNotifications.updateStream.listen((affectedIds) async {
+      if (affectedIds.contains(healthDataType)) {
+        final latest = await _fetch();
+        if (latest != state.value) {
+          state = AsyncData(latest);
+        }
+      }
+    });
+  }
+
+  @override
+  Future<List<JournalEntity>> build({
+    required String healthDataType,
+    required DateTime rangeStart,
+    required DateTime rangeEnd,
+  }) async {
+    ref
+      ..onDispose(() {
+        _updateSubscription?.cancel();
+      })
+      ..cacheFor(dashboardCacheDuration);
+
+    final data = await _fetch();
+    listen();
+    return data;
+  }
+
+  Future<List<JournalEntity>> _fetch() async {
+    return _journalDb.getQuantitativeByType(
+      type: healthDataType,
+      rangeStart: rangeStart,
+      rangeEnd: rangeEnd,
+    );
+  }
+}
+
+@riverpod
+class HealthObservationsController extends _$HealthObservationsController {
+  HealthObservationsController() {
+    if (!Platform.environment.containsKey('FLUTTER_TEST')) {
+      Future.delayed(Duration(milliseconds: 500 + Random().nextInt(500)), () {
+        getIt<HealthImport>().fetchHealthDataDelta(healthDataType);
+      });
+    }
+  }
+
+  @override
+  Future<List<Observation>> build({
+    required String healthDataType,
+    required DateTime rangeStart,
+    required DateTime rangeEnd,
+  }) async {
+    ref.cacheFor(dashboardCacheDuration);
+
+    final items = ref
+            .watch(
+              healthChartDataControllerProvider(
+                healthDataType: healthDataType,
+                rangeStart: rangeStart,
+                rangeEnd: rangeEnd,
+              ),
+            )
+            .valueOrNull ??
+        [];
+
+    return aggregateByType(items, healthDataType);
+  }
+}

--- a/lib/features/dashboards/state/health_chart_controller.g.dart
+++ b/lib/features/dashboards/state/health_chart_controller.g.dart
@@ -1,0 +1,424 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'health_chart_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$healthChartDataControllerHash() =>
+    r'a8861ff8ffc25462e01bf2de63cb864fbe0e9bb2';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+abstract class _$HealthChartDataController
+    extends BuildlessAutoDisposeAsyncNotifier<List<JournalEntity>> {
+  late final String healthDataType;
+  late final DateTime rangeStart;
+  late final DateTime rangeEnd;
+
+  FutureOr<List<JournalEntity>> build({
+    required String healthDataType,
+    required DateTime rangeStart,
+    required DateTime rangeEnd,
+  });
+}
+
+/// See also [HealthChartDataController].
+@ProviderFor(HealthChartDataController)
+const healthChartDataControllerProvider = HealthChartDataControllerFamily();
+
+/// See also [HealthChartDataController].
+class HealthChartDataControllerFamily
+    extends Family<AsyncValue<List<JournalEntity>>> {
+  /// See also [HealthChartDataController].
+  const HealthChartDataControllerFamily();
+
+  /// See also [HealthChartDataController].
+  HealthChartDataControllerProvider call({
+    required String healthDataType,
+    required DateTime rangeStart,
+    required DateTime rangeEnd,
+  }) {
+    return HealthChartDataControllerProvider(
+      healthDataType: healthDataType,
+      rangeStart: rangeStart,
+      rangeEnd: rangeEnd,
+    );
+  }
+
+  @override
+  HealthChartDataControllerProvider getProviderOverride(
+    covariant HealthChartDataControllerProvider provider,
+  ) {
+    return call(
+      healthDataType: provider.healthDataType,
+      rangeStart: provider.rangeStart,
+      rangeEnd: provider.rangeEnd,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'healthChartDataControllerProvider';
+}
+
+/// See also [HealthChartDataController].
+class HealthChartDataControllerProvider
+    extends AutoDisposeAsyncNotifierProviderImpl<HealthChartDataController,
+        List<JournalEntity>> {
+  /// See also [HealthChartDataController].
+  HealthChartDataControllerProvider({
+    required String healthDataType,
+    required DateTime rangeStart,
+    required DateTime rangeEnd,
+  }) : this._internal(
+          () => HealthChartDataController()
+            ..healthDataType = healthDataType
+            ..rangeStart = rangeStart
+            ..rangeEnd = rangeEnd,
+          from: healthChartDataControllerProvider,
+          name: r'healthChartDataControllerProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$healthChartDataControllerHash,
+          dependencies: HealthChartDataControllerFamily._dependencies,
+          allTransitiveDependencies:
+              HealthChartDataControllerFamily._allTransitiveDependencies,
+          healthDataType: healthDataType,
+          rangeStart: rangeStart,
+          rangeEnd: rangeEnd,
+        );
+
+  HealthChartDataControllerProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.healthDataType,
+    required this.rangeStart,
+    required this.rangeEnd,
+  }) : super.internal();
+
+  final String healthDataType;
+  final DateTime rangeStart;
+  final DateTime rangeEnd;
+
+  @override
+  FutureOr<List<JournalEntity>> runNotifierBuild(
+    covariant HealthChartDataController notifier,
+  ) {
+    return notifier.build(
+      healthDataType: healthDataType,
+      rangeStart: rangeStart,
+      rangeEnd: rangeEnd,
+    );
+  }
+
+  @override
+  Override overrideWith(HealthChartDataController Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: HealthChartDataControllerProvider._internal(
+        () => create()
+          ..healthDataType = healthDataType
+          ..rangeStart = rangeStart
+          ..rangeEnd = rangeEnd,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        healthDataType: healthDataType,
+        rangeStart: rangeStart,
+        rangeEnd: rangeEnd,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeAsyncNotifierProviderElement<HealthChartDataController,
+      List<JournalEntity>> createElement() {
+    return _HealthChartDataControllerProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is HealthChartDataControllerProvider &&
+        other.healthDataType == healthDataType &&
+        other.rangeStart == rangeStart &&
+        other.rangeEnd == rangeEnd;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, healthDataType.hashCode);
+    hash = _SystemHash.combine(hash, rangeStart.hashCode);
+    hash = _SystemHash.combine(hash, rangeEnd.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+mixin HealthChartDataControllerRef
+    on AutoDisposeAsyncNotifierProviderRef<List<JournalEntity>> {
+  /// The parameter `healthDataType` of this provider.
+  String get healthDataType;
+
+  /// The parameter `rangeStart` of this provider.
+  DateTime get rangeStart;
+
+  /// The parameter `rangeEnd` of this provider.
+  DateTime get rangeEnd;
+}
+
+class _HealthChartDataControllerProviderElement
+    extends AutoDisposeAsyncNotifierProviderElement<HealthChartDataController,
+        List<JournalEntity>> with HealthChartDataControllerRef {
+  _HealthChartDataControllerProviderElement(super.provider);
+
+  @override
+  String get healthDataType =>
+      (origin as HealthChartDataControllerProvider).healthDataType;
+  @override
+  DateTime get rangeStart =>
+      (origin as HealthChartDataControllerProvider).rangeStart;
+  @override
+  DateTime get rangeEnd =>
+      (origin as HealthChartDataControllerProvider).rangeEnd;
+}
+
+String _$healthObservationsControllerHash() =>
+    r'ac52068fe735260ad5fca783a267cb4f15747e6f';
+
+abstract class _$HealthObservationsController
+    extends BuildlessAutoDisposeAsyncNotifier<List<Observation>> {
+  late final String healthDataType;
+  late final DateTime rangeStart;
+  late final DateTime rangeEnd;
+
+  FutureOr<List<Observation>> build({
+    required String healthDataType,
+    required DateTime rangeStart,
+    required DateTime rangeEnd,
+  });
+}
+
+/// See also [HealthObservationsController].
+@ProviderFor(HealthObservationsController)
+const healthObservationsControllerProvider =
+    HealthObservationsControllerFamily();
+
+/// See also [HealthObservationsController].
+class HealthObservationsControllerFamily
+    extends Family<AsyncValue<List<Observation>>> {
+  /// See also [HealthObservationsController].
+  const HealthObservationsControllerFamily();
+
+  /// See also [HealthObservationsController].
+  HealthObservationsControllerProvider call({
+    required String healthDataType,
+    required DateTime rangeStart,
+    required DateTime rangeEnd,
+  }) {
+    return HealthObservationsControllerProvider(
+      healthDataType: healthDataType,
+      rangeStart: rangeStart,
+      rangeEnd: rangeEnd,
+    );
+  }
+
+  @override
+  HealthObservationsControllerProvider getProviderOverride(
+    covariant HealthObservationsControllerProvider provider,
+  ) {
+    return call(
+      healthDataType: provider.healthDataType,
+      rangeStart: provider.rangeStart,
+      rangeEnd: provider.rangeEnd,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'healthObservationsControllerProvider';
+}
+
+/// See also [HealthObservationsController].
+class HealthObservationsControllerProvider
+    extends AutoDisposeAsyncNotifierProviderImpl<HealthObservationsController,
+        List<Observation>> {
+  /// See also [HealthObservationsController].
+  HealthObservationsControllerProvider({
+    required String healthDataType,
+    required DateTime rangeStart,
+    required DateTime rangeEnd,
+  }) : this._internal(
+          () => HealthObservationsController()
+            ..healthDataType = healthDataType
+            ..rangeStart = rangeStart
+            ..rangeEnd = rangeEnd,
+          from: healthObservationsControllerProvider,
+          name: r'healthObservationsControllerProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$healthObservationsControllerHash,
+          dependencies: HealthObservationsControllerFamily._dependencies,
+          allTransitiveDependencies:
+              HealthObservationsControllerFamily._allTransitiveDependencies,
+          healthDataType: healthDataType,
+          rangeStart: rangeStart,
+          rangeEnd: rangeEnd,
+        );
+
+  HealthObservationsControllerProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.healthDataType,
+    required this.rangeStart,
+    required this.rangeEnd,
+  }) : super.internal();
+
+  final String healthDataType;
+  final DateTime rangeStart;
+  final DateTime rangeEnd;
+
+  @override
+  FutureOr<List<Observation>> runNotifierBuild(
+    covariant HealthObservationsController notifier,
+  ) {
+    return notifier.build(
+      healthDataType: healthDataType,
+      rangeStart: rangeStart,
+      rangeEnd: rangeEnd,
+    );
+  }
+
+  @override
+  Override overrideWith(HealthObservationsController Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: HealthObservationsControllerProvider._internal(
+        () => create()
+          ..healthDataType = healthDataType
+          ..rangeStart = rangeStart
+          ..rangeEnd = rangeEnd,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        healthDataType: healthDataType,
+        rangeStart: rangeStart,
+        rangeEnd: rangeEnd,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeAsyncNotifierProviderElement<HealthObservationsController,
+      List<Observation>> createElement() {
+    return _HealthObservationsControllerProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is HealthObservationsControllerProvider &&
+        other.healthDataType == healthDataType &&
+        other.rangeStart == rangeStart &&
+        other.rangeEnd == rangeEnd;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, healthDataType.hashCode);
+    hash = _SystemHash.combine(hash, rangeStart.hashCode);
+    hash = _SystemHash.combine(hash, rangeEnd.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+mixin HealthObservationsControllerRef
+    on AutoDisposeAsyncNotifierProviderRef<List<Observation>> {
+  /// The parameter `healthDataType` of this provider.
+  String get healthDataType;
+
+  /// The parameter `rangeStart` of this provider.
+  DateTime get rangeStart;
+
+  /// The parameter `rangeEnd` of this provider.
+  DateTime get rangeEnd;
+}
+
+class _HealthObservationsControllerProviderElement
+    extends AutoDisposeAsyncNotifierProviderElement<
+        HealthObservationsController,
+        List<Observation>> with HealthObservationsControllerRef {
+  _HealthObservationsControllerProviderElement(super.provider);
+
+  @override
+  String get healthDataType =>
+      (origin as HealthObservationsControllerProvider).healthDataType;
+  @override
+  DateTime get rangeStart =>
+      (origin as HealthObservationsControllerProvider).rangeStart;
+  @override
+  DateTime get rangeEnd =>
+      (origin as HealthObservationsControllerProvider).rangeEnd;
+}
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/dashboards/state/measurables_controller.g.dart
+++ b/lib/features/dashboards/state/measurables_controller.g.dart
@@ -7,7 +7,7 @@ part of 'measurables_controller.dart';
 // **************************************************************************
 
 String _$measurableDataTypeControllerHash() =>
-    r'2692c821723c36f5b6c417c2cdfccf4de32f23fd';
+    r'766d72c5025d5834bcbb5db6d16305039305bff2';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/features/speech/ui/widgets/transcription_progress_modal.dart
+++ b/lib/features/speech/ui/widgets/transcription_progress_modal.dart
@@ -5,6 +5,7 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/utils/modals.dart';
+import 'package:lotti/widgets/misc/wolt_modal_config.dart';
 
 class TranscriptionProgressModalContent extends StatelessWidget {
   const TranscriptionProgressModalContent({super.key});
@@ -33,14 +34,19 @@ class TranscriptionProgressModalContent extends StatelessWidget {
         }
 
         return Padding(
-          padding: const EdgeInsets.all(16),
-          child: MarkdownBody(
-            data: text,
-            styleSheet: MarkdownStyleSheet(
-              p: TextStyle(
-                color: hasError ? context.colorScheme.error : null,
+          padding: WoltModalConfig.pagePadding,
+          child: Column(
+            children: [
+              MarkdownBody(
+                data: text,
+                styleSheet: MarkdownStyleSheet(
+                  p: TextStyle(
+                    color: hasError ? context.colorScheme.error : null,
+                  ),
+                ),
               ),
-            ),
+              verticalModalSpacer,
+            ],
           ),
         );
       },

--- a/lib/features/sync/ui/homeserver_config_page.dart
+++ b/lib/features/sync/ui/homeserver_config_page.dart
@@ -30,12 +30,12 @@ SliverWoltModalSheetPage homeServerConfigPage({
     ),
     isTopBarLayerAlwaysVisible: true,
     trailingNavBarWidget: IconButton(
-      padding: const EdgeInsets.all(WoltModalConfig.pagePadding),
+      padding: WoltModalConfig.pagePadding,
       icon: const Icon(Icons.close),
       onPressed: Navigator.of(context).pop,
     ),
     child: Padding(
-      padding: const EdgeInsets.all(WoltModalConfig.pagePadding),
+      padding: WoltModalConfig.pagePadding,
       child: HomeserverSettingsWidget(
         pageIndexNotifier: pageIndexNotifier,
       ),
@@ -56,7 +56,7 @@ class HomeserverConfigPageStickyActionBar extends ConsumerWidget {
     WidgetRef ref,
   ) {
     return Padding(
-      padding: const EdgeInsets.all(WoltModalConfig.pagePadding),
+      padding: WoltModalConfig.pagePadding,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [

--- a/lib/features/sync/ui/matrix_logged_in_config_page.dart
+++ b/lib/features/sync/ui/matrix_logged_in_config_page.dart
@@ -27,12 +27,12 @@ SliverWoltModalSheetPage homeServerLoggedInPage({
     ),
     isTopBarLayerAlwaysVisible: true,
     trailingNavBarWidget: IconButton(
-      padding: const EdgeInsets.all(WoltModalConfig.pagePadding),
+      padding: WoltModalConfig.pagePadding,
       icon: const Icon(Icons.close),
       onPressed: Navigator.of(context).pop,
     ),
     child: const Padding(
-      padding: EdgeInsets.all(WoltModalConfig.pagePadding),
+      padding: WoltModalConfig.pagePadding,
       child: HomeserverLoggedInWidget(),
     ),
   );
@@ -51,7 +51,7 @@ class LoggedInPageStickyActionBar extends ConsumerWidget {
     WidgetRef ref,
   ) {
     return Padding(
-      padding: const EdgeInsets.all(WoltModalConfig.pagePadding),
+      padding: WoltModalConfig.pagePadding,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [

--- a/lib/features/sync/ui/matrix_stats_page.dart
+++ b/lib/features/sync/ui/matrix_stats_page.dart
@@ -12,7 +12,7 @@ SliverWoltModalSheetPage matrixStatsPage({
 }) {
   return WoltModalSheetPage(
     stickyActionBar: Padding(
-      padding: const EdgeInsets.all(WoltModalConfig.pagePadding),
+      padding: WoltModalConfig.pagePadding,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
@@ -39,13 +39,12 @@ SliverWoltModalSheetPage matrixStatsPage({
     ),
     isTopBarLayerAlwaysVisible: true,
     trailingNavBarWidget: IconButton(
-      padding: const EdgeInsets.all(WoltModalConfig.pagePadding),
+      padding: WoltModalConfig.pagePadding,
       icon: const Icon(Icons.close),
       onPressed: Navigator.of(context).pop,
     ),
     child: Padding(
-      padding: const EdgeInsets.all(WoltModalConfig.pagePadding) +
-          const EdgeInsets.only(bottom: 80),
+      padding: WoltModalConfig.pagePadding + const EdgeInsets.only(bottom: 80),
       child: const IncomingStats(),
     ),
   );

--- a/lib/features/sync/ui/room_config_page.dart
+++ b/lib/features/sync/ui/room_config_page.dart
@@ -17,7 +17,7 @@ SliverWoltModalSheetPage roomConfigPage({
 }) {
   return WoltModalSheetPage(
     stickyActionBar: Padding(
-      padding: const EdgeInsets.all(WoltModalConfig.pagePadding),
+      padding: WoltModalConfig.pagePadding,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
@@ -45,13 +45,12 @@ SliverWoltModalSheetPage roomConfigPage({
     ),
     isTopBarLayerAlwaysVisible: true,
     trailingNavBarWidget: IconButton(
-      padding: const EdgeInsets.all(WoltModalConfig.pagePadding),
+      padding: WoltModalConfig.pagePadding,
       icon: const Icon(Icons.close),
       onPressed: Navigator.of(context).pop,
     ),
     child: Padding(
-      padding: const EdgeInsets.all(WoltModalConfig.pagePadding) +
-          const EdgeInsets.only(bottom: 80),
+      padding: WoltModalConfig.pagePadding + const EdgeInsets.only(bottom: 80),
       child: const RoomConfig(),
     ),
   );

--- a/lib/features/sync/ui/unverified_devices_page.dart
+++ b/lib/features/sync/ui/unverified_devices_page.dart
@@ -15,7 +15,7 @@ SliverWoltModalSheetPage unverifiedDevicesPage({
 }) {
   return WoltModalSheetPage(
     stickyActionBar: Padding(
-      padding: const EdgeInsets.all(WoltModalConfig.pagePadding),
+      padding: WoltModalConfig.pagePadding,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
@@ -43,13 +43,12 @@ SliverWoltModalSheetPage unverifiedDevicesPage({
     ),
     isTopBarLayerAlwaysVisible: true,
     trailingNavBarWidget: IconButton(
-      padding: const EdgeInsets.all(WoltModalConfig.pagePadding),
+      padding: WoltModalConfig.pagePadding,
       icon: const Icon(Icons.close),
       onPressed: Navigator.of(context).pop,
     ),
     child: Padding(
-      padding: const EdgeInsets.all(WoltModalConfig.pagePadding) +
-          const EdgeInsets.only(bottom: 80),
+      padding: WoltModalConfig.pagePadding + const EdgeInsets.only(bottom: 80),
       child: const UnverifiedDevices(),
     ),
   );

--- a/lib/logic/persistence_logic.dart
+++ b/lib/logic/persistence_logic.dart
@@ -116,7 +116,11 @@ class PersistenceLogic {
           uuidV5Input: json.encode(data),
         ),
       );
-      await createDbEntity(journalEntity, shouldAddGeolocation: false);
+      await createDbEntity(
+        journalEntity,
+        shouldAddGeolocation: false,
+        addTags: false,
+      );
       return journalEntity;
     } catch (exception, stackTrace) {
       _loggingService.captureException(
@@ -140,7 +144,12 @@ class PersistenceLogic {
           uuidV5Input: data.id,
         ),
       );
-      await createDbEntity(workout, shouldAddGeolocation: false);
+
+      await createDbEntity(
+        workout,
+        shouldAddGeolocation: false,
+        addTags: false,
+      );
 
       return workout;
     } catch (exception, stackTrace) {
@@ -365,6 +374,7 @@ class PersistenceLogic {
     JournalEntity journalEntity, {
     bool shouldAddGeolocation = true,
     bool enqueueSync = true,
+    bool addTags = true,
     String? linkedId,
   }) async {
     try {
@@ -388,11 +398,18 @@ class PersistenceLogic {
         ),
       );
 
-      final res = await _journalDb.updateJournalEntity(withTags);
+      final res = await _journalDb.updateJournalEntity(
+        withTags,
+        overwrite: false,
+      );
+
       _updateNotifications.notify(withTags.affectedIds);
 
       final saved = res != 0;
-      await _journalDb.addTagged(withTags);
+
+      if (addTags) {
+        await _journalDb.addTagged(withTags);
+      }
 
       if (saved && enqueueSync) {
         await outboxService.enqueueMessage(

--- a/lib/utils/modals.dart
+++ b/lib/utils/modals.dart
@@ -22,8 +22,7 @@ class ModalUtils {
     Color? backgroundColor,
     bool isTopBarLayerAlwaysVisible = true,
     bool showCloseButton = true,
-    EdgeInsetsGeometry padding =
-        const EdgeInsets.all(WoltModalConfig.pagePadding),
+    EdgeInsetsGeometry padding = WoltModalConfig.pagePadding,
   }) {
     final textTheme = context.textTheme;
     return WoltModalSheetPage(
@@ -34,7 +33,7 @@ class ModalUtils {
       isTopBarLayerAlwaysVisible: isTopBarLayerAlwaysVisible,
       trailingNavBarWidget: showCloseButton
           ? IconButton(
-              padding: const EdgeInsets.all(WoltModalConfig.pagePadding),
+              padding: WoltModalConfig.pagePadding,
               icon: const Icon(Icons.close),
               onPressed: Navigator.of(context).pop,
             )

--- a/lib/widgets/charts/dashboard_health_bp_chart.dart
+++ b/lib/widgets/charts/dashboard_health_bp_chart.dart
@@ -87,6 +87,7 @@ class DashboardHealthBpChart extends StatelessWidget {
                   },
                   getDrawingVerticalLine: (value) => gridLine,
                 ),
+                clipData: const FlClipData.horizontal(),
                 lineTouchData: LineTouchData(
                   touchTooltipData: LineTouchTooltipData(
                     tooltipMargin: isMobile ? 24 : 16,

--- a/lib/widgets/charts/dashboard_health_chart.dart
+++ b/lib/widgets/charts/dashboard_health_chart.dart
@@ -1,14 +1,11 @@
 import 'dart:core';
-import 'dart:io';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/entity_definitions.dart';
-import 'package:lotti/classes/journal_entities.dart';
-import 'package:lotti/database/database.dart';
+import 'package:lotti/features/dashboards/state/health_chart_controller.dart';
 import 'package:lotti/features/dashboards/ui/widgets/charts/dashboard_chart.dart';
-import 'package:lotti/get_it.dart';
-import 'package:lotti/logic/health_import.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/widgets/charts/dashboard_health_bmi_chart.dart';
 import 'package:lotti/widgets/charts/dashboard_health_bp_chart.dart';
@@ -17,102 +14,6 @@ import 'package:lotti/widgets/charts/dashboard_health_data.dart';
 import 'package:lotti/widgets/charts/time_series/time_series_bar_chart.dart';
 import 'package:lotti/widgets/charts/time_series/time_series_line_chart.dart';
 import 'package:lotti/widgets/charts/utils.dart';
-
-class DashboardHealthChart extends StatefulWidget {
-  const DashboardHealthChart({
-    required this.chartConfig,
-    required this.rangeStart,
-    required this.rangeEnd,
-    super.key,
-  });
-
-  final DashboardHealthItem chartConfig;
-  final DateTime rangeStart;
-  final DateTime rangeEnd;
-
-  @override
-  State<DashboardHealthChart> createState() => _DashboardHealthChartState();
-}
-
-class _DashboardHealthChartState extends State<DashboardHealthChart> {
-  final JournalDb _db = getIt<JournalDb>();
-  final HealthImport _healthImport = getIt<HealthImport>();
-
-  @override
-  void initState() {
-    super.initState();
-    if (Platform.environment.containsKey('FLUTTER_TEST')) {
-      return;
-    }
-
-    Future.delayed(Duration(milliseconds: 200 + Random().nextInt(100)), () {
-      _healthImport.fetchHealthDataDelta(widget.chartConfig.healthType);
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final dataType = widget.chartConfig.healthType;
-
-    if (dataType == 'BLOOD_PRESSURE') {
-      return DashboardHealthBpChart(
-        chartConfig: widget.chartConfig,
-        rangeStart: widget.rangeStart,
-        rangeEnd: widget.rangeEnd,
-      );
-    }
-
-    if (dataType == 'BODY_MASS_INDEX') {
-      return DashboardHealthBmiChart(
-        chartConfig: widget.chartConfig,
-        rangeStart: widget.rangeStart,
-        rangeEnd: widget.rangeEnd,
-      );
-    }
-
-    final healthType = healthTypes[dataType];
-    final isBarChart = healthType?.chartType == HealthChartType.barChart;
-
-    return StreamBuilder<List<JournalEntity>>(
-      stream: _db.watchQuantitativeByType(
-        type: widget.chartConfig.healthType,
-        rangeStart: widget.rangeStart,
-        rangeEnd: widget.rangeEnd,
-      ),
-      builder: (
-        BuildContext context,
-        AsyncSnapshot<List<JournalEntity>> snapshot,
-      ) {
-        final items = snapshot.data ?? [];
-        final data = aggregateByType(items, dataType);
-
-        return DashboardChart(
-          chart: isBarChart
-              ? TimeSeriesBarChart(
-                  data: data,
-                  rangeStart: widget.rangeStart,
-                  rangeEnd: widget.rangeEnd,
-                  unit: healthType?.unit ?? '',
-                  valueInHours: healthType?.unit == 'h',
-                  colorByValue: (Observation observation) =>
-                      colorByValueAndType(
-                    observation,
-                    healthType,
-                  ),
-                )
-              : TimeSeriesLineChart(
-                  data: data,
-                  rangeStart: widget.rangeStart,
-                  rangeEnd: widget.rangeEnd,
-                  unit: healthType?.unit ?? '',
-                ),
-          chartHeader: HealthChartInfoWidget(widget.chartConfig),
-          height: isBarChart ? 180 : 150,
-        );
-      },
-    );
-  }
-}
 
 class HealthChartInfoWidget extends StatelessWidget {
   const HealthChartInfoWidget(
@@ -143,6 +44,76 @@ class HealthChartInfoWidget extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+class DashboardHealthChart extends ConsumerWidget {
+  const DashboardHealthChart({
+    required this.chartConfig,
+    required this.rangeStart,
+    required this.rangeEnd,
+    super.key,
+  });
+
+  final DashboardHealthItem chartConfig;
+  final DateTime rangeStart;
+  final DateTime rangeEnd;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final healthType = healthTypes[chartConfig.healthType];
+    final isBarChart = healthType?.chartType == HealthChartType.barChart;
+    final dataType = chartConfig.healthType;
+
+    if (dataType == 'BLOOD_PRESSURE') {
+      return DashboardHealthBpChart(
+        chartConfig: chartConfig,
+        rangeStart: rangeStart,
+        rangeEnd: rangeEnd,
+      );
+    }
+
+    if (dataType == 'BODY_MASS_INDEX') {
+      return DashboardHealthBmiChart(
+        chartConfig: chartConfig,
+        rangeStart: rangeStart,
+        rangeEnd: rangeEnd,
+      );
+    }
+
+    final data = ref
+            .watch(
+              healthObservationsControllerProvider(
+                healthDataType: chartConfig.healthType,
+                rangeStart: rangeStart,
+                rangeEnd: rangeEnd,
+              ),
+            )
+            .valueOrNull ??
+        [];
+
+    return DashboardChart(
+      chart: isBarChart
+          ? TimeSeriesBarChart(
+              data: data,
+              rangeStart: rangeStart,
+              rangeEnd: rangeEnd,
+              unit: healthType?.unit ?? '',
+              valueInHours: healthType?.unit == 'h',
+              colorByValue: (Observation observation) => colorByValueAndType(
+                observation,
+                healthType,
+              ),
+            )
+          : TimeSeriesLineChart(
+              data: data,
+              rangeStart: rangeStart,
+              rangeEnd: rangeEnd,
+              unit: healthType?.unit ?? '',
+            ),
+      chartHeader: HealthChartInfoWidget(chartConfig),
+      height: isBarChart ? 180 : 150,
     );
   }
 }

--- a/lib/widgets/charts/time_series/time_series_bar_chart.dart
+++ b/lib/widgets/charts/time_series/time_series_bar_chart.dart
@@ -40,10 +40,6 @@ class TimeSeriesBarChart extends StatelessWidget {
       byDay[day] = observation;
     }
 
-    final minVal = data.isEmpty ? 0 : data.map((e) => e.value).reduce(min);
-    final maxVal = data.isEmpty ? 0 : data.map((e) => e.value).reduce(max);
-    final valRange = maxVal - minVal;
-
     final dataWithEmptyDays = inRange.map((day) {
       final observation = byDay[day] ?? Observation(DateTime.parse(day), 0);
       return observation;
@@ -162,8 +158,6 @@ class TimeSeriesBarChart extends StatelessWidget {
             show: true,
             border: Border.all(color: const Color(0xff37434d)),
           ),
-          minY: max(minVal - valRange * 0.2, 0),
-          maxY: maxVal + valRange * 0.2,
           barGroups: barGroups,
         ),
         //duration: Duration.zero,

--- a/lib/widgets/charts/time_series/time_series_line_chart.dart
+++ b/lib/widgets/charts/time_series/time_series_line_chart.dart
@@ -1,5 +1,4 @@
 import 'dart:core';
-import 'dart:math';
 
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
@@ -25,10 +24,6 @@ class TimeSeriesLineChart extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final minVal = data.isEmpty ? 0 : data.map((e) => e.value).reduce(min);
-    final maxVal = data.isEmpty ? 0 : data.map((e) => e.value).reduce(max);
-    final valRange = maxVal - minVal;
-
     final rangeInDays = rangeEnd.difference(rangeStart).inDays;
 
     final gridInterval = rangeInDays > 182
@@ -77,6 +72,7 @@ class TimeSeriesLineChart extends StatelessWidget {
             getDrawingHorizontalLine: (value) => gridLine,
             getDrawingVerticalLine: (value) => gridLine,
           ),
+          clipData: const FlClipData.horizontal(),
           lineTouchData: LineTouchData(
             touchTooltipData: LineTouchTooltipData(
               tooltipMargin: isMobile ? 24 : 16,
@@ -125,7 +121,6 @@ class TimeSeriesLineChart extends StatelessWidget {
             leftTitles: const AxisTitles(
               sideTitles: SideTitles(
                 showTitles: true,
-                interval: double.maxFinite,
                 getTitlesWidget: leftTitleWidgets,
                 reservedSize: 40,
               ),
@@ -137,17 +132,12 @@ class TimeSeriesLineChart extends StatelessWidget {
           ),
           minX: rangeStart.millisecondsSinceEpoch.toDouble(),
           maxX: rangeEnd.millisecondsSinceEpoch.toDouble(),
-          minY: max(minVal - valRange * 0.2, 0),
-          maxY: maxVal + valRange * 0.2,
           lineBarsData: [
             LineChartBarData(
               spots: spots,
-              isCurved: true,
-              curveSmoothness: 0.1,
               gradient: LinearGradient(
                 colors: gradientColors,
               ),
-              isStrokeCapRound: true,
               dotData: const FlDotData(
                 show: false,
               ),

--- a/lib/widgets/misc/wolt_modal_config.dart
+++ b/lib/widgets/misc/wolt_modal_config.dart
@@ -1,6 +1,8 @@
+import 'package:flutter/material.dart';
+
 class WoltModalConfig {
   static const pageBreakpoint = 560;
-  static const pagePadding = 16.0;
+  static const pagePadding = EdgeInsets.all(16);
   static const maxDialogWidth = 600.0;
   static const minDialogWidth = 400.0;
   static const minPageHeight = 0.3;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.551+2800
+version: 0.9.551+2801
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.551+2801
+version: 0.9.552+2802
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR replaces the StreamBuilder previously used in health charts with a riverpod controller, with caching which improves UX by reducing latency on reload. Also less load on the database as the StreamBuilder doesn't rebuild on every database insert. Also adds some small chart improvements.

From GitHub Copilot:
This pull request includes several changes aimed at enhancing the functionality and consistency of the codebase. The most important changes include adding new methods for handling quantitative entries, updating the padding configuration for modal widgets, and introducing new controllers for health data.

### Enhancements to Quantitative Entries:

* [`lib/classes/journal_entities.dart`](diffhunk://#diff-033cb11f85b85b702b7d046dfe9420035dd9024230f3da59f6ad864bb48132a7R222-R226): Added handling for `QuantitativeEntry` in the `JournalEntityExtension` to include `dataType` in the IDs list.
* [`lib/database/database.dart`](diffhunk://#diff-58403ca793c79f9cac8520ba22f0b9cb3527232f194f5feefdda0a1089aff2b1R705-R714): Introduced a new method `getQuantitativeByType` to fetch quantitative entries by type within a specified date range.

### Padding Configuration Updates:

* [`lib/features/calendar/ui/time_by_category_chart_card.dart`](diffhunk://#diff-11c2531064f7ccd8d4d104e9c846bd0bb4126699eb7093bbf44a35b5f3b61ec9L30-R30): Updated padding configuration to use `WoltModalConfig.pagePadding` instead of constant values.
* Multiple files (`lib/features/sync/ui/homeserver_config_page.dart`, `lib/features/sync/ui/matrix_logged_in_config_page.dart`, `lib/features/sync/ui/matrix_stats_page.dart`, `lib/features/sync/ui/room_config_page.dart`, `lib/features/sync/ui/unverified_devices_page.dart`): Standardized the padding configuration to use `WoltModalConfig.pagePadding`. [[1]](diffhunk://#diff-b5de24924337ac1f66b3ac8ca743cde3e7e724c19e5e88e98e1e50c6f92e1bf0L33-R38) [[2]](diffhunk://#diff-b5de24924337ac1f66b3ac8ca743cde3e7e724c19e5e88e98e1e50c6f92e1bf0L59-R59) [[3]](diffhunk://#diff-4004677ab54b068c0f2e6a6c53cb7800b6d78c6d833fc4aa72128101672de9e1L30-R35) [[4]](diffhunk://#diff-4004677ab54b068c0f2e6a6c53cb7800b6d78c6d833fc4aa72128101672de9e1L54-R54) [[5]](diffhunk://#diff-a2091d50dcb79a5b50e8a87cae4744af548d2e5b693ea5925b6669af67a23755L15-R15) [[6]](diffhunk://#diff-a2091d50dcb79a5b50e8a87cae4744af548d2e5b693ea5925b6669af67a23755L42-R47) [[7]](diffhunk://#diff-c76ce6291ecb373eb80a86130503dc875f0417ac42a75ddd00f1cb8721f5e1f8L20-R20) [[8]](diffhunk://#diff-c76ce6291ecb373eb80a86130503dc875f0417ac42a75ddd00f1cb8721f5e1f8L48-R53) [[9]](diffhunk://#diff-ecfd1ba58018a816ac5e84c1416126e044480b3967619e18ce5e8e78616cb6d1L18-R18) [[10]](diffhunk://#diff-ecfd1ba58018a816ac5e84c1416126e044480b3967619e18ce5e8e78616cb6d1L46-R51)

### Introduction of Health Data Controllers:

* [`lib/features/dashboards/state/health_chart_controller.dart`](diffhunk://#diff-d0147c7c75e7b318ebf77d0c69f2fd9a36736907905c59fe07f687e108337b04R1-R93): Added new controllers `HealthChartDataController` and `HealthObservationsController` for managing health data and observations.

### Persistence Logic Enhancements:

* [`lib/logic/persistence_logic.dart`](diffhunk://#diff-7c20418a00fc5ed6612eb5686a687b56a462be0f82d669034b8ef9e73baad27eL119-R123): Enhanced the `createDbEntity` method to include an `addTags` parameter and updated the logic to respect this parameter. [[1]](diffhunk://#diff-7c20418a00fc5ed6612eb5686a687b56a462be0f82d669034b8ef9e73baad27eL119-R123) [[2]](diffhunk://#diff-7c20418a00fc5ed6612eb5686a687b56a462be0f82d669034b8ef9e73baad27eL143-R152) [[3]](diffhunk://#diff-7c20418a00fc5ed6612eb5686a687b56a462be0f82d669034b8ef9e73baad27eR377) [[4]](diffhunk://#diff-7c20418a00fc5ed6612eb5686a687b56a462be0f82d669034b8ef9e73baad27eL391-R412)

### Miscellaneous Updates:

* [`lib/widgets/charts/dashboard_health_bp_chart.dart`](diffhunk://#diff-2ee8edbb4b5c70dce7f6ea6840245f8608439808165e9e64ac4b019ca0474b75R90): Added clipping data to the `FlClipData.horizontal()` for better chart rendering.
* [`lib/widgets/charts/dashboard_health_chart.dart`](diffhunk://#diff-213b9ff416a62d1d872700ba58c2fac6629587eff1e32e8a879651581d4af1ccL2-L11): Removed unused imports and updated the file to use the new health chart controller.