### PR TITLE
chore: clean up unused config flags

### DIFF
--- a/lib/database/journal_db/config_flags.dart
+++ b/lib/database/journal_db/config_flags.dart
@@ -13,24 +13,10 @@ Future<void> initConfigFlags(
     ),
   );
   await db.insertFlagIfNotExists(
-    const ConfigFlag(
-      name: attemptEmbedding,
-      description: 'Create LLM embedding',
-      status: false,
-    ),
-  );
-  await db.insertFlagIfNotExists(
     ConfigFlag(
       name: enableSyncFlag,
       description: 'Enable sync? (requires restart)',
       status: inMemoryDatabase,
-    ),
-  );
-  await db.insertFlagIfNotExists(
-    const ConfigFlag(
-      name: autoTranscribeFlag,
-      description: 'Automatically transcribe audio',
-      status: false,
     ),
   );
   await db.insertFlagIfNotExists(
@@ -66,20 +52,6 @@ Future<void> initConfigFlags(
     const ConfigFlag(
       name: enableLoggingFlag,
       description: 'Enable logging?',
-      status: false,
-    ),
-  );
-  await db.insertFlagIfNotExists(
-    const ConfigFlag(
-      name: useCloudInferenceFlag,
-      description: 'Use Cloud Inference',
-      status: false,
-    ),
-  );
-  await db.insertFlagIfNotExists(
-    const ConfigFlag(
-      name: enableAutoTaskTldrFlag,
-      description: 'Enable auto task TLDR',
       status: false,
     ),
   );

--- a/lib/features/speech/repository/speech_repository.dart
+++ b/lib/features/speech/repository/speech_repository.dart
@@ -7,7 +7,6 @@ import 'package:lotti/database/database.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/logging_service.dart';
-import 'package:lotti/utils/consts.dart';
 
 class SpeechRepository {
   static Future<JournalAudio?> createAudioEntry(
@@ -19,17 +18,12 @@ class SpeechRepository {
     try {
       final persistenceLogic = getIt<PersistenceLogic>();
 
-      final autoTranscribe = await getIt<JournalDb>().getConfigFlag(
-        autoTranscribeFlag,
-      );
-
       final audioData = AudioData(
         audioDirectory: audioNote.audioDirectory,
         duration: audioNote.duration,
         audioFile: audioNote.audioFile,
         dateTo: audioNote.createdAt.add(audioNote.duration),
         dateFrom: audioNote.createdAt,
-        autoTranscribeWasActive: autoTranscribe,
         language: language,
       );
 

--- a/lib/pages/settings/flags_page.dart
+++ b/lib/pages/settings/flags_page.dart
@@ -17,19 +17,13 @@ class FlagsPage extends StatefulWidget {
 
 class _FlagsPageState extends State<FlagsPage> {
   final GlobalKey<State<StatefulWidget>> _privateFlagKey = GlobalKey();
-  final GlobalKey<State<StatefulWidget>> _embeddingFlagKey = GlobalKey();
-  final GlobalKey<State<StatefulWidget>> _autoTranscribeFlagKey = GlobalKey();
   final GlobalKey<State<StatefulWidget>> _enableMatrixFlagKey = GlobalKey();
   final GlobalKey<State<StatefulWidget>> _enableTooltipFlagKey = GlobalKey();
   final GlobalKey<State<StatefulWidget>> _recordLocationFlagKey = GlobalKey();
   final GlobalKey<State<StatefulWidget>> _resendAttachmentsFlagKey =
       GlobalKey();
   final GlobalKey<State<StatefulWidget>> _enableLoggingFlagKey = GlobalKey();
-  final GlobalKey<State<StatefulWidget>> _useCloudInferenceFlagKey =
-      GlobalKey();
   final GlobalKey<State<StatefulWidget>> _enableNotificationFlagKey =
-      GlobalKey();
-  final GlobalKey<State<StatefulWidget>> _enableAutoTaskTldrFlagKey =
       GlobalKey();
 
   final GlobalKey<State<StatefulWidget>> _enableHabitsPageFlagKey = GlobalKey();
@@ -40,16 +34,12 @@ class _FlagsPageState extends State<FlagsPage> {
 
   static const List<String> displayedItems = [
     privateFlag,
-    attemptEmbedding,
     enableNotificationsFlag,
-    autoTranscribeFlag,
     recordLocationFlag,
     enableTooltipFlag,
     enableLoggingFlag,
     enableMatrixFlag,
     resendAttachments,
-    useCloudInferenceFlag,
-    enableAutoTaskTldrFlag,
     enableHabitsPageFlag,
     enableDashboardsPageFlag,
     enableCalendarPageFlag,
@@ -75,16 +65,12 @@ class _FlagsPageState extends State<FlagsPage> {
             onPressed: () {
               ShowCaseWidget.of(context).startShowCase([
                 _privateFlagKey,
-                _embeddingFlagKey,
                 _enableNotificationFlagKey,
-                _autoTranscribeFlagKey,
                 _recordLocationFlagKey,
                 _enableTooltipFlagKey,
                 _enableLoggingFlagKey,
                 _enableMatrixFlagKey,
                 _resendAttachmentsFlagKey,
-                _useCloudInferenceFlagKey,
-                _enableAutoTaskTldrFlagKey,
                 _enableHabitsPageFlagKey,
                 _enableDashboardsPageFlagKey,
                 _enableCalendarPageFlagKey,
@@ -118,10 +104,6 @@ class _FlagsPageState extends State<FlagsPage> {
     switch (flagName) {
       case privateFlag:
         return _privateFlagKey;
-      case attemptEmbedding:
-        return _embeddingFlagKey;
-      case autoTranscribeFlag:
-        return _autoTranscribeFlagKey;
       case enableMatrixFlag:
         return _enableMatrixFlagKey;
       case enableTooltipFlag:
@@ -132,12 +114,8 @@ class _FlagsPageState extends State<FlagsPage> {
         return _resendAttachmentsFlagKey;
       case enableLoggingFlag:
         return _enableLoggingFlagKey;
-      case useCloudInferenceFlag:
-        return _useCloudInferenceFlagKey;
       case enableNotificationsFlag:
         return _enableNotificationFlagKey;
-      case enableAutoTaskTldrFlag:
-        return _enableAutoTaskTldrFlagKey;
       case enableHabitsPageFlag:
         return _enableHabitsPageFlagKey;
       case enableDashboardsPageFlag:

--- a/lib/utils/consts.dart
+++ b/lib/utils/consts.dart
@@ -2,14 +2,10 @@ const privateFlag = 'private';
 const enableNotificationsFlag = 'enable_notifications';
 const enableSyncFlag = 'enable_sync';
 const recordLocationFlag = 'record_location';
-const autoTranscribeFlag = 'auto_transcribe';
 const enableMatrixFlag = 'enable_matrix';
 const enableTooltipFlag = 'enable_tooltip';
 const resendAttachments = 'resend_attachments';
-const attemptEmbedding = 'attempt_embedding';
 const enableLoggingFlag = 'enable_logging';
-const useCloudInferenceFlag = 'use_cloud_inference';
-const enableAutoTaskTldrFlag = 'enable_auto_task_tldr';
 
 const enableHabitsPageFlag = 'enable_habits_page';
 const enableDashboardsPageFlag = 'enable_dashboards_page';

--- a/lib/widgets/settings/config_flag_card.dart
+++ b/lib/widgets/settings/config_flag_card.dart
@@ -86,10 +86,6 @@ class ConfigFlagCard extends StatelessWidget {
     switch (item.name) {
       case privateFlag:
         return context.messages.configFlagPrivateDescription;
-      case attemptEmbedding:
-        return context.messages.configFlagAttemptEmbeddingDescription;
-      case autoTranscribeFlag:
-        return context.messages.configFlagAutoTranscribeDescription;
       case enableMatrixFlag:
         return context.messages.configFlagEnableMatrixDescription;
       case enableTooltipFlag:
@@ -100,12 +96,8 @@ class ConfigFlagCard extends StatelessWidget {
         return context.messages.configFlagResendAttachmentsDescription;
       case enableLoggingFlag:
         return context.messages.configFlagEnableLoggingDescription;
-      case useCloudInferenceFlag:
-        return context.messages.configFlagUseCloudInferenceDescription;
       case enableNotificationsFlag:
         return context.messages.configFlagEnableNotificationsDescription;
-      case enableAutoTaskTldrFlag:
-        return context.messages.configFlagEnableAutoTaskTldrDescription;
       case enableHabitsPageFlag:
         return context.messages.configFlagEnableHabitsPageDescription;
       case enableDashboardsPageFlag:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.640+3138
+version: 0.9.641+3140
 
 msix_config:
   display_name: LottiApp

--- a/test/database/database_test.dart
+++ b/test/database/database_test.dart
@@ -41,16 +41,6 @@ final expectedFlags = <ConfigFlag>{
     status: true,
   ),
   const ConfigFlag(
-    name: attemptEmbedding,
-    description: 'Create LLM embedding',
-    status: false,
-  ),
-  const ConfigFlag(
-    name: autoTranscribeFlag,
-    description: 'Automatically transcribe audio',
-    status: false,
-  ),
-  const ConfigFlag(
     name: recordLocationFlag,
     description: 'Record geolocation?',
     status: false,
@@ -78,16 +68,6 @@ final expectedFlags = <ConfigFlag>{
   const ConfigFlag(
     name: enableLoggingFlag,
     description: 'Enable logging?',
-    status: false,
-  ),
-  const ConfigFlag(
-    name: useCloudInferenceFlag,
-    description: 'Use Cloud Inference',
-    status: false,
-  ),
-  const ConfigFlag(
-    name: enableAutoTaskTldrFlag,
-    description: 'Enable auto task TLDR',
     status: false,
   ),
   const ConfigFlag(


### PR DESCRIPTION
This pull request removes several configuration flags and their associated logic, simplifying the codebase and streamlining the application's feature set. The removed flags include `autoTranscribeFlag`, `attemptEmbedding`, `useCloudInferenceFlag`, and `enableAutoTaskTldrFlag`. Changes span multiple files, including the removal of flag definitions, database initialization logic, settings UI elements, and related tests.

### Configuration Flag Removal:

* [`lib/database/journal_db/config_flags.dart`](diffhunk://#diff-39bb266ee30b590e88152913951d305211880bf2f73d076f1f2c6361a09ef9a5L15-L35): Removed initialization of the `autoTranscribeFlag`, `attemptEmbedding`, `useCloudInferenceFlag`, and `enableAutoTaskTldrFlag` flags from the database configuration. [[1]](diffhunk://#diff-39bb266ee30b590e88152913951d305211880bf2f73d076f1f2c6361a09ef9a5L15-L35) [[2]](diffhunk://#diff-39bb266ee30b590e88152913951d305211880bf2f73d076f1f2c6361a09ef9a5L72-L85)
* [`lib/utils/consts.dart`](diffhunk://#diff-ae9c77db8d06976197004d884d06f46d46ee048af40208727501d44e346d8cc2L5-L12): Deleted constants for the removed flags.

### UI Simplification:

* [`lib/pages/settings/flags_page.dart`](diffhunk://#diff-26b45654cc5cd447bb728098110332c878a360b41ad9b55a44c3ccbe23b1682dL20-L33): Removed references to the deleted flags from the settings page, including UI keys and displayed items. [[1]](diffhunk://#diff-26b45654cc5cd447bb728098110332c878a360b41ad9b55a44c3ccbe23b1682dL20-L33) [[2]](diffhunk://#diff-26b45654cc5cd447bb728098110332c878a360b41ad9b55a44c3ccbe23b1682dL43-L52) [[3]](diffhunk://#diff-26b45654cc5cd447bb728098110332c878a360b41ad9b55a44c3ccbe23b1682dL78-L87) [[4]](diffhunk://#diff-26b45654cc5cd447bb728098110332c878a360b41ad9b55a44c3ccbe23b1682dL121-L124) [[5]](diffhunk://#diff-26b45654cc5cd447bb728098110332c878a360b41ad9b55a44c3ccbe23b1682dL135-L140)
* [`lib/widgets/settings/config_flag_card.dart`](diffhunk://#diff-4a56d4be9dd3510480846d557942520aebb0c4f5e973044ec69bbbc3d1d04acfL89-L92): Removed descriptions for the deleted flags from the configuration flag card widget. [[1]](diffhunk://#diff-4a56d4be9dd3510480846d557942520aebb0c4f5e973044ec69bbbc3d1d04acfL89-L92) [[2]](diffhunk://#diff-4a56d4be9dd3510480846d557942520aebb0c4f5e973044ec69bbbc3d1d04acfL103-L108)

### Speech Repository Updates:

* [`lib/features/speech/repository/speech_repository.dart`](diffhunk://#diff-852dcd17bcbf0539057fbef0d1022d9afd02725ac8a677ef1f2884ada5204bfaL10): Removed logic related to the `autoTranscribeFlag` and its usage in audio entry creation. [[1]](diffhunk://#diff-852dcd17bcbf0539057fbef0d1022d9afd02725ac8a677ef1f2884ada5204bfaL10) [[2]](diffhunk://#diff-852dcd17bcbf0539057fbef0d1022d9afd02725ac8a677ef1f2884ada5204bfaL22-L32)

### Test Updates:

* [`test/database/database_test.dart`](diffhunk://#diff-5d94915a791875ec0c3b4703ccfdc535a20354a6c8a1c4adeb6763611ec735e3L43-L52): Updated expected flags in tests to exclude the removed flags. [[1]](diffhunk://#diff-5d94915a791875ec0c3b4703ccfdc535a20354a6c8a1c4adeb6763611ec735e3L43-L52) [[2]](diffhunk://#diff-5d94915a791875ec0c3b4703ccfdc535a20354a6c8a1c4adeb6763611ec735e3L83-L92)
* [`test/features/speech/repository/speech_repository_test.dart`](diffhunk://#diff-a1d5c109eb9d1523bab9ed5be15368098eaa094c0a5ca55f0aa7dbf6a0c4193fL12): Removed tests related to the `autoTranscribeFlag`, including cases where the flag influenced behavior or caused exceptions. [[1]](diffhunk://#diff-a1d5c109eb9d1523bab9ed5be15368098eaa094c0a5ca55f0aa7dbf6a0c4193fL12) [[2]](diffhunk://#diff-a1d5c109eb9d1523bab9ed5be15368098eaa094c0a5ca55f0aa7dbf6a0c4193fL104-L167) [[3]](diffhunk://#diff-a1d5c109eb9d1523bab9ed5be15368098eaa094c0a5ca55f0aa7dbf6a0c4193fL196-L203) [[4]](diffhunk://#diff-a1d5c109eb9d1523bab9ed5be15368098eaa094c0a5ca55f0aa7dbf6a0c4193fL263-L302) [[5]](diffhunk://#diff-a1d5c109eb9d1523bab9ed5be15368098eaa094c0a5ca55f0aa7dbf6a0c4193fL341-L342)

### Miscellaneous:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Updated the app version to `0.9.641+3140`.