### PR TITLE
feat: bring back workouts in calendar view

### DIFF
--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -481,6 +481,15 @@ class JournalDb extends _$JournalDb {
     return dbEntities.map(fromDbEntity).toList();
   }
 
+  Future<List<JournalEntity>> sortedCalendarEntries({
+    required DateTime rangeStart,
+    required DateTime rangeEnd,
+  }) async {
+    final dbEntities =
+        await sortedCalenderEntriesInRange(rangeStart, rangeEnd).get();
+    return dbEntities.map(fromDbEntity).toList();
+  }
+
   Future<int> getTaggedCount() async {
     return (await countTagged().get()).first;
   }

--- a/lib/database/database.drift
+++ b/lib/database/database.drift
@@ -253,6 +253,14 @@ SELECT * FROM journal
   AND date_to <= :rangeEnd
   ORDER BY date_from DESC;
 
+sortedCalenderEntriesInRange:
+SELECT * FROM journal
+  WHERE type in ('JournalEntry', 'WorkoutEntry') AND
+  deleted = false
+  AND date_from >= :rangeStart
+  AND date_to <= :rangeEnd
+  ORDER BY date_from DESC;
+
 filteredByTagMatch:
 SELECT * FROM journal
   WHERE deleted = false

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -4891,6 +4891,19 @@ abstract class _$JournalDb extends GeneratedDatabase {
         }).asyncMap(journal.mapFromRow);
   }
 
+  Selectable<JournalDbEntity> sortedCalenderEntriesInRange(
+      DateTime rangeStart, DateTime rangeEnd) {
+    return customSelect(
+        'SELECT * FROM journal WHERE type IN (\'JournalEntry\', \'WorkoutEntry\') AND deleted = FALSE AND date_from >= ?1 AND date_to <= ?2 ORDER BY date_from DESC',
+        variables: [
+          Variable<DateTime>(rangeStart),
+          Variable<DateTime>(rangeEnd)
+        ],
+        readsFrom: {
+          journal,
+        }).asyncMap(journal.mapFromRow);
+  }
+
   Selectable<JournalDbEntity> filteredByTagMatch(
       String match, DateTime rangeStart, DateTime rangeEnd) {
     return customSelect(

--- a/lib/features/calendar/state/day_view_controller.dart
+++ b/lib/features/calendar/state/day_view_controller.dart
@@ -78,7 +78,7 @@ class DayViewController extends _$DayViewController {
     final data = <CalendarEventData<CalendarEvent>>[];
     final start = now.dayAtMidnight.subtract(Duration(days: timeSpanDays));
 
-    final items = await db.sortedTextEntries(
+    final items = await db.sortedCalendarEntries(
       rangeStart: start,
       rangeEnd: now.add(const Duration(days: 1)).dayAtMidnight,
     );

--- a/lib/features/calendar/state/day_view_controller.g.dart
+++ b/lib/features/calendar/state/day_view_controller.g.dart
@@ -6,7 +6,7 @@ part of 'day_view_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$dayViewControllerHash() => r'56f04bd41dc93aec0233fce2a1c0616c7421dbf0';
+String _$dayViewControllerHash() => r'95e3a2986718e40bec9117eba55090bc2917363e';
 
 /// See also [DayViewController].
 @ProviderFor(DayViewController)

--- a/lib/features/calendar/state/time_by_category_controller.dart
+++ b/lib/features/calendar/state/time_by_category_controller.dart
@@ -77,7 +77,7 @@ class TimeByCategoryController extends _$TimeByCategoryController {
       data[day] = <CategoryDefinition?, Duration>{};
     });
 
-    final items = await db.sortedTextEntries(
+    final items = await db.sortedCalendarEntries(
       rangeStart: start,
       rangeEnd: now.add(const Duration(days: 1)).dayAtMidnight,
     );

--- a/lib/features/calendar/state/time_by_category_controller.g.dart
+++ b/lib/features/calendar/state/time_by_category_controller.g.dart
@@ -44,7 +44,7 @@ final maxCategoriesCountProvider = AutoDisposeFutureProvider<int>.internal(
 // ignore: unused_element
 typedef MaxCategoriesCountRef = AutoDisposeFutureProviderRef<int>;
 String _$timeByCategoryControllerHash() =>
-    r'1d0e809a59d324ed0caa9997f061f64677190f84';
+    r'f570caba0e728e9a1841b5c3a4d1f004d31fea25';
 
 /// See also [TimeByCategoryController].
 @ProviderFor(TimeByCategoryController)

--- a/lib/features/tasks/state/checklist_controller.g.dart
+++ b/lib/features/tasks/state/checklist_controller.g.dart
@@ -7,7 +7,7 @@ part of 'checklist_controller.dart';
 // **************************************************************************
 
 String _$checklistControllerHash() =>
-    r'e2a4cdf2c4d48fc2f99f3401696f77c51881e7dd';
+    r'fe0020d8a3f7283b2c138a756595705f8101361e';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -242,10 +242,10 @@ packages:
     dependency: "direct main"
     description:
       name: calendar_view
-      sha256: "40612640fc84b84ba6bc188315fa62b329c143b06599f00f144b5239a5b3be50"
+      sha256: "94b5ccc06f6ab11fa3e40eda19f6f925bc49a355dfad8cfafece3bad54ce9773"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   canonical_json:
     dependency: transitive
     description:
@@ -1035,10 +1035,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_quill_delta_from_html
-      sha256: "3809961f59b323e3ff368921c8f4a2ae559ff05a6bd132e565d7e6180db868e8"
+      sha256: "79405765612016de9de2361be86383360b0b43a6bf88b818c079a953583f1849"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.5"
+    version: "1.5.0"
   flutter_quill_extensions:
     dependency: "direct main"
     description:
@@ -1451,10 +1451,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_platform_interface
-      sha256: "9ec26d410ff46f483c5519c29c02ef0e02e13a543f882b152d4bfd2f06802f80"
+      sha256: "886d57f0be73c4b140004e78b9f28a8914a09e50c2d816bdd0520051a71236a0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.10.1"
   image_picker_windows:
     dependency: transitive
     description:
@@ -2200,10 +2200,10 @@ packages:
     dependency: transitive
     description:
       name: pubspec_parse
-      sha256: "81876843eb50dc2e1e5b151792c9a985c5ed2536914115ed04e9c8528f6647b0"
+      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   qr:
     dependency: transitive
     description:
@@ -3086,10 +3086,10 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics_codec
-      sha256: "2430b973a4ca3c4dbc9999b62b8c719a160100dcbae5c819bae0cacce32c9cdb"
+      sha256: "99fd9fbd34d9f9a32efd7b6a6aae14125d8237b10403b422a6a6dfeac2806146"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.12"
+    version: "1.1.13"
   vector_graphics_compiler:
     dependency: transitive
     description:
@@ -3126,10 +3126,10 @@ packages:
     dependency: transitive
     description:
       name: video_player_android
-      sha256: "391e092ba4abe2f93b3e625bd6b6a6ec7d7414279462c1c0ee42b5ab8d0a0898"
+      sha256: "7018dbcb395e2bca0b9a898e73989e67c0c4a5db269528e1b036ca38bcca0d0b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.16"
+    version: "2.7.17"
   video_player_avfoundation:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.553+2823
+version: 0.9.553+2824
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
From Copilot:
This pull request introduces new functionality for retrieving sorted calendar entries within a specified date range and updates related code to use this new functionality. The changes span multiple files, including database queries and controller classes.

Key changes include:

### Database Functionality Enhancements:
* Added a new method `sortedCalendarEntries` to the `JournalDb` class to fetch sorted calendar entries within a date range (`lib/database/database.dart`).
* Introduced a new SQL query `sortedCalenderEntriesInRange` to select entries from the `journal` table based on date range and entry type (`lib/database/database.drift`).
* Added the `sortedCalenderEntriesInRange` method to the generated database class to support the new query (`lib/database/database.g.dart`).

### Controller Updates:
* Updated `DayViewController` to use the new `sortedCalendarEntries` method instead of `sortedTextEntries` (`lib/features/calendar/state/day_view_controller.dart`).
* Updated `TimeByCategoryController` to use the new `sortedCalendarEntries` method instead of `sortedTextEntries` (`lib/features/calendar/state/time_by_category_controller.dart`).

### Miscellaneous:
* Updated hash values in generated files to reflect changes (`lib/features/calendar/state/day_view_controller.g.dart`, `lib/features/calendar/state/time_by_category_controller.g.dart`, `lib/features/tasks/state/checklist_controller.g.dart`). [[1]](diffhunk://#diff-75dd15f82237f2bb2d09a1985e0cbdbd2654096ae2310c221a8486020c9e0919L9-R9) [[2]](diffhunk://#diff-5a883185212b72fc801ca63cc226d4256d5db27f05091e21b64e5e830aa904b0L47-R47) [[3]](diffhunk://#diff-4d6baa5d2ea4626f02cd2cf46be1f711d9a5b89a80bb68f31b44b383a8ad5d27L10-R10)
* Incremented the version number in `pubspec.yaml` to `0.9.553+2824` (`pubspec.yaml`).