### PR TITLE
feat: add waveforms for audio longer than 3 min

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stabilized labels/task widget tests by awaiting `getIt.reset()`, providing scoped service mocks,
   and giving sheet/editor hosts real `MediaQuery` sizes so chips, toggles, and CTAs are tappable
   during automation.
+- Waveform: show visualization for recordings longer than 3 minutes by removing the duration gate
+  and introducing dynamic zoom scaling for long clips; updated tests and docs accordingly.
 
 ## [0.9.704] - 2025-10-24
 ### Added

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.706+3404
+version: 0.9.707+3405
 
 msix_config:
   display_name: LottiApp

--- a/test/features/speech/services/audio_waveform_service_test.dart
+++ b/test/features/speech/services/audio_waveform_service_test.dart
@@ -212,7 +212,7 @@ void main() {
     return files;
   }
 
-  test('returns null when audio duration exceeds limit', () async {
+  test('extracts waveform for long audio (no gating)', () async {
     final audio = createAudio(
       duration: const Duration(minutes: 5),
     );
@@ -222,14 +222,14 @@ void main() {
       targetBuckets: 200,
     );
 
-    expect(result, isNull);
-    verify(
+    expect(result, isNotNull);
+    verifyNever(
       () => loggingService.captureEvent(
         any<String>(),
         domain: 'audio_waveform_service',
         subDomain: 'duration_gate',
       ),
-    ).called(1);
+    );
   });
 
   test('normalizes waveform and caches result', () async {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Waveform visualization now displays for recordings of all lengths with dynamic zoom scaling for longer audio clips.

* **Documentation**
  * Updated implementation plan to reflect removal of recording duration limitations for waveform display.

* **Tests**
  * Updated test coverage to validate waveform extraction for longer audio durations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->