### PR TITLE
feat: improve Gemma 4 support

### DIFF
--- a/lib/features/agents/ui/wake_activity_chart.dart
+++ b/lib/features/agents/ui/wake_activity_chart.dart
@@ -228,6 +228,12 @@ class _HourBar extends StatelessWidget {
     required this.onTap,
   });
 
+  /// Wakes/hour at which the bar turns "high activity" (error color).
+  static const int _highActivityThreshold = 10;
+
+  /// Wakes/hour at which the bar turns "medium activity" (tertiary color).
+  static const int _mediumActivityThreshold = 5;
+
   final HourlyWakeActivity bucket;
   final int maxCount;
   final bool isSelected;
@@ -274,8 +280,8 @@ class _HourBar extends StatelessWidget {
 
   Color _barColor(BuildContext context, int count) {
     if (count == 0) return Colors.transparent;
-    if (count >= 10) return context.colorScheme.error;
-    if (count >= 5) return context.colorScheme.tertiary;
+    if (count >= _highActivityThreshold) return context.colorScheme.error;
+    if (count >= _mediumActivityThreshold) return context.colorScheme.tertiary;
     return context.colorScheme.primary;
   }
 }

--- a/lib/features/ai/conversation/conversation_repository.dart
+++ b/lib/features/ai/conversation/conversation_repository.dart
@@ -12,6 +12,23 @@ import 'package:uuid/uuid.dart';
 
 part 'conversation_repository.g.dart';
 
+/// Matches `<think>...</think>` and `<thinking>...</thinking>` blocks
+/// (case-insensitive, possibly spanning newlines). Used to remove
+/// chain-of-thought reasoning from assistant content before it is stored
+/// in conversation history. Persisting and resending these blocks wastes
+/// tokens and, for Gemma 4, violates Google's guidance that past
+/// reasoning must not be carried forward into subsequent turns.
+final _thinkBlockPattern = RegExp(
+  r'<think(?:ing)?\b[^>]*>[\s\S]*?</think(?:ing)?>',
+  caseSensitive: false,
+);
+
+String? _stripThinkBlocks(String? content) {
+  if (content == null) return null;
+  final stripped = content.replaceAll(_thinkBlockPattern, '').trim();
+  return stripped.isEmpty ? null : stripped;
+}
+
 /// Repository for managing AI conversations.
 ///
 /// Streaming expectations for tool calls (for providers and tests):
@@ -279,19 +296,27 @@ class ConversationRepository extends _$ConversationRepository {
           accumulated = accumulated.merge(turnUsage);
         }
 
-        // Add assistant message
-        final content = contentBuffer.toString();
+        // Add assistant message.
+        //
+        // Strip `<think>...</think>` blocks before persisting. The streaming
+        // UI has already received the thinking content in real time; what
+        // gets stored here is later resent on subsequent turns via
+        // `getMessagesForRequest()`, and we must not echo past reasoning
+        // back to the model.
+        final rawContent = contentBuffer.toString();
+        final persistedContent = _stripThinkBlocks(rawContent);
 
         developer.log(
           'Stream completed: collected ${toolCalls.length} tool calls, '
-          '${content.length} chars of content, '
+          '${rawContent.length} chars of content '
+          '(${persistedContent?.length ?? 0} chars after stripping think blocks), '
           '${signatureCollector.signatures.length} signatures captured',
           name: 'ConversationRepository',
         );
 
         // Pass captured signatures to manager for use in subsequent turns
         manager.addAssistantMessage(
-          content: content.isNotEmpty ? content : null,
+          content: persistedContent,
           toolCalls: toolCalls.isNotEmpty ? toolCalls : null,
           signatures: signatureCollector.hasSignatures
               ? signatureCollector.signatures

--- a/lib/features/ai/repository/ollama_inference_repository.dart
+++ b/lib/features/ai/repository/ollama_inference_repository.dart
@@ -34,6 +34,33 @@ class OllamaInferenceRepository implements InferenceRepositoryInterface {
   // default to avoid console noise in production.
   static const bool kVerboseStreamLogging = false;
 
+  /// Model prefix for Gemma 4 family (supports thinking mode).
+  static const String _gemma4Prefix = 'gemma4';
+
+  /// Returns true if the model supports Ollama's thinking mode.
+  ///
+  /// When enabled, Ollama returns chain-of-thought reasoning in a separate
+  /// `thinking` field. We wrap this in `<think>` tags so the downstream
+  /// response parser can extract it (same format as Gemini/OpenAI thinking).
+  static bool shouldEnableThinking(String model) {
+    return model.startsWith(_gemma4Prefix);
+  }
+
+  /// Creates a single-choice stream chunk with the given [content].
+  static CreateChatCompletionStreamResponse _contentChunk(String content) {
+    return CreateChatCompletionStreamResponse(
+      id: '$ollamaResponseIdPrefix${DateTime.now().millisecondsSinceEpoch}',
+      choices: [
+        ChatCompletionStreamResponseChoice(
+          delta: ChatCompletionStreamResponseDelta(content: content),
+          index: 0,
+        ),
+      ],
+      object: 'chat.completion.chunk',
+      created: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+    );
+  }
+
   /// Generate text using Ollama's API
   ///
   /// This method handles the specific requirements for Ollama text generation:
@@ -334,6 +361,11 @@ class OllamaInferenceRepository implements InferenceRepositoryInterface {
     required AiConfigInferenceProvider provider,
     String? model,
   }) async* {
+    // Enable thinking mode for supported models
+    if (model != null && shouldEnableThinking(model)) {
+      requestBody['think'] = true;
+    }
+
     try {
       final request = await _retryWithExponentialBackoff(
         operation: () => _httpClient
@@ -383,6 +415,11 @@ class OllamaInferenceRepository implements InferenceRepositoryInterface {
       // continuation chunks (which may omit `index`) merge correctly.
       final idToIndex = <String, int>{};
 
+      // Tracks whether we are inside a thinking block so we can wrap
+      // Ollama's `thinking` field content in `<think>...</think>` tags,
+      // matching the format used by Gemini and OpenAI reasoning models.
+      var inThinking = false;
+
       // Process streaming response
       await for (final chunk
           in request.stream
@@ -404,9 +441,22 @@ class OllamaInferenceRepository implements InferenceRepositoryInterface {
 
           // Check if this is a tool call response
           if (message != null) {
-            // Skip thinking content - we only care about actual content or tool calls
+            // Capture thinking content wrapped in <think> tags for
+            // consistent downstream parsing across all providers.
             if (message['thinking'] != null) {
+              final thinking = message['thinking'] as String;
+              if (thinking.isNotEmpty) {
+                final prefix = inThinking ? '' : '<think>';
+                inThinking = true;
+                yield _contentChunk('$prefix$thinking');
+              }
               continue;
+            }
+
+            // Close the thinking block when transitioning to content
+            if (inThinking) {
+              inThinking = false;
+              yield _contentChunk('</think>');
             }
 
             if (message['tool_calls'] != null) {
@@ -513,6 +563,11 @@ class OllamaInferenceRepository implements InferenceRepositoryInterface {
           }
 
           // Check if done — extract usage from the final chunk.
+          // Safety: close any unclosed thinking block before finishing.
+          if (json['done'] == true && inThinking) {
+            inThinking = false;
+            yield _contentChunk('</think>');
+          }
           if (json['done'] == true) {
             developer.log(
               'Ollama done response: $chunk',

--- a/lib/features/ai/repository/ollama_inference_repository.dart
+++ b/lib/features/ai/repository/ollama_inference_repository.dart
@@ -47,9 +47,13 @@ class OllamaInferenceRepository implements InferenceRepositoryInterface {
   }
 
   /// Creates a single-choice stream chunk with the given [content].
+  ///
+  /// Uses [DateTime.now().microsecondsSinceEpoch] for the id so chunks
+  /// emitted within the same millisecond still receive distinct ids.
   static CreateChatCompletionStreamResponse _contentChunk(String content) {
+    final now = DateTime.now();
     return CreateChatCompletionStreamResponse(
-      id: '$ollamaResponseIdPrefix${DateTime.now().millisecondsSinceEpoch}',
+      id: '$ollamaResponseIdPrefix${now.microsecondsSinceEpoch}',
       choices: [
         ChatCompletionStreamResponseChoice(
           delta: ChatCompletionStreamResponseDelta(content: content),
@@ -57,7 +61,7 @@ class OllamaInferenceRepository implements InferenceRepositoryInterface {
         ),
       ],
       object: 'chat.completion.chunk',
-      created: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      created: now.millisecondsSinceEpoch ~/ 1000,
     );
   }
 
@@ -443,18 +447,31 @@ class OllamaInferenceRepository implements InferenceRepositoryInterface {
           if (message != null) {
             // Capture thinking content wrapped in <think> tags for
             // consistent downstream parsing across all providers.
+            // Use a defensive toString() so unexpected non-string payloads
+            // (e.g. null inside a nested object) do not crash the stream.
+            //
+            // We do NOT `continue` after emitting thinking: a single chunk
+            // can carry `thinking` together with `content`, `tool_calls`,
+            // or `done: true`. Falling through lets the same chunk close
+            // the thinking block, yield content/tool_calls, and trigger
+            // usage extraction below.
             if (message['thinking'] != null) {
-              final thinking = message['thinking'] as String;
+              final thinking = message['thinking']?.toString() ?? '';
               if (thinking.isNotEmpty) {
                 final prefix = inThinking ? '' : '<think>';
                 inThinking = true;
                 yield _contentChunk('$prefix$thinking');
               }
-              continue;
             }
 
-            // Close the thinking block when transitioning to content
-            if (inThinking) {
+            // Close the thinking block only when we are about to yield
+            // real content or tool calls. Intermediate metadata-only
+            // chunks (no thinking, content, or tool_calls) must not flip
+            // `inThinking` off, otherwise a subsequent thinking chunk
+            // would reopen the block and produce malformed nesting.
+            final hasOutput =
+                message['tool_calls'] != null || message['content'] != null;
+            if (inThinking && hasOutput) {
               inThinking = false;
               yield _contentChunk('</think>');
             }
@@ -530,8 +547,9 @@ class OllamaInferenceRepository implements InferenceRepositoryInterface {
 
               // Create the response with tool calls
               // We'll emit this as a single chunk containing all tool calls
+              final toolNow = DateTime.now();
               yield CreateChatCompletionStreamResponse(
-                id: '$ollamaResponseIdPrefix${DateTime.now().millisecondsSinceEpoch}',
+                id: '$ollamaResponseIdPrefix${toolNow.microsecondsSinceEpoch}',
                 choices: [
                   ChatCompletionStreamResponseChoice(
                     delta: ChatCompletionStreamResponseDelta.fromJson({
@@ -541,13 +559,14 @@ class OllamaInferenceRepository implements InferenceRepositoryInterface {
                   ),
                 ],
                 object: 'chat.completion.chunk',
-                created: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+                created: toolNow.millisecondsSinceEpoch ~/ 1000,
               );
             } else if (message['content'] != null) {
               // Regular content response
               final frag = message['content'] as String;
+              final contentNow = DateTime.now();
               yield CreateChatCompletionStreamResponse(
-                id: '$ollamaResponseIdPrefix${DateTime.now().millisecondsSinceEpoch}',
+                id: '$ollamaResponseIdPrefix${contentNow.microsecondsSinceEpoch}',
                 choices: [
                   ChatCompletionStreamResponseChoice(
                     delta: ChatCompletionStreamResponseDelta(
@@ -557,7 +576,7 @@ class OllamaInferenceRepository implements InferenceRepositoryInterface {
                   ),
                 ],
                 object: 'chat.completion.chunk',
-                created: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+                created: contentNow.millisecondsSinceEpoch ~/ 1000,
               );
             }
           }
@@ -580,11 +599,12 @@ class OllamaInferenceRepository implements InferenceRepositoryInterface {
             if (promptEval is int || evalCount is int) {
               final prompt = promptEval is int ? promptEval : 0;
               final completion = evalCount is int ? evalCount : 0;
+              final usageNow = DateTime.now();
               yield CreateChatCompletionStreamResponse(
-                id: '$ollamaResponseIdPrefix${DateTime.now().millisecondsSinceEpoch}',
+                id: '$ollamaResponseIdPrefix${usageNow.microsecondsSinceEpoch}',
                 choices: const [],
                 object: 'chat.completion.chunk',
-                created: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+                created: usageNow.millisecondsSinceEpoch ~/ 1000,
                 usage: CompletionUsage(
                   promptTokens: prompt,
                   completionTokens: completion,

--- a/lib/features/ai/util/known_models.dart
+++ b/lib/features/ai/util/known_models.dart
@@ -277,6 +277,44 @@ const List<KnownModel> ollamaModels = [
         'Text-only — pair with Qwen 3.5 27B for image recognition.',
   ),
 
+  // Gemma 4 — multimodal with reasoning and tool calling
+  KnownModel(
+    providerModelId: 'gemma4:e4b',
+    name: 'Gemma 4 E4B',
+    inputModalities: [Modality.text, Modality.image],
+    outputModalities: [Modality.text],
+    isReasoningModel: true,
+    supportsFunctionCalling: true,
+    description:
+        'Efficient edge model with 4.5B effective parameters. '
+        '9.6GB download, ~12GB RAM. 128K context. '
+        'Vision, reasoning, and tool calling.',
+  ),
+  KnownModel(
+    providerModelId: 'gemma4:26b',
+    name: 'Gemma 4 26B MoE',
+    inputModalities: [Modality.text, Modality.image],
+    outputModalities: [Modality.text],
+    isReasoningModel: true,
+    supportsFunctionCalling: true,
+    description:
+        'Sparse MoE model with only 3.8B active parameters out of 25.2B total. '
+        '18GB download, ~22GB RAM. 256K context. '
+        'Near-frontier quality at efficient inference speed.',
+  ),
+  KnownModel(
+    providerModelId: 'gemma4:31b',
+    name: 'Gemma 4 31B',
+    inputModalities: [Modality.text, Modality.image],
+    outputModalities: [Modality.text],
+    isReasoningModel: true,
+    supportsFunctionCalling: true,
+    description:
+        'Dense 30.7B model with best benchmark scores. '
+        '20GB download, ~24GB RAM. 256K context. '
+        'Vision, reasoning, and tool calling.',
+  ),
+
   // Embeddings
   KnownModel(
     providerModelId: 'mxbai-embed-large',

--- a/lib/features/ai/util/profile_seeding_service.dart
+++ b/lib/features/ai/util/profile_seeding_service.dart
@@ -15,6 +15,8 @@ const profileAlibabaId = 'profile-alibaba-001';
 const profileAnthropicId = 'profile-anthropic-001';
 const profileLocalId = 'profile-local-001';
 const profileLocalPowerId = 'profile-local-power-001';
+const profileLocalGemmaId = 'profile-local-gemma-001';
+const profileLocalGemmaPowerId = 'profile-local-gemma-power-001';
 
 const _logTag = 'ProfileSeedingService';
 
@@ -223,6 +225,29 @@ class ProfileSeedingService {
       name: 'Local Power (Ollama)',
       thinkingModelId: 'qwen3.6:35b-a3b-coding-nvfp4',
       imageRecognitionModelId: 'qwen3.5:27b',
+      desktopOnly: true,
+      createdAt: DateTime(2026),
+    ),
+    AiConfigInferenceProfile(
+      id: profileLocalGemmaId,
+      name: 'Local Gemma 4 (Ollama)',
+      thinkingModelId: 'gemma4:26b',
+      imageRecognitionModelId: 'gemma4:26b',
+      skillAssignments: [
+        const SkillAssignment(
+          skillId: skillImageAnalysisContextId,
+          automate: true,
+        ),
+      ],
+      isDefault: true,
+      desktopOnly: true,
+      createdAt: DateTime(2026),
+    ),
+    AiConfigInferenceProfile(
+      id: profileLocalGemmaPowerId,
+      name: 'Local Gemma 4 Power (Ollama)',
+      thinkingModelId: 'gemma4:31b',
+      imageRecognitionModelId: 'gemma4:31b',
       desktopOnly: true,
       createdAt: DateTime(2026),
     ),

--- a/test/features/ai/conversation/conversation_repository_test.dart
+++ b/test/features/ai/conversation/conversation_repository_test.dart
@@ -202,6 +202,122 @@ void main() {
         expect(manager.messages[1].content, 'Hello, human!');
       });
 
+      test(
+        'strips <think> blocks from assistant content before persisting',
+        () async {
+          final streamController =
+              StreamController<CreateChatCompletionStreamResponse>();
+
+          when(
+            () => mockOllamaRepo.generateTextWithMessages(
+              messages: any(named: 'messages'),
+              model: any(named: 'model'),
+              provider: any(named: 'provider'),
+              tools: any(named: 'tools'),
+              temperature: any(named: 'temperature'),
+              thoughtSignatures: any(named: 'thoughtSignatures'),
+              signatureCollector: any(named: 'signatureCollector'),
+              turnIndex: any(named: 'turnIndex'),
+            ),
+          ).thenAnswer((_) => streamController.stream);
+
+          final sendFuture = repository.sendMessage(
+            conversationId: conversationId,
+            message: 'Why is the sky blue?',
+            model: 'gemma4:e4b',
+            provider: provider,
+            inferenceRepo: mockOllamaRepo,
+          );
+
+          // Stream chunks the way Ollama emits thinking + content:
+          // `<think>...</think>` interleaved with the visible answer.
+          for (final chunk in const [
+            '<think>',
+            'private reasoning the user must never see again',
+            '</think>',
+            'The sky is blue because of Rayleigh scattering.',
+          ]) {
+            streamController.add(
+              CreateChatCompletionStreamResponse(
+                id: 'chunk',
+                choices: [
+                  ChatCompletionStreamResponseChoice(
+                    index: 0,
+                    delta: ChatCompletionStreamResponseDelta(content: chunk),
+                  ),
+                ],
+                object: 'chat.completion.chunk',
+                created: 1710500000,
+              ),
+            );
+          }
+          await streamController.close();
+          await sendFuture;
+
+          final manager = repository.getConversation(conversationId)!;
+          final assistantContent = manager.messages.last.content;
+          expect(assistantContent, isNotNull);
+          expect(assistantContent, isNot(contains('<think>')));
+          expect(assistantContent, isNot(contains('</think>')));
+          expect(assistantContent, isNot(contains('private reasoning')));
+          expect(
+            assistantContent,
+            equals('The sky is blue because of Rayleigh scattering.'),
+          );
+        },
+      );
+
+      test('drops assistant content that is only a <think> block', () async {
+        final streamController =
+            StreamController<CreateChatCompletionStreamResponse>();
+
+        when(
+          () => mockOllamaRepo.generateTextWithMessages(
+            messages: any(named: 'messages'),
+            model: any(named: 'model'),
+            provider: any(named: 'provider'),
+            tools: any(named: 'tools'),
+            temperature: any(named: 'temperature'),
+            thoughtSignatures: any(named: 'thoughtSignatures'),
+            signatureCollector: any(named: 'signatureCollector'),
+            turnIndex: any(named: 'turnIndex'),
+          ),
+        ).thenAnswer((_) => streamController.stream);
+
+        final sendFuture = repository.sendMessage(
+          conversationId: conversationId,
+          message: 'Think only',
+          model: 'gemma4:e4b',
+          provider: provider,
+          inferenceRepo: mockOllamaRepo,
+        );
+
+        streamController.add(
+          const CreateChatCompletionStreamResponse(
+            id: 'chunk',
+            choices: [
+              ChatCompletionStreamResponseChoice(
+                index: 0,
+                delta: ChatCompletionStreamResponseDelta(
+                  content: '<think>private reasoning</think>',
+                ),
+              ),
+            ],
+            object: 'chat.completion.chunk',
+            created: 1710500000,
+          ),
+        );
+        await streamController.close();
+        await sendFuture;
+
+        final manager = repository.getConversation(conversationId)!;
+        // The assistant turn is still recorded so turn accounting stays
+        // accurate, but its persisted content is null instead of a stale
+        // `<think>` payload.
+        expect(manager.messages.last.role, ChatCompletionMessageRole.assistant);
+        expect(manager.messages.last.content, isNull);
+      });
+
       test('handles tool calls', () async {
         final streamController =
             StreamController<CreateChatCompletionStreamResponse>();

--- a/test/features/ai/repository/ollama_inference_repository_test.dart
+++ b/test/features/ai/repository/ollama_inference_repository_test.dart
@@ -673,7 +673,7 @@ void main() {
       expect(firstMessage['content'], 'Direct string content');
     });
 
-    test('should skip thinking content in chat completion', () async {
+    test('should capture thinking content wrapped in think tags', () async {
       final messages = [
         const ChatCompletionMessage.user(
           content: ChatCompletionUserMessageContent.string('Test'),
@@ -715,24 +715,13 @@ void main() {
       );
 
       final events = await stream.toList();
+      final allContent = events
+          .map((e) => e.choices?.first.delta?.content ?? '')
+          .join();
 
-      // Should have received content but not thinking
-      expect(
-        events.any(
-          (CreateChatCompletionStreamResponse e) =>
-              e.choices?.first.delta?.content?.contains('Actual response') ??
-              false,
-        ),
-        true,
-      );
-      expect(
-        events.any(
-          (CreateChatCompletionStreamResponse e) =>
-              e.choices?.first.delta?.content?.contains('Internal thoughts') ??
-              false,
-        ),
-        false,
-      );
+      // Thinking content is wrapped in <think> tags
+      expect(allContent, contains('<think>Internal thoughts...</think>'));
+      expect(allContent, contains('Actual response'));
     });
 
     test('should handle tool messages correctly', () async {
@@ -2137,7 +2126,7 @@ void main() {
       expect(responses, hasLength(1));
     });
 
-    test('should handle response with thinking content', () async {
+    test('should capture thinking content from response', () async {
       final messages = [
         const ChatCompletionMessage.user(
           content: ChatCompletionUserMessageContent.string('Hello'),
@@ -2149,7 +2138,6 @@ void main() {
       when(() => mockResponse.stream).thenAnswer(
         (_) => http.ByteStream(
           Stream.fromIterable([
-            // Thinking content should be skipped
             utf8.encode(
               '{"message":{"thinking":"processing..."},"done":false}\n',
             ),
@@ -2181,8 +2169,14 @@ void main() {
       );
 
       final responses = await stream.toList();
-      // Should have 1 response (thinking skipped, final response included)
-      expect(responses, hasLength(1));
+      // Should have 3 responses: thinking (with <think> prefix),
+      // </think> closing tag, and final content
+      expect(responses, hasLength(3));
+      final allContent = responses
+          .map((e) => e.choices?.first.delta?.content ?? '')
+          .join();
+      expect(allContent, contains('<think>processing...</think>'));
+      expect(allContent, contains('final response'));
     });
   });
 
@@ -2230,6 +2224,199 @@ void main() {
             .toList(),
         throwsA(isA<Exception>()),
       );
+    });
+  });
+
+  group('shouldEnableThinking', () {
+    test('returns true for Gemma 4 models', () {
+      expect(
+        OllamaInferenceRepository.shouldEnableThinking('gemma4:e4b'),
+        isTrue,
+      );
+      expect(
+        OllamaInferenceRepository.shouldEnableThinking('gemma4:26b'),
+        isTrue,
+      );
+      expect(
+        OllamaInferenceRepository.shouldEnableThinking('gemma4:31b'),
+        isTrue,
+      );
+      expect(
+        OllamaInferenceRepository.shouldEnableThinking(
+          'gemma4:26b-a4b-it-q4_K_M',
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns false for non-Gemma 4 models', () {
+      expect(
+        OllamaInferenceRepository.shouldEnableThinking('qwen3.5:9b'),
+        isFalse,
+      );
+      expect(
+        OllamaInferenceRepository.shouldEnableThinking('qwen3.5:27b'),
+        isFalse,
+      );
+      expect(
+        OllamaInferenceRepository.shouldEnableThinking('gemma3:12b'),
+        isFalse,
+      );
+      expect(
+        OllamaInferenceRepository.shouldEnableThinking('llama3:8b'),
+        isFalse,
+      );
+      expect(
+        OllamaInferenceRepository.shouldEnableThinking('mxbai-embed-large'),
+        isFalse,
+      );
+    });
+  });
+
+  group('Thinking mode request body', () {
+    late OllamaInferenceRepository thinkingRepo;
+    late MockHttpClient thinkingMockClient;
+
+    setUp(() {
+      thinkingMockClient = MockHttpClient();
+      thinkingRepo = OllamaInferenceRepository(httpClient: thinkingMockClient);
+    });
+
+    test('adds think:true for gemma4 models', () async {
+      final mockResponse = MockStreamedResponse();
+      when(() => mockResponse.statusCode).thenReturn(200);
+      when(() => mockResponse.stream).thenAnswer(
+        (_) => http.ByteStream(
+          Stream.fromIterable([
+            utf8.encode('{"message":{"content":"hi"},"done":true}\n'),
+          ]),
+        ),
+      );
+
+      http.BaseRequest? capturedRequest;
+      when(
+        () => thinkingMockClient.send(any()),
+      ).thenAnswer((invocation) async {
+        capturedRequest = invocation.positionalArguments[0] as http.BaseRequest;
+        return mockResponse;
+      });
+
+      final provider = AiConfigInferenceProvider(
+        id: 'test-provider',
+        name: 'Test',
+        baseUrl: 'http://localhost:11434',
+        apiKey: '',
+        createdAt: DateTime(2026, 3, 15),
+        inferenceProviderType: InferenceProviderType.ollama,
+      );
+
+      await thinkingRepo
+          .generateText(
+            prompt: 'Hello',
+            model: 'gemma4:26b',
+            temperature: 0.7,
+            systemMessage: null,
+            provider: provider,
+          )
+          .toList();
+
+      expect(capturedRequest, isNotNull);
+      final body =
+          jsonDecode((capturedRequest! as http.Request).body)
+              as Map<String, dynamic>;
+      expect(body['think'], isTrue);
+    });
+
+    test('does not add think for non-gemma4 models', () async {
+      final mockResponse = MockStreamedResponse();
+      when(() => mockResponse.statusCode).thenReturn(200);
+      when(() => mockResponse.stream).thenAnswer(
+        (_) => http.ByteStream(
+          Stream.fromIterable([
+            utf8.encode('{"message":{"content":"hi"},"done":true}\n'),
+          ]),
+        ),
+      );
+
+      http.BaseRequest? capturedRequest;
+      when(
+        () => thinkingMockClient.send(any()),
+      ).thenAnswer((invocation) async {
+        capturedRequest = invocation.positionalArguments[0] as http.BaseRequest;
+        return mockResponse;
+      });
+
+      final provider = AiConfigInferenceProvider(
+        id: 'test-provider',
+        name: 'Test',
+        baseUrl: 'http://localhost:11434',
+        apiKey: '',
+        createdAt: DateTime(2026, 3, 15),
+        inferenceProviderType: InferenceProviderType.ollama,
+      );
+
+      await thinkingRepo
+          .generateText(
+            prompt: 'Hello',
+            model: 'qwen3.5:9b',
+            temperature: 0.7,
+            systemMessage: null,
+            provider: provider,
+          )
+          .toList();
+
+      expect(capturedRequest, isNotNull);
+      final body =
+          jsonDecode((capturedRequest! as http.Request).body)
+              as Map<String, dynamic>;
+      expect(body.containsKey('think'), isFalse);
+    });
+
+    test('closes thinking block on done when thinking was not followed by '
+        'content', () async {
+      final mockResponse = MockStreamedResponse();
+      when(() => mockResponse.statusCode).thenReturn(200);
+      when(() => mockResponse.stream).thenAnswer(
+        (_) => http.ByteStream(
+          Stream.fromIterable([
+            utf8.encode(
+              '{"message":{"thinking":"deep thought"},"done":false}\n',
+            ),
+            utf8.encode('{"done":true}\n'),
+          ]),
+        ),
+      );
+
+      when(
+        () => thinkingMockClient.send(any()),
+      ).thenAnswer((_) async => mockResponse);
+
+      final provider = AiConfigInferenceProvider(
+        id: 'test-provider',
+        name: 'Test',
+        baseUrl: 'http://localhost:11434',
+        apiKey: '',
+        createdAt: DateTime(2026, 3, 15),
+        inferenceProviderType: InferenceProviderType.ollama,
+      );
+
+      final events = await thinkingRepo
+          .generateTextWithMessages(
+            messages: [
+              const ChatCompletionMessage.user(
+                content: ChatCompletionUserMessageContent.string('Hi'),
+              ),
+            ],
+            model: 'gemma4:26b',
+            temperature: 0.7,
+            provider: provider,
+          )
+          .toList();
+
+      final allContent = events
+          .map((e) => e.choices?.first.delta?.content ?? '')
+          .join();
+      expect(allContent, contains('<think>deep thought</think>'));
     });
   });
 }

--- a/test/features/ai/repository/ollama_inference_repository_test.dart
+++ b/test/features/ai/repository/ollama_inference_repository_test.dart
@@ -2418,6 +2418,231 @@ void main() {
           .join();
       expect(allContent, contains('<think>deep thought</think>'));
     });
+
+    test('metadata-only chunks between thinking chunks do not close the '
+        'block prematurely', () async {
+      final mockResponse = MockStreamedResponse();
+      when(() => mockResponse.statusCode).thenReturn(200);
+      when(() => mockResponse.stream).thenAnswer(
+        (_) => http.ByteStream(
+          Stream.fromIterable([
+            utf8.encode('{"message":{"thinking":"part one "},"done":false}\n'),
+            // Metadata-only chunk: a `message` payload that contains
+            // neither `thinking`, nor `content`, nor `tool_calls`.
+            // Ollama can emit such chunks for intermediate state, and
+            // they must not flip `inThinking` off.
+            utf8.encode('{"message":{"role":"assistant"},"done":false}\n'),
+            utf8.encode('{"message":{"thinking":"part two"},"done":false}\n'),
+            utf8.encode(
+              '{"message":{"content":"final answer"},"done":true}\n',
+            ),
+          ]),
+        ),
+      );
+
+      when(
+        () => thinkingMockClient.send(any()),
+      ).thenAnswer((_) async => mockResponse);
+
+      final provider = AiConfigInferenceProvider(
+        id: 'test-provider',
+        name: 'Test',
+        baseUrl: 'http://localhost:11434',
+        apiKey: '',
+        createdAt: DateTime(2026, 3, 15),
+        inferenceProviderType: InferenceProviderType.ollama,
+      );
+
+      final events = await thinkingRepo
+          .generateTextWithMessages(
+            messages: [
+              const ChatCompletionMessage.user(
+                content: ChatCompletionUserMessageContent.string('Hi'),
+              ),
+            ],
+            model: 'gemma4:26b',
+            temperature: 0.7,
+            provider: provider,
+          )
+          .toList();
+
+      final allContent = events
+          .map((e) => e.choices?.first.delta?.content ?? '')
+          .join();
+
+      // Exactly one `<think>` opener and one `</think>` closer should
+      // appear — no premature close before "part two".
+      expect('<think>'.allMatches(allContent), hasLength(1));
+      expect('</think>'.allMatches(allContent), hasLength(1));
+      expect(allContent, contains('<think>part one part two</think>'));
+      expect(allContent, contains('final answer'));
+    });
+
+    test(
+      'extracts usage when thinking and done arrive in the same chunk',
+      () async {
+        final mockResponse = MockStreamedResponse();
+        when(() => mockResponse.statusCode).thenReturn(200);
+        when(() => mockResponse.stream).thenAnswer(
+          (_) => http.ByteStream(
+            Stream.fromIterable([
+              // Single chunk carries both `thinking` and `done: true`
+              // together with usage counters. A bare `continue` after
+              // emitting thinking would skip the usage-extraction branch
+              // entirely, dropping the token counts.
+              utf8.encode(
+                '{"message":{"thinking":"final thoughts"},'
+                ' "done":true,'
+                ' "prompt_eval_count":7,'
+                ' "eval_count":11}\n',
+              ),
+            ]),
+          ),
+        );
+
+        when(
+          () => thinkingMockClient.send(any()),
+        ).thenAnswer((_) async => mockResponse);
+
+        final provider = AiConfigInferenceProvider(
+          id: 'test-provider',
+          name: 'Test',
+          baseUrl: 'http://localhost:11434',
+          apiKey: '',
+          createdAt: DateTime(2026, 3, 15),
+          inferenceProviderType: InferenceProviderType.ollama,
+        );
+
+        final events = await thinkingRepo
+            .generateTextWithMessages(
+              messages: [
+                const ChatCompletionMessage.user(
+                  content: ChatCompletionUserMessageContent.string('Hi'),
+                ),
+              ],
+              model: 'gemma4:26b',
+              temperature: 0.7,
+              provider: provider,
+            )
+            .toList();
+
+        final allContent = events
+            .map((e) => e.choices?.firstOrNull?.delta?.content ?? '')
+            .join();
+        expect(allContent, contains('<think>final thoughts</think>'));
+
+        // The terminal chunk's usage must still be reported.
+        final usage = events.lastWhere((e) => e.usage != null).usage!;
+        expect(usage.promptTokens, 7);
+        expect(usage.completionTokens, 11);
+        expect(usage.totalTokens, 18);
+      },
+    );
+
+    test(
+      'closes thinking and yields content when both arrive in one chunk',
+      () async {
+        final mockResponse = MockStreamedResponse();
+        when(() => mockResponse.statusCode).thenReturn(200);
+        when(() => mockResponse.stream).thenAnswer(
+          (_) => http.ByteStream(
+            Stream.fromIterable([
+              // Single chunk carries `thinking` and `content` together.
+              // A bare `continue` after thinking would drop the content.
+              utf8.encode(
+                '{"message":{"thinking":"reason","content":"answer"},'
+                ' "done":false}\n',
+              ),
+              utf8.encode('{"done":true}\n'),
+            ]),
+          ),
+        );
+
+        when(
+          () => thinkingMockClient.send(any()),
+        ).thenAnswer((_) async => mockResponse);
+
+        final provider = AiConfigInferenceProvider(
+          id: 'test-provider',
+          name: 'Test',
+          baseUrl: 'http://localhost:11434',
+          apiKey: '',
+          createdAt: DateTime(2026, 3, 15),
+          inferenceProviderType: InferenceProviderType.ollama,
+        );
+
+        final events = await thinkingRepo
+            .generateTextWithMessages(
+              messages: [
+                const ChatCompletionMessage.user(
+                  content: ChatCompletionUserMessageContent.string('Hi'),
+                ),
+              ],
+              model: 'gemma4:26b',
+              temperature: 0.7,
+              provider: provider,
+            )
+            .toList();
+
+        final allContent = events
+            .map((e) => e.choices?.first.delta?.content ?? '')
+            .join();
+        expect(allContent, contains('<think>reason</think>'));
+        expect(allContent, contains('answer'));
+        // Ordering: thinking closes before the visible content is emitted.
+        expect(
+          allContent.indexOf('</think>'),
+          lessThan(allContent.indexOf('answer')),
+        );
+      },
+    );
+
+    test('handles non-string thinking payload without crashing', () async {
+      final mockResponse = MockStreamedResponse();
+      when(() => mockResponse.statusCode).thenReturn(200);
+      when(() => mockResponse.stream).thenAnswer(
+        (_) => http.ByteStream(
+          Stream.fromIterable([
+            // `thinking` is a number — older defensive casts would crash
+            // here. The repository must tolerate this and stringify it.
+            utf8.encode('{"message":{"thinking":42},"done":false}\n'),
+            utf8.encode('{"message":{"content":"done"},"done":true}\n'),
+          ]),
+        ),
+      );
+
+      when(
+        () => thinkingMockClient.send(any()),
+      ).thenAnswer((_) async => mockResponse);
+
+      final provider = AiConfigInferenceProvider(
+        id: 'test-provider',
+        name: 'Test',
+        baseUrl: 'http://localhost:11434',
+        apiKey: '',
+        createdAt: DateTime(2026, 3, 15),
+        inferenceProviderType: InferenceProviderType.ollama,
+      );
+
+      final events = await thinkingRepo
+          .generateTextWithMessages(
+            messages: [
+              const ChatCompletionMessage.user(
+                content: ChatCompletionUserMessageContent.string('Hi'),
+              ),
+            ],
+            model: 'gemma4:26b',
+            temperature: 0.7,
+            provider: provider,
+          )
+          .toList();
+
+      final allContent = events
+          .map((e) => e.choices?.first.delta?.content ?? '')
+          .join();
+      expect(allContent, contains('<think>42</think>'));
+      expect(allContent, contains('done'));
+    });
   });
 }
 

--- a/test/features/ai/util/known_models_test.dart
+++ b/test/features/ai/util/known_models_test.dart
@@ -616,6 +616,38 @@ void main() {
         },
       );
 
+      test('Gemma 4 E4B should be a multimodal reasoning model', () {
+        final model = ollamaModels.firstWhere(
+          (m) => m.providerModelId == 'gemma4:e4b',
+        );
+        expect(model.isReasoningModel, isTrue);
+        expect(model.supportsFunctionCalling, isTrue);
+        expect(model.inputModalities, contains(Modality.text));
+        expect(model.inputModalities, contains(Modality.image));
+        expect(model.outputModalities, contains(Modality.text));
+      });
+
+      test('Gemma 4 26B MoE should be a multimodal reasoning model', () {
+        final model = ollamaModels.firstWhere(
+          (m) => m.providerModelId == 'gemma4:26b',
+        );
+        expect(model.isReasoningModel, isTrue);
+        expect(model.supportsFunctionCalling, isTrue);
+        expect(model.inputModalities, contains(Modality.text));
+        expect(model.inputModalities, contains(Modality.image));
+        expect(model.name, contains('MoE'));
+      });
+
+      test('Gemma 4 31B should be a multimodal reasoning model', () {
+        final model = ollamaModels.firstWhere(
+          (m) => m.providerModelId == 'gemma4:31b',
+        );
+        expect(model.isReasoningModel, isTrue);
+        expect(model.supportsFunctionCalling, isTrue);
+        expect(model.inputModalities, contains(Modality.text));
+        expect(model.inputModalities, contains(Modality.image));
+      });
+
       test('should not contain removed models', () {
         final modelIds = ollamaModels.map((m) => m.providerModelId).toSet();
         expect(modelIds, isNot(contains('qwen3:8b')));

--- a/test/features/ai/util/profile_seeding_service_test.dart
+++ b/test/features/ai/util/profile_seeding_service_test.dart
@@ -32,10 +32,10 @@ void main() {
   });
 
   group('ProfileSeedingService', () {
-    test('seeds all 8 default profiles when none exist', () async {
+    test('seeds all 10 default profiles when none exist', () async {
       await service.seedDefaults();
 
-      verify(() => mockRepo.saveConfig(any())).called(8);
+      verify(() => mockRepo.saveConfig(any())).called(10);
     });
 
     test('skips profiles that already exist', () async {
@@ -65,8 +65,8 @@ void main() {
 
       await service.seedDefaults();
 
-      // Only 7 profiles should be saved (Gemini Flash skipped).
-      verify(() => mockRepo.saveConfig(any())).called(7);
+      // Only 9 profiles should be saved (Gemini Flash skipped).
+      verify(() => mockRepo.saveConfig(any())).called(9);
     });
 
     test(
@@ -111,9 +111,9 @@ void main() {
 
         await service.seedDefaults();
 
-        // Only the 7 missing profiles get written. The existing Local
+        // Only the 9 missing profiles get written. The existing Local
         // profile is left untouched — user edit survives.
-        verify(() => mockRepo.saveConfig(any())).called(7);
+        verify(() => mockRepo.saveConfig(any())).called(9);
         verifyNever(
           () => mockRepo.saveConfig(
             any(
@@ -147,9 +147,9 @@ void main() {
 
         await service.seedDefaults();
 
-        // 7 new profiles only — the Local profile is not re-asserted to
+        // 9 new profiles only — the Local profile is not re-asserted to
         // isDefault: true.
-        verify(() => mockRepo.saveConfig(any())).called(7);
+        verify(() => mockRepo.saveConfig(any())).called(9);
       },
     );
 
@@ -166,6 +166,8 @@ void main() {
         profileAnthropicId,
         profileLocalId,
         profileLocalPowerId,
+        profileLocalGemmaId,
+        profileLocalGemmaPowerId,
       ]) {
         verify(() => mockRepo.getConfigById(id)).called(1);
       }
@@ -190,8 +192,8 @@ void main() {
 
         await service.seedDefaults();
 
-        // 7 new profiles only — Local profile preserved as-is.
-        verify(() => mockRepo.saveConfig(any())).called(7);
+        // 9 new profiles only — Local profile preserved as-is.
+        verify(() => mockRepo.saveConfig(any())).called(9);
       },
     );
 
@@ -257,9 +259,9 @@ void main() {
 
         for (final config in capturedConfigs) {
           final profile = config as AiConfigInferenceProfile;
-          if (profile.id == profileLocalPowerId) {
-            // Local Power is opt-in until the Qwen3.6 coding MoE
-            // tool-calling path stabilises.
+          if (profile.id == profileLocalPowerId ||
+              profile.id == profileLocalGemmaPowerId) {
+            // Power profiles are opt-in (require large models).
             expect(
               profile.isDefault,
               isFalse,
@@ -290,8 +292,9 @@ void main() {
 
       for (final config in capturedConfigs) {
         final profile = config as AiConfigInferenceProfile;
-        // Local Power has no skill assignments (opt-in profile).
+        // Power profiles have no skill assignments (opt-in profiles).
         if (profile.id == profileLocalPowerId) continue;
+        if (profile.id == profileLocalGemmaPowerId) continue;
         expect(
           profile.skillAssignments,
           isNotEmpty,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ollama "thinking mode" for Gemma 4 models: streams intermediate reasoning as <think>…</think> blocks in live output
  * Three Gemma 4 local models (E4B, 26B MoE, 31B) added as selectable inference options
  * Default local Gemma 4 profiles for quick setup

* **Bug Fixes**
  * Persisted conversation content now strips hidden <think> reasoning blocks

* **Refactor**
  * Activity chart thresholds centralized for clearer tuning

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matthiasn/lotti/pull/2906?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->