### PR TITLE
feat: auto-create default prompts when adding Gemini provider

### DIFF
--- a/lib/features/ai/ui/settings/inference_provider_edit_page.dart
+++ b/lib/features/ai/ui/settings/inference_provider_edit_page.dart
@@ -8,6 +8,7 @@ import 'package:lotti/features/ai/model/inference_provider_form_state.dart';
 import 'package:lotti/features/ai/state/settings/ai_config_by_type_controller.dart';
 import 'package:lotti/features/ai/state/settings/inference_provider_form_controller.dart';
 import 'package:lotti/features/ai/ui/settings/form_bottom_bar.dart';
+import 'package:lotti/features/ai/ui/settings/services/gemini_prompt_setup_service.dart';
 import 'package:lotti/features/ai/ui/settings/widgets/form_components/form_components.dart';
 import 'package:lotti/features/ai/ui/settings/widgets/form_components/form_error_extension.dart';
 import 'package:lotti/features/ai/ui/settings/widgets/provider_type_selection_modal.dart';
@@ -64,6 +65,16 @@ class _InferenceProviderEditPageState
 
       if (widget.configId == null) {
         await controller.addConfig(config);
+
+        // Offer to set up default prompts for Gemini provider
+        if (context.mounted && config is AiConfigInferenceProvider) {
+          final setupService = ref.read(geminiPromptSetupServiceProvider);
+          await setupService.offerPromptSetup(
+            context: context,
+            ref: ref,
+            provider: config,
+          );
+        }
       } else {
         await controller.updateConfig(config);
       }

--- a/lib/features/ai/ui/settings/services/gemini_prompt_setup_service.dart
+++ b/lib/features/ai/ui/settings/services/gemini_prompt_setup_service.dart
@@ -1,0 +1,417 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/repository/ai_config_repository.dart';
+import 'package:lotti/features/ai/util/preconfigured_prompts.dart';
+import 'package:lotti/themes/theme.dart';
+import 'package:lotti/widgets/buttons/lotti_primary_button.dart';
+import 'package:lotti/widgets/buttons/lotti_tertiary_button.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:uuid/uuid.dart';
+
+part 'gemini_prompt_setup_service.g.dart';
+
+/// Provider for [GeminiPromptSetupService].
+@riverpod
+GeminiPromptSetupService geminiPromptSetupService(Ref ref) {
+  return const GeminiPromptSetupService();
+}
+
+/// Service that handles automatic prompt setup after creating a Gemini provider.
+///
+/// When a user adds Gemini for the first time, this service:
+/// 1. Shows a confirmation dialog asking if they want default prompts
+/// 2. Creates prompts with dynamic naming (e.g., "Audio Transcript - Gemini Flash")
+/// 3. Associates prompts with appropriate models (Flash for audio, Pro for others)
+/// 4. Shows a success snackbar with the number of prompts created
+class GeminiPromptSetupService {
+  const GeminiPromptSetupService();
+
+  /// Shows a dialog offering to set up default prompts for Gemini.
+  ///
+  /// Returns true if prompts were created, false otherwise.
+  Future<bool> offerPromptSetup({
+    required BuildContext context,
+    required WidgetRef ref,
+    required AiConfigInferenceProvider provider,
+  }) async {
+    // Only offer for Gemini provider
+    if (provider.inferenceProviderType != InferenceProviderType.gemini) {
+      return false;
+    }
+
+    // Fetch models first to determine what will be shown in the dialog
+    final repository = ref.read(aiConfigRepositoryProvider);
+    final modelSelection = await _selectModelsForProvider(
+      repository: repository,
+      provider: provider,
+    );
+
+    // If no models available, skip the dialog
+    if (modelSelection == null) {
+      return false;
+    }
+
+    if (!context.mounted) return false;
+
+    // Show confirmation dialog with actual model names
+    final confirmed = await _showSetupDialog(
+      context,
+      flashModelName: modelSelection.flashModel.name,
+      proModelName: modelSelection.proModel.name,
+    );
+    if (!confirmed) return false;
+
+    if (!context.mounted) return false;
+
+    // Create the prompts
+    final promptsCreated = await _createDefaultPromptsWithModels(
+      repository: repository,
+      flashModel: modelSelection.flashModel,
+      proModel: modelSelection.proModel,
+    );
+
+    if (context.mounted && promptsCreated > 0) {
+      _showSuccessSnackbar(context, promptsCreated);
+    }
+
+    return promptsCreated > 0;
+  }
+
+  /// Selects the appropriate Flash and Pro models for the provider.
+  /// Returns null if no models are available.
+  Future<_ModelSelection?> _selectModelsForProvider({
+    required AiConfigRepository repository,
+    required AiConfigInferenceProvider provider,
+  }) async {
+    final allConfigs = await repository.getConfigsByType(AiConfigType.model);
+    final providerModels = allConfigs
+        .whereType<AiConfigModel>()
+        .where((model) => model.inferenceProviderId == provider.id)
+        .toList();
+
+    if (providerModels.isEmpty) {
+      return null;
+    }
+
+    // Find Flash model (for audio - fast processing)
+    final flashModel = providerModels.firstWhere(
+      (m) =>
+          m.name.toLowerCase().contains('flash') &&
+          m.inputModalities.contains(Modality.audio),
+      orElse: () => providerModels.first,
+    );
+
+    // Find Pro model (for reasoning tasks - image analysis, checklist, summary)
+    // Prioritize models with "pro" in the name, fall back to others excluding flash
+    final proModel = providerModels.firstWhere(
+      (m) => m.name.toLowerCase().contains('pro'),
+      orElse: () => providerModels.firstWhere(
+        (m) => !m.name.toLowerCase().contains('flash'),
+        orElse: () => providerModels.first,
+      ),
+    );
+
+    return _ModelSelection(flashModel: flashModel, proModel: proModel);
+  }
+
+  /// Shows the confirmation dialog for setting up prompts.
+  Future<bool> _showSetupDialog(
+    BuildContext context, {
+    required String flashModelName,
+    required String proModelName,
+  }) async {
+    return await showDialog<bool>(
+          context: context,
+          builder: (context) => AlertDialog(
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(16),
+            ),
+            title: Row(
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(8),
+                  decoration: BoxDecoration(
+                    color: context.colorScheme.primary.withValues(alpha: 0.1),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Icon(
+                    Icons.auto_awesome,
+                    color: context.colorScheme.primary,
+                    size: 24,
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    'Set Up Default Prompts?',
+                    style: context.textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            content: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Info message
+                  Container(
+                    padding: const EdgeInsets.all(16),
+                    decoration: BoxDecoration(
+                      color: context.colorScheme.primaryContainer
+                          .withValues(alpha: 0.3),
+                      borderRadius: BorderRadius.circular(12),
+                      border: Border.all(
+                        color:
+                            context.colorScheme.primary.withValues(alpha: 0.2),
+                      ),
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Get started quickly',
+                          style: context.textTheme.titleSmall?.copyWith(
+                            color: context.colorScheme.onPrimaryContainer,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          "We'll create ready-to-use prompts for common AI tasks, "
+                          'so you can start using AI features right away.',
+                          style: context.textTheme.bodySmall?.copyWith(
+                            color: context.colorScheme.onPrimaryContainer
+                                .withValues(alpha: 0.8),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+
+                  const SizedBox(height: 16),
+
+                  // Prompts that will be created
+                  Container(
+                    padding: const EdgeInsets.all(16),
+                    decoration: BoxDecoration(
+                      color: context.colorScheme.surfaceContainerHighest
+                          .withValues(alpha: 0.5),
+                      borderRadius: BorderRadius.circular(12),
+                      border: Border.all(
+                        color:
+                            context.colorScheme.outline.withValues(alpha: 0.2),
+                      ),
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Prompts to create:',
+                          style: context.textTheme.titleSmall?.copyWith(
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        const SizedBox(height: 12),
+                        _buildPromptPreview(
+                          context,
+                          Icons.mic,
+                          'Audio Transcript',
+                          flashModelName,
+                        ),
+                        const SizedBox(height: 8),
+                        _buildPromptPreview(
+                          context,
+                          Icons.image,
+                          'Image Analysis',
+                          proModelName,
+                        ),
+                        const SizedBox(height: 8),
+                        _buildPromptPreview(
+                          context,
+                          Icons.checklist,
+                          'Checklist Updates',
+                          proModelName,
+                        ),
+                        const SizedBox(height: 8),
+                        _buildPromptPreview(
+                          context,
+                          Icons.summarize,
+                          'Task Summary',
+                          proModelName,
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            actions: [
+              LottiTertiaryButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                label: 'No Thanks',
+              ),
+              LottiPrimaryButton(
+                onPressed: () => Navigator.of(context).pop(true),
+                label: 'Set Up Prompts',
+                icon: Icons.auto_awesome,
+              ),
+            ],
+          ),
+        ) ??
+        false;
+  }
+
+  Widget _buildPromptPreview(
+    BuildContext context,
+    IconData icon,
+    String name,
+    String modelHint,
+  ) {
+    return Row(
+      children: [
+        Container(
+          padding: const EdgeInsets.all(6),
+          decoration: BoxDecoration(
+            color: context.colorScheme.primary.withValues(alpha: 0.1),
+            borderRadius: BorderRadius.circular(6),
+          ),
+          child: Icon(
+            icon,
+            color: context.colorScheme.primary,
+            size: 16,
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                name,
+                style: context.textTheme.bodyMedium?.copyWith(
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+              Text(
+                'Uses $modelHint',
+                style: context.textTheme.bodySmall?.copyWith(
+                  color: context.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// Creates the default prompts using the pre-selected models.
+  Future<int> _createDefaultPromptsWithModels({
+    required AiConfigRepository repository,
+    required AiConfigModel flashModel,
+    required AiConfigModel proModel,
+  }) async {
+    var promptsCreated = 0;
+    const uuid = Uuid();
+
+    // Define prompts to create with their configurations
+    final promptConfigs = [
+      (
+        template: audioTranscriptionPrompt,
+        model: flashModel,
+      ),
+      (
+        template: imageAnalysisInTaskContextPrompt,
+        model: proModel,
+      ),
+      (
+        template: checklistUpdatesPrompt,
+        model: proModel,
+      ),
+      (
+        template: taskSummaryPrompt,
+        model: proModel,
+      ),
+    ];
+
+    for (final config in promptConfigs) {
+      final prompt = AiConfig.prompt(
+        id: uuid.v4(),
+        name: '${config.template.name} - ${config.model.name}',
+        systemMessage: config.template.systemMessage,
+        userMessage: config.template.userMessage,
+        defaultModelId: config.model.id,
+        modelIds: [config.model.id],
+        createdAt: DateTime.now(),
+        useReasoning: config.template.useReasoning,
+        requiredInputData: config.template.requiredInputData,
+        aiResponseType: config.template.aiResponseType,
+        description: config.template.description,
+        trackPreconfigured: true,
+        preconfiguredPromptId: config.template.id,
+        defaultVariables: config.template.defaultVariables,
+      );
+
+      await repository.saveConfig(prompt);
+      promptsCreated++;
+    }
+
+    return promptsCreated;
+  }
+
+  /// Shows a success snackbar after prompts are created.
+  void _showSuccessSnackbar(BuildContext context, int promptsCreated) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        backgroundColor: context.colorScheme.inversePrimary,
+        behavior: SnackBarBehavior.floating,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
+        duration: const Duration(seconds: 5),
+        dismissDirection: DismissDirection.down,
+        content: Row(
+          children: [
+            Container(
+              padding: const EdgeInsets.all(6),
+              decoration: BoxDecoration(
+                color: context.colorScheme.primary.withValues(alpha: 0.1),
+                borderRadius: BorderRadius.circular(6),
+              ),
+              child: Icon(
+                Icons.check_circle,
+                color: context.colorScheme.primary,
+                size: 18,
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                '$promptsCreated ${promptsCreated == 1 ? 'prompt' : 'prompts'} created successfully!',
+                style: context.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w600,
+                  color: context.colorScheme.onSurface,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Internal class to hold the selected models for prompt creation.
+class _ModelSelection {
+  const _ModelSelection({
+    required this.flashModel,
+    required this.proModel,
+  });
+
+  final AiConfigModel flashModel;
+  final AiConfigModel proModel;
+}

--- a/lib/features/ai/ui/settings/services/gemini_prompt_setup_service.g.dart
+++ b/lib/features/ai/ui/settings/services/gemini_prompt_setup_service.g.dart
@@ -1,0 +1,32 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'gemini_prompt_setup_service.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$geminiPromptSetupServiceHash() =>
+    r'2dbc176b45c20f89661c53ba101480fa2a56a37c';
+
+/// Provider for [GeminiPromptSetupService].
+///
+/// Copied from [geminiPromptSetupService].
+@ProviderFor(geminiPromptSetupService)
+final geminiPromptSetupServiceProvider =
+    AutoDisposeProvider<GeminiPromptSetupService>.internal(
+  geminiPromptSetupService,
+  name: r'geminiPromptSetupServiceProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$geminiPromptSetupServiceHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef GeminiPromptSetupServiceRef
+    = AutoDisposeProviderRef<GeminiPromptSetupService>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/journal/state/entry_controller.g.dart
+++ b/lib/features/journal/state/entry_controller.g.dart
@@ -6,7 +6,7 @@ part of 'entry_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$entryControllerHash() => r'b644ba2c3471edf6b8bb81ef00932d124ec2f55f';
+String _$entryControllerHash() => r'c64e13372f33af54d0919e09a4ba4c5f55a40ae2';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/test/features/ai/ui/settings/services/gemini_prompt_setup_service_test.dart
+++ b/test/features/ai/ui/settings/services/gemini_prompt_setup_service_test.dart
@@ -1,0 +1,658 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/ui/settings/services/gemini_prompt_setup_service.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../test_utils.dart';
+
+void main() {
+  group('GeminiPromptSetupService', () {
+    late GeminiPromptSetupService setupService;
+    late MockAiConfigRepository mockRepository;
+    late AiConfigInferenceProvider geminiProvider;
+    late AiConfigInferenceProvider openAiProvider;
+    late List<AiConfigModel> geminiModels;
+
+    setUpAll(AiTestSetup.registerFallbackValues);
+
+    setUp(() {
+      setupService = const GeminiPromptSetupService();
+      mockRepository = MockAiConfigRepository();
+
+      geminiProvider = AiTestDataFactory.createTestProvider(
+        id: 'gemini-provider-id',
+        name: 'My Gemini',
+        type: InferenceProviderType.gemini,
+        apiKey: 'test-gemini-key',
+        baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai',
+      );
+
+      openAiProvider = AiTestDataFactory.createTestProvider(
+        id: 'openai-provider-id',
+        name: 'My OpenAI',
+        type: InferenceProviderType.openAi,
+        apiKey: 'test-openai-key',
+        baseUrl: 'https://api.openai.com/v1',
+      );
+
+      // Create Gemini models - Flash for audio, Pro for reasoning
+      geminiModels = [
+        AiTestDataFactory.createTestModel(
+          id: 'gemini-provider-id_models_gemini_2_5_flash',
+          name: 'Gemini 2.5 Flash',
+          inferenceProviderId: geminiProvider.id,
+          inputModalities: [Modality.text, Modality.image, Modality.audio],
+          isReasoningModel: true,
+        ),
+        AiTestDataFactory.createTestModel(
+          id: 'gemini-provider-id_models_gemini_2_5_pro',
+          name: 'Gemini 2.5 Pro',
+          inferenceProviderId: geminiProvider.id,
+          inputModalities: [Modality.text, Modality.image, Modality.audio],
+          isReasoningModel: true,
+        ),
+      ];
+    });
+
+    Widget createTestWidget({
+      required Widget child,
+      required Future<void> Function(BuildContext, WidgetRef) onPressed,
+    }) {
+      return AiTestWidgets.createTestWidget(
+        repository: mockRepository,
+        child: Consumer(
+          builder: (context, ref, _) => ElevatedButton(
+            onPressed: () => onPressed(context, ref),
+            child: child,
+          ),
+        ),
+      );
+    }
+
+    group('offerPromptSetup() - Provider Type Checks', () {
+      testWidgets('should return false for non-Gemini providers',
+          (WidgetTester tester) async {
+        await tester.binding.setSurfaceSize(const Size(1024, 900));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        bool? result;
+
+        await tester.pumpWidget(createTestWidget(
+          child: const Text('Test Button'),
+          onPressed: (context, ref) async {
+            result = await setupService.offerPromptSetup(
+              context: context,
+              ref: ref,
+              provider: openAiProvider,
+            );
+          },
+        ));
+
+        await tester.tap(find.text('Test Button'));
+        await tester.pumpAndSettle();
+
+        expect(result, isFalse);
+        expect(find.text('Set Up Default Prompts?'), findsNothing);
+      });
+
+      testWidgets('should show dialog for Gemini provider',
+          (WidgetTester tester) async {
+        await tester.binding.setSurfaceSize(const Size(1024, 900));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        when(() => mockRepository.getConfigsByType(AiConfigType.model))
+            .thenAnswer((_) async => geminiModels);
+
+        await tester.pumpWidget(createTestWidget(
+          child: const Text('Test Button'),
+          onPressed: (context, ref) async {
+            await setupService.offerPromptSetup(
+              context: context,
+              ref: ref,
+              provider: geminiProvider,
+            );
+          },
+        ));
+
+        await tester.tap(find.text('Test Button'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Set Up Default Prompts?'), findsOneWidget);
+      });
+    });
+
+    group('Dialog UI', () {
+      testWidgets('should display dialog with correct title and content',
+          (WidgetTester tester) async {
+        await tester.binding.setSurfaceSize(const Size(1024, 900));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        when(() => mockRepository.getConfigsByType(AiConfigType.model))
+            .thenAnswer((_) async => geminiModels);
+
+        await tester.pumpWidget(createTestWidget(
+          child: const Text('Test Button'),
+          onPressed: (context, ref) async {
+            await setupService.offerPromptSetup(
+              context: context,
+              ref: ref,
+              provider: geminiProvider,
+            );
+          },
+        ));
+
+        await tester.tap(find.text('Test Button'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Set Up Default Prompts?'), findsOneWidget);
+        expect(find.byIcon(Icons.auto_awesome), findsAtLeastNWidgets(1));
+        expect(find.text('Get started quickly'), findsOneWidget);
+        expect(find.textContaining('ready-to-use prompts'), findsOneWidget);
+        expect(find.text('Prompts to create:'), findsOneWidget);
+        expect(find.text('Audio Transcript'), findsOneWidget);
+        expect(find.text('Image Analysis'), findsOneWidget);
+        expect(find.text('Checklist Updates'), findsOneWidget);
+        expect(find.text('Task Summary'), findsOneWidget);
+        // Dynamic model names from actual available models
+        expect(find.text('Uses Gemini 2.5 Flash'), findsOneWidget);
+        expect(find.text('Uses Gemini 2.5 Pro'), findsNWidgets(3));
+        expect(find.text('No Thanks'), findsOneWidget);
+        expect(find.text('Set Up Prompts'), findsOneWidget);
+      });
+
+      testWidgets('should display correct icons for each prompt type',
+          (WidgetTester tester) async {
+        await tester.binding.setSurfaceSize(const Size(1024, 900));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        when(() => mockRepository.getConfigsByType(AiConfigType.model))
+            .thenAnswer((_) async => geminiModels);
+
+        await tester.pumpWidget(createTestWidget(
+          child: const Text('Test Button'),
+          onPressed: (context, ref) async {
+            await setupService.offerPromptSetup(
+              context: context,
+              ref: ref,
+              provider: geminiProvider,
+            );
+          },
+        ));
+
+        await tester.tap(find.text('Test Button'));
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.mic), findsOneWidget);
+        expect(find.byIcon(Icons.image), findsOneWidget);
+        expect(find.byIcon(Icons.checklist), findsOneWidget);
+        expect(find.byIcon(Icons.summarize), findsOneWidget);
+      });
+    });
+
+    group('User Interaction - Cancel', () {
+      testWidgets('should return false when user taps "No Thanks"',
+          (WidgetTester tester) async {
+        await tester.binding.setSurfaceSize(const Size(1024, 900));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        when(() => mockRepository.getConfigsByType(AiConfigType.model))
+            .thenAnswer((_) async => geminiModels);
+
+        bool? result;
+
+        await tester.pumpWidget(createTestWidget(
+          child: const Text('Test Button'),
+          onPressed: (context, ref) async {
+            result = await setupService.offerPromptSetup(
+              context: context,
+              ref: ref,
+              provider: geminiProvider,
+            );
+          },
+        ));
+
+        await tester.tap(find.text('Test Button'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('No Thanks'));
+        await tester.pumpAndSettle();
+
+        expect(result, isFalse);
+        expect(find.text('Set Up Default Prompts?'), findsNothing);
+        verifyNever(() => mockRepository.saveConfig(any()));
+      });
+    });
+
+    group('User Interaction - Confirm', () {
+      testWidgets('should create prompts when user confirms',
+          (WidgetTester tester) async {
+        await tester.binding.setSurfaceSize(const Size(1024, 900));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        when(() => mockRepository.getConfigsByType(AiConfigType.model))
+            .thenAnswer((_) async => geminiModels);
+        when(() => mockRepository.saveConfig(any())).thenAnswer((_) async {});
+
+        bool? result;
+
+        await tester.pumpWidget(createTestWidget(
+          child: const Text('Test Button'),
+          onPressed: (context, ref) async {
+            result = await setupService.offerPromptSetup(
+              context: context,
+              ref: ref,
+              provider: geminiProvider,
+            );
+          },
+        ));
+
+        await tester.tap(find.text('Test Button'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Set Up Prompts'));
+        await tester.pumpAndSettle();
+
+        expect(result, isTrue);
+        verify(() => mockRepository.saveConfig(any())).called(4);
+      });
+
+      testWidgets('should create prompts with correct dynamic names',
+          (WidgetTester tester) async {
+        await tester.binding.setSurfaceSize(const Size(1024, 900));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        when(() => mockRepository.getConfigsByType(AiConfigType.model))
+            .thenAnswer((_) async => geminiModels);
+
+        final savedConfigs = <AiConfig>[];
+        when(() => mockRepository.saveConfig(any())).thenAnswer((invocation) {
+          savedConfigs.add(invocation.positionalArguments[0] as AiConfig);
+          return Future.value();
+        });
+
+        await tester.pumpWidget(createTestWidget(
+          child: const Text('Test Button'),
+          onPressed: (context, ref) async {
+            await setupService.offerPromptSetup(
+              context: context,
+              ref: ref,
+              provider: geminiProvider,
+            );
+          },
+        ));
+
+        await tester.tap(find.text('Test Button'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Set Up Prompts'));
+        await tester.pumpAndSettle();
+
+        final promptNames = savedConfigs
+            .whereType<AiConfigPrompt>()
+            .map((p) => p.name)
+            .toList();
+
+        // Prompt names now use actual model names
+        expect(promptNames, contains('Audio Transcription - Gemini 2.5 Flash'));
+        expect(promptNames,
+            contains('Image Analysis in Task Context - Gemini 2.5 Pro'));
+        expect(promptNames, contains('Checklist Updates - Gemini 2.5 Pro'));
+        expect(promptNames, contains('Task Summary - Gemini 2.5 Pro'));
+      });
+
+      testWidgets('should assign Flash model to audio transcription',
+          (WidgetTester tester) async {
+        await tester.binding.setSurfaceSize(const Size(1024, 900));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        when(() => mockRepository.getConfigsByType(AiConfigType.model))
+            .thenAnswer((_) async => geminiModels);
+
+        final savedConfigs = <AiConfig>[];
+        when(() => mockRepository.saveConfig(any())).thenAnswer((invocation) {
+          savedConfigs.add(invocation.positionalArguments[0] as AiConfig);
+          return Future.value();
+        });
+
+        await tester.pumpWidget(createTestWidget(
+          child: const Text('Test Button'),
+          onPressed: (context, ref) async {
+            await setupService.offerPromptSetup(
+              context: context,
+              ref: ref,
+              provider: geminiProvider,
+            );
+          },
+        ));
+
+        await tester.tap(find.text('Test Button'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Set Up Prompts'));
+        await tester.pumpAndSettle();
+
+        final audioPrompt = savedConfigs
+            .whereType<AiConfigPrompt>()
+            .firstWhere((p) => p.name.contains('Audio Transcription'));
+
+        expect(audioPrompt.defaultModelId,
+            geminiModels.firstWhere((m) => m.name.contains('Flash')).id);
+      });
+
+      testWidgets('should assign Pro model to reasoning prompts',
+          (WidgetTester tester) async {
+        await tester.binding.setSurfaceSize(const Size(1024, 900));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        when(() => mockRepository.getConfigsByType(AiConfigType.model))
+            .thenAnswer((_) async => geminiModels);
+
+        final savedConfigs = <AiConfig>[];
+        when(() => mockRepository.saveConfig(any())).thenAnswer((invocation) {
+          savedConfigs.add(invocation.positionalArguments[0] as AiConfig);
+          return Future.value();
+        });
+
+        await tester.pumpWidget(createTestWidget(
+          child: const Text('Test Button'),
+          onPressed: (context, ref) async {
+            await setupService.offerPromptSetup(
+              context: context,
+              ref: ref,
+              provider: geminiProvider,
+            );
+          },
+        ));
+
+        await tester.tap(find.text('Test Button'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Set Up Prompts'));
+        await tester.pumpAndSettle();
+
+        final proModelId =
+            geminiModels.firstWhere((m) => m.name.contains('Pro')).id;
+
+        final imagePrompt = savedConfigs
+            .whereType<AiConfigPrompt>()
+            .firstWhere((p) => p.name.contains('Image Analysis'));
+        expect(imagePrompt.defaultModelId, proModelId);
+
+        final checklistPrompt = savedConfigs
+            .whereType<AiConfigPrompt>()
+            .firstWhere((p) => p.name.contains('Checklist'));
+        expect(checklistPrompt.defaultModelId, proModelId);
+
+        final summaryPrompt = savedConfigs
+            .whereType<AiConfigPrompt>()
+            .firstWhere((p) => p.name.contains('Task Summary'));
+        expect(summaryPrompt.defaultModelId, proModelId);
+      });
+
+      testWidgets('should set trackPreconfigured to true',
+          (WidgetTester tester) async {
+        await tester.binding.setSurfaceSize(const Size(1024, 900));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        when(() => mockRepository.getConfigsByType(AiConfigType.model))
+            .thenAnswer((_) async => geminiModels);
+
+        final savedConfigs = <AiConfig>[];
+        when(() => mockRepository.saveConfig(any())).thenAnswer((invocation) {
+          savedConfigs.add(invocation.positionalArguments[0] as AiConfig);
+          return Future.value();
+        });
+
+        await tester.pumpWidget(createTestWidget(
+          child: const Text('Test Button'),
+          onPressed: (context, ref) async {
+            await setupService.offerPromptSetup(
+              context: context,
+              ref: ref,
+              provider: geminiProvider,
+            );
+          },
+        ));
+
+        await tester.tap(find.text('Test Button'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Set Up Prompts'));
+        await tester.pumpAndSettle();
+
+        for (final config in savedConfigs.whereType<AiConfigPrompt>()) {
+          expect(config.trackPreconfigured, isTrue);
+        }
+      });
+
+      testWidgets('should set correct aiResponseType for each prompt',
+          (WidgetTester tester) async {
+        await tester.binding.setSurfaceSize(const Size(1024, 900));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        when(() => mockRepository.getConfigsByType(AiConfigType.model))
+            .thenAnswer((_) async => geminiModels);
+
+        final savedConfigs = <AiConfig>[];
+        when(() => mockRepository.saveConfig(any())).thenAnswer((invocation) {
+          savedConfigs.add(invocation.positionalArguments[0] as AiConfig);
+          return Future.value();
+        });
+
+        await tester.pumpWidget(createTestWidget(
+          child: const Text('Test Button'),
+          onPressed: (context, ref) async {
+            await setupService.offerPromptSetup(
+              context: context,
+              ref: ref,
+              provider: geminiProvider,
+            );
+          },
+        ));
+
+        await tester.tap(find.text('Test Button'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Set Up Prompts'));
+        await tester.pumpAndSettle();
+
+        final prompts = savedConfigs.whereType<AiConfigPrompt>().toList();
+
+        final audioPrompt = prompts.firstWhere((p) => p.name.contains('Audio'));
+        expect(audioPrompt.aiResponseType, AiResponseType.audioTranscription);
+
+        final imagePrompt = prompts.firstWhere((p) => p.name.contains('Image'));
+        expect(imagePrompt.aiResponseType, AiResponseType.imageAnalysis);
+
+        final checklistPrompt =
+            prompts.firstWhere((p) => p.name.contains('Checklist'));
+        expect(checklistPrompt.aiResponseType, AiResponseType.checklistUpdates);
+
+        final summaryPrompt =
+            prompts.firstWhere((p) => p.name.contains('Summary'));
+        expect(summaryPrompt.aiResponseType, AiResponseType.taskSummary);
+      });
+    });
+
+    group('Snackbar Feedback', () {
+      testWidgets('should show success snackbar after creating prompts',
+          (WidgetTester tester) async {
+        await tester.binding.setSurfaceSize(const Size(1024, 900));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        when(() => mockRepository.getConfigsByType(AiConfigType.model))
+            .thenAnswer((_) async => geminiModels);
+        when(() => mockRepository.saveConfig(any())).thenAnswer((_) async {});
+
+        await tester.pumpWidget(createTestWidget(
+          child: const Text('Test Button'),
+          onPressed: (context, ref) async {
+            await setupService.offerPromptSetup(
+              context: context,
+              ref: ref,
+              provider: geminiProvider,
+            );
+          },
+        ));
+
+        await tester.tap(find.text('Test Button'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Set Up Prompts'));
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.check_circle), findsOneWidget);
+        expect(find.text('4 prompts created successfully!'), findsOneWidget);
+      });
+    });
+
+    group('Edge Cases', () {
+      testWidgets(
+          'should return false and not show dialog when no models available',
+          (WidgetTester tester) async {
+        await tester.binding.setSurfaceSize(const Size(1024, 900));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        when(() => mockRepository.getConfigsByType(AiConfigType.model))
+            .thenAnswer((_) async => []);
+
+        bool? result;
+
+        await tester.pumpWidget(createTestWidget(
+          child: const Text('Test Button'),
+          onPressed: (context, ref) async {
+            result = await setupService.offerPromptSetup(
+              context: context,
+              ref: ref,
+              provider: geminiProvider,
+            );
+          },
+        ));
+
+        await tester.tap(find.text('Test Button'));
+        await tester.pumpAndSettle();
+
+        // Dialog should not appear when no models are available
+        expect(find.text('Set Up Default Prompts?'), findsNothing);
+        expect(result, isFalse);
+        verifyNever(() => mockRepository.saveConfig(any()));
+      });
+
+      testWidgets('should handle models from different providers',
+          (WidgetTester tester) async {
+        await tester.binding.setSurfaceSize(const Size(1024, 900));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        final mixedModels = [
+          ...geminiModels,
+          AiTestDataFactory.createTestModel(
+            id: 'openai-model',
+            name: 'GPT-4',
+            inferenceProviderId: 'other-provider-id',
+          ),
+        ];
+
+        when(() => mockRepository.getConfigsByType(AiConfigType.model))
+            .thenAnswer((_) async => mixedModels);
+
+        final savedConfigs = <AiConfig>[];
+        when(() => mockRepository.saveConfig(any())).thenAnswer((invocation) {
+          savedConfigs.add(invocation.positionalArguments[0] as AiConfig);
+          return Future.value();
+        });
+
+        await tester.pumpWidget(createTestWidget(
+          child: const Text('Test Button'),
+          onPressed: (context, ref) async {
+            await setupService.offerPromptSetup(
+              context: context,
+              ref: ref,
+              provider: geminiProvider,
+            );
+          },
+        ));
+
+        await tester.tap(find.text('Test Button'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Set Up Prompts'));
+        await tester.pumpAndSettle();
+
+        final geminiModelIds = geminiModels.map((m) => m.id).toSet();
+        for (final config in savedConfigs.whereType<AiConfigPrompt>()) {
+          expect(config.defaultModelId, isNot('openai-model'));
+          expect(geminiModelIds.contains(config.defaultModelId), isTrue);
+        }
+      });
+
+      testWidgets('should use first available model when no Flash found',
+          (WidgetTester tester) async {
+        await tester.binding.setSurfaceSize(const Size(1024, 900));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        final proOnlyModels = [
+          AiTestDataFactory.createTestModel(
+            id: 'gemini-pro-only',
+            name: 'Gemini 2.5 Pro',
+            inferenceProviderId: geminiProvider.id,
+            inputModalities: [Modality.text, Modality.image, Modality.audio],
+            isReasoningModel: true,
+          ),
+        ];
+
+        when(() => mockRepository.getConfigsByType(AiConfigType.model))
+            .thenAnswer((_) async => proOnlyModels);
+
+        final savedConfigs = <AiConfig>[];
+        when(() => mockRepository.saveConfig(any())).thenAnswer((invocation) {
+          savedConfigs.add(invocation.positionalArguments[0] as AiConfig);
+          return Future.value();
+        });
+
+        await tester.pumpWidget(createTestWidget(
+          child: const Text('Test Button'),
+          onPressed: (context, ref) async {
+            await setupService.offerPromptSetup(
+              context: context,
+              ref: ref,
+              provider: geminiProvider,
+            );
+          },
+        ));
+
+        await tester.tap(find.text('Test Button'));
+        await tester.pumpAndSettle();
+
+        // Dialog should show the only available model for both Flash and Pro
+        expect(find.text('Uses Gemini 2.5 Pro'), findsNWidgets(4));
+
+        await tester.tap(find.text('Set Up Prompts'));
+        await tester.pumpAndSettle();
+
+        final audioPrompt = savedConfigs
+            .whereType<AiConfigPrompt>()
+            .firstWhere((p) => p.name.contains('Audio'));
+        expect(audioPrompt.defaultModelId, 'gemini-pro-only');
+        // Audio prompt should use the fallback model name
+        expect(audioPrompt.name, 'Audio Transcription - Gemini 2.5 Pro');
+      });
+    });
+
+    group('Service Construction', () {
+      test('should be const constructible', () {
+        const service1 = GeminiPromptSetupService();
+        const service2 = GeminiPromptSetupService();
+        expect(service1, isA<GeminiPromptSetupService>());
+        expect(service2, isA<GeminiPromptSetupService>());
+      });
+
+      test('should maintain consistent behavior across instances', () {
+        const service1 = GeminiPromptSetupService();
+        const service2 = GeminiPromptSetupService();
+        expect(identical(service1, service2), isTrue);
+      });
+    });
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When adding a new Gemini AI provider, users are now prompted to automatically set up default prompts for Flash and Pro models with a confirmation preview dialog.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->