### PR TITLE
fix: duration widget

### DIFF
--- a/lib/features/journal/ui/widgets/entry_details/entry_detail_footer.dart
+++ b/lib/features/journal/ui/widgets/entry_details/entry_detail_footer.dart
@@ -39,7 +39,7 @@ class EntryDetailFooter extends ConsumerWidget {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               const SizedBox(width: 100),
-              if (entry is! Task)
+               if (entry is JournalEntry)
                 DurationWidget(
                   item: entry,
                   linkedFrom: linkedFrom,


### PR DESCRIPTION
The issue where the duration was displayed for both images and audio entries, has been resolved.