### PR TITLE
chore: add maintenance task for purging audio models

### DIFF
--- a/lib/database/maintenance.dart
+++ b/lib/database/maintenance.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/sync_message.dart';
 import 'package:lotti/database/common.dart';
@@ -15,6 +17,8 @@ import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/tags_service.dart';
+import 'package:lotti/utils/file_utils.dart';
+import 'package:path/path.dart';
 
 class Maintenance {
   final JournalDb _db = getIt<JournalDb>();
@@ -170,6 +174,11 @@ class Maintenance {
   Future<void> deleteEditorDb() async {
     final file = await getDatabaseFile(editorDbFileName);
     file.deleteSync();
+  }
+
+  Future<void> purgeAudioModels() async {
+    File(join(getDocumentsDirectory().path, 'huggingface'))
+        .deleteSync(recursive: true);
   }
 
   Future<void> deleteLoggingDb() async {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -161,6 +161,7 @@
   "maintenanceDeleteTagged": "Delete tagged",
   "maintenancePersistTaskCategories": "Persist task categories",
   "maintenancePurgeDeleted": "Purge deleted items",
+  "maintenancePurgeAudioModels": "Purge audio models",
   "maintenanceRecreateFts5": "Recreate full-text index",
   "maintenanceRecreateTagged": "Recreate tagged",
   "maintenanceReprocessSync": "Reprocess sync messages",

--- a/lib/pages/settings/advanced/maintenance_page.dart
+++ b/lib/pages/settings/advanced/maintenance_page.dart
@@ -65,6 +65,10 @@ class MaintenancePage extends StatelessWidget {
                 onTap: db.purgeDeleted,
               ),
               SettingsCard(
+                title: context.messages.maintenancePurgeAudioModels,
+                onTap: maintenance.purgeAudioModels,
+              ),
+              SettingsCard(
                 title: context.messages.maintenanceCancelNotifications,
                 onTap: () => getIt<NotificationService>().cancelAll(),
               ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.567+2876
+version: 0.9.567+2877
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR adds a workaround for audio model files occasionally getting corrupted, in which case every attempt to run speech recognition results in a hard crash. It would be better to properly handle this on the Swift side, but deleting the entire folder is easier right now and also solves the issue. Once deleted, the audio models need to be downloaded again, which can take a while.

From Copilot:
This pull request includes several changes to add a new feature for purging audio models and updating the localization files. Additionally, there are some minor updates to dependencies and versioning. The most important changes include the addition of the `purgeAudioModels` method, updates to the settings page to include this new feature, and localization updates.

### New Feature: Purge Audio Models

* [`lib/database/maintenance.dart`](diffhunk://#diff-3181a930a3fc0b654a42fa7e456f4dfa84a2f85258cc79a07387dca90852cd66R179-R183): Added a new method `purgeAudioModels` to delete the audio models directory. This method uses the `File` class and the `join` function from the `path` package to locate and delete the directory.
* [`lib/pages/settings/advanced/maintenance_page.dart`](diffhunk://#diff-9629a2a007ae47f07a96d05d0ee0e3dfb0800201a7ae590bbdc1e4dd6a24d205R67-R70): Added a new `SettingsCard` to the maintenance page to allow users to trigger the `purgeAudioModels` method.

### Localization Updates

* [`lib/l10n/app_en.arb`](diffhunk://#diff-9796fde3771f42a3a759ccc941731d83f96037a661e47dde27ce81d3447a69c2R164): Added a new localization string for the "Purge audio models" action.

### Dependency and Version Updates

* [`lib/database/maintenance.dart`](diffhunk://#diff-3181a930a3fc0b654a42fa7e456f4dfa84a2f85258cc79a07387dca90852cd66R1-R2): Added imports for `dart:io`, `file_utils.dart`, and `path.dart` to support the new `purgeAudioModels` method. [[1]](diffhunk://#diff-3181a930a3fc0b654a42fa7e456f4dfa84a2f85258cc79a07387dca90852cd66R1-R2) [[2]](diffhunk://#diff-3181a930a3fc0b654a42fa7e456f4dfa84a2f85258cc79a07387dca90852cd66R20-R21)
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Updated the version number from `0.9.567+2876` to `0.9.567+2877`.