### PR TITLE
feat: add known models for OpenRouter and Anthropic

### DIFF
--- a/lib/features/ai/state/inference_provider_form_controller.dart
+++ b/lib/features/ai/state/inference_provider_form_controller.dart
@@ -136,6 +136,18 @@ class InferenceProviderFormController
         newName = 'OpenAI';
       }
     }
+    if (value == InferenceProviderType.anthropic) {
+      newBaseUrl = 'https://api.anthropic.com/v1';
+      if (nameController.text.isEmpty) {
+        newName = 'Anthropic';
+      }
+    }
+    if (value == InferenceProviderType.openRouter) {
+      newBaseUrl = 'https://openrouter.ai/api/v1';
+      if (nameController.text.isEmpty) {
+        newName = 'OpenRouter';
+      }
+    }
 
     // Update text controllers if needed
     if (newBaseUrl != null) {

--- a/lib/features/ai/util/known_models.dart
+++ b/lib/features/ai/util/known_models.dart
@@ -57,6 +57,8 @@ const Map<InferenceProviderType, List<KnownModel>> knownModelsByProvider = {
   InferenceProviderType.nebiusAiStudio: nebiusModels,
   InferenceProviderType.ollama: ollamaModels,
   InferenceProviderType.openAi: openaiModels,
+  InferenceProviderType.anthropic: anthropicModels,
+  InferenceProviderType.openRouter: openRouterModels,
 };
 
 /// Gemini models - Google's multimodal AI models
@@ -124,30 +126,102 @@ const List<KnownModel> ollamaModels = [
 /// OpenAI models - Advanced language and multimodal models
 const List<KnownModel> openaiModels = [
   KnownModel(
-    providerModelId: 'gpt-4',
+    providerModelId: 'gpt-4.1-2025-04-14',
     name: 'GPT-4',
-    inputModalities: [Modality.text],
+    inputModalities: [Modality.text, Modality.image],
     outputModalities: [Modality.text],
-    isReasoningModel: true,
-    description: 'Most capable model for complex reasoning and analysis',
+    isReasoningModel: false,
+    description: 'Flagship GPT model for complex tasks',
   ),
   KnownModel(
-    providerModelId: 'gpt-4-turbo',
-    name: 'GPT-4 Turbo',
+    providerModelId: 'o3-2025-04-16',
+    name: 'o3',
+    inputModalities: [Modality.text, Modality.image],
+    outputModalities: [Modality.text],
+    isReasoningModel: true,
+    description: 'Our most powerful reasoning model',
+  ),
+  KnownModel(
+    providerModelId: 'o4-mini',
+    name: 'o4-mini-2025-04-16',
+    inputModalities: [Modality.text, Modality.image],
+    outputModalities: [Modality.text],
+    isReasoningModel: true,
+    description: 'Faster, more affordable reasoning model',
+  ),
+];
+
+/// Anthropic models - Advanced language and multimodal models
+const List<KnownModel> anthropicModels = [
+  KnownModel(
+    providerModelId: 'claude-opus-4-20250514',
+    name: 'Claude Opus 4',
+    inputModalities: [Modality.text, Modality.image],
+    outputModalities: [Modality.text],
+    isReasoningModel: true,
+    description: 'Highest level of intelligence and capability',
+  ),
+  KnownModel(
+    providerModelId: 'claude-sonnet-4-20250514',
+    name: 'Claude Sonnet 4',
+    inputModalities: [Modality.text, Modality.image],
+    outputModalities: [Modality.text],
+    isReasoningModel: true,
+    description: 'High intelligence and balanced performance',
+  ),
+  KnownModel(
+    providerModelId: 'claude-3-5-haiku-20241022',
+    name: 'Claude Haiku 3.5',
+    inputModalities: [Modality.text, Modality.image],
+    outputModalities: [Modality.text],
+    isReasoningModel: false,
+    description: 'Intelligence at blazing speeds',
+  ),
+];
+
+/// OpenRouter models - Advanced language and multimodal models
+const List<KnownModel> openRouterModels = [
+  KnownModel(
+    providerModelId: 'anthropic/claude-opus-4',
+    name: 'Anthropic: Claude Opus 4',
+    inputModalities: [Modality.text, Modality.image],
+    outputModalities: [Modality.text],
+    isReasoningModel: true,
+    description: 'Highest level of intelligence and capability',
+  ),
+  KnownModel(
+    providerModelId: 'anthropic/claude-sonnet-4',
+    name: 'Anthropic: Claude Sonnet 4',
+    inputModalities: [Modality.text, Modality.image],
+    outputModalities: [Modality.text],
+    isReasoningModel: true,
+    description: 'High intelligence and balanced performance',
+  ),
+  KnownModel(
+    providerModelId: 'openai/o4-mini',
+    name: 'OpenAI: o4 Mini',
+    inputModalities: [Modality.text, Modality.image],
+    outputModalities: [Modality.text],
+    isReasoningModel: true,
+    description: 'OpenAI o4-mini is a compact reasoning model in the o-series.',
+  ),
+  KnownModel(
+    providerModelId: 'openai/o4-mini-high',
+    name: 'OpenAI: o4 Mini High',
+    inputModalities: [Modality.text, Modality.image],
+    outputModalities: [Modality.text],
+    isReasoningModel: true,
+    description:
+        'OpenAI o4-mini-high is the same model as o4-mini with reasoning_effort set to high',
+  ),
+  KnownModel(
+    providerModelId: 'openai/gpt-4.1',
+    name: 'OpenAI: GPT-4.1',
     inputModalities: [Modality.text, Modality.image],
     outputModalities: [Modality.text],
     isReasoningModel: false,
     description:
-        'Latest GPT-4 model with vision capabilities and 128K context window',
-  ),
-  KnownModel(
-    providerModelId: 'gpt-3.5-turbo',
-    name: 'GPT-3.5 Turbo',
-    inputModalities: [Modality.text],
-    outputModalities: [Modality.text],
-    isReasoningModel: true,
-    description:
-        'Fast and efficient model with 16K context window for text-based tasks',
+        'GPT-4.1 is a flagship large language model optimized for advanced instruction following, real-world software engineering, and long-context reasoning.',
   ),
 ];
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.611+3063
+version: 0.9.612+3064
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This pull request introduces support for two new inference providers, Anthropic and OpenRouter, along with updates to the known models and configuration files. The most important changes include adding logic for these providers in the form controller, updating the known models mapping, and defining new models for these providers. Additionally, there is a minor version update in the project configuration.

### Support for new inference providers:

* [`lib/features/ai/state/inference_provider_form_controller.dart`](diffhunk://#diff-0b6f81620300b8553952fcfd430685aa83fcf177f5affa4273d3619e6165b765R139-R150): Added logic to handle `InferenceProviderType.anthropic` and `InferenceProviderType.openRouter`, including default base URLs and names.

* [`lib/features/ai/util/known_models.dart`](diffhunk://#diff-ed4907bc1ae36989b0a195c87724b3e6f672c512e7b3f0429fe250d6c703e4f2R60-R61): Updated the `knownModelsByProvider` map to include entries for `InferenceProviderType.anthropic` and `InferenceProviderType.openRouter`.

### Updates to known models:

* [`lib/features/ai/util/known_models.dart`](diffhunk://#diff-ed4907bc1ae36989b0a195c87724b3e6f672c512e7b3f0429fe250d6c703e4f2L127-R224): Added detailed definitions for models under Anthropic and OpenRouter providers, including properties like input/output modalities, reasoning capabilities, and descriptions. Updated OpenAI models with new identifiers and descriptions.

### Project configuration:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Incremented the project version from `0.9.611+3063` to `0.9.612+3064`.