### PR TITLE
fix: create directory for JSON attachments

### DIFF
--- a/lib/features/sync/matrix/save_attachment.dart
+++ b/lib/features/sync/matrix/save_attachment.dart
@@ -42,7 +42,8 @@ Future<void> saveAttachment(Event event) async {
 
 Future<void> writeToFile(Uint8List? data, String filePath) async {
   if (data != null) {
-    await File(filePath).writeAsBytes(data);
+    final file = await File(filePath).create(recursive: true);
+    await file.writeAsBytes(data);
   } else {
     debugPrint('No bytes for $filePath');
     getIt<LoggingService>().captureEvent(

--- a/lib/logic/image_import.dart
+++ b/lib/logic/image_import.dart
@@ -151,7 +151,7 @@ Future<void> importPastedImages({
   final targetFileName = '$id.$fileExtension';
   final targetFilePath = '$directory$targetFileName';
 
-  final file = File(targetFilePath);
+  final file = await File(targetFilePath).create(recursive: true);
   await file.writeAsBytes(data);
 
   final imageData = ImageData(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.583+2950
+version: 0.9.583+2951
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This pull request includes changes to file handling and a version update. The most important changes include ensuring files are created recursively before writing data to them and updating the project version.

File handling improvements:

* [`lib/features/sync/matrix/save_attachment.dart`](diffhunk://#diff-378944b3f34329cd3294623a31175effaf0d4e22e9aba1f6f5bc33c1b00b6685L45-R46): Modified the `writeToFile` method to create the file recursively before writing bytes to it.
* [`lib/logic/image_import.dart`](diffhunk://#diff-1655f19893cbede94f77d77d222e83403d993733ea862f1f80f5dc9345be9d23L154-R154): Updated the `importPastedImages` method to create the file recursively before writing bytes to it.

Version update:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Incremented the project version from `0.9.583+2950` to `0.9.583+2951`.