### PR TITLE
feat: prevent gap detection for hosts never seen online

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.757+3521
+version: 0.9.758+3522
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Gap detection now limited to hosts that have been online, preventing false positives from unobserved hosts. Added logging for skipped gap detection events.

* **Tests**
  * Expanded test coverage for gap detection across offline host scenarios and multi-host vector clock cases.

* **Chores**
  * Version bump to 0.9.758.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->