### PR TITLE
chore: update infinite_scroll_pagination to 5.0.0

### DIFF
--- a/lib/blocs/journal/journal_page_state.dart
+++ b/lib/blocs/journal/journal_page_state.dart
@@ -22,7 +22,7 @@ class JournalPageState with _$JournalPageState {
     required bool taskAsListView,
     required List<String> selectedEntryTypes,
     required Set<String> fullTextMatches,
-    required PagingController<int, JournalEntity> pagingController,
+    required PagingController<int, JournalEntity>? pagingController,
     required List<String> taskStatuses,
     required Set<String> selectedTaskStatuses,
     required Set<String?> selectedCategoryIds,

--- a/lib/blocs/journal/journal_page_state.freezed.dart
+++ b/lib/blocs/journal/journal_page_state.freezed.dart
@@ -24,7 +24,7 @@ mixin _$JournalPageState {
   bool get taskAsListView => throw _privateConstructorUsedError;
   List<String> get selectedEntryTypes => throw _privateConstructorUsedError;
   Set<String> get fullTextMatches => throw _privateConstructorUsedError;
-  PagingController<int, JournalEntity> get pagingController =>
+  PagingController<int, JournalEntity>? get pagingController =>
       throw _privateConstructorUsedError;
   List<String> get taskStatuses => throw _privateConstructorUsedError;
   Set<String> get selectedTaskStatuses => throw _privateConstructorUsedError;
@@ -52,7 +52,7 @@ abstract class $JournalPageStateCopyWith<$Res> {
       bool taskAsListView,
       List<String> selectedEntryTypes,
       Set<String> fullTextMatches,
-      PagingController<int, JournalEntity> pagingController,
+      PagingController<int, JournalEntity>? pagingController,
       List<String> taskStatuses,
       Set<String> selectedTaskStatuses,
       Set<String?> selectedCategoryIds});
@@ -81,7 +81,7 @@ class _$JournalPageStateCopyWithImpl<$Res, $Val extends JournalPageState>
     Object? taskAsListView = null,
     Object? selectedEntryTypes = null,
     Object? fullTextMatches = null,
-    Object? pagingController = null,
+    Object? pagingController = freezed,
     Object? taskStatuses = null,
     Object? selectedTaskStatuses = null,
     Object? selectedCategoryIds = null,
@@ -119,10 +119,10 @@ class _$JournalPageStateCopyWithImpl<$Res, $Val extends JournalPageState>
           ? _value.fullTextMatches
           : fullTextMatches // ignore: cast_nullable_to_non_nullable
               as Set<String>,
-      pagingController: null == pagingController
+      pagingController: freezed == pagingController
           ? _value.pagingController
           : pagingController // ignore: cast_nullable_to_non_nullable
-              as PagingController<int, JournalEntity>,
+              as PagingController<int, JournalEntity>?,
       taskStatuses: null == taskStatuses
           ? _value.taskStatuses
           : taskStatuses // ignore: cast_nullable_to_non_nullable
@@ -156,7 +156,7 @@ abstract class _$$JournalPageStateImplCopyWith<$Res>
       bool taskAsListView,
       List<String> selectedEntryTypes,
       Set<String> fullTextMatches,
-      PagingController<int, JournalEntity> pagingController,
+      PagingController<int, JournalEntity>? pagingController,
       List<String> taskStatuses,
       Set<String> selectedTaskStatuses,
       Set<String?> selectedCategoryIds});
@@ -183,7 +183,7 @@ class __$$JournalPageStateImplCopyWithImpl<$Res>
     Object? taskAsListView = null,
     Object? selectedEntryTypes = null,
     Object? fullTextMatches = null,
-    Object? pagingController = null,
+    Object? pagingController = freezed,
     Object? taskStatuses = null,
     Object? selectedTaskStatuses = null,
     Object? selectedCategoryIds = null,
@@ -221,10 +221,10 @@ class __$$JournalPageStateImplCopyWithImpl<$Res>
           ? _value._fullTextMatches
           : fullTextMatches // ignore: cast_nullable_to_non_nullable
               as Set<String>,
-      pagingController: null == pagingController
+      pagingController: freezed == pagingController
           ? _value.pagingController
           : pagingController // ignore: cast_nullable_to_non_nullable
-              as PagingController<int, JournalEntity>,
+              as PagingController<int, JournalEntity>?,
       taskStatuses: null == taskStatuses
           ? _value._taskStatuses
           : taskStatuses // ignore: cast_nullable_to_non_nullable
@@ -307,7 +307,7 @@ class _$JournalPageStateImpl implements _JournalPageState {
   }
 
   @override
-  final PagingController<int, JournalEntity> pagingController;
+  final PagingController<int, JournalEntity>? pagingController;
   final List<String> _taskStatuses;
   @override
   List<String> get taskStatuses {
@@ -403,7 +403,7 @@ abstract class _JournalPageState implements JournalPageState {
           required final bool taskAsListView,
           required final List<String> selectedEntryTypes,
           required final Set<String> fullTextMatches,
-          required final PagingController<int, JournalEntity> pagingController,
+          required final PagingController<int, JournalEntity>? pagingController,
           required final List<String> taskStatuses,
           required final Set<String> selectedTaskStatuses,
           required final Set<String?> selectedCategoryIds}) =
@@ -426,7 +426,7 @@ abstract class _JournalPageState implements JournalPageState {
   @override
   Set<String> get fullTextMatches;
   @override
-  PagingController<int, JournalEntity> get pagingController;
+  PagingController<int, JournalEntity>? get pagingController;
   @override
   List<String> get taskStatuses;
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1460,10 +1460,10 @@ packages:
     dependency: "direct main"
     description:
       name: infinite_scroll_pagination
-      sha256: "4047eb8191e8b33573690922a9e995af64c3949dc87efc844f936b039ea279df"
+      sha256: ff5232d9066f664d31eee1b7dd0dedf79c71e7d8874567a7af5a51630e38b234
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "5.0.0"
   ini:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.606+3034
+version: 0.9.606+3036
 
 msix_config:
   display_name: LottiApp
@@ -82,7 +82,7 @@ dependencies:
   graphic: ^2.3.0
   health: ^12.2.0
   hotkey_manager: ^0.2.0
-  infinite_scroll_pagination: ^4.0.0
+  infinite_scroll_pagination: ^5.0.0
   intersperse: ^2.0.0
   intl: ^0.19.0
   ionicons: ^0.2.2

--- a/test/features/journal/ui/pages/infinite_journal_page_test.dart
+++ b/test/features/journal/ui/pages/infinite_journal_page_test.dart
@@ -77,6 +77,31 @@ void main() {
 
       when(mockJournalDb.getTasksCount).thenAnswer((_) async => 42);
 
+      // Add default implementations for pagination (subsequent pages should return empty lists)
+      when(
+        () => mockJournalDb.getJournalEntities(
+          types: any(named: 'types'),
+          starredStatuses: any(named: 'starredStatuses'),
+          privateStatuses: any(named: 'privateStatuses'),
+          flaggedStatuses: any(named: 'flaggedStatuses'),
+          ids: any(named: 'ids'),
+          limit: any(named: 'limit'),
+          offset: any(named: 'offset'),
+          categoryIds: any(named: 'categoryIds'),
+        ),
+      ).thenAnswer((_) async => <JournalEntity>[]);
+
+      when(
+        () => mockJournalDb.getTasks(
+          ids: any(named: 'ids'),
+          starredStatuses: any(named: 'starredStatuses'),
+          taskStatuses: any(named: 'taskStatuses'),
+          categoryIds: any(named: 'categoryIds'),
+          limit: any(named: 'limit'),
+          offset: any(named: 'offset'),
+        ),
+      ).thenAnswer((_) async => <JournalEntity>[]);
+
       getIt
         ..registerSingleton<Directory>(await getApplicationDocumentsDirectory())
         ..registerSingleton<UserActivityService>(UserActivityService())
@@ -119,6 +144,18 @@ void main() {
     });
     tearDown(getIt.reset);
 
+    // Helper function to replace pumpAndSettle
+    Future<void> pumpWithDelay(WidgetTester tester) async {
+      // Give the widget time to build and load initial data
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      // Additional pumps to progress animations
+      for (var i = 0; i < 10; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+    }
+
     testWidgets('page is rendered with text entry', (tester) async {
       Future<MeasurementEntry?> mockCreateMeasurementEntry() {
         return mockPersistenceLogic.createMeasurementEntry(
@@ -153,9 +190,7 @@ void main() {
         ),
       );
 
-      await tester.pumpAndSettle(const Duration(seconds: 2));
-
-      // TODO: test that entry text is rendered
+      await pumpWithDelay(tester);
 
       // test entry displays expected date
       expect(
@@ -204,7 +239,7 @@ void main() {
         ),
       );
 
-      await tester.pumpAndSettle(const Duration(seconds: 2));
+      await pumpWithDelay(tester);
 
       // test task title is displayed
       expect(
@@ -240,7 +275,7 @@ void main() {
         ),
       );
 
-      await tester.pumpAndSettle(const Duration(seconds: 2));
+      await pumpWithDelay(tester);
 
       // test task title is displayed
       expect(
@@ -283,7 +318,7 @@ void main() {
         ),
       );
 
-      await tester.pumpAndSettle(const Duration(seconds: 2));
+      await pumpWithDelay(tester);
 
       // task entry displays expected date
       expect(
@@ -379,7 +414,7 @@ void main() {
         ),
       );
 
-      await tester.pumpAndSettle(const Duration(seconds: 2));
+      await pumpWithDelay(tester);
 
       // measurement entry displays expected date
       expect(
@@ -464,7 +499,7 @@ void main() {
         ),
       );
 
-      await tester.pumpAndSettle(const Duration(seconds: 2));
+      await pumpWithDelay(tester);
 
       // measurement entry displays expected date
       expect(

--- a/test/mocks/mocks.dart
+++ b/test/mocks/mocks.dart
@@ -56,6 +56,30 @@ MockJournalDb mockJournalDbWithMeasurableTypes(
     (_) => Stream<List<MeasurableDataType>>.fromIterable([dataTypes]),
   );
 
+  when(
+    () => mock.getJournalEntities(
+      types: any(named: 'types'),
+      starredStatuses: any(named: 'starredStatuses'),
+      privateStatuses: any(named: 'privateStatuses'),
+      flaggedStatuses: any(named: 'flaggedStatuses'),
+      ids: any(named: 'ids'),
+      limit: any(named: 'limit'),
+      offset: any(named: 'offset'),
+      categoryIds: any(named: 'categoryIds'),
+    ),
+  ).thenAnswer((_) async => <JournalEntity>[]);
+
+  when(
+    () => mock.getTasks(
+      ids: any(named: 'ids'),
+      starredStatuses: any(named: 'starredStatuses'),
+      taskStatuses: any(named: 'taskStatuses'),
+      categoryIds: any(named: 'categoryIds'),
+      limit: any(named: 'limit'),
+      offset: any(named: 'offset'),
+    ),
+  ).thenAnswer((_) async => <JournalEntity>[]);
+
   for (final dataType in dataTypes) {
     when(() => mock.watchMeasurableDataTypeById(dataType.id)).thenAnswer(
       (_) => Stream<MeasurableDataType>.fromIterable([dataType]),


### PR DESCRIPTION
This pull request refactors the `JournalPageCubit` to improve paging functionality, updates dependencies, and enhances the user interface for infinite scrolling. Key changes include replacing the paging controller initialization logic, making the paging controller nullable, and updating the UI to handle the new paging controller state.

### Refactoring of `JournalPageCubit`:

* The paging controller is now initialized after the `JournalPageCubit` is constructed, and the `_fetchPage` method has been updated to return a list of items instead of directly interacting with the controller. This simplifies the logic and delegates state management to the controller. [[1]](diffhunk://#diff-33f77896ed78898e42dd43a1ddeb6fda349c8ca55068b2ec7c71a45a6aa833b3L33-R35) [[2]](diffhunk://#diff-33f77896ed78898e42dd43a1ddeb6fda349c8ca55068b2ec7c71a45a6aa833b3R53-R108) [[3]](diffhunk://#diff-33f77896ed78898e42dd43a1ddeb6fda349c8ca55068b2ec7c71a45a6aa833b3L301-R381)
* The paging controller in `JournalPageState` has been made nullable, with appropriate null checks added to avoid runtime errors. This ensures the controller is only used when initialized. [[1]](diffhunk://#diff-ae8d431499eca2f8ecf9e2acf82d9b7ee7c1d80f514cb799f60734add6d766e7L25-R25) [[2]](diffhunk://#diff-5d3f5cf465ea097465b86a5c42f9afe45979f5ff79e363e1d007c8cba2073467L27-R27) [[3]](diffhunk://#diff-5d3f5cf465ea097465b86a5c42f9afe45979f5ff79e363e1d007c8cba2073467L406-R406)
* The `refreshQuery` method now handles cases where the paging controller is null by printing a warning and skipping the refresh operation.

### User Interface Enhancements:

* The infinite scrolling UI in `InfiniteJournalPage` now uses the updated paging controller. A loading indicator is displayed when the controller is null, and a `PagedSliverList` is used when the controller is available. [[1]](diffhunk://#diff-58bac7ac8ac8c070e5f4932908bab69270db5632de32d09355682ec9d92a9728L97-R117) [[2]](diffhunk://#diff-58bac7ac8ac8c070e5f4932908bab69270db5632de32d09355682ec9d92a9728R126-R133)
* An initial fetch is triggered after the widget is mounted to ensure data is loaded as soon as the page is displayed.

### Dependency Updates:

* Upgraded the `infinite_scroll_pagination` package from version `4.0.0` to `5.0.0` to leverage the latest features and improvements.

### Miscellaneous:

* Updated the app version in `pubspec.yaml` from `0.9.606+3034` to `0.9.606+3036`.