### PR TITLE
ci: use larger runner to speed up tests

### DIFF
--- a/.github/workflows/flutter-test.yml
+++ b/.github/workflows/flutter-test.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     name: Flutter Test on macOS
-    runs-on: macos-latest
+    runs-on: macos-latest-xlarge
     steps:
       - uses: actions/checkout@v3
       - uses: kuhnroyal/flutter-fvm-config-action@v2


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to allocate a larger macOS runner for the Flutter test job.

* [`.github/workflows/flutter-test.yml`](diffhunk://#diff-b50233b18ba85f68ec7cc7bdb17ce903d73ac28c744cfe23d6916445bb2aa2e5L11-R11): Changed the `runs-on` parameter from `macos-latest` to `macos-latest-xlarge` to provide more resources for running Flutter tests.