### PR TITLE
fix: time picker values being overwritten in habit settings

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -258,7 +258,7 @@ SPEC CHECKSUMS:
   flutter_local_notifications: 395056b3175ba4f08480a7c5de30cd36d69827e4
   flutter_native_splash: 6cad9122ea0fad137d23137dd14b937f3e90b145
   flutter_native_timezone: 5fe32678d72d1894880e94303ef41c2919f014e5
-  flutter_olm: dc9ebc19d23ed96b0f0a238db0716e4a628c26fd
+  flutter_olm: 381bdf22eaeb0b5120539a79fb45199e2dbef163
   flutter_openssl_crypto: 73dcefff7611c3ac324d82726047d8335d0b6e57
   flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
   health: a38a2b7480871e575ef403a8746cb2c08d20f1a4

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -258,7 +258,7 @@ SPEC CHECKSUMS:
   flutter_local_notifications: 395056b3175ba4f08480a7c5de30cd36d69827e4
   flutter_native_splash: 6cad9122ea0fad137d23137dd14b937f3e90b145
   flutter_native_timezone: 5fe32678d72d1894880e94303ef41c2919f014e5
-  flutter_olm: 381bdf22eaeb0b5120539a79fb45199e2dbef163
+  flutter_olm: dc9ebc19d23ed96b0f0a238db0716e4a628c26fd
   flutter_openssl_crypto: 73dcefff7611c3ac324d82726047d8335d0b6e57
   flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
   health: a38a2b7480871e575ef403a8746cb2c08d20f1a4

--- a/lib/blocs/settings/habits/habit_settings_cubit.dart
+++ b/lib/blocs/settings/habits/habit_settings_cubit.dart
@@ -79,7 +79,7 @@ class HabitSettingsCubit extends Cubit<HabitSettingsState> {
     emitState();
   }
 
-   void setShowFrom(DateTime? showFrom) {
+  void setShowFrom(DateTime? showFrom) {
     _dirty = true;
 
     final currentSchedule = _habitDefinition.habitSchedule;
@@ -89,15 +89,33 @@ class HabitSettingsCubit extends Cubit<HabitSettingsState> {
         requiredCompletions: daily.requiredCompletions,
         showFrom: showFrom,
         alertAtTime: daily.alertAtTime,
-
-    ),
-      
+      ),
       orElse: () => HabitSchedule.daily(
         requiredCompletions: 1,
         showFrom: showFrom,
       ),
     );
-     _habitDefinition = _habitDefinition.copyWith(habitSchedule: newSchedule);
+    _habitDefinition = _habitDefinition.copyWith(habitSchedule: newSchedule);
+    emitState();
+  }
+
+  void clearShowFrom() {
+    _dirty = true;
+
+    final currentSchedule = _habitDefinition.habitSchedule;
+
+    final newSchedule = currentSchedule.maybeMap(
+      daily: (daily) => HabitSchedule.daily(
+        requiredCompletions: daily.requiredCompletions,
+        alertAtTime: daily.alertAtTime,
+      ),
+      orElse: () => const HabitSchedule.daily(
+        requiredCompletions: 1,
+      ),
+    );
+    _habitDefinition = _habitDefinition.copyWith(
+      habitSchedule: newSchedule,
+    );
     emitState();
   }
 
@@ -126,13 +144,12 @@ class HabitSettingsCubit extends Cubit<HabitSettingsState> {
     _dirty = true;
 
     final currentSchedule = _habitDefinition.habitSchedule;
-    
+
     final newSchedule = currentSchedule.maybeMap(
       daily: (daily) => HabitSchedule.daily(
         requiredCompletions: daily.requiredCompletions,
-        alertAtTime: daily.showFrom,
+        showFrom: daily.showFrom,
       ),
-
       orElse: () => const HabitSchedule.daily(
         requiredCompletions: 1,
       ),

--- a/lib/blocs/settings/habits/habit_settings_cubit.dart
+++ b/lib/blocs/settings/habits/habit_settings_cubit.dart
@@ -79,34 +79,66 @@ class HabitSettingsCubit extends Cubit<HabitSettingsState> {
     emitState();
   }
 
-  void setShowFrom(DateTime? showFrom) {
+   void setShowFrom(DateTime? showFrom) {
     _dirty = true;
-    _habitDefinition = _habitDefinition.copyWith(
-      habitSchedule: HabitSchedule.daily(
+
+    final currentSchedule = _habitDefinition.habitSchedule;
+
+    final newSchedule = currentSchedule.maybeMap(
+      daily: (daily) => HabitSchedule.daily(
+        requiredCompletions: daily.requiredCompletions,
+        showFrom: showFrom,
+        alertAtTime: daily.alertAtTime,
+
+    ),
+      
+      orElse: () => HabitSchedule.daily(
         requiredCompletions: 1,
         showFrom: showFrom,
       ),
     );
+     _habitDefinition = _habitDefinition.copyWith(habitSchedule: newSchedule);
     emitState();
   }
 
   void setAlertAtTime(DateTime? alertAtTime) {
     _dirty = true;
-    _habitDefinition = _habitDefinition.copyWith(
-      habitSchedule: HabitSchedule.daily(
+
+    final currentSchedule = _habitDefinition.habitSchedule;
+    final newSchedule = currentSchedule.maybeMap(
+      daily: (daily) => HabitSchedule.daily(
+        requiredCompletions: daily.requiredCompletions,
+        showFrom: daily.showFrom,
+        alertAtTime: alertAtTime,
+      ),
+      orElse: () => HabitSchedule.daily(
         requiredCompletions: 1,
         alertAtTime: alertAtTime,
       ),
+    );
+    _habitDefinition = _habitDefinition.copyWith(
+      habitSchedule: newSchedule,
     );
     emitState();
   }
 
   void clearAlertAtTime() {
     _dirty = true;
-    _habitDefinition = _habitDefinition.copyWith(
-      habitSchedule: const HabitSchedule.daily(
+
+    final currentSchedule = _habitDefinition.habitSchedule;
+    
+    final newSchedule = currentSchedule.maybeMap(
+      daily: (daily) => HabitSchedule.daily(
+        requiredCompletions: daily.requiredCompletions,
+        alertAtTime: daily.showFrom,
+      ),
+
+      orElse: () => const HabitSchedule.daily(
         requiredCompletions: 1,
       ),
+    );
+    _habitDefinition = _habitDefinition.copyWith(
+      habitSchedule: newSchedule,
     );
     emitState();
   }

--- a/lib/features/ai/ui/ai_response_summary_modal.dart
+++ b/lib/features/ai/ui/ai_response_summary_modal.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:gpt_markdown/gpt_markdown.dart';
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:super_clipboard/super_clipboard.dart';
 
 class AiResponseSummaryModalContent extends StatelessWidget {
   const AiResponseSummaryModalContent(
@@ -60,8 +61,17 @@ class AiResponseSummaryModalContent extends StatelessWidget {
               SingleChildScrollView(
                 child: Padding(
                   padding: padding,
-                  child: SelectionArea(
-                    child: GptMarkdown(aiResponse.data.prompt),
+                  child: GestureDetector(
+                    onDoubleTap: () {
+                      final clipboard = SystemClipboard.instance;
+                      final item = DataWriterItem();
+                      final data = aiResponse.data.prompt;
+                      item.add(Formats.plainText(data));
+                      clipboard?.write([item]);
+                    },
+                    child: SelectionArea(
+                      child: GptMarkdown(aiResponse.data.prompt),
+                    ),
                   ),
                 ),
               ),

--- a/lib/pages/settings/habits/habit_details_page.dart
+++ b/lib/pages/settings/habits/habit_details_page.dart
@@ -122,6 +122,7 @@ class HabitDetailsPage extends StatelessWidget {
                           labelText: context.messages.habitShowFromLabel,
                           setDateTime: cubit.setShowFrom,
                           mode: CupertinoDatePickerMode.time,
+                          clear: cubit.clearShowFrom,
                         ),
                         inputSpacer,
                         DateTimeField(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.580+2932
+version: 0.9.580+2933
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
When editing habit details, setting the reminder time would erase the "Show From" time and vice versa. This was caused by the setShowFrom and setAlertAtTime methods creating new HabitSchedule objects without preserving existing values.