### PR TITLE
feat: resolve sync conflict with remote version

### DIFF
--- a/lib/pages/settings/advanced/conflicts_page.dart
+++ b/lib/pages/settings/advanced/conflicts_page.dart
@@ -183,7 +183,11 @@ class ConflictDetailRoute extends StatelessWidget {
               fromSync.meta.vectorClock,
             );
 
-            final withResolvedVectorClock = local.copyWith(
+            final localWithResolvedVectorClock = local.copyWith(
+              meta: local.meta.copyWith(vectorClock: merged),
+            );
+
+            final remoteWithResolvedVectorClock = fromSync.copyWith(
               meta: local.meta.copyWith(vectorClock: merged),
             );
 
@@ -201,7 +205,7 @@ class ConflictDetailRoute extends StatelessWidget {
                       padding: const EdgeInsets.symmetric(vertical: 8),
                       child: IgnorePointer(
                         child: JournalCard(
-                          item: withResolvedVectorClock,
+                          item: localWithResolvedVectorClock,
                           maxHeight: 1000,
                         ),
                       ),
@@ -219,8 +223,8 @@ class ConflictDetailRoute extends StatelessWidget {
                           clipBehavior: Clip.antiAlias,
                           onPressed: () {
                             getIt<PersistenceLogic>().updateJournalEntity(
-                              withResolvedVectorClock,
-                              withResolvedVectorClock.meta,
+                              localWithResolvedVectorClock,
+                              localWithResolvedVectorClock.meta,
                             );
                             settingsBeamerDelegate.beamBack();
                           },
@@ -237,10 +241,28 @@ class ConflictDetailRoute extends StatelessWidget {
                       padding: const EdgeInsets.symmetric(vertical: 8),
                       child: IgnorePointer(
                         child: JournalCard(
-                          item: fromSync,
+                          item: remoteWithResolvedVectorClock,
                           maxHeight: 1000,
                         ),
                       ),
+                    ),
+                    Row(
+                      children: [
+                        TextButton(
+                          clipBehavior: Clip.antiAlias,
+                          onPressed: () {
+                            getIt<PersistenceLogic>().updateJournalEntity(
+                              remoteWithResolvedVectorClock,
+                              remoteWithResolvedVectorClock.meta,
+                            );
+                            settingsBeamerDelegate.beamBack();
+                          },
+                          child: const Text(
+                            'Resolve with remote version',
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      ],
                     ),
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceAround,
@@ -264,7 +286,7 @@ class ConflictDetailRoute extends StatelessWidget {
                     ),
                     const SizedBox(height: 5),
                     Text(
-                      'Merged: ${withResolvedVectorClock.meta.vectorClock}',
+                      'Resolved with local: ${localWithResolvedVectorClock.meta.vectorClock}',
                       style: monospaceTextStyleSmall,
                     ),
                     const SizedBox(height: 5),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.576+2914
+version: 0.9.576+2915
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
From Copilot:

This pull request includes changes to the `ConflictDetailRoute` class in the `conflicts_page.dart` file to improve the handling of resolved vector clocks and adds a new button for resolving with the remote version. Additionally, there is a minor version update in the `pubspec.yaml` file.

Improvements to vector clock handling and conflict resolution:

* [`lib/pages/settings/advanced/conflicts_page.dart`](diffhunk://#diff-72352166409b550e97d1a8cf99d27df60464a2e522f0bb75783d4f5d02177248L186-R190): Renamed `withResolvedVectorClock` to `localWithResolvedVectorClock` and added `remoteWithResolvedVectorClock` for better clarity and handling of local and remote vector clocks. [[1]](diffhunk://#diff-72352166409b550e97d1a8cf99d27df60464a2e522f0bb75783d4f5d02177248L186-R190) [[2]](diffhunk://#diff-72352166409b550e97d1a8cf99d27df60464a2e522f0bb75783d4f5d02177248L204-R208) [[3]](diffhunk://#diff-72352166409b550e97d1a8cf99d27df60464a2e522f0bb75783d4f5d02177248L222-R227) [[4]](diffhunk://#diff-72352166409b550e97d1a8cf99d27df60464a2e522f0bb75783d4f5d02177248L240-R266)
* [`lib/pages/settings/advanced/conflicts_page.dart`](diffhunk://#diff-72352166409b550e97d1a8cf99d27df60464a2e522f0bb75783d4f5d02177248L240-R266): Added a new button to resolve conflicts using the remote version of the vector clock.
* [`lib/pages/settings/advanced/conflicts_page.dart`](diffhunk://#diff-72352166409b550e97d1a8cf99d27df60464a2e522f0bb75783d4f5d02177248L267-R289): Updated the display text to reflect the resolution with the local vector clock.

Version update:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Incremented the version number from `0.9.576+2914` to `0.9.576+2915`.