### PR TITLE
feat: automatically update task TLDR every 5s when outdated

### DIFF
--- a/lib/database/journal_db/config_flags.dart
+++ b/lib/database/journal_db/config_flags.dart
@@ -91,6 +91,13 @@ Future<void> initConfigFlags(
   );
   await db.insertFlagIfNotExists(
     const ConfigFlag(
+      name: enableAutoTaskTldrFlag,
+      description: 'Enable auto task TLDR',
+      status: false,
+    ),
+  );
+  await db.insertFlagIfNotExists(
+    const ConfigFlag(
       name: enableNotificationsFlag,
       description: 'Enable notifications?',
       status: false,

--- a/lib/features/ai/state/action_item_suggestions.dart
+++ b/lib/features/ai/state/action_item_suggestions.dart
@@ -24,7 +24,6 @@ class ActionItemSuggestionsController
   String build({
     required String id,
   }) {
-    //ref.cacheFor(inferenceStateCacheDuration);
     Future<void>.delayed(const Duration(milliseconds: 10)).then((_) {
       getActionItemSuggestion();
     });

--- a/lib/features/ai/state/image_analysis.g.dart
+++ b/lib/features/ai/state/image_analysis.g.dart
@@ -7,7 +7,7 @@ part of 'image_analysis.dart';
 // **************************************************************************
 
 String _$aiImageAnalysisControllerHash() =>
-    r'ad20c9695be14476256d96a4b92b4dba6ddf0bdf';
+    r'0d6f3ba686d723394cf39a87ffa32dd95eb258a7';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/features/ai/state/latest_summary_controller.dart
+++ b/lib/features/ai/state/latest_summary_controller.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/database/database.dart';
 import 'package:lotti/features/ai/state/action_item_suggestions_prompt.dart';
 import 'package:lotti/features/ai/state/consts.dart';
 import 'package:lotti/features/ai/state/inference_status_controller.dart';
@@ -9,6 +10,7 @@ import 'package:lotti/features/ai/state/task_summary_prompt.dart';
 import 'package:lotti/features/journal/repository/journal_repository.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/db_notification.dart';
+import 'package:lotti/utils/consts.dart';
 import 'package:lotti/utils/platform.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -97,6 +99,13 @@ class IsLatestSummaryOutdatedController
       _timer ??= Timer.periodic(
         const Duration(seconds: 5),
         (timer) async {
+          final enableAutoTaskTldr =
+              await getIt<JournalDb>().getConfigFlag(enableAutoTaskTldrFlag);
+
+          if (!enableAutoTaskTldr) {
+            return;
+          }
+
           final isOutdated = await _checkOutdated();
 
           if (!isOutdated) {

--- a/lib/features/ai/state/latest_summary_controller.g.dart
+++ b/lib/features/ai/state/latest_summary_controller.g.dart
@@ -202,7 +202,7 @@ class _LatestSummaryControllerProviderElement
 }
 
 String _$isLatestSummaryOutdatedControllerHash() =>
-    r'4d24db7145c785617edf63d049f0d59255e31e1b';
+    r'4f22b7eb4fa4fc7290428445b29ae6b2a74d373d';
 
 abstract class _$IsLatestSummaryOutdatedController
     extends BuildlessAutoDisposeAsyncNotifier<bool> {

--- a/lib/features/ai/state/task_summary_controller.dart
+++ b/lib/features/ai/state/task_summary_controller.dart
@@ -31,12 +31,16 @@ class TaskSummaryController extends _$TaskSummaryController {
     final start = DateTime.now();
     final entry = await ref.read(aiInputRepositoryProvider).getEntity(id);
 
-    final inferenceStatusNotifier = ref.read(
-      inferenceStatusControllerProvider(
-        id: id,
-        aiResponseType: taskSummary,
-      ).notifier,
+    if (entry is! Task) {
+      return;
+    }
+
+    final inferenceStatusProvider = inferenceStatusControllerProvider(
+      id: id,
+      aiResponseType: taskSummary,
     );
+
+    final inferenceStatusNotifier = ref.read(inferenceStatusProvider.notifier);
 
     getIt<LoggingService>().captureEvent(
       'Starting task summary for $id',
@@ -44,7 +48,10 @@ class TaskSummaryController extends _$TaskSummaryController {
       domain: 'TaskSummaryController',
     );
 
-    if (entry is! Task) {
+    final isRunning =
+        ref.read(inferenceStatusProvider) == InferenceStatus.running;
+
+    if (isRunning) {
       return;
     }
 

--- a/lib/features/ai/state/task_summary_controller.g.dart
+++ b/lib/features/ai/state/task_summary_controller.g.dart
@@ -7,7 +7,7 @@ part of 'task_summary_controller.dart';
 // **************************************************************************
 
 String _$taskSummaryControllerHash() =>
-    r'439dc28590a86e34f6aaa2c0c02a0aa3547e4593';
+    r'9a37af06096134155f44dc9bae74d989a93d73c2';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/features/ai/ui/latest_ai_response_summary.dart
+++ b/lib/features/ai/ui/latest_ai_response_summary.dart
@@ -48,7 +48,7 @@ class LatestAiResponseSummary extends ConsumerWidget {
             .watch(
               isLatestSummaryOutdatedControllerProvider(
                 id: id,
-                aiResponseType: taskSummary,
+                aiResponseType: aiResponseType,
               ),
             )
             .valueOrNull ??

--- a/lib/pages/settings/flags_page.dart
+++ b/lib/pages/settings/flags_page.dart
@@ -33,6 +33,7 @@ class FlagsPage extends StatelessWidget {
           enableMatrixFlag,
           resendAttachments,
           useCloudInferenceFlag,
+          enableAutoTaskTldrFlag,
         };
 
         final filteredItems =

--- a/lib/utils/consts.dart
+++ b/lib/utils/consts.dart
@@ -11,3 +11,4 @@ const attemptEmbedding = 'attempt_embedding';
 const releaseHideLinkedEntries = 'release_hide_linked_entries';
 const enableLoggingFlag = 'enable_logging';
 const useCloudInferenceFlag = 'use_cloud_inference';
+const enableAutoTaskTldrFlag = 'enable_auto_task_tldr';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.586+2961
+version: 0.9.586+2963
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.586+2959
+version: 0.9.586+2961
 
 msix_config:
   display_name: LottiApp

--- a/test/database/database_test.dart
+++ b/test/database/database_test.dart
@@ -77,6 +77,11 @@ final expectedFlags = <ConfigFlag>{
     description: 'Use Cloud Inference',
     status: false,
   ),
+  const ConfigFlag(
+    name: enableAutoTaskTldrFlag,
+    description: 'Enable auto task TLDR',
+    status: false,
+  ),
 };
 
 final expectedMacFlags = <ConfigFlag>{


### PR DESCRIPTION
This pull request includes multiple changes to improve the functionality and performance of the AI state management in the application. The most important changes include the addition of a timer to periodically check for outdated summaries, updates to the inference status handling, and various refactorings to optimize the codebase.

Improvements to AI state management:

* [`lib/features/ai/state/latest_summary_controller.dart`](diffhunk://#diff-b37cf4347da8e4ffa6b4b883684bd50bb0d1a18c0f122061a160307e3ad17eeaL83-R126): Added a timer in the `IsLatestSummaryOutdatedController` class to periodically check for outdated summaries and trigger updates if necessary.
* [`lib/features/ai/state/latest_summary_controller.dart`](diffhunk://#diff-b37cf4347da8e4ffa6b4b883684bd50bb0d1a18c0f122061a160307e3ad17eeaL101-R140): Refactored the `IsLatestSummaryOutdatedController` class to use `ref.read` instead of `ref.watch` for better performance.

Updates to inference status handling:

* [`lib/features/ai/state/task_summary_controller.dart`](diffhunk://#diff-3e9788c55e0e812753f011ce4ed92bebf8ed47b9f4ec3ca12756f7eb29c4d606L34-R54): Added a check to ensure the inference status is not running before starting a new task summary.

Refactorings and optimizations:

* [`lib/features/ai/state/latest_summary_controller.dart`](diffhunk://#diff-b37cf4347da8e4ffa6b4b883684bd50bb0d1a18c0f122061a160307e3ad17eeaL83-R126): Changed the annotation to `@Riverpod(keepAlive: true)` for the `IsLatestSummaryOutdatedController` class to improve state management.
* [`lib/features/ai/state/latest_summary_controller.g.dart`](diffhunk://#diff-e365ed50a7eab7dd448cbbaf33a1e25febe531b5b71b97c1e424cb0e2698ff67L205-R208): Updated various classes and mixins to remove `AutoDispose` for better resource management. [[1]](diffhunk://#diff-e365ed50a7eab7dd448cbbaf33a1e25febe531b5b71b97c1e424cb0e2698ff67L205-R208) [[2]](diffhunk://#diff-e365ed50a7eab7dd448cbbaf33a1e25febe531b5b71b97c1e424cb0e2698ff67L266-R266) [[3]](diffhunk://#diff-e365ed50a7eab7dd448cbbaf33a1e25febe531b5b71b97c1e424cb0e2698ff67L333-R333) [[4]](diffhunk://#diff-e365ed50a7eab7dd448cbbaf33a1e25febe531b5b71b97c1e424cb0e2698ff67L357-R356) [[5]](diffhunk://#diff-e365ed50a7eab7dd448cbbaf33a1e25febe531b5b71b97c1e424cb0e2698ff67L367-R365)