### PR TITLE
feat: create ollama task summary with images WIP

### DIFF
--- a/lib/features/ai/state/ollama_task_summary.dart
+++ b/lib/features/ai/state/ollama_task_summary.dart
@@ -45,6 +45,9 @@ class AiTaskSummaryController extends _$AiTaskSummaryController {
         'COMPLETED or TO DO. '
         'Summarize the task, the achieved results, and the remaining steps '
         'that have not been completed yet. '
+        'If there are images, include their content in the summary. '
+        'Consider that the content of the images, likely screenshots, '
+        'are related to the completion of the task. '
         'Note that the logbook is in reverse chronological order. '
         'Keep it short and succinct. ';
 
@@ -74,7 +77,8 @@ class AiTaskSummaryController extends _$AiTaskSummaryController {
     for (final imageEntry in imageEntries) {
       final fullPath = getFullImagePath(imageEntry);
       final bytes = await File(fullPath).readAsBytes();
-      base64Images.add(base64Encode(bytes));
+      final base64String = base64Encode(bytes);
+      base64Images.add(base64String);
     }
 
     return base64Images;

--- a/lib/features/ai/state/ollama_task_summary.g.dart
+++ b/lib/features/ai/state/ollama_task_summary.g.dart
@@ -7,7 +7,7 @@ part of 'ollama_task_summary.dart';
 // **************************************************************************
 
 String _$aiTaskSummaryControllerHash() =>
-    r'812f36f50ae58d65bd17066d6e40289c0bb11e27';
+    r'89f4b03fe8670d9b701786e56f0e96b74a235930';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -33,9 +33,11 @@ class _SystemHash {
 abstract class _$AiTaskSummaryController
     extends BuildlessAutoDisposeNotifier<String> {
   late final String id;
+  late final bool processImages;
 
   String build({
     required String id,
+    required bool processImages,
   });
 }
 
@@ -51,9 +53,11 @@ class AiTaskSummaryControllerFamily extends Family<String> {
   /// See also [AiTaskSummaryController].
   AiTaskSummaryControllerProvider call({
     required String id,
+    required bool processImages,
   }) {
     return AiTaskSummaryControllerProvider(
       id: id,
+      processImages: processImages,
     );
   }
 
@@ -63,6 +67,7 @@ class AiTaskSummaryControllerFamily extends Family<String> {
   ) {
     return call(
       id: provider.id,
+      processImages: provider.processImages,
     );
   }
 
@@ -87,8 +92,11 @@ class AiTaskSummaryControllerProvider
   /// See also [AiTaskSummaryController].
   AiTaskSummaryControllerProvider({
     required String id,
+    required bool processImages,
   }) : this._internal(
-          () => AiTaskSummaryController()..id = id,
+          () => AiTaskSummaryController()
+            ..id = id
+            ..processImages = processImages,
           from: aiTaskSummaryControllerProvider,
           name: r'aiTaskSummaryControllerProvider',
           debugGetCreateSourceHash:
@@ -99,6 +107,7 @@ class AiTaskSummaryControllerProvider
           allTransitiveDependencies:
               AiTaskSummaryControllerFamily._allTransitiveDependencies,
           id: id,
+          processImages: processImages,
         );
 
   AiTaskSummaryControllerProvider._internal(
@@ -109,9 +118,11 @@ class AiTaskSummaryControllerProvider
     required super.debugGetCreateSourceHash,
     required super.from,
     required this.id,
+    required this.processImages,
   }) : super.internal();
 
   final String id;
+  final bool processImages;
 
   @override
   String runNotifierBuild(
@@ -119,6 +130,7 @@ class AiTaskSummaryControllerProvider
   ) {
     return notifier.build(
       id: id,
+      processImages: processImages,
     );
   }
 
@@ -127,13 +139,16 @@ class AiTaskSummaryControllerProvider
     return ProviderOverride(
       origin: this,
       override: AiTaskSummaryControllerProvider._internal(
-        () => create()..id = id,
+        () => create()
+          ..id = id
+          ..processImages = processImages,
         from: from,
         name: null,
         dependencies: null,
         allTransitiveDependencies: null,
         debugGetCreateSourceHash: null,
         id: id,
+        processImages: processImages,
       ),
     );
   }
@@ -146,13 +161,16 @@ class AiTaskSummaryControllerProvider
 
   @override
   bool operator ==(Object other) {
-    return other is AiTaskSummaryControllerProvider && other.id == id;
+    return other is AiTaskSummaryControllerProvider &&
+        other.id == id &&
+        other.processImages == processImages;
   }
 
   @override
   int get hashCode {
     var hash = _SystemHash.combine(0, runtimeType.hashCode);
     hash = _SystemHash.combine(hash, id.hashCode);
+    hash = _SystemHash.combine(hash, processImages.hashCode);
 
     return _SystemHash.finish(hash);
   }
@@ -163,6 +181,9 @@ class AiTaskSummaryControllerProvider
 mixin AiTaskSummaryControllerRef on AutoDisposeNotifierProviderRef<String> {
   /// The parameter `id` of this provider.
   String get id;
+
+  /// The parameter `processImages` of this provider.
+  bool get processImages;
 }
 
 class _AiTaskSummaryControllerProviderElement
@@ -172,6 +193,9 @@ class _AiTaskSummaryControllerProviderElement
 
   @override
   String get id => (origin as AiTaskSummaryControllerProvider).id;
+  @override
+  bool get processImages =>
+      (origin as AiTaskSummaryControllerProvider).processImages;
 }
 
 String _$taskMarkdownControllerHash() =>

--- a/lib/features/ai/state/ollama_task_summary.g.dart
+++ b/lib/features/ai/state/ollama_task_summary.g.dart
@@ -7,7 +7,7 @@ part of 'ollama_task_summary.dart';
 // **************************************************************************
 
 String _$aiTaskSummaryControllerHash() =>
-    r'e537f7f1e4f1eb075474d2afd5166bceb413da32';
+    r'812f36f50ae58d65bd17066d6e40289c0bb11e27';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/features/ai/ui/ai_popup_menu.dart
+++ b/lib/features/ai/ui/ai_popup_menu.dart
@@ -31,6 +31,13 @@ class AiPopUpMenu extends StatelessWidget {
               AiTaskSummaryListTile(
                 journalEntity: journalEntity,
                 linkedFromId: linkedFromId,
+                processImages: true,
+              ),
+            if (journalEntity != null && journalEntity is Task)
+              AiTaskSummaryListTile(
+                journalEntity: journalEntity,
+                linkedFromId: linkedFromId,
+                processImages: false,
               ),
             if (journalEntity is! Task)
               AiPromptListTile(

--- a/lib/features/ai/ui/ai_popup_menu.dart
+++ b/lib/features/ai/ui/ai_popup_menu.dart
@@ -27,12 +27,12 @@ class AiPopUpMenu extends StatelessWidget {
         title: context.messages.aiAssistantTitle,
         builder: (_) => Column(
           children: [
-            if (journalEntity != null && journalEntity is Task)
-              AiTaskSummaryListTile(
-                journalEntity: journalEntity,
-                linkedFromId: linkedFromId,
-                processImages: true,
-              ),
+            // if (journalEntity != null && journalEntity is Task)
+            //   AiTaskSummaryListTile(
+            //     journalEntity: journalEntity,
+            //     linkedFromId: linkedFromId,
+            //     processImages: true,
+            //   ),
             if (journalEntity != null && journalEntity is Task)
               AiTaskSummaryListTile(
                 journalEntity: journalEntity,

--- a/lib/features/ai/ui/task_summary/ai_task_summary_list_tile.dart
+++ b/lib/features/ai/ui/task_summary/ai_task_summary_list_tile.dart
@@ -7,18 +7,24 @@ import 'package:lotti/l10n/app_localizations_context.dart';
 class AiTaskSummaryListTile extends ConsumerWidget {
   const AiTaskSummaryListTile({
     required this.journalEntity,
+    required this.processImages,
     this.linkedFromId,
     super.key,
   });
 
   final JournalEntity journalEntity;
   final String? linkedFromId;
+  final bool processImages;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return ListTile(
       leading: const Icon(Icons.chat_rounded),
-      title: Text(context.messages.aiAssistantSummarizeTask),
+      title: Text(
+        processImages
+            ? context.messages.aiAssistantSummarizeTaskWithImages
+            : context.messages.aiAssistantSummarizeTask,
+      ),
       onTap: () {
         Navigator.of(context).pop();
         showModalBottomSheet<void>(
@@ -26,6 +32,7 @@ class AiTaskSummaryListTile extends ConsumerWidget {
           isScrollControlled: true,
           builder: (BuildContext context) => AiTaskSummaryView(
             id: journalEntity.id,
+            processImages: processImages,
           ),
         );
       },

--- a/lib/features/ai/ui/task_summary/ai_task_summary_view.dart
+++ b/lib/features/ai/ui/task_summary/ai_task_summary_view.dart
@@ -6,17 +6,24 @@ import 'package:lotti/features/ai/state/ollama_task_summary.dart';
 class AiTaskSummaryView extends ConsumerWidget {
   const AiTaskSummaryView({
     required this.id,
+    required this.processImages,
     super.key,
   });
 
   final String id;
+  final bool processImages;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     const showInput = false;
     final markdown =
         ref.watch(taskMarkdownControllerProvider(id: id)).valueOrNull;
-    final summary = ref.watch(aiTaskSummaryControllerProvider(id: id));
+    final summary = ref.watch(
+      aiTaskSummaryControllerProvider(
+        id: id,
+        processImages: processImages,
+      ),
+    );
 
     return SingleChildScrollView(
       child: Padding(

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -23,6 +23,7 @@
   "aiAssistantCreateChecklist": "Create checklist items",
   "aiAssistantRunPrompt": "Ask Llama3",
   "aiAssistantSummarizeTask": "Summarize task",
+  "aiAssistantSummarizeTaskWithImages": "Summarize task with images",
   "aiAssistantTitle": "AI Assistant",
   "appBarBack": "Back",
   "cancelButton": "Cancel",

--- a/lib/themes/theme.dart
+++ b/lib/themes/theme.dart
@@ -209,12 +209,7 @@ ThemeData withOverrides(ThemeData themeData) {
     hoverColor: Colors.transparent,
     cardTheme: themeData.cardTheme.copyWith(
       clipBehavior: Clip.hardEdge,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(inputBorderRadius),
-        side: BorderSide(
-          color: themeData.colorScheme.outline.withAlpha(100),
-        ),
-      ),
+      color: themeData.colorScheme.surfaceContainerHigh,
     ),
     sliderTheme: themeData.sliderTheme.copyWith(
       activeTrackColor: themeData.colorScheme.secondary,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1964,6 +1964,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  ollama:
+    dependency: "direct main"
+    description:
+      name: ollama
+      sha256: "653a434cc7695dc2243975434015f4831f4ce524cccc1cc8fdb2d31551e3867b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   ollama_dart:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.563+2848
+version: 0.9.564+2849
 
 msix_config:
   display_name: LottiApp
@@ -116,6 +116,7 @@ dependencies:
   media_kit_native_event_loop: ^1.0.3
   meta: ^1.15.0
   multi_select_flutter: ^4.0.0
+  ollama: ^1.0.4
   ollama_dart: ^0.2.0
   package_info_plus: ^8.0.0
   path: ^1.8.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.564+2851
+version: 0.9.564+2852
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.564+2849
+version: 0.9.564+2851
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR contains using a different Ollama client that allows image analysis when using a multimodal model such as `llama3.2-vision:latest`. For now the task summary is hidden though as this doesn't work yet when a task contains multiple images, such as screenshots. The feature will be enabled in a future PR. For now, I just want to get using the [`ollama`](https://pub.dev/packages/ollama) into main. Also contains a styling change for better contrast between cards and background.

From Copilot:
This pull request includes several changes focused on enhancing the AI task summary functionality and adding support for processing images. The most important changes include updating the `AiTaskSummaryController` to handle images, modifying the UI to support image processing, and updating the localization files to include new messages.

Enhancements to AI task summary functionality:

* [`lib/features/ai/state/ollama_task_summary.dart`](diffhunk://#diff-0b78f378a08d425414051d187abc25e480481eb66b56b03019d1b1986a0bc889R2-R31): Updated `AiTaskSummaryController` to include a new `processImages` parameter and added logic to handle image processing. [[1]](diffhunk://#diff-0b78f378a08d425414051d187abc25e480481eb66b56b03019d1b1986a0bc889R2-R31) [[2]](diffhunk://#diff-0b78f378a08d425414051d187abc25e480481eb66b56b03019d1b1986a0bc889L33-R84)
* [`lib/features/ai/state/ollama_task_summary.g.dart`](diffhunk://#diff-877a2a08e9c287b9c1b4bb4b3e421ef772f581af2ad9b869640b7b017461572cL10-R10): Updated generated code to support the new `processImages` parameter in various methods and classes. [[1]](diffhunk://#diff-877a2a08e9c287b9c1b4bb4b3e421ef772f581af2ad9b869640b7b017461572cL10-R10) [[2]](diffhunk://#diff-877a2a08e9c287b9c1b4bb4b3e421ef772f581af2ad9b869640b7b017461572cR36-R40) [[3]](diffhunk://#diff-877a2a08e9c287b9c1b4bb4b3e421ef772f581af2ad9b869640b7b017461572cR56-R60) [[4]](diffhunk://#diff-877a2a08e9c287b9c1b4bb4b3e421ef772f581af2ad9b869640b7b017461572cR70) [[5]](diffhunk://#diff-877a2a08e9c287b9c1b4bb4b3e421ef772f581af2ad9b869640b7b017461572cR95-R99) [[6]](diffhunk://#diff-877a2a08e9c287b9c1b4bb4b3e421ef772f581af2ad9b869640b7b017461572cR110) [[7]](diffhunk://#diff-877a2a08e9c287b9c1b4bb4b3e421ef772f581af2ad9b869640b7b017461572cR121-R133) [[8]](diffhunk://#diff-877a2a08e9c287b9c1b4bb4b3e421ef772f581af2ad9b869640b7b017461572cL130-R151) [[9]](diffhunk://#diff-877a2a08e9c287b9c1b4bb4b3e421ef772f581af2ad9b869640b7b017461572cL149-R173) [[10]](diffhunk://#diff-877a2a08e9c287b9c1b4bb4b3e421ef772f581af2ad9b869640b7b017461572cR184-R186)

UI modifications to support image processing:

* [`lib/features/ai/ui/ai_popup_menu.dart`](diffhunk://#diff-ffcb87d546496ab34540b9a3dd2913bdf15b2a0b948883c5100399372ad2e673R30-R40): Added a new `AiTaskSummaryListTile` with `processImages` set to `true`.
* [`lib/features/ai/ui/task_summary/ai_task_summary_list_tile.dart`](diffhunk://#diff-99c2573106cba5ea8de131b2924be882807a23ceedaf44d67e4000f70ef85bc0R10-R35): Updated `AiTaskSummaryListTile` to include the `processImages` parameter and display the appropriate title based on its value.
* [`lib/features/ai/ui/task_summary/ai_task_summary_view.dart`](diffhunk://#diff-73695f8dcb445abccbe9106caa3aeaaea2135e8a21ca93bdc797d36d2d082e6aR9-R26): Updated `AiTaskSummaryView` to pass the `processImages` parameter to the controller provider.

Localization updates:

* [`lib/l10n/app_en.arb`](diffhunk://#diff-9796fde3771f42a3a759ccc941731d83f96037a661e47dde27ce81d3447a69c2R26): Added a new message for summarizing tasks with images.

Additional changes:

* [`lib/themes/theme.dart`](diffhunk://#diff-4cdef9be184226fd81d6a14d05f00d4f8e9f0b3a67c2638c7d53a1faa2e65e8dL212-R212): Modified card theme color.
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Updated project version and added a new dependency for `ollama`. [[1]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4) [[2]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25R119)