### PR TITLE
feat: add button for selecting all category ids, including not set

### DIFF
--- a/lib/blocs/journal/journal_page_cubit.dart
+++ b/lib/blocs/journal/journal_page_cubit.dart
@@ -196,6 +196,13 @@ class JournalPageCubit extends Cubit<JournalPageState> {
     emitState();
   }
 
+  void selectedAllCategories() {
+    _selectedCategoryIds = {};
+    persistTasksFilter();
+    refreshQuery();
+    emitState();
+  }
+
   void toggleTaskAsListView() {
     taskAsListView = !taskAsListView;
     emitState();

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -329,6 +329,7 @@
   "syncAssistantStatusValid": "Account is valid.",
   "taskCategoryLabel": "Task category:",
   "taskCategoryUnassignedLabel": "unassigned",
+  "taskCategoryAllLabel": "all",
   "taskDueLabel": "Task due:",
   "taskEditHint": "Edit Task",
   "taskEstimateLabel": "Estimated time:",

--- a/lib/widgets/search/task_category_filter.dart
+++ b/lib/widgets/search/task_category_filter.dart
@@ -71,6 +71,12 @@ class _TaskCategoryFilterState extends State<TaskCategoryFilter> {
                   selectedColor: Colors.grey,
                   isSelected: state.selectedCategoryIds.contains(''),
                 ),
+                FilterChoiceChip(
+                  onTap: cubit.selectedAllCategories,
+                  label: context.messages.taskCategoryAllLabel,
+                  selectedColor: Colors.grey,
+                  isSelected: state.selectedCategoryIds.isEmpty,
+                ),
                 if (!_showAll)
                   FilterChoiceChip(
                     onTap: () => setState(() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.552+2806
+version: 0.9.552+2807
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
From Copilot:
This pull request includes several changes to enhance the task category filtering functionality and update the project version. The most important changes include adding a new method to select all categories, updating localization strings, and modifying the task category filter widget.

Enhancements to task category filtering:

* [`lib/blocs/journal/journal_page_cubit.dart`](diffhunk://#diff-33f77896ed78898e42dd43a1ddeb6fda349c8ca55068b2ec7c71a45a6aa833b3R199-R205): Added a new method `selectedAllCategories` to select all task categories.
* [`lib/widgets/search/task_category_filter.dart`](diffhunk://#diff-29c84a73f13e7666ad8fee568e05bca76c0479eeb955d6c0cc55a576b05012efR74-R79): Added a new `FilterChoiceChip` to allow users to select all task categories.

Localization updates:

* [`lib/l10n/app_en.arb`](diffhunk://#diff-9796fde3771f42a3a759ccc941731d83f96037a661e47dde27ce81d3447a69c2R332): Added a new localization string `taskCategoryAllLabel` for the "all" task category label.

Version update:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Updated the project version from `0.9.552+2806` to `0.9.552+2807`.