### PR TITLE
feat: task details page

### DIFF
--- a/lib/beamer/locations/journal_location.dart
+++ b/lib/beamer/locations/journal_location.dart
@@ -35,7 +35,7 @@ class JournalLocation extends BeamLocation<BeamState> {
       if (isUuid(entryId))
         BeamPage(
           key: ValueKey('journal-$entryId'),
-          child: EntryDetailPage(itemId: entryId!),
+          child: EntryDetailsPage(itemId: entryId!),
         ),
       if (pathContains('fill_survey/') && pathContainsKey('surveyType'))
         BeamPage(

--- a/lib/beamer/locations/settings_location.dart
+++ b/lib/beamer/locations/settings_location.dart
@@ -298,7 +298,7 @@ class SettingsLocation extends BeamLocation<BeamState> {
           key: ValueKey(
             'settings-conflict-edit-${state.pathParameters['conflictId']}',
           ),
-          child: EntryDetailPage(itemId: state.pathParameters['conflictId']!),
+          child: EntryDetailsPage(itemId: state.pathParameters['conflictId']!),
         ),
 
       if (pathContains('advanced/maintenance'))

--- a/lib/beamer/locations/tasks_location.dart
+++ b/lib/beamer/locations/tasks_location.dart
@@ -1,8 +1,8 @@
 import 'package:beamer/beamer.dart';
 import 'package:flutter/material.dart';
-import 'package:lotti/features/journal/ui/pages/entry_details_page.dart';
 import 'package:lotti/features/journal/ui/pages/infinite_journal_page.dart';
 import 'package:lotti/features/speech/ui/pages/record_audio_page.dart';
+import 'package:lotti/features/tasks/ui/pages/task_details_page.dart';
 import 'package:lotti/utils/uuid.dart';
 
 class TasksLocation extends BeamLocation<BeamState> {
@@ -11,15 +11,15 @@ class TasksLocation extends BeamLocation<BeamState> {
   @override
   List<String> get pathPatterns => [
         '/tasks',
-        '/tasks/:entryId',
-        '/tasks/:entryId/record_audio/:linkedId',
+        '/tasks/:taskId',
+        '/tasks/:taskId/record_audio/:linkedId',
       ];
 
   @override
   List<BeamPage> buildPages(BuildContext context, BeamState state) {
     bool pathContains(String s) => state.uri.path.contains(s);
 
-    final entryId = state.pathParameters['entryId'];
+    final taskId = state.pathParameters['taskId'];
     final linkedId = state.pathParameters['linkedId'];
     final categoryId = state.queryParameters['categoryId'];
 
@@ -29,10 +29,10 @@ class TasksLocation extends BeamLocation<BeamState> {
         title: 'Tasks',
         child: InfiniteJournalPage(showTasks: true),
       ),
-      if (isUuid(entryId))
+      if (isUuid(taskId))
         BeamPage(
-          key: ValueKey('tasks-$entryId'),
-          child: EntryDetailPage(itemId: entryId!),
+          key: ValueKey('tasks-$taskId'),
+          child: TaskDetailsPage(taskId: taskId!),
         ),
       if (pathContains('record_audio/'))
         BeamPage(

--- a/lib/features/journal/repository/journal_repository.dart
+++ b/lib/features/journal/repository/journal_repository.dart
@@ -13,6 +13,7 @@ import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/notification_service.dart';
+import 'package:lotti/services/time_service.dart';
 import 'package:lotti/services/vector_clock_service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -129,7 +130,9 @@ class JournalRepository {
           dateTo: dateTo,
         ),
       );
+
       await persistenceLogic.updateDbEntity(updated);
+      getIt<TimeService>().updateCurrent(updated);
     } catch (exception, stackTrace) {
       getIt<LoggingService>().captureException(
         exception,

--- a/lib/features/journal/ui/pages/entry_details_page.dart
+++ b/lib/features/journal/ui/pages/entry_details_page.dart
@@ -3,26 +3,22 @@ import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
-import 'package:lotti/features/ai/state/consts.dart';
-import 'package:lotti/features/ai/ui/animation/ai_running_animation.dart';
 import 'package:lotti/features/journal/state/entry_controller.dart';
 import 'package:lotti/features/journal/ui/widgets/create/create_entry_action_button.dart';
 import 'package:lotti/features/journal/ui/widgets/entry_detail_linked.dart';
 import 'package:lotti/features/journal/ui/widgets/entry_detail_linked_from.dart';
 import 'package:lotti/features/journal/ui/widgets/entry_details_widget.dart';
+import 'package:lotti/features/journal/ui/widgets/journal_app_bar.dart';
 import 'package:lotti/features/tasks/state/task_app_bar_controller.dart';
 import 'package:lotti/features/tasks/ui/checklists/linked_from_checklist_widget.dart';
 import 'package:lotti/features/tasks/ui/checklists/linked_from_task_widget.dart';
-import 'package:lotti/features/tasks/ui/header/task_title_header.dart';
-import 'package:lotti/features/tasks/ui/task_app_bar.dart';
-import 'package:lotti/features/tasks/ui/task_form.dart';
 import 'package:lotti/features/user_activity/state/user_activity_service.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/image_import.dart';
 import 'package:lotti/pages/empty_scaffold.dart';
 
-class EntryDetailPage extends ConsumerStatefulWidget {
-  const EntryDetailPage({
+class EntryDetailsPage extends ConsumerStatefulWidget {
+  const EntryDetailsPage({
     required this.itemId,
     super.key,
     this.readOnly = false,
@@ -32,10 +28,10 @@ class EntryDetailPage extends ConsumerStatefulWidget {
   final bool readOnly;
 
   @override
-  ConsumerState<EntryDetailPage> createState() => _EntryDetailPageState();
+  ConsumerState<EntryDetailsPage> createState() => _EntryDetailsPageState();
 }
 
-class _EntryDetailPageState extends ConsumerState<EntryDetailPage> {
+class _EntryDetailsPageState extends ConsumerState<EntryDetailsPage> {
   final _scrollController = ScrollController();
 
   @override
@@ -81,22 +77,7 @@ class _EntryDetailPageState extends ConsumerState<EntryDetailPage> {
             CustomScrollView(
               controller: _scrollController,
               slivers: [
-                TaskSliverAppBar(taskId: widget.itemId),
-                if (item is Task)
-                  PinnedHeaderSliver(
-                    child: TaskTitleHeader(taskId: widget.itemId),
-                  ),
-                if (item is Task)
-                  SliverToBoxAdapter(
-                    child: Padding(
-                      padding: const EdgeInsets.only(
-                        left: 20,
-                        right: 20,
-                        top: 10,
-                      ),
-                      child: TaskForm(taskId: widget.itemId),
-                    ),
-                  ),
+                JournalSliverAppBar(entryId: widget.itemId),
                 SliverToBoxAdapter(
                   child: Padding(
                     padding: const EdgeInsets.only(
@@ -108,13 +89,12 @@ class _EntryDetailPageState extends ConsumerState<EntryDetailPage> {
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.end,
                       children: <Widget>[
-                        if (item is! Task)
-                          EntryDetailsWidget(
-                            itemId: widget.itemId,
-                            popOnDelete: true,
-                            showTaskDetails: true,
-                            showAiEntry: true,
-                          ),
+                        EntryDetailsWidget(
+                          itemId: widget.itemId,
+                          popOnDelete: true,
+                          showTaskDetails: true,
+                          showAiEntry: true,
+                        ),
                         LinkedEntriesWidget(item),
                         LinkedFromEntriesWidget(item),
                         if (item is ChecklistItem)
@@ -130,19 +110,6 @@ class _EntryDetailPageState extends ConsumerState<EntryDetailPage> {
                 ),
               ],
             ),
-            if (item is Task)
-              Align(
-                alignment: Alignment.bottomCenter,
-                child: AiRunningAnimationWrapperCard(
-                  entryId: widget.itemId,
-                  height: 50,
-                  responseTypes: const {
-                    taskSummary,
-                    actionItemSuggestions,
-                    imageAnalysis,
-                  },
-                ),
-              ),
           ],
         ),
       ),

--- a/lib/features/journal/ui/widgets/entry_details/duration_widget.dart
+++ b/lib/features/journal/ui/widgets/entry_details/duration_widget.dart
@@ -26,6 +26,7 @@ class DurationWidget extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final provider = entryControllerProvider(id: item.meta.id);
+    final entry = ref.watch(provider).value?.entry;
 
     return StreamBuilder(
       stream: _timeService.getStream(),
@@ -88,7 +89,9 @@ class DurationWidget extends ConsumerWidget {
                     tooltip: 'Record',
                     color: context.colorScheme.error,
                     onPressed: () {
-                      _timeService.start(item, linkedFrom);
+                      if (entry != null) {
+                        _timeService.start(entry, linkedFrom);
+                      }
                     },
                   ),
                 ),

--- a/lib/features/journal/ui/widgets/journal_app_bar.dart
+++ b/lib/features/journal/ui/widgets/journal_app_bar.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/features/journal/ui/widgets/entry_details/save_button.dart';
+import 'package:lotti/widgets/app_bar/title_app_bar.dart';
+
+class JournalSliverAppBar extends ConsumerWidget {
+  const JournalSliverAppBar({
+    required this.entryId,
+    super.key,
+  });
+
+  final String entryId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SliverAppBar(
+      leadingWidth: 100,
+      leading: const BackWidget(),
+      pinned: true,
+      actions: [
+        SaveButton(entryId: entryId),
+      ],
+      automaticallyImplyLeading: false,
+    );
+  }
+}

--- a/lib/features/tasks/ui/pages/task_details_page.dart
+++ b/lib/features/tasks/ui/pages/task_details_page.dart
@@ -1,0 +1,144 @@
+import 'package:desktop_drop/desktop_drop.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/ai/state/consts.dart';
+import 'package:lotti/features/ai/ui/animation/ai_running_animation.dart';
+import 'package:lotti/features/journal/state/entry_controller.dart';
+import 'package:lotti/features/journal/ui/widgets/create/create_entry_action_button.dart';
+import 'package:lotti/features/journal/ui/widgets/entry_detail_linked.dart';
+import 'package:lotti/features/journal/ui/widgets/entry_detail_linked_from.dart';
+import 'package:lotti/features/tasks/state/task_app_bar_controller.dart';
+import 'package:lotti/features/tasks/ui/header/task_title_header.dart';
+import 'package:lotti/features/tasks/ui/task_app_bar.dart';
+import 'package:lotti/features/tasks/ui/task_form.dart';
+import 'package:lotti/features/user_activity/state/user_activity_service.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/logic/image_import.dart';
+import 'package:lotti/pages/empty_scaffold.dart';
+
+class TaskDetailsPage extends ConsumerStatefulWidget {
+  const TaskDetailsPage({
+    required this.taskId,
+    super.key,
+    this.readOnly = false,
+  });
+
+  final String taskId;
+  final bool readOnly;
+
+  @override
+  ConsumerState<TaskDetailsPage> createState() => _TaskDetailsPageState();
+}
+
+class _TaskDetailsPageState extends ConsumerState<TaskDetailsPage> {
+  final _scrollController = ScrollController();
+  final _listener = getIt<UserActivityService>().updateActivity;
+  late final void Function() _updateOffsetListener;
+
+  @override
+  void initState() {
+    final provider = taskAppBarControllerProvider(id: widget.taskId);
+    _updateOffsetListener = () => ref.read(provider.notifier).updateOffset(
+          _scrollController.offset,
+        );
+
+    _scrollController
+      ..addListener(_listener)
+      ..addListener(_updateOffsetListener);
+
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    _scrollController
+      ..removeListener(_listener)
+      ..removeListener(_updateOffsetListener)
+      ..dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = entryControllerProvider(id: widget.taskId);
+    final task = ref.watch(provider).value?.entry;
+
+    if (task == null || task is! Task) {
+      return const EmptyScaffoldWithTitle('');
+    }
+
+    return DropTarget(
+      onDragDone: (data) {
+        importDroppedImages(
+          data: data,
+          linkedId: task.meta.id,
+          categoryId: task.meta.categoryId,
+        );
+      },
+      child: Scaffold(
+        floatingActionButton: FloatingAddActionButton(
+          linkedFromId: task.meta.id,
+          categoryId: task.meta.categoryId,
+        ),
+        body: Stack(
+          children: [
+            CustomScrollView(
+              controller: _scrollController,
+              slivers: [
+                TaskSliverAppBar(taskId: widget.taskId),
+                PinnedHeaderSliver(
+                  child: TaskTitleHeader(taskId: widget.taskId),
+                ),
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.only(
+                      left: 20,
+                      right: 20,
+                      top: 10,
+                    ),
+                    child: TaskForm(taskId: widget.taskId),
+                  ),
+                ),
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.only(
+                      top: 8,
+                      bottom: 200,
+                      left: 5,
+                      right: 5,
+                    ),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.end,
+                      children: <Widget>[
+                        LinkedEntriesWidget(task),
+                        LinkedFromEntriesWidget(task),
+                      ],
+                    ).animate().fadeIn(
+                          duration: const Duration(
+                            milliseconds: 100,
+                          ),
+                        ),
+                  ),
+                ),
+              ],
+            ),
+            Align(
+              alignment: Alignment.bottomCenter,
+              child: AiRunningAnimationWrapperCard(
+                entryId: widget.taskId,
+                height: 50,
+                responseTypes: const {
+                  taskSummary,
+                  actionItemSuggestions,
+                  imageAnalysis,
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/tasks/ui/task_app_bar.dart
+++ b/lib/features/tasks/ui/task_app_bar.dart
@@ -4,7 +4,7 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/ai/ui/ai_popup_menu.dart';
 import 'package:lotti/features/journal/state/journal_card_controller.dart';
 import 'package:lotti/features/journal/ui/widgets/entry_details/header/extended_header_modal.dart';
-import 'package:lotti/features/journal/ui/widgets/entry_details/save_button.dart';
+import 'package:lotti/features/journal/ui/widgets/journal_app_bar.dart';
 import 'package:lotti/features/tasks/ui/linked_duration.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/widgets/app_bar/title_app_bar.dart';
@@ -23,15 +23,7 @@ class TaskSliverAppBar extends ConsumerWidget {
     final item = ref.watch(provider).value;
 
     if (item == null || item is! Task) {
-      return SliverAppBar(
-        leadingWidth: 100,
-        leading: const BackWidget(),
-        pinned: true,
-        actions: [
-          SaveButton(entryId: item?.meta.id ?? ''),
-        ],
-        automaticallyImplyLeading: false,
-      );
+      return JournalSliverAppBar(entryId: taskId);
     }
 
     return SliverAppBar(

--- a/lib/services/time_service.dart
+++ b/lib/services/time_service.dart
@@ -1,8 +1,6 @@
 import 'dart:async';
 
 import 'package:lotti/classes/journal_entities.dart';
-import 'package:lotti/database/database.dart';
-import 'package:lotti/get_it.dart';
 
 class TimeService {
   TimeService() {
@@ -22,14 +20,6 @@ class TimeService {
     _current = journalEntity;
     linkedFrom = linked;
     const interval = Duration(seconds: 1);
-
-    unawaited(
-      getIt<JournalDb>()
-          .watchJournalEntityById(journalEntity.id)
-          .forEach((entry) {
-        _current = entry;
-      }),
-    );
 
     int callback(int value) {
       return value;
@@ -62,5 +52,11 @@ class TimeService {
 
   Stream<JournalEntity?> getStream() {
     return _controller.stream;
+  }
+
+  void updateCurrent(JournalEntity? current) {
+    if (_current?.id == current?.id) {
+      _current = current;
+    }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.595+2992
+version: 0.9.595+2993
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.595+2993
+version: 0.9.595+2994
 
 msix_config:
   display_name: LottiApp

--- a/test/features/journal/ui/pages/entry_details_page_test.dart
+++ b/test/features/journal/ui/pages/entry_details_page_test.dart
@@ -157,7 +157,7 @@ void main() {
 
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(
-          EntryDetailPage(itemId: testTextEntry.meta.id),
+          EntryDetailsPage(itemId: testTextEntry.meta.id),
         ),
       );
 
@@ -181,46 +181,6 @@ void main() {
       expect(find.byIcon(Icons.star_rounded), findsOneWidget);
     });
 
-    testWidgets('Task Entry is rendered', (tester) async {
-      when(() => mockJournalDb.journalEntityById(testTask.meta.id))
-          .thenAnswer((_) async => testTask);
-
-      await tester.pumpWidget(
-        makeTestableWidgetWithScaffold(
-          EntryDetailPage(itemId: testTask.id),
-        ),
-      );
-
-      await tester.pumpAndSettle();
-
-      // TODO: test that entry text is rendered
-
-      // test entry displays expected date
-      expect(
-        find.text(dfShorter.format(testTask.meta.dateFrom)),
-        findsOneWidget,
-      );
-
-      // test task displays progress bar with 2 hours progress and 4 hours total
-      final progressBar =
-          tester.firstWidget(find.byType(LinearProgressIndicator))
-              as LinearProgressIndicator;
-      expect(progressBar, isNotNull);
-      expect(progressBar.value, 0.25);
-
-      // test task title is displayed
-      expect(find.text(testTask.data.title), findsNWidgets(2));
-
-      // task entry duration estimate is rendered
-      expect(
-        find.text('04:00'),
-        findsNWidgets(1),
-      );
-
-      // test task is starred
-      expect(find.byIcon(Icons.star_rounded), findsOneWidget);
-    });
-
     testWidgets('Weight Entry is rendered properly', (tester) async {
       Future<MeasurementEntry?> mockCreateMeasurementEntry() {
         return mockPersistenceLogic.createMeasurementEntry(
@@ -236,7 +196,7 @@ void main() {
 
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(
-          EntryDetailPage(itemId: testWeightEntry.meta.id),
+          EntryDetailsPage(itemId: testWeightEntry.meta.id),
         ),
       );
 

--- a/test/features/journal/ui/pages/entry_details_page_test.dart
+++ b/test/features/journal/ui/pages/entry_details_page_test.dart
@@ -118,12 +118,6 @@ void main() {
             .fetchHealthDataDelta(testWeightEntry.data.dataType),
       ).thenAnswer((_) async {});
 
-      when(
-        () => mockJournalDb.getLinkedEntities(testTask.meta.id),
-      ).thenAnswer(
-        (_) async => [testTextEntry],
-      );
-
       when(mockTimeService.getStream)
           .thenAnswer((_) => Stream<JournalEntity>.fromIterable([]));
 

--- a/test/features/tasks/ui/pages/task_details_page_test.dart
+++ b/test/features/tasks/ui/pages/task_details_page_test.dart
@@ -1,0 +1,194 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/classes/tag_type_definitions.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/database/logging_db.dart';
+import 'package:lotti/features/journal/util/entry_tools.dart';
+import 'package:lotti/features/speech/state/asr_service.dart';
+import 'package:lotti/features/tasks/ui/pages/task_details_page.dart';
+import 'package:lotti/features/user_activity/state/user_activity_service.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/logic/health_import.dart';
+import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/services/db_notification.dart';
+import 'package:lotti/services/editor_state_service.dart';
+import 'package:lotti/services/entities_cache_service.dart';
+import 'package:lotti/services/link_service.dart';
+import 'package:lotti/services/tags_service.dart';
+import 'package:lotti/services/time_service.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:path_provider/path_provider.dart';
+
+import '../../../../helpers/path_provider.dart';
+import '../../../../mocks/mocks.dart';
+import '../../../../test_data/test_data.dart';
+import '../../../../widget_test_utils.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  var mockJournalDb = MockJournalDb();
+  var mockPersistenceLogic = MockPersistenceLogic();
+  final mockUpdateNotifications = MockUpdateNotifications();
+  final mockEntitiesCacheService = MockEntitiesCacheService();
+
+  group('TaskDetailPage Widget Tests - ', () {
+    setUpAll(() {
+      setFakeDocumentsPath();
+      registerFallbackValue(FakeMeasurementData());
+    });
+
+    setUp(() async {
+      mockJournalDb = mockJournalDbWithMeasurableTypes([
+        measurableWater,
+        measurableChocolate,
+      ]);
+      mockPersistenceLogic = MockPersistenceLogic();
+
+      final mockTagsService = mockTagsServiceWithTags([]);
+      final mockTimeService = MockTimeService();
+      final mockEditorStateService = MockEditorStateService();
+      final mockHealthImport = MockHealthImport();
+
+      getIt
+        ..registerSingleton<Directory>(await getApplicationDocumentsDirectory())
+        ..registerSingleton<UserActivityService>(UserActivityService())
+        ..registerSingleton<UpdateNotifications>(mockUpdateNotifications)
+        ..registerSingleton<LoggingDb>(MockLoggingDb())
+        ..registerSingleton<AsrService>(MockAsrService())
+        ..registerSingleton<EditorStateService>(mockEditorStateService)
+        ..registerSingleton<EntitiesCacheService>(mockEntitiesCacheService)
+        ..registerSingleton<LinkService>(MockLinkService())
+        ..registerSingleton<TagsService>(mockTagsService)
+        ..registerSingleton<HealthImport>(mockHealthImport)
+        ..registerSingleton<TimeService>(mockTimeService)
+        ..registerSingleton<JournalDb>(mockJournalDb)
+        ..registerSingleton<PersistenceLogic>(mockPersistenceLogic);
+
+      when(() => mockEntitiesCacheService.sortedCategories).thenAnswer(
+        (_) => [categoryMindfulness],
+      );
+
+      when(
+        () => mockJournalDb
+            .getMeasurableDataTypeById('83ebf58d-9cea-4c15-a034-89c84a8b8178'),
+      ).thenAnswer((_) async => measurableWater);
+
+      when(() => mockUpdateNotifications.updateStream).thenAnswer(
+        (_) => Stream<Set<String>>.fromIterable([]),
+      );
+
+      when(mockTagsService.watchTags).thenAnswer(
+        (_) => Stream<List<TagEntity>>.fromIterable([
+          [testStoryTag1],
+        ]),
+      );
+
+      when(() => mockTagsService.stream).thenAnswer(
+        (_) => Stream<List<TagEntity>>.fromIterable([[]]),
+      );
+
+      when(() => mockJournalDb.watchConfigFlags()).thenAnswer(
+        (_) => Stream<Set<ConfigFlag>>.fromIterable([
+          <ConfigFlag>{
+            const ConfigFlag(
+              name: 'private',
+              description: 'Show private entries?',
+              status: true,
+            ),
+          }
+        ]),
+      );
+
+      when(
+        () => mockEditorStateService.getUnsavedStream(
+          any(),
+          any(),
+        ),
+      ).thenAnswer(
+        (_) => Stream<bool>.fromIterable([false]),
+      );
+
+      when(
+        () => mockHealthImport
+            .fetchHealthDataDelta(testWeightEntry.data.dataType),
+      ).thenAnswer((_) async {});
+
+      when(
+        () => mockJournalDb.getLinkedEntities(testTask.meta.id),
+      ).thenAnswer(
+        (_) async => [testTextEntry],
+      );
+
+      when(mockTimeService.getStream)
+          .thenAnswer((_) => Stream<JournalEntity>.fromIterable([]));
+
+      when(
+        () => mockJournalDb.watchMeasurableDataTypeById(
+          '83ebf58d-9cea-4c15-a034-89c84a8b8178',
+        ),
+      ).thenAnswer(
+        (_) => Stream<MeasurableDataType>.fromIterable([
+          measurableWater,
+        ]),
+      );
+
+      when(
+        () => mockJournalDb.getMeasurementsByType(
+          rangeStart: any(named: 'rangeStart'),
+          rangeEnd: any(named: 'rangeEnd'),
+          type: '83ebf58d-9cea-4c15-a034-89c84a8b8178',
+        ),
+      ).thenAnswer((_) async => []);
+
+      when(
+        () => mockJournalDb.getMeasurableDataTypeById(any()),
+      ).thenAnswer((_) async => measurableWater);
+    });
+    tearDown(getIt.reset);
+
+    testWidgets('Task Entry is rendered', (tester) async {
+      when(() => mockJournalDb.journalEntityById(testTask.meta.id))
+          .thenAnswer((_) async => testTask);
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          TaskDetailsPage(taskId: testTask.id),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // TODO: test that entry text is rendered
+
+      // test entry displays expected date
+      expect(
+        find.text(dfShorter.format(testTask.meta.dateFrom)),
+        findsOneWidget,
+      );
+
+      // test task displays progress bar with 2 hours progress and 4 hours total
+      final progressBar =
+          tester.firstWidget(find.byType(LinearProgressIndicator))
+              as LinearProgressIndicator;
+      expect(progressBar, isNotNull);
+      expect(progressBar.value, 0.25);
+
+      // test task title is displayed
+      expect(find.text(testTask.data.title), findsNWidgets(2));
+
+      // task entry duration estimate is rendered
+      expect(
+        find.text('04:00'),
+        findsNWidgets(1),
+      );
+
+      // test task is starred
+      expect(find.byIcon(Icons.star_rounded), findsOneWidget);
+    });
+  });
+}

--- a/test/features/tasks/ui/pages/task_details_page_test.dart
+++ b/test/features/tasks/ui/pages/task_details_page_test.dart
@@ -114,11 +114,6 @@ void main() {
       );
 
       when(
-        () => mockHealthImport
-            .fetchHealthDataDelta(testWeightEntry.data.dataType),
-      ).thenAnswer((_) async {});
-
-      when(
         () => mockJournalDb.getLinkedEntities(testTask.meta.id),
       ).thenAnswer(
         (_) async => [testTextEntry],
@@ -144,10 +139,6 @@ void main() {
           type: '83ebf58d-9cea-4c15-a034-89c84a8b8178',
         ),
       ).thenAnswer((_) async => []);
-
-      when(
-        () => mockJournalDb.getMeasurableDataTypeById(any()),
-      ).thenAnswer((_) async => measurableWater);
     });
     tearDown(getIt.reset);
 


### PR DESCRIPTION
This pull request includes several changes aimed at improving the `lotti` application by refactoring class names, updating imports, and enhancing functionality. The most important changes include renaming `EntryDetailPage` to `EntryDetailsPage`, updating paths and identifiers in `TasksLocation`, and adding new classes for better UI management.

### Refactoring and Renaming:
* [`lib/features/journal/ui/pages/entry_details_page.dart`](diffhunk://#diff-d32e1aafdc3cba360a85b50733ac339715c6ef74ce58fa1d92f58306ea903f72L6-R21): Renamed `EntryDetailPage` to `EntryDetailsPage` and updated the corresponding state class. [[1]](diffhunk://#diff-d32e1aafdc3cba360a85b50733ac339715c6ef74ce58fa1d92f58306ea903f72L6-R21) [[2]](diffhunk://#diff-d32e1aafdc3cba360a85b50733ac339715c6ef74ce58fa1d92f58306ea903f72L35-R34)
* `lib/beamer/locations/journal_location.dart` and `lib/beamer/locations/settings_location.dart`: Updated references to `EntryDetailsPage` to reflect the new class name. [[1]](diffhunk://#diff-4e01856671719fc2aabe4cd7b472839d492e085c46369382e2193d6cc5a7a2e4L38-R38) [[2]](diffhunk://#diff-ae62dc2c791889d63ea64958f9d4ef881fd620362992373f8215d63c8535c968L301-R301)

### Path and Identifier Updates:
* [`lib/beamer/locations/tasks_location.dart`](diffhunk://#diff-53cbe1a50dc9c027c8ee826c8b26bf607d4078aa54c5610080f3c752267d88d1L14-R22): Updated path patterns and identifiers from `entryId` to `taskId` for better clarity and consistency. [[1]](diffhunk://#diff-53cbe1a50dc9c027c8ee826c8b26bf607d4078aa54c5610080f3c752267d88d1L14-R22) [[2]](diffhunk://#diff-53cbe1a50dc9c027c8ee826c8b26bf607d4078aa54c5610080f3c752267d88d1L32-R35)

### New Classes and UI Enhancements:
* [`lib/features/journal/ui/widgets/journal_app_bar.dart`](diffhunk://#diff-bc3f71d19defd1cb3c6eab9a12efa2aa4fa5a980b4a14f82f9a78e6f6f930815R1-R26): Added a new `JournalSliverAppBar` class to manage the journal-specific app bar.
* [`lib/features/tasks/ui/pages/task_details_page.dart`](diffhunk://#diff-f237b4a70d29d59b38a1c1307321ab55948ae77b08089329447923c85240ca4bR1-R144): Introduced a new `TaskDetailsPage` class to handle task-specific details, including animations and linked entries.

### Service and Repository Updates:
* [`lib/features/journal/repository/journal_repository.dart`](diffhunk://#diff-001fbe4c939fb8084bdbcd1691a4bbe931c8bc39e39095f375c9b18f24ace751R133-R135): Added a call to `TimeService` to update the current time on database updates.
* [`lib/services/time_service.dart`](diffhunk://#diff-632f1a0ddc52baa45cab7ddd3960c98a20b54109ab0ed83c3bd99b026f22ca9fR56-R61): Added a method to update the current journal entity in `TimeService`.

### Test Updates:
* [`test/features/journal/ui/pages/entry_details_page_test.dart`](diffhunk://#diff-0a89c543e6fab71c28d3c77b61ec19078acfc67920431608bbb8a336c0e3f115L121-L126): Renamed the test file and updated references to `EntryDetailsPage`. [[1]](diffhunk://#diff-0a89c543e6fab71c28d3c77b61ec19078acfc67920431608bbb8a336c0e3f115L121-L126) [[2]](diffhunk://#diff-0a89c543e6fab71c28d3c77b61ec19078acfc67920431608bbb8a336c0e3f115L160-R154)