### PR TITLE
fix: adjusted the height from the showcase appbar header

### DIFF
--- a/lib/pages/settings/flags_page.dart
+++ b/lib/pages/settings/flags_page.dart
@@ -89,16 +89,18 @@ class _FlagsPageState extends State<FlagsPage> {
             ),
             title: context.messages.settingsFlagsTitle,
             showBackButton: true,
-            child: Column(
-              children: [
-                ...filteredItems.mapIndexed(
-                  (index, flag) => ConfigFlagCard(
-                    item: flag,
-                    index: index,
-                    showcaseKey: _getShowcaseKeyForFlag(flag.name),
+            child: SingleChildScrollView(
+              child: Column(
+                children: [
+                  ...filteredItems.mapIndexed(
+                    (index, flag) => ConfigFlagCard(
+                      item: flag,
+                      index: index,
+                      showcaseKey: _getShowcaseKeyForFlag(flag.name),
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         );

--- a/lib/pages/settings/sliver_box_adapter_page.dart
+++ b/lib/pages/settings/sliver_box_adapter_page.dart
@@ -86,7 +86,7 @@ class _SliverBoxAdapterShowcasePageState
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: PreferredSize(
-        preferredSize: const Size.fromHeight(120),
+        preferredSize: const Size.fromHeight(kToolbarHeight),
         child: AppBar(
           leading: GestureDetector(
             onTap: () {


### PR DESCRIPTION
fix: adjust header height and improve flag page scroll.

- Adjusted the height of the showcase header to ensure proper layout.
- Enabled scrolling on the config flag page to make all flags visible, including those at the bottom.
