### PR TITLE
fix: focus issues

### DIFF
--- a/lib/features/ai/state/latest_summary_controller.dart
+++ b/lib/features/ai/state/latest_summary_controller.dart
@@ -68,8 +68,10 @@ class ChecklistItemSuggestionsController
       multiLine: true,
     );
 
+    final response = latestAiEntry?.data.response ?? '';
+
     final checklistItems = exp
-        .allMatches(latestAiEntry?.data.response ?? '')
+        .allMatches(response.replaceAll('*', ''))
         .map((e) {
           final title = e.group(1);
           if (title != null) {

--- a/lib/features/journal/state/entry_controller.dart
+++ b/lib/features/journal/state/entry_controller.dart
@@ -363,10 +363,6 @@ class EntryController extends _$EntryController {
     }
   }
 
-  void focus() {
-    focusNode.requestFocus();
-  }
-
   Future<void> toggleFlagged() async {
     final item = await _journalDb.journalEntityById(id);
     if (item != null) {

--- a/lib/features/tasks/ui/checklists/checklist_widget.dart
+++ b/lib/features/tasks/ui/checklists/checklist_widget.dart
@@ -42,6 +42,7 @@ class ChecklistWidget extends StatefulWidget {
 class _ChecklistWidgetState extends State<ChecklistWidget> {
   bool _isEditing = false;
   late List<String> _itemIds;
+  final FocusNode _focusNode = FocusNode();
 
   @override
   void initState() {
@@ -179,6 +180,7 @@ class _ChecklistWidgetState extends State<ChecklistWidget> {
             vertical: 10,
           ),
           child: TitleTextField(
+            focusNode: _focusNode,
             onSave: (title) async {
               final id = await widget.onCreateChecklistItem.call(title);
               setState(() {

--- a/lib/features/tasks/ui/title_text_field.dart
+++ b/lib/features/tasks/ui/title_text_field.dart
@@ -9,6 +9,7 @@ class TitleTextField extends StatefulWidget {
   const TitleTextField({
     required this.onSave,
     this.onClear,
+    this.focusNode,
     this.clearOnSave = false,
     this.resetToInitialValue = false,
     this.initialValue,
@@ -22,6 +23,7 @@ class TitleTextField extends StatefulWidget {
   final String? semanticsLabel;
   final bool clearOnSave;
   final bool resetToInitialValue;
+  final FocusNode? focusNode;
 
   @override
   State<TitleTextField> createState() => _TitleTextFieldState();
@@ -54,6 +56,7 @@ class _TitleTextFieldState extends State<TitleTextField> {
         _showClearButton = widget.resetToInitialValue;
         _dirty = false;
       });
+      widget.focusNode?.requestFocus();
     }
 
     void onClear() {
@@ -77,6 +80,7 @@ class _TitleTextFieldState extends State<TitleTextField> {
           _showClearButton = value != widget.initialValue;
         });
       },
+      focusNode: widget.focusNode,
       decoration: inputDecoration(
         labelText: context.messages.checklistAddItem,
         semanticsLabel: widget.semanticsLabel,

--- a/lib/widgets/events/event_form.dart
+++ b/lib/widgets/events/event_form.dart
@@ -77,7 +77,10 @@ class _EventFormState extends ConsumerState<EventForm> {
                   maxLines: null,
                   style: const TextStyle(fontSize: fontSizeLarge),
                   name: 'title',
-                  onChanged: (_) => notifier.setDirty(value: true),
+                  onChanged: (_) => notifier.setDirty(
+                    value: true,
+                    requestFocus: false,
+                  ),
                 ),
                 inputSpacer,
                 Wrap(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.576+2913
+version: 0.9.576+2914
 
 msix_config:
   display_name: LottiApp

--- a/test/features/journal/state/entry_controller_test.dart
+++ b/test/features/journal/state/entry_controller_test.dart
@@ -505,8 +505,6 @@ void main() {
           ),
         ),
       );
-
-      notifier.focus();
     });
   });
 }


### PR DESCRIPTION
From Copilot:
This pull request includes several changes to improve focus management and clean up unused code in various parts of the codebase. The most important changes include adding a `FocusNode` to the `TitleTextField` widget, cleaning up unused focus-related methods, and ensuring focus is requested appropriately when saving checklist items.

Focus management improvements:

* [`lib/features/tasks/ui/title_text_field.dart`](diffhunk://#diff-2bc39c091eb38967f3fca0ede006745549ea85b24839350c6084f367986b663aR12): Added an optional `FocusNode` parameter to the `TitleTextField` widget and ensured focus is requested when saving. [[1]](diffhunk://#diff-2bc39c091eb38967f3fca0ede006745549ea85b24839350c6084f367986b663aR12) [[2]](diffhunk://#diff-2bc39c091eb38967f3fca0ede006745549ea85b24839350c6084f367986b663aR26) [[3]](diffhunk://#diff-2bc39c091eb38967f3fca0ede006745549ea85b24839350c6084f367986b663aR59) [[4]](diffhunk://#diff-2bc39c091eb38967f3fca0ede006745549ea85b24839350c6084f367986b663aR83)
* [`lib/features/tasks/ui/checklists/checklist_widget.dart`](diffhunk://#diff-255c40de059be69649e497177d75c60f5f9e0d8ea515e0cd98639bb18d7ab1f2R45): Added a `FocusNode` to the `_ChecklistWidgetState` and passed it to the `TitleTextField`. [[1]](diffhunk://#diff-255c40de059be69649e497177d75c60f5f9e0d8ea515e0cd98639bb18d7ab1f2R45) [[2]](diffhunk://#diff-255c40de059be69649e497177d75c60f5f9e0d8ea515e0cd98639bb18d7ab1f2R183)

Code cleanup:

* [`lib/features/journal/state/entry_controller.dart`](diffhunk://#diff-073fb67f5d87a4ca641101e845ee4b45cc2cdb2ee4a6cd4698bb94093921c235L366-L369): Removed the unused `focus` method from the `EntryController` class.
* [`test/features/journal/state/entry_controller_test.dart`](diffhunk://#diff-46e13a82386c5782e23b4fd72c7a0250ff9808b1b1eb3d90ccf4e95df7448ddaL508-L509): Removed the call to the now-deleted `focus` method in the test file.

Minor changes:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Updated the version number.
* [`lib/features/ai/state/latest_summary_controller.dart`](diffhunk://#diff-b37cf4347da8e4ffa6b4b883684bd50bb0d1a18c0f122061a160307e3ad17eeaR71-R74): Simplified the regex matching by replacing asterisks in the response.