### PR TITLE
feat: add color coding in checklist card & spacing

### DIFF
--- a/lib/features/journal/ui/widgets/entry_details/habit_summary.dart
+++ b/lib/features/journal/ui/widgets/entry_details/habit_summary.dart
@@ -11,6 +11,7 @@ class HabitSummary extends StatelessWidget {
   HabitSummary(
     this.habitCompletion, {
     this.paddingLeft = 0,
+    this.paddingBottom = 0,
     this.showIcon = false,
     this.showText = true,
     super.key,
@@ -19,6 +20,7 @@ class HabitSummary extends StatelessWidget {
   final JournalDb _db = getIt<JournalDb>();
   final HabitCompletionEntry habitCompletion;
   final double paddingLeft;
+  final double paddingBottom;
   final bool showText;
   final bool showIcon;
 
@@ -39,7 +41,11 @@ class HabitSummary extends StatelessWidget {
         }
 
         return Padding(
-          padding: EdgeInsets.only(top: 5, left: paddingLeft),
+          padding: EdgeInsets.only(
+            top: 5,
+            left: paddingLeft,
+            bottom: paddingBottom,
+          ),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -53,9 +59,11 @@ class HabitSummary extends StatelessWidget {
                         size: 30,
                       ),
                     ),
-                  EntryTextWidget(
-                    'Habit completed: ${habitDefinition.name}',
-                    padding: EdgeInsets.zero,
+                  Flexible(
+                    child: EntryTextWidget(
+                      'Habit completed: ${habitDefinition.name}',
+                      padding: EdgeInsets.zero,
+                    ),
                   ),
                 ],
               ),

--- a/lib/features/journal/ui/widgets/entry_details_widget.dart
+++ b/lib/features/journal/ui/widgets/entry_details_widget.dart
@@ -162,6 +162,7 @@ class EntryDetailsContent extends ConsumerWidget {
           habitCompletion: (habit) => HabitSummary(
             habit,
             paddingLeft: 10,
+            paddingBottom: 5,
             showIcon: true,
             showText: false,
           ),

--- a/lib/features/journal/ui/widgets/helpers.dart
+++ b/lib/features/journal/ui/widgets/helpers.dart
@@ -20,6 +20,7 @@ class EntryTextWidget extends StatelessWidget {
       child: Text(
         text,
         maxLines: maxLines,
+        softWrap: true,
         style: monospaceTextStyle.copyWith(
           fontWeight: FontWeight.w300,
         ),

--- a/lib/features/journal/ui/widgets/journal_card.dart
+++ b/lib/features/journal/ui/widgets/journal_card.dart
@@ -255,7 +255,6 @@ class _JournalCardState extends ConsumerState<JournalCard> {
                     : errorColor.withAlpha(102),
               );
             },
-            checklist: (_) => LeadingIcon(MdiIcons.checkAll),
             checklistItem: (item) {
               final categoryId = item.meta.categoryId;
               final category =
@@ -264,6 +263,17 @@ class _JournalCardState extends ConsumerState<JournalCard> {
                 item.data.isChecked
                     ? MdiIcons.check
                     : MdiIcons.checkboxBlankOutline,
+                color: category != null
+                    ? colorFromCssHex(category.color)
+                    : context.colorScheme.outline,
+              );
+            },
+            checklist: (checklist) {
+              final categoryId = checklist.meta.categoryId;
+              final category =
+                  getIt<EntitiesCacheService>().getCategoryById(categoryId);
+              return LeadingIcon(
+                MdiIcons.checkAll,
                 color: category != null
                     ? colorFromCssHex(category.color)
                     : context.colorScheme.outline,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.553+2822
+version: 0.9.553+2823
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
From Copilot:
This pull request includes several changes to the `lib/features/journal/ui/widgets` directory to improve the flexibility and functionality of the `HabitSummary` and other related widgets. The most important changes include adding a new padding property, improving text wrapping, and updating the checklist item rendering.

### Enhancements to `HabitSummary`:

* Added a new `paddingBottom` property to the `HabitSummary` class to allow for more flexible padding configuration. (`lib/features/journal/ui/widgets/entry_details/habit_summary.dart`) [[1]](diffhunk://#diff-ef813b4a3fc8664e1f65f9dbb47db0d73863b387c3aef23736cd7f0383d38f5fR14) [[2]](diffhunk://#diff-ef813b4a3fc8664e1f65f9dbb47db0d73863b387c3aef23736cd7f0383d38f5fR23)
* Updated the `Padding` widget within `HabitSummary` to utilize the new `paddingBottom` property. (`lib/features/journal/ui/widgets/entry_details/habit_summary.dart`)
* Wrapped `EntryTextWidget` in a `Flexible` widget to improve layout flexibility. (`lib/features/journal/ui/widgets/entry_details/habit_summary.dart`)

### Updates to other widgets:

* Added the `paddingBottom` property to the `HabitSummary` instantiation in `EntryDetailsContent`. (`lib/features/journal/ui/widgets/entry_details_widget.dart`)
* Enabled `softWrap` for text in `EntryTextWidget` to improve text wrapping. (`lib/features/journal/ui/widgets/helpers.dart`)

### Checklist rendering improvements:

* Updated the `checklist` rendering to use category-specific colors in `JournalCard`. (`lib/features/journal/ui/widgets/journal_card.dart`) [[1]](diffhunk://#diff-83cffd946045977273d7f4ff6e4ec3c4b7c44a4e25b296436582954522988d38L258) [[2]](diffhunk://#diff-83cffd946045977273d7f4ff6e4ec3c4b7c44a4e25b296436582954522988d38R271-R281)

### Miscellaneous:

* Incremented the version number in `pubspec.yaml`. (`pubspec.yaml`)