### PR TITLE
feat: adapt whitespace in VU meter

### DIFF
--- a/lib/features/speech/ui/widgets/recording/analog_vu_meter.dart
+++ b/lib/features/speech/ui/widgets/recording/analog_vu_meter.dart
@@ -209,7 +209,7 @@ class _AnalogVuMeterState extends State<AnalogVuMeter>
   Widget build(BuildContext context) {
     return SizedBox(
       width: widget.size,
-      height: widget.size * 0.5,
+      height: widget.size * 0.4,
       child: AnimatedBuilder(
         animation: Listenable.merge(
             [_needleAnimation, _peakAnimation, _clipAnimation]),

--- a/lib/features/speech/ui/widgets/recording/audio_recording_modal.dart
+++ b/lib/features/speech/ui/widgets/recording/audio_recording_modal.dart
@@ -28,6 +28,7 @@ class AudioRecordingModal {
       await ModalUtils.showSinglePageModal<void>(
         context: context,
         hasTopBarLayer: false,
+        showCloseButton: false,
         builder: (BuildContext _) {
           return AudioRecordingModalContent(
             linkedId: linkedId,

--- a/lib/features/speech/ui/widgets/recording/vu_meter_painter.dart
+++ b/lib/features/speech/ui/widgets/recording/vu_meter_painter.dart
@@ -22,12 +22,13 @@ class VuMeterPainter extends CustomPainter {
   // Needle sweeps from about 200 degrees (lower left) to 340 degrees (lower right)
   static const double _startAngle = 200 * math.pi / 180;
   static const double _sweepAngle = 140 * math.pi / 180;
+  static const _needlePositionVertical = 0.90;
 
   @override
   void paint(Canvas canvas, Size size) {
     // Define internal coordinate system
     const double internalWidth = 350;
-    const double internalHeight = 175;
+    const double internalHeight = 140;
 
     // Calculate scale factor to fit the actual size
     final scaleX = size.width / internalWidth;
@@ -49,7 +50,8 @@ class VuMeterPainter extends CustomPainter {
     _drawVuText(canvas, internalSize);
 
     // Needle pivot at bottom center of meter face - moved down slightly
-    const needlePivot = Offset(internalWidth / 2, internalHeight * 0.8);
+    const needlePivot =
+        Offset(internalWidth / 2, internalHeight * _needlePositionVertical);
 
     // Draw peak indicator line
     if (peakValue > 0) {
@@ -71,7 +73,7 @@ class VuMeterPainter extends CustomPainter {
 
   void _drawScale(Canvas canvas, Size size) {
     // Needle pivot at bottom center of meter face - moved down slightly
-    final pivot = Offset(size.width / 2, size.height * 0.8);
+    final pivot = Offset(size.width / 2, size.height * _needlePositionVertical);
     final radius = size.width * 0.275; // Medium size arc
 
     // Get theme colors with better contrast

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.645+3184
+version: 0.9.645+3185
 
 msix_config:
   display_name: LottiApp

--- a/test/features/speech/ui/widgets/recording/analog_vu_meter_test.dart
+++ b/test/features/speech/ui/widgets/recording/analog_vu_meter_test.dart
@@ -52,7 +52,7 @@ void main() {
       final sizedBox = find.byType(SizedBox).first;
       final sizedBoxWidget = tester.widget<SizedBox>(sizedBox);
       expect(sizedBoxWidget.width, 400);
-      expect(sizedBoxWidget.height, 200); // size * 0.5
+      expect(sizedBoxWidget.height, 160); // size * 0.4
     });
 
     testWidgets('needle animates when decibels change', (tester) async {
@@ -115,7 +115,7 @@ void main() {
 
       var sizedBox = tester.widget<SizedBox>(find.byType(SizedBox).first);
       expect(sizedBox.width, 200);
-      expect(sizedBox.height, 100); // Maintains 2:1 ratio
+      expect(sizedBox.height, 80); // Maintains 2.5:1 ratio (size * 0.4)
 
       // Test large size
       await tester.pumpWidget(makeTestableWidget(
@@ -126,7 +126,7 @@ void main() {
 
       sizedBox = tester.widget<SizedBox>(find.byType(SizedBox).first);
       expect(sizedBox.width, 600);
-      expect(sizedBox.height, 300); // Maintains 2:1 ratio
+      expect(sizedBox.height, 240); // Maintains 2.5:1 ratio (size * 0.4)
     });
 
     testWidgets('CustomPainter receives correct theme mode', (tester) async {


### PR DESCRIPTION
This pull request includes UI adjustments for the analog VU meter and audio recording modal, along with a minor version update in the `pubspec.yaml` file. Key changes include refining the visual design of the VU meter, adding a new constant for needle positioning, and modifying modal behavior.

### UI Adjustments for VU Meter:

* [`lib/features/speech/ui/widgets/recording/analog_vu_meter.dart`](diffhunk://#diff-4dd47adf4b5b24eb9656326219ee5f8a33b0201b7456765419852cd894517b22L212-R212): Reduced the height of the VU meter widget from 50% to 40% of its width for a more compact design.
* `lib/features/speech/ui/widgets/recording/vu_meter_painter.dart`:
  - Adjusted the internal height of the VU meter from 175 to 140 for better proportionality.
  - Introduced `_needlePositionVertical` constant to centralize the needle's vertical position logic. Updated needle pivot calculations in both `_drawVuText` and `_drawScale` methods to use this constant. [[1]](diffhunk://#diff-b1f6ed1f4877f9079779a7eaa79fe203a5f511803937b84d78ae8fbdb2058c55L52-R54) [[2]](diffhunk://#diff-b1f6ed1f4877f9079779a7eaa79fe203a5f511803937b84d78ae8fbdb2058c55L74-R76)

### Audio Recording Modal Behavior:

* [`lib/features/speech/ui/widgets/recording/audio_recording_modal.dart`](diffhunk://#diff-dceed0403496fc6c63a65e84029b3ab0cc192035d8f2e602f01b3fd713f19694R31): Disabled the close button in the modal by setting `showCloseButton` to `false`, likely to streamline the user experience.

### Version Update:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4): Incremented the app version from `0.9.645+3184` to `0.9.645+3185` to reflect the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the vertical dimensions of the analog VU meter for a sleeker appearance.
  * Refined the vertical positioning of the VU meter’s needle and scale for improved visual alignment.
  * Removed the close button from the audio recording modal for a cleaner interface.

* **Tests**
  * Updated tests to match the new dimensions and proportions of the analog VU meter.

* **Chores**
  * Incremented the app version number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->