### PR TITLE
refactor: remove link to Lotti doc from GETTING_STARTED doc

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -231,8 +231,6 @@ Now that AI is set up, explore these features:
 - **Smart Checklists:** Dictate tasks and let AI organize them
 - **Weekly Reviews:** Generate AI summaries of your accomplishments
 
-For more detailed documentation, visit the [Lotti Documentation](https://github.com/matthiasn/lotti-docs).
-
 ---
 
 *This guide covers Lotti version 0.9.751 and later. UI may vary slightly between versions.*


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed an outdated documentation reference from the getting started guide's "Next Steps" section to streamline the onboarding experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->