### PR TITLE
fix: read marker short-circuiting sync catch-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.927] - 2026-03-16
+### Fixed
+- Matrix sync catch-up: fixed two bugs that prevented cold-restart catch-up
+  from paginating server history correctly. Backfill no longer short-circuits
+  on marker ID before reaching the timestamp boundary, and the local expansion
+  loop no longer overwrites paginated events with a smaller local-only snapshot.
+
 ## [0.9.926] - 2026-03-15
 ### Added
 - Category AI defaults: categories can now define a default inference profile

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -31,6 +31,11 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="0.9.927" date="2026-03-16">
+      <description>
+          <p>Matrix sync catch-up: fixed two bugs that prevented cold-restart catch-up from paginating server history correctly, ensuring reliable message delivery after app restart.</p>
+      </description>
+    </release>
     <release version="0.9.926" date="2026-03-15">
       <description>
           <p>Category AI defaults: categories can now define a default inference profile and agent template. New tasks inherit the profile for speech-to-text/image analysis, and get an agent auto-assigned that waits for content before activating.</p>

--- a/integration_test/matrix_service_test.dart
+++ b/integration_test/matrix_service_test.dart
@@ -190,6 +190,8 @@ void main() {
     // reuse the already-verified Alice & Bob from the first test.
     late MatrixService alice;
     late MatrixService bob;
+    var aliceInitialized = false;
+    var bobInitialized = false;
     late String roomId;
     // Bob's SettingsDb must persist across tests so the pipeline's
     // last-processed marker survives the cold restart in test 2.
@@ -230,15 +232,19 @@ void main() {
 
     tearDownAll(() async {
       // Ensure proper cleanup before resetting GetIt
-      try {
-        await alice.dispose();
-      } catch (e) {
-        debugPrint('Error disposing Alice: $e');
+      if (aliceInitialized) {
+        try {
+          await alice.dispose();
+        } catch (e) {
+          debugPrint('Error disposing Alice: $e');
+        }
       }
-      try {
-        await bob.dispose();
-      } catch (e) {
-        debugPrint('Error disposing Bob: $e');
+      if (bobInitialized) {
+        try {
+          await bob.dispose();
+        } catch (e) {
+          debugPrint('Error disposing Bob: $e');
+        }
       }
       try {
         await aliceDb.close();
@@ -287,6 +293,7 @@ void main() {
           aiConfigRepository: sharedAiConfigRepository,
           sentEventRegistry: aliceRegistry,
         );
+        aliceInitialized = true;
 
         await alice.init();
         expect(alice.debugPipeline, isNotNull);
@@ -321,6 +328,7 @@ void main() {
           updateNotifications: mockUpdateNotifications,
           aiConfigRepository: sharedAiConfigRepository,
         );
+        bobInitialized = true;
 
         await bob.init();
         expect(bob.debugPipeline, isNotNull);
@@ -458,6 +466,7 @@ void main() {
         // Phase 1: Dispose Bob entirely (simulates closing the app)
         debugPrint('\n--- Phase 1: Bob goes offline (full dispose)');
         await bob.dispose();
+        bobInitialized = false;
         debugPrint('Bob disposed');
 
         final bobCountWhileOffline = await bobDb.getJournalCount();
@@ -530,6 +539,7 @@ void main() {
           aiConfigRepository: sharedAiConfigRepository,
           singleInstance: false,
         );
+        bobInitialized = true;
 
         await bob.init();
         expect(bob.debugPipeline, isNotNull);

--- a/integration_test/matrix_service_test.dart
+++ b/integration_test/matrix_service_test.dart
@@ -207,6 +207,7 @@ void main() {
       sharedAiConfigRepository = AiConfigRepository(aiConfigDb);
       sharedLoggingService = LoggingService();
       sharedUserActivityService = UserActivityService();
+      bobSettingsDb = SettingsDb(inMemoryDatabase: true);
 
       // Register essential dependencies
       getIt
@@ -242,6 +243,7 @@ void main() {
       try {
         await aliceDb.close();
         await bobDb.close();
+        await bobSettingsDb.close();
         await aiConfigDb.close();
       } catch (e) {
         debugPrint('Error during database cleanup: $e');
@@ -308,7 +310,6 @@ void main() {
         );
 
         debugPrint('\n--- Bob goes live');
-        bobSettingsDb = SettingsDb(inMemoryDatabase: true);
         bob = await _createBobService(
           documentsDirectory: sharedDocumentsDirectory,
           config: config2,

--- a/integration_test/matrix_service_test.dart
+++ b/integration_test/matrix_service_test.dart
@@ -308,29 +308,17 @@ void main() {
         );
 
         debugPrint('\n--- Bob goes live');
-        final bobClient = await createMatrixClient(
-          documentsDirectory: sharedDocumentsDirectory,
-          dbName: 'BobV2',
-        );
-        final bobRegistry = SentEventRegistry();
-        final bobGateway = MatrixSdkGateway(
-          client: bobClient,
-          sentEventRegistry: bobRegistry,
-        );
         bobSettingsDb = SettingsDb(inMemoryDatabase: true);
-        bob = _createMatrixService(
+        bob = await _createBobService(
+          documentsDirectory: sharedDocumentsDirectory,
           config: config2,
-          gateway: bobGateway,
           loggingService: sharedLoggingService,
           journalDb: bobDb,
           settingsDb: bobSettingsDb,
           secureStorage: secureStorageMock,
-          deviceName: 'BobV2',
           activityService: sharedUserActivityService,
-          documentsDirectory: sharedDocumentsDirectory,
           updateNotifications: mockUpdateNotifications,
           aiConfigRepository: sharedAiConfigRepository,
-          sentEventRegistry: bobRegistry,
         );
 
         await bob.init();
@@ -529,29 +517,17 @@ void main() {
         // from the same DB path (simulates app relaunch).
         // Use singleInstance: false to avoid sqflite connection-cache
         // contention with the disposed first client's cached handle.
-        final bobClient2 = await createMatrixClient(
+        bob = await _createBobService(
           documentsDirectory: sharedDocumentsDirectory,
-          dbName: 'BobV2',
-          singleInstance: false,
-        );
-        final bobRegistry2 = SentEventRegistry();
-        final bobGateway2 = MatrixSdkGateway(
-          client: bobClient2,
-          sentEventRegistry: bobRegistry2,
-        );
-        bob = _createMatrixService(
           config: config2,
-          gateway: bobGateway2,
           loggingService: sharedLoggingService,
           journalDb: bobDb,
           settingsDb: bobSettingsDb,
           secureStorage: secureStorageMock,
-          deviceName: 'BobV2',
           activityService: sharedUserActivityService,
-          documentsDirectory: sharedDocumentsDirectory,
           updateNotifications: mockUpdateNotifications,
           aiConfigRepository: sharedAiConfigRepository,
-          sentEventRegistry: bobRegistry2,
+          singleInstance: false,
         );
 
         await bob.init();
@@ -659,6 +635,46 @@ void main() {
       skip: skipReason ?? false,
     );
   });
+}
+
+/// Creates a fresh Bob [MatrixService] instance with a new Matrix client and
+/// gateway. Used both for initial setup and cold-restart simulation.
+Future<MatrixService> _createBobService({
+  required Directory documentsDirectory,
+  required MatrixConfig config,
+  required LoggingService loggingService,
+  required JournalDb journalDb,
+  required SettingsDb settingsDb,
+  required SecureStorage secureStorage,
+  required UserActivityService activityService,
+  required MockUpdateNotifications updateNotifications,
+  required AiConfigRepository aiConfigRepository,
+  bool? singleInstance,
+}) async {
+  final client = await createMatrixClient(
+    documentsDirectory: documentsDirectory,
+    dbName: 'BobV2',
+    singleInstance: singleInstance,
+  );
+  final registry = SentEventRegistry();
+  final gateway = MatrixSdkGateway(
+    client: client,
+    sentEventRegistry: registry,
+  );
+  return _createMatrixService(
+    config: config,
+    gateway: gateway,
+    loggingService: loggingService,
+    journalDb: journalDb,
+    settingsDb: settingsDb,
+    secureStorage: secureStorage,
+    deviceName: 'BobV2',
+    activityService: activityService,
+    documentsDirectory: documentsDirectory,
+    updateNotifications: updateNotifications,
+    aiConfigRepository: aiConfigRepository,
+    sentEventRegistry: registry,
+  );
 }
 
 Future<void> _sendTestMessage(

--- a/integration_test/matrix_service_test.dart
+++ b/integration_test/matrix_service_test.dart
@@ -89,6 +89,7 @@ MatrixService _createMatrixService({
     ownsActivityGate: true,
     attachmentIndex: AttachmentIndex(logging: loggingService),
     sentEventRegistry: sentEventRegistry,
+    collectSyncMetrics: true,
   );
 }
 
@@ -190,6 +191,9 @@ void main() {
     late MatrixService alice;
     late MatrixService bob;
     late String roomId;
+    // Bob's SettingsDb must persist across tests so the pipeline's
+    // last-processed marker survives the cold restart in test 2.
+    late SettingsDb bobSettingsDb;
 
     setUpAll(() async {
       await vod.init();
@@ -313,7 +317,7 @@ void main() {
           client: bobClient,
           sentEventRegistry: bobRegistry,
         );
-        final bobSettingsDb = SettingsDb(inMemoryDatabase: true);
+        bobSettingsDb = SettingsDb(inMemoryDatabase: true);
         bob = _createMatrixService(
           config: config2,
           gateway: bobGateway,
@@ -355,9 +359,10 @@ void main() {
         );
 
         const n = testSlowNetwork ? 10 : 100;
-        // With signal-driven consumer and self-event suppression, each device
-        // applies only the other device's messages. Expect n entries per DB.
-        const expectedEntriesPerDb = n;
+        // Each device now persists its own entries at send time (matching
+        // production behavior) plus receives the other device's entries via
+        // sync. Self-sent events are deduplicated by vector clock comparison.
+        const expectedEntriesPerDb = 2 * n;
 
         debugPrint('\n--- Alice sends $n message');
         for (var i = 0; i < n; i++) {
@@ -366,6 +371,7 @@ void main() {
             device: alice,
             deviceName: 'aliceDeviceV2',
             roomId: roomId,
+            journalDb: aliceDb,
           );
         }
 
@@ -376,6 +382,7 @@ void main() {
             device: bob,
             deviceName: 'bobDeviceV2',
             roomId: roomId,
+            journalDb: bobDb,
           );
         }
 
@@ -443,30 +450,37 @@ void main() {
     );
 
     test(
-      'Large-volume convergence: Bob catches up 2000 messages with '
-      'concurrent processing',
+      'Large-volume convergence: Bob catches up 2000 messages after '
+      'cold restart',
       () async {
-        // Reuses the already-verified Alice & Bob from test 1 — no new
-        // clients, no SAS dance. Alice sends a large burst into the
-        // existing room while Bob processes concurrently via periodic
-        // forceRescan calls, then Alice goes offline and Bob catches up
-        // any remaining messages. This mirrors the production incident
-        // where ~1500 entries accumulated faster than the receiver could
-        // process them.
+        // Simulates the real-world scenario: Bob's app is closed while
+        // Alice sends a large burst, then Bob reopens the app (fresh client,
+        // fresh pipeline, but same persisted DB with sync token + journal).
+        // This is the strictest form of the catch-up test: Bob has zero
+        // concurrent processing during sending, and must bootstrap from
+        // scratch when coming back.
         const convergenceTimeout = Duration(minutes: 15);
-        const n = testSlowNetwork ? 50 : 2000;
+        const n = testSlowNetwork ? 250 : 2000;
 
         // Snapshot Bob's DB count before this test's messages
         final bobCountBefore = await bobDb.getJournalCount();
         debugPrint('Bob DB count before convergence test: $bobCountBefore');
 
-        // Skip the 30s sync wait in catch-up — we drive sync explicitly
-        bob.debugPipeline!.skipSyncWait = true;
+        // Phase 1: Dispose Bob entirely (simulates closing the app)
+        debugPrint('\n--- Phase 1: Bob goes offline (full dispose)');
+        await bob.dispose();
+        debugPrint('Bob disposed');
 
-        // Phase 1: Alice sends n messages while Bob processes concurrently.
-        // Bob's background sync receives events during sending, and periodic
-        // forceRescan calls process them into the DB.
-        debugPrint('\n--- Phase 1: Alice sends $n messages');
+        final bobCountWhileOffline = await bobDb.getJournalCount();
+        debugPrint('Bob DB count while offline: $bobCountWhileOffline');
+        expect(
+          bobCountWhileOffline,
+          bobCountBefore,
+          reason: 'Bob count should not change while offline',
+        );
+
+        // Phase 2: Alice sends n messages while Bob is offline
+        debugPrint('\n--- Phase 2: Alice sends $n messages (Bob offline)');
         final sendStopwatch = Stopwatch()..start();
         for (var i = 0; i < n; i++) {
           await _sendTestMessage(
@@ -474,11 +488,10 @@ void main() {
             device: alice,
             deviceName: 'aliceConvergence',
             roomId: roomId,
+            journalDb: aliceDb,
           );
           if ((i + 1) % 100 == 0) {
             debugPrint('  Sent ${i + 1}/$n messages');
-            // Periodically nudge Bob to process accumulated sync events
-            await bob.forceRescan();
           }
         }
         sendStopwatch.stop();
@@ -487,43 +500,84 @@ void main() {
           'in ${sendStopwatch.elapsed.inSeconds}s',
         );
 
-        // Final sync+rescan so Bob picks up the last batch before Alice
-        // goes offline. Without this, the tail messages (after the last
-        // periodic forceRescan) may not have been fetched yet.
-        await bob.client.sync();
-        await bob.forceRescan();
-        await bob.retryNow();
-        final countAfterFinalSync = await bobDb.getJournalCount();
+        // Verify Bob hasn't received anything while offline
+        final bobCountAfterSend = await bobDb.getJournalCount();
         debugPrint(
-          'Bob count after final pre-offline sync: $countAfterFinalSync '
-          '(+${countAfterFinalSync - bobCountBefore}/$n new)',
+          'Bob DB count after Alice sent (still offline): '
+          '$bobCountAfterSend',
+        );
+        expect(
+          bobCountAfterSend,
+          bobCountBefore,
+          reason: 'Bob should not have received messages while offline',
         );
 
-        // Take Alice offline so Bob catches up purely from the server
+        // Phase 3: Alice goes offline after sending
+        debugPrint('\n--- Phase 3: Alice goes offline');
         alice.client.backgroundSync = false;
         await alice.client.abortSync();
         debugPrint('Alice is now offline (sync stopped)');
 
-        // Phase 2: Bob catches up remaining messages
-        debugPrint('\n--- Phase 2: Bob catching up $n messages');
+        // Phase 4: Bob cold-starts (fresh client + pipeline, same DB)
+        debugPrint(
+          '\n--- Phase 4: Bob cold-starts, catching up $n messages',
+        );
         final expectedTotal = bobCountBefore + n;
         final catchupStopwatch = Stopwatch()..start();
 
-        debugPrint('Triggering Bob SDK sync + forceRescan...');
-        await bob.client.sync();
-        await bob.forceRescan();
-        debugPrint(
-          'Bob initial sync+rescan done, '
-          'syncPending=${bob.client.syncPending}, '
-          'prevBatch=${bob.client.prevBatch}',
+        // Create a brand-new client that picks up the stored sync token
+        // from the same DB path (simulates app relaunch).
+        // Use singleInstance: false to avoid sqflite connection-cache
+        // contention with the disposed first client's cached handle.
+        final bobClient2 = await createMatrixClient(
+          documentsDirectory: sharedDocumentsDirectory,
+          dbName: 'BobV2',
+          singleInstance: false,
         );
+        final bobRegistry2 = SentEventRegistry();
+        final bobGateway2 = MatrixSdkGateway(
+          client: bobClient2,
+          sentEventRegistry: bobRegistry2,
+        );
+        bob = _createMatrixService(
+          config: config2,
+          gateway: bobGateway2,
+          loggingService: sharedLoggingService,
+          journalDb: bobDb,
+          settingsDb: bobSettingsDb,
+          secureStorage: secureStorageMock,
+          deviceName: 'BobV2',
+          activityService: sharedUserActivityService,
+          documentsDirectory: sharedDocumentsDirectory,
+          updateNotifications: mockUpdateNotifications,
+          aiConfigRepository: sharedAiConfigRepository,
+          sentEventRegistry: bobRegistry2,
+        );
+
+        await bob.init();
+        expect(bob.debugPipeline, isNotNull);
+        await Future<void>.delayed(const Duration(seconds: 1));
+
+        await bob.login();
+        debugPrint('Bob cold-started - deviceId: ${bob.client.deviceID}');
+
+        // Do NOT set skipSyncWait — the production code path waits for the
+        // SDK to complete a sync before running catch-up, which is essential
+        // for populating the timeline with gap events.
+
+        // Join the existing room (the new client needs to re-join)
+        await bob.joinRoom(roomId);
+        // Save room so pipeline attaches to it (triggers start + forceRescan)
+        await bob.saveRoom(roomId);
+        debugPrint('Bob re-joined room $roomId');
+
+        // Allow startup catch-up to run (sync wait is up to 30s, plus
+        // catch-up pagination time for the backlog)
+        await Future<void>.delayed(const Duration(seconds: 5));
+
         debugPrint(
-          'Bob metrics after initial rescan: '
+          'Bob metrics after startup: '
           '${bob.debugPipeline?.metricsSnapshot()}',
-        );
-        debugPrint(
-          'Bob diagnostics: '
-          '${bob.debugPipeline?.diagnosticsStrings()}',
         );
 
         var lastBobCount = -1;
@@ -539,19 +593,18 @@ void main() {
               );
               lastBobCount = currentCount;
             }
+            // No manual forceRescan/retryNow — the pipeline must
+            // self-drive catch-up through its signal-driven architecture.
             if (currentCount < expectedTotal) {
-              await bob.client.sync();
-              await bob.forceRescan();
-              await bob.retryNow();
               // Log metrics every ~30s to diagnose stalls
               final elapsed = catchupStopwatch.elapsed.inSeconds;
               if (elapsed > 0 && elapsed % 30 == 0) {
                 debugPrint(
-                  'Bob polling metrics @ ${elapsed}s: '
+                  'Bob metrics @ ${elapsed}s: '
                   '${bob.debugPipeline?.metricsSnapshot()}',
                 );
               }
-              await Future<void>.delayed(const Duration(milliseconds: 200));
+              await Future<void>.delayed(const Duration(seconds: 1));
             }
             return currentCount >= expectedTotal;
           },
@@ -559,8 +612,8 @@ void main() {
         );
         catchupStopwatch.stop();
 
-        // Phase 3: Assertions
-        debugPrint('\n--- Phase 3: Assertions');
+        // Phase 5: Assertions
+        debugPrint('\n--- Phase 5: Assertions');
         final bobEntriesCount = await bobDb.getJournalCount();
         final newEntries = bobEntriesCount - bobCountBefore;
         final metricsMap = bob.debugPipeline?.metricsSnapshot();
@@ -575,6 +628,9 @@ void main() {
         );
         debugPrint('Bob final metrics: $metricsMap');
 
+        // With sender-side DB persistence, the pre-context overlap window
+        // events from test 1 are deduplicated by vector clock comparison,
+        // so Bob should receive exactly n new entries.
         expect(newEntries, n);
 
         if (metrics != null) {
@@ -610,6 +666,7 @@ Future<void> _sendTestMessage(
   required MatrixService device,
   required String deviceName,
   required String roomId,
+  JournalDb? journalDb,
 }) async {
   final id = const Uuid().v1();
   final now = DateTime.now();
@@ -632,6 +689,12 @@ Future<void> _sendTestMessage(
   final jsonPath = relativeEntityPath(entity);
 
   await saveJournalEntityJson(entity);
+
+  // In production, entries exist in the sender's local DB before being synced
+  // out. Persist here so cold-restart catch-up deduplicates correctly.
+  if (journalDb != null) {
+    await journalDb.updateJournalEntity(entity);
+  }
 
   await device.sendMatrixMsg(
     SyncMessage.journalEntity(

--- a/lib/features/sync/matrix/client.dart
+++ b/lib/features/sync/matrix/client.dart
@@ -10,6 +10,7 @@ Future<Client> createMatrixClient({
   required Directory documentsDirectory,
   String? deviceDisplayName,
   String? dbName,
+  bool? singleInstance,
 }) async {
   final name = dbName ?? 'lotti_sync';
   final path = '${documentsDirectory.path}/matrix/$name.db';
@@ -28,7 +29,7 @@ Future<Client> createMatrixClient({
     database: await dbFactory.openDatabase(
       path,
       options: OpenDatabaseOptions(
-        singleInstance: !isActorClient,
+        singleInstance: singleInstance ?? !isActorClient,
         onConfigure: (db) async {
           await db.execute('PRAGMA journal_mode = WAL');
           await db.execute('PRAGMA busy_timeout = 5000');

--- a/lib/features/sync/matrix/pipeline/catch_up_strategy.dart
+++ b/lib/features/sync/matrix/pipeline/catch_up_strategy.dart
@@ -195,7 +195,10 @@ class CatchUpStrategy {
       // reported end-of-timeline prematurely, or there was no server gap),
       // expand the local timeline with larger limits. The SDK may have cached
       // more events locally than the initial limit returned.
-      while (!boundarySatisfied && needsMore(ordered)) {
+      // Skip when pagingSatisfied: server backfill already loaded events into
+      // the snapshot; creating new timelines would overwrite them with fewer
+      // local-only events.
+      while (!boundarySatisfied && !pagingSatisfied && needsMore(ordered)) {
         final doubled = limit * 2;
         limit = doubled > maxLookback ? maxLookback : doubled;
         final next = await room.getTimeline(limit: limit);

--- a/lib/features/sync/matrix/sdk_pagination_compat.dart
+++ b/lib/features/sync/matrix/sdk_pagination_compat.dart
@@ -57,20 +57,50 @@ class SdkPaginationCompat {
       var markerReached = false;
       final requireServerBoundaryPage =
           untilTimestamp != null && _enableServerHistoryPaging(timeline);
+      logging.captureEvent(
+        'backfill.start events=${timeline.events.length} '
+        'requireServerBoundaryPage=$requireServerBoundaryPage '
+        'lastEventId=$lastEventId '
+        'untilTimestamp=$untilTimestamp',
+        domain: syncLoggingDomain,
+        subDomain: 'sdkPagination.backfill',
+      );
       while (maxPages == null || pages < maxPages) {
         final events = TimelineEventOrdering.sortStableByTimestamp(
           timeline.events,
         );
-        if (untilTimestamp != null &&
+        final tsBoundaryMet =
+            untilTimestamp != null &&
             events.isNotEmpty &&
-            TimelineEventOrdering.timestamp(events.first) <= untilTimestamp &&
-            (!requireServerBoundaryPage || boundaryReached)) {
+            TimelineEventOrdering.timestamp(events.first) <= untilTimestamp;
+        if (tsBoundaryMet && (!requireServerBoundaryPage || boundaryReached)) {
+          logging.captureEvent(
+            'backfill.tsBoundary events=${events.length} pages=$pages',
+            domain: syncLoggingDomain,
+            subDomain: 'sdkPagination.backfill',
+          );
           return true;
         }
         markerReached = events.any((e) => e.eventId == lastEventId);
-        if (markerReached) return true;
+        if (markerReached && !requireServerBoundaryPage) {
+          logging.captureEvent(
+            'backfill.markerReached events=${events.length} pages=$pages',
+            domain: syncLoggingDomain,
+            subDomain: 'sdkPagination.backfill',
+          );
+          return true;
+        }
 
-        if (!timeline.canRequestHistory) break;
+        if (!timeline.canRequestHistory) {
+          logging.captureEvent(
+            'backfill.cannotRequestHistory events=${events.length} '
+            'pages=$pages boundaryReached=$boundaryReached '
+            'tsBoundaryMet=$tsBoundaryMet',
+            domain: syncLoggingDomain,
+            subDomain: 'sdkPagination.backfill',
+          );
+          break;
+        }
 
         final beforeCount = timeline.events.length;
         var ok = true;

--- a/lib/features/sync/matrix/sdk_pagination_compat.dart
+++ b/lib/features/sync/matrix/sdk_pagination_compat.dart
@@ -82,7 +82,9 @@ class SdkPaginationCompat {
           return true;
         }
         markerReached = events.any((e) => e.eventId == lastEventId);
-        if (markerReached && !requireServerBoundaryPage) {
+        if (markerReached &&
+            !requireServerBoundaryPage &&
+            untilTimestamp == null) {
           logging.captureEvent(
             'backfill.markerReached events=${events.length} pages=$pages',
             domain: syncLoggingDomain,
@@ -136,6 +138,9 @@ class SdkPaginationCompat {
         if (TimelineEventOrdering.timestamp(events.first) <= untilTimestamp) {
           return true;
         }
+      }
+      if (untilTimestamp != null) {
+        return boundaryReached;
       }
       return markerReached || boundaryReached;
     } catch (e, st) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.926+3811
+version: 0.9.927+3812
 
 msix_config:
   display_name: LottiApp

--- a/test/features/sync/matrix/sdk_pagination_compat_test.dart
+++ b/test/features/sync/matrix/sdk_pagination_compat_test.dart
@@ -271,6 +271,115 @@ void main() {
       },
     );
 
+    test(
+      'returns true immediately when marker is found and no timestamp is set',
+      () async {
+        final timeline = MockTimeline();
+        final room = MockRoom();
+        final logging = MockLoggingService();
+
+        final visibleEvents = [event('target-id', 200), event('other', 300)];
+
+        stubLogging(logging);
+        when(() => room.prev_batch).thenReturn(null);
+        when(() => timeline.room).thenReturn(room);
+        when(() => timeline.events).thenReturn(visibleEvents);
+
+        final result = await SdkPaginationCompat.backfillUntilContains(
+          timeline: timeline,
+          lastEventId: 'target-id',
+          pageSize: 200,
+          maxPages: null,
+          logging: logging,
+        );
+
+        expect(result, isTrue);
+        verifyNever(
+          () => timeline.requestHistory(
+            historyCount: any(named: 'historyCount'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'returns true via fallback when marker is found after paging '
+      'without timestamp',
+      () async {
+        final timeline = MockTimeline();
+        final room = MockRoom();
+        final logging = MockLoggingService();
+
+        final initial = <Event>[event('other', 200)];
+        final withMarker = <Event>[
+          event('other', 200),
+          event('target-id', 100),
+        ];
+        var current = initial;
+        var requested = 0;
+
+        stubLogging(logging);
+        when(() => room.prev_batch).thenReturn(null);
+        when(() => timeline.room).thenReturn(room);
+        when(() => timeline.events).thenAnswer((_) => current);
+        when(
+          () => timeline.canRequestHistory,
+        ).thenAnswer((_) => requested < 1);
+        when(
+          () => timeline.requestHistory(
+            historyCount: any(named: 'historyCount'),
+          ),
+        ).thenAnswer((_) async {
+          current = withMarker;
+          requested++;
+        });
+
+        final result = await SdkPaginationCompat.backfillUntilContains(
+          timeline: timeline,
+          lastEventId: 'target-id',
+          pageSize: 200,
+          maxPages: null,
+          logging: logging,
+        );
+
+        // Marker found on second iteration but canRequestHistory is false,
+        // so it falls through the loop and returns via markerReached fallback
+        expect(result, isTrue);
+        expect(requested, 1);
+      },
+    );
+
+    test(
+      'returns false via boundaryReached fallback when timestamp boundary '
+      'is not reached and history is exhausted',
+      () async {
+        final timeline = MockTimeline();
+        final room = MockRoom();
+        final logging = MockLoggingService();
+
+        // Events don't cross the timestamp boundary (all newer than 50)
+        final visibleEvents = [event('e1', 200), event('e2', 300)];
+
+        stubLogging(logging);
+        when(() => room.prev_batch).thenReturn(null);
+        when(() => timeline.room).thenReturn(room);
+        when(() => timeline.events).thenReturn(visibleEvents);
+        when(() => timeline.canRequestHistory).thenReturn(false);
+
+        final result = await SdkPaginationCompat.backfillUntilContains(
+          timeline: timeline,
+          lastEventId: null,
+          pageSize: 200,
+          maxPages: null,
+          logging: logging,
+          untilTimestamp: 50,
+        );
+
+        // untilTimestamp is set, boundaryReached is false → returns false
+        expect(result, isFalse);
+      },
+    );
+
     test('returns false when paging makes no progress', () async {
       final timeline = MockTimeline();
       final room = MockRoom();

--- a/test/features/sync/matrix/sdk_pagination_compat_test.dart
+++ b/test/features/sync/matrix/sdk_pagination_compat_test.dart
@@ -27,6 +27,13 @@ void main() {
           stackTrace: any<StackTrace>(named: 'stackTrace'),
         ),
       ).thenAnswer((_) async {});
+      when(
+        () => logging.captureEvent(
+          any<String>(),
+          domain: any<String>(named: 'domain'),
+          subDomain: any<String>(named: 'subDomain'),
+        ),
+      ).thenAnswer((_) {});
     }
 
     test(
@@ -220,6 +227,49 @@ void main() {
         ),
       ).called(1);
     });
+
+    test(
+      'does not short-circuit on marker when untilTimestamp is set',
+      () async {
+        final timeline = MockTimeline();
+        final room = MockRoom();
+        final logging = MockLoggingService();
+
+        // Events contain the marker but don't cross the timestamp boundary
+        final events = [event('marker-id', 200), event('new', 300)];
+        var current = events;
+        final older = [event('old', 40)];
+        var requested = 0;
+
+        stubLogging(logging);
+        when(() => room.prev_batch).thenReturn(null);
+        when(() => timeline.room).thenReturn(room);
+        when(() => timeline.events).thenAnswer((_) => current);
+        when(() => timeline.canRequestHistory).thenAnswer((_) => requested < 1);
+        when(
+          () => timeline.requestHistory(
+            historyCount: any(named: 'historyCount'),
+          ),
+        ).thenAnswer((_) async {
+          current = [...current, ...older];
+          requested++;
+        });
+
+        final result = await SdkPaginationCompat.backfillUntilContains(
+          timeline: timeline,
+          lastEventId: 'marker-id',
+          pageSize: 200,
+          maxPages: null,
+          logging: logging,
+          untilTimestamp: 50,
+        );
+
+        // Should have paged to reach the timestamp boundary, not stopped at
+        // the marker
+        expect(result, isTrue);
+        expect(requested, 1);
+      },
+    );
 
     test('returns false when paging makes no progress', () async {
       final timeline = MockTimeline();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Matrix sync catch-up for cold restarts so server history paginates correctly and messages reliably arrive after restart.
  * Prevented local snapshot expansion from overwriting paginated/synced messages.

* **Tests**
  * Strengthened cold-start and pagination tests, including timestamp-boundary behavior to ensure robust post-restart delivery.

* **Chore**
  * Published release 0.9.927 with updated changelog, metadata, and version.

* **Stability**
  * Improved sync diagnostics and startup catch-up reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->