### PR TITLE
feat: configurable pane widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.950] - 2026-04-10
+### Added
+- Resizable panes in desktop layout: users can drag dividers between the
+  navigation sidebar and content area, and between the list and detail panes,
+  to adjust widths. Pane sizes persist across sessions via SettingsDb.
+
 ## [0.9.949] - 2026-04-10
 ### Changed
 - Redesigned dashboard list page: removed the old SliverAppBar top bar,

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -31,6 +31,11 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="0.9.950" date="2026-04-10">
+      <description>
+          <p>Resizable panes in desktop layout: drag dividers between the navigation sidebar and content area, and between the list and detail panes, to adjust widths. Pane sizes persist across sessions.</p>
+      </description>
+    </release>
     <release version="0.9.949" date="2026-04-10">
       <description>
           <p>Dashboard list page redesigned: the old SliverAppBar top bar has been removed and list items now use rounded grouped cards with design system tokens for a modern, consistent look.</p>

--- a/lib/beamer/beamer_app.dart
+++ b/lib/beamer/beamer_app.dart
@@ -14,6 +14,8 @@ import 'package:lotti/features/ai/ui/settings/services/ai_setup_prompt_service.d
 import 'package:lotti/features/ai/ui/settings/widgets/ai_provider_selection_modal.dart';
 import 'package:lotti/features/design_system/components/navigation/design_system_navigation_tab_bar.dart';
 import 'package:lotti/features/design_system/components/navigation/desktop_navigation_sidebar.dart';
+import 'package:lotti/features/design_system/components/navigation/resizable_divider.dart';
+import 'package:lotti/features/design_system/state/pane_width_controller.dart';
 import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/settings/state/zoom_controller.dart';
 import 'package:lotti/features/settings/ui/pages/outbox/outbox_badge.dart';
@@ -330,6 +332,8 @@ class _AppScreenState extends ConsumerState<AppScreen> {
       }
     }
 
+    final paneWidths = ref.watch(paneWidthControllerProvider);
+
     return Scaffold(
       body: Row(
         children: [
@@ -363,6 +367,12 @@ class _AppScreenState extends ConsumerState<AppScreen> {
                 : null,
             isSettingsActive: isSettingsActive,
             onNewPressed: createTextEntry,
+            width: paneWidths.sidebarWidth,
+          ),
+          ResizableDivider(
+            onDrag: (delta) => ref
+                .read(paneWidthControllerProvider.notifier)
+                .updateSidebarWidth(delta),
           ),
           Expanded(
             child: Stack(

--- a/lib/features/dashboards/ui/pages/dashboards_list_page.dart
+++ b/lib/features/dashboards/ui/pages/dashboards_list_page.dart
@@ -4,6 +4,8 @@ import 'package:lotti/features/dashboards/ui/pages/dashboard_page.dart';
 import 'package:lotti/features/dashboards/ui/widgets/dashboards_filter.dart';
 import 'package:lotti/features/dashboards/ui/widgets/dashboards_list.dart';
 import 'package:lotti/features/design_system/components/navigation/desktop_detail_empty_state.dart';
+import 'package:lotti/features/design_system/components/navigation/resizable_divider.dart';
+import 'package:lotti/features/design_system/state/pane_width_controller.dart';
 import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/user_activity/state/user_activity_service.dart';
@@ -88,11 +90,18 @@ class _DashboardsListPageState extends ConsumerState<DashboardsListPage> {
       return listScaffold;
     }
 
+    final paneWidths = ref.watch(paneWidthControllerProvider);
+
     return Row(
       children: [
         SizedBox(
-          width: 540,
+          width: paneWidths.listPaneWidth,
           child: listScaffold,
+        ),
+        ResizableDivider(
+          onDrag: (delta) => ref
+              .read(paneWidthControllerProvider.notifier)
+              .updateListPaneWidth(delta),
         ),
         Expanded(
           child: ValueListenableBuilder<String?>(

--- a/lib/features/design_system/components/navigation/resizable_divider.dart
+++ b/lib/features/design_system/components/navigation/resizable_divider.dart
@@ -42,6 +42,7 @@ class _ResizableDividerState extends State<ResizableDivider> {
         behavior: HitTestBehavior.opaque,
         onHorizontalDragStart: (_) => setState(() => _isDragging = true),
         onHorizontalDragUpdate: (details) => widget.onDrag(details.delta.dx),
+        onHorizontalDragCancel: () => setState(() => _isDragging = false),
         onHorizontalDragEnd: (_) => setState(() => _isDragging = false),
         child: SizedBox(
           width: widget.hitTargetWidth,

--- a/lib/features/design_system/components/navigation/resizable_divider.dart
+++ b/lib/features/design_system/components/navigation/resizable_divider.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+
+/// A draggable vertical divider that allows resizing adjacent panes.
+///
+/// Displays a thin visual line with a wider hit target area. Shows a
+/// horizontal resize cursor on hover and while dragging.
+class ResizableDivider extends StatefulWidget {
+  const ResizableDivider({
+    required this.onDrag,
+    this.hitTargetWidth = 8,
+    super.key,
+  });
+
+  /// Called with the horizontal drag delta when the user drags the divider.
+  final ValueChanged<double> onDrag;
+
+  /// Width of the invisible hit target area for easier grabbing.
+  final double hitTargetWidth;
+
+  @override
+  State<ResizableDivider> createState() => _ResizableDividerState();
+}
+
+class _ResizableDividerState extends State<ResizableDivider> {
+  bool _isDragging = false;
+  bool _isHovering = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final isActive = _isDragging || _isHovering;
+    final lineColor = isActive
+        ? tokens.colors.interactive.enabled
+        : tokens.colors.decorative.level01;
+
+    return MouseRegion(
+      cursor: SystemMouseCursors.resizeColumn,
+      onEnter: (_) => setState(() => _isHovering = true),
+      onExit: (_) => setState(() => _isHovering = false),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onHorizontalDragStart: (_) => setState(() => _isDragging = true),
+        onHorizontalDragUpdate: (details) => widget.onDrag(details.delta.dx),
+        onHorizontalDragEnd: (_) => setState(() => _isDragging = false),
+        child: SizedBox(
+          width: widget.hitTargetWidth,
+          child: Center(
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 150),
+              width: isActive ? 3 : 1,
+              color: lineColor,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/design_system/state/pane_width_controller.dart
+++ b/lib/features/design_system/state/pane_width_controller.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/foundation.dart';
+import 'package:lotti/database/settings_db.dart';
+import 'package:lotti/get_it.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'pane_width_controller.g.dart';
+
+/// Settings keys for persisted pane widths.
+const sidebarWidthKey = 'PANE_WIDTH_SIDEBAR';
+const listPaneWidthKey = 'PANE_WIDTH_LIST';
+
+/// Default and constraint values for pane widths.
+const defaultSidebarWidth = 320.0;
+const minSidebarWidth = 200.0;
+const maxSidebarWidth = 500.0;
+
+const defaultListPaneWidth = 540.0;
+const minListPaneWidth = 300.0;
+const maxListPaneWidth = 800.0;
+
+/// State holding the current widths for the sidebar and list pane.
+@immutable
+class PaneWidths {
+  const PaneWidths({
+    this.sidebarWidth = defaultSidebarWidth,
+    this.listPaneWidth = defaultListPaneWidth,
+  });
+
+  final double sidebarWidth;
+  final double listPaneWidth;
+
+  PaneWidths copyWith({
+    double? sidebarWidth,
+    double? listPaneWidth,
+  }) {
+    return PaneWidths(
+      sidebarWidth: sidebarWidth ?? this.sidebarWidth,
+      listPaneWidth: listPaneWidth ?? this.listPaneWidth,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is PaneWidths &&
+          runtimeType == other.runtimeType &&
+          sidebarWidth == other.sidebarWidth &&
+          listPaneWidth == other.listPaneWidth;
+
+  @override
+  int get hashCode => Object.hash(sidebarWidth, listPaneWidth);
+}
+
+@Riverpod(keepAlive: true)
+class PaneWidthController extends _$PaneWidthController {
+  bool _userAdjusted = false;
+
+  @override
+  PaneWidths build() {
+    _loadPersistedWidths();
+    return const PaneWidths();
+  }
+
+  Future<void> _loadPersistedWidths() async {
+    final settingsDb = getIt<SettingsDb>();
+    final values = await settingsDb.itemsByKeys({
+      sidebarWidthKey,
+      listPaneWidthKey,
+    });
+
+    if (_userAdjusted) return;
+
+    final sidebarWidth = _parseWidth(
+      values[sidebarWidthKey],
+      defaultSidebarWidth,
+      minSidebarWidth,
+      maxSidebarWidth,
+    );
+    final listPaneWidth = _parseWidth(
+      values[listPaneWidthKey],
+      defaultListPaneWidth,
+      minListPaneWidth,
+      maxListPaneWidth,
+    );
+
+    state = PaneWidths(
+      sidebarWidth: sidebarWidth,
+      listPaneWidth: listPaneWidth,
+    );
+  }
+
+  double _parseWidth(
+    String? stored,
+    double defaultValue,
+    double minValue,
+    double maxValue,
+  ) {
+    if (stored == null) return defaultValue;
+    final parsed = double.tryParse(stored);
+    if (parsed == null) return defaultValue;
+    return parsed.clamp(minValue, maxValue);
+  }
+
+  void updateSidebarWidth(double delta) {
+    _userAdjusted = true;
+    final newWidth = (state.sidebarWidth + delta).clamp(
+      minSidebarWidth,
+      maxSidebarWidth,
+    );
+    state = state.copyWith(sidebarWidth: newWidth);
+    _persistSidebarWidth();
+  }
+
+  void updateListPaneWidth(double delta) {
+    _userAdjusted = true;
+    final newWidth = (state.listPaneWidth + delta).clamp(
+      minListPaneWidth,
+      maxListPaneWidth,
+    );
+    state = state.copyWith(listPaneWidth: newWidth);
+    _persistListPaneWidth();
+  }
+
+  void _persistSidebarWidth() {
+    getIt<SettingsDb>().saveSettingsItem(
+      sidebarWidthKey,
+      state.sidebarWidth.toStringAsFixed(1),
+    );
+  }
+
+  void _persistListPaneWidth() {
+    getIt<SettingsDb>().saveSettingsItem(
+      listPaneWidthKey,
+      state.listPaneWidth.toStringAsFixed(1),
+    );
+  }
+
+  void resetToDefaults() {
+    _userAdjusted = true;
+    state = const PaneWidths();
+    _persistSidebarWidth();
+    _persistListPaneWidth();
+  }
+}

--- a/lib/features/design_system/state/pane_width_controller.dart
+++ b/lib/features/design_system/state/pane_width_controller.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'pane_width_controller.g.dart';
@@ -17,6 +20,10 @@ const maxSidebarWidth = 500.0;
 const defaultListPaneWidth = 540.0;
 const minListPaneWidth = 300.0;
 const maxListPaneWidth = 800.0;
+
+/// How long to wait after the last drag update before persisting to disk.
+@visibleForTesting
+const persistDebounce = Duration(milliseconds: 300);
 
 /// State holding the current widths for the sidebar and list pane.
 @immutable
@@ -54,39 +61,54 @@ class PaneWidths {
 @Riverpod(keepAlive: true)
 class PaneWidthController extends _$PaneWidthController {
   bool _userAdjusted = false;
+  Timer? _sidebarDebounce;
+  Timer? _listPaneDebounce;
 
   @override
   PaneWidths build() {
-    _loadPersistedWidths();
+    ref.onDispose(() {
+      _sidebarDebounce?.cancel();
+      _listPaneDebounce?.cancel();
+    });
+    unawaited(_loadPersistedWidths());
     return const PaneWidths();
   }
 
   Future<void> _loadPersistedWidths() async {
-    final settingsDb = getIt<SettingsDb>();
-    final values = await settingsDb.itemsByKeys({
-      sidebarWidthKey,
-      listPaneWidthKey,
-    });
+    try {
+      final settingsDb = getIt<SettingsDb>();
+      final values = await settingsDb.itemsByKeys({
+        sidebarWidthKey,
+        listPaneWidthKey,
+      });
 
-    if (_userAdjusted) return;
+      if (_userAdjusted) return;
 
-    final sidebarWidth = _parseWidth(
-      values[sidebarWidthKey],
-      defaultSidebarWidth,
-      minSidebarWidth,
-      maxSidebarWidth,
-    );
-    final listPaneWidth = _parseWidth(
-      values[listPaneWidthKey],
-      defaultListPaneWidth,
-      minListPaneWidth,
-      maxListPaneWidth,
-    );
+      final sidebarWidth = _parseWidth(
+        values[sidebarWidthKey],
+        defaultSidebarWidth,
+        minSidebarWidth,
+        maxSidebarWidth,
+      );
+      final listPaneWidth = _parseWidth(
+        values[listPaneWidthKey],
+        defaultListPaneWidth,
+        minListPaneWidth,
+        maxListPaneWidth,
+      );
 
-    state = PaneWidths(
-      sidebarWidth: sidebarWidth,
-      listPaneWidth: listPaneWidth,
-    );
+      state = PaneWidths(
+        sidebarWidth: sidebarWidth,
+        listPaneWidth: listPaneWidth,
+      );
+    } catch (error, stackTrace) {
+      getIt<LoggingService>().captureException(
+        error,
+        domain: 'PANE_WIDTH',
+        subDomain: 'loadPersistedWidths',
+        stackTrace: stackTrace,
+      );
+    }
   }
 
   double _parseWidth(
@@ -97,7 +119,7 @@ class PaneWidthController extends _$PaneWidthController {
   ) {
     if (stored == null) return defaultValue;
     final parsed = double.tryParse(stored);
-    if (parsed == null) return defaultValue;
+    if (parsed == null || !parsed.isFinite) return defaultValue;
     return parsed.clamp(minValue, maxValue);
   }
 
@@ -108,7 +130,7 @@ class PaneWidthController extends _$PaneWidthController {
       maxSidebarWidth,
     );
     state = state.copyWith(sidebarWidth: newWidth);
-    _persistSidebarWidth();
+    _debounceSidebarPersist();
   }
 
   void updateListPaneWidth(double delta) {
@@ -118,25 +140,47 @@ class PaneWidthController extends _$PaneWidthController {
       maxListPaneWidth,
     );
     state = state.copyWith(listPaneWidth: newWidth);
-    _persistListPaneWidth();
+    _debounceListPanePersist();
+  }
+
+  void _debounceSidebarPersist() {
+    _sidebarDebounce?.cancel();
+    _sidebarDebounce = Timer(persistDebounce, _persistSidebarWidth);
+  }
+
+  void _debounceListPanePersist() {
+    _listPaneDebounce?.cancel();
+    _listPaneDebounce = Timer(persistDebounce, _persistListPaneWidth);
   }
 
   void _persistSidebarWidth() {
-    getIt<SettingsDb>().saveSettingsItem(
-      sidebarWidthKey,
-      state.sidebarWidth.toStringAsFixed(1),
-    );
+    unawaited(_persistWidth(sidebarWidthKey, state.sidebarWidth));
   }
 
   void _persistListPaneWidth() {
-    getIt<SettingsDb>().saveSettingsItem(
-      listPaneWidthKey,
-      state.listPaneWidth.toStringAsFixed(1),
-    );
+    unawaited(_persistWidth(listPaneWidthKey, state.listPaneWidth));
+  }
+
+  Future<void> _persistWidth(String key, double width) async {
+    try {
+      await getIt<SettingsDb>().saveSettingsItem(
+        key,
+        width.toStringAsFixed(1),
+      );
+    } catch (error, stackTrace) {
+      getIt<LoggingService>().captureException(
+        error,
+        domain: 'PANE_WIDTH',
+        subDomain: 'persistWidth:$key',
+        stackTrace: stackTrace,
+      );
+    }
   }
 
   void resetToDefaults() {
     _userAdjusted = true;
+    _sidebarDebounce?.cancel();
+    _listPaneDebounce?.cancel();
     state = const PaneWidths();
     _persistSidebarWidth();
     _persistListPaneWidth();

--- a/lib/features/design_system/state/pane_width_controller.g.dart
+++ b/lib/features/design_system/state/pane_width_controller.g.dart
@@ -1,0 +1,63 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'pane_width_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(PaneWidthController)
+final paneWidthControllerProvider = PaneWidthControllerProvider._();
+
+final class PaneWidthControllerProvider
+    extends $NotifierProvider<PaneWidthController, PaneWidths> {
+  PaneWidthControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'paneWidthControllerProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$paneWidthControllerHash();
+
+  @$internal
+  @override
+  PaneWidthController create() => PaneWidthController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(PaneWidths value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<PaneWidths>(value),
+    );
+  }
+}
+
+String _$paneWidthControllerHash() =>
+    r'645c279c3a6e1ecb4e6e6a1c3ed47345b8181e9b';
+
+abstract class _$PaneWidthController extends $Notifier<PaneWidths> {
+  PaneWidths build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<PaneWidths, PaneWidths>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<PaneWidths, PaneWidths>,
+              PaneWidths,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/lib/features/projects/ui/pages/projects_tab_page.dart
+++ b/lib/features/projects/ui/pages/projects_tab_page.dart
@@ -3,7 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_floating_action_button.dart';
 import 'package:lotti/features/design_system/components/navigation/desktop_detail_empty_state.dart';
+import 'package:lotti/features/design_system/components/navigation/resizable_divider.dart';
 import 'package:lotti/features/design_system/components/task_filters/design_system_filter_modal.dart';
+import 'package:lotti/features/design_system/state/pane_width_controller.dart';
 import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/projects/model/projects_overview_models.dart';
 import 'package:lotti/features/projects/state/project_providers.dart';
@@ -48,6 +50,8 @@ class _ProjectsTabPageState extends ConsumerState<ProjectsTabPage> {
     final isDesktop = isDesktopLayout(context);
 
     if (isDesktop) {
+      final paneWidths = ref.watch(paneWidthControllerProvider);
+
       return DecoratedBox(
         decoration: BoxDecoration(
           color: ShowcasePalette.page(context),
@@ -55,10 +59,15 @@ class _ProjectsTabPageState extends ConsumerState<ProjectsTabPage> {
         child: Row(
           children: [
             SizedBox(
-              width: 540,
+              width: paneWidths.listPaneWidth,
               child: _ProjectsListScaffold(
                 scrollController: _scrollController,
               ),
+            ),
+            ResizableDivider(
+              onDrag: (delta) => ref
+                  .read(paneWidthControllerProvider.notifier)
+                  .updateListPaneWidth(delta),
             ),
             Expanded(
               child: ValueListenableBuilder<String?>(

--- a/lib/features/tasks/ui/pages/tasks_root_page.dart
+++ b/lib/features/tasks/ui/pages/tasks_root_page.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/design_system/components/navigation/desktop_detail_empty_state.dart';
+import 'package:lotti/features/design_system/components/navigation/resizable_divider.dart';
+import 'package:lotti/features/design_system/state/pane_width_controller.dart';
 import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/tasks/ui/pages/task_details_page.dart';
 import 'package:lotti/features/tasks/ui/pages/tasks_tab_page.dart';
@@ -8,14 +11,16 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/services/nav_service.dart';
 
-class TasksRootPage extends StatelessWidget {
+class TasksRootPage extends ConsumerWidget {
   const TasksRootPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     if (!isDesktopLayout(context)) {
       return const TasksTabPage();
     }
+
+    final paneWidths = ref.watch(paneWidthControllerProvider);
 
     return DecoratedBox(
       decoration: BoxDecoration(
@@ -23,9 +28,14 @@ class TasksRootPage extends StatelessWidget {
       ),
       child: Row(
         children: [
-          const SizedBox(
-            width: 540,
-            child: TasksTabPage(),
+          SizedBox(
+            width: paneWidths.listPaneWidth,
+            child: const TasksTabPage(),
+          ),
+          ResizableDivider(
+            onDrag: (delta) => ref
+                .read(paneWidthControllerProvider.notifier)
+                .updateListPaneWidth(delta),
           ),
           Expanded(
             child: ValueListenableBuilder<String?>(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.949+3911
+version: 0.9.950+3912
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.950+3912
+version: 0.9.950+3913
 
 msix_config:
   display_name: LottiApp

--- a/test/features/dashboards/ui/pages/dashboards_list_page_test.dart
+++ b/test/features/dashboards/ui/pages/dashboards_list_page_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/features/dashboards/ui/pages/dashboard_page.dart';
 import 'package:lotti/features/dashboards/ui/pages/dashboards_list_page.dart';
 import 'package:lotti/features/design_system/components/navigation/desktop_detail_empty_state.dart';
@@ -8,6 +9,7 @@ import 'package:lotti/features/user_activity/state/user_activity_service.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/entities_cache_service.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -48,9 +50,20 @@ void main() {
         () => mockNavService.desktopSelectedDashboardId,
       ).thenReturn(ValueNotifier<String?>(null));
 
+      final mockSettingsDb = MockSettingsDb();
+      when(() => mockSettingsDb.itemByKey(any())).thenAnswer((_) async => null);
+      when(
+        () => mockSettingsDb.itemsByKeys(any()),
+      ).thenAnswer((_) async => <String, String?>{});
+      when(
+        () => mockSettingsDb.saveSettingsItem(any(), any()),
+      ).thenAnswer((_) async => 1);
+
       getIt
         ..registerSingleton<UpdateNotifications>(mockUpdateNotifications)
         ..registerSingleton<JournalDb>(mockJournalDb)
+        ..registerSingleton<SettingsDb>(mockSettingsDb)
+        ..registerSingleton<LoggingService>(LoggingService())
         ..registerSingleton<UserActivityService>(UserActivityService())
         ..registerSingleton<EntitiesCacheService>(mockEntitiesCacheService)
         ..registerSingleton<NavService>(mockNavService);

--- a/test/features/design_system/components/navigation/resizable_divider_test.dart
+++ b/test/features/design_system/components/navigation/resizable_divider_test.dart
@@ -1,0 +1,192 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/components/navigation/resizable_divider.dart';
+
+import '../../../../widget_test_utils.dart';
+
+void main() {
+  setUp(setUpTestGetIt);
+  tearDown(tearDownTestGetIt);
+
+  Widget buildTestWidget({
+    required ValueChanged<double> onDrag,
+    double hitTargetWidth = 8,
+  }) {
+    return makeTestableWidgetNoScroll(
+      Row(
+        children: [
+          const Expanded(child: SizedBox()),
+          ResizableDivider(
+            onDrag: onDrag,
+            hitTargetWidth: hitTargetWidth,
+          ),
+          const Expanded(child: SizedBox()),
+        ],
+      ),
+      mediaQueryData: const MediaQueryData(size: Size(800, 600)),
+    );
+  }
+
+  group('ResizableDivider rendering', () {
+    testWidgets('renders with correct hit target width', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(onDrag: (_) {}),
+      );
+
+      final sizedBox = tester.widget<SizedBox>(
+        find.descendant(
+          of: find.byType(ResizableDivider),
+          matching: find.byType(SizedBox),
+        ),
+      );
+      expect(sizedBox.width, 8);
+    });
+
+    testWidgets('renders with custom hit target width', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(onDrag: (_) {}, hitTargetWidth: 12),
+      );
+
+      final sizedBox = tester.widget<SizedBox>(
+        find.descendant(
+          of: find.byType(ResizableDivider),
+          matching: find.byType(SizedBox),
+        ),
+      );
+      expect(sizedBox.width, 12);
+    });
+
+    testWidgets('shows resize column cursor via MouseRegion', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(onDrag: (_) {}),
+      );
+
+      final mouseRegion = tester.widget<MouseRegion>(
+        find.descendant(
+          of: find.byType(ResizableDivider),
+          matching: find.byType(MouseRegion),
+        ),
+      );
+      expect(mouseRegion.cursor, SystemMouseCursors.resizeColumn);
+    });
+
+    testWidgets('contains an AnimatedContainer for the visual line', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTestWidget(onDrag: (_) {}),
+      );
+
+      expect(
+        find.descendant(
+          of: find.byType(ResizableDivider),
+          matching: find.byType(AnimatedContainer),
+        ),
+        findsOneWidget,
+      );
+    });
+  });
+
+  group('ResizableDivider drag interaction', () {
+    testWidgets('calls onDrag with positive delta when dragged right', (
+      tester,
+    ) async {
+      final deltas = <double>[];
+      await tester.pumpWidget(
+        buildTestWidget(onDrag: deltas.add),
+      );
+
+      final center = tester.getCenter(find.byType(ResizableDivider));
+      await tester.timedDragFrom(
+        center,
+        const Offset(50, 0),
+        const Duration(milliseconds: 200),
+      );
+
+      expect(deltas, isNotEmpty);
+      final totalDelta = deltas.fold<double>(0, (sum, d) => sum + d);
+      expect(totalDelta, greaterThan(0));
+    });
+
+    testWidgets('calls onDrag with negative delta when dragged left', (
+      tester,
+    ) async {
+      final deltas = <double>[];
+      await tester.pumpWidget(
+        buildTestWidget(onDrag: deltas.add),
+      );
+
+      final center = tester.getCenter(find.byType(ResizableDivider));
+      await tester.timedDragFrom(
+        center,
+        const Offset(-50, 0),
+        const Duration(milliseconds: 200),
+      );
+
+      expect(deltas, isNotEmpty);
+      final totalDelta = deltas.fold<double>(0, (sum, d) => sum + d);
+      expect(totalDelta, lessThan(0));
+    });
+
+    testWidgets('reports zero horizontal delta for vertical-only drags', (
+      tester,
+    ) async {
+      final deltas = <double>[];
+      await tester.pumpWidget(
+        buildTestWidget(onDrag: deltas.add),
+      );
+
+      final center = tester.getCenter(find.byType(ResizableDivider));
+      await tester.timedDragFrom(
+        center,
+        const Offset(0, 50),
+        const Duration(milliseconds: 200),
+      );
+
+      // Vertical drags produce zero horizontal deltas
+      final totalDelta = deltas.fold<double>(0, (sum, d) => sum + d);
+      expect(totalDelta, 0);
+    });
+  });
+
+  group('ResizableDivider visual line width', () {
+    testWidgets('line is thin (1px) by default', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(onDrag: (_) {}),
+      );
+
+      final animatedContainer = tester.widget<AnimatedContainer>(
+        find.descendant(
+          of: find.byType(ResizableDivider),
+          matching: find.byType(AnimatedContainer),
+        ),
+      );
+      // Default state: not hovering, not dragging → width should be 1
+      expect(animatedContainer.constraints?.maxWidth ?? 1, 1);
+    });
+
+    testWidgets('line thickens during drag', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(onDrag: (_) {}),
+      );
+
+      // Start a drag but hold it
+      final center = tester.getCenter(find.byType(ResizableDivider));
+      final gesture = await tester.startGesture(center);
+      await gesture.moveBy(const Offset(10, 0));
+      await tester.pump();
+
+      final animatedContainer = tester.widget<AnimatedContainer>(
+        find.descendant(
+          of: find.byType(ResizableDivider),
+          matching: find.byType(AnimatedContainer),
+        ),
+      );
+      // During drag: width should be 3
+      expect(animatedContainer.constraints?.maxWidth ?? 3, 3);
+
+      await gesture.up();
+      await tester.pump();
+    });
+  });
+}

--- a/test/features/design_system/components/navigation/resizable_divider_test.dart
+++ b/test/features/design_system/components/navigation/resizable_divider_test.dart
@@ -162,7 +162,8 @@ void main() {
         ),
       );
       // Default state: not hovering, not dragging → width should be 1
-      expect(animatedContainer.constraints?.maxWidth ?? 1, 1);
+      expect(animatedContainer.constraints, isNotNull);
+      expect(animatedContainer.constraints!.maxWidth, 1);
     });
 
     testWidgets('line thickens during drag', (tester) async {
@@ -183,10 +184,36 @@ void main() {
         ),
       );
       // During drag: width should be 3
-      expect(animatedContainer.constraints?.maxWidth ?? 3, 3);
+      expect(animatedContainer.constraints, isNotNull);
+      expect(animatedContainer.constraints!.maxWidth, 3);
 
       await gesture.up();
       await tester.pump();
+    });
+
+    testWidgets('line returns to thin after drag ends', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(onDrag: (_) {}),
+      );
+
+      final center = tester.getCenter(find.byType(ResizableDivider));
+      final gesture = await tester.startGesture(center);
+      await gesture.moveBy(const Offset(10, 0));
+      await tester.pump();
+
+      // End drag
+      await gesture.up();
+      await tester.pump();
+
+      final animatedContainer = tester.widget<AnimatedContainer>(
+        find.descendant(
+          of: find.byType(ResizableDivider),
+          matching: find.byType(AnimatedContainer),
+        ),
+      );
+      // After drag ends: width should be back to 1
+      expect(animatedContainer.constraints, isNotNull);
+      expect(animatedContainer.constraints!.maxWidth, 1);
     });
   });
 }

--- a/test/features/design_system/state/pane_width_controller_test.dart
+++ b/test/features/design_system/state/pane_width_controller_test.dart
@@ -1,5 +1,4 @@
-import 'dart:async';
-
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/database/settings_db.dart';
@@ -28,25 +27,15 @@ Future<ProviderContainer> _createContainerWithPersistedWidths({
   return ProviderContainer();
 }
 
-/// Waits for the async hydration in [PaneWidthController] to settle.
-Future<PaneWidths> _awaitHydration(
-  ProviderContainer container, {
-  Duration timeout = const Duration(milliseconds: 50),
-}) async {
-  final completer = Completer<PaneWidths>();
-  container.listen(paneWidthControllerProvider, (prev, next) {
-    if (!completer.isCompleted && next != const PaneWidths()) {
-      completer.complete(next);
-    }
-  });
-  // ignore: cascade_invocations
+/// Triggers provider read and flushes microtasks so the async
+/// `_loadPersistedWidths` (which calls the mocked `itemsByKeys`)
+/// completes deterministically.
+Future<PaneWidths> _awaitHydration(ProviderContainer container) async {
+  // Force provider build, which fires _loadPersistedWidths.
   container.read(paneWidthControllerProvider);
-
-  final result = await Future.any([
-    completer.future,
-    Future<PaneWidths>.delayed(timeout, PaneWidths.new),
-  ]);
-  return result;
+  // The mock resolves synchronously as a microtask — flush it.
+  await Future<void>.value();
+  return container.read(paneWidthControllerProvider);
 }
 
 void main() {
@@ -238,16 +227,50 @@ void main() {
       );
     });
 
-    test('persists to SettingsDb', () {
-      container
-          .read(paneWidthControllerProvider.notifier)
-          .updateSidebarWidth(30);
-      verify(
-        () => getIt<SettingsDb>().saveSettingsItem(
-          sidebarWidthKey,
-          '350.0',
-        ),
-      ).called(1);
+    test('persists to SettingsDb after debounce', () {
+      fakeAsync((async) {
+        container
+            .read(paneWidthControllerProvider.notifier)
+            .updateSidebarWidth(30);
+        async.flushMicrotasks();
+
+        // Not yet persisted before debounce fires
+        verifyNever(
+          () => getIt<SettingsDb>().saveSettingsItem(
+            sidebarWidthKey,
+            any(),
+          ),
+        );
+
+        async.elapse(persistDebounce);
+
+        verify(
+          () => getIt<SettingsDb>().saveSettingsItem(
+            sidebarWidthKey,
+            '350.0',
+          ),
+        ).called(1);
+      });
+    });
+
+    test('debounce coalesces rapid updates into one write', () {
+      fakeAsync((async) {
+        container.read(paneWidthControllerProvider.notifier)
+          ..updateSidebarWidth(10)
+          ..updateSidebarWidth(20)
+          ..updateSidebarWidth(30);
+        async
+          ..flushMicrotasks()
+          ..elapse(persistDebounce);
+
+        // Only the final accumulated value is persisted
+        verify(
+          () => getIt<SettingsDb>().saveSettingsItem(
+            sidebarWidthKey,
+            '380.0',
+          ),
+        ).called(1);
+      });
     });
   });
 
@@ -302,16 +325,29 @@ void main() {
       );
     });
 
-    test('persists to SettingsDb', () {
-      container
-          .read(paneWidthControllerProvider.notifier)
-          .updateListPaneWidth(60);
-      verify(
-        () => getIt<SettingsDb>().saveSettingsItem(
-          listPaneWidthKey,
-          '600.0',
-        ),
-      ).called(1);
+    test('persists to SettingsDb after debounce', () {
+      fakeAsync((async) {
+        container
+            .read(paneWidthControllerProvider.notifier)
+            .updateListPaneWidth(60);
+        async.flushMicrotasks();
+
+        verifyNever(
+          () => getIt<SettingsDb>().saveSettingsItem(
+            listPaneWidthKey,
+            any(),
+          ),
+        );
+
+        async.elapse(persistDebounce);
+
+        verify(
+          () => getIt<SettingsDb>().saveSettingsItem(
+            listPaneWidthKey,
+            '600.0',
+          ),
+        ).called(1);
+      });
     });
   });
 
@@ -326,7 +362,7 @@ void main() {
       expect(state.listPaneWidth, defaultListPaneWidth);
     });
 
-    test('persists both widths to SettingsDb', () {
+    test('persists immediately without debounce', () {
       container.read(paneWidthControllerProvider.notifier).resetToDefaults();
       verify(
         () => getIt<SettingsDb>().saveSettingsItem(
@@ -340,6 +376,33 @@ void main() {
           '540.0',
         ),
       ).called(1);
+    });
+
+    test('cancels pending debounced writes', () {
+      fakeAsync((async) {
+        container.read(paneWidthControllerProvider.notifier)
+          ..updateSidebarWidth(50)
+          ..updateListPaneWidth(100)
+          ..resetToDefaults();
+        async
+          ..flushMicrotasks()
+          ..elapse(persistDebounce);
+
+        // The debounced writes from updateSidebarWidth/updateListPaneWidth
+        // should be cancelled; only resetToDefaults writes should fire.
+        verify(
+          () => getIt<SettingsDb>().saveSettingsItem(
+            sidebarWidthKey,
+            '320.0',
+          ),
+        ).called(1);
+        verify(
+          () => getIt<SettingsDb>().saveSettingsItem(
+            listPaneWidthKey,
+            '540.0',
+          ),
+        ).called(1);
+      });
     });
   });
 
@@ -373,6 +436,79 @@ void main() {
       final state = container.read(paneWidthControllerProvider);
       expect(state.sidebarWidth, defaultSidebarWidth + 50);
       expect(state.listPaneWidth, defaultListPaneWidth - 100);
+    });
+  });
+
+  group('PaneWidthController non-finite values', () {
+    test('rejects NaN persisted sidebar width', () async {
+      container.dispose();
+      container = await _createContainerWithPersistedWidths(
+        sidebarWidth: 'NaN',
+        listPaneWidth: '450.0',
+      );
+
+      final result = await _awaitHydration(container);
+      expect(result.sidebarWidth, defaultSidebarWidth);
+      expect(result.listPaneWidth, 450.0);
+    });
+
+    test('rejects Infinity persisted list pane width', () async {
+      container.dispose();
+      container = await _createContainerWithPersistedWidths(
+        sidebarWidth: '280.0',
+        listPaneWidth: 'Infinity',
+      );
+
+      final result = await _awaitHydration(container);
+      expect(result.sidebarWidth, 280.0);
+      expect(result.listPaneWidth, defaultListPaneWidth);
+    });
+
+    test('rejects -Infinity persisted width', () async {
+      container.dispose();
+      container = await _createContainerWithPersistedWidths(
+        sidebarWidth: '-Infinity',
+      );
+
+      final result = await _awaitHydration(container);
+      expect(result.sidebarWidth, defaultSidebarWidth);
+    });
+  });
+
+  group('PaneWidthController error handling', () {
+    test('keeps defaults when loadPersistedWidths throws', () async {
+      container.dispose();
+      await tearDownTestGetIt();
+      final mocks = await setUpTestGetIt();
+      when(
+        () => mocks.settingsDb.itemsByKeys(any()),
+      ).thenThrow(Exception('database error'));
+      container = ProviderContainer();
+
+      final result = await _awaitHydration(container);
+      expect(result.sidebarWidth, defaultSidebarWidth);
+      expect(result.listPaneWidth, defaultListPaneWidth);
+    });
+
+    test('logs error when persist write fails', () {
+      fakeAsync((async) {
+        when(
+          () => getIt<SettingsDb>().saveSettingsItem(any(), any()),
+        ).thenThrow(Exception('write error'));
+
+        container
+            .read(paneWidthControllerProvider.notifier)
+            .updateSidebarWidth(30);
+        async
+          ..flushMicrotasks()
+          ..elapse(persistDebounce);
+
+        // State should still have updated despite persist failure
+        expect(
+          container.read(paneWidthControllerProvider).sidebarWidth,
+          defaultSidebarWidth + 30,
+        );
+      });
     });
   });
 }

--- a/test/features/design_system/state/pane_width_controller_test.dart
+++ b/test/features/design_system/state/pane_width_controller_test.dart
@@ -1,0 +1,378 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/database/settings_db.dart';
+import 'package:lotti/features/design_system/state/pane_width_controller.dart';
+import 'package:lotti/get_it.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../widget_test_utils.dart';
+
+/// Creates a fresh [ProviderContainer] with [SettingsDb.itemsByKeys] stubbed
+/// to return the given values for the pane width keys.
+Future<ProviderContainer> _createContainerWithPersistedWidths({
+  String? sidebarWidth,
+  String? listPaneWidth,
+}) async {
+  await tearDownTestGetIt();
+  final mocks = await setUpTestGetIt();
+  when(
+    () => mocks.settingsDb.itemsByKeys(any()),
+  ).thenAnswer(
+    (_) async => <String, String?>{
+      sidebarWidthKey: sidebarWidth,
+      listPaneWidthKey: listPaneWidth,
+    },
+  );
+  return ProviderContainer();
+}
+
+/// Waits for the async hydration in [PaneWidthController] to settle.
+Future<PaneWidths> _awaitHydration(
+  ProviderContainer container, {
+  Duration timeout = const Duration(milliseconds: 50),
+}) async {
+  final completer = Completer<PaneWidths>();
+  container.listen(paneWidthControllerProvider, (prev, next) {
+    if (!completer.isCompleted && next != const PaneWidths()) {
+      completer.complete(next);
+    }
+  });
+  // ignore: cascade_invocations
+  container.read(paneWidthControllerProvider);
+
+  final result = await Future.any([
+    completer.future,
+    Future<PaneWidths>.delayed(timeout, PaneWidths.new),
+  ]);
+  return result;
+}
+
+void main() {
+  late ProviderContainer container;
+
+  setUp(() async {
+    final mocks = await setUpTestGetIt();
+    when(
+      () => mocks.settingsDb.itemsByKeys(any()),
+    ).thenAnswer(
+      (_) async => <String, String?>{
+        sidebarWidthKey: null,
+        listPaneWidthKey: null,
+      },
+    );
+    container = ProviderContainer();
+  });
+
+  tearDown(() async {
+    container.dispose();
+    await tearDownTestGetIt();
+  });
+
+  group('PaneWidths', () {
+    test('default values match constants', () {
+      const widths = PaneWidths();
+      expect(widths.sidebarWidth, defaultSidebarWidth);
+      expect(widths.listPaneWidth, defaultListPaneWidth);
+    });
+
+    test('copyWith creates new instance with updated values', () {
+      const widths = PaneWidths();
+      final updated = widths.copyWith(sidebarWidth: 400);
+      expect(updated.sidebarWidth, 400);
+      expect(updated.listPaneWidth, defaultListPaneWidth);
+    });
+
+    test('copyWith preserves existing values when not specified', () {
+      const widths = PaneWidths(sidebarWidth: 250, listPaneWidth: 600);
+      final updated = widths.copyWith(listPaneWidth: 700);
+      expect(updated.sidebarWidth, 250);
+      expect(updated.listPaneWidth, 700);
+    });
+
+    test('equality compares field values', () {
+      const a = PaneWidths(sidebarWidth: 300, listPaneWidth: 500);
+      const b = PaneWidths(sidebarWidth: 300, listPaneWidth: 500);
+      const c = PaneWidths(sidebarWidth: 300, listPaneWidth: 600);
+      expect(a, equals(b));
+      expect(a, isNot(equals(c)));
+    });
+
+    test('hashCode is consistent with equality', () {
+      const a = PaneWidths(sidebarWidth: 300, listPaneWidth: 500);
+      const b = PaneWidths(sidebarWidth: 300, listPaneWidth: 500);
+      expect(a.hashCode, equals(b.hashCode));
+    });
+  });
+
+  group('PaneWidthController build', () {
+    test('returns default PaneWidths on init', () {
+      final state = container.read(paneWidthControllerProvider);
+      expect(state.sidebarWidth, defaultSidebarWidth);
+      expect(state.listPaneWidth, defaultListPaneWidth);
+    });
+
+    test('loads persisted widths from SettingsDb', () async {
+      container.dispose();
+      container = await _createContainerWithPersistedWidths(
+        sidebarWidth: '280.0',
+        listPaneWidth: '450.0',
+      );
+
+      final result = await _awaitHydration(container);
+      expect(result.sidebarWidth, 280.0);
+      expect(result.listPaneWidth, 450.0);
+    });
+
+    test('clamps persisted sidebar width below minimum', () async {
+      container.dispose();
+      container = await _createContainerWithPersistedWidths(
+        sidebarWidth: '50.0',
+      );
+
+      final result = await _awaitHydration(container);
+      expect(result.sidebarWidth, minSidebarWidth);
+    });
+
+    test('clamps persisted sidebar width above maximum', () async {
+      container.dispose();
+      container = await _createContainerWithPersistedWidths(
+        sidebarWidth: '999.0',
+      );
+
+      final result = await _awaitHydration(container);
+      expect(result.sidebarWidth, maxSidebarWidth);
+    });
+
+    test('clamps persisted list pane width below minimum', () async {
+      container.dispose();
+      container = await _createContainerWithPersistedWidths(
+        listPaneWidth: '50.0',
+      );
+
+      final result = await _awaitHydration(container);
+      expect(result.listPaneWidth, minListPaneWidth);
+    });
+
+    test('clamps persisted list pane width above maximum', () async {
+      container.dispose();
+      container = await _createContainerWithPersistedWidths(
+        listPaneWidth: '2000.0',
+      );
+
+      final result = await _awaitHydration(container);
+      expect(result.listPaneWidth, maxListPaneWidth);
+    });
+
+    test('handles non-numeric persisted values gracefully', () async {
+      container.dispose();
+      container = await _createContainerWithPersistedWidths(
+        sidebarWidth: 'invalid',
+        listPaneWidth: 'abc',
+      );
+
+      final result = await _awaitHydration(container);
+      expect(result.sidebarWidth, defaultSidebarWidth);
+      expect(result.listPaneWidth, defaultListPaneWidth);
+    });
+
+    test('handles null persisted values gracefully', () async {
+      container.dispose();
+      container = await _createContainerWithPersistedWidths();
+
+      final result = await _awaitHydration(container);
+      expect(result.sidebarWidth, defaultSidebarWidth);
+      expect(result.listPaneWidth, defaultListPaneWidth);
+    });
+  });
+
+  group('PaneWidthController updateSidebarWidth', () {
+    test('increases sidebar width by delta', () {
+      container
+          .read(paneWidthControllerProvider.notifier)
+          .updateSidebarWidth(50);
+      expect(
+        container.read(paneWidthControllerProvider).sidebarWidth,
+        defaultSidebarWidth + 50,
+      );
+    });
+
+    test('decreases sidebar width by negative delta', () {
+      container
+          .read(paneWidthControllerProvider.notifier)
+          .updateSidebarWidth(-50);
+      expect(
+        container.read(paneWidthControllerProvider).sidebarWidth,
+        defaultSidebarWidth - 50,
+      );
+    });
+
+    test('clamps at minSidebarWidth', () {
+      container
+          .read(paneWidthControllerProvider.notifier)
+          .updateSidebarWidth(-500);
+      expect(
+        container.read(paneWidthControllerProvider).sidebarWidth,
+        minSidebarWidth,
+      );
+    });
+
+    test('clamps at maxSidebarWidth', () {
+      container
+          .read(paneWidthControllerProvider.notifier)
+          .updateSidebarWidth(500);
+      expect(
+        container.read(paneWidthControllerProvider).sidebarWidth,
+        maxSidebarWidth,
+      );
+    });
+
+    test('does not affect list pane width', () {
+      container
+          .read(paneWidthControllerProvider.notifier)
+          .updateSidebarWidth(50);
+      expect(
+        container.read(paneWidthControllerProvider).listPaneWidth,
+        defaultListPaneWidth,
+      );
+    });
+
+    test('persists to SettingsDb', () {
+      container
+          .read(paneWidthControllerProvider.notifier)
+          .updateSidebarWidth(30);
+      verify(
+        () => getIt<SettingsDb>().saveSettingsItem(
+          sidebarWidthKey,
+          '350.0',
+        ),
+      ).called(1);
+    });
+  });
+
+  group('PaneWidthController updateListPaneWidth', () {
+    test('increases list pane width by delta', () {
+      container
+          .read(paneWidthControllerProvider.notifier)
+          .updateListPaneWidth(100);
+      expect(
+        container.read(paneWidthControllerProvider).listPaneWidth,
+        defaultListPaneWidth + 100,
+      );
+    });
+
+    test('decreases list pane width by negative delta', () {
+      container
+          .read(paneWidthControllerProvider.notifier)
+          .updateListPaneWidth(-100);
+      expect(
+        container.read(paneWidthControllerProvider).listPaneWidth,
+        defaultListPaneWidth - 100,
+      );
+    });
+
+    test('clamps at minListPaneWidth', () {
+      container
+          .read(paneWidthControllerProvider.notifier)
+          .updateListPaneWidth(-500);
+      expect(
+        container.read(paneWidthControllerProvider).listPaneWidth,
+        minListPaneWidth,
+      );
+    });
+
+    test('clamps at maxListPaneWidth', () {
+      container
+          .read(paneWidthControllerProvider.notifier)
+          .updateListPaneWidth(500);
+      expect(
+        container.read(paneWidthControllerProvider).listPaneWidth,
+        maxListPaneWidth,
+      );
+    });
+
+    test('does not affect sidebar width', () {
+      container
+          .read(paneWidthControllerProvider.notifier)
+          .updateListPaneWidth(100);
+      expect(
+        container.read(paneWidthControllerProvider).sidebarWidth,
+        defaultSidebarWidth,
+      );
+    });
+
+    test('persists to SettingsDb', () {
+      container
+          .read(paneWidthControllerProvider.notifier)
+          .updateListPaneWidth(60);
+      verify(
+        () => getIt<SettingsDb>().saveSettingsItem(
+          listPaneWidthKey,
+          '600.0',
+        ),
+      ).called(1);
+    });
+  });
+
+  group('PaneWidthController resetToDefaults', () {
+    test('resets both widths to defaults', () {
+      container.read(paneWidthControllerProvider.notifier)
+        ..updateSidebarWidth(50)
+        ..updateListPaneWidth(100)
+        ..resetToDefaults();
+      final state = container.read(paneWidthControllerProvider);
+      expect(state.sidebarWidth, defaultSidebarWidth);
+      expect(state.listPaneWidth, defaultListPaneWidth);
+    });
+
+    test('persists both widths to SettingsDb', () {
+      container.read(paneWidthControllerProvider.notifier).resetToDefaults();
+      verify(
+        () => getIt<SettingsDb>().saveSettingsItem(
+          sidebarWidthKey,
+          '320.0',
+        ),
+      ).called(1);
+      verify(
+        () => getIt<SettingsDb>().saveSettingsItem(
+          listPaneWidthKey,
+          '540.0',
+        ),
+      ).called(1);
+    });
+  });
+
+  group('PaneWidthController incremental updates', () {
+    test('accumulates multiple sidebar width updates', () {
+      container.read(paneWidthControllerProvider.notifier)
+        ..updateSidebarWidth(10)
+        ..updateSidebarWidth(20)
+        ..updateSidebarWidth(30);
+      expect(
+        container.read(paneWidthControllerProvider).sidebarWidth,
+        defaultSidebarWidth + 60,
+      );
+    });
+
+    test('accumulates multiple list pane width updates', () {
+      container.read(paneWidthControllerProvider.notifier)
+        ..updateListPaneWidth(10)
+        ..updateListPaneWidth(20)
+        ..updateListPaneWidth(30);
+      expect(
+        container.read(paneWidthControllerProvider).listPaneWidth,
+        defaultListPaneWidth + 60,
+      );
+    });
+
+    test('independent updates do not interfere', () {
+      container.read(paneWidthControllerProvider.notifier)
+        ..updateSidebarWidth(50)
+        ..updateListPaneWidth(-100);
+      final state = container.read(paneWidthControllerProvider);
+      expect(state.sidebarWidth, defaultSidebarWidth + 50);
+      expect(state.listPaneWidth, defaultListPaneWidth - 100);
+    });
+  });
+}

--- a/test/widget_test_utils.dart
+++ b/test/widget_test_utils.dart
@@ -69,6 +69,9 @@ Future<TestGetItMocks> setUpTestGetIt({
   ).thenAnswer((_) async => null);
   when(() => mockSettingsDb.itemByKey(any())).thenAnswer((_) async => null);
   when(
+    () => mockSettingsDb.itemsByKeys(any()),
+  ).thenAnswer((_) async => <String, String?>{});
+  when(
     () => mockSettingsDb.saveSettingsItem(any(), any()),
   ).thenAnswer((_) async => 1);
   final mockEmbeddingStore = MockEmbeddingStore();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop-only resizable panes: drag dividers to adjust navigation sidebar and list/detail widths; sizes persist across sessions.

* **Tests**
  * Added widget and provider tests covering the resizable divider, drag interactions, persistence, debounce and reset behaviors; test helpers updated for settings stubbing.

* **Documentation**
  * Recorded release 0.9.950 with details about the new resizable desktop layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->