### PR TITLE
fix: download media in sync

### DIFF
--- a/lib/features/sync/matrix/matrix_service.dart
+++ b/lib/features/sync/matrix/matrix_service.dart
@@ -25,6 +25,7 @@ import 'package:lotti/features/sync/model/sync_message.dart';
 import 'package:lotti/features/sync/secure_storage.dart';
 import 'package:lotti/features/user_activity/state/user_activity_gate.dart';
 import 'package:lotti/services/logging_service.dart';
+import 'package:lotti/utils/file_utils.dart';
 import 'package:lotti/utils/platform.dart' show isTestEnv;
 import 'package:matrix/encryption/utils/key_verification.dart';
 import 'package:matrix/matrix.dart';
@@ -134,6 +135,7 @@ class MatrixService {
             attachmentIndex: attachmentIndex,
             collectMetrics: collectSyncMetrics,
             sentEventRegistry: _sentEventRegistry,
+            documentsDirectory: getDocumentsDirectory(),
           );
       _pipeline = pipeline;
 

--- a/lib/features/sync/matrix/pipeline/attachment_ingestor.dart
+++ b/lib/features/sync/matrix/pipeline/attachment_ingestor.dart
@@ -1,24 +1,38 @@
-// Records attachment descriptors; no filesystem access here.
+// Records attachment descriptors and eagerly downloads attachments to disk.
+
+import 'dart:io';
 
 import 'package:lotti/features/sync/matrix/consts.dart';
 import 'package:lotti/features/sync/matrix/pipeline/attachment_index.dart';
 import 'package:lotti/features/sync/matrix/pipeline/descriptor_catch_up_manager.dart';
+import 'package:lotti/features/sync/matrix/utils/atomic_write.dart';
 import 'package:lotti/services/logging_service.dart';
 import 'package:matrix/matrix.dart';
+import 'package:path/path.dart' as p;
 
 /// AttachmentIngestor
 ///
 /// Purpose
 /// - Encapsulates first-pass attachment handling for the sync pipeline:
 ///   - Record descriptors into AttachmentIndex and emit observability logs
+///   - Eagerly download and save attachments to disk
 ///   - Clear pending jsonPaths via [DescriptorCatchUpManager] and nudge scans
 ///
-/// This helper has no internal state; it operates on provided arguments.
+/// This helper operates on provided arguments and the documents directory.
 class AttachmentIngestor {
-  const AttachmentIngestor();
+  const AttachmentIngestor({
+    this.documentsDirectory,
+  });
+
+  /// The documents directory for saving attachments. If null, eager download
+  /// is skipped (descriptor-only mode for testing or when fs access is not
+  /// available).
+  final Directory? documentsDirectory;
 
   /// Processes attachment-related behavior for an event.
-  Future<void> process({
+  ///
+  /// Returns `true` if a new file was written to disk, `false` otherwise.
+  Future<bool> process({
     required Event event,
     required LoggingService logging,
     required AttachmentIndex? attachmentIndex,
@@ -26,6 +40,8 @@ class AttachmentIngestor {
     required void Function() scheduleLiveScan,
     required Future<void> Function() retryNow,
   }) async {
+    var fileWritten = false;
+
     // Record descriptors when present and emit a compact observability line.
     final rpAny = event.content['relativePath'];
     if (rpAny is String && rpAny.isNotEmpty) {
@@ -48,11 +64,113 @@ class AttachmentIngestor {
       } catch (_) {
         // best-effort logging only
       }
+
+      // Eagerly download and save the attachment to disk.
+      if (documentsDirectory != null) {
+        fileWritten = await _saveAttachment(
+          event: event,
+          relativePath: rpAny,
+          logging: logging,
+        );
+      }
+
       if (descriptorCatchUp?.removeIfPresent(rpAny) ?? false) {
         scheduleLiveScan();
         await retryNow();
       }
     }
-    // No media downloads here.
+
+    return fileWritten;
+  }
+
+  /// Downloads and saves an attachment if it isn't already present on disk.
+  ///
+  /// Returns `true` if a new file was written, `false` if skipped or failed.
+  Future<bool> _saveAttachment({
+    required Event event,
+    required String relativePath,
+    required LoggingService logging,
+  }) async {
+    final docDir = documentsDirectory;
+    if (docDir == null) {
+      return false;
+    }
+
+    final attachmentMimetype = event.attachmentMimetype;
+    if (attachmentMimetype.isEmpty) {
+      return false;
+    }
+
+    try {
+      // Build a safe, normalized path under documentsDirectory.
+      var rel = relativePath;
+      if (p.isAbsolute(rel)) {
+        final prefix = p.rootPrefix(rel);
+        rel = rel.substring(prefix.length);
+      }
+      final resolved = p.normalize(p.join(docDir.path, rel));
+      if (!p.isWithin(docDir.path, resolved)) {
+        logging.captureEvent(
+          'pathTraversal.blocked path=$relativePath resolved=$resolved',
+          domain: syncLoggingDomain,
+          subDomain: 'attachment.save',
+        );
+        return false;
+      }
+
+      final file = File(resolved);
+      // Fast-path dedupe: if the file already exists and is non-empty,
+      // skip re-downloading to avoid repeated writes and log spam.
+      if (file.existsSync()) {
+        try {
+          final len = file.lengthSync();
+          if (len > 0) {
+            return false; // already present
+          }
+        } catch (_) {
+          // If querying length fails, fall through to re-download.
+        }
+      }
+
+      logging.captureEvent(
+        'downloading $relativePath',
+        domain: syncLoggingDomain,
+        subDomain: 'attachment.download',
+      );
+
+      final matrixFile = await event.downloadAndDecryptAttachment();
+      final bytes = matrixFile.bytes;
+      if (bytes.isEmpty) {
+        logging.captureEvent(
+          'emptyBytes path=$relativePath',
+          domain: syncLoggingDomain,
+          subDomain: 'attachment.download',
+        );
+        return false;
+      }
+
+      await atomicWriteBytes(
+        bytes: bytes,
+        filePath: resolved,
+        logging: logging,
+        subDomain: 'attachment.write',
+      );
+
+      logging.captureEvent(
+        'wrote file $relativePath bytes=${bytes.length}',
+        domain: syncLoggingDomain,
+        subDomain: 'attachment.save',
+      );
+      return true;
+    } catch (e, st) {
+      // Log but don't throw - SmartJournalEntityLoader can retry later
+      logging.captureException(
+        e,
+        domain: syncLoggingDomain,
+        subDomain: 'attachment.save',
+        stackTrace: st,
+      );
+      return false;
+    }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.748+3492
+version: 0.9.748+3493
 
 msix_config:
   display_name: LottiApp

--- a/test/features/sync/matrix/pipeline/attachment_ingestor_test.dart
+++ b/test/features/sync/matrix/pipeline/attachment_ingestor_test.dart
@@ -1,4 +1,6 @@
+import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/sync/matrix/pipeline/attachment_index.dart';
@@ -15,122 +17,384 @@ class MockLoggingService extends Mock implements LoggingService {}
 class MockDescriptorCatchUpManager extends Mock
     implements DescriptorCatchUpManager {}
 
+class MockMatrixFile extends Mock implements MatrixFile {}
+
 void main() {
   setUpAll(() {
     registerFallbackValue(StackTrace.empty);
   });
 
-  test('records descriptor, logs observe, updates metrics, and clears pending',
-      () async {
-    final logging = MockLoggingService();
-    when(() => logging.captureEvent(any<String>(),
-        domain: any<String>(named: 'domain'),
-        subDomain: any<String>(named: 'subDomain'))).thenReturn(null);
-    when(() => logging.captureException(any<Object>(),
-        domain: any<String>(named: 'domain'),
-        subDomain: any<String>(named: 'subDomain'),
-        stackTrace: any<StackTrace?>(named: 'stackTrace'))).thenReturn(null);
-
-    final ev = MockEvent();
-    when(() => ev.eventId).thenReturn('e1');
-    when(() => ev.content)
-        .thenReturn({'relativePath': '/p/a.bin', 'msgtype': 'm.file'});
-    when(() => ev.attachmentMimetype).thenReturn('application/json');
-    when(() => ev.senderId).thenReturn('@other:u');
-
-    final index = AttachmentIndex(logging: logging);
-    var liveScanCalls = 0;
-    var retryNowCalls = 0;
-    final desc = MockDescriptorCatchUpManager();
-    when(() => desc.removeIfPresent('/p/a.bin')).thenReturn(true);
-
-    await const AttachmentIngestor().process(
-      event: ev,
-      logging: logging,
-      attachmentIndex: index,
-      descriptorCatchUp: desc,
-      scheduleLiveScan: () => liveScanCalls++,
-      retryNow: () async => retryNowCalls++,
-    );
-    // Prefetch metrics removed
-    // Logs emitted
-    verify(() => logging.captureEvent(
-          any<String>(),
+  group('descriptor-only mode (no documentsDirectory)', () {
+    test(
+        'records descriptor, logs observe, updates metrics, and clears pending',
+        () async {
+      final logging = MockLoggingService();
+      when(() => logging.captureEvent(any<String>(),
           domain: any<String>(named: 'domain'),
-          subDomain: 'attachment.observe',
-        )).called(greaterThan(0));
-    // Pending cleared triggers scan and retry (no media write here)
-    expect(liveScanCalls, 1);
-    expect(retryNowCalls, 1);
-    // AttachmentIndex has the descriptor
-    expect(index.find('/p/a.bin'), isNotNull);
+          subDomain: any<String>(named: 'subDomain'))).thenReturn(null);
+      when(() => logging.captureException(any<Object>(),
+          domain: any<String>(named: 'domain'),
+          subDomain: any<String>(named: 'subDomain'),
+          stackTrace: any<StackTrace?>(named: 'stackTrace'))).thenReturn(null);
+
+      final ev = MockEvent();
+      when(() => ev.eventId).thenReturn('e1');
+      when(() => ev.content)
+          .thenReturn({'relativePath': '/p/a.bin', 'msgtype': 'm.file'});
+      when(() => ev.attachmentMimetype).thenReturn('application/json');
+      when(() => ev.senderId).thenReturn('@other:u');
+
+      final index = AttachmentIndex(logging: logging);
+      var liveScanCalls = 0;
+      var retryNowCalls = 0;
+      final desc = MockDescriptorCatchUpManager();
+      when(() => desc.removeIfPresent('/p/a.bin')).thenReturn(true);
+
+      // No documentsDirectory = descriptor-only mode
+      final result = await const AttachmentIngestor().process(
+        event: ev,
+        logging: logging,
+        attachmentIndex: index,
+        descriptorCatchUp: desc,
+        scheduleLiveScan: () => liveScanCalls++,
+        retryNow: () async => retryNowCalls++,
+      );
+
+      // No file written in descriptor-only mode
+      expect(result, isFalse);
+      // Logs emitted
+      verify(() => logging.captureEvent(
+            any<String>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: 'attachment.observe',
+          )).called(greaterThan(0));
+      // Pending cleared triggers scan and retry (no media write here)
+      expect(liveScanCalls, 1);
+      expect(retryNowCalls, 1);
+      // AttachmentIndex has the descriptor
+      expect(index.find('/p/a.bin'), isNotNull);
+    });
+
+    test('no file written without documentsDirectory; clears pending',
+        () async {
+      final logging = MockLoggingService();
+      when(() => logging.captureEvent(any<String>(),
+          domain: any<String>(named: 'domain'),
+          subDomain: any<String>(named: 'subDomain'))).thenReturn(null);
+      when(() => logging.captureException(any<Object>(),
+          domain: any<String>(named: 'domain'),
+          subDomain: any<String>(named: 'subDomain'),
+          stackTrace: any<StackTrace?>(named: 'stackTrace'))).thenReturn(null);
+
+      final tmp = Directory.systemTemp.createTempSync('ingestor');
+      addTearDown(() => tmp.deleteSync(recursive: true));
+
+      final ev = MockEvent();
+      when(() => ev.eventId).thenReturn('e2');
+      when(() => ev.content)
+          .thenReturn({'relativePath': '/media/x.jpg', 'msgtype': 'm.image'});
+      when(() => ev.attachmentMimetype).thenReturn('image/jpeg');
+      when(() => ev.senderId).thenReturn('@other:u');
+      when(() => ev.originServerTs)
+          .thenReturn(DateTime.fromMillisecondsSinceEpoch(2000));
+
+      final index = AttachmentIndex(logging: logging);
+      var liveScanCalls = 0;
+      final desc = MockDescriptorCatchUpManager();
+      when(() => desc.removeIfPresent('/media/x.jpg')).thenReturn(true);
+
+      // No documentsDirectory = descriptor-only mode
+      await const AttachmentIngestor().process(
+        event: ev,
+        logging: logging,
+        attachmentIndex: index,
+        descriptorCatchUp: desc,
+        scheduleLiveScan: () => liveScanCalls++,
+        retryNow: () async {},
+      );
+      expect(liveScanCalls, 1); // schedule on descriptor removal only
+      expect(File('${tmp.path}/media/x.jpg').existsSync(), isFalse);
+    });
+
+    test('removeIfPresent false does not trigger scan/retry', () async {
+      final logging = MockLoggingService();
+      final ev = MockEvent();
+      when(() => ev.eventId).thenReturn('e5');
+      when(() => ev.content).thenReturn({'relativePath': '/p/b.bin'});
+      when(() => ev.attachmentMimetype).thenReturn('application/json');
+      when(() => ev.senderId).thenReturn('@other:u');
+
+      final index = AttachmentIndex();
+      var liveScanCalls = 0;
+      var retryNowCalls = 0;
+      final desc = MockDescriptorCatchUpManager();
+      when(() => desc.removeIfPresent('/p/b.bin')).thenReturn(false);
+
+      await const AttachmentIngestor().process(
+        event: ev,
+        logging: logging,
+        attachmentIndex: index,
+        descriptorCatchUp: desc,
+        scheduleLiveScan: () => liveScanCalls++,
+        retryNow: () async => retryNowCalls++,
+      );
+
+      expect(liveScanCalls, 0);
+      expect(retryNowCalls, 0);
+    });
   });
 
-  test('no media prefetch; still clears pending and schedules scan', () async {
-    final logging = MockLoggingService();
-    when(() => logging.captureEvent(any<String>(),
-        domain: any<String>(named: 'domain'),
-        subDomain: any<String>(named: 'subDomain'))).thenReturn(null);
-    when(() => logging.captureException(any<Object>(),
-        domain: any<String>(named: 'domain'),
-        subDomain: any<String>(named: 'subDomain'),
-        stackTrace: any<StackTrace?>(named: 'stackTrace'))).thenReturn(null);
+  group('eager download mode (with documentsDirectory)', () {
+    test('downloads and writes attachment to disk', () async {
+      final logging = MockLoggingService();
+      when(() => logging.captureEvent(any<String>(),
+          domain: any<String>(named: 'domain'),
+          subDomain: any<String>(named: 'subDomain'))).thenReturn(null);
+      when(() => logging.captureException(any<Object>(),
+          domain: any<String>(named: 'domain'),
+          subDomain: any<String>(named: 'subDomain'),
+          stackTrace: any<StackTrace?>(named: 'stackTrace'))).thenReturn(null);
 
-    final tmp = Directory.systemTemp.createTempSync('ingestor');
-    addTearDown(() => tmp.deleteSync(recursive: true));
+      final tmp = Directory.systemTemp.createTempSync('ingestor_eager');
+      addTearDown(() => tmp.deleteSync(recursive: true));
 
-    final ev = MockEvent();
-    when(() => ev.eventId).thenReturn('e2');
-    when(() => ev.content)
-        .thenReturn({'relativePath': '/media/x.jpg', 'msgtype': 'm.image'});
-    when(() => ev.attachmentMimetype).thenReturn('image/jpeg');
-    when(() => ev.senderId).thenReturn('@other:u');
-    // Ensure event is fresh enough
-    when(() => ev.originServerTs)
-        .thenReturn(DateTime.fromMillisecondsSinceEpoch(2000));
-    // No media prefetch: any SDK download paths are unused
+      final testContent =
+          Uint8List.fromList(utf8.encode('test attachment content'));
+      final matrixFile = MockMatrixFile();
+      when(() => matrixFile.bytes).thenReturn(testContent);
 
-    final index = AttachmentIndex(logging: logging);
-    var liveScanCalls = 0;
-    final desc = MockDescriptorCatchUpManager();
-    when(() => desc.removeIfPresent('/media/x.jpg')).thenReturn(true);
+      final ev = MockEvent();
+      when(() => ev.eventId).thenReturn('e10');
+      when(() => ev.content)
+          .thenReturn({'relativePath': '/data/test.json', 'msgtype': 'm.file'});
+      when(() => ev.attachmentMimetype).thenReturn('application/json');
+      when(() => ev.senderId).thenReturn('@other:u');
+      when(ev.downloadAndDecryptAttachment).thenAnswer((_) async => matrixFile);
 
-    await const AttachmentIngestor().process(
-      event: ev,
-      logging: logging,
-      attachmentIndex: index,
-      descriptorCatchUp: desc,
-      scheduleLiveScan: () => liveScanCalls++,
-      retryNow: () async {},
-    );
-    expect(liveScanCalls, 1); // schedule on descriptor removal only
-    expect(File('${tmp.path}/media/x.jpg').existsSync(), isFalse);
-  });
+      final index = AttachmentIndex(logging: logging);
+      final desc = MockDescriptorCatchUpManager();
+      when(() => desc.removeIfPresent('/data/test.json')).thenReturn(false);
 
-  test('removeIfPresent false does not trigger scan/retry', () async {
-    final logging = MockLoggingService();
-    final ev = MockEvent();
-    when(() => ev.eventId).thenReturn('e5');
-    when(() => ev.content).thenReturn({'relativePath': '/p/b.bin'});
-    when(() => ev.attachmentMimetype).thenReturn('application/json');
-    when(() => ev.senderId).thenReturn('@other:u');
+      final ingestor = AttachmentIngestor(documentsDirectory: tmp);
+      final result = await ingestor.process(
+        event: ev,
+        logging: logging,
+        attachmentIndex: index,
+        descriptorCatchUp: desc,
+        scheduleLiveScan: () {},
+        retryNow: () async {},
+      );
 
-    final index = AttachmentIndex();
-    var liveScanCalls = 0;
-    var retryNowCalls = 0;
-    final desc = MockDescriptorCatchUpManager();
-    when(() => desc.removeIfPresent('/p/b.bin')).thenReturn(false);
+      expect(result, isTrue);
+      final writtenFile = File('${tmp.path}/data/test.json');
+      expect(writtenFile.existsSync(), isTrue);
+      expect(writtenFile.readAsStringSync(), 'test attachment content');
 
-    await const AttachmentIngestor().process(
-      event: ev,
-      logging: logging,
-      attachmentIndex: index,
-      descriptorCatchUp: desc,
-      scheduleLiveScan: () => liveScanCalls++,
-      retryNow: () async => retryNowCalls++,
-    );
+      // Verify download log was emitted
+      verify(() => logging.captureEvent(
+            any<String>(that: contains('downloading')),
+            domain: any<String>(named: 'domain'),
+            subDomain: 'attachment.download',
+          )).called(1);
 
-    expect(liveScanCalls, 0);
-    expect(retryNowCalls, 0);
+      // Verify write success log was emitted
+      verify(() => logging.captureEvent(
+            any<String>(that: contains('wrote file')),
+            domain: any<String>(named: 'domain'),
+            subDomain: 'attachment.save',
+          )).called(1);
+    });
+
+    test('skips download if file already exists and is non-empty', () async {
+      final logging = MockLoggingService();
+      when(() => logging.captureEvent(any<String>(),
+          domain: any<String>(named: 'domain'),
+          subDomain: any<String>(named: 'subDomain'))).thenReturn(null);
+      when(() => logging.captureException(any<Object>(),
+          domain: any<String>(named: 'domain'),
+          subDomain: any<String>(named: 'subDomain'),
+          stackTrace: any<StackTrace?>(named: 'stackTrace'))).thenReturn(null);
+
+      final tmp = Directory.systemTemp.createTempSync('ingestor_dedupe');
+      addTearDown(() => tmp.deleteSync(recursive: true));
+
+      // Pre-create the file
+      final existingFile = File('${tmp.path}/data/existing.json')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('existing content');
+
+      final ev = MockEvent();
+      when(() => ev.eventId).thenReturn('e11');
+      when(() => ev.content).thenReturn(
+          {'relativePath': '/data/existing.json', 'msgtype': 'm.file'});
+      when(() => ev.attachmentMimetype).thenReturn('application/json');
+      when(() => ev.senderId).thenReturn('@other:u');
+
+      final index = AttachmentIndex(logging: logging);
+      final desc = MockDescriptorCatchUpManager();
+      when(() => desc.removeIfPresent('/data/existing.json')).thenReturn(false);
+
+      final ingestor = AttachmentIngestor(documentsDirectory: tmp);
+      final result = await ingestor.process(
+        event: ev,
+        logging: logging,
+        attachmentIndex: index,
+        descriptorCatchUp: desc,
+        scheduleLiveScan: () {},
+        retryNow: () async {},
+      );
+
+      expect(result, isFalse); // No new file written
+      expect(existingFile.readAsStringSync(), 'existing content'); // Unchanged
+
+      // Verify download was NOT called
+      verifyNever(ev.downloadAndDecryptAttachment);
+    });
+
+    test('handles empty bytes gracefully', () async {
+      final logging = MockLoggingService();
+      when(() => logging.captureEvent(any<String>(),
+          domain: any<String>(named: 'domain'),
+          subDomain: any<String>(named: 'subDomain'))).thenReturn(null);
+      when(() => logging.captureException(any<Object>(),
+          domain: any<String>(named: 'domain'),
+          subDomain: any<String>(named: 'subDomain'),
+          stackTrace: any<StackTrace?>(named: 'stackTrace'))).thenReturn(null);
+
+      final tmp = Directory.systemTemp.createTempSync('ingestor_empty');
+      addTearDown(() => tmp.deleteSync(recursive: true));
+
+      final matrixFile = MockMatrixFile();
+      when(() => matrixFile.bytes).thenReturn(Uint8List(0)); // Empty bytes
+
+      final ev = MockEvent();
+      when(() => ev.eventId).thenReturn('e12');
+      when(() => ev.content).thenReturn(
+          {'relativePath': '/data/empty.json', 'msgtype': 'm.file'});
+      when(() => ev.attachmentMimetype).thenReturn('application/json');
+      when(() => ev.senderId).thenReturn('@other:u');
+      when(ev.downloadAndDecryptAttachment).thenAnswer((_) async => matrixFile);
+
+      final index = AttachmentIndex(logging: logging);
+      final desc = MockDescriptorCatchUpManager();
+      when(() => desc.removeIfPresent('/data/empty.json')).thenReturn(false);
+
+      final ingestor = AttachmentIngestor(documentsDirectory: tmp);
+      final result = await ingestor.process(
+        event: ev,
+        logging: logging,
+        attachmentIndex: index,
+        descriptorCatchUp: desc,
+        scheduleLiveScan: () {},
+        retryNow: () async {},
+      );
+
+      expect(result, isFalse); // No file written
+      expect(File('${tmp.path}/data/empty.json').existsSync(), isFalse);
+
+      // Verify empty bytes log was emitted
+      verify(() => logging.captureEvent(
+            any<String>(that: contains('emptyBytes')),
+            domain: any<String>(named: 'domain'),
+            subDomain: 'attachment.download',
+          )).called(1);
+    });
+
+    test('handles download exception gracefully', () async {
+      final logging = MockLoggingService();
+      when(() => logging.captureEvent(any<String>(),
+          domain: any<String>(named: 'domain'),
+          subDomain: any<String>(named: 'subDomain'))).thenReturn(null);
+      when(() => logging.captureException(any<Object>(),
+          domain: any<String>(named: 'domain'),
+          subDomain: any<String>(named: 'subDomain'),
+          stackTrace: any<StackTrace?>(named: 'stackTrace'))).thenReturn(null);
+
+      final tmp = Directory.systemTemp.createTempSync('ingestor_error');
+      addTearDown(() => tmp.deleteSync(recursive: true));
+
+      final ev = MockEvent();
+      when(() => ev.eventId).thenReturn('e13');
+      when(() => ev.content).thenReturn(
+          {'relativePath': '/data/error.json', 'msgtype': 'm.file'});
+      when(() => ev.attachmentMimetype).thenReturn('application/json');
+      when(() => ev.senderId).thenReturn('@other:u');
+      when(ev.downloadAndDecryptAttachment)
+          .thenThrow(Exception('Network error'));
+
+      final index = AttachmentIndex(logging: logging);
+      final desc = MockDescriptorCatchUpManager();
+      when(() => desc.removeIfPresent('/data/error.json')).thenReturn(false);
+
+      final ingestor = AttachmentIngestor(documentsDirectory: tmp);
+      final result = await ingestor.process(
+        event: ev,
+        logging: logging,
+        attachmentIndex: index,
+        descriptorCatchUp: desc,
+        scheduleLiveScan: () {},
+        retryNow: () async {},
+      );
+
+      expect(result, isFalse); // No file written due to error
+      expect(File('${tmp.path}/data/error.json').existsSync(), isFalse);
+
+      // Verify exception was logged (not thrown)
+      verify(() => logging.captureException(
+            any<Object>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: 'attachment.save',
+            stackTrace: any<StackTrace?>(named: 'stackTrace'),
+          )).called(1);
+    });
+
+    test('blocks path traversal attempts', () async {
+      final logging = MockLoggingService();
+      when(() => logging.captureEvent(any<String>(),
+          domain: any<String>(named: 'domain'),
+          subDomain: any<String>(named: 'subDomain'))).thenReturn(null);
+      when(() => logging.captureException(any<Object>(),
+          domain: any<String>(named: 'domain'),
+          subDomain: any<String>(named: 'subDomain'),
+          stackTrace: any<StackTrace?>(named: 'stackTrace'))).thenReturn(null);
+
+      final tmp = Directory.systemTemp.createTempSync('ingestor_traversal');
+      addTearDown(() => tmp.deleteSync(recursive: true));
+
+      final ev = MockEvent();
+      when(() => ev.eventId).thenReturn('e14');
+      // Attempt path traversal
+      when(() => ev.content).thenReturn(
+          {'relativePath': '/../../../etc/passwd', 'msgtype': 'm.file'});
+      when(() => ev.attachmentMimetype).thenReturn('application/octet-stream');
+      when(() => ev.senderId).thenReturn('@other:u');
+
+      final index = AttachmentIndex(logging: logging);
+      final desc = MockDescriptorCatchUpManager();
+      when(() => desc.removeIfPresent('/../../../etc/passwd'))
+          .thenReturn(false);
+
+      final ingestor = AttachmentIngestor(documentsDirectory: tmp);
+      final result = await ingestor.process(
+        event: ev,
+        logging: logging,
+        attachmentIndex: index,
+        descriptorCatchUp: desc,
+        scheduleLiveScan: () {},
+        retryNow: () async {},
+      );
+
+      expect(result, isFalse); // Blocked
+
+      // Verify path traversal was logged
+      verify(() => logging.captureEvent(
+            any<String>(that: contains('pathTraversal.blocked')),
+            domain: any<String>(named: 'domain'),
+            subDomain: 'attachment.save',
+          )).called(1);
+
+      // Verify download was NOT called
+      verifyNever(ev.downloadAndDecryptAttachment);
+    });
   });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Attachments now download and persist to disk immediately during sync operations.
  * Failed sync events are now persistently stored in the database.

* **Improvements**
  * Added deduplication to skip re-downloading existing attachments.
  * Enhanced error handling and path traversal protection for attachment writes.

* **Tests**
  * Expanded test coverage for attachment processing workflows.

* **Chores**
  * Version bump.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->