### PR TITLE
Add baby icon, and resize category icons

### DIFF
--- a/lib/beamer/locations/settings_location.dart
+++ b/lib/beamer/locations/settings_location.dart
@@ -99,7 +99,9 @@ class SettingsLocation extends BeamLocation<BeamState> {
           child: new_category_details.CategoryDetailsPage(),
         ),
 
-      if (pathContains('categories') && pathContainsKey('categoryId'))
+      if (pathContains('categories') &&
+          pathContainsKey('categoryId') &&
+          state.pathParameters['categoryId'] != 'create')
         BeamPage(
           key: ValueKey(
             'settings-categories-${state.pathParameters['categoryId']}',

--- a/lib/features/categories/domain/category_icon.dart
+++ b/lib/features/categories/domain/category_icon.dart
@@ -9,7 +9,7 @@ class CategoryIconConstants {
   CategoryIconConstants._(); // Private constructor to prevent instantiation
 
   /// Default icon size multiplier for category display
-  static const double iconSizeMultiplier = 0.6;
+  static const double iconSizeMultiplier = 0.56;
 
   /// Default text size multiplier for category display
   static const double textSizeMultiplier = 0.4;
@@ -33,14 +33,14 @@ class CategoryIconConstants {
   static const double pickerTextSize = 10;
 
   /// Default category icon display size
-  static const double defaultIconSize = 48;
+  static const double defaultIconSize = 43.2;
 
   /// Icon sizes for different contexts - Single source of truth
   /// Large icons for prominent displays (category details, large cards)
-  static const double iconSizeLarge = 32;
+  static const double iconSizeLarge = 38.4;
 
   /// Medium icons for list items, cards with text (task definition)
-  static const double iconSizeMedium = 24;
+  static const double iconSizeMedium = 35.2;
 
   /// Small icons for compact lists, inline displays (journal entries)
   static const double iconSizeSmall = 20;
@@ -83,7 +83,7 @@ class CategoryIconConstants {
   static const double smallSectionSpacing = 8;
 
   /// Icon preview size in forms
-  static const double iconPreviewSize = 48;
+  static const double iconPreviewSize = 35.2;
 
   /// Standard icon size for buttons and UI elements
   static const double standardIconSize = 28;
@@ -179,6 +179,7 @@ enum CategoryIcon {
   people,
   relationships,
   social,
+  baby,
   gaming,
   music,
   art,
@@ -301,6 +302,8 @@ extension CategoryIconExtension on CategoryIcon {
         return Icons.palette;
       case CategoryIcon.photography:
         return MdiIcons.cameraOutline;
+      case CategoryIcon.baby:
+        return Icons.baby_changing_station;
 
       // Utility & Tracking Icons
       case CategoryIcon.wallet:
@@ -445,6 +448,8 @@ extension CategoryIconExtension on CategoryIcon {
         return 'Computer';
       case CategoryIcon.connectivity:
         return 'Internet';
+      case CategoryIcon.baby:
+        return 'Baby';
     }
   }
 
@@ -538,6 +543,12 @@ extension CategoryIconExtension on CategoryIcon {
       'learn': CategoryIcon.learning,
       'friend': CategoryIcon.relationships,
       'family': CategoryIcon.relationships,
+      'baby': CategoryIcon.baby,
+      'child': CategoryIcon.baby,
+      'kid': CategoryIcon.baby,
+      'nursing': CategoryIcon.baby,
+      'infant': CategoryIcon.baby,
+      'toddler': CategoryIcon.baby,
       'game': CategoryIcon.gaming,
       'play': CategoryIcon.gaming,
       'sing': CategoryIcon.music,

--- a/lib/features/categories/domain/category_icon.dart
+++ b/lib/features/categories/domain/category_icon.dart
@@ -83,7 +83,7 @@ class CategoryIconConstants {
   static const double smallSectionSpacing = 8;
 
   /// Icon preview size in forms
-  static const double iconPreviewSize = 35.2;
+  static const double iconPreviewSize = iconSizeMedium;
 
   /// Standard icon size for buttons and UI elements
   static const double standardIconSize = 28;

--- a/lib/features/categories/ui/pages/category_details_page.dart
+++ b/lib/features/categories/ui/pages/category_details_page.dart
@@ -648,8 +648,8 @@ class _CategoryDetailsPageState extends ConsumerState<CategoryDetailsPage> {
               children: [
                 if (isCreateMode)
                   Container(
-                    width: 48,
-                    height: 48,
+                    width: CategoryIconConstants.defaultIconSize,
+                    height: CategoryIconConstants.defaultIconSize,
                     decoration: BoxDecoration(
                       shape: BoxShape.circle,
                       border: Border.all(

--- a/lib/features/tasks/ui/header/task_category_widget.dart
+++ b/lib/features/tasks/ui/header/task_category_widget.dart
@@ -55,9 +55,12 @@ class TaskCategoryWidget extends StatelessWidget {
             Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                CategoryIconCompact(
-                  category?.id,
-                  size: CategoryIconConstants.iconSizeMedium,
+                Padding(
+                  padding: const EdgeInsets.only(right: CategoryIconConstants.smallSectionSpacing),
+                  child: CategoryIconCompact(
+                    category?.id,
+                    size: CategoryIconConstants.iconSizeMedium,
+                  ),
                 ),
                 Flexible(
                   child: Text(

--- a/lib/features/tasks/ui/header/task_category_widget.dart
+++ b/lib/features/tasks/ui/header/task_category_widget.dart
@@ -44,7 +44,7 @@ class TaskCategoryWidget extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.only(right: 5),
         child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.end,
           children: [
             Text(
               context.messages.taskCategoryLabel,
@@ -52,7 +52,6 @@ class TaskCategoryWidget extends StatelessWidget {
                 color: context.colorScheme.outline,
               ),
             ),
-            const SizedBox(height: 4),
             Row(
               mainAxisSize: MainAxisSize.min,
               children: [
@@ -60,7 +59,6 @@ class TaskCategoryWidget extends StatelessWidget {
                   category?.id,
                   size: CategoryIconConstants.iconSizeMedium,
                 ),
-                const SizedBox(width: 10),
                 Flexible(
                   child: Text(
                     category?.name ?? '-',

--- a/test/features/categories/ui/widgets/category_icon_picker_test.dart
+++ b/test/features/categories/ui/widgets/category_icon_picker_test.dart
@@ -24,10 +24,6 @@ void main() {
       // (The close button is not part of the GridView, it's in the header)
       expect(gridView.semanticChildCount, equals(CategoryIcon.values.length));
 
-      // Also verify the data source: ensure all CategoryIcon values are represented
-      expect(CategoryIcon.values.length, equals(57),
-          reason: 'Expected 57 CategoryIcon enum values');
-
       // Verify that the close button exists separately (not in the GridView)
       expect(find.byIcon(Icons.close), findsOneWidget);
 

--- a/test/features/categories/ui/widgets/category_icon_picker_test.dart
+++ b/test/features/categories/ui/widgets/category_icon_picker_test.dart
@@ -25,8 +25,8 @@ void main() {
       expect(gridView.semanticChildCount, equals(CategoryIcon.values.length));
 
       // Also verify the data source: ensure all CategoryIcon values are represented
-      expect(CategoryIcon.values.length, equals(56),
-          reason: 'Expected 56 CategoryIcon enum values');
+      expect(CategoryIcon.values.length, equals(57),
+          reason: 'Expected 57 CategoryIcon enum values');
 
       // Verify that the close button exists separately (not in the GridView)
       expect(find.byIcon(Icons.close), findsOneWidget);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "Baby" icon option for categories, including support for baby-related keywords in icon suggestions.

* **Style**
  * Updated icon sizing throughout the app for a more consistent appearance.
  * Adjusted layout and alignment of the task category widget for improved visual presentation.
  * Standardized icon container sizing in the category icon picker UI.

* **Bug Fixes**
  * Prevented the category details page from displaying when creating a new category.

* **Tests**
  * Removed a hardcoded check on the number of category icons to improve test flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->