### PR TITLE
feat: reorganize entry layout

### DIFF
--- a/lib/features/ai/ui/ai_response_summary.dart
+++ b/lib/features/ai/ui/ai_response_summary.dart
@@ -11,7 +11,7 @@ class AiResponseSummary extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+      padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 5),
       child: GestureDetector(
         onDoubleTap: () {
           ModalUtils.showSinglePageModal<void>(

--- a/lib/features/journal/state/entry_controller.dart
+++ b/lib/features/journal/state/entry_controller.dart
@@ -41,6 +41,10 @@ class EntryController extends _$EntryController {
     _isFocused = focusNode.hasFocus;
     if (_isFocused) {
       _shouldShowEditorToolBar = true;
+    } else {
+      if (!_dirty) {
+        _shouldShowEditorToolBar = false;
+      }
     }
     emitState();
 
@@ -224,6 +228,10 @@ class EntryController extends _$EntryController {
           getIt<TimeService>().stop();
         });
       }
+
+      _shouldShowEditorToolBar = false;
+      focusNode.unfocus();
+      emitState();
     }
 
     await _editorStateService.entryWasSaved(

--- a/lib/features/journal/state/entry_controller.g.dart
+++ b/lib/features/journal/state/entry_controller.g.dart
@@ -6,7 +6,7 @@ part of 'entry_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$entryControllerHash() => r'f27eb05d2bff528ce53c6197665aab18dca39b92';
+String _$entryControllerHash() => r'ceabe29829682698d98468f86f23287871cc2ade';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/features/journal/state/linked_entries_controller.dart
+++ b/lib/features/journal/state/linked_entries_controller.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:collection/collection.dart';
 import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/features/journal/repository/journal_repository.dart';
 import 'package:lotti/get_it.dart';
@@ -77,4 +78,25 @@ class IncludeHiddenController extends _$IncludeHiddenController {
   }
 
   bool get includeHidden => state;
+}
+
+@riverpod
+class NewestLinkedIdController extends _$NewestLinkedIdController {
+  @override
+  Future<String?> build({required String? id}) async {
+    if (id == null) {
+      return null;
+    }
+
+    final provider = linkedEntriesControllerProvider(id: id);
+    final entryLinks = ref.watch(provider).valueOrNull;
+
+    final newestLinkedId = entryLinks
+        ?.sortedBy((entryLink) => entryLink.createdAt)
+        .reversed
+        .firstOrNull
+        ?.toId;
+
+    return newestLinkedId;
+  }
 }

--- a/lib/features/journal/state/linked_entries_controller.g.dart
+++ b/lib/features/journal/state/linked_entries_controller.g.dart
@@ -323,5 +323,154 @@ class _IncludeHiddenControllerProviderElement
   @override
   String get id => (origin as IncludeHiddenControllerProvider).id;
 }
+
+String _$newestLinkedIdControllerHash() =>
+    r'61d42af166607a4262d284b86caa40eec3caa728';
+
+abstract class _$NewestLinkedIdController
+    extends BuildlessAutoDisposeAsyncNotifier<String?> {
+  late final String? id;
+
+  FutureOr<String?> build({
+    required String? id,
+  });
+}
+
+/// See also [NewestLinkedIdController].
+@ProviderFor(NewestLinkedIdController)
+const newestLinkedIdControllerProvider = NewestLinkedIdControllerFamily();
+
+/// See also [NewestLinkedIdController].
+class NewestLinkedIdControllerFamily extends Family<AsyncValue<String?>> {
+  /// See also [NewestLinkedIdController].
+  const NewestLinkedIdControllerFamily();
+
+  /// See also [NewestLinkedIdController].
+  NewestLinkedIdControllerProvider call({
+    required String? id,
+  }) {
+    return NewestLinkedIdControllerProvider(
+      id: id,
+    );
+  }
+
+  @override
+  NewestLinkedIdControllerProvider getProviderOverride(
+    covariant NewestLinkedIdControllerProvider provider,
+  ) {
+    return call(
+      id: provider.id,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'newestLinkedIdControllerProvider';
+}
+
+/// See also [NewestLinkedIdController].
+class NewestLinkedIdControllerProvider
+    extends AutoDisposeAsyncNotifierProviderImpl<NewestLinkedIdController,
+        String?> {
+  /// See also [NewestLinkedIdController].
+  NewestLinkedIdControllerProvider({
+    required String? id,
+  }) : this._internal(
+          () => NewestLinkedIdController()..id = id,
+          from: newestLinkedIdControllerProvider,
+          name: r'newestLinkedIdControllerProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$newestLinkedIdControllerHash,
+          dependencies: NewestLinkedIdControllerFamily._dependencies,
+          allTransitiveDependencies:
+              NewestLinkedIdControllerFamily._allTransitiveDependencies,
+          id: id,
+        );
+
+  NewestLinkedIdControllerProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.id,
+  }) : super.internal();
+
+  final String? id;
+
+  @override
+  FutureOr<String?> runNotifierBuild(
+    covariant NewestLinkedIdController notifier,
+  ) {
+    return notifier.build(
+      id: id,
+    );
+  }
+
+  @override
+  Override overrideWith(NewestLinkedIdController Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: NewestLinkedIdControllerProvider._internal(
+        () => create()..id = id,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        id: id,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeAsyncNotifierProviderElement<NewestLinkedIdController, String?>
+      createElement() {
+    return _NewestLinkedIdControllerProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is NewestLinkedIdControllerProvider && other.id == id;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, id.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+mixin NewestLinkedIdControllerRef
+    on AutoDisposeAsyncNotifierProviderRef<String?> {
+  /// The parameter `id` of this provider.
+  String? get id;
+}
+
+class _NewestLinkedIdControllerProviderElement
+    extends AutoDisposeAsyncNotifierProviderElement<NewestLinkedIdController,
+        String?> with NewestLinkedIdControllerRef {
+  _NewestLinkedIdControllerProviderElement(super.provider);
+
+  @override
+  String? get id => (origin as NewestLinkedIdControllerProvider).id;
+}
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/journal/ui/widgets/editor/editor_widget.dart
+++ b/lib/features/journal/ui/widgets/editor/editor_widget.dart
@@ -15,13 +15,11 @@ class EditorWidget extends ConsumerWidget {
     this.minHeight = 40,
     this.maxHeight = double.maxFinite,
     this.padding = 10,
-    this.autoFocus = false,
   });
 
   final String entryId;
   final double maxHeight;
   final double minHeight;
-  final bool autoFocus;
   final double padding;
 
   @override
@@ -36,56 +34,69 @@ class EditorWidget extends ConsumerWidget {
     final shouldShowEditorToolBar =
         entryState.value?.shouldShowEditorToolBar ?? false;
 
-    return Card(
-      color: context.colorScheme.surface.brighten(),
-      elevation: 0,
-      clipBehavior: Clip.hardEdge,
-      shape: RoundedRectangleBorder(
-        borderRadius:
-            const BorderRadius.all(Radius.circular(inputBorderRadius)),
-        side: BorderSide(
-          color: context.colorScheme.outline.withAlpha(100),
+    if (shouldShowEditorToolBar) {
+      focusNode.requestFocus();
+    }
+
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 300),
+      child: Card(
+        key: ValueKey('$emptyTextSelectionControls $shouldShowEditorToolBar'),
+        color: shouldShowEditorToolBar
+            ? context.colorScheme.surface.brighten()
+            : Colors.transparent,
+        elevation: 0,
+        clipBehavior: Clip.hardEdge,
+        shape: RoundedRectangleBorder(
+          borderRadius:
+              const BorderRadius.all(Radius.circular(inputBorderRadius)),
+          side: BorderSide(
+            color: shouldShowEditorToolBar
+                ? context.colorScheme.outline.withAlpha(100)
+                : Colors.transparent,
+          ),
         ),
-      ),
-      child: ConstrainedBox(
-        constraints: BoxConstraints(
-          maxHeight: maxHeight,
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            if (shouldShowEditorToolBar)
-              ToolbarWidget(
-                controller: controller,
-                entryId: entryId,
-              ),
-            Flexible(
-              child: QuillEditor(
-                controller: controller,
-                scrollController: ScrollController(),
-                focusNode: focusNode,
-                configurations: QuillEditorConfigurations(
-                  textSelectionThemeData: TextSelectionThemeData(
-                    cursorColor: context.colorScheme.onSurface,
-                    selectionColor: context.colorScheme.primary.withAlpha(127),
-                  ),
-                  autoFocus: autoFocus,
-                  minHeight: minHeight,
-                  placeholder: context.messages.editorPlaceholder,
-                  padding: EdgeInsets.only(
-                    top: 8,
-                    bottom: 16,
-                    left: padding,
-                    right: padding,
-                  ),
-                  keyboardAppearance: Theme.of(context).brightness,
-                  customStyles: customEditorStyles(
-                    themeData: Theme.of(context),
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxHeight: maxHeight,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (shouldShowEditorToolBar)
+                ToolbarWidget(
+                  controller: controller,
+                  entryId: entryId,
+                ),
+              Flexible(
+                child: QuillEditor(
+                  controller: controller,
+                  scrollController: ScrollController(),
+                  focusNode: focusNode,
+                  configurations: QuillEditorConfigurations(
+                    textSelectionThemeData: TextSelectionThemeData(
+                      cursorColor: context.colorScheme.onSurface,
+                      selectionColor:
+                          context.colorScheme.primary.withAlpha(127),
+                    ),
+                    autoFocus: shouldShowEditorToolBar,
+                    minHeight: minHeight,
+                    placeholder: context.messages.editorPlaceholder,
+                    padding: EdgeInsets.only(
+                      top: 8,
+                      bottom: 16,
+                      left: shouldShowEditorToolBar ? padding : 0,
+                      right: padding,
+                    ),
+                    keyboardAppearance: Theme.of(context).brightness,
+                    customStyles: customEditorStyles(
+                      themeData: Theme.of(context),
+                    ),
                   ),
                 ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/journal/ui/widgets/editor/editor_widget.dart
+++ b/lib/features/journal/ui/widgets/editor/editor_widget.dart
@@ -38,65 +38,60 @@ class EditorWidget extends ConsumerWidget {
       focusNode.requestFocus();
     }
 
-    return AnimatedSwitcher(
-      duration: const Duration(milliseconds: 300),
-      child: Card(
-        key: ValueKey('$emptyTextSelectionControls $shouldShowEditorToolBar'),
-        color: shouldShowEditorToolBar
-            ? context.colorScheme.surface.brighten()
-            : Colors.transparent,
-        elevation: 0,
-        clipBehavior: Clip.hardEdge,
-        shape: RoundedRectangleBorder(
-          borderRadius:
-              const BorderRadius.all(Radius.circular(inputBorderRadius)),
-          side: BorderSide(
-            color: shouldShowEditorToolBar
-                ? context.colorScheme.outline.withAlpha(100)
-                : Colors.transparent,
-          ),
+    return Card(
+      color: shouldShowEditorToolBar
+          ? context.colorScheme.surface.brighten()
+          : Colors.transparent,
+      elevation: 0,
+      clipBehavior: Clip.hardEdge,
+      shape: RoundedRectangleBorder(
+        borderRadius:
+            const BorderRadius.all(Radius.circular(inputBorderRadius)),
+        side: BorderSide(
+          color: shouldShowEditorToolBar
+              ? context.colorScheme.outline.withAlpha(100)
+              : Colors.transparent,
         ),
-        child: ConstrainedBox(
-          constraints: BoxConstraints(
-            maxHeight: maxHeight,
-          ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              if (shouldShowEditorToolBar)
-                ToolbarWidget(
-                  controller: controller,
-                  entryId: entryId,
-                ),
-              Flexible(
-                child: QuillEditor(
-                  controller: controller,
-                  scrollController: ScrollController(),
-                  focusNode: focusNode,
-                  configurations: QuillEditorConfigurations(
-                    textSelectionThemeData: TextSelectionThemeData(
-                      cursorColor: context.colorScheme.onSurface,
-                      selectionColor:
-                          context.colorScheme.primary.withAlpha(127),
-                    ),
-                    autoFocus: shouldShowEditorToolBar,
-                    minHeight: minHeight,
-                    placeholder: context.messages.editorPlaceholder,
-                    padding: EdgeInsets.only(
-                      top: 8,
-                      bottom: 16,
-                      left: shouldShowEditorToolBar ? padding : 0,
-                      right: padding,
-                    ),
-                    keyboardAppearance: Theme.of(context).brightness,
-                    customStyles: customEditorStyles(
-                      themeData: Theme.of(context),
-                    ),
+      ),
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: maxHeight,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (shouldShowEditorToolBar)
+              ToolbarWidget(
+                controller: controller,
+                entryId: entryId,
+              ),
+            Flexible(
+              child: QuillEditor(
+                controller: controller,
+                scrollController: ScrollController(),
+                focusNode: focusNode,
+                configurations: QuillEditorConfigurations(
+                  textSelectionThemeData: TextSelectionThemeData(
+                    cursorColor: context.colorScheme.onSurface,
+                    selectionColor: context.colorScheme.primary.withAlpha(127),
+                  ),
+                  autoFocus: shouldShowEditorToolBar,
+                  minHeight: minHeight,
+                  placeholder: context.messages.editorPlaceholder,
+                  padding: EdgeInsets.only(
+                    top: 8,
+                    bottom: shouldShowEditorToolBar ? 16 : 0,
+                    left: shouldShowEditorToolBar ? padding : 0,
+                    right: padding,
+                  ),
+                  keyboardAppearance: Theme.of(context).brightness,
+                  customStyles: customEditorStyles(
+                    themeData: Theme.of(context),
                   ),
                 ),
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/features/journal/ui/widgets/entry_details/duration_widget.dart
+++ b/lib/features/journal/ui/widgets/entry_details/duration_widget.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/journal/state/entry_controller.dart';
+import 'package:lotti/features/journal/state/linked_entries_controller.dart';
 import 'package:lotti/features/journal/util/entry_tools.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/time_service.dart';
@@ -38,7 +39,14 @@ class DurationWidget extends ConsumerWidget {
             DateTime.now().difference(item.meta.dateFrom).inHours < 12;
 
         final recording = snapshot.data;
-        final showRecordIcon = item is JournalEntry;
+
+        final latestLinkedId = ref
+            .watch(newestLinkedIdControllerProvider(id: linkedFrom?.id))
+            .valueOrNull;
+
+        final showRecordIcon = item is JournalEntry &&
+            (latestLinkedId == item.id || linkedFrom == null);
+
         var displayed = item;
         var isRecording = false;
 
@@ -53,8 +61,7 @@ class DurationWidget extends ConsumerWidget {
         final saveFn = ref.read(provider.notifier).save;
 
         return Visibility(
-          visible: entryDuration(displayed).inMilliseconds > 0 ||
-              (isRecent && showRecordIcon),
+          visible: entryDuration(displayed).inMilliseconds > 0 || isRecent,
           child: Row(
             children: [
               Padding(

--- a/lib/features/journal/ui/widgets/entry_details/entry_datetime_widget.dart
+++ b/lib/features/journal/ui/widgets/entry_details/entry_datetime_widget.dart
@@ -39,7 +39,7 @@ class EntryDatetimeWidget extends ConsumerWidget {
           );
         },
         child: Padding(
-          padding: const EdgeInsets.only(left: 10),
+          padding: const EdgeInsets.only(left: 5),
           child: Text(
             dfShorter.format(entry.meta.dateFrom),
             style: const TextStyle(

--- a/lib/features/journal/ui/widgets/entry_details/entry_detail_footer.dart
+++ b/lib/features/journal/ui/widgets/entry_details/entry_detail_footer.dart
@@ -3,18 +3,20 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/journal/state/entry_controller.dart';
 import 'package:lotti/features/journal/ui/widgets/entry_details/duration_widget.dart';
-import 'package:lotti/features/journal/ui/widgets/entry_details/entry_datetime_widget.dart';
+import 'package:lotti/features/journal/ui/widgets/entry_details/save_button.dart';
 import 'package:lotti/widgets/misc/map_widget.dart';
 
 class EntryDetailFooter extends ConsumerWidget {
   const EntryDetailFooter({
     required this.entryId,
     required this.linkedFrom,
+    this.inLinkedEntries = false,
     super.key,
   });
 
   final String entryId;
   final JournalEntity? linkedFrom;
+  final bool inLinkedEntries;
 
   @override
   Widget build(
@@ -36,11 +38,12 @@ class EntryDetailFooter extends ConsumerWidget {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              EntryDatetimeWidget(entryId: entry.meta.id),
+              const SizedBox(width: 100),
               DurationWidget(
                 item: entry,
                 linkedFrom: linkedFrom,
               ),
+              if (inLinkedEntries) SaveButton(entryId: entryId),
             ],
           ),
         ),

--- a/lib/features/journal/ui/widgets/entry_details/header/entry_detail_header.dart
+++ b/lib/features/journal/ui/widgets/entry_details/header/entry_detail_header.dart
@@ -6,8 +6,8 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/ai/ui/ai_popup_menu.dart';
 import 'package:lotti/features/categories/ui/widgets/category_selection_icon_button.dart';
 import 'package:lotti/features/journal/state/entry_controller.dart';
+import 'package:lotti/features/journal/ui/widgets/entry_details/entry_datetime_widget.dart';
 import 'package:lotti/features/journal/ui/widgets/entry_details/header/extended_header_modal.dart';
-import 'package:lotti/features/journal/ui/widgets/entry_details/save_button.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/themes/colors.dart';
 import 'package:lotti/themes/theme.dart';
@@ -49,54 +49,58 @@ class _EntryDetailHeaderState extends ConsumerState<EntryDetailHeader> {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
-        Expanded(
-          child: SingleChildScrollView(
-            scrollDirection: Axis.horizontal,
-            child: Row(
-              children: [
-                if (entry is! JournalEvent)
-                  SwitchIconWidget(
-                    tooltip: context.messages.journalFavoriteTooltip,
-                    onPressed: notifier.toggleStarred,
-                    value: entry?.meta.starred ?? false,
-                    icon: Icons.star_outline_rounded,
-                    activeIcon: Icons.star_rounded,
-                    activeColor: starredGold,
-                  ),
+        Padding(
+          padding: const EdgeInsets.only(
+            top: 5,
+          ),
+          child: EntryDatetimeWidget(entryId: widget.entryId),
+        ),
+        const SizedBox.shrink(),
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: Row(
+            children: [
+              if (entry is! JournalEvent)
                 SwitchIconWidget(
-                  tooltip: context.messages.journalFlaggedTooltip,
-                  onPressed: notifier.toggleFlagged,
-                  value: entry?.meta.flag == EntryFlag.import,
-                  icon: Icons.flag_outlined,
-                  activeIcon: Icons.flag,
-                  activeColor: context.colorScheme.error,
+                  tooltip: context.messages.journalFavoriteTooltip,
+                  onPressed: notifier.toggleStarred,
+                  value: entry?.meta.starred ?? false,
+                  icon: Icons.star_outline_rounded,
+                  activeIcon: Icons.star_rounded,
+                  activeColor: starredGold,
                 ),
-                if (isDesktop)
-                  AiPopUpMenu(
-                    journalEntity: entry,
-                    linkedFromId: widget.linkedFromId,
-                  ),
-                IconButton(
-                  icon: const Icon(Icons.more_horiz),
-                  onPressed: () => ExtendedHeaderModal.show(
-                    context: context,
-                    entryId: id,
-                    inLinkedEntries: widget.inLinkedEntries,
-                    linkedFromId: widget.linkedFromId,
-                    link: widget.link,
-                  ),
+              SwitchIconWidget(
+                tooltip: context.messages.journalFlaggedTooltip,
+                onPressed: notifier.toggleFlagged,
+                value: entry?.meta.flag == EntryFlag.import,
+                icon: Icons.flag_outlined,
+                activeIcon: Icons.flag,
+                activeColor: context.colorScheme.error,
+              ),
+              if (isDesktop)
+                AiPopUpMenu(
+                  journalEntity: entry,
+                  linkedFromId: widget.linkedFromId,
                 ),
-                const SizedBox(width: 20),
-                if (entry != null &&
-                    entry is! Task &&
-                    entry is! JournalEvent &&
-                    !widget.inLinkedEntries)
-                  CategorySelectionIconButton(entry: entry),
-              ],
-            ),
+              IconButton(
+                icon: const Icon(Icons.more_horiz),
+                onPressed: () => ExtendedHeaderModal.show(
+                  context: context,
+                  entryId: id,
+                  inLinkedEntries: widget.inLinkedEntries,
+                  linkedFromId: widget.linkedFromId,
+                  link: widget.link,
+                ),
+              ),
+              const SizedBox(width: 20),
+              if (entry != null &&
+                  entry is! Task &&
+                  entry is! JournalEvent &&
+                  !widget.inLinkedEntries)
+                CategorySelectionIconButton(entry: entry),
+            ],
           ),
         ),
-        if (widget.inLinkedEntries) SaveButton(entryId: widget.entryId),
       ],
     );
   }

--- a/lib/features/journal/ui/widgets/entry_details/save_button.dart
+++ b/lib/features/journal/ui/widgets/entry_details/save_button.dart
@@ -21,19 +21,16 @@ class SaveButton extends ConsumerWidget {
       curve: Curves.easeInOutQuint,
       opacity: unsaved ? 1 : 0,
       duration: const Duration(milliseconds: 500),
-      child: Padding(
-        padding: const EdgeInsets.only(right: 10),
-        child: TextButton(
-          onPressed: () {
-            ref.read(provider.notifier).save();
-            FocusManager.instance.primaryFocus?.unfocus();
-          },
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 8),
-            child: Text(
-              context.messages.saveLabel,
-              style: saveButtonStyle(Theme.of(context)),
-            ),
+      child: TextButton(
+        onPressed: () {
+          ref.read(provider.notifier).save();
+          FocusManager.instance.primaryFocus?.unfocus();
+        },
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8),
+          child: Text(
+            context.messages.saveLabel,
+            style: saveButtonStyle(Theme.of(context)),
           ),
         ),
       ),

--- a/lib/features/journal/ui/widgets/entry_details_widget.dart
+++ b/lib/features/journal/ui/widgets/entry_details_widget.dart
@@ -182,6 +182,7 @@ class EntryDetailsContent extends ConsumerWidget {
         EntryDetailFooter(
           entryId: itemId,
           linkedFrom: linkedFrom,
+          inLinkedEntries: linkedFrom != null,
         ),
       ],
     );

--- a/lib/features/speech/ui/widgets/audio_player.dart
+++ b/lib/features/speech/ui/widgets/audio_player.dart
@@ -39,81 +39,74 @@ class AudioPlayerWidget extends ConsumerWidget {
         final isActive = state.audioNote?.meta.id == journalAudio.meta.id;
         final cubit = context.read<AudioPlayerCubit>();
 
-        return Column(
+        return Row(
           mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              mainAxisSize: MainAxisSize.min,
-              children: <Widget>[
-                IconButton(
-                  icon: const Icon(Icons.play_arrow_rounded),
-                  iconSize: 32,
-                  tooltip: 'Play',
-                  color: (state.status == AudioPlayerStatus.playing && isActive)
-                      ? context.colorScheme.error
-                      : context.colorScheme.outline,
-                  onPressed: () {
-                    cubit
-                      ..setAudioNote(journalAudio)
-                      ..play();
-                  },
-                ),
-                IgnorePointer(
-                  ignoring: !isActive,
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    mainAxisSize: MainAxisSize.min,
-                    children: <Widget>[
-                      IconButton(
-                        icon: const Icon(Icons.pause_rounded),
-                        iconSize: 32,
-                        tooltip: 'Pause',
-                        color: context.colorScheme.outline,
-                        onPressed: cubit.pause,
-                      ),
-                      IconButton(
-                        icon: Text(
-                          speedLabelMap[state.speed] ?? '1x',
-                          style: TextStyle(
-                            fontFamily: 'Oswald',
-                            fontWeight: FontWeight.bold,
-                            color: (state.speed != 1)
-                                ? context.colorScheme.error
-                                : context.colorScheme.outline,
-                          ),
-                        ),
-                        iconSize: 32,
-                        tooltip: 'Toggle speed',
-                        onPressed: () =>
-                            cubit.setSpeed(speedToggleMap[state.speed] ?? 1),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
+          children: <Widget>[
+            IconButton(
+              icon: const Icon(Icons.play_arrow_rounded),
+              iconSize: 32,
+              tooltip: 'Play',
+              color: (state.status == AudioPlayerStatus.playing && isActive)
+                  ? context.colorScheme.error
+                  : context.colorScheme.outline,
+              onPressed: () {
+                cubit
+                  ..setAudioNote(journalAudio)
+                  ..play();
+              },
             ),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                SizedBox(
-                  width: 250,
-                  child: ProgressBar(
-                    progress: isActive ? state.progress : Duration.zero,
-                    total: journalAudio.data.duration,
-                    progressBarColor: Colors.red,
-                    baseBarColor: Colors.white.withAlpha(61),
-                    bufferedBarColor: Colors.white.withAlpha(61),
-                    thumbColor: Colors.white,
-                    barHeight: 3,
-                    thumbRadius: 5,
-                    onSeek: cubit.seek,
-                    timeLabelTextStyle: monospaceTextStyle.copyWith(
-                      color: context.colorScheme.outline,
+            IgnorePointer(
+              ignoring: !isActive,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  IconButton(
+                    icon: const Icon(Icons.pause_rounded),
+                    iconSize: 32,
+                    tooltip: 'Pause',
+                    color: context.colorScheme.outline,
+                    onPressed: cubit.pause,
+                  ),
+                  IconButton(
+                    icon: Text(
+                      speedLabelMap[state.speed] ?? '1x',
+                      style: TextStyle(
+                        fontFamily: 'Oswald',
+                        fontWeight: FontWeight.bold,
+                        color: (state.speed != 1)
+                            ? context.colorScheme.error
+                            : context.colorScheme.outline,
+                      ),
                     ),
+                    iconSize: 32,
+                    tooltip: 'Toggle speed',
+                    onPressed: () =>
+                        cubit.setSpeed(speedToggleMap[state.speed] ?? 1),
+                  ),
+                ],
+              ),
+            ),
+            const Spacer(),
+            SizedBox(
+              width: 200,
+              child: Opacity(
+                opacity: isActive ? 1 : 0.4,
+                child: ProgressBar(
+                  progress: isActive ? state.progress : Duration.zero,
+                  total: journalAudio.data.duration,
+                  progressBarColor: Colors.red,
+                  baseBarColor: Colors.white.withAlpha(61),
+                  bufferedBarColor: Colors.white.withAlpha(61),
+                  thumbColor: Colors.white,
+                  barHeight: 3,
+                  thumbRadius: 5,
+                  onSeek: cubit.seek,
+                  timeLabelTextStyle: monospaceTextStyle.copyWith(
+                    color: context.colorScheme.outline,
                   ),
                 ),
-              ],
+              ),
             ),
           ],
         );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.571+2891
+version: 0.9.571+2892
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.571+2890
+version: 0.9.571+2891
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.570+2889
+version: 0.9.571+2890
 
 msix_config:
   display_name: LottiApp

--- a/test/features/journal/ui/widgets/editor/editor_widget_test.dart
+++ b/test/features/journal/ui/widgets/editor/editor_widget_test.dart
@@ -53,7 +53,6 @@ void main() {
         makeTestableWidgetWithScaffold(
           EditorWidget(
             entryId: testTextEntry.meta.id,
-            autoFocus: true,
             key: key,
           ),
         ),

--- a/test/features/journal/ui/widgets/entry_details/entry_detail_footer_test.dart
+++ b/test/features/journal/ui/widgets/entry_details/entry_detail_footer_test.dart
@@ -6,7 +6,6 @@ import 'package:lotti/classes/tag_type_definitions.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/editor_db.dart';
 import 'package:lotti/features/journal/ui/widgets/entry_details/entry_detail_footer.dart';
-import 'package:lotti/features/journal/util/entry_tools.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/db_notification.dart';
@@ -90,22 +89,6 @@ void main() {
       ).thenAnswer(
         (_) => Stream<bool>.fromIterable([false]),
       );
-    });
-
-    testWidgets('entry date is visible', (WidgetTester tester) async {
-      await tester.pumpWidget(
-        makeTestableWidgetWithScaffold(
-          EntryDetailFooter(
-            entryId: testTextEntry.meta.id,
-            linkedFrom: null,
-          ),
-        ),
-      );
-      await tester.pumpAndSettle();
-
-      final entryDateFromFinder =
-          find.text(dfShorter.format(testTextEntry.meta.dateFrom));
-      expect(entryDateFromFinder, findsOneWidget);
     });
 
     testWidgets('map is invisible when not set in cubit',

--- a/test/features/journal/ui/widgets/entry_details/entry_detail_header_test.dart
+++ b/test/features/journal/ui/widgets/entry_details/entry_detail_header_test.dart
@@ -4,6 +4,7 @@ import 'package:lotti/classes/tag_type_definitions.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/editor_db.dart';
 import 'package:lotti/features/journal/ui/widgets/entry_details/header/entry_detail_header.dart';
+import 'package:lotti/features/journal/util/entry_tools.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/db_notification.dart';
@@ -215,5 +216,20 @@ void main() {
       // TODO: check that provider method is called instead
       // verify(entryCubit.toggleMapVisible).called(1);
     });
+  });
+
+  testWidgets('entry date is visible', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      makeTestableWidgetWithScaffold(
+        EntryDetailHeader(
+          entryId: testTextEntry.meta.id,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final entryDateFromFinder =
+        find.text(dfShorter.format(testTextEntry.meta.dateFrom));
+    expect(entryDateFromFinder, findsOneWidget);
   });
 }

--- a/test/widget_test_utils.dart
+++ b/test/widget_test_utils.dart
@@ -38,8 +38,12 @@ Widget makeTestableWidget2(Widget child) {
   );
 }
 
-Widget makeTestableWidgetWithScaffold(Widget child) {
+Widget makeTestableWidgetWithScaffold(
+  Widget child, {
+  List<Override> overrides = const [],
+}) {
   return ProviderScope(
+    overrides: overrides,
     child: MediaQuery(
       data: const MediaQueryData(),
       child: MaterialApp(


### PR DESCRIPTION
From Copilot:

This pull request includes several changes to improve the user experience and functionality of the journal feature. The most important changes involve the handling of the editor toolbar visibility, padding adjustments, and the addition of a save button in specific contexts.

### Improvements to Editor Toolbar Visibility:

* [`lib/features/journal/state/entry_controller.dart`](diffhunk://#diff-073fb67f5d87a4ca641101e845ee4b45cc2cdb2ee4a6cd4698bb94093921c235R44-R47): Updated the `EntryController` to manage the visibility of the editor toolbar more effectively by setting `_shouldShowEditorToolBar` to false when the focus is lost and the entry is not dirty. [[1]](diffhunk://#diff-073fb67f5d87a4ca641101e845ee4b45cc2cdb2ee4a6cd4698bb94093921c235R44-R47) [[2]](diffhunk://#diff-073fb67f5d87a4ca641101e845ee4b45cc2cdb2ee4a6cd4698bb94093921c235R231-R234)
* [`lib/features/journal/ui/widgets/editor/editor_widget.dart`](diffhunk://#diff-558b2c8ca968b697db88d7a84042919d64183136d91d94657bd1d2668b49ac7eL18-L24): Removed the `autoFocus` property and dynamically set focus and padding based on the toolbar visibility. [[1]](diffhunk://#diff-558b2c8ca968b697db88d7a84042919d64183136d91d94657bd1d2668b49ac7eL18-L24) [[2]](diffhunk://#diff-558b2c8ca968b697db88d7a84042919d64183136d91d94657bd1d2668b49ac7eL39-R56) [[3]](diffhunk://#diff-558b2c8ca968b697db88d7a84042919d64183136d91d94657bd1d2668b49ac7eL70-R88) [[4]](diffhunk://#diff-558b2c8ca968b697db88d7a84042919d64183136d91d94657bd1d2668b49ac7eR101)

### Padding Adjustments:

* [`lib/features/ai/ui/ai_response_summary.dart`](diffhunk://#diff-5ede4ba7236014c6a418c6e3ceb9b781bb650bf91a377c7ff2f0ccc3cde6d9cbL14-R14): Adjusted horizontal padding from 10 to 5 for better layout consistency.
* [`lib/features/journal/ui/widgets/entry_details/entry_datetime_widget.dart`](diffhunk://#diff-6c47dc5ee590077317bfc3a792abbe04dc26ca58bfae5955bf259e9d9dc95614L42-R42): Reduced left padding from 10 to 5 for a more compact display.

### Save Button Integration:

* [`lib/features/journal/ui/widgets/entry_details/entry_detail_footer.dart`](diffhunk://#diff-129a8b74256dd5252279c1e07527cc204b111ba9cdf0947d4b8c32beb1bfef21L6-R19): Added a `SaveButton` when `inLinkedEntries` is true and adjusted the layout accordingly. [[1]](diffhunk://#diff-129a8b74256dd5252279c1e07527cc204b111ba9cdf0947d4b8c32beb1bfef21L6-R19) [[2]](diffhunk://#diff-129a8b74256dd5252279c1e07527cc204b111ba9cdf0947d4b8c32beb1bfef21L39-R46)
* [`lib/features/journal/ui/widgets/entry_details/header/entry_detail_header.dart`](diffhunk://#diff-daa5674187c7a4aff0ab5f34c4342f4d9c9ad504ca9cd6a9b4cb55b5c7108ad6R9-L10): Removed the `SaveButton` from the header and adjusted the layout to include the `EntryDatetimeWidget`. [[1]](diffhunk://#diff-daa5674187c7a4aff0ab5f34c4342f4d9c9ad504ca9cd6a9b4cb55b5c7108ad6R9-L10) [[2]](diffhunk://#diff-daa5674187c7a4aff0ab5f34c4342f4d9c9ad504ca9cd6a9b4cb55b5c7108ad6L52-R59) [[3]](diffhunk://#diff-daa5674187c7a4aff0ab5f34c4342f4d9c9ad504ca9cd6a9b4cb55b5c7108ad6L98-L99)
* [`lib/features/journal/ui/widgets/entry_details/save_button.dart`](diffhunk://#diff-c8bff648d9c28f1d61916da80aee70a68565d264ea7aa60f081da263af920ebeL24-L25): Simplified the `SaveButton` widget by removing unnecessary padding. [[1]](diffhunk://#diff-c8bff648d9c28f1d61916da80aee70a68565d264ea7aa60f081da263af920ebeL24-L25) [[2]](diffhunk://#diff-c8bff648d9c28f1d61916da80aee70a68565d264ea7aa60f081da263af920ebeL39)

### Other Changes:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Bumped the version number from 0.9.570+2889 to 0.9.571+2890.
* [`test/features/journal/ui/widgets/editor/editor_widget_test.dart`](diffhunk://#diff-e0edfe19b8dc35912ab7ed0fecc31ad53ad5d7ca2b622f3642a3cc78996ffae1L56): Removed the `autoFocus` property from the `EditorWidget` initialization in tests.