### PR TITLE
fix: focus issue in editor

### DIFF
--- a/lib/features/journal/state/entry_controller.dart
+++ b/lib/features/journal/state/entry_controller.dart
@@ -321,11 +321,14 @@ class EntryController extends _$EntryController {
     }
   }
 
-  void setDirty({required bool value}) {
+  void setDirty({required bool value, bool requestFocus = true}) {
     if (_dirty == value) {
       return;
     }
     _dirty = value;
+    if (value && requestFocus) {
+      focusNode.requestFocus();
+    }
     emitState();
   }
 

--- a/lib/features/journal/ui/widgets/editor/editor_widget.dart
+++ b/lib/features/journal/ui/widgets/editor/editor_widget.dart
@@ -34,10 +34,6 @@ class EditorWidget extends ConsumerWidget {
     final shouldShowEditorToolBar =
         entryState.value?.shouldShowEditorToolBar ?? false;
 
-    if (shouldShowEditorToolBar) {
-      focusNode.requestFocus();
-    }
-
     return Card(
       color: shouldShowEditorToolBar
           ? context.colorScheme.surface.brighten()
@@ -75,7 +71,6 @@ class EditorWidget extends ConsumerWidget {
                     cursorColor: context.colorScheme.onSurface,
                     selectionColor: context.colorScheme.primary.withAlpha(127),
                   ),
-                  autoFocus: shouldShowEditorToolBar,
                   minHeight: minHeight,
                   placeholder: context.messages.editorPlaceholder,
                   padding: EdgeInsets.only(

--- a/lib/features/tasks/ui/task_form.dart
+++ b/lib/features/tasks/ui/task_form.dart
@@ -71,7 +71,10 @@ class _TaskFormState extends ConsumerState<TaskForm> {
                   maxLines: null,
                   style: Theme.of(context).textTheme.titleLarge,
                   name: 'title',
-                  onChanged: (_) => notifier.setDirty(value: true),
+                  onChanged: (_) => notifier.setDirty(
+                    value: true,
+                    requestFocus: false,
+                  ),
                 ),
                 inputSpacer,
                 Row(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.576+2912
+version: 0.9.576+2913
 
 msix_config:
   display_name: LottiApp

--- a/test/features/journal/ui/widgets/editor/editor_widget_test.dart
+++ b/test/features/journal/ui/widgets/editor/editor_widget_test.dart
@@ -73,6 +73,7 @@ void main() {
           EditorWidget(entryId: testTextEntry.meta.id),
         ),
       );
+
       await tester.pumpAndSettle();
 
       final boldIconFinder = find.byIcon(Icons.format_bold);


### PR DESCRIPTION
This pull request includes several changes to improve the handling of focus and state management in the journal and task form features. The most important changes include adding an optional `requestFocus` parameter to the `setDirty` method, removing redundant focus requests, and updating tests accordingly.

### Focus and State Management Improvements:

* [`lib/features/journal/state/entry_controller.dart`](diffhunk://#diff-073fb67f5d87a4ca641101e845ee4b45cc2cdb2ee4a6cd4698bb94093921c235L324-R331): Added an optional `requestFocus` parameter to the `setDirty` method to control focus behavior when the dirty state is set.
* [`lib/features/tasks/ui/task_form.dart`](diffhunk://#diff-c2f40a14894d9668c8c244d4676b1ddb55c8e552328ee00bca18e5d0e12096aaL74-R77): Updated the `onChanged` callback in the `_TaskFormState` class to pass `requestFocus: false` when setting the dirty state.

### UI Enhancements:

* [`lib/features/journal/ui/widgets/editor/editor_widget.dart`](diffhunk://#diff-558b2c8ca968b697db88d7a84042919d64183136d91d94657bd1d2668b49ac7eL37-L40): Removed redundant focus requests and the `autoFocus` property from the `EditorWidget` class to streamline focus management. [[1]](diffhunk://#diff-558b2c8ca968b697db88d7a84042919d64183136d91d94657bd1d2668b49ac7eL37-L40) [[2]](diffhunk://#diff-558b2c8ca968b697db88d7a84042919d64183136d91d94657bd1d2668b49ac7eL78)

### Version Update:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Incremented the version number to `0.9.576+2913` to reflect the latest changes.

### Test Adjustments:

* [`test/features/journal/ui/widgets/editor/editor_widget_test.dart`](diffhunk://#diff-e0edfe19b8dc35912ab7ed0fecc31ad53ad5d7ca2b622f3642a3cc78996ffae1R76): Added a blank line for better readability in the `main` function of the `editor_widget_test` file.