### PR TITLE
fix: duplicate image paste

### DIFF
--- a/lib/features/ai/state/settings/prompt_form_controller.g.dart
+++ b/lib/features/ai/state/settings/prompt_form_controller.g.dart
@@ -7,7 +7,7 @@ part of 'prompt_form_controller.dart';
 // **************************************************************************
 
 String _$promptFormControllerHash() =>
-    r'8678f4cd76d0802496dff774d02f96f2d6d49455';
+    r'137e63779cf50eb271bfd02af733d1079501f3ae';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/features/journal/state/image_paste_controller.dart
+++ b/lib/features/journal/state/image_paste_controller.dart
@@ -29,22 +29,20 @@ class ImagePasteController extends _$ImagePasteController {
     }
     final reader = await clipboard.read();
 
-    if (reader.canProvide(Formats.png)) {
-      reader.getFile(Formats.png, (file) async {
-        await importPastedImages(
-          data: await file.readAll(),
-          fileExtension: 'png',
-          linkedId: linkedFromId,
-          categoryId: categoryId,
-        );
-      });
-    }
-
     if (reader.canProvide(Formats.jpeg)) {
       reader.getFile(Formats.jpeg, (file) async {
         await importPastedImages(
           data: await file.readAll(),
           fileExtension: 'jpg',
+          linkedId: linkedFromId,
+          categoryId: categoryId,
+        );
+      });
+    } else if (reader.canProvide(Formats.png)) {
+      reader.getFile(Formats.png, (file) async {
+        await importPastedImages(
+          data: await file.readAll(),
+          fileExtension: 'png',
           linkedId: linkedFromId,
           categoryId: categoryId,
         );

--- a/lib/features/journal/state/image_paste_controller.g.dart
+++ b/lib/features/journal/state/image_paste_controller.g.dart
@@ -7,7 +7,7 @@ part of 'image_paste_controller.dart';
 // **************************************************************************
 
 String _$imagePasteControllerHash() =>
-    r'5b545dd1cbc757ecba3b2231fecc8c374725f380';
+    r'b6880249f5da9f64d6665198bbdc54b1926f19d5';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.642+3162
+version: 0.9.642+3163
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated image paste behavior to prioritize JPEG images over PNG when both formats are available on the clipboard.

* **Tests**
  * Added a test to verify that JPEG images are prioritized over PNG during paste operations.

* **Chores**
  * Incremented the app version number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->