### PR TITLE
feat: add Done tab to checklist filters and skip initial animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.948] - 2026-04-10
 ### Added
+- Checklist filter tabs: added a "Done" tab alongside "Open" and "All" to
+  filter checklist items by completion state. Tab order is Open, Done, All.
 - Desktop mode: responsive layout switches from mobile bottom navigation to a
   persistent left sidebar when the window is wider than 960px. The sidebar
   includes all navigation destinations with Settings pinned at the bottom,
@@ -19,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   marked in the list pane when a detail view is open.
 - Localized empty-state placeholders for the detail pane in all seven
   languages.
+### Fixed
+- Checklist cards no longer play a visible collapse/expand animation on first
+  render. Items snap into their initial state immediately, preventing jank
+  when multiple checklists load at once on slower devices.
 
 ## [0.9.947] - 2026-04-09
 ### Changed

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -35,6 +35,7 @@
       <description>
           <p>Desktop mode: responsive layout switches from mobile bottom navigation to a persistent left sidebar when the window is wider than 960px, with all navigation destinations and Settings pinned at the bottom.</p>
           <p>Desktop split-pane view for Tasks, Projects, and Dashboards: list and detail views shown side by side with reactive selection and active item highlighting in the list pane.</p>
+          <p>Checklist filter tabs now include Open, Done, and All. Initial collapse animation on checklists is disabled to prevent jank on slower devices.</p>
       </description>
     </release>
     <release version="0.9.947" date="2026-04-09">

--- a/lib/features/journal/state/journal_page_controller.g.dart
+++ b/lib/features/journal/state/journal_page_controller.g.dart
@@ -71,7 +71,7 @@ final class JournalPageControllerProvider
 }
 
 String _$journalPageControllerHash() =>
-    r'5e5cfb9305bd2db8fbd5b7c464db38c8ba5c70df';
+    r'6942b88b695e9733ad30e287988b82a41e8baf08';
 
 /// Controller for managing journal/tasks page state.
 ///

--- a/lib/features/tasks/ui/checklists/checklist_card.dart
+++ b/lib/features/tasks/ui/checklists/checklist_card.dart
@@ -94,6 +94,11 @@ class _ChecklistCardState extends State<ChecklistCard> {
   bool _isCreatingItem = false;
   final FocusNode _addFocusNode = FocusNode();
 
+  /// Whether the widget has completed its first frame. Animations use
+  /// [Duration.zero] until this is `true` so the initial layout snaps
+  /// into place without a visible collapse/expand transition.
+  bool _hasRendered = false;
+
   @override
   void initState() {
     super.initState();
@@ -103,7 +108,10 @@ class _ChecklistCardState extends State<ChecklistCard> {
         (widget.completionRate < 1 || widget.itemIds.isEmpty);
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) widget.onExpansionChanged?.call(_isExpanded);
+      if (mounted) {
+        widget.onExpansionChanged?.call(_isExpanded);
+        setState(() => _hasRendered = true);
+      }
     });
 
     _loadFilterPreference();
@@ -131,17 +139,34 @@ class _ChecklistCardState extends State<ChecklistCard> {
 
   Future<void> _loadFilterPreference() async {
     final key = 'checklist_filter_mode_${widget.id}';
-    final value = await makeSharedPrefsService().getBool(key);
-    if (!mounted || value == null) return;
-    setState(() {
-      _filter = value ? ChecklistFilter.openOnly : ChecklistFilter.all;
-    });
+    final prefs = makeSharedPrefsService();
+
+    // Try new string-based key first, fall back to legacy bool key.
+    final stringValue = await prefs.getString(key);
+    if (!mounted) return;
+
+    if (stringValue != null) {
+      final parsed = ChecklistFilter.values.where((v) => v.name == stringValue);
+      if (parsed.isNotEmpty) {
+        setState(() => _filter = parsed.first);
+        return;
+      }
+    }
+
+    // Legacy bool migration: true → openOnly, false → all.
+    final boolValue = await prefs.getBool(key);
+    if (!mounted || boolValue == null) return;
+    final migrated = boolValue ? ChecklistFilter.openOnly : ChecklistFilter.all;
+    setState(() => _filter = migrated);
+    // Persist as the new string format so future reads use the string path.
+    // TODO(cleanup): remove legacy bool migration after a few releases.
+    await prefs.setString(key: key, value: migrated.name);
   }
 
   Future<void> _saveFilterPreference(ChecklistFilter filter) {
-    return makeSharedPrefsService().setBool(
+    return makeSharedPrefsService().setString(
       key: 'checklist_filter_mode_${widget.id}',
-      value: filter == ChecklistFilter.openOnly,
+      value: filter.name,
     );
   }
 
@@ -164,6 +189,12 @@ class _ChecklistCardState extends State<ChecklistCard> {
         (total == 0 ? 0 : (widget.completionRate * total).round());
 
     final showBody = _isExpanded && !widget.isSortingMode;
+    final animationDuration = _hasRendered
+        ? checklistCardCollapseAnimationDuration
+        : Duration.zero;
+    final chevronDuration = _hasRendered
+        ? checklistChevronRotationDuration
+        : Duration.zero;
 
     return Material(
       color: Colors.transparent,
@@ -189,6 +220,8 @@ class _ChecklistCardState extends State<ChecklistCard> {
               totalCount: total,
               completionRate: widget.completionRate,
               filter: _filter,
+              chevronDuration: chevronDuration,
+              filterStripDuration: animationDuration,
               onToggleExpand: () => _setExpanded(!_isExpanded),
               onTitleTap: () => setState(() => _isEditingTitle = true),
               onTitleSave: (t) {
@@ -204,7 +237,7 @@ class _ChecklistCardState extends State<ChecklistCard> {
 
           // ── Body (animated) ───────────────────────────────────────────────
           AnimatedCrossFade(
-            duration: checklistCardCollapseAnimationDuration,
+            duration: animationDuration,
             sizeCurve: Curves.easeInOut,
             crossFadeState: showBody
                 ? CrossFadeState.showFirst
@@ -215,6 +248,7 @@ class _ChecklistCardState extends State<ChecklistCard> {
               taskId: widget.taskId,
               filter: _filter,
               completionRate: widget.completionRate,
+              activeTotalCount: total,
               focusNode: _addFocusNode,
               onCreateItem: (title) async {
                 if (_isCreatingItem) return;
@@ -271,6 +305,8 @@ class _Header extends StatelessWidget {
     required this.totalCount,
     required this.completionRate,
     required this.filter,
+    required this.chevronDuration,
+    required this.filterStripDuration,
     required this.onToggleExpand,
     required this.onTitleTap,
     required this.onTitleSave,
@@ -288,6 +324,8 @@ class _Header extends StatelessWidget {
   final int totalCount;
   final double completionRate;
   final ChecklistFilter filter;
+  final Duration chevronDuration;
+  final Duration filterStripDuration;
   final VoidCallback onToggleExpand;
   final VoidCallback onTitleTap;
   final StringCallback onTitleSave;
@@ -349,7 +387,7 @@ class _Header extends StatelessWidget {
                   // Chevron
                   AnimatedRotation(
                     turns: isExpanded ? 0.0 : -0.25,
-                    duration: checklistChevronRotationDuration,
+                    duration: chevronDuration,
                     child: GestureDetector(
                       onTap: onToggleExpand,
                       child: Icon(
@@ -379,7 +417,7 @@ class _Header extends StatelessWidget {
         // Filter strip — full-width grey background, only when expanded and
         // has items.
         AnimatedCrossFade(
-          duration: const Duration(milliseconds: 200),
+          duration: filterStripDuration,
           sizeCurve: Curves.easeInOut,
           crossFadeState: isExpanded && totalCount > 0
               ? CrossFadeState.showFirst
@@ -535,6 +573,12 @@ class _FilterStrip extends StatelessWidget {
                 isSelected: filter == ChecklistFilter.openOnly,
                 tokens: tokens,
                 onTap: () => onFilterChanged(ChecklistFilter.openOnly),
+              ),
+              _FilterTab(
+                label: context.messages.taskStatusDone,
+                isSelected: filter == ChecklistFilter.doneOnly,
+                tokens: tokens,
+                onTap: () => onFilterChanged(ChecklistFilter.doneOnly),
               ),
               _FilterTab(
                 label: context.messages.taskStatusAll,
@@ -778,6 +822,7 @@ class _Body extends StatelessWidget {
     required this.taskId,
     required this.filter,
     required this.completionRate,
+    required this.activeTotalCount,
     required this.focusNode,
     required this.onCreateItem,
     required this.onReorder,
@@ -788,6 +833,11 @@ class _Body extends StatelessWidget {
   final String taskId;
   final ChecklistFilter filter;
   final double completionRate;
+
+  /// Number of active (non-archived) items. Used to avoid showing the "none
+  /// done" empty state when all items are archived — archived items count as
+  /// done at the row level.
+  final int activeTotalCount;
   final FocusNode focusNode;
   final Future<void> Function(String?) onCreateItem;
   final void Function(int oldIndex, int newIndex) onReorder;
@@ -796,13 +846,22 @@ class _Body extends StatelessWidget {
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final hideChecked = filter == ChecklistFilter.openOnly;
+    final hideUnchecked = filter == ChecklistFilter.doneOnly;
     final allDone = hideChecked && completionRate == 1.0 && itemIds.isNotEmpty;
+    // Only show "none done" when there are active (non-archived) items that
+    // are all unchecked. When activeTotalCount is 0 all items are archived,
+    // and archived items are shown as "done" by the row filter.
+    final noneDone =
+        hideUnchecked &&
+        activeTotalCount > 0 &&
+        completionRate == 0 &&
+        itemIds.isNotEmpty;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
       children: [
-        if (allDone)
+        if (allDone || noneDone)
           Padding(
             padding: EdgeInsets.symmetric(
               horizontal: tokens.spacing.step4,
@@ -810,7 +869,9 @@ class _Body extends StatelessWidget {
             ),
             child: Center(
               child: Text(
-                context.messages.checklistAllDone,
+                allDone
+                    ? context.messages.checklistAllDone
+                    : context.messages.checklistNoneDone,
                 style: tokens.typography.styles.body.bodySmall.copyWith(
                   color: tokens.colors.text.lowEmphasis,
                 ),
@@ -843,6 +904,7 @@ class _Body extends StatelessWidget {
                 taskId: taskId,
                 index: index,
                 hideIfChecked: hideChecked,
+                hideIfUnchecked: hideUnchecked,
                 showDivider: index < itemIds.length - 1,
               );
             },

--- a/lib/features/tasks/ui/checklists/checklist_item_row.dart
+++ b/lib/features/tasks/ui/checklists/checklist_item_row.dart
@@ -42,6 +42,7 @@ class ChecklistItemRow extends ConsumerStatefulWidget {
     required this.taskId,
     required this.index,
     this.hideIfChecked = false,
+    this.hideIfUnchecked = false,
     this.showDivider = false,
     super.key,
   });
@@ -53,6 +54,9 @@ class ChecklistItemRow extends ConsumerStatefulWidget {
 
   /// When true, completed/archived items animate out after a short hold.
   final bool hideIfChecked;
+
+  /// When true, uncompleted items are hidden (for the "Done" filter tab).
+  final bool hideIfUnchecked;
 
   /// Whether to show a divider below this row.
   final bool showDivider;
@@ -71,7 +75,6 @@ class _ChecklistItemRowState extends ConsumerState<ChecklistItemRow>
   late AnimationController _suggestionController;
   late Animation<double> _suggestionPulse;
 
-  bool _lastHideIfChecked = false;
   bool _lastIsChecked = false;
   bool _lastIsArchived = false;
   bool _receivedInitialData = false;
@@ -79,7 +82,6 @@ class _ChecklistItemRowState extends ConsumerState<ChecklistItemRow>
   @override
   void initState() {
     super.initState();
-    _lastHideIfChecked = widget.hideIfChecked;
     _suggestionController = AnimationController(
       duration: const Duration(seconds: 1),
       vsync: this,
@@ -92,10 +94,10 @@ class _ChecklistItemRowState extends ConsumerState<ChecklistItemRow>
   @override
   void didUpdateWidget(ChecklistItemRow old) {
     super.didUpdateWidget(old);
-    // React to parent-driven filter changes (hideIfChecked prop).
-    if (old.hideIfChecked != widget.hideIfChecked) {
+    // React to parent-driven filter changes — no animation for tab switches.
+    if (old.hideIfChecked != widget.hideIfChecked ||
+        old.hideIfUnchecked != widget.hideIfUnchecked) {
       _handleHideStateChange(
-        newHideIfChecked: widget.hideIfChecked,
         newIsChecked: _lastIsChecked,
         newIsArchived: _lastIsArchived,
       );
@@ -110,8 +112,13 @@ class _ChecklistItemRowState extends ConsumerState<ChecklistItemRow>
     super.dispose();
   }
 
-  bool get _shouldHide =>
-      widget.hideIfChecked && (_lastIsChecked || _lastIsArchived);
+  bool get _shouldHide {
+    // Archived items count as "done" for filtering purposes.
+    final isCompleted = _lastIsChecked || _lastIsArchived;
+    if (widget.hideIfChecked && isCompleted) return true;
+    if (widget.hideIfUnchecked && !isCompleted) return true;
+    return false;
+  }
 
   void _cancelTimers() {
     _holdTimer?.cancel();
@@ -127,47 +134,34 @@ class _ChecklistItemRowState extends ConsumerState<ChecklistItemRow>
   }
 
   void _handleHideStateChange({
-    required bool newHideIfChecked,
     required bool newIsChecked,
     required bool newIsArchived,
+    bool animate = false,
   }) {
-    final wasHideChecked = _lastHideIfChecked;
     final wasChecked = _lastIsChecked;
     final wasArchived = _lastIsArchived;
 
-    _lastHideIfChecked = newHideIfChecked;
     _lastIsChecked = newIsChecked;
     _lastIsArchived = newIsArchived;
 
-    // Item just got completed/archived while filter hides them — fade then hide.
-    if ((!wasChecked && newIsChecked && newHideIfChecked) ||
-        (!wasArchived && newIsArchived && newHideIfChecked)) {
+    final isCompleted = newIsChecked || newIsArchived;
+
+    // If the user just interactively checked an item while the Open filter
+    // is active, use the delayed hide animation so they see the checkmark
+    // feedback before the row disappears.
+    if (animate &&
+        widget.hideIfChecked &&
+        isCompleted &&
+        (!wasChecked && newIsChecked || !wasArchived && newIsArchived)) {
       _cancelTimers();
       _startHideSequence();
       return;
     }
 
-    // Filter toggled to hide completed items for an already completed item.
-    if (!wasHideChecked &&
-        newHideIfChecked &&
-        (newIsChecked || newIsArchived)) {
-      _cancelTimers();
-      setState(() => _showRow = false);
-      return;
-    }
-
-    // Filter toggled back to show all.
-    if (wasHideChecked && !newHideIfChecked) {
-      _cancelTimers();
-      setState(() => _showRow = true);
-      return;
-    }
-
-    // Item unchecked or unarchived.
-    if ((wasChecked && !newIsChecked) || (wasArchived && !newIsArchived)) {
-      _cancelTimers();
-      setState(() => _showRow = true);
-    }
+    // For everything else, compute the desired visibility directly from
+    // the current filter flags and item state.
+    _cancelTimers();
+    setState(() => _showRow = !_shouldHide);
   }
 
   @override
@@ -183,24 +177,25 @@ class _ChecklistItemRowState extends ConsumerState<ChecklistItemRow>
       final item = next.whenOrNull(data: (item) => item);
       if (item == null) return;
 
-      // On the first data load, immediately hide pre-checked items
-      // instead of using the animation delay (which is only for items
-      // the user just checked off interactively).
+      // On the first data load, immediately hide items that don't match
+      // the active filter instead of using the animation delay (which is
+      // only for items the user just checked off interactively).
       if (!_receivedInitialData) {
         _receivedInitialData = true;
         _lastIsChecked = item.data.isChecked;
         _lastIsArchived = item.data.isArchived;
-        if (widget.hideIfChecked &&
-            (item.data.isChecked || item.data.isArchived)) {
+        final isCompleted = item.data.isChecked || item.data.isArchived;
+        if ((widget.hideIfChecked && isCompleted) ||
+            (widget.hideIfUnchecked && !isCompleted)) {
           setState(() => _showRow = false);
         }
         return;
       }
 
       _handleHideStateChange(
-        newHideIfChecked: widget.hideIfChecked,
         newIsChecked: item.data.isChecked,
         newIsArchived: item.data.isArchived,
+        animate: true,
       );
     });
 
@@ -215,16 +210,17 @@ class _ChecklistItemRowState extends ConsumerState<ChecklistItemRow>
 
         // Synchronous first-frame fix: if the provider already has data
         // on the first build, ref.listen may not have fired yet.
+        // Set _showRow immediately so the row never renders its content
+        // before being hidden — avoids a single visible frame of
+        // strikethrough items in the Open tab.
         if (!_receivedInitialData) {
           _receivedInitialData = true;
           _lastIsChecked = item.data.isChecked;
           _lastIsArchived = item.data.isArchived;
-          if (widget.hideIfChecked &&
-              (item.data.isChecked || item.data.isArchived) &&
-              _showRow) {
-            WidgetsBinding.instance.addPostFrameCallback((_) {
-              if (mounted) setState(() => _showRow = false);
-            });
+          final isCompleted = item.data.isChecked || item.data.isArchived;
+          if ((widget.hideIfChecked && isCompleted) ||
+              (widget.hideIfUnchecked && !isCompleted)) {
+            _showRow = false;
           }
         }
 
@@ -504,8 +500,8 @@ class _ChecklistItemRowState extends ConsumerState<ChecklistItemRow>
           ),
         );
 
-        // Animated hide/show for open-only filter mode.
-        if (widget.hideIfChecked) {
+        // Animated hide/show for filtered modes (open-only or done-only).
+        if (widget.hideIfChecked || widget.hideIfUnchecked) {
           child = AnimatedCrossFade(
             duration: checklistCompletionFadeDuration,
             sizeCurve: Curves.easeInOut,

--- a/lib/features/tasks/ui/checklists/consts.dart
+++ b/lib/features/tasks/ui/checklists/consts.dart
@@ -12,6 +12,9 @@ enum ChecklistFilter {
   /// Show only unchecked items.
   openOnly,
 
+  /// Show only checked/completed items.
+  doneOnly,
+
   /// Show all items (checked and unchecked).
   all,
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -698,6 +698,7 @@
   "checklistAiSuggestionBody": "Tato položka se zdá být dokončena:",
   "checklistAiSuggestionTitle": "Návrh AI",
   "checklistAllDone": "Všechny položky splněny!",
+  "checklistNoneDone": "Zatím žádné dokončené položky.",
   "checklistCompletedShort": "{completed}/{total} hotovo",
   "@checklistCompletedShort": {
     "placeholders": {

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -927,6 +927,7 @@
   "checklistAiSuggestionBody": "Diese Aufgabe scheint erledigt zu sein:",
   "checklistAiSuggestionTitle": "KI-Vorschlag",
   "checklistAllDone": "Alle Punkte erledigt!",
+  "checklistNoneDone": "Noch keine erledigten Punkte.",
   "checklistCompletedShort": "{completed}/{total} erledigt",
   "@checklistCompletedShort": {
     "placeholders": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1132,6 +1132,7 @@
   "checklistAiSuggestionBody": "This item appears to be completed:",
   "checklistAiSuggestionTitle": "AI Suggestion",
   "checklistAllDone": "All items completed!",
+  "checklistNoneDone": "No completed items yet.",
   "checklistCompletedShort": "{completed}/{total} done",
   "@checklistCompletedShort": {
     "placeholders": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -927,6 +927,7 @@
   "checklistAiSuggestionBody": "Este elemento parece estar completado:",
   "checklistAiSuggestionTitle": "Sugerencia de IA",
   "checklistAllDone": "¡Todos los elementos completados!",
+  "checklistNoneDone": "Aún no hay elementos completados.",
   "checklistCompletedShort": "{completed}/{total} completados",
   "@checklistCompletedShort": {
     "placeholders": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -927,6 +927,7 @@
   "checklistAiSuggestionBody": "Cet élément semble être terminé :",
   "checklistAiSuggestionTitle": "Suggestion IA",
   "checklistAllDone": "Tous les éléments sont terminés !",
+  "checklistNoneDone": "Aucun élément terminé pour le moment.",
   "checklistCompletedShort": "{completed}/{total} terminés",
   "@checklistCompletedShort": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3594,6 +3594,12 @@ abstract class AppLocalizations {
   /// **'All items completed!'**
   String get checklistAllDone;
 
+  /// No description provided for @checklistNoneDone.
+  ///
+  /// In en, this message translates to:
+  /// **'No completed items yet.'**
+  String get checklistNoneDone;
+
   /// No description provided for @checklistCompletedShort.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -2030,6 +2030,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get checklistAllDone => 'Všechny položky splněny!';
 
   @override
+  String get checklistNoneDone => 'Zatím žádné dokončené položky.';
+
+  @override
   String checklistCompletedShort(int completed, int total) {
     return '$completed/$total hotovo';
   }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2048,6 +2048,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get checklistAllDone => 'Alle Punkte erledigt!';
 
   @override
+  String get checklistNoneDone => 'Noch keine erledigten Punkte.';
+
+  @override
   String checklistCompletedShort(int completed, int total) {
     return '$completed/$total erledigt';
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2013,6 +2013,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get checklistAllDone => 'All items completed!';
 
   @override
+  String get checklistNoneDone => 'No completed items yet.';
+
+  @override
   String checklistCompletedShort(int completed, int total) {
     return '$completed/$total done';
   }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2080,6 +2080,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get checklistAllDone => '¡Todos los elementos completados!';
 
   @override
+  String get checklistNoneDone => 'Aún no hay elementos completados.';
+
+  @override
   String checklistCompletedShort(int completed, int total) {
     return '$completed/$total completados';
   }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2075,6 +2075,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get checklistAllDone => 'Tous les éléments sont terminés !';
 
   @override
+  String get checklistNoneDone => 'Aucun élément terminé pour le moment.';
+
+  @override
   String checklistCompletedShort(int completed, int total) {
     return '$completed/$total terminés';
   }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -2047,6 +2047,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get checklistAllDone => 'Toate elementele sunt finalizate!';
 
   @override
+  String get checklistNoneDone => 'Niciun element finalizat încă.';
+
+  @override
   String checklistCompletedShort(int completed, int total) {
     return '$completed/$total finalizate';
   }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -927,6 +927,7 @@
   "checklistAiSuggestionBody": "Acest element pare să fie finalizat:",
   "checklistAiSuggestionTitle": "Sugestie AI",
   "checklistAllDone": "Toate elementele sunt finalizate!",
+  "checklistNoneDone": "Niciun element finalizat încă.",
   "checklistCompletedShort": "{completed}/{total} finalizate",
   "@checklistCompletedShort": {
     "placeholders": {

--- a/lib/services/app_prefs_service.dart
+++ b/lib/services/app_prefs_service.dart
@@ -3,11 +3,19 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 /// Abstraction over simple key/value app preferences to enable mocking in tests.
 class AppPrefs {
-  const AppPrefs({required this.getBool, required this.setBool});
+  const AppPrefs({
+    required this.getBool,
+    required this.setBool,
+    required this.getString,
+    required this.setString,
+  });
 
   final Future<bool?> Function(String key) getBool;
   final Future<bool> Function({required String key, required bool value})
   setBool;
+  final Future<String?> Function(String key) getString;
+  final Future<bool> Function({required String key, required String value})
+  setString;
 }
 
 AppPrefs makeSharedPrefsService() => AppPrefs(
@@ -20,6 +28,18 @@ AppPrefs makeSharedPrefsService() => AppPrefs(
     if (isTestEnv) return true;
     final prefs = await SharedPreferences.getInstance();
     return prefs.setBool(key, value);
+  },
+  // Note: getString returns null in test env (unlike getBool which returns
+  // true), so callers fall through to their default/legacy paths in tests.
+  getString: (String key) async {
+    if (isTestEnv) return null;
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(key);
+  },
+  setString: ({required String key, required String value}) async {
+    if (isTestEnv) return true;
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.setString(key, value);
   },
 );
 

--- a/test/features/tasks/ui/checklists/checklist_card_test.dart
+++ b/test/features/tasks/ui/checklists/checklist_card_test.dart
@@ -616,5 +616,90 @@ void main() {
 
       expect(states, [true, false]);
     });
+
+    // ── Done filter tab ────────────────────────────────────────────────────
+
+    testWidgets('filter strip shows Open, Done, and All tabs', (tester) async {
+      await _pump(
+        tester,
+        initiallyExpanded: true,
+        itemIds: const ['x'],
+        completionRate: 0.5,
+        completedCount: 1,
+        totalCount: 2,
+      );
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(find.text('Open'), findsOneWidget);
+      expect(find.text('Done'), findsOneWidget);
+      expect(find.text('All'), findsOneWidget);
+    });
+
+    testWidgets(
+      'shows noneDone message when doneOnly filter and no items done',
+      (tester) async {
+        await _pump(
+          tester,
+          initiallyExpanded: true,
+          itemIds: const ['x'],
+          completedCount: 0,
+          totalCount: 1,
+        );
+        await tester.pump(const Duration(milliseconds: 400));
+
+        // Tap the Done tab
+        await tester.tap(find.text('Done'));
+        await tester.pump(const Duration(milliseconds: 400));
+
+        expect(find.text('No completed items yet.'), findsOneWidget);
+      },
+    );
+
+    // ── Initial animation skip ─────────────────────────────────────────────
+
+    testWidgets('body appears instantly on first render without animation', (
+      tester,
+    ) async {
+      await _pump(tester, initiallyExpanded: true);
+
+      // On the very first frame the add-field should already be visible
+      // (no animation needed) because _hasRendered is false → Duration.zero.
+      expect(find.byKey(_addFieldKey).hitTestable(), findsOneWidget);
+    });
+
+    testWidgets(
+      'collapsed card shows no body on first render without animation',
+      (tester) async {
+        await _pump(tester, initiallyExpanded: false);
+
+        // Collapsed immediately, no animation.
+        expect(find.byKey(_addFieldKey).hitTestable(), findsNothing);
+      },
+    );
+
+    testWidgets('subsequent toggle uses real animation duration', (
+      tester,
+    ) async {
+      await _pump(tester, initiallyExpanded: true);
+
+      // First frame — body is already visible.
+      expect(find.byKey(_addFieldKey).hitTestable(), findsOneWidget);
+
+      // Post-frame callback fires, _hasRendered = true.
+      await tester.pump();
+
+      // Now collapse — should use real animation duration (250ms).
+      await tester.tap(find.byIcon(Icons.expand_less));
+
+      // After only 50ms, the cross-fade should still be in progress.
+      await tester.pump(const Duration(milliseconds: 50));
+      // The AnimatedCrossFade is mid-transition — the add field is still
+      // in the tree (even if fading) because the animation hasn't completed.
+      expect(find.byKey(_addFieldKey), findsOneWidget);
+
+      // After 400ms total, animation should be complete.
+      await tester.pump(const Duration(milliseconds: 350));
+      expect(find.byKey(_addFieldKey).hitTestable(), findsNothing);
+    });
   });
 }

--- a/test/features/tasks/ui/checklists/checklist_item_row_test.dart
+++ b/test/features/tasks/ui/checklists/checklist_item_row_test.dart
@@ -149,6 +149,7 @@ Future<void> _pump(
   WidgetTester tester, {
   ChecklistItem? item,
   bool hideIfChecked = false,
+  bool hideIfUnchecked = false,
   bool showDivider = false,
   List<ChecklistCompletionSuggestion> suggestions = const [],
 }) async {
@@ -176,6 +177,7 @@ Future<void> _pump(
           taskId: 'task-1',
           index: 0,
           hideIfChecked: hideIfChecked,
+          hideIfUnchecked: hideIfUnchecked,
           showDivider: showDivider,
         ),
       ),
@@ -196,6 +198,7 @@ _pumpWithControllers(
   WidgetTester tester, {
   ChecklistItem? item,
   bool hideIfChecked = false,
+  bool hideIfUnchecked = false,
   List<ChecklistCompletionSuggestion> suggestions = const [],
 }) async {
   final testItem = item ?? _makeItem();
@@ -224,6 +227,7 @@ _pumpWithControllers(
           taskId: 'task-1',
           index: 0,
           hideIfChecked: hideIfChecked,
+          hideIfUnchecked: hideIfUnchecked,
         ),
       ),
     ),
@@ -759,6 +763,58 @@ void main() {
       );
     });
 
+    // ── Done-only filter (hideIfUnchecked) ──────────────────────────────
+
+    group('done-only filter (hideIfUnchecked)', () {
+      testWidgets(
+        'unchecked item is hidden immediately when hideIfUnchecked=true',
+        (tester) async {
+          // Unchecked item with done-only filter → should be hidden.
+          await _pump(tester, hideIfUnchecked: true);
+          await tester.pump();
+
+          final crossFade = tester.widget<AnimatedCrossFade>(
+            find.byType(AnimatedCrossFade),
+          );
+          expect(crossFade.crossFadeState, CrossFadeState.showSecond);
+        },
+      );
+
+      testWidgets(
+        'checked item remains visible when hideIfUnchecked=true',
+        (tester) async {
+          await _pump(
+            tester,
+            item: _makeItem(isChecked: true),
+            hideIfUnchecked: true,
+          );
+          await tester.pump();
+
+          final crossFade = tester.widget<AnimatedCrossFade>(
+            find.byType(AnimatedCrossFade),
+          );
+          expect(crossFade.crossFadeState, CrossFadeState.showFirst);
+        },
+      );
+
+      testWidgets(
+        'archived item remains visible when hideIfUnchecked=true',
+        (tester) async {
+          await _pump(
+            tester,
+            item: _makeItem(isArchived: true),
+            hideIfUnchecked: true,
+          );
+          await tester.pump();
+
+          final crossFade = tester.widget<AnimatedCrossFade>(
+            find.byType(AnimatedCrossFade),
+          );
+          expect(crossFade.crossFadeState, CrossFadeState.showFirst);
+        },
+      );
+    });
+
     // ── AnimatedCrossFade wrapping ──────────────────────────────────────
 
     group('AnimatedCrossFade wrapping', () {
@@ -766,6 +822,14 @@ void main() {
         'hideIfChecked=true wraps in AnimatedCrossFade',
         (tester) async {
           await _pump(tester, hideIfChecked: true);
+          expect(find.byType(AnimatedCrossFade), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'hideIfUnchecked=true wraps in AnimatedCrossFade',
+        (tester) async {
+          await _pump(tester, hideIfUnchecked: true);
           expect(find.byType(AnimatedCrossFade), findsOneWidget);
         },
       );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Done" filter tab to checklists to show only completed items
  * Added "No completed items yet" message when the Done filter has no completed items

* **Localization**
  * New translated text for the "no completed items" message in multiple languages

* **Bug Fixes**
  * Checklist cards initialize without the first-render expand/collapse animation to avoid UI jank

* **Tests**
  * Added widget tests covering the new filter and first-render behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->