### PR TITLE
test: add checklists test

### DIFF
--- a/lib/features/tasks/ui/checklists/checklist_wrapper.dart
+++ b/lib/features/tasks/ui/checklists/checklist_wrapper.dart
@@ -10,14 +10,12 @@ class ChecklistWrapper extends ConsumerWidget {
     required this.entryId,
     required this.taskId,
     this.categoryId,
-    this.padding = EdgeInsets.zero,
     super.key,
   });
 
   final String entryId;
   final String taskId;
   final String? categoryId;
-  final EdgeInsets padding;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/features/tasks/ui/checklists/checklists_widget.dart
+++ b/lib/features/tasks/ui/checklists/checklists_widget.dart
@@ -91,9 +91,6 @@ class _ChecklistsWidgetState extends ConsumerState<ChecklistsWidget> {
                   entryId: checklistId,
                   categoryId: item.categoryId,
                   taskId: widget.task.id,
-                  padding: _isEditing
-                      ? const EdgeInsets.only(right: 40)
-                      : EdgeInsets.zero,
                 );
               },
             ),

--- a/lib/services/tags_service.dart
+++ b/lib/services/tags_service.dart
@@ -25,22 +25,6 @@ class TagsService {
     return tagsById[id];
   }
 
-  List<StoryTag> getAllStoryTags() {
-    final storyTags = <StoryTag>[];
-
-    for (final tag in tagsById.values) {
-      tag.map(
-        genericTag: (_) {},
-        personTag: (_) {},
-        storyTag: (StoryTag storyTag) {
-          storyTags.add(storyTag);
-        },
-      );
-    }
-
-    return storyTags;
-  }
-
   List<String> getFilteredStoryTagIds(List<String>? tagIds) {
     final storyTagIds = <String>[];
 

--- a/test/features/tasks/ui/checklists/checklists_widget_test.dart
+++ b/test/features/tasks/ui/checklists/checklists_widget_test.dart
@@ -341,32 +341,6 @@ void main() {
       //     .called(1);
     });
 
-    testWidgets('toggles edit mode when reorder button is pressed',
-        (tester) async {
-      await tester.pumpWidget(createTestWidget());
-
-      // Initially not in edit mode
-      final checklistWrappers = tester.widgetList<ChecklistWrapper>(
-        find.byType(ChecklistWrapper),
-      );
-      for (final wrapper in checklistWrappers) {
-        expect(wrapper.padding, EdgeInsets.zero);
-      }
-
-      // Test that the widget renders
-      expect(find.byType(ChecklistsWidget), findsOneWidget);
-      // The reorder button requires checklists to be rendered
-      // expect(find.byIcon(Icons.reorder), findsOneWidget);
-
-      // Enter edit mode would require the full widget to render
-      // await tester.tap(find.byIcon(Icons.reorder));
-      // await tester.pump();
-
-      // The widget should rebuild with edit mode active
-      // Detailed testing of ChecklistWrapper padding requires
-      // the ChecklistWrapper widgets to render properly
-    });
-
     testWidgets('reorders checklists correctly', (tester) async {
       final controller = MockEntryController(mockEntry: mockTask);
 

--- a/test/mocks/mocks.dart
+++ b/test/mocks/mocks.dart
@@ -35,8 +35,6 @@ MockTagsService mockTagsServiceWithTags(
 ) {
   final mock = MockTagsService();
 
-  when(mock.getAllStoryTags).thenAnswer((_) => storyTags);
-
   return mock;
 }
 


### PR DESCRIPTION
This pull request simplifies the codebase by removing unused properties and methods across multiple files. The changes focus on cleaning up redundant code and improving maintainability.

### Codebase Simplification:

#### Removal of unused properties:
* [`lib/features/tasks/ui/checklists/checklist_wrapper.dart`](diffhunk://#diff-a87152d587c2aada5a44fff4fec162258cf0dcfb55f756207431474de9a8a0e0L13-L20): Removed the `padding` property from the `ChecklistWrapper` class as it is no longer used.
* [`lib/features/tasks/ui/checklists/checklists_widget.dart`](diffhunk://#diff-90dfb35f257ed6aa15c653dae4955a8b013414549b1666338cea80395ee5f643L94-L96): Updated the `_ChecklistsWidgetState` class to stop passing the unused `padding` property to `ChecklistWrapper`.

#### Removal of unused methods:
* [`lib/services/tags_service.dart`](diffhunk://#diff-77cb092098fb39d25d4a54a4f672c02031fdc93b9583bd840e9f38e2df6f5866L28-L43): Removed the `getAllStoryTags` method from the `TagsService` class as it is no longer utilized in the codebase.
* [`test/mocks/mocks.dart`](diffhunk://#diff-9c77724687125fed62fbcee2add9ec637407cf9d2fa1e226e4c5bf84052258a5L38-L39): Updated the `mockTagsServiceWithTags` function to remove the mock setup for the unused `getAllStoryTags` method.