### PR TITLE
fix: sleep import data types & updated library

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -24,7 +24,7 @@ PODS:
     - OpenSSL-Universal
   - flutter_secure_storage (6.0.0):
     - Flutter
-  - health (12.2.1):
+  - health (13.1.0):
     - Flutter
   - image_picker_ios (0.0.1):
     - Flutter
@@ -242,7 +242,7 @@ SPEC CHECKSUMS:
   flutter_olm: 381bdf22eaeb0b5120539a79fb45199e2dbef163
   flutter_openssl_crypto: 73dcefff7611c3ac324d82726047d8335d0b6e57
   flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
-  health: fe206e65f13a9b88623605fbd8af8f029e23dc35
+  health: e42053a628b0e9a2de7c78d4a01bf9d90ce33d76
   image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   irondash_engine_context: 8e58ca8e0212ee9d1c7dc6a42121849986c88486

--- a/lib/features/dashboards/config/dashboard_health_config.dart
+++ b/lib/features/dashboards/config/dashboard_health_config.dart
@@ -139,25 +139,25 @@ Map<String, HealthTypeConfig> healthTypes = {
     hoursMinutes: true,
     unit: 'h',
   ),
-  'HealthDataType.SLEEP_ASLEEP_CORE': HealthTypeConfig(
-    displayName: 'Asleep - core',
-    healthType: 'HealthDataType.SLEEP_ASLEEP_CORE',
+  'HealthDataType.SLEEP_LIGHT': HealthTypeConfig(
+    displayName: 'Asleep - light',
+    healthType: 'HealthDataType.SLEEP_LIGHT',
     chartType: HealthChartType.barChart,
     aggregationType: HealthAggregationType.dailyTimeSum,
     hoursMinutes: true,
     unit: 'h',
   ),
-  'HealthDataType.SLEEP_ASLEEP_DEEP': HealthTypeConfig(
+  'HealthDataType.SLEEP_DEEP': HealthTypeConfig(
     displayName: 'Asleep - deep',
-    healthType: 'HealthDataType.SLEEP_ASLEEP_DEEP',
+    healthType: 'HealthDataType.SLEEP_DEEP',
     chartType: HealthChartType.barChart,
     aggregationType: HealthAggregationType.dailyTimeSum,
     hoursMinutes: true,
     unit: 'h',
   ),
-  'HealthDataType.SLEEP_ASLEEP_REM': HealthTypeConfig(
+  'HealthDataType.SLEEP_REM': HealthTypeConfig(
     displayName: 'Asleep - REM',
-    healthType: 'HealthDataType.SLEEP_ASLEEP_REM',
+    healthType: 'HealthDataType.SLEEP_REM',
     chartType: HealthChartType.barChart,
     aggregationType: HealthAggregationType.dailyTimeSum,
     hoursMinutes: true,

--- a/lib/logic/health_import.dart
+++ b/lib/logic/health_import.dart
@@ -158,9 +158,10 @@ class HealthImport {
     if (isDesktop) {
       return false;
     }
+    final allowed = health.requestAuthorization(types);
     await health.requestHealthDataHistoryAuthorization();
     await health.requestHealthDataInBackgroundAuthorization();
-    return health.requestAuthorization(types);
+    return allowed;
   }
 
   Future<void> fetchHealthData({

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1260,10 +1260,10 @@ packages:
     dependency: "direct main"
     description:
       name: health
-      sha256: "0432c4e5c5348164adff57e78ca3191c88f0cdf7c2b0d72b6785a6af965177ac"
+      sha256: "8f809e4f3483353976e4e3e50f5755af8bc6ae8f2e8b82f6d88c818617311bde"
       url: "https://pub.dev"
     source: hosted
-    version: "12.2.1"
+    version: "13.1.0"
   hotkey_manager:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.613+3078
+version: 0.9.614+3079
 
 msix_config:
   display_name: LottiApp
@@ -79,7 +79,7 @@ dependencies:
   google_fonts: ^6.1.0
   gpt_markdown: ^1.0.11
   graphic: ^2.3.0
-  health: ^12.2.0
+  health: ^13.1.0
   hotkey_manager: ^0.2.0
   infinite_scroll_pagination: ^5.0.0
   intersperse: ^2.0.0


### PR DESCRIPTION
This pull request includes updates to the health data configuration, authorization flow, and dependencies, along with a version bump for the application. Below is a summary of the most significant changes:

### Health Data Configuration Updates:
* Renamed several health data keys and their associated configurations in `dashboard_health_config.dart` to align with updated naming conventions:
  - `'HealthDataType.SLEEP_ASLEEP_CORE'` → `'HealthDataType.SLEEP_LIGHT'`
  - `'HealthDataType.SLEEP_ASLEEP_DEEP'` → `'HealthDataType.SLEEP_DEEP'`
  - `'HealthDataType.SLEEP_ASLEEP_REM'` → `'HealthDataType.SLEEP_REM'`

### Authorization Flow Adjustment:
* Refactored the health data authorization logic in `health_import.dart` to store the result of `requestAuthorization` in a variable (`allowed`) for reuse, ensuring consistent behavior.

### Dependency and Version Updates:
* Updated the `health` package dependency from `^12.2.0` to `^13.1.0` in `pubspec.yaml`.
* Bumped the application version from `0.9.613+3078` to `0.9.614+3079` in `pubspec.yaml`.