### PR TITLE
feat: paste image from clipboard

### DIFF
--- a/lib/features/ai/state/ollama_image_analysis.g.dart
+++ b/lib/features/ai/state/ollama_image_analysis.g.dart
@@ -7,7 +7,7 @@ part of 'ollama_image_analysis.dart';
 // **************************************************************************
 
 String _$aiImageAnalysisControllerHash() =>
-    r'b021aabb3039aae959620cd1938ee1ffaac9c3cc';
+    r'0d8410804b0c260380022bb2e1c1072e457fedda';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/features/journal/repository/clipboard_repository.dart
+++ b/lib/features/journal/repository/clipboard_repository.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:super_clipboard/super_clipboard.dart';
+
+part 'clipboard_repository.g.dart';
+
+@riverpod
+SystemClipboard? clipboardRepository(Ref ref) {
+  return SystemClipboard.instance;
+}

--- a/lib/features/journal/repository/clipboard_repository.g.dart
+++ b/lib/features/journal/repository/clipboard_repository.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'clipboard_repository.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$clipboardRepositoryHash() =>
+    r'eb05e5d6d99885a2f58405d5da7a86fa23c54c12';
+
+/// See also [clipboardRepository].
+@ProviderFor(clipboardRepository)
+final clipboardRepositoryProvider =
+    AutoDisposeProvider<SystemClipboard?>.internal(
+  clipboardRepository,
+  name: r'clipboardRepositoryProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$clipboardRepositoryHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef ClipboardRepositoryRef = AutoDisposeProviderRef<SystemClipboard?>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/journal/state/entry_controller.g.dart
+++ b/lib/features/journal/state/entry_controller.g.dart
@@ -6,7 +6,7 @@ part of 'entry_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$entryControllerHash() => r'cba4fca1e0fe1d4b1aa42131111698e30b7e6b5a';
+String _$entryControllerHash() => r'f27eb05d2bff528ce53c6197665aab18dca39b92';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/features/journal/state/image_paste_controller.dart
+++ b/lib/features/journal/state/image_paste_controller.dart
@@ -1,0 +1,54 @@
+import 'dart:async';
+
+import 'package:lotti/features/journal/repository/clipboard_repository.dart';
+import 'package:lotti/logic/image_import.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:super_clipboard/super_clipboard.dart';
+
+part 'image_paste_controller.g.dart';
+
+@riverpod
+class ImagePasteController extends _$ImagePasteController {
+  @override
+  Future<bool> build({
+    required String? linkedFromId,
+    required String? categoryId,
+  }) async {
+    final clipboard = ref.read(clipboardRepositoryProvider);
+    if (clipboard == null) {
+      return false;
+    }
+    final reader = await clipboard.read();
+    return reader.canProvide(Formats.png) || reader.canProvide(Formats.jpeg);
+  }
+
+  Future<void> paste() async {
+    final clipboard = ref.read(clipboardRepositoryProvider);
+    if (clipboard == null) {
+      return;
+    }
+    final reader = await clipboard.read();
+
+    if (reader.canProvide(Formats.png)) {
+      reader.getFile(Formats.png, (file) async {
+        await importPastedImages(
+          data: await file.readAll(),
+          fileExtension: 'png',
+          linkedId: linkedFromId,
+          categoryId: categoryId,
+        );
+      });
+    }
+
+    if (reader.canProvide(Formats.jpeg)) {
+      reader.getFile(Formats.jpeg, (file) async {
+        await importPastedImages(
+          data: await file.readAll(),
+          fileExtension: 'jpg',
+          linkedId: linkedFromId,
+          categoryId: categoryId,
+        );
+      });
+    }
+  }
+}

--- a/lib/features/journal/state/image_paste_controller.g.dart
+++ b/lib/features/journal/state/image_paste_controller.g.dart
@@ -1,0 +1,201 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'image_paste_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$imagePasteControllerHash() =>
+    r'5b545dd1cbc757ecba3b2231fecc8c374725f380';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+abstract class _$ImagePasteController
+    extends BuildlessAutoDisposeAsyncNotifier<bool> {
+  late final String? linkedFromId;
+  late final String? categoryId;
+
+  FutureOr<bool> build({
+    required String? linkedFromId,
+    required String? categoryId,
+  });
+}
+
+/// See also [ImagePasteController].
+@ProviderFor(ImagePasteController)
+const imagePasteControllerProvider = ImagePasteControllerFamily();
+
+/// See also [ImagePasteController].
+class ImagePasteControllerFamily extends Family<AsyncValue<bool>> {
+  /// See also [ImagePasteController].
+  const ImagePasteControllerFamily();
+
+  /// See also [ImagePasteController].
+  ImagePasteControllerProvider call({
+    required String? linkedFromId,
+    required String? categoryId,
+  }) {
+    return ImagePasteControllerProvider(
+      linkedFromId: linkedFromId,
+      categoryId: categoryId,
+    );
+  }
+
+  @override
+  ImagePasteControllerProvider getProviderOverride(
+    covariant ImagePasteControllerProvider provider,
+  ) {
+    return call(
+      linkedFromId: provider.linkedFromId,
+      categoryId: provider.categoryId,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'imagePasteControllerProvider';
+}
+
+/// See also [ImagePasteController].
+class ImagePasteControllerProvider
+    extends AutoDisposeAsyncNotifierProviderImpl<ImagePasteController, bool> {
+  /// See also [ImagePasteController].
+  ImagePasteControllerProvider({
+    required String? linkedFromId,
+    required String? categoryId,
+  }) : this._internal(
+          () => ImagePasteController()
+            ..linkedFromId = linkedFromId
+            ..categoryId = categoryId,
+          from: imagePasteControllerProvider,
+          name: r'imagePasteControllerProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$imagePasteControllerHash,
+          dependencies: ImagePasteControllerFamily._dependencies,
+          allTransitiveDependencies:
+              ImagePasteControllerFamily._allTransitiveDependencies,
+          linkedFromId: linkedFromId,
+          categoryId: categoryId,
+        );
+
+  ImagePasteControllerProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.linkedFromId,
+    required this.categoryId,
+  }) : super.internal();
+
+  final String? linkedFromId;
+  final String? categoryId;
+
+  @override
+  FutureOr<bool> runNotifierBuild(
+    covariant ImagePasteController notifier,
+  ) {
+    return notifier.build(
+      linkedFromId: linkedFromId,
+      categoryId: categoryId,
+    );
+  }
+
+  @override
+  Override overrideWith(ImagePasteController Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: ImagePasteControllerProvider._internal(
+        () => create()
+          ..linkedFromId = linkedFromId
+          ..categoryId = categoryId,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        linkedFromId: linkedFromId,
+        categoryId: categoryId,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeAsyncNotifierProviderElement<ImagePasteController, bool>
+      createElement() {
+    return _ImagePasteControllerProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is ImagePasteControllerProvider &&
+        other.linkedFromId == linkedFromId &&
+        other.categoryId == categoryId;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, linkedFromId.hashCode);
+    hash = _SystemHash.combine(hash, categoryId.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+mixin ImagePasteControllerRef on AutoDisposeAsyncNotifierProviderRef<bool> {
+  /// The parameter `linkedFromId` of this provider.
+  String? get linkedFromId;
+
+  /// The parameter `categoryId` of this provider.
+  String? get categoryId;
+}
+
+class _ImagePasteControllerProviderElement
+    extends AutoDisposeAsyncNotifierProviderElement<ImagePasteController, bool>
+    with ImagePasteControllerRef {
+  _ImagePasteControllerProviderElement(super.provider);
+
+  @override
+  String? get linkedFromId =>
+      (origin as ImagePasteControllerProvider).linkedFromId;
+  @override
+  String? get categoryId => (origin as ImagePasteControllerProvider).categoryId;
+}
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/journal/ui/widgets/create/create_entry_action_modal.dart
+++ b/lib/features/journal/ui/widgets/create/create_entry_action_modal.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:lotti/features/journal/ui/widgets/create/create_entry_action_list_tile.dart';
+import 'package:lotti/features/journal/ui/widgets/create/paste_image_list_tile.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/utils/modals.dart';
@@ -24,6 +25,7 @@ class CreateEntryModal {
           ImportImageAssetsListTile(linkedFromId, categoryId: categoryId),
           if (isMacOS)
             CreateScreenshotListTile(linkedFromId, categoryId: categoryId),
+          PasteImageListTile(linkedFromId, categoryId: categoryId),
           verticalModalSpacer,
         ],
       ),

--- a/lib/features/journal/ui/widgets/create/paste_image_list_tile.dart
+++ b/lib/features/journal/ui/widgets/create/paste_image_list_tile.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/features/journal/state/image_paste_controller.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+
+class PasteImageListTile extends ConsumerWidget {
+  const PasteImageListTile(
+    this.linkedFromId, {
+    this.categoryId,
+    super.key,
+  });
+
+  final String? linkedFromId;
+  final String? categoryId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final provider = imagePasteControllerProvider(
+      linkedFromId: linkedFromId,
+      categoryId: categoryId,
+    );
+    final canPasteImage = ref.watch(provider).valueOrNull ?? false;
+
+    if (!canPasteImage) {
+      return const SizedBox.shrink();
+    }
+
+    return ListTile(
+      leading: const Icon(Icons.paste),
+      title: Text(context.messages.addActionAddImageFromClipboard),
+      onTap: () {
+        Navigator.of(context).pop();
+        ref.read(provider.notifier).paste();
+      },
+    );
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4,6 +4,7 @@
   "addActionAddEvent": "Event",
   "addActionAddMeasurable": "Measurable",
   "addActionAddPhotos": "Photo(s)",
+  "addActionAddImageFromClipboard": "Paste Image",
   "addActionAddScreenshot": "Screenshot",
   "addActionAddSurvey": "Fill Survey",
   "addActionAddTask": "Task",

--- a/lib/logic/image_import.dart
+++ b/lib/logic/image_import.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:desktop_drop/desktop_drop.dart';
 import 'package:flutter/widgets.dart';
@@ -133,4 +134,36 @@ Future<void> importDroppedImages({
       categoryId: categoryId,
     );
   }
+}
+
+Future<void> importPastedImages({
+  required Uint8List data,
+  required String fileExtension,
+  String? linkedId,
+  String? categoryId,
+}) async {
+  final capturedAt = DateTime.now();
+  final id = uuid.v1();
+
+  final day = DateFormat('yyyy-MM-dd').format(capturedAt);
+  final relativePath = '/images/$day/';
+  final directory = await createAssetDirectory(relativePath);
+  final targetFileName = '$id.$fileExtension';
+  final targetFilePath = '$directory$targetFileName';
+
+  final file = File(targetFilePath);
+  await file.writeAsBytes(data);
+
+  final imageData = ImageData(
+    imageId: id,
+    imageFile: targetFileName,
+    imageDirectory: relativePath,
+    capturedAt: capturedAt,
+  );
+
+  await JournalRepository.createImageEntry(
+    imageData,
+    linkedId: linkedId,
+    categoryId: categoryId,
+  );
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.567+2870
+version: 0.9.567+2871
 
 msix_config:
   display_name: LottiApp

--- a/test/features/journal/state/image_paste_controller_test.dart
+++ b/test/features/journal/state/image_paste_controller_test.dart
@@ -1,0 +1,151 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/journal/repository/clipboard_repository.dart';
+import 'package:lotti/features/journal/state/image_paste_controller.dart';
+import 'package:lotti/get_it.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:riverpod/riverpod.dart';
+import 'package:super_clipboard/super_clipboard.dart';
+
+import '../../../helpers/path_provider.dart';
+
+class MockSystemClipboard extends Mock implements SystemClipboard {}
+
+class MockClipboardReader extends Mock implements ClipboardReader {}
+
+class MockDataReaderFile extends Mock implements DataReaderFile {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late ProviderContainer container;
+  late MockSystemClipboard mockClipboard;
+  late MockClipboardReader mockReader;
+  late MockDataReaderFile mockFile;
+
+  setUpAll(() async {
+    setFakeDocumentsPath();
+    getIt
+        .registerSingleton<Directory>(await getApplicationDocumentsDirectory());
+  });
+
+  setUp(() {
+    mockClipboard = MockSystemClipboard();
+    mockReader = MockClipboardReader();
+    mockFile = MockDataReaderFile();
+
+    container = ProviderContainer(
+      overrides: [
+        clipboardRepositoryProvider.overrideWithValue(mockClipboard),
+      ],
+    );
+
+    when(() => mockClipboard.read()).thenAnswer((_) async => mockReader);
+  });
+
+  group('ImagePasteController', () {
+    test('build returns false when clipboard is null', () async {
+      final container = ProviderContainer(
+        overrides: [
+          clipboardRepositoryProvider.overrideWithValue(null),
+        ],
+      );
+
+      final result = await container.read(
+        imagePasteControllerProvider(
+          linkedFromId: null,
+          categoryId: null,
+        ).future,
+      );
+
+      expect(result, false);
+    });
+
+    test('build returns true when PNG is available', () async {
+      when(() => mockReader.canProvide(Formats.png)).thenReturn(true);
+      when(() => mockReader.canProvide(Formats.jpeg)).thenReturn(false);
+
+      final result = await container.read(
+        imagePasteControllerProvider(
+          linkedFromId: null,
+          categoryId: null,
+        ).future,
+      );
+
+      expect(result, true);
+    });
+
+    test('build returns true when JPEG is available', () async {
+      when(() => mockReader.canProvide(Formats.png)).thenReturn(false);
+      when(() => mockReader.canProvide(Formats.jpeg)).thenReturn(true);
+
+      final result = await container.read(
+        imagePasteControllerProvider(
+          linkedFromId: null,
+          categoryId: null,
+        ).future,
+      );
+
+      expect(result, true);
+    });
+
+    test('paste handles PNG data correctly', () async {
+      when(() => mockReader.canProvide(Formats.png)).thenReturn(true);
+      when(() => mockReader.canProvide(Formats.jpeg)).thenReturn(false);
+
+      when(() => mockReader.getFile(Formats.png, any()))
+          .thenAnswer((invocation) {
+        final callback =
+            invocation.positionalArguments[1] as void Function(DataReaderFile);
+        callback(mockFile);
+        return null;
+      });
+
+      when(() => mockFile.readAll())
+          .thenAnswer((_) async => Uint8List.fromList([1, 2, 3]));
+
+      final controller = container.read(
+        imagePasteControllerProvider(
+          linkedFromId: 'testLink',
+          categoryId: 'testCategory',
+        ).notifier,
+      );
+
+      await controller.paste();
+
+      verify(() => mockReader.getFile(Formats.png, any())).called(1);
+      verify(() => mockFile.readAll()).called(1);
+    });
+
+    test('paste handles JPEG data correctly', () async {
+      when(() => mockReader.canProvide(Formats.png)).thenReturn(false);
+      when(() => mockReader.canProvide(Formats.jpeg)).thenReturn(true);
+
+      when(() => mockReader.getFile(Formats.jpeg, any()))
+          .thenAnswer((invocation) {
+        final callback =
+            invocation.positionalArguments[1] as void Function(DataReaderFile);
+        callback(mockFile);
+        return null;
+      });
+
+      when(() => mockFile.readAll())
+          .thenAnswer((_) async => Uint8List.fromList([1, 2, 3]));
+
+      final controller = container.read(
+        imagePasteControllerProvider(
+          linkedFromId: 'testLink',
+          categoryId: 'testCategory',
+        ).notifier,
+      );
+
+      await controller.paste();
+
+      verify(() => mockReader.getFile(Formats.jpeg, any())).called(1);
+      verify(() => mockFile.readAll()).called(1);
+    });
+  });
+}

--- a/test/features/journal/ui/widgets/create/paste_image_list_tile_test.dart
+++ b/test/features/journal/ui/widgets/create/paste_image_list_tile_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/journal/repository/clipboard_repository.dart';
+import 'package:lotti/features/journal/ui/widgets/create/paste_image_list_tile.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:super_clipboard/super_clipboard.dart';
+
+import '../../../../../test_helper.dart';
+
+class MockSystemClipboard extends Mock implements SystemClipboard {}
+
+class MockClipboardReader extends Mock implements ClipboardReader {}
+
+void main() {
+  late MockSystemClipboard mockClipboard;
+  late MockClipboardReader mockReader;
+
+  setUp(() {
+    mockClipboard = MockSystemClipboard();
+    mockReader = MockClipboardReader();
+
+    when(() => mockClipboard.read()).thenAnswer((_) async => mockReader);
+  });
+
+  testWidgets('PasteImageListTile shows when image is available',
+      (tester) async {
+    when(() => mockReader.canProvide(Formats.png)).thenReturn(true);
+    when(() => mockReader.canProvide(Formats.jpeg)).thenReturn(false);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          clipboardRepositoryProvider.overrideWithValue(mockClipboard),
+        ],
+        child: createTestApp(
+          const Material(
+            child: PasteImageListTile(
+              'testId',
+              categoryId: 'testCategory',
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Wait for async operations to complete
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ListTile), findsOneWidget);
+    expect(find.byIcon(Icons.paste), findsOneWidget);
+  });
+
+  testWidgets('PasteImageListTile hides when no image is available',
+      (tester) async {
+    when(() => mockReader.canProvide(Formats.png)).thenReturn(false);
+    when(() => mockReader.canProvide(Formats.jpeg)).thenReturn(false);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          clipboardRepositoryProvider.overrideWithValue(mockClipboard),
+        ],
+        child: createTestApp(
+          const Material(
+            child: PasteImageListTile(
+              'testId',
+              categoryId: 'testCategory',
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Wait for async operations to complete
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ListTile), findsNothing);
+    expect(find.byIcon(Icons.paste), findsNothing);
+  });
+
+  testWidgets('PasteImageListTile handles tap correctly', (tester) async {
+    when(() => mockReader.canProvide(Formats.png)).thenReturn(true);
+    when(() => mockReader.canProvide(Formats.jpeg)).thenReturn(false);
+
+    // Mock the file reading part
+    when(() => mockReader.getFile(Formats.png, any())).thenAnswer((_) => null);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          clipboardRepositoryProvider.overrideWithValue(mockClipboard),
+        ],
+        child: createTestApp(
+          Navigator(
+            onGenerateRoute: (settings) {
+              return MaterialPageRoute<void>(
+                builder: (context) => const Material(
+                  child: PasteImageListTile(
+                    'testId',
+                    categoryId: 'testCategory',
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    // Verify the ListTile is shown
+    expect(find.byType(ListTile), findsOneWidget);
+
+    // Tap the ListTile
+    await tester.tap(find.byType(ListTile));
+    await tester.pumpAndSettle();
+
+    // Verify that Navigator.pop was called (widget is no longer visible)
+    expect(find.byType(ListTile), findsNothing);
+  });
+
+  testWidgets('PasteImageListTile hides when clipboard is null',
+      (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          clipboardRepositoryProvider.overrideWithValue(null),
+        ],
+        child: createTestApp(
+          const Material(
+            child: PasteImageListTile(
+              'testId',
+              categoryId: 'testCategory',
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ListTile), findsNothing);
+    expect(find.byIcon(Icons.paste), findsNothing);
+  });
+}


### PR DESCRIPTION
This PR adds pasting images from the clipboard.

From Copilot:
This pull request introduces a new feature for handling image pasting from the clipboard and includes several related changes across multiple files. The main changes involve adding the capability to read images from the clipboard, updating the UI to include an option for pasting images, and adding tests for the new functionality.

### New Feature: Image Pasting from Clipboard

* [`lib/features/journal/repository/clipboard_repository.dart`](diffhunk://#diff-ee1ac8ffe911d22eb1527daf932b23cabc61d59c256269fc033dffa697c98806R1-R10): Introduced a new repository for accessing the system clipboard using `SystemClipboard`.
* [`lib/features/journal/state/image_paste_controller.dart`](diffhunk://#diff-53bb7ef0b19f0a4ad93ad83cfac32f47b9b9dd04b9f54231401770a96d894ff7R1-R54): Added `ImagePasteController` to manage the logic for checking clipboard content and pasting images.
* [`lib/features/journal/ui/widgets/create/paste_image_list_tile.dart`](diffhunk://#diff-e27458be6b63a25709be3d44e9ea67d9651f705177edda4183a6ea9b76a977b9R1-R37): Created a new UI component `PasteImageListTile` to allow users to paste images from the clipboard.
* [`lib/logic/image_import.dart`](diffhunk://#diff-1655f19893cbede94f77d77d222e83403d993733ea862f1f80f5dc9345be9d23R138-R169): Added `importPastedImages` function to handle the import of pasted images.
* [`test/features/journal/state/image_paste_controller_test.dart`](diffhunk://#diff-a1fdd17a422f6e86d41e4b31d6caa07ba42f97ecd46aa6bc1f8aa343fd01f509R1-R151): Added tests for `ImagePasteController` to ensure proper handling of PNG and JPEG data from the clipboard.

### UI Updates

* [`lib/features/journal/ui/widgets/create/create_entry_action_modal.dart`](diffhunk://#diff-cd5373ab69178d72beaf1b5f911740db669bfef74b37e6b54d388b13caf6bb0fR28): Updated the action modal to include the new `PasteImageListTile`.
* [`lib/l10n/app_en.arb`](diffhunk://#diff-9796fde3771f42a3a759ccc941731d83f96037a661e47dde27ce81d3447a69c2R7): Added localization string for the new paste image action.

### Generated Code and Hash Updates

* [`lib/features/journal/repository/clipboard_repository.g.dart`](diffhunk://#diff-175fa43abe719b13cc66dfac2e89f07bd599d29012cd3234b4cac6a9c1166009R1-R29): Generated code for the clipboard repository.
* [`lib/features/journal/state/entry_controller.g.dart`](diffhunk://#diff-932d97aab947e09371268b0a433688fe08f31ff2896792e738fe6340f97c15f2L9-R9): Updated hash for the entry controller.
* [`lib/features/journal/state/image_paste_controller.g.dart`](diffhunk://#diff-923f9fd95561ebe369f501b0d51034422fe7f912d94f14bb1d47700cac0c3d14R1-R201): Generated code for the image paste controller.
* [`lib/features/ai/state/ollama_image_analysis.g.dart`](diffhunk://#diff-0aa9e0c1a151459e46dd2ee1a255dbd90a2da9805f4b8d6ef62ef90565b6b9bfL10-R10): Updated hash for the AI image analysis controller.

### Miscellaneous

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Bumped the version number.