### PR TITLE
fix: updating start date did not update running timer

### DIFF
--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -241,6 +241,16 @@ class JournalDb extends _$JournalDb {
     return null;
   }
 
+  Stream<JournalEntity?> watchJournalEntityById(String id) {
+    final res = (select(journal)
+          ..where((t) => t.id.equals(id))
+          ..where((t) => t.deleted.equals(false)))
+        .watchSingleOrNull()
+        .map((dbEntity) => dbEntity != null ? fromDbEntity(dbEntity) : null);
+
+    return res;
+  }
+
   Future<List<String>> entryIdsByTagId(String tagId) async {
     return entryIdsForTagId(tagId).get();
   }

--- a/lib/features/journal/ui/widgets/entry_details/duration_widget.dart
+++ b/lib/features/journal/ui/widgets/entry_details/duration_widget.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/journal/state/entry_controller.dart';
 import 'package:lotti/features/journal/state/linked_entries_controller.dart';
+import 'package:lotti/features/journal/ui/widgets/entry_details/entry_datetime_modal.dart';
 import 'package:lotti/features/journal/util/entry_tools.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/time_service.dart';
@@ -60,48 +61,54 @@ class DurationWidget extends ConsumerWidget {
 
         final saveFn = ref.read(provider.notifier).save;
 
-        return Visibility(
-          visible: entryDuration(displayed).inMilliseconds > 0 || isRecent,
-          child: Row(
-            children: [
-              Padding(
-                padding: const EdgeInsets.only(right: 6),
-                child: Icon(
-                  MdiIcons.timerOutline,
-                  color: labelColor,
-                  size: 15,
+        return GestureDetector(
+          onTap: () => EntryDateTimeModal.show<void>(
+            entry: item,
+            context: context,
+          ),
+          child: Visibility(
+            visible: entryDuration(displayed).inMilliseconds > 0 || isRecent,
+            child: Row(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.only(right: 6),
+                  child: Icon(
+                    MdiIcons.timerOutline,
+                    color: labelColor,
+                    size: 15,
+                  ),
                 ),
-              ),
-              FormattedTime(
-                labelColor: labelColor,
-                displayed: displayed,
-              ),
-              Visibility(
-                visible: isRecent && showRecordIcon && !isRecording,
-                child: IconButton(
-                  icon: const Icon(Icons.fiber_manual_record_sharp),
-                  iconSize: 20,
-                  tooltip: 'Record',
-                  color: context.colorScheme.error,
-                  onPressed: () {
-                    _timeService.start(item, linkedFrom);
-                  },
+                FormattedTime(
+                  labelColor: labelColor,
+                  displayed: displayed,
                 ),
-              ),
-              Visibility(
-                visible: isRecording,
-                child: IconButton(
-                  icon: const Icon(Icons.stop),
-                  iconSize: 20,
-                  tooltip: 'Stop',
-                  color: labelColor,
-                  onPressed: () async {
-                    await saveFn(stopRecording: true);
-                  },
+                Visibility(
+                  visible: isRecent && showRecordIcon && !isRecording,
+                  child: IconButton(
+                    icon: const Icon(Icons.fiber_manual_record_sharp),
+                    iconSize: 20,
+                    tooltip: 'Record',
+                    color: context.colorScheme.error,
+                    onPressed: () {
+                      _timeService.start(item, linkedFrom);
+                    },
+                  ),
                 ),
-              ),
-              const SizedBox(width: 15),
-            ],
+                Visibility(
+                  visible: isRecording,
+                  child: IconButton(
+                    icon: const Icon(Icons.stop),
+                    iconSize: 20,
+                    tooltip: 'Stop',
+                    color: labelColor,
+                    onPressed: () async {
+                      await saveFn(stopRecording: true);
+                    },
+                  ),
+                ),
+                const SizedBox(width: 15),
+              ],
+            ),
           ),
         );
       },

--- a/lib/features/journal/ui/widgets/entry_details/entry_datetime_modal.dart
+++ b/lib/features/journal/ui/widgets/entry_details/entry_datetime_modal.dart
@@ -14,6 +14,8 @@ class EntryDateTimeModal {
     required BuildContext context,
     required JournalEntity entry,
   }) async {
+    final pageIndexNotifier = ValueNotifier(0);
+
     return WoltModalSheet.show<T>(
       context: context,
       pageListBuilder: (modalSheetContext) {
@@ -29,6 +31,7 @@ class EntryDateTimeModal {
       },
       modalTypeBuilder: ModalUtils.modalTypeBuilder,
       barrierDismissible: true,
+      pageIndexNotifier: pageIndexNotifier,
     );
   }
 }

--- a/lib/features/journal/ui/widgets/entry_details/entry_datetime_modal.dart
+++ b/lib/features/journal/ui/widgets/entry_details/entry_datetime_modal.dart
@@ -5,10 +5,36 @@ import 'package:lotti/features/journal/state/entry_controller.dart';
 import 'package:lotti/features/journal/util/entry_tools.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/themes/theme.dart';
+import 'package:lotti/utils/modals.dart';
 import 'package:lotti/widgets/date_time/datetime_field.dart';
+import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
-class EntryDateTimeModal extends ConsumerStatefulWidget {
-  const EntryDateTimeModal({
+class EntryDateTimeModal {
+  static Future<T?> show<T>({
+    required BuildContext context,
+    required JournalEntity entry,
+  }) async {
+    return WoltModalSheet.show<T>(
+      context: context,
+      pageListBuilder: (modalSheetContext) {
+        return [
+          ModalUtils.modalSheetPage(
+            context: modalSheetContext,
+            child: EntryDateTimeModalContent(item: entry),
+            navBarHeight: 20,
+            isTopBarLayerAlwaysVisible: false,
+            showCloseButton: false,
+          ),
+        ];
+      },
+      modalTypeBuilder: ModalUtils.modalTypeBuilder,
+      barrierDismissible: true,
+    );
+  }
+}
+
+class EntryDateTimeModalContent extends ConsumerStatefulWidget {
+  const EntryDateTimeModalContent({
     required this.item,
     super.key,
     this.readOnly = false,
@@ -18,10 +44,12 @@ class EntryDateTimeModal extends ConsumerStatefulWidget {
   final bool readOnly;
 
   @override
-  ConsumerState<EntryDateTimeModal> createState() => _EntryDateTimeModalState();
+  ConsumerState<EntryDateTimeModalContent> createState() =>
+      _EntryDateTimeModalContentState();
 }
 
-class _EntryDateTimeModalState extends ConsumerState<EntryDateTimeModal> {
+class _EntryDateTimeModalContentState
+    extends ConsumerState<EntryDateTimeModalContent> {
   late DateTime dateFrom;
   late DateTime dateTo;
 

--- a/lib/features/journal/ui/widgets/entry_details/entry_datetime_widget.dart
+++ b/lib/features/journal/ui/widgets/entry_details/entry_datetime_widget.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/journal/state/entry_controller.dart';
 import 'package:lotti/features/journal/ui/widgets/entry_details/entry_datetime_modal.dart';
 import 'package:lotti/features/journal/util/entry_tools.dart';
-import 'package:lotti/utils/modals.dart';
 
 class EntryDatetimeWidget extends ConsumerWidget {
   const EntryDatetimeWidget({
@@ -29,15 +28,8 @@ class EntryDatetimeWidget extends ConsumerWidget {
     return Padding(
       padding: const EdgeInsets.only(bottom: 5),
       child: GestureDetector(
-        onTap: () {
-          ModalUtils.showSinglePageModal<void>(
-            context: context,
-            builder: (BuildContext _) {
-              return EntryDateTimeModal(item: entry);
-            },
-            navBarHeight: 20,
-          );
-        },
+        onTap: () =>
+            EntryDateTimeModal.show<void>(entry: entry, context: context),
         child: Padding(
           padding: const EdgeInsets.only(left: 5),
           child: Text(

--- a/lib/services/time_service.dart
+++ b/lib/services/time_service.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/get_it.dart';
 
 class TimeService {
   TimeService() {
@@ -20,6 +22,14 @@ class TimeService {
     _current = journalEntity;
     linkedFrom = linked;
     const interval = Duration(seconds: 1);
+
+    unawaited(
+      getIt<JournalDb>()
+          .watchJournalEntityById(journalEntity.id)
+          .forEach((entry) {
+        _current = entry;
+      }),
+    );
 
     int callback(int value) {
       return value;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.588+2968
+version: 0.9.589+2969
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and user experience of the journal entry features. The most significant changes include the addition of a new method to watch journal entities by ID, the introduction of a modal for editing entry date and time, and updates to the `TimeService` class to use the new watch method.

### Database Enhancements:
* Added a new method `watchJournalEntityById` to the `JournalDb` class to stream updates of a specific journal entity by its ID.

### UI Improvements:
* Updated the `DurationWidget` to use a `GestureDetector` to show the `EntryDateTimeModal` when tapped. [[1]](diffhunk://#diff-b271557ef3d9d6531ae6da7eff4b642aeea17b456be0081f01b835fac7fc1fcaL63-R69) [[2]](diffhunk://#diff-b271557ef3d9d6531ae6da7eff4b642aeea17b456be0081f01b835fac7fc1fcaR112)
* Introduced the `EntryDateTimeModal` class with a static `show` method to display a modal for editing entry date and time. [[1]](diffhunk://#diff-0712dbd8e402e916cf7fda6f41aa90af3f0bf78b1ce954e31990bb87e1aa66fdR8-R40) [[2]](diffhunk://#diff-0712dbd8e402e916cf7fda6f41aa90af3f0bf78b1ce954e31990bb87e1aa66fdL21-R55)
* Modified the `EntryDatetimeWidget` to use the new `EntryDateTimeModal.show` method for displaying the modal.

### Service Updates:
* Updated the `TimeService` class to utilize the new `watchJournalEntityById` method for real-time updates on journal entries.

### Miscellaneous:
* Incremented the version number in `pubspec.yaml` to `0.9.589+2969`.