### PR TITLE
refactor: flathub submission feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Tests: service unit tests and widget tests updated; i18n keys added with missing translations noted
 
 ### Changed
+- Flatpak: AppStream metadata version/date now come directly from the checked-in `com.matthiasn.lotti.metainfo.xml`; the manifest tool no longer rewrites them during Flathub prep.
 - Journal/Tasks: Refactored scroll-to-entry and highlight logic into `HighlightScrollMixin` with configurable durations and a small retry backoff; `LinkedEntriesWithTimer` scopes rebuilds to the linked entries section only. Focus intent is cleared early (next frame) for responsiveness and also on success/terminal failure for robustness.
 - Tasks UI: Checklist item vertical spacing reduced (outer padding 2px; content padding vertical 2px) for a more compact list.
 - UI/Tasks: Redesigned the active label filters header below the search bar

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -28,7 +28,7 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
-    <release version="{{LOTTI_VERSION}}" date="{{LOTTI_RELEASE_DATE}}">
+    <release version="0.9.737" date="2025-11-20">
       <description>
         <p>Latest release with improved screenshot functionality and Linux compatibility.</p>
       </description>

--- a/flatpak/com.matthiasn.lotti.source.yml
+++ b/flatpak/com.matthiasn.lotti.source.yml
@@ -155,8 +155,6 @@ modules:
       - chmod +x /app/lotti
       - install -D linux/com.matthiasn.lotti.desktop /app/share/applications/com.matthiasn.lotti.desktop
       - install -D flatpak/com.matthiasn.lotti.metainfo.xml /app/share/metainfo/com.matthiasn.lotti.metainfo.xml
-      - sed -i "s/{{LOTTI_VERSION}}/{{MANIFEST_VERSION}}/g" /app/share/metainfo/com.matthiasn.lotti.metainfo.xml
-      - sed -i "s/{{LOTTI_RELEASE_DATE}}/{{MANIFEST_DATE}}/g" /app/share/metainfo/com.matthiasn.lotti.metainfo.xml
       - install -D lotti-wrapper.sh /app/bin/lotti
       - install -D flatpak/app_icon_512.png /app/share/icons/hicolor/512x512/apps/com.matthiasn.lotti.png
       - install -D flatpak/app_icon_256.png /app/share/icons/hicolor/256x256/apps/com.matthiasn.lotti.png

--- a/flatpak/manifest_tool/prepare_flathub_refactor_plan.md
+++ b/flatpak/manifest_tool/prepare_flathub_refactor_plan.md
@@ -40,7 +40,7 @@ Refactor `flatpak/prepare_flathub_submission.sh` into a thin wrapper that delega
 
 ### Environment & Inputs
 - Detects repo and script paths, defines work/output directories under `flatpak/flathub-build`.
-- Reads version data from `pubspec.yaml` or Git metadata (`LOTTI_VERSION`, `LOTTI_RELEASE_DATE`).
+- Assumes AppStream metadata ships with the release version/date already committed upstream (no placeholder substitution).
 - Determines current git branch and validates remote presence (uses `GITHUB_HEAD_REF`, `GITHUB_REF_NAME`).
 - Behaviour toggles via env vars: `CLEAN_AFTER_GEN`, `PIN_COMMIT`, `USE_NESTED_FLUTTER`, `DOWNLOAD_MISSING_SOURCES`, `NO_FLATPAK_FLUTTER`, `FLATPAK_FLUTTER_TIMEOUT`, `TEST_BUILD`, plus optional caches (`PUB_CACHE`, `LOTTI_ROOT`, etc.).
 

--- a/flatpak/manifest_tool/tests/prepare/test_orchestrator.py
+++ b/flatpak/manifest_tool/tests/prepare/test_orchestrator.py
@@ -65,8 +65,6 @@ def _make_context(base: Path) -> PrepareFlathubContext:
         manifest_work=manifest_path,
         manifest_output=output_dir / "com.matthiasn.lotti.yml",
         env={},
-        lotti_version="0.0.0",
-        release_date="1970-01-01",
         current_branch="main",
         app_commit="deadbeef",
         flutter_tag=DEFAULT_FLUTTER_TAG,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * App metadata now uses the checked-in release version/date instead of template substitutions.
  * Flatpak build config: tool binaries added via append-path; PATH is no longer overridden when unset.
  * Removed a manual pkg-config override for the media runtime.
  * Manifest preparation no longer rewrites release/version fields during packaging; environment PATH updates only occur when PATH exists.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->