### PR TITLE
chore: upgrade to WhisperKit v0.11.0

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -613,7 +613,7 @@
 			repositoryURL = "https://github.com/argmaxinc/whisperkit";
 			requirement = {
 				kind = exactVersion;
-				version = 0.10.2;
+				version = 0.11.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/argmaxinc/whisperkit",
       "state" : {
-        "revision" : "600303e5e5f1861427ba57804ea3a5310466afe6",
-        "version" : "0.10.2"
+        "revision" : "e753c568a6e180b3c78a718797e6066884137490",
+        "version" : "0.11.0"
       }
     }
   ],

--- a/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/argmaxinc/whisperkit",
       "state" : {
-        "revision" : "600303e5e5f1861427ba57804ea3a5310466afe6",
-        "version" : "0.10.2"
+        "revision" : "e753c568a6e180b3c78a718797e6066884137490",
+        "version" : "0.11.0"
       }
     }
   ],

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -708,7 +708,7 @@
 			repositoryURL = "https://github.com/argmaxinc/whisperkit";
 			requirement = {
 				kind = exactVersion;
-				version = 0.10.2;
+				version = 0.11.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/argmaxinc/whisperkit",
       "state" : {
-        "revision" : "600303e5e5f1861427ba57804ea3a5310466afe6",
-        "version" : "0.10.2"
+        "revision" : "e753c568a6e180b3c78a718797e6066884137490",
+        "version" : "0.11.0"
       }
     }
   ],

--- a/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/argmaxinc/whisperkit",
       "state" : {
-        "revision" : "600303e5e5f1861427ba57804ea3a5310466afe6",
-        "version" : "0.10.2"
+        "revision" : "e753c568a6e180b3c78a718797e6066884137490",
+        "version" : "0.11.0"
       }
     }
   ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.571+2893
+version: 0.9.571+2894
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
From Copilot:

This pull request includes updates to several project files to upgrade the `whisperkit` dependency version and a minor version bump for the project itself.

Dependency version updates:

* [`ios/Runner.xcodeproj/project.pbxproj`](diffhunk://#diff-413fd2395fd4377132c8c1135c9bc9ab215c6f97322d27717a487223bd03e2c7L616-R616): Upgraded `whisperkit` version from `0.10.2` to `0.11.0`.
* [`ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved`](diffhunk://#diff-2bbba4945556820d8d37758665ea4779d8016b7020a2601d0ee9cfcadc97ecb4L27-R28): Updated `whisperkit` revision and version from `0.10.2` to `0.11.0`.
* [`macos/Runner.xcodeproj/project.pbxproj`](diffhunk://#diff-ec40d5406d2e5b54c265f64285bf1f073febb06b92a906239f8905a6244e68efL711-R711): Upgraded `whisperkit` version from `0.10.2` to `0.11.0`.
* [`macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved`](diffhunk://#diff-2bbba4945556820d8d37758665ea4779d8016b7020a2601d0ee9cfcadc97ecb4L27-R28): Updated `whisperkit` revision and version from `0.10.2` to `0.11.0`.

Project version bump:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Incremented project version from `0.9.571+2893` to `0.9.571+2894`.