### PR TITLE
chore: remove unused config flag

### DIFF
--- a/lib/database/journal_db/config_flags.dart
+++ b/lib/database/journal_db/config_flags.dart
@@ -20,13 +20,6 @@ Future<void> initConfigFlags(
     ),
   );
   await db.insertFlagIfNotExists(
-    const ConfigFlag(
-      name: allowInvalidCertFlag,
-      description: 'Allow invalid certificate? (not recommended)',
-      status: false,
-    ),
-  );
-  await db.insertFlagIfNotExists(
     ConfigFlag(
       name: enableSyncFlag,
       description: 'Enable sync? (requires restart)',

--- a/lib/pages/settings/flags_page.dart
+++ b/lib/pages/settings/flags_page.dart
@@ -29,7 +29,6 @@ class FlagsPage extends StatelessWidget {
           enableNotificationsFlag,
           autoTranscribeFlag,
           recordLocationFlag,
-          allowInvalidCertFlag,
           enableTooltipFlag,
           enableLoggingFlag,
           enableMatrixFlag,

--- a/lib/utils/consts.dart
+++ b/lib/utils/consts.dart
@@ -1,6 +1,5 @@
 const privateFlag = 'private';
 const enableNotificationsFlag = 'enable_notifications';
-const allowInvalidCertFlag = 'allow_invalid_cert';
 const enableSyncFlag = 'enable_sync';
 const recordLocationFlag = 'record_location';
 const autoTranscribeFlag = 'auto_transcribe';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: accessibility_tools
-      sha256: "1ee3612b9439ca315f92dcc31c6a4828e95b96c1aa64ac3a7776c149722deca8"
+      sha256: "3a36d23e8566f0618730c89b304f4faa5bc843255e26a47ee0ff15df0c30b15d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   analyzer:
     dependency: "direct dev"
     description:
@@ -1627,18 +1627,18 @@ packages:
     dependency: transitive
     description:
       name: just_audio_platform_interface
-      sha256: "271b93b484c6f494ecd72a107fffbdb26b425f170c665b9777a0a24a726f2f24"
+      sha256: "4cd94536af0219fa306205a58e78d67e02b0555283c1c094ee41e402a14a5c4a"
       url: "https://pub.dev"
     source: hosted
-    version: "4.4.0"
+    version: "4.5.0"
   just_audio_web:
     dependency: transitive
     description:
       name: just_audio_web
-      sha256: "58915be64509a7683c44bf11cd1a23c15a48de104927bee116e3c63c8eeea0d4"
+      sha256: "8c7e779892e180cbc9ffb5a3c52f6e90e1cbbf4a63694cc450972a7edbd2bb6d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.14"
+    version: "0.4.15"
   langchain:
     dependency: "direct main"
     description:

--- a/test/database/database_test.dart
+++ b/test/database/database_test.dart
@@ -38,11 +38,6 @@ final expectedFlags = <ConfigFlag>{
     status: false,
   ),
   const ConfigFlag(
-    name: allowInvalidCertFlag,
-    description: 'Allow invalid certificate? (not recommended)',
-    status: false,
-  ),
-  const ConfigFlag(
     name: enableSyncFlag,
     description: 'Enable sync? (requires restart)',
     status: true,


### PR DESCRIPTION
This pull request removes the `allowInvalidCertFlag` configuration flag from the codebase. The changes span across multiple files to ensure the flag is completely removed.

### Removal of `allowInvalidCertFlag`:

* [`lib/database/journal_db/config_flags.dart`](diffhunk://#diff-39bb266ee30b590e88152913951d305211880bf2f73d076f1f2c6361a09ef9a5L22-L28): Removed the insertion of the `allowInvalidCertFlag` configuration flag.
* [`lib/pages/settings/flags_page.dart`](diffhunk://#diff-26b45654cc5cd447bb728098110332c878a360b41ad9b55a44c3ccbe23b1682dL32): Removed the `allowInvalidCertFlag` from the list of flags displayed on the settings page.
* [`lib/utils/consts.dart`](diffhunk://#diff-ae9c77db8d06976197004d884d06f46d46ee048af40208727501d44e346d8cc2L3): Removed the constant definition for `allowInvalidCertFlag`.
* [`test/database/database_test.dart`](diffhunk://#diff-5d94915a791875ec0c3b4703ccfdc535a20354a6c8a1c4adeb6763611ec735e3L40-L44): Removed the `allowInvalidCertFlag` from the list of expected configuration flags in the database tests.