### PR TITLE
fix: ai config

### DIFF
--- a/lib/features/ai/state/consts.dart
+++ b/lib/features/ai/state/consts.dart
@@ -32,4 +32,18 @@ extension AiResponseTypeDisplay on AiResponseType {
         return l10n.aiResponseTypeAudioTranscription;
     }
   }
+
+  /// Returns the appropriate icon for this response type
+  IconData get icon {
+    switch (this) {
+      case AiResponseType.taskSummary:
+        return Icons.summarize_outlined;
+      case AiResponseType.actionItemSuggestions:
+        return Icons.checklist_outlined;
+      case AiResponseType.imageAnalysis:
+        return Icons.image_outlined;
+      case AiResponseType.audioTranscription:
+        return Icons.mic_outlined;
+    }
+  }
 }

--- a/lib/features/ai/ui/settings/ai_config_list_page.dart
+++ b/lib/features/ai/ui/settings/ai_config_list_page.dart
@@ -345,11 +345,13 @@ class AiConfigListPage extends ConsumerWidget {
               label: messages.aiConfigListUndoDelete,
               textColor: colorScheme.primary,
               onPressed: () {
-                final controller = ref.read(
-                  inferenceProviderFormControllerProvider(configId: config.id)
-                      .notifier,
-                );
-                controller.addConfig(config);
+                ref
+                    .read(
+                      inferenceProviderFormControllerProvider(
+                              configId: config.id)
+                          .notifier,
+                    )
+                    .addConfig(config);
               },
             ),
           ),

--- a/lib/features/ai/ui/settings/ai_config_list_page.dart
+++ b/lib/features/ai/ui/settings/ai_config_list_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 import 'package:lotti/features/ai/state/ai_config_by_type_controller.dart';
 import 'package:lotti/features/ai/state/inference_provider_form_controller.dart';
 import 'package:lotti/features/ai/ui/settings/model_subtitle_widget.dart';
@@ -184,175 +185,215 @@ class AiConfigListPage extends ConsumerWidget {
   }
 
   void _deleteConfig(AiConfig config, WidgetRef ref, BuildContext context) {
-    final controller = ref.read(
-      inferenceProviderFormControllerProvider(configId: config.id).notifier,
-    );
-
     final scaffoldMessenger = ScaffoldMessenger.of(context);
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final textTheme = theme.textTheme;
     final messages = context.messages;
 
-    controller.deleteConfig(config.id).then((result) {
-      // Show snackbar for the provider deletion
-      scaffoldMessenger.showSnackBar(
-        SnackBar(
-          content: IntrinsicHeight(
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Container(
-                  margin: const EdgeInsets.only(right: 12, top: 4),
-                  child: Icon(
-                    Icons.delete_outline,
-                    color: colorScheme.onInverseSurface,
-                    size: 24,
+    // Use appropriate deletion method based on config type
+    if (config is AiConfigInferenceProvider) {
+      // For inference providers, use the cascade deletion
+      final controller = ref.read(
+        inferenceProviderFormControllerProvider(configId: config.id).notifier,
+      );
+
+      controller.deleteConfig(config.id).then((result) {
+        // Show snackbar for the provider deletion
+        scaffoldMessenger.showSnackBar(
+          SnackBar(
+            content: IntrinsicHeight(
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    margin: const EdgeInsets.only(right: 12, top: 4),
+                    child: Icon(
+                      Icons.delete_outline,
+                      color: colorScheme.onInverseSurface,
+                      size: 24,
+                    ),
                   ),
-                ),
-                Expanded(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        config.name,
-                        style: textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.w600,
-                          color: colorScheme.onInverseSurface,
-                          height: 1.2,
-                        ),
-                      ),
-                      const SizedBox(height: 4),
-                      Text(
-                        messages.aiConfigProviderDeletedSuccessfully,
-                        style: textTheme.bodyMedium?.copyWith(
-                          color: colorScheme.onInverseSurface
-                              .withValues(alpha: 0.85),
-                          height: 1.3,
-                        ),
-                      ),
-                      if (result.deletedModels.isNotEmpty) ...[
-                        const SizedBox(height: 10),
-                        Container(
-                          padding: const EdgeInsets.all(10),
-                          decoration: BoxDecoration(
-                            color: colorScheme.inverseSurface
-                                .withValues(alpha: 0.3),
-                            borderRadius: BorderRadius.circular(8),
-                            border: Border.all(
-                              color: colorScheme.outline.withValues(alpha: 0.3),
-                            ),
+                  Expanded(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          config.name,
+                          style: textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.w600,
+                            color: colorScheme.onInverseSurface,
+                            height: 1.2,
                           ),
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Row(
-                                children: [
-                                  Icon(
-                                    Icons.analytics_outlined,
-                                    size: 16,
-                                    color: colorScheme.onInverseSurface
-                                        .withValues(alpha: 0.9),
-                                  ),
-                                  const SizedBox(width: 8),
-                                  Text(
-                                    messages.aiConfigAssociatedModelsRemoved(
-                                        result.deletedModels.length),
-                                    style: textTheme.bodyMedium?.copyWith(
-                                      fontWeight: FontWeight.w500,
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          messages.aiConfigProviderDeletedSuccessfully,
+                          style: textTheme.bodyMedium?.copyWith(
+                            color: colorScheme.onInverseSurface
+                                .withValues(alpha: 0.85),
+                            height: 1.3,
+                          ),
+                        ),
+                        if (result.deletedModels.isNotEmpty) ...[
+                          const SizedBox(height: 10),
+                          Container(
+                            padding: const EdgeInsets.all(10),
+                            decoration: BoxDecoration(
+                              color: colorScheme.inverseSurface
+                                  .withValues(alpha: 0.3),
+                              borderRadius: BorderRadius.circular(8),
+                              border: Border.all(
+                                color:
+                                    colorScheme.outline.withValues(alpha: 0.3),
+                              ),
+                            ),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Row(
+                                  children: [
+                                    Icon(
+                                      Icons.analytics_outlined,
+                                      size: 16,
                                       color: colorScheme.onInverseSurface
-                                          .withValues(alpha: 0.95),
+                                          .withValues(alpha: 0.9),
+                                    ),
+                                    const SizedBox(width: 8),
+                                    Text(
+                                      messages.aiConfigAssociatedModelsRemoved(
+                                          result.deletedModels.length),
+                                      style: textTheme.bodyMedium?.copyWith(
+                                        fontWeight: FontWeight.w500,
+                                        color: colorScheme.onInverseSurface
+                                            .withValues(alpha: 0.95),
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                                if (result.deletedModels.length <= 4) ...[
+                                  const SizedBox(height: 8),
+                                  ...result.deletedModels.map((model) =>
+                                      Padding(
+                                        padding:
+                                            const EdgeInsets.only(bottom: 3),
+                                        child: Row(
+                                          children: [
+                                            const SizedBox(width: 24),
+                                            Container(
+                                              width: 4,
+                                              height: 4,
+                                              decoration: BoxDecoration(
+                                                color: colorScheme
+                                                    .onInverseSurface
+                                                    .withValues(alpha: 0.7),
+                                                shape: BoxShape.circle,
+                                              ),
+                                            ),
+                                            const SizedBox(width: 10),
+                                            Expanded(
+                                              child: Text(
+                                                model.name,
+                                                style: textTheme.bodySmall
+                                                    ?.copyWith(
+                                                  fontFamily: 'monospace',
+                                                  color: colorScheme
+                                                      .onInverseSurface
+                                                      .withValues(alpha: 0.8),
+                                                  height: 1.3,
+                                                ),
+                                                overflow: TextOverflow.ellipsis,
+                                              ),
+                                            ),
+                                          ],
+                                        ),
+                                      )),
+                                ] else ...[
+                                  const SizedBox(height: 6),
+                                  Text(
+                                    'Including: ${result.deletedModels.take(2).map((m) => m.name).join(', ')}${result.deletedModels.length > 2 ? ', and ${result.deletedModels.length - 2} more' : ''}',
+                                    style: textTheme.bodySmall?.copyWith(
+                                      fontFamily: 'monospace',
+                                      color: colorScheme.onInverseSurface
+                                          .withValues(alpha: 0.75),
+                                      height: 1.3,
                                     ),
                                   ),
                                 ],
-                              ),
-                              if (result.deletedModels.length <= 4) ...[
-                                const SizedBox(height: 8),
-                                ...result.deletedModels.map((model) => Padding(
-                                      padding: const EdgeInsets.only(bottom: 3),
-                                      child: Row(
-                                        children: [
-                                          const SizedBox(width: 24),
-                                          Container(
-                                            width: 4,
-                                            height: 4,
-                                            decoration: BoxDecoration(
-                                              color: colorScheme
-                                                  .onInverseSurface
-                                                  .withValues(alpha: 0.7),
-                                              shape: BoxShape.circle,
-                                            ),
-                                          ),
-                                          const SizedBox(width: 10),
-                                          Expanded(
-                                            child: Text(
-                                              model.name,
-                                              style:
-                                                  textTheme.bodySmall?.copyWith(
-                                                fontFamily: 'monospace',
-                                                color: colorScheme
-                                                    .onInverseSurface
-                                                    .withValues(alpha: 0.8),
-                                                height: 1.3,
-                                              ),
-                                              overflow: TextOverflow.ellipsis,
-                                            ),
-                                          ),
-                                        ],
-                                      ),
-                                    )),
-                              ] else ...[
-                                const SizedBox(height: 6),
-                                Text(
-                                  'Including: ${result.deletedModels.take(2).map((m) => m.name).join(', ')}${result.deletedModels.length > 2 ? ', and ${result.deletedModels.length - 2} more' : ''}',
-                                  style: textTheme.bodySmall?.copyWith(
-                                    fontFamily: 'monospace',
-                                    color: colorScheme.onInverseSurface
-                                        .withValues(alpha: 0.75),
-                                    height: 1.3,
-                                  ),
-                                ),
                               ],
-                            ],
+                            ),
                           ),
-                        ),
+                        ],
                       ],
-                    ],
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
+            ),
+            backgroundColor: colorScheme.inverseSurface,
+            behavior: SnackBarBehavior.floating,
+            margin: const EdgeInsets.all(16),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+              side: BorderSide(
+                color: colorScheme.outline.withValues(alpha: 0.3),
+              ),
+            ),
+            duration: const Duration(seconds: 5),
+            action: SnackBarAction(
+              label: messages.aiConfigListUndoDelete,
+              textColor: colorScheme.primary,
+              onPressed: () {
+                final controller = ref.read(
+                  inferenceProviderFormControllerProvider(configId: config.id)
+                      .notifier,
+                );
+                controller.addConfig(config);
+              },
             ),
           ),
-          backgroundColor: colorScheme.inverseSurface,
-          behavior: SnackBarBehavior.floating,
-          margin: const EdgeInsets.all(16),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(12),
-            side: BorderSide(
-              color: colorScheme.outline.withValues(alpha: 0.3),
+        );
+      }).catchError((dynamic error) {
+        scaffoldMessenger.showSnackBar(
+          SnackBar(
+            content: Text(
+              messages.aiConfigListErrorDeleting(config.name, error.toString()),
+            ),
+            backgroundColor: colorScheme.error,
+          ),
+        );
+      });
+    } else {
+      // For models and prompts, use the regular delete method
+      final repository = ref.read(aiConfigRepositoryProvider);
+
+      repository.deleteConfig(config.id).then((_) {
+        // Show simple success snackbar
+        scaffoldMessenger.showSnackBar(
+          SnackBar(
+            content: Text(
+              messages.aiConfigListItemDeleted(config.name),
+            ),
+            action: SnackBarAction(
+              label: messages.aiConfigListUndoDelete,
+              onPressed: () {
+                repository.saveConfig(config);
+              },
             ),
           ),
-          duration: const Duration(seconds: 5),
-          action: SnackBarAction(
-            label: messages.aiConfigListUndoDelete,
-            textColor: colorScheme.primary,
-            onPressed: () {
-              controller.addConfig(config);
-            },
+        );
+      }).catchError((dynamic error) {
+        scaffoldMessenger.showSnackBar(
+          SnackBar(
+            content: Text(
+              messages.aiConfigListErrorDeleting(config.name, error.toString()),
+            ),
+            backgroundColor: colorScheme.error,
           ),
-        ),
-      );
-    }).catchError((dynamic error) {
-      scaffoldMessenger.showSnackBar(
-        SnackBar(
-          content: Text(
-            messages.aiConfigListErrorDeleting(config.name, error.toString()),
-          ),
-          backgroundColor: colorScheme.error,
-        ),
-      );
-    });
+        );
+      });
+    }
   }
 
   Widget _buildConfigListTile(

--- a/lib/features/ai/ui/settings/preconfigured_prompt_selection_modal.dart
+++ b/lib/features/ai/ui/settings/preconfigured_prompt_selection_modal.dart
@@ -7,6 +7,8 @@
 
 import 'package:flutter/material.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/model/input_data_type_extensions.dart';
+import 'package:lotti/features/ai/state/consts.dart';
 import 'package:lotti/features/ai/util/preconfigured_prompts.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/themes/theme.dart';
@@ -20,33 +22,17 @@ Future<PreconfiguredPrompt?> showPreconfiguredPromptSelectionModal(
 ) async {
   return showModalActionSheet<PreconfiguredPrompt>(
     context: context,
-    title: 'Select Preconfigured Prompt',
+    title: context.messages.promptSelectionModalTitle,
     actions: preconfiguredPrompts
         .map(
           (prompt) => ModalSheetAction<PreconfiguredPrompt>(
-            icon: _getIconForPromptType(prompt.type),
+            icon: prompt.aiResponseType.icon,
             label: prompt.name,
             key: prompt,
           ),
         )
         .toList(),
   );
-}
-
-/// Gets the appropriate icon for a prompt type
-IconData _getIconForPromptType(String type) {
-  switch (type) {
-    case 'task_summary':
-      return Icons.summarize_outlined;
-    case 'action_item_suggestions':
-      return Icons.checklist_outlined;
-    case 'image_analysis':
-      return Icons.image_outlined;
-    case 'audio_transcription':
-      return Icons.mic_outlined;
-    default:
-      return Icons.description_outlined;
-  }
 }
 
 /// Widget that displays information about a preconfigured prompt
@@ -74,7 +60,7 @@ class PreconfiguredPromptTile extends StatelessWidget {
               Row(
                 children: [
                   Icon(
-                    _getIconForPromptType(prompt.type),
+                    prompt.aiResponseType.icon,
                     color: context.colorScheme.primary,
                   ),
                   const SizedBox(width: 12),
@@ -101,7 +87,7 @@ class PreconfiguredPromptTile extends StatelessWidget {
                   ...prompt.requiredInputData.map(
                     (inputType) => Chip(
                       label: Text(
-                        _getInputTypeLabel(inputType),
+                        _getInputTypeLabel(inputType, context),
                         style: context.textTheme.labelSmall,
                       ),
                       backgroundColor: context.colorScheme.secondaryContainer,
@@ -131,16 +117,7 @@ class PreconfiguredPromptTile extends StatelessWidget {
     );
   }
 
-  String _getInputTypeLabel(InputDataType type) {
-    switch (type) {
-      case InputDataType.task:
-        return 'Task';
-      case InputDataType.tasksList:
-        return 'Tasks List';
-      case InputDataType.audioFiles:
-        return 'Audio';
-      case InputDataType.images:
-        return 'Images';
-    }
+  String _getInputTypeLabel(InputDataType type, BuildContext context) {
+    return type.displayName(context);
   }
 }

--- a/lib/features/ai/ui/settings/prompt_form.dart
+++ b/lib/features/ai/ui/settings/prompt_form.dart
@@ -49,7 +49,7 @@ class _PromptFormState extends ConsumerState<PromptForm> {
               }
             },
             icon: const Icon(Icons.auto_awesome_outlined),
-            label: const Text('Use Preconfigured Prompt'),
+            label: Text(context.messages.promptUsePreconfiguredButton),
             style: FilledButton.styleFrom(
               minimumSize: const Size(double.infinity, 48),
             ),

--- a/lib/features/ai/util/preconfigured_prompts.dart
+++ b/lib/features/ai/util/preconfigured_prompts.dart
@@ -17,7 +17,6 @@ import 'package:lotti/features/ai/state/consts.dart';
 /// to quickly create common prompt types.
 class PreconfiguredPrompt {
   const PreconfiguredPrompt({
-    required this.type,
     required this.name,
     required this.systemMessage,
     required this.userMessage,
@@ -28,7 +27,6 @@ class PreconfiguredPrompt {
     this.defaultVariables,
   });
 
-  final String type;
   final String name;
   final String systemMessage;
   final String userMessage;
@@ -49,7 +47,6 @@ const List<PreconfiguredPrompt> preconfiguredPrompts = [
 
 /// Task Summary prompt template
 const taskSummaryPrompt = PreconfiguredPrompt(
-  type: 'task_summary',
   name: 'Task Summary',
   systemMessage: '''
 You are a helpful AI assistant that creates clear, concise task summaries. 
@@ -102,7 +99,6 @@ Annoyances:
 
 /// Action Item Suggestions prompt template
 const actionItemSuggestionsPrompt = PreconfiguredPrompt(
-  type: 'action_item_suggestions',
   name: 'Action Item Suggestions',
   systemMessage: '''
 You are a helpful AI assistant that identifies actionable items from task logs and conversations. 
@@ -148,7 +144,6 @@ If any is very similar to an item already listed in the actionItems array of the
 
 /// Image Analysis prompt template
 const imageAnalysisPrompt = PreconfiguredPrompt(
-  type: 'image_analysis',
   name: 'Image Analysis',
   systemMessage: '''
 You are a helpful AI assistant specialized in analyzing images. 
@@ -175,7 +170,6 @@ Image {{index}}: [Image will be provided]
 
 /// Audio Transcription prompt template
 const audioTranscriptionPrompt = PreconfiguredPrompt(
-  type: 'audio_transcription',
   name: 'Audio Transcription',
   systemMessage: '''
 You are a helpful AI assistant that transcribes audio content. 

--- a/lib/features/ai/util/preconfigured_prompts.dart
+++ b/lib/features/ai/util/preconfigured_prompts.dart
@@ -141,7 +141,7 @@ If any is very similar to an item already listed in the actionItems array of the
 ```''',
   requiredInputData: [InputDataType.task],
   aiResponseType: AiResponseType.actionItemSuggestions,
-  useReasoning: false,
+  useReasoning: true,
   description:
       "Extract actionable items from task logs that haven't been formally captured yet",
 );

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -340,6 +340,8 @@
   "promptEditLoadError": "Failed to load prompt",
   "promptEditPageTitle": "Edit Prompt",
   "promptSettingsPageTitle": "AI Prompts",
+  "promptSelectionModalTitle": "Select Preconfigured Prompt",
+  "promptUsePreconfiguredButton": "Use Preconfigured Prompt",
   "saveButtonLabel": "Save",
   "saveLabel": "Save",
   "searchHint": "Search...",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1839,6 +1839,18 @@ abstract class AppLocalizations {
   /// **'AI Prompts'**
   String get promptSettingsPageTitle;
 
+  /// No description provided for @promptSelectionModalTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Select Preconfigured Prompt'**
+  String get promptSelectionModalTitle;
+
+  /// No description provided for @promptUsePreconfiguredButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Use Preconfigured Prompt'**
+  String get promptUsePreconfiguredButton;
+
   /// No description provided for @saveButtonLabel.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -939,6 +939,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get promptSettingsPageTitle => 'AI Prompts';
 
   @override
+  String get promptSelectionModalTitle => 'Select Preconfigured Prompt';
+
+  @override
+  String get promptUsePreconfiguredButton => 'Use Preconfigured Prompt';
+
+  @override
   String get saveButtonLabel => 'Save';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -935,6 +935,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get promptSettingsPageTitle => 'AI Prompts';
 
   @override
+  String get promptSelectionModalTitle => 'Select Preconfigured Prompt';
+
+  @override
+  String get promptUsePreconfiguredButton => 'Use Preconfigured Prompt';
+
+  @override
   String get saveButtonLabel => 'Save';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -943,6 +943,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get promptSettingsPageTitle => 'AI Prompts';
 
   @override
+  String get promptSelectionModalTitle => 'Select Preconfigured Prompt';
+
+  @override
+  String get promptUsePreconfiguredButton => 'Use Preconfigured Prompt';
+
+  @override
   String get saveButtonLabel => 'Save';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -947,6 +947,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get promptSettingsPageTitle => 'AI Prompts';
 
   @override
+  String get promptSelectionModalTitle => 'Select Preconfigured Prompt';
+
+  @override
+  String get promptUsePreconfiguredButton => 'Use Preconfigured Prompt';
+
+  @override
   String get saveButtonLabel => 'Save';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -938,6 +938,12 @@ class AppLocalizationsRo extends AppLocalizations {
   String get promptSettingsPageTitle => 'AI Prompts';
 
   @override
+  String get promptSelectionModalTitle => 'Select Preconfigured Prompt';
+
+  @override
+  String get promptUsePreconfiguredButton => 'Use Preconfigured Prompt';
+
+  @override
   String get saveButtonLabel => 'Save';
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.611+3058
+version: 0.9.611+3059
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.611+3057
+version: 0.9.611+3058
 
 msix_config:
   display_name: LottiApp

--- a/test/features/ai/ui/settings/preconfigured_prompt_selection_modal_test.dart
+++ b/test/features/ai/ui/settings/preconfigured_prompt_selection_modal_test.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:form_builder_validators/localization/l10n.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/state/consts.dart';
 import 'package:lotti/features/ai/ui/settings/preconfigured_prompt_selection_modal.dart';
 import 'package:lotti/features/ai/util/preconfigured_prompts.dart';
+import 'package:lotti/l10n/app_localizations.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../../widget_test_utils.dart';
@@ -22,6 +25,14 @@ void main() {
   Widget buildTestWidget({NavigatorObserver? navigatorObserver}) {
     return MaterialApp(
       navigatorObservers: navigatorObserver != null ? [navigatorObserver] : [],
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        FormBuilderLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: AppLocalizations.supportedLocales,
       home: Scaffold(
         body: Builder(
           builder: (context) => ElevatedButton(
@@ -78,6 +89,14 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            FormBuilderLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
             body: Builder(
               builder: (context) => ElevatedButton(
@@ -107,6 +126,14 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            FormBuilderLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
             body: Builder(
               builder: (context) => ElevatedButton(
@@ -148,8 +175,8 @@ void main() {
     });
   });
 
-  group('_getIconForPromptType', () {
-    testWidgets('returns correct icons for known prompt types',
+  group('AiResponseType icon display', () {
+    testWidgets('displays correct icons for each response type',
         (WidgetTester tester) async {
       await tester.pumpWidget(buildTestWidget());
 
@@ -193,7 +220,6 @@ void main() {
 
   group('PreconfiguredPromptTile', () {
     const testPrompt = PreconfiguredPrompt(
-      type: 'test_type',
       name: 'Test Prompt',
       systemMessage: 'Test system message',
       userMessage: 'Test user message',
@@ -217,8 +243,8 @@ void main() {
       // Check that all prompt information is displayed
       expect(find.text('Test Prompt'), findsOneWidget);
       expect(find.text('Test description for the prompt'), findsOneWidget);
-      expect(find.byIcon(Icons.description_outlined),
-          findsOneWidget); // Default icon for unknown type
+      expect(find.byIcon(Icons.summarize_outlined),
+          findsOneWidget); // Icon for task summary response type
     });
 
     testWidgets('displays required input data chips',
@@ -257,7 +283,6 @@ void main() {
     testWidgets('does not display reasoning chip when useReasoning is false',
         (WidgetTester tester) async {
       const promptWithoutReasoning = PreconfiguredPrompt(
-        type: 'test_type',
         name: 'Test Prompt',
         systemMessage: 'Test system message',
         userMessage: 'Test user message',
@@ -296,11 +321,10 @@ void main() {
       expect(tapped, isTrue);
     });
 
-    testWidgets('displays correct icons for different prompt types',
+    testWidgets('displays correct icons for different response types',
         (WidgetTester tester) async {
-      // Test task summary prompt
+      // Test task summary response type
       const taskPrompt = PreconfiguredPrompt(
-        type: 'task_summary',
         name: 'Task Summary',
         systemMessage: 'System',
         userMessage: 'User',
@@ -326,7 +350,6 @@ void main() {
       testWidgets('displays correct labels for input types',
           (WidgetTester tester) async {
         const promptWithAllInputTypes = PreconfiguredPrompt(
-          type: 'test_type',
           name: 'Test Prompt',
           systemMessage: 'System',
           userMessage: 'User',
@@ -353,7 +376,7 @@ void main() {
         // Check that all input type labels are displayed correctly
         expect(find.text('Task'), findsOneWidget);
         expect(find.text('Tasks List'), findsOneWidget);
-        expect(find.text('Audio'), findsOneWidget);
+        expect(find.text('Audio Files'), findsOneWidget);
         expect(find.text('Images'), findsOneWidget);
       });
     });
@@ -364,6 +387,14 @@ void main() {
         (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            FormBuilderLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
             body: Builder(
               builder: (context) => ElevatedButton(

--- a/test/features/ai/util/preconfigured_prompts_test.dart
+++ b/test/features/ai/util/preconfigured_prompts_test.dart
@@ -10,21 +10,23 @@ void main() {
     });
 
     test('should contain all expected prompt types', () {
-      final promptTypes = preconfiguredPrompts.map((p) => p.type).toSet();
+      final promptTypes =
+          preconfiguredPrompts.map((p) => p.aiResponseType).toSet();
       expect(
         promptTypes,
         containsAll([
-          'task_summary',
-          'action_item_suggestions',
-          'image_analysis',
-          'audio_transcription',
+          AiResponseType.taskSummary,
+          AiResponseType.actionItemSuggestions,
+          AiResponseType.imageAnalysis,
+          AiResponseType.audioTranscription,
         ]),
       );
     });
 
     group('Task Summary Prompt', () {
       test('should have correct configuration', () {
-        expect(taskSummaryPrompt.type, equals('task_summary'));
+        expect(taskSummaryPrompt.aiResponseType,
+            equals(AiResponseType.taskSummary));
         expect(taskSummaryPrompt.name, equals('Task Summary'));
         expect(
             taskSummaryPrompt.requiredInputData, equals([InputDataType.task]));
@@ -52,15 +54,15 @@ void main() {
 
     group('Action Item Suggestions Prompt', () {
       test('should have correct configuration', () {
-        expect(actionItemSuggestionsPrompt.type,
-            equals('action_item_suggestions'));
+        expect(actionItemSuggestionsPrompt.aiResponseType,
+            equals(AiResponseType.actionItemSuggestions));
         expect(actionItemSuggestionsPrompt.name,
             equals('Action Item Suggestions'));
         expect(actionItemSuggestionsPrompt.requiredInputData,
             equals([InputDataType.task]));
         expect(actionItemSuggestionsPrompt.aiResponseType,
             equals(AiResponseType.actionItemSuggestions));
-        expect(actionItemSuggestionsPrompt.useReasoning, isFalse);
+        expect(actionItemSuggestionsPrompt.useReasoning, isTrue);
       });
 
       test('should have non-empty messages', () {
@@ -83,7 +85,8 @@ void main() {
 
     group('Image Analysis Prompt', () {
       test('should have correct configuration', () {
-        expect(imageAnalysisPrompt.type, equals('image_analysis'));
+        expect(imageAnalysisPrompt.aiResponseType,
+            equals(AiResponseType.imageAnalysis));
         expect(imageAnalysisPrompt.name, equals('Image Analysis'));
         expect(imageAnalysisPrompt.requiredInputData,
             equals([InputDataType.images]));
@@ -113,7 +116,8 @@ void main() {
 
     group('Audio Transcription Prompt', () {
       test('should have correct configuration', () {
-        expect(audioTranscriptionPrompt.type, equals('audio_transcription'));
+        expect(audioTranscriptionPrompt.aiResponseType,
+            equals(AiResponseType.audioTranscription));
         expect(audioTranscriptionPrompt.name, equals('Audio Transcription'));
         expect(audioTranscriptionPrompt.requiredInputData,
             equals([InputDataType.audioFiles]));
@@ -148,7 +152,6 @@ void main() {
     group('PreconfiguredPrompt Class', () {
       test('should create instance with all required fields', () {
         const testPrompt = PreconfiguredPrompt(
-          type: 'test_type',
           name: 'Test Prompt',
           systemMessage: 'System message',
           userMessage: 'User message',
@@ -158,7 +161,6 @@ void main() {
           description: 'Test description',
         );
 
-        expect(testPrompt.type, equals('test_type'));
         expect(testPrompt.name, equals('Test Prompt'));
         expect(testPrompt.systemMessage, equals('System message'));
         expect(testPrompt.userMessage, equals('User message'));
@@ -171,7 +173,6 @@ void main() {
 
       test('should create instance with optional defaultVariables', () {
         const testPrompt = PreconfiguredPrompt(
-          type: 'test_type',
           name: 'Test Prompt',
           systemMessage: 'System message',
           userMessage: 'User message',
@@ -188,7 +189,8 @@ void main() {
 
     group('Prompt Content Validation', () {
       test('all prompts should have unique types', () {
-        final types = preconfiguredPrompts.map((p) => p.type).toList();
+        final types =
+            preconfiguredPrompts.map((p) => p.aiResponseType).toList();
         expect(types.length, equals(types.toSet().length));
       });
 


### PR DESCRIPTION
This pull request introduces several enhancements and refactors related to AI response types and preconfigured prompts. The most significant changes include the removal of the `type` field from `PreconfiguredPrompt`, the addition of an `icon` getter to `AiResponseType`, and improvements to localization support for prompt-related UI elements.

### Refactoring of `PreconfiguredPrompt`:

* Removed the `type` field from the `PreconfiguredPrompt` class, simplifying its structure. The `aiResponseType` field now directly handles response type-specific functionality. (`[[1]](diffhunk://#diff-afbd44c0f099151b685659a715ac044166654453365f23cbc7edd62bc52194b4L20)`, `[[2]](diffhunk://#diff-afbd44c0f099151b685659a715ac044166654453365f23cbc7edd62bc52194b4L31)`, `[[3]](diffhunk://#diff-afbd44c0f099151b685659a715ac044166654453365f23cbc7edd62bc52194b4L52)`, `[[4]](diffhunk://#diff-afbd44c0f099151b685659a715ac044166654453365f23cbc7edd62bc52194b4L105)`, `[[5]](diffhunk://#diff-afbd44c0f099151b685659a715ac044166654453365f23cbc7edd62bc52194b4L144-L151)`, `[[6]](diffhunk://#diff-afbd44c0f099151b685659a715ac044166654453365f23cbc7edd62bc52194b4L178)`)

### Enhancements to `AiResponseType`:

* Added an `icon` getter to `AiResponseType` to provide an appropriate icon for each response type, replacing the `_getIconForPromptType` helper function. (`[lib/features/ai/state/consts.dartR35-R48](diffhunk://#diff-d4968c4a680a61595e5b8e9dab6c64cf33376e81f433065a5da25f0bee1dfd7fR35-R48)`)

### UI Improvements:

* Updated the `PreconfiguredPromptTile` and modal selection components to use the `icon` getter from `AiResponseType` for displaying icons. (`[[1]](diffhunk://#diff-3fcf048dcc41fa8cacb9cdb64c6142420f4d79a7fe6eef0f9b33068c729beb20L23-R29)`, `[[2]](diffhunk://#diff-3fcf048dcc41fa8cacb9cdb64c6142420f4d79a7fe6eef0f9b33068c729beb20L36-L51)`, `[[3]](diffhunk://#diff-3fcf048dcc41fa8cacb9cdb64c6142420f4d79a7fe6eef0f9b33068c729beb20L77-R63)`)
* Refactored the `_getInputTypeLabel` function to use the `displayName` method from `InputDataType`, improving context-based localization. (`[[1]](diffhunk://#diff-3fcf048dcc41fa8cacb9cdb64c6142420f4d79a7fe6eef0f9b33068c729beb20L104-R90)`, `[[2]](diffhunk://#diff-3fcf048dcc41fa8cacb9cdb64c6142420f4d79a7fe6eef0f9b33068c729beb20L134-R121)`)

### Localization Updates:

* Added new localization keys (`promptSelectionModalTitle` and `promptUsePreconfiguredButton`) and integrated them into the UI for better internationalization support. (`[[1]](diffhunk://#diff-9796fde3771f42a3a759ccc941731d83f96037a661e47dde27ce81d3447a69c2R343-R344)`, `[[2]](diffhunk://#diff-86a65e07f881bf3da78e06902f92759b712cf3c498529e6478a49914c85fa69eR1842-R1853)`, `[[3]](diffhunk://#diff-c3b640c659667189d01f9b62febb8d1053d8442613fbf579ebfdcfa8e55e2122R941-R946)`, `[[4]](diffhunk://#diff-e60f92e17bf4747aae4f57a00d2503eea8ce33d7d8366867ef7657259ec5845eR937-R942)`, `[[5]](diffhunk://#diff-3334cc67d149f2a2039619b319f023e9655825b81ac49d90cc0b2380d1ca2fe3R945-R950)`, `[[6]](diffhunk://#diff-32807699943784dc8a5f8cdefee91f79e2e4d8528dff62d1e86e8fd895dc8a8eR949-R954)`, `[[7]](diffhunk://#diff-1417f11fea5a62bf0f8061f8ded1ed910151d855ba838939562354b0dfbee549R940-R945)`)

### Test Updates:

* Updated tests to reflect changes in `PreconfiguredPrompt` and `AiResponseType`, including the removal of the `type` field and the addition of localization delegates. (`[[1]](diffhunk://#diff-fb288bbf158a47009c79082c3cd9a2656c10261c95f0094d420c596c1fb44e1eR2-R9)`, `[[2]](diffhunk://#diff-fb288bbf158a47009c79082c3cd9a2656c10261c95f0094d420c596c1fb44e1eR28-R35)`, `[[3]](diffhunk://#diff-fb288bbf158a47009c79082c3cd9a2656c10261c95f0094d420c596c1fb44e1eR92-R99)`, `[[4]](diffhunk://#diff-fb288bbf158a47009c79082c3cd9a2656c10261c95f0094d420c596c1fb44e1eR129-R136)`, `[[5]](diffhunk://#diff-fb288bbf158a47009c79082c3cd9a2656c10261c95f0094d420c596c1fb44e1eL151-R179)`, `[[6]](diffhunk://#diff-fb288bbf158a47009c79082c3cd9a2656c10261c95f0094d420c596c1fb44e1eL196)`, `[[7]](diffhunk://#diff-fb288bbf158a47009c79082c3cd9a2656c10261c95f0094d420c596c1fb44e1eL220-R247)`, `[[8]](diffhunk://#diff-fb288bbf158a47009c79082c3cd9a2656c10261c95f0094d420c596c1fb44e1eL260)`, `[[9]](diffhunk://#diff-fb288bbf158a47009c79082c3cd9a2656c10261c95f0094d420c596c1fb44e1eL299-L303)`)