### PR TITLE
feat: save checklist correction after countdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.773] - 2025-12-25
+### Changed
+- Checklist Correction UX: Corrections now use a delayed-save pattern with cancel option
+  - When editing a checklist item triggers a correction, a snackbar appears with a 5-second countdown
+  - Users can tap "CANCEL" to discard the correction before it's saved
+  - If the countdown completes without cancellation, the correction is saved to the database
+  - Prevents accidental one-time fixes from being permanently saved as AI learning examples
+
 ## [0.9.772] - 2025-12-24
 ### Added
 - AI Linked Task Context: AI prompts now include context from related tasks

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -31,6 +31,11 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="0.9.773" date="2025-12-25">
+      <description>
+        <p>Checklist Correction UX: Corrections now use a delayed-save pattern with a cancel option. A 5-second countdown snackbar lets you discard accidental corrections before they're saved as AI learning examples.</p>
+      </description>
+    </release>
     <release version="0.9.771" date="2025-12-23">
       <description>
         <p>Task Summary Link Extraction: AI summaries now include a Links section that automatically extracts and displays all URLs from task entries with succinct titles (e.g., "Linear: APP-123", "Lotti PR #456"). Links are deduplicated and formatted as clickable Markdown.</p>

--- a/lib/features/checklist/services/correction_capture_service.dart
+++ b/lib/features/checklist/services/correction_capture_service.dart
@@ -5,9 +5,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/features/categories/repository/categories_repository.dart';
 import 'package:lotti/utils/string_utils.dart' as string_utils;
+import 'package:meta/meta.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'correction_capture_service.g.dart';
+
+/// Duration before a pending correction is automatically saved.
+const kCorrectionSaveDelay = Duration(seconds: 5);
 
 /// Provider for the correction capture service.
 @riverpod
@@ -18,45 +22,100 @@ CorrectionCaptureService correctionCaptureService(Ref ref) {
   );
 }
 
-/// Notifier for correction capture events.
-/// UI can watch this to show snackbar notifications.
+/// Notifier for pending correction with countdown.
+/// UI watches this to show the snackbar with undo functionality.
 @riverpod
 class CorrectionCaptureNotifier extends _$CorrectionCaptureNotifier {
-  Timer? _resetTimer;
+  Timer? _saveTimer;
 
   @override
-  CorrectionCaptureEvent? build() {
+  PendingCorrection? build() {
     ref.onDispose(() {
-      _resetTimer?.cancel();
-      _resetTimer = null;
+      _saveTimer?.cancel();
+      _saveTimer = null;
     });
     return null;
   }
 
-  void notify(CorrectionCaptureEvent event) {
-    state = event;
-    // Cancel any pending reset timer
-    _resetTimer?.cancel();
-    // Reset after a short delay to allow UI to react
-    _resetTimer = Timer(const Duration(milliseconds: 100), () {
-      if (state == event) {
+  /// Sets a pending correction and starts the countdown timer.
+  /// After the delay, the correction will be saved automatically.
+  void setPending({
+    required PendingCorrection pending,
+    required Future<void> Function() onSave,
+  }) {
+    // Cancel any existing timer
+    _saveTimer?.cancel();
+
+    state = pending;
+
+    // Start the countdown timer
+    _saveTimer = Timer(kCorrectionSaveDelay, () async {
+      if (state == pending) {
+        await onSave();
         state = null;
       }
     });
   }
+
+  /// Cancels the pending correction (user clicked undo).
+  /// Returns true if there was a pending correction to cancel.
+  bool cancel() {
+    _saveTimer?.cancel();
+    _saveTimer = null;
+    if (state != null) {
+      developer.log(
+        'Correction capture: cancelled by user',
+        name: 'CorrectionCaptureService',
+      );
+      state = null;
+      return true;
+    }
+    return false;
+  }
+
+  /// Clears the state without cancelling (used after save completes).
+  void clear() {
+    state = null;
+  }
 }
 
-/// Event emitted when a correction is captured.
-class CorrectionCaptureEvent {
-  const CorrectionCaptureEvent({
+/// Represents a pending correction that hasn't been saved yet.
+@immutable
+class PendingCorrection {
+  PendingCorrection({
     required this.before,
     required this.after,
+    required this.categoryId,
     required this.categoryName,
-  });
+    required this.createdAt,
+  }) : id = _nextId++;
 
+  static int _nextId = 0;
+
+  /// Unique ID for this pending correction instance.
+  final int id;
   final String before;
   final String after;
+  final String categoryId;
   final String categoryName;
+  final DateTime createdAt;
+
+  /// Returns the remaining time until the correction is saved.
+  Duration get remainingTime {
+    final elapsed = DateTime.now().difference(createdAt);
+    final remaining = kCorrectionSaveDelay - elapsed;
+    return remaining.isNegative ? Duration.zero : remaining;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is PendingCorrection &&
+          runtimeType == other.runtimeType &&
+          id == other.id;
+
+  @override
+  int get hashCode => id.hashCode;
 }
 
 /// Service for capturing user corrections to checklist item titles.
@@ -76,6 +135,9 @@ class CorrectionCaptureService {
   final CorrectionCaptureNotifier? notifier;
 
   /// Captures a correction if the before and after texts differ meaningfully.
+  ///
+  /// Instead of saving immediately, this creates a pending correction that
+  /// will be saved after [kCorrectionSaveDelay] unless the user cancels.
   ///
   /// Returns a result enum indicating success or the reason for skipping.
   Future<CorrectionCaptureResult> captureCorrection({
@@ -130,6 +192,61 @@ class CorrectionCaptureService {
       return CorrectionCaptureResult.duplicate;
     }
 
+    // Create a pending correction and notify the UI
+    final pending = PendingCorrection(
+      before: normalizedBefore,
+      after: normalizedAfter,
+      categoryId: categoryId,
+      categoryName: category.name,
+      createdAt: DateTime.now(),
+    );
+
+    developer.log(
+      'Correction capture: pending "$normalizedBefore" -> "$normalizedAfter" '
+      'for category "${category.name}" (will save in ${kCorrectionSaveDelay.inSeconds}s)',
+      name: 'CorrectionCaptureService',
+    );
+
+    // Set up the pending correction with delayed save
+    notifier?.setPending(
+      pending: pending,
+      onSave: () => _saveCorrection(
+        categoryId: categoryId,
+        normalizedBefore: normalizedBefore,
+        normalizedAfter: normalizedAfter,
+      ),
+    );
+
+    return CorrectionCaptureResult.pending;
+  }
+
+  /// Actually saves the correction to the database.
+  /// Called after the countdown expires without cancellation.
+  Future<void> _saveCorrection({
+    required String categoryId,
+    required String normalizedBefore,
+    required String normalizedAfter,
+  }) async {
+    // Re-fetch category to get latest state
+    final category = await categoryRepository.getCategoryById(categoryId);
+    if (category == null) {
+      developer.log(
+        'Correction capture: save aborted (category not found)',
+        name: 'CorrectionCaptureService',
+      );
+      return;
+    }
+
+    // Re-check for duplicates in case one was added during the delay
+    final existingExamples = category.correctionExamples ?? [];
+    if (_isDuplicate(existingExamples, normalizedBefore, normalizedAfter)) {
+      developer.log(
+        'Correction capture: save aborted (duplicate)',
+        name: 'CorrectionCaptureService',
+      );
+      return;
+    }
+
     // Add the correction example
     final newExample = ChecklistCorrectionExample(
       before: normalizedBefore,
@@ -150,23 +267,11 @@ class CorrectionCaptureService {
         'to category "${category.name}"',
         name: 'CorrectionCaptureService',
       );
-
-      // Notify UI for snackbar display - service has full context
-      notifier?.notify(
-        CorrectionCaptureEvent(
-          before: normalizedBefore,
-          after: normalizedAfter,
-          categoryName: category.name,
-        ),
-      );
-
-      return CorrectionCaptureResult.success;
     } on Exception catch (e) {
       developer.log(
         'Correction capture: save failed: $e',
         name: 'CorrectionCaptureService',
       );
-      return CorrectionCaptureResult.saveFailed;
     }
   }
 
@@ -193,7 +298,10 @@ class CorrectionCaptureService {
 
 /// Result of attempting to capture a correction.
 enum CorrectionCaptureResult {
-  /// Correction was captured successfully.
+  /// Correction is pending and will be saved after countdown.
+  pending,
+
+  /// Correction was captured successfully (immediate save - legacy).
   success,
 
   /// Skipped: No category ID available on the checklist item.

--- a/lib/features/checklist/services/correction_capture_service.dart
+++ b/lib/features/checklist/services/correction_capture_service.dart
@@ -51,7 +51,15 @@ class CorrectionCaptureNotifier extends _$CorrectionCaptureNotifier {
     // Start the countdown timer
     _saveTimer = Timer(kCorrectionSaveDelay, () async {
       if (state == pending) {
-        await onSave();
+        try {
+          await onSave();
+        } catch (e) {
+          // Log error but don't crash - correction save is fire-and-forget
+          developer.log(
+            'Correction capture: timer callback failed: $e',
+            name: 'CorrectionCaptureService',
+          );
+        }
         state = null;
       }
     });

--- a/lib/features/checklist/services/correction_capture_service.g.dart
+++ b/lib/features/checklist/services/correction_capture_service.g.dart
@@ -29,15 +29,15 @@ final correctionCaptureServiceProvider =
 typedef CorrectionCaptureServiceRef
     = AutoDisposeProviderRef<CorrectionCaptureService>;
 String _$correctionCaptureNotifierHash() =>
-    r'f86442af5e9604f99d708168f5d04fdfad835948';
+    r'0abaac382c1656d97314e2b87639d14bd78bb1be';
 
-/// Notifier for correction capture events.
-/// UI can watch this to show snackbar notifications.
+/// Notifier for pending correction with countdown.
+/// UI watches this to show the snackbar with undo functionality.
 ///
 /// Copied from [CorrectionCaptureNotifier].
 @ProviderFor(CorrectionCaptureNotifier)
 final correctionCaptureNotifierProvider = AutoDisposeNotifierProvider<
-    CorrectionCaptureNotifier, CorrectionCaptureEvent?>.internal(
+    CorrectionCaptureNotifier, PendingCorrection?>.internal(
   CorrectionCaptureNotifier.new,
   name: r'correctionCaptureNotifierProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
@@ -47,7 +47,6 @@ final correctionCaptureNotifierProvider = AutoDisposeNotifierProvider<
   allTransitiveDependencies: null,
 );
 
-typedef _$CorrectionCaptureNotifier
-    = AutoDisposeNotifier<CorrectionCaptureEvent?>;
+typedef _$CorrectionCaptureNotifier = AutoDisposeNotifier<PendingCorrection?>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/tasks/ui/checklists/correction_undo_snackbar.dart
+++ b/lib/features/tasks/ui/checklists/correction_undo_snackbar.dart
@@ -1,0 +1,144 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:lotti/features/checklist/services/correction_capture_service.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+
+/// A snackbar content widget that displays a pending correction with
+/// a countdown timer and undo button.
+///
+/// The countdown visually indicates when the correction will be saved.
+/// The user can tap "UNDO" to cancel the correction before it's saved.
+class CorrectionUndoSnackbarContent extends StatefulWidget {
+  const CorrectionUndoSnackbarContent({
+    required this.pending,
+    required this.onUndo,
+    super.key,
+  });
+
+  /// The pending correction to display.
+  final PendingCorrection pending;
+
+  /// Callback when the user taps the undo button.
+  final VoidCallback onUndo;
+
+  @override
+  State<CorrectionUndoSnackbarContent> createState() =>
+      _CorrectionUndoSnackbarContentState();
+}
+
+class _CorrectionUndoSnackbarContentState
+    extends State<CorrectionUndoSnackbarContent>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _progressController;
+  Timer? _updateTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    const totalDuration = kCorrectionSaveDelay;
+    final remaining = widget.pending.remainingTime;
+
+    // Calculate progress: 1.0 = just started, 0.0 = about to save
+    final initialProgress =
+        remaining.inMilliseconds / totalDuration.inMilliseconds;
+
+    _progressController = AnimationController(
+      vsync: this,
+      duration: remaining,
+      value: initialProgress.clamp(0.0, 1.0),
+    );
+
+    // Animate from current progress down to 0
+    _progressController.reverse(from: _progressController.value);
+
+    // Update remaining time display periodically
+    _updateTimer = Timer.periodic(const Duration(milliseconds: 100), (_) {
+      if (mounted) {
+        setState(() {});
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _progressController.dispose();
+    _updateTimer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final remaining = widget.pending.remainingTime;
+    final secondsLeft = (remaining.inMilliseconds / 1000).ceil();
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // Progress indicator at top
+        AnimatedBuilder(
+          animation: _progressController,
+          builder: (context, child) {
+            return LinearProgressIndicator(
+              value: _progressController.value,
+              backgroundColor: colorScheme.surfaceContainerHighest,
+              valueColor: AlwaysStoppedAnimation<Color>(
+                colorScheme.primary,
+              ),
+              minHeight: 3,
+            );
+          },
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 8, 12),
+          child: Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      context.messages.correctionExamplePending(secondsLeft),
+                      style: TextStyle(
+                        color: colorScheme.onPrimaryContainer,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      '"${widget.pending.before}" \u2192 "${widget.pending.after}"',
+                      style: TextStyle(
+                        color: colorScheme.onPrimaryContainer.withValues(
+                          alpha: 0.8,
+                        ),
+                        fontSize: 12,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+              TextButton(
+                onPressed: widget.onUndo,
+                style: TextButton.styleFrom(
+                  foregroundColor: colorScheme.error,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 8,
+                  ),
+                ),
+                child: Text(
+                  context.messages.correctionExampleCancel,
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/tasks/ui/checklists/correction_undo_snackbar.dart
+++ b/lib/features/tasks/ui/checklists/correction_undo_snackbar.dart
@@ -52,8 +52,9 @@ class _CorrectionUndoSnackbarContentState
     // Animate from current progress down to 0
     _progressController.reverse(from: _progressController.value);
 
-    // Update remaining time display periodically
-    _updateTimer = Timer.periodic(const Duration(milliseconds: 100), (_) {
+    // Update remaining time display periodically (500ms is sufficient since
+    // secondsLeft only changes once per second)
+    _updateTimer = Timer.periodic(const Duration(milliseconds: 500), (_) {
       if (mounted) {
         setState(() {});
       }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -414,6 +414,13 @@
     }
   },
   "correctionExampleCaptured": "Korrektur für KI-Lernen gespeichert",
+  "correctionExamplePending": "Korrektur wird in {seconds}s gespeichert...",
+  "@correctionExamplePending": {
+    "placeholders": {
+      "seconds": { "type": "int" }
+    }
+  },
+  "correctionExampleCancel": "ABBRECHEN",
   "aiResponseTypePromptGeneration": "Generierter Prompt",
   "promptGenerationCardTitle": "KI-Coding-Prompt",
   "promptGenerationCopyTooltip": "Prompt in Zwischenablage kopieren",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1032,5 +1032,12 @@
       "max": { "type": "int" }
     }
   },
-  "correctionExampleCaptured": "Correction saved for AI learning"
+  "correctionExampleCaptured": "Correction saved for AI learning",
+  "correctionExamplePending": "Saving correction in {seconds}s...",
+  "@correctionExamplePending": {
+    "placeholders": {
+      "seconds": { "type": "int" }
+    }
+  },
+  "correctionExampleCancel": "CANCEL"
 }

--- a/lib/l10n/app_en_GB.arb
+++ b/lib/l10n/app_en_GB.arb
@@ -425,5 +425,12 @@
       "max": { "type": "int" }
     }
   },
-  "correctionExampleCaptured": "Correction saved for AI learning"
+  "correctionExampleCaptured": "Correction saved for AI learning",
+  "correctionExamplePending": "Saving correction in {seconds}s...",
+  "@correctionExamplePending": {
+    "placeholders": {
+      "seconds": { "type": "int" }
+    }
+  },
+  "correctionExampleCancel": "CANCEL"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -377,5 +377,12 @@
       "max": { "type": "int" }
     }
   },
-  "correctionExampleCaptured": "Corrección guardada para aprendizaje de IA"
+  "correctionExampleCaptured": "Corrección guardada para aprendizaje de IA",
+  "correctionExamplePending": "Guardando corrección en {seconds}s...",
+  "@correctionExamplePending": {
+    "placeholders": {
+      "seconds": { "type": "int" }
+    }
+  },
+  "correctionExampleCancel": "CANCELAR"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -378,5 +378,12 @@
       "max": { "type": "int" }
     }
   },
-  "correctionExampleCaptured": "Correction enregistrée pour l'apprentissage IA"
+  "correctionExampleCaptured": "Correction enregistrée pour l'apprentissage IA",
+  "correctionExamplePending": "Enregistrement de la correction dans {seconds}s...",
+  "@correctionExamplePending": {
+    "placeholders": {
+      "seconds": { "type": "int" }
+    }
+  },
+  "correctionExampleCancel": "ANNULER"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5235,6 +5235,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Correction saved for AI learning'**
   String get correctionExampleCaptured;
+
+  /// No description provided for @correctionExamplePending.
+  ///
+  /// In en, this message translates to:
+  /// **'Saving correction in {seconds}s...'**
+  String correctionExamplePending(int seconds);
+
+  /// No description provided for @correctionExampleCancel.
+  ///
+  /// In en, this message translates to:
+  /// **'CANCEL'**
+  String get correctionExampleCancel;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2812,4 +2812,12 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get correctionExampleCaptured => 'Korrektur für KI-Lernen gespeichert';
+
+  @override
+  String correctionExamplePending(int seconds) {
+    return 'Korrektur wird in ${seconds}s gespeichert...';
+  }
+
+  @override
+  String get correctionExampleCancel => 'ABBRECHEN';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2794,6 +2794,14 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get correctionExampleCaptured => 'Correction saved for AI learning';
+
+  @override
+  String correctionExamplePending(int seconds) {
+    return 'Saving correction in ${seconds}s...';
+  }
+
+  @override
+  String get correctionExampleCancel => 'CANCEL';
 }
 
 /// The translations for English, as used in the United Kingdom (`en_GB`).
@@ -4100,4 +4108,12 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
 
   @override
   String get correctionExampleCaptured => 'Correction saved for AI learning';
+
+  @override
+  String correctionExamplePending(int seconds) {
+    return 'Saving correction in ${seconds}s...';
+  }
+
+  @override
+  String get correctionExampleCancel => 'CANCEL';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2816,4 +2816,12 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get correctionExampleCaptured =>
       'Corrección guardada para aprendizaje de IA';
+
+  @override
+  String correctionExamplePending(int seconds) {
+    return 'Guardando corrección en ${seconds}s...';
+  }
+
+  @override
+  String get correctionExampleCancel => 'CANCELAR';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2818,4 +2818,12 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get correctionExampleCaptured =>
       'Correction enregistrée pour l\'apprentissage IA';
+
+  @override
+  String correctionExamplePending(int seconds) {
+    return 'Enregistrement de la correction dans ${seconds}s...';
+  }
+
+  @override
+  String get correctionExampleCancel => 'ANNULER';
 }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -2807,4 +2807,12 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get correctionExampleCaptured =>
       'Corecție salvată pentru învățarea AI';
+
+  @override
+  String correctionExamplePending(int seconds) {
+    return 'Salvare corecție în ${seconds}s...';
+  }
+
+  @override
+  String get correctionExampleCancel => 'ANULEAZĂ';
 }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -377,5 +377,12 @@
       "max": { "type": "int" }
     }
   },
-  "correctionExampleCaptured": "Corecție salvată pentru învățarea AI"
+  "correctionExampleCaptured": "Corecție salvată pentru învățarea AI",
+  "correctionExamplePending": "Salvare corecție în {seconds}s...",
+  "@correctionExamplePending": {
+    "placeholders": {
+      "seconds": { "type": "int" }
+    }
+  },
+  "correctionExampleCancel": "ANULEAZĂ"
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.772+3556
+version: 0.9.773+3557
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.773+3557
+version: 0.9.773+3558
 
 msix_config:
   display_name: LottiApp

--- a/test/features/tasks/ui/checklists/checklist_wrapper_test.dart
+++ b/test/features/tasks/ui/checklists/checklist_wrapper_test.dart
@@ -568,18 +568,21 @@ void main() {
 
       await tester.pumpAndSettle();
 
-      // Emit a correction capture event
-      container.read(correctionCaptureNotifierProvider.notifier).notify(
-            const CorrectionCaptureEvent(
+      // Set a pending correction to trigger snackbar
+      container.read(correctionCaptureNotifierProvider.notifier).setPending(
+            pending: PendingCorrection(
               before: 'test flight',
               after: 'TestFlight',
+              categoryId: 'cat-1',
               categoryName: 'Dev',
+              createdAt: DateTime.now(),
             ),
+            onSave: () async {},
           );
 
       await tester.pump();
 
-      // Snackbar should appear with correction captured message
+      // Snackbar should appear with pending correction UI
       expect(find.byType(SnackBar), findsOneWidget);
     });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Corrections now enter a short countdown before being saved, showing a progress bar and seconds remaining.
  * An undo/cancel action is provided in the snackbar to discard pending corrections.
  * Added localized messages for the pending-correction state and cancel label across supported languages.

* **Chores**
  * Bumped app version to 0.9.773.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->