### PR TITLE
fix: calculation of VU as RMS of dBFS with 0 VU as -18 dBFS avg

### DIFF
--- a/lib/features/speech/repository/audio_recorder_repository.dart
+++ b/lib/features/speech/repository/audio_recorder_repository.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:lotti/classes/audio_note.dart';
+import 'package:lotti/features/speech/state/recorder_controller.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/utils/file_utils.dart';
@@ -40,9 +41,9 @@ class AudioRecorderRepository {
   final LoggingService _loggingService = getIt<LoggingService>();
 
   /// Stream of amplitude updates for VU meter visualization.
-  /// Emits amplitude values every 100ms while recording.
+  /// Emits amplitude values every 20ms while recording.
   Stream<Amplitude> get amplitudeStream => _audioRecorder.onAmplitudeChanged(
-        const Duration(milliseconds: 100),
+        const Duration(milliseconds: intervalMs),
       );
 
   /// Checks if the app has microphone permission.
@@ -108,7 +109,7 @@ class AudioRecorderRepository {
       );
 
       await _audioRecorder.start(
-        const RecordConfig(sampleRate: 48000),
+        const RecordConfig(sampleRate: 48000, autoGain: true),
         path: filePath,
       );
 

--- a/lib/features/speech/state/recorder_controller.dart
+++ b/lib/features/speech/state/recorder_controller.dart
@@ -120,6 +120,8 @@ class AudioRecorderController extends _$AudioRecorderController {
     final rms = math.sqrt(sumOfSquares / _dbfsBuffer.length);
 
     // Convert RMS back to dB
+    // Formula: 20 * log10(rms) where math.log is natural log (ln)
+    // So: 20 * ln(rms) / ln(10) = 20 * log10(rms)
     final rmsDb = 20 * (math.log(rms) / math.ln10);
 
     // Apply VU reference level: 0 VU = -18 dBFS

--- a/lib/features/speech/state/recorder_controller.g.dart
+++ b/lib/features/speech/state/recorder_controller.g.dart
@@ -7,7 +7,7 @@ part of 'recorder_controller.dart';
 // **************************************************************************
 
 String _$audioRecorderControllerHash() =>
-    r'1283333d2732d7c0dccce8a554bf9d62e9aba36a';
+    r'07684afc4914f522725e1a0f38daafa7686007f0';
 
 /// Main controller for audio recording functionality.
 ///

--- a/lib/features/speech/state/recorder_state.dart
+++ b/lib/features/speech/state/recorder_state.dart
@@ -36,7 +36,8 @@ class AudioRecorderState with _$AudioRecorderState {
 
     /// Current audio level in decibels (0-160 range).
     /// Used for VU meter visualization.
-    required double decibels,
+    required double vu,
+    required double dBFS,
 
     /// Whether to show the floating recording indicator.
     /// Only relevant when recording and modal is not visible.

--- a/lib/features/speech/state/recorder_state.freezed.dart
+++ b/lib/features/speech/state/recorder_state.freezed.dart
@@ -24,7 +24,8 @@ mixin _$AudioRecorderState {
 
   /// Current audio level in decibels (0-160 range).
   /// Used for VU meter visualization.
-  double get decibels => throw _privateConstructorUsedError;
+  double get vu => throw _privateConstructorUsedError;
+  double get dBFS => throw _privateConstructorUsedError;
 
   /// Whether to show the floating recording indicator.
   /// Only relevant when recording and modal is not visible.
@@ -57,7 +58,8 @@ abstract class $AudioRecorderStateCopyWith<$Res> {
   $Res call(
       {AudioRecorderStatus status,
       Duration progress,
-      double decibels,
+      double vu,
+      double dBFS,
       bool showIndicator,
       bool modalVisible,
       String? language,
@@ -81,7 +83,8 @@ class _$AudioRecorderStateCopyWithImpl<$Res, $Val extends AudioRecorderState>
   $Res call({
     Object? status = null,
     Object? progress = null,
-    Object? decibels = null,
+    Object? vu = null,
+    Object? dBFS = null,
     Object? showIndicator = null,
     Object? modalVisible = null,
     Object? language = freezed,
@@ -96,9 +99,13 @@ class _$AudioRecorderStateCopyWithImpl<$Res, $Val extends AudioRecorderState>
           ? _value.progress
           : progress // ignore: cast_nullable_to_non_nullable
               as Duration,
-      decibels: null == decibels
-          ? _value.decibels
-          : decibels // ignore: cast_nullable_to_non_nullable
+      vu: null == vu
+          ? _value.vu
+          : vu // ignore: cast_nullable_to_non_nullable
+              as double,
+      dBFS: null == dBFS
+          ? _value.dBFS
+          : dBFS // ignore: cast_nullable_to_non_nullable
               as double,
       showIndicator: null == showIndicator
           ? _value.showIndicator
@@ -131,7 +138,8 @@ abstract class _$$AudioRecorderStateImplCopyWith<$Res>
   $Res call(
       {AudioRecorderStatus status,
       Duration progress,
-      double decibels,
+      double vu,
+      double dBFS,
       bool showIndicator,
       bool modalVisible,
       String? language,
@@ -153,7 +161,8 @@ class __$$AudioRecorderStateImplCopyWithImpl<$Res>
   $Res call({
     Object? status = null,
     Object? progress = null,
-    Object? decibels = null,
+    Object? vu = null,
+    Object? dBFS = null,
     Object? showIndicator = null,
     Object? modalVisible = null,
     Object? language = freezed,
@@ -168,9 +177,13 @@ class __$$AudioRecorderStateImplCopyWithImpl<$Res>
           ? _value.progress
           : progress // ignore: cast_nullable_to_non_nullable
               as Duration,
-      decibels: null == decibels
-          ? _value.decibels
-          : decibels // ignore: cast_nullable_to_non_nullable
+      vu: null == vu
+          ? _value.vu
+          : vu // ignore: cast_nullable_to_non_nullable
+              as double,
+      dBFS: null == dBFS
+          ? _value.dBFS
+          : dBFS // ignore: cast_nullable_to_non_nullable
               as double,
       showIndicator: null == showIndicator
           ? _value.showIndicator
@@ -198,7 +211,8 @@ class _$AudioRecorderStateImpl implements _AudioRecorderState {
   _$AudioRecorderStateImpl(
       {required this.status,
       required this.progress,
-      required this.decibels,
+      required this.vu,
+      required this.dBFS,
       required this.showIndicator,
       required this.modalVisible,
       required this.language,
@@ -215,7 +229,9 @@ class _$AudioRecorderStateImpl implements _AudioRecorderState {
   /// Current audio level in decibels (0-160 range).
   /// Used for VU meter visualization.
   @override
-  final double decibels;
+  final double vu;
+  @override
+  final double dBFS;
 
   /// Whether to show the floating recording indicator.
   /// Only relevant when recording and modal is not visible.
@@ -238,7 +254,7 @@ class _$AudioRecorderStateImpl implements _AudioRecorderState {
 
   @override
   String toString() {
-    return 'AudioRecorderState(status: $status, progress: $progress, decibels: $decibels, showIndicator: $showIndicator, modalVisible: $modalVisible, language: $language, linkedId: $linkedId)';
+    return 'AudioRecorderState(status: $status, progress: $progress, vu: $vu, dBFS: $dBFS, showIndicator: $showIndicator, modalVisible: $modalVisible, language: $language, linkedId: $linkedId)';
   }
 
   @override
@@ -249,8 +265,8 @@ class _$AudioRecorderStateImpl implements _AudioRecorderState {
             (identical(other.status, status) || other.status == status) &&
             (identical(other.progress, progress) ||
                 other.progress == progress) &&
-            (identical(other.decibels, decibels) ||
-                other.decibels == decibels) &&
+            (identical(other.vu, vu) || other.vu == vu) &&
+            (identical(other.dBFS, dBFS) || other.dBFS == dBFS) &&
             (identical(other.showIndicator, showIndicator) ||
                 other.showIndicator == showIndicator) &&
             (identical(other.modalVisible, modalVisible) ||
@@ -262,7 +278,7 @@ class _$AudioRecorderStateImpl implements _AudioRecorderState {
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, status, progress, decibels,
+  int get hashCode => Object.hash(runtimeType, status, progress, vu, dBFS,
       showIndicator, modalVisible, language, linkedId);
 
   /// Create a copy of AudioRecorderState
@@ -279,7 +295,8 @@ abstract class _AudioRecorderState implements AudioRecorderState {
   factory _AudioRecorderState(
       {required final AudioRecorderStatus status,
       required final Duration progress,
-      required final double decibels,
+      required final double vu,
+      required final double dBFS,
       required final bool showIndicator,
       required final bool modalVisible,
       required final String? language,
@@ -296,7 +313,9 @@ abstract class _AudioRecorderState implements AudioRecorderState {
   /// Current audio level in decibels (0-160 range).
   /// Used for VU meter visualization.
   @override
-  double get decibels;
+  double get vu;
+  @override
+  double get dBFS;
 
   /// Whether to show the floating recording indicator.
   /// Only relevant when recording and modal is not visible.

--- a/lib/features/speech/ui/widgets/recording/audio_recording_modal.dart
+++ b/lib/features/speech/ui/widgets/recording/audio_recording_modal.dart
@@ -116,9 +116,9 @@ class _AudioRecordingModalContentState
           Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              // VU Meter
               AnalogVuMeter(
-                decibels: state.decibels,
+                vu: state.vu,
+                dBFS: state.dBFS,
                 size: 400,
                 colorScheme: theme.colorScheme,
               ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.622+3095
+version: 0.9.622+3097
 
 msix_config:
   display_name: LottiApp

--- a/test/features/speech/ui/widgets/recording/audio_recording_indicator_test.dart
+++ b/test/features/speech/ui/widgets/recording/audio_recording_indicator_test.dart
@@ -117,7 +117,8 @@ void main() {
     testWidgets('shows nothing when not recording', (tester) async {
       final state = AudioRecorderState(
         status: AudioRecorderStatus.initialized,
-        decibels: 0,
+        dBFS: -160,
+        vu: -20,
         progress: Duration.zero,
         showIndicator: false,
         modalVisible: false,
@@ -133,7 +134,8 @@ void main() {
     testWidgets('shows nothing when modal is visible', (tester) async {
       final state = AudioRecorderState(
         status: AudioRecorderStatus.recording,
-        decibels: 0,
+        dBFS: -160,
+        vu: -20,
         progress: const Duration(seconds: 10),
         showIndicator: true,
         modalVisible: true,
@@ -150,7 +152,8 @@ void main() {
         (tester) async {
       final state = AudioRecorderState(
         status: AudioRecorderStatus.recording,
-        decibels: 0,
+        dBFS: -160,
+        vu: -20,
         progress: const Duration(seconds: 10),
         showIndicator: true,
         modalVisible: false,
@@ -178,7 +181,8 @@ void main() {
     testWidgets('indicator has correct styling', (tester) async {
       final state = AudioRecorderState(
         status: AudioRecorderStatus.recording,
-        decibels: 0,
+        dBFS: -160,
+        vu: -20,
         progress: const Duration(minutes: 1, seconds: 23),
         showIndicator: true,
         modalVisible: false,
@@ -211,7 +215,8 @@ void main() {
     testWidgets('indicator has correct interaction behavior', (tester) async {
       final state = AudioRecorderState(
         status: AudioRecorderStatus.recording,
-        decibels: 0,
+        dBFS: -160,
+        vu: -20,
         progress: const Duration(seconds: 30),
         showIndicator: true,
         modalVisible: false,
@@ -255,7 +260,8 @@ void main() {
       for (final (duration, expectedText) in testCases) {
         final state = AudioRecorderState(
           status: AudioRecorderStatus.recording,
-          decibels: 0,
+          dBFS: -160,
+          vu: -20,
           progress: duration,
           showIndicator: true,
           modalVisible: false,
@@ -283,8 +289,9 @@ void main() {
     testWidgets('indicator has correct dimensions', (tester) async {
       final state = AudioRecorderState(
         status: AudioRecorderStatus.recording,
-        decibels: 0,
         progress: const Duration(seconds: 10),
+        dBFS: -160,
+        vu: -20,
         showIndicator: true,
         modalVisible: false,
         language: 'en',
@@ -304,7 +311,8 @@ void main() {
     testWidgets('indicator has correct border radius', (tester) async {
       final state = AudioRecorderState(
         status: AudioRecorderStatus.recording,
-        decibels: 0,
+        dBFS: -160,
+        vu: -20,
         progress: const Duration(seconds: 10),
         showIndicator: true,
         modalVisible: false,

--- a/test/features/speech/ui/widgets/recording/audio_recording_modal_test.dart
+++ b/test/features/speech/ui/widgets/recording/audio_recording_modal_test.dart
@@ -102,7 +102,8 @@ void main() {
       final testState = state ??
           AudioRecorderState(
             status: AudioRecorderStatus.initialized,
-            decibels: 0,
+            vu: 0,
+            dBFS: -60,
             progress: Duration.zero,
             showIndicator: false,
             modalVisible: false,
@@ -141,7 +142,8 @@ void main() {
     testWidgets('displays duration in correct format', (tester) async {
       final state = AudioRecorderState(
         status: AudioRecorderStatus.recording,
-        decibels: 80,
+        vu: -10,
+        dBFS: -20,
         progress: const Duration(minutes: 1, seconds: 23),
         showIndicator: false,
         modalVisible: false,
@@ -181,7 +183,8 @@ void main() {
               controller = TestAudioRecorderController(
                 AudioRecorderState(
                   status: AudioRecorderStatus.initialized,
-                  decibels: 0,
+                  vu: 0,
+                  dBFS: -60,
                   progress: Duration.zero,
                   showIndicator: false,
                   modalVisible: false,
@@ -216,7 +219,8 @@ void main() {
     testWidgets('shows stop button when recording', (tester) async {
       final state = AudioRecorderState(
         status: AudioRecorderStatus.recording,
-        decibels: 80,
+        vu: -10,
+        dBFS: -20,
         progress: const Duration(seconds: 5),
         showIndicator: false,
         modalVisible: false,
@@ -234,7 +238,8 @@ void main() {
         (tester) async {
       final state = AudioRecorderState(
         status: AudioRecorderStatus.initialized,
-        decibels: 0,
+        vu: 0,
+        dBFS: -60,
         progress: Duration.zero,
         showIndicator: false,
         modalVisible: false,
@@ -288,7 +293,8 @@ void main() {
     testWidgets('stop button shows recording indicator', (tester) async {
       final state = AudioRecorderState(
         status: AudioRecorderStatus.recording,
-        decibels: 80,
+        vu: -10,
+        dBFS: -20,
         progress: const Duration(seconds: 5),
         showIndicator: false,
         modalVisible: false,
@@ -316,7 +322,8 @@ void main() {
       final controller = TestAudioRecorderController(
         AudioRecorderState(
           status: AudioRecorderStatus.initialized,
-          decibels: 0,
+          vu: 0,
+          dBFS: -60,
           progress: Duration.zero,
           showIndicator: false,
           modalVisible: false,
@@ -386,7 +393,8 @@ void main() {
               controller = TestAudioRecorderController(
                 AudioRecorderState(
                   status: AudioRecorderStatus.recording,
-                  decibels: 80,
+                  vu: -10,
+                  dBFS: -20,
                   progress: const Duration(seconds: 30),
                   showIndicator: false,
                   modalVisible: false,
@@ -446,7 +454,8 @@ void main() {
       final testState = state ??
           AudioRecorderState(
             status: AudioRecorderStatus.initialized,
-            decibels: 0,
+            vu: 0,
+            dBFS: -60,
             progress: Duration.zero,
             showIndicator: false,
             modalVisible: false,
@@ -489,7 +498,8 @@ void main() {
               controller = TestAudioRecorderController(
                 AudioRecorderState(
                   status: AudioRecorderStatus.initialized,
-                  decibels: 0,
+                  vu: 0,
+                  dBFS: -60,
                   progress: Duration.zero,
                   showIndicator: false,
                   modalVisible: false,
@@ -561,7 +571,8 @@ void main() {
       final testState = state ??
           AudioRecorderState(
             status: AudioRecorderStatus.initialized,
-            decibels: 0,
+            vu: 0,
+            dBFS: -60,
             progress: Duration.zero,
             showIndicator: false,
             modalVisible: false,
@@ -587,7 +598,8 @@ void main() {
       // Test the duration formatting through the widget
       final state = AudioRecorderState(
         status: AudioRecorderStatus.recording,
-        decibels: 0,
+        vu: 0,
+        dBFS: -60,
         progress: const Duration(minutes: 1, seconds: 23, milliseconds: 456),
         showIndicator: false,
         modalVisible: false,
@@ -613,7 +625,8 @@ void main() {
       for (final (duration, expected) in testCases) {
         final state = AudioRecorderState(
           status: AudioRecorderStatus.recording,
-          decibels: 0,
+          vu: 0,
+          dBFS: -60,
           progress: duration,
           showIndicator: false,
           modalVisible: false,


### PR DESCRIPTION
This pull request introduces significant updates to the audio recording functionality, focusing on improving the VU meter visualization and adding RMS-based calculations for audio levels. Key changes include replacing the `decibels` field with `vu` and `dBFS` fields, implementing a sliding window for RMS calculations, and enhancing the configuration options for the VU meter.

### Updates to VU Meter Functionality:
* [`lib/features/speech/state/recorder_controller.dart`](diffhunk://#diff-2823dea1121b945ffd49b99b1ffbe251b8951845ac4c88adcb2d71937a20396bL17-R25): Added a circular buffer and RMS calculation logic for VU meter values, introduced `vuReferenceLevelDbfs` and `defaultVuWindowMs` constants, and updated the amplitude listener to calculate `vu` and `dBFS` values. [[1]](diffhunk://#diff-2823dea1121b945ffd49b99b1ffbe251b8951845ac4c88adcb2d71937a20396bL17-R25) [[2]](diffhunk://#diff-2823dea1121b945ffd49b99b1ffbe251b8951845ac4c88adcb2d71937a20396bR48-R56) [[3]](diffhunk://#diff-2823dea1121b945ffd49b99b1ffbe251b8951845ac4c88adcb2d71937a20396bR71-R79) [[4]](diffhunk://#diff-2823dea1121b945ffd49b99b1ffbe251b8951845ac4c88adcb2d71937a20396bL70-R139) [[5]](diffhunk://#diff-2823dea1121b945ffd49b99b1ffbe251b8951845ac4c88adcb2d71937a20396bR202-R206)

### Changes to State Management:
* [`lib/features/speech/state/recorder_state.dart`](diffhunk://#diff-e9cfb7fb28f2706de838580f71256134f0fd7b4d52005baf1204cc47f65df2e1L39-R40): Replaced `decibels` with `vu` and `dBFS` fields in `AudioRecorderState`.
* [`lib/features/speech/state/recorder_state.freezed.dart`](diffhunk://#diff-a99fa4f08169712a0b9053ac81ffb465313c0769e9fb14d1c64a95e09bc0f7d3L27-R28): Updated all references to `decibels` to use `vu` and `dBFS` in state-related classes and methods. [[1]](diffhunk://#diff-a99fa4f08169712a0b9053ac81ffb465313c0769e9fb14d1c64a95e09bc0f7d3L27-R28) [[2]](diffhunk://#diff-a99fa4f08169712a0b9053ac81ffb465313c0769e9fb14d1c64a95e09bc0f7d3L60-R62) [[3]](diffhunk://#diff-a99fa4f08169712a0b9053ac81ffb465313c0769e9fb14d1c64a95e09bc0f7d3L84-R87) [[4]](diffhunk://#diff-a99fa4f08169712a0b9053ac81ffb465313c0769e9fb14d1c64a95e09bc0f7d3L99-R108) [[5]](diffhunk://#diff-a99fa4f08169712a0b9053ac81ffb465313c0769e9fb14d1c64a95e09bc0f7d3L134-R142) [[6]](diffhunk://#diff-a99fa4f08169712a0b9053ac81ffb465313c0769e9fb14d1c64a95e09bc0f7d3L156-R165) [[7]](diffhunk://#diff-a99fa4f08169712a0b9053ac81ffb465313c0769e9fb14d1c64a95e09bc0f7d3L171-R186) [[8]](diffhunk://#diff-a99fa4f08169712a0b9053ac81ffb465313c0769e9fb14d1c64a95e09bc0f7d3L201-R215) [[9]](diffhunk://#diff-a99fa4f08169712a0b9053ac81ffb465313c0769e9fb14d1c64a95e09bc0f7d3L218-R234) [[10]](diffhunk://#diff-a99fa4f08169712a0b9053ac81ffb465313c0769e9fb14d1c64a95e09bc0f7d3L241-R257) [[11]](diffhunk://#diff-a99fa4f08169712a0b9053ac81ffb465313c0769e9fb14d1c64a95e09bc0f7d3L252-R269) [[12]](diffhunk://#diff-a99fa4f08169712a0b9053ac81ffb465313c0769e9fb14d1c64a95e09bc0f7d3L265-R281) [[13]](diffhunk://#diff-a99fa4f08169712a0b9053ac81ffb465313c0769e9fb14d1c64a95e09bc0f7d3L282-R299) [[14]](diffhunk://#diff-a99fa4f08169712a0b9053ac81ffb465313c0769e9fb14d1c64a95e09bc0f7d3L299-R318)

### Enhancements to Audio Recorder Repository:
* [`lib/features/speech/repository/audio_recorder_repository.dart`](diffhunk://#diff-4098eb84d3b57ec055aea6e4da2f7cd6859c62cb70790c43e5a915b8ac215b97L43-R46): Reduced amplitude update interval from 100ms to 20ms and enabled auto-gain in the recording configuration. [[1]](diffhunk://#diff-4098eb84d3b57ec055aea6e4da2f7cd6859c62cb70790c43e5a915b8ac215b97L43-R46) [[2]](diffhunk://#diff-4098eb84d3b57ec055aea6e4da2f7cd6859c62cb70790c43e5a915b8ac215b97L111-R112)

### Documentation Updates:
* [`lib/features/speech/ui/widgets/recording/README.md`](diffhunk://#diff-8cdcf567fbf5a2c13a3743a531c7a2fd26dc6bd0bb3a2bf5fb20ef8d3aa3068cL21-R22): Updated the `AnalogVuMeter` widget documentation to reflect the new `vu` and `dBFS` properties.

These changes collectively enhance the accuracy and configurability of audio level monitoring, making the VU meter more responsive and suitable for real-time audio analysis.