### PR TITLE
feat: bring back workout import

### DIFF
--- a/lib/features/dashboards/state/workout_chart_controller.dart
+++ b/lib/features/dashboards/state/workout_chart_controller.dart
@@ -5,6 +5,7 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/features/dashboards/state/workout_data.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/logic/health_import.dart';
 import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/utils/cache_extension.dart';
 import 'package:lotti/widgets/charts/utils.dart';
@@ -14,6 +15,10 @@ part 'workout_chart_controller.g.dart';
 
 @riverpod
 class WorkoutChartDataController extends _$WorkoutChartDataController {
+  WorkoutChartDataController() {
+    getIt<HealthImport>().getWorkoutsHealthDataDelta();
+  }
+
   final JournalDb _journalDb = getIt<JournalDb>();
 
   StreamSubscription<Set<String>>? _updateSubscription;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.553+2824
+version: 0.9.553+2825
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
From Copilot:
This pull request includes updates to the `workout_chart_controller.dart` and `pubspec.yaml` files. The most important changes involve adding a new import and initializing a health data fetch operation in the `WorkoutChartDataController` constructor.

### Changes:

Initialization improvements:

* [`lib/features/dashboards/state/workout_chart_controller.dart`](diffhunk://#diff-3502a1418b6ea04b8b2b01617db33962f46d5889608df79d3734d0dc9a0f9ac7R18-R21): Added a call to `getWorkoutsHealthDataDelta` in the `WorkoutChartDataController` constructor to initialize health data fetching.

Dependency updates:

* [`lib/features/dashboards/state/workout_chart_controller.dart`](diffhunk://#diff-3502a1418b6ea04b8b2b01617db33962f46d5889608df79d3734d0dc9a0f9ac7R8): Added import for `health_import.dart` to facilitate health data operations.

Version bump:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Incremented the version number from `0.9.553+2824` to `0.9.553+2825`.