### PR TITLE
feat: show favorite categories first

### DIFF
--- a/lib/features/calendar/ui/widgets/time_by_category_chart_legend.dart
+++ b/lib/features/calendar/ui/widgets/time_by_category_chart_legend.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/calendar/state/day_view_controller.dart';
-import 'package:lotti/features/categories/ui/widgets/categories_type_card.dart';
+import 'package:lotti/features/categories/ui/widgets/category_color_icon.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/utils/date_utils_extension.dart';

--- a/lib/features/categories/ui/widgets/category_color_icon.dart
+++ b/lib/features/categories/ui/widgets/category_color_icon.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/entities_cache_service.dart';
+import 'package:lotti/themes/theme.dart';
+import 'package:lotti/utils/color.dart';
+
+class ColorIcon extends StatelessWidget {
+  const ColorIcon(
+    this.color, {
+    this.size = 20.0,
+    super.key,
+  });
+
+  final Color color;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(size / 4),
+      child: Container(
+        height: size,
+        width: size,
+        color: color,
+      ),
+    );
+  }
+}
+
+class CategoryColorIcon extends StatelessWidget {
+  const CategoryColorIcon(
+    this.categoryId, {
+    this.size = 20.0,
+    super.key,
+  });
+
+  final String? categoryId;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final category = getIt<EntitiesCacheService>().getCategoryById(categoryId);
+
+    return ColorIcon(
+      category != null
+          ? colorFromCssHex(category.color)
+          : context.colorScheme.outline.withAlpha(51),
+      size: size,
+    );
+  }
+}

--- a/lib/features/categories/ui/widgets/category_selection_icon_button.dart
+++ b/lib/features/categories/ui/widgets/category_selection_icon_button.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/categories/ui/widgets/category_color_icon.dart';
+import 'package:lotti/features/categories/ui/widgets/category_selection_modal_content.dart';
+import 'package:lotti/features/journal/state/entry_controller.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/utils/modals.dart';
+
+class CategorySelectionIconButton extends ConsumerWidget {
+  const CategorySelectionIconButton({
+    required this.entry,
+    super.key,
+  });
+
+  final JournalEntity entry;
+
+  @override
+  Widget build(
+    BuildContext context,
+    WidgetRef ref,
+  ) {
+    final provider = entryControllerProvider(id: entry.id);
+    final notifier = ref.read(provider.notifier);
+
+    return GestureDetector(
+      onTap: () {
+        ModalUtils.showSinglePageModal<void>(
+          context: context,
+          title: context.messages.habitCategoryLabel,
+          builder: (BuildContext _) {
+            return CategorySelectionModalContent(
+              onCategorySelected: (category) {
+                notifier.updateCategoryId(category?.id);
+                Navigator.pop(context);
+              },
+              initialCategoryId: entry.categoryId,
+            );
+          },
+        );
+      },
+      child: CategoryColorIcon(entry.categoryId),
+    );
+  }
+}

--- a/lib/features/categories/ui/widgets/category_selection_modal_content.dart
+++ b/lib/features/categories/ui/widgets/category_selection_modal_content.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/features/categories/ui/widgets/category_color_icon.dart';
+import 'package:lotti/features/categories/ui/widgets/category_create_modal.dart';
+import 'package:lotti/features/categories/ui/widgets/category_field.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/services/entities_cache_service.dart';
+import 'package:lotti/themes/theme.dart';
+import 'package:lotti/utils/modals.dart';
+import 'package:lotti/widgets/settings/settings_card.dart';
+
+class CategorySelectionModalContent extends ConsumerStatefulWidget {
+  const CategorySelectionModalContent({
+    required this.onCategorySelected,
+    this.initialCategoryId,
+    super.key,
+  });
+
+  final CategoryCallback onCategorySelected;
+  final String? initialCategoryId;
+
+  @override
+  ConsumerState<CategorySelectionModalContent> createState() =>
+      CategorySelectionModalContentState();
+}
+
+class CategorySelectionModalContentState
+    extends ConsumerState<CategorySelectionModalContent> {
+  final searchController = TextEditingController();
+  String searchQuery = '';
+
+  @override
+  void dispose() {
+    searchController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _showColorPicker(String categoryName) async {
+    if (!mounted) return;
+
+    await ModalUtils.showSinglePageModal<void>(
+      context: context,
+      title: context.messages.createCategoryTitle,
+      builder: (BuildContext context) {
+        return CategoryCreateModal(
+          initialName: categoryName,
+          onCategoryCreated: (category) {
+            widget.onCategorySelected(category);
+          },
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final categories = getIt<EntitiesCacheService>().sortedCategories;
+    final filteredCategories = categories
+        .where(
+          (category) =>
+              category.name.toLowerCase().contains(searchQuery.toLowerCase()),
+        )
+        .toList();
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: TextField(
+            controller: searchController,
+            decoration: InputDecoration(
+              hintText: context.messages.categorySearchPlaceholder,
+              prefixIcon: const Icon(Icons.search),
+            ),
+            onChanged: (value) {
+              setState(() {
+                searchQuery = value;
+              });
+            },
+            onSubmitted: (value) {
+              if (filteredCategories.isEmpty && value.isNotEmpty) {
+                _showColorPicker(value);
+              }
+            },
+          ),
+        ),
+        if (filteredCategories.isEmpty && searchQuery.isNotEmpty)
+          SettingsCard(
+            onTap: () => _showColorPicker(searchQuery),
+            title: searchQuery,
+            titleColor: context.colorScheme.outline,
+            leading: Icon(
+              Icons.add_circle_outline,
+              color: context.colorScheme.outline,
+            ),
+          )
+        else
+          ...filteredCategories.map(
+            (category) => SettingsCard(
+              onTap: () => widget.onCategorySelected(category),
+              title: category.name,
+              leading: CategoryColorIcon(category.id),
+            ),
+          ),
+        if (widget.initialCategoryId != null)
+          SettingsCard(
+            onTap: () => widget.onCategorySelected(null),
+            title: 'clear',
+            titleColor: context.colorScheme.outline,
+            leading: Icon(
+              Icons.clear,
+              color: context.colorScheme.outline,
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/features/categories/ui/widgets/category_selection_modal_content.dart
+++ b/lib/features/categories/ui/widgets/category_selection_modal_content.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:lotti/features/categories/ui/widgets/category_color_icon.dart';
 import 'package:lotti/features/categories/ui/widgets/category_create_modal.dart';
 import 'package:lotti/features/categories/ui/widgets/category_field.dart';
+import 'package:lotti/features/categories/ui/widgets/category_type_card.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/services/entities_cache_service.dart';
@@ -63,6 +63,12 @@ class CategorySelectionModalContentState
         )
         .toList();
 
+    final favoriteCategories =
+        categories.where((category) => category.favorite ?? false).toList();
+
+    final otherCategories =
+        categories.where((category) => !(category.favorite ?? false)).toList();
+
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -96,14 +102,20 @@ class CategorySelectionModalContentState
               color: context.colorScheme.outline,
             ),
           )
-        else
-          ...filteredCategories.map(
-            (category) => SettingsCard(
+        else ...[
+          ...favoriteCategories.map(
+            (category) => CategoryTypeCard(
+              category,
               onTap: () => widget.onCategorySelected(category),
-              title: category.name,
-              leading: CategoryColorIcon(category.id),
             ),
           ),
+          ...otherCategories.map(
+            (category) => CategoryTypeCard(
+              category,
+              onTap: () => widget.onCategorySelected(category),
+            ),
+          ),
+        ],
         if (widget.initialCategoryId != null)
           SettingsCard(
             onTap: () => widget.onCategorySelected(null),

--- a/lib/features/categories/ui/widgets/category_type_card.dart
+++ b/lib/features/categories/ui/widgets/category_type_card.dart
@@ -1,30 +1,29 @@
 import 'package:flutter/material.dart';
 import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/features/categories/ui/widgets/category_color_icon.dart';
 import 'package:lotti/features/journal/util/entry_tools.dart';
-import 'package:lotti/get_it.dart';
-import 'package:lotti/services/entities_cache_service.dart';
+import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/themes/colors.dart';
 import 'package:lotti/themes/theme.dart';
-import 'package:lotti/utils/color.dart';
 import 'package:lotti/widgets/settings/settings_card.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
-class CategoriesTypeCard extends StatelessWidget {
-  const CategoriesTypeCard(
+class CategoryTypeCard extends StatelessWidget {
+  const CategoryTypeCard(
     this.categoryDefinition, {
-    required this.index,
+    required this.onTap,
     super.key,
   });
 
   final CategoryDefinition categoryDefinition;
-  final int index;
+  final void Function() onTap;
 
   @override
   Widget build(BuildContext context) {
-    return SettingsNavCard(
-      path: '/settings/categories/${categoryDefinition.id}',
+    return SettingsCard(
+      onTap: onTap,
       title: categoryDefinition.name,
-      leading: ColorIcon(colorFromCssHex(categoryDefinition.color)),
+      leading: CategoryColorIcon(categoryDefinition.id),
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
@@ -52,48 +51,21 @@ class CategoriesTypeCard extends StatelessWidget {
   }
 }
 
-class ColorIcon extends StatelessWidget {
-  const ColorIcon(
-    this.color, {
-    this.size = 20.0,
+class CategoryTypeNavCard extends StatelessWidget {
+  const CategoryTypeNavCard(
+    this.categoryDefinition, {
+    required this.index,
     super.key,
   });
 
-  final Color color;
-  final double size;
+  final CategoryDefinition categoryDefinition;
+  final int index;
 
   @override
   Widget build(BuildContext context) {
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(size / 4),
-      child: Container(
-        height: size,
-        width: size,
-        color: color,
-      ),
-    );
-  }
-}
-
-class CategoryColorIcon extends StatelessWidget {
-  const CategoryColorIcon(
-    this.categoryId, {
-    this.size = 20.0,
-    super.key,
-  });
-
-  final String? categoryId;
-  final double size;
-
-  @override
-  Widget build(BuildContext context) {
-    final category = getIt<EntitiesCacheService>().getCategoryById(categoryId);
-
-    return ColorIcon(
-      category != null
-          ? colorFromCssHex(category.color)
-          : context.colorScheme.outline.withAlpha(51),
-      size: size,
+    return CategoryTypeCard(
+      categoryDefinition,
+      onTap: () => beamToNamed('/settings/categories/${categoryDefinition.id}'),
     );
   }
 }

--- a/lib/features/categories/ui/widgets/select_color_field.dart
+++ b/lib/features/categories/ui/widgets/select_color_field.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_colorpicker/flutter_colorpicker.dart';
-import 'package:lotti/features/categories/ui/widgets/categories_type_card.dart';
+import 'package:lotti/features/categories/ui/widgets/category_color_icon.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/utils/color.dart';

--- a/lib/features/dashboards/ui/widgets/dashboards_card.dart
+++ b/lib/features/dashboards/ui/widgets/dashboards_card.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:lotti/classes/entity_definitions.dart';
-import 'package:lotti/features/categories/ui/widgets/categories_type_card.dart';
+import 'package:lotti/features/categories/ui/widgets/category_color_icon.dart';
 import 'package:lotti/widgets/settings/settings_card.dart';
 
 class DashboardCard extends StatelessWidget {

--- a/lib/features/habits/ui/widgets/habit_completion_card.dart
+++ b/lib/features/habits/ui/widgets/habit_completion_card.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intersperse/intersperse.dart';
 import 'package:lotti/classes/entity_definitions.dart';
-import 'package:lotti/features/categories/ui/widgets/categories_type_card.dart';
+import 'package:lotti/features/categories/ui/widgets/category_color_icon.dart';
 import 'package:lotti/features/habits/state/habit_completion_controller.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/pages/create/complete_habit_dialog.dart';

--- a/lib/features/habits/ui/widgets/habit_completion_color_icon.dart
+++ b/lib/features/habits/ui/widgets/habit_completion_color_icon.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:lotti/features/categories/ui/widgets/categories_type_card.dart';
+import 'package:lotti/features/categories/ui/widgets/category_color_icon.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 

--- a/lib/features/journal/ui/widgets/entry_details/habit_summary.dart
+++ b/lib/features/journal/ui/widgets/entry_details/habit_summary.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
-import 'package:lotti/features/categories/ui/widgets/categories_type_card.dart';
+import 'package:lotti/features/categories/ui/widgets/category_color_icon.dart';
 import 'package:lotti/features/journal/ui/widgets/helpers.dart';
 import 'package:lotti/features/journal/ui/widgets/text_viewer_widget.dart';
 import 'package:lotti/get_it.dart';

--- a/lib/features/journal/ui/widgets/entry_details/header/entry_detail_header.dart
+++ b/lib/features/journal/ui/widgets/entry_details/header/entry_detail_header.dart
@@ -4,7 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/ai/ui/ai_popup_menu.dart';
-import 'package:lotti/features/categories/ui/widgets/category_field.dart';
+import 'package:lotti/features/categories/ui/widgets/category_selection_icon_button.dart';
 import 'package:lotti/features/journal/state/entry_controller.dart';
 import 'package:lotti/features/journal/ui/widgets/entry_details/header/extended_header_modal.dart';
 import 'package:lotti/features/journal/ui/widgets/entry_details/save_button.dart';

--- a/lib/features/journal/ui/widgets/journal_card.dart
+++ b/lib/features/journal/ui/widgets/journal_card.dart
@@ -5,7 +5,7 @@ import 'package:flutter_rating/flutter_rating.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gpt_markdown/gpt_markdown.dart';
 import 'package:lotti/classes/journal_entities.dart';
-import 'package:lotti/features/categories/ui/widgets/categories_type_card.dart';
+import 'package:lotti/features/categories/ui/widgets/category_color_icon.dart';
 import 'package:lotti/features/habits/ui/widgets/habit_completion_color_icon.dart';
 import 'package:lotti/features/journal/state/journal_card_controller.dart';
 import 'package:lotti/features/journal/ui/widgets/card_image_widget.dart';

--- a/lib/features/tasks/ui/time_recording_icon.dart
+++ b/lib/features/tasks/ui/time_recording_icon.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:lotti/classes/journal_entities.dart';
-import 'package:lotti/features/categories/ui/widgets/categories_type_card.dart';
+import 'package:lotti/features/categories/ui/widgets/category_color_icon.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/time_service.dart';
 import 'package:lotti/themes/theme.dart';

--- a/lib/pages/settings/categories/categories_page.dart
+++ b/lib/pages/settings/categories/categories_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/database/database.dart';
-import 'package:lotti/features/categories/ui/widgets/categories_type_card.dart';
+import 'package:lotti/features/categories/ui/widgets/category_type_card.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/pages/settings/definitions_list_page.dart';
@@ -21,7 +21,7 @@ class CategoriesPage extends StatelessWidget {
       title: context.messages.settingsCategoriesTitle,
       getName: (category) => category.name.toLowerCase(),
       definitionCard: (int index, CategoryDefinition categoryDefinition) =>
-          CategoriesTypeCard(categoryDefinition, index: index),
+          CategoryTypeNavCard(categoryDefinition, index: index),
     );
   }
 }

--- a/lib/widgets/settings/dashboards/dashboard_category.dart
+++ b/lib/widgets/settings/dashboards/dashboard_category.dart
@@ -2,7 +2,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/database/database.dart';
-import 'package:lotti/features/categories/ui/widgets/categories_type_card.dart';
+import 'package:lotti/features/categories/ui/widgets/category_color_icon.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/themes/theme.dart';
@@ -54,7 +54,7 @@ class SelectDashboardCategoryWidget extends StatelessWidget {
                         Navigator.pop(context);
                       },
                       title: category.name,
-                      leading: ColorIcon(colorFromCssHex(category.color)),
+                      leading: CategoryColorIcon(category.id),
                     ),
                   ),
                 ],

--- a/lib/widgets/settings/dashboards/dashboard_definition_card.dart
+++ b/lib/widgets/settings/dashboards/dashboard_definition_card.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:lotti/classes/entity_definitions.dart';
-import 'package:lotti/features/categories/ui/widgets/categories_type_card.dart';
+import 'package:lotti/features/categories/ui/widgets/category_color_icon.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/widgets/settings/settings_card.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';

--- a/lib/widgets/settings/habits/habits_type_card.dart
+++ b/lib/widgets/settings/habits/habits_type_card.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:lotti/classes/entity_definitions.dart';
-import 'package:lotti/features/categories/ui/widgets/categories_type_card.dart';
+import 'package:lotti/features/categories/ui/widgets/category_color_icon.dart';
 import 'package:lotti/features/journal/util/entry_tools.dart';
 import 'package:lotti/themes/colors.dart';
 import 'package:lotti/themes/theme.dart';

--- a/lib/widgets/settings/settings_card.dart
+++ b/lib/widgets/settings/settings_card.dart
@@ -76,20 +76,15 @@ class SettingsNavCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Material(
-      color: backgroundColor,
-      child: ListTile(
-        contentPadding: contentPadding,
-        title: Text(
-          title,
-          semanticsLabel: semanticsLabel,
-          style: settingsCardTextStyle,
-        ),
-        subtitle: subtitle,
-        leading: leading,
-        trailing: trailing,
-        onTap: () => beamToNamed(path),
-      ),
+    return SettingsCard(
+      title: title,
+      leading: leading,
+      trailing: trailing,
+      backgroundColor: backgroundColor,
+      contentPadding: contentPadding,
+      onTap: () => beamToNamed(path),
+      subtitle: subtitle,
+      semanticsLabel: semanticsLabel,
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.570+2888
+version: 0.9.570+2889
 
 msix_config:
   display_name: LottiApp

--- a/test/features/categories/ui/widgets/categories_type_card_test.dart
+++ b/test/features/categories/ui/widgets/categories_type_card_test.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
-import 'package:lotti/features/categories/ui/widgets/categories_type_card.dart';
+import 'package:lotti/features/categories/ui/widgets/category_color_icon.dart';
+import 'package:lotti/features/categories/ui/widgets/category_type_card.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
@@ -38,7 +39,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: CategoriesTypeCard(
+          body: CategoryTypeNavCard(
             category,
             index: 0,
           ),
@@ -86,7 +87,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: CategoriesTypeCard(
+          body: CategoryTypeNavCard(
             category,
             index: 0,
           ),

--- a/test/features/habits/ui/widgets/habit_completion_color_icon_test.dart
+++ b/test/features/habits/ui/widgets/habit_completion_color_icon_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
-import 'package:lotti/features/categories/ui/widgets/categories_type_card.dart';
+import 'package:lotti/features/categories/ui/widgets/category_color_icon.dart';
 import 'package:lotti/features/habits/ui/widgets/habit_completion_color_icon.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/entities_cache_service.dart';

--- a/test/pages/settings/categories/categories_page_test.dart
+++ b/test/pages/settings/categories/categories_page_test.dart
@@ -4,6 +4,7 @@ import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/pages/settings/categories/categories_page.dart';
+import 'package:lotti/services/entities_cache_service.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../mocks/mocks.dart';
@@ -14,6 +15,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   final mockJournalDb = MockJournalDb();
+  final mockEntitiesCacheService = MockEntitiesCacheService();
 
   group('Categories Page Widget Tests - ', () {
     setUp(() {
@@ -23,7 +25,9 @@ void main() {
         ]),
       );
 
-      getIt.registerSingleton<JournalDb>(mockJournalDb);
+      getIt
+        ..registerSingleton<JournalDb>(mockJournalDb)
+        ..registerSingleton<EntitiesCacheService>(mockEntitiesCacheService);
     });
     tearDown(getIt.reset);
 


### PR DESCRIPTION
From Copilot:

This pull request includes several changes to the category-related widgets and their usage across different parts of the project. The main changes involve the creation of new widgets for category color icons and selection modals, as well as the refactoring of existing widgets to use these new components.

### Key Changes:

#### New Widgets:
* [`lib/features/categories/ui/widgets/category_color_icon.dart`](diffhunk://#diff-fac6a9218346e3c9f2976edc9e7c7fabe9b85c33c9478e5a311764141af1c721R1-R51): Introduced `ColorIcon` and `CategoryColorIcon` widgets to handle category color display.

#### Refactoring:
* [`lib/features/categories/ui/widgets/category_field.dart`](diffhunk://#diff-f646f96452ba3bda944c07b4b941c34f47ae66283f4532f413d9fd05b4478fdcL2-L14): Replaced the inline `ColorIcon` implementation with the new `CategoryColorIcon` widget. Updated the modal content to use `CategorySelectionModalContent`. [[1]](diffhunk://#diff-f646f96452ba3bda944c07b4b941c34f47ae66283f4532f413d9fd05b4478fdcL2-L14) [[2]](diffhunk://#diff-f646f96452ba3bda944c07b4b941c34f47ae66283f4532f413d9fd05b4478fdcL38-R33) [[3]](diffhunk://#diff-f646f96452ba3bda944c07b4b941c34f47ae66283f4532f413d9fd05b4478fdcL62-R57)
* [`lib/features/categories/ui/widgets/category_selection_modal_content.dart`](diffhunk://#diff-20998e2c0f5b662d2f44ab18a2ef5ac5063e42eaebe4c6cb192912bb0a9b1ebdR1-R132): Created a new widget `CategorySelectionModalContent` to handle category selection with search functionality.

#### Widget Renaming:
* `lib/features/categories/ui/widgets/categories_type_card.dart` was renamed to `category_type_card.dart` and refactored to use the new `CategoryColorIcon` widget. [[1]](diffhunk://#diff-ce3e9b765819924f3c7bb05b677c2d73cf5f299bde830714a5cb46b39e090169R3-R26) [[2]](diffhunk://#diff-ce3e9b765819924f3c7bb05b677c2d73cf5f299bde830714a5cb46b39e090169L55-R68)

#### Import Updates:
* Updated import statements across multiple files to replace the old `categories_type_card.dart` with `category_color_icon.dart`. [[1]](diffhunk://#diff-c333fbbc963c923e590f4fe19df584703a4b41786e7dbc8bbb43e571334d8b13L4-R4) [[2]](diffhunk://#diff-3566d8c14508cd6062c4555768ed2ce97fbd0aa7ec90a53ae878f5b00caceba4L3-R3) [[3]](diffhunk://#diff-2b1f83f292215ae83e237aaa454c64cc59da906479d180e8ffcb3b8aefd4bfc3L3-R3) [[4]](diffhunk://#diff-1a94a2bc264ac88e476f96393e8c0475323816ee99e93b65fce1e1a79608d372L7-R7) [[5]](diffhunk://#diff-39ea7268b1f8ca67589ff48fdeca734c275931de454f2459af9df31660799521L2-R2) [[6]](diffhunk://#diff-ef813b4a3fc8664e1f65f9dbb47db0d73863b387c3aef23736cd7f0383d38f5fL5-R5) [[7]](diffhunk://#diff-daa5674187c7a4aff0ab5f34c4342f4d9c9ad504ca9cd6a9b4cb55b5c7108ad6L7-R7) [[8]](diffhunk://#diff-83cffd946045977273d7f4ff6e4ec3c4b7c44a4e25b296436582954522988d38L8-R8)

These changes improve the modularity and reusability of category-related components, making the codebase easier to maintain and extend.