### PR TITLE
refactor: use controller in BP chart

### DIFF
--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -740,16 +740,6 @@ class JournalDb extends _$JournalDb {
         .map(entityStreamMapper);
   }
 
-  Stream<List<JournalEntity>> watchQuantitativeByTypes({
-    required List<String> types,
-    required DateTime rangeStart,
-    required DateTime rangeEnd,
-  }) {
-    return quantitativeByTypes(types, rangeStart, rangeEnd)
-        .watch()
-        .map(entityStreamMapper);
-  }
-
   Stream<List<JournalEntity>> watchWorkouts({
     required DateTime rangeStart,
     required DateTime rangeEnd,

--- a/lib/database/database.drift
+++ b/lib/database/database.drift
@@ -417,15 +417,6 @@ SELECT * FROM journal
   ORDER BY date_from DESC
   LIMIT 1;
 
-quantitativeByTypes:
-SELECT * FROM journal
-  WHERE type = 'QuantitativeEntry'
-  AND subtype IN :subtypes
-  AND date_from >= :rangeStart
-  AND date_to <= :rangeEnd
-  AND deleted = false
-  ORDER BY date_from DESC;
-
 workouts:
 SELECT * FROM journal
   WHERE type = 'WorkoutEntry'

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -5214,23 +5214,6 @@ abstract class _$JournalDb extends GeneratedDatabase {
         }).asyncMap(journal.mapFromRow);
   }
 
-  Selectable<JournalDbEntity> quantitativeByTypes(
-      List<String?> subtypes, DateTime rangeStart, DateTime rangeEnd) {
-    var $arrayStartIndex = 3;
-    final expandedsubtypes = $expandVar($arrayStartIndex, subtypes.length);
-    $arrayStartIndex += subtypes.length;
-    return customSelect(
-        'SELECT * FROM journal WHERE type = \'QuantitativeEntry\' AND subtype IN ($expandedsubtypes) AND date_from >= ?1 AND date_to <= ?2 AND deleted = FALSE ORDER BY date_from DESC',
-        variables: [
-          Variable<DateTime>(rangeStart),
-          Variable<DateTime>(rangeEnd),
-          for (var $ in subtypes) Variable<String>($)
-        ],
-        readsFrom: {
-          journal,
-        }).asyncMap(journal.mapFromRow);
-  }
-
   Selectable<JournalDbEntity> workouts(DateTime rangeStart, DateTime rangeEnd) {
     return customSelect(
         'SELECT * FROM journal WHERE type = \'WorkoutEntry\' AND date_from >= ?1 AND date_to <= ?2 AND deleted = FALSE ORDER BY date_from DESC',

--- a/lib/widgets/charts/dashboard_health_bp_chart.dart
+++ b/lib/widgets/charts/dashboard_health_bp_chart.dart
@@ -2,19 +2,17 @@ import 'dart:core';
 
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/entity_definitions.dart';
-import 'package:lotti/classes/journal_entities.dart';
-import 'package:lotti/database/database.dart';
+import 'package:lotti/features/dashboards/state/health_chart_controller.dart';
 import 'package:lotti/features/dashboards/ui/widgets/charts/dashboard_chart.dart';
-import 'package:lotti/get_it.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/utils/platform.dart';
-import 'package:lotti/widgets/charts/dashboard_health_data.dart';
 import 'package:lotti/widgets/charts/time_series/utils.dart';
 import 'package:lotti/widgets/charts/utils.dart';
 import 'package:tinycolor2/tinycolor2.dart';
 
-class DashboardHealthBpChart extends StatelessWidget {
+class DashboardHealthBpChart extends ConsumerWidget {
   const DashboardHealthBpChart({
     required this.chartConfig,
     required this.rangeStart,
@@ -27,178 +25,179 @@ class DashboardHealthBpChart extends StatelessWidget {
   final DateTime rangeEnd;
 
   @override
-  Widget build(BuildContext context) {
-    const systolicType = 'HealthDataType.BLOOD_PRESSURE_SYSTOLIC';
-    const diastolicType = 'HealthDataType.BLOOD_PRESSURE_DIASTOLIC';
-    final dataTypes = <String>[systolicType, diastolicType];
-
-    return StreamBuilder<List<JournalEntity>>(
-      stream: getIt<JournalDb>().watchQuantitativeByTypes(
-        types: dataTypes,
-        rangeStart: rangeStart,
-        rangeEnd: rangeEnd,
-      ),
-      builder: (
-        BuildContext context,
-        AsyncSnapshot<List<JournalEntity>> snapshot,
-      ) {
-        final rangeInDays = rangeEnd.difference(rangeStart).inDays;
-
-        final items = snapshot.data ?? [];
-
-        final systolicData = aggregateNoneFilteredBy(items, systolicType);
-        final diastolicData = aggregateNoneFilteredBy(items, diastolicType);
-
-        Widget bottomTitleWidgets(double value, TitleMeta meta) {
-          final ymd = DateTime.fromMillisecondsSinceEpoch(value.toInt());
-          if (ymd.day == 1 ||
-              (rangeInDays < 90 && ymd.day == 15) ||
-              (rangeInDays < 30 && ymd.day == 8) ||
-              (rangeInDays < 30 && ymd.day == 22)) {
-            return SideTitleWidget(
-              axisSide: meta.axisSide,
-              child: ChartLabel(chartDateFormatterMmDd(value)),
-            );
-          }
-          return const SizedBox.shrink();
-        }
-
-        return DashboardChart(
-          chart: Padding(
-            padding: const EdgeInsets.only(top: 20, right: 20),
-            child: LineChart(
-              LineChartData(
-                gridData: FlGridData(
-                  horizontalInterval: 10,
-                  verticalInterval: double.maxFinite,
-                  getDrawingHorizontalLine: (value) {
-                    if (value == 80.0) {
-                      return gridLineEmphasized.copyWith(
-                        color: Colors.blue.withAlpha(102),
-                      );
-                    }
-                    if (value == 120.0) {
-                      return gridLineEmphasized.copyWith(
-                        color: Colors.red.withAlpha(102),
-                      );
-                    }
-
-                    return gridLine;
-                  },
-                  getDrawingVerticalLine: (value) => gridLine,
-                ),
-                clipData: const FlClipData.horizontal(),
-                lineTouchData: LineTouchData(
-                  touchTooltipData: LineTouchTooltipData(
-                    tooltipMargin: isMobile ? 24 : 16,
-                    tooltipPadding: const EdgeInsets.symmetric(
-                      horizontal: 8,
-                      vertical: 3,
-                    ),
-                    getTooltipColor: (_) =>
-                        Theme.of(context).primaryColor.desaturate(),
-                    tooltipRoundedRadius: 8,
-                    getTooltipItems: (List<LineBarSpot> spots) {
-                      return spots.map((spot) {
-                        return LineTooltipItem(
-                          '',
-                          const TextStyle(
-                            fontSize: fontSizeSmall,
-                            fontWeight: FontWeight.w300,
-                          ),
-                          children: [
-                            TextSpan(
-                              text: '${spot.y.toInt()} mmHg\n',
-                              style: chartTooltipStyleBold,
-                            ),
-                            TextSpan(
-                              text: chartDateFormatterFull(spot.x),
-                              style: chartTooltipStyle,
-                            ),
-                          ],
-                        );
-                      }).toList();
-                    },
-                  ),
-                ),
-                titlesData: FlTitlesData(
-                  rightTitles: const AxisTitles(),
-                  topTitles: const AxisTitles(),
-                  bottomTitles: AxisTitles(
-                    sideTitles: SideTitles(
-                      showTitles: true,
-                      reservedSize: 30,
-                      interval: Duration.millisecondsPerDay.toDouble(),
-                      getTitlesWidget: bottomTitleWidgets,
-                    ),
-                  ),
-                  leftTitles: const AxisTitles(
-                    sideTitles: SideTitles(
-                      showTitles: true,
-                      interval: 10,
-                      getTitlesWidget: leftTitleWidgets,
-                      reservedSize: 30,
-                    ),
-                  ),
-                ),
-                borderData: FlBorderData(
-                  show: true,
-                  border: Border.all(color: const Color(0xff37434d)),
-                ),
-                minX: rangeStart.millisecondsSinceEpoch.toDouble(),
-                maxX: rangeEnd.millisecondsSinceEpoch.toDouble(),
-                minY: 60,
-                maxY: 160,
-                lineBarsData: [
-                  LineChartBarData(
-                    spots: systolicData
-                        .map(
-                          (item) => FlSpot(
-                            item.dateTime.millisecondsSinceEpoch.toDouble(),
-                            item.value.toDouble(),
-                          ),
-                        )
-                        .toList(),
-                    isCurved: true,
-                    color: Colors.red,
-                    belowBarData: BarAreaData(
-                      show: true,
-                      color: Colors.red.withAlpha(26),
-                    ),
-                    curveSmoothness: 0.1,
-                    isStrokeCapRound: true,
-                    dotData: const FlDotData(show: false),
-                  ),
-                  LineChartBarData(
-                    spots: diastolicData
-                        .map(
-                          (item) => FlSpot(
-                            item.dateTime.millisecondsSinceEpoch.toDouble(),
-                            item.value.toDouble(),
-                          ),
-                        )
-                        .toList(),
-                    isCurved: true,
-                    curveSmoothness: 0.1,
-                    color: Colors.blue,
-                    belowBarData: BarAreaData(
-                      show: true,
-                      color: Colors.blue.withAlpha(51),
-                    ),
-                    isStrokeCapRound: true,
-                    dotData: const FlDotData(
-                      show: false,
-                    ),
-                  ),
-                ],
+  Widget build(BuildContext context, WidgetRef ref) {
+    final systolicData = ref
+            .watch(
+              healthObservationsControllerProvider(
+                healthDataType: 'HealthDataType.BLOOD_PRESSURE_SYSTOLIC',
+                rangeStart: rangeStart,
+                rangeEnd: rangeEnd,
               ),
-              duration: Duration.zero,
-            ),
-          ),
-          chartHeader: const BpChartInfoWidget(),
-          height: 220,
+            )
+            .valueOrNull ??
+        [];
+
+    final diastolicData = ref
+            .watch(
+              healthObservationsControllerProvider(
+                healthDataType: 'HealthDataType.BLOOD_PRESSURE_DIASTOLIC',
+                rangeStart: rangeStart,
+                rangeEnd: rangeEnd,
+              ),
+            )
+            .valueOrNull ??
+        [];
+
+    final rangeInDays = rangeEnd.difference(rangeStart).inDays;
+
+    Widget bottomTitleWidgets(double value, TitleMeta meta) {
+      final ymd = DateTime.fromMillisecondsSinceEpoch(value.toInt());
+      if (ymd.day == 1 ||
+          (rangeInDays < 90 && ymd.day == 15) ||
+          (rangeInDays < 30 && ymd.day == 8) ||
+          (rangeInDays < 30 && ymd.day == 22)) {
+        return SideTitleWidget(
+          axisSide: meta.axisSide,
+          child: ChartLabel(chartDateFormatterMmDd(value)),
         );
-      },
+      }
+      return const SizedBox.shrink();
+    }
+
+    return DashboardChart(
+      chart: Padding(
+        padding: const EdgeInsets.only(top: 20, right: 20),
+        child: LineChart(
+          LineChartData(
+            gridData: FlGridData(
+              horizontalInterval: 10,
+              verticalInterval: double.maxFinite,
+              getDrawingHorizontalLine: (value) {
+                if (value == 80.0) {
+                  return gridLineEmphasized.copyWith(
+                    color: Colors.blue.withAlpha(102),
+                  );
+                }
+                if (value == 120.0) {
+                  return gridLineEmphasized.copyWith(
+                    color: Colors.red.withAlpha(102),
+                  );
+                }
+
+                return gridLine;
+              },
+              getDrawingVerticalLine: (value) => gridLine,
+            ),
+            clipData: const FlClipData.horizontal(),
+            lineTouchData: LineTouchData(
+              touchTooltipData: LineTouchTooltipData(
+                tooltipMargin: isMobile ? 24 : 16,
+                tooltipPadding: const EdgeInsets.symmetric(
+                  horizontal: 8,
+                  vertical: 3,
+                ),
+                getTooltipColor: (_) =>
+                    Theme.of(context).primaryColor.desaturate(),
+                tooltipRoundedRadius: 8,
+                getTooltipItems: (List<LineBarSpot> spots) {
+                  return spots.map((spot) {
+                    return LineTooltipItem(
+                      '',
+                      const TextStyle(
+                        fontSize: fontSizeSmall,
+                        fontWeight: FontWeight.w300,
+                      ),
+                      children: [
+                        TextSpan(
+                          text: '${spot.y.toInt()} mmHg\n',
+                          style: chartTooltipStyleBold,
+                        ),
+                        TextSpan(
+                          text: chartDateFormatterFull(spot.x),
+                          style: chartTooltipStyle,
+                        ),
+                      ],
+                    );
+                  }).toList();
+                },
+              ),
+            ),
+            titlesData: FlTitlesData(
+              rightTitles: const AxisTitles(),
+              topTitles: const AxisTitles(),
+              bottomTitles: AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: true,
+                  reservedSize: 30,
+                  interval: Duration.millisecondsPerDay.toDouble(),
+                  getTitlesWidget: bottomTitleWidgets,
+                ),
+              ),
+              leftTitles: const AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: true,
+                  interval: 10,
+                  getTitlesWidget: leftTitleWidgets,
+                  reservedSize: 30,
+                ),
+              ),
+            ),
+            borderData: FlBorderData(
+              show: true,
+              border: Border.all(color: const Color(0xff37434d)),
+            ),
+            minX: rangeStart.millisecondsSinceEpoch.toDouble(),
+            maxX: rangeEnd.millisecondsSinceEpoch.toDouble(),
+            minY: 60,
+            maxY: 160,
+            lineBarsData: [
+              LineChartBarData(
+                spots: systolicData
+                    .map(
+                      (item) => FlSpot(
+                        item.dateTime.millisecondsSinceEpoch.toDouble(),
+                        item.value.toDouble(),
+                      ),
+                    )
+                    .toList(),
+                isCurved: true,
+                color: Colors.red,
+                belowBarData: BarAreaData(
+                  show: true,
+                  color: Colors.red.withAlpha(26),
+                ),
+                curveSmoothness: 0.1,
+                isStrokeCapRound: true,
+                dotData: const FlDotData(show: false),
+              ),
+              LineChartBarData(
+                spots: diastolicData
+                    .map(
+                      (item) => FlSpot(
+                        item.dateTime.millisecondsSinceEpoch.toDouble(),
+                        item.value.toDouble(),
+                      ),
+                    )
+                    .toList(),
+                isCurved: true,
+                curveSmoothness: 0.1,
+                color: Colors.blue,
+                belowBarData: BarAreaData(
+                  show: true,
+                  color: Colors.blue.withAlpha(51),
+                ),
+                isStrokeCapRound: true,
+                dotData: const FlDotData(
+                  show: false,
+                ),
+              ),
+            ],
+          ),
+          duration: Duration.zero,
+        ),
+      ),
+      chartHeader: const BpChartInfoWidget(),
+      height: 220,
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.552+2802
+version: 0.9.552+2803
 
 msix_config:
   display_name: LottiApp

--- a/test/widgets/charts/dashboard_health_test.dart
+++ b/test/widgets/charts/dashboard_health_test.dart
@@ -69,21 +69,25 @@ void main() {
 
     testWidgets('BP chart is rendered', (tester) async {
       when(
-        () => mockJournalDb.watchQuantitativeByTypes(
-          types: [
-            'HealthDataType.BLOOD_PRESSURE_SYSTOLIC',
-            'HealthDataType.BLOOD_PRESSURE_DIASTOLIC',
-          ],
+        () => mockJournalDb.getQuantitativeByType(
+          type: 'HealthDataType.BLOOD_PRESSURE_SYSTOLIC',
           rangeEnd: any(named: 'rangeEnd'),
           rangeStart: any(named: 'rangeStart'),
         ),
-      ).thenAnswer((_) {
-        return Stream<List<JournalEntity>>.fromIterable([
-          [
-            testBpSystolicEntry,
-            testBpDiastolicEntry,
-          ]
-        ]);
+      ).thenAnswer((_) async {
+        return [testBpSystolicEntry];
+      });
+
+      when(
+        () => mockJournalDb.getQuantitativeByType(
+          type: 'HealthDataType.BLOOD_PRESSURE_DIASTOLIC',
+          rangeEnd: any(named: 'rangeEnd'),
+          rangeStart: any(named: 'rangeStart'),
+        ),
+      ).thenAnswer((_) async {
+        return [
+          testBpDiastolicEntry,
+        ];
       });
 
       const bpType = 'BLOOD_PRESSURE';
@@ -113,90 +117,5 @@ void main() {
         findsOneWidget,
       );
     });
-
-    // testWidgets('BMI chart is rendered', (tester) async {
-    //   when(
-    //     () => mockJournalDb.watchQuantitativeByType(
-    //       type: testHeightEntry.data.dataType,
-    //       rangeEnd: any(named: 'rangeEnd'),
-    //       rangeStart: any(named: 'rangeStart'),
-    //     ),
-    //   ).thenAnswer(
-    //     (_) => Stream<List<JournalEntity>>.fromIterable([
-    //       [testHeightEntry],
-    //     ]),
-    //   );
-    //
-    //   when(
-    //     () => mockJournalDb.watchQuantitativeByType(
-    //       type: testWeightEntry.data.dataType,
-    //       rangeEnd: any(named: 'rangeEnd'),
-    //       rangeStart: any(named: 'rangeStart'),
-    //     ),
-    //   ).thenAnswer(
-    //     (_) => Stream<List<JournalEntity>>.fromIterable([
-    //       [
-    //         testWeightEntry,
-    //         testWeightEntry2,
-    //       ]
-    //     ]),
-    //   );
-    //
-    //   when(
-    //     () => mockJournalDb.watchQuantitativeByTypes(
-    //       types: [
-    //         'HealthDataType.BLOOD_PRESSURE_SYSTOLIC',
-    //         'HealthDataType.BLOOD_PRESSURE_DIASTOLIC',
-    //       ],
-    //       rangeEnd: any(named: 'rangeEnd'),
-    //       rangeStart: any(named: 'rangeStart'),
-    //     ),
-    //   ).thenAnswer((_) {
-    //     return Stream<List<JournalEntity>>.fromIterable([
-    //       [
-    //         testBpSystolicEntry,
-    //         testBpDiastolicEntry,
-    //       ]
-    //     ]);
-    //   });
-    //
-    //   const healthType = 'BODY_MASS_INDEX';
-    //
-    //   when(
-    //     () => mockHealthImport.fetchHealthDataDelta(healthType),
-    //   ).thenAnswer((_) async {});
-    //
-    //   when(
-    //     () => mockHealthImport.fetchHealthData(
-    //       dateFrom: any(named: 'dateFrom'),
-    //       dateTo: any(named: 'dateTo'),
-    //       types: any(named: 'types'),
-    //     ),
-    //   ).thenAnswer((_) async {});
-    //
-    //   await tester.pumpWidget(
-    //     makeTestableWidgetWithScaffold(
-    //       DashboardHealthChart(
-    //         rangeStart: DateTime(2022),
-    //         rangeEnd: DateTime(2023),
-    //         chartConfig: const DashboardHealthItem(
-    //           color: '#0000FF',
-    //           healthType: healthType,
-    //         ),
-    //       ),
-    //     ),
-    //   );
-    //
-    //   await tester.pumpAndSettle();
-    //
-    //   // chart displays expected title
-    //   expect(
-    //     find.text('Weight vs. Body Mass Index'),
-    //     findsOneWidget,
-    //   );
-    //
-    //   // chart displays expected min and max weights
-    //   expect(find.text('94.5 kg - 99.2 kg'), findsOneWidget);
-    // });
   });
 }


### PR DESCRIPTION
From GitHub Copilot:
This pull request includes several changes to the `lib/database` and `lib/widgets/charts` directories, as well as updates to the `pubspec.yaml` and test files. The primary focus is on refactoring database queries and updating the `DashboardHealthBpChart` widget to use Riverpod for state management.

Database refactoring:
* Removed the `watchQuantitativeByTypes` method and its corresponding SQL query from `lib/database/database.dart`, `lib/database/database.drift`, and `lib/database/database.g.dart`. This method and query were used to fetch quantitative entries by types within a date range. [[1]](diffhunk://#diff-58403ca793c79f9cac8520ba22f0b9cb3527232f194f5feefdda0a1089aff2b1L743-L752) [[2]](diffhunk://#diff-f15738f2bc6c1b31110fb4764da8e38d087199352136230dff90e7af2390d3fcL420-L428) [[3]](diffhunk://#diff-f2e06c503fca0bd510178a88926212593efb49183357afcb5e852f59fac63676L5217-L5233)

Widget refactoring:
* Updated the `DashboardHealthBpChart` widget to use Riverpod for state management. This includes changing the widget to extend `ConsumerWidget` instead of `StatelessWidget` and modifying the build method to use `WidgetRef` for fetching data. [[1]](diffhunk://#diff-2ee8edbb4b5c70dce7f6ea6840245f8608439808165e9e64ac4b019ca0474b75R5-R15) [[2]](diffhunk://#diff-2ee8edbb4b5c70dce7f6ea6840245f8608439808165e9e64ac4b019ca0474b75L30-R51) [[3]](diffhunk://#diff-2ee8edbb4b5c70dce7f6ea6840245f8608439808165e9e64ac4b019ca0474b75L201-L202)

Test updates:
* Modified the `dashboard_health_test.dart` file to replace the `watchQuantitativeByTypes` method with the new `getQuantitativeByType` method for fetching blood pressure data in tests. [[1]](diffhunk://#diff-90532776499f65f0f6c7260fbfe7150e3b9aede97a128179738a8657acbf74a0L72-R90) [[2]](diffhunk://#diff-90532776499f65f0f6c7260fbfe7150e3b9aede97a128179738a8657acbf74a0L116-L200)

Version update:
* Incremented the version number in `pubspec.yaml` from `0.9.552+2802` to `0.9.552+2803`.