### PR TITLE
fix: update task status in task form when changed via sync

### DIFF
--- a/lib/features/journal/state/entry_controller.dart
+++ b/lib/features/journal/state/entry_controller.dart
@@ -181,7 +181,6 @@ class EntryController extends _$EntryController {
       formKey.currentState?.save();
       final formData = formKey.currentState?.value ?? {};
       final title = formData['title'] as String?;
-      final status = formData['status'] as String?;
 
       await _persistenceLogic.updateTask(
         entryText: entryTextFromController(controller),
@@ -189,8 +188,6 @@ class EntryController extends _$EntryController {
         taskData: task.data.copyWith(
           title: title ?? task.data.title,
           estimate: estimate ?? task.data.estimate,
-          status:
-              status != null ? taskStatusFromString(status) : task.data.status,
         ),
       );
     }
@@ -231,6 +228,22 @@ class EntryController extends _$EntryController {
       controller: controller,
     );
     setDirty(value: false);
+    await HapticFeedback.heavyImpact();
+  }
+
+  Future<void> updateTaskStatus(String? status) async {
+    final task = state.value?.entry;
+
+    if (task is Task) {
+      await _persistenceLogic.updateTask(
+        journalEntityId: id,
+        taskData: task.data.copyWith(
+          status:
+              status != null ? taskStatusFromString(status) : task.data.status,
+        ),
+      );
+    }
+
     await HapticFeedback.heavyImpact();
   }
 

--- a/lib/features/tasks/ui/task_form.dart
+++ b/lib/features/tasks/ui/task_form.dart
@@ -114,11 +114,12 @@ class _TaskFormState extends ConsumerState<TaskForm> {
                         name: 'status',
                         borderRadius: BorderRadius.circular(10),
                         elevation: 2,
-                        onChanged: (dynamic _) => save(),
+                        onChanged: notifier.updateTaskStatus,
                         decoration: inputDecoration(
                           labelText: 'Status:',
                           themeData: Theme.of(context),
                         ),
+                        key: Key('task_status_dropdown_${taskData.status}'),
                         initialValue: taskData.status.map(
                               open: (_) => 'OPEN',
                               groomed: (_) => 'GROOMED',

--- a/lib/logic/persistence_logic.dart
+++ b/lib/logic/persistence_logic.dart
@@ -541,7 +541,7 @@ class PersistenceLogic {
           await updateDbEntity(
             task.copyWith(
               meta: await updateMetadata(journalEntity.meta),
-              entryText: entryText,
+              entryText: entryText ?? task.entryText,
               data: taskData,
             ),
           );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.557+2834
+version: 0.9.558+2835
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
From Copilot:
This pull request includes several changes to the `EntryController`, `TaskForm`, `PersistenceLogic`, and `pubspec.yaml` files to improve task status handling and update the app version.

Improvements to task status handling:

* [`lib/features/journal/state/entry_controller.dart`](diffhunk://#diff-073fb67f5d87a4ca641101e845ee4b45cc2cdb2ee4a6cd4698bb94093921c235L184-L193): Removed the status update logic from the `updateTask` method and added a new `updateTaskStatus` method to handle status updates separately. [[1]](diffhunk://#diff-073fb67f5d87a4ca641101e845ee4b45cc2cdb2ee4a6cd4698bb94093921c235L184-L193) [[2]](diffhunk://#diff-073fb67f5d87a4ca641101e845ee4b45cc2cdb2ee4a6cd4698bb94093921c235R234-R249)
* [`lib/features/tasks/ui/task_form.dart`](diffhunk://#diff-c2f40a14894d9668c8c244d4676b1ddb55c8e552328ee00bca18e5d0e12096aaL117-R122): Updated the `onChanged` callback for the status dropdown to use the new `updateTaskStatus` method and added a unique key for the dropdown.
* [`lib/logic/persistence_logic.dart`](diffhunk://#diff-7c20418a00fc5ed6612eb5686a687b56a462be0f82d669034b8ef9e73baad27eL544-R544): Ensured that the `entryText` is only updated if a new value is provided.

Version update:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Incremented the app version from `0.9.557+2834` to `0.9.558+2835`.