### PR TITLE
feat: improve task cards

### DIFF
--- a/lib/features/journal/ui/widgets/create/modern_create_entry_items.dart
+++ b/lib/features/journal/ui/widgets/create/modern_create_entry_items.dart
@@ -58,12 +58,13 @@ class ModernCreateTaskItem extends ConsumerWidget {
           linkedId: linkedFromId,
           categoryId: categoryId,
         );
+        if (!context.mounted) {
+          return;
+        }
         if (task != null) {
           beamToNamed('/tasks/${task.meta.id}');
         }
-        if (context.mounted) {
-          Navigator.of(context).pop();
-        }
+        Navigator.of(context).pop();
       },
     );
   }

--- a/lib/features/journal/ui/widgets/create/modern_create_entry_items.dart
+++ b/lib/features/journal/ui/widgets/create/modern_create_entry_items.dart
@@ -5,6 +5,7 @@ import 'package:lotti/features/journal/state/image_paste_controller.dart';
 import 'package:lotti/features/speech/ui/widgets/recording/audio_recording_modal.dart';
 import 'package:lotti/logic/create/create_entry.dart';
 import 'package:lotti/logic/image_import.dart';
+import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/widgets/modal/modern_modal_entry_type_item.dart';
 
 /// Modern version of create event item
@@ -53,10 +54,13 @@ class ModernCreateTaskItem extends ConsumerWidget {
       icon: Icons.task_alt_rounded,
       title: 'Task',
       onTap: () async {
-        await createTask(
+        final task = await createTask(
           linkedId: linkedFromId,
           categoryId: categoryId,
         );
+        if (task != null) {
+          beamToNamed('/tasks/${task.meta.id}');
+        }
         if (context.mounted) {
           Navigator.of(context).pop();
         }

--- a/lib/features/journal/ui/widgets/entry_detail_linked_from.dart
+++ b/lib/features/journal/ui/widgets/entry_detail_linked_from.dart
@@ -41,19 +41,27 @@ class LinkedFromEntriesWidget extends ConsumerWidget {
             return item.maybeMap(
               journalImage: (JournalImage image) {
                 return Padding(
-                  padding: const EdgeInsets.only(left: 5, right: 5, bottom: 4),
+                  padding: const EdgeInsets.only(
+                    left: AppTheme.spacingXSmall,
+                    right: AppTheme.spacingXSmall,
+                    bottom: AppTheme.spacingXSmall,
+                  ),
                   child: ModernJournalImageCard(
                     item: image,
-                    key: Key('${item.meta.id}-${item.meta.id}'),
+                    key: ValueKey(image.meta.id),
                   ),
                 );
               },
               orElse: () {
                 return Padding(
-                  padding: const EdgeInsets.only(left: 5, right: 5, bottom: 4),
+                  padding: const EdgeInsets.only(
+                    left: AppTheme.spacingXSmall,
+                    right: AppTheme.spacingXSmall,
+                    bottom: AppTheme.spacingXSmall,
+                  ),
                   child: ModernJournalCard(
                     item: item,
-                    key: Key('${item.meta.id}-${item.meta.id}'),
+                    key: ValueKey(item.meta.id),
                     showLinkedDuration: true,
                     removeHorizontalMargin: true,
                   ),

--- a/lib/features/journal/ui/widgets/entry_detail_linked_from.dart
+++ b/lib/features/journal/ui/widgets/entry_detail_linked_from.dart
@@ -40,16 +40,23 @@ class LinkedFromEntriesWidget extends ConsumerWidget {
             final item = items.elementAt(index);
             return item.maybeMap(
               journalImage: (JournalImage image) {
-                return ModernJournalImageCard(
-                  item: image,
-                  key: Key('${item.meta.id}-${item.meta.id}'),
+                return Padding(
+                  padding: const EdgeInsets.only(left: 5, right: 5, bottom: 4),
+                  child: ModernJournalImageCard(
+                    item: image,
+                    key: Key('${item.meta.id}-${item.meta.id}'),
+                  ),
                 );
               },
               orElse: () {
-                return ModernJournalCard(
-                  item: item,
-                  key: Key('${item.meta.id}-${item.meta.id}'),
-                  showLinkedDuration: true,
+                return Padding(
+                  padding: const EdgeInsets.only(left: 5, right: 5, bottom: 4),
+                  child: ModernJournalCard(
+                    item: item,
+                    key: Key('${item.meta.id}-${item.meta.id}'),
+                    showLinkedDuration: true,
+                    removeHorizontalMargin: true,
+                  ),
                 );
               },
             );

--- a/lib/features/journal/ui/widgets/entry_details_widget.dart
+++ b/lib/features/journal/ui/widgets/entry_details_widget.dart
@@ -18,6 +18,7 @@ import 'package:lotti/features/journal/ui/widgets/tags/tags_list_widget.dart';
 import 'package:lotti/features/speech/ui/widgets/audio_player.dart';
 import 'package:lotti/features/tasks/ui/checklists/checklist_item_wrapper.dart';
 import 'package:lotti/features/tasks/ui/checklists/checklist_wrapper.dart';
+import 'package:lotti/themes/theme.dart';
 import 'package:lotti/widgets/events/event_form.dart';
 
 class EntryDetailsWidget extends ConsumerWidget {
@@ -61,7 +62,11 @@ class EntryDetailsWidget extends ConsumerWidget {
 
     if (isTask && !showTaskDetails) {
       return Padding(
-        padding: const EdgeInsets.only(left: 5, right: 5, bottom: 4),
+        padding: const EdgeInsets.only(
+          left: AppTheme.spacingXSmall,
+          right: AppTheme.spacingXSmall,
+          bottom: AppTheme.spacingXSmall,
+        ),
         child: ModernJournalCard(
           item: item,
           showLinkedDuration: true,
@@ -72,9 +77,13 @@ class EntryDetailsWidget extends ConsumerWidget {
 
     return Card(
       key: isAudio ? Key('$itemId-${item.meta.vectorClock}') : Key(itemId),
-      margin: const EdgeInsets.only(left: 5, right: 5, bottom: 10),
+      margin: const EdgeInsets.only(
+        left: AppTheme.spacingXSmall,
+        right: AppTheme.spacingXSmall,
+        bottom: AppTheme.spacingMedium,
+      ),
       child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 10),
+        padding: const EdgeInsets.symmetric(horizontal: AppTheme.spacingMedium),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [

--- a/lib/features/journal/ui/widgets/entry_details_widget.dart
+++ b/lib/features/journal/ui/widgets/entry_details_widget.dart
@@ -60,9 +60,13 @@ class EntryDetailsWidget extends ConsumerWidget {
     final isAudio = item is JournalAudio;
 
     if (isTask && !showTaskDetails) {
-      return ModernJournalCard(
-        item: item,
-        showLinkedDuration: true,
+      return Padding(
+        padding: const EdgeInsets.only(left: 5, right: 5, bottom: 4),
+        child: ModernJournalCard(
+          item: item,
+          showLinkedDuration: true,
+          removeHorizontalMargin: true,
+        ),
       );
     }
 

--- a/lib/features/journal/ui/widgets/list_cards/animated_modern_task_card.dart
+++ b/lib/features/journal/ui/widgets/list_cards/animated_modern_task_card.dart
@@ -29,6 +29,7 @@ class AnimatedModernTaskCard extends StatelessWidget {
       tapScale: 0.985, // Subtle tap effect
       hoverElevation: 2, // Less elevation for list items
       margin: EdgeInsets.zero, // ModernTaskCard already has its own margins
+      disableShadow: true, // ModernTaskCard already has its own shadow
       child: ModernTaskCard(
         task: task,
         isCompact: isCompact,

--- a/lib/features/journal/ui/widgets/list_cards/modern_journal_card.dart
+++ b/lib/features/journal/ui/widgets/list_cards/modern_journal_card.dart
@@ -63,7 +63,7 @@ class ModernJournalCard extends StatelessWidget {
       onTap: onTap,
       isCompact: isCompact,
       margin: EdgeInsets.symmetric(
-        horizontal: removeHorizontalMargin ? 0 : 12,
+        horizontal: removeHorizontalMargin ? 0 : AppTheme.spacingLarge,
         vertical: AppTheme.cardSpacing / 2,
       ),
       child: _buildContent(context),

--- a/lib/features/journal/ui/widgets/list_cards/modern_journal_card.dart
+++ b/lib/features/journal/ui/widgets/list_cards/modern_journal_card.dart
@@ -33,6 +33,7 @@ class ModernJournalCard extends StatelessWidget {
     this.maxHeight = 120,
     this.showLinkedDuration = false,
     this.isCompact = false,
+    this.removeHorizontalMargin = false,
     super.key,
   });
   // Widget height constants
@@ -42,6 +43,7 @@ class ModernJournalCard extends StatelessWidget {
   final double maxHeight;
   final bool showLinkedDuration;
   final bool isCompact;
+  final bool removeHorizontalMargin;
 
   @override
   Widget build(BuildContext context) {
@@ -60,8 +62,8 @@ class ModernJournalCard extends StatelessWidget {
     return ModernBaseCard(
       onTap: onTap,
       isCompact: isCompact,
-      margin: const EdgeInsets.symmetric(
-        horizontal: 12,
+      margin: EdgeInsets.symmetric(
+        horizontal: removeHorizontalMargin ? 0 : 12,
         vertical: AppTheme.cardSpacing / 2,
       ),
       child: _buildContent(context),

--- a/lib/widgets/modal/animated_modal_item.dart
+++ b/lib/widgets/modal/animated_modal_item.dart
@@ -14,6 +14,7 @@ class AnimatedModalItem extends StatefulWidget {
     this.hoverElevation = 4,
     this.controller,
     this.margin,
+    this.disableShadow = false,
     super.key,
   });
 
@@ -26,6 +27,7 @@ class AnimatedModalItem extends StatefulWidget {
   final double hoverElevation;
   final AnimatedModalItemController? controller;
   final EdgeInsetsGeometry? margin;
+  final bool disableShadow;
 
   @override
   State<AnimatedModalItem> createState() => _AnimatedModalItemState();
@@ -177,20 +179,22 @@ class _AnimatedModalItemState extends State<AnimatedModalItem>
                     decoration: BoxDecoration(
                       borderRadius:
                           BorderRadius.circular(AppTheme.cardBorderRadius),
-                      boxShadow: [
-                        BoxShadow(
-                          color: context.colorScheme.shadow.withValues(
-                            alpha: isDark
-                                ? AppTheme.alphaShadowDark
-                                : AppTheme.alphaShadowLight,
-                          ),
-                          blurRadius: (isDark
-                                  ? AppTheme.cardElevationDark
-                                  : AppTheme.cardElevationLight) +
-                              _hoverElevationAnimation.value,
-                          offset: AppTheme.shadowOffset,
-                        ),
-                      ],
+                      boxShadow: widget.disableShadow
+                          ? null
+                          : [
+                              BoxShadow(
+                                color: context.colorScheme.shadow.withValues(
+                                  alpha: isDark
+                                      ? AppTheme.alphaShadowDark
+                                      : AppTheme.alphaShadowLight,
+                                ),
+                                blurRadius: (isDark
+                                        ? AppTheme.cardElevationDark
+                                        : AppTheme.cardElevationLight) +
+                                    _hoverElevationAnimation.value,
+                                offset: AppTheme.shadowOffset,
+                              ),
+                            ],
                     ),
                     child: widget.child,
                   ),

--- a/lib/widgets/modal/animated_modal_item_with_icon.dart
+++ b/lib/widgets/modal/animated_modal_item_with_icon.dart
@@ -13,6 +13,7 @@ class AnimatedModalItemWithIcon extends StatefulWidget {
     this.tapOpacity = 1.0,
     this.hoverElevation = 4,
     this.iconScaleOnTap = 0.9,
+    this.disableShadow = false,
     super.key,
   });
 
@@ -26,6 +27,7 @@ class AnimatedModalItemWithIcon extends StatefulWidget {
   final double tapOpacity;
   final double hoverElevation;
   final double iconScaleOnTap;
+  final bool disableShadow;
 
   @override
   State<AnimatedModalItemWithIcon> createState() =>
@@ -179,20 +181,22 @@ class _AnimatedModalItemWithIconState extends State<AnimatedModalItemWithIcon>
                   decoration: BoxDecoration(
                     borderRadius:
                         BorderRadius.circular(AppTheme.cardBorderRadius),
-                    boxShadow: [
-                      BoxShadow(
-                        color: context.colorScheme.shadow.withValues(
-                          alpha: isDark
-                              ? AppTheme.alphaShadowDark
-                              : AppTheme.alphaShadowLight,
-                        ),
-                        blurRadius: (isDark
-                                ? AppTheme.cardElevationDark
-                                : AppTheme.cardElevationLight) +
-                            _hoverElevationAnimation.value,
-                        offset: AppTheme.shadowOffset,
-                      ),
-                    ],
+                    boxShadow: widget.disableShadow
+                        ? null
+                        : [
+                            BoxShadow(
+                              color: context.colorScheme.shadow.withValues(
+                                alpha: isDark
+                                    ? AppTheme.alphaShadowDark
+                                    : AppTheme.alphaShadowLight,
+                              ),
+                              blurRadius: (isDark
+                                      ? AppTheme.cardElevationDark
+                                      : AppTheme.cardElevationLight) +
+                                  _hoverElevationAnimation.value,
+                              offset: AppTheme.shadowOffset,
+                            ),
+                          ],
                   ),
                   child: AnimatedOpacity(
                     opacity:

--- a/lib/widgets/settings/animated_settings_cards.dart
+++ b/lib/widgets/settings/animated_settings_cards.dart
@@ -34,6 +34,7 @@ class AnimatedModernSettingsCardWithIcon extends StatelessWidget {
   Widget build(BuildContext context) {
     return AnimatedModalItemWithIcon(
       onTap: onTap,
+      disableShadow: true, // ModernBaseCard already has its own shadow
       iconBuilder: (context, iconAnimation, {required isPressed}) {
         return Positioned(
           left: isCompact ? 12 : 16,
@@ -114,6 +115,7 @@ class AnimatedModernMaintenanceCard extends StatelessWidget {
 
     return AnimatedModalItemWithIcon(
       onTap: onTap,
+      disableShadow: true, // ModernBaseCard already has its own shadow
       iconBuilder: icon != null
           ? (context, iconAnimation, {required isPressed}) {
               return Positioned(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.639+3136
+version: 0.9.640+3137
 
 msix_config:
   display_name: LottiApp

--- a/test/features/journal/ui/widgets/create/modern_create_entry_items_test.dart
+++ b/test/features/journal/ui/widgets/create/modern_create_entry_items_test.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/journal/ui/widgets/create/modern_create_entry_items.dart';
+import 'package:lotti/widgets/modal/modern_modal_entry_type_item.dart';
+
+import '../../../../../widget_test_utils.dart';
+
+void main() {
+  group('ModernCreateTaskItem Tests', () {
+    testWidgets('renders task item correctly', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const ModernCreateTaskItem(
+            'linked-id',
+            categoryId: 'category-id',
+          ),
+        ),
+      );
+
+      // Verify the task item is rendered
+      expect(find.byType(ModernModalEntryTypeItem), findsOneWidget);
+      expect(find.text('Task'), findsOneWidget);
+      expect(find.byIcon(Icons.task_alt_rounded), findsOneWidget);
+    });
+
+    testWidgets('shows task item in modal', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          Builder(
+            builder: (context) => Column(
+              children: [
+                ElevatedButton(
+                  onPressed: () {
+                    showModalBottomSheet<void>(
+                      context: context,
+                      builder: (_) => const ModernCreateTaskItem(
+                        'linked-id',
+                        categoryId: 'category-id',
+                      ),
+                    );
+                  },
+                  child: const Text('Show Modal'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // Open the modal
+      await tester.tap(find.text('Show Modal'));
+      await tester.pumpAndSettle();
+
+      // Verify the task item is shown
+      expect(find.byType(ModernModalEntryTypeItem), findsOneWidget);
+      expect(find.text('Task'), findsOneWidget);
+      expect(find.byIcon(Icons.task_alt_rounded), findsOneWidget);
+    });
+  });
+
+  group('ModernCreateEventItem Tests', () {
+    testWidgets('renders correctly', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const ModernCreateEventItem(
+            'linked-id',
+            categoryId: 'category-id',
+          ),
+        ),
+      );
+
+      // Verify the event item is rendered
+      expect(find.byType(ModernModalEntryTypeItem), findsOneWidget);
+      expect(find.text('Event'), findsOneWidget);
+      expect(find.byIcon(Icons.event_rounded), findsOneWidget);
+    });
+  });
+
+  group('ModernCreateAudioItem Tests', () {
+    testWidgets('renders correctly', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const ModernCreateAudioItem(
+            'linked-id',
+            categoryId: 'category-id',
+          ),
+        ),
+      );
+
+      // Verify the audio item is rendered
+      expect(find.byType(ModernModalEntryTypeItem), findsOneWidget);
+      expect(find.text('Audio'), findsOneWidget);
+      expect(find.byIcon(Icons.mic_none_rounded), findsOneWidget);
+    });
+  });
+
+  // ModernCreateTimerItem requires GetIt services and EntryController
+  // which makes it more complex to test. Consider integration tests
+  // or a more complete test setup for this widget.
+
+  group('ModernCreateTextItem Tests', () {
+    testWidgets('renders correctly', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const ModernCreateTextItem(
+            'linked-id',
+            categoryId: 'category-id',
+          ),
+        ),
+      );
+
+      // Verify the text item is rendered
+      expect(find.byType(ModernModalEntryTypeItem), findsOneWidget);
+      expect(find.text('Text'), findsOneWidget);
+      expect(find.byIcon(Icons.notes_rounded), findsOneWidget);
+    });
+  });
+
+  group('ModernImportImageItem Tests', () {
+    testWidgets('renders correctly', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const ModernImportImageItem(
+            'linked-id',
+            categoryId: 'category-id',
+          ),
+        ),
+      );
+
+      // Verify the import image item is rendered
+      expect(find.byType(ModernModalEntryTypeItem), findsOneWidget);
+      expect(find.text('Import Image'), findsOneWidget);
+      expect(find.byIcon(Icons.photo_library_rounded), findsOneWidget);
+    });
+  });
+
+  group('ModernCreateScreenshotItem Tests', () {
+    testWidgets('renders correctly', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const ModernCreateScreenshotItem(
+            'linked-id',
+            categoryId: 'category-id',
+          ),
+        ),
+      );
+
+      // Verify the screenshot item is rendered
+      expect(find.byType(ModernModalEntryTypeItem), findsOneWidget);
+      expect(find.text('Screenshot'), findsOneWidget);
+      expect(find.byIcon(Icons.screenshot_monitor_rounded), findsOneWidget);
+    });
+  });
+}

--- a/test/features/journal/ui/widgets/entry_detail_linked_from_test.dart
+++ b/test/features/journal/ui/widgets/entry_detail_linked_from_test.dart
@@ -62,7 +62,6 @@ class TestLinkedFromWidget extends StatelessWidget {
   }
 }
 
-
 void main() {
   group('LinkedFromWidget Structure Tests', () {
     testWidgets('renders correctly with image entries', (tester) async {

--- a/test/features/journal/ui/widgets/entry_detail_linked_from_test.dart
+++ b/test/features/journal/ui/widgets/entry_detail_linked_from_test.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/themes/theme.dart';
+
+import '../../../../widget_test_utils.dart';
+
+// Simple widget that mimics LinkedFromEntriesWidget structure for testing
+class TestLinkedFromWidget extends StatelessWidget {
+  const TestLinkedFromWidget({
+    required this.hasData,
+    required this.hasImageEntries,
+    super.key,
+  });
+
+  final bool hasData;
+  final bool hasImageEntries;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!hasData) {
+      return const SizedBox.shrink();
+    }
+
+    return Column(
+      children: [
+        Text(
+          context.messages.journalLinkedFromLabel,
+          style: context.textTheme.titleSmall
+              ?.copyWith(color: context.colorScheme.outline),
+        ),
+        if (hasImageEntries)
+          Padding(
+            padding: const EdgeInsets.only(
+              left: AppTheme.spacingXSmall,
+              right: AppTheme.spacingXSmall,
+              bottom: AppTheme.spacingXSmall,
+            ),
+            child: Container(
+              key: const ValueKey('image-1'),
+              height: 100,
+              color: Colors.grey,
+              child: const Text('Mock Image Card'),
+            ),
+          ),
+        if (!hasImageEntries)
+          Padding(
+            padding: const EdgeInsets.only(
+              left: AppTheme.spacingXSmall,
+              right: AppTheme.spacingXSmall,
+              bottom: AppTheme.spacingXSmall,
+            ),
+            child: Container(
+              key: const ValueKey('text-1'),
+              height: 80,
+              color: Colors.blue,
+              child: const Text('Mock Journal Card'),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+
+void main() {
+  group('LinkedFromWidget Structure Tests', () {
+    testWidgets('renders correctly with image entries', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const TestLinkedFromWidget(
+            hasData: true,
+            hasImageEntries: true,
+          ),
+        ),
+      );
+
+      // Verify the section title is rendered
+      expect(find.text('Linked from:'), findsOneWidget);
+
+      // Verify image container is rendered with correct key
+      expect(find.byKey(const ValueKey('image-1')), findsOneWidget);
+
+      // Verify padding is applied correctly
+      final padding = tester.widget<Padding>(
+        find
+            .ancestor(
+              of: find.byKey(const ValueKey('image-1')),
+              matching: find.byType(Padding),
+            )
+            .first,
+      );
+
+      expect(
+        padding.padding,
+        const EdgeInsets.only(
+          left: AppTheme.spacingXSmall,
+          right: AppTheme.spacingXSmall,
+          bottom: AppTheme.spacingXSmall,
+        ),
+      );
+    });
+
+    testWidgets('renders correctly with regular entries', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const TestLinkedFromWidget(
+            hasData: true,
+            hasImageEntries: false,
+          ),
+        ),
+      );
+
+      // Verify the section title is rendered
+      expect(find.text('Linked from:'), findsOneWidget);
+
+      // Verify text container is rendered with correct key
+      expect(find.byKey(const ValueKey('text-1')), findsOneWidget);
+
+      // Verify padding is applied correctly
+      final padding = tester.widget<Padding>(
+        find
+            .ancestor(
+              of: find.byKey(const ValueKey('text-1')),
+              matching: find.byType(Padding),
+            )
+            .first,
+      );
+
+      expect(
+        padding.padding,
+        const EdgeInsets.only(
+          left: AppTheme.spacingXSmall,
+          right: AppTheme.spacingXSmall,
+          bottom: AppTheme.spacingXSmall,
+        ),
+      );
+    });
+
+    testWidgets('renders empty when no data', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const TestLinkedFromWidget(
+            hasData: false,
+            hasImageEntries: false,
+          ),
+        ),
+      );
+
+      // Empty list should show nothing
+      expect(find.text('Linked from:'), findsNothing);
+      expect(find.byKey(const ValueKey('image-1')), findsNothing);
+      expect(find.byKey(const ValueKey('text-1')), findsNothing);
+    });
+  });
+}

--- a/test/features/journal/ui/widgets/entry_details_widget_test.dart
+++ b/test/features/journal/ui/widgets/entry_details_widget_test.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/themes/theme.dart';
+
+import '../../../../widget_test_utils.dart';
+
+// Simplified test widget that mimics EntryDetailsWidget behavior
+class TestEntryDetailsWidget extends StatelessWidget {
+  const TestEntryDetailsWidget({
+    required this.isTask,
+    required this.showTaskDetails,
+    super.key,
+  });
+
+  final bool isTask;
+  final bool showTaskDetails;
+
+  @override
+  Widget build(BuildContext context) {
+    if (isTask && !showTaskDetails) {
+      return Padding(
+        padding: const EdgeInsets.only(
+          left: AppTheme.spacingXSmall,
+          right: AppTheme.spacingXSmall,
+          bottom: AppTheme.spacingXSmall,
+        ),
+        child: Container(
+          key: const Key('modern-journal-card'),
+          height: 100,
+          color: Colors.blue,
+          child: const Text('Mock Modern Journal Card'),
+        ),
+      );
+    }
+
+    return const Card(
+      key: Key('entry-details-card'),
+      margin: EdgeInsets.only(
+        left: AppTheme.spacingXSmall,
+        right: AppTheme.spacingXSmall,
+        bottom: AppTheme.spacingMedium,
+      ),
+      child: Padding(
+        padding: EdgeInsets.symmetric(horizontal: AppTheme.spacingMedium),
+        child: Text('Entry Details Content'),
+      ),
+    );
+  }
+}
+
+void main() {
+  group('EntryDetailsWidget Layout Tests', () {
+    testWidgets(
+        'wraps task cards with proper padding when showTaskDetails is false',
+        (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const TestEntryDetailsWidget(
+            isTask: true,
+            showTaskDetails: false,
+          ),
+        ),
+      );
+
+      // Find the container that represents our mock card
+      final containerFinder = find.byKey(const Key('modern-journal-card'));
+      expect(containerFinder, findsOneWidget);
+
+      // Find the padding widget that wraps it
+      final paddingFinder = find.ancestor(
+        of: containerFinder,
+        matching: find.byType(Padding),
+      );
+
+      expect(paddingFinder, findsOneWidget);
+
+      final padding = tester.widget<Padding>(paddingFinder);
+      expect(
+        padding.padding,
+        const EdgeInsets.only(
+          left: AppTheme.spacingXSmall,
+          right: AppTheme.spacingXSmall,
+          bottom: AppTheme.spacingXSmall,
+        ),
+      );
+    });
+
+    testWidgets('renders card layout when showTaskDetails is true',
+        (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const TestEntryDetailsWidget(
+            isTask: true,
+            showTaskDetails: true,
+          ),
+        ),
+      );
+
+      // When showTaskDetails is true, it should render a Card
+      expect(find.byType(Card), findsOneWidget);
+      expect(find.byKey(const Key('entry-details-card')), findsOneWidget);
+
+      // Mock modern journal card should not be present
+      expect(find.byKey(const Key('modern-journal-card')), findsNothing);
+
+      // Verify card margins
+      final card = tester.widget<Card>(find.byType(Card));
+      expect(
+        card.margin,
+        const EdgeInsets.only(
+          left: AppTheme.spacingXSmall,
+          right: AppTheme.spacingXSmall,
+          bottom: AppTheme.spacingMedium,
+        ),
+      );
+    });
+
+    testWidgets('renders card layout for non-task entries', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const TestEntryDetailsWidget(
+            isTask: false,
+            showTaskDetails: false,
+          ),
+        ),
+      );
+
+      // Non-task entries should always render a Card
+      expect(find.byType(Card), findsOneWidget);
+      expect(find.byKey(const Key('entry-details-card')), findsOneWidget);
+    });
+
+    testWidgets('verifies padding structure for task cards', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const TestEntryDetailsWidget(
+            isTask: true,
+            showTaskDetails: false,
+          ),
+        ),
+      );
+
+      // Verify the widget tree structure
+      final container = find.byKey(const Key('modern-journal-card'));
+      final padding = find.ancestor(
+        of: container,
+        matching: find.byType(Padding),
+      );
+
+      expect(container, findsOneWidget);
+      expect(padding, findsOneWidget);
+
+      // Verify no Card widget is present
+      expect(find.byType(Card), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
This pull request introduces several enhancements across the codebase, focusing on improving UI consistency, adding navigation functionality, and refining shadow behavior for card components. Additionally, it includes a minor version update in the `pubspec.yaml` file.

### UI Enhancements
* [`lib/features/journal/ui/widgets/entry_detail_linked_from.dart`](diffhunk://#diff-21b7fb6475a891c47ebb336dd0c0c8ebbe3d5b4d52cd50fad843a0dbcfd6154eL43-R59): Added padding to `ModernJournalImageCard` and `ModernJournalCard` components to ensure consistent spacing.  
* [`lib/features/journal/ui/widgets/entry_details_widget.dart`](diffhunk://#diff-93ad37855c712656d71406176b0b0815f16d66de387ecedcd35ef18d990fa51aL63-R69): Wrapped `ModernJournalCard` in a `Padding` widget to improve visual alignment and added support for removing horizontal margins.  
* [`lib/features/journal/ui/widgets/list_cards/modern_journal_card.dart`](diffhunk://#diff-25cc3432042668551efdc0c747a6cbb46679265f2020aee100b296e11cab3595R36): Introduced a `removeHorizontalMargin` property to control horizontal margins dynamically. [[1]](diffhunk://#diff-25cc3432042668551efdc0c747a6cbb46679265f2020aee100b296e11cab3595R36) [[2]](diffhunk://#diff-25cc3432042668551efdc0c747a6cbb46679265f2020aee100b296e11cab3595R46) [[3]](diffhunk://#diff-25cc3432042668551efdc0c747a6cbb46679265f2020aee100b296e11cab3595L63-R66)

### Navigation Improvements
* [`lib/features/journal/ui/widgets/create/modern_create_entry_items.dart`](diffhunk://#diff-26c0028d960785c1ccbf0d50373980c55c49ee8dbca8d864c6f971af3bc2e3b0L56-R63): Enhanced the task creation flow by navigating to the newly created task's detail page using `beamToNamed` if the task is successfully created.

### Shadow Behavior Refinements
* [`lib/widgets/modal/animated_modal_item.dart`](diffhunk://#diff-0daf6610ca9168bd8874171c48d063036c2b26090b2f284e734473dd13ae8551R17): Added a `disableShadow` property to conditionally disable shadows for modal items. [[1]](diffhunk://#diff-0daf6610ca9168bd8874171c48d063036c2b26090b2f284e734473dd13ae8551R17) [[2]](diffhunk://#diff-0daf6610ca9168bd8874171c48d063036c2b26090b2f284e734473dd13ae8551R30) [[3]](diffhunk://#diff-0daf6610ca9168bd8874171c48d063036c2b26090b2f284e734473dd13ae8551L180-R184)  
* [`lib/widgets/modal/animated_modal_item_with_icon.dart`](diffhunk://#diff-30e7e9e5859a97cc56882c6902904859707108509176503e8c5c9423ae2fe09eR16): Introduced a `disableShadow` property for modal items with icons, ensuring consistency with shadow behavior. [[1]](diffhunk://#diff-30e7e9e5859a97cc56882c6902904859707108509176503e8c5c9423ae2fe09eR16) [[2]](diffhunk://#diff-30e7e9e5859a97cc56882c6902904859707108509176503e8c5c9423ae2fe09eR30) [[3]](diffhunk://#diff-30e7e9e5859a97cc56882c6902904859707108509176503e8c5c9423ae2fe09eL182-R186)  
* [`lib/widgets/settings/animated_settings_cards.dart`](diffhunk://#diff-72c61906ddae8c5586c1234bdfa2eb85693a1905e62c5138b7708dbe52c35dcfR37): Disabled shadows for `AnimatedModernSettingsCardWithIcon` and `AnimatedModernMaintenanceCard` to avoid redundant shadow effects. [[1]](diffhunk://#diff-72c61906ddae8c5586c1234bdfa2eb85693a1905e62c5138b7708dbe52c35dcfR37) [[2]](diffhunk://#diff-72c61906ddae8c5586c1234bdfa2eb85693a1905e62c5138b7708dbe52c35dcfR118)

### Miscellaneous
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Updated the application version from `0.9.639+3136` to `0.9.640+3137`.