### PR TITLE
fix: illegible text in modal due to wrong background color

### DIFF
--- a/lib/features/surveys/tools/run_surveys.dart
+++ b/lib/features/surveys/tools/run_surveys.dart
@@ -21,7 +21,7 @@ Future<void> runSurvey({
     pageListBuilder: (modalSheetContext) {
       return [
         ModalUtils.modalSheetPage(
-          context: modalSheetContext,
+          context: context,
           backgroundColor: themeData.canvasColor,
           isTopBarLayerAlwaysVisible: false,
           showCloseButton: false,

--- a/lib/utils/modals.dart
+++ b/lib/utils/modals.dart
@@ -26,7 +26,7 @@ class ModalUtils {
   }) {
     final textTheme = context.textTheme;
     return WoltModalSheetPage(
-      backgroundColor: context.colorScheme.surfaceContainerLow,
+      backgroundColor: context.colorScheme.surfaceContainerHigh,
       hasSabGradient: false,
       topBarTitle:
           title != null ? Text(title, style: textTheme.titleSmall) : null,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.567+2874
+version: 0.9.567+2875
 
 msix_config:
   display_name: LottiApp

--- a/test/utils/modals_test.dart
+++ b/test/utils/modals_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/utils/modals.dart';
+import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
+
+void main() {
+  group('ModalUtils', () {
+    testWidgets('modalTypeBuilder returns bottomSheet for small screens',
+        (tester) async {
+      await tester.binding.setSurfaceSize(const Size(300, 600));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              final modalType = ModalUtils.modalTypeBuilder(context);
+              expect(modalType, isA<WoltModalType>());
+              expect(
+                modalType.runtimeType.toString(),
+                'WoltDialogType',
+              );
+              return const Scaffold();
+            },
+          ),
+        ),
+      );
+    });
+
+    testWidgets('modalTypeBuilder returns dialog for large screens',
+        (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1024, 800));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              final modalType = ModalUtils.modalTypeBuilder(context);
+              expect(modalType, isA<WoltModalType>());
+              expect(modalType.runtimeType.toString(), 'WoltDialogType');
+              return const Scaffold();
+            },
+          ),
+        ),
+      );
+    });
+
+    testWidgets('modalSheetPage creates page with title and close button',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              final page = ModalUtils.modalSheetPage(
+                context: context,
+                title: 'Test Title',
+                child: const Text('Test Content'),
+              );
+
+              expect(page, isA<WoltModalSheetPage>());
+              expect(page.topBarTitle, isA<Text>());
+              expect(page.trailingNavBarWidget, isA<IconButton>());
+              expect(page.child, isA<Padding>());
+              return const Scaffold();
+            },
+          ),
+        ),
+      );
+    });
+
+    testWidgets('modalSheetPage creates page without title and close button',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              final page = ModalUtils.modalSheetPage(
+                context: context,
+                child: const Text('Test Content'),
+                showCloseButton: false,
+              );
+
+              expect(page, isA<WoltModalSheetPage>());
+              expect(page.topBarTitle, isNull);
+              expect(page.trailingNavBarWidget, isNull);
+              expect(page.child, isA<Padding>());
+              return const Scaffold();
+            },
+          ),
+        ),
+      );
+    });
+
+    testWidgets('showSinglePageModal shows modal and can be closed',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) {
+                return ElevatedButton(
+                  onPressed: () {
+                    ModalUtils.showSinglePageModal(
+                      context: context,
+                      title: 'Test Modal',
+                      builder: (context) => const Text('Modal Content'),
+                    );
+                  },
+                  child: const Text('Show Modal'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      // Open modal
+      await tester.tap(find.text('Show Modal'));
+      await tester.pumpAndSettle();
+
+      // Verify modal content is visible
+      expect(find.text('Modal Content'), findsOneWidget);
+      expect(find.text('Test Modal'), findsOneWidget);
+
+      // Close modal using close button
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pumpAndSettle();
+
+      // Verify modal is closed
+      expect(find.text('Modal Content'), findsNothing);
+      expect(find.text('Test Modal'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION

From Copilot:
This pull request includes several changes to improve the `ModalUtils` class and its usage in the project, along with a version update in the `pubspec.yaml` file. The most important changes include fixing a context parameter, updating modal background color, adding comprehensive tests for `ModalUtils`, and updating the project version.

### Improvements to `ModalUtils`:

* [`lib/features/surveys/tools/run_surveys.dart`](diffhunk://#diff-bbdfc5301a494b4cc6f2e8fa41f36f3d85f16078db9613dc401ced74500d0280L24-R24): Fixed the context parameter in the `pageListBuilder` method to use the correct context.
* [`lib/utils/modals.dart`](diffhunk://#diff-4ac64a38abf5cd5347344b350fdbe625465bb437bb80e553bc3de1f2ccbcfebbL29-R29): Updated the modal background color to use `surfaceContainerHigh` instead of `surfaceContainerLow`.

### Tests for `ModalUtils`:

* [`test/utils/modals_test.dart`](diffhunk://#diff-aa5f0ade9f955e687e4274dfb9026a5cfef180a861b8852e9fd1528977394f34R1-R133): Added comprehensive widget tests for `ModalUtils`, including tests for `modalTypeBuilder`, `modalSheetPage`, and `showSinglePageModal`.

### Version update:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Updated the project version from `0.9.567+2874` to `0.9.567+2875`.