### PR TITLE
fix: app icon on Kubuntu

### DIFF
--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -91,6 +91,7 @@ static void my_application_activate(GApplication* application) {
   // Set the icon name for desktop integration fallback
   gtk_window_set_icon_name(window, ICON_THEME_NAME);
 
+  gtk_window_set_icon_from_file(window, "assets/icon/app_icon_1024.png", NULL);
   gtk_window_set_default_size(window, 1280, 720);
   gtk_widget_show(GTK_WIDGET(window));
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The application window now explicitly uses a high-resolution icon for improved appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->