### PR TITLE
fix: remove dependency on FFmpeg, use m4a instead of aac

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -5,13 +5,6 @@ PODS:
     - Flutter
   - device_info_plus (0.0.1):
     - Flutter
-  - ffmpeg-kit-ios-https (6.0)
-  - ffmpeg_kit_flutter (6.0.3):
-    - ffmpeg_kit_flutter/https (= 6.0.3)
-    - Flutter
-  - ffmpeg_kit_flutter/https (6.0.3):
-    - ffmpeg-kit-ios-https (= 6.0)
-    - Flutter
   - Flutter (1.0.0)
   - flutter_health_fit (0.0.1):
     - Flutter
@@ -132,7 +125,6 @@ DEPENDENCIES:
   - audio_session (from `.symlinks/plugins/audio_session/ios`)
   - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
-  - ffmpeg_kit_flutter (from `.symlinks/plugins/ffmpeg_kit_flutter/ios`)
   - Flutter (from `Flutter`)
   - flutter_health_fit (from `.symlinks/plugins/flutter_health_fit/ios`)
   - flutter_image_compress_common (from `.symlinks/plugins/flutter_image_compress_common/ios`)
@@ -167,7 +159,6 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - ffmpeg-kit-ios-https
     - libwebp
     - Mantle
     - MTBBarcodeScanner
@@ -183,8 +174,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/connectivity_plus/ios"
   device_info_plus:
     :path: ".symlinks/plugins/device_info_plus/ios"
-  ffmpeg_kit_flutter:
-    :path: ".symlinks/plugins/ffmpeg_kit_flutter/ios"
   Flutter:
     :path: Flutter
   flutter_health_fit:
@@ -252,8 +241,6 @@ SPEC CHECKSUMS:
   audio_session: 9bb7f6c970f21241b19f5a3658097ae459681ba0
   connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
   device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
-  ffmpeg-kit-ios-https: ac1fbdb6095fc1595b446084a3447de2c6d78347
-  ffmpeg_kit_flutter: 66a088989cd7aa07aa8cde7c93a2e4611753fea5
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_health_fit: a3de34d7ef2daf1f29f60306584702a7e165f8b1
   flutter_image_compress_common: 1697a328fd72bfb335507c6bca1a65fa5ad87df1

--- a/lib/features/speech/state/recorder_cubit.dart
+++ b/lib/features/speech/state/recorder_cubit.dart
@@ -61,7 +61,7 @@ class AudioRecorderCubit extends Cubit<AudioRecorderState> {
         } else {
           final created = DateTime.now();
           final fileName =
-              '${DateFormat('yyyy-MM-dd_HH-mm-ss-S').format(created)}.aac';
+              '${DateFormat('yyyy-MM-dd_HH-mm-ss-S').format(created)}.m4a';
           final day = DateFormat('yyyy-MM-dd').format(created);
           final relativePath = '/audio/$day/';
           final directory = await createAssetDirectory(relativePath);

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,7 +9,6 @@ import audio_session
 import connectivity_plus
 import desktop_drop
 import device_info_plus
-import ffmpeg_kit_flutter
 import file_selector_macos
 import flutter_image_compress_macos
 import flutter_local_notifications
@@ -40,7 +39,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   DesktopDropPlugin.register(with: registry.registrar(forPlugin: "DesktopDropPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
-  FFmpegKitFlutterPlugin.register(with: registry.registrar(forPlugin: "FFmpegKitFlutterPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FlutterImageCompressMacosPlugin.register(with: registry.registrar(forPlugin: "FlutterImageCompressMacosPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -7,13 +7,6 @@ PODS:
     - FlutterMacOS
   - device_info_plus (0.0.1):
     - FlutterMacOS
-  - ffmpeg-kit-macos-https (6.0)
-  - ffmpeg_kit_flutter (6.0.3):
-    - ffmpeg_kit_flutter/https (= 6.0.3)
-    - FlutterMacOS
-  - ffmpeg_kit_flutter/https (6.0.3):
-    - ffmpeg-kit-macos-https (= 6.0)
-    - FlutterMacOS
   - file_selector_macos (0.0.1):
     - FlutterMacOS
   - flutter_image_compress_macos (1.0.0):
@@ -100,7 +93,6 @@ DEPENDENCIES:
   - connectivity_plus (from `Flutter/ephemeral/.symlinks/plugins/connectivity_plus/macos`)
   - desktop_drop (from `Flutter/ephemeral/.symlinks/plugins/desktop_drop/macos`)
   - device_info_plus (from `Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos`)
-  - ffmpeg_kit_flutter (from `Flutter/ephemeral/.symlinks/plugins/ffmpeg_kit_flutter/macos`)
   - file_selector_macos (from `Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos`)
   - flutter_image_compress_macos (from `Flutter/ephemeral/.symlinks/plugins/flutter_image_compress_macos/macos`)
   - flutter_local_notifications (from `Flutter/ephemeral/.symlinks/plugins/flutter_local_notifications/macos`)
@@ -131,7 +123,6 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - ffmpeg-kit-macos-https
     - HotKey
     - OpenSSL-Universal
     - sqlite3
@@ -145,8 +136,6 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/desktop_drop/macos
   device_info_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos
-  ffmpeg_kit_flutter:
-    :path: Flutter/ephemeral/.symlinks/plugins/ffmpeg_kit_flutter/macos
   file_selector_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos
   flutter_image_compress_macos:
@@ -205,8 +194,6 @@ SPEC CHECKSUMS:
   connectivity_plus: 4adf20a405e25b42b9c9f87feff8f4b6fde18a4e
   desktop_drop: e0b672a7d84c0a6cbc378595e82cdb15f2970a43
   device_info_plus: 4fb280989f669696856f8b129e4a5e3cd6c48f76
-  ffmpeg-kit-macos-https: 8fe9a5bdb2a42ecb2caf067522aa9a8ce386294e
-  ffmpeg_kit_flutter: ba222540001fc4d9c90530e0f9d8dd7f15f64a97
   file_selector_macos: 6280b52b459ae6c590af5d78fc35c7267a3c4b31
   flutter_image_compress_macos: e68daf54bb4bf2144c580fd4d151c949cbf492f0
   flutter_local_notifications: 4bf37a31afde695b56091b4ae3e4d9c7a7e6cda0

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -682,22 +682,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  ffmpeg_kit_flutter:
-    dependency: "direct main"
-    description:
-      name: ffmpeg_kit_flutter
-      sha256: "843aae41823ca94a0988d975b4b6cdc6948744b9b7e2707d81a3a9cd237b0100"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.0.3"
-  ffmpeg_kit_flutter_platform_interface:
-    dependency: transitive
-    description:
-      name: ffmpeg_kit_flutter_platform_interface
-      sha256: addf046ae44e190ad0101b2fde2ad909a3cd08a2a109f6106d2f7048b7abedee
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.1"
   file:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.591+2976
+version: 0.9.592+2977
 
 msix_config:
   display_name: LottiApp
@@ -45,7 +45,6 @@ dependencies:
   equatable: ^2.0.3
   exif: ^3.0.1
 
-  ffmpeg_kit_flutter: ^6.0.3
   fl_chart: ^0.70.2
   flex_color_scheme: ^8.0.1
   flutter:


### PR DESCRIPTION
This pull request removes the dependency on `ffmpeg_kit_flutter` and updates audio file handling in the `AsrService` and `AudioRecorderCubit` classes. It also includes minor version updates and cleanup in the `pubspec.yaml` file.

Removal of `ffmpeg_kit_flutter`:

* [`lib/features/speech/state/asr_service.dart`](diffhunk://#diff-01cf561c7fcb33e54fbee2be986cd90095156473dfa7cbd8bef074e0b5f9fa85L6-L7): Removed the import and usage of `ffmpeg_kit_flutter` for audio file conversion. Updated the transcribe method to use the original audio file path directly. [[1]](diffhunk://#diff-01cf561c7fcb33e54fbee2be986cd90095156473dfa7cbd8bef074e0b5f9fa85L6-L7) [[2]](diffhunk://#diff-01cf561c7fcb33e54fbee2be986cd90095156473dfa7cbd8bef074e0b5f9fa85L106-R109) [[3]](diffhunk://#diff-01cf561c7fcb33e54fbee2be986cd90095156473dfa7cbd8bef074e0b5f9fa85L158-R149)
* [`macos/Flutter/GeneratedPluginRegistrant.swift`](diffhunk://#diff-e0a0e103075365af1fb906fa24889fc5ed61c2020ef2efeb23fe020123abc325L12): Removed the registration of `FFmpegKitFlutterPlugin`. [[1]](diffhunk://#diff-e0a0e103075365af1fb906fa24889fc5ed61c2020ef2efeb23fe020123abc325L12) [[2]](diffhunk://#diff-e0a0e103075365af1fb906fa24889fc5ed61c2020ef2efeb23fe020123abc325L43)

Audio file handling updates:

* [`lib/features/speech/state/recorder_cubit.dart`](diffhunk://#diff-bf7a2bda8bfa84addb4e44d121b2831a6554ce2a8b7cce94c364da29985acbe7L64-R64): Changed the audio file extension from `.aac` to `.m4a` when creating new audio files.

Version update and cleanup:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Updated the project version and removed the `ffmpeg_kit_flutter` dependency. [[1]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4) [[2]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L48)