### PR TITLE
chore: revert matrix upgrade for testing

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1840,10 +1840,10 @@ packages:
     dependency: "direct main"
     description:
       name: matrix
-      sha256: "519e1d18623f741de5aa984a9d04cf3f660149d1e167fa06e17ddec8cec5f52d"
+      sha256: de99186797fddbf309dae0d9b9b4d35b49ca10d7bb362727f7cd916ce71a77d7
       url: "https://pub.dev"
     source: hosted
-    version: "0.37.0"
+    version: "0.36.0"
   media_kit:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.567+2875
+version: 0.9.567+2876
 
 msix_config:
   display_name: LottiApp
@@ -108,7 +108,7 @@ dependencies:
   latlong2: ^0.9.0
   location: ^8.0.0
   material_design_icons_flutter: ^7.0.7096
-  matrix: ^0.37.0
+  matrix: ^0.36.0
   media_kit: ^1.0.2
   media_kit_libs_android_audio: ^1.0.3
   media_kit_libs_ios_audio: ^1.0.4


### PR DESCRIPTION
This pull request includes minor version updates and a dependency downgrade in the `pubspec.yaml` file.

Version update:

* Updated the version of the `lotti` package from `0.9.567+2875` to `0.9.567+2876`.

Dependency changes:

* Downgraded the `matrix` dependency from `^0.37.0` to `^0.36.0`.