### PR TITLE
fix: debug send issue

### DIFF
--- a/lib/features/sync/matrix/client.dart
+++ b/lib/features/sync/matrix/client.dart
@@ -20,7 +20,6 @@ Client createMatrixClient({
       KeyVerificationMethod.emoji,
       KeyVerificationMethod.reciprocate,
     },
-    shareKeysWithUnverifiedDevices: false,
     sendTimelineEventTimeout: const Duration(minutes: 2),
     databaseBuilder: (_) async {
       final docDir = getIt<Directory>();

--- a/lib/features/sync/matrix/send_message.dart
+++ b/lib/features/sync/matrix/send_message.dart
@@ -32,7 +32,7 @@ extension SendExtension on MatrixService {
   /// Also updates some stats on sent message counts on the [MatrixService].
   /// The send function will terminate early (and thus refuse to send anything)
   /// when there are users with unverified device in the room.
-  Future<void> sendMatrixMsg(
+  Future<bool> sendMatrixMsg(
     SyncMessage syncMessage, {
     String? myRoomId,
   }) async {
@@ -56,7 +56,7 @@ extension SendExtension on MatrixService {
         domain: 'MATRIX_SERVICE',
         subDomain: 'sendMatrixMsg',
       );
-      throw Exception(configNotFound);
+      return false;
     }
 
     loggingService.captureEvent(
@@ -117,6 +117,7 @@ extension SendExtension on MatrixService {
         orElse: () {},
       );
     }
+    return true;
   }
 
   /// Sends a file attachment to the sync room.

--- a/lib/features/sync/outbox/outbox_service.dart
+++ b/lib/features/sync/outbox/outbox_service.dart
@@ -158,11 +158,16 @@ class OutboxService {
         );
 
         try {
-          await getIt<MatrixService>().sendMatrixMsg(
+          final success = await getIt<MatrixService>().sendMatrixMsg(
             SyncMessage.fromJson(
               json.decode(nextPending.message) as Map<String, dynamic>,
             ),
           );
+
+          if (!success) {
+            await enqueueNextSendRequest(delay: const Duration(seconds: 5));
+            return;
+          }
 
           await _syncDatabase.updateOutboxItem(
             OutboxCompanion(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1840,10 +1840,10 @@ packages:
     dependency: "direct main"
     description:
       name: matrix
-      sha256: de99186797fddbf309dae0d9b9b4d35b49ca10d7bb362727f7cd916ce71a77d7
+      sha256: d0da69e5ee8dfc1692c02e4b460a1bc136120f0dcf5e02cf604b23cd39d76903
       url: "https://pub.dev"
     source: hosted
-    version: "0.36.0"
+    version: "0.38.0"
   media_kit:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.567+2881
+version: 0.9.567+2882
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.567+2880
+version: 0.9.567+2881
 
 msix_config:
   display_name: LottiApp
@@ -108,7 +108,7 @@ dependencies:
   latlong2: ^0.9.0
   location: ^8.0.0
   material_design_icons_flutter: ^7.0.7096
-  matrix: ^0.36.0
+  matrix: ^0.38.0
   media_kit: ^1.0.2
   media_kit_libs_android_audio: ^1.0.3
   media_kit_libs_ios_audio: ^1.0.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.567+2879
+version: 0.9.567+2880
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR adds some logging around an intermittent sync issue. Not entirely certain what the issue might me. Could also be an issue on the server side.


From Copilot:
This pull request includes several changes to improve the functionality and error handling of the Matrix client and to update dependencies. The most important changes include modifying the `sendMatrixMsg` method to return a boolean, adding error handling in the `sendFile` method, and updating the `pubspec.yaml` file to use a newer version of the `matrix` dependency.

Improvements to error handling and functionality:

* [`lib/features/sync/matrix/send_message.dart`](diffhunk://#diff-4f804bc4768a191df8103ec9f2940225bff8df498406580833aa73b7b69d80fdL35-R35): Modified the `sendMatrixMsg` method to return a boolean instead of void, and updated the method to handle configuration not found errors by returning false instead of throwing an exception. [[1]](diffhunk://#diff-4f804bc4768a191df8103ec9f2940225bff8df498406580833aa73b7b69d80fdL35-R35) [[2]](diffhunk://#diff-4f804bc4768a191df8103ec9f2940225bff8df498406580833aa73b7b69d80fdL59-R59) [[3]](diffhunk://#diff-4f804bc4768a191df8103ec9f2940225bff8df498406580833aa73b7b69d80fdR120-R129)
* [`lib/features/sync/matrix/send_message.dart`](diffhunk://#diff-4f804bc4768a191df8103ec9f2940225bff8df498406580833aa73b7b69d80fdL148-R161): Added error handling in the `sendFile` method to capture exceptions and log them using the `LoggingService`.

Dependency updates:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L111-R111): Updated the `matrix` dependency from version `0.36.0` to `0.38.0`.

Other changes:

* [`lib/features/sync/matrix/client.dart`](diffhunk://#diff-0415579100cb5e000989b4e572cfef47e1a389ffe9de2d4ccfc6bea576c99213L23): Removed the `shareKeysWithUnverifiedDevices` configuration option.
* [`lib/features/sync/outbox/outbox_service.dart`](diffhunk://#diff-faf3f488a7f4fded6bcc246677a38fa8ff54b6133ce00418a05ee11ed1f6ac6cL161-R171): Updated the `OutboxService` to handle the boolean return value of `sendMatrixMsg` and retry sending messages if the send operation fails.
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Incremented the version number from `0.9.567+2879` to `0.9.567+2882`.