### PR TITLE
chore: replace show modal bottom sheet in date picker

### DIFF
--- a/lib/features/ai/ui/ai_popup_menu.dart
+++ b/lib/features/ai/ui/ai_popup_menu.dart
@@ -21,7 +21,7 @@ class AiPopUpMenu extends StatelessWidget {
     final journalEntity = this.journalEntity;
     return IconButton(
       icon: const Icon(Icons.assistant_rounded),
-      onPressed: () => ModalUtils.showSinglePageModal(
+      onPressed: () => ModalUtils.showSinglePageModal<void>(
         context: context,
         title: context.messages.aiAssistantTitle,
         builder: (_) => Column(

--- a/lib/features/ai/ui/ai_response_summary.dart
+++ b/lib/features/ai/ui/ai_response_summary.dart
@@ -14,7 +14,7 @@ class AiResponseSummary extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
       child: GestureDetector(
         onDoubleTap: () {
-          ModalUtils.showSinglePageModal(
+          ModalUtils.showSinglePageModal<void>(
             context: context,
             builder: (BuildContext _) {
               return AiResponseSummaryModalContent(aiResponse);

--- a/lib/features/ai/ui/image_analysis/ai_image_analysis_list_tile.dart
+++ b/lib/features/ai/ui/image_analysis/ai_image_analysis_list_tile.dart
@@ -30,7 +30,7 @@ class AiImageAnalysisListTile extends ConsumerWidget {
         ref.invalidate(provider);
         ref.read(provider.notifier).analyzeImage();
 
-        ModalUtils.showSinglePageModal(
+        ModalUtils.showSinglePageModal<void>(
           context: context,
           title: context.messages.aiAssistantTitle,
           builder: (_) => AiImageAnalysisView(

--- a/lib/features/ai/ui/task_summary/ai_task_summary_list_tile.dart
+++ b/lib/features/ai/ui/task_summary/ai_task_summary_list_tile.dart
@@ -24,7 +24,7 @@ class AiTaskSummaryListTile extends ConsumerWidget {
       ),
       onTap: () {
         Navigator.of(context).pop();
-        ModalUtils.showSinglePageModal(
+        ModalUtils.showSinglePageModal<void>(
           context: context,
           title: context.messages.aiAssistantTitle,
           builder: (_) => AiTaskSummaryView(

--- a/lib/features/categories/ui/widgets/category_field.dart
+++ b/lib/features/categories/ui/widgets/category_field.dart
@@ -29,7 +29,7 @@ class CategoryField extends StatelessWidget {
     final controller = TextEditingController()..text = category?.name ?? '';
 
     void onTap() {
-      ModalUtils.showSinglePageModal(
+      ModalUtils.showSinglePageModal<void>(
         context: context,
         title: context.messages.habitCategoryLabel,
         builder: (BuildContext _) {
@@ -110,7 +110,7 @@ class _CategorySelectionContentState
   Future<void> _showColorPicker(String categoryName) async {
     if (!mounted) return;
 
-    await ModalUtils.showSinglePageModal(
+    await ModalUtils.showSinglePageModal<void>(
       context: context,
       title: context.messages.createCategoryTitle,
       builder: (BuildContext context) {

--- a/lib/features/categories/ui/widgets/select_color_field.dart
+++ b/lib/features/categories/ui/widgets/select_color_field.dart
@@ -55,7 +55,7 @@ class _SelectColorFieldState extends State<SelectColorField> {
         : context.colorScheme.outline;
 
     Future<void> onTap() async {
-      await ModalUtils.showSinglePageModal(
+      await ModalUtils.showSinglePageModal<void>(
         context: context,
         title: context.messages.createCategoryTitle,
         builder: (BuildContext context) {

--- a/lib/features/journal/ui/widgets/create/create_entry_action_modal.dart
+++ b/lib/features/journal/ui/widgets/create/create_entry_action_modal.dart
@@ -12,7 +12,7 @@ class CreateEntryModal {
     required String? linkedFromId,
     required String? categoryId,
   }) async {
-    await ModalUtils.showSinglePageModal(
+    await ModalUtils.showSinglePageModal<void>(
       context: context,
       title: context.messages.createEntryTitle,
       builder: (_) => Column(

--- a/lib/features/journal/ui/widgets/entry_detail_linked.dart
+++ b/lib/features/journal/ui/widgets/entry_detail_linked.dart
@@ -41,7 +41,7 @@ class LinkedEntriesWidget extends ConsumerWidget {
             IconButton(
               icon: Icon(Icons.filter_list, color: color),
               onPressed: () {
-                ModalUtils.showSinglePageModal(
+                ModalUtils.showSinglePageModal<void>(
                   context: context,
                   builder: (BuildContext _) =>
                       LinkedFilterModalContent(entryId: item.id),

--- a/lib/features/journal/ui/widgets/entry_details/entry_datetime_widget.dart
+++ b/lib/features/journal/ui/widgets/entry_details/entry_datetime_widget.dart
@@ -30,7 +30,7 @@ class EntryDatetimeWidget extends ConsumerWidget {
       padding: const EdgeInsets.only(bottom: 5),
       child: GestureDetector(
         onTap: () {
-          ModalUtils.showSinglePageModal(
+          ModalUtils.showSinglePageModal<void>(
             context: context,
             builder: (BuildContext _) {
               return EntryDateTimeModal(item: entry);

--- a/lib/features/journal/ui/widgets/entry_details/entry_datetime_widget.dart
+++ b/lib/features/journal/ui/widgets/entry_details/entry_datetime_widget.dart
@@ -35,6 +35,7 @@ class EntryDatetimeWidget extends ConsumerWidget {
             builder: (BuildContext _) {
               return EntryDateTimeModal(item: entry);
             },
+            navBarHeight: 20,
           );
         },
         child: Padding(

--- a/lib/features/journal/ui/widgets/entry_details/header/extended_header_modal.dart
+++ b/lib/features/journal/ui/widgets/entry_details/header/extended_header_modal.dart
@@ -22,7 +22,7 @@ class ExtendedHeaderModal {
   }) async {
     final linkService = getIt<LinkService>();
 
-    await ModalUtils.showSinglePageModal(
+    await ModalUtils.showSinglePageModal<void>(
       context: context,
       title: context.messages.entryActions,
       builder: (context) => Column(

--- a/lib/features/speech/ui/widgets/speech_modal/speech_modal.dart
+++ b/lib/features/speech/ui/widgets/speech_modal/speech_modal.dart
@@ -26,7 +26,7 @@ class SpeechModalListTile extends ConsumerWidget {
       return const SizedBox.shrink();
     }
 
-    void onTapAdd() => ModalUtils.showSinglePageModal(
+    void onTapAdd() => ModalUtils.showSinglePageModal<void>(
           context: context,
           title: context.messages.speechModalTitle,
           builder: (_) => Column(

--- a/lib/features/speech/ui/widgets/transcription_progress_modal.dart
+++ b/lib/features/speech/ui/widgets/transcription_progress_modal.dart
@@ -57,7 +57,7 @@ class TranscriptionProgressModalContent extends StatelessWidget {
 
 class TranscriptionProgressModal {
   static Future<void> show(BuildContext context) async {
-    await ModalUtils.showSinglePageModal(
+    await ModalUtils.showSinglePageModal<void>(
       context: context,
       title: context.messages.speechModalTranscriptionProgress,
       builder: (_) => const TranscriptionProgressModalContent(),

--- a/lib/features/sync/ui/re_sync_modal.dart
+++ b/lib/features/sync/ui/re_sync_modal.dart
@@ -68,7 +68,7 @@ class _ReSyncModalContentState extends State<ReSyncModalContent> {
 
 class ReSyncModal {
   static Future<void> show(BuildContext context) async {
-    await ModalUtils.showSinglePageModal(
+    await ModalUtils.showSinglePageModal<void>(
       context: context,
       title: 'Re-sync entries',
       builder: (_) => const ReSyncModalContent(),

--- a/lib/utils/modals.dart
+++ b/lib/utils/modals.dart
@@ -45,13 +45,13 @@ class ModalUtils {
     );
   }
 
-  static Future<void> showSinglePageModal({
+  static Future<T?> showSinglePageModal<T>({
     required BuildContext context,
     required Widget Function(BuildContext) builder,
     String? title,
     Widget Function(Widget)? modalDecorator,
   }) async {
-    await WoltModalSheet.show<void>(
+    return WoltModalSheet.show<T>(
       context: context,
       pageListBuilder: (modalSheetContext) {
         return [

--- a/lib/utils/modals.dart
+++ b/lib/utils/modals.dart
@@ -23,11 +23,13 @@ class ModalUtils {
     bool isTopBarLayerAlwaysVisible = true,
     bool showCloseButton = true,
     EdgeInsetsGeometry padding = WoltModalConfig.pagePadding,
+    double? navBarHeight,
   }) {
     final textTheme = context.textTheme;
     return WoltModalSheetPage(
       backgroundColor: context.colorScheme.surfaceContainerHigh,
       hasSabGradient: false,
+      navBarHeight: navBarHeight,
       topBarTitle:
           title != null ? Text(title, style: textTheme.titleSmall) : null,
       isTopBarLayerAlwaysVisible: isTopBarLayerAlwaysVisible,
@@ -50,6 +52,8 @@ class ModalUtils {
     required Widget Function(BuildContext) builder,
     String? title,
     Widget Function(Widget)? modalDecorator,
+    EdgeInsetsGeometry padding = WoltModalConfig.pagePadding,
+    double? navBarHeight,
   }) async {
     return WoltModalSheet.show<T>(
       context: context,
@@ -61,6 +65,8 @@ class ModalUtils {
             child: builder(modalSheetContext),
             isTopBarLayerAlwaysVisible: title != null,
             showCloseButton: title != null,
+            padding: padding,
+            navBarHeight: navBarHeight,
           ),
         ];
       },

--- a/lib/widgets/app_bar/journal_sliver_appbar.dart
+++ b/lib/widgets/app_bar/journal_sliver_appbar.dart
@@ -127,7 +127,7 @@ class JournalFilterIcon extends StatelessWidget {
       padding: const EdgeInsets.only(right: 30),
       child: IconButton(
         onPressed: () {
-          ModalUtils.showSinglePageModal(
+          ModalUtils.showSinglePageModal<void>(
             context: context,
             title: context.messages.journalSearchHint,
             modalDecorator: (child) {

--- a/lib/widgets/date_time/datetime_bottom_sheet.dart
+++ b/lib/widgets/date_time/datetime_bottom_sheet.dart
@@ -31,6 +31,25 @@ class _DateTimeBottomSheetState extends State<DateTimeBottomSheet> {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
+        CupertinoTheme(
+          data: CupertinoThemeData(
+            textTheme: CupertinoTextThemeData(
+              dateTimePickerTextStyle:
+                  context.textTheme.titleLarge?.withTabularFigures,
+            ),
+          ),
+          child: SizedBox(
+            height: 265,
+            child: CupertinoDatePicker(
+              initialDateTime: widget.initial,
+              mode: widget.mode,
+              use24hFormat: true,
+              onDateTimeChanged: (DateTime value) {
+                dateTime = value;
+              },
+            ),
+          ),
+        ),
         Container(
           padding: const EdgeInsets.symmetric(
             horizontal: 20,
@@ -59,25 +78,6 @@ class _DateTimeBottomSheetState extends State<DateTimeBottomSheet> {
                 child: Text(context.messages.doneButton),
               ),
             ],
-          ),
-        ),
-        CupertinoTheme(
-          data: CupertinoThemeData(
-            textTheme: CupertinoTextThemeData(
-              dateTimePickerTextStyle:
-                  context.textTheme.titleLarge?.withTabularFigures,
-            ),
-          ),
-          child: SizedBox(
-            height: 265,
-            child: CupertinoDatePicker(
-              initialDateTime: widget.initial,
-              mode: widget.mode,
-              use24hFormat: true,
-              onDateTimeChanged: (DateTime value) {
-                dateTime = value;
-              },
-            ),
           ),
         ),
       ],

--- a/lib/widgets/date_time/datetime_field.dart
+++ b/lib/widgets/date_time/datetime_field.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:lotti/features/journal/util/entry_tools.dart';
 import 'package:lotti/themes/theme.dart';
+import 'package:lotti/utils/modals.dart';
 import 'package:lotti/widgets/date_time/datetime_bottom_sheet.dart';
 
 class DateTimeField extends StatefulWidget {
@@ -54,14 +55,16 @@ class _DateTimeFieldState extends State<DateTimeField> {
         text: widget.dateTime != null ? df.format(widget.dateTime!) : '',
       ),
       onTap: () async {
-        final newDateTime = await showModalBottomSheet<DateTime>(
+        final newDateTime = await ModalUtils.showSinglePageModal<DateTime>(
           context: context,
-          builder: (context) {
+          builder: (_) {
             return DateTimeBottomSheet(
               widget.dateTime ?? DateTime.now(),
               mode: widget.mode,
             );
           },
+          padding: EdgeInsets.zero,
+          navBarHeight: 5,
         );
 
         if (newDateTime != null) {

--- a/lib/widgets/search/task_filter_icon.dart
+++ b/lib/widgets/search/task_filter_icon.dart
@@ -18,7 +18,7 @@ class TaskFilterIcon extends StatelessWidget {
       padding: const EdgeInsets.only(right: 30),
       child: IconButton(
         onPressed: () {
-          ModalUtils.showSinglePageModal(
+          ModalUtils.showSinglePageModal<void>(
             context: context,
             title: context.messages.tasksFilterTitle,
             builder: (_) => const Column(

--- a/lib/widgets/settings/dashboards/dashboard_category.dart
+++ b/lib/widgets/settings/dashboards/dashboard_category.dart
@@ -40,7 +40,7 @@ class SelectDashboardCategoryWidget extends StatelessWidget {
         controller.text = category?.name ?? '';
 
         void onTap() {
-          ModalUtils.showSinglePageModal(
+          ModalUtils.showSinglePageModal<void>(
             context: context,
             title: context.messages.dashboardCategoryLabel,
             builder: (BuildContext _) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.567+2870
+version: 0.9.567+2879
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.567+2878
+version: 0.9.567+2870
 
 msix_config:
   display_name: LottiApp

--- a/test/utils/modals_test.dart
+++ b/test/utils/modals_test.dart
@@ -99,7 +99,7 @@ void main() {
               builder: (context) {
                 return ElevatedButton(
                   onPressed: () {
-                    ModalUtils.showSinglePageModal(
+                    ModalUtils.showSinglePageModal<void>(
                       context: context,
                       title: 'Test Modal',
                       builder: (context) => const Text('Modal Content'),


### PR DESCRIPTION
This PR replaces one more occurrence of `showModalBottomSheet` with `ModalUtils.showSinglePageModal`. Eventually, they should all use the latter.

From Copilot:
This pull request includes several updates to the `ModalUtils.showSinglePageModal` method across multiple files to specify a return type of `void`. Additionally, there are changes to the `ModalUtils` class to include new parameters for `padding` and `navBarHeight`. Below are the most important changes:

Updates to `ModalUtils.showSinglePageModal` method:

* [`lib/features/ai/ui/ai_popup_menu.dart`](diffhunk://#diff-ffcb87d546496ab34540b9a3dd2913bdf15b2a0b948883c5100399372ad2e673L24-R24): Updated `ModalUtils.showSinglePageModal` to specify a return type of `void`.
* [`lib/features/ai/ui/ai_response_summary.dart`](diffhunk://#diff-5ede4ba7236014c6a418c6e3ceb9b781bb650bf91a377c7ff2f0ccc3cde6d9cbL17-R17): Updated `ModalUtils.showSinglePageModal` to specify a return type of `void`.
* [`lib/features/ai/ui/image_analysis/ai_image_analysis_list_tile.dart`](diffhunk://#diff-66670fbe9679d161a35d462b3e3e73b3cc078612a05fa13b93f10b871e907708L33-R33): Updated `ModalUtils.showSinglePageModal` to specify a return type of `void`.
* [`lib/features/ai/ui/task_summary/ai_task_summary_list_tile.dart`](diffhunk://#diff-99c2573106cba5ea8de131b2924be882807a23ceedaf44d67e4000f70ef85bc0L27-R27): Updated `ModalUtils.showSinglePageModal` to specify a return type of `void`.
* [`lib/features/categories/ui/widgets/category_field.dart`](diffhunk://#diff-f646f96452ba3bda944c07b4b941c34f47ae66283f4532f413d9fd05b4478fdcL32-R32): Updated `ModalUtils.showSinglePageModal` to specify a return type of `void`. [[1]](diffhunk://#diff-f646f96452ba3bda944c07b4b941c34f47ae66283f4532f413d9fd05b4478fdcL32-R32) [[2]](diffhunk://#diff-f646f96452ba3bda944c07b4b941c34f47ae66283f4532f413d9fd05b4478fdcL113-R113)

Enhancements to `ModalUtils` class:

* [`lib/utils/modals.dart`](diffhunk://#diff-4ac64a38abf5cd5347344b350fdbe625465bb437bb80e553bc3de1f2ccbcfebbR26-R32): Added `padding` and `navBarHeight` parameters to the `showSinglePageModal` method and the `WoltModalSheetPage` class. [[1]](diffhunk://#diff-4ac64a38abf5cd5347344b350fdbe625465bb437bb80e553bc3de1f2ccbcfebbR26-R32) [[2]](diffhunk://#diff-4ac64a38abf5cd5347344b350fdbe625465bb437bb80e553bc3de1f2ccbcfebbL48-R58) [[3]](diffhunk://#diff-4ac64a38abf5cd5347344b350fdbe625465bb437bb80e553bc3de1f2ccbcfebbR68-R69)

Other notable changes:

* [`lib/widgets/date_time/datetime_bottom_sheet.dart`](diffhunk://#diff-811281c595d316723558cbf6080cdd64d228eb764a816607865111cc56494944R34-R52): Refactored to use `ModalUtils.showSinglePageModal` and adjusted the layout for the date picker. [[1]](diffhunk://#diff-811281c595d316723558cbf6080cdd64d228eb764a816607865111cc56494944R34-R52) [[2]](diffhunk://#diff-811281c595d316723558cbf6080cdd64d228eb764a816607865111cc56494944L64-L82)
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Updated the version number.