### PR TITLE
feat: improve AI modal

### DIFF
--- a/lib/features/ai/ui/ai_popup_menu.dart
+++ b/lib/features/ai/ui/ai_popup_menu.dart
@@ -1,11 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/ai/ui/image_analysis/ai_image_analysis_list_tile.dart';
+import 'package:lotti/features/ai/ui/image_analysis/ai_image_analysis_view.dart';
 import 'package:lotti/features/ai/ui/task_summary/action_item_suggestions_list_tile.dart';
+import 'package:lotti/features/ai/ui/task_summary/action_item_suggestions_view.dart';
 import 'package:lotti/features/ai/ui/task_summary/ai_task_summary_list_tile.dart';
+import 'package:lotti/features/ai/ui/task_summary/ai_task_summary_view.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/utils/modals.dart';
+import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
 class AiPopUpMenu extends StatelessWidget {
   const AiPopUpMenu({
@@ -14,7 +18,7 @@ class AiPopUpMenu extends StatelessWidget {
     super.key,
   });
 
-  final JournalEntity? journalEntity;
+  final JournalEntity journalEntity;
   final String? linkedFromId;
 
   @override
@@ -22,35 +26,85 @@ class AiPopUpMenu extends StatelessWidget {
     final journalEntity = this.journalEntity;
     return IconButton(
       icon: const Icon(Icons.assistant_rounded),
-      onPressed: () => ModalUtils.showSinglePageModal<void>(
+      onPressed: () => AiModal.show<void>(
         context: context,
-        title: context.messages.aiAssistantTitle,
-        builder: (_) => Column(
-          children: [
-            if (journalEntity != null && journalEntity is Task)
-              AiTaskSummaryListTile(
-                journalEntity: journalEntity,
-                linkedFromId: linkedFromId,
-              ),
-            if (journalEntity != null && journalEntity is Task)
-              ActionItemSuggestionsListTile(
-                journalEntity: journalEntity,
-                linkedFromId: linkedFromId,
-              ),
-            // if (journalEntity is! Task)
-            //   AiChecklistListTile(
-            //     journalEntity: journalEntity,
-            //     linkedFromId: linkedFromId,
-            //   ),
-            if (journalEntity is JournalImage)
-              AiImageAnalysisListTile(
-                journalImage: journalEntity,
-                linkedFromId: linkedFromId,
-              ),
-            verticalModalSpacer,
-          ],
-        ),
+        journalEntity: journalEntity,
+        linkedFromId: linkedFromId,
       ),
+    );
+  }
+}
+
+class AiModal {
+  static Future<void> show<T>({
+    required BuildContext context,
+    required JournalEntity journalEntity,
+    required String? linkedFromId,
+  }) async {
+    final pageIndexNotifier = ValueNotifier(0);
+
+    final initialModalPage = ModalUtils.modalSheetPage(
+      context: context,
+      title: context.messages.aiAssistantTitle,
+      child: Column(
+        children: [
+          if (journalEntity is Task)
+            AiTaskSummaryListTile(
+              journalEntity: journalEntity,
+              linkedFromId: linkedFromId,
+              onTap: () => pageIndexNotifier.value = 1,
+            ),
+          if (journalEntity is Task)
+            ActionItemSuggestionsListTile(
+              journalEntity: journalEntity,
+              linkedFromId: linkedFromId,
+              onTap: () => pageIndexNotifier.value = 2,
+            ),
+          if (journalEntity is JournalImage)
+            AiImageAnalysisListTile(
+              journalImage: journalEntity,
+              linkedFromId: linkedFromId,
+              onTap: () => pageIndexNotifier.value = 3,
+            ),
+          verticalModalSpacer,
+        ],
+      ),
+    );
+
+    final taskSummaryModalPage = ModalUtils.modalSheetPage(
+      context: context,
+      title: context.messages.aiAssistantSummarizeTask,
+      child: AiTaskSummaryView(id: journalEntity.id),
+      onTapBack: () => pageIndexNotifier.value = 0,
+    );
+
+    final actionItemSuggestionsModalPage = ModalUtils.modalSheetPage(
+      context: context,
+      title: context.messages.aiAssistantActionItemSuggestions,
+      child: ActionItemSuggestionsView(id: journalEntity.id),
+      onTapBack: () => pageIndexNotifier.value = 0,
+    );
+
+    final imageAnalysisModalPage = ModalUtils.modalSheetPage(
+      context: context,
+      title: context.messages.aiAssistantAnalyzeImage,
+      child: AiImageAnalysisView(id: journalEntity.id),
+      onTapBack: () => pageIndexNotifier.value = 0,
+    );
+
+    return WoltModalSheet.show<void>(
+      context: context,
+      pageListBuilder: (modalSheetContext) {
+        return [
+          initialModalPage,
+          taskSummaryModalPage,
+          actionItemSuggestionsModalPage,
+          imageAnalysisModalPage,
+        ];
+      },
+      modalTypeBuilder: ModalUtils.modalTypeBuilder,
+      barrierDismissible: true,
+      pageIndexNotifier: pageIndexNotifier,
     );
   }
 }

--- a/lib/features/ai/ui/image_analysis/ai_image_analysis_list_tile.dart
+++ b/lib/features/ai/ui/image_analysis/ai_image_analysis_list_tile.dart
@@ -2,19 +2,19 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/ai/state/image_analysis.dart';
-import 'package:lotti/features/ai/ui/image_analysis/ai_image_analysis_view.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
-import 'package:lotti/utils/modals.dart';
 
 class AiImageAnalysisListTile extends ConsumerWidget {
   const AiImageAnalysisListTile({
     required this.journalImage,
+    required this.onTap,
     this.linkedFromId,
     super.key,
   });
 
   final JournalImage journalImage;
   final String? linkedFromId;
+  final void Function() onTap;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -24,19 +24,10 @@ class AiImageAnalysisListTile extends ConsumerWidget {
         context.messages.aiAssistantAnalyzeImage,
       ),
       onTap: () {
-        Navigator.of(context).pop();
-
         final provider = aiImageAnalysisControllerProvider(id: journalImage.id);
         ref.invalidate(provider);
         ref.read(provider.notifier).analyzeImage();
-
-        ModalUtils.showSinglePageModal<void>(
-          context: context,
-          title: context.messages.aiAssistantTitle,
-          builder: (_) => AiImageAnalysisView(
-            id: journalImage.id,
-          ),
-        );
+        onTap();
       },
     );
   }

--- a/lib/features/ai/ui/image_analysis/ai_image_analysis_view.dart
+++ b/lib/features/ai/ui/image_analysis/ai_image_analysis_view.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:gpt_markdown/gpt_markdown.dart';
 import 'package:lotti/features/ai/state/image_analysis.dart';
+import 'package:lotti/themes/theme.dart';
 
 class AiImageAnalysisView extends ConsumerWidget {
   const AiImageAnalysisView({
@@ -17,13 +17,20 @@ class AiImageAnalysisView extends ConsumerWidget {
       aiImageAnalysisControllerProvider(id: id),
     );
 
-    return SingleChildScrollView(
-      child: Padding(
-        padding: const EdgeInsets.all(32),
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(minWidth: 600),
-          child: SelectionArea(
-            child: GptMarkdown(summary),
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxHeight: 240),
+      child: SingleChildScrollView(
+        reverse: true,
+        child: Padding(
+          padding: const EdgeInsets.all(32),
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(minWidth: 600),
+            child: Text(
+              summary,
+              style: monospaceTextStyleSmall.copyWith(
+                fontWeight: FontWeight.w300,
+              ),
+            ),
           ),
         ),
       ),

--- a/lib/features/ai/ui/task_summary/action_item_suggestions_list_tile.dart
+++ b/lib/features/ai/ui/task_summary/action_item_suggestions_list_tile.dart
@@ -1,18 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:lotti/classes/journal_entities.dart';
-import 'package:lotti/features/ai/ui/task_summary/action_item_suggestions_view.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
-import 'package:lotti/utils/modals.dart';
 
 class ActionItemSuggestionsListTile extends StatelessWidget {
   const ActionItemSuggestionsListTile({
     required this.journalEntity,
+    required this.onTap,
     this.linkedFromId,
     super.key,
   });
 
   final JournalEntity journalEntity;
   final String? linkedFromId;
+  final void Function()? onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -21,16 +21,7 @@ class ActionItemSuggestionsListTile extends StatelessWidget {
       title: Text(
         context.messages.aiAssistantActionItemSuggestions,
       ),
-      onTap: () {
-        Navigator.of(context).pop();
-        ModalUtils.showSinglePageModal<void>(
-          context: context,
-          title: context.messages.aiAssistantTitle,
-          builder: (_) => ActionItemSuggestionsView(
-            id: journalEntity.id,
-          ),
-        );
-      },
+      onTap: onTap,
     );
   }
 }

--- a/lib/features/ai/ui/task_summary/action_item_suggestions_view.dart
+++ b/lib/features/ai/ui/task_summary/action_item_suggestions_view.dart
@@ -18,7 +18,7 @@ class ActionItemSuggestionsView extends ConsumerWidget {
     );
 
     return ConstrainedBox(
-      constraints: const BoxConstraints(maxHeight: 200),
+      constraints: const BoxConstraints(maxHeight: 240),
       child: SingleChildScrollView(
         reverse: true,
         child: Padding(

--- a/lib/features/ai/ui/task_summary/ai_task_summary_list_tile.dart
+++ b/lib/features/ai/ui/task_summary/ai_task_summary_list_tile.dart
@@ -1,36 +1,25 @@
 import 'package:flutter/material.dart';
 import 'package:lotti/classes/journal_entities.dart';
-import 'package:lotti/features/ai/ui/task_summary/ai_task_summary_view.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
-import 'package:lotti/utils/modals.dart';
 
 class AiTaskSummaryListTile extends StatelessWidget {
   const AiTaskSummaryListTile({
     required this.journalEntity,
+    required this.onTap,
     this.linkedFromId,
     super.key,
   });
 
   final JournalEntity journalEntity;
   final String? linkedFromId;
+  final void Function()? onTap;
 
   @override
   Widget build(BuildContext context) {
     return ListTile(
       leading: const Icon(Icons.chat_rounded),
-      title: Text(
-        context.messages.aiAssistantSummarizeTask,
-      ),
-      onTap: () {
-        Navigator.of(context).pop();
-        ModalUtils.showSinglePageModal<void>(
-          context: context,
-          title: context.messages.aiAssistantTitle,
-          builder: (_) => AiTaskSummaryView(
-            id: journalEntity.id,
-          ),
-        );
-      },
+      title: Text(context.messages.aiAssistantSummarizeTask),
+      onTap: onTap,
     );
   }
 }

--- a/lib/features/ai/ui/task_summary/ai_task_summary_view.dart
+++ b/lib/features/ai/ui/task_summary/ai_task_summary_view.dart
@@ -16,7 +16,7 @@ class AiTaskSummaryView extends ConsumerWidget {
     final state = ref.watch(taskSummaryControllerProvider(id: id));
 
     return ConstrainedBox(
-      constraints: const BoxConstraints(maxHeight: 200),
+      constraints: const BoxConstraints(maxHeight: 240),
       child: SingleChildScrollView(
         reverse: true,
         child: Padding(

--- a/lib/features/journal/ui/widgets/entry_details/header/entry_detail_header.dart
+++ b/lib/features/journal/ui/widgets/entry_details/header/entry_detail_header.dart
@@ -82,9 +82,9 @@ class _EntryDetailHeaderState extends ConsumerState<EntryDetailHeader> {
                 activeIcon: Icons.flag,
                 activeColor: context.colorScheme.error,
               ),
-              if (entry is Task || entry is JournalImage)
+              if (entry != null && entry is Task || entry is JournalImage)
                 AiPopUpMenu(
-                  journalEntity: entry,
+                  journalEntity: entry!,
                   linkedFromId: widget.linkedFromId,
                 ),
               IconButton(

--- a/lib/features/tasks/ui/checklists/checklist_suggestions_widget.dart
+++ b/lib/features/tasks/ui/checklists/checklist_suggestions_widget.dart
@@ -61,9 +61,7 @@ class _ChecklistSuggestionsWidgetState
       ModalUtils.showSinglePageModal<void>(
         context: context,
         title: context.messages.aiAssistantThinking,
-        builder: (_) => ActionItemSuggestionsView(
-          id: widget.itemId,
-        ),
+        builder: (_) => ActionItemSuggestionsView(id: widget.itemId),
       );
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.589+2969
+version: 0.9.589+2970
 
 msix_config:
   display_name: LottiApp

--- a/test/features/ai/ui/ai_popup_menu_test.dart
+++ b/test/features/ai/ui/ai_popup_menu_test.dart
@@ -6,6 +6,7 @@ import 'package:lotti/features/ai/ui/ai_popup_menu.dart';
 import 'package:lotti/features/ai/ui/image_analysis/ai_image_analysis_list_tile.dart';
 import 'package:lotti/features/ai/ui/task_summary/ai_task_summary_list_tile.dart';
 
+import '../../../test_data/test_data.dart';
 import '../../../test_helper.dart';
 
 void main() {
@@ -13,8 +14,8 @@ void main() {
     testWidgets('renders AI assistant icon button', (tester) async {
       await tester.pumpWidget(
         createTestApp(
-          const AiPopUpMenu(
-            journalEntity: null,
+          AiPopUpMenu(
+            journalEntity: testTask,
             linkedFromId: null,
           ),
         ),
@@ -99,12 +100,12 @@ void main() {
       expect(find.byType(AiTaskSummaryListTile), findsNothing);
     });
 
-    testWidgets('shows no AI options when journalEntity is null',
+    testWidgets('shows no AI options when journalEntity is not Task or Image',
         (tester) async {
       await tester.pumpWidget(
         createTestApp(
-          const AiPopUpMenu(
-            journalEntity: null,
+          AiPopUpMenu(
+            journalEntity: testAudioEntry,
             linkedFromId: null,
           ),
         ),

--- a/test/features/ai/ui/image_analysis/ai_image_analysis_list_tile_test.dart
+++ b/test/features/ai/ui/image_analysis/ai_image_analysis_list_tile_test.dart
@@ -39,6 +39,7 @@ void main() {
         ProviderScope(
           child: AiImageAnalysisListTile(
             journalImage: mockJournalImage,
+            onTap: () {},
           ),
         ),
       ),
@@ -56,6 +57,7 @@ void main() {
           child: AiImageAnalysisListTile(
             journalImage: mockJournalImage,
             linkedFromId: 'linked-id',
+            onTap: () {},
           ),
         ),
       ),

--- a/test/features/ai/ui/image_analysis/ai_image_analysis_view_test.dart
+++ b/test/features/ai/ui/image_analysis/ai_image_analysis_view_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:gpt_markdown/gpt_markdown.dart';
 import 'package:lotti/features/ai/state/image_analysis.dart';
 import 'package:lotti/features/ai/ui/image_analysis/ai_image_analysis_view.dart';
 
@@ -26,7 +25,6 @@ void main() {
     );
 
     expect(find.byType(SingleChildScrollView), findsOneWidget);
-    expect(find.byType(GptMarkdown), findsOneWidget);
     expect(find.text(''), findsOneWidget);
   });
 
@@ -48,7 +46,6 @@ void main() {
     );
 
     expect(find.byType(SingleChildScrollView), findsOneWidget);
-    expect(find.byType(GptMarkdown), findsOneWidget);
     expect(find.text(testAnalysis), findsOneWidget);
   });
 }

--- a/test/features/ai/ui/task_summary/action_item_suggestions_list_tile_test.dart
+++ b/test/features/ai/ui/task_summary/action_item_suggestions_list_tile_test.dart
@@ -41,6 +41,7 @@ void main() {
           ActionItemSuggestionsListTile(
             journalEntity: mockTask,
             linkedFromId: 'linked-id',
+            onTap: null,
           ),
         ),
       );
@@ -56,6 +57,7 @@ void main() {
         createTestApp(
           AiTaskSummaryListTile(
             journalEntity: mockTask,
+            onTap: null,
           ),
         ),
       );
@@ -71,6 +73,7 @@ void main() {
           AiTaskSummaryListTile(
             journalEntity: mockTask,
             linkedFromId: 'linked-id',
+            onTap: () {},
           ),
         ),
       );

--- a/test/features/ai/ui/task_summary/ai_task_summary_list_tile_test.dart
+++ b/test/features/ai/ui/task_summary/ai_task_summary_list_tile_test.dart
@@ -40,6 +40,7 @@ void main() {
           AiTaskSummaryListTile(
             journalEntity: mockTask,
             linkedFromId: 'linked-id',
+            onTap: null,
           ),
         ),
       );
@@ -55,6 +56,7 @@ void main() {
         createTestApp(
           AiTaskSummaryListTile(
             journalEntity: mockTask,
+            onTap: null,
           ),
         ),
       );
@@ -70,6 +72,7 @@ void main() {
           AiTaskSummaryListTile(
             journalEntity: mockTask,
             linkedFromId: 'linked-id',
+            onTap: () {},
           ),
         ),
       );


### PR DESCRIPTION
This pull request includes several changes to the AI-related UI components in the project. The most important changes involve refactoring the `AiPopUpMenu` class, updating related list tiles, and modifying the views for task summary and image analysis.

### Refactoring and Improvements:

* [`lib/features/ai/ui/ai_popup_menu.dart`](diffhunk://#diff-ffcb87d546496ab34540b9a3dd2913bdf15b2a0b948883c5100399372ad2e673R4-R12): Refactored `AiPopUpMenu` to use a new `AiModal` class for displaying modal sheets and updated the `journalEntity` parameter to be non-nullable. [[1]](diffhunk://#diff-ffcb87d546496ab34540b9a3dd2913bdf15b2a0b948883c5100399372ad2e673R4-R12) [[2]](diffhunk://#diff-ffcb87d546496ab34540b9a3dd2913bdf15b2a0b948883c5100399372ad2e673L17-R107)
* [`lib/features/ai/ui/image_analysis/ai_image_analysis_list_tile.dart`](diffhunk://#diff-66670fbe9679d161a35d462b3e3e73b3cc078612a05fa13b93f10b871e907708L5-R17): Added an `onTap` callback to `AiImageAnalysisListTile` and removed the modal display logic from the `onTap` method. [[1]](diffhunk://#diff-66670fbe9679d161a35d462b3e3e73b3cc078612a05fa13b93f10b871e907708L5-R17) [[2]](diffhunk://#diff-66670fbe9679d161a35d462b3e3e73b3cc078612a05fa13b93f10b871e907708L27-R30)
* [`lib/features/ai/ui/task_summary/action_item_suggestions_list_tile.dart`](diffhunk://#diff-41aed21b1d46607dc0f50e6fc8318f68769f701bd0770c3f4cb40a705307f2faL3-R15): Added an `onTap` callback to `ActionItemSuggestionsListTile` and removed the modal display logic from the `onTap` method. [[1]](diffhunk://#diff-41aed21b1d46607dc0f50e6fc8318f68769f701bd0770c3f4cb40a705307f2faL3-R15) [[2]](diffhunk://#diff-41aed21b1d46607dc0f50e6fc8318f68769f701bd0770c3f4cb40a705307f2faL24-R24)
* [`lib/features/ai/ui/task_summary/ai_task_summary_list_tile.dart`](diffhunk://#diff-99c2573106cba5ea8de131b2924be882807a23ceedaf44d67e4000f70ef85bc0L3-R22): Added an `onTap` callback to `AiTaskSummaryListTile` and removed the modal display logic from the `onTap` method. ([lib/features/ai/ui/task_summary/ai_task_summary_list_tile.dartL3-R22](diffhunk://#diff-99c2573106cba5ea8de131b2924be882807a23ceedaf44d67e4000f70ef85bc0L3-R22), Ff8c1499L21R21)

### View Modifications:

* [`lib/features/ai/ui/image_analysis/ai_image_analysis_view.dart`](diffhunk://#diff-ea3cb00cd532b121c54dea99acf4d647eea00e2c20146342f110d35f376681d4L3-R4): Modified `AiImageAnalysisView` to use a constrained box with a maximum height of 240 and replaced `GptMarkdown` with a simple `Text` widget styled with `monospaceTextStyleSmall`. [[1]](diffhunk://#diff-ea3cb00cd532b121c54dea99acf4d647eea00e2c20146342f110d35f376681d4L3-R4) [[2]](diffhunk://#diff-ea3cb00cd532b121c54dea99acf4d647eea00e2c20146342f110d35f376681d4L20-R33)
* [`lib/features/ai/ui/task_summary/action_item_suggestions_view.dart`](diffhunk://#diff-cab4f06613b3e491f3b745a31b0d77a8192c10979a342b487ba1adca6218b1f4L21-R21): Updated the maximum height constraint to 240 for `ActionItemSuggestionsView`.
* [`lib/features/ai/ui/task_summary/ai_task_summary_view.dart`](diffhunk://#diff-73695f8dcb445abccbe9106caa3aeaaea2135e8a21ca93bdc797d36d2d082e6aL19-R19): Updated the maximum height constraint to 240 for `AiTaskSummaryView`.

### Miscellaneous:

* [`lib/features/journal/ui/widgets/entry_details/header/entry_detail_header.dart`](diffhunk://#diff-daa5674187c7a4aff0ab5f34c4342f4d9c9ad504ca9cd6a9b4cb55b5c7108ad6L85-R87): Added a null check for `entry` before passing it to `AiPopUpMenu`.
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Updated the version number from `0.9.589+2969` to `0.9.589+2970`.

### Test Updates:

* Updated various test files to accommodate the changes in the `AiPopUpMenu`, `AiImageAnalysisListTile`, `ActionItemSuggestionsListTile`, and `AiTaskSummaryListTile` classes by adding the necessary `onTap` callbacks and adjusting test expectations.
  * `test/features/ai/ui/ai_popup_menu_test.dart` [[1]](diffhunk://#diff-a3c0e609576c14b1a80dc91565ec16abf2d185f656c890595dbed45a015f1531R9-R18) [[2]](diffhunk://#diff-a3c0e609576c14b1a80dc91565ec16abf2d185f656c890595dbed45a015f1531L102-R108)
  * `test/features/ai/ui/image_analysis/ai_image_analysis_list_tile_test.dart` [[1]](diffhunk://#diff-e24309437a9be35562baf138e6ce60ec921bbe88f06de26f5d22eed0d66b3700R42) [[2]](diffhunk://#diff-e24309437a9be35562baf138e6ce60ec921bbe88f06de26f5d22eed0d66b3700R60)
  * `test/features/ai/ui/image_analysis/ai_image_analysis_view_test.dart` [[1]](diffhunk://#diff-0b81563b31a2dd78aa51c07b20b1d77eff4d347568c9c1886fd521d212018b41L4) [[2]](diffhunk://#diff-0b81563b31a2dd78aa51c07b20b1d77eff4d347568c9c1886fd521d212018b41L29) [[3]](diffhunk://#diff-0b81563b31a2dd78aa51c07b20b1d77eff4d347568c9c1886fd521d212018b41L51)
  * `test/features/ai/ui/task_summary/action_item_suggestions_list_tile_test.dart` [[1]](diffhunk://#diff-cfbdf06b17daed1b18a425e76125734a67859970eb1fad71619c049a1692c9a6R44) [[2]](diffhunk://#diff-cfbdf06b17daed1b18a425e76125734a67859970eb1fad71619c049a1692c9a6R60) [[3]](diffhunk://#diff-cfbdf06b17daed1b18a425e76125734a67859970eb1fad71619c049a1692c9a6R76)
  * `test/features/ai/ui/task_summary/ai_task_summary_list_tile_test.dart` [[1]](diffhunk://#diff-a85848ac927919c20824397c500278dbfdfa9b04acaf95cf4c9d5832da854fffR43) [[2]](diffhunk://#diff-a85848ac927919c20824397c500278dbfdfa9b04acaf95cf4c9d5832da854fffR59) [[3]](diffhunk://#diff-a85848ac927919c20824397c500278dbfdfa9b04acaf95cf4c9d5832da854fffR75)