### PR TITLE
fix: remove invalidateSelf & refactoring

### DIFF
--- a/lib/features/ai/repository/ai_input_repository.dart
+++ b/lib/features/ai/repository/ai_input_repository.dart
@@ -1,9 +1,13 @@
+import 'dart:convert';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/checklist_item_data.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/features/ai/model/ai_input.dart';
+import 'package:lotti/features/ai/repository/prompts.dart';
+import 'package:lotti/features/ai/state/consts.dart';
 import 'package:lotti/features/journal/util/entry_tools.dart';
 import 'package:lotti/features/tasks/repository/task_progress_repository.dart';
 import 'package:lotti/get_it.dart';
@@ -121,6 +125,28 @@ class AiInputRepository {
     );
 
     return aiInput;
+  }
+
+  Future<String?> buildPrompt({
+    required String id,
+    required String aiResponseType,
+  }) async {
+    final aiInput = await generate(id);
+
+    if (aiInput == null) {
+      return null;
+    }
+
+    const encoder = JsonEncoder.withIndent('    ');
+    final jsonString = encoder.convert(aiInput);
+
+    if (aiResponseType == taskSummary) {
+      return createTaskSummaryPrompt(jsonString);
+    }
+    if (aiResponseType == actionItemSuggestions) {
+      return createActionItemSuggestionsPrompt(jsonString);
+    }
+    return null;
   }
 }
 

--- a/lib/features/ai/repository/prompts.dart
+++ b/lib/features/ai/repository/prompts.dart
@@ -1,0 +1,66 @@
+String createActionItemSuggestionsPrompt(String jsonString) {
+  return '''
+**Prompt:**
+
+"Based on the provided task details and log entries, identify potential action items that are mentioned in
+the text of the logs but have not yet been captured as existing action items. These suggestions should be
+formatted as a list of new `AiInputActionItemObject` instances, each containing a title and completion
+status. Ensure that only actions not already listed under `actionItems` are included in your suggestions.
+Provide these suggested action items in JSON format, adhering to the structure defined by the given classes."
+
+**Task Details:**
+```json
+$jsonString
+```
+
+Provide these suggested action items in JSON format, adhering to the structure 
+defined by the given classes.
+Double check that the returned JSON ONLY contains action items that are not 
+already listed under `actionItems` array in the task details. Do not simply
+return the example response, but the open action items you have found. If there 
+are none, return an empty array. Double check the items you want to return. If 
+any is very similar to an item already listed in the in actionItems array of the 
+task details, then remove it from the response. 
+
+**Example Response:**
+
+```json
+[
+  {
+    "title": "Review project documentation",
+    "completed": false
+  },
+  {
+    "title": "Schedule team meeting for next week",
+    "completed": true
+  }
+]
+```
+    ''';
+}
+
+String createTaskSummaryPrompt(String jsonString) {
+  return '''
+**Prompt:**
+
+Create a task summary as a TLDR; for the provided task details and log entries. Imagine the
+user has not been involved in the task for a long time, and you want to refresh
+their memory. Summarize the task, the achieved results, and the remaining steps
+that have not been completed yet, if any. Also note when the task is done. Note any 
+learnings or insights that can be drawn from the task, if anything is 
+significant. Talk to the user directly, instead of referring to them as "the user"
+or "they". Don't start with a greeting, don't repeat the task title, get straight 
+to the point. Keep it short and succinct. Assume the the task title is shown 
+directly above in the UI, so starting with the title is not necessary and would 
+feel redundant. While staying succinct, give the output some structure and 
+organization. Use a bullet point list for the achieved results, and a numbered 
+list for the remaining steps. If there are any learnings or insights that can be 
+drawn from the task, include them in the output. If the task is done, end the 
+output with a concluding statement.
+
+**Task Details:**
+```json
+$jsonString
+```
+    ''';
+}

--- a/lib/features/ai/state/action_item_suggestions.dart
+++ b/lib/features/ai/state/action_item_suggestions.dart
@@ -8,7 +8,6 @@ import 'package:lotti/features/ai/model/ai_input.dart';
 import 'package:lotti/features/ai/repository/ai_input_repository.dart';
 import 'package:lotti/features/ai/repository/cloud_inference_repository.dart';
 import 'package:lotti/features/ai/repository/ollama_repository.dart';
-import 'package:lotti/features/ai/state/action_item_suggestions_prompt.dart';
 import 'package:lotti/features/ai/state/consts.dart';
 import 'package:lotti/features/ai/state/inference_status_controller.dart';
 import 'package:lotti/get_it.dart';
@@ -54,13 +53,9 @@ class ActionItemSuggestionsController
       suggestionsStatusNotifier.setStatus(InferenceStatus.running);
       final entry = await repository.getEntity(id);
 
-      ref.invalidate(
-        actionItemSuggestionsPromptControllerProvider(id: id),
-      );
-
-      final prompt = await ref.read(
-        actionItemSuggestionsPromptControllerProvider(id: id).future,
-      );
+      final prompt = await ref
+          .read(aiInputRepositoryProvider)
+          .buildPrompt(id: id, aiResponseType: aiResponseType);
 
       if (entry is! Task || prompt == null) {
         return;

--- a/lib/features/ai/state/action_item_suggestions.g.dart
+++ b/lib/features/ai/state/action_item_suggestions.g.dart
@@ -7,7 +7,7 @@ part of 'action_item_suggestions.dart';
 // **************************************************************************
 
 String _$actionItemSuggestionsControllerHash() =>
-    r'12cb834071bb63c18e05195ed9ec4e5ede7758dc';
+    r'6340a1c7798eeb5293488a36855a2fdfd4c419d7';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/features/ai/state/action_item_suggestions_prompt.dart
+++ b/lib/features/ai/state/action_item_suggestions_prompt.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:lotti/features/ai/repository/ai_input_repository.dart';
+import 'package:lotti/features/ai/state/consts.dart';
 import 'package:lotti/features/journal/repository/journal_repository.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/db_notification.dart';
@@ -46,55 +46,9 @@ class ActionItemSuggestionsPromptController
   }
 
   Future<String?> _buildPrompt({required String id}) async {
-    final repository = ref.read(aiInputRepositoryProvider);
-    final aiInput = await repository.generate(id);
-
-    if (aiInput == null) {
-      return null;
-    }
-
-    const encoder = JsonEncoder.withIndent('    ');
-    final jsonString = encoder.convert(aiInput);
-
-    final prompt = '''
-**Prompt:**
-
-"Based on the provided task details and log entries, identify potential action items that are mentioned in
-the text of the logs but have not yet been captured as existing action items. These suggestions should be
-formatted as a list of new `AiInputActionItemObject` instances, each containing a title and completion
-status. Ensure that only actions not already listed under `actionItems` are included in your suggestions.
-Provide these suggested action items in JSON format, adhering to the structure defined by the given classes."
-
-**Task Details:**
-```json
-$jsonString
-```
-
-Provide these suggested action items in JSON format, adhering to the structure 
-defined by the given classes.
-Double check that the returned JSON ONLY contains action items that are not 
-already listed under `actionItems` array in the task details. Do not simply
-return the example response, but the open action items you have found. If there 
-are none, return an empty array. Double check the items you want to return. If 
-any is very similar to an item already listed in the in actionItems array of the 
-task details, then remove it from the response. 
-
-**Example Response:**
-
-```json
-[
-  {
-    "title": "Review project documentation",
-    "completed": false
-  },
-  {
-    "title": "Schedule team meeting for next week",
-    "completed": true
-  }
-]
-```
-    ''';
-
-    return prompt;
+    return ref.read(aiInputRepositoryProvider).buildPrompt(
+          id: id,
+          aiResponseType: actionItemSuggestions,
+        );
   }
 }

--- a/lib/features/ai/state/action_item_suggestions_prompt.g.dart
+++ b/lib/features/ai/state/action_item_suggestions_prompt.g.dart
@@ -7,7 +7,7 @@ part of 'action_item_suggestions_prompt.dart';
 // **************************************************************************
 
 String _$actionItemSuggestionsPromptControllerHash() =>
-    r'b8971d11e12e8ec99b8976296c4e159c7b121bec';
+    r'b4d4b74fef8df4adbbbef3bc9e2129aaedc61d1c';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/features/ai/state/latest_summary_controller.dart
+++ b/lib/features/ai/state/latest_summary_controller.dart
@@ -77,7 +77,6 @@ class LatestSummaryController extends _$LatestSummaryController {
 
     state = AsyncData(updated);
     await ref.read(journalRepositoryProvider).updateJournalEntity(updated);
-    ref.invalidateSelf();
   }
 }
 

--- a/lib/features/ai/state/latest_summary_controller.g.dart
+++ b/lib/features/ai/state/latest_summary_controller.g.dart
@@ -7,7 +7,7 @@ part of 'latest_summary_controller.dart';
 // **************************************************************************
 
 String _$latestSummaryControllerHash() =>
-    r'e3ecf880a04771d4bff9e1a5a4dc6498e979db9c';
+    r'52ab0dc9495771ac4de9bcf7454ad7088748c80f';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/features/ai/state/ollama_image_analysis.dart
+++ b/lib/features/ai/state/ollama_image_analysis.dart
@@ -38,7 +38,7 @@ class AiImageAnalysisController extends _$AiImageAnalysisController {
         'Describe the image in detail, including its content, style, and any '
         'relevant information that can be gleaned from the image. '
         'If the image is the screenshot of a website, then focus on the '
-        'the content of the website. Do not make up names. ';
+        'content of the website. Do not make up names. ';
 
     final buffer = StringBuffer();
     final image = await getImage(entry);

--- a/lib/features/ai/state/ollama_image_analysis.g.dart
+++ b/lib/features/ai/state/ollama_image_analysis.g.dart
@@ -7,7 +7,7 @@ part of 'ollama_image_analysis.dart';
 // **************************************************************************
 
 String _$aiImageAnalysisControllerHash() =>
-    r'0d8410804b0c260380022bb2e1c1072e457fedda';
+    r'80002c653f807d3b7188555d03c24c4aa70408df';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/features/ai/state/task_summary_controller.dart
+++ b/lib/features/ai/state/task_summary_controller.dart
@@ -8,7 +8,6 @@ import 'package:lotti/features/ai/repository/cloud_inference_repository.dart';
 import 'package:lotti/features/ai/repository/ollama_repository.dart';
 import 'package:lotti/features/ai/state/consts.dart';
 import 'package:lotti/features/ai/state/inference_status_controller.dart';
-import 'package:lotti/features/ai/state/task_summary_prompt.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/utils/consts.dart';
@@ -22,7 +21,6 @@ class TaskSummaryController extends _$TaskSummaryController {
   String build({
     required String id,
   }) {
-    // ref.cacheFor(inferenceStateCacheDuration);
     Future<void>.delayed(const Duration(milliseconds: 10)).then((_) {
       getTaskSummary();
     });
@@ -53,13 +51,9 @@ class TaskSummaryController extends _$TaskSummaryController {
     try {
       inferenceStatusNotifier.setStatus(InferenceStatus.running);
 
-      ref.invalidate(
-        taskSummaryPromptControllerProvider(id: id),
-      );
-
-      final prompt = await ref.read(
-        taskSummaryPromptControllerProvider(id: id).future,
-      );
+      final prompt = await ref
+          .read(aiInputRepositoryProvider)
+          .buildPrompt(id: id, aiResponseType: taskSummary);
 
       if (prompt == null) {
         return;

--- a/lib/features/ai/state/task_summary_controller.g.dart
+++ b/lib/features/ai/state/task_summary_controller.g.dart
@@ -7,7 +7,7 @@ part of 'task_summary_controller.dart';
 // **************************************************************************
 
 String _$taskSummaryControllerHash() =>
-    r'edf8121d941e4abe235d638a5b8aae2835ba4715';
+    r'd9aa42093742d10a961c4fcfa4b7559bb677ab5d';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/features/ai/state/task_summary_prompt.dart
+++ b/lib/features/ai/state/task_summary_prompt.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:lotti/features/ai/repository/ai_input_repository.dart';
+import 'package:lotti/features/ai/state/consts.dart';
 import 'package:lotti/features/journal/repository/journal_repository.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/db_notification.dart';
@@ -45,40 +45,9 @@ class TaskSummaryPromptController extends _$TaskSummaryPromptController {
   }
 
   Future<String?> _buildPrompt({required String id}) async {
-    final repository = ref.read(aiInputRepositoryProvider);
-    final aiInput = await repository.generate(id);
-
-    if (aiInput == null) {
-      return null;
-    }
-
-    const encoder = JsonEncoder.withIndent('    ');
-    final jsonString = encoder.convert(aiInput);
-
-    final prompt = '''
-**Prompt:**
-
-Create a task summary as a TLDR; for the provided task details and log entries. Imagine the
-user has not been involved in the task for a long time, and you want to refresh
-their memory. Summarize the task, the achieved results, and the remaining steps
-that have not been completed yet, if any. Also note when the task is done. Note any 
-learnings or insights that can be drawn from the task, if anything is 
-significant. Talk to the user directly, instead of referring to them as "the user"
-or "they". Don't start with a greeting, don't repeat the task title, get straight 
-to the point. Keep it short and succinct. Assume the the task title is shown 
-directly above in the UI, so starting with the title is not necessary and would 
-feel redundant. While staying succinct, give the output some structure and 
-organization. Use a bullet point list for the achieved results, and a numbered 
-list for the remaining steps. If there are any learnings or insights that can be 
-drawn from the task, include them in the output. If the task is done, end the 
-output with a concluding statement.
-
-**Task Details:**
-```json
-$jsonString
-```
-    ''';
-
-    return prompt;
+    return ref.read(aiInputRepositoryProvider).buildPrompt(
+          id: id,
+          aiResponseType: taskSummary,
+        );
   }
 }

--- a/lib/features/ai/state/task_summary_prompt.g.dart
+++ b/lib/features/ai/state/task_summary_prompt.g.dart
@@ -7,7 +7,7 @@ part of 'task_summary_prompt.dart';
 // **************************************************************************
 
 String _$taskSummaryPromptControllerHash() =>
-    r'8e523a32766082535634ae528372c9e44b434eaa';
+    r'6c105aa0e9477b20247f9a887904b8d39996d59c';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.583+2951
+version: 0.9.583+2952
 
 msix_config:
   display_name: LottiApp

--- a/test/features/ai/state/action_item_suggestions_prompt_test.dart
+++ b/test/features/ai/state/action_item_suggestions_prompt_test.dart
@@ -11,14 +11,14 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/services/db_notification.dart';
 import 'package:mocktail/mocktail.dart';
 
+class MockUpdateNotifications extends Mock implements UpdateNotifications {}
+
 class MockAiInputRepository extends Mock implements AiInputRepository {}
 
 class MockJournalRepository extends Mock implements JournalRepository {}
 
-class MockUpdateNotifications extends Mock implements UpdateNotifications {}
-
 class Listener<T> extends Mock {
-  void call(T? previous, T next);
+  void call(T? previous, T? next);
 }
 
 void main() {
@@ -104,6 +104,27 @@ void main() {
       when(() => mockAiInputRepository.generate(testId))
           .thenAnswer((_) async => mockAiInput);
 
+      when(
+        () => mockAiInputRepository.buildPrompt(
+          id: testId,
+          aiResponseType: any(named: 'aiResponseType'),
+        ),
+      ).thenAnswer(
+        (_) async => '''
+**Prompt:**
+{
+    "title": "Test Task",
+    "status": "OPEN",
+    "actionItems": [
+        {
+            "title": "Existing action item",
+            "completed": false
+        }
+    ]
+}
+''',
+      );
+
       // Act - Listen to the provider
       final future = container.read(
         actionItemSuggestionsPromptControllerProvider(id: testId).future,
@@ -120,7 +141,12 @@ void main() {
 
       // Assert
       verify(() => mockJournalRepository.getLinksFromId(testId)).called(1);
-      verify(() => mockAiInputRepository.generate(testId)).called(1);
+      verify(
+        () => mockAiInputRepository.buildPrompt(
+          id: testId,
+          aiResponseType: any(named: 'aiResponseType'),
+        ),
+      ).called(1);
 
       final state = container
           .read(actionItemSuggestionsPromptControllerProvider(id: testId));
@@ -135,6 +161,13 @@ void main() {
       // Arrange
       when(() => mockAiInputRepository.generate(testId))
           .thenAnswer((_) async => null);
+
+      when(
+        () => mockAiInputRepository.buildPrompt(
+          id: testId,
+          aiResponseType: any(named: 'aiResponseType'),
+        ),
+      ).thenAnswer((_) async => null);
 
       // Act - Get the future first
       final future = container.read(
@@ -152,7 +185,12 @@ void main() {
 
       // Assert
       verify(() => mockJournalRepository.getLinksFromId(testId)).called(1);
-      verify(() => mockAiInputRepository.generate(testId)).called(1);
+      verify(
+        () => mockAiInputRepository.buildPrompt(
+          id: testId,
+          aiResponseType: any(named: 'aiResponseType'),
+        ),
+      ).called(1);
 
       final state = container
           .read(actionItemSuggestionsPromptControllerProvider(id: testId));
@@ -200,6 +238,28 @@ void main() {
       when(() => mockAiInputRepository.generate(testId))
           .thenAnswer((_) async => mockAiInput);
 
+      // Initial prompt
+      when(
+        () => mockAiInputRepository.buildPrompt(
+          id: testId,
+          aiResponseType: any(named: 'aiResponseType'),
+        ),
+      ).thenAnswer(
+        (_) async => '''
+**Prompt:**
+{
+    "title": "Test Task",
+    "status": "OPEN",
+    "actionItems": [
+        {
+            "title": "Initial action item",
+            "completed": false
+        }
+    ]
+}
+''',
+      );
+
       // Act - initial load with future first
       final future = container.read(
         actionItemSuggestionsPromptControllerProvider(id: testId).future,
@@ -216,7 +276,12 @@ void main() {
 
       // Verify initial state
       verify(() => mockJournalRepository.getLinksFromId(testId)).called(1);
-      verify(() => mockAiInputRepository.generate(testId)).called(1);
+      verify(
+        () => mockAiInputRepository.buildPrompt(
+          id: testId,
+          aiResponseType: any(named: 'aiResponseType'),
+        ),
+      ).called(1);
 
       final initialState = container
           .read(actionItemSuggestionsPromptControllerProvider(id: testId));
@@ -230,6 +295,32 @@ void main() {
       when(() => mockAiInputRepository.generate(testId))
           .thenAnswer((_) async => updatedMockAiInput);
 
+      // Updated prompt after notification
+      when(
+        () => mockAiInputRepository.buildPrompt(
+          id: testId,
+          aiResponseType: any(named: 'aiResponseType'),
+        ),
+      ).thenAnswer(
+        (_) async => '''
+**Prompt:**
+{
+    "title": "Test Task",
+    "status": "OPEN",
+    "actionItems": [
+        {
+            "title": "Initial action item",
+            "completed": false
+        },
+        {
+            "title": "New action item",
+            "completed": false
+        }
+    ]
+}
+''',
+      );
+
       // Simulate a notification for the task ID
       updateStreamController.add({testId});
 
@@ -237,7 +328,12 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 100));
 
       // Verify updated state
-      verify(() => mockAiInputRepository.generate(testId)).called(1);
+      verify(
+        () => mockAiInputRepository.buildPrompt(
+          id: testId,
+          aiResponseType: any(named: 'aiResponseType'),
+        ),
+      ).called(1);
 
       final updatedState = container
           .read(actionItemSuggestionsPromptControllerProvider(id: testId));
@@ -285,6 +381,28 @@ void main() {
       when(() => mockAiInputRepository.generate(testId))
           .thenAnswer((_) async => mockAiInput);
 
+      // Initial prompt
+      when(
+        () => mockAiInputRepository.buildPrompt(
+          id: testId,
+          aiResponseType: any(named: 'aiResponseType'),
+        ),
+      ).thenAnswer(
+        (_) async => '''
+**Prompt:**
+{
+    "title": "Test Task",
+    "status": "OPEN",
+    "actionItems": [
+        {
+            "title": "Initial action item",
+            "completed": false
+        }
+    ]
+}
+''',
+      );
+
       // Act - initial load with future first
       final future = container.read(
         actionItemSuggestionsPromptControllerProvider(id: testId).future,
@@ -301,7 +419,12 @@ void main() {
 
       // Verify initial state
       verify(() => mockJournalRepository.getLinksFromId(testId)).called(1);
-      verify(() => mockAiInputRepository.generate(testId)).called(1);
+      verify(
+        () => mockAiInputRepository.buildPrompt(
+          id: testId,
+          aiResponseType: any(named: 'aiResponseType'),
+        ),
+      ).called(1);
 
       final initialState = container
           .read(actionItemSuggestionsPromptControllerProvider(id: testId));
@@ -318,6 +441,32 @@ void main() {
       when(() => mockAiInputRepository.generate(testId))
           .thenAnswer((_) async => updatedMockAiInput);
 
+      // Updated prompt after notification
+      when(
+        () => mockAiInputRepository.buildPrompt(
+          id: testId,
+          aiResponseType: any(named: 'aiResponseType'),
+        ),
+      ).thenAnswer(
+        (_) async => '''
+**Prompt:**
+{
+    "title": "Test Task",
+    "status": "OPEN",
+    "actionItems": [
+        {
+            "title": "Initial action item",
+            "completed": false
+        },
+        {
+            "title": "Linked action item",
+            "completed": false
+        }
+    ]
+}
+''',
+      );
+
       // Simulate a notification for a linked ID
       updateStreamController.add({linkedIds[0]});
 
@@ -325,7 +474,12 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 100));
 
       // Verify updated state
-      verify(() => mockAiInputRepository.generate(testId)).called(1);
+      verify(
+        () => mockAiInputRepository.buildPrompt(
+          id: testId,
+          aiResponseType: any(named: 'aiResponseType'),
+        ),
+      ).called(1);
 
       final updatedState = container
           .read(actionItemSuggestionsPromptControllerProvider(id: testId));
@@ -347,6 +501,22 @@ void main() {
 
       when(() => mockAiInputRepository.generate(testId))
           .thenAnswer((_) async => mockAiInput);
+
+      when(
+        () => mockAiInputRepository.buildPrompt(
+          id: testId,
+          aiResponseType: any(named: 'aiResponseType'),
+        ),
+      ).thenAnswer(
+        (_) async => '''
+**Prompt:**
+{
+    "title": "Test Task",
+    "status": "OPEN",
+    "actionItems": []
+}
+''',
+      );
 
       // Create a scope to allow for proper disposal testing
       {

--- a/test/features/ai/state/task_summary_prompt_test.dart
+++ b/test/features/ai/state/task_summary_prompt_test.dart
@@ -104,6 +104,27 @@ void main() {
       when(() => mockAiInputRepository.generate(testId))
           .thenAnswer((_) async => mockAiInput);
 
+      when(
+        () => mockAiInputRepository.buildPrompt(
+          id: testId,
+          aiResponseType: any(named: 'aiResponseType'),
+        ),
+      ).thenAnswer(
+        (_) async => '''
+**Prompt:**
+{
+    "title": "Test Task",
+    "status": "OPEN",
+    "actionItems": [
+        {
+            "title": "Existing action item",
+            "completed": false
+        }
+    ]
+}
+''',
+      );
+
       // Act - Listen to the provider
       final future = container.read(
         taskSummaryPromptControllerProvider(id: testId).future,
@@ -120,7 +141,12 @@ void main() {
 
       // Assert
       verify(() => mockJournalRepository.getLinksFromId(testId)).called(1);
-      verify(() => mockAiInputRepository.generate(testId)).called(1);
+      verify(
+        () => mockAiInputRepository.buildPrompt(
+          id: testId,
+          aiResponseType: any(named: 'aiResponseType'),
+        ),
+      ).called(1);
 
       final state =
           container.read(taskSummaryPromptControllerProvider(id: testId));
@@ -135,6 +161,13 @@ void main() {
       // Arrange
       when(() => mockAiInputRepository.generate(testId))
           .thenAnswer((_) async => null);
+
+      when(
+        () => mockAiInputRepository.buildPrompt(
+          id: testId,
+          aiResponseType: any(named: 'aiResponseType'),
+        ),
+      ).thenAnswer((_) async => null);
 
       // Act - Get the future first
       final future = container.read(
@@ -152,7 +185,12 @@ void main() {
 
       // Assert
       verify(() => mockJournalRepository.getLinksFromId(testId)).called(1);
-      verify(() => mockAiInputRepository.generate(testId)).called(1);
+      verify(
+        () => mockAiInputRepository.buildPrompt(
+          id: testId,
+          aiResponseType: any(named: 'aiResponseType'),
+        ),
+      ).called(1);
 
       final state =
           container.read(taskSummaryPromptControllerProvider(id: testId));
@@ -200,6 +238,28 @@ void main() {
       when(() => mockAiInputRepository.generate(testId))
           .thenAnswer((_) async => mockAiInput);
 
+      // Initial prompt
+      when(
+        () => mockAiInputRepository.buildPrompt(
+          id: testId,
+          aiResponseType: any(named: 'aiResponseType'),
+        ),
+      ).thenAnswer(
+        (_) async => '''
+**Prompt:**
+{
+    "title": "Test Task",
+    "status": "OPEN",
+    "actionItems": [
+        {
+            "title": "Initial action item",
+            "completed": false
+        }
+    ]
+}
+''',
+      );
+
       // Act - initial load with future first
       final future = container.read(
         taskSummaryPromptControllerProvider(id: testId).future,
@@ -216,7 +276,12 @@ void main() {
 
       // Verify initial state
       verify(() => mockJournalRepository.getLinksFromId(testId)).called(1);
-      verify(() => mockAiInputRepository.generate(testId)).called(1);
+      verify(
+        () => mockAiInputRepository.buildPrompt(
+          id: testId,
+          aiResponseType: any(named: 'aiResponseType'),
+        ),
+      ).called(1);
 
       final initialState =
           container.read(taskSummaryPromptControllerProvider(id: testId));
@@ -230,6 +295,32 @@ void main() {
       when(() => mockAiInputRepository.generate(testId))
           .thenAnswer((_) async => updatedMockAiInput);
 
+      // Updated prompt after notification
+      when(
+        () => mockAiInputRepository.buildPrompt(
+          id: testId,
+          aiResponseType: any(named: 'aiResponseType'),
+        ),
+      ).thenAnswer(
+        (_) async => '''
+**Prompt:**
+{
+    "title": "Test Task",
+    "status": "OPEN",
+    "actionItems": [
+        {
+            "title": "Initial action item",
+            "completed": false
+        },
+        {
+            "title": "New action item",
+            "completed": false
+        }
+    ]
+}
+''',
+      );
+
       // Simulate a notification for the task ID
       updateStreamController.add({testId});
 
@@ -237,7 +328,12 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 100));
 
       // Verify updated state
-      verify(() => mockAiInputRepository.generate(testId)).called(1);
+      verify(
+        () => mockAiInputRepository.buildPrompt(
+          id: testId,
+          aiResponseType: any(named: 'aiResponseType'),
+        ),
+      ).called(1);
 
       final updatedState =
           container.read(taskSummaryPromptControllerProvider(id: testId));
@@ -285,6 +381,28 @@ void main() {
       when(() => mockAiInputRepository.generate(testId))
           .thenAnswer((_) async => mockAiInput);
 
+      // Initial prompt
+      when(
+        () => mockAiInputRepository.buildPrompt(
+          id: testId,
+          aiResponseType: any(named: 'aiResponseType'),
+        ),
+      ).thenAnswer(
+        (_) async => '''
+**Prompt:**
+{
+    "title": "Test Task",
+    "status": "OPEN",
+    "actionItems": [
+        {
+            "title": "Initial action item",
+            "completed": false
+        }
+    ]
+}
+''',
+      );
+
       // Act - initial load with future first
       final future = container.read(
         taskSummaryPromptControllerProvider(id: testId).future,
@@ -301,7 +419,12 @@ void main() {
 
       // Verify initial state
       verify(() => mockJournalRepository.getLinksFromId(testId)).called(1);
-      verify(() => mockAiInputRepository.generate(testId)).called(1);
+      verify(
+        () => mockAiInputRepository.buildPrompt(
+          id: testId,
+          aiResponseType: any(named: 'aiResponseType'),
+        ),
+      ).called(1);
 
       final initialState =
           container.read(taskSummaryPromptControllerProvider(id: testId));
@@ -318,6 +441,32 @@ void main() {
       when(() => mockAiInputRepository.generate(testId))
           .thenAnswer((_) async => updatedMockAiInput);
 
+      // Updated prompt after notification
+      when(
+        () => mockAiInputRepository.buildPrompt(
+          id: testId,
+          aiResponseType: any(named: 'aiResponseType'),
+        ),
+      ).thenAnswer(
+        (_) async => '''
+**Prompt:**
+{
+    "title": "Test Task",
+    "status": "OPEN",
+    "actionItems": [
+        {
+            "title": "Initial action item",
+            "completed": false
+        },
+        {
+            "title": "Linked action item",
+            "completed": false
+        }
+    ]
+}
+''',
+      );
+
       // Simulate a notification for a linked ID
       updateStreamController.add({linkedIds[0]});
 
@@ -325,7 +474,12 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 100));
 
       // Verify updated state
-      verify(() => mockAiInputRepository.generate(testId)).called(1);
+      verify(
+        () => mockAiInputRepository.buildPrompt(
+          id: testId,
+          aiResponseType: any(named: 'aiResponseType'),
+        ),
+      ).called(1);
 
       final updatedState =
           container.read(taskSummaryPromptControllerProvider(id: testId));
@@ -347,6 +501,22 @@ void main() {
 
       when(() => mockAiInputRepository.generate(testId))
           .thenAnswer((_) async => mockAiInput);
+
+      when(
+        () => mockAiInputRepository.buildPrompt(
+          id: testId,
+          aiResponseType: any(named: 'aiResponseType'),
+        ),
+      ).thenAnswer(
+        (_) async => '''
+**Prompt:**
+{
+    "title": "Test Task",
+    "status": "OPEN",
+    "actionItems": []
+}
+''',
+      );
 
       // Create a scope to allow for proper disposal testing
       {


### PR DESCRIPTION
This pull request introduces significant changes to the AI input handling and prompt generation in the `lotti` application. The main changes include the creation of new prompt generation methods, the removal of redundant code, and updates to the state controllers to use the new prompt generation methods.

### Prompt Generation Enhancements:
* [`lib/features/ai/repository/ai_input_repository.dart`](diffhunk://#diff-dc8c7eb5401a5a4bf69e58e3db6ce50b90d6a2f491cad09f25aa889096aa1ccaR129-R150): Added a new method `buildPrompt` to generate prompts based on AI input and response type.
* [`lib/features/ai/repository/prompts.dart`](diffhunk://#diff-16344e54d34573c1cc91d3477b5e4793e5ae30b07cb28a20a6139b5b6a66ea3fR1-R66): Implemented two new functions, `createActionItemSuggestionsPrompt` and `createTaskSummaryPrompt`, to generate specific prompts for action item suggestions and task summaries.

### Code Simplification:
* [`lib/features/ai/state/action_item_suggestions.dart`](diffhunk://#diff-827b509b05a09d64edc5fc7f4e608b0944e876dbc2a1823e5352c2546b50d730L57-R58): Removed redundant code and updated the `ActionItemSuggestionsController` to use the new `buildPrompt` method from `AiInputRepository`.
* [`lib/features/ai/state/task_summary_controller.dart`](diffhunk://#diff-3e9788c55e0e812753f011ce4ed92bebf8ed47b9f4ec3ca12756f7eb29c4d606L56-R56): Updated the `TaskSummaryController` to use the new `buildPrompt` method, removing the dependency on `task_summary_prompt.dart`.
* [`lib/features/ai/state/action_item_suggestions_prompt.dart`](diffhunk://#diff-e3d439961994e7fb02e0e8600033dfb7890df1c53067cccb6736dbe964d6d452L49-R52): Removed the old prompt generation logic and replaced it with a call to the new `buildPrompt` method.

### Miscellaneous:
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Updated the version number from `0.9.583+2951` to `0.9.583+2952`.