### PR TITLE
fix: add libmpv dependency to Flatpak for audio recording playback

### DIFF
--- a/flatpak/com.matthiasnehlsen.lotti.yml
+++ b/flatpak/com.matthiasnehlsen.lotti.yml
@@ -102,7 +102,7 @@ modules:
       - |
         cat > /app/lotti-wrapper << 'EOF'
         #!/bin/bash
-        export LD_LIBRARY_PATH=/app/lib:/app/lib/ffmpeg:$LD_LIBRARY_PATH
+        export LD_LIBRARY_PATH=/app/lib:$LD_LIBRARY_PATH
 
         # Set GDK_BACKEND conditionally: prefer Wayland, fallback to X11 when needed
         if [ -z "$WAYLAND_DISPLAY" ] && [ "$XDG_SESSION_TYPE" != "wayland" ]; then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an embedded media engine for in-app video/audio playback.
  * Improved subtitle rendering quality and compatibility.
  * Enhanced video rendering for smoother, more reliable playback.

* **Chores**
  * Updated Flatpak packaging to include required media components and include an additional library directory for bundled codecs/libraries.
  * Removed prior public notice about a missing media component; runtime now provides the bundled media stack.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->