### PR TITLE
fix: desktop task list update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to adjust widths. Pane sizes persist across sessions via SettingsDb.
 
 ### Fixed
-- Tasks desktop split view now keeps the current list rows mounted until the
-  refreshed first page resolves, which reduces visible flicker during task
-  saves and other live updates.
+- Tasks desktop split view now keeps the current loaded list window mounted
+  until refreshed pages resolve, which reduces visible flicker during task
+  saves and other live updates while preserving regrouping after sort changes.
 
 ## [0.9.949] - 2026-04-10
 ### Changed

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -35,7 +35,7 @@
       <description>
           <p>Removed the gamey theme and all gamey-styled widgets. Standard Flutter widgets and existing modern cards are used instead.</p>
           <p>Resizable panes in desktop layout: drag dividers between the navigation sidebar and content area, and between the list and detail panes, to adjust widths. Pane sizes persist across sessions.</p>
-          <p>Tasks desktop split view now keeps the current list rows mounted until the refreshed first page resolves, which reduces visible flicker during task saves and other live updates.</p>
+          <p>Tasks desktop split view now keeps the current loaded list window mounted until refreshed pages resolve, which reduces visible flicker during task saves and other live updates while preserving regrouping after sort changes.</p>
       </description>
     </release>
     <release version="0.9.949" date="2026-04-10">

--- a/lib/features/journal/README.md
+++ b/lib/features/journal/README.md
@@ -193,7 +193,7 @@ The controller owns:
 - feature-flag gating for entry types and vector search
 - private-entry visibility
 - persisted filter state in `SettingsDb`
-- update-driven refresh behavior, including retained first-page refreshes that
+- update-driven refresh behavior, including retained loaded-page refreshes that
   keep visible rows mounted until replacement data resolves
 - vector-search timing and distance metadata for the UI
 
@@ -219,9 +219,15 @@ flowchart TD
 ```
 
 When a visible browse page already has rows on screen, the controller now
-replaces the first page only after the new first-page query resolves. That
-avoids the `PagingController.reset()` path that would otherwise clear the list
-immediately and produce a visible desktop flicker during saves or live updates.
+replaces the currently loaded page window only after the refreshed pages
+resolve. That avoids the `PagingController.reset()` path that would otherwise
+clear the list immediately and produce a visible desktop flicker during saves
+or live updates, while still allowing regrouping when task ordering changes.
+For the normal offset-based path, those already-loaded pages are refreshed in
+parallel; the slower sequential reload is kept only for post-filtered task
+queries where project or agent filters consume raw rows before returning a
+page. Visible task-row updates also bypass the extra leading-page probe and
+refresh the retained page window directly.
 
 ### What The Page Controller Persists
 

--- a/lib/features/journal/state/journal_page_controller.dart
+++ b/lib/features/journal/state/journal_page_controller.dart
@@ -38,7 +38,6 @@ class JournalPageController extends _$JournalPageController {
   static const journalCategoryFiltersKey = 'JOURNAL_CATEGORY_FILTERS';
   static const selectedEntryTypesKey = 'SELECTED_ENTRY_TYPES';
   static const pageSize = 50;
-
   // Services (via GetIt)
   late final JournalDb _db;
   late final SettingsDb _settingsDb;
@@ -177,75 +176,147 @@ class JournalPageController extends _$JournalPageController {
 
   PagingController<int, JournalEntity> _createPagingController() {
     return _JournalPagingController(
-      getNextPageKey: (PagingState<int, JournalEntity> pagingState) {
-        final currentKeys = pagingState.keys;
-        if (currentKeys == null || currentKeys.isEmpty) {
-          return 0; // First page key (offset)
-        }
-        if (!pagingState.hasNextPage) {
-          return null; // No next page if controller says so
-        }
-        final currentPages = pagingState.pages;
-        // If last page had fewer items than pageSize, it's the last page
-        if (currentPages != null &&
-            currentPages.isNotEmpty &&
-            currentPages.last.length < pageSize) {
-          return null; // No more pages
-        }
-        // When post-filters consumed more raw rows than returned filtered
-        // results, use the tracked raw offset so we don't re-read rows.
-        if (_postFilterNextRawOffset != null) {
-          final offset = _postFilterNextRawOffset!;
-          _postFilterNextRawOffset = null;
-          return offset;
-        }
-        if (currentPages != null &&
-            currentPages.isNotEmpty &&
-            currentKeys.length == currentPages.length) {
-          final lastFetchedItemsCount = currentPages.last.length;
-          return currentKeys.last + lastFetchedItemsCount;
-        }
-        // Fallback: if keys exist but pages inconsistent or last page empty.
-        return currentKeys.last +
-            ((currentPages != null &&
-                    currentPages.isNotEmpty &&
-                    currentKeys.length == currentPages.length)
-                ? currentPages.last.length
-                : 0);
-      },
+      getNextPageKey: _getNextPageKey,
       fetchPage: _fetchPage,
     );
   }
 
-  Future<void> _refreshFirstPagePreservingVisibleItems(
+  int? _getNextPageKey(
+    PagingState<int, JournalEntity> pagingState, {
+    bool consumePostFilterOffset = true,
+  }) {
+    final currentKeys = pagingState.keys;
+    if (currentKeys == null || currentKeys.isEmpty) {
+      return 0; // First page key (offset)
+    }
+    if (!pagingState.hasNextPage) {
+      return null; // No next page if controller says so
+    }
+    final currentPages = pagingState.pages;
+    // If last page had fewer items than pageSize, it's the last page
+    if (currentPages != null &&
+        currentPages.isNotEmpty &&
+        currentPages.last.length < pageSize) {
+      return null; // No more pages
+    }
+    // When post-filters consumed more raw rows than returned filtered
+    // results, use the tracked raw offset so we don't re-read rows.
+    if (_postFilterNextRawOffset != null) {
+      final offset = _postFilterNextRawOffset!;
+      if (consumePostFilterOffset) {
+        _postFilterNextRawOffset = null;
+      }
+      return offset;
+    }
+    if (currentPages != null &&
+        currentPages.isNotEmpty &&
+        currentKeys.length == currentPages.length) {
+      final lastFetchedItemsCount = currentPages.last.length;
+      return currentKeys.last + lastFetchedItemsCount;
+    }
+    // Fallback: if keys exist but pages inconsistent or last page empty.
+    return currentKeys.last +
+        ((currentPages != null &&
+                currentPages.isNotEmpty &&
+                currentKeys.length == currentPages.length)
+            ? currentPages.last.length
+            : 0);
+  }
+
+  Future<void> _refreshLoadedPagesPreservingVisibleItems(
     _JournalPagingController pagingController,
   ) async {
+    final loadedPageKeys = _loadedVisiblePageKeys(pagingController);
+    final loadedPageCount = loadedPageKeys.length;
+    if (loadedPageCount == 0) {
+      pagingController
+        ..refresh()
+        ..fetchNextPage();
+      return;
+    }
+
     final refreshToken = Object();
-    final previousPostFilterNextRawOffset = _postFilterNextRawOffset;
     pagingController.startRetainedRefresh(refreshToken);
-    _postFilterNextRawOffset = null;
 
     try {
-      final items = await _runQuery(0);
-      // _runQuery mutates _postFilterNextRawOffset as a side effect.
-      // Capture locally and restore; only publish if this refresh is
-      // still current, so a slower stale query cannot overwrite a
-      // newer offset.
-      final localNextRawOffset = _postFilterNextRawOffset;
-      _postFilterNextRawOffset = previousPostFilterNextRawOffset;
+      late final List<List<JournalEntity>> refreshedPages;
+      late final List<int> refreshedKeys;
+      int? retainedNextRawOffset;
+      if (_requiresSequentialRetainedRefresh) {
+        refreshedPages = <List<JournalEntity>>[];
+        refreshedKeys = <int>[];
+        int? nextPageKey = 0;
 
-      if (!ref.mounted || !pagingController.isRetainedRefresh(refreshToken)) {
-        return;
+        for (
+          var pageIndex = 0;
+          pageIndex < loadedPageCount && nextPageKey != null;
+          pageIndex++
+        ) {
+          final pageKey = nextPageKey;
+          refreshedKeys.add(pageKey);
+
+          final items = await _runQuery(
+            pageKey,
+            setPostFilterNextRawOffset: (value) {
+              retainedNextRawOffset = value;
+            },
+          );
+          if (!ref.mounted) {
+            return;
+          }
+          if (!pagingController.isRetainedRefresh(refreshToken)) {
+            return;
+          }
+
+          refreshedPages.add(items);
+
+          if (pageIndex < loadedPageCount - 1) {
+            nextPageKey = items.length < pageSize
+                ? null
+                : retainedNextRawOffset ?? pageKey + items.length;
+          }
+        }
+      } else {
+        refreshedKeys = loadedPageKeys;
+        refreshedPages = await Future.wait(
+          refreshedKeys.map(_runQuery),
+        );
+        if (!ref.mounted) {
+          return;
+        }
+        if (!pagingController.isRetainedRefresh(refreshToken)) {
+          return;
+        }
       }
 
-      pagingController.replaceFirstPage(items, pageSize: pageSize);
-      _postFilterNextRawOffset = localNextRawOffset;
+      final hasNextPage =
+          refreshedPages.length == loadedPageCount &&
+          refreshedPages.isNotEmpty &&
+          refreshedPages.last.length == pageSize;
+
+      _postFilterNextRawOffset =
+          _requiresSequentialRetainedRefresh && hasNextPage
+          ? retainedNextRawOffset
+          : null;
+
+      if (refreshedPages.isNotEmpty) {
+        _rememberLeadingTaskIds(refreshedPages.first);
+      }
+
+      pagingController.replacePages(
+        refreshedPages,
+        keys: refreshedKeys,
+        hasNextPage: hasNextPage,
+      );
     } catch (error, stackTrace) {
       DevLogger.warning(
         name: 'JournalPageController',
-        message: 'Error in retained first-page refresh: $error\n$stackTrace',
+        message: 'Error in retained visible-page refresh: $error\n$stackTrace',
       );
       if (!ref.mounted) {
+        return;
+      }
+      if (!pagingController.isRetainedRefresh(refreshToken)) {
         return;
       }
       pagingController.finishRetainedRefreshWithError(
@@ -368,42 +439,42 @@ class JournalPageController extends _$JournalPageController {
               }
             });
 
-    // Setup update notifications with throttling
+    // Setup update notifications
     String idMapper(JournalEntity entity) => entity.meta.id;
 
-    _updatesSub = _updateNotifications.updateStream
-        .throttleTime(
-          const Duration(milliseconds: 500),
-          leading: false,
-          trailing: true,
-        )
-        .listen((affectedIds) async {
-          if (_isVisible) {
-            final displayedIds =
-                state.pagingController?.value.items?.map(idMapper).toSet() ??
-                <String>{};
+    _updatesSub = _updateNotifications.updateStream.listen((affectedIds) async {
+      if (_isVisible) {
+        final displayedIds =
+            state.pagingController?.value.items?.map(idMapper).toSet() ??
+            <String>{};
+        final affectsDisplayedItems = displayedIds
+            .intersection(affectedIds)
+            .isNotEmpty;
 
-            if (showTasks) {
-              // Probe call: save/restore offset so the probe doesn't
-              // mutate pagination state consumed by the real fetch.
-              final savedOffset = _postFilterNextRawOffset;
-              final newIds = (await _runQuery(0)).map(idMapper).toSet();
-              _postFilterNextRawOffset = savedOffset;
-              if (!setEquals(_lastIds, newIds)) {
-                _lastIds = newIds;
-                await refreshQuery(preserveVisibleItems: true);
-              } else if (displayedIds.intersection(affectedIds).isNotEmpty) {
-                await refreshQuery(preserveVisibleItems: true);
-              }
-            } else {
-              if (displayedIds.intersection(affectedIds).isNotEmpty) {
-                await refreshQuery(preserveVisibleItems: true);
-              }
-            }
-          } else {
-            _needsRefreshOnVisible = true;
+        if (showTasks) {
+          if (affectsDisplayedItems) {
+            await refreshQuery(preserveVisibleItems: true);
+            return;
           }
-        });
+
+          // Probe call: save/restore offset so the probe doesn't
+          // mutate pagination state consumed by the real fetch.
+          final savedOffset = _postFilterNextRawOffset;
+          final newIds = (await _runQuery(0)).map(idMapper).toSet();
+          _postFilterNextRawOffset = savedOffset;
+          if (!setEquals(_lastIds, newIds)) {
+            _lastIds = newIds;
+            await refreshQuery(preserveVisibleItems: true);
+          }
+        } else {
+          if (affectsDisplayedItems) {
+            await refreshQuery(preserveVisibleItems: true);
+          }
+        }
+      } else {
+        _needsRefreshOnVisible = true;
+      }
+    });
   }
 
   void _registerHotkeys() {
@@ -859,7 +930,7 @@ class JournalPageController extends _$JournalPageController {
     if (preserveVisibleItems &&
         pagingController is _JournalPagingController &&
         pagingController.hasVisibleItems) {
-      await _refreshFirstPagePreservingVisibleItems(pagingController);
+      await _refreshLoadedPagesPreservingVisibleItems(pagingController);
       return;
     }
 
@@ -879,7 +950,11 @@ class JournalPageController extends _$JournalPageController {
 
   Future<List<JournalEntity>> _fetchPage(int pageKey) async {
     try {
-      return _runQuery(pageKey);
+      final items = await _runQuery(pageKey);
+      if (pageKey == 0) {
+        _rememberLeadingTaskIds(items);
+      }
+      return items;
     } catch (error, stackTrace) {
       if (kDebugMode) {
         print('Error in _fetchPage: $error\n$stackTrace');
@@ -888,7 +963,14 @@ class JournalPageController extends _$JournalPageController {
     }
   }
 
-  Future<List<JournalEntity>> _runQuery(int pageKey) async {
+  Future<List<JournalEntity>> _runQuery(
+    int pageKey, {
+    void Function(int? nextRawOffset)? setPostFilterNextRawOffset,
+  }) async {
+    final applyPostFilterNextRawOffset =
+        setPostFilterNextRawOffset ??
+        (int? value) => _postFilterNextRawOffset = value;
+
     // Vector search: bypass FTS5 and DB pagination entirely.
     if (_enableVectorSearch &&
         _searchMode == SearchMode.vector &&
@@ -949,7 +1031,7 @@ class JournalPageController extends _$JournalPageController {
       final needsPostFilter = agentFilterActive || projectFilterActive;
 
       if (!needsPostFilter) {
-        _postFilterNextRawOffset = null;
+        applyPostFilterNextRawOffset(null);
         final res = await _db.getTasks(
           ids: ids,
           starredStatuses: starredEntriesOnly ? [true] : [true, false],
@@ -1027,7 +1109,7 @@ class JournalPageController extends _$JournalPageController {
       }
 
       // Record the raw offset so getNextPageKey resumes correctly.
-      _postFilterNextRawOffset = currentOffset;
+      applyPostFilterNextRawOffset(currentOffset);
 
       // Sort before truncating so the page contains the correct items.
       if (_sortOption == TaskSortOption.byDueDate) {
@@ -1128,6 +1210,38 @@ class JournalPageController extends _$JournalPageController {
     return ids;
   }
 
+  bool get _requiresSequentialRetainedRefresh =>
+      _showTasks &&
+      (_agentAssignmentFilter != AgentAssignmentFilter.all ||
+          _selectedProjectIds.isNotEmpty);
+
+  List<int> _loadedVisiblePageKeys(_JournalPagingController pagingController) {
+    final pages = pagingController.value.pages;
+    final keys = pagingController.value.keys;
+    if (pages == null || keys == null) {
+      return const [];
+    }
+
+    final sharedLength = pages.length < keys.length
+        ? pages.length
+        : keys.length;
+    final loadedPageKeys = <int>[];
+    for (var index = 0; index < sharedLength; index++) {
+      if (pages[index].isNotEmpty) {
+        loadedPageKeys.add(keys[index]);
+      }
+    }
+    return loadedPageKeys;
+  }
+
+  void _rememberLeadingTaskIds(Iterable<JournalEntity> items) {
+    if (!_showTasks) {
+      return;
+    }
+
+    _lastIds = items.map((entity) => entity.meta.id).toSet();
+  }
+
   /// Sorts tasks by due date (soonest first, tasks without due dates at end).
   /// Preserves creation date order for tasks with the same due date or no due date.
   ///
@@ -1186,11 +1300,15 @@ class _JournalPagingController extends PagingController<int, JournalEntity> {
 
   bool isRetainedRefresh(Object refreshToken) => operation == refreshToken;
 
-  void replaceFirstPage(List<JournalEntity> items, {required int pageSize}) {
+  void replacePages(
+    List<List<JournalEntity>> pages, {
+    required List<int> keys,
+    required bool hasNextPage,
+  }) {
     value = PagingState<int, JournalEntity>(
-      pages: [items],
-      keys: const [0],
-      hasNextPage: items.length == pageSize,
+      pages: pages,
+      keys: keys,
+      hasNextPage: hasNextPage,
     );
     operation = null;
   }

--- a/lib/logic/persistence_logic.dart
+++ b/lib/logic/persistence_logic.dart
@@ -556,24 +556,21 @@ class PersistenceLogic {
 
       await journalEntity.maybeMap(
         task: (Task task) async {
+          final priorityChanged = task.data.priority != taskData.priority;
           await updateDbEntity(
             task.copyWith(
               meta: await updateMetadata(journalEntity.meta),
               entryText: entryText ?? task.entryText,
               data: taskData,
             ),
+            beforeNotify: priorityChanged
+                ? () => _journalDb.updateTaskPriorityColumn(
+                    id: journalEntityId,
+                    priority: taskData.priority.short,
+                    rank: taskData.priority.rank,
+                  )
+                : null,
           );
-
-          // Ensure denormalized priority columns are updated for reliable UI reads
-          try {
-            await _journalDb.updateTaskPriorityColumn(
-              id: journalEntityId,
-              priority: taskData.priority.short,
-              rank: taskData.priority.rank,
-            );
-          } catch (_) {
-            // ignore best-effort denormalized update errors
-          }
         },
         orElse: () async {
           _loggingService.captureException(
@@ -668,7 +665,25 @@ class PersistenceLogic {
       final entityWithUpdatedMeta = journalEntity.copyWith(
         meta: updatedMeta.copyWith(labelIds: preservedLabelIds),
       );
-      final applied = (await updateDbEntity(entityWithUpdatedMeta)) ?? false;
+      Future<void> Function()? beforeNotify;
+      if (entityWithUpdatedMeta is Task) {
+        final task = entityWithUpdatedMeta;
+        final priorityChanged =
+            current is! Task || current.data.priority != task.data.priority;
+        if (priorityChanged) {
+          beforeNotify = () => _journalDb.updateTaskPriorityColumn(
+            id: task.id,
+            priority: task.data.priority.short,
+            rank: task.data.priority.rank,
+          );
+        }
+      }
+      final applied =
+          (await updateDbEntity(
+            entityWithUpdatedMeta,
+            beforeNotify: beforeNotify,
+          )) ??
+          false;
       if (applied) {
         await _journalDb.addLabeled(entityWithUpdatedMeta);
       }
@@ -689,6 +704,7 @@ class PersistenceLogic {
     String? linkedId,
     bool enqueueSync = true,
     bool overrideComparison = false,
+    Future<void> Function()? beforeNotify,
   }) async {
     try {
       final updateResult = await _journalDb.updateJournalEntity(
@@ -696,6 +712,19 @@ class PersistenceLogic {
         overrideComparison: overrideComparison,
       );
       final applied = updateResult.applied;
+
+      if (applied && beforeNotify != null) {
+        try {
+          await beforeNotify();
+        } catch (exception, stackTrace) {
+          _loggingService.captureException(
+            exception,
+            domain: 'persistence_logic',
+            subDomain: 'updateDbEntity.beforeNotify',
+            stackTrace: stackTrace,
+          );
+        }
+      }
 
       // Include parent linked entry IDs so that agents subscribed to a
       // parent (e.g. a task) are notified when a child entry is edited.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.950+3919
+version: 0.9.950+3920
 
 msix_config:
   display_name: LottiApp

--- a/test/features/journal/state/journal_page_controller_test.dart
+++ b/test/features/journal/state/journal_page_controller_test.dart
@@ -3290,6 +3290,249 @@ void main() {
           });
         },
       );
+
+      test(
+        'sequential retained refresh aborts loop iteration when a second '
+        'refresh supersedes the first',
+        () {
+          fakeAsync((async) {
+            final initialFirstPage = List<JournalEntity>.generate(
+              JournalPageController.pageSize,
+              (index) => _buildTestTask(
+                id: 'task-$index',
+                title: 'Initial task $index',
+                createdAt: _testDate.add(Duration(minutes: index)),
+                priority: TaskPriority.p1High,
+              ),
+              growable: false,
+            );
+            final initialSecondPageTask = _buildTestTask(
+              id: 'task-late',
+              title: 'Initial late task',
+              createdAt: _testDate.add(const Duration(hours: 3)),
+              priority: TaskPriority.p2Medium,
+            );
+            final winnerTask = _buildTestTask(
+              id: 'winner-task',
+              title: 'Winner task',
+              createdAt: _testDate.add(const Duration(hours: 10)),
+              priority: TaskPriority.p0Urgent,
+            );
+            final allProjectIds = {
+              ...initialFirstPage.map((e) => e.meta.id),
+              initialSecondPageTask.meta.id,
+              winnerTask.meta.id,
+            };
+            final firstRefreshPage0Completer = Completer<List<JournalEntity>>();
+            var getTasksCallCount = 0;
+
+            when(
+              () => mockJournalDb.getTaskIdsForProjects(any()),
+            ).thenAnswer((_) async => allProjectIds);
+
+            final state = container.read(journalPageControllerProvider(true));
+            final controller = container.read(
+              journalPageControllerProvider(true).notifier,
+            );
+
+            async.flushMicrotasks();
+
+            unawaited(controller.toggleProjectFilter('proj-1'));
+            async.flushMicrotasks();
+
+            // Set up two pages so sequential loop iterates twice.
+            state.pagingController!.value = PagingState<int, JournalEntity>(
+              pages: [
+                initialFirstPage,
+                [initialSecondPageTask],
+              ],
+              keys: const [0, JournalPageController.pageSize],
+              hasNextPage: false,
+            );
+
+            clearInteractions(mockJournalDb);
+
+            when(
+              () => mockJournalDb.getTasks(
+                ids: any(named: 'ids'),
+                starredStatuses: any(named: 'starredStatuses'),
+                taskStatuses: any(named: 'taskStatuses'),
+                categoryIds: any(named: 'categoryIds'),
+                labelIds: any(named: 'labelIds'),
+                priorities: any(named: 'priorities'),
+                sortByDate: any(named: 'sortByDate'),
+                limit: any(named: 'limit'),
+                offset: any(named: 'offset'),
+              ),
+            ).thenAnswer((_) {
+              getTasksCallCount++;
+              // First call (first refresh, page 0): slow — use completer.
+              if (getTasksCallCount == 1) {
+                return firstRefreshPage0Completer.future;
+              }
+              // All subsequent calls (second refresh): resolve instantly.
+              return Future.value([winnerTask]);
+            });
+
+            // Start first sequential retained refresh (page 0 will block).
+            unawaited(
+              controller.refreshQuery(preserveVisibleItems: true),
+            );
+            async.flushMicrotasks();
+
+            // First refresh is now awaiting page 0. Start second refresh
+            // which supersedes the first's refresh token.
+            unawaited(
+              controller.refreshQuery(preserveVisibleItems: true),
+            );
+            async.flushMicrotasks();
+
+            // Complete the first refresh's page 0 — the loop should detect
+            // the stale token and abort before fetching page 1.
+            firstRefreshPage0Completer.complete(initialFirstPage);
+            async.flushMicrotasks();
+
+            // The winning (second) refresh should have replaced the pages.
+            expect(
+              state.pagingController?.value.items,
+              equals([winnerTask]),
+            );
+            expect(state.pagingController?.value.isLoading, isFalse);
+          });
+        },
+      );
+
+      test(
+        'refreshQuery with preserveVisibleItems rethrows non-Exception errors',
+        () {
+          fakeAsync((async) {
+            final initialTask = _buildTestTask(
+              id: 'task-1',
+              title: 'Initial task',
+              createdAt: _testDate,
+              priority: TaskPriority.p1High,
+            );
+            var getTasksCallCount = 0;
+
+            when(
+              () => mockJournalDb.getTasks(
+                ids: any(named: 'ids'),
+                starredStatuses: any(named: 'starredStatuses'),
+                taskStatuses: any(named: 'taskStatuses'),
+                categoryIds: any(named: 'categoryIds'),
+                labelIds: any(named: 'labelIds'),
+                priorities: any(named: 'priorities'),
+                sortByDate: any(named: 'sortByDate'),
+                limit: any(named: 'limit'),
+                offset: any(named: 'offset'),
+              ),
+            ).thenAnswer((_) {
+              getTasksCallCount++;
+              if (getTasksCallCount == 1) {
+                return Future.value([initialTask]);
+              }
+              // Throw a non-Exception (Error) to trigger the rethrow path.
+              return Future<List<JournalEntity>>.error(
+                StateError('fatal error'),
+              );
+            });
+
+            final state = container.read(journalPageControllerProvider(true));
+            container.read(journalPageControllerProvider(true).notifier);
+
+            async.flushMicrotasks();
+
+            expect(
+              state.pagingController?.value.items,
+              equals([initialTask]),
+            );
+
+            // The Error should propagate as an uncaught error in the zone.
+            Object? caughtError;
+            runZonedGuarded(
+              () {
+                fakeAsync((innerAsync) {
+                  // Re-read because we're in a new fakeAsync zone — but we
+                  // only need to trigger refreshQuery on the existing
+                  // controller.  Directly call the paging controller's
+                  // retained-refresh path by calling refreshQuery.
+                  final ctrl = container.read(
+                    journalPageControllerProvider(true).notifier,
+                  );
+                  unawaited(
+                    ctrl.refreshQuery(preserveVisibleItems: true),
+                  );
+                  innerAsync.flushMicrotasks();
+                });
+              },
+              (error, stack) {
+                caughtError = error;
+              },
+            );
+
+            async.flushMicrotasks();
+
+            // StateError is not an Exception, so it should be rethrown.
+            expect(caughtError, isA<StateError>());
+          });
+        },
+      );
+
+      test(
+        'refreshQuery with preserveVisibleItems falls back to full refresh '
+        'when no visible page keys exist',
+        () {
+          fakeAsync((async) {
+            var getTasksCallCount = 0;
+
+            when(
+              () => mockJournalDb.getTasks(
+                ids: any(named: 'ids'),
+                starredStatuses: any(named: 'starredStatuses'),
+                taskStatuses: any(named: 'taskStatuses'),
+                categoryIds: any(named: 'categoryIds'),
+                labelIds: any(named: 'labelIds'),
+                priorities: any(named: 'priorities'),
+                sortByDate: any(named: 'sortByDate'),
+                limit: any(named: 'limit'),
+                offset: any(named: 'offset'),
+              ),
+            ).thenAnswer((_) async {
+              getTasksCallCount++;
+              return <JournalEntity>[];
+            });
+
+            final state = container.read(journalPageControllerProvider(true));
+            final controller = container.read(
+              journalPageControllerProvider(true).notifier,
+            );
+
+            async.flushMicrotasks();
+
+            // Manually set paging state with an empty page so that
+            // hasVisibleItems is false — refreshQuery should fall through
+            // to the full refresh path.
+            state.pagingController!.value = PagingState<int, JournalEntity>(
+              pages: const [[]],
+              keys: const [0],
+              hasNextPage: false,
+            );
+
+            clearInteractions(mockJournalDb);
+            getTasksCallCount = 0;
+
+            // preserveVisibleItems=true but no visible items →
+            // hasVisibleItems is false, so it should do a full refresh.
+            unawaited(
+              controller.refreshQuery(preserveVisibleItems: true),
+            );
+            async.flushMicrotasks();
+
+            // A full refresh re-fetches page 0
+            expect(getTasksCallCount, greaterThan(0));
+          });
+        },
+      );
     });
 
     group('Visibility Edge Cases', () {

--- a/test/features/journal/state/journal_page_controller_test.dart
+++ b/test/features/journal/state/journal_page_controller_test.dart
@@ -7,7 +7,7 @@ import 'package:fake_async/fake_async.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:infinite_scroll_pagination/src/core/extensions.dart';
+import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/journal_entities.dart';
@@ -1996,6 +1996,344 @@ void main() {
           });
         },
       );
+
+      test(
+        'visible tasks refresh affected displayed items without an extra probe',
+        () {
+          fakeAsync((async) {
+            final initialTask = _buildTestTask(
+              id: 'task-1',
+              title: 'Initial task',
+              createdAt: _testDate,
+              priority: TaskPriority.p1High,
+            );
+            var getTasksCallCount = 0;
+
+            when(
+              () => mockJournalDb.getTasks(
+                ids: any(named: 'ids'),
+                starredStatuses: any(named: 'starredStatuses'),
+                taskStatuses: any(named: 'taskStatuses'),
+                categoryIds: any(named: 'categoryIds'),
+                labelIds: any(named: 'labelIds'),
+                priorities: any(named: 'priorities'),
+                sortByDate: any(named: 'sortByDate'),
+                limit: any(named: 'limit'),
+                offset: any(named: 'offset'),
+              ),
+            ).thenAnswer((_) async {
+              getTasksCallCount++;
+              return [initialTask];
+            });
+
+            final state = container.read(journalPageControllerProvider(true));
+            final controller = container.read(
+              journalPageControllerProvider(true).notifier,
+            );
+
+            async.flushMicrotasks();
+
+            controller.updateVisibility(
+              const MockVisibilityInfo(
+                visibleBounds: Rect.fromLTWH(0, 0, 100, 100),
+              ),
+            );
+
+            clearInteractions(mockJournalDb);
+            getTasksCallCount = 0;
+
+            updateStreamController.add({'task-1'});
+
+            async.elapse(const Duration(milliseconds: 200));
+            async.flushMicrotasks();
+
+            expect(state.pagingController?.value.items, equals([initialTask]));
+            expect(getTasksCallCount, 1);
+            verify(
+              () => mockJournalDb.getTasks(
+                ids: any(named: 'ids'),
+                starredStatuses: any(named: 'starredStatuses'),
+                taskStatuses: any(named: 'taskStatuses'),
+                categoryIds: any(named: 'categoryIds'),
+                labelIds: any(named: 'labelIds'),
+                priorities: any(named: 'priorities'),
+                sortByDate: any(named: 'sortByDate'),
+                limit: any(named: 'limit'),
+                offset: 0,
+              ),
+            ).called(1);
+          });
+        },
+      );
+
+      test(
+        'visible tasks still probe first page when only off-screen ids change',
+        () {
+          fakeAsync((async) {
+            final initialTask = _buildTestTask(
+              id: 'task-1',
+              title: 'Initial task',
+              createdAt: _testDate,
+              priority: TaskPriority.p1High,
+            );
+            final refreshedLeadingTask = _buildTestTask(
+              id: 'task-2',
+              title: 'Refreshed leading task',
+              createdAt: _testDate.add(const Duration(minutes: 1)),
+              priority: TaskPriority.p0Urgent,
+            );
+            var getTasksCallCount = 0;
+
+            when(
+              () => mockJournalDb.getTasks(
+                ids: any(named: 'ids'),
+                starredStatuses: any(named: 'starredStatuses'),
+                taskStatuses: any(named: 'taskStatuses'),
+                categoryIds: any(named: 'categoryIds'),
+                labelIds: any(named: 'labelIds'),
+                priorities: any(named: 'priorities'),
+                sortByDate: any(named: 'sortByDate'),
+                limit: any(named: 'limit'),
+                offset: any(named: 'offset'),
+              ),
+            ).thenAnswer((_) async {
+              getTasksCallCount++;
+              return getTasksCallCount == 1
+                  ? [initialTask]
+                  : [refreshedLeadingTask];
+            });
+
+            final state = container.read(journalPageControllerProvider(true));
+            final controller = container.read(
+              journalPageControllerProvider(true).notifier,
+            );
+
+            async.flushMicrotasks();
+
+            controller.updateVisibility(
+              const MockVisibilityInfo(
+                visibleBounds: Rect.fromLTWH(0, 0, 100, 100),
+              ),
+            );
+
+            clearInteractions(mockJournalDb);
+            getTasksCallCount = 1;
+
+            updateStreamController.add({'off-screen-task'});
+
+            async.elapse(const Duration(milliseconds: 200));
+            async.flushMicrotasks();
+
+            expect(
+              state.pagingController?.value.items,
+              equals([refreshedLeadingTask]),
+            );
+            expect(getTasksCallCount, 3);
+            verify(
+              () => mockJournalDb.getTasks(
+                ids: any(named: 'ids'),
+                starredStatuses: any(named: 'starredStatuses'),
+                taskStatuses: any(named: 'taskStatuses'),
+                categoryIds: any(named: 'categoryIds'),
+                labelIds: any(named: 'labelIds'),
+                priorities: any(named: 'priorities'),
+                sortByDate: any(named: 'sortByDate'),
+                limit: any(named: 'limit'),
+                offset: 0,
+              ),
+            ).called(2);
+          });
+        },
+      );
+
+      test(
+        'visible tasks preserve the post-filter next-page offset when a probe finds unchanged ids',
+        () {
+          fakeAsync((async) {
+            List<JournalEntity> buildRawChunk(String prefix) =>
+                List<JournalEntity>.generate(
+                  JournalPageController.pageSize,
+                  (index) => _buildTestTask(
+                    id: '$prefix-$index',
+                    title: '$prefix task $index',
+                    createdAt: _testDate.add(Duration(minutes: index)),
+                    priority: TaskPriority.p1High,
+                  ),
+                  growable: false,
+                );
+
+            final rawChunk0 = buildRawChunk('chunk-a');
+            final rawChunk50 = buildRawChunk('chunk-b');
+            final projectTaskIds = {
+              ...rawChunk0.take(25).map((entity) => entity.meta.id),
+              ...rawChunk50.take(25).map((entity) => entity.meta.id),
+            };
+
+            when(
+              () => mockJournalDb.getTaskIdsForProjects({'proj-1'}),
+            ).thenAnswer((_) async => projectTaskIds);
+
+            when(
+              () => mockJournalDb.getTasks(
+                ids: any(named: 'ids'),
+                starredStatuses: any(named: 'starredStatuses'),
+                taskStatuses: any(named: 'taskStatuses'),
+                categoryIds: any(named: 'categoryIds'),
+                labelIds: any(named: 'labelIds'),
+                priorities: any(named: 'priorities'),
+                sortByDate: any(named: 'sortByDate'),
+                limit: any(named: 'limit'),
+                offset: any(named: 'offset'),
+              ),
+            ).thenAnswer((invocation) async {
+              final offset = invocation.namedArguments[#offset] as int;
+              if (offset == 0) {
+                return rawChunk0;
+              }
+              if (offset == JournalPageController.pageSize) {
+                return rawChunk50;
+              }
+              return <JournalEntity>[];
+            });
+
+            final state = container.read(journalPageControllerProvider(true));
+            final controller = container.read(
+              journalPageControllerProvider(true).notifier,
+            );
+
+            async.flushMicrotasks();
+
+            unawaited(controller.toggleProjectFilter('proj-1'));
+            async.elapse(const Duration(milliseconds: 100));
+            async.flushMicrotasks();
+
+            controller.updateVisibility(
+              const MockVisibilityInfo(
+                visibleBounds: Rect.fromLTWH(0, 0, 100, 100),
+              ),
+            );
+
+            clearInteractions(mockJournalDb);
+
+            updateStreamController.add({'off-screen-task'});
+            async.elapse(const Duration(milliseconds: 50));
+            async.flushMicrotasks();
+
+            verify(
+              () => mockJournalDb.getTasks(
+                ids: any(named: 'ids'),
+                starredStatuses: any(named: 'starredStatuses'),
+                taskStatuses: any(named: 'taskStatuses'),
+                categoryIds: any(named: 'categoryIds'),
+                labelIds: any(named: 'labelIds'),
+                priorities: any(named: 'priorities'),
+                sortByDate: any(named: 'sortByDate'),
+                limit: any(named: 'limit'),
+                offset: 0,
+              ),
+            ).called(1);
+            verify(
+              () => mockJournalDb.getTasks(
+                ids: any(named: 'ids'),
+                starredStatuses: any(named: 'starredStatuses'),
+                taskStatuses: any(named: 'taskStatuses'),
+                categoryIds: any(named: 'categoryIds'),
+                labelIds: any(named: 'labelIds'),
+                priorities: any(named: 'priorities'),
+                sortByDate: any(named: 'sortByDate'),
+                limit: any(named: 'limit'),
+                offset: JournalPageController.pageSize,
+              ),
+            ).called(1);
+
+            state.pagingController!.fetchNextPage();
+            async.flushMicrotasks();
+
+            verify(
+              () => mockJournalDb.getTasks(
+                ids: any(named: 'ids'),
+                starredStatuses: any(named: 'starredStatuses'),
+                taskStatuses: any(named: 'taskStatuses'),
+                categoryIds: any(named: 'categoryIds'),
+                labelIds: any(named: 'labelIds'),
+                priorities: any(named: 'priorities'),
+                sortByDate: any(named: 'sortByDate'),
+                limit: any(named: 'limit'),
+                offset: 75,
+              ),
+            ).called(1);
+          });
+        },
+      );
+
+      test(
+        'visible journal entries refresh when an affected displayed item changes',
+        () {
+          fakeAsync((async) {
+            final entry = JournalEntity.journalEntry(
+              meta: Metadata(
+                id: 'entry-1',
+                createdAt: _testDate,
+                updatedAt: _testDate,
+                dateFrom: _testDate,
+                dateTo: _testDate,
+              ),
+              entryText: const EntryText(plainText: 'Entry'),
+            );
+            var queryCallCount = 0;
+
+            when(
+              () => mockJournalDb.getJournalEntities(
+                types: any(named: 'types'),
+                starredStatuses: any(named: 'starredStatuses'),
+                privateStatuses: any(named: 'privateStatuses'),
+                flaggedStatuses: any(named: 'flaggedStatuses'),
+                ids: any(named: 'ids'),
+                limit: any(named: 'limit'),
+                offset: any(named: 'offset'),
+                categoryIds: any(named: 'categoryIds'),
+              ),
+            ).thenAnswer((_) async {
+              queryCallCount++;
+              return [entry];
+            });
+
+            final controller = container.read(
+              journalPageControllerProvider(false).notifier,
+            );
+
+            async.flushMicrotasks();
+
+            controller.updateVisibility(
+              const MockVisibilityInfo(
+                visibleBounds: Rect.fromLTWH(0, 0, 100, 100),
+              ),
+            );
+
+            clearInteractions(mockJournalDb);
+            queryCallCount = 0;
+
+            updateStreamController.add({'entry-1'});
+
+            async.elapse(const Duration(milliseconds: 200));
+            async.flushMicrotasks();
+
+            expect(queryCallCount, 1);
+            verify(
+              () => mockJournalDb.getJournalEntities(
+                types: any(named: 'types'),
+                starredStatuses: any(named: 'starredStatuses'),
+                privateStatuses: any(named: 'privateStatuses'),
+                flaggedStatuses: any(named: 'flaggedStatuses'),
+                ids: any(named: 'ids'),
+                limit: any(named: 'limit'),
+                offset: 0,
+                categoryIds: any(named: 'categoryIds'),
+              ),
+            ).called(1);
+          });
+        },
+      );
     });
 
     group('Controller Disposal', () {
@@ -2351,10 +2689,7 @@ void main() {
               if (getTasksCallCount == 1) {
                 return Future.value([initialTask]);
               }
-              // Second call (the retained refresh) throws
-              return Future<List<JournalEntity>>.error(
-                Exception('DB error'),
-              );
+              return Future<List<JournalEntity>>.error(Exception('DB error'));
             });
 
             final state = container.read(journalPageControllerProvider(true));
@@ -2369,20 +2704,16 @@ void main() {
               equals([initialTask]),
             );
 
-            // Trigger retained refresh that will fail
             unawaited(
               controller.refreshQuery(preserveVisibleItems: true),
             );
             async.flushMicrotasks();
 
-            // After error, old items remain visible
             expect(
               state.pagingController?.value.items,
               equals([initialTask]),
             );
-            // Error is set on the paging state
             expect(state.pagingController?.value.error, isA<Exception>());
-            // Loading is finished
             expect(state.pagingController?.value.isLoading, isFalse);
           });
         },
@@ -2447,31 +2778,25 @@ void main() {
 
             async.flushMicrotasks();
 
-            // Start first retained refresh
             unawaited(
               controller.refreshQuery(preserveVisibleItems: true),
             );
             async.flushMicrotasks();
 
-            // Start second retained refresh — supersedes first
             unawaited(
               controller.refreshQuery(preserveVisibleItems: true),
             );
             async.flushMicrotasks();
 
-            // First refresh completes with error — should be ignored
-            // because its token no longer matches
             firstRefreshCompleter.completeError(Exception('stale'));
             async.flushMicrotasks();
 
-            // Items still visible, no error set (stale error was ignored)
             expect(
               state.pagingController?.value.items,
               equals([initialTask]),
             );
             expect(state.pagingController?.value.isLoading, isTrue);
 
-            // Second refresh succeeds
             final updatedTask = JournalEntity.task(
               meta: Metadata(
                 id: 'task-2',
@@ -2501,6 +2826,467 @@ void main() {
             );
             expect(state.pagingController?.value.isLoading, isFalse);
             expect(state.pagingController?.value.error, isNull);
+          });
+        },
+      );
+
+      test(
+        'refreshQuery replaces all loaded pages so later-page tasks can regroup',
+        () {
+          fakeAsync((async) {
+            final initialFirstPage = List<JournalEntity>.generate(
+              JournalPageController.pageSize,
+              (index) => _buildTestTask(
+                id: 'task-$index',
+                title: 'Initial task $index',
+                createdAt: _testDate.add(Duration(minutes: index)),
+                priority: TaskPriority.p1High,
+              ),
+              growable: false,
+            );
+            final initialSecondPageTask = _buildTestTask(
+              id: 'task-late',
+              title: 'Initial late task',
+              createdAt: _testDate.add(const Duration(hours: 3)),
+              priority: TaskPriority.p2Medium,
+            );
+            final regroupedTask = _buildTestTask(
+              id: 'task-late',
+              title: 'Regrouped late task',
+              createdAt: _testDate.add(const Duration(hours: 3)),
+              updatedAt: _testDate.add(const Duration(days: 1)),
+              priority: TaskPriority.p0Urgent,
+            );
+            final refreshedFirstPage = <JournalEntity>[
+              regroupedTask,
+              ...initialFirstPage.take(JournalPageController.pageSize - 1),
+            ];
+            final refreshedSecondPageTask = _buildTestTask(
+              id: 'task-tail',
+              title: 'Refreshed tail task',
+              createdAt: _testDate.add(const Duration(hours: 4)),
+              priority: TaskPriority.p2Medium,
+            );
+            final firstPageCompleter = Completer<List<JournalEntity>>();
+            final secondPageCompleter = Completer<List<JournalEntity>>();
+
+            final state = container.read(journalPageControllerProvider(true));
+            final controller = container.read(
+              journalPageControllerProvider(true).notifier,
+            );
+
+            async.flushMicrotasks();
+
+            state.pagingController!.value = PagingState<int, JournalEntity>(
+              pages: [
+                initialFirstPage,
+                [initialSecondPageTask],
+              ],
+              keys: const [0, JournalPageController.pageSize],
+              hasNextPage: false,
+            );
+
+            clearInteractions(mockJournalDb);
+
+            when(
+              () => mockJournalDb.getTasks(
+                ids: any(named: 'ids'),
+                starredStatuses: any(named: 'starredStatuses'),
+                taskStatuses: any(named: 'taskStatuses'),
+                categoryIds: any(named: 'categoryIds'),
+                labelIds: any(named: 'labelIds'),
+                priorities: any(named: 'priorities'),
+                sortByDate: any(named: 'sortByDate'),
+                limit: any(named: 'limit'),
+                offset: any(named: 'offset'),
+              ),
+            ).thenAnswer((invocation) {
+              final offset = invocation.namedArguments[#offset] as int;
+              if (offset == 0) {
+                return firstPageCompleter.future;
+              }
+              if (offset == JournalPageController.pageSize) {
+                return secondPageCompleter.future;
+              }
+              return Future.value(<JournalEntity>[]);
+            });
+
+            unawaited(
+              controller.refreshQuery(preserveVisibleItems: true),
+            );
+            async.flushMicrotasks();
+
+            expect(
+              state.pagingController?.value.items,
+              equals([
+                ...initialFirstPage,
+                initialSecondPageTask,
+              ]),
+            );
+            expect(state.pagingController?.value.isLoading, isTrue);
+            verify(
+              () => mockJournalDb.getTasks(
+                ids: any(named: 'ids'),
+                starredStatuses: any(named: 'starredStatuses'),
+                taskStatuses: any(named: 'taskStatuses'),
+                categoryIds: any(named: 'categoryIds'),
+                labelIds: any(named: 'labelIds'),
+                priorities: any(named: 'priorities'),
+                sortByDate: any(named: 'sortByDate'),
+                limit: any(named: 'limit'),
+                offset: 0,
+              ),
+            ).called(1);
+            verify(
+              () => mockJournalDb.getTasks(
+                ids: any(named: 'ids'),
+                starredStatuses: any(named: 'starredStatuses'),
+                taskStatuses: any(named: 'taskStatuses'),
+                categoryIds: any(named: 'categoryIds'),
+                labelIds: any(named: 'labelIds'),
+                priorities: any(named: 'priorities'),
+                sortByDate: any(named: 'sortByDate'),
+                limit: any(named: 'limit'),
+                offset: JournalPageController.pageSize,
+              ),
+            ).called(1);
+
+            firstPageCompleter.complete(refreshedFirstPage);
+            async.flushMicrotasks();
+
+            expect(
+              state.pagingController?.value.items,
+              equals([
+                ...initialFirstPage,
+                initialSecondPageTask,
+              ]),
+            );
+            expect(state.pagingController?.value.isLoading, isTrue);
+
+            secondPageCompleter.complete([refreshedSecondPageTask]);
+            async.flushMicrotasks();
+
+            expect(
+              state.pagingController?.value.items,
+              equals([
+                ...refreshedFirstPage,
+                refreshedSecondPageTask,
+              ]),
+            );
+            expect(
+              state.pagingController?.value.items,
+              isNot(contains(initialSecondPageTask)),
+            );
+            expect(state.pagingController?.value.isLoading, isFalse);
+          });
+        },
+      );
+
+      test(
+        'refreshQuery keeps sequential retained refresh when project filters are active',
+        () {
+          fakeAsync((async) {
+            final initialFirstPage = List<JournalEntity>.generate(
+              JournalPageController.pageSize,
+              (index) => _buildTestTask(
+                id: 'task-$index',
+                title: 'Initial task $index',
+                createdAt: _testDate.add(Duration(minutes: index)),
+                priority: TaskPriority.p1High,
+              ),
+              growable: false,
+            );
+            final initialSecondPageTask = _buildTestTask(
+              id: 'task-late',
+              title: 'Initial late task',
+              createdAt: _testDate.add(const Duration(hours: 3)),
+              priority: TaskPriority.p2Medium,
+            );
+            final refreshedFirstPage = List<JournalEntity>.generate(
+              JournalPageController.pageSize,
+              (index) => _buildTestTask(
+                id: 'refreshed-$index',
+                title: 'Refreshed task $index',
+                createdAt: _testDate.add(Duration(hours: index)),
+                priority: TaskPriority.p1High,
+              ),
+              growable: false,
+            );
+            final refreshedSecondPageTask = _buildTestTask(
+              id: 'refreshed-tail',
+              title: 'Refreshed tail task',
+              createdAt: _testDate.add(const Duration(hours: 5)),
+              priority: TaskPriority.p2Medium,
+            );
+            final firstPageCompleter = Completer<List<JournalEntity>>();
+            final secondPageCompleter = Completer<List<JournalEntity>>();
+
+            when(
+              () => mockJournalDb.getTaskIdsForProjects(any()),
+            ).thenAnswer(
+              (_) async => {
+                ...initialFirstPage.map((entity) => entity.meta.id),
+                initialSecondPageTask.meta.id,
+                ...refreshedFirstPage.map((entity) => entity.meta.id),
+                refreshedSecondPageTask.meta.id,
+              },
+            );
+
+            final state = container.read(journalPageControllerProvider(true));
+            final controller = container.read(
+              journalPageControllerProvider(true).notifier,
+            );
+
+            async.flushMicrotasks();
+
+            unawaited(controller.toggleProjectFilter('proj-1'));
+            async.flushMicrotasks();
+
+            state.pagingController!.value = PagingState<int, JournalEntity>(
+              pages: [
+                initialFirstPage,
+                [initialSecondPageTask],
+              ],
+              keys: const [0, JournalPageController.pageSize],
+              hasNextPage: false,
+            );
+
+            clearInteractions(mockJournalDb);
+
+            when(
+              () => mockJournalDb.getTasks(
+                ids: any(named: 'ids'),
+                starredStatuses: any(named: 'starredStatuses'),
+                taskStatuses: any(named: 'taskStatuses'),
+                categoryIds: any(named: 'categoryIds'),
+                labelIds: any(named: 'labelIds'),
+                priorities: any(named: 'priorities'),
+                sortByDate: any(named: 'sortByDate'),
+                limit: any(named: 'limit'),
+                offset: any(named: 'offset'),
+              ),
+            ).thenAnswer((invocation) {
+              final offset = invocation.namedArguments[#offset] as int;
+              if (offset == 0) {
+                return firstPageCompleter.future;
+              }
+              if (offset == JournalPageController.pageSize) {
+                return secondPageCompleter.future;
+              }
+              return Future.value(<JournalEntity>[]);
+            });
+
+            unawaited(
+              controller.refreshQuery(preserveVisibleItems: true),
+            );
+            async.flushMicrotasks();
+
+            verify(
+              () => mockJournalDb.getTasks(
+                ids: any(named: 'ids'),
+                starredStatuses: any(named: 'starredStatuses'),
+                taskStatuses: any(named: 'taskStatuses'),
+                categoryIds: any(named: 'categoryIds'),
+                labelIds: any(named: 'labelIds'),
+                priorities: any(named: 'priorities'),
+                sortByDate: any(named: 'sortByDate'),
+                limit: any(named: 'limit'),
+                offset: 0,
+              ),
+            ).called(1);
+            verifyNever(
+              () => mockJournalDb.getTasks(
+                ids: any(named: 'ids'),
+                starredStatuses: any(named: 'starredStatuses'),
+                taskStatuses: any(named: 'taskStatuses'),
+                categoryIds: any(named: 'categoryIds'),
+                labelIds: any(named: 'labelIds'),
+                priorities: any(named: 'priorities'),
+                sortByDate: any(named: 'sortByDate'),
+                limit: any(named: 'limit'),
+                offset: JournalPageController.pageSize,
+              ),
+            );
+
+            firstPageCompleter.complete(refreshedFirstPage);
+            async.flushMicrotasks();
+
+            verify(
+              () => mockJournalDb.getTasks(
+                ids: any(named: 'ids'),
+                starredStatuses: any(named: 'starredStatuses'),
+                taskStatuses: any(named: 'taskStatuses'),
+                categoryIds: any(named: 'categoryIds'),
+                labelIds: any(named: 'labelIds'),
+                priorities: any(named: 'priorities'),
+                sortByDate: any(named: 'sortByDate'),
+                limit: any(named: 'limit'),
+                offset: JournalPageController.pageSize,
+              ),
+            ).called(1);
+
+            secondPageCompleter.complete([refreshedSecondPageTask]);
+            async.flushMicrotasks();
+
+            expect(
+              state.pagingController?.value.items,
+              equals([
+                ...refreshedFirstPage,
+                refreshedSecondPageTask,
+              ]),
+            );
+          });
+        },
+      );
+
+      test(
+        'stale project-filter refresh does not overwrite the winning next-page offset',
+        () {
+          fakeAsync((async) {
+            List<JournalEntity> buildRawChunk(String prefix) =>
+                List<JournalEntity>.generate(
+                  JournalPageController.pageSize,
+                  (index) => _buildTestTask(
+                    id: '$prefix-$index',
+                    title: '$prefix task $index',
+                    createdAt: _testDate.add(Duration(minutes: index)),
+                    priority: TaskPriority.p1High,
+                  ),
+                  growable: false,
+                );
+
+            final initialFirstPage = List<JournalEntity>.generate(
+              JournalPageController.pageSize,
+              (index) => _buildTestTask(
+                id: 'initial-$index',
+                title: 'Initial task $index',
+                createdAt: _testDate.add(Duration(minutes: index)),
+                priority: TaskPriority.p1High,
+              ),
+              growable: false,
+            );
+            final firstRefreshChunk0 = buildRawChunk('first-a');
+            final firstRefreshChunk50 = buildRawChunk('first-b');
+            final secondRefreshChunk0 = buildRawChunk('second-a');
+            final secondRefreshChunk50 = buildRawChunk('second-b');
+            final firstRefreshProjectIds = {
+              ...firstRefreshChunk0.take(25).map((entity) => entity.meta.id),
+              ...firstRefreshChunk50.take(25).map((entity) => entity.meta.id),
+            };
+            final secondRefreshProjectIds = {
+              ...secondRefreshChunk0.take(10).map((entity) => entity.meta.id),
+              ...secondRefreshChunk50.take(40).map((entity) => entity.meta.id),
+            };
+            final firstRefreshSecondChunkCompleter =
+                Completer<List<JournalEntity>>();
+            final nextPageCompleter = Completer<List<JournalEntity>>();
+            var projectIdsCallCount = 0;
+            var offset0CallCount = 0;
+            var offset50CallCount = 0;
+
+            when(
+              () => mockJournalDb.getTaskIdsForProjects(any()),
+            ).thenAnswer((_) async {
+              projectIdsCallCount++;
+              if (projectIdsCallCount == 1) {
+                return firstRefreshProjectIds;
+              }
+              return secondRefreshProjectIds;
+            });
+
+            final state = container.read(journalPageControllerProvider(true));
+            final controller = container.read(
+              journalPageControllerProvider(true).notifier,
+            );
+
+            async.flushMicrotasks();
+
+            unawaited(controller.toggleProjectFilter('proj-1'));
+            async.flushMicrotasks();
+
+            state.pagingController!.value = PagingState<int, JournalEntity>(
+              pages: [initialFirstPage],
+              keys: const [0],
+              hasNextPage: true,
+            );
+
+            clearInteractions(mockJournalDb);
+
+            when(
+              () => mockJournalDb.getTasks(
+                ids: any(named: 'ids'),
+                starredStatuses: any(named: 'starredStatuses'),
+                taskStatuses: any(named: 'taskStatuses'),
+                categoryIds: any(named: 'categoryIds'),
+                labelIds: any(named: 'labelIds'),
+                priorities: any(named: 'priorities'),
+                sortByDate: any(named: 'sortByDate'),
+                limit: any(named: 'limit'),
+                offset: any(named: 'offset'),
+              ),
+            ).thenAnswer((invocation) {
+              final offset = invocation.namedArguments[#offset] as int;
+              if (offset == 0) {
+                offset0CallCount++;
+                return Future.value(
+                  offset0CallCount == 1
+                      ? firstRefreshChunk0
+                      : secondRefreshChunk0,
+                );
+              }
+              if (offset == JournalPageController.pageSize) {
+                offset50CallCount++;
+                return offset50CallCount == 1
+                    ? firstRefreshSecondChunkCompleter.future
+                    : Future.value(secondRefreshChunk50);
+              }
+              if (offset == 90) {
+                return nextPageCompleter.future;
+              }
+              return Future.value(<JournalEntity>[]);
+            });
+
+            unawaited(
+              controller.refreshQuery(preserveVisibleItems: true),
+            );
+            async.flushMicrotasks();
+
+            unawaited(
+              controller.refreshQuery(preserveVisibleItems: true),
+            );
+            async.flushMicrotasks();
+
+            firstRefreshSecondChunkCompleter.complete(firstRefreshChunk50);
+            async.flushMicrotasks();
+
+            expect(
+              state.pagingController?.value.items,
+              equals([
+                ...secondRefreshChunk0.take(10),
+                ...secondRefreshChunk50.take(40),
+              ]),
+            );
+            expect(state.pagingController?.value.hasNextPage, isTrue);
+
+            state.pagingController!.fetchNextPage();
+            async.flushMicrotasks();
+
+            verify(
+              () => mockJournalDb.getTasks(
+                ids: any(named: 'ids'),
+                starredStatuses: any(named: 'starredStatuses'),
+                taskStatuses: any(named: 'taskStatuses'),
+                categoryIds: any(named: 'categoryIds'),
+                labelIds: any(named: 'labelIds'),
+                priorities: any(named: 'priorities'),
+                sortByDate: any(named: 'sortByDate'),
+                limit: any(named: 'limit'),
+                offset: 90,
+              ),
+            ).called(1);
+
+            nextPageCompleter.complete(<JournalEntity>[]);
+            async.flushMicrotasks();
           });
         },
       );
@@ -4439,4 +5225,34 @@ class MockVisibilityInfo extends VisibilityInfo {
         key: const Key('test'),
         size: const Size(100, 100),
       );
+}
+
+Task _buildTestTask({
+  required String id,
+  required String title,
+  required DateTime createdAt,
+  DateTime? updatedAt,
+  TaskPriority priority = TaskPriority.p2Medium,
+}) {
+  return Task(
+    data: TaskData(
+      status: TaskStatus.open(
+        id: 'status-$id',
+        createdAt: createdAt,
+        utcOffset: 0,
+      ),
+      dateFrom: createdAt,
+      dateTo: createdAt,
+      statusHistory: const [],
+      title: title,
+      priority: priority,
+    ),
+    meta: Metadata(
+      id: id,
+      createdAt: createdAt,
+      dateFrom: createdAt,
+      dateTo: createdAt,
+      updatedAt: updatedAt ?? createdAt,
+    ),
+  );
 }

--- a/test/features/labels/race_condition_labels_persistence_test.dart
+++ b/test/features/labels/race_condition_labels_persistence_test.dart
@@ -149,8 +149,10 @@ class _TestPersistenceLogic extends PersistenceLogic {
     String? linkedId,
     bool enqueueSync = true,
     bool overrideComparison = false,
+    Future<void> Function()? beforeNotify,
   }) async {
     _lastSaved = journalEntity;
+    await beforeNotify?.call();
     // Simulate applied
     return true;
   }

--- a/test/logic/persistence_logic_update_test.dart
+++ b/test/logic/persistence_logic_update_test.dart
@@ -33,6 +33,7 @@ class TestPersistenceLogic extends PersistenceLogic {
     String? linkedId,
     bool enqueueSync,
     bool overrideComparison,
+    Future<void> Function()? beforeNotify,
   })?
   updateDbEntityHandler;
   int updateMetadataCalls = 0;
@@ -68,6 +69,7 @@ class TestPersistenceLogic extends PersistenceLogic {
     String? linkedId,
     bool enqueueSync = true,
     bool overrideComparison = false,
+    Future<void> Function()? beforeNotify,
   }) async {
     lastUpdateDbEntity = journalEntity;
     if (updateDbEntityHandler != null) {
@@ -76,6 +78,7 @@ class TestPersistenceLogic extends PersistenceLogic {
         linkedId: linkedId,
         enqueueSync: enqueueSync,
         overrideComparison: overrideComparison,
+        beforeNotify: beforeNotify,
       );
     }
     return super.updateDbEntity(
@@ -83,6 +86,7 @@ class TestPersistenceLogic extends PersistenceLogic {
       linkedId: linkedId,
       enqueueSync: enqueueSync,
       overrideComparison: overrideComparison,
+      beforeNotify: beforeNotify,
     );
   }
 }
@@ -174,6 +178,13 @@ void main() {
     when(
       () => journalDb.parentLinkedEntityIds(any<String>()),
     ).thenReturn(MockSelectable<String>([]));
+    when(
+      () => journalDb.updateTaskPriorityColumn(
+        id: any(named: 'id'),
+        priority: any(named: 'priority'),
+        rank: any(named: 'rank'),
+      ),
+    ).thenAnswer((_) async {});
 
     getIt
       ..registerSingleton<JournalDb>(journalDb)
@@ -203,6 +214,37 @@ void main() {
     verify(() => outboxService.enqueueMessage(any<SyncMessage>())).called(1);
     verify(() => updateNotifications.notify(any<Set<String>>())).called(1);
   });
+
+  test(
+    'updateDbEntity logs beforeNotify failures and still propagates changes',
+    () async {
+      stubUpdateResult(JournalUpdateResult.applied());
+
+      final result = await logic.updateDbEntity(
+        buildEntry(),
+        beforeNotify: () async => throw Exception('beforeNotify failed'),
+      );
+
+      expect(result, isTrue);
+      verify(
+        () => loggingService.captureException(
+          any<Object>(),
+          domain: 'persistence_logic',
+          subDomain: 'updateDbEntity.beforeNotify',
+          stackTrace: any<StackTrace?>(named: 'stackTrace'),
+        ),
+      ).called(1);
+      verify(() => updateNotifications.notify(any<Set<String>>())).called(1);
+      verify(() => outboxService.enqueueMessage(any<SyncMessage>())).called(1);
+      verify(
+        () => fts5Db.insertText(
+          any<JournalEntity>(),
+          removePrevious: true,
+        ),
+      ).called(1);
+      verify(notificationService.updateBadge).called(1);
+    },
+  );
 
   test('updateDbEntity returns false when update skipped', () async {
     stubUpdateResult(
@@ -286,6 +328,7 @@ void main() {
                 linkedId,
                 enqueueSync = true,
                 overrideComparison = false,
+                beforeNotify,
               }) async => true,
         );
 
@@ -314,6 +357,7 @@ void main() {
                 linkedId,
                 enqueueSync = true,
                 overrideComparison = false,
+                beforeNotify,
               }) async => false,
         );
 
@@ -324,6 +368,117 @@ void main() {
 
         expect(skipped, isFalse);
         verifyNever(() => journalDb.addLabeled(any<JournalEntity>()));
+      },
+    );
+
+    test(
+      'updates task priority columns before notifying listeners for task updates',
+      () async {
+        final testDate = DateTime(2024, 3, 15, 10, 30);
+        final callOrder = <String>[];
+        Set<String>? notifiedIds;
+        final task = Task(
+          meta: Metadata(
+            id: 'task-id',
+            createdAt: testDate,
+            updatedAt: testDate,
+            dateFrom: testDate,
+            dateTo: testDate,
+            vectorClock: const VectorClock({'host': 1}),
+          ),
+          data: TaskData(
+            status: TaskStatus.open(
+              id: 'status-id',
+              createdAt: testDate,
+              utcOffset: 60,
+            ),
+            title: 'task',
+            statusHistory: const [],
+            dateTo: testDate,
+            dateFrom: testDate,
+            priority: TaskPriority.p0Urgent,
+          ),
+        );
+
+        when(() => journalDb.journalEntityById('task-id')).thenAnswer(
+          (_) async => task,
+        );
+        stubUpdateResult(JournalUpdateResult.applied());
+        when(
+          () => journalDb.updateTaskPriorityColumn(
+            id: 'task-id',
+            priority: 'P1',
+            rank: 1,
+          ),
+        ).thenAnswer((_) async {
+          callOrder.add('priority-column');
+        });
+        when(
+          () => updateNotifications.notify(
+            any<Set<String>>(),
+            fromSync: any(named: 'fromSync'),
+          ),
+        ).thenAnswer((invocation) {
+          callOrder.add('notify');
+          notifiedIds = invocation.positionalArguments.first as Set<String>;
+        });
+
+        final updatedTask = task.copyWith(
+          data: task.data.copyWith(priority: TaskPriority.p1High),
+        );
+        final result = await logic.updateJournalEntity(
+          updatedTask,
+          updatedTask.meta,
+        );
+
+        expect(result, isTrue);
+        expect(callOrder, equals(['priority-column', 'notify']));
+        expect(notifiedIds, contains('task-id'));
+      },
+    );
+
+    test(
+      'skips task priority column updates when updateJournalEntity keeps priority unchanged',
+      () async {
+        final testDate = DateTime(2024, 3, 15, 10, 30);
+        final task = Task(
+          meta: Metadata(
+            id: 'task-id',
+            createdAt: testDate,
+            updatedAt: testDate,
+            dateFrom: testDate,
+            dateTo: testDate,
+            vectorClock: const VectorClock({'host': 1}),
+          ),
+          data: TaskData(
+            status: TaskStatus.open(
+              id: 'status-id',
+              createdAt: testDate,
+              utcOffset: 60,
+            ),
+            title: 'task',
+            statusHistory: const [],
+            dateTo: testDate,
+            dateFrom: testDate,
+            priority: TaskPriority.p1High,
+          ),
+        );
+
+        when(
+          () => journalDb.journalEntityById('task-id'),
+        ).thenAnswer((_) async => task);
+        stubUpdateResult(JournalUpdateResult.applied());
+
+        final result = await logic.updateJournalEntity(task, task.meta);
+
+        expect(result, isTrue);
+        verifyNever(
+          () => journalDb.updateTaskPriorityColumn(
+            id: any(named: 'id'),
+            priority: any(named: 'priority'),
+            rank: any(named: 'rank'),
+          ),
+        );
       },
     );
   });
@@ -396,6 +551,7 @@ void main() {
               linkedId,
               enqueueSync = true,
               overrideComparison = false,
+              beforeNotify,
             }) async => true,
       );
 
@@ -445,6 +601,7 @@ void main() {
               linkedId,
               enqueueSync = true,
               overrideComparison = false,
+              beforeNotify,
             }) async => true,
       );
 
@@ -509,6 +666,74 @@ void main() {
         ),
       ).called(1);
     });
+  });
+
+  group('updateTask', () {
+    test(
+      'updates priority columns before notifying listeners for priority changes',
+      () async {
+        final testDate = DateTime(2024, 3, 15, 10, 30);
+        final callOrder = <String>[];
+        Set<String>? notifiedIds;
+        final task = Task(
+          meta: Metadata(
+            id: 'task-id',
+            createdAt: testDate,
+            updatedAt: testDate,
+            dateFrom: testDate,
+            dateTo: testDate,
+            vectorClock: const VectorClock({'host': 1}),
+          ),
+          data: TaskData(
+            status: TaskStatus.open(
+              id: 'status-id',
+              createdAt: testDate,
+              utcOffset: 60,
+            ),
+            title: 'task',
+            statusHistory: const [],
+            dateTo: testDate,
+            dateFrom: testDate,
+            priority: TaskPriority.p1High,
+          ),
+        );
+
+        when(
+          () => journalDb.journalEntityById('task-id'),
+        ).thenAnswer((_) async => task);
+        stubUpdateResult(JournalUpdateResult.applied());
+        when(
+          () => journalDb.updateTaskPriorityColumn(
+            id: 'task-id',
+            priority: 'P0',
+            rank: 0,
+          ),
+        ).thenAnswer((_) async {
+          callOrder.add('priority-column');
+        });
+        when(
+          () => updateNotifications.notify(
+            any<Set<String>>(),
+            fromSync: any(named: 'fromSync'),
+          ),
+        ).thenAnswer((invocation) {
+          callOrder.add('notify');
+          notifiedIds = invocation.positionalArguments.first as Set<String>;
+        });
+
+        final updatedTaskData = task.data.copyWith(
+          priority: TaskPriority.p0Urgent,
+        );
+
+        await logic.updateTask(
+          journalEntityId: 'task-id',
+          taskData: updatedTaskData,
+        );
+
+        expect(callOrder, equals(['priority-column', 'notify']));
+        expect(notifiedIds, contains('task-id'));
+      },
+    );
   });
 
   group('updateEvent - orElse path', () {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tasks desktop split view keeps the currently loaded list window mounted during refreshes, reducing flicker and preserving regrouping after sort or sort-related changes.

* **Refactor**
  * Pagination now refreshes all loaded pages (sequentially when needed or concurrently), preserves visible items during retained refreshes, and simplifies update-notification triggering.
  * Persistence updates can run a pre-notification hook so denormalized priority changes occur before notifications.

* **Tests**
  * Added extensive retained-refresh, visible-item update, sequential-refresh, and update-order tests.

* **Documentation**
  * Updated changelog and journal docs to describe the retained-refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->