### PR TITLE
fix: no original transcript if edited text exists

### DIFF
--- a/lib/features/ai/repository/ai_input_repository.dart
+++ b/lib/features/ai/repository/ai_input_repository.dart
@@ -73,7 +73,8 @@ class AiInputRepository {
         String? transcriptLanguage;
         String? entryType;
         final editedText = linked.entryText?.plainText;
-        final hasEditedText = editedText != null && editedText.isNotEmpty;
+        // An explicit edit (even to empty string) takes precedence over transcript
+        final hasEditedText = editedText != null;
 
         if (linked is JournalAudio) {
           entryType = 'audio';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.741+3482
+version: 0.9.741+3483
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio transcription now honors user edits: manually edited text is used in entries and suppresses the original transcript when present.
  * Explicitly empty edits are respected, producing an empty entry text instead of falling back to the transcript.

* **Tests**
  * Added tests covering edited-text precedence, empty-edit behavior, and transcript fallback when no edits exist.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->