### PR TITLE
fix: hiding running time record icon

### DIFF
--- a/lib/features/journal/ui/widgets/entry_details/duration_widget.dart
+++ b/lib/features/journal/ui/widgets/entry_details/duration_widget.dart
@@ -77,35 +77,27 @@ class DurationWidget extends ConsumerWidget {
                 displayed: displayed,
               ),
               Visibility(
-                visible: isRecent && showRecordIcon,
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Visibility(
-                      visible: !isRecording,
-                      child: IconButton(
-                        icon: const Icon(Icons.fiber_manual_record_sharp),
-                        iconSize: 20,
-                        tooltip: 'Record',
-                        color: context.colorScheme.error,
-                        onPressed: () {
-                          _timeService.start(item, linkedFrom);
-                        },
-                      ),
-                    ),
-                    Visibility(
-                      visible: isRecording,
-                      child: IconButton(
-                        icon: const Icon(Icons.stop),
-                        iconSize: 20,
-                        tooltip: 'Stop',
-                        color: labelColor,
-                        onPressed: () async {
-                          await saveFn(stopRecording: true);
-                        },
-                      ),
-                    ),
-                  ],
+                visible: isRecent && showRecordIcon && !isRecording,
+                child: IconButton(
+                  icon: const Icon(Icons.fiber_manual_record_sharp),
+                  iconSize: 20,
+                  tooltip: 'Record',
+                  color: context.colorScheme.error,
+                  onPressed: () {
+                    _timeService.start(item, linkedFrom);
+                  },
+                ),
+              ),
+              Visibility(
+                visible: isRecording,
+                child: IconButton(
+                  icon: const Icon(Icons.stop),
+                  iconSize: 20,
+                  tooltip: 'Stop',
+                  color: labelColor,
+                  onPressed: () async {
+                    await saveFn(stopRecording: true);
+                  },
                 ),
               ),
               const SizedBox(width: 15),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.571+2892
+version: 0.9.571+2893
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
From Copilot:

This pull request includes changes to the `DurationWidget` class in the `entry_details` widget and an update to the `pubspec.yaml` file. The most important changes are focused on improving the visibility logic for the recording icon in the `DurationWidget`.

Enhancements to `DurationWidget`:

* [`lib/features/journal/ui/widgets/entry_details/duration_widget.dart`](diffhunk://#diff-b271557ef3d9d6531ae6da7eff4b642aeea17b456be0081f01b835fac7fc1fcaL80-R80): Modified the visibility condition for the record icon to combine multiple checks into a single condition, ensuring the icon is only shown when `isRecent`, `showRecordIcon`, and `!isRecording` are all true.

General updates:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Updated the version number from `0.9.571+2892` to `0.9.571+2893`.