### PR TITLE
ci: only run Matrix integration test with degraded network simulation

### DIFF
--- a/.github/workflows/flutter-matrix-test.yml
+++ b/.github/workflows/flutter-matrix-test.yml
@@ -6,33 +6,33 @@ on:
       - '**'
 
 jobs:
-  test:
-    name: Matrix Test on Linux
-    runs-on: ubuntu-latest
-    steps:
-      - name: Update apt-get
-        run: sudo apt-get update
-      - name: Install libraries
-        run: sudo apt-get install libgtk-3-dev cmake libolm3 cmake-doc ninja-build libsecret-1-dev libjsoncpp-dev libsecret-1-0 sqlite3 libsqlite3-dev keybinder-3.0 network-manager mpv libmpv-dev
-      - uses: actions/checkout@v3
-      - uses: kuhnroyal/flutter-fvm-config-action@v2
-        id: fvm-config-action
-      - uses: subosito/flutter-action@v2
-        with:
-          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
-          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
-      - uses: hoverkraft-tech/compose-action@v2.0.0
-        with:
-          cwd: "integration_test/docker"
-      - name: Run Matrix integration test
-        uses: GabrielBB/xvfb-action@v1.7
-        env:
-          SLOW_NETWORK: false
-        with:
-          working-directory: ./integration_test
-          run: |
-            ./setup_toxiproxy_docker.sh
-            ./run_matrix_tests.sh
+#  test:
+#    name: Matrix Test on Linux
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Update apt-get
+#        run: sudo apt-get update
+#      - name: Install libraries
+#        run: sudo apt-get install libgtk-3-dev cmake libolm3 cmake-doc ninja-build libsecret-1-dev libjsoncpp-dev libsecret-1-0 sqlite3 libsqlite3-dev keybinder-3.0 network-manager mpv libmpv-dev
+#      - uses: actions/checkout@v3
+#      - uses: kuhnroyal/flutter-fvm-config-action@v2
+#        id: fvm-config-action
+#      - uses: subosito/flutter-action@v2
+#        with:
+#          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
+#          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+#      - uses: hoverkraft-tech/compose-action@v2.0.0
+#        with:
+#          cwd: "integration_test/docker"
+#      - name: Run Matrix integration test
+#        uses: GabrielBB/xvfb-action@v1.7
+#        env:
+#          SLOW_NETWORK: false
+#        with:
+#          working-directory: ./integration_test
+#          run: |
+#            ./setup_toxiproxy_docker.sh
+#            ./run_matrix_tests.sh
 
   test_degraded_network:
     name: Matrix Test on Linux with degraded network


### PR DESCRIPTION
This PR comments out running the matrix integration test without the simulated bad network, as oddly this one fails a lot more often than the one where we simulate terrible network conditions.

From Copilot:

This pull request includes changes to the GitHub Actions workflow configuration file `.github/workflows/flutter-matrix-test.yml`. The main change involves commenting out the existing matrix test job configuration.

Changes to GitHub Actions workflow:

* [`.github/workflows/flutter-matrix-test.yml`](diffhunk://#diff-a3eb9f37f4106d7a1f4eb6a059ba44f2838e6528da58440cc6c906c0c0067482L9-R35): Commented out the matrix test job configuration, which includes steps for updating `apt-get`, installing necessary libraries, checking out the repository, configuring Flutter, running Docker Compose, and executing the matrix integration tests.