### PR TITLE
fix: flicker in desktop task list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   navigation sidebar and content area, and between the list and detail panes,
   to adjust widths. Pane sizes persist across sessions via SettingsDb.
 
+### Fixed
+- Tasks desktop split view now keeps the current list rows mounted until the
+  refreshed first page resolves, which reduces visible flicker during task
+  saves and other live updates.
+
 ## [0.9.949] - 2026-04-10
 ### Changed
 - Redesigned dashboard list page: removed the old SliverAppBar top bar,

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -35,6 +35,7 @@
       <description>
           <p>Removed the gamey theme and all gamey-styled widgets. Standard Flutter widgets and existing modern cards are used instead.</p>
           <p>Resizable panes in desktop layout: drag dividers between the navigation sidebar and content area, and between the list and detail panes, to adjust widths. Pane sizes persist across sessions.</p>
+          <p>Tasks desktop split view now keeps the current list rows mounted until the refreshed first page resolves, which reduces visible flicker during task saves and other live updates.</p>
       </description>
     </release>
     <release version="0.9.949" date="2026-04-10">

--- a/lib/features/journal/README.md
+++ b/lib/features/journal/README.md
@@ -193,7 +193,8 @@ The controller owns:
 - feature-flag gating for entry types and vector search
 - private-entry visibility
 - persisted filter state in `SettingsDb`
-- update-driven refresh behavior
+- update-driven refresh behavior, including retained first-page refreshes that
+  keep visible rows mounted until replacement data resolves
 - vector-search timing and distance metadata for the UI
 
 ### Browse and Search Flow
@@ -216,6 +217,11 @@ flowchart TD
   Updates["Throttled UpdateNotifications"] --> Refresh["Refresh if page is visible\nand affected IDs matter"]
   Refresh --> Paging
 ```
+
+When a visible browse page already has rows on screen, the controller now
+replaces the first page only after the new first-page query resolves. That
+avoids the `PagingController.reset()` path that would otherwise clear the list
+immediately and produce a visible desktop flicker during saves or live updates.
 
 ### What The Page Controller Persists
 

--- a/lib/features/journal/state/journal_page_controller.dart
+++ b/lib/features/journal/state/journal_page_controller.dart
@@ -176,7 +176,7 @@ class JournalPageController extends _$JournalPageController {
   }
 
   PagingController<int, JournalEntity> _createPagingController() {
-    return PagingController<int, JournalEntity>(
+    return _JournalPagingController(
       getNextPageKey: (PagingState<int, JournalEntity> pagingState) {
         final currentKeys = pagingState.keys;
         if (currentKeys == null || currentKeys.isEmpty) {
@@ -215,6 +215,37 @@ class JournalPageController extends _$JournalPageController {
       },
       fetchPage: _fetchPage,
     );
+  }
+
+  Future<void> _refreshFirstPagePreservingVisibleItems(
+    _JournalPagingController pagingController,
+  ) async {
+    final refreshToken = Object();
+    pagingController.startRetainedRefresh(refreshToken);
+    _postFilterNextRawOffset = null;
+
+    try {
+      final items = await _runQuery(0);
+      if (!ref.mounted || !pagingController.isRetainedRefresh(refreshToken)) {
+        return;
+      }
+
+      pagingController.replaceFirstPage(items, pageSize: pageSize);
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        print('Error in retained first-page refresh: $error\n$stackTrace');
+      }
+      if (!ref.mounted) {
+        return;
+      }
+      pagingController.finishRetainedRefreshWithError(
+        error,
+        refreshToken: refreshToken,
+      );
+      if (error is! Exception) {
+        rethrow;
+      }
+    }
   }
 
   void _setupSubscriptions(bool showTasks) {
@@ -804,7 +835,8 @@ class JournalPageController extends _$JournalPageController {
 
     _emitState();
 
-    if (state.pagingController == null) {
+    final pagingController = state.pagingController;
+    if (pagingController == null) {
       DevLogger.warning(
         name: 'JournalPageController',
         message: 'refreshQuery called but pagingController is null',
@@ -812,8 +844,15 @@ class JournalPageController extends _$JournalPageController {
       return;
     }
 
-    state.pagingController!.refresh();
-    state.pagingController!.fetchNextPage();
+    if (pagingController is _JournalPagingController &&
+        pagingController.hasVisibleItems) {
+      await _refreshFirstPagePreservingVisibleItems(pagingController);
+      return;
+    }
+
+    pagingController
+      ..refresh()
+      ..fetchNextPage();
   }
 
   void updateVisibility(VisibilityInfo visibilityInfo) {
@@ -1113,4 +1152,48 @@ class JournalPageController extends _$JournalPageController {
   bool get enableDashboards => _enableDashboards;
   bool get enableVectorSearchInternal => _enableVectorSearch;
   SearchMode get searchModeInternal => _searchMode;
+}
+
+class _JournalPagingController extends PagingController<int, JournalEntity> {
+  _JournalPagingController({
+    required super.getNextPageKey,
+    required super.fetchPage,
+  });
+
+  bool get hasVisibleItems =>
+      value.pages?.any((page) => page.isNotEmpty) ?? false;
+
+  void startRetainedRefresh(Object refreshToken) {
+    operation = refreshToken;
+    value = value.copyWith(
+      error: null,
+      isLoading: true,
+    );
+  }
+
+  bool isRetainedRefresh(Object refreshToken) => operation == refreshToken;
+
+  void replaceFirstPage(List<JournalEntity> items, {required int pageSize}) {
+    value = PagingState<int, JournalEntity>(
+      pages: [items],
+      keys: const [0],
+      hasNextPage: items.length == pageSize,
+    );
+    operation = null;
+  }
+
+  void finishRetainedRefreshWithError(
+    Object error, {
+    required Object refreshToken,
+  }) {
+    if (operation != refreshToken) {
+      return;
+    }
+
+    value = value.copyWith(
+      error: error,
+      isLoading: false,
+    );
+    operation = null;
+  }
 }

--- a/lib/features/journal/state/journal_page_controller.dart
+++ b/lib/features/journal/state/journal_page_controller.dart
@@ -221,20 +221,30 @@ class JournalPageController extends _$JournalPageController {
     _JournalPagingController pagingController,
   ) async {
     final refreshToken = Object();
+    final previousPostFilterNextRawOffset = _postFilterNextRawOffset;
     pagingController.startRetainedRefresh(refreshToken);
     _postFilterNextRawOffset = null;
 
     try {
       final items = await _runQuery(0);
+      // _runQuery mutates _postFilterNextRawOffset as a side effect.
+      // Capture locally and restore; only publish if this refresh is
+      // still current, so a slower stale query cannot overwrite a
+      // newer offset.
+      final localNextRawOffset = _postFilterNextRawOffset;
+      _postFilterNextRawOffset = previousPostFilterNextRawOffset;
+
       if (!ref.mounted || !pagingController.isRetainedRefresh(refreshToken)) {
         return;
       }
 
       pagingController.replaceFirstPage(items, pageSize: pageSize);
+      _postFilterNextRawOffset = localNextRawOffset;
     } catch (error, stackTrace) {
-      if (kDebugMode) {
-        print('Error in retained first-page refresh: $error\n$stackTrace');
-      }
+      DevLogger.warning(
+        name: 'JournalPageController',
+        message: 'Error in retained first-page refresh: $error\n$stackTrace',
+      );
       if (!ref.mounted) {
         return;
       }
@@ -347,7 +357,9 @@ class JournalPageController extends _$JournalPageController {
               _emitState();
 
               if (shouldRefreshAfterModeFallback) {
-                unawaited(refreshQuery());
+                unawaited(
+                  refreshQuery(preserveVisibleItems: true),
+                );
               }
 
               // Only persist if selection actually changed
@@ -379,13 +391,13 @@ class JournalPageController extends _$JournalPageController {
               _postFilterNextRawOffset = savedOffset;
               if (!setEquals(_lastIds, newIds)) {
                 _lastIds = newIds;
-                await refreshQuery();
+                await refreshQuery(preserveVisibleItems: true);
               } else if (displayedIds.intersection(affectedIds).isNotEmpty) {
-                await refreshQuery();
+                await refreshQuery(preserveVisibleItems: true);
               }
             } else {
               if (displayedIds.intersection(affectedIds).isNotEmpty) {
-                await refreshQuery();
+                await refreshQuery(preserveVisibleItems: true);
               }
             }
           } else {
@@ -402,7 +414,7 @@ class JournalPageController extends _$JournalPageController {
           modifiers: [HotKeyModifier.meta],
           scope: HotKeyScope.inapp,
         ),
-        keyDownHandler: (hotKey) => refreshQuery(),
+        keyDownHandler: (hotKey) => refreshQuery(preserveVisibleItems: true),
       );
     }
   }
@@ -830,7 +842,7 @@ class JournalPageController extends _$JournalPageController {
     await refreshQuery();
   }
 
-  Future<void> refreshQuery() async {
+  Future<void> refreshQuery({bool preserveVisibleItems = false}) async {
     _cachedAgentLinkedIds = null;
 
     _emitState();
@@ -844,7 +856,8 @@ class JournalPageController extends _$JournalPageController {
       return;
     }
 
-    if (pagingController is _JournalPagingController &&
+    if (preserveVisibleItems &&
+        pagingController is _JournalPagingController &&
         pagingController.hasVisibleItems) {
       await _refreshFirstPagePreservingVisibleItems(pagingController);
       return;
@@ -859,7 +872,7 @@ class JournalPageController extends _$JournalPageController {
     final isVisible = visibilityInfo.visibleBounds.size.width > 0;
     if (!_isVisible && isVisible && _needsRefreshOnVisible) {
       _needsRefreshOnVisible = false;
-      refreshQuery();
+      refreshQuery(preserveVisibleItems: true);
     }
     _isVisible = isVisible;
   }

--- a/lib/features/tasks/README.md
+++ b/lib/features/tasks/README.md
@@ -76,6 +76,11 @@ The redesigned tasks tab is an in-place browse-page migration, not a new query s
 
 `TasksTabPage` still reads from `JournalPageController(showTasks: true)` and still uses the journal feature's existing infinite paging path. The redesign only swaps the browse presentation layer on top of that controller.
 
+In desktop split-pane mode, `TasksRootPage` keeps the list pane mounted while
+the detail pane is keyed by the selected task ID. That gives each task detail
+surface its own state lifetime instead of reusing the previous task's
+stateful page internals across selection changes.
+
 At runtime the browse page does three specific things:
 
 1. it converts paged `JournalEntity` results into `TaskBrowseEntry` rows via `buildTaskBrowseEntries`

--- a/lib/features/tasks/ui/pages/tasks_root_page.dart
+++ b/lib/features/tasks/ui/pages/tasks_root_page.dart
@@ -42,7 +42,10 @@ class TasksRootPage extends ConsumerWidget {
               valueListenable: getIt<NavService>().desktopSelectedTaskId,
               builder: (context, selectedTaskId, _) {
                 if (selectedTaskId != null) {
-                  return TaskDetailsPage(taskId: selectedTaskId);
+                  return TaskDetailsPage(
+                    key: ValueKey(selectedTaskId),
+                    taskId: selectedTaskId,
+                  );
                 }
                 return DesktopDetailEmptyState(
                   message: context.messages.desktopEmptyStateSelectTask,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.950+3918
-
+version: 0.9.950+3919
 msix_config:
   display_name: LottiApp
   publisher_display_name: Nehlsen EDV Beratung GmbH

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,6 +2,7 @@ name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
 version: 0.9.950+3919
+
 msix_config:
   display_name: LottiApp
   publisher_display_name: Nehlsen EDV Beratung GmbH

--- a/test/features/journal/state/journal_page_controller_test.dart
+++ b/test/features/journal/state/journal_page_controller_test.dart
@@ -2183,7 +2183,9 @@ void main() {
               equals([initialTask]),
             );
 
-            unawaited(controller.refreshQuery());
+            unawaited(
+              controller.refreshQuery(preserveVisibleItems: true),
+            );
             async.flushMicrotasks();
 
             expect(
@@ -2200,6 +2202,305 @@ void main() {
               equals([refreshedTask]),
             );
             expect(state.pagingController?.value.isLoading, isFalse);
+          });
+        },
+      );
+
+      test(
+        'refreshQuery without preserveVisibleItems does full refresh — '
+        'items are transiently cleared',
+        () {
+          fakeAsync((async) {
+            final initialTask = JournalEntity.task(
+              meta: Metadata(
+                id: 'task-1',
+                createdAt: _testDate,
+                updatedAt: _testDate,
+                dateFrom: _testDate,
+                dateTo: _testDate,
+              ),
+              data: TaskData(
+                dateFrom: _testDate,
+                dateTo: _testDate,
+                statusHistory: const [],
+                title: 'Initial task',
+                status: TaskStatus.open(
+                  id: 'status-initial',
+                  createdAt: _testDate,
+                  utcOffset: 0,
+                ),
+              ),
+            );
+            final refreshedTask = JournalEntity.task(
+              meta: Metadata(
+                id: 'task-2',
+                createdAt: _testDate,
+                updatedAt: _testDate,
+                dateFrom: _testDate,
+                dateTo: _testDate,
+              ),
+              data: TaskData(
+                dateFrom: _testDate,
+                dateTo: _testDate,
+                statusHistory: const [],
+                title: 'Refreshed task',
+                status: TaskStatus.open(
+                  id: 'status-refreshed',
+                  createdAt: _testDate,
+                  utcOffset: 0,
+                ),
+              ),
+            );
+            final refreshCompleter = Completer<List<JournalEntity>>();
+            var getTasksCallCount = 0;
+
+            when(
+              () => mockJournalDb.getTasks(
+                ids: any(named: 'ids'),
+                starredStatuses: any(named: 'starredStatuses'),
+                taskStatuses: any(named: 'taskStatuses'),
+                categoryIds: any(named: 'categoryIds'),
+                labelIds: any(named: 'labelIds'),
+                priorities: any(named: 'priorities'),
+                sortByDate: any(named: 'sortByDate'),
+                limit: any(named: 'limit'),
+                offset: any(named: 'offset'),
+              ),
+            ).thenAnswer((_) {
+              getTasksCallCount++;
+              if (getTasksCallCount == 1) {
+                return Future.value([initialTask]);
+              }
+              return refreshCompleter.future;
+            });
+
+            final state = container.read(journalPageControllerProvider(true));
+            final controller = container.read(
+              journalPageControllerProvider(true).notifier,
+            );
+
+            async.flushMicrotasks();
+
+            expect(
+              state.pagingController?.value.items,
+              equals([initialTask]),
+            );
+
+            // Default refreshQuery (preserveVisibleItems: false) triggers
+            // a full refresh — items are transiently cleared.
+            unawaited(controller.refreshQuery());
+            async.flushMicrotasks();
+
+            // Items are cleared during full refresh (unlike retained refresh)
+            expect(state.pagingController?.value.items, isNull);
+
+            // Complete the refresh query
+            refreshCompleter.complete([refreshedTask]);
+            async.flushMicrotasks();
+
+            // Items are now repopulated with the new data
+            expect(
+              state.pagingController?.value.items,
+              equals([refreshedTask]),
+            );
+          });
+        },
+      );
+
+      test(
+        'refreshQuery with preserveVisibleItems handles query error '
+        'by restoring offset and setting error state',
+        () {
+          fakeAsync((async) {
+            final initialTask = JournalEntity.task(
+              meta: Metadata(
+                id: 'task-1',
+                createdAt: _testDate,
+                updatedAt: _testDate,
+                dateFrom: _testDate,
+                dateTo: _testDate,
+              ),
+              data: TaskData(
+                dateFrom: _testDate,
+                dateTo: _testDate,
+                statusHistory: const [],
+                title: 'Initial task',
+                status: TaskStatus.open(
+                  id: 'status-initial',
+                  createdAt: _testDate,
+                  utcOffset: 0,
+                ),
+              ),
+            );
+            var getTasksCallCount = 0;
+
+            when(
+              () => mockJournalDb.getTasks(
+                ids: any(named: 'ids'),
+                starredStatuses: any(named: 'starredStatuses'),
+                taskStatuses: any(named: 'taskStatuses'),
+                categoryIds: any(named: 'categoryIds'),
+                labelIds: any(named: 'labelIds'),
+                priorities: any(named: 'priorities'),
+                sortByDate: any(named: 'sortByDate'),
+                limit: any(named: 'limit'),
+                offset: any(named: 'offset'),
+              ),
+            ).thenAnswer((_) {
+              getTasksCallCount++;
+              if (getTasksCallCount == 1) {
+                return Future.value([initialTask]);
+              }
+              // Second call (the retained refresh) throws
+              return Future<List<JournalEntity>>.error(
+                Exception('DB error'),
+              );
+            });
+
+            final state = container.read(journalPageControllerProvider(true));
+            final controller = container.read(
+              journalPageControllerProvider(true).notifier,
+            );
+
+            async.flushMicrotasks();
+
+            expect(
+              state.pagingController?.value.items,
+              equals([initialTask]),
+            );
+
+            // Trigger retained refresh that will fail
+            unawaited(
+              controller.refreshQuery(preserveVisibleItems: true),
+            );
+            async.flushMicrotasks();
+
+            // After error, old items remain visible
+            expect(
+              state.pagingController?.value.items,
+              equals([initialTask]),
+            );
+            // Error is set on the paging state
+            expect(state.pagingController?.value.error, isA<Exception>());
+            // Loading is finished
+            expect(state.pagingController?.value.isLoading, isFalse);
+          });
+        },
+      );
+
+      test(
+        'finishRetainedRefreshWithError is no-op when refresh token '
+        'does not match',
+        () {
+          fakeAsync((async) {
+            final initialTask = JournalEntity.task(
+              meta: Metadata(
+                id: 'task-1',
+                createdAt: _testDate,
+                updatedAt: _testDate,
+                dateFrom: _testDate,
+                dateTo: _testDate,
+              ),
+              data: TaskData(
+                dateFrom: _testDate,
+                dateTo: _testDate,
+                statusHistory: const [],
+                title: 'Initial task',
+                status: TaskStatus.open(
+                  id: 'status-initial',
+                  createdAt: _testDate,
+                  utcOffset: 0,
+                ),
+              ),
+            );
+            final firstRefreshCompleter = Completer<List<JournalEntity>>();
+            final secondRefreshCompleter = Completer<List<JournalEntity>>();
+            var getTasksCallCount = 0;
+
+            when(
+              () => mockJournalDb.getTasks(
+                ids: any(named: 'ids'),
+                starredStatuses: any(named: 'starredStatuses'),
+                taskStatuses: any(named: 'taskStatuses'),
+                categoryIds: any(named: 'categoryIds'),
+                labelIds: any(named: 'labelIds'),
+                priorities: any(named: 'priorities'),
+                sortByDate: any(named: 'sortByDate'),
+                limit: any(named: 'limit'),
+                offset: any(named: 'offset'),
+              ),
+            ).thenAnswer((_) {
+              getTasksCallCount++;
+              if (getTasksCallCount == 1) {
+                return Future.value([initialTask]);
+              }
+              if (getTasksCallCount == 2) {
+                return firstRefreshCompleter.future;
+              }
+              return secondRefreshCompleter.future;
+            });
+
+            final state = container.read(journalPageControllerProvider(true));
+            final controller = container.read(
+              journalPageControllerProvider(true).notifier,
+            );
+
+            async.flushMicrotasks();
+
+            // Start first retained refresh
+            unawaited(
+              controller.refreshQuery(preserveVisibleItems: true),
+            );
+            async.flushMicrotasks();
+
+            // Start second retained refresh — supersedes first
+            unawaited(
+              controller.refreshQuery(preserveVisibleItems: true),
+            );
+            async.flushMicrotasks();
+
+            // First refresh completes with error — should be ignored
+            // because its token no longer matches
+            firstRefreshCompleter.completeError(Exception('stale'));
+            async.flushMicrotasks();
+
+            // Items still visible, no error set (stale error was ignored)
+            expect(
+              state.pagingController?.value.items,
+              equals([initialTask]),
+            );
+            expect(state.pagingController?.value.isLoading, isTrue);
+
+            // Second refresh succeeds
+            final updatedTask = JournalEntity.task(
+              meta: Metadata(
+                id: 'task-2',
+                createdAt: _testDate,
+                updatedAt: _testDate,
+                dateFrom: _testDate,
+                dateTo: _testDate,
+              ),
+              data: TaskData(
+                dateFrom: _testDate,
+                dateTo: _testDate,
+                statusHistory: const [],
+                title: 'Updated task',
+                status: TaskStatus.open(
+                  id: 'status-updated',
+                  createdAt: _testDate,
+                  utcOffset: 0,
+                ),
+              ),
+            );
+            secondRefreshCompleter.complete([updatedTask]);
+            async.flushMicrotasks();
+
+            expect(
+              state.pagingController?.value.items,
+              equals([updatedTask]),
+            );
+            expect(state.pagingController?.value.isLoading, isFalse);
+            expect(state.pagingController?.value.error, isNull);
           });
         },
       );

--- a/test/features/journal/state/journal_page_controller_test.dart
+++ b/test/features/journal/state/journal_page_controller_test.dart
@@ -2100,6 +2100,111 @@ void main() {
       });
     });
 
+    group('Refresh Behavior', () {
+      test(
+        'refreshQuery keeps visible first-page items until replacement data arrives',
+        () {
+          fakeAsync((async) {
+            final initialTask = JournalEntity.task(
+              meta: Metadata(
+                id: 'task-1',
+                createdAt: _testDate,
+                updatedAt: _testDate,
+                dateFrom: _testDate,
+                dateTo: _testDate,
+              ),
+              data: TaskData(
+                dateFrom: _testDate,
+                dateTo: _testDate,
+                statusHistory: const [],
+                title: 'Initial task',
+                status: TaskStatus.open(
+                  id: 'status-initial',
+                  createdAt: _testDate,
+                  utcOffset: 0,
+                ),
+              ),
+            );
+            final refreshedTask = JournalEntity.task(
+              meta: Metadata(
+                id: 'task-1',
+                createdAt: _testDate,
+                updatedAt: _testDate.add(const Duration(minutes: 1)),
+                dateFrom: _testDate,
+                dateTo: _testDate,
+              ),
+              data: TaskData(
+                dateFrom: _testDate,
+                dateTo: _testDate,
+                statusHistory: const [],
+                title: 'Refreshed task',
+                status: TaskStatus.open(
+                  id: 'status-refreshed',
+                  createdAt: _testDate,
+                  utcOffset: 0,
+                ),
+              ),
+            );
+            final refreshCompleter = Completer<List<JournalEntity>>();
+            var getTasksCallCount = 0;
+
+            when(
+              () => mockJournalDb.getTasks(
+                ids: any(named: 'ids'),
+                starredStatuses: any(named: 'starredStatuses'),
+                taskStatuses: any(named: 'taskStatuses'),
+                categoryIds: any(named: 'categoryIds'),
+                labelIds: any(named: 'labelIds'),
+                priorities: any(named: 'priorities'),
+                sortByDate: any(named: 'sortByDate'),
+                limit: any(named: 'limit'),
+                offset: any(named: 'offset'),
+              ),
+            ).thenAnswer((_) {
+              getTasksCallCount++;
+              if (getTasksCallCount == 1) {
+                return Future.value([initialTask]);
+              }
+              if (getTasksCallCount == 2) {
+                return refreshCompleter.future;
+              }
+              return Future.value([refreshedTask]);
+            });
+
+            final state = container.read(journalPageControllerProvider(true));
+            final controller = container.read(
+              journalPageControllerProvider(true).notifier,
+            );
+
+            async.flushMicrotasks();
+
+            expect(
+              state.pagingController?.value.items,
+              equals([initialTask]),
+            );
+
+            unawaited(controller.refreshQuery());
+            async.flushMicrotasks();
+
+            expect(
+              state.pagingController?.value.items,
+              equals([initialTask]),
+            );
+            expect(state.pagingController?.value.isLoading, isTrue);
+
+            refreshCompleter.complete([refreshedTask]);
+            async.flushMicrotasks();
+
+            expect(
+              state.pagingController?.value.items,
+              equals([refreshedTask]),
+            );
+            expect(state.pagingController?.value.isLoading, isFalse);
+          });
+        },
+      );
+    });
+
     group('Visibility Edge Cases', () {
       test('does not refresh when transitioning from visible to invisible', () {
         fakeAsync((async) {

--- a/test/features/journal/ui/pages/infinite_journal_page_bottom_padding_test.dart
+++ b/test/features/journal/ui/pages/infinite_journal_page_bottom_padding_test.dart
@@ -26,7 +26,7 @@ class _FakeJournalPageController extends JournalPageController {
   JournalPageState get state => _testState;
 
   @override
-  Future<void> refreshQuery() async {}
+  Future<void> refreshQuery({bool preserveVisibleItems = false}) async {}
 
   @override
   void updateVisibility(VisibilityInfo info) {}

--- a/test/features/tasks/ui/pages/tasks_root_page_test.dart
+++ b/test/features/tasks/ui/pages/tasks_root_page_test.dart
@@ -126,6 +126,10 @@ void main() {
     expect(find.byType(TasksTabPage), findsOneWidget);
     expect(find.byType(DesktopDetailEmptyState), findsNothing);
     expect(find.byType(TaskDetailsPage), findsOneWidget);
+    expect(
+      tester.widget<TaskDetailsPage>(find.byType(TaskDetailsPage)).key,
+      const ValueKey('task-42'),
+    );
 
     // Dispose the widget tree and flush pending timers from
     // flutter_animate inside the detail page.

--- a/test/test_utils/fake_journal_page_controller.dart
+++ b/test/test_utils/fake_journal_page_controller.dart
@@ -200,7 +200,7 @@ class FakeJournalPageController extends JournalPageController {
   }
 
   @override
-  Future<void> refreshQuery() async {
+  Future<void> refreshQuery({bool preserveVisibleItems = false}) async {
     refreshQueryCalled++;
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced visible flicker in the Tasks desktop split view by keeping visible list rows mounted while the refreshed first page loads during saves and live updates.

* **Documentation**
  * Clarified desktop split-pane and journal refresh behavior: retained-list refresh and detail-pane keying.

* **Tests**
  * Added tests for retained-first-page refresh behavior and task-detail keying.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->