### PR TITLE
feat: assign category on entry creation

### DIFF
--- a/lib/beamer/locations/journal_location.dart
+++ b/lib/beamer/locations/journal_location.dart
@@ -24,6 +24,7 @@ class JournalLocation extends BeamLocation<BeamState> {
 
     final entryId = state.pathParameters['entryId'];
     final linkedId = state.pathParameters['linkedId'];
+    final categoryId = state.queryParameters['categoryId'];
 
     return [
       const BeamPage(
@@ -46,7 +47,7 @@ class JournalLocation extends BeamLocation<BeamState> {
       if (pathContains('record_audio/'))
         BeamPage(
           key: ValueKey('record_audio-$linkedId'),
-          child: RecordAudioPage(linkedId: linkedId),
+          child: RecordAudioPage(linkedId: linkedId, categoryId: categoryId),
         ),
     ];
   }

--- a/lib/beamer/locations/tasks_location.dart
+++ b/lib/beamer/locations/tasks_location.dart
@@ -21,6 +21,7 @@ class TasksLocation extends BeamLocation<BeamState> {
 
     final entryId = state.pathParameters['entryId'];
     final linkedId = state.pathParameters['linkedId'];
+    final categoryId = state.queryParameters['categoryId'];
 
     return [
       const BeamPage(
@@ -36,7 +37,7 @@ class TasksLocation extends BeamLocation<BeamState> {
       if (pathContains('record_audio/'))
         BeamPage(
           key: ValueKey('record_audio-$linkedId'),
-          child: RecordAudioPage(linkedId: linkedId),
+          child: RecordAudioPage(linkedId: linkedId, categoryId: categoryId),
         ),
     ];
   }

--- a/lib/features/dashboards/state/chart_scale_controller.dart
+++ b/lib/features/dashboards/state/chart_scale_controller.dart
@@ -11,7 +11,6 @@ class BarWidthController extends _$BarWidthController {
   }
 
   void updateScale(Matrix4 scale) {
-    final scaleX = scale.row0.x;
-    state = scaleX.floorToDouble();
+    state = scale.row0.x;
   }
 }

--- a/lib/features/journal/repository/journal_repository.dart
+++ b/lib/features/journal/repository/journal_repository.dart
@@ -128,13 +128,17 @@ class JournalRepository {
     required DateTime started,
     required String id,
     String? linkedId,
+    String? categoryId,
   }) async {
     try {
       final persistenceLogic = getIt<PersistenceLogic>();
 
       final journalEntity = JournalEntity.journalEntry(
         entryText: entryText,
-        meta: await persistenceLogic.createMetadata(dateFrom: started),
+        meta: await persistenceLogic.createMetadata(
+          dateFrom: started,
+          categoryId: categoryId,
+        ),
       );
 
       await persistenceLogic.createDbEntity(journalEntity, linkedId: linkedId);
@@ -154,6 +158,7 @@ class JournalRepository {
   static Future<JournalEntity?> createImageEntry(
     ImageData imageData, {
     String? linkedId,
+    String? categoryId,
   }) async {
     try {
       final persistenceLogic = getIt<PersistenceLogic>();
@@ -165,6 +170,7 @@ class JournalRepository {
           dateTo: imageData.capturedAt,
           uuidV5Input: json.encode(imageData),
           flag: EntryFlag.import,
+          categoryId: categoryId,
         ),
         geolocation: imageData.geolocation,
       );

--- a/lib/features/journal/ui/pages/infinite_journal_page.dart
+++ b/lib/features/journal/ui/pages/infinite_journal_page.dart
@@ -32,27 +32,27 @@ class InfiniteJournalPage extends StatelessWidget {
     return BlocProvider<JournalPageCubit>(
       create: (BuildContext context) => JournalPageCubit(showTasks: showTasks),
       child: Scaffold(
-        floatingActionButton: showTasks
-            ? BlocBuilder<JournalPageCubit, JournalPageState>(
-                builder: (context, snapshot) {
-                  return FloatingAddIcon(
+        floatingActionButton: BlocBuilder<JournalPageCubit, JournalPageState>(
+          builder: (context, snapshot) {
+            final selectedCategoryIds = snapshot.selectedCategoryIds;
+            final categoryId = selectedCategoryIds.length == 1
+                ? selectedCategoryIds.first
+                : null;
+
+            return showTasks
+                ? FloatingAddIcon(
                     createFn: () async {
-                      final selectedCategoryIds = snapshot.selectedCategoryIds;
-                      final task = await createTask(
-                        categoryId: selectedCategoryIds.length == 1
-                            ? selectedCategoryIds.first
-                            : null,
-                      );
+                      final task = await createTask(categoryId: categoryId);
                       if (task != null) {
                         getIt<NavService>()
                             .beamToNamed('/tasks/${task.meta.id}');
                       }
                     },
                     semanticLabel: context.messages.addActionAddTask,
-                  );
-                },
-              )
-            : const FloatingAddActionButton(),
+                  )
+                : FloatingAddActionButton(categoryId: categoryId);
+          },
+        ),
         body: InfiniteJournalPageBody(
           showTasks: showTasks,
         ),

--- a/lib/features/journal/ui/widgets/create/create_entry_action_list_tile.dart
+++ b/lib/features/journal/ui/widgets/create/create_entry_action_list_tile.dart
@@ -11,10 +11,12 @@ import 'package:material_design_icons_flutter/material_design_icons_flutter.dart
 class CreateTextEntryListTile extends StatelessWidget {
   const CreateTextEntryListTile(
     this.linkedFromId, {
+    this.categoryId,
     super.key,
   });
 
   final String? linkedFromId;
+  final String? categoryId;
 
   @override
   Widget build(BuildContext context) {
@@ -23,7 +25,7 @@ class CreateTextEntryListTile extends StatelessWidget {
       title: Text(context.messages.addActionAddText),
       onTap: () {
         Navigator.of(context).pop();
-        createTextEntry(linkedId: linkedFromId);
+        createTextEntry(linkedId: linkedFromId, categoryId: categoryId);
       },
     );
   }
@@ -32,10 +34,12 @@ class CreateTextEntryListTile extends StatelessWidget {
 class CreateScreenshotListTile extends StatelessWidget {
   const CreateScreenshotListTile(
     this.linkedFromId, {
+    this.categoryId,
     super.key,
   });
 
   final String? linkedFromId;
+  final String? categoryId;
 
   @override
   Widget build(BuildContext context) {
@@ -43,7 +47,7 @@ class CreateScreenshotListTile extends StatelessWidget {
       leading: Icon(MdiIcons.monitorScreenshot),
       title: Text(context.messages.addActionAddScreenshot),
       onTap: () {
-        createScreenshot(linkedId: linkedFromId);
+        createScreenshot(linkedId: linkedFromId, categoryId: categoryId);
         Navigator.of(context).pop();
       },
     );
@@ -77,10 +81,12 @@ class CreateTimerListTile extends ConsumerWidget {
 class CreateAudioRecordingListTile extends StatelessWidget {
   const CreateAudioRecordingListTile(
     this.linkedFromId, {
+    this.categoryId,
     super.key,
   });
 
   final String? linkedFromId;
+  final String? categoryId;
 
   @override
   Widget build(BuildContext context) {
@@ -90,9 +96,15 @@ class CreateAudioRecordingListTile extends StatelessWidget {
       onTap: () {
         Navigator.of(context).pop();
         if (getIt<NavService>().isTasksTabActive()) {
-          beamToNamed('/tasks/$linkedFromId/record_audio/$linkedFromId');
+          beamToNamed(
+            '/tasks/$linkedFromId/record_audio/$linkedFromId?categoryId=$categoryId',
+            data: {'categoryId': categoryId},
+          );
         } else {
-          beamToNamed('/journal/$linkedFromId/record_audio/$linkedFromId');
+          beamToNamed(
+            '/journal/$linkedFromId/record_audio/$linkedFromId?categoryId=$categoryId',
+            data: {'categoryId': categoryId},
+          );
         }
       },
     );
@@ -133,10 +145,12 @@ class CreateTaskListTile extends StatelessWidget {
 class CreateEventListTile extends StatelessWidget {
   const CreateEventListTile(
     this.linkedFromId, {
+    this.categoryId,
     super.key,
   });
 
   final String? linkedFromId;
+  final String? categoryId;
 
   @override
   Widget build(BuildContext context) {
@@ -148,6 +162,7 @@ class CreateEventListTile extends StatelessWidget {
 
         final event = await createEvent(
           linkedId: linkedFromId,
+          categoryId: categoryId,
         );
 
         if (event != null) {
@@ -161,10 +176,12 @@ class CreateEventListTile extends StatelessWidget {
 class ImportImageAssetsListTile extends StatelessWidget {
   const ImportImageAssetsListTile(
     this.linkedFromId, {
+    this.categoryId,
     super.key,
   });
 
   final String? linkedFromId;
+  final String? categoryId;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/journal/ui/widgets/create/create_entry_action_modal.dart
+++ b/lib/features/journal/ui/widgets/create/create_entry_action_modal.dart
@@ -16,13 +16,14 @@ class CreateEntryModal {
       title: context.messages.createEntryTitle,
       builder: (_) => Column(
         children: [
-          CreateEventListTile(linkedFromId),
+          CreateEventListTile(linkedFromId, categoryId: categoryId),
           CreateTaskListTile(linkedFromId, categoryId: categoryId),
-          CreateAudioRecordingListTile(linkedFromId),
+          CreateAudioRecordingListTile(linkedFromId, categoryId: categoryId),
           if (linkedFromId != null) CreateTimerListTile(linkedFromId),
-          CreateTextEntryListTile(linkedFromId),
-          ImportImageAssetsListTile(linkedFromId),
-          if (isMacOS) CreateScreenshotListTile(linkedFromId),
+          CreateTextEntryListTile(linkedFromId, categoryId: categoryId),
+          ImportImageAssetsListTile(linkedFromId, categoryId: categoryId),
+          if (isMacOS)
+            CreateScreenshotListTile(linkedFromId, categoryId: categoryId),
           verticalModalSpacer,
         ],
       ),

--- a/lib/features/speech/repository/speech_repository.dart
+++ b/lib/features/speech/repository/speech_repository.dart
@@ -17,6 +17,7 @@ class SpeechRepository {
     AudioNote audioNote, {
     required String? language,
     String? linkedId,
+    String? categoryId,
   }) async {
     try {
       final persistenceLogic = getIt<PersistenceLogic>();
@@ -45,6 +46,7 @@ class SpeechRepository {
           dateTo: dateTo,
           uuidV5Input: json.encode(audioData),
           flag: EntryFlag.import,
+          categoryId: categoryId,
         ),
       );
       await persistenceLogic.createDbEntity(journalEntity, linkedId: linkedId);

--- a/lib/features/speech/state/recorder_cubit.dart
+++ b/lib/features/speech/state/recorder_cubit.dart
@@ -43,6 +43,7 @@ class AudioRecorderCubit extends Cubit<AudioRecorderState> {
   final LoggingService _loggingService = getIt<LoggingService>();
   final PersistenceLogic persistenceLogic = getIt<PersistenceLogic>();
   String? _linkedId;
+  String? _categoryId;
   String? _language;
   AudioNote? _audioNote;
 
@@ -110,6 +111,7 @@ class AudioRecorderCubit extends Cubit<AudioRecorderState> {
           _audioNote!,
           language: _language,
           linkedId: _linkedId,
+          categoryId: _categoryId,
         );
         _linkedId = null;
         final entryId = journalAudio?.meta.id;
@@ -148,5 +150,10 @@ class AudioRecorderCubit extends Cubit<AudioRecorderState> {
     await super.close();
     await _audioRecorder.dispose();
     await _amplitudeSub?.cancel();
+  }
+
+  // ignore: use_setters_to_change_properties
+  void setCategoryId(String? categoryId) {
+    _categoryId = categoryId;
   }
 }

--- a/lib/features/speech/ui/pages/record_audio_page.dart
+++ b/lib/features/speech/ui/pages/record_audio_page.dart
@@ -7,8 +7,11 @@ class RecordAudioPage extends StatelessWidget {
   const RecordAudioPage({
     super.key,
     this.linkedId,
+    this.categoryId,
   });
+
   final String? linkedId;
+  final String? categoryId;
 
   @override
   Widget build(BuildContext context) {
@@ -16,7 +19,12 @@ class RecordAudioPage extends StatelessWidget {
       appBar: TitleAppBar(title: context.messages.addAudioTitle),
       body: Column(
         mainAxisAlignment: MainAxisAlignment.center,
-        children: [AudioRecorderWidget(linkedId: linkedId)],
+        children: [
+          AudioRecorderWidget(
+            linkedId: linkedId,
+            categoryId: categoryId,
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/speech/ui/widgets/audio_recorder.dart
+++ b/lib/features/speech/ui/widgets/audio_recorder.dart
@@ -19,9 +19,11 @@ class AudioRecorderWidget extends ConsumerWidget {
   const AudioRecorderWidget({
     super.key,
     this.linkedId,
+    this.categoryId,
   });
 
   final String? linkedId;
+  final String? categoryId;
 
   String formatDuration(String str) {
     return str.substring(0, str.length - 7);
@@ -31,7 +33,8 @@ class AudioRecorderWidget extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return BlocBuilder<AudioRecorderCubit, AudioRecorderState>(
       builder: (context, state) {
-        final cubit = context.read<AudioRecorderCubit>();
+        final cubit = context.read<AudioRecorderCubit>()
+          ..setCategoryId(categoryId);
 
         Future<void> stop() async {
           final entryId = await cubit.stop();

--- a/lib/logic/create/create_entry.dart
+++ b/lib/logic/create/create_entry.dart
@@ -13,11 +13,13 @@ import 'package:lotti/services/time_service.dart';
 import 'package:lotti/utils/file_utils.dart';
 import 'package:lotti/utils/screenshots.dart';
 
-Future<JournalEntity?> createTextEntry({String? linkedId}) async {
+Future<JournalEntity?> createTextEntry(
+    {String? linkedId, String? categoryId,}) async {
   final entry = await JournalRepository.createTextEntry(
     const EntryText(plainText: ''),
     id: uuid.v1(),
     linkedId: linkedId,
+    categoryId: categoryId,
     started: DateTime.now(),
   );
 
@@ -68,7 +70,7 @@ Future<Task?> createTask({String? linkedId, String? categoryId}) async {
   return task;
 }
 
-Future<JournalEvent?> createEvent({String? linkedId}) =>
+Future<JournalEvent?> createEvent({String? linkedId, String? categoryId}) =>
     getIt<PersistenceLogic>().createEventEntry(
       data: const EventData(
         status: EventStatus.tentative,
@@ -77,9 +79,13 @@ Future<JournalEvent?> createEvent({String? linkedId}) =>
       ),
       entryText: const EntryText(plainText: ''),
       linkedId: linkedId,
+      categoryId: categoryId,
     );
 
-Future<JournalEntity?> createScreenshot({String? linkedId}) async {
+Future<JournalEntity?> createScreenshot({
+  String? linkedId,
+  String? categoryId,
+}) async {
   final persistenceLogic = getIt<PersistenceLogic>();
   final imageData = await takeScreenshotMac();
   final entry = await JournalRepository.createImageEntry(

--- a/lib/logic/image_import.dart
+++ b/lib/logic/image_import.dart
@@ -13,6 +13,7 @@ import 'package:wechat_assets_picker/wechat_assets_picker.dart';
 Future<void> importImageAssets(
   BuildContext context, {
   String? linkedId,
+  String? categoryId,
 }) async {
   final assets = await AssetPicker.pickAssets(
     context,
@@ -78,6 +79,7 @@ Future<void> importImageAssets(
         await JournalRepository.createImageEntry(
           imageData,
           linkedId: linkedId,
+          categoryId: categoryId,
         );
       }
     }

--- a/lib/logic/persistence_logic.dart
+++ b/lib/logic/persistence_logic.dart
@@ -317,6 +317,7 @@ class PersistenceLogic {
     required EventData data,
     required EntryText entryText,
     String? linkedId,
+    String? categoryId,
   }) async {
     try {
       final journalEvent = JournalEvent(
@@ -324,6 +325,7 @@ class PersistenceLogic {
         entryText: entryText,
         meta: await createMetadata(
           starred: true,
+          categoryId: categoryId,
         ),
       );
 
@@ -391,7 +393,7 @@ class PersistenceLogic {
       final withTags = journalEntity.copyWith(
         meta: journalEntity.meta.copyWith(
           private: linked?.meta.private,
-          categoryId: linked?.categoryId,
+          categoryId: journalEntity.categoryId ?? linked?.categoryId,
           tagIds: <String>{
             ...?journalEntity.meta.tagIds,
             ...storyTags,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.561+2843
+version: 0.9.562+2844
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
From Copilot:
This pull request includes several changes to add support for `categoryId` throughout various parts of the codebase. The changes span multiple files and involve modifying constructors, methods, and function calls to include the new `categoryId` parameter.

### Support for `categoryId`:

* `lib/beamer/locations/journal_location.dart` and `lib/beamer/locations/tasks_location.dart`: Added `categoryId` to query parameters and passed it to `RecordAudioPage`. [[1]](diffhunk://#diff-4e01856671719fc2aabe4cd7b472839d492e085c46369382e2193d6cc5a7a2e4R27) [[2]](diffhunk://#diff-4e01856671719fc2aabe4cd7b472839d492e085c46369382e2193d6cc5a7a2e4L49-R50) [[3]](diffhunk://#diff-53cbe1a50dc9c027c8ee826c8b26bf607d4078aa54c5610080f3c752267d88d1R24) [[4]](diffhunk://#diff-53cbe1a50dc9c027c8ee826c8b26bf607d4078aa54c5610080f3c752267d88d1L39-R40)
* [`lib/features/journal/repository/journal_repository.dart`](diffhunk://#diff-001fbe4c939fb8084bdbcd1691a4bbe931c8bc39e39095f375c9b18f24ace751R131-R141): Included `categoryId` in `createTextEntry`, `createImageEntry`, and metadata creation. [[1]](diffhunk://#diff-001fbe4c939fb8084bdbcd1691a4bbe931c8bc39e39095f375c9b18f24ace751R131-R141) [[2]](diffhunk://#diff-001fbe4c939fb8084bdbcd1691a4bbe931c8bc39e39095f375c9b18f24ace751R161) [[3]](diffhunk://#diff-001fbe4c939fb8084bdbcd1691a4bbe931c8bc39e39095f375c9b18f24ace751R173)
* [`lib/features/journal/ui/widgets/create/create_entry_action_list_tile.dart`](diffhunk://#diff-da1d5f4b136c89a9d8f278d8c5e05ee3c5b01b0670ddba90ac67784b452f9fa3R14-R19): Modified multiple list tiles to accept and use `categoryId`. [[1]](diffhunk://#diff-da1d5f4b136c89a9d8f278d8c5e05ee3c5b01b0670ddba90ac67784b452f9fa3R14-R19) [[2]](diffhunk://#diff-da1d5f4b136c89a9d8f278d8c5e05ee3c5b01b0670ddba90ac67784b452f9fa3L26-R28) [[3]](diffhunk://#diff-da1d5f4b136c89a9d8f278d8c5e05ee3c5b01b0670ddba90ac67784b452f9fa3R37-R50) [[4]](diffhunk://#diff-da1d5f4b136c89a9d8f278d8c5e05ee3c5b01b0670ddba90ac67784b452f9fa3R84-R89) [[5]](diffhunk://#diff-da1d5f4b136c89a9d8f278d8c5e05ee3c5b01b0670ddba90ac67784b452f9fa3L93-R107) [[6]](diffhunk://#diff-da1d5f4b136c89a9d8f278d8c5e05ee3c5b01b0670ddba90ac67784b452f9fa3R148-R153) [[7]](diffhunk://#diff-da1d5f4b136c89a9d8f278d8c5e05ee3c5b01b0670ddba90ac67784b452f9fa3R165) [[8]](diffhunk://#diff-da1d5f4b136c89a9d8f278d8c5e05ee3c5b01b0670ddba90ac67784b452f9fa3R179-R184)
* [`lib/features/speech/repository/speech_repository.dart`](diffhunk://#diff-852dcd17bcbf0539057fbef0d1022d9afd02725ac8a677ef1f2884ada5204bfaR20): Added `categoryId` to `createAudioNote` and metadata creation. [[1]](diffhunk://#diff-852dcd17bcbf0539057fbef0d1022d9afd02725ac8a677ef1f2884ada5204bfaR20) [[2]](diffhunk://#diff-852dcd17bcbf0539057fbef0d1022d9afd02725ac8a677ef1f2884ada5204bfaR49)
* [`lib/features/speech/state/recorder_cubit.dart`](diffhunk://#diff-bf7a2bda8bfa84addb4e44d121b2831a6554ce2a8b7cce94c364da29985acbe7R46): Introduced `categoryId` and a method to set it. [[1]](diffhunk://#diff-bf7a2bda8bfa84addb4e44d121b2831a6554ce2a8b7cce94c364da29985acbe7R46) [[2]](diffhunk://#diff-bf7a2bda8bfa84addb4e44d121b2831a6554ce2a8b7cce94c364da29985acbe7R114) [[3]](diffhunk://#diff-bf7a2bda8bfa84addb4e44d121b2831a6554ce2a8b7cce94c364da29985acbe7R154-R158)
* `lib/features/speech/ui/pages/record_audio_page.dart` and `lib/features/speech/ui/widgets/audio_recorder.dart`: Passed `categoryId` to `AudioRecorderWidget` and set it in the cubit. [[1]](diffhunk://#diff-686a0a7a9112674286242806be0423b90626367ceed286ad915e3b4ea9cc18d7R10-R27) [[2]](diffhunk://#diff-63a3cd3eeecf7b8d6551646dcdf541b99e0f92871d5ee6192b9d0221d7f28bbfR22-R26) [[3]](diffhunk://#diff-63a3cd3eeecf7b8d6551646dcdf541b99e0f92871d5ee6192b9d0221d7f28bbfL34-R37)
* [`lib/logic/create/create_entry.dart`](diffhunk://#diff-1a766539a6c82aa450a74e3eb36ca35a1eda0830981663de597bdb0a1aa9b2c3L16-R22): Updated functions to include `categoryId` in entry creation. [[1]](diffhunk://#diff-1a766539a6c82aa450a74e3eb36ca35a1eda0830981663de597bdb0a1aa9b2c3L16-R22) [[2]](diffhunk://#diff-1a766539a6c82aa450a74e3eb36ca35a1eda0830981663de597bdb0a1aa9b2c3L71-R73) [[3]](diffhunk://#diff-1a766539a6c82aa450a74e3eb36ca35a1eda0830981663de597bdb0a1aa9b2c3R82-R88) [[4]](diffhunk://#diff-1a766539a6c82aa450a74e3eb36ca35a1eda0830981663de597bdb0a1aa9b2c3R82-R88)
* [`lib/logic/image_import.dart`](diffhunk://#diff-1655f19893cbede94f77d77d222e83403d993733ea862f1f80f5dc9345be9d23R16): Added `categoryId` to `importImageAssets` function. [[1]](diffhunk://#diff-1655f19893cbede94f77d77d222e83403d993733ea862f1f80f5dc9345be9d23R16) [[2]](diffhunk://#diff-1655f19893cbede94f77d77d222e83403d993733ea862f1f80f5dc9345be9d23R82)

### UI and State Management:

* [`lib/features/journal/ui/pages/infinite_journal_page.dart`](diffhunk://#diff-58bac7ac8ac8c070e5f4932908bab69270db5632de32d09355682ec9d92a9728L35-R55): Simplified the logic for `FloatingActionButton` and included `categoryId` where necessary.
* [`lib/features/journal/ui/widgets/create/create_entry_action_modal.dart`](diffhunk://#diff-cd5373ab69178d72beaf1b5f911740db669bfef74b37e6b54d388b13caf6bb0fL19-R26): Passed `categoryId` to various create entry list tiles.

### Code Simplification:

* [`lib/features/dashboards/state/chart_scale_controller.dart`](diffhunk://#diff-ea24c4ca9a414c954927da02eaba23fe39e948fb4b27d5e63bf411b5f6813f8cL14-R14): Simplified the `updateScale` method by directly assigning `scale.row0.x` to `state`.