### PR TITLE
feat: assign category to linked entry

### DIFF
--- a/lib/features/journal/state/entry_controller.dart
+++ b/lib/features/journal/state/entry_controller.dart
@@ -238,8 +238,12 @@ class EntryController extends _$EntryController {
         });
       }
 
-      _shouldShowEditorToolBar = false;
       focusNode.unfocus();
+
+      _isFocused = false;
+      _shouldShowEditorToolBar = false;
+      _dirty = false;
+
       emitState();
     }
 
@@ -248,7 +252,6 @@ class EntryController extends _$EntryController {
       lastSaved: entry.meta.updatedAt,
       controller: controller,
     );
-    setDirty(value: false);
     await HapticFeedback.heavyImpact();
   }
 

--- a/lib/features/journal/state/entry_controller.dart
+++ b/lib/features/journal/state/entry_controller.dart
@@ -166,10 +166,22 @@ class EntryController extends _$EntryController {
   }
 
   Future<bool> updateCategoryId(String? categoryId) async {
-    return ref.read(journalRepositoryProvider).updateCategoryId(
-          id,
-          categoryId: categoryId,
-        );
+    final res = await ref
+        .read(journalRepositoryProvider)
+        .updateCategoryId(id, categoryId: categoryId);
+
+    final linkedEntries = await ref
+        .read(journalRepositoryProvider)
+        .getLinkedEntities(linkedTo: id);
+
+    for (final entry in linkedEntries) {
+      if (entry.categoryId == null) {
+        await ref
+            .read(journalRepositoryProvider)
+            .updateCategoryId(entry.id, categoryId: categoryId);
+      }
+    }
+    return res;
   }
 
   Future<JournalEntity?> _fetch() async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: accessibility_tools
-      sha256: "3a36d23e8566f0618730c89b304f4faa5bc843255e26a47ee0ff15df0c30b15d"
+      sha256: c5792b8094e1086b4587cd99ee4ca67767d0ee083b246529429634f48c889600
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.5.0"
   analyzer:
     dependency: "direct dev"
     description:
@@ -944,10 +944,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: "33b3e0269ae9d51669957a923f2376bee96299b09915d856395af8c4238aebfa"
+      sha256: b94a50aabbe56ef254f95f3be75640f99120429f0a153b2dc30143cffc9bfdf3
       url: "https://pub.dev"
     source: hosted
-    version: "19.1.0"
+    version: "19.2.1"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
@@ -1029,10 +1029,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_quill
-      sha256: de019f6160023d36ad3e89343da6d740ab66ae7839875c89871fbeabcb9e8f9b
+      sha256: "7e60963632bbc8615627f0bae8e178515f69ecb378ad49fa68c43c2aabf33e21"
       url: "https://pub.dev"
     source: hosted
-    version: "11.4.0"
+    version: "11.4.1"
   flutter_quill_delta_from_html:
     dependency: transitive
     description:
@@ -1260,10 +1260,10 @@ packages:
     dependency: "direct main"
     description:
       name: gpt_markdown
-      sha256: a4370a8e9886d686e534efb65438ca8c7c9a9ee814ede51d3fc5b340b173e67a
+      sha256: "80f45e45c4c5636c040a64910aa543a4697442f7224391f0aeced3d2ed3a8c06"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.18"
+    version: "1.0.19"
   graphic:
     dependency: "direct main"
     description:
@@ -1356,10 +1356,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
+      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   http_client_helper:
     dependency: transitive
     description:
@@ -1617,10 +1617,10 @@ packages:
     dependency: transitive
     description:
       name: just_audio_web
-      sha256: "8c7e779892e180cbc9ffb5a3c52f6e90e1cbbf4a63694cc450972a7edbd2bb6d"
+      sha256: "6ba8a2a7e87d57d32f0f7b42856ade3d6a9fbe0f1a11fabae0a4f00bb73f0663"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.15"
+    version: "0.4.16"
   langchain:
     dependency: "direct main"
     description:
@@ -2369,10 +2369,10 @@ packages:
     dependency: transitive
     description:
       name: record_android
-      sha256: "36e009c3b83e034321a44a7683d95dd055162a231f95600f7da579dcc79701f9"
+      sha256: "97d7122455f30de89a01c6c244c839085be6b12abca251fc0e78f67fed73628b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   record_ios:
     dependency: transitive
     description:
@@ -3191,10 +3191,10 @@ packages:
     dependency: transitive
     description:
       name: video_player_android
-      sha256: ae7d4f1b41e3ac6d24dd9b9d5d6831b52d74a61bdd90a7a6262a33d8bb97c29a
+      sha256: "1f4e8e0e02403452d699ef7cf73fe9936fac8f6f0605303d111d71acb375d1bc"
       url: "https://pub.dev"
     source: hosted
-    version: "2.8.2"
+    version: "2.8.3"
   video_player_avfoundation:
     dependency: transitive
     description:
@@ -3255,10 +3255,10 @@ packages:
     dependency: transitive
     description:
       name: web_socket
-      sha256: bfe6f435f6ec49cb6c01da1e275ae4228719e59a6b067048c51e72d9d63bcc4b
+      sha256: "34d64019aa8e36bf9842ac014bb5d2f5586ca73df5e4d9bf5c936975cae6982c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   web_socket_channel:
     dependency: transitive
     description:
@@ -3319,26 +3319,26 @@ packages:
     dependency: "direct main"
     description:
       name: widgetbook
-      sha256: "8e3cd3157c0c24e28278d62835383fab65098433dcde946fe958361094aa1401"
+      sha256: "6a89bf28efd62e07824fa56a4394352e04dc9a84e01a233887a9cb0f7d5aa60d"
       url: "https://pub.dev"
     source: hosted
-    version: "3.13.1"
+    version: "3.14.0"
   widgetbook_annotation:
     dependency: transitive
     description:
       name: widgetbook_annotation
-      sha256: "03274209fe93f32a2e548663a6fc671341804271980e2c65550e7f989c356fdf"
+      sha256: "41662c48c2a0e82cac676a83727203d863621a5f6fb2505395287b8789afdf38"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.0"
+    version: "3.5.0"
   win32:
     dependency: transitive
     description:
       name: win32
-      sha256: dc6ecaa00a7c708e5b4d10ee7bec8c270e9276dfcab1783f57e9962d7884305f
+      sha256: "329edf97fdd893e0f1e3b9e88d6a0e627128cc17cc316a8d67fda8f1451178ba"
       url: "https://pub.dev"
     source: hosted
-    version: "5.12.0"
+    version: "5.13.0"
   win32_registry:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.607+3042
+version: 0.9.607+3043
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.607+3043
+version: 0.9.607+3044
 
 msix_config:
   display_name: LottiApp

--- a/test/features/speech/repository/speech_repository_test.dart
+++ b/test/features/speech/repository/speech_repository_test.dart
@@ -1,0 +1,1065 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/audio_note.dart';
+import 'package:lotti/classes/entry_text.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/features/speech/repository/speech_repository.dart';
+import 'package:lotti/features/speech/state/asr_service.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/logic/persistence_logic.dart';
+import 'package:lotti/services/logging_service.dart';
+import 'package:lotti/utils/consts.dart';
+import 'package:mocktail/mocktail.dart';
+
+// Mocks
+class MockPersistenceLogic extends Mock implements PersistenceLogic {}
+
+class MockJournalDb extends Mock implements JournalDb {}
+
+class MockAsrService extends Mock implements AsrService {}
+
+class MockLoggingService extends Mock implements LoggingService {}
+
+// Fakes
+class FakeJournalAudio extends Fake implements JournalAudio {}
+
+class FakeMetadata extends Fake implements Metadata {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MockPersistenceLogic mockPersistenceLogic;
+  late MockJournalDb mockJournalDb;
+  late MockAsrService mockAsrService;
+  late MockLoggingService mockLoggingService;
+
+  setUpAll(() {
+    // Register fakes for any() matchers if needed for complex objects
+    registerFallbackValue(FakeJournalAudio());
+    registerFallbackValue(FakeMetadata());
+    registerFallbackValue(DateTime.now()); // For date matching
+  });
+
+  setUp(() {
+    mockPersistenceLogic = MockPersistenceLogic();
+    mockJournalDb = MockJournalDb();
+    mockAsrService = MockAsrService();
+    mockLoggingService = MockLoggingService();
+
+    // Unregister specific services before re-registering for the test
+    if (getIt.isRegistered<PersistenceLogic>()) {
+      getIt.unregister<PersistenceLogic>();
+    }
+    if (getIt.isRegistered<JournalDb>()) {
+      getIt.unregister<JournalDb>();
+    }
+    if (getIt.isRegistered<AsrService>()) {
+      getIt.unregister<AsrService>();
+    }
+    if (getIt.isRegistered<LoggingService>()) {
+      getIt.unregister<LoggingService>();
+    }
+
+    // Register mocks with getIt
+    getIt.registerSingleton<PersistenceLogic>(mockPersistenceLogic);
+    // ignore_for_file: cascade_invocations
+    getIt.registerSingleton<JournalDb>(mockJournalDb);
+    getIt.registerSingleton<AsrService>(mockAsrService);
+    getIt.registerSingleton<LoggingService>(mockLoggingService);
+
+    // Default stub for logging to avoid errors in tests not focused on logging
+    when(
+      () => mockLoggingService.captureException(
+        // ignore_for_file: inference_failure_on_function_invocation
+        any(),
+        domain: any(named: 'domain'),
+        subDomain: any(named: 'subDomain'),
+        stackTrace: any(named: 'stackTrace'),
+      ),
+    ).thenAnswer((_) async {});
+  });
+
+  group('SpeechRepository', () {
+    group('createAudioEntry', () {
+      final testAudioNote = AudioNote(
+        audioDirectory: '/test/dir',
+        audioFile: 'test.aac',
+        duration: const Duration(seconds: 30),
+        createdAt: DateTime(2023, 1, 1, 10),
+      );
+      const testLanguage = 'en-US';
+      const testLinkedId = 'linked_entry_123';
+      const testCategoryId = 'category_abc';
+      final expectedAudioData = AudioData(
+        audioDirectory: testAudioNote.audioDirectory,
+        duration: testAudioNote.duration,
+        audioFile: testAudioNote.audioFile,
+        dateTo: testAudioNote.createdAt.add(testAudioNote.duration),
+        dateFrom: testAudioNote.createdAt,
+        language: testLanguage,
+      );
+      final testMetadata = Metadata(
+        id: 'new_audio_id',
+        createdAt: DateTime(2023, 1, 1, 10),
+        updatedAt: DateTime(2023, 1, 1, 10),
+        dateFrom: expectedAudioData.dateFrom,
+        dateTo: expectedAudioData.dateTo,
+        flag: EntryFlag.import,
+      );
+
+      test(
+          'successfully creates audio entry and enqueues for ASR when autoTranscribe is true',
+          () async {
+        // Arrange
+        when(() => mockJournalDb.getConfigFlag(autoTranscribeFlag))
+            .thenAnswer((_) async => true);
+        when(
+          () => mockPersistenceLogic.createMetadata(
+            dateFrom: expectedAudioData.dateFrom,
+            dateTo: expectedAudioData.dateTo,
+            uuidV5Input: json.encode(
+              expectedAudioData.copyWith(
+                autoTranscribeWasActive: true,
+                language: testLanguage,
+              ),
+            ),
+            flag: EntryFlag.import,
+          ),
+        ).thenAnswer((_) async => testMetadata);
+        when(
+          () => mockPersistenceLogic.createDbEntity(
+            any(that: isA<JournalAudio>()),
+          ),
+        ).thenAnswer((_) async => true);
+        when(() => mockAsrService.enqueue(entry: any(named: 'entry')))
+            .thenAnswer((_) async {
+          return true;
+        });
+
+        // Act
+        final result = await SpeechRepository.createAudioEntry(
+          testAudioNote,
+          language: testLanguage,
+        );
+
+        // Assert
+        expect(result, isA<JournalAudio>());
+        expect(result?.data.audioFile, testAudioNote.audioFile);
+        expect(result?.data.autoTranscribeWasActive, isTrue);
+        expect(result?.meta.id, testMetadata.id);
+
+        verify(() => mockJournalDb.getConfigFlag(autoTranscribeFlag)).called(1);
+        verify(
+          () => mockPersistenceLogic.createMetadata(
+            dateFrom: expectedAudioData.dateFrom,
+            dateTo: expectedAudioData.dateTo,
+            uuidV5Input: json.encode(
+              expectedAudioData.copyWith(
+                autoTranscribeWasActive: true,
+                language: testLanguage,
+              ),
+            ),
+            flag: EntryFlag.import,
+          ),
+        ).called(1);
+        verify(
+          () => mockPersistenceLogic.createDbEntity(
+            any(that: isA<JournalAudio>()),
+          ),
+        ).called(1);
+        verify(
+          () => mockAsrService.enqueue(
+            entry: any(named: 'entry', that: isA<JournalAudio>()),
+          ),
+        ).called(1);
+      });
+
+      test(
+          'successfully creates audio entry but does NOT enqueue for ASR when autoTranscribe is false',
+          () async {
+        // Arrange
+        when(() => mockJournalDb.getConfigFlag(autoTranscribeFlag))
+            .thenAnswer((_) async => false);
+        when(
+          () => mockPersistenceLogic.createMetadata(
+            dateFrom: expectedAudioData.dateFrom,
+            dateTo: expectedAudioData.dateTo,
+            uuidV5Input: json.encode(
+              expectedAudioData.copyWith(
+                autoTranscribeWasActive: false,
+                language: testLanguage,
+              ),
+            ),
+            flag: EntryFlag.import,
+          ),
+        ).thenAnswer((_) async => testMetadata);
+        when(
+          () => mockPersistenceLogic.createDbEntity(
+            any(that: isA<JournalAudio>()),
+          ),
+        ).thenAnswer((_) async => true);
+
+        // Act
+        final result = await SpeechRepository.createAudioEntry(
+          testAudioNote,
+          language: testLanguage,
+        );
+
+        // Assert
+        expect(result, isA<JournalAudio>());
+        expect(result?.data.autoTranscribeWasActive, isFalse);
+        verify(() => mockJournalDb.getConfigFlag(autoTranscribeFlag)).called(1);
+        verifyNever(() => mockAsrService.enqueue(entry: any(named: 'entry')));
+      });
+
+      test('successfully creates audio entry with linkedId and categoryId',
+          () async {
+        // Arrange
+        when(() => mockJournalDb.getConfigFlag(autoTranscribeFlag))
+            .thenAnswer((_) async => false); // ASR not relevant here
+        when(
+          () => mockPersistenceLogic.createMetadata(
+            dateFrom: expectedAudioData.dateFrom,
+            dateTo: expectedAudioData.dateTo,
+            uuidV5Input: json.encode(
+              expectedAudioData.copyWith(
+                autoTranscribeWasActive: false,
+                language: testLanguage,
+              ),
+            ),
+            flag: EntryFlag.import,
+            categoryId: testCategoryId,
+          ),
+        ).thenAnswer(
+          (_) async => testMetadata.copyWith(categoryId: testCategoryId),
+        );
+        when(
+          () => mockPersistenceLogic.createDbEntity(
+            any(that: isA<JournalAudio>()),
+            linkedId: testLinkedId,
+          ),
+        ).thenAnswer((_) async => true);
+
+        // Act
+        final result = await SpeechRepository.createAudioEntry(
+          testAudioNote,
+          language: testLanguage,
+          linkedId: testLinkedId,
+          categoryId: testCategoryId,
+        );
+
+        // Assert
+        expect(result, isA<JournalAudio>());
+        expect(result?.meta.categoryId, testCategoryId);
+
+        final capturedEntity = verify(
+          () => mockPersistenceLogic.createDbEntity(
+            captureAny(that: isA<JournalAudio>()),
+            linkedId: testLinkedId,
+          ),
+        ).captured.single as JournalAudio;
+        expect(capturedEntity.meta.categoryId, testCategoryId);
+
+        verify(
+          () => mockPersistenceLogic.createMetadata(
+            dateFrom: expectedAudioData.dateFrom,
+            dateTo: expectedAudioData.dateTo,
+            uuidV5Input: json.encode(
+              expectedAudioData.copyWith(
+                autoTranscribeWasActive: false,
+                language: testLanguage,
+              ),
+            ),
+            flag: EntryFlag.import,
+            categoryId: testCategoryId,
+          ),
+        ).called(1);
+      });
+
+      test('returns null and logs exception when getConfigFlag throws',
+          () async {
+        // Arrange
+        final exception = Exception('DB error');
+        when(() => mockJournalDb.getConfigFlag(autoTranscribeFlag))
+            .thenThrow(exception);
+
+        // Act
+        final result = await SpeechRepository.createAudioEntry(
+          testAudioNote,
+          language: testLanguage,
+        );
+
+        // Assert
+        expect(result, isNull);
+        verify(
+          () => mockLoggingService.captureException(
+            exception,
+            domain: 'persistence_logic',
+            subDomain: 'createAudioEntry',
+            stackTrace: any(named: 'stackTrace'),
+          ),
+        ).called(1);
+        verifyNever(
+          () => mockPersistenceLogic.createMetadata(
+            dateFrom: any(named: 'dateFrom'),
+            dateTo: any(named: 'dateTo'),
+            uuidV5Input: any(named: 'uuidV5Input'),
+            flag: any(named: 'flag'),
+            categoryId: any(named: 'categoryId'),
+          ),
+        );
+      });
+
+      test('returns null and logs exception when createMetadata throws',
+          () async {
+        // Arrange
+        final exception = Exception('Metadata creation error');
+        when(() => mockJournalDb.getConfigFlag(autoTranscribeFlag))
+            .thenAnswer((_) async => false);
+        when(
+          () => mockPersistenceLogic.createMetadata(
+            dateFrom: any(named: 'dateFrom'),
+            dateTo: any(named: 'dateTo'),
+            uuidV5Input: any(named: 'uuidV5Input'),
+            flag: any(named: 'flag'),
+            categoryId: any(named: 'categoryId'),
+          ),
+        ).thenThrow(exception);
+
+        // Act
+        final result = await SpeechRepository.createAudioEntry(
+          testAudioNote,
+          language: testLanguage,
+        );
+
+        // Assert
+        expect(result, isNull);
+        verify(
+          () => mockLoggingService.captureException(
+            exception,
+            domain: 'persistence_logic',
+            subDomain: 'createAudioEntry',
+            stackTrace: any(named: 'stackTrace'),
+          ),
+        ).called(1);
+        verifyNever(
+          () => mockPersistenceLogic.createDbEntity(
+            any(),
+            linkedId: any(named: 'linkedId'),
+          ),
+        );
+      });
+
+      test('returns null and logs exception when createDbEntity throws',
+          () async {
+        // Arrange
+        final exception = Exception('DB entity creation error');
+        when(() => mockJournalDb.getConfigFlag(autoTranscribeFlag))
+            .thenAnswer((_) async => false);
+        when(
+          () => mockPersistenceLogic.createMetadata(
+            dateFrom: expectedAudioData.dateFrom,
+            dateTo: expectedAudioData.dateTo,
+            uuidV5Input: json.encode(
+              expectedAudioData.copyWith(
+                autoTranscribeWasActive: false,
+                language: testLanguage,
+              ),
+            ),
+            flag: EntryFlag.import,
+          ),
+        ).thenAnswer((_) async => testMetadata);
+        when(
+          () => mockPersistenceLogic.createDbEntity(
+            any(that: isA<JournalAudio>()),
+          ),
+        ).thenThrow(exception);
+
+        // Act
+        final result = await SpeechRepository.createAudioEntry(
+          testAudioNote,
+          language: testLanguage,
+        );
+
+        // Assert
+        expect(result, isNull);
+        verify(
+          () => mockLoggingService.captureException(
+            exception,
+            domain: 'persistence_logic',
+            subDomain: 'createAudioEntry',
+            stackTrace: any(named: 'stackTrace'),
+          ),
+        ).called(1);
+        verifyNever(() => mockAsrService.enqueue(entry: any(named: 'entry')));
+      });
+    });
+
+    group('updateLanguage', () {
+      const testEntryId = 'audio_entry_123';
+      const newLanguage = 'es-ES';
+      final initialAudioData = AudioData(
+        audioDirectory: '/test/dir',
+        audioFile: 'test.aac',
+        duration: const Duration(seconds: 30),
+        dateFrom: DateTime(2023, 1, 1, 10),
+        dateTo: DateTime(2023, 1, 1, 10, 0, 30),
+        language: 'en-US',
+      );
+      final initialMetadata = Metadata(
+        id: testEntryId,
+        createdAt: DateTime(2023, 1, 1, 9),
+        updatedAt: DateTime(2023, 1, 1, 9, 30),
+        dateFrom: initialAudioData.dateFrom,
+        dateTo: initialAudioData.dateTo,
+      );
+      final testJournalAudioEntry = JournalAudio(
+        meta: initialMetadata,
+        data: initialAudioData,
+      );
+
+      test('successfully updates language for a JournalAudio entry', () async {
+        // Arrange
+        when(() => mockJournalDb.journalEntityById(testEntryId))
+            .thenAnswer((_) async => testJournalAudioEntry);
+        when(() => mockPersistenceLogic.updateMetadata(initialMetadata))
+            .thenAnswer(
+          (_) async => initialMetadata.copyWith(
+            updatedAt: DateTime.now(),
+          ),
+        ); // Simulate updatedAt change
+        when(
+          () => mockPersistenceLogic.updateDbEntity(
+            any(that: isA<JournalAudio>()),
+          ),
+        ).thenAnswer((_) async => true);
+
+        // Act
+        await SpeechRepository.updateLanguage(
+          journalEntityId: testEntryId,
+          language: newLanguage,
+        );
+
+        // Assert
+        verify(() => mockJournalDb.journalEntityById(testEntryId)).called(1);
+        verify(() => mockPersistenceLogic.updateMetadata(initialMetadata))
+            .called(1);
+        final captured = verify(
+          () => mockPersistenceLogic
+              .updateDbEntity(captureAny(that: isA<JournalAudio>())),
+        ).captured;
+        expect(captured.length, 1);
+        final updatedEntry = captured.first as JournalAudio;
+        expect(updatedEntry.data.language, newLanguage);
+        expect(updatedEntry.meta.id, testEntryId);
+      });
+
+      test('does nothing and logs if entry is not JournalAudio', () async {
+        // Arrange
+        final notAudioEntry = JournalEntry(
+          meta: initialMetadata,
+          entryText: const EntryText(plainText: 'text'),
+        );
+        when(() => mockJournalDb.journalEntityById(testEntryId))
+            .thenAnswer((_) async => notAudioEntry);
+
+        // Act
+        await SpeechRepository.updateLanguage(
+          journalEntityId: testEntryId,
+          language: newLanguage,
+        );
+
+        // Assert
+        verify(() => mockJournalDb.journalEntityById(testEntryId)).called(1);
+        verify(
+          () => mockLoggingService.captureException(
+            'not an audio entry',
+            domain: 'persistence_logic',
+            subDomain: 'updateLanguage',
+            // stackTrace is optional here as it might not be generated for simple string exceptions
+          ),
+        ).called(1);
+        verifyNever(() => mockPersistenceLogic.updateMetadata(any()));
+        verifyNever(() => mockPersistenceLogic.updateDbEntity(any()));
+      });
+
+      test('does nothing if journal entity is not found', () async {
+        // Arrange
+        when(() => mockJournalDb.journalEntityById(testEntryId))
+            .thenAnswer((_) async => null);
+
+        // Act
+        await SpeechRepository.updateLanguage(
+          journalEntityId: testEntryId,
+          language: newLanguage,
+        );
+
+        // Assert
+        verify(() => mockJournalDb.journalEntityById(testEntryId)).called(1);
+        verifyNever(
+          () => mockLoggingService.captureException(
+            any(),
+            domain: any(named: 'domain'),
+            subDomain: any(named: 'subDomain'),
+            stackTrace: any(named: 'stackTrace'),
+          ),
+        );
+        verifyNever(() => mockPersistenceLogic.updateMetadata(any()));
+        verifyNever(() => mockPersistenceLogic.updateDbEntity(any()));
+      });
+
+      test('logs exception if journalEntityById throws', () async {
+        // Arrange
+        final exception = Exception('DB fetch error');
+        when(() => mockJournalDb.journalEntityById(testEntryId))
+            .thenThrow(exception);
+
+        // Act
+        await SpeechRepository.updateLanguage(
+          journalEntityId: testEntryId,
+          language: newLanguage,
+        );
+
+        // Assert
+        verify(() => mockJournalDb.journalEntityById(testEntryId)).called(1);
+        verify(
+          () => mockLoggingService.captureException(
+            exception,
+            domain: 'persistence_logic',
+            subDomain: 'updateLanguage',
+            stackTrace: any(named: 'stackTrace'),
+          ),
+        ).called(1);
+        verifyNever(() => mockPersistenceLogic.updateMetadata(any()));
+        verifyNever(() => mockPersistenceLogic.updateDbEntity(any()));
+      });
+
+      test('logs exception if updateMetadata throws', () async {
+        // Arrange
+        final exception = Exception('Metadata update error');
+        when(() => mockJournalDb.journalEntityById(testEntryId))
+            .thenAnswer((_) async => testJournalAudioEntry);
+        when(() => mockPersistenceLogic.updateMetadata(initialMetadata))
+            .thenThrow(exception);
+
+        // Act
+        await SpeechRepository.updateLanguage(
+          journalEntityId: testEntryId,
+          language: newLanguage,
+        );
+
+        // Assert
+        verify(
+          () => mockLoggingService.captureException(
+            exception,
+            domain: 'persistence_logic',
+            subDomain: 'updateLanguage',
+            stackTrace: any(named: 'stackTrace'),
+          ),
+        ).called(1);
+        verifyNever(() => mockPersistenceLogic.updateDbEntity(any()));
+      });
+
+      test('logs exception if updateDbEntity throws', () async {
+        // Arrange
+        final exception = Exception('DB entity update error');
+        when(() => mockJournalDb.journalEntityById(testEntryId))
+            .thenAnswer((_) async => testJournalAudioEntry);
+        when(() => mockPersistenceLogic.updateMetadata(initialMetadata))
+            .thenAnswer(
+          (_) async => initialMetadata.copyWith(updatedAt: DateTime.now()),
+        );
+        when(
+          () => mockPersistenceLogic.updateDbEntity(
+            any(that: isA<JournalAudio>()),
+          ),
+        ).thenThrow(exception);
+
+        // Act
+        await SpeechRepository.updateLanguage(
+          journalEntityId: testEntryId,
+          language: newLanguage,
+        );
+
+        // Assert
+        verify(
+          () => mockLoggingService.captureException(
+            exception,
+            domain: 'persistence_logic',
+            subDomain: 'updateLanguage',
+            stackTrace: any(named: 'stackTrace'),
+          ),
+        ).called(1);
+      });
+    });
+
+    group('addAudioTranscript', () {
+      const testEntryId = 'audio_entry_add_transcript_123';
+      final testTranscript = AudioTranscript(
+        created: DateTime(2023, 1, 2, 10),
+        library: 'test_library',
+        model: 'test_model',
+        detectedLanguage: 'en-US',
+        transcript: 'This is a test transcript.',
+        processingTime: const Duration(seconds: 5),
+      );
+      final initialAudioData = AudioData(
+        audioDirectory: '/test/dir',
+        audioFile: 'test.aac',
+        duration: const Duration(seconds: 60),
+        dateFrom: DateTime(2023, 1, 2, 9),
+        dateTo: DateTime(2023, 1, 2, 9, 1),
+        language: 'en-US',
+        transcripts: [],
+      );
+      final initialMetadata = Metadata(
+        id: testEntryId,
+        createdAt: DateTime(2023, 1, 2, 8),
+        updatedAt: DateTime(2023, 1, 2, 8, 30),
+        dateFrom: initialAudioData.dateFrom,
+        dateTo: initialAudioData.dateTo,
+      );
+      final testJournalAudioEntryNoText = JournalAudio(
+        meta: initialMetadata,
+        data: initialAudioData,
+      );
+      final testJournalAudioEntryWithEmptyText = JournalAudio(
+        meta: initialMetadata,
+        data: initialAudioData,
+        entryText:
+            const EntryText(plainText: '', markdown: ' '), // Empty/whitespace
+      );
+      final testJournalAudioEntryWithExistingText = JournalAudio(
+        meta: initialMetadata,
+        data: initialAudioData.copyWith(
+          transcripts: [
+            testTranscript.copyWith(
+              transcript: 'Initial pre-existing transcript',
+            ),
+          ],
+        ), // Ensure this is a different transcript
+        entryText: const EntryText(
+          plainText: 'Existing text.',
+          markdown: 'Existing text.',
+        ),
+      );
+
+      setUp(() {
+        // Common stubs for this group
+        when(() => mockPersistenceLogic.updateMetadata(any<Metadata>()))
+            .thenAnswer((invocation) async {
+          final originalMeta = invocation.positionalArguments[0] as Metadata;
+          return originalMeta.copyWith(updatedAt: DateTime.now());
+        });
+        when(
+          () => mockPersistenceLogic.updateDbEntity(
+            any(that: isA<JournalAudio>()),
+          ),
+        ).thenAnswer((_) async => true);
+      });
+
+      test(
+          'successfully adds transcript and updates entryText if initially null',
+          () async {
+        // Arrange
+        when(() => mockJournalDb.journalEntityById(testEntryId))
+            .thenAnswer((_) async => testJournalAudioEntryNoText);
+
+        // Act
+        final result = await SpeechRepository.addAudioTranscript(
+          journalEntityId: testEntryId,
+          transcript: testTranscript,
+        );
+
+        // Assert
+        expect(result, isTrue);
+        final captured = verify(
+          () => mockPersistenceLogic
+              .updateDbEntity(captureAny(that: isA<JournalAudio>())),
+        ).captured;
+        expect(captured.length, 1);
+        final updatedEntry = captured.first as JournalAudio;
+        expect(updatedEntry.data.transcripts, contains(testTranscript));
+        expect(updatedEntry.entryText?.plainText, testTranscript.transcript);
+        expect(updatedEntry.entryText?.markdown, testTranscript.transcript);
+      });
+
+      test(
+          'successfully adds transcript and updates entryText if initially empty',
+          () async {
+        // Arrange
+        when(() => mockJournalDb.journalEntityById(testEntryId))
+            .thenAnswer((_) async => testJournalAudioEntryWithEmptyText);
+
+        // Act
+        final result = await SpeechRepository.addAudioTranscript(
+          journalEntityId: testEntryId,
+          transcript: testTranscript,
+        );
+
+        // Assert
+        expect(result, isTrue);
+        final captured = verify(
+          () => mockPersistenceLogic
+              .updateDbEntity(captureAny(that: isA<JournalAudio>())),
+        ).captured;
+        expect(captured.length, 1);
+        final updatedEntry = captured.first as JournalAudio;
+        expect(updatedEntry.data.transcripts, contains(testTranscript));
+        expect(updatedEntry.entryText?.plainText, testTranscript.transcript);
+        expect(updatedEntry.entryText?.markdown, testTranscript.transcript);
+      });
+
+      test(
+          'successfully adds transcript but does NOT overwrite existing entryText',
+          () async {
+        // Arrange
+        final initialText = testJournalAudioEntryWithExistingText.entryText!;
+        when(() => mockJournalDb.journalEntityById(testEntryId))
+            .thenAnswer((_) async => testJournalAudioEntryWithExistingText);
+        // Use the main testTranscript for adding, ensuring it's different from any pre-existing one in this specific test
+        final transcriptToAdd = testTranscript.copyWith(
+          transcript: 'Another new transcript being added',
+        );
+
+        // Act
+        final result = await SpeechRepository.addAudioTranscript(
+          journalEntityId: testEntryId,
+          transcript: transcriptToAdd,
+        );
+
+        // Assert
+        expect(result, isTrue);
+        final captured = verify(
+          () => mockPersistenceLogic
+              .updateDbEntity(captureAny(that: isA<JournalAudio>())),
+        ).captured;
+        expect(captured.length, 1);
+        final updatedEntry = captured.first as JournalAudio;
+        expect(updatedEntry.data.transcripts, contains(transcriptToAdd));
+        expect(updatedEntry.data.transcripts?.length, 2); // initial + new one
+        expect(updatedEntry.entryText?.plainText, initialText.plainText);
+        expect(updatedEntry.entryText?.markdown, initialText.markdown);
+      });
+
+      test('returns false if journal entity is not found', () async {
+        // Arrange
+        when(() => mockJournalDb.journalEntityById(testEntryId))
+            .thenAnswer((_) async => null);
+
+        // Act
+        final result = await SpeechRepository.addAudioTranscript(
+          journalEntityId: testEntryId,
+          transcript: testTranscript,
+        );
+
+        // Assert
+        expect(result, isFalse);
+        verifyNever(() => mockPersistenceLogic.updateDbEntity(any()));
+      });
+
+      test('does nothing and logs if entry is not JournalAudio', () async {
+        // Arrange
+        final notAudioEntry = JournalEntry(
+          meta: initialMetadata,
+          entryText: const EntryText(plainText: 'text'),
+        );
+        when(() => mockJournalDb.journalEntityById(testEntryId))
+            .thenAnswer((_) async => notAudioEntry);
+
+        // Act
+        final result = await SpeechRepository.addAudioTranscript(
+          journalEntityId: testEntryId,
+          transcript: testTranscript,
+        ); // Note: original method returns true even in this orElse case
+
+        // Assert
+        expect(result, isTrue);
+        verify(
+          () => mockLoggingService.captureException(
+            'not an audio entry',
+            domain: 'persistence_logic',
+            subDomain: 'addAudioTranscript',
+          ),
+        ).called(1);
+        verifyNever(() => mockPersistenceLogic.updateDbEntity(any()));
+      });
+
+      test('logs exception if journalEntityById throws', () async {
+        // Arrange
+        final exception = Exception('DB fetch error for transcript add');
+        when(() => mockJournalDb.journalEntityById(testEntryId))
+            .thenThrow(exception);
+
+        // Act
+        final result = await SpeechRepository.addAudioTranscript(
+          journalEntityId: testEntryId,
+          transcript: testTranscript,
+        );
+
+        // Assert
+        expect(result, isTrue); // Original method returns true on catch
+        verify(
+          () => mockLoggingService.captureException(
+            exception,
+            domain: 'persistence_logic',
+            subDomain: 'addAudioTranscript',
+            stackTrace: any(named: 'stackTrace'),
+          ),
+        ).called(1);
+        verifyNever(() => mockPersistenceLogic.updateDbEntity(any()));
+      });
+
+      test('logs exception if updateDbEntity throws', () async {
+        // Arrange
+        final exception =
+            Exception('DB entity update error for transcript add');
+        when(() => mockJournalDb.journalEntityById(testEntryId))
+            .thenAnswer((_) async => testJournalAudioEntryNoText);
+        when(
+          () => mockPersistenceLogic.updateDbEntity(
+            any(that: isA<JournalAudio>()),
+          ),
+        ).thenThrow(exception);
+
+        // Act
+        final result = await SpeechRepository.addAudioTranscript(
+          journalEntityId: testEntryId,
+          transcript: testTranscript,
+        );
+
+        // Assert
+        expect(result, isTrue); // Original method returns true on catch
+        verify(
+          () => mockLoggingService.captureException(
+            exception,
+            domain: 'persistence_logic',
+            subDomain: 'addAudioTranscript',
+            stackTrace: any(named: 'stackTrace'),
+          ),
+        ).called(1);
+      });
+    });
+
+    group('removeAudioTranscript', () {
+      const testEntryId = 'audio_entry_remove_transcript_123';
+      final transcript1 = AudioTranscript(
+        created: DateTime(2023, 1, 3, 10),
+        library: 'lib1',
+        model: 'mod1',
+        detectedLanguage: 'en',
+        transcript: 'Transcript 1',
+      );
+      final transcript2 = AudioTranscript(
+        created: DateTime(2023, 1, 3, 11),
+        library: 'lib2',
+        model: 'mod2',
+        detectedLanguage: 'es',
+        transcript: 'Transcript 2',
+      );
+      final transcriptToRemove = transcript1; // The one we intend to remove
+      final transcriptToKeep = transcript2; // The one that should remain
+      final nonExistingTranscript = AudioTranscript(
+        created: DateTime(2023, 1, 3, 12), // Different created time
+        library: 'lib_other', model: 'mod_other', detectedLanguage: 'fr',
+        transcript: 'Non-existing',
+      );
+
+      final initialAudioDataWithTwoTranscripts = AudioData(
+        audioDirectory: '/test/dir',
+        audioFile: 'test_remove.aac',
+        duration: const Duration(seconds: 120),
+        dateFrom: DateTime(2023, 1, 3, 9),
+        dateTo: DateTime(2023, 1, 3, 9, 2),
+        language: 'en-US',
+        transcripts: [transcriptToRemove, transcriptToKeep],
+      );
+      final initialMetadata = Metadata(
+        id: testEntryId,
+        createdAt: DateTime(2023, 1, 3, 8),
+        updatedAt: DateTime(2023, 1, 3, 8, 30),
+        dateFrom: initialAudioDataWithTwoTranscripts.dateFrom,
+        dateTo: initialAudioDataWithTwoTranscripts.dateTo,
+      );
+      final testJournalAudioEntryWithTranscripts = JournalAudio(
+        meta: initialMetadata,
+        data: initialAudioDataWithTwoTranscripts,
+        entryText: const EntryText(plainText: 'Some audio text'),
+      );
+
+      setUp(() {
+        // Common stubs for this group
+        when(() => mockPersistenceLogic.updateMetadata(any<Metadata>()))
+            .thenAnswer((invocation) async {
+          final originalMeta = invocation.positionalArguments[0] as Metadata;
+          return originalMeta.copyWith(updatedAt: DateTime.now());
+        });
+        when(
+          () => mockPersistenceLogic.updateDbEntity(
+            any(that: isA<JournalAudio>()),
+          ),
+        ).thenAnswer((_) async => true);
+      });
+
+      test('successfully removes an existing transcript', () async {
+        // Arrange
+        when(() => mockJournalDb.journalEntityById(testEntryId))
+            .thenAnswer((_) async => testJournalAudioEntryWithTranscripts);
+
+        // Act
+        final result = await SpeechRepository.removeAudioTranscript(
+          journalEntityId: testEntryId,
+          transcript: transcriptToRemove,
+        );
+
+        // Assert
+        expect(result, isTrue);
+        final captured = verify(
+          () => mockPersistenceLogic
+              .updateDbEntity(captureAny(that: isA<JournalAudio>())),
+        ).captured;
+        expect(captured.length, 1);
+        final updatedEntry = captured.first as JournalAudio;
+        expect(updatedEntry.data.transcripts, isNotNull);
+        expect(
+          updatedEntry.data.transcripts,
+          isNot(contains(transcriptToRemove)),
+        );
+        expect(updatedEntry.data.transcripts, contains(transcriptToKeep));
+        expect(updatedEntry.data.transcripts?.length, 1);
+      });
+
+      test(
+          'does nothing if transcript to remove does not exist (based on created time)',
+          () async {
+        // Arrange
+        when(() => mockJournalDb.journalEntityById(testEntryId))
+            .thenAnswer((_) async => testJournalAudioEntryWithTranscripts);
+
+        // Act
+        final result = await SpeechRepository.removeAudioTranscript(
+          journalEntityId: testEntryId,
+          transcript: nonExistingTranscript,
+        );
+
+        // Assert
+        expect(result, isTrue);
+        final captured = verify(
+          () => mockPersistenceLogic
+              .updateDbEntity(captureAny(that: isA<JournalAudio>())),
+        ).captured;
+        expect(captured.length, 1);
+        final updatedEntry = captured.first as JournalAudio;
+        expect(
+          updatedEntry.data.transcripts?.length,
+          2,
+        ); // Should remain unchanged
+        expect(updatedEntry.data.transcripts, contains(transcriptToRemove));
+        expect(updatedEntry.data.transcripts, contains(transcriptToKeep));
+      });
+
+      test('returns false if journal entity is not found', () async {
+        // Arrange
+        when(() => mockJournalDb.journalEntityById(testEntryId))
+            .thenAnswer((_) async => null);
+
+        // Act
+        final result = await SpeechRepository.removeAudioTranscript(
+          journalEntityId: testEntryId,
+          transcript: transcriptToRemove,
+        );
+
+        // Assert
+        expect(result, isFalse);
+        verifyNever(() => mockPersistenceLogic.updateDbEntity(any()));
+      });
+
+      test('does nothing and logs if entry is not JournalAudio', () async {
+        // Arrange
+        final notAudioEntry = JournalEntry(
+          meta: initialMetadata,
+          entryText: const EntryText(plainText: 'text'),
+        );
+        when(() => mockJournalDb.journalEntityById(testEntryId))
+            .thenAnswer((_) async => notAudioEntry);
+
+        // Act
+        final result = await SpeechRepository.removeAudioTranscript(
+          journalEntityId: testEntryId,
+          transcript: transcriptToRemove,
+        );
+
+        // Assert
+        expect(
+          result,
+          isTrue,
+        ); // Original method returns true even in orElse/catch
+        verify(
+          () => mockLoggingService.captureException(
+            'not an audio entry',
+            domain: 'persistence_logic',
+            subDomain: 'removeAudioTranscript',
+          ),
+        ).called(1);
+        verifyNever(() => mockPersistenceLogic.updateDbEntity(any()));
+      });
+
+      test('logs exception if journalEntityById throws', () async {
+        // Arrange
+        final exception = Exception('DB fetch error for transcript removal');
+        when(() => mockJournalDb.journalEntityById(testEntryId))
+            .thenThrow(exception);
+
+        // Act
+        final result = await SpeechRepository.removeAudioTranscript(
+          journalEntityId: testEntryId,
+          transcript: transcriptToRemove,
+        );
+
+        // Assert
+        expect(result, isTrue);
+        verify(
+          () => mockLoggingService.captureException(
+            exception,
+            domain: 'persistence_logic',
+            subDomain: 'removeAudioTranscript',
+            stackTrace: any(named: 'stackTrace'),
+          ),
+        ).called(1);
+        verifyNever(() => mockPersistenceLogic.updateDbEntity(any()));
+      });
+
+      test('logs exception if updateDbEntity throws', () async {
+        // Arrange
+        final exception =
+            Exception('DB entity update error for transcript removal');
+        when(() => mockJournalDb.journalEntityById(testEntryId))
+            .thenAnswer((_) async => testJournalAudioEntryWithTranscripts);
+        when(
+          () => mockPersistenceLogic.updateDbEntity(
+            any(that: isA<JournalAudio>()),
+          ),
+        ).thenThrow(exception);
+
+        // Act
+        final result = await SpeechRepository.removeAudioTranscript(
+          journalEntityId: testEntryId,
+          transcript: transcriptToRemove,
+        );
+
+        // Assert
+        expect(result, isTrue);
+        verify(
+          () => mockLoggingService.captureException(
+            exception,
+            domain: 'persistence_logic',
+            subDomain: 'removeAudioTranscript',
+            stackTrace: any(named: 'stackTrace'),
+          ),
+        ).called(1);
+      });
+    });
+  });
+}


### PR DESCRIPTION
This pull request includes changes to enhance the functionality of the `updateCategoryId` method in the `EntryController` class and updates the version number in the `pubspec.yaml` file. Below are the key changes:

### Functional Enhancements:

* [`lib/features/journal/state/entry_controller.dart`](diffhunk://#diff-073fb67f5d87a4ca641101e845ee4b45cc2cdb2ee4a6cd4698bb94093921c235L169-R184): Updated the `updateCategoryId` method to ensure that linked entries with a `null` `categoryId` are also updated with the new `categoryId`. This change ensures consistency across linked entries.

### Version Update:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Incremented the app version from `0.9.607+3042` to `0.9.607+3043`.