### PR TITLE
fix: category assignment of audio recording & navigation

### DIFF
--- a/lib/features/journal/ui/widgets/create/modern_create_entry_items.dart
+++ b/lib/features/journal/ui/widgets/create/modern_create_entry_items.dart
@@ -91,6 +91,7 @@ class ModernCreateAudioItem extends ConsumerWidget {
         AudioRecordingModal.show(
           context,
           linkedId: linkedFromId,
+          categoryId: categoryId,
         );
       },
     );

--- a/lib/features/journal/ui/widgets/list_cards/modern_journal_card.dart
+++ b/lib/features/journal/ui/widgets/list_cards/modern_journal_card.dart
@@ -66,6 +66,10 @@ class ModernJournalCard extends StatelessWidget {
         horizontal: removeHorizontalMargin ? 0 : AppTheme.spacingLarge,
         vertical: AppTheme.cardSpacing / 2,
       ),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppTheme.cardPadding,
+        vertical: AppTheme.cardPaddingCompact,
+      ),
       child: _buildContent(context),
     );
   }
@@ -75,18 +79,16 @@ class ModernJournalCard extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         _buildHeader(context),
-        if (!isCompact) ...[
-          const SizedBox(height: 8),
-          TagsViewWidget(item: item),
-        ],
-        const SizedBox(height: 8),
+        const SizedBox(height: 5),
         _buildBody(context),
+        const SizedBox(height: 5),
+        TagsViewWidget(item: item),
       ],
     );
   }
 
   Widget _buildHeader(BuildContext context) {
-    return Column(
+    return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         // Leading icon
@@ -100,34 +102,39 @@ class ModernJournalCard extends StatelessWidget {
           ),
         ],
 
-        Row(
-          children: [
-            Text(
-              _formatDate(),
-              style: context.textTheme.bodySmall?.copyWith(
-                fontFeatures: [const FontFeature.tabularFigures()],
-                color: context.colorScheme.onSurfaceVariant
-                    .withValues(alpha: AppTheme.alphaSurfaceVariant),
-                fontSize: isCompact
-                    ? AppTheme.subtitleFontSizeCompact
-                    : AppTheme.subtitleFontSize,
+        // Main content
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Text(
+                    _formatDate(),
+                    style: context.textTheme.bodySmall?.copyWith(
+                      fontFeatures: [const FontFeature.tabularFigures()],
+                      color: context.colorScheme.onSurfaceVariant
+                          .withValues(alpha: AppTheme.alphaSurfaceVariant),
+                      fontSize: isCompact
+                          ? AppTheme.subtitleFontSizeCompact
+                          : AppTheme.subtitleFontSize,
+                    ),
+                  ),
+                  if (_shouldShowCategoryIcon()) ...[
+                    const SizedBox(width: 8),
+                    CategoryColorIcon(item.meta.categoryId, size: 16),
+                  ],
+                  const Spacer(),
+                  _buildStatusIndicators(context),
+                ],
               ),
-            ),
-            if (_shouldShowCategoryIcon()) ...[
-              const SizedBox(width: 8),
-              CategoryColorIcon(item.meta.categoryId, size: 16),
+              if (item is Task || item is JournalEvent) ...[
+                const SizedBox(height: 4),
+                _buildTitleRow(context),
+              ],
             ],
-          ],
+          ),
         ),
-        if (item is Task || item is JournalEvent) ...[
-          const SizedBox(height: 4),
-          _buildTitleRow(context),
-        ],
-
-        // Status indicators
-        const SizedBox(height: 10),
-        _buildStatusIndicators(context),
-        const SizedBox(height: 5),
       ],
     );
   }
@@ -159,18 +166,22 @@ class ModernJournalCard extends StatelessWidget {
       );
     } else if (item is JournalEvent) {
       final event = item as JournalEvent;
-      return Text(
-        event.data.title,
-        style: context.textTheme.titleSmall?.copyWith(
-          fontWeight: FontWeight.w700,
-          letterSpacing: AppTheme.letterSpacingTitle,
-          fontSize: isCompact
-              ? AppTheme.titleFontSizeCompact
-              : AppTheme.titleFontSize,
-        ),
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-      );
+      final title = event.data.title;
+
+      if (title.isNotEmpty) {
+        return Text(
+          title,
+          style: context.textTheme.titleSmall?.copyWith(
+            fontWeight: FontWeight.w700,
+            letterSpacing: AppTheme.letterSpacingTitle,
+            fontSize: isCompact
+                ? AppTheme.titleFontSizeCompact
+                : AppTheme.titleFontSize,
+          ),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        );
+      }
     }
     return const SizedBox.shrink();
   }

--- a/lib/features/journal/ui/widgets/tags/tags_view_widget.dart
+++ b/lib/features/journal/ui/widgets/tags/tags_view_widget.dart
@@ -71,6 +71,7 @@ class TagChip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Chip(
+      labelPadding: EdgeInsets.zero,
       label: Text(
         tagEntity.tag,
         style: const TextStyle(
@@ -80,6 +81,7 @@ class TagChip extends StatelessWidget {
       ),
       backgroundColor: getTagColor(tagEntity),
       visualDensity: VisualDensity.compact,
+      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
     );
   }
 }

--- a/lib/features/speech/ui/widgets/recording/audio_recording_modal.dart
+++ b/lib/features/speech/ui/widgets/recording/audio_recording_modal.dart
@@ -4,6 +4,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:lotti/features/speech/state/recorder_controller.dart';
 import 'package:lotti/features/speech/state/recorder_state.dart';
 import 'package:lotti/features/speech/ui/widgets/recording/analog_vu_meter.dart';
+import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/widgets/modal/modal_utils.dart';
 
@@ -81,102 +82,99 @@ class _AudioRecordingModalContentState
     final state = ref.watch(audioRecorderControllerProvider);
     final controller = ref.read(audioRecorderControllerProvider.notifier);
 
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 24),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              AnalogVuMeter(
-                vu: state.vu,
-                dBFS: state.dBFS,
-                size: 400,
-                colorScheme: theme.colorScheme,
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            AnalogVuMeter(
+              vu: state.vu,
+              dBFS: state.dBFS,
+              size: 400,
+              colorScheme: theme.colorScheme,
+            ),
+
+            // Duration display
+            Text(
+              formatDuration(state.progress.toString()),
+              style: GoogleFonts.inconsolata(
+                fontSize: fontSizeLarge,
+                fontWeight: FontWeight.w300,
+                color: theme.colorScheme.primaryFixedDim,
               ),
+            ),
 
-              // Duration display
-              Text(
-                formatDuration(state.progress.toString()),
-                style: GoogleFonts.inconsolata(
-                  fontSize: fontSizeLarge,
-                  fontWeight: FontWeight.w300,
-                  color: theme.colorScheme.primaryFixedDim,
-                ),
-              ),
+            const SizedBox(height: 20),
 
-              const SizedBox(height: 20),
-
-              // Control buttons in a row
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  // Language selector - compact
-                  Container(
-                    height: 48, // Same height as record/stop button
-                    decoration: BoxDecoration(
-                      color: theme.colorScheme.surfaceContainerHighest
-                          .withValues(alpha: 0.5),
-                      borderRadius: BorderRadius.circular(24), // Same radius
-                      border: Border.all(
-                        color: theme.colorScheme.outline.withValues(alpha: 0.3),
-                      ),
+            // Control buttons in a row
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                // Language selector - compact
+                Container(
+                  height: 48, // Same height as record/stop button
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.surfaceContainerHighest
+                        .withValues(alpha: 0.5),
+                    borderRadius: BorderRadius.circular(24), // Same radius
+                    border: Border.all(
+                      color: theme.colorScheme.outline.withValues(alpha: 0.3),
                     ),
-                    child: Material(
-                      color: Colors.transparent,
-                      child: InkWell(
-                        borderRadius: BorderRadius.circular(24),
-                        onTap: () => _showLanguageMenu(
-                            context, controller, state.language ?? ''),
-                        child: Padding(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 16,
-                          ),
-                          child: Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              Icon(
-                                Icons.language,
-                                color: theme.colorScheme.onSurfaceVariant,
-                                size: 18,
+                  ),
+                  child: Material(
+                    color: Colors.transparent,
+                    child: InkWell(
+                      borderRadius: BorderRadius.circular(24),
+                      onTap: () => _showLanguageMenu(
+                          context, controller, state.language ?? ''),
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(
+                              Icons.language,
+                              color: theme.colorScheme.onSurfaceVariant,
+                              size: 18,
+                            ),
+                            const SizedBox(width: 8),
+                            Text(
+                              _getLanguageDisplay(state.language ?? ''),
+                              style: TextStyle(
+                                color: theme.colorScheme.onSurface,
+                                fontSize: 14,
+                                fontWeight: FontWeight.w400,
                               ),
-                              const SizedBox(width: 8),
-                              Text(
-                                _getLanguageDisplay(state.language ?? ''),
-                                style: TextStyle(
-                                  color: theme.colorScheme.onSurface,
-                                  fontSize: 14,
-                                  fontWeight: FontWeight.w400,
-                                ),
-                              ),
-                              const SizedBox(width: 4),
-                              Icon(
-                                Icons.keyboard_arrow_down,
-                                color: theme.colorScheme.onSurfaceVariant,
-                                size: 18,
-                              ),
-                            ],
-                          ),
+                            ),
+                            const SizedBox(width: 4),
+                            Icon(
+                              Icons.keyboard_arrow_down,
+                              color: theme.colorScheme.onSurfaceVariant,
+                              size: 18,
+                            ),
+                          ],
                         ),
                       ),
                     ),
                   ),
+                ),
 
-                  const SizedBox(width: 20),
-                  // Record/Stop button
-                  AnimatedSwitcher(
-                    duration: const Duration(milliseconds: 200),
-                    child: _isRecording(state)
-                        ? _buildStopButton(context, _stop, theme)
-                        : _buildRecordButton(context, controller, theme),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ],
-      ),
+                const SizedBox(width: 20),
+                // Record/Stop button
+                AnimatedSwitcher(
+                  duration: const Duration(milliseconds: 200),
+                  child: _isRecording(state)
+                      ? _buildStopButton(context, _stop, theme)
+                      : _buildRecordButton(context, controller, theme),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ],
     );
   }
 
@@ -187,9 +185,13 @@ class _AudioRecordingModalContentState
 
   Future<void> _stop() async {
     final controller = ref.read(audioRecorderControllerProvider.notifier);
-    await controller.stop();
+    final createdId = await controller.stop();
+
     if (mounted) {
       Navigator.of(context).pop();
+    }
+    if (widget.linkedId == null && createdId != null) {
+      beamToNamed('/journal/$createdId');
     }
   }
 

--- a/lib/themes/theme.dart
+++ b/lib/themes/theme.dart
@@ -454,7 +454,7 @@ ThemeData withOverrides(ThemeData themeData) {
       chipTheme: ChipThemeData(
         side: BorderSide.none,
         shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12), // More rounded
+          borderRadius: BorderRadius.circular(8),
         ),
       ),
       inputDecorationTheme: InputDecorationTheme(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -590,18 +590,18 @@ packages:
     dependency: "direct main"
     description:
       name: drift
-      sha256: e60c715f045dd33624fc533efb0075e057debec9f39e83843e518f488a0e21fb
+      sha256: dce2723fb0dd03563af21f305f8f96514c27f870efba934b4fe84d4fedb4eff7
       url: "https://pub.dev"
     source: hosted
-    version: "2.27.0"
+    version: "2.28.0"
   drift_dev:
     dependency: "direct dev"
     description:
       name: drift_dev
-      sha256: "7ad88b8982e753eadcdbc0ea7c7d30500598af733601428b5c9d264baf5106d6"
+      sha256: "68c138e884527d2bd61df2ade276c3a144df84d1adeb0ab8f3196b5afe021bd4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.27.0"
+    version: "2.28.0"
   easy_debounce:
     dependency: "direct main"
     description:
@@ -952,10 +952,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_local_notifications_windows
-      sha256: f8fc0652a601f83419d623c85723a3e82ad81f92b33eaa9bcc21ea1b94773e6e
+      sha256: "593625e6833c0def4853b361c5276464b314983c6c819178bf0fa5aba2540d86"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -1730,10 +1730,10 @@ packages:
     dependency: "direct main"
     description:
       name: matrix
-      sha256: "996e3b1560959afaa3118ec2b5a06734ad29acf64f9c3c09a605c3ddef22039f"
+      sha256: "0c033a6ebf4ed2f56ed604769984072961fefc0cb255a802ed441dcaec490196"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   media_kit:
     dependency: "direct main"
     description:
@@ -2242,10 +2242,10 @@ packages:
     dependency: transitive
     description:
       name: quill_native_bridge_linux
-      sha256: "5fcc60cab2ab9079e0746941f05c5ca5fec85cc050b738c8c8b9da7c09da17eb"
+      sha256: "388aaa62017dbd746742ce0bfae99f4ffe1dda2462e8a866df630c67b63c54fe"
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.1"
+    version: "0.0.2"
   quill_native_bridge_macos:
     dependency: transitive
     description:
@@ -2274,10 +2274,10 @@ packages:
     dependency: transitive
     description:
       name: quill_native_bridge_windows
-      sha256: "60e50d74238f22ceb43113d9a42b6627451dab9fc27f527b979a32051cf1da45"
+      sha256: "3f96ced19e3206ddf4f6f7dde3eb16bdd05e10294964009ea3a806d995aa7caa"
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.1"
+    version: "0.0.2"
   quiver:
     dependency: "direct main"
     description:
@@ -2768,10 +2768,10 @@ packages:
     dependency: transitive
     description:
       name: sqlparser
-      sha256: "27dd0a9f0c02e22ac0eb42a23df9ea079ce69b52bb4a3b478d64e0ef34a263ee"
+      sha256: "7c859c803cf7e9a84d6db918bac824545045692bbe94a6386bd3a45132235d09"
       url: "https://pub.dev"
     source: hosted
-    version: "0.41.0"
+    version: "0.41.1"
   stack_trace:
     dependency: transitive
     description:
@@ -3000,10 +3000,10 @@ packages:
     dependency: "direct main"
     description:
       name: url_launcher
-      sha256: "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603"
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.1"
+    version: "6.3.2"
   url_launcher_android:
     dependency: transitive
     description:
@@ -3288,10 +3288,10 @@ packages:
     dependency: "direct main"
     description:
       name: window_manager
-      sha256: "51d50168ab267d344b975b15390426b1243600d436770d3f13de67e55b05ec16"
+      sha256: "7eb6d6c4164ec08e1bf978d6e733f3cebe792e2a23fb07cbca25c2872bfdbdcd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.5.1"
   wkt_parser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.642+3167
+version: 0.9.642+3168
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.642+3166
+version: 0.9.642+3167
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.642+3168
+version: 0.9.642+3169
 
 msix_config:
   display_name: LottiApp

--- a/test/features/journal/ui/widgets/create/modern_create_entry_items_test.dart
+++ b/test/features/journal/ui/widgets/create/modern_create_entry_items_test.dart
@@ -1,9 +1,52 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/database/database.dart';
 import 'package:lotti/features/journal/ui/widgets/create/modern_create_entry_items.dart';
+import 'package:lotti/features/speech/repository/audio_recorder_repository.dart';
+import 'package:lotti/features/speech/state/recorder_controller.dart';
+import 'package:lotti/features/speech/state/recorder_state.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/logging_service.dart';
+import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/widgets/modal/modern_modal_entry_type_item.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:record/record.dart' show Amplitude;
 
+import '../../../../../mocks/mocks.dart';
 import '../../../../../widget_test_utils.dart';
+
+class MockAudioRecorderRepository extends Mock
+    implements AudioRecorderRepository {}
+
+class MockLoggingService extends Mock implements LoggingService {}
+
+class TestAudioRecorderController extends AudioRecorderController {
+  TestAudioRecorderController();
+
+  String? capturedCategoryId;
+
+  @override
+  AudioRecorderState build() => AudioRecorderState(
+        status: AudioRecorderStatus.initializing,
+        vu: 0,
+        dBFS: -60,
+        progress: Duration.zero,
+        showIndicator: false,
+        modalVisible: false,
+        language: 'en',
+      );
+
+  @override
+  void setCategoryId(String? categoryId) {
+    capturedCategoryId = categoryId;
+  }
+
+  @override
+  void setModalVisible({required bool modalVisible}) {
+    state = state.copyWith(modalVisible: modalVisible);
+  }
+}
 
 void main() {
   group('ModernCreateTaskItem Tests', () {
@@ -91,6 +134,63 @@ void main() {
       expect(find.byType(ModernModalEntryTypeItem), findsOneWidget);
       expect(find.text('Audio'), findsOneWidget);
       expect(find.byIcon(Icons.mic_none_rounded), findsOneWidget);
+    });
+
+    testWidgets('passes categoryId to AudioRecordingModal.show',
+        (tester) async {
+      // Set up required dependencies
+      late MockJournalDb mockJournalDb;
+      late MockNavService mockNavService;
+      late MockAudioRecorderRepository mockRecorderRepository;
+      late MockLoggingService mockLoggingService;
+      late TestAudioRecorderController testController;
+
+      mockJournalDb = MockJournalDb();
+      mockNavService = MockNavService();
+      mockRecorderRepository = MockAudioRecorderRepository();
+      mockLoggingService = MockLoggingService();
+      testController = TestAudioRecorderController();
+
+      getIt
+        ..registerSingleton<JournalDb>(mockJournalDb)
+        ..registerSingleton<NavService>(mockNavService)
+        ..registerSingleton<LoggingService>(mockLoggingService);
+
+      when(() => mockJournalDb.getConfigFlag(any()))
+          .thenAnswer((_) async => false);
+      when(() => mockNavService.beamBack()).thenReturn(null);
+      when(() => mockRecorderRepository.amplitudeStream)
+          .thenAnswer((_) => const Stream<Amplitude>.empty());
+      when(() => mockRecorderRepository.dispose()).thenAnswer((_) async {});
+
+      // Create the widget with proper provider scope
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            audioRecorderRepositoryProvider
+                .overrideWithValue(mockRecorderRepository),
+            audioRecorderControllerProvider.overrideWith(() => testController),
+          ],
+          child: makeTestableWidgetWithScaffold(
+            Builder(
+              builder: (context) => const ModernCreateAudioItem(
+                'test-linked-id',
+                categoryId: 'test-category-id',
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Tap the audio item to trigger the modal
+      await tester.tap(find.byType(ModernCreateAudioItem));
+      await tester.pump();
+
+      // Verify that setCategoryId was called with the correct value
+      expect(testController.capturedCategoryId, 'test-category-id');
+
+      // Clean up
+      await getIt.reset();
     });
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved audio recording flow by passing category information when creating a new audio entry.
  * After stopping an audio recording, users are now automatically navigated to the related journal entry if applicable.

* **Style**
  * Simplified the layout of the audio recording modal for a cleaner appearance.
  * Updated journal card layout for better alignment, consistent spacing, and always visible tags.
  * Adjusted chip styling with reduced padding, tap target size, and corner radius for a refined look.

* **Tests**
  * Added tests verifying category ID passing to the audio recording modal.
  * Added tests confirming navigation behavior after stopping recordings based on linked entry presence.
  * Introduced mock and fake classes to support enhanced testing scenarios.

* **Chores**
  * Updated app version number.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->