### PR TITLE
feat: add category filter in Logbook tab

### DIFF
--- a/lib/blocs/journal/journal_page_cubit.dart
+++ b/lib/blocs/journal/journal_page_cubit.dart
@@ -358,6 +358,8 @@ class JournalPageCubit extends Cubit<JournalPageState> {
         starredStatuses: starredEntriesOnly ? [true] : [true, false],
         privateStatuses: privateEntriesOnly ? [true] : [true, false],
         flaggedStatuses: flaggedEntriesOnly ? [1] : [1, 0],
+        categoryIds:
+            _selectedCategoryIds.isNotEmpty ? _selectedCategoryIds : null,
         limit: _pageSize,
         offset: pageKey,
       );

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -251,6 +251,7 @@ class JournalDb extends _$JournalDb {
     required List<bool> privateStatuses,
     required List<int> flaggedStatuses,
     required List<String>? ids,
+    Set<String>? categoryIds,
     int limit = 500,
     int offset = 0,
   }) async {
@@ -259,6 +260,7 @@ class JournalDb extends _$JournalDb {
       starredStatuses: starredStatuses,
       privateStatuses: privateStatuses,
       flaggedStatuses: flaggedStatuses,
+      categoryIds: categoryIds?.toList(),
       ids: ids,
       limit: limit,
       offset: offset,
@@ -299,6 +301,7 @@ class JournalDb extends _$JournalDb {
     required List<bool> privateStatuses,
     required List<int> flaggedStatuses,
     required List<String>? ids,
+    required List<String>? categoryIds,
     int limit = 500,
     int offset = 0,
   }) {
@@ -309,6 +312,16 @@ class JournalDb extends _$JournalDb {
         starredStatuses,
         privateStatuses,
         flaggedStatuses,
+        limit,
+        offset,
+      );
+    } else if (categoryIds != null) {
+      return filteredJournalByCategories(
+        types,
+        starredStatuses,
+        privateStatuses,
+        flaggedStatuses,
+        categoryIds,
         limit,
         offset,
       );

--- a/lib/database/database.drift
+++ b/lib/database/database.drift
@@ -187,6 +187,19 @@ SELECT * FROM journal
   LIMIT :limit
   OFFSET :offset;
 
+filteredJournalByCategories:
+SELECT * FROM journal
+  WHERE type IN :types
+  AND deleted = false
+  AND private IN (0, (SELECT status FROM config_flags WHERE name = 'private'))
+  AND starred IN :starredStatuses
+  AND private IN :privateStatuses
+  AND flag IN :flaggedStatuses
+  AND category IN :categories
+  ORDER BY date_from DESC
+  LIMIT :limit
+  OFFSET :offset;
+
 filteredJournalIds:
 SELECT id FROM journal
   WHERE type IN :types

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -4728,6 +4728,45 @@ abstract class _$JournalDb extends GeneratedDatabase {
         }).asyncMap(journal.mapFromRow);
   }
 
+  Selectable<JournalDbEntity> filteredJournalByCategories(
+      List<String> types,
+      List<bool> starredStatuses,
+      List<bool> privateStatuses,
+      List<int> flaggedStatuses,
+      List<String> categories,
+      int limit,
+      int offset) {
+    var $arrayStartIndex = 3;
+    final expandedtypes = $expandVar($arrayStartIndex, types.length);
+    $arrayStartIndex += types.length;
+    final expandedstarredStatuses =
+        $expandVar($arrayStartIndex, starredStatuses.length);
+    $arrayStartIndex += starredStatuses.length;
+    final expandedprivateStatuses =
+        $expandVar($arrayStartIndex, privateStatuses.length);
+    $arrayStartIndex += privateStatuses.length;
+    final expandedflaggedStatuses =
+        $expandVar($arrayStartIndex, flaggedStatuses.length);
+    $arrayStartIndex += flaggedStatuses.length;
+    final expandedcategories = $expandVar($arrayStartIndex, categories.length);
+    $arrayStartIndex += categories.length;
+    return customSelect(
+        'SELECT * FROM journal WHERE type IN ($expandedtypes) AND deleted = FALSE AND private IN (0, (SELECT status FROM config_flags WHERE name = \'private\')) AND starred IN ($expandedstarredStatuses) AND private IN ($expandedprivateStatuses) AND flag IN ($expandedflaggedStatuses) AND category IN ($expandedcategories) ORDER BY date_from DESC LIMIT ?1 OFFSET ?2',
+        variables: [
+          Variable<int>(limit),
+          Variable<int>(offset),
+          for (var $ in types) Variable<String>($),
+          for (var $ in starredStatuses) Variable<bool>($),
+          for (var $ in privateStatuses) Variable<bool>($),
+          for (var $ in flaggedStatuses) Variable<int>($),
+          for (var $ in categories) Variable<String>($)
+        ],
+        readsFrom: {
+          journal,
+          configFlags,
+        }).asyncMap(journal.mapFromRow);
+  }
+
   Selectable<String> filteredJournalIds(
       List<String> types,
       List<bool> starredStatuses,

--- a/lib/features/journal/ui/widgets/journal_card.dart
+++ b/lib/features/journal/ui/widgets/journal_card.dart
@@ -56,14 +56,27 @@ class JournalCardTitle extends StatelessWidget {
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Text(
-                item is JournalEvent
-                    ? dfShort.format(item.meta.dateFrom)
-                    : dfShorter.format(item.meta.dateFrom),
-                style: monospaceTextStyle,
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    item is JournalEvent
+                        ? dfShort.format(item.meta.dateFrom)
+                        : dfShorter.format(item.meta.dateFrom),
+                    style: monospaceTextStyle,
+                  ),
+                  if (item is! ChecklistItem &&
+                      item is! Checklist &&
+                      item is! HabitCompletionEntry &&
+                      item is! MeasurementEntry &&
+                      item is! WorkoutEntry &&
+                      item is! QuantitativeEntry &&
+                      item is! SurveyEntry) ...[
+                    const SizedBox(width: 20),
+                    CategoryColorIcon(item.meta.categoryId),
+                  ],
+                ],
               ),
-              if (item is Task)
-                CategoryColorIcon((item as Task).meta.categoryId),
               if (item is Task) TaskStatusWidget(item as Task),
               Row(
                 children: [

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -330,7 +330,7 @@
   "syncAssistantStatusSuccess": "Account is successfully configured.",
   "syncAssistantStatusTesting": "Testing IMAP connection...",
   "syncAssistantStatusValid": "Account is valid.",
-  "taskCategoryLabel": "Task category:",
+  "taskCategoryLabel": "Category:",
   "taskCategoryUnassignedLabel": "unassigned",
   "taskCategoryAllLabel": "all",
   "taskDueLabel": "Task due:",

--- a/lib/widgets/app_bar/journal_sliver_appbar.dart
+++ b/lib/widgets/app_bar/journal_sliver_appbar.dart
@@ -7,6 +7,7 @@ import 'package:lotti/themes/theme.dart';
 import 'package:lotti/utils/modals.dart';
 import 'package:lotti/widgets/search/entry_type_filter.dart';
 import 'package:lotti/widgets/search/search_widget.dart';
+import 'package:lotti/widgets/search/task_category_filter.dart';
 import 'package:lotti/widgets/search/task_filter_icon.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
@@ -40,8 +41,10 @@ class JournalSliverAppBar extends StatelessWidget {
                       onChanged: cubit.setSearchString,
                     ),
                   ),
-                  if (showTasks) const TaskFilterIcon(),
-                  if (!showTasks) const JournalFilterIcon(),
+                  if (showTasks)
+                    const TaskFilterIcon()
+                  else
+                    const JournalFilterIcon(),
                 ],
               ),
             ],
@@ -136,10 +139,13 @@ class JournalFilterIcon extends StatelessWidget {
               );
             },
             builder: (_) => const Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 JournalFilter(),
                 SizedBox(height: 10),
                 EntryTypeFilter(),
+                SizedBox(height: 10),
+                TaskCategoryFilter(),
               ],
             ),
           );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.560+2842
+version: 0.9.561+2843
 
 msix_config:
   display_name: LottiApp

--- a/test/features/journal/ui/pages/entry_detail_page_test.dart
+++ b/test/features/journal/ui/pages/entry_detail_page_test.dart
@@ -24,10 +24,10 @@ import 'package:lotti/utils/consts.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path_provider/path_provider.dart';
 
-import '../../helpers/path_provider.dart';
-import '../../mocks/mocks.dart';
-import '../../test_data/test_data.dart';
-import '../../widget_test_utils.dart';
+import '../../../../helpers/path_provider.dart';
+import '../../../../mocks/mocks.dart';
+import '../../../../test_data/test_data.dart';
+import '../../../../widget_test_utils.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/features/journal/ui/pages/infinite_journal_page_test.dart
+++ b/test/features/journal/ui/pages/infinite_journal_page_test.dart
@@ -29,11 +29,11 @@ import 'package:mocktail/mocktail.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:visibility_detector/visibility_detector.dart';
 
-import '../../helpers/path_provider.dart';
-import '../../mocks/mocks.dart';
-import '../../test_data/test_data.dart';
-import '../../utils/utils.dart';
-import '../../widget_test_utils.dart';
+import '../../../../helpers/path_provider.dart';
+import '../../../../mocks/mocks.dart';
+import '../../../../test_data/test_data.dart';
+import '../../../../utils/utils.dart';
+import '../../../../widget_test_utils.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/features/journal/ui/widgets/editor/editor_widget_test.dart
+++ b/test/features/journal/ui/widgets/editor/editor_widget_test.dart
@@ -16,9 +16,9 @@ import 'package:lotti/services/time_service.dart';
 import 'package:lotti/services/vector_clock_service.dart';
 import 'package:mocktail/mocktail.dart';
 
-import '../../../mocks/mocks.dart';
-import '../../../test_data/test_data.dart';
-import '../../../widget_test_utils.dart';
+import '../../../../../mocks/mocks.dart';
+import '../../../../../test_data/test_data.dart';
+import '../../../../../widget_test_utils.dart';
 
 void main() {
   group('EditorWidget', () {

--- a/test/features/journal/ui/widgets/entry_details/delete_icon_widget_test.dart
+++ b/test/features/journal/ui/widgets/entry_details/delete_icon_widget_test.dart
@@ -11,9 +11,9 @@ import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/services/notification_service.dart';
 import 'package:mocktail/mocktail.dart';
 
-import '../../../mocks/mocks.dart';
-import '../../../test_data/test_data.dart';
-import '../../../widget_test_utils.dart';
+import '../../../../../mocks/mocks.dart';
+import '../../../../../test_data/test_data.dart';
+import '../../../../../widget_test_utils.dart';
 
 void main() {
   group('DeleteIconWidget', () {

--- a/test/features/journal/ui/widgets/entry_details/entry_datetime_widget_test.dart
+++ b/test/features/journal/ui/widgets/entry_details/entry_datetime_widget_test.dart
@@ -10,9 +10,9 @@ import 'package:lotti/services/editor_state_service.dart';
 import 'package:lotti/services/tags_service.dart';
 import 'package:mocktail/mocktail.dart';
 
-import '../../../mocks/mocks.dart';
-import '../../../test_data/test_data.dart';
-import '../../../widget_test_utils.dart';
+import '../../../../../mocks/mocks.dart';
+import '../../../../../test_data/test_data.dart';
+import '../../../../../widget_test_utils.dart';
 
 void main() {
   group('EntryDetailFooter', () {

--- a/test/features/journal/ui/widgets/entry_details/entry_detail_footer_test.dart
+++ b/test/features/journal/ui/widgets/entry_details/entry_detail_footer_test.dart
@@ -15,9 +15,9 @@ import 'package:lotti/services/tags_service.dart';
 import 'package:lotti/services/time_service.dart';
 import 'package:mocktail/mocktail.dart';
 
-import '../../../mocks/mocks.dart';
-import '../../../test_data/test_data.dart';
-import '../../../widget_test_utils.dart';
+import '../../../../../mocks/mocks.dart';
+import '../../../../../test_data/test_data.dart';
+import '../../../../../widget_test_utils.dart';
 
 void main() {
   group('EntryDetailFooter', () {

--- a/test/features/journal/ui/widgets/entry_details/entry_detail_header_test.dart
+++ b/test/features/journal/ui/widgets/entry_details/entry_detail_header_test.dart
@@ -14,9 +14,9 @@ import 'package:lotti/services/tags_service.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:mocktail/mocktail.dart';
 
-import '../../../mocks/mocks.dart';
-import '../../../test_data/test_data.dart';
-import '../../../widget_test_utils.dart';
+import '../../../../../mocks/mocks.dart';
+import '../../../../../test_data/test_data.dart';
+import '../../../../../widget_test_utils.dart';
 
 void main() {
   group('EntryDetailHeader', () {

--- a/test/features/journal/ui/widgets/entry_details/measurement_summary_test.dart
+++ b/test/features/journal/ui/widgets/entry_details/measurement_summary_test.dart
@@ -6,9 +6,9 @@ import 'package:lotti/logic/health_import.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:mocktail/mocktail.dart';
 
-import '../../../mocks/mocks.dart';
-import '../../../test_data/test_data.dart';
-import '../../../widget_test_utils.dart';
+import '../../../../../mocks/mocks.dart';
+import '../../../../../test_data/test_data.dart';
+import '../../../../../widget_test_utils.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/features/journal/ui/widgets/entry_details/share_button_widget_test.dart
+++ b/test/features/journal/ui/widgets/entry_details/share_button_widget_test.dart
@@ -13,10 +13,10 @@ import 'package:material_design_icons_flutter/material_design_icons_flutter.dart
 import 'package:mocktail/mocktail.dart';
 import 'package:path_provider/path_provider.dart';
 
-import '../../../helpers/path_provider.dart';
-import '../../../mocks/mocks.dart';
-import '../../../test_data/test_data.dart';
-import '../../../widget_test_utils.dart';
+import '../../../../../helpers/path_provider.dart';
+import '../../../../../mocks/mocks.dart';
+import '../../../../../test_data/test_data.dart';
+import '../../../../../widget_test_utils.dart';
 
 void main() {
   group('ShareButtonWidget', () {

--- a/test/features/journal/ui/widgets/entry_details/survey_summary_test.dart
+++ b/test/features/journal/ui/widgets/entry_details/survey_summary_test.dart
@@ -8,8 +8,8 @@ import 'package:lotti/features/journal/ui/widgets/entry_details/survey_summary.d
 import 'package:lotti/get_it.dart';
 import 'package:mocktail/mocktail.dart';
 
-import '../../../mocks/mocks.dart';
-import '../../../widget_test_utils.dart';
+import '../../../../../mocks/mocks.dart';
+import '../../../../../widget_test_utils.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/features/journal/ui/widgets/entry_details/workout_summary_test.dart
+++ b/test/features/journal/ui/widgets/entry_details/workout_summary_test.dart
@@ -5,9 +5,9 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/health_import.dart';
 import 'package:mocktail/mocktail.dart';
 
-import '../../../mocks/mocks.dart';
-import '../../../test_data/test_data.dart';
-import '../../../widget_test_utils.dart';
+import '../../../../../mocks/mocks.dart';
+import '../../../../../test_data/test_data.dart';
+import '../../../../../widget_test_utils.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/features/journal/ui/widgets/journal_card_test.dart
+++ b/test/features/journal/ui/widgets/journal_card_test.dart
@@ -19,11 +19,11 @@ import 'package:lotti/services/time_service.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path_provider/path_provider.dart';
 
-import '../../helpers/path_provider.dart';
-import '../../mocks/mocks.dart';
-import '../../test_data/test_data.dart';
-import '../../utils/utils.dart';
-import '../../widget_test_utils.dart';
+import '../../../../helpers/path_provider.dart';
+import '../../../../mocks/mocks.dart';
+import '../../../../test_data/test_data.dart';
+import '../../../../utils/utils.dart';
+import '../../../../widget_test_utils.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/features/journal/ui/widgets/tags/tag_add_test.dart
+++ b/test/features/journal/ui/widgets/tags/tag_add_test.dart
@@ -11,9 +11,9 @@ import 'package:lotti/services/tags_service.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:mocktail/mocktail.dart';
 
-import '../../../mocks/mocks.dart';
-import '../../../test_data/test_data.dart';
-import '../../../widget_test_utils.dart';
+import '../../../../../mocks/mocks.dart';
+import '../../../../../test_data/test_data.dart';
+import '../../../../../widget_test_utils.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/features/journal/ui/widgets/tags/tag_widget_test.dart
+++ b/test/features/journal/ui/widgets/tags/tag_widget_test.dart
@@ -4,8 +4,8 @@ import 'package:lotti/features/journal/ui/widgets/tags/tag_widget.dart';
 import 'package:lotti/themes/colors.dart';
 import 'package:mocktail/mocktail.dart';
 
-import '../../../test_data/test_data.dart';
-import '../../../widget_test_utils.dart';
+import '../../../../../test_data/test_data.dart';
+import '../../../../../widget_test_utils.dart';
 
 class TestCallbackClass {
   void onTapRemove() {}

--- a/test/features/journal/ui/widgets/tags/tags_modal_widget_test.dart
+++ b/test/features/journal/ui/widgets/tags/tags_modal_widget_test.dart
@@ -17,10 +17,10 @@ import 'package:lotti/services/vector_clock_service.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:mocktail/mocktail.dart';
 
-import '../../../mocks/mocks.dart';
-import '../../../mocks/sync_config_test_mocks.dart';
-import '../../../test_data/test_data.dart';
-import '../../../widget_test_utils.dart';
+import '../../../../../mocks/mocks.dart';
+import '../../../../../mocks/sync_config_test_mocks.dart';
+import '../../../../../test_data/test_data.dart';
+import '../../../../../widget_test_utils.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/features/journal/ui/widgets/tags/tags_view_widget_test.dart
+++ b/test/features/journal/ui/widgets/tags/tags_view_widget_test.dart
@@ -5,9 +5,9 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/services/tags_service.dart';
 import 'package:mocktail/mocktail.dart';
 
-import '../../../mocks/mocks.dart';
-import '../../../test_data/test_data.dart';
-import '../../../widget_test_utils.dart';
+import '../../../../../mocks/mocks.dart';
+import '../../../../../test_data/test_data.dart';
+import '../../../../../widget_test_utils.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/widgets/journal/journal_card_test.dart
+++ b/test/widgets/journal/journal_card_test.dart
@@ -12,6 +12,7 @@ import 'package:lotti/features/speech/state/asr_service.dart';
 import 'package:lotti/features/speech/state/player_cubit.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/db_notification.dart';
+import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/tags_service.dart';
 import 'package:lotti/services/time_service.dart';
@@ -41,6 +42,7 @@ void main() {
 
       final mockTagsService = mockTagsServiceWithTags([]);
       final mockTimeService = MockTimeService();
+      final mockEntitiesCacheService = MockEntitiesCacheService();
 
       final mockUpdateNotifications = MockUpdateNotifications();
       when(() => mockUpdateNotifications.updateStream).thenAnswer(
@@ -49,6 +51,7 @@ void main() {
 
       getIt
         ..registerSingleton<Directory>(await getApplicationDocumentsDirectory())
+        ..registerSingleton<EntitiesCacheService>(mockEntitiesCacheService)
         ..registerSingleton<UpdateNotifications>(mockUpdateNotifications)
         ..registerSingleton<LoggingDb>(MockLoggingDb())
         ..registerSingleton<LoggingService>(LoggingService())


### PR DESCRIPTION
From Copilot:
This pull request introduces several changes to the `Journal` feature, focusing on adding category filtering capabilities and renaming test files for better organization. The most important changes include updates to the database queries to support category filtering, adjustments to the UI to display category information, and renaming test files to reflect their new locations.

### Category Filtering Enhancements:
* [`lib/blocs/journal/journal_page_cubit.dart`](diffhunk://#diff-33f77896ed78898e42dd43a1ddeb6fda349c8ca55068b2ec7c71a45a6aa833b3R361-R362): Added logic to include category IDs in the query parameters for fetching journal entries.
* [`lib/database/database.dart`](diffhunk://#diff-58403ca793c79f9cac8520ba22f0b9cb3527232f194f5feefdda0a1089aff2b1R254): Updated the `JournalDb` class to handle category IDs in journal entry queries and added a new query method `filteredJournalByCategories`. [[1]](diffhunk://#diff-58403ca793c79f9cac8520ba22f0b9cb3527232f194f5feefdda0a1089aff2b1R254) [[2]](diffhunk://#diff-58403ca793c79f9cac8520ba22f0b9cb3527232f194f5feefdda0a1089aff2b1R263) [[3]](diffhunk://#diff-58403ca793c79f9cac8520ba22f0b9cb3527232f194f5feefdda0a1089aff2b1R304) [[4]](diffhunk://#diff-58403ca793c79f9cac8520ba22f0b9cb3527232f194f5feefdda0a1089aff2b1R318-R327)
* [`lib/database/database.drift`](diffhunk://#diff-f15738f2bc6c1b31110fb4764da8e38d087199352136230dff90e7af2390d3fcR190-R202): Added a new SQL query `filteredJournalByCategories` to filter journal entries by categories.
* [`lib/database/database.g.dart`](diffhunk://#diff-f2e06c503fca0bd510178a88926212593efb49183357afcb5e852f59fac63676R4731-R4769): Implemented the `filteredJournalByCategories` method to execute the new SQL query.

### UI Adjustments:
* [`lib/features/journal/ui/widgets/journal_card.dart`](diffhunk://#diff-83cffd946045977273d7f4ff6e4ec3c4b7c44a4e25b296436582954522988d38R58-R79): Modified the `JournalCardTitle` widget to conditionally display the category color icon based on the entry type.
* [`lib/l10n/app_en.arb`](diffhunk://#diff-9796fde3771f42a3a759ccc941731d83f96037a661e47dde27ce81d3447a69c2L333-R333): Updated the label for task categories from "Task category:" to "Category:".
* [`lib/widgets/app_bar/journal_sliver_appbar.dart`](diffhunk://#diff-75b5099bd4bcc66c8a088ded0bd68d6e691b08d4e49f8fe5c064f48b15a1016aR10): Added the `TaskCategoryFilter` widget to the journal filter options. [[1]](diffhunk://#diff-75b5099bd4bcc66c8a088ded0bd68d6e691b08d4e49f8fe5c064f48b15a1016aR10) [[2]](diffhunk://#diff-75b5099bd4bcc66c8a088ded0bd68d6e691b08d4e49f8fe5c064f48b15a1016aL43-R47) [[3]](diffhunk://#diff-75b5099bd4bcc66c8a088ded0bd68d6e691b08d4e49f8fe5c064f48b15a1016aR142-R148)

### Test File Renaming:
* Renamed several test files to better reflect their new locations and improved import paths accordingly. [[1]](diffhunk://#diff-966fa825c87fc422951ff8d8e4660bd3ccb245fc9166dcdf425d01382fa836a5L27-R30) [[2]](diffhunk://#diff-b4ac96ba391038a1d1f86990876275e7cebfb2e58617b9d71c5c721c628a1919L32-R36) [[3]](diffhunk://#diff-e0edfe19b8dc35912ab7ed0fecc31ad53ad5d7ca2b622f3642a3cc78996ffae1L19-R21) [[4]](diffhunk://#diff-841b5ecf0eb708b8ce441d6beb12781e8373030800b628581b5fd0a65c40fa59L14-R16) [[5]](diffhunk://#diff-dfa59085e3b4cc4bdb9dd08baf8031ae9bea56ec34659796e78e4ec60fbf860dL13-R15) [[6]](diffhunk://#diff-56d14c87f5ffed2934efcace8ba4642ba76b445338ec87ac75db5646e33e9edcL18-R20) [[7]](diffhunk://#diff-9acb630b288e0d20ff5e8069b742198607390f1e0e5baa88603661ff301aecf9L17-R19) [[8]](diffhunk://#diff-7f154bb25ad978d7e74d080fcb644d3013b10bbf0852740501cf01868717d7c7L9-R11) [[9]](diffhunk://#diff-63aa6da652c3dee5df72eac9a6263eee1e3f4b0e9814a6bf78e81e9023113c57L16-R19) [[10]](diffhunk://#diff-662a7bde252dbf48cf8daa349bc6f98d0ae4325b920af154e649cf9381ee48b8L11-R12) [[11]](diffhunk://#diff-48fb376bb2e4586a39b2dcca8c419bb00f0994c9e83cc2c5b949c8c697c1c13fL8-R10) [[12]](diffhunk://#diff-6b0a4aebfd936544893a3f4ff63a9404ce5c430607ef33dd9bf0138ea7fa6787R15-R26) [[13]](diffhunk://#diff-6b0a4aebfd936544893a3f4ff63a9404ce5c430607ef33dd9bf0138ea7fa6787R45)

### Miscellaneous:
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Incremented the version number of the project.