### PR TITLE
chore: upgrade Whisperkit and Flutter dependencies

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -613,7 +613,7 @@
 			repositoryURL = "https://github.com/argmaxinc/whisperkit";
 			requirement = {
 				kind = exactVersion;
-				version = 0.10.1;
+				version = 0.10.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/argmaxinc/whisperkit",
       "state" : {
-        "revision" : "63d955bc99e4dce9ba3e733f2f8815b9a9f53eee",
-        "version" : "0.10.1"
+        "revision" : "600303e5e5f1861427ba57804ea3a5310466afe6",
+        "version" : "0.10.2"
       }
     }
   ],

--- a/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/argmaxinc/whisperkit",
       "state" : {
-        "revision" : "63d955bc99e4dce9ba3e733f2f8815b9a9f53eee",
-        "version" : "0.10.1"
+        "revision" : "600303e5e5f1861427ba57804ea3a5310466afe6",
+        "version" : "0.10.2"
       }
     }
   ],

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -708,7 +708,7 @@
 			repositoryURL = "https://github.com/argmaxinc/whisperkit";
 			requirement = {
 				kind = exactVersion;
-				version = 0.10.1;
+				version = 0.10.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/argmaxinc/whisperkit",
       "state" : {
-        "revision" : "63d955bc99e4dce9ba3e733f2f8815b9a9f53eee",
-        "version" : "0.10.1"
+        "revision" : "600303e5e5f1861427ba57804ea3a5310466afe6",
+        "version" : "0.10.2"
       }
     }
   ],

--- a/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/argmaxinc/whisperkit",
       "state" : {
-        "revision" : "63d955bc99e4dce9ba3e733f2f8815b9a9f53eee",
-        "version" : "0.10.1"
+        "revision" : "600303e5e5f1861427ba57804ea3a5310466afe6",
+        "version" : "0.10.2"
       }
     }
   ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -555,10 +555,10 @@ packages:
     dependency: "direct main"
     description:
       name: device_info_plus
-      sha256: "4fa68e53e26ab17b70ca39f072c285562cfc1589df5bb1e9295db90f6645f431"
+      sha256: b37d37c2f912ad4e8ec694187de87d05de2a3cb82b465ff1f65f65a2d05de544
       url: "https://pub.dev"
     source: hosted
-    version: "11.2.0"
+    version: "11.2.1"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -1992,10 +1992,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "70c421fe9d9cc1a9a7f3b05ae56befd469fe4f8daa3b484823141a55442d858d"
+      sha256: "739e0a5c3c4055152520fa321d0645ee98e932718b4c8efeeb51451968fe0790"
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.2"
+    version: "8.1.3"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -2545,10 +2545,10 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: "6327c3f233729374d0abaafd61f6846115b2a481b4feddd8534211dc10659400"
+      sha256: fce43200aa03ea87b91ce4c3ac79f0cecd52e2a7a56c7a4185023c271fbfa6da
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.3"
+    version: "10.1.4"
   share_plus_platform_interface:
     dependency: transitive
     description:
@@ -3158,10 +3158,10 @@ packages:
     dependency: transitive
     description:
       name: video_player_avfoundation
-      sha256: "61c54fb08fee52861d819a9b3b8e30b92456dad43a875434c677c892eb7772de"
+      sha256: "8a4e73a3faf2b13512978a43cf1cdda66feeeb900a0527f1fbfd7b19cf3458d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.6"
+    version: "2.6.7"
   video_player_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.557+2833
+version: 0.9.557+2834
 
 msix_config:
   display_name: LottiApp
@@ -45,7 +45,7 @@ dependencies:
   exif: ^3.0.1
 
   ffmpeg_kit_flutter: ^6.0.3
-  fl_chart: ^0.70.0
+  fl_chart: 0.70.0
   flex_color_scheme: ^8.0.1
   flutter:
     sdk: flutter


### PR DESCRIPTION
From Copilot:
This pull request includes updates to several dependencies and version numbers across multiple files. The most important changes are as follows:

Dependency updates:

* [`ios/Runner.xcodeproj/project.pbxproj`](diffhunk://#diff-413fd2395fd4377132c8c1135c9bc9ab215c6f97322d27717a487223bd03e2c7L616-R616): Updated `whisperkit` dependency version from `0.10.1` to `0.10.2`.
* [`macos/Runner.xcodeproj/project.pbxproj`](diffhunk://#diff-ec40d5406d2e5b54c265f64285bf1f073febb06b92a906239f8905a6244e68efL711-R711): Updated `whisperkit` dependency version from `0.10.1` to `0.10.2`.
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L48-R48): Updated `fl_chart` dependency version specification to `0.70.0` without the caret (^) symbol.

Version number updates:

* [`ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved`](diffhunk://#diff-2bbba4945556820d8d37758665ea4779d8016b7020a2601d0ee9cfcadc97ecb4L27-R28): Updated `whisperkit` version from `0.10.1` to `0.10.2` and corresponding revision.
* [`macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved`](diffhunk://#diff-2bbba4945556820d8d37758665ea4779d8016b7020a2601d0ee9cfcadc97ecb4L27-R28): Updated `whisperkit` version from `0.10.1` to `0.10.2` and corresponding revision.
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Incremented the project version from `0.9.557+2833` to `0.9.557+2834`.