### PR TITLE
ci: remove rust toolchain

### DIFF
--- a/.github/workflows/flutter-test-linux-faster.yml
+++ b/.github/workflows/flutter-test-linux-faster.yml
@@ -16,10 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
       - name: Cache Pub Packages
         uses: actions/cache@v4
         with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow by removing Rust toolchain setup step from the Linux testing pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->