### PR TITLE
fix: make category icon sizes consistent across all definition pages

### DIFF
--- a/lib/features/categories/ui/widgets/category_field.dart
+++ b/lib/features/categories/ui/widgets/category_field.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/features/categories/domain/category_icon.dart';
 import 'package:lotti/features/categories/ui/widgets/category_icon_compact.dart';
 import 'package:lotti/features/categories/ui/widgets/category_selection_modal_content.dart';
 import 'package:lotti/get_it.dart';
@@ -54,7 +55,10 @@ class CategoryField extends StatelessWidget {
         semanticsLabel: 'Select category',
         themeData: Theme.of(context),
       ).copyWith(
-        icon: CategoryIconCompact(categoryId),
+        icon: CategoryIconCompact(
+          categoryId,
+          size: CategoryIconConstants.iconSizeMedium,
+        ),
         suffixIcon: categoryUndefined
             ? null
             : GestureDetector(

--- a/lib/features/settings/ui/widgets/dashboards/dashboard_category.dart
+++ b/lib/features/settings/ui/widgets/dashboards/dashboard_category.dart
@@ -82,7 +82,10 @@ class SelectDashboardCategoryWidget extends StatelessWidget {
             semanticsLabel: 'Select category',
             themeData: Theme.of(context),
           ).copyWith(
-            icon: CategoryIconCompact(category?.id),
+            icon: CategoryIconCompact(
+              category?.id,
+              size: CategoryIconConstants.iconSizeMedium,
+            ),
             suffixIcon: categoryUndefined
                 ? null
                 : GestureDetector(

--- a/test/features/categories/ui/widgets/category_field_test.dart
+++ b/test/features/categories/ui/widgets/category_field_test.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/features/categories/domain/category_icon.dart';
 import 'package:lotti/features/categories/ui/widgets/category_field.dart';
+import 'package:lotti/features/categories/ui/widgets/category_icon_compact.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:mocktail/mocktail.dart';
@@ -167,5 +169,20 @@ void main() {
     // Verify create category option is shown
     expect(find.text('New Category'), findsNWidgets(2));
     expect(find.byIcon(Icons.add_circle_outline), findsOneWidget);
+  });
+
+  testWidgets('displays category icon with correct size', (tester) async {
+    when(() => mockCacheService.getCategoryById('test-id'))
+        .thenReturn(testCategory);
+
+    await tester.pumpWidget(
+      createTestWidget(
+        categoryId: 'test-id',
+        onSave: (_) {},
+      ),
+    );
+
+    final icon = tester.widget<CategoryIconCompact>(find.byType(CategoryIconCompact));
+    expect(icon.size, equals(CategoryIconConstants.iconSizeMedium));
   });
 }

--- a/test/features/settings/ui/widgets/dashboard_category_test.dart
+++ b/test/features/settings/ui/widgets/dashboard_category_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/features/categories/domain/category_icon.dart';
+import 'package:lotti/features/categories/ui/widgets/category_icon_compact.dart';
+import 'package:lotti/features/settings/ui/widgets/dashboards/dashboard_category.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/entities_cache_service.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../test_helper.dart';
+
+class MockEntitiesCacheService extends Mock implements EntitiesCacheService {}
+class MockJournalDb extends Mock implements JournalDb {}
+
+void main() {
+  late MockEntitiesCacheService mockCacheService;
+  late MockJournalDb mockJournalDb;
+  final testCategory = CategoryDefinition(
+    id: 'test-id',
+    name: 'Test Category',
+    color: '#FF0000',
+    createdAt: DateTime.now(),
+    updatedAt: DateTime.now(),
+    vectorClock: null,
+    private: false,
+    active: true,
+  );
+
+  setUp(() {
+    mockCacheService = MockEntitiesCacheService();
+    mockJournalDb = MockJournalDb();
+    
+    // Mock JournalDb methods
+    when(() => mockJournalDb.watchCategories()).thenAnswer(
+      (_) => Stream<List<CategoryDefinition>>.fromIterable([[testCategory]]),
+    );
+    
+    getIt
+      ..registerSingleton<EntitiesCacheService>(mockCacheService)
+      ..registerSingleton<JournalDb>(mockJournalDb);
+  });
+
+  tearDown(() {
+    getIt
+      ..unregister<EntitiesCacheService>()
+      ..unregister<JournalDb>();
+  });
+
+  Widget createTestWidget({
+    required void Function(String?) setCategory,
+    String? categoryId,
+  }) {
+    return WidgetTestBench(
+      child: SelectDashboardCategoryWidget(
+        setCategory: setCategory,
+        categoryId: categoryId,
+      ),
+    );
+  }
+
+  testWidgets('displays category icon with correct size', (tester) async {
+    when(() => mockCacheService.getCategoryById('test-id'))
+        .thenReturn(testCategory);
+
+    await tester.pumpWidget(
+      createTestWidget(
+        categoryId: 'test-id',
+        setCategory: (_) {},
+      ),
+    );
+
+    final icon = tester.widget<CategoryIconCompact>(find.byType(CategoryIconCompact));
+    expect(icon.size, equals(CategoryIconConstants.iconSizeMedium));
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized category icons to a consistent medium size across category selection fields and dashboard selector for improved visual consistency.
  * Slight visual polish to category inputs for cleaner alignment and readability.

* **Tests**
  * Added widget tests verifying category icons render at the expected medium size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->