### PR TITLE
fix: set verbosity to null - incompatible with Gemini

### DIFF
--- a/lib/features/ai/repository/cloud_inference_repository.dart
+++ b/lib/features/ai/repository/cloud_inference_repository.dart
@@ -117,6 +117,7 @@ class CloudInferenceRepository {
         ],
         model: ChatCompletionModel.modelId(model),
         temperature: temperature,
+        verbosity: null,
         maxCompletionTokens: maxCompletionTokens,
         stream: true,
         tools: tools,
@@ -193,6 +194,7 @@ class CloudInferenceRepository {
         temperature: temperature,
         maxTokens: maxCompletionTokens,
         stream: true,
+        verbosity: null,
         tools: tools,
         toolChoice: tools != null
             ? const ChatCompletionToolChoiceOption.mode(
@@ -281,6 +283,7 @@ class CloudInferenceRepository {
             model: ChatCompletionModel.modelId(model),
             maxCompletionTokens: maxCompletionTokens,
             stream: true,
+            verbosity: null,
             tools: tools,
             toolChoice: tools != null
                 ? const ChatCompletionToolChoiceOption.mode(

--- a/lib/features/ai/repository/cloud_inference_repository.dart
+++ b/lib/features/ai/repository/cloud_inference_repository.dart
@@ -39,7 +39,7 @@ class CloudInferenceRepository {
       stream: true,
       verbosity: null, // Explicitly null for Gemini compatibility
       tools: tools,
-      toolChoice: tools != null
+      toolChoice: tools != null && tools.isNotEmpty
           ? const ChatCompletionToolChoiceOption.mode(
               ChatCompletionToolChoiceMode.auto,
             )

--- a/lib/features/ai/ui/settings/widgets/form_components/ai_switch_field.dart
+++ b/lib/features/ai/ui/settings/widgets/form_components/ai_switch_field.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:lotti/widgets/selection/unified_toggle.dart';
 
 /// DEPRECATED: Use UnifiedAiToggleField directly instead
-/// 
+///
 /// This wrapper is being removed to consolidate toggle implementations.
 /// Replace usage with:
 /// ```dart

--- a/lib/map/cached_tile_provider.dart
+++ b/lib/map/cached_tile_provider.dart
@@ -3,12 +3,13 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 
 class CachedTileProvider extends TileProvider {
-  CachedTileProvider();
+  CachedTileProvider({super.headers});
+
   @override
   ImageProvider getImage(TileCoordinates coordinates, TileLayer options) {
     return CachedNetworkImageProvider(
       getTileUrl(coordinates, options),
-      //Now you can set options that determine how the image gets cached via whichever plugin you use.
+      headers: headers,
     );
   }
 }

--- a/lib/widgets/misc/map_widget.dart
+++ b/lib/widgets/misc/map_widget.dart
@@ -61,7 +61,11 @@ class _MapWidgetState extends State<MapWidget> {
               options: MapOptions(initialCenter: loc),
               children: [
                 TileLayer(
-                  tileProvider: CachedTileProvider(),
+                  tileProvider: CachedTileProvider(
+                    headers: {
+                      'User-Agent': 'com.matthiasnehlsen.lotti',
+                    },
+                  ),
                   urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
                   userAgentPackageName: 'com.matthiasnehlsen.lotti',
                 ),

--- a/lib/widgets/misc/map_widget.dart
+++ b/lib/widgets/misc/map_widget.dart
@@ -63,6 +63,7 @@ class _MapWidgetState extends State<MapWidget> {
                 TileLayer(
                   tileProvider: CachedTileProvider(),
                   urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                  userAgentPackageName: 'com.matthiasnehlsen.lotti',
                 ),
                 MarkerLayer(
                   markers: [

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.652+3228
+version: 0.9.652+3229
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.652+3229
+version: 0.9.652+3230
 
 msix_config:
   display_name: LottiApp

--- a/test/features/ai/repository/cloud_inference_repository_test.dart
+++ b/test/features/ai/repository/cloud_inference_repository_test.dart
@@ -1316,5 +1316,154 @@ void main() {
       expect(response.choices?[0].delta?.content, equals(transcribedText));
       expect(response.choices?[0].delta?.role, isNull);
     });
+
+    test('generate sets verbosity to null for Gemini compatibility', () async {
+      // Arrange
+      when(
+        () => mockClient.createChatCompletionStream(
+          request: any(named: 'request'),
+        ),
+      ).thenAnswer(
+        (_) => Stream.fromIterable([
+          CreateChatCompletionStreamResponse(
+            id: 'response-id',
+            choices: [
+              const ChatCompletionStreamResponseChoice(
+                delta: ChatCompletionStreamResponseDelta(
+                  content: 'Test response',
+                ),
+                index: 0,
+              ),
+            ],
+            object: 'chat.completion.chunk',
+            created: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          ),
+        ]),
+      );
+
+      // Act
+      await repository
+          .generate(
+            prompt,
+            model: model,
+            temperature: temperature,
+            baseUrl: baseUrl,
+            apiKey: apiKey,
+            overrideClient: mockClient,
+          )
+          .toList();
+
+      // Assert
+      final captured = verify(
+        () => mockClient.createChatCompletionStream(
+          request: captureAny(named: 'request'),
+        ),
+      ).captured;
+
+      final request = captured.first as CreateChatCompletionRequest;
+      expect(request.verbosity, isNull);
+    });
+
+    test('generateWithImages sets verbosity to null for Gemini compatibility',
+        () async {
+      // Arrange
+      const images = ['base64-image-data'];
+
+      when(
+        () => mockClient.createChatCompletionStream(
+          request: any(named: 'request'),
+        ),
+      ).thenAnswer(
+        (_) => Stream.fromIterable([
+          CreateChatCompletionStreamResponse(
+            id: 'response-id',
+            choices: [
+              const ChatCompletionStreamResponseChoice(
+                delta: ChatCompletionStreamResponseDelta(
+                  content: 'Test response',
+                ),
+                index: 0,
+              ),
+            ],
+            object: 'chat.completion.chunk',
+            created: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          ),
+        ]),
+      );
+
+      // Act
+      await repository
+          .generateWithImages(
+            prompt,
+            model: model,
+            temperature: temperature,
+            baseUrl: baseUrl,
+            apiKey: apiKey,
+            images: images,
+            overrideClient: mockClient,
+          )
+          .toList();
+
+      // Assert
+      final captured = verify(
+        () => mockClient.createChatCompletionStream(
+          request: captureAny(named: 'request'),
+        ),
+      ).captured;
+
+      final request = captured.first as CreateChatCompletionRequest;
+      expect(request.verbosity, isNull);
+    });
+
+    test('generateWithAudio sets verbosity to null for Gemini compatibility',
+        () async {
+      // Arrange
+      const audioBase64 = 'base64-audio-data';
+
+      when(
+        () => mockClient.createChatCompletionStream(
+          request: any(named: 'request'),
+        ),
+      ).thenAnswer(
+        (_) => Stream.fromIterable([
+          CreateChatCompletionStreamResponse(
+            id: 'response-id',
+            choices: [
+              const ChatCompletionStreamResponseChoice(
+                delta: ChatCompletionStreamResponseDelta(
+                  content: 'Test response',
+                ),
+                index: 0,
+              ),
+            ],
+            object: 'chat.completion.chunk',
+            created: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          ),
+        ]),
+      );
+
+      // Act
+      await repository
+          .generateWithAudio(
+            prompt,
+            model: model,
+            audioBase64: audioBase64,
+            baseUrl: baseUrl,
+            apiKey: apiKey,
+            provider: testProvider,
+            overrideClient: mockClient,
+          )
+          .toList();
+
+      // Assert
+      final captured = verify(
+        () => mockClient.createChatCompletionStream(
+          request: captureAny(named: 'request'),
+        ),
+      ).captured;
+
+      final request = captured.first as CreateChatCompletionRequest;
+      expect(request.verbosity, isNull);
+    });
   });
 }

--- a/test/features/categories/ui/widgets/category_field_test.dart
+++ b/test/features/categories/ui/widgets/category_field_test.dart
@@ -182,7 +182,8 @@ void main() {
       ),
     );
 
-    final icon = tester.widget<CategoryIconCompact>(find.byType(CategoryIconCompact));
+    final icon =
+        tester.widget<CategoryIconCompact>(find.byType(CategoryIconCompact));
     expect(icon.size, equals(CategoryIconConstants.iconSizeMedium));
   });
 }

--- a/test/features/settings/ui/widgets/dashboard_category_test.dart
+++ b/test/features/settings/ui/widgets/dashboard_category_test.dart
@@ -12,6 +12,7 @@ import 'package:mocktail/mocktail.dart';
 import '../../../../test_helper.dart';
 
 class MockEntitiesCacheService extends Mock implements EntitiesCacheService {}
+
 class MockJournalDb extends Mock implements JournalDb {}
 
 void main() {
@@ -31,12 +32,14 @@ void main() {
   setUp(() {
     mockCacheService = MockEntitiesCacheService();
     mockJournalDb = MockJournalDb();
-    
+
     // Mock JournalDb methods
     when(() => mockJournalDb.watchCategories()).thenAnswer(
-      (_) => Stream<List<CategoryDefinition>>.fromIterable([[testCategory]]),
+      (_) => Stream<List<CategoryDefinition>>.fromIterable([
+        [testCategory]
+      ]),
     );
-    
+
     getIt
       ..registerSingleton<EntitiesCacheService>(mockCacheService)
       ..registerSingleton<JournalDb>(mockJournalDb);
@@ -71,7 +74,8 @@ void main() {
       ),
     );
 
-    final icon = tester.widget<CategoryIconCompact>(find.byType(CategoryIconCompact));
+    final icon =
+        tester.widget<CategoryIconCompact>(find.byType(CategoryIconCompact));
     expect(icon.size, equals(CategoryIconConstants.iconSizeMedium));
   });
 }

--- a/test/map/cached_tile_provider_test.dart
+++ b/test/map/cached_tile_provider_test.dart
@@ -1,0 +1,122 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/map/cached_tile_provider.dart';
+
+void main() {
+  group('CachedTileProvider', () {
+    late CachedTileProvider provider;
+    late TileLayer tileLayer;
+
+    setUp(() {
+      tileLayer = TileLayer(
+        urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+      );
+    });
+
+    test('constructor accepts headers parameter', () {
+      final headers = {'User-Agent': 'test-app'};
+      provider = CachedTileProvider(headers: headers);
+
+      expect(provider, isNotNull);
+    });
+
+    test('getImage returns CachedNetworkImageProvider', () {
+      provider = CachedTileProvider();
+      const coordinates = TileCoordinates(0, 0, 1);
+
+      final imageProvider = provider.getImage(coordinates, tileLayer);
+
+      expect(imageProvider, isA<CachedNetworkImageProvider>());
+    });
+
+    test('getImage passes headers to CachedNetworkImageProvider', () {
+      final headers = {
+        'User-Agent': 'com.example.app',
+        'Custom-Header': 'test'
+      };
+      provider = CachedTileProvider(headers: headers);
+      const coordinates = TileCoordinates(0, 0, 1);
+
+      final imageProvider = provider.getImage(coordinates, tileLayer)
+          as CachedNetworkImageProvider;
+
+      // CachedNetworkImageProvider stores headers internally
+      // We can't directly access them, but we can verify the provider was created
+      expect(imageProvider, isNotNull);
+      expect(imageProvider.url, contains('tile.openstreetmap.org'));
+    });
+
+    test('getImage without headers creates provider with null headers', () {
+      provider = CachedTileProvider();
+      const coordinates = TileCoordinates(0, 0, 1);
+
+      final imageProvider = provider.getImage(coordinates, tileLayer)
+          as CachedNetworkImageProvider;
+
+      expect(imageProvider, isNotNull);
+    });
+
+    test('getTileUrl generates correct URL format', () {
+      provider = CachedTileProvider();
+      const coordinates = TileCoordinates(10, 20, 5);
+
+      final url = provider.getTileUrl(coordinates, tileLayer);
+
+      expect(url, equals('https://tile.openstreetmap.org/5/10/20.png'));
+    });
+
+    test('getTileUrl handles different URL templates', () {
+      provider = CachedTileProvider();
+      final customTileLayer = TileLayer(
+        urlTemplate: 'https://example.com/tiles/{z}/{x}/{y}.jpg?key=123',
+      );
+      const coordinates = TileCoordinates(15, 25, 8);
+
+      final url = provider.getTileUrl(coordinates, customTileLayer);
+
+      expect(url, equals('https://example.com/tiles/8/15/25.jpg?key=123'));
+    });
+
+    test('getTileUrl handles subdomains correctly', () {
+      provider = CachedTileProvider();
+      final subdomainTileLayer = TileLayer(
+        urlTemplate: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      );
+      const coordinates = TileCoordinates(0, 0, 1);
+
+      final url = provider.getTileUrl(coordinates, subdomainTileLayer);
+
+      // The URL should contain one of the subdomains
+      expect(
+          url,
+          matches(
+              RegExp(r'https://[abc]\.tile\.openstreetmap\.org/1/0/0\.png')));
+    });
+
+    test('multiple instances with different headers', () {
+      final provider1 = CachedTileProvider(headers: {'User-Agent': 'app1'});
+      final provider2 = CachedTileProvider(headers: {'User-Agent': 'app2'});
+      final provider3 = CachedTileProvider();
+
+      // All providers should be independent instances
+      expect(provider1, isNot(equals(provider2)));
+      expect(provider1, isNot(equals(provider3)));
+      expect(provider2, isNot(equals(provider3)));
+    });
+
+    test('headers parameter is optional', () {
+      // Should not throw when creating without headers
+      expect(CachedTileProvider.new, returnsNormally);
+    });
+
+    test('empty headers map is handled correctly', () {
+      final provider = CachedTileProvider(headers: {});
+      const coordinates = TileCoordinates(0, 0, 1);
+
+      final imageProvider = provider.getImage(coordinates, tileLayer);
+
+      expect(imageProvider, isA<CachedNetworkImageProvider>());
+    });
+  });
+}

--- a/test/widgets/misc/map_widget_test.dart
+++ b/test/widgets/misc/map_widget_test.dart
@@ -3,9 +3,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/geolocation.dart';
+import 'package:lotti/map/cached_tile_provider.dart';
 import 'package:lotti/widgets/misc/map_widget.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // Note: Some tests in this file require assets (e.g., marker images) to be loaded.
+  // These tests may fail if assets are not properly configured in the test environment.
   group('MapWidget', () {
     Widget createTestWidget({
       Geolocation? geolocation,
@@ -253,6 +258,34 @@ void main() {
         tileLayer.urlTemplate,
         'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
       );
+    });
+
+    testWidgets('TileLayer uses CachedTileProvider', (tester) async {
+      final geolocation = Geolocation(
+        createdAt: DateTime.now(),
+        latitude: 37.7749,
+        longitude: -122.4194,
+        geohashString: '9q8yy',
+      );
+
+      await tester.pumpWidget(
+        createTestWidget(
+          geolocation: geolocation,
+        ),
+      );
+
+      // Allow the widget tree to settle
+      await tester.pump();
+
+      // Find TileLayer widgets
+      final tileLayers = find.byType(TileLayer);
+      expect(tileLayers, findsOneWidget);
+
+      final tileLayer = tester.widget<TileLayer>(tileLayers);
+
+      // Verify tileProvider is CachedTileProvider
+      expect(tileLayer.tileProvider, isNotNull);
+      expect(tileLayer.tileProvider, isA<CachedTileProvider>());
     });
   });
 }


### PR DESCRIPTION
## Fix Gemini API compatibility by explicitly setting verbosity to null

  Summary

  - Fixed OpenAI API compatibility issue with Google Gemini by explicitly setting the verbosity
  parameter to null in all CreateChatCompletionRequest instances
  - Resolved ASR (Automatic Speech Recognition) failures when using Gemini 2.5 Flash

  Problem

  The openai_dart package v0.5.4 introduced support for the verbosity parameter, a new GPT-5 feature
  that controls response length and detail. However, Google's Gemini API OpenAI-compatible endpoint
  doesn't recognize this parameter, resulting in 400 errors:

  "Invalid JSON payload received. Unknown name \"verbosity\": Cannot find field."

  Solution

  Instead of downgrading the package, we explicitly set verbosity: null in all three places where
  CreateChatCompletionRequest is created:
  1. Text generation (generate method)
  2. Image-based generation (generateWithImages method)
  3. Audio-based generation (generateWithAudio method)

  This approach maintains compatibility with both providers that support the verbosity parameter and
  those that don't.

  Test plan

  - Test ASR with Gemini 2.5 Flash model
  - Verify text generation still works with all providers
  - Confirm image and audio-based completions function correctly
  - Ensure no regression with OpenAI/Anthropic/other providers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved AI provider compatibility and request behavior (Gemini compatibility, filtered provider pings).
  * Bumped app version to 0.9.652+3230.
* **Maintenance**
  * Added a User-Agent header for map tile requests and enabled passing request headers to tile fetching.
* **Tests**
  * Added extensive AI request tests and new tests for tile provider and map widget behavior; added test mocking utilities.
* **Style**
  * Minor formatting and doc-comment cleanups in UI and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->