### PR TITLE
ci: set up signing for android

### DIFF
--- a/.github/workflows/flutter-android-release.yml
+++ b/.github/workflows/flutter-android-release.yml
@@ -47,21 +47,17 @@ jobs:
       - name: Flutter pub get
         run: flutter pub get
 
-      # Uncomment and configure secrets for release signing:
-      # - name: Decode Android Keystore
-      #   run: echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > android/app/upload-keystore.jks
-      #
-      # - name: Create key.properties
-      #   run: |
-      #     cat > android/key.properties << EOF
-      #     storePassword=${{ secrets.ANDROID_STORE_PASSWORD }}
-      #     keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
-      #     keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}
-      #     storeFile=upload-keystore.jks
-      #     EOF
+      - name: Decode Android Keystore
+        run: echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > android/app/upload-keystore.jks
 
-      - name: Create Android debug keystore directory
-        run: mkdir -p /home/runner/.config/.android
+      - name: Create key.properties
+        run: |
+          cat > android/key.properties << EOF
+          storePassword=${{ secrets.ANDROID_STORE_PASSWORD }}
+          keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
+          keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}
+          storeFile=${{ github.workspace }}/android/app/upload-keystore.jks
+          EOF
 
       - name: Build App Bundle
         run: flutter build appbundle --release

--- a/.github/workflows/flutter-linux-release.yml
+++ b/.github/workflows/flutter-linux-release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Update apt-get
         run: sudo apt-get update
       - name: Install libraries
-        run: sudo apt-get install libgtk-3-dev cmake cmake-doc ninja-build libsecret-1-dev libjsoncpp-dev libsecret-1-0 sqlite3 libsqlite3-dev keybinder-3.0 network-manager mpv libmpv-dev
+        run: sudo apt-get install -y --no-install-recommends libgtk-3-dev cmake cmake-doc ninja-build libsecret-1-dev libjsoncpp-dev libsecret-1-0 sqlite3 libsqlite3-dev keybinder-3.0 network-manager mpv libmpv-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-good
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/flutter-matrix-test.yml
+++ b/.github/workflows/flutter-matrix-test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Update apt-get
         run: sudo apt-get update
       - name: Install libraries
-        run: sudo apt-get install libgtk-3-dev cmake libolm3 cmake-doc ninja-build libsecret-1-dev libjsoncpp-dev libsecret-1-0 sqlite3 libsqlite3-dev keybinder-3.0 network-manager mpv libmpv-dev
+        run: sudo apt-get install -y --no-install-recommends libgtk-3-dev cmake libolm3 cmake-doc ninja-build libsecret-1-dev libjsoncpp-dev libsecret-1-0 sqlite3 libsqlite3-dev keybinder-3.0 network-manager mpv libmpv-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-good
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -54,7 +54,7 @@ jobs:
       - name: Update apt-get
         run: sudo apt-get update
       - name: Install libraries
-        run: sudo apt-get install libgtk-3-dev cmake libolm3 cmake-doc ninja-build libsecret-1-dev libjsoncpp-dev libsecret-1-0 sqlite3 libsqlite3-dev keybinder-3.0 network-manager mpv libmpv-dev
+        run: sudo apt-get install -y --no-install-recommends libgtk-3-dev cmake libolm3 cmake-doc ninja-build libsecret-1-dev libjsoncpp-dev libsecret-1-0 sqlite3 libsqlite3-dev keybinder-3.0 network-manager mpv libmpv-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-good
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -86,7 +86,7 @@ jobs:
       - name: Update apt-get
         run: sudo apt-get update
       - name: Install libraries
-        run: sudo apt-get install libgtk-3-dev cmake libolm3 cmake-doc ninja-build libsecret-1-dev libjsoncpp-dev libsecret-1-0 sqlite3 libsqlite3-dev keybinder-3.0 network-manager mpv libmpv-dev
+        run: sudo apt-get install -y --no-install-recommends libgtk-3-dev cmake libolm3 cmake-doc ninja-build libsecret-1-dev libjsoncpp-dev libsecret-1-0 sqlite3 libsqlite3-dev keybinder-3.0 network-manager mpv libmpv-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-good
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -19,6 +19,14 @@ if (flutterRoot == null) {
     throw new RuntimeException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
+def keystoreProperties = new Properties()
+def keystorePropertiesFile = rootProject.file('key.properties')
+if (keystorePropertiesFile.exists()) {
+    keystorePropertiesFile.withReader('UTF-8') { reader ->
+        keystoreProperties.load(reader)
+    }
+}
+
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
 if (flutterVersionCode == null) {
     flutterVersionCode = '1'
@@ -56,11 +64,22 @@ android {
         versionName flutterVersionName
     }
 
+    signingConfigs {
+        release {
+            if (keystorePropertiesFile.exists()) {
+                keyAlias keystoreProperties['keyAlias']
+                keyPassword keystoreProperties['keyPassword']
+                storeFile file(keystoreProperties['storeFile'])
+                storePassword keystoreProperties['storePassword']
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig signingConfigs.debug
+            signingConfig keystorePropertiesFile.exists()
+                ? signingConfigs.release
+                : signingConfigs.debug
         }
     }
 }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -67,9 +67,17 @@ android {
     signingConfigs {
         release {
             if (keystorePropertiesFile.exists()) {
+                def requiredKeys = ['storeFile', 'keyAlias', 'keyPassword', 'storePassword']
+                def missing = requiredKeys.findAll { !keystoreProperties[it] }
+                if (missing) {
+                    throw new GradleException(
+                        "keystoreProperties is missing required entries: ${missing}. " +
+                        "Check ${keystorePropertiesFile.absolutePath}."
+                    )
+                }
                 keyAlias keystoreProperties['keyAlias']
                 keyPassword keystoreProperties['keyPassword']
-                storeFile file(keystoreProperties['storeFile'])
+                storeFile rootProject.file(keystoreProperties['storeFile'])
                 storePassword keystoreProperties['storePassword']
             }
         }
@@ -77,9 +85,22 @@ android {
 
     buildTypes {
         release {
-            signingConfig keystorePropertiesFile.exists()
-                ? signingConfigs.release
-                : signingConfigs.debug
+            signingConfig signingConfigs.release
+        }
+    }
+}
+
+// Fail fast for release builds when keystorePropertiesFile is missing,
+// but only at execution time so debug builds are not affected.
+afterEvaluate {
+    if (!keystorePropertiesFile.exists()) {
+        tasks.matching { it.name =~ /bundle.*Release|assemble.*Release/ }.configureEach {
+            doFirst {
+                throw new GradleException(
+                    "Release signing requires ${keystorePropertiesFile.absolutePath}. " +
+                    "See .github/workflows/flutter-android-release.yml for CI setup."
+                )
+            }
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release builds now require production signing credentials from CI secrets; build configuration enforces presence of signing information and removes the debug-signing fallback.
* **CI**
  * Linux build and test workflows install additional GStreamer development and plugin packages and use non-interactive, no-recommends package installation to improve media support in CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->