### PR TITLE
feat: improve matrix service send & retry

### DIFF
--- a/lib/features/sync/matrix/send_message.dart
+++ b/lib/features/sync/matrix/send_message.dart
@@ -47,7 +47,7 @@ extension SendExtension on MatrixService {
         domain: 'MATRIX_SERVICE',
         subDomain: 'sendMatrixMsg',
       );
-      return;
+      throw Exception('Unverified Matrix devices found');
     }
 
     if (roomId == null) {
@@ -56,6 +56,7 @@ extension SendExtension on MatrixService {
         domain: 'MATRIX_SERVICE',
         subDomain: 'sendMatrixMsg',
       );
+      throw Exception(configNotFound);
     }
 
     loggingService.captureEvent(
@@ -70,6 +71,10 @@ extension SendExtension on MatrixService {
       parseCommands: false,
       parseMarkdown: false,
     );
+
+    if (eventId == null) {
+      throw Exception('Failed sending text message');
+    }
 
     incrementSentCount();
 
@@ -133,6 +138,10 @@ extension SendExtension on MatrixService {
       ),
       extraContent: {'relativePath': relativePath},
     );
+
+    if (eventId == null) {
+      throw Exception('Failed sending file');
+    }
 
     incrementSentCount();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.553+2825
+version: 0.9.554+2825
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This pull request includes several changes to improve error handling in the `MatrixService` and a version bump in the `pubspec.yaml` file. The most important changes include adding exceptions for various error conditions in the `send_message.dart` file.

Error handling improvements in `send_message.dart`:

* Added an exception for unverified Matrix devices. (`lib/features/sync/matrix/send_message.dart`)
* Added an exception for missing configuration. (`lib/features/sync/matrix/send_message.dart`)
* Added an exception for failed text message sending. (`lib/features/sync/matrix/send_message.dart`)
* Added an exception for failed file sending. (`lib/features/sync/matrix/send_message.dart`)

Version update:

* Bumped the version in `pubspec.yaml` from `0.9.553+2824` to `0.9.554+2825`. (`pubspec.yaml`)