### PR TITLE
feat: improve time calculation for overlapping time, e.g. workout entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.830] - 2026-01-29
+### Fixed
+- Daily OS Time Calculation: Overlapping time entries within the same category no longer double-count
+  - A 1.5h "Gym Trip" containing a 45m "Fitness Entry" now correctly reports 1.5h total (not 2.25h)
+  - Uses time range union algorithm to calculate actual time coverage without overlap inflation
+  - Applies to all budget progress calculations and time summaries
+
+### Changed
+- Daily OS Timeline: Same-category entries that fully contain another now nest visually
+  - Child entries (e.g., the workout) render inset inside their parent block (e.g., the gym trip)
+  - Reduces visual clutter by not using separate lanes for related entries
+  - Different-category entries still display in separate lanes when overlapping
+
 ## [0.9.829] - 2026-01-29
 ### Added
 - Daily OS Priority Indicators: Tasks now display priority badges (P0, P1, P3) styled like Linear

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -31,6 +31,12 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="0.9.830" date="2026-01-29">
+      <description>
+        <p>Daily OS Overlap Fix: Time entries within the same category no longer double-count when they overlap. For example, a 1.5-hour "Gym Trip" containing a 45-minute "Fitness Entry" now correctly reports 1.5 hours total instead of 2.25 hours. Uses a time range union algorithm to calculate actual time coverage.</p>
+        <p>Visual Nesting: Same-category entries that fully contain another now nest visually in the timeline. Child entries render inset inside their parent block, reducing visual clutter. Different-category overlapping entries still display in separate lanes.</p>
+      </description>
+    </release>
     <release version="0.9.829" date="2026-01-29">
       <description>
         <p>Daily OS Priority System: Tasks now display Linear-style priority badges (P0 red, P1 orange, P3 gray) in both list and grid views. P2 (Medium) is hidden to reduce visual noise. Tasks without tracked time are sorted by priority first (P0→P1→P2→P3), then by urgency, then alphabetically.</p>

--- a/lib/features/daily_os/util/time_range_utils.dart
+++ b/lib/features/daily_os/util/time_range_utils.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/foundation.dart' show immutable;
+
+/// Represents a time range with a start and end time.
+@immutable
+class TimeRange {
+  const TimeRange({required this.start, required this.end});
+
+  final DateTime start;
+  final DateTime end;
+
+  Duration get duration => end.difference(start);
+
+  /// Returns true if this range overlaps with [other].
+  ///
+  /// Two ranges overlap if they share any common time, including touching
+  /// at endpoints (to allow merging adjacent ranges).
+  bool overlaps(TimeRange other) {
+    return !end.isBefore(other.start) && !other.end.isBefore(start);
+  }
+
+  /// Merges this range with [other], returning a new range that covers both.
+  ///
+  /// Should only be called when the ranges overlap (or are adjacent).
+  TimeRange merge(TimeRange other) {
+    return TimeRange(
+      start: start.isBefore(other.start) ? start : other.start,
+      end: end.isAfter(other.end) ? end : other.end,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TimeRange &&
+          runtimeType == other.runtimeType &&
+          start == other.start &&
+          end == other.end;
+
+  @override
+  int get hashCode => Object.hash(start, end);
+
+  @override
+  String toString() => 'TimeRange($start - $end)';
+}
+
+/// Calculates the union of overlapping time ranges.
+///
+/// Given a list of potentially overlapping ranges, returns a list of
+/// non-overlapping ranges that cover the same total time span.
+///
+/// Example:
+/// ```text
+/// Input:   |======| |====|  |======|
+///                    |====|
+/// Output:  |======| |=========|
+/// ```
+///
+/// The algorithm:
+/// 1. Sort ranges by start time
+/// 2. Iterate through ranges, merging any that overlap with the current range
+/// 3. When a gap is found, start a new merged range
+List<TimeRange> mergeOverlappingRanges(List<TimeRange> ranges) {
+  if (ranges.isEmpty) return [];
+  if (ranges.length == 1) return ranges;
+
+  // Sort by start time
+  final sorted = [...ranges]..sort((a, b) => a.start.compareTo(b.start));
+
+  final merged = <TimeRange>[];
+  var current = sorted.first;
+
+  for (var i = 1; i < sorted.length; i++) {
+    final next = sorted[i];
+
+    if (current.overlaps(next)) {
+      // Ranges overlap or touch - merge them
+      current = current.merge(next);
+    } else {
+      // Gap found - save current and start new
+      merged.add(current);
+      current = next;
+    }
+  }
+
+  // Don't forget the last range
+  merged.add(current);
+
+  return merged;
+}
+
+/// Calculates the total duration covered by a list of potentially overlapping
+/// time ranges, without double-counting overlapping portions.
+///
+/// This is the core function for preventing double-counting of overlapping
+/// time entries within the same category.
+Duration calculateUnionDuration(List<TimeRange> ranges) {
+  if (ranges.isEmpty) return Duration.zero;
+
+  final merged = mergeOverlappingRanges(ranges);
+  return merged.fold(
+    Duration.zero,
+    (total, range) => total + range.duration,
+  );
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.830+3639
+version: 0.9.830+3640
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.829+3638
+version: 0.9.830+3639
 
 msix_config:
   display_name: LottiApp

--- a/test/features/daily_os/util/time_range_utils_test.dart
+++ b/test/features/daily_os/util/time_range_utils_test.dart
@@ -123,6 +123,58 @@ void main() {
       expect(range1, equals(range2));
       expect(range1, isNot(equals(range3)));
     });
+
+    test('hashCode is consistent with equality', () {
+      final range1 = TimeRange(
+        start: DateTime(2024, 1, 15, 10),
+        end: DateTime(2024, 1, 15, 12),
+      );
+      final range2 = TimeRange(
+        start: DateTime(2024, 1, 15, 10),
+        end: DateTime(2024, 1, 15, 12),
+      );
+      final range3 = TimeRange(
+        start: DateTime(2024, 1, 15, 10),
+        end: DateTime(2024, 1, 15, 13),
+      );
+
+      // Equal objects must have equal hash codes
+      expect(range1.hashCode, equals(range2.hashCode));
+      // Different objects should (usually) have different hash codes
+      expect(range1.hashCode, isNot(equals(range3.hashCode)));
+    });
+
+    test('toString returns readable representation', () {
+      final range = TimeRange(
+        start: DateTime(2024, 1, 15, 10),
+        end: DateTime(2024, 1, 15, 12),
+      );
+
+      final str = range.toString();
+      expect(str, contains('TimeRange'));
+      expect(str, contains('2024'));
+    });
+
+    test('identical ranges are equal', () {
+      final range = TimeRange(
+        start: DateTime(2024, 1, 15, 10),
+        end: DateTime(2024, 1, 15, 12),
+      );
+
+      expect(range == range, isTrue);
+    });
+
+    test('equality with non-TimeRange returns false', () {
+      final range = TimeRange(
+        start: DateTime(2024, 1, 15, 10),
+        end: DateTime(2024, 1, 15, 12),
+      );
+
+      // ignore: unrelated_type_equality_checks
+      expect(range == 'not a range', isFalse);
+      // ignore: unrelated_type_equality_checks
+      expect(range == 42, isFalse);
+    });
   });
 
   group('mergeOverlappingRanges', () {

--- a/test/features/daily_os/util/time_range_utils_test.dart
+++ b/test/features/daily_os/util/time_range_utils_test.dart
@@ -1,0 +1,414 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/daily_os/util/time_range_utils.dart';
+
+void main() {
+  group('TimeRange', () {
+    test('calculates duration correctly', () {
+      final range = TimeRange(
+        start: DateTime(2024, 1, 15, 10),
+        end: DateTime(2024, 1, 15, 11, 30),
+      );
+
+      expect(range.duration, const Duration(hours: 1, minutes: 30));
+    });
+
+    group('overlaps', () {
+      test('returns true when ranges overlap', () {
+        final range1 = TimeRange(
+          start: DateTime(2024, 1, 15, 10),
+          end: DateTime(2024, 1, 15, 12),
+        );
+        final range2 = TimeRange(
+          start: DateTime(2024, 1, 15, 11),
+          end: DateTime(2024, 1, 15, 13),
+        );
+
+        expect(range1.overlaps(range2), isTrue);
+        expect(range2.overlaps(range1), isTrue);
+      });
+
+      test('returns true when one range contains another', () {
+        final outer = TimeRange(
+          start: DateTime(2024, 1, 15, 10),
+          end: DateTime(2024, 1, 15, 14),
+        );
+        final inner = TimeRange(
+          start: DateTime(2024, 1, 15, 11),
+          end: DateTime(2024, 1, 15, 13),
+        );
+
+        expect(outer.overlaps(inner), isTrue);
+        expect(inner.overlaps(outer), isTrue);
+      });
+
+      test('returns true when ranges touch at endpoints', () {
+        final range1 = TimeRange(
+          start: DateTime(2024, 1, 15, 10),
+          end: DateTime(2024, 1, 15, 12),
+        );
+        final range2 = TimeRange(
+          start: DateTime(2024, 1, 15, 12),
+          end: DateTime(2024, 1, 15, 14),
+        );
+
+        expect(range1.overlaps(range2), isTrue);
+        expect(range2.overlaps(range1), isTrue);
+      });
+
+      test('returns false when ranges do not overlap', () {
+        final range1 = TimeRange(
+          start: DateTime(2024, 1, 15, 10),
+          end: DateTime(2024, 1, 15, 11),
+        );
+        final range2 = TimeRange(
+          start: DateTime(2024, 1, 15, 12),
+          end: DateTime(2024, 1, 15, 13),
+        );
+
+        expect(range1.overlaps(range2), isFalse);
+        expect(range2.overlaps(range1), isFalse);
+      });
+    });
+
+    group('merge', () {
+      test('merges overlapping ranges correctly', () {
+        final range1 = TimeRange(
+          start: DateTime(2024, 1, 15, 10),
+          end: DateTime(2024, 1, 15, 12),
+        );
+        final range2 = TimeRange(
+          start: DateTime(2024, 1, 15, 11),
+          end: DateTime(2024, 1, 15, 13),
+        );
+
+        final merged = range1.merge(range2);
+
+        expect(merged.start, DateTime(2024, 1, 15, 10));
+        expect(merged.end, DateTime(2024, 1, 15, 13));
+        expect(merged.duration, const Duration(hours: 3));
+      });
+
+      test('merges when one range contains another', () {
+        final outer = TimeRange(
+          start: DateTime(2024, 1, 15, 10),
+          end: DateTime(2024, 1, 15, 14),
+        );
+        final inner = TimeRange(
+          start: DateTime(2024, 1, 15, 11),
+          end: DateTime(2024, 1, 15, 13),
+        );
+
+        final merged = outer.merge(inner);
+
+        expect(merged.start, DateTime(2024, 1, 15, 10));
+        expect(merged.end, DateTime(2024, 1, 15, 14));
+        expect(merged.duration, const Duration(hours: 4));
+      });
+    });
+
+    test('equality works correctly', () {
+      final range1 = TimeRange(
+        start: DateTime(2024, 1, 15, 10),
+        end: DateTime(2024, 1, 15, 12),
+      );
+      final range2 = TimeRange(
+        start: DateTime(2024, 1, 15, 10),
+        end: DateTime(2024, 1, 15, 12),
+      );
+      final range3 = TimeRange(
+        start: DateTime(2024, 1, 15, 10),
+        end: DateTime(2024, 1, 15, 13),
+      );
+
+      expect(range1, equals(range2));
+      expect(range1, isNot(equals(range3)));
+    });
+  });
+
+  group('mergeOverlappingRanges', () {
+    test('returns empty list for empty input', () {
+      expect(mergeOverlappingRanges([]), isEmpty);
+    });
+
+    test('returns single range for single input', () {
+      final range = TimeRange(
+        start: DateTime(2024, 1, 15, 10),
+        end: DateTime(2024, 1, 15, 12),
+      );
+
+      expect(mergeOverlappingRanges([range]), [range]);
+    });
+
+    test('merges two overlapping ranges', () {
+      final range1 = TimeRange(
+        start: DateTime(2024, 1, 15, 10),
+        end: DateTime(2024, 1, 15, 12),
+      );
+      final range2 = TimeRange(
+        start: DateTime(2024, 1, 15, 11),
+        end: DateTime(2024, 1, 15, 13),
+      );
+
+      final merged = mergeOverlappingRanges([range1, range2]);
+
+      expect(merged.length, 1);
+      expect(merged[0].start, DateTime(2024, 1, 15, 10));
+      expect(merged[0].end, DateTime(2024, 1, 15, 13));
+    });
+
+    test('keeps non-overlapping ranges separate', () {
+      final range1 = TimeRange(
+        start: DateTime(2024, 1, 15, 10),
+        end: DateTime(2024, 1, 15, 11),
+      );
+      final range2 = TimeRange(
+        start: DateTime(2024, 1, 15, 12),
+        end: DateTime(2024, 1, 15, 13),
+      );
+
+      final merged = mergeOverlappingRanges([range1, range2]);
+
+      expect(merged.length, 2);
+    });
+
+    test('merges multiple overlapping ranges into one', () {
+      final ranges = [
+        TimeRange(
+          start: DateTime(2024, 1, 15, 10),
+          end: DateTime(2024, 1, 15, 11),
+        ),
+        TimeRange(
+          start: DateTime(2024, 1, 15, 10, 30),
+          end: DateTime(2024, 1, 15, 11, 30),
+        ),
+        TimeRange(
+          start: DateTime(2024, 1, 15, 11),
+          end: DateTime(2024, 1, 15, 12),
+        ),
+      ];
+
+      final merged = mergeOverlappingRanges(ranges);
+
+      expect(merged.length, 1);
+      expect(merged[0].start, DateTime(2024, 1, 15, 10));
+      expect(merged[0].end, DateTime(2024, 1, 15, 12));
+    });
+
+    test('handles contained ranges (gym trip scenario)', () {
+      // Gym trip: 10:00 - 11:30 (1.5 hours)
+      // Fitness entry: 10:30 - 11:15 (45 minutes)
+      // Should merge to a single 1.5 hour block
+
+      final gymTrip = TimeRange(
+        start: DateTime(2024, 1, 15, 10),
+        end: DateTime(2024, 1, 15, 11, 30),
+      );
+      final fitnessEntry = TimeRange(
+        start: DateTime(2024, 1, 15, 10, 30),
+        end: DateTime(2024, 1, 15, 11, 15),
+      );
+
+      final merged = mergeOverlappingRanges([gymTrip, fitnessEntry]);
+
+      expect(merged.length, 1);
+      expect(merged[0].start, DateTime(2024, 1, 15, 10));
+      expect(merged[0].end, DateTime(2024, 1, 15, 11, 30));
+      expect(merged[0].duration, const Duration(hours: 1, minutes: 30));
+    });
+
+    test('handles out-of-order input', () {
+      final ranges = [
+        TimeRange(
+          start: DateTime(2024, 1, 15, 14),
+          end: DateTime(2024, 1, 15, 15),
+        ),
+        TimeRange(
+          start: DateTime(2024, 1, 15, 10),
+          end: DateTime(2024, 1, 15, 11),
+        ),
+        TimeRange(
+          start: DateTime(2024, 1, 15, 10, 30),
+          end: DateTime(2024, 1, 15, 11, 30),
+        ),
+      ];
+
+      final merged = mergeOverlappingRanges(ranges);
+
+      expect(merged.length, 2);
+      // First merged group
+      expect(merged[0].start, DateTime(2024, 1, 15, 10));
+      expect(merged[0].end, DateTime(2024, 1, 15, 11, 30));
+      // Separate later range
+      expect(merged[1].start, DateTime(2024, 1, 15, 14));
+      expect(merged[1].end, DateTime(2024, 1, 15, 15));
+    });
+  });
+
+  group('calculateUnionDuration', () {
+    test('returns zero for empty input', () {
+      expect(calculateUnionDuration([]), Duration.zero);
+    });
+
+    test('returns duration of single range', () {
+      final range = TimeRange(
+        start: DateTime(2024, 1, 15, 10),
+        end: DateTime(2024, 1, 15, 11, 30),
+      );
+
+      expect(
+        calculateUnionDuration([range]),
+        const Duration(hours: 1, minutes: 30),
+      );
+    });
+
+    test('calculates union for overlapping ranges (no double counting)', () {
+      final range1 = TimeRange(
+        start: DateTime(2024, 1, 15, 10),
+        end: DateTime(2024, 1, 15, 12),
+      );
+      final range2 = TimeRange(
+        start: DateTime(2024, 1, 15, 11),
+        end: DateTime(2024, 1, 15, 13),
+      );
+
+      // Without union: 2h + 2h = 4h
+      // With union: 10:00 - 13:00 = 3h
+      expect(
+          calculateUnionDuration([range1, range2]), const Duration(hours: 3));
+    });
+
+    test('sums non-overlapping ranges', () {
+      final range1 = TimeRange(
+        start: DateTime(2024, 1, 15, 10),
+        end: DateTime(2024, 1, 15, 11),
+      );
+      final range2 = TimeRange(
+        start: DateTime(2024, 1, 15, 12),
+        end: DateTime(2024, 1, 15, 13),
+      );
+
+      expect(
+          calculateUnionDuration([range1, range2]), const Duration(hours: 2));
+    });
+
+    test('gym trip scenario: prevents double counting', () {
+      // This is the exact scenario from the requirements:
+      // Gym trip: 10:00 - 11:30 (1.5 hours total including travel)
+      // Fitness entry: 10:30 - 11:15 (45 minutes of actual lifting)
+      //
+      // OLD behavior (simple sum): 1.5h + 0.75h = 2.25h (WRONG)
+      // NEW behavior (union): 1.5h (CORRECT)
+
+      final gymTrip = TimeRange(
+        start: DateTime(2024, 1, 15, 10),
+        end: DateTime(2024, 1, 15, 11, 30),
+      );
+      final fitnessEntry = TimeRange(
+        start: DateTime(2024, 1, 15, 10, 30),
+        end: DateTime(2024, 1, 15, 11, 15),
+      );
+
+      // Simple sum would be 90 + 45 = 135 minutes = 2h 15m
+      final simpleSumMinutes =
+          gymTrip.duration.inMinutes + fitnessEntry.duration.inMinutes;
+      expect(simpleSumMinutes, 135);
+
+      // Union should be 90 minutes = 1h 30m
+      final unionDuration = calculateUnionDuration([gymTrip, fitnessEntry]);
+      expect(unionDuration, const Duration(hours: 1, minutes: 30));
+    });
+
+    test('multiple contained entries scenario', () {
+      // Morning block: 9:00 - 12:00 (3 hours)
+      // Call 1: 9:30 - 10:00 (30 min)
+      // Call 2: 10:30 - 11:00 (30 min)
+      // Call 3: 11:15 - 11:45 (30 min)
+      //
+      // All calls are within the morning block
+      // Total should be 3 hours, not 3h + 1.5h = 4.5h
+
+      final morningBlock = TimeRange(
+        start: DateTime(2024, 1, 15, 9),
+        end: DateTime(2024, 1, 15, 12),
+      );
+      final call1 = TimeRange(
+        start: DateTime(2024, 1, 15, 9, 30),
+        end: DateTime(2024, 1, 15, 10),
+      );
+      final call2 = TimeRange(
+        start: DateTime(2024, 1, 15, 10, 30),
+        end: DateTime(2024, 1, 15, 11),
+      );
+      final call3 = TimeRange(
+        start: DateTime(2024, 1, 15, 11, 15),
+        end: DateTime(2024, 1, 15, 11, 45),
+      );
+
+      final unionDuration = calculateUnionDuration([
+        morningBlock,
+        call1,
+        call2,
+        call3,
+      ]);
+
+      expect(unionDuration, const Duration(hours: 3));
+    });
+
+    test('partially overlapping multiple ranges', () {
+      // Range 1: 10:00 - 11:00
+      // Range 2: 10:30 - 11:30
+      // Range 3: 11:00 - 12:00
+      // Union: 10:00 - 12:00 = 2 hours
+
+      final ranges = [
+        TimeRange(
+          start: DateTime(2024, 1, 15, 10),
+          end: DateTime(2024, 1, 15, 11),
+        ),
+        TimeRange(
+          start: DateTime(2024, 1, 15, 10, 30),
+          end: DateTime(2024, 1, 15, 11, 30),
+        ),
+        TimeRange(
+          start: DateTime(2024, 1, 15, 11),
+          end: DateTime(2024, 1, 15, 12),
+        ),
+      ];
+
+      expect(calculateUnionDuration(ranges), const Duration(hours: 2));
+    });
+
+    test('complex scenario with gaps and overlaps', () {
+      // Group 1: 9:00 - 10:30 (merged from overlaps)
+      //   - Entry A: 9:00 - 10:00
+      //   - Entry B: 9:30 - 10:30
+      //
+      // Gap: 10:30 - 11:00
+      //
+      // Group 2: 11:00 - 12:00
+      //   - Entry C: 11:00 - 12:00
+      //
+      // Total: 1.5h + 1h = 2.5h
+
+      final entryA = TimeRange(
+        start: DateTime(2024, 1, 15, 9),
+        end: DateTime(2024, 1, 15, 10),
+      );
+      final entryB = TimeRange(
+        start: DateTime(2024, 1, 15, 9, 30),
+        end: DateTime(2024, 1, 15, 10, 30),
+      );
+      final entryC = TimeRange(
+        start: DateTime(2024, 1, 15, 11),
+        end: DateTime(2024, 1, 15, 12),
+      );
+
+      final unionDuration = calculateUnionDuration([entryA, entryB, entryC]);
+
+      expect(
+        unionDuration,
+        const Duration(hours: 2, minutes: 30),
+      );
+    });
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed double-counting of overlapping time entries within the same category; combined entries now reflect actual covered time and budget progress/summaries.

* **Changes**
  * Daily OS Timeline now visually nests same‑category entries that fully contain others to reduce clutter; different‑category overlaps stay in separate lanes.

* **Tests**
  * Added unit and widget tests for time-range merging, union-duration calculations, and nesting rendering/behavior.

* **Documentation**
  * Added a new release entry describing the fixes and visual changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->