### PR TITLE
refactor: consolidate monospace font use

### DIFF
--- a/docs/implementation_plans/2025-10-20_timer_tabular_figures_fix.md
+++ b/docs/implementation_plans/2025-10-20_timer_tabular_figures_fix.md
@@ -166,6 +166,9 @@ New (core + speech timers)
   future changes? Proposed: yes, but optional. YES
 - If we find no timer text in the journal card for tasks (only the red dot), should we still reserve
   placeholder space to anticipate later? NO
+ - Deprecate `monospaceTextStyle` and `monospaceTextStyleSmall` in favor of `monoTabularStyle`?
+   Proposed: YES. Plan: mark as `@Deprecated`, optionally re-implement to delegate to
+   `monoTabularStyle` to preserve behavior, then migrate call sites incrementally.
 
 ## Implementation Checklist
 

--- a/lib/features/ai/ui/unified_ai_progress_view.dart
+++ b/lib/features/ai/ui/unified_ai_progress_view.dart
@@ -388,7 +388,8 @@ class _UnifiedAiProgressContentState
         }
 
         // Default: show the state (result or idle)
-        final textStyle = monospaceTextStyleSmall.copyWith(
+        final textStyle = monoTabularStyle(
+          fontSize: fontSizeSmall,
           fontWeight: FontWeight.w300,
         );
         return Padding(

--- a/lib/features/journal/ui/widgets/helpers.dart
+++ b/lib/features/journal/ui/widgets/helpers.dart
@@ -21,7 +21,8 @@ class EntryTextWidget extends StatelessWidget {
         text,
         maxLines: maxLines,
         softWrap: true,
-        style: monospaceTextStyle.copyWith(
+        style: monoTabularStyle(
+          fontSize: fontSizeMedium,
           fontWeight: FontWeight.w300,
         ),
       ),

--- a/lib/features/journal/util/entry_tools.dart
+++ b/lib/features/journal/util/entry_tools.dart
@@ -59,7 +59,7 @@ class InfoText extends StatelessWidget {
     return Text(
       text,
       maxLines: maxLines,
-      style: monospaceTextStyle,
+      style: monoTabularStyle(fontSize: fontSizeMedium),
     );
   }
 }

--- a/lib/features/settings/ui/pages/advanced/conflicts_page.dart
+++ b/lib/features/settings/ui/pages/advanced/conflicts_page.dart
@@ -124,7 +124,7 @@ class ConflictCard extends StatelessWidget {
         ),
         subtitle: Text(
           '${fromSerialized(conflict.serialized).meta.vectorClock}',
-          style: monospaceTextStyleSmall,
+          style: monoTabularStyle(fontSize: fontSizeSmall),
         ),
         onTap: () {
           beamToNamed('/settings/advanced/conflicts/${conflict.id}');
@@ -268,17 +268,17 @@ class ConflictDetailRoute extends StatelessWidget {
                     const Divider(),
                     Text(
                       'Local: ${local.meta.vectorClock}',
-                      style: monospaceTextStyleSmall,
+                      style: monoTabularStyle(fontSize: fontSizeSmall),
                     ),
                     const SizedBox(height: 5),
                     Text(
                       'Resolved with local: ${localWithResolvedVectorClock.meta.vectorClock}',
-                      style: monospaceTextStyleSmall,
+                      style: monoTabularStyle(fontSize: fontSizeSmall),
                     ),
                     const SizedBox(height: 5),
                     Text(
                       'From Sync: ${fromSync.meta.vectorClock}',
-                      style: monospaceTextStyleSmall,
+                      style: monoTabularStyle(fontSize: fontSizeSmall),
                     ),
                   ],
                 ),

--- a/lib/features/settings/ui/pages/advanced/logging_page.dart
+++ b/lib/features/settings/ui/pages/advanced/logging_page.dart
@@ -604,11 +604,12 @@ class LogDetailPage extends StatelessWidget {
               '$timestamp $level $domain $subDomain\n\n$message\n\n$stacktrace';
 
           final headerStyle = level == 'ERROR'
-              ? monospaceTextStyle.copyWith(
+              ? monoTabularStyle(
+                  fontSize: fontSizeMedium,
                   color: context.colorScheme.error,
                   fontWeight: FontWeight.bold,
                 )
-              : monospaceTextStyle;
+              : monoTabularStyle(fontSize: fontSizeMedium);
 
           return SingleChildScrollView(
             padding: const EdgeInsets.all(8),
@@ -631,13 +632,19 @@ class LogDetailPage extends StatelessWidget {
                   padding: EdgeInsets.only(top: 16),
                   child: Text('Message:'),
                 ),
-                SelectableText(message, style: monospaceTextStyle),
+                SelectableText(
+                  message,
+                  style: monoTabularStyle(fontSize: fontSizeMedium),
+                ),
                 if (stacktrace != null) ...[
                   const Padding(
                     padding: EdgeInsets.only(top: 16),
                     child: Text('Stack Trace:'),
                   ),
-                  SelectableText(stacktrace, style: monospaceTextStyle),
+                  SelectableText(
+                    stacktrace,
+                    style: monoTabularStyle(fontSize: fontSizeMedium),
+                  ),
                 ],
                 IconButton(
                   icon: Icon(MdiIcons.clipboardOutline),

--- a/lib/features/settings/ui/widgets/habits/habit_autocomplete_widget.dart
+++ b/lib/features/settings/ui/widgets/habits/habit_autocomplete_widget.dart
@@ -323,9 +323,9 @@ class RuleInfoWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return Text(
       info,
-      style: monospaceTextStyle.copyWith(
-        fontWeight: FontWeight.normal,
+      style: monoTabularStyle(
         fontSize: fontSizeMedium,
+        fontWeight: FontWeight.normal,
       ),
     );
   }
@@ -345,9 +345,9 @@ class RuleListInfoWidget extends StatelessWidget {
       quarterTurns: 3,
       child: Text(
         info,
-        style: monospaceTextStyle.copyWith(
-          fontWeight: FontWeight.w300,
+        style: monoTabularStyle(
           fontSize: fontSizeLarge,
+          fontWeight: FontWeight.w300,
         ),
       ),
     );

--- a/lib/features/speech/ui/widgets/audio_player.dart
+++ b/lib/features/speech/ui/widgets/audio_player.dart
@@ -102,7 +102,8 @@ class AudioPlayerWidget extends ConsumerWidget {
                   barHeight: 3,
                   thumbRadius: 5,
                   onSeek: cubit.seek,
-                  timeLabelTextStyle: monospaceTextStyle.copyWith(
+                  timeLabelTextStyle: monoTabularStyle(
+                    fontSize: fontSizeMedium,
                     color: context.colorScheme.outline,
                   ),
                 ),

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -655,7 +655,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get configFlagEnableEventsDescription =>
-      'Zeigen Sie die Ereignisfunktion an, um Ereignisse in Ihrem Journal zu erstellen, verfolgen und verwalten.';
+      'Show the Events feature to create, track, and manage events in your journal.';
 
   @override
   String get configFlagEnableHabitsPageDescription =>
@@ -720,7 +720,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get configFlagEnableCalendarPage => 'Seite Kalender aktivieren';
 
   @override
-  String get configFlagEnableEvents => 'Ereignisse aktivieren';
+  String get configFlagEnableEvents => 'Enable Events';
 
   @override
   String get configFlagUseCloudInferenceDescription =>

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -656,7 +656,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get configFlagEnableEventsDescription =>
-      'Muestre la función Eventos para crear, rastrear y administrar eventos en su diario.';
+      'Show the Events feature to create, track, and manage events in your journal.';
 
   @override
   String get configFlagEnableHabitsPageDescription =>
@@ -722,7 +722,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get configFlagEnableCalendarPage => 'Habilitar página Calendario';
 
   @override
-  String get configFlagEnableEvents => 'Activar Eventos';
+  String get configFlagEnableEvents => 'Enable Events';
 
   @override
   String get configFlagUseCloudInferenceDescription =>

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -657,7 +657,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get configFlagEnableEventsDescription =>
-      'Affichez la fonction Événements pour créer, suivre et gérer les événements dans votre journal.';
+      'Show the Events feature to create, track, and manage events in your journal.';
 
   @override
   String get configFlagEnableHabitsPageDescription =>
@@ -723,7 +723,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get configFlagEnableCalendarPage => 'Activer la page Calendrier';
 
   @override
-  String get configFlagEnableEvents => 'Activer les événements';
+  String get configFlagEnableEvents => 'Enable Events';
 
   @override
   String get configFlagUseCloudInferenceDescription =>

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -653,7 +653,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get configFlagEnableEventsDescription =>
-      'Afișați funcția Evenimente pentru a crea, urmări și gestiona evenimente în jurnal.';
+      'Show the Events feature to create, track, and manage events in your journal.';
 
   @override
   String get configFlagEnableHabitsPageDescription =>
@@ -720,7 +720,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get configFlagEnableCalendarPage => 'Activează pagina Calendar';
 
   @override
-  String get configFlagEnableEvents => 'Activați Evenimente';
+  String get configFlagEnableEvents => 'Enable Events';
 
   @override
   String get configFlagUseCloudInferenceDescription =>

--- a/lib/themes/theme.dart
+++ b/lib/themes/theme.dart
@@ -291,18 +291,6 @@ const chartTooltipStyleBold = TextStyle(
   fontWeight: FontWeight.bold,
 );
 
-const monospaceTextStyle = TextStyle(
-  fontSize: fontSizeMedium,
-  fontWeight: FontWeight.w500,
-  fontFeatures: [
-    FontFeature.tabularFigures(),
-  ],
-);
-
-final TextStyle monospaceTextStyleSmall = monospaceTextStyle.copyWith(
-  fontSize: fontSizeSmall,
-);
-
 const appBarTextStyle = TextStyle(
   fontSize: fontSizeMedium,
   fontWeight: FontWeight.bold,

--- a/lib/widgets/README.md
+++ b/lib/widgets/README.md
@@ -192,7 +192,7 @@ Visual indicator showing whether time recording is currently active.
 
 - Typography: Uses `monoTabularStyle` with tabular figures to ensure the duration text does not jitter as digits change.
 - Dimensions: Matches width/height with the audio recording indicator to keep overlays consistent.
-- Sizing: Font size aligns with `AppTheme.statusIndicatorFontSize`.
+- Sizing: Font size aligns with `fontSizeMedium`.
 
 ### TimeSpanSegmentedControl
 Segmented control for selecting time spans (day, week, month, year).


### PR DESCRIPTION
  - Deprecate monospaceTextStyle/Small in theme; redirect to monoTabularStyle(fontSize: …).
  - Migrate safe call sites to monoTabularStyle (AI progress, journal helpers, entry tools, logging/conflicts pages, audio player, habits autocomplete).
  - Clarify indicator sizing and deprecation plan in docs; update widgets README to fontSizeMedium for TimeRecordingIndicator.
  - No functional changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced typography rendering with improved tabular figure support across UI components including journal entries, conflict displays, logging details, and audio playback controls for consistent visual presentation.

* **Localization**
  * Events feature labels now display in English across German, Spanish, French, and Romanian language settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->