### PR TITLE
feat: improve dashboard chart legends & tooltips

### DIFF
--- a/lib/features/dashboards/ui/pages/dashboard_page.dart
+++ b/lib/features/dashboards/ui/pages/dashboard_page.dart
@@ -9,7 +9,6 @@ import 'package:lotti/pages/settings/sliver_box_adapter_page.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/utils/date_utils_extension.dart';
-import 'package:lotti/utils/platform.dart';
 import 'package:lotti/widgets/misc/timespan_segmented_control.dart';
 
 class DashboardPage extends ConsumerStatefulWidget {
@@ -31,7 +30,7 @@ class _DashboardPageState extends ConsumerState<DashboardPage> {
   double scale = 10;
   double horizontalPan = 0;
   bool zoomInProgress = false;
-  int timeSpanDays = isDesktop ? 30 : 14;
+  int timeSpanDays = 180;
 
   late TransformationController _transformationController;
 
@@ -80,6 +79,7 @@ class _DashboardPageState extends ConsumerState<DashboardPage> {
           const SizedBox(height: 15),
           TimeSpanSegmentedControl(
             timeSpanDays: timeSpanDays,
+            segments: const [180, 365],
             onValueChanged: (int value) {
               setState(() {
                 timeSpanDays = value;

--- a/lib/features/dashboards/ui/widgets/charts/time_series/time_series_bar_chart.dart
+++ b/lib/features/dashboards/ui/widgets/charts/time_series/time_series_bar_chart.dart
@@ -138,7 +138,7 @@ class TimeSeriesBarChart extends ConsumerWidget {
               getTooltipItem: (groupData, timestamp, rodData, foo) {
                 final formatted = valueInHours
                     ? hoursToHhMm(rodData.toY)
-                    : NumberFormat('#,###').format(rodData.toY);
+                    : NumberFormat('#,###.##').format(rodData.toY);
                 return BarTooltipItem(
                   '$formatted $unit\n'
                   '${chartDateFormatterYMD(groupData.x)}',

--- a/lib/features/dashboards/ui/widgets/charts/time_series/time_series_line_chart.dart
+++ b/lib/features/dashboards/ui/widgets/charts/time_series/time_series_line_chart.dart
@@ -1,7 +1,9 @@
 import 'dart:core';
+import 'dart:math';
 
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:lotti/features/dashboards/ui/widgets/charts/time_series/utils.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/utils/platform.dart';
@@ -45,6 +47,10 @@ class TimeSeriesLineChart extends StatelessWidget {
         )
         .toList();
 
+    final spotValues = spots.map((spot) => spot.y).toList();
+    final minY = spotValues.isNotEmpty ? spotValues.reduce(min).floor() : 0;
+    final maxY = spotValues.isNotEmpty ? spotValues.reduce(max).ceil() : 1;
+
     Widget bottomTitleWidgets(double value, TitleMeta meta) {
       final ymd = DateTime.fromMillisecondsSinceEpoch(value.toInt());
       if (ymd.day == 1 ||
@@ -60,10 +66,7 @@ class TimeSeriesLineChart extends StatelessWidget {
     }
 
     return Padding(
-      padding: const EdgeInsets.only(
-        top: 20,
-        right: 20,
-      ),
+      padding: const EdgeInsets.only(top: 20, right: 20),
       child: LineChart(
         transformationConfig: FlTransformationConfig(
           scaleAxis: FlScaleAxis.horizontal,
@@ -92,6 +95,9 @@ class TimeSeriesLineChart extends StatelessWidget {
               tooltipRoundedRadius: 8,
               getTooltipItems: (List<LineBarSpot> spots) {
                 return spots.map((spot) {
+                  final formattedValue =
+                      NumberFormat('#,###.##').format(spot.y);
+
                   return LineTooltipItem(
                     '',
                     TextStyle(
@@ -101,7 +107,7 @@ class TimeSeriesLineChart extends StatelessWidget {
                     ),
                     children: [
                       TextSpan(
-                        text: '${spot.y.toInt()} $unit\n',
+                        text: '$formattedValue $unit\n',
                         style: chartTooltipStyleBold,
                       ),
                       TextSpan(
@@ -130,6 +136,7 @@ class TimeSeriesLineChart extends StatelessWidget {
                 showTitles: true,
                 getTitlesWidget: leftTitleWidgets,
                 reservedSize: 40,
+                interval: double.maxFinite,
               ),
             ),
           ),
@@ -139,6 +146,8 @@ class TimeSeriesLineChart extends StatelessWidget {
           ),
           minX: rangeStart.millisecondsSinceEpoch.toDouble(),
           maxX: rangeEnd.millisecondsSinceEpoch.toDouble(),
+          minY: minY - 1,
+          maxY: maxY + 1,
           lineBarsData: [
             LineChartBarData(
               spots: spots,

--- a/lib/features/dashboards/ui/widgets/charts/time_series/utils.dart
+++ b/lib/features/dashboards/ui/widgets/charts/time_series/utils.dart
@@ -1,5 +1,6 @@
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:lotti/themes/colors.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/widgets/charts/utils.dart';
@@ -29,7 +30,9 @@ class ChartLabel extends StatelessWidget {
 }
 
 Widget leftTitleWidgets(double value, TitleMeta meta) {
-  return ChartLabel(value.toInt().toString());
+  final formattedValue =
+      NumberFormat(value > 100 ? '####' : '####.#').format(value);
+  return ChartLabel(formattedValue);
 }
 
 final gridLine = FlLine(

--- a/lib/features/journal/ui/widgets/entry_details/measurement_summary.dart
+++ b/lib/features/journal/ui/widgets/entry_details/measurement_summary.dart
@@ -1,22 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:lotti/classes/journal_entities.dart';
-import 'package:lotti/features/dashboards/ui/widgets/charts/dashboard_measurables_chart.dart';
 import 'package:lotti/features/journal/ui/widgets/helpers.dart';
 import 'package:lotti/features/journal/ui/widgets/text_viewer_widget.dart';
 import 'package:lotti/features/journal/util/entry_tools.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/entities_cache_service.dart';
-import 'package:lotti/widgets/charts/utils.dart';
 
 class MeasurementSummary extends StatelessWidget {
   const MeasurementSummary(
     this.measurementEntry, {
-    this.showChart = true,
     super.key,
   });
 
   final MeasurementEntry measurementEntry;
-  final bool showChart;
 
   @override
   Widget build(BuildContext context) {
@@ -34,23 +30,19 @@ class MeasurementSummary extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          if (measurementEntry.entryText?.plainText != null && !showChart)
+          if (measurementEntry.entryText?.plainText != null)
             TextViewerWidget(
               entryText: measurementEntry.entryText,
               maxHeight: 120,
             ),
-          if (showChart)
-            MeasurablesBarChart(
-              dashboardId: null,
-              rangeStart: getRangeStart(context: context),
-              rangeEnd: getRangeEnd(),
-              measurableDataTypeId: measurementEntry.data.dataTypeId,
+          Padding(
+            padding: const EdgeInsets.only(left: 5),
+            child: EntryTextWidget(
+              entryTextForMeasurable(data, dataType),
+              padding: EdgeInsets.zero,
             ),
-          const SizedBox(height: 8),
-          EntryTextWidget(
-            entryTextForMeasurable(data, dataType),
-            padding: EdgeInsets.zero,
           ),
+          const SizedBox(height: 10),
         ],
       ),
     );

--- a/lib/features/journal/ui/widgets/journal_card.dart
+++ b/lib/features/journal/ui/widgets/journal_card.dart
@@ -153,10 +153,7 @@ class JournalCardTitle extends StatelessWidget {
                 surveyEntry,
                 showChart: false,
               ),
-              measurement: (measurementEntry) => MeasurementSummary(
-                measurementEntry,
-                showChart: false,
-              ),
+              measurement: MeasurementSummary.new,
               task: (Task task) {
                 final data = task.data;
                 return Column(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.574+2908
+version: 0.9.575+2909
 
 msix_config:
   display_name: LottiApp

--- a/test/features/journal/ui/widgets/entry_details/measurement_summary_test.dart
+++ b/test/features/journal/ui/widgets/entry_details/measurement_summary_test.dart
@@ -47,9 +47,6 @@ void main() {
 
       await tester.pumpAndSettle();
 
-      // charts display expected titles
-      expect(find.text('Coverage'), findsOneWidget);
-
       // entry value is displayed
       expect(find.text('Coverage: 55 %'), findsOneWidget);
     });


### PR DESCRIPTION
From Copilot:

This pull request includes multiple updates to the dashboard and chart features, focusing on improving the user interface and enhancing the data formatting.

### Dashboard Page Updates:
* Removed unnecessary import `platform.dart` from `dashboard_page.dart`.
* Changed the default `timeSpanDays` value from 30 or 14 to 180 days.
* Added new segments `[180, 365]` to the `TimeSpanSegmentedControl`.

### Time Series Bar Chart Enhancements:
* Modified the tooltip formatting to include two decimal places for better precision.

### Time Series Line Chart Enhancements:
* Added imports for `dart:math` and `intl` packages.
* Calculated and set `minY` and `maxY` values dynamically based on the data points. [[1]](diffhunk://#diff-dbd828720e6b9ac95f1d30e2b1d7b097daa075ed4a8c811133dabd6b35db5347R50-R53) [[2]](diffhunk://#diff-dbd828720e6b9ac95f1d30e2b1d7b097daa075ed4a8c811133dabd6b35db5347R149-R150)
* Improved tooltip formatting to include two decimal places. [[1]](diffhunk://#diff-dbd828720e6b9ac95f1d30e2b1d7b097daa075ed4a8c811133dabd6b35db5347R98-R100) [[2]](diffhunk://#diff-dbd828720e6b9ac95f1d30e2b1d7b097daa075ed4a8c811133dabd6b35db5347L104-R110)
* Adjusted left title interval to use `double.maxFinite` for better scaling.

### Miscellaneous Changes:
* Removed `showChart` parameter and related chart display logic from `MeasurementSummary` in `entry_details/measurement_summary.dart`. [[1]](diffhunk://#diff-97dfe5979a35a95b667f0b975cf9a44fc24b9e1f1816394fc7c12d25a64925fcL3-L19) [[2]](diffhunk://#diff-97dfe5979a35a95b667f0b975cf9a44fc24b9e1f1816394fc7c12d25a64925fcL37-R45)
* Updated the `JournalCardTitle` to use the new `MeasurementSummary` constructor.
* Incremented the app version in `pubspec.yaml` from `0.9.574+2908` to `0.9.575+2909`.
* Removed chart title expectation checks from `measurement_summary_test.dart`.