### PR TITLE
fix: open matrix sync settings & modal utils use refactor

### DIFF
--- a/lib/features/settings/ui/pages/advanced_settings_page.dart
+++ b/lib/features/settings/ui/pages/advanced_settings_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:lotti/features/settings/ui/pages/outbox/outbox_badge.dart';
 import 'package:lotti/features/settings/ui/pages/sliver_box_adapter_page.dart';
 import 'package:lotti/features/settings/ui/widgets/animated_settings_cards.dart';
+import 'package:lotti/features/sync/ui/matrix_settings_modal.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/utils/platform.dart';
@@ -17,13 +18,7 @@ class AdvancedSettingsPage extends StatelessWidget {
       title: context.messages.settingsAdvancedTitle,
       child: Column(
         children: [
-          // Matrix sync card
-          AnimatedModernSettingsCardWithIcon(
-            title: 'Matrix Sync',
-            subtitle: context.messages.settingsAdvancedMatrixSyncSubtitle,
-            icon: Icons.sync,
-            onTap: () => context.beamToNamed('/settings/advanced/matrix_sync'),
-          ),
+          const MatrixSettingsCard(),
           AnimatedModernSettingsCardWithIcon(
             title: context.messages.settingsSyncOutboxTitle,
             subtitle: context.messages.settingsAdvancedOutboxSubtitle,

--- a/lib/features/sync/ui/login/sync_login_modal_page.dart
+++ b/lib/features/sync/ui/login/sync_login_modal_page.dart
@@ -2,8 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:lotti/features/sync/ui/login/login_sticky_action_bar.dart';
 import 'package:lotti/features/sync/ui/login/sync_login_form.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
-import 'package:lotti/themes/theme.dart';
-import 'package:lotti/widgets/misc/wolt_modal_config.dart';
+import 'package:lotti/widgets/modal/index.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
 SliverWoltModalSheetPage syncLoginModalPage({
@@ -11,22 +10,11 @@ SliverWoltModalSheetPage syncLoginModalPage({
   required TextTheme textTheme,
   required ValueNotifier<int> pageIndexNotifier,
 }) {
-  return WoltModalSheetPage(
+  return ModalUtils.modalSheetPage(
+    context: context,
+    showCloseButton: true,
     stickyActionBar: LoginStickyActionBar(pageIndexNotifier: pageIndexNotifier),
-    topBarTitle: Text(
-      context.messages.settingsMatrixHomeserverConfigTitle,
-      style: textTheme.titleMedium
-          ?.copyWith(color: Theme.of(context).colorScheme.outline),
-    ),
-    isTopBarLayerAlwaysVisible: true,
-    trailingNavBarWidget: IconButton(
-      padding: WoltModalConfig.pagePadding,
-      icon: Icon(Icons.close, color: context.colorScheme.outline),
-      onPressed: Navigator.of(context).pop,
-    ),
-    child: Padding(
-      padding: WoltModalConfig.pagePadding,
-      child: SyncLoginForm(pageIndexNotifier: pageIndexNotifier),
-    ),
+    title: context.messages.settingsMatrixHomeserverConfigTitle,
+    child: SyncLoginForm(pageIndexNotifier: pageIndexNotifier),
   );
 }

--- a/lib/features/sync/ui/login/sync_login_modal_page.dart
+++ b/lib/features/sync/ui/login/sync_login_modal_page.dart
@@ -7,7 +7,6 @@ import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
 SliverWoltModalSheetPage syncLoginModalPage({
   required BuildContext context,
-  required TextTheme textTheme,
   required ValueNotifier<int> pageIndexNotifier,
 }) {
   return ModalUtils.modalSheetPage(

--- a/lib/features/sync/ui/matrix_logged_in_config_page.dart
+++ b/lib/features/sync/ui/matrix_logged_in_config_page.dart
@@ -10,7 +10,6 @@ import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
 SliverWoltModalSheetPage homeServerLoggedInPage({
   required BuildContext context,
-  required TextTheme textTheme,
   required ValueNotifier<int> pageIndexNotifier,
 }) {
   return ModalUtils.modalSheetPage(

--- a/lib/features/sync/ui/matrix_logged_in_config_page.dart
+++ b/lib/features/sync/ui/matrix_logged_in_config_page.dart
@@ -4,6 +4,7 @@ import 'package:lotti/features/sync/state/matrix_login_controller.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/widgets/misc/wolt_modal_config.dart';
+import 'package:lotti/widgets/modal/modal_utils.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
@@ -12,24 +13,14 @@ SliverWoltModalSheetPage homeServerLoggedInPage({
   required TextTheme textTheme,
   required ValueNotifier<int> pageIndexNotifier,
 }) {
-  return WoltModalSheetPage(
+  return ModalUtils.modalSheetPage(
+    context: context,
+    showCloseButton: true,
     stickyActionBar: LoggedInPageStickyActionBar(
       pageIndexNotifier: pageIndexNotifier,
     ),
-    topBarTitle: Text(
-      context.messages.settingsMatrixHomeserverConfigTitle,
-      style: textTheme.titleMedium,
-    ),
-    isTopBarLayerAlwaysVisible: true,
-    trailingNavBarWidget: IconButton(
-      padding: WoltModalConfig.pagePadding,
-      icon: const Icon(Icons.close),
-      onPressed: Navigator.of(context).pop,
-    ),
-    child: const Padding(
-      padding: WoltModalConfig.pagePadding,
-      child: HomeserverLoggedInWidget(),
-    ),
+    title: context.messages.settingsMatrixHomeserverConfigTitle,
+    child: const HomeserverLoggedInWidget(),
   );
 }
 

--- a/lib/features/sync/ui/matrix_settings_modal.dart
+++ b/lib/features/sync/ui/matrix_settings_modal.dart
@@ -8,7 +8,6 @@ import 'package:lotti/features/sync/ui/room_config_page.dart';
 import 'package:lotti/features/sync/ui/unverified_devices_page.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
-import 'package:lotti/themes/theme.dart';
 import 'package:lotti/widgets/modal/modal_utils.dart';
 
 class MatrixSettingsCard extends StatelessWidget {
@@ -32,36 +31,28 @@ class MatrixSettingsCard extends StatelessWidget {
         ModalUtils.showMultiPageModal<void>(
           context: context,
           pageIndexNotifier: pageIndexNotifier,
-          pageListBuilder: (modalSheetContext) {
-            final textTheme = context.textTheme;
-            return [
-              syncLoginModalPage(
-                context: modalSheetContext,
-                textTheme: textTheme,
-                pageIndexNotifier: pageIndexNotifier,
-              ),
-              homeServerLoggedInPage(
-                context: modalSheetContext,
-                textTheme: textTheme,
-                pageIndexNotifier: pageIndexNotifier,
-              ),
-              roomConfigPage(
-                context: modalSheetContext,
-                textTheme: textTheme,
-                pageIndexNotifier: pageIndexNotifier,
-              ),
-              unverifiedDevicesPage(
-                context: modalSheetContext,
-                textTheme: textTheme,
-                pageIndexNotifier: pageIndexNotifier,
-              ),
-              matrixStatsPage(
-                context: modalSheetContext,
-                textTheme: textTheme,
-                pageIndexNotifier: pageIndexNotifier,
-              ),
-            ];
-          },
+          pageListBuilder: (modalSheetContext) => [
+            syncLoginModalPage(
+              context: modalSheetContext,
+              pageIndexNotifier: pageIndexNotifier,
+            ),
+            homeServerLoggedInPage(
+              context: modalSheetContext,
+              pageIndexNotifier: pageIndexNotifier,
+            ),
+            roomConfigPage(
+              context: modalSheetContext,
+              pageIndexNotifier: pageIndexNotifier,
+            ),
+            unverifiedDevicesPage(
+              context: modalSheetContext,
+              pageIndexNotifier: pageIndexNotifier,
+            ),
+            matrixStatsPage(
+              context: modalSheetContext,
+              pageIndexNotifier: pageIndexNotifier,
+            ),
+          ],
         );
       },
     );

--- a/lib/features/sync/ui/matrix_settings_modal.dart
+++ b/lib/features/sync/ui/matrix_settings_modal.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/features/settings/ui/widgets/animated_settings_cards.dart';
+import 'package:lotti/features/sync/matrix.dart';
+import 'package:lotti/features/sync/ui/login/sync_login_modal_page.dart';
+import 'package:lotti/features/sync/ui/matrix_logged_in_config_page.dart';
+import 'package:lotti/features/sync/ui/matrix_stats_page.dart';
+import 'package:lotti/features/sync/ui/room_config_page.dart';
+import 'package:lotti/features/sync/ui/unverified_devices_page.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/themes/theme.dart';
+import 'package:lotti/widgets/modal/modal_utils.dart';
+
+class MatrixSettingsCard extends StatelessWidget {
+  const MatrixSettingsCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final pageIndexNotifier = ValueNotifier(0);
+
+    return AnimatedModernSettingsCardWithIcon(
+      title: context.messages.settingsMatrixTitle,
+      subtitle: 'Configure end-to-end encrypted sync',
+      icon: Icons.sync,
+      onTap: () {
+        if (getIt<MatrixService>().isLoggedIn()) {
+          pageIndexNotifier.value = 1;
+        } else {
+          pageIndexNotifier.value = 0;
+        }
+
+        ModalUtils.showMultiPageModal<void>(
+          context: context,
+          pageIndexNotifier: pageIndexNotifier,
+          pageListBuilder: (modalSheetContext) {
+            final textTheme = context.textTheme;
+            return [
+              syncLoginModalPage(
+                context: modalSheetContext,
+                textTheme: textTheme,
+                pageIndexNotifier: pageIndexNotifier,
+              ),
+              homeServerLoggedInPage(
+                context: modalSheetContext,
+                textTheme: textTheme,
+                pageIndexNotifier: pageIndexNotifier,
+              ),
+              roomConfigPage(
+                context: modalSheetContext,
+                textTheme: textTheme,
+                pageIndexNotifier: pageIndexNotifier,
+              ),
+              unverifiedDevicesPage(
+                context: modalSheetContext,
+                textTheme: textTheme,
+                pageIndexNotifier: pageIndexNotifier,
+              ),
+              matrixStatsPage(
+                context: modalSheetContext,
+                textTheme: textTheme,
+                pageIndexNotifier: pageIndexNotifier,
+              ),
+            ];
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/features/sync/ui/matrix_settings_modal.dart
+++ b/lib/features/sync/ui/matrix_settings_modal.dart
@@ -10,13 +10,30 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/widgets/modal/modal_utils.dart';
 
-class MatrixSettingsCard extends StatelessWidget {
+class MatrixSettingsCard extends StatefulWidget {
   const MatrixSettingsCard({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final pageIndexNotifier = ValueNotifier(0);
+  State<MatrixSettingsCard> createState() => _MatrixSettingsCardState();
+}
 
+class _MatrixSettingsCardState extends State<MatrixSettingsCard> {
+  late final ValueNotifier<int> pageIndexNotifier;
+
+  @override
+  void initState() {
+    super.initState();
+    pageIndexNotifier = ValueNotifier(0);
+  }
+
+  @override
+  void dispose() {
+    pageIndexNotifier.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return AnimatedModernSettingsCardWithIcon(
       title: context.messages.settingsMatrixTitle,
       subtitle: 'Configure end-to-end encrypted sync',

--- a/lib/features/sync/ui/matrix_stats_page.dart
+++ b/lib/features/sync/ui/matrix_stats_page.dart
@@ -8,7 +8,6 @@ import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
 SliverWoltModalSheetPage matrixStatsPage({
   required BuildContext context,
-  required TextTheme textTheme,
   required ValueNotifier<int> pageIndexNotifier,
 }) {
   return ModalUtils.modalSheetPage(

--- a/lib/features/sync/ui/matrix_stats_page.dart
+++ b/lib/features/sync/ui/matrix_stats_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/sync/state/matrix_stats_provider.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/widgets/misc/wolt_modal_config.dart';
+import 'package:lotti/widgets/modal/modal_utils.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
 SliverWoltModalSheetPage matrixStatsPage({
@@ -10,7 +11,9 @@ SliverWoltModalSheetPage matrixStatsPage({
   required TextTheme textTheme,
   required ValueNotifier<int> pageIndexNotifier,
 }) {
-  return WoltModalSheetPage(
+  return ModalUtils.modalSheetPage(
+    context: context,
+    showCloseButton: true,
     stickyActionBar: Padding(
       padding: WoltModalConfig.pagePadding,
       child: Row(
@@ -33,20 +36,9 @@ SliverWoltModalSheetPage matrixStatsPage({
         ],
       ),
     ),
-    topBarTitle: Text(
-      context.messages.settingsMatrixStatsTitle,
-      style: textTheme.titleMedium,
-    ),
-    isTopBarLayerAlwaysVisible: true,
-    trailingNavBarWidget: IconButton(
-      padding: WoltModalConfig.pagePadding,
-      icon: const Icon(Icons.close),
-      onPressed: Navigator.of(context).pop,
-    ),
-    child: Padding(
-      padding: WoltModalConfig.pagePadding + const EdgeInsets.only(bottom: 80),
-      child: const IncomingStats(),
-    ),
+    title: context.messages.settingsMatrixStatsTitle,
+    padding: WoltModalConfig.pagePadding + const EdgeInsets.only(bottom: 80),
+    child: const IncomingStats(),
   );
 }
 

--- a/lib/features/sync/ui/room_config_page.dart
+++ b/lib/features/sync/ui/room_config_page.dart
@@ -13,7 +13,6 @@ import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
 SliverWoltModalSheetPage roomConfigPage({
   required BuildContext context,
-  required TextTheme textTheme,
   required ValueNotifier<int> pageIndexNotifier,
 }) {
   return ModalUtils.modalSheetPage(

--- a/lib/features/sync/ui/room_config_page.dart
+++ b/lib/features/sync/ui/room_config_page.dart
@@ -7,6 +7,7 @@ import 'package:lotti/features/sync/state/matrix_room_provider.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/utils/platform.dart';
 import 'package:lotti/widgets/misc/wolt_modal_config.dart';
+import 'package:lotti/widgets/modal/modal_utils.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
@@ -15,7 +16,9 @@ SliverWoltModalSheetPage roomConfigPage({
   required TextTheme textTheme,
   required ValueNotifier<int> pageIndexNotifier,
 }) {
-  return WoltModalSheetPage(
+  return ModalUtils.modalSheetPage(
+    context: context,
+    showCloseButton: true,
     stickyActionBar: Padding(
       padding: WoltModalConfig.pagePadding,
       child: Row(
@@ -39,20 +42,9 @@ SliverWoltModalSheetPage roomConfigPage({
         ],
       ),
     ),
-    topBarTitle: Text(
-      context.messages.settingsMatrixRoomConfigTitle,
-      style: textTheme.titleMedium,
-    ),
-    isTopBarLayerAlwaysVisible: true,
-    trailingNavBarWidget: IconButton(
-      padding: WoltModalConfig.pagePadding,
-      icon: const Icon(Icons.close),
-      onPressed: Navigator.of(context).pop,
-    ),
-    child: Padding(
-      padding: WoltModalConfig.pagePadding + const EdgeInsets.only(bottom: 80),
-      child: const RoomConfig(),
-    ),
+    title: context.messages.settingsMatrixRoomConfigTitle,
+    padding: WoltModalConfig.pagePadding + const EdgeInsets.only(bottom: 80),
+    child: const RoomConfig(),
   );
 }
 

--- a/lib/features/sync/ui/unverified_devices_page.dart
+++ b/lib/features/sync/ui/unverified_devices_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/sync/state/matrix_unverified_provider.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/widgets/misc/wolt_modal_config.dart';
+import 'package:lotti/widgets/modal/modal_utils.dart';
 import 'package:lotti/widgets/sync/matrix/device_card.dart';
 import 'package:lotti/widgets/sync/matrix/status_indicator.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
@@ -13,7 +14,9 @@ SliverWoltModalSheetPage unverifiedDevicesPage({
   required TextTheme textTheme,
   required ValueNotifier<int> pageIndexNotifier,
 }) {
-  return WoltModalSheetPage(
+  return ModalUtils.modalSheetPage(
+    context: context,
+    showCloseButton: true,
     stickyActionBar: Padding(
       padding: WoltModalConfig.pagePadding,
       child: Row(
@@ -37,20 +40,9 @@ SliverWoltModalSheetPage unverifiedDevicesPage({
         ],
       ),
     ),
-    topBarTitle: Text(
-      context.messages.settingsMatrixUnverifiedDevicesPage,
-      style: textTheme.titleMedium,
-    ),
-    isTopBarLayerAlwaysVisible: true,
-    trailingNavBarWidget: IconButton(
-      padding: WoltModalConfig.pagePadding,
-      icon: const Icon(Icons.close),
-      onPressed: Navigator.of(context).pop,
-    ),
-    child: Padding(
-      padding: WoltModalConfig.pagePadding + const EdgeInsets.only(bottom: 80),
-      child: const UnverifiedDevices(),
-    ),
+    title: context.messages.settingsMatrixUnverifiedDevicesPage,
+    padding: WoltModalConfig.pagePadding + const EdgeInsets.only(bottom: 80),
+    child: const UnverifiedDevices(),
   );
 }
 

--- a/lib/features/sync/ui/unverified_devices_page.dart
+++ b/lib/features/sync/ui/unverified_devices_page.dart
@@ -11,7 +11,6 @@ import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
 SliverWoltModalSheetPage unverifiedDevicesPage({
   required BuildContext context,
-  required TextTheme textTheme,
   required ValueNotifier<int> pageIndexNotifier,
 }) {
   return ModalUtils.modalSheetPage(

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -245,6 +245,7 @@
   "settingsMatrixStartVerificationLabel": "Verifizierung starten",
   "settingsMatrixStatsTitle": "Matrix-Statistiken",
   "settingsMatrixTitle": "Matrix-Synchronisierungseinstellungen",
+  "settingsMatrixSubtitle": "Ende-zu-Ende verschlüsselte Synchronisation konfigurieren",
   "settingsMatrixUnverifiedDevicesPage": "Nicht verifizierte Geräte",
   "settingsMatrixUserLabel": "Benutzer",
   "settingsMatrixUserNameTooShort": "Benutzername zu kurz",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -538,6 +538,7 @@
   "settingsMatrixStartVerificationLabel": "Start Verification",
   "settingsMatrixStatsTitle": "Matrix Stats",
   "settingsMatrixTitle": "Matrix Sync Settings",
+  "settingsMatrixSubtitle": "Configure end-to-end encrypted sync",
   "settingsMatrixUnverifiedDevicesPage": "Unverified Devices",
   "settingsMatrixUserLabel": "User",
   "settingsMatrixUserNameTooShort": "User name too short",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2895,6 +2895,12 @@ abstract class AppLocalizations {
   /// **'Matrix Sync Settings'**
   String get settingsMatrixTitle;
 
+  /// No description provided for @settingsMatrixSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Configure end-to-end encrypted sync'**
+  String get settingsMatrixSubtitle;
+
   /// No description provided for @settingsMatrixUnverifiedDevicesPage.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1522,6 +1522,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settingsMatrixTitle => 'Matrix-Synchronisierungseinstellungen';
 
   @override
+  String get settingsMatrixSubtitle =>
+      'Ende-zu-Ende verschlüsselte Synchronisation konfigurieren';
+
+  @override
   String get settingsMatrixUnverifiedDevicesPage => 'Nicht verifizierte Geräte';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1514,6 +1514,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingsMatrixTitle => 'Matrix Sync Settings';
 
   @override
+  String get settingsMatrixSubtitle => 'Configure end-to-end encrypted sync';
+
+  @override
   String get settingsMatrixUnverifiedDevicesPage => 'Unverified Devices';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1527,6 +1527,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settingsMatrixTitle => 'Ajustes de sincronización de Matrix';
 
   @override
+  String get settingsMatrixSubtitle => 'Configure end-to-end encrypted sync';
+
+  @override
   String get settingsMatrixUnverifiedDevicesPage =>
       'Dispositivos no verificados';
 

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1530,6 +1530,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settingsMatrixTitle => 'Paramètres de synchronisation Matrix';
 
   @override
+  String get settingsMatrixSubtitle => 'Configure end-to-end encrypted sync';
+
+  @override
   String get settingsMatrixUnverifiedDevicesPage => 'Appareils non vérifiés';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1521,6 +1521,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get settingsMatrixTitle => 'Setări sincronizare Matrix';
 
   @override
+  String get settingsMatrixSubtitle => 'Configure end-to-end encrypted sync';
+
+  @override
   String get settingsMatrixUnverifiedDevicesPage => 'Dispozitive neverificate';
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.642+3163
+version: 0.9.642+3164
 
 msix_config:
   display_name: LottiApp

--- a/test/features/settings/ui/pages/advanced_settings_page_test.dart
+++ b/test/features/settings/ui/pages/advanced_settings_page_test.dart
@@ -47,7 +47,7 @@ void main() {
       final context = tester.element(find.byType(AdvancedSettingsPage));
 
       // Verify all cards are present
-      expect(find.text('Matrix Sync'), findsOneWidget);
+      expect(find.text(context.messages.settingsMatrixTitle), findsOneWidget);
       expect(
           find.text(context.messages.settingsSyncOutboxTitle), findsOneWidget);
       expect(

--- a/test/features/sync/ui/matrix_settings_modal_test.dart
+++ b/test/features/sync/ui/matrix_settings_modal_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/features/sync/matrix.dart';
+import 'package:lotti/features/sync/ui/matrix_settings_modal.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/services/logging_service.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../mocks/mocks.dart';
+import '../../../widget_test_utils.dart';
+
+class MockMatrixService extends Mock implements MatrixService {}
+
+class MockLoggingService extends Mock implements LoggingService {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MockMatrixService mockMatrixService;
+  late MockJournalDb mockJournalDb;
+  late MockLoggingService mockLoggingService;
+
+  setUp(() {
+    mockMatrixService = MockMatrixService();
+    mockJournalDb = MockJournalDb();
+    mockLoggingService = MockLoggingService();
+
+    // Register mocks with GetIt
+    getIt
+      ..registerSingleton<MatrixService>(mockMatrixService)
+      ..registerSingleton<JournalDb>(mockJournalDb)
+      ..registerSingleton<LoggingService>(mockLoggingService);
+
+    // Default stubs
+    when(() => mockMatrixService.isLoggedIn()).thenReturn(false);
+    when(() => mockMatrixService.logout()).thenAnswer((_) async {});
+
+    when(() => mockJournalDb.watchConfigFlag(any()))
+        .thenAnswer((_) => Stream.value(true));
+  });
+
+  tearDown(getIt.reset);
+
+  group('MatrixSettingsCard', () {
+    testWidgets('displays correct title and subtitle', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const MatrixSettingsCard(),
+        ),
+      );
+
+      final context = tester.element(find.byType(MatrixSettingsCard));
+
+      expect(find.text(context.messages.settingsMatrixTitle), findsOneWidget);
+      expect(find.text('Configure end-to-end encrypted sync'), findsOneWidget);
+      // The icon appears multiple times due to animation states
+      expect(find.byIcon(Icons.sync), findsWidgets);
+    });
+
+    testWidgets('card is tappable', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const MatrixSettingsCard(),
+        ),
+      );
+
+      // Verify the card is present and tappable
+      final card = find.byType(MatrixSettingsCard);
+      expect(card, findsOneWidget);
+
+      // The card uses AnimatedModernSettingsCardWithIcon which has a GestureDetector
+      expect(
+          find.descendant(
+            of: card,
+            matching: find.byType(GestureDetector),
+          ),
+          findsWidgets);
+    });
+
+    testWidgets('renders without errors', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const MatrixSettingsCard(),
+        ),
+      );
+
+      // Verify the card rendered successfully
+      expect(find.byType(MatrixSettingsCard), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a dedicated Matrix Sync settings card that opens a multi-step modal for configuration and management.

* **Refactor**
  * Simplified modal pages for Matrix Sync-related features by using a unified modal utility, resulting in a more consistent appearance and easier navigation.
  * Replaced manual close button and title configurations with standardized modal parameters.

* **Tests**
  * Updated tests to use localized strings for verifying the presence of the Matrix Sync card.

* **Chores**
  * Incremented app version number.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->