### PR TITLE
test: add missing divider tests

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.950+3914
+version: 0.9.950+3915
 
 msix_config:
   display_name: LottiApp

--- a/test/features/dashboards/ui/pages/dashboards_list_page_test.dart
+++ b/test/features/dashboards/ui/pages/dashboards_list_page_test.dart
@@ -5,6 +5,8 @@ import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/features/dashboards/ui/pages/dashboard_page.dart';
 import 'package:lotti/features/dashboards/ui/pages/dashboards_list_page.dart';
 import 'package:lotti/features/design_system/components/navigation/desktop_detail_empty_state.dart';
+import 'package:lotti/features/design_system/components/navigation/resizable_divider.dart';
+import 'package:lotti/features/design_system/state/pane_width_controller.dart';
 import 'package:lotti/features/user_activity/state/user_activity_service.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/db_notification.dart';
@@ -360,5 +362,39 @@ void main() {
         await tester.pumpAndSettle();
       },
     );
+
+    testWidgets('dragging divider updates list pane width', (tester) async {
+      when(mockJournalDb.getAllDashboards).thenAnswer(
+        (_) async => [testDashboardConfig],
+      );
+
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          const DashboardsListPage(),
+          mediaQueryData: const MediaQueryData(size: Size(1280, 800)),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ResizableDivider), findsOneWidget);
+
+      final dividerCenter = tester.getCenter(find.byType(ResizableDivider));
+      await tester.timedDragFrom(
+        dividerCenter,
+        const Offset(50, 0),
+        const Duration(milliseconds: 200),
+      );
+      await tester.pump();
+
+      final sizedBox = tester.widget<SizedBox>(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is SizedBox &&
+              widget.width != null &&
+              widget.width! > defaultListPaneWidth,
+        ),
+      );
+      expect(sizedBox.width, greaterThan(defaultListPaneWidth));
+    });
   });
 }

--- a/test/features/dashboards/ui/pages/dashboards_list_page_test.dart
+++ b/test/features/dashboards/ui/pages/dashboards_list_page_test.dart
@@ -379,22 +379,16 @@ void main() {
       expect(find.byType(ResizableDivider), findsOneWidget);
 
       final dividerCenter = tester.getCenter(find.byType(ResizableDivider));
-      await tester.timedDragFrom(
-        dividerCenter,
-        const Offset(50, 0),
-        const Duration(milliseconds: 200),
-      );
+      await tester.dragFrom(dividerCenter, const Offset(50, 0));
       await tester.pump();
 
       final sizedBox = tester.widget<SizedBox>(
         find.byWidgetPredicate(
           (widget) =>
-              widget is SizedBox &&
-              widget.width != null &&
-              widget.width! > defaultListPaneWidth,
+              widget is SizedBox && widget.width == defaultListPaneWidth + 50,
         ),
       );
-      expect(sizedBox.width, greaterThan(defaultListPaneWidth));
+      expect(sizedBox.width, defaultListPaneWidth + 50);
     });
   });
 }

--- a/test/features/design_system/components/navigation/resizable_divider_test.dart
+++ b/test/features/design_system/components/navigation/resizable_divider_test.dart
@@ -165,8 +165,9 @@ void main() {
       final gesture = await tester.createGesture(
         kind: PointerDeviceKind.mouse,
       );
-      await gesture.addPointer(location: center);
+      await gesture.addPointer(location: Offset.zero);
       addTearDown(gesture.removePointer);
+      await gesture.moveTo(center);
       await tester.pump();
 
       var animatedContainer = tester.widget<AnimatedContainer>(

--- a/test/features/design_system/components/navigation/resizable_divider_test.dart
+++ b/test/features/design_system/components/navigation/resizable_divider_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/design_system/components/navigation/resizable_divider.dart';
@@ -146,6 +148,74 @@ void main() {
       // Vertical drags produce zero horizontal deltas
       final totalDelta = deltas.fold<double>(0, (sum, d) => sum + d);
       expect(totalDelta, 0);
+    });
+  });
+
+  group('ResizableDivider hover interaction', () {
+    testWidgets('activates on mouse enter and deactivates on exit', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTestWidget(onDrag: (_) {}),
+      );
+
+      final center = tester.getCenter(find.byType(ResizableDivider));
+
+      // Simulate mouse hover enter
+      final gesture = await tester.createGesture(
+        kind: PointerDeviceKind.mouse,
+      );
+      await gesture.addPointer(location: center);
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+
+      var animatedContainer = tester.widget<AnimatedContainer>(
+        find.descendant(
+          of: find.byType(ResizableDivider),
+          matching: find.byType(AnimatedContainer),
+        ),
+      );
+      expect(animatedContainer.constraints, isNotNull);
+      expect(animatedContainer.constraints!.maxWidth, 3);
+
+      // Simulate mouse hover exit
+      await gesture.moveTo(Offset.zero);
+      await tester.pump();
+
+      animatedContainer = tester.widget<AnimatedContainer>(
+        find.descendant(
+          of: find.byType(ResizableDivider),
+          matching: find.byType(AnimatedContainer),
+        ),
+      );
+      expect(animatedContainer.constraints, isNotNull);
+      expect(animatedContainer.constraints!.maxWidth, 1);
+    });
+  });
+
+  group('ResizableDivider drag cancel', () {
+    testWidgets('resets active state when drag is cancelled', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(onDrag: (_) {}),
+      );
+
+      final center = tester.getCenter(find.byType(ResizableDivider));
+      final gesture = await tester.startGesture(center);
+      await gesture.moveBy(const Offset(10, 0));
+      await tester.pump();
+
+      // Cancel the drag
+      await gesture.cancel();
+      await tester.pump();
+
+      final animatedContainer = tester.widget<AnimatedContainer>(
+        find.descendant(
+          of: find.byType(ResizableDivider),
+          matching: find.byType(AnimatedContainer),
+        ),
+      );
+      expect(animatedContainer.constraints, isNotNull);
+      expect(animatedContainer.constraints!.maxWidth, 1);
     });
   });
 

--- a/test/features/projects/ui/pages/projects_tab_page_test.dart
+++ b/test/features/projects/ui/pages/projects_tab_page_test.dart
@@ -5,7 +5,9 @@ import 'package:lotti/classes/project_data.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_floating_action_button.dart';
 import 'package:lotti/features/design_system/components/checkboxes/design_system_checkbox.dart';
 import 'package:lotti/features/design_system/components/navigation/desktop_detail_empty_state.dart';
+import 'package:lotti/features/design_system/components/navigation/resizable_divider.dart';
 import 'package:lotti/features/design_system/components/task_filters/design_system_filter_selection_modal.dart';
+import 'package:lotti/features/design_system/state/pane_width_controller.dart';
 import 'package:lotti/features/projects/model/projects_overview_models.dart';
 import 'package:lotti/features/projects/state/project_providers.dart';
 import 'package:lotti/features/projects/ui/pages/project_details_page.dart';
@@ -447,4 +449,34 @@ void main() {
       expect(find.text('Apply filter'), findsNothing);
     },
   );
+
+  testWidgets('dragging divider updates list pane width in desktop layout', (
+    tester,
+  ) async {
+    await pumpPage(
+      tester,
+      groups: [buildWorkGroup()],
+      mediaQueryData: const MediaQueryData(size: Size(1280, 800)),
+    );
+
+    expect(find.byType(ResizableDivider), findsOneWidget);
+
+    final dividerCenter = tester.getCenter(find.byType(ResizableDivider));
+    await tester.timedDragFrom(
+      dividerCenter,
+      const Offset(50, 0),
+      const Duration(milliseconds: 200),
+    );
+    await tester.pump();
+
+    final sizedBox = tester.widget<SizedBox>(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is SizedBox &&
+            widget.width != null &&
+            widget.width! > defaultListPaneWidth,
+      ),
+    );
+    expect(sizedBox.width, greaterThan(defaultListPaneWidth));
+  });
 }

--- a/test/features/projects/ui/pages/projects_tab_page_test.dart
+++ b/test/features/projects/ui/pages/projects_tab_page_test.dart
@@ -462,21 +462,15 @@ void main() {
     expect(find.byType(ResizableDivider), findsOneWidget);
 
     final dividerCenter = tester.getCenter(find.byType(ResizableDivider));
-    await tester.timedDragFrom(
-      dividerCenter,
-      const Offset(50, 0),
-      const Duration(milliseconds: 200),
-    );
+    await tester.dragFrom(dividerCenter, const Offset(50, 0));
     await tester.pump();
 
     final sizedBox = tester.widget<SizedBox>(
       find.byWidgetPredicate(
         (widget) =>
-            widget is SizedBox &&
-            widget.width != null &&
-            widget.width! > defaultListPaneWidth,
+            widget is SizedBox && widget.width == defaultListPaneWidth + 50,
       ),
     );
-    expect(sizedBox.width, greaterThan(defaultListPaneWidth));
+    expect(sizedBox.width, defaultListPaneWidth + 50);
   });
 }

--- a/test/features/tasks/ui/pages/tasks_root_page_test.dart
+++ b/test/features/tasks/ui/pages/tasks_root_page_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/design_system/components/navigation/desktop_detail_empty_state.dart';
+import 'package:lotti/features/design_system/components/navigation/resizable_divider.dart';
+import 'package:lotti/features/design_system/state/pane_width_controller.dart';
 import 'package:lotti/features/journal/state/journal_page_controller.dart';
 import 'package:lotti/features/journal/state/journal_page_scope.dart';
 import 'package:lotti/features/journal/state/journal_page_state.dart';
@@ -129,5 +131,44 @@ void main() {
     // flutter_animate inside the detail page.
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pumpAndSettle();
+  });
+
+  testWidgets('dragging divider updates list pane width', (tester) async {
+    fakeController = FakeJournalPageController(state());
+
+    await tester.pumpWidget(
+      makeTestableWidgetNoScroll(
+        const TasksRootPage(),
+        mediaQueryData: const MediaQueryData(size: Size(1280, 800)),
+        overrides: [
+          journalPageScopeProvider.overrideWithValue(true),
+          journalPageControllerProvider(
+            true,
+          ).overrideWith(() => fakeController),
+        ],
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byType(ResizableDivider), findsOneWidget);
+
+    final dividerCenter = tester.getCenter(find.byType(ResizableDivider));
+    await tester.timedDragFrom(
+      dividerCenter,
+      const Offset(50, 0),
+      const Duration(milliseconds: 200),
+    );
+    await tester.pump();
+
+    // Verify the list pane SizedBox width changed from the default
+    final sizedBox = tester.widget<SizedBox>(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is SizedBox &&
+            widget.width != null &&
+            widget.width! > defaultListPaneWidth,
+      ),
+    );
+    expect(sizedBox.width, greaterThan(defaultListPaneWidth));
   });
 }

--- a/test/features/tasks/ui/pages/tasks_root_page_test.dart
+++ b/test/features/tasks/ui/pages/tasks_root_page_test.dart
@@ -153,22 +153,15 @@ void main() {
     expect(find.byType(ResizableDivider), findsOneWidget);
 
     final dividerCenter = tester.getCenter(find.byType(ResizableDivider));
-    await tester.timedDragFrom(
-      dividerCenter,
-      const Offset(50, 0),
-      const Duration(milliseconds: 200),
-    );
+    await tester.dragFrom(dividerCenter, const Offset(50, 0));
     await tester.pump();
 
-    // Verify the list pane SizedBox width changed from the default
     final sizedBox = tester.widget<SizedBox>(
       find.byWidgetPredicate(
         (widget) =>
-            widget is SizedBox &&
-            widget.width != null &&
-            widget.width! > defaultListPaneWidth,
+            widget is SizedBox && widget.width == defaultListPaneWidth + 50,
       ),
     );
-    expect(sizedBox.width, greaterThan(defaultListPaneWidth));
+    expect(sizedBox.width, defaultListPaneWidth + 50);
   });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded widget tests for desktop split-pane behavior across dashboards, projects, and tasks: verifies dragging updates sidebar widths, hover visual transitions, and drag-cancel recovery for more reliable/responsive divider interaction (including pointer/mouse simulations).
* **Chores**
  * Bumped package version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->