### PR TITLE
refactor: remove stream builder & stream queries

### DIFF
--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -347,32 +347,6 @@ class JournalDb extends _$JournalDb {
     }
   }
 
-  Stream<List<JournalEntity>> watchJournalEntitiesByTag({
-    required String tagId,
-    required DateTime rangeStart,
-    required DateTime rangeEnd,
-    int limit = 1000,
-  }) {
-    return filteredByTaggedWithId(
-      tagId,
-      rangeStart,
-      rangeEnd,
-      limit,
-    ).watch().map(entityStreamMapper);
-  }
-
-  Stream<List<JournalEntity>> watchJournalByTagIds({
-    required String match,
-    required DateTime rangeStart,
-    required DateTime rangeEnd,
-  }) {
-    return filteredByTagMatch(
-      '%$match%',
-      rangeStart,
-      rangeEnd,
-    ).watch().map(entityStreamMapper);
-  }
-
   Future<List<JournalEntity>> getTasks({
     required List<bool> starredStatuses,
     required List<String> taskStatuses,
@@ -478,29 +452,11 @@ class JournalDb extends _$JournalDb {
     return res.length;
   }
 
-  Stream<List<JournalEntity>> watchLinkedEntities({
-    required String linkedFrom,
-  }) {
-    return linkedJournalEntities(linkedFrom).watch().map(entityStreamMapper);
-  }
-
   FutureOr<List<String>> getSortedLinkedEntityIds(
     List<String> linkedIds,
   ) async {
     final dbEntities = await journalEntitiesByIds(linkedIds).get();
     return dbEntities.map((dbEntity) => dbEntity.id).toList();
-  }
-
-  // Returns stream with a sorted list of items IDs linked to from the
-  // provided item id.
-  Stream<List<String>> watchLinkedEntityIds(
-    String linkedFrom, {
-    bool includeHidden = false,
-  }) {
-    return linkedJournalEntityIds(
-      linkedFrom,
-      includeHidden ? [false, true] : [false],
-    ).watch().asyncMap(getSortedLinkedEntityIds);
   }
 
   Future<List<JournalEntity>> getLinkedEntities(String linkedFrom) async {
@@ -514,18 +470,6 @@ class JournalDb extends _$JournalDb {
   }) async {
     final dbEntities = await sortedInRange(rangeStart, rangeEnd).get();
     return dbEntities.map(fromDbEntity).toList();
-  }
-
-  Stream<List<JournalEntity>> watchLinkedToEntities({
-    required String linkedTo,
-  }) {
-    return linkedToJournalEntities(linkedTo).watch().map(entityStreamMapper);
-  }
-
-  Stream<List<JournalEntity>> watchFlaggedImport({
-    int limit = 1000,
-  }) {
-    return entriesFlaggedImport(limit).watch().map(entityStreamMapper);
   }
 
   Stream<int> watchJournalCount() {
@@ -646,9 +590,9 @@ class JournalDb extends _$JournalDb {
   }
 
   Stream<int> watchInProgressTasksCount() {
-    return countInProgressTasks(['IN PROGRESS'])
-        .watch()
-        .map((event) => event.first);
+    return countInProgressTasks(['IN PROGRESS']).watch().map((event) {
+      return event.first;
+    });
   }
 
   Stream<List<MeasurableDataType>> watchMeasurableDataTypes() {
@@ -795,16 +739,6 @@ class JournalDb extends _$JournalDb {
     return (await matchingTagEntities('%$match%', inactive, limit).get())
         .map(fromTagDbEntity)
         .toList();
-  }
-
-  Stream<List<TagEntity>> watchMatchingTags(
-    String match, {
-    int limit = 10,
-    bool inactive = false,
-  }) {
-    return matchingTagEntities('%$match%', inactive, limit).watch().map(
-          (dbEntities) => dbEntities.map(fromTagDbEntity).toList(),
-        );
   }
 
   Future<int> resolveConflict(Conflict conflict) {

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -692,16 +692,6 @@ class JournalDb extends _$JournalDb {
     return habitCompletionsInRange(rangeStart).watch().map(entityStreamMapper);
   }
 
-  Stream<List<JournalEntity>> watchQuantitativeByType({
-    required String type,
-    required DateTime rangeStart,
-    required DateTime rangeEnd,
-  }) {
-    return quantitativeByType(type, rangeStart, rangeEnd)
-        .watch()
-        .map(entityStreamMapper);
-  }
-
   Future<List<JournalEntity>> getQuantitativeByType({
     required String type,
     required DateTime rangeStart,

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -8,7 +8,7 @@ import 'package:lotti/database/journal_db/config_flags.dart';
 import 'package:lotti/database/maintenance.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/features/speech/state/asr_service.dart';
-import 'package:lotti/features/sync/matrix.dart';
+import 'package:lotti/features/sync/matrix/matrix_service.dart';
 import 'package:lotti/features/sync/outbox/outbox_service.dart';
 import 'package:lotti/features/user_activity/state/user_activity_service.dart';
 import 'package:lotti/logic/ai/ai_logic.dart';

--- a/lib/widgets/misc/desktop_menu.dart
+++ b/lib/widgets/misc/desktop_menu.dart
@@ -16,6 +16,7 @@ class DesktopMenuWrapper extends StatelessWidget {
   });
 
   final JournalDb _db = getIt<JournalDb>();
+
   final Widget child;
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.552+2803
+version: 0.9.552+2804
 
 msix_config:
   display_name: LottiApp

--- a/test/database/database_test.dart
+++ b/test/database/database_test.dart
@@ -116,29 +116,6 @@ void main() {
     );
 
     test(
-      'Active config flag names are shown as expected',
-      () async {
-        final flags = await db?.watchActiveConfigFlagNames().first;
-        expect(flags, expectedActiveFlagNames);
-      },
-    );
-
-    test(
-      'Toggle config flag works',
-      () async {
-        expect(
-          await db?.watchActiveConfigFlagNames().first,
-          expectedActiveFlagNames,
-        );
-
-        expect(
-          await db?.watchActiveConfigFlagNames().first,
-          expectedActiveFlagNames,
-        );
-      },
-    );
-
-    test(
       'ConfigFlag can be retrieved by name',
       () async {
         expect(

--- a/test/logic/persistence_logic_test.dart
+++ b/test/logic/persistence_logic_test.dart
@@ -338,35 +338,6 @@ void main() {
         addedTagIds: [testStoryTag.id],
       );
 
-      // expect tagged entry in journal by tag query
-      expect(
-        (await getIt<JournalDb>()
-                .watchJournalEntitiesByTag(
-                  tagId: testTagId,
-                  rangeStart: DateTime(0),
-                  rangeEnd: DateTime(2100),
-                )
-                .first)
-            .map((entity) => entity.meta.id)
-            .toSet()
-            .contains(task.meta.id),
-        true,
-      );
-
-      expect(
-        (await getIt<JournalDb>()
-                .watchJournalEntitiesByTag(
-                  tagId: testTagId,
-                  rangeStart: DateTime(0),
-                  rangeEnd: DateTime(2100),
-                )
-                .first)
-            .map((entity) => entity.meta.id)
-            .toSet()
-            .contains(comment?.meta.id),
-        true,
-      );
-
       await getIt<PersistenceLogic>().updateJournalEntityText(
         comment!.meta.id,
         const EntryText(
@@ -375,35 +346,12 @@ void main() {
         comment.meta.dateTo,
       );
 
-      // expect linked comment entry to appear in stream
-      final linked = await getIt<JournalDb>()
-          .watchLinkedEntities(linkedFrom: task.meta.id)
-          .first;
-
-      expect(linked.first.entryText?.plainText, updatedTestText);
-      expect(linked.first.meta.tagIds?.toSet(), {testTagId});
-
       expect(
         (await getIt<JournalDb>().getLinkedEntities(task.meta.id))
             .first
             .entryText,
         (await getIt<JournalDb>().journalEntityById(comment.meta.id))
             ?.entryText,
-      );
-
-      expect(
-        (await getIt<JournalDb>()
-                .watchLinkedToEntities(linkedTo: comment.meta.id)
-                .first)
-            .first
-            .entryText,
-        (await getIt<JournalDb>().journalEntityById(task.meta.id))?.entryText,
-      );
-
-      // linked ids can be watched
-      expect(
-        await getIt<JournalDb>().watchLinkedEntityIds(task.meta.id).first,
-        [comment.meta.id],
       );
 
       expect(await getIt<JournalDb>().watchTaggedCount().first, 2);

--- a/test/logic/persistence_logic_test.dart
+++ b/test/logic/persistence_logic_test.dart
@@ -493,20 +493,6 @@ void main() {
             ?.data,
         testWeightEntry.data,
       );
-
-      // workout is retrieved on workout watch stream
-      expect(
-        ((await getIt<JournalDb>()
-                    .watchQuantitativeByType(
-                      rangeStart: DateTime(0),
-                      rangeEnd: DateTime(2100),
-                      type: 'HealthDataType.WEIGHT',
-                    )
-                    .first)
-                .first as QuantitativeEntry)
-            .data,
-        testWeightEntry.data,
-      );
     });
 
     test('create and retrieve measurement entry', () async {

--- a/test/pages/dashboards/dashboard_page_test.dart
+++ b/test/pages/dashboards/dashboard_page_test.dart
@@ -93,16 +93,6 @@ void main() {
       );
 
       when(
-        () => mockJournalDb.watchQuantitativeByType(
-          type: any(named: 'type'),
-          rangeStart: any(named: 'rangeStart'),
-          rangeEnd: any(named: 'rangeEnd'),
-        ),
-      ).thenAnswer(
-        (_) => Stream<List<JournalEntity>>.fromIterable([]),
-      );
-
-      when(
         () => mockHealthImport.fetchHealthDataDelta(any()),
       ).thenAnswer((_) async {});
 

--- a/test/pages/journal/entry_detail_page_test.dart
+++ b/test/pages/journal/entry_detail_page_test.dart
@@ -160,14 +160,6 @@ void main() {
       ).thenAnswer((_) async {});
 
       when(
-        () => mockJournalDb.watchQuantitativeByType(
-          type: testWeightEntry.data.dataType,
-          rangeEnd: any(named: 'rangeEnd'),
-          rangeStart: any(named: 'rangeStart'),
-        ),
-      ).thenAnswer((_) => Stream<List<JournalEntity>>.fromIterable([]));
-
-      when(
         () => mockJournalDb.getLinkedEntities(testTask.meta.id),
       ).thenAnswer(
         (_) async => [testTextEntry],

--- a/test/pages/journal/entry_detail_page_test.dart
+++ b/test/pages/journal/entry_detail_page_test.dart
@@ -106,46 +106,6 @@ void main() {
       );
 
       when(
-        () => mockJournalDb.watchLinkedEntityIds(testTextEntry.meta.id),
-      ).thenAnswer(
-        (_) => Stream<List<String>>.fromIterable([]),
-      );
-
-      when(
-        () => mockJournalDb.watchLinkedEntityIds(testTask.meta.id),
-      ).thenAnswer(
-        (_) => Stream<List<String>>.fromIterable([]),
-      );
-
-      when(
-        () => mockJournalDb.watchLinkedEntityIds(testWeightEntry.meta.id),
-      ).thenAnswer(
-        (_) => Stream<List<String>>.fromIterable([]),
-      );
-
-      when(
-        () => mockJournalDb.watchLinkedToEntities(
-          linkedTo: testTextEntry.meta.id,
-        ),
-      ).thenAnswer(
-        (_) => Stream<List<JournalEntity>>.fromIterable([]),
-      );
-
-      when(
-        () => mockJournalDb.watchLinkedToEntities(linkedTo: testTask.meta.id),
-      ).thenAnswer(
-        (_) => Stream<List<JournalEntity>>.fromIterable([]),
-      );
-
-      when(
-        () => mockJournalDb.watchLinkedToEntities(
-          linkedTo: testWeightEntry.meta.id,
-        ),
-      ).thenAnswer(
-        (_) => Stream<List<JournalEntity>>.fromIterable([]),
-      );
-
-      when(
         () => mockEditorStateService.getUnsavedStream(
           any(),
           any(),

--- a/test/widgets/charts/dashboard_health_test.dart
+++ b/test/widgets/charts/dashboard_health_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
-import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/health_import.dart';
@@ -29,16 +28,12 @@ void main() {
 
     testWidgets('weight chart is rendered', (tester) async {
       when(
-        () => mockJournalDb.watchQuantitativeByType(
+        () => mockJournalDb.getQuantitativeByType(
           type: testWeightEntry.data.dataType,
           rangeEnd: any(named: 'rangeEnd'),
           rangeStart: any(named: 'rangeStart'),
         ),
-      ).thenAnswer(
-        (_) => Stream<List<JournalEntity>>.fromIterable([
-          [testWeightEntry],
-        ]),
-      );
+      ).thenAnswer((_) async => [testWeightEntry]);
 
       when(
         () => mockHealthImport


### PR DESCRIPTION
From GitHub Copilot:
This pull request involves significant refactoring and cleanup of the `JournalDb` class, as well as updates to the `DashboardHealthBmiChart` widget. The changes include the removal of several stream methods from `JournalDb`, modifications to the `DashboardHealthBmiChart` to use Riverpod for state management, and updates to various tests to reflect these changes.

### Database Refactoring:

* Removed multiple stream methods from the `JournalDb` class, including `watchJournalEntitiesByTag`, `watchJournalByTagIds`, `watchLinkedEntities`, `watchLinkedEntityIds`, `watchLinkedToEntities`, `watchFlaggedImport`, `watchActiveConfigFlagNames`, and `watchQuantitativeByType`. [[1]](diffhunk://#diff-58403ca793c79f9cac8520ba22f0b9cb3527232f194f5feefdda0a1089aff2b1L350-L375) [[2]](diffhunk://#diff-58403ca793c79f9cac8520ba22f0b9cb3527232f194f5feefdda0a1089aff2b1L481-L505) [[3]](diffhunk://#diff-58403ca793c79f9cac8520ba22f0b9cb3527232f194f5feefdda0a1089aff2b1L519-L530) [[4]](diffhunk://#diff-58403ca793c79f9cac8520ba22f0b9cb3527232f194f5feefdda0a1089aff2b1L556-L567) [[5]](diffhunk://#diff-58403ca793c79f9cac8520ba22f0b9cb3527232f194f5feefdda0a1089aff2b1L649-R584) [[6]](diffhunk://#diff-58403ca793c79f9cac8520ba22f0b9cb3527232f194f5feefdda0a1089aff2b1L695-L704) [[7]](diffhunk://#diff-58403ca793c79f9cac8520ba22f0b9cb3527232f194f5feefdda0a1089aff2b1L810-L819)

### Widget Updates:

* Refactored `DashboardHealthBmiChart` to use Riverpod for state management instead of relying on direct database streams. This includes converting the widget to a `ConsumerWidget` and updating the `BmiChartInfoWidget` to use `WidgetRef` for accessing state. [[1]](diffhunk://#diff-b731a3b9903f5bf8c5e3ba827cc2ab8f3d8a9284d36b2949e04bf39dbdb8ad34L4-L111) [[2]](diffhunk://#diff-b731a3b9903f5bf8c5e3ba827cc2ab8f3d8a9284d36b2949e04bf39dbdb8ad34L179-R116) [[3]](diffhunk://#diff-b731a3b9903f5bf8c5e3ba827cc2ab8f3d8a9284d36b2949e04bf39dbdb8ad34R149-R192)

### Test Updates:

* Removed tests that depended on the deleted stream methods from `JournalDb`, including tests in `database_test.dart`, `persistence_logic_test.dart`, `dashboard_page_test.dart`, and `entry_detail_page_test.dart`. [[1]](diffhunk://#diff-5d94915a791875ec0c3b4703ccfdc535a20354a6c8a1c4adeb6763611ec735e3L118-L140) [[2]](diffhunk://#diff-013701f3e006b392c32c1a286b8bf7457d52bebd26a573d75dfe6d50b8234d0fL341-L369) [[3]](diffhunk://#diff-013701f3e006b392c32c1a286b8bf7457d52bebd26a573d75dfe6d50b8234d0fL378-L385) [[4]](diffhunk://#diff-013701f3e006b392c32c1a286b8bf7457d52bebd26a573d75dfe6d50b8234d0fL394-L408) [[5]](diffhunk://#diff-013701f3e006b392c32c1a286b8bf7457d52bebd26a573d75dfe6d50b8234d0fL496-L509) [[6]](diffhunk://#diff-786489c8590169de6fe18f3473bd368ff9bf71d30b74fb3caecc5a9af4b7a767L95-L104) [[7]](diffhunk://#diff-e3719c094ce46f4d5f1abd264cf0ac548292467ab30bdf45c89489562af6908cL108-L147) [[8]](diffhunk://#diff-e3719c094ce46f4d5f1abd264cf0ac548292467ab30bdf45c89489562af6908cL162-L169)

### Miscellaneous:

* Updated the version number in `pubspec.yaml`.

These changes streamline the codebase by removing unused methods and modernizing state management in the `DashboardHealthBmiChart` widget.