### PR TITLE
feat: use composite SQLite indices

### DIFF
--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -42,7 +42,7 @@ class JournalDb extends _$JournalDb {
   bool inMemoryDatabase = false;
 
   @override
-  int get schemaVersion => 23;
+  int get schemaVersion => 24;
 
   @override
   MigrationStrategy get migration {
@@ -87,6 +87,18 @@ class JournalDb extends _$JournalDb {
             debugPrint('Add timestamps in linked_entries table, with index');
             await m.addColumn(linkedEntries, linkedEntries.createdAt);
             await m.addColumn(linkedEntries, linkedEntries.updatedAt);
+          }();
+        }
+
+        if (from < 24) {
+          await () async {
+            debugPrint('Adding composite indices');
+            await m.createIndex(idxJournalComposite);
+            await m.createIndex(idxJournalHabitCompletions);
+            await m.createIndex(idxJournalHabitCompletions2);
+            await m.createIndex(idxJournalLinked);
+            await m.createIndex(idxLinkedEntriesFromIdHidden);
+            await m.createIndex(idxLinkedEntriesToIdHidden);
           }();
         }
       },

--- a/lib/database/database.drift
+++ b/lib/database/database.drift
@@ -39,6 +39,12 @@ CREATE INDEX idx_journal_geohash_string ON journal (geohash_string);
 CREATE INDEX idx_journal_geohash_int ON journal (geohash_int);
 CREATE INDEX idx_journal_category ON journal (category);
 
+CREATE INDEX idx_journal_composite ON journal(type COLLATE BINARY ASC, private COLLATE BINARY ASC, starred COLLATE BINARY ASC, flag COLLATE BINARY ASC, deleted COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+CREATE INDEX idx_journal_habit_completions ON journal(type COLLATE BINARY ASC, subtype COLLATE BINARY ASC, deleted COLLATE BINARY ASC, private COLLATE BINARY ASC, date_from COLLATE BINARY ASC, date_from COLLATE BINARY DESC, date_to COLLATE BINARY ASC, date_to COLLATE BINARY DESC);
+CREATE INDEX idx_journal_habit_completions2 ON journal(type COLLATE BINARY ASC, deleted COLLATE BINARY ASC, private COLLATE BINARY ASC, date_from COLLATE BINARY ASC, date_from COLLATE BINARY DESC, created_at COLLATE BINARY ASC);
+CREATE INDEX idx_journal_linked ON journal(id COLLATE BINARY ASC, private COLLATE BINARY ASC, deleted COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+CREATE INDEX idx_journal_filtered_tasks ON journal(type COLLATE BINARY ASC, private COLLATE BINARY ASC, starred COLLATE BINARY ASC, private COLLATE BINARY ASC, deleted COLLATE BINARY ASC, task COLLATE BINARY ASC, task_status COLLATE BINARY ASC, category COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+
 CREATE TABLE conflicts (
   id TEXT NOT NULL,
   created_at DATETIME NOT NULL,
@@ -168,6 +174,9 @@ CREATE INDEX idx_linked_entries_from_id ON linked_entries (from_id);
 CREATE INDEX idx_linked_entries_to_id ON linked_entries (to_id);
 CREATE INDEX idx_linked_entries_type ON linked_entries (type);
 CREATE INDEX idx_linked_entries_hidden ON linked_entries (hidden);
+
+CREATE INDEX idx_linked_entries_from_id_hidden ON linked_entries(from_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
+CREATE INDEX idx_linked_entries_to_id_hidden ON linked_entries(from_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC);
 
 /* Queries ----------------------------------------------------- */
 listConfigFlags:

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -4627,6 +4627,18 @@ abstract class _$JournalDb extends GeneratedDatabase {
       'CREATE INDEX idx_journal_geohash_int ON journal (geohash_int)');
   late final Index idxJournalCategory = Index('idx_journal_category',
       'CREATE INDEX idx_journal_category ON journal (category)');
+  late final Index idxJournalComposite = Index('idx_journal_composite',
+      'CREATE INDEX idx_journal_composite ON journal (type COLLATE BINARY ASC, private COLLATE BINARY ASC, starred COLLATE BINARY ASC, flag COLLATE BINARY ASC, deleted COLLATE BINARY ASC, date_from COLLATE BINARY DESC)');
+  late final Index idxJournalHabitCompletions = Index(
+      'idx_journal_habit_completions',
+      'CREATE INDEX idx_journal_habit_completions ON journal (type COLLATE BINARY ASC, subtype COLLATE BINARY ASC, deleted COLLATE BINARY ASC, private COLLATE BINARY ASC, date_from COLLATE BINARY ASC, date_from COLLATE BINARY DESC, date_to COLLATE BINARY ASC, date_to COLLATE BINARY DESC)');
+  late final Index idxJournalHabitCompletions2 = Index(
+      'idx_journal_habit_completions2',
+      'CREATE INDEX idx_journal_habit_completions2 ON journal (type COLLATE BINARY ASC, deleted COLLATE BINARY ASC, private COLLATE BINARY ASC, date_from COLLATE BINARY ASC, date_from COLLATE BINARY DESC, created_at COLLATE BINARY ASC)');
+  late final Index idxJournalLinked = Index('idx_journal_linked',
+      'CREATE INDEX idx_journal_linked ON journal (id COLLATE BINARY ASC, private COLLATE BINARY ASC, deleted COLLATE BINARY ASC, date_from COLLATE BINARY DESC)');
+  late final Index idxJournalFilteredTasks = Index('idx_journal_filtered_tasks',
+      'CREATE INDEX idx_journal_filtered_tasks ON journal (type COLLATE BINARY ASC, private COLLATE BINARY ASC, starred COLLATE BINARY ASC, private COLLATE BINARY ASC, deleted COLLATE BINARY ASC, task COLLATE BINARY ASC, task_status COLLATE BINARY ASC, category COLLATE BINARY ASC, date_from COLLATE BINARY DESC)');
   late final Conflicts conflicts = Conflicts(this);
   late final MeasurableTypes measurableTypes = MeasurableTypes(this);
   late final HabitDefinitions habitDefinitions = HabitDefinitions(this);
@@ -4685,6 +4697,12 @@ abstract class _$JournalDb extends GeneratedDatabase {
       'CREATE INDEX idx_linked_entries_type ON linked_entries (type)');
   late final Index idxLinkedEntriesHidden = Index('idx_linked_entries_hidden',
       'CREATE INDEX idx_linked_entries_hidden ON linked_entries (hidden)');
+  late final Index idxLinkedEntriesFromIdHidden = Index(
+      'idx_linked_entries_from_id_hidden',
+      'CREATE INDEX idx_linked_entries_from_id_hidden ON linked_entries (from_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC)');
+  late final Index idxLinkedEntriesToIdHidden = Index(
+      'idx_linked_entries_to_id_hidden',
+      'CREATE INDEX idx_linked_entries_to_id_hidden ON linked_entries (from_id COLLATE BINARY ASC, hidden COLLATE BINARY ASC)');
   Selectable<ConfigFlag> listConfigFlags() {
     return customSelect('SELECT * FROM config_flags',
         variables: [],
@@ -5590,6 +5608,11 @@ abstract class _$JournalDb extends GeneratedDatabase {
         idxJournalGeohashString,
         idxJournalGeohashInt,
         idxJournalCategory,
+        idxJournalComposite,
+        idxJournalHabitCompletions,
+        idxJournalHabitCompletions2,
+        idxJournalLinked,
+        idxJournalFilteredTasks,
         conflicts,
         measurableTypes,
         habitDefinitions,
@@ -5618,7 +5641,9 @@ abstract class _$JournalDb extends GeneratedDatabase {
         idxLinkedEntriesFromId,
         idxLinkedEntriesToId,
         idxLinkedEntriesType,
-        idxLinkedEntriesHidden
+        idxLinkedEntriesHidden,
+        idxLinkedEntriesFromIdHidden,
+        idxLinkedEntriesToIdHidden
       ];
   @override
   StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules(

--- a/lib/services/db_notification.dart
+++ b/lib/services/db_notification.dart
@@ -14,7 +14,7 @@ class UpdateNotifications {
   void notify(Set<String> affectedIds, {bool fromSync = false}) {
     if (fromSync) {
       _affectedIdsFromSync.addAll(affectedIds);
-      _fromSyncTimer ??= Timer(const Duration(seconds: 2), () {
+      _fromSyncTimer ??= Timer(const Duration(seconds: 1), () {
         if (_affectedIdsFromSync.isNotEmpty) {
           _controller.add({..._affectedIdsFromSync});
           _affectedIdsFromSync.clear();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.552+2818
+version: 0.9.552+2819
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.552+2817
+version: 0.9.552+2818
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR makes queries faster by adding composite indices and reducing the timespan in the habit completions query to what is actually selected, not 180 days, which both reduces the time needed for the database query and for deserializing the contained JSON and running computations on the result.

From Copilot:
This pull request includes multiple changes to the `habits_cubit.dart` and `database` files to improve performance and functionality. The most important changes include removing the `rxdart` dependency, modifying the `startWatching` method to simplify the logic, updating the database schema version, and adding new indices to the database.

Improvements to `habits_cubit.dart`:

* Removed `rxdart` dependency from `lib/blocs/habits/habits_cubit.dart` and simplified the `startWatching` method by removing the throttle time and adding a delay after fetching habit completions. [[1]](diffhunk://#diff-2d1ab1a40de156b2d0cf1c294e16505cc07aa782affd791aa99015de6c792018L16) [[2]](diffhunk://#diff-2d1ab1a40de156b2d0cf1c294e16505cc07aa782affd791aa99015de6c792018L82-R94)
* Changed the `setTimeSpan` method to be asynchronous and fetch habit completions immediately after setting the time span.

Database schema updates:

* Updated the `schemaVersion` in `lib/database/database.dart` from 23 to 24.
* Added multiple new indices to the database in `lib/database/database.drift` to improve query performance. [[1]](diffhunk://#diff-58403ca793c79f9cac8520ba22f0b9cb3527232f194f5feefdda0a1089aff2b1R92-R103) [[2]](diffhunk://#diff-f15738f2bc6c1b31110fb4764da8e38d087199352136230dff90e7af2390d3fcR42-R47) [[3]](diffhunk://#diff-f15738f2bc6c1b31110fb4764da8e38d087199352136230dff90e7af2390d3fcR178-R180)
* Updated the generated database file `lib/database/database.g.dart` to include the new indices. [[1]](diffhunk://#diff-f2e06c503fca0bd510178a88926212593efb49183357afcb5e852f59fac63676R4630-R4641) [[2]](diffhunk://#diff-f2e06c503fca0bd510178a88926212593efb49183357afcb5e852f59fac63676R4700-R4705) [[3]](diffhunk://#diff-f2e06c503fca0bd510178a88926212593efb49183357afcb5e852f59fac63676R5611-R5615) [[4]](diffhunk://#diff-f2e06c503fca0bd510178a88926212593efb49183357afcb5e852f59fac63676L5621-R5646)

Other changes:

* Reduced the timer duration in the `notify` method of `UpdateNotifications` class from 2 seconds to 1 second to speed up notifications.
* Updated the version in `pubspec.yaml` to `0.9.552+2819`.