### PR TITLE
feat: always show checklist progress bar

### DIFF
--- a/lib/features/tasks/state/checklist_controller.dart
+++ b/lib/features/tasks/state/checklist_controller.dart
@@ -184,7 +184,9 @@ class ChecklistCompletionController extends _$ChecklistCompletionController {
   ChecklistCompletionController();
 
   @override
-  Future<double> build({required String id}) async {
+  Future<({int completedCount, int totalCount})> build({
+    required String id,
+  }) async {
     final checklistData =
         ref.watch(checklistControllerProvider(id: id)).value?.data;
 
@@ -197,6 +199,24 @@ class ChecklistCompletionController extends _$ChecklistCompletionController {
     final totalCount = linkedChecklistItems.length;
     final completedCount =
         linkedChecklistItems.where((item) => item.data.isChecked).length;
+
+    return (
+      completedCount: completedCount,
+      totalCount: totalCount,
+    );
+  }
+}
+
+@riverpod
+class ChecklistCompletionRateController
+    extends _$ChecklistCompletionRateController {
+  ChecklistCompletionRateController();
+
+  @override
+  Future<double> build({required String id}) async {
+    final res = ref.watch(checklistCompletionControllerProvider(id: id)).value;
+    final totalCount = res?.totalCount ?? 0;
+    final completedCount = res?.completedCount ?? 0;
 
     return totalCount == 0 ? 0.0 : completedCount / totalCount;
   }

--- a/lib/features/tasks/state/checklist_controller.g.dart
+++ b/lib/features/tasks/state/checklist_controller.g.dart
@@ -176,13 +176,14 @@ class _ChecklistControllerProviderElement
 }
 
 String _$checklistCompletionControllerHash() =>
-    r'4b310c9e55f67f91e4734baec26dfd420e9754de';
+    r'd796843fda52a555c99a80012d0c5cab4a839329';
 
 abstract class _$ChecklistCompletionController
-    extends BuildlessAutoDisposeAsyncNotifier<double> {
+    extends BuildlessAutoDisposeAsyncNotifier<
+        ({int completedCount, int totalCount})> {
   late final String id;
 
-  FutureOr<double> build({
+  FutureOr<({int completedCount, int totalCount})> build({
     required String id,
   });
 }
@@ -193,7 +194,8 @@ const checklistCompletionControllerProvider =
     ChecklistCompletionControllerFamily();
 
 /// See also [ChecklistCompletionController].
-class ChecklistCompletionControllerFamily extends Family<AsyncValue<double>> {
+class ChecklistCompletionControllerFamily
+    extends Family<AsyncValue<({int completedCount, int totalCount})>> {
   /// See also [ChecklistCompletionController].
   const ChecklistCompletionControllerFamily();
 
@@ -233,7 +235,7 @@ class ChecklistCompletionControllerFamily extends Family<AsyncValue<double>> {
 /// See also [ChecklistCompletionController].
 class ChecklistCompletionControllerProvider
     extends AutoDisposeAsyncNotifierProviderImpl<ChecklistCompletionController,
-        double> {
+        ({int completedCount, int totalCount})> {
   /// See also [ChecklistCompletionController].
   ChecklistCompletionControllerProvider({
     required String id,
@@ -264,7 +266,7 @@ class ChecklistCompletionControllerProvider
   final String id;
 
   @override
-  FutureOr<double> runNotifierBuild(
+  FutureOr<({int completedCount, int totalCount})> runNotifierBuild(
     covariant ChecklistCompletionController notifier,
   ) {
     return notifier.build(
@@ -289,8 +291,8 @@ class ChecklistCompletionControllerProvider
   }
 
   @override
-  AutoDisposeAsyncNotifierProviderElement<ChecklistCompletionController, double>
-      createElement() {
+  AutoDisposeAsyncNotifierProviderElement<ChecklistCompletionController,
+      ({int completedCount, int totalCount})> createElement() {
     return _ChecklistCompletionControllerProviderElement(this);
   }
 
@@ -310,20 +312,172 @@ class ChecklistCompletionControllerProvider
 
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
-mixin ChecklistCompletionControllerRef
-    on AutoDisposeAsyncNotifierProviderRef<double> {
+mixin ChecklistCompletionControllerRef on AutoDisposeAsyncNotifierProviderRef<
+    ({int completedCount, int totalCount})> {
   /// The parameter `id` of this provider.
   String get id;
 }
 
 class _ChecklistCompletionControllerProviderElement
     extends AutoDisposeAsyncNotifierProviderElement<
-        ChecklistCompletionController,
-        double> with ChecklistCompletionControllerRef {
+        ChecklistCompletionController, ({int completedCount, int totalCount})>
+    with ChecklistCompletionControllerRef {
   _ChecklistCompletionControllerProviderElement(super.provider);
 
   @override
   String get id => (origin as ChecklistCompletionControllerProvider).id;
+}
+
+String _$checklistCompletionRateControllerHash() =>
+    r'9913f84d9b1bd4500b1bdb772334d69796aed242';
+
+abstract class _$ChecklistCompletionRateController
+    extends BuildlessAutoDisposeAsyncNotifier<double> {
+  late final String id;
+
+  FutureOr<double> build({
+    required String id,
+  });
+}
+
+/// See also [ChecklistCompletionRateController].
+@ProviderFor(ChecklistCompletionRateController)
+const checklistCompletionRateControllerProvider =
+    ChecklistCompletionRateControllerFamily();
+
+/// See also [ChecklistCompletionRateController].
+class ChecklistCompletionRateControllerFamily
+    extends Family<AsyncValue<double>> {
+  /// See also [ChecklistCompletionRateController].
+  const ChecklistCompletionRateControllerFamily();
+
+  /// See also [ChecklistCompletionRateController].
+  ChecklistCompletionRateControllerProvider call({
+    required String id,
+  }) {
+    return ChecklistCompletionRateControllerProvider(
+      id: id,
+    );
+  }
+
+  @override
+  ChecklistCompletionRateControllerProvider getProviderOverride(
+    covariant ChecklistCompletionRateControllerProvider provider,
+  ) {
+    return call(
+      id: provider.id,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'checklistCompletionRateControllerProvider';
+}
+
+/// See also [ChecklistCompletionRateController].
+class ChecklistCompletionRateControllerProvider
+    extends AutoDisposeAsyncNotifierProviderImpl<
+        ChecklistCompletionRateController, double> {
+  /// See also [ChecklistCompletionRateController].
+  ChecklistCompletionRateControllerProvider({
+    required String id,
+  }) : this._internal(
+          () => ChecklistCompletionRateController()..id = id,
+          from: checklistCompletionRateControllerProvider,
+          name: r'checklistCompletionRateControllerProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$checklistCompletionRateControllerHash,
+          dependencies: ChecklistCompletionRateControllerFamily._dependencies,
+          allTransitiveDependencies: ChecklistCompletionRateControllerFamily
+              ._allTransitiveDependencies,
+          id: id,
+        );
+
+  ChecklistCompletionRateControllerProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.id,
+  }) : super.internal();
+
+  final String id;
+
+  @override
+  FutureOr<double> runNotifierBuild(
+    covariant ChecklistCompletionRateController notifier,
+  ) {
+    return notifier.build(
+      id: id,
+    );
+  }
+
+  @override
+  Override overrideWith(ChecklistCompletionRateController Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: ChecklistCompletionRateControllerProvider._internal(
+        () => create()..id = id,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        id: id,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeAsyncNotifierProviderElement<ChecklistCompletionRateController,
+      double> createElement() {
+    return _ChecklistCompletionRateControllerProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is ChecklistCompletionRateControllerProvider && other.id == id;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, id.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+mixin ChecklistCompletionRateControllerRef
+    on AutoDisposeAsyncNotifierProviderRef<double> {
+  /// The parameter `id` of this provider.
+  String get id;
+}
+
+class _ChecklistCompletionRateControllerProviderElement
+    extends AutoDisposeAsyncNotifierProviderElement<
+        ChecklistCompletionRateController,
+        double> with ChecklistCompletionRateControllerRef {
+  _ChecklistCompletionRateControllerProviderElement(super.provider);
+
+  @override
+  String get id => (origin as ChecklistCompletionRateControllerProvider).id;
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/tasks/ui/checklists/checklist_widget.dart
+++ b/lib/features/tasks/ui/checklists/checklist_widget.dart
@@ -17,6 +17,8 @@ class ChecklistWidget extends StatefulWidget {
     required this.completionRate,
     required this.id,
     required this.updateItemOrder,
+    required this.totalCount,
+    required this.completedCount,
     this.onDelete,
     super.key,
   });
@@ -30,6 +32,8 @@ class ChecklistWidget extends StatefulWidget {
       updateItemOrder;
   final double completionRate;
   final VoidCallback? onDelete;
+  final int totalCount;
+  final int completedCount;
 
   @override
   State<ChecklistWidget> createState() => _ChecklistWidgetState();
@@ -81,25 +85,34 @@ class _ChecklistWidgetState extends State<ChecklistWidget> {
             },
           ),
         ),
-        secondChild: Row(
+        secondChild: Column(
           children: [
-            Flexible(
-              child: Text(
-                widget.title,
-                softWrap: true,
-                maxLines: 3,
-              ),
+            Row(
+              children: [
+                Flexible(
+                  child: Text(
+                    widget.title,
+                    softWrap: true,
+                    maxLines: 3,
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(
+                    Icons.edit,
+                    size: 20,
+                  ),
+                  onPressed: () {
+                    setState(() {
+                      _isEditing = !_isEditing;
+                    });
+                  },
+                ),
+              ],
             ),
-            IconButton(
-              icon: const Icon(
-                Icons.edit,
-                size: 20,
-              ),
-              onPressed: () {
-                setState(() {
-                  _isEditing = !_isEditing;
-                });
-              },
+            ProgressBar(
+              completionRate: widget.completionRate,
+              totalCount: widget.totalCount,
+              completedCount: widget.completedCount,
             ),
           ],
         ),
@@ -110,18 +123,14 @@ class _ChecklistWidgetState extends State<ChecklistWidget> {
         Row(
           children: [
             const SizedBox(width: 20),
-            Flexible(
-              child: ClipRRect(
-                borderRadius: BorderRadius.circular(3),
-                child: LinearProgressIndicator(
-                  minHeight: 5,
-                  color: successColor,
-                  backgroundColor: successColor.desaturate().withAlpha(77),
-                  value: widget.completionRate,
-                  semanticsLabel: 'Checklist progress',
+            if (_isEditing)
+              Flexible(
+                child: ProgressBar(
+                  completionRate: widget.completionRate,
+                  totalCount: widget.totalCount,
+                  completedCount: widget.completedCount,
                 ),
               ),
-            ),
             if (_isEditing)
               IconButton(
                 padding: EdgeInsets.zero,
@@ -208,6 +217,47 @@ class _ChecklistWidgetState extends State<ChecklistWidget> {
                 key: Key('$itemId${widget.id}$index'),
               );
             },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class ProgressBar extends StatelessWidget {
+  const ProgressBar({
+    required this.completionRate,
+    required this.completedCount,
+    required this.totalCount,
+    super.key,
+  });
+
+  final double completionRate;
+  final int completedCount;
+  final int totalCount;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(3),
+            child: LinearProgressIndicator(
+              minHeight: 5,
+              color: successColor,
+              backgroundColor: successColor.desaturate().withAlpha(77),
+              value: completionRate,
+              semanticsLabel: 'Checklist progress',
+            ),
+          ),
+        ),
+        const SizedBox(width: 10),
+        Text(
+          '$completedCount/$totalCount',
+          style: TextStyle(
+            color: successColor,
+            fontSize: fontSizeMedium,
           ),
         ),
       ],

--- a/lib/features/tasks/ui/checklists/checklist_wrapper.dart
+++ b/lib/features/tasks/ui/checklists/checklist_wrapper.dart
@@ -22,7 +22,12 @@ class ChecklistWrapper extends ConsumerWidget {
     final checklist = ref.watch(provider).value;
 
     final completionRate =
+        ref.watch(checklistCompletionRateControllerProvider(id: entryId)).value;
+
+    final res =
         ref.watch(checklistCompletionControllerProvider(id: entryId)).value;
+    final totalCount = res?.totalCount ?? 0;
+    final completedCount = res?.completedCount ?? 0;
 
     if (checklist == null || completionRate == null) {
       return const SizedBox.shrink();
@@ -54,6 +59,8 @@ class ChecklistWrapper extends ConsumerWidget {
           updateItemOrder: notifier.updateItemOrder,
           completionRate: completionRate,
           onDelete: ref.read(provider.notifier).delete,
+          totalCount: totalCount,
+          completedCount: completedCount,
         ),
       ),
     );

--- a/lib/widgetbook.dart
+++ b/lib/widgetbook.dart
@@ -125,8 +125,11 @@ class WidgetbookApp extends StatelessWidget {
                         checklistItem1.meta.id,
                         checklistItem2.meta.id,
                         checklistItem3.meta.id,
+                        checklistItem4.meta.id,
                       ],
                       completionRate: 0.5,
+                      totalCount: 4,
+                      completedCount: 2,
                       onCreateChecklistItem: (title) async {
                         return null;
                       },

--- a/lib/widgetbook/mock_data.dart
+++ b/lib/widgetbook/mock_data.dart
@@ -15,7 +15,7 @@ final checklistItem2 = ChecklistItem(
   meta: createMetadata(uuid.v4()),
   data: const ChecklistItemData(
     title: 'release iOS',
-    isChecked: false,
+    isChecked: true,
     linkedChecklists: [],
   ),
 );
@@ -24,6 +24,15 @@ final checklistItem3 = ChecklistItem(
   meta: createMetadata(uuid.v4()),
   data: const ChecklistItemData(
     title: 'release macOS',
+    isChecked: false,
+    linkedChecklists: [],
+  ),
+);
+
+final checklistItem4 = ChecklistItem(
+  meta: createMetadata(uuid.v4()),
+  data: const ChecklistItemData(
+    title: 'merge PR',
     isChecked: false,
     linkedChecklists: [],
   ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.571+2897
+version: 0.9.572+2899
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This PR changes the checklist display to always show the progress bar & add counts, e.g. `5/6`.

<img width="528" alt="image" src="https://github.com/user-attachments/assets/c2077de9-8d96-42be-a61b-a69764981573" />


From Copilot:
This pull request includes several changes to the `ChecklistWidget` and a version update in the `pubspec.yaml` file. The most important changes involve refactoring the progress bar implementation and updating the widget structure.

Refactoring and widget structure updates:

* [`lib/features/tasks/ui/checklists/checklist_widget.dart`](diffhunk://#diff-255c40de059be69649e497177d75c60f5f9e0d8ea515e0cd98639bb18d7ab1f2L84-R86): Changed `secondChild` from `Row` to `Column` to accommodate the new progress bar.
* [`lib/features/tasks/ui/checklists/checklist_widget.dart`](diffhunk://#diff-255c40de059be69649e497177d75c60f5f9e0d8ea515e0cd98639bb18d7ab1f2R108-R120): Added a `ProgressBar` widget to display the completion rate within the `Column`.
* [`lib/features/tasks/ui/checklists/checklist_widget.dart`](diffhunk://#diff-255c40de059be69649e497177d75c60f5f9e0d8ea515e0cd98639bb18d7ab1f2R108-R120): Removed the inline `LinearProgressIndicator` and replaced it with the reusable `ProgressBar` widget.
* [`lib/features/tasks/ui/checklists/checklist_widget.dart`](diffhunk://#diff-255c40de059be69649e497177d75c60f5f9e0d8ea515e0cd98639bb18d7ab1f2R214-R236): Defined a new `ProgressBar` class to encapsulate the progress bar logic and styling.

Version update:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Updated the version from `0.9.571+2897` to `0.9.572+2898`.