### PR TITLE
fix: calendar refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.803] - 2026-01-08
+### Fixed
+- Calendar Auto-Refresh: Fixed calendar not updating when returning from creating a time recording
+  - Improved `onVisibilityChanged` to track visibility transitions (invisible → visible)
+  - Uses `ref.invalidateSelf()` on transition instead of direct fetch to ensure full provider rebuild
+  - Added missing `ref.mounted` guard to `DayViewController.onVisibilityChanged`
+  - More efficient than the removed `onResume` approach (no CPU overhead when staying on page)
+
 ## [0.9.802] - 2026-01-07
 ### Changed
 - Scroll Performance Optimizations: Significant improvements to reduce jank during scrolling

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -31,6 +31,11 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="0.9.803" date="2026-01-08">
+      <description>
+        <p>Calendar Auto-Refresh Fix: Fixed calendar not updating when returning from creating a time recording. Improved visibility change handling to track transitions from invisible to visible, triggering full provider rebuild only when needed. More efficient than the previous onResume approach with zero CPU overhead when staying on the calendar page.</p>
+      </description>
+    </release>
     <release version="0.9.802" date="2026-01-07">
       <description>
         <p>Scroll Performance Optimizations: Significant improvements to reduce jank during scrolling. Added cacheExtent to key scrollable views (Entry Details, Tasks List), converted Labels Modal to sliver-based lazy loading architecture, and added RepaintBoundary isolation for task cards, linked entries, and checklist items. Fixed memory leaks in editor widgets where ScrollControllers were being recreated on every build. These optimizations target smooth 60/120fps scrolling, especially beneficial for tasks with many checklist items.</p>

--- a/lib/features/calendar/state/day_view_controller.dart
+++ b/lib/features/calendar/state/day_view_controller.dart
@@ -58,13 +58,13 @@ class DayViewController extends _$DayViewController {
   }
 
   void onVisibilityChanged(VisibilityInfo info) {
+    if (!ref.mounted) return;
+    final wasVisible = _isVisible;
     _isVisible = info.visibleFraction > 0.5;
-    if (_isVisible) {
-      _fetch().then((latest) {
-        if (latest != state.value) {
-          state = AsyncData(latest);
-        }
-      });
+    // Only refresh when transitioning from not visible to visible
+    // Using invalidateSelf ensures fresh data is fetched via full rebuild
+    if (_isVisible && !wasVisible) {
+      Future.microtask(ref.invalidateSelf);
     }
   }
 

--- a/lib/features/calendar/state/time_by_category_controller.dart
+++ b/lib/features/calendar/state/time_by_category_controller.dart
@@ -58,14 +58,12 @@ class TimeByCategoryController extends AsyncNotifier<TimeByCategoryData> {
 
   void onVisibilityChanged(VisibilityInfo info) {
     if (!ref.mounted) return;
+    final wasVisible = _isVisible;
     _isVisible = info.visibleFraction > 0.5;
-    if (_isVisible) {
-      final timeSpanDays = ref.read(timeFrameControllerProvider);
-      _fetch(timeSpanDays).then((latest) {
-        if (ref.mounted && latest != state.value) {
-          state = AsyncData(latest);
-        }
-      });
+    // Only refresh when transitioning from not visible to visible
+    // Using invalidateSelf ensures fresh data is fetched via full rebuild
+    if (_isVisible && !wasVisible) {
+      Future.microtask(ref.invalidateSelf);
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.802+3603
+version: 0.9.803+3604
 
 msix_config:
   display_name: LottiApp

--- a/test/features/calendar/state/day_view_controller_test.dart
+++ b/test/features/calendar/state/day_view_controller_test.dart
@@ -248,16 +248,17 @@ void main() {
     ).called(greaterThan(1));
   });
 
-  test('registers onResume callback that triggers invalidation', () async {
-    // This test verifies that the onResume callback is registered and that
-    // invalidating the provider causes a refetch. The full pause/resume
-    // lifecycle (via TickerMode and navigation) is an integration concern
-    // that requires real route transitions to test properly.
+  test('visibility change triggers invalidation on transition to visible',
+      () async {
+    // This test verifies that onVisibilityChanged triggers invalidation
+    // when transitioning from not visible to visible.
     //
-    // The fix for Riverpod 3's auto-pause behavior:
-    //   ..onResume(() => Future.microtask(ref.invalidateSelf))
+    // The fix uses visibility tracking to refresh data:
+    //   if (_isVisible && !wasVisible) {
+    //     Future.microtask(ref.invalidateSelf);
+    //   }
     //
-    // This test verifies the invalidation path works correctly.
+    // This ensures fresh data is fetched when returning to the calendar view.
 
     // Arrange
     final now = DateTime.now();
@@ -312,10 +313,12 @@ void main() {
     // Wait for initial state
     await container.read(dayViewControllerProvider.future);
 
-    // Simulate what onResume does: invalidate the provider
-    // In production, this is triggered by Riverpod 3's TickerMode-based
-    // pause/resume lifecycle when navigating back to the calendar view
-    container.invalidate(dayViewControllerProvider);
+    // Simulate visibility transition: not visible -> visible
+    // First call will transition from _isVisible=false to _isVisible=true
+    final controller = container.read(dayViewControllerProvider.notifier);
+    final mockVisibilityInfo = MockVisibilityInfo();
+    when(() => mockVisibilityInfo.visibleFraction).thenReturn(1);
+    controller.onVisibilityChanged(mockVisibilityInfo);
 
     // Allow microtask to process the invalidation
     await Future<void>.delayed(Duration.zero);
@@ -325,7 +328,7 @@ void main() {
 
     // Verify the data was fetched twice:
     // 1. Initial load
-    // 2. After invalidation (simulating onResume behavior)
+    // 2. After visibility change triggered invalidation
     verify(
       () => mockDb.sortedCalendarEntries(
         rangeStart: any(named: 'rangeStart'),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Calendar now auto-refreshes when returning from creating a time recording.
  * Enhanced visibility tracking to reduce CPU overhead on the calendar page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->