### PR TITLE
feat: add maxOutputTokens field & fix anthropic issue

### DIFF
--- a/lib/features/ai/model/ai_config.dart
+++ b/lib/features/ai/model/ai_config.dart
@@ -52,6 +52,7 @@ class AiConfig with _$AiConfig {
     required bool isReasoningModel,
     DateTime? updatedAt,
     String? description,
+    int? maxCompletionTokens,
   }) = AiConfigModel;
 
   const factory AiConfig.prompt({

--- a/lib/features/ai/model/ai_config.freezed.dart
+++ b/lib/features/ai/model/ai_config.freezed.dart
@@ -58,7 +58,8 @@ mixin _$AiConfig {
             List<Modality> outputModalities,
             bool isReasoningModel,
             DateTime? updatedAt,
-            String? description)
+            String? description,
+            int? maxCompletionTokens)
         model,
     required TResult Function(
             String id,
@@ -102,7 +103,8 @@ mixin _$AiConfig {
             List<Modality> outputModalities,
             bool isReasoningModel,
             DateTime? updatedAt,
-            String? description)?
+            String? description,
+            int? maxCompletionTokens)?
         model,
     TResult? Function(
             String id,
@@ -146,7 +148,8 @@ mixin _$AiConfig {
             List<Modality> outputModalities,
             bool isReasoningModel,
             DateTime? updatedAt,
-            String? description)?
+            String? description,
+            int? maxCompletionTokens)?
         model,
     TResult Function(
             String id,
@@ -441,7 +444,8 @@ class _$AiConfigInferenceProviderImpl implements AiConfigInferenceProvider {
             List<Modality> outputModalities,
             bool isReasoningModel,
             DateTime? updatedAt,
-            String? description)
+            String? description,
+            int? maxCompletionTokens)
         model,
     required TResult Function(
             String id,
@@ -489,7 +493,8 @@ class _$AiConfigInferenceProviderImpl implements AiConfigInferenceProvider {
             List<Modality> outputModalities,
             bool isReasoningModel,
             DateTime? updatedAt,
-            String? description)?
+            String? description,
+            int? maxCompletionTokens)?
         model,
     TResult? Function(
             String id,
@@ -537,7 +542,8 @@ class _$AiConfigInferenceProviderImpl implements AiConfigInferenceProvider {
             List<Modality> outputModalities,
             bool isReasoningModel,
             DateTime? updatedAt,
-            String? description)?
+            String? description,
+            int? maxCompletionTokens)?
         model,
     TResult Function(
             String id,
@@ -663,7 +669,8 @@ abstract class _$$AiConfigModelImplCopyWith<$Res>
       List<Modality> outputModalities,
       bool isReasoningModel,
       DateTime? updatedAt,
-      String? description});
+      String? description,
+      int? maxCompletionTokens});
 }
 
 /// @nodoc
@@ -689,6 +696,7 @@ class __$$AiConfigModelImplCopyWithImpl<$Res>
     Object? isReasoningModel = null,
     Object? updatedAt = freezed,
     Object? description = freezed,
+    Object? maxCompletionTokens = freezed,
   }) {
     return _then(_$AiConfigModelImpl(
       id: null == id
@@ -731,6 +739,10 @@ class __$$AiConfigModelImplCopyWithImpl<$Res>
           ? _value.description
           : description // ignore: cast_nullable_to_non_nullable
               as String?,
+      maxCompletionTokens: freezed == maxCompletionTokens
+          ? _value.maxCompletionTokens
+          : maxCompletionTokens // ignore: cast_nullable_to_non_nullable
+              as int?,
     ));
   }
 }
@@ -749,6 +761,7 @@ class _$AiConfigModelImpl implements AiConfigModel {
       required this.isReasoningModel,
       this.updatedAt,
       this.description,
+      this.maxCompletionTokens,
       final String? $type})
       : _inputModalities = inputModalities,
         _outputModalities = outputModalities,
@@ -790,13 +803,15 @@ class _$AiConfigModelImpl implements AiConfigModel {
   final DateTime? updatedAt;
   @override
   final String? description;
+  @override
+  final int? maxCompletionTokens;
 
   @JsonKey(name: 'runtimeType')
   final String $type;
 
   @override
   String toString() {
-    return 'AiConfig.model(id: $id, name: $name, providerModelId: $providerModelId, inferenceProviderId: $inferenceProviderId, createdAt: $createdAt, inputModalities: $inputModalities, outputModalities: $outputModalities, isReasoningModel: $isReasoningModel, updatedAt: $updatedAt, description: $description)';
+    return 'AiConfig.model(id: $id, name: $name, providerModelId: $providerModelId, inferenceProviderId: $inferenceProviderId, createdAt: $createdAt, inputModalities: $inputModalities, outputModalities: $outputModalities, isReasoningModel: $isReasoningModel, updatedAt: $updatedAt, description: $description, maxCompletionTokens: $maxCompletionTokens)';
   }
 
   @override
@@ -821,7 +836,9 @@ class _$AiConfigModelImpl implements AiConfigModel {
             (identical(other.updatedAt, updatedAt) ||
                 other.updatedAt == updatedAt) &&
             (identical(other.description, description) ||
-                other.description == description));
+                other.description == description) &&
+            (identical(other.maxCompletionTokens, maxCompletionTokens) ||
+                other.maxCompletionTokens == maxCompletionTokens));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
@@ -837,7 +854,8 @@ class _$AiConfigModelImpl implements AiConfigModel {
       const DeepCollectionEquality().hash(_outputModalities),
       isReasoningModel,
       updatedAt,
-      description);
+      description,
+      maxCompletionTokens);
 
   /// Create a copy of AiConfig
   /// with the given fields replaced by the non-null parameter values.
@@ -870,7 +888,8 @@ class _$AiConfigModelImpl implements AiConfigModel {
             List<Modality> outputModalities,
             bool isReasoningModel,
             DateTime? updatedAt,
-            String? description)
+            String? description,
+            int? maxCompletionTokens)
         model,
     required TResult Function(
             String id,
@@ -901,7 +920,8 @@ class _$AiConfigModelImpl implements AiConfigModel {
         outputModalities,
         isReasoningModel,
         updatedAt,
-        description);
+        description,
+        maxCompletionTokens);
   }
 
   @override
@@ -927,7 +947,8 @@ class _$AiConfigModelImpl implements AiConfigModel {
             List<Modality> outputModalities,
             bool isReasoningModel,
             DateTime? updatedAt,
-            String? description)?
+            String? description,
+            int? maxCompletionTokens)?
         model,
     TResult? Function(
             String id,
@@ -958,7 +979,8 @@ class _$AiConfigModelImpl implements AiConfigModel {
         outputModalities,
         isReasoningModel,
         updatedAt,
-        description);
+        description,
+        maxCompletionTokens);
   }
 
   @override
@@ -984,7 +1006,8 @@ class _$AiConfigModelImpl implements AiConfigModel {
             List<Modality> outputModalities,
             bool isReasoningModel,
             DateTime? updatedAt,
-            String? description)?
+            String? description,
+            int? maxCompletionTokens)?
         model,
     TResult Function(
             String id,
@@ -1017,7 +1040,8 @@ class _$AiConfigModelImpl implements AiConfigModel {
           outputModalities,
           isReasoningModel,
           updatedAt,
-          description);
+          description,
+          maxCompletionTokens);
     }
     return orElse();
   }
@@ -1076,7 +1100,8 @@ abstract class AiConfigModel implements AiConfig {
       required final List<Modality> outputModalities,
       required final bool isReasoningModel,
       final DateTime? updatedAt,
-      final String? description}) = _$AiConfigModelImpl;
+      final String? description,
+      final int? maxCompletionTokens}) = _$AiConfigModelImpl;
 
   factory AiConfigModel.fromJson(Map<String, dynamic> json) =
       _$AiConfigModelImpl.fromJson;
@@ -1096,6 +1121,7 @@ abstract class AiConfigModel implements AiConfig {
   DateTime? get updatedAt;
   @override
   String? get description;
+  int? get maxCompletionTokens;
 
   /// Create a copy of AiConfig
   /// with the given fields replaced by the non-null parameter values.
@@ -1411,7 +1437,8 @@ class _$AiConfigPromptImpl implements AiConfigPrompt {
             List<Modality> outputModalities,
             bool isReasoningModel,
             DateTime? updatedAt,
-            String? description)
+            String? description,
+            int? maxCompletionTokens)
         model,
     required TResult Function(
             String id,
@@ -1474,7 +1501,8 @@ class _$AiConfigPromptImpl implements AiConfigPrompt {
             List<Modality> outputModalities,
             bool isReasoningModel,
             DateTime? updatedAt,
-            String? description)?
+            String? description,
+            int? maxCompletionTokens)?
         model,
     TResult? Function(
             String id,
@@ -1537,7 +1565,8 @@ class _$AiConfigPromptImpl implements AiConfigPrompt {
             List<Modality> outputModalities,
             bool isReasoningModel,
             DateTime? updatedAt,
-            String? description)?
+            String? description,
+            int? maxCompletionTokens)?
         model,
     TResult Function(
             String id,

--- a/lib/features/ai/model/ai_config.g.dart
+++ b/lib/features/ai/model/ai_config.g.dart
@@ -66,6 +66,7 @@ _$AiConfigModelImpl _$$AiConfigModelImplFromJson(Map<String, dynamic> json) =>
           ? null
           : DateTime.parse(json['updatedAt'] as String),
       description: json['description'] as String?,
+      maxCompletionTokens: (json['maxCompletionTokens'] as num?)?.toInt(),
       $type: json['runtimeType'] as String?,
     );
 
@@ -83,6 +84,7 @@ Map<String, dynamic> _$$AiConfigModelImplToJson(_$AiConfigModelImpl instance) =>
       'isReasoningModel': instance.isReasoningModel,
       'updatedAt': instance.updatedAt?.toIso8601String(),
       'description': instance.description,
+      'maxCompletionTokens': instance.maxCompletionTokens,
       'runtimeType': instance.$type,
     };
 

--- a/lib/features/ai/model/inference_model_form_state.dart
+++ b/lib/features/ai/model/inference_model_form_state.dart
@@ -4,6 +4,7 @@ import 'package:lotti/utils/file_utils.dart';
 
 enum ModelFormError {
   tooShort,
+  invalidNumber,
 }
 
 // Input validation classes
@@ -37,6 +38,19 @@ class ModelDescription extends FormzInput<String, String> {
   }
 }
 
+class MaxCompletionTokens extends FormzInput<String, ModelFormError> {
+  const MaxCompletionTokens.pure([super.value = '']) : super.pure();
+  const MaxCompletionTokens.dirty([super.value = '']) : super.dirty();
+
+  @override
+  ModelFormError? validator(String value) {
+    if (value.isEmpty) return null; // Optional field
+    final intValue = int.tryParse(value);
+    if (intValue == null || intValue <= 0) return ModelFormError.invalidNumber;
+    return null;
+  }
+}
+
 // Form state class
 class InferenceModelFormState with FormzMixin {
   InferenceModelFormState({
@@ -44,6 +58,7 @@ class InferenceModelFormState with FormzMixin {
     this.name = const ModelName.pure(),
     this.providerModelId = const ProviderModelId.pure(),
     this.description = const ModelDescription.pure(),
+    this.maxCompletionTokens = const MaxCompletionTokens.pure(),
     this.inferenceProviderId = '',
     this.inputModalities = const [Modality.text],
     this.outputModalities = const [Modality.text],
@@ -56,6 +71,7 @@ class InferenceModelFormState with FormzMixin {
   final ModelName name;
   final ProviderModelId providerModelId;
   final ModelDescription description;
+  final MaxCompletionTokens maxCompletionTokens;
   final String inferenceProviderId;
   final List<Modality> inputModalities;
   final List<Modality> outputModalities;
@@ -68,6 +84,7 @@ class InferenceModelFormState with FormzMixin {
     ModelName? name,
     ProviderModelId? providerModelId,
     ModelDescription? description,
+    MaxCompletionTokens? maxCompletionTokens,
     String? inferenceProviderId,
     List<Modality>? inputModalities,
     List<Modality>? outputModalities,
@@ -79,6 +96,7 @@ class InferenceModelFormState with FormzMixin {
       id: id ?? this.id,
       name: name ?? this.name,
       description: description ?? this.description,
+      maxCompletionTokens: maxCompletionTokens ?? this.maxCompletionTokens,
       providerModelId: providerModelId ?? this.providerModelId,
       inferenceProviderId: inferenceProviderId ?? this.inferenceProviderId,
       inputModalities: inputModalities ?? this.inputModalities,
@@ -94,6 +112,7 @@ class InferenceModelFormState with FormzMixin {
         name,
         providerModelId,
         description,
+        maxCompletionTokens,
       ];
 
   // Convert form state to AiConfig model
@@ -108,6 +127,9 @@ class InferenceModelFormState with FormzMixin {
       inputModalities: inputModalities,
       outputModalities: outputModalities,
       isReasoningModel: isReasoningModel,
+      maxCompletionTokens: maxCompletionTokens.value.isEmpty
+          ? null
+          : int.tryParse(maxCompletionTokens.value),
     );
   }
 }

--- a/lib/features/ai/repository/cloud_inference_repository.dart
+++ b/lib/features/ai/repository/cloud_inference_repository.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:developer' as developer;
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openai_dart/openai_dart.dart';
@@ -21,13 +22,22 @@ class CloudInferenceRepository {
     stream.listen(
       controller.add,
       onError: (Object error, StackTrace stackTrace) {
-        // If the error is due to a ping message, skip it
-        if (error.toString().contains("type 'Null' is not a subtype") ||
-            error.toString().contains('choices')) {
+        // Check if this is specifically an Anthropic ping message error
+        final errorString = error.toString();
+
+        // Anthropic ping messages cause a specific null subtype error when parsing choices
+        final isAnthropicPingError = errorString.contains(
+                "type 'Null' is not a subtype of type 'List<dynamic>'") &&
+            errorString.contains('choices');
+
+        if (isAnthropicPingError) {
           // Log but don't propagate the error
-          // TODO: Replace with proper logging
-          // ignore: avoid_print
-          print('Skipping Anthropic ping message or malformed response');
+          developer.log(
+            'Skipping Anthropic ping message',
+            name: 'CloudInferenceRepository',
+            error: error,
+            stackTrace: stackTrace,
+          );
           return;
         }
         // Propagate other errors

--- a/lib/features/ai/repository/cloud_inference_repository.dart
+++ b/lib/features/ai/repository/cloud_inference_repository.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openai_dart/openai_dart.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -9,6 +11,34 @@ class CloudInferenceRepository {
 
   final Ref ref;
 
+  /// Filters out Anthropic ping messages from the stream
+  Stream<CreateChatCompletionStreamResponse> _filterAnthropicPings(
+    Stream<CreateChatCompletionStreamResponse> stream,
+  ) {
+    // Use where to filter out errors instead of handleError
+    final controller = StreamController<CreateChatCompletionStreamResponse>();
+
+    stream.listen(
+      controller.add,
+      onError: (Object error, StackTrace stackTrace) {
+        // If the error is due to a ping message, skip it
+        if (error.toString().contains("type 'Null' is not a subtype") ||
+            error.toString().contains('choices')) {
+          // Log but don't propagate the error
+          // TODO: Replace with proper logging
+          // ignore: avoid_print
+          print('Skipping Anthropic ping message or malformed response');
+          return;
+        }
+        // Propagate other errors
+        controller.addError(error, stackTrace);
+      },
+      onDone: controller.close,
+    );
+
+    return controller.stream;
+  }
+
   Stream<CreateChatCompletionStreamResponse> generate(
     String prompt, {
     required String model,
@@ -16,6 +46,7 @@ class CloudInferenceRepository {
     required String baseUrl,
     required String apiKey,
     String? systemMessage,
+    int? maxCompletionTokens,
     OpenAIClient? overrideClient,
   }) {
     final client = overrideClient ??
@@ -35,11 +66,12 @@ class CloudInferenceRepository {
         ],
         model: ChatCompletionModel.modelId(model),
         temperature: temperature,
+        maxCompletionTokens: maxCompletionTokens,
         stream: true,
       ),
     );
 
-    return res.asBroadcastStream();
+    return _filterAnthropicPings(res).asBroadcastStream();
   }
 
   Stream<CreateChatCompletionStreamResponse> generateWithImages(
@@ -49,6 +81,7 @@ class CloudInferenceRepository {
     required String model,
     required double temperature,
     required List<String> images,
+    int? maxCompletionTokens,
     OpenAIClient? overrideClient,
   }) {
     final client = overrideClient ??
@@ -79,6 +112,7 @@ class CloudInferenceRepository {
         ],
         model: ChatCompletionModel.modelId(model),
         temperature: temperature,
+        maxTokens: maxCompletionTokens,
         stream: true,
       ),
     );
@@ -92,6 +126,7 @@ class CloudInferenceRepository {
     required String apiKey,
     required String model,
     required String audioBase64,
+    int? maxCompletionTokens,
     OpenAIClient? overrideClient,
   }) {
     final client = overrideClient ??
@@ -119,6 +154,7 @@ class CloudInferenceRepository {
               ),
             ],
             model: ChatCompletionModel.modelId(model),
+            maxCompletionTokens: maxCompletionTokens,
             stream: true,
           ),
         )

--- a/lib/features/ai/repository/unified_ai_inference_repository.dart
+++ b/lib/features/ai/repository/unified_ai_inference_repository.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:developer' as developer;
 import 'dart:io';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/entry_text.dart';
@@ -252,7 +252,11 @@ class UnifiedAiInferenceRepository {
       return choices.firstOrNull?.delta?.content ?? '';
     } catch (e) {
       // Log error but continue processing stream
-      debugPrint('Error extracting text from chunk: $e');
+      developer.log(
+        'Error extracting text from chunk',
+        name: 'UnifiedAiInferenceRepository',
+        error: e,
+      );
       return '';
     }
   }

--- a/lib/features/ai/state/inference_model_form_controller.dart
+++ b/lib/features/ai/state/inference_model_form_controller.dart
@@ -12,6 +12,7 @@ class InferenceModelFormController extends _$InferenceModelFormController {
   final nameController = TextEditingController();
   final providerModelIdController = TextEditingController();
   final descriptionController = TextEditingController();
+  final maxCompletionTokensController = TextEditingController();
 
   AiConfigModel? _config;
 
@@ -27,11 +28,14 @@ class InferenceModelFormController extends _$InferenceModelFormController {
     nameController.text = _config?.name ?? '';
     providerModelIdController.text = _config?.providerModelId ?? '';
     descriptionController.text = _config?.description ?? '';
+    maxCompletionTokensController.text =
+        _config?.maxCompletionTokens?.toString() ?? '';
 
     ref.onDispose(() {
       nameController.dispose();
       providerModelIdController.dispose();
       descriptionController.dispose();
+      maxCompletionTokensController.dispose();
     });
 
     if (_config != null) {
@@ -40,6 +44,8 @@ class InferenceModelFormController extends _$InferenceModelFormController {
         name: ModelName.pure(_config!.name),
         providerModelId: ProviderModelId.pure(_config!.providerModelId),
         description: ModelDescription.pure(_config!.description ?? ''),
+        maxCompletionTokens: MaxCompletionTokens.pure(
+            _config!.maxCompletionTokens?.toString() ?? ''),
         inferenceProviderId: _config!.inferenceProviderId,
         inputModalities: _config!.inputModalities,
         outputModalities: _config!.outputModalities,
@@ -54,6 +60,7 @@ class InferenceModelFormController extends _$InferenceModelFormController {
     String? description,
     String? name,
     String? providerModelId,
+    String? maxCompletionTokens,
     String? inferenceProviderId,
     List<Modality>? inputModalities,
     List<Modality>? outputModalities,
@@ -82,6 +89,11 @@ class InferenceModelFormController extends _$InferenceModelFormController {
         providerModelId: providerModelId != null
             ? ProviderModelId.dirty(providerModelId)
             : prev.providerModelId,
+        maxCompletionTokens: maxCompletionTokens != null
+            ? MaxCompletionTokens.dirty(maxCompletionTokens)
+            : (isNonFormzFieldChanging && prev.maxCompletionTokens.isPure
+                ? MaxCompletionTokens.dirty(prev.maxCompletionTokens.value)
+                : prev.maxCompletionTokens),
         inferenceProviderId: inferenceProviderId,
         inputModalities: inputModalities,
         outputModalities: outputModalities,
@@ -109,6 +121,13 @@ class InferenceModelFormController extends _$InferenceModelFormController {
       descriptionController.text = value;
     }
     _setAllFields(description: value);
+  }
+
+  void maxCompletionTokensChanged(String value) {
+    if (maxCompletionTokensController.text != value) {
+      maxCompletionTokensController.text = value;
+    }
+    _setAllFields(maxCompletionTokens: value);
   }
 
   void inferenceProviderIdChanged(String value) {
@@ -155,6 +174,7 @@ class InferenceModelFormController extends _$InferenceModelFormController {
   void reset() {
     nameController.clear();
     descriptionController.clear();
+    maxCompletionTokensController.clear();
     state = AsyncData(InferenceModelFormState());
   }
 }

--- a/lib/features/ai/state/inference_model_form_controller.g.dart
+++ b/lib/features/ai/state/inference_model_form_controller.g.dart
@@ -7,7 +7,7 @@ part of 'inference_model_form_controller.dart';
 // **************************************************************************
 
 String _$inferenceModelFormControllerHash() =>
-    r'68d740eb2156dc9d4dc1cfe03560f0d698f86192';
+    r'e321802cc6f346168852e16edf25545fc3b990de';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/features/ai/ui/settings/enhanced_model_form.dart
+++ b/lib/features/ai/ui/settings/enhanced_model_form.dart
@@ -197,6 +197,18 @@ class _EnhancedInferenceModelFormState
                   minLines: 3,
                   helperText: 'Optional notes about this model configuration',
                 ),
+
+                const SizedBox(height: 24),
+
+                // Max Completion Tokens
+                EnhancedFormField(
+                  controller: formController.maxCompletionTokensController,
+                  labelText: 'Max Completion Tokens',
+                  onChanged: formController.maxCompletionTokensChanged,
+                  keyboardType: TextInputType.number,
+                  helperText:
+                      'Optional limit for response length (leave empty for unlimited)',
+                ),
               ],
             ),
 

--- a/lib/features/ai/ui/settings/inference_model_edit_page.dart
+++ b/lib/features/ai/ui/settings/inference_model_edit_page.dart
@@ -244,6 +244,17 @@ class _InferenceModelEditPageState
                 minLines: 2,
                 prefixIcon: Icons.description_rounded,
               ),
+
+              // Max Completion Tokens
+              AiTextField(
+                label: 'Max Completion Tokens',
+                hint: 'Optional - leave empty for unlimited',
+                controller: formController.maxCompletionTokensController,
+                onChanged: formController.maxCompletionTokensChanged,
+                validator: (_) => formState.maxCompletionTokens.error?.name,
+                keyboardType: TextInputType.number,
+                prefixIcon: Icons.numbers_rounded,
+              ),
             ],
           ),
           const SizedBox(height: 32),

--- a/lib/features/ai/ui/settings/inference_model_edit_page.dart
+++ b/lib/features/ai/ui/settings/inference_model_edit_page.dart
@@ -251,7 +251,8 @@ class _InferenceModelEditPageState
                 hint: 'Optional - leave empty for unlimited',
                 controller: formController.maxCompletionTokensController,
                 onChanged: formController.maxCompletionTokensChanged,
-                validator: (_) => formState.maxCompletionTokens.error?.name,
+                validator: (_) =>
+                    formState.maxCompletionTokens.error?.displayMessage,
                 keyboardType: TextInputType.number,
                 prefixIcon: Icons.numbers_rounded,
               ),

--- a/lib/features/ai/ui/settings/widgets/form_components/form_error_extension.dart
+++ b/lib/features/ai/ui/settings/widgets/form_components/form_error_extension.dart
@@ -7,6 +7,8 @@ extension ModelFormErrorExtension on ModelFormError {
     switch (this) {
       case ModelFormError.tooShort:
         return 'Must be at least 3 characters';
+      case ModelFormError.invalidNumber:
+        return 'Please enter a valid number';
     }
   }
 }

--- a/lib/features/ai/util/known_models.dart
+++ b/lib/features/ai/util/known_models.dart
@@ -23,6 +23,7 @@ class KnownModel {
     required this.outputModalities,
     required this.isReasoningModel,
     required this.description,
+    this.maxCompletionTokens,
   });
 
   final String providerModelId;
@@ -31,6 +32,7 @@ class KnownModel {
   final List<Modality> outputModalities;
   final bool isReasoningModel;
   final String description;
+  final int? maxCompletionTokens;
 
   /// Creates an AiConfigModel from this known model configuration
   AiConfigModel toAiConfigModel({
@@ -47,6 +49,7 @@ class KnownModel {
       outputModalities: outputModalities,
       isReasoningModel: isReasoningModel,
       description: description,
+      maxCompletionTokens: maxCompletionTokens,
     );
   }
 }
@@ -160,6 +163,7 @@ const List<KnownModel> anthropicModels = [
     outputModalities: [Modality.text],
     isReasoningModel: true,
     description: 'Highest level of intelligence and capability',
+    maxCompletionTokens: 2000,
   ),
   KnownModel(
     providerModelId: 'claude-sonnet-4-20250514',
@@ -168,6 +172,7 @@ const List<KnownModel> anthropicModels = [
     outputModalities: [Modality.text],
     isReasoningModel: true,
     description: 'High intelligence and balanced performance',
+    maxCompletionTokens: 2000,
   ),
   KnownModel(
     providerModelId: 'claude-3-5-haiku-20241022',
@@ -176,6 +181,7 @@ const List<KnownModel> anthropicModels = [
     outputModalities: [Modality.text],
     isReasoningModel: false,
     description: 'Intelligence at blazing speeds',
+    maxCompletionTokens: 2000,
   ),
 ];
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -26,13 +26,13 @@ packages:
     source: hosted
     version: "7.4.5"
   analyzer_plugin:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: analyzer_plugin
-      sha256: "1d460d14e3c2ae36dc2b32cef847c4479198cf87704f63c3c3c8150ee50c3916"
+      sha256: ee188b6df6c85f1441497c7171c84f1392affadc0384f71089cb10a3bc508cef
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.0"
+    version: "0.13.1"
   ansicolor:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.615+3080
+version: 0.9.615+3081
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -145,6 +145,7 @@ dependencies:
   wolt_modal_sheet: ^0.11.0
 
 dependency_overrides:
+  analyzer_plugin: ^0.13.1
   flutter_math_fork: 0.7.3
   get_it: ^8.0.2
   rxdart: ^0.28.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.614+3079
+version: 0.9.615+3080
 
 msix_config:
   display_name: LottiApp

--- a/test/features/ai/model/inference_model_form_state_test.dart
+++ b/test/features/ai/model/inference_model_form_state_test.dart
@@ -1,0 +1,345 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/model/inference_model_form_state.dart';
+
+void main() {
+  group('InferenceModelFormState Tests', () {
+    group('Input Validation Classes', () {
+      test('ModelName validation', () {
+        const validName = ModelName.dirty('Valid Model Name');
+        const shortName = ModelName.dirty('Ab');
+        const emptyName = ModelName.dirty();
+        const exactlyThree = ModelName.dirty('ABC');
+
+        expect(validName.isValid, isTrue);
+        expect(validName.error, isNull);
+
+        expect(shortName.isValid, isFalse);
+        expect(shortName.error, ModelFormError.tooShort);
+
+        expect(emptyName.isValid, isFalse);
+        expect(emptyName.error, ModelFormError.tooShort);
+
+        expect(exactlyThree.isValid, isTrue);
+        expect(exactlyThree.error, isNull);
+      });
+
+      test('ProviderModelId validation', () {
+        const validId = ProviderModelId.dirty('gpt-4o');
+        const shortId = ProviderModelId.dirty('gp');
+        const emptyId = ProviderModelId.dirty();
+        const exactlyThree = ProviderModelId.dirty('gpt');
+
+        expect(validId.isValid, isTrue);
+        expect(validId.error, isNull);
+
+        expect(shortId.isValid, isFalse);
+        expect(shortId.error, ModelFormError.tooShort);
+
+        expect(emptyId.isValid, isFalse);
+        expect(emptyId.error, ModelFormError.tooShort);
+
+        expect(exactlyThree.isValid, isTrue);
+        expect(exactlyThree.error, isNull);
+      });
+
+      test('ModelDescription validation', () {
+        const description = ModelDescription.dirty('Some description');
+        final longDescription =
+            ModelDescription.dirty('A very long description ' * 50);
+        const emptyDescription = ModelDescription.dirty();
+
+        expect(description.isValid, isTrue);
+        expect(description.error, isNull);
+
+        expect(longDescription.isValid, isTrue);
+        expect(longDescription.error, isNull);
+
+        expect(emptyDescription.isValid, isTrue); // Optional field
+        expect(emptyDescription.error, isNull);
+      });
+
+      test('MaxCompletionTokens validation', () {
+        const validTokens = MaxCompletionTokens.dirty('1000');
+        const largeTokens = MaxCompletionTokens.dirty('999999');
+        const emptyTokens = MaxCompletionTokens.dirty();
+        const invalidTokens = MaxCompletionTokens.dirty('abc');
+        const negativeTokens = MaxCompletionTokens.dirty('-100');
+        const zeroTokens = MaxCompletionTokens.dirty('0');
+        const decimalTokens = MaxCompletionTokens.dirty('100.5');
+
+        expect(validTokens.isValid, isTrue);
+        expect(validTokens.error, isNull);
+
+        expect(largeTokens.isValid, isTrue);
+        expect(largeTokens.error, isNull);
+
+        expect(emptyTokens.isValid, isTrue); // Optional field
+        expect(emptyTokens.error, isNull);
+
+        expect(invalidTokens.isValid, isFalse);
+        expect(invalidTokens.error, ModelFormError.invalidNumber);
+
+        expect(negativeTokens.isValid, isFalse);
+        expect(negativeTokens.error, ModelFormError.invalidNumber);
+
+        expect(zeroTokens.isValid, isFalse);
+        expect(zeroTokens.error, ModelFormError.invalidNumber);
+
+        expect(decimalTokens.isValid, isFalse);
+        expect(decimalTokens.error, ModelFormError.invalidNumber);
+      });
+
+      test('Pure vs Dirty states', () {
+        const pureName = ModelName.pure('Test');
+        const dirtyName = ModelName.dirty('Test');
+
+        expect(pureName.isPure, isTrue);
+        expect(dirtyName.isPure, isFalse);
+      });
+    });
+
+    group('InferenceModelFormState', () {
+      test('Default constructor creates valid state', () {
+        final state = InferenceModelFormState();
+
+        expect(state.id, isNull);
+        expect(state.name.value, isEmpty);
+        expect(state.providerModelId.value, isEmpty);
+        expect(state.description.value, isEmpty);
+        expect(state.maxCompletionTokens.value, isEmpty);
+        expect(state.inferenceProviderId, isEmpty);
+        expect(state.inputModalities, equals([Modality.text]));
+        expect(state.outputModalities, equals([Modality.text]));
+        expect(state.isReasoningModel, isFalse);
+        expect(state.isSubmitting, isFalse);
+        expect(state.submitFailed, isFalse);
+        expect(state.isValid,
+            isFalse); // Invalid because required fields are empty
+      });
+
+      test('Constructor with all parameters', () {
+        final state = InferenceModelFormState(
+          id: 'test-id',
+          name: const ModelName.dirty('Test Model'),
+          providerModelId: const ProviderModelId.dirty('test-model-id'),
+          description: const ModelDescription.dirty('Test description'),
+          maxCompletionTokens: const MaxCompletionTokens.dirty('2000'),
+          inferenceProviderId: 'provider-id',
+          inputModalities: [Modality.text, Modality.image],
+          outputModalities: [Modality.text],
+          isReasoningModel: true,
+          isSubmitting: true,
+          submitFailed: true,
+        );
+
+        expect(state.id, equals('test-id'));
+        expect(state.name.value, equals('Test Model'));
+        expect(state.providerModelId.value, equals('test-model-id'));
+        expect(state.description.value, equals('Test description'));
+        expect(state.maxCompletionTokens.value, equals('2000'));
+        expect(state.inferenceProviderId, equals('provider-id'));
+        expect(state.inputModalities, equals([Modality.text, Modality.image]));
+        expect(state.outputModalities, equals([Modality.text]));
+        expect(state.isReasoningModel, isTrue);
+        expect(state.isSubmitting, isTrue);
+        expect(state.submitFailed, isTrue);
+      });
+
+      test('copyWith maintains existing values when not specified', () {
+        final original = InferenceModelFormState(
+          id: 'test-id',
+          name: const ModelName.dirty('Original Name'),
+          providerModelId: const ProviderModelId.dirty('original-id'),
+          inferenceProviderId: 'provider-id',
+          isReasoningModel: true,
+        );
+
+        final copied = original.copyWith();
+
+        expect(copied.id, equals(original.id));
+        expect(copied.name, equals(original.name));
+        expect(copied.providerModelId, equals(original.providerModelId));
+        expect(
+            copied.inferenceProviderId, equals(original.inferenceProviderId));
+        expect(copied.isReasoningModel, equals(original.isReasoningModel));
+      });
+
+      test('copyWith updates specified values', () {
+        final original = InferenceModelFormState();
+
+        final updated = original.copyWith(
+          id: 'new-id',
+          name: const ModelName.dirty('Updated Name'),
+          providerModelId: const ProviderModelId.dirty('updated-id'),
+          description: const ModelDescription.dirty('New description'),
+          maxCompletionTokens: const MaxCompletionTokens.dirty('3000'),
+          inferenceProviderId: 'new-provider',
+          inputModalities: [Modality.text, Modality.audio],
+          outputModalities: [Modality.text, Modality.image],
+          isReasoningModel: true,
+          isSubmitting: true,
+          submitFailed: true,
+        );
+
+        expect(updated.id, equals('new-id'));
+        expect(updated.name.value, equals('Updated Name'));
+        expect(updated.providerModelId.value, equals('updated-id'));
+        expect(updated.description.value, equals('New description'));
+        expect(updated.maxCompletionTokens.value, equals('3000'));
+        expect(updated.inferenceProviderId, equals('new-provider'));
+        expect(
+            updated.inputModalities, equals([Modality.text, Modality.audio]));
+        expect(
+            updated.outputModalities, equals([Modality.text, Modality.image]));
+        expect(updated.isReasoningModel, isTrue);
+        expect(updated.isSubmitting, isTrue);
+        expect(updated.submitFailed, isTrue);
+      });
+
+      test('FormzMixin validation works correctly', () {
+        // Invalid state - missing required fields
+        final invalidState = InferenceModelFormState();
+        expect(invalidState.isValid, isFalse);
+
+        // Valid state - all required fields provided
+        final validState = InferenceModelFormState(
+          name: const ModelName.dirty('Valid Model'),
+          providerModelId: const ProviderModelId.dirty('valid-model-id'),
+          inferenceProviderId: 'provider-id',
+        );
+        expect(validState.isValid, isTrue);
+
+        // Invalid state - one required field too short
+        final partiallyInvalidState = InferenceModelFormState(
+          name: const ModelName.dirty('Va'), // Too short
+          providerModelId: const ProviderModelId.dirty('valid-model-id'),
+          inferenceProviderId: 'provider-id',
+        );
+        expect(partiallyInvalidState.isValid, isFalse);
+      });
+
+      test('inputs getter returns all form inputs', () {
+        final state = InferenceModelFormState(
+          name: const ModelName.dirty('Test'),
+          providerModelId: const ProviderModelId.dirty('test-id'),
+          description: const ModelDescription.dirty('Description'),
+          maxCompletionTokens: const MaxCompletionTokens.dirty('1000'),
+        );
+
+        final inputs = state.inputs;
+
+        expect(inputs.length, equals(4));
+        expect(inputs[0], equals(state.name));
+        expect(inputs[1], equals(state.providerModelId));
+        expect(inputs[2], equals(state.description));
+        expect(inputs[3], equals(state.maxCompletionTokens));
+      });
+
+      group('toAiConfig conversion', () {
+        test('creates new AiConfig with generated UUID when id is null', () {
+          final state = InferenceModelFormState(
+            name: const ModelName.dirty('Test Model'),
+            providerModelId: const ProviderModelId.dirty('test-model-id'),
+            description: const ModelDescription.dirty('Test description'),
+            maxCompletionTokens: const MaxCompletionTokens.dirty('2000'),
+            inferenceProviderId: 'provider-id',
+            inputModalities: [Modality.text, Modality.image],
+            outputModalities: [Modality.text],
+            isReasoningModel: true,
+          );
+
+          final config = state.toAiConfig();
+
+          expect(config, isA<AiConfigModel>());
+          final modelConfig = config as AiConfigModel;
+          expect(modelConfig.id, isNotEmpty); // UUID generated
+          expect(modelConfig.name, equals('Test Model'));
+          expect(modelConfig.providerModelId, equals('test-model-id'));
+          expect(modelConfig.description, equals('Test description'));
+          expect(modelConfig.inferenceProviderId, equals('provider-id'));
+          expect(modelConfig.inputModalities,
+              equals([Modality.text, Modality.image]));
+          expect(modelConfig.outputModalities, equals([Modality.text]));
+          expect(modelConfig.isReasoningModel, isTrue);
+          expect(modelConfig.maxCompletionTokens, equals(2000));
+          expect(modelConfig.createdAt, isA<DateTime>());
+        });
+
+        test('uses existing id when provided', () {
+          final state = InferenceModelFormState(
+            id: 'existing-id',
+            name: const ModelName.dirty('Test Model'),
+            providerModelId: const ProviderModelId.dirty('test-model-id'),
+            inferenceProviderId: 'provider-id',
+          );
+
+          final config = state.toAiConfig();
+
+          expect(config, isA<AiConfigModel>());
+          final modelConfig = config as AiConfigModel;
+          expect(modelConfig.id, equals('existing-id'));
+        });
+
+        test('handles empty maxCompletionTokens correctly', () {
+          final state = InferenceModelFormState(
+            name: const ModelName.dirty('Test Model'),
+            providerModelId: const ProviderModelId.dirty('test-model-id'),
+            inferenceProviderId: 'provider-id',
+            maxCompletionTokens: const MaxCompletionTokens.dirty(),
+          );
+
+          final config = state.toAiConfig();
+
+          expect(config, isA<AiConfigModel>());
+          final modelConfig = config as AiConfigModel;
+          expect(modelConfig.maxCompletionTokens, isNull);
+        });
+
+        test('parses valid maxCompletionTokens correctly', () {
+          final state = InferenceModelFormState(
+            name: const ModelName.dirty('Test Model'),
+            providerModelId: const ProviderModelId.dirty('test-model-id'),
+            inferenceProviderId: 'provider-id',
+            maxCompletionTokens: const MaxCompletionTokens.dirty('5000'),
+          );
+
+          final config = state.toAiConfig();
+
+          expect(config, isA<AiConfigModel>());
+          final modelConfig = config as AiConfigModel;
+          expect(modelConfig.maxCompletionTokens, equals(5000));
+        });
+
+        test('all modality combinations work correctly', () {
+          final testCases = [
+            ([Modality.text], [Modality.text]),
+            ([Modality.text, Modality.image], [Modality.text]),
+            ([Modality.text, Modality.audio], [Modality.text]),
+            (
+              [Modality.text, Modality.image, Modality.audio],
+              [Modality.text, Modality.image]
+            ),
+          ];
+
+          for (final testCase in testCases) {
+            final state = InferenceModelFormState(
+              name: const ModelName.dirty('Test Model'),
+              providerModelId: const ProviderModelId.dirty('test-model-id'),
+              inferenceProviderId: 'provider-id',
+              inputModalities: testCase.$1,
+              outputModalities: testCase.$2,
+            );
+
+            final config = state.toAiConfig();
+
+            expect(config, isA<AiConfigModel>());
+            final modelConfig = config as AiConfigModel;
+            expect(modelConfig.inputModalities, equals(testCase.$1));
+            expect(modelConfig.outputModalities, equals(testCase.$2));
+          }
+        });
+      });
+    });
+  });
+}

--- a/test/features/ai/repository/cloud_inference_repository_test.dart
+++ b/test/features/ai/repository/cloud_inference_repository_test.dart
@@ -256,6 +256,159 @@ void main() {
       expect(requestString.contains('mp3'), isTrue);
     });
 
+    test('generate with maxCompletionTokens sets maxTokens parameter correctly',
+        () {
+      // Arrange
+      const maxCompletionTokens = 2000;
+
+      when(
+        () => mockClient.createChatCompletionStream(
+          request: any(named: 'request'),
+        ),
+      ).thenAnswer(
+        (_) => Stream.fromIterable([
+          CreateChatCompletionStreamResponse(
+            id: 'response-id',
+            choices: [
+              const ChatCompletionStreamResponseChoice(
+                delta: ChatCompletionStreamResponseDelta(
+                  content: 'Test response',
+                ),
+                index: 0,
+              ),
+            ],
+            object: 'chat.completion.chunk',
+            created: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          ),
+        ]),
+      );
+
+      // Act
+      repository.generate(
+        prompt,
+        model: model,
+        temperature: temperature,
+        baseUrl: baseUrl,
+        apiKey: apiKey,
+        maxCompletionTokens: maxCompletionTokens,
+        overrideClient: mockClient,
+      );
+
+      // Capture call for verification
+      final captured = verify(
+        () => mockClient.createChatCompletionStream(
+          request: captureAny(named: 'request'),
+        ),
+      ).captured;
+
+      final request = captured.first as CreateChatCompletionRequest;
+      expect(request.maxCompletionTokens, equals(maxCompletionTokens));
+    });
+
+    test(
+        'generateWithImages with maxCompletionTokens sets maxTokens parameter correctly',
+        () {
+      // Arrange
+      const maxCompletionTokens = 3000;
+      const images = ['base64ImageData'];
+
+      when(
+        () => mockClient.createChatCompletionStream(
+          request: any(named: 'request'),
+        ),
+      ).thenAnswer(
+        (_) => Stream.fromIterable([
+          CreateChatCompletionStreamResponse(
+            id: 'response-id',
+            choices: [
+              const ChatCompletionStreamResponseChoice(
+                delta: ChatCompletionStreamResponseDelta(
+                  content: 'Test response',
+                ),
+                index: 0,
+              ),
+            ],
+            object: 'chat.completion.chunk',
+            created: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          ),
+        ]),
+      );
+
+      // Act
+      repository.generateWithImages(
+        prompt,
+        model: model,
+        temperature: temperature,
+        images: images,
+        baseUrl: baseUrl,
+        apiKey: apiKey,
+        maxCompletionTokens: maxCompletionTokens,
+        overrideClient: mockClient,
+      );
+
+      // Capture call for verification
+      final captured = verify(
+        () => mockClient.createChatCompletionStream(
+          request: captureAny(named: 'request'),
+        ),
+      ).captured;
+
+      final request = captured.first as CreateChatCompletionRequest;
+      // Note: generateWithImages uses maxTokens instead of maxCompletionTokens
+      expect(request.maxTokens, equals(maxCompletionTokens));
+    });
+
+    test(
+        'generateWithAudio with maxCompletionTokens sets maxCompletionTokens parameter correctly',
+        () {
+      // Arrange
+      const maxCompletionTokens = 4000;
+      const audioBase64 = 'base64AudioData';
+
+      when(
+        () => mockClient.createChatCompletionStream(
+          request: any(named: 'request'),
+        ),
+      ).thenAnswer(
+        (_) => Stream.fromIterable([
+          CreateChatCompletionStreamResponse(
+            id: 'response-id',
+            choices: [
+              const ChatCompletionStreamResponseChoice(
+                delta: ChatCompletionStreamResponseDelta(
+                  content: 'Test response',
+                ),
+                index: 0,
+              ),
+            ],
+            object: 'chat.completion.chunk',
+            created: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          ),
+        ]),
+      );
+
+      // Act
+      repository.generateWithAudio(
+        prompt,
+        model: model,
+        audioBase64: audioBase64,
+        baseUrl: baseUrl,
+        apiKey: apiKey,
+        maxCompletionTokens: maxCompletionTokens,
+        overrideClient: mockClient,
+      );
+
+      // Capture call for verification
+      final captured = verify(
+        () => mockClient.createChatCompletionStream(
+          request: captureAny(named: 'request'),
+        ),
+      ).captured;
+
+      final request = captured.first as CreateChatCompletionRequest;
+      expect(request.maxCompletionTokens, equals(maxCompletionTokens));
+    });
+
     test('cloudInferenceRepository provider creates instance correctly', () {
       final repository = container.read(cloudInferenceRepositoryProvider);
       expect(repository, isA<CloudInferenceRepository>());

--- a/test/features/ai/state/inference_model_form_controller_test.dart
+++ b/test/features/ai/state/inference_model_form_controller_test.dart
@@ -23,6 +23,7 @@ void main() {
     outputModalities: [Modality.text],
     isReasoningModel: true,
     description: 'Test description',
+    maxCompletionTokens: 4000,
   );
 
   setUpAll(() {
@@ -63,6 +64,7 @@ void main() {
         equals('test-provider-model-id'),
       );
       expect(controller.descriptionController.text, equals('Test description'));
+      expect(controller.maxCompletionTokensController.text, equals('4000'));
       expect(formState?.inferenceProviderId, equals(testProviderId));
       expect(formState?.inputModalities, equals([Modality.text]));
       expect(formState?.outputModalities, equals([Modality.text]));
@@ -83,6 +85,7 @@ void main() {
       expect(controller.nameController.text, isEmpty);
       expect(controller.providerModelIdController.text, isEmpty);
       expect(controller.descriptionController.text, isEmpty);
+      expect(controller.maxCompletionTokensController.text, isEmpty);
       expect(formState?.inferenceProviderId, isEmpty);
       expect(formState?.inputModalities, equals([Modality.text]));
       expect(formState?.outputModalities, equals([Modality.text]));
@@ -130,6 +133,7 @@ void main() {
         outputModalities: [Modality.text],
         isReasoningModel: false,
         description: 'Updated description',
+        maxCompletionTokens: 8000,
       );
 
       // Act
@@ -171,6 +175,7 @@ void main() {
       // Verify fields are populated
       expect(controller.nameController.text, isNotEmpty);
       expect(controller.descriptionController.text, isNotEmpty);
+      expect(controller.maxCompletionTokensController.text, isNotEmpty);
 
       // Act
       controller.reset();
@@ -178,6 +183,7 @@ void main() {
       // Assert
       expect(controller.nameController.text, isEmpty);
       expect(controller.descriptionController.text, isEmpty);
+      expect(controller.maxCompletionTokensController.text, isEmpty);
     });
 
     test('should update form state when name is changed', () async {
@@ -214,6 +220,25 @@ void main() {
 
       // Assert
       expect(formState?.description.value, equals('New description'));
+    });
+
+    test('should update form state when maxCompletionTokens is changed',
+        () async {
+      // Arrange
+      final controller = container.read(
+        inferenceModelFormControllerProvider(configId: null).notifier,
+      );
+      await container
+          .read(inferenceModelFormControllerProvider(configId: null).future);
+
+      // Act
+      controller.maxCompletionTokensChanged('2000');
+      final formState = container
+          .read(inferenceModelFormControllerProvider(configId: null))
+          .valueOrNull;
+
+      // Assert
+      expect(formState?.maxCompletionTokens.value, equals('2000'));
     });
 
     test('should update form state when inferenceProviderId is changed',

--- a/test/features/ai/util/known_models_test.dart
+++ b/test/features/ai/util/known_models_test.dart
@@ -1,0 +1,210 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/util/known_models.dart';
+
+void main() {
+  group('KnownModel', () {
+    group('maxCompletionTokens', () {
+      test('should be filled when defined in known models', () {
+        // Test Anthropic models which have maxCompletionTokens defined
+        for (final model in anthropicModels) {
+          expect(
+            model.maxCompletionTokens,
+            isNotNull,
+            reason:
+                'Anthropic model ${model.name} should have maxCompletionTokens defined',
+          );
+          expect(
+            model.maxCompletionTokens,
+            equals(2000),
+            reason:
+                'Anthropic model ${model.name} should have maxCompletionTokens set to 2000',
+          );
+        }
+
+        // Test that other providers don't have maxCompletionTokens set
+        for (final model in geminiModels) {
+          expect(
+            model.maxCompletionTokens,
+            isNull,
+            reason:
+                'Gemini model ${model.name} should not have maxCompletionTokens defined',
+          );
+        }
+
+        for (final model in nebiusModels) {
+          expect(
+            model.maxCompletionTokens,
+            isNull,
+            reason:
+                'Nebius model ${model.name} should not have maxCompletionTokens defined',
+          );
+        }
+
+        for (final model in ollamaModels) {
+          expect(
+            model.maxCompletionTokens,
+            isNull,
+            reason:
+                'Ollama model ${model.name} should not have maxCompletionTokens defined',
+          );
+        }
+
+        for (final model in openaiModels) {
+          expect(
+            model.maxCompletionTokens,
+            isNull,
+            reason:
+                'OpenAI model ${model.name} should not have maxCompletionTokens defined',
+          );
+        }
+
+        for (final model in openRouterModels) {
+          expect(
+            model.maxCompletionTokens,
+            isNull,
+            reason:
+                'OpenRouter model ${model.name} should not have maxCompletionTokens defined',
+          );
+        }
+      });
+
+      test(
+          'should transfer maxCompletionTokens to AiConfigModel when converting',
+          () {
+        const testId = 'test-id';
+        const testProviderId = 'test-provider-id';
+
+        // Test model with maxCompletionTokens
+        const modelWithTokens = KnownModel(
+          providerModelId: 'test-model-with-tokens',
+          name: 'Test Model With Tokens',
+          inputModalities: [Modality.text],
+          outputModalities: [Modality.text],
+          isReasoningModel: false,
+          description: 'Test model with max completion tokens',
+          maxCompletionTokens: 5000,
+        );
+
+        final aiConfigWithTokens = modelWithTokens.toAiConfigModel(
+          id: testId,
+          inferenceProviderId: testProviderId,
+        );
+
+        expect(aiConfigWithTokens.maxCompletionTokens, equals(5000));
+
+        // Test model without maxCompletionTokens
+        const modelWithoutTokens = KnownModel(
+          providerModelId: 'test-model-without-tokens',
+          name: 'Test Model Without Tokens',
+          inputModalities: [Modality.text],
+          outputModalities: [Modality.text],
+          isReasoningModel: false,
+          description: 'Test model without max completion tokens',
+        );
+
+        final aiConfigWithoutTokens = modelWithoutTokens.toAiConfigModel(
+          id: testId,
+          inferenceProviderId: testProviderId,
+        );
+
+        expect(aiConfigWithoutTokens.maxCompletionTokens, isNull);
+      });
+
+      test(
+          'should properly transfer all fields including maxCompletionTokens in toAiConfigModel',
+          () {
+        const testId = 'test-id';
+        const testProviderId = 'test-provider-id';
+
+        // Take a real Anthropic model as example
+        final anthropicModel = anthropicModels.first;
+        final aiConfig = anthropicModel.toAiConfigModel(
+          id: testId,
+          inferenceProviderId: testProviderId,
+        );
+
+        // Verify all fields are transferred correctly
+        expect(aiConfig.id, equals(testId));
+        expect(aiConfig.name, equals(anthropicModel.name));
+        expect(
+            aiConfig.providerModelId, equals(anthropicModel.providerModelId));
+        expect(aiConfig.inferenceProviderId, equals(testProviderId));
+        expect(
+            aiConfig.inputModalities, equals(anthropicModel.inputModalities));
+        expect(
+            aiConfig.outputModalities, equals(anthropicModel.outputModalities));
+        expect(
+            aiConfig.isReasoningModel, equals(anthropicModel.isReasoningModel));
+        expect(aiConfig.description, equals(anthropicModel.description));
+        expect(aiConfig.maxCompletionTokens,
+            equals(anthropicModel.maxCompletionTokens));
+        expect(aiConfig.createdAt, isA<DateTime>());
+      });
+    });
+
+    group('generateModelId', () {
+      test('should generate valid IDs', () {
+        expect(
+          generateModelId('provider1', 'model/test-name:123'),
+          equals('provider1_model_test_name_123'),
+        );
+
+        expect(
+          generateModelId('Provider-2', 'model.test.name'),
+          equals('provider_2_model_test_name'),
+        );
+      });
+    });
+
+    group('knownModelsByProvider', () {
+      test('should contain all provider types', () {
+        expect(
+          knownModelsByProvider.keys.toSet(),
+          containsAll([
+            InferenceProviderType.gemini,
+            InferenceProviderType.nebiusAiStudio,
+            InferenceProviderType.ollama,
+            InferenceProviderType.openAi,
+            InferenceProviderType.anthropic,
+            InferenceProviderType.openRouter,
+          ]),
+        );
+      });
+
+      test('all models should have valid configurations', () {
+        for (final entry in knownModelsByProvider.entries) {
+          final providerType = entry.key;
+          final models = entry.value;
+
+          for (final model in models) {
+            // Verify required fields are not empty
+            expect(model.providerModelId, isNotEmpty,
+                reason:
+                    'Model in $providerType should have non-empty providerModelId');
+            expect(model.name, isNotEmpty,
+                reason: 'Model in $providerType should have non-empty name');
+            expect(model.description, isNotEmpty,
+                reason:
+                    'Model in $providerType should have non-empty description');
+
+            // Verify modalities are not empty
+            expect(model.inputModalities, isNotEmpty,
+                reason:
+                    'Model ${model.name} should have at least one input modality');
+            expect(model.outputModalities, isNotEmpty,
+                reason:
+                    'Model ${model.name} should have at least one output modality');
+
+            // Verify maxCompletionTokens is positive if defined
+            if (model.maxCompletionTokens != null) {
+              expect(model.maxCompletionTokens! > 0, isTrue,
+                  reason:
+                      'Model ${model.name} should have positive maxCompletionTokens if defined');
+            }
+          }
+        }
+      });
+    });
+  });
+}


### PR DESCRIPTION
This change appears to be needed with Anthropic with a fresh API key, where my limits were only 4K output tokens per minute, leading to some API error code that the limit was breached or something like that. Interestingly, I cannot reproduce this any longer since my limit got upgraded to 80K output tokens per minute with a bigger plan and/or more spending on tokens. But then another issue appeared, with some ping messages in between actual messages on the output stream, specific to Anthropic. This PR fixes that, and introduces the configurable field for maximum output tokens per request.

From copilot:
This pull request introduces a new `maxCompletionTokens` field to the `AiConfig` model and updates the related codebase to support this addition. The changes include modifications to the model, serialization/deserialization logic, and form validation to handle the new field.

### Model Updates:
* Added the `maxCompletionTokens` field to the `AiConfig` model, making it an optional integer to represent the maximum number of tokens for completions. (`lib/features/ai/model/ai_config.dart`, `lib/features/ai/model/ai_config.freezed.dart`) [[1]](diffhunk://#diff-5d5d9db437a82dab48d41fdeaa104de8612bcb9061917919e94fbb99d47dbf9aR55) [[2]](diffhunk://#diff-553478f2f5cee6bfa014f88cbf632cd99c68cb1656a0879068d7366ced877438L61-R62) [[3]](diffhunk://#diff-553478f2f5cee6bfa014f88cbf632cd99c68cb1656a0879068d7366ced877438L149-R152) [[4]](diffhunk://#diff-553478f2f5cee6bfa014f88cbf632cd99c68cb1656a0879068d7366ced877438R764)

### Serialization/Deserialization:
* Updated JSON serialization and deserialization logic to include the `maxCompletionTokens` field in the `AiConfig` model. (`lib/features/ai/model/ai_config.g.dart`) [[1]](diffhunk://#diff-32ad12729764f87351c1da350829769d4cc6127bf42f0532ea81d93b338c3e77R69) [[2]](diffhunk://#diff-32ad12729764f87351c1da350829769d4cc6127bf42f0532ea81d93b338c3e77R87)

### Form Validation:
* Introduced a new `MaxCompletionTokens` input validation class to validate the `maxCompletionTokens` field in forms. (`lib/features/ai/model/inference_model_form_state.dart`) [[1]](diffhunk://#diff-9e10816e6b3b2e69722f4133aec70455b2ad2d840de66e36fd8205b660bd35bdR41-R61) [[2]](diffhunk://#diff-9e10816e6b3b2e69722f4133aec70455b2ad2d840de66e36fd8205b660bd35bdR130-R132)
* Updated the `InferenceModelFormState` class to include the `maxCompletionTokens` field, with validation logic to ensure it is either empty or a positive integer. (`lib/features/ai/model/inference_model_form_state.dart`) [[1]](diffhunk://#diff-9e10816e6b3b2e69722f4133aec70455b2ad2d840de66e36fd8205b660bd35bdR74) [[2]](diffhunk://#diff-9e10816e6b3b2e69722f4133aec70455b2ad2d840de66e36fd8205b660bd35bdR115)