### PR TITLE
refactor: adapt matrix integration test

### DIFF
--- a/integration_test/matrix_service_test.dart
+++ b/integration_test/matrix_service_test.dart
@@ -5,6 +5,7 @@ import 'package:drift/drift.dart' as drift;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_vodozemac/flutter_vodozemac.dart' as vod;
 import 'package:lotti/classes/config.dart';
 import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/journal_entities.dart';
@@ -107,6 +108,7 @@ void main() {
     const defaultDelay = 5;
 
     setUpAll(() async {
+      await vod.init();
       final tmpDir = await getTemporaryDirectory();
       final docDir = Directory('${tmpDir.path}/${uuid.v1()}')
         ..createSync(recursive: true);

--- a/lib/features/sync/matrix/client.dart
+++ b/lib/features/sync/matrix/client.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter_vodozemac/flutter_vodozemac.dart' as vod;
 import 'package:lotti/features/sync/matrix.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/logging_service.dart';
@@ -15,8 +14,6 @@ Future<Client> createMatrixClient({
   String? deviceDisplayName,
   String? dbName,
 }) async {
-  await vod.init();
-
   final docDir = getIt<Directory>();
   final name = dbName ?? 'lotti_sync';
   final path = '${docDir.path}/matrix/$name.db';

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter_vodozemac/flutter_vodozemac.dart' as vod;
 import 'package:get_it/get_it.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/editor_db.dart';
@@ -43,6 +44,7 @@ Future<void> registerSingletons() async {
     ..registerSingleton<TimeService>(TimeService())
     ..registerSingleton<OutboxService>(OutboxService());
 
+  await vod.init();
   final client = await createMatrixClient();
 
   getIt

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.622+3094
+version: 0.9.622+3095
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
This pull request introduces changes to integrate the `flutter_vodozemac` package into the project and refactors its initialization logic. Additionally, there is a minor version bump in `pubspec.yaml`. The most important changes include adding `flutter_vodozemac` initialization to the dependency injection setup and removing redundant initialization calls from individual components.

### Integration of `flutter_vodozemac` package:

* [`integration_test/matrix_service_test.dart`](diffhunk://#diff-e5a55efa9a1b47bf1cfbc486a12993b5ce794be50641fbd1abbda132b7ddbe7fR8): Added `flutter_vodozemac` import and initialized it during the `setUpAll()` phase of the integration tests. [[1]](diffhunk://#diff-e5a55efa9a1b47bf1cfbc486a12993b5ce794be50641fbd1abbda132b7ddbe7fR8) [[2]](diffhunk://#diff-e5a55efa9a1b47bf1cfbc486a12993b5ce794be50641fbd1abbda132b7ddbe7fR111)
* [`lib/get_it.dart`](diffhunk://#diff-30e5297dfd41011e24b29714f092e2cd39c92353fd097ecc02c4cecb89053b86R3): Imported `flutter_vodozemac` and added its initialization (`vod.init()`) to the `registerSingletons()` method for centralized dependency injection. [[1]](diffhunk://#diff-30e5297dfd41011e24b29714f092e2cd39c92353fd097ecc02c4cecb89053b86R3) [[2]](diffhunk://#diff-30e5297dfd41011e24b29714f092e2cd39c92353fd097ecc02c4cecb89053b86R47)

### Refactoring redundant initialization:

* [`lib/features/sync/matrix/client.dart`](diffhunk://#diff-0415579100cb5e000989b4e572cfef47e1a389ffe9de2d4ccfc6bea576c99213L5): Removed the `vod.init()` call from the `createMatrixClient()` method to avoid redundant initialization. [[1]](diffhunk://#diff-0415579100cb5e000989b4e572cfef47e1a389ffe9de2d4ccfc6bea576c99213L5) [[2]](diffhunk://#diff-0415579100cb5e000989b4e572cfef47e1a389ffe9de2d4ccfc6bea576c99213L18-L19)

### Version update:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Incremented the patch version from `0.9.622+3094` to `0.9.622+3095`.