### PR TITLE
test: add missing tests in router

### DIFF
--- a/lib/features/speech/state/recorder_controller.g.dart
+++ b/lib/features/speech/state/recorder_controller.g.dart
@@ -7,7 +7,7 @@ part of 'recorder_controller.dart';
 // **************************************************************************
 
 String _$audioRecorderControllerHash() =>
-    r'a03336662fa8670d2cc0246dfe25e4d19e75c14c';
+    r'7816a48a597c43d72c76e5c01e0feba9a07ae0bd';
 
 /// Main controller for audio recording functionality.
 ///

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -55,7 +55,7 @@ Future<void> main() async {
     };
 
     runApp(
-      ProviderScope(
+      const ProviderScope(
         child: MyBeamerApp(),
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -157,7 +157,7 @@ dependency_overrides:
 dev_dependencies:
   analyzer: ^7.3.0
   archive: ^3.3.0
-  build_runner: ^2.3.0
+  build_runner: ^2.5.4
   dart_style: ^3.0.1
   drift_dev: ^2.16.0
   flutter_launcher_icons: ^0.14.1

--- a/test/beamer/beamer_delegates_test.dart
+++ b/test/beamer/beamer_delegates_test.dart
@@ -1,0 +1,79 @@
+import 'package:beamer/beamer.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/beamer/beamer_delegates.dart';
+import 'package:lotti/beamer/locations/calendar_location.dart';
+import 'package:lotti/beamer/locations/dashboards_location.dart';
+import 'package:lotti/beamer/locations/habits_location.dart';
+import 'package:lotti/beamer/locations/journal_location.dart';
+import 'package:lotti/beamer/locations/settings_location.dart';
+import 'package:lotti/beamer/locations/tasks_location.dart';
+
+void main() {
+  group('BeamerDelegates', () {
+    test('habitsBeamerDelegate returns HabitsLocation', () {
+      final routeInformation = RouteInformation(uri: Uri.parse('/habits'));
+      final location =
+          habitsBeamerDelegate.locationBuilder(routeInformation, null);
+      expect(location, isA<HabitsLocation>());
+    });
+
+    test('dashboardsBeamerDelegate returns DashboardsLocation', () {
+      final routeInformation = RouteInformation(uri: Uri.parse('/dashboards'));
+      final location =
+          dashboardsBeamerDelegate.locationBuilder(routeInformation, null);
+      expect(location, isA<DashboardsLocation>());
+    });
+
+    test('journalBeamerDelegate returns JournalLocation', () {
+      final routeInformation = RouteInformation(uri: Uri.parse('/journal'));
+      final location =
+          journalBeamerDelegate.locationBuilder(routeInformation, null);
+      expect(location, isA<JournalLocation>());
+    });
+
+    test('tasksBeamerDelegate returns TasksLocation', () {
+      final routeInformation = RouteInformation(uri: Uri.parse('/tasks'));
+      final location =
+          tasksBeamerDelegate.locationBuilder(routeInformation, null);
+      expect(location, isA<TasksLocation>());
+    });
+
+    test('calendarBeamerDelegate returns CalendarLocation', () {
+      final routeInformation = RouteInformation(uri: Uri.parse('/calendar'));
+      final location =
+          calendarBeamerDelegate.locationBuilder(routeInformation, null);
+      expect(location, isA<CalendarLocation>());
+    });
+
+    test('settingsBeamerDelegate returns SettingsLocation', () {
+      final routeInformation = RouteInformation(uri: Uri.parse('/settings'));
+      final location =
+          settingsBeamerDelegate.locationBuilder(routeInformation, null);
+      expect(location, isA<SettingsLocation>());
+    });
+
+    test('returns NotFound for unknown routes', () {
+      final routeInformation = RouteInformation(uri: Uri.parse('/unknown'));
+      final habitsLocation =
+          habitsBeamerDelegate.locationBuilder(routeInformation, null);
+      final dashboardsLocation =
+          dashboardsBeamerDelegate.locationBuilder(routeInformation, null);
+      final journalLocation =
+          journalBeamerDelegate.locationBuilder(routeInformation, null);
+      final tasksLocation =
+          tasksBeamerDelegate.locationBuilder(routeInformation, null);
+      final calendarLocation =
+          calendarBeamerDelegate.locationBuilder(routeInformation, null);
+      final settingsLocation =
+          settingsBeamerDelegate.locationBuilder(routeInformation, null);
+
+      expect(habitsLocation, isA<NotFound>());
+      expect(dashboardsLocation, isA<NotFound>());
+      expect(journalLocation, isA<NotFound>());
+      expect(tasksLocation, isA<NotFound>());
+      expect(calendarLocation, isA<NotFound>());
+      expect(settingsLocation, isA<NotFound>());
+    });
+  });
+}

--- a/test/beamer/locations/calendar_location_test.dart
+++ b/test/beamer/locations/calendar_location_test.dart
@@ -1,0 +1,57 @@
+import 'package:beamer/beamer.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/beamer/locations/calendar_location.dart';
+import 'package:lotti/features/calendar/ui/pages/day_view_page.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockBuildContext extends Mock implements BuildContext {}
+
+void main() {
+  group('CalendarLocation', () {
+    late MockBuildContext mockBuildContext;
+
+    setUp(() {
+      mockBuildContext = MockBuildContext();
+    });
+
+    test('pathPatterns are correct', () {
+      final location =
+          CalendarLocation(RouteInformation(uri: Uri.parse('/calendar')));
+      expect(location.pathPatterns, ['/calendar']);
+    });
+
+    test('buildPages builds DayViewPage with default values', () {
+      final routeInformation = RouteInformation(uri: Uri.parse('/calendar'));
+      final location = CalendarLocation(routeInformation);
+      final beamState = BeamState.fromRouteInformation(routeInformation);
+      final pages = location.buildPages(
+        mockBuildContext,
+        beamState,
+      );
+      expect(pages.length, 1);
+      expect(pages[0].key, isA<ValueKey<String>>());
+      expect(pages[0].child, isA<DayViewPage>());
+      final dayViewPage = pages[0].child as DayViewPage;
+      expect(dayViewPage.initialDayYmd, 'null');
+      expect(dayViewPage.timeSpanDays, 30);
+    });
+
+    test('buildPages builds DayViewPage with provided values', () {
+      final routeInformation = RouteInformation(
+          uri: Uri.parse('/calendar?ymd=2023-01-01&timeSpanDays=7'));
+      final location = CalendarLocation(routeInformation);
+      final beamState = BeamState.fromRouteInformation(routeInformation);
+      final pages = location.buildPages(
+        mockBuildContext,
+        beamState,
+      );
+      expect(pages.length, 1);
+      expect(pages[0].key, isA<ValueKey<String>>());
+      expect(pages[0].child, isA<DayViewPage>());
+      final dayViewPage = pages[0].child as DayViewPage;
+      expect(dayViewPage.initialDayYmd, '2023-01-01');
+      expect(dayViewPage.timeSpanDays, 7);
+    });
+  });
+}

--- a/test/beamer/locations/dashboards_location_test.dart
+++ b/test/beamer/locations/dashboards_location_test.dart
@@ -1,0 +1,67 @@
+import 'package:beamer/beamer.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/beamer/locations/dashboards_location.dart';
+import 'package:lotti/features/dashboards/ui/pages/dashboard_page.dart';
+import 'package:lotti/features/dashboards/ui/pages/dashboards_list_page.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:uuid/uuid.dart';
+
+class MockBuildContext extends Mock implements BuildContext {}
+
+void main() {
+  group('DashboardsLocation', () {
+    late MockBuildContext mockBuildContext;
+
+    setUp(() {
+      mockBuildContext = MockBuildContext();
+    });
+
+    test('pathPatterns are correct', () {
+      final location =
+          DashboardsLocation(RouteInformation(uri: Uri.parse('/dashboards')));
+      expect(
+          location.pathPatterns, ['/dashboards', '/dashboards/:dashboardId']);
+    });
+
+    test('buildPages builds DashboardsListPage', () {
+      final routeInformation = RouteInformation(uri: Uri.parse('/dashboards'));
+      final location = DashboardsLocation(routeInformation);
+      final beamState = BeamState.fromRouteInformation(routeInformation);
+      final pages = location.buildPages(
+        mockBuildContext,
+        beamState,
+      );
+      expect(pages.length, 1);
+      expect(pages[0].key, isA<ValueKey<String>>());
+      expect(pages[0].child, isA<DashboardsListPage>());
+    });
+
+    test('buildPages builds DashboardPage', () {
+      final dashboardId = const Uuid().v4();
+      final routeInformation =
+          RouteInformation(uri: Uri.parse('/dashboards/$dashboardId'));
+      final location = DashboardsLocation(routeInformation);
+      final beamState = BeamState.fromRouteInformation(
+        routeInformation,
+      );
+      final newPathParameters =
+          Map<String, String>.from(beamState.pathParameters);
+      newPathParameters['dashboardId'] = dashboardId;
+      final newBeamState = beamState.copyWith(
+        pathParameters: newPathParameters,
+      );
+      final pages = location.buildPages(
+        mockBuildContext,
+        newBeamState,
+      );
+      expect(pages.length, 2);
+      expect(pages[0].key, isA<ValueKey<String>>());
+      expect(pages[0].child, isA<DashboardsListPage>());
+      expect(pages[1].key, isA<ValueKey<String>>());
+      expect(pages[1].child, isA<DashboardPage>());
+      final dashboardPage = pages[1].child as DashboardPage;
+      expect(dashboardPage.dashboardId, dashboardId);
+    });
+  });
+}

--- a/test/beamer/locations/habits_location_test.dart
+++ b/test/beamer/locations/habits_location_test.dart
@@ -1,0 +1,41 @@
+import 'package:beamer/beamer.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/beamer/locations/habits_location.dart';
+import 'package:lotti/blocs/habits/habits_cubit.dart';
+import 'package:lotti/features/habits/ui/habits_page.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockBuildContext extends Mock implements BuildContext {}
+
+void main() {
+  group('HabitsLocation', () {
+    late MockBuildContext mockBuildContext;
+
+    setUp(() {
+      mockBuildContext = MockBuildContext();
+    });
+
+    test('pathPatterns are correct', () {
+      final location =
+          HabitsLocation(RouteInformation(uri: Uri.parse('/habits')));
+      expect(location.pathPatterns, ['/habits']);
+    });
+
+    test('buildPages builds HabitsTabPage', () {
+      final routeInformation = RouteInformation(uri: Uri.parse('/habits'));
+      final location = HabitsLocation(routeInformation);
+      final beamState = BeamState.fromRouteInformation(routeInformation);
+      final pages = location.buildPages(
+        mockBuildContext,
+        beamState,
+      );
+      expect(pages.length, 1);
+      expect(pages[0].key, isA<ValueKey<String>>());
+      expect(pages[0].child, isA<BlocProvider<HabitsCubit>>());
+      final blocProvider = pages[0].child as BlocProvider<HabitsCubit>;
+      expect(blocProvider.child, isA<HabitsTabPage>());
+    });
+  });
+}

--- a/test/beamer/locations/journal_location_test.dart
+++ b/test/beamer/locations/journal_location_test.dart
@@ -1,0 +1,98 @@
+import 'package:beamer/beamer.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/beamer/locations/journal_location.dart';
+import 'package:lotti/features/journal/ui/pages/entry_details_page.dart';
+import 'package:lotti/features/journal/ui/pages/infinite_journal_page.dart';
+import 'package:lotti/features/surveys/ui/fill_survey_page.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:uuid/uuid.dart';
+
+class MockBuildContext extends Mock implements BuildContext {}
+
+void main() {
+  group('JournalLocation', () {
+    late MockBuildContext mockBuildContext;
+
+    setUp(() {
+      mockBuildContext = MockBuildContext();
+    });
+
+    test('pathPatterns are correct', () {
+      final location =
+          JournalLocation(RouteInformation(uri: Uri.parse('/journal')));
+      expect(location.pathPatterns, [
+        '/journal',
+        '/journal/:entryId',
+        '/journal/fill_survey/:surveyType'
+      ]);
+    });
+
+    test('buildPages builds InfiniteJournalPage', () {
+      final routeInformation = RouteInformation(uri: Uri.parse('/journal'));
+      final location = JournalLocation(routeInformation);
+      final beamState = BeamState.fromRouteInformation(routeInformation);
+      final pages = location.buildPages(
+        mockBuildContext,
+        beamState,
+      );
+      expect(pages.length, 1);
+      expect(pages[0].key, isA<ValueKey<String>>());
+      expect(pages[0].child, isA<InfiniteJournalPage>());
+    });
+
+    test('buildPages builds EntryDetailsPage', () {
+      final entryId = const Uuid().v4();
+      final routeInformation =
+          RouteInformation(uri: Uri.parse('/journal/$entryId'));
+      final location = JournalLocation(routeInformation);
+      final beamState = BeamState.fromRouteInformation(
+        routeInformation,
+      );
+      final newPathParameters =
+          Map<String, String>.from(beamState.pathParameters);
+      newPathParameters['entryId'] = entryId;
+      final newBeamState = beamState.copyWith(
+        pathParameters: newPathParameters,
+      );
+      final pages = location.buildPages(
+        mockBuildContext,
+        newBeamState,
+      );
+      expect(pages.length, 2);
+      expect(pages[0].key, isA<ValueKey<String>>());
+      expect(pages[0].child, isA<InfiniteJournalPage>());
+      expect(pages[1].key, isA<ValueKey<String>>());
+      expect(pages[1].child, isA<EntryDetailsPage>());
+      final entryDetailsPage = pages[1].child as EntryDetailsPage;
+      expect(entryDetailsPage.itemId, entryId);
+    });
+
+    test('buildPages builds FillSurveyWithTypePage', () {
+      const surveyType = 'some-survey';
+      final routeInformation =
+          RouteInformation(uri: Uri.parse('/journal/fill_survey/$surveyType'));
+      final location = JournalLocation(routeInformation);
+      final beamState = BeamState.fromRouteInformation(
+        routeInformation,
+      );
+      final newPathParameters =
+          Map<String, String>.from(beamState.pathParameters);
+      newPathParameters['surveyType'] = surveyType;
+      final newBeamState = beamState.copyWith(
+        pathParameters: newPathParameters,
+      );
+      final pages = location.buildPages(
+        mockBuildContext,
+        newBeamState,
+      );
+      expect(pages.length, 2);
+      expect(pages[0].key, isA<ValueKey<String>>());
+      expect(pages[0].child, isA<InfiniteJournalPage>());
+      expect(pages[1].key, isA<ValueKey<String>>());
+      expect(pages[1].child, isA<FillSurveyWithTypePage>());
+      final fillSurveyPage = pages[1].child as FillSurveyWithTypePage;
+      expect(fillSurveyPage.surveyType, surveyType);
+    });
+  });
+}

--- a/test/beamer/locations/settings_location_test.dart
+++ b/test/beamer/locations/settings_location_test.dart
@@ -1,0 +1,83 @@
+import 'package:beamer/beamer.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/beamer/locations/settings_location.dart';
+import 'package:lotti/pages/settings/settings_page.dart';
+import 'package:lotti/pages/settings/tags/tags_page.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockBuildContext extends Mock implements BuildContext {}
+
+void main() {
+  group('SettingsLocation', () {
+    late MockBuildContext mockBuildContext;
+
+    setUp(() {
+      mockBuildContext = MockBuildContext();
+    });
+
+    test('pathPatterns are correct', () {
+      final location =
+          SettingsLocation(RouteInformation(uri: Uri.parse('/settings')));
+      expect(location.pathPatterns, [
+        '/settings',
+        '/settings/ai',
+        '/settings/tags',
+        '/settings/tags/:tagEntityId',
+        '/settings/tags/create/:tagType',
+        '/settings/categories',
+        '/settings/categories/:categoryId',
+        '/settings/categories/create',
+        '/settings/dashboards',
+        '/settings/dashboards/:dashboardId',
+        '/settings/dashboards/create',
+        '/settings/measurables',
+        '/settings/measurables/:measurableId',
+        '/settings/measurables/create',
+        '/settings/habits',
+        '/settings/habits/by_id/:habitId',
+        '/settings/habits/create',
+        '/settings/habits/search/:searchTerm',
+        '/settings/flags',
+        '/settings/theming',
+        '/settings/advanced',
+        '/settings/outbox_monitor',
+        '/settings/logging',
+        '/settings/advanced/logging/:logEntryId',
+        '/settings/advanced/conflicts/:conflictId',
+        '/settings/advanced/conflicts/:conflictId/edit',
+        '/settings/advanced/conflicts',
+        '/settings/maintenance',
+      ]);
+    });
+
+    test('buildPages builds SettingsPage', () {
+      final routeInformation = RouteInformation(uri: Uri.parse('/settings'));
+      final location = SettingsLocation(routeInformation);
+      final beamState = BeamState.fromRouteInformation(routeInformation);
+      final pages = location.buildPages(
+        mockBuildContext,
+        beamState,
+      );
+      expect(pages.length, 1);
+      expect(pages[0].key, isA<ValueKey<String>>());
+      expect(pages[0].child, isA<SettingsPage>());
+    });
+
+    test('buildPages builds TagsPage', () {
+      final routeInformation =
+          RouteInformation(uri: Uri.parse('/settings/tags'));
+      final location = SettingsLocation(routeInformation);
+      final beamState = BeamState.fromRouteInformation(routeInformation);
+      final pages = location.buildPages(
+        mockBuildContext,
+        beamState,
+      );
+      expect(pages.length, 2);
+      expect(pages[0].key, isA<ValueKey<String>>());
+      expect(pages[0].child, isA<SettingsPage>());
+      expect(pages[1].key, isA<ValueKey<String>>());
+      expect(pages[1].child, isA<TagsPage>());
+    });
+  });
+}

--- a/test/beamer/locations/tasks_location_test.dart
+++ b/test/beamer/locations/tasks_location_test.dart
@@ -1,0 +1,68 @@
+import 'package:beamer/beamer.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/beamer/locations/tasks_location.dart';
+import 'package:lotti/features/journal/ui/pages/infinite_journal_page.dart';
+import 'package:lotti/features/tasks/ui/pages/task_details_page.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:uuid/uuid.dart';
+
+class MockBuildContext extends Mock implements BuildContext {}
+
+void main() {
+  group('TasksLocation', () {
+    late MockBuildContext mockBuildContext;
+
+    setUp(() {
+      mockBuildContext = MockBuildContext();
+    });
+
+    test('pathPatterns are correct', () {
+      final location =
+          TasksLocation(RouteInformation(uri: Uri.parse('/tasks')));
+      expect(location.pathPatterns, ['/tasks', '/tasks/:taskId']);
+    });
+
+    test('buildPages builds InfiniteJournalPage', () {
+      final routeInformation = RouteInformation(uri: Uri.parse('/tasks'));
+      final location = TasksLocation(routeInformation);
+      final beamState = BeamState.fromRouteInformation(routeInformation);
+      final pages = location.buildPages(
+        mockBuildContext,
+        beamState,
+      );
+      expect(pages.length, 1);
+      expect(pages[0].key, isA<ValueKey<String>>());
+      expect(pages[0].child, isA<InfiniteJournalPage>());
+      final journalPage = pages[0].child as InfiniteJournalPage;
+      expect(journalPage.showTasks, isTrue);
+    });
+
+    test('buildPages builds TaskDetailsPage', () {
+      final taskId = const Uuid().v4();
+      final routeInformation =
+          RouteInformation(uri: Uri.parse('/tasks/$taskId'));
+      final location = TasksLocation(routeInformation);
+      final beamState = BeamState.fromRouteInformation(
+        routeInformation,
+      );
+      final newPathParameters =
+          Map<String, String>.from(beamState.pathParameters);
+      newPathParameters['taskId'] = taskId;
+      final newBeamState = beamState.copyWith(
+        pathParameters: newPathParameters,
+      );
+      final pages = location.buildPages(
+        mockBuildContext,
+        newBeamState,
+      );
+      expect(pages.length, 2);
+      expect(pages[0].key, isA<ValueKey<String>>());
+      expect(pages[0].child, isA<InfiniteJournalPage>());
+      expect(pages[1].key, isA<ValueKey<String>>());
+      expect(pages[1].child, isA<TaskDetailsPage>());
+      final taskDetailsPage = pages[1].child as TaskDetailsPage;
+      expect(taskDetailsPage.taskId, taskId);
+    });
+  });
+}


### PR DESCRIPTION
This pull request introduces several enhancements and modifications to the `beamer_app.dart` file and related tests, focusing on improving dependency injection, configurability, and test coverage for Beamer-based navigation. The changes include adding optional dependencies for better flexibility, updating the test suite to validate navigation behavior, and upgrading a development dependency.

### Dependency Injection Enhancements:
* [`lib/beamer/beamer_app.dart`](diffhunk://#diff-350ebc719538001d1544da4250b6cf3bc2390b3308862d2232af08e8f69b1f34L32-R37): Added optional parameters (`journalDb`, `navService`, `themingCubit`, `outboxCubit`, `audioPlayerCubit`, `userActivityService`) to `AppScreen` and `MyBeamerApp` for improved configurability. These parameters default to `getIt` instances when not provided. [[1]](diffhunk://#diff-350ebc719538001d1544da4250b6cf3bc2390b3308862d2232af08e8f69b1f34L32-R37) [[2]](diffhunk://#diff-350ebc719538001d1544da4250b6cf3bc2390b3308862d2232af08e8f69b1f34L175-L185) [[3]](diffhunk://#diff-350ebc719538001d1544da4250b6cf3bc2390b3308862d2232af08e8f69b1f34L194-R229) [[4]](diffhunk://#diff-350ebc719538001d1544da4250b6cf3bc2390b3308862d2232af08e8f69b1f34L216-R247)

### Test Coverage for Beamer Locations:
* [`test/beamer/beamer_delegates_test.dart`](diffhunk://#diff-3a9a952ee52483f34b9eef3990c9569bce907a574ff8df1bfa4618f8b899d125R1-R80): Added tests for Beamer delegates to ensure proper routing and fallback behavior for unknown routes.
* [`test/beamer/locations/*_location_test.dart`](diffhunk://#diff-721221323f23d7c240ee47c60ee0e7eb4c93d828a0db5d622cfc4f2bf8f10b6cR1-R57): Added comprehensive tests for `CalendarLocation`, `DashboardsLocation`, `HabitsLocation`, `JournalLocation`, and `SettingsLocation` to validate path patterns and page-building logic. [[1]](diffhunk://#diff-721221323f23d7c240ee47c60ee0e7eb4c93d828a0db5d622cfc4f2bf8f10b6cR1-R57) [[2]](diffhunk://#diff-841e98d1418f2fc059bbe6b67a7056b8635561f330e0ddcb8f5ee0035f43b7efR1-R67) [[3]](diffhunk://#diff-3c1d4d31dd73b1adf78fab0580e343ff4d2679dedc46f6224da353bbca928b56R1-R41) [[4]](diffhunk://#diff-4c4d0dcbf5f8828df5bcc8e7e76309d7ea33cb2c2ae943c13fb9e2b35c63c967R1-R98) [[5]](diffhunk://#diff-9f7d4e9572c0256e66d3c19014b9aac471c2cae74daa97469688855dcad9b56fR1-R83)

### Development Dependency Update:
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L160-R160): Upgraded `build_runner` from version `^2.3.0` to `^2.5.4` to ensure compatibility and access to the latest features.

### Minor Code Adjustments:
* [`lib/main.dart`](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L58-R58): Marked `ProviderScope` as `const` in the `main` function for consistency and optimization.
* [`lib/features/speech/state/recorder_controller.g.dart`](diffhunk://#diff-8c771d6d8feae43dc17522d45b0cccffc0505f3cfffefecfceca688fa9455ba3L10-R10): Updated the hash value for `audioRecorderController` to reflect changes.