### PR TITLE
fix: image analysis with Gemini

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -24,7 +24,7 @@ PODS:
     - OpenSSL-Universal
   - flutter_secure_storage (6.0.0):
     - Flutter
-  - health (12.2.0):
+  - health (12.2.1):
     - Flutter
   - image_picker_ios (0.0.1):
     - Flutter
@@ -242,7 +242,7 @@ SPEC CHECKSUMS:
   flutter_olm: 381bdf22eaeb0b5120539a79fb45199e2dbef163
   flutter_openssl_crypto: 73dcefff7611c3ac324d82726047d8335d0b6e57
   flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
-  health: 5f06d2b77cede1909be85dcd588570668caa5be2
+  health: fe206e65f13a9b88623605fbd8af8f029e23dc35
   image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   irondash_engine_context: 8e58ca8e0212ee9d1c7dc6a42121849986c88486

--- a/lib/features/ai/repository/cloud_inference_repository.dart
+++ b/lib/features/ai/repository/cloud_inference_repository.dart
@@ -70,7 +70,7 @@ class CloudInferenceRepository {
                   (image) {
                     return ChatCompletionMessageContentPart.image(
                       imageUrl: ChatCompletionMessageImageUrl(
-                        url: 'data:image;base64,{$image}',
+                        url: 'data:image/jpeg;base64,$image',
                       ),
                     );
                   },

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1268,10 +1268,10 @@ packages:
     dependency: "direct main"
     description:
       name: health
-      sha256: "4c7458f35e5e74f709e99af5e7f5d78d4b2ac25b09d6a70eedec1c7b5cf091e8"
+      sha256: "0432c4e5c5348164adff57e78ca3191c88f0cdf7c2b0d72b6785a6af965177ac"
       url: "https://pub.dev"
     source: hosted
-    version: "12.2.0"
+    version: "12.2.1"
   hotkey_manager:
     dependency: "direct main"
     description:
@@ -1713,10 +1713,10 @@ packages:
     dependency: "direct main"
     description:
       name: matrix
-      sha256: "7d15fdbc760be7e40c58bb65e03baa8241b1e31db2bc67dab61883aabc083a85"
+      sha256: "6646a39b95005f0b1df2d8aaeb71edb0a3cbeb6e13f433bd4f8a32013b273a58"
       url: "https://pub.dev"
     source: hosted
-    version: "0.40.0"
+    version: "0.40.1"
   media_kit:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.611+3059
+version: 0.9.611+3060
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.611+3060
+version: 0.9.611+3062
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This pull request includes updates to the `CloudInferenceRepository` class to fix the image URL format and changes to the `pubspec.yaml` file to increment the version number.

**Updates to image URL format:**

* [`lib/features/ai/repository/cloud_inference_repository.dart`](diffhunk://#diff-64ddb4da404a5c1b05d6a6ebedfb69a1008cf17d70c0067a368753dfc068413fL73-R73): Modified the `url` field in `ChatCompletionMessageImageUrl` to use the correct MIME type (`image/jpeg`) instead of the previous incorrect format (`image`).

**Version increment:**

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Updated the version number from `0.9.611+3059` to `0.9.611+3062` for tracking changes.