### PR TITLE
fix: navigation bar index clamping

### DIFF
--- a/lib/beamer/beamer_app.dart
+++ b/lib/beamer/beamer_app.dart
@@ -93,11 +93,15 @@ class _AppScreenState extends State<AppScreen> {
         final rawIndex = snapshot.data ?? 0;
 
         // Calculate the number of navigation items based on enabled flags
-        final itemCount = 2 + // Tasks and Journal (always enabled)
-            (_isCalendarPageEnabled ? 1 : 0) +
-            (_isHabitsPageEnabled ? 1 : 0) +
-            (_isDashboardsPageEnabled ? 1 : 0) +
-            1; // Settings (always enabled)
+        final navItems = [
+          true, // Tasks
+          _isCalendarPageEnabled, // Calendar
+          _isHabitsPageEnabled, // Habits
+          _isDashboardsPageEnabled, // Dashboards
+          true, // Journal
+          true, // Settings
+        ];
+        final itemCount = navItems.where((isEnabled) => isEnabled).length;
 
         // Clamp index to valid range to prevent out of bounds errors
         // when flags are toggled and items list shrinks

--- a/test/beamer/beamer_app_test.dart
+++ b/test/beamer/beamer_app_test.dart
@@ -8,11 +8,15 @@ int calculateClampedIndex({
   required bool isDashboardsEnabled,
 }) {
   // Calculate the number of navigation items based on enabled flags
-  final itemCount = 2 + // Tasks and Journal (always enabled)
-      (isCalendarEnabled ? 1 : 0) +
-      (isHabitsEnabled ? 1 : 0) +
-      (isDashboardsEnabled ? 1 : 0) +
-      1; // Settings (always enabled)
+  final navItems = [
+    true, // Tasks
+    isCalendarEnabled, // Calendar
+    isHabitsEnabled, // Habits
+    isDashboardsEnabled, // Dashboards
+    true, // Journal
+    true, // Settings
+  ];
+  final itemCount = navItems.where((isEnabled) => isEnabled).length;
 
   // Clamp index to valid range to prevent out of bounds errors
   return rawIndex.clamp(0, itemCount - 1);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stabilized bottom navigation when optional tabs (Calendar, Habits, Dashboards) change. The selected tab is clamped to available items so the visible screen always matches the current navigation state.
* **Tests**
  * Added comprehensive tests validating index clamping across feature-flag combinations and edge cases (negative, zero, oversized indices) and during sequential flag changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->