### PR TITLE
fix: save issue when underlining text

### DIFF
--- a/lib/features/calendar/ui/pages/day_view_page.dart
+++ b/lib/features/calendar/ui/pages/day_view_page.dart
@@ -122,13 +122,19 @@ class _DayViewWidgetState extends ConsumerState<DayViewWidget> {
               showHalfHours: true,
               heightPerMinute: _heightPerMinute,
               keepScrollOffset: true,
-              initialDay: DateTime.now(),
               headerStyle: HeaderStyle(
                 headerTextStyle: chartTitleStyleMonospace.copyWith(
                   fontWeight: FontWeight.w400,
+                  color: context.colorScheme.primary,
                 ),
                 decoration: BoxDecoration(
-                  color: context.colorScheme.primaryContainer,
+                  color: context.colorScheme.surfaceContainer,
+                ),
+                leftIconConfig: IconDataConfig(
+                  color: context.colorScheme.primary,
+                ),
+                rightIconConfig: IconDataConfig(
+                  color: context.colorScheme.primary,
                 ),
               ),
               dateStringBuilder: (date, {DateTime? secondaryDate}) => date.ymwd,

--- a/lib/features/journal/ui/widgets/editor/editor_toolbar.dart
+++ b/lib/features/journal/ui/widgets/editor/editor_toolbar.dart
@@ -35,6 +35,7 @@ class ToolbarWidget extends ConsumerWidget {
           multiRowsDisplay: false,
           showColorButton: false,
           showFontFamily: false,
+          showUnderLineButton: false,
           showBackgroundColorButton: false,
           showSubscript: false,
           showSuperscript: false,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.565+2853
+version: 0.9.565+2854
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.564+2852
+version: 0.9.565+2853
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR fixes an issue with underlining text where saving would fail by removing the underline button from the editor toolbar. Personally, I never noticed because I never feel the need to underline text, and it#s not supported in Markdown anyway. Also improves the app bar style in the calendar view.

From Copilot:
This pull request includes changes to the UI components and version update of the `lotti` application. The most important changes include updates to the `DayViewWidget` and `ToolbarWidget` for improved UI consistency, and a version increment in the `pubspec.yaml` file.

UI improvements:

* [`lib/features/calendar/ui/pages/day_view_page.dart`](diffhunk://#diff-7016e6cb4d6c181db092e926d0bd9d094abd1c1e54f5d58ca7d8f26ce1c276ffL125-R137): Modified the header style to use the primary color for text and surface container for background, and added left and right icon configurations.
* [`lib/features/journal/ui/widgets/editor/editor_toolbar.dart`](diffhunk://#diff-f875087ecfb2dc2957bcef6e0ef6783c9bb3cdd251de448936e51da62fddcacaR38): Added an option to hide the underline button in the toolbar.

Version update:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Incremented the version from `0.9.564+2852` to `0.9.565+2854`.

