### PR TITLE
fix: unregister Cmd+S hotkey after saving text entries

### DIFF
--- a/lib/features/journal/state/entry_controller.dart
+++ b/lib/features/journal/state/entry_controller.dart
@@ -46,12 +46,14 @@ class EntryController extends _$EntryController {
 
     if (isDesktop) {
       if (focusNode.hasFocus) {
-        hotKeyManager.register(
-          saveHotKey,
-          keyDownHandler: (hotKey) => save(),
+        unawaited(
+          hotKeyManager.register(
+            saveHotKey,
+            keyDownHandler: (hotKey) => save(),
+          ),
         );
       } else {
-        hotKeyManager.unregister(saveHotKey);
+        unawaited(hotKeyManager.unregister(saveHotKey));
       }
     }
   }
@@ -59,12 +61,14 @@ class EntryController extends _$EntryController {
   void taskTitleFocusNodeListener() {
     if (isDesktop) {
       if (taskTitleFocusNode.hasFocus) {
-        hotKeyManager.register(
-          saveHotKey,
-          keyDownHandler: (hotKey) => save(),
+        unawaited(
+          hotKeyManager.register(
+            saveHotKey,
+            keyDownHandler: (hotKey) => save(),
+          ),
         );
       } else {
-        hotKeyManager.unregister(saveHotKey);
+        unawaited(hotKeyManager.unregister(saveHotKey));
       }
     }
   }
@@ -238,13 +242,8 @@ class EntryController extends _$EntryController {
         });
       }
 
-      if (isDesktop) {
-        unawaited(hotKeyManager.unregister(saveHotKey));
-      }
-
       focusNode.unfocus();
 
-      _isFocused = false;
       _shouldShowEditorToolBar = false;
       _dirty = false;
 

--- a/lib/features/journal/state/entry_controller.dart
+++ b/lib/features/journal/state/entry_controller.dart
@@ -238,6 +238,10 @@ class EntryController extends _$EntryController {
         });
       }
 
+      if (isDesktop) {
+        unawaited(hotKeyManager.unregister(saveHotKey));
+      }
+
       focusNode.unfocus();
 
       _isFocused = false;

--- a/lib/features/journal/ui/widgets/editor/editor_widget.dart
+++ b/lib/features/journal/ui/widgets/editor/editor_widget.dart
@@ -35,8 +35,8 @@ class EditorWidget extends ConsumerWidget {
         entryState.value?.shouldShowEditorToolBar ?? false;
 
     final contentPadding = shouldShowEditorToolBar
-        ? const EdgeInsets.only(top: 10, bottom: 10, left: 10, right: 10)
-        : const EdgeInsets.only(top: 10);
+        ? const EdgeInsets.only(top: 5, bottom: 15, left: 10, right: 10)
+        : EdgeInsets.zero;
 
     return Card(
       margin: margin,

--- a/lib/features/journal/ui/widgets/editor/editor_widget.dart
+++ b/lib/features/journal/ui/widgets/editor/editor_widget.dart
@@ -14,15 +14,12 @@ class EditorWidget extends ConsumerWidget {
     super.key,
     this.minHeight = 40,
     this.maxHeight = double.maxFinite,
-    this.contentPadding =
-        const EdgeInsets.only(top: 5, bottom: 15, left: 10, right: 10),
     this.margin,
   });
 
   final String entryId;
   final double maxHeight;
   final double minHeight;
-  final EdgeInsets contentPadding;
   final EdgeInsets? margin;
 
   @override
@@ -36,6 +33,10 @@ class EditorWidget extends ConsumerWidget {
 
     final shouldShowEditorToolBar =
         entryState.value?.shouldShowEditorToolBar ?? false;
+
+    final contentPadding = shouldShowEditorToolBar
+        ? const EdgeInsets.only(top: 10, bottom: 10, left: 10, right: 10)
+        : const EdgeInsets.only(top: 10);
 
     return Card(
       margin: margin,
@@ -84,9 +85,7 @@ class EditorWidget extends ConsumerWidget {
                   ],
                   minHeight: minHeight,
                   placeholder: context.messages.editorPlaceholder,
-                  padding: shouldShowEditorToolBar
-                      ? contentPadding
-                      : EdgeInsets.zero,
+                  padding: contentPadding,
                   keyboardAppearance: Theme.of(context).brightness,
                   customStyles: customEditorStyles(
                     themeData: Theme.of(context),

--- a/lib/features/journal/ui/widgets/entry_details_widget.dart
+++ b/lib/features/journal/ui/widgets/entry_details_widget.dart
@@ -127,6 +127,47 @@ class EntryDetailsContent extends ConsumerWidget {
       return const SizedBox.shrink();
     }
 
+    final shouldHideEditor = switch (item) {
+      JournalEvent() ||
+      QuantitativeEntry() ||
+      WorkoutEntry() ||
+      Checklist() ||
+      ChecklistItem() ||
+      AiResponseEntry() => true,
+      _ => false,
+    };
+
+    final detailSection = switch (item) {
+      JournalAudio() => AudioPlayerWidget(item),
+      WorkoutEntry() => WorkoutSummary(item),
+      SurveyEntry() => SurveySummary(item),
+      QuantitativeEntry() => HealthSummary(item),
+      MeasurementEntry() => MeasurementSummary(item),
+      JournalEvent() => EventForm(item),
+      HabitCompletionEntry() => HabitSummary(
+          item,
+          paddingLeft: 10,
+          paddingBottom: 5,
+          showIcon: true,
+          showText: false,
+        ),
+      AiResponseEntry() => AiResponseSummary(
+          item,
+          linkedFromId: linkedFrom?.id,
+          fadeOut: true,
+        ),
+      Checklist() => ChecklistWrapper(
+          entryId: item.meta.id,
+          taskId: item.data.linkedTasks.first,
+        ),
+      ChecklistItem() => ChecklistItemWrapper(
+          item.id,
+          checklistId: '',
+          taskId: '',
+        ),
+      _ => null,
+    };
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -137,71 +178,9 @@ class EntryDetailsContent extends ConsumerWidget {
           link: link,
         ),
         TagsListWidget(entryId: itemId, parentTags: parentTags),
-        () {
-          if (item is JournalImage) {
-            return EntryImageWidget(item);
-          }
-          return const SizedBox.shrink();
-        }(),
-        () {
-          switch (item) {
-            //case Task():
-            case JournalEvent():
-            case QuantitativeEntry():
-            case WorkoutEntry():
-            case Checklist():
-            case ChecklistItem():
-            case AiResponseEntry():
-              return const SizedBox.shrink();
-            default:
-              return EditorWidget(entryId: itemId);
-          }
-        }(),
-        () {
-          if (item is JournalAudio) {
-            return AudioPlayerWidget(item);
-          } else if (item is WorkoutEntry) {
-            return WorkoutSummary(item);
-          } else if (item is SurveyEntry) {
-            return SurveySummary(item);
-          } else if (item is QuantitativeEntry) {
-            return HealthSummary(item);
-          } else if (item is MeasurementEntry) {
-            return MeasurementSummary(item);
-          } else if (item is Task) {
-            return const SizedBox.shrink();
-          } else if (item is JournalEvent) {
-            return EventForm(item);
-          } else if (item is HabitCompletionEntry) {
-            return HabitSummary(
-              item,
-              paddingLeft: 10,
-              paddingBottom: 5,
-              showIcon: true,
-              showText: false,
-            );
-          } else if (item is JournalEntry || item is JournalImage) {
-            return const SizedBox.shrink();
-          } else if (item is AiResponseEntry) {
-            return AiResponseSummary(
-              item,
-              linkedFromId: linkedFrom?.id,
-              fadeOut: true,
-            );
-          } else if (item is Checklist) {
-            return ChecklistWrapper(
-              entryId: item.meta.id,
-              taskId: item.data.linkedTasks.first,
-            );
-          } else if (item is ChecklistItem) {
-            return ChecklistItemWrapper(
-              item.id,
-              checklistId: '',
-              taskId: '',
-            );
-          }
-          return const SizedBox.shrink();
-        }(),
+        if (item is JournalImage) EntryImageWidget(item),
+        if (!shouldHideEditor) EditorWidget(entryId: itemId),
+        if (detailSection != null) detailSection,
         EntryDetailFooter(
           entryId: itemId,
           linkedFrom: linkedFrom,

--- a/lib/features/journal/ui/widgets/entry_details_widget.dart
+++ b/lib/features/journal/ui/widgets/entry_details_widget.dart
@@ -133,7 +133,8 @@ class EntryDetailsContent extends ConsumerWidget {
       WorkoutEntry() ||
       Checklist() ||
       ChecklistItem() ||
-      AiResponseEntry() => true,
+      AiResponseEntry() =>
+        true,
       _ => false,
     };
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.672+3279
+version: 0.9.673+3280
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.673+3280
+version: 0.9.673+3281
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Desktop: keyboard shortcut registration/unregistration made non-blocking to improve reliability.
  * Save flow: focus is no longer explicitly cleared during save, preventing unintended focus changes.

* **Refactor**
  * Editor: removed public padding parameter; editor now computes and applies padding internally for consistent toolbar spacing.
  * Entry details: consolidated conditional rendering into explicit type-based dispatch for clearer, more maintainable UI composition.

* **Chores**
  * Bumped version to 0.9.673+3281.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->