### PR TITLE
refactor: cleanup

### DIFF
--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -244,20 +244,6 @@ class JournalDb extends _$JournalDb {
     return null;
   }
 
-  Stream<JournalEntity?> watchJournalEntityById(String id) {
-    final res = (select(journal)
-          ..where((t) => t.id.equals(id))
-          ..where((t) => t.deleted.equals(false)))
-        .watchSingleOrNull()
-        .map((dbEntity) => dbEntity != null ? fromDbEntity(dbEntity) : null);
-
-    return res;
-  }
-
-  Future<List<String>> entryIdsByTagId(String tagId) async {
-    return entryIdsForTagId(tagId).get();
-  }
-
   Future<List<JournalEntity>> getJournalEntities({
     required List<String> types,
     required List<bool> starredStatuses,
@@ -286,26 +272,6 @@ class JournalDb extends _$JournalDb {
   ) async {
     final res = await entriesForIds(ids.toList()).get();
     return res.map(fromDbEntity).toList();
-  }
-
-  Future<List<String>> getJournalEntityIds({
-    required List<String> types,
-    required List<bool> starredStatuses,
-    required List<bool> privateStatuses,
-    required List<int> flaggedStatuses,
-    required List<String>? ids,
-    int limit = 500,
-    int offset = 0,
-  }) async {
-    return _selectJournalEntityIds(
-      types: types,
-      starredStatuses: starredStatuses,
-      privateStatuses: privateStatuses,
-      flaggedStatuses: flaggedStatuses,
-      ids: ids,
-      limit: limit,
-      offset: offset,
-    ).get();
   }
 
   Selectable<JournalDbEntity> _selectJournalEntities({
@@ -350,37 +316,6 @@ class JournalDb extends _$JournalDb {
     }
   }
 
-  Selectable<String> _selectJournalEntityIds({
-    required List<String> types,
-    required List<bool> starredStatuses,
-    required List<bool> privateStatuses,
-    required List<int> flaggedStatuses,
-    required List<String>? ids,
-    int limit = 500,
-    int offset = 0,
-  }) {
-    if (ids != null) {
-      return filteredJournalIds2(
-        types,
-        ids,
-        starredStatuses,
-        privateStatuses,
-        flaggedStatuses,
-        limit,
-        offset,
-      );
-    } else {
-      return filteredJournalIds(
-        types,
-        starredStatuses,
-        privateStatuses,
-        flaggedStatuses,
-        limit,
-        offset,
-      );
-    }
-  }
-
   Future<List<JournalEntity>> getTasks({
     required List<bool> starredStatuses,
     required List<String> taskStatuses,
@@ -399,22 +334,6 @@ class JournalDb extends _$JournalDb {
     ).get();
 
     return res.map(fromDbEntity).toList();
-  }
-
-  Future<List<String>> getTasksIds({
-    required List<bool> starredStatuses,
-    required List<String> taskStatuses,
-    List<String>? ids,
-    int limit = 500,
-    int offset = 0,
-  }) async {
-    return _selectTaskIds(
-      starredStatuses: starredStatuses,
-      taskStatuses: taskStatuses,
-      ids: ids,
-      limit: limit,
-      offset: offset,
-    ).get();
   }
 
   Selectable<JournalDbEntity> _selectTasks({
@@ -448,33 +367,6 @@ class JournalDb extends _$JournalDb {
     }
   }
 
-  Selectable<String> _selectTaskIds({
-    required List<bool> starredStatuses,
-    required List<String> taskStatuses,
-    List<String>? ids,
-    int limit = 500,
-    int offset = 0,
-  }) {
-    final types = <String>['Task'];
-    if (ids != null) {
-      return filteredTaskIds2(
-        types,
-        ids,
-        starredStatuses,
-        taskStatuses,
-        limit,
-        offset,
-      );
-    } else {
-      return filteredTaskIds(
-        types,
-        starredStatuses,
-        taskStatuses,
-        limit,
-        offset,
-      );
-    }
-  }
 
   Future<int> getWipCount() async {
     final res = await _selectTasks(
@@ -486,12 +378,6 @@ class JournalDb extends _$JournalDb {
     return res.length;
   }
 
-  FutureOr<List<String>> getSortedLinkedEntityIds(
-    List<String> linkedIds,
-  ) async {
-    final dbEntities = await journalEntitiesByIds(linkedIds).get();
-    return dbEntities.map((dbEntity) => dbEntity.id).toList();
-  }
 
   Future<List<JournalEntity>> getLinkedEntities(String linkedFrom) async {
     final dbEntities = await linkedJournalEntities(linkedFrom).get();
@@ -702,13 +588,7 @@ class JournalDb extends _$JournalDb {
     }
   }
 
-  Future<void> setConfigFlag(String flagName, {required bool value}) async {
-    final configFlag = await getConfigFlagByName(flagName);
 
-    if (configFlag != null) {
-      await upsertConfigFlag(configFlag.copyWith(status: value));
-    }
-  }
 
   Future<int> getCountImportFlagEntries() async {
     final res = await countImportFlagEntries().get();

--- a/lib/database/maintenance.dart
+++ b/lib/database/maintenance.dart
@@ -97,66 +97,6 @@ class Maintenance {
     }
   }
 
-  Future<void> syncDefinitions() async {
-    final outboxService = getIt<OutboxService>();
-    final tags = await _db.watchTags().first;
-    final measurables = await _db.watchMeasurableDataTypes().first;
-    final dashboards = await _db.watchDashboards().first;
-    final habits = await _db.watchHabitDefinitions().first;
-
-    for (final tag in tags) {
-      await outboxService.enqueueMessage(
-        SyncMessage.tagEntity(
-          tagEntity: tag,
-          status: SyncEntryStatus.update,
-        ),
-      );
-    }
-    for (final measurable in measurables) {
-      await outboxService.enqueueMessage(
-        SyncMessage.entityDefinition(
-          entityDefinition: measurable,
-          status: SyncEntryStatus.update,
-        ),
-      );
-    }
-    for (final dashboard in dashboards) {
-      await outboxService.enqueueMessage(
-        SyncMessage.entityDefinition(
-          entityDefinition: dashboard,
-          status: SyncEntryStatus.update,
-        ),
-      );
-    }
-    for (final habit in habits) {
-      await outboxService.enqueueMessage(
-        SyncMessage.entityDefinition(
-          entityDefinition: habit,
-          status: SyncEntryStatus.update,
-        ),
-      );
-    }
-  }
-
-  Future<void> syncCategories() async {
-    final outboxService = getIt<OutboxService>();
-    final categories = await _db.watchCategories().first;
-
-    for (final category in categories) {
-      await outboxService.enqueueMessage(
-        SyncMessage.entityDefinition(
-          entityDefinition: category,
-          status: SyncEntryStatus.update,
-        ),
-      );
-    }
-  }
-
-  Future<void> deleteTaggedLinks() async {
-    await createDbBackup(journalDbFileName);
-    await _db.deleteTagged();
-  }
-
   Future<void> deleteEditorDb() async {
     final file = await getDatabaseFile(editorDbFileName);
     file.deleteSync();

--- a/lib/features/sync/ui/unverified_devices_page.dart
+++ b/lib/features/sync/ui/unverified_devices_page.dart
@@ -3,8 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/sync/state/matrix_unverified_provider.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/widgets/misc/wolt_modal_config.dart';
-import 'package:lotti/widgets/sync/imap_config_status.dart';
 import 'package:lotti/widgets/sync/matrix/device_card.dart';
+import 'package:lotti/widgets/sync/matrix/status_indicator.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 

--- a/lib/widgets/sync/matrix/status_indicator.dart
+++ b/lib/widgets/sync/matrix/status_indicator.dart
@@ -1,25 +1,5 @@
 import 'package:flutter/material.dart';
 
-class StatusText extends StatelessWidget {
-  const StatusText(
-    this.text, {
-    super.key,
-  });
-
-  final String text;
-
-  @override
-  Widget build(BuildContext context) {
-    return Flexible(
-      child: Text(
-        text,
-        softWrap: true,
-        overflow: TextOverflow.ellipsis,
-      ),
-    );
-  }
-}
-
 class StatusIndicator extends StatelessWidget {
   const StatusIndicator(
     this.statusColor, {

--- a/lib/widgets/sync/matrix/unverified_devices.dart
+++ b/lib/widgets/sync/matrix/unverified_devices.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:lotti/features/sync/matrix.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
-import 'package:lotti/widgets/sync/imap_config_status.dart';
 import 'package:lotti/widgets/sync/matrix/device_card.dart';
+import 'package:lotti/widgets/sync/matrix/status_indicator.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:matrix/matrix.dart';
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: dc27559385e905ad30838356c5f5d574014ba39872d732111cd07ac0beff4c57
+      sha256: e55636ed79578b9abca5fecf9437947798f5ef7456308b5cb85720b793eac92f
       url: "https://pub.dev"
     source: hosted
-    version: "80.0.0"
+    version: "82.0.0"
   accessibility_tools:
     dependency: transitive
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: "direct dev"
     description:
       name: analyzer
-      sha256: "192d1c5b944e7e53b24b5586db760db934b177d4147c42fbca8c8c5f1eb8d11e"
+      sha256: "904ae5bb474d32c38fb9482e2d925d5454cda04ddd0e55d2e6826bc72f6ba8c0"
       url: "https://pub.dev"
     source: hosted
-    version: "7.3.0"
+    version: "7.4.5"
   analyzer_plugin:
     dependency: transitive
     description:
@@ -381,10 +381,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: "802bd084fb82e55df091ec8ad1553a7331b61c08251eef19a508b6f3f3a9858d"
+      sha256: "4b8701e48a58f7712492c9b1f7ba0bb9d525644dd66d023b62e1fc8cdb560c8a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.13.1"
+    version: "1.14.0"
   cross_file:
     dependency: transitive
     description:
@@ -445,10 +445,10 @@ packages:
     dependency: transitive
     description:
       name: custom_lint_visitor
-      sha256: "36282d85714af494ee2d7da8c8913630aa6694da99f104fb2ed4afcf8fc857d8"
+      sha256: cba5b6d7a6217312472bf4468cdf68c949488aed7ffb0eab792cd0b6c435054d
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0+7.3.0"
+    version: "1.0.0+7.4.5"
   dart_console:
     dependency: transitive
     description:
@@ -3095,10 +3095,10 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: "1b4b9e706a10294258727674a340ae0d6e64a7231980f9f9a3d12e4b42407aad"
+      sha256: "557a315b7d2a6dbb0aaaff84d857967ce6bdc96a63dc6ee2a57ce5a6ee5d3331"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.16"
+    version: "1.1.17"
   vector_math:
     dependency: "direct main"
     description:
@@ -3127,10 +3127,10 @@ packages:
     dependency: transitive
     description:
       name: video_player_android
-      sha256: "28dcc4122079f40f93a0965b3679aff1a5f4251cf79611bd8011f937eb6b69de"
+      sha256: "4a5135754a62dbc827a64a42ef1f8ed72c962e191c97e2d48744225c2b9ebb73"
       url: "https://pub.dev"
     source: hosted
-    version: "2.8.4"
+    version: "2.8.7"
   video_player_avfoundation:
     dependency: transitive
     description:
@@ -3247,10 +3247,10 @@ packages:
     dependency: "direct main"
     description:
       name: widgetbook
-      sha256: "6a89bf28efd62e07824fa56a4394352e04dc9a84e01a233887a9cb0f7d5aa60d"
+      sha256: "116efd339f9d060ac4a063f3c1c91266757198bcfb43083fb3f1b7bcbb9e6f75"
       url: "https://pub.dev"
     source: hosted
-    version: "3.14.0"
+    version: "3.14.2"
   widgetbook_annotation:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.610+3051
+version: 0.9.610+3052
 
 msix_config:
   display_name: LottiApp

--- a/test/database/database_test.dart
+++ b/test/database/database_test.dart
@@ -215,17 +215,6 @@ void main() {
     );
 
     test(
-      'setConfigFlag updates flag status correctly',
-      () async {
-        expect(await db?.getConfigFlag(recordLocationFlag), false);
-        await db?.setConfigFlag(recordLocationFlag, value: true);
-        expect(await db?.getConfigFlag(recordLocationFlag), true);
-        await db?.setConfigFlag(recordLocationFlag, value: false);
-        expect(await db?.getConfigFlag(recordLocationFlag), false);
-      },
-    );
-
-    test(
       'watchActiveConfigFlagNames returns active flag names correctly',
       () async {
         final activeFlags = await db?.watchActiveConfigFlagNames().first;
@@ -400,46 +389,6 @@ void main() {
 
         final retrieved = await db?.journalEntityById(entry.meta.id);
         expect(retrieved?.meta.starred, false);
-      });
-
-      test('watchJournalEntityById streams entity updates', () async {
-        final entry = createJournalEntry('Stream test');
-        await db?.updateJournalEntity(entry);
-
-        // Setup stream for watching entity
-        final completer = Completer<JournalEntity>();
-
-        // Start listening to the stream
-        final subscription =
-            db!.watchJournalEntityById(entry.meta.id).listen((updated) {
-          if (updated != null && (updated.meta.starred ?? false)) {
-            completer.complete(updated);
-          }
-        });
-
-        // Update the entity with starred = true
-        final now = DateTime.now();
-        final updatedEntry = JournalEntity.journalEntry(
-          meta: Metadata(
-            id: entry.meta.id,
-            createdAt: entry.meta.createdAt,
-            updatedAt: now,
-            dateFrom: now,
-            dateTo: now,
-            starred: true,
-            private: false,
-          ),
-          entryText: const EntryText(plainText: 'Updated for stream'),
-        );
-
-        await db?.updateJournalEntity(updatedEntry);
-
-        // Wait for the stream to emit the updated entity
-        final updated =
-            await completer.future.timeout(const Duration(seconds: 2));
-        expect(updated.meta.starred, true);
-
-        await subscription.cancel();
       });
     });
 


### PR DESCRIPTION
This pull request focuses on simplifying the codebase by removing unused methods and streamlining functionality in the database and related classes. Additionally, a minor version update and cleanup of test cases were included.

### Database-related code cleanup:
* Removed unused methods such as `watchJournalEntityById`, `entryIdsByTagId`, `getJournalEntityIds`, `_selectJournalEntityIds`, `getTasksIds`, `_selectTaskIds`, `getSortedLinkedEntityIds`, and `setConfigFlag` from `JournalDb` to reduce code complexity and improve maintainability. [[1]](diffhunk://#diff-58403ca793c79f9cac8520ba22f0b9cb3527232f194f5feefdda0a1089aff2b1L247-L260) [[2]](diffhunk://#diff-58403ca793c79f9cac8520ba22f0b9cb3527232f194f5feefdda0a1089aff2b1L291-L310) [[3]](diffhunk://#diff-58403ca793c79f9cac8520ba22f0b9cb3527232f194f5feefdda0a1089aff2b1L353-L383) [[4]](diffhunk://#diff-58403ca793c79f9cac8520ba22f0b9cb3527232f194f5feefdda0a1089aff2b1L404-L419) [[5]](diffhunk://#diff-58403ca793c79f9cac8520ba22f0b9cb3527232f194f5feefdda0a1089aff2b1L451-L477) [[6]](diffhunk://#diff-58403ca793c79f9cac8520ba22f0b9cb3527232f194f5feefdda0a1089aff2b1L489-L494) [[7]](diffhunk://#diff-58403ca793c79f9cac8520ba22f0b9cb3527232f194f5feefdda0a1089aff2b1L705-L711)

* Removed unused methods `syncDefinitions`, `syncCategories`, and `deleteTaggedLinks` from the `Maintenance` class, further simplifying the codebase.

### Refactoring and file structure changes:
* Renamed `lib/widgets/sync/imap_config_status.dart` to `lib/widgets/sync/matrix/status_indicator.dart` and removed the `StatusText` class, keeping only the `StatusIndicator` class in the new file. Updated imports in affected files accordingly. [[1]](diffhunk://#diff-13135c4e6d8d250b768b94e9cb82492632a708b307f0c704575bbc55b1599afcL3-L22) [[2]](diffhunk://#diff-ecfd1ba58018a816ac5e84c1416126e044480b3967619e18ce5e8e78616cb6d1L6-R7) [[3]](diffhunk://#diff-4e29b0246a0bcc4e4d7b504e143f609ab2cb14cf25159db1a1b43f8e229cf677L5-R6)

### Test case cleanup:
* Removed outdated test cases related to deleted methods such as `setConfigFlag` and `watchJournalEntityById` in `test/database/database_test.dart`. [[1]](diffhunk://#diff-5d94915a791875ec0c3b4703ccfdc535a20354a6c8a1c4adeb6763611ec735e3L217-L227) [[2]](diffhunk://#diff-5d94915a791875ec0c3b4703ccfdc535a20354a6c8a1c4adeb6763611ec735e3L404-L443)

### Miscellaneous:
* Updated the app version in `pubspec.yaml` from `0.9.610+3051` to `0.9.610+3052`.