### PR TITLE
feat: add project one-liner summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.951] - 2026-04-12
+### Added
+- Project one-liner: AI-generated summary subtitle on project list cards,
+  giving an at-a-glance status for each project (mirrors the existing task
+  one-liner feature).
+- Project agent now produces a dedicated `one_liner` field in its report,
+  separate from the longer TLDR summary.
+
 ## [0.9.950] - 2026-04-11
 ### Removed
 - Removed the gamey theme and all gamey-styled widgets (GameyFab, GameyCard,

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -31,6 +31,11 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="0.9.951" date="2026-04-12">
+      <description>
+          <p>Project one-liner: AI-generated summary subtitle on project list cards, giving an at-a-glance status for each project. The project agent now produces a dedicated one-liner field in its report, separate from the longer TLDR summary.</p>
+      </description>
+    </release>
     <release version="0.9.950" date="2026-04-11">
       <description>
           <p>Removed the gamey theme and all gamey-styled widgets. Standard Flutter widgets and existing modern cards are used instead.</p>

--- a/lib/features/agents/model/project_agent_report_contract.dart
+++ b/lib/features/agents/model/project_agent_report_contract.dart
@@ -11,6 +11,7 @@
 abstract final class ProjectAgentReportToolArgs {
   static const markdown = 'markdown';
   static const tldr = 'tldr';
+  static const oneLiner = 'one_liner';
   static const healthBand = 'health_band';
   static const healthRationale = 'health_rationale';
   static const healthConfidence = 'health_confidence';
@@ -18,6 +19,7 @@ abstract final class ProjectAgentReportToolArgs {
   static const required = <String>[
     markdown,
     tldr,
+    oneLiner,
     healthBand,
     healthRationale,
   ];

--- a/lib/features/agents/tools/project_tool_definitions.dart
+++ b/lib/features/agents/tools/project_tool_definitions.dart
@@ -41,6 +41,14 @@ const projectAgentTools = <AgentToolDefinition>[
               'A concise 1-3 sentence overview of the project state. This is '
               'shown in the collapsed view, so make it useful on its own.',
         },
+        ProjectAgentReportToolArgs.oneLiner: {
+          'type': 'string',
+          'description':
+              'A concise project tagline for compact project-card subtitles '
+              'in the project list. One or two short sentences that capture '
+              'the current state, next step, or primary risk. Longer than '
+              'a task one-liner but much shorter than the tldr.',
+        },
         ProjectAgentReportToolArgs.healthBand: {
           'type': 'string',
           'enum': ProjectAgentHealthBandValues.values,

--- a/lib/features/agents/workflow/project_agent_strategy.dart
+++ b/lib/features/agents/workflow/project_agent_strategy.dart
@@ -51,6 +51,7 @@ class ProjectAgentStrategy extends ConversationStrategy {
 
   String? _reportContent;
   String? _reportTldr;
+  String? _reportOneLiner;
   String? _reportHealthBand;
   String? _reportHealthRationale;
   double? _reportHealthConfidence;
@@ -154,6 +155,9 @@ class ProjectAgentStrategy extends ConversationStrategy {
   /// Extracts the TLDR published via `update_project_report`.
   String? extractReportTldr() => _reportTldr;
 
+  /// Extracts the one-liner published via `update_project_report`.
+  String? extractReportOneLiner() => _reportOneLiner;
+
   /// Extracts the health band published via `update_project_report`.
   String? extractReportHealthBand() => _reportHealthBand;
 
@@ -182,6 +186,10 @@ class ProjectAgentStrategy extends ConversationStrategy {
     final markdown = markdownValue is String ? markdownValue.trim() : '';
     final tldrValue = args[ProjectAgentReportToolArgs.tldr];
     final tldr = tldrValue is String ? tldrValue.trim() : null;
+    final rawOneLiner = args[ProjectAgentReportToolArgs.oneLiner];
+    final oneLiner = (rawOneLiner is String && rawOneLiner.trim().isNotEmpty)
+        ? rawOneLiner.trim()
+        : null;
     final healthBandValue = args[ProjectAgentReportToolArgs.healthBand];
     final healthBand = healthBandValue is String ? healthBandValue.trim() : '';
     final healthRationaleValue =
@@ -232,6 +240,7 @@ class ProjectAgentStrategy extends ConversationStrategy {
 
     _reportContent = markdown;
     _reportTldr = tldr;
+    _reportOneLiner = oneLiner;
     _reportHealthBand = healthBand;
     _reportHealthRationale = healthRationale;
     _reportHealthConfidence = healthConfidence;

--- a/lib/features/agents/workflow/project_agent_workflow.dart
+++ b/lib/features/agents/workflow/project_agent_workflow.dart
@@ -325,6 +325,7 @@ class ProjectAgentWorkflow {
       // 9. Persist all wake outputs.
       final reportContent = strategy.extractReportContent();
       final reportTldr = strategy.extractReportTldr();
+      final reportOneLiner = strategy.extractReportOneLiner();
       final reportHealthBand = strategy.extractReportHealthBand();
       final reportHealthRationale = strategy.extractReportHealthRationale();
       final reportHealthConfidence = strategy.extractReportHealthConfidence();
@@ -374,6 +375,7 @@ class ProjectAgentWorkflow {
               vectorClock: null,
               content: reportContent,
               tldr: reportTldr,
+              oneLiner: reportOneLiner,
               provenance: <String, Object?>{
                 ProjectAgentReportProvenanceKeys.healthBand: reportHealthBand,
                 ProjectAgentReportProvenanceKeys.healthRationale:

--- a/lib/features/design_system/state/pane_width_controller.g.dart
+++ b/lib/features/design_system/state/pane_width_controller.g.dart
@@ -42,7 +42,7 @@ final class PaneWidthControllerProvider
 }
 
 String _$paneWidthControllerHash() =>
-    r'645c279c3a6e1ecb4e6e6a1c3ed47345b8181e9b';
+    r'dbe6038574eeb269003e24d7238344639f6cf871';
 
 abstract class _$PaneWidthController extends $Notifier<PaneWidths> {
   PaneWidths build();

--- a/lib/features/journal/state/journal_page_controller.g.dart
+++ b/lib/features/journal/state/journal_page_controller.g.dart
@@ -71,7 +71,7 @@ final class JournalPageControllerProvider
 }
 
 String _$journalPageControllerHash() =>
-    r'6942b88b695e9733ad30e287988b82a41e8baf08';
+    r'0cdad2485ae5416065a97a91e8b3af2fcc1d7a04';
 
 /// Controller for managing journal/tasks page state.
 ///

--- a/lib/features/projects/state/project_one_liner_provider.dart
+++ b/lib/features/projects/state/project_one_liner_provider.dart
@@ -1,0 +1,31 @@
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/state/agent_providers.dart';
+import 'package:lotti/features/agents/state/project_agent_providers.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'project_one_liner_provider.g.dart';
+
+/// Fetches the AI-generated one-liner subtitle for a project from its agent
+/// report.
+///
+/// Chains `projectAgentProvider` to resolve the project's agent, then watches
+/// `agentReportProvider` for the latest report and extracts the `oneLiner`
+/// field. Auto-disposes when the project card scrolls off-screen.
+@riverpod
+Future<String?> projectOneLiner(Ref ref, String projectId) async {
+  final agentEntity = await ref.watch(
+    projectAgentProvider(projectId).future,
+  );
+  final identity = agentEntity?.mapOrNull(agent: (agent) => agent);
+  if (identity == null) return null;
+
+  final reportEntity = await ref.watch(
+    agentReportProvider(identity.agentId).future,
+  );
+  final report = reportEntity?.mapOrNull(agentReport: (r) => r);
+  final oneLiner = report?.oneLiner?.trim();
+  if (oneLiner != null && oneLiner.isNotEmpty) {
+    return oneLiner;
+  }
+  return null;
+}

--- a/lib/features/projects/state/project_one_liner_provider.g.dart
+++ b/lib/features/projects/state/project_one_liner_provider.g.dart
@@ -1,0 +1,112 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'project_one_liner_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Fetches the AI-generated one-liner subtitle for a project from its agent
+/// report.
+///
+/// Chains [projectAgentProvider] to resolve the project's agent, then watches
+/// [agentReportProvider] for the latest report and extracts the [oneLiner]
+/// field. Auto-disposes when the project card scrolls off-screen.
+
+@ProviderFor(projectOneLiner)
+final projectOneLinerProvider = ProjectOneLinerFamily._();
+
+/// Fetches the AI-generated one-liner subtitle for a project from its agent
+/// report.
+///
+/// Chains [projectAgentProvider] to resolve the project's agent, then watches
+/// [agentReportProvider] for the latest report and extracts the [oneLiner]
+/// field. Auto-disposes when the project card scrolls off-screen.
+
+final class ProjectOneLinerProvider
+    extends $FunctionalProvider<AsyncValue<String?>, String?, FutureOr<String?>>
+    with $FutureModifier<String?>, $FutureProvider<String?> {
+  /// Fetches the AI-generated one-liner subtitle for a project from its agent
+  /// report.
+  ///
+  /// Chains [projectAgentProvider] to resolve the project's agent, then watches
+  /// [agentReportProvider] for the latest report and extracts the [oneLiner]
+  /// field. Auto-disposes when the project card scrolls off-screen.
+  ProjectOneLinerProvider._({
+    required ProjectOneLinerFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'projectOneLinerProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$projectOneLinerHash();
+
+  @override
+  String toString() {
+    return r'projectOneLinerProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<String?> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<String?> create(Ref ref) {
+    final argument = this.argument as String;
+    return projectOneLiner(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is ProjectOneLinerProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$projectOneLinerHash() => r'1519ce99e2f0d63f7859ce894925307f26df9bab';
+
+/// Fetches the AI-generated one-liner subtitle for a project from its agent
+/// report.
+///
+/// Chains [projectAgentProvider] to resolve the project's agent, then watches
+/// [agentReportProvider] for the latest report and extracts the [oneLiner]
+/// field. Auto-disposes when the project card scrolls off-screen.
+
+final class ProjectOneLinerFamily extends $Family
+    with $FunctionalFamilyOverride<FutureOr<String?>, String> {
+  ProjectOneLinerFamily._()
+    : super(
+        retry: null,
+        name: r'projectOneLinerProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// Fetches the AI-generated one-liner subtitle for a project from its agent
+  /// report.
+  ///
+  /// Chains [projectAgentProvider] to resolve the project's agent, then watches
+  /// [agentReportProvider] for the latest report and extracts the [oneLiner]
+  /// field. Auto-disposes when the project card scrolls off-screen.
+
+  ProjectOneLinerProvider call(String projectId) =>
+      ProjectOneLinerProvider._(argument: projectId, from: this);
+
+  @override
+  String toString() => r'projectOneLinerProvider';
+}

--- a/lib/features/projects/ui/widgets/project_list_shared.dart
+++ b/lib/features/projects/ui/widgets/project_list_shared.dart
@@ -1,12 +1,14 @@
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:lotti/features/categories/domain/category_icon.dart';
 import 'package:lotti/features/design_system/components/lists/grouped_card_row_interactions.dart';
 import 'package:lotti/features/design_system/components/lists/grouped_card_row_surface.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/projects/model/projects_overview_models.dart';
+import 'package:lotti/features/projects/state/project_one_liner_provider.dart';
 import 'package:lotti/features/projects/ui/widgets/shared_widgets.dart';
 import 'package:lotti/features/projects/ui/widgets/showcase/showcase_palette.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
@@ -191,7 +193,7 @@ class _ProjectGroupSectionState extends State<ProjectGroupSection> {
 
 /// A single project row in the list, with task-progress ring, task count,
 /// due label, and status tag.
-class ProjectRow extends StatelessWidget {
+class ProjectRow extends ConsumerWidget {
   const ProjectRow({
     required this.item,
     required this.selected,
@@ -216,16 +218,18 @@ class ProjectRow extends StatelessWidget {
   final VoidCallback onTap;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final tokens = context.designTokens;
     final metaStyle = tokens.typography.styles.others.caption.copyWith(
       color: ShowcasePalette.lowText(context),
     );
+    final projectId = item.project.meta.id;
+    final oneLiner = ref.watch(projectOneLinerProvider(projectId)).value;
 
     return GroupedCardRowSurface(
-      key: key ?? ValueKey('project-row-surface-${item.project.meta.id}'),
-      rowKey: ValueKey('project-overview-row-${item.project.meta.id}'),
-      backgroundKey: ValueKey('project-row-background-${item.project.meta.id}'),
+      key: key ?? ValueKey('project-row-surface-$projectId'),
+      rowKey: ValueKey('project-overview-row-$projectId'),
+      backgroundKey: ValueKey('project-row-background-$projectId'),
       selected: selected,
       hoverColor: ShowcasePalette.hoverFill(context),
       selectedColor: ShowcasePalette.selectedRow(context),
@@ -257,6 +261,17 @@ class ProjectRow extends StatelessWidget {
                     color: ShowcasePalette.highText(context),
                   ),
                 ),
+                if (oneLiner != null && oneLiner.isNotEmpty) ...[
+                  const SizedBox(height: 4),
+                  Text(
+                    oneLiner,
+                    maxLines: 3,
+                    overflow: TextOverflow.ellipsis,
+                    style: tokens.typography.styles.others.caption.copyWith(
+                      color: ShowcasePalette.lowText(context),
+                    ),
+                  ),
+                ],
                 const SizedBox(height: 4),
                 RichText(
                   maxLines: 1,

--- a/lib/features/projects/ui/widgets/project_list_shared.dart
+++ b/lib/features/projects/ui/widgets/project_list_shared.dart
@@ -262,7 +262,7 @@ class ProjectRow extends ConsumerWidget {
                   ),
                 ),
                 if (oneLiner != null && oneLiner.isNotEmpty) ...[
-                  const SizedBox(height: 4),
+                  SizedBox(height: tokens.spacing.step1),
                   Text(
                     oneLiner,
                     maxLines: 3,

--- a/lib/features/theming/state/theming_controller.g.dart
+++ b/lib/features/theming/state/theming_controller.g.dart
@@ -85,7 +85,7 @@ final class ThemingControllerProvider
   }
 }
 
-String _$themingControllerHash() => r'bce8de4446539716a12a5a5163f5e29a0483b806';
+String _$themingControllerHash() => r'8226faba7a4fabe7e947989d83e02224a62f8733';
 
 /// Notifier managing the complete theming state.
 /// Marked as keepAlive since theme state should persist for the entire app lifecycle.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.950+3921
+version: 0.9.951+3922
 
 msix_config:
   display_name: LottiApp

--- a/test/features/agents/workflow/project_agent_strategy_test.dart
+++ b/test/features/agents/workflow/project_agent_strategy_test.dart
@@ -56,13 +56,14 @@ void main() {
 
   group('ProjectAgentStrategy', () {
     group('update_project_report', () {
-      test('accumulates report content and tldr', () async {
+      test('accumulates report content, tldr, and oneLiner', () async {
         final toolCalls = [
           _makeToolCall(
             name: ProjectAgentToolNames.updateProjectReport,
             args: {
               'markdown': '# Project Report\nAll good.',
               'tldr': 'Everything is on track.',
+              'one_liner': 'Steady progress; API v2 next.',
               'health_band': 'on_track',
               'health_rationale': 'Recent work is landing cleanly.',
               'health_confidence': 0.82,
@@ -77,6 +78,10 @@ void main() {
 
         expect(strategy.extractReportContent(), '# Project Report\nAll good.');
         expect(strategy.extractReportTldr(), 'Everything is on track.');
+        expect(
+          strategy.extractReportOneLiner(),
+          'Steady progress; API v2 next.',
+        );
         expect(strategy.extractReportHealthBand(), 'on_track');
         expect(
           strategy.extractReportHealthRationale(),
@@ -90,6 +95,49 @@ void main() {
             response: 'Report updated successfully.',
           ),
         ).called(1);
+      });
+
+      test('oneLiner defaults to null when omitted', () async {
+        final toolCalls = [
+          _makeToolCall(
+            name: ProjectAgentToolNames.updateProjectReport,
+            args: {
+              'markdown': '# Report',
+              'tldr': 'Summary here.',
+              'health_band': 'on_track',
+              'health_rationale': 'All good.',
+            },
+          ),
+        ];
+
+        await strategy.processToolCalls(
+          toolCalls: toolCalls,
+          manager: mockManager,
+        );
+
+        expect(strategy.extractReportOneLiner(), isNull);
+      });
+
+      test('oneLiner trims whitespace and ignores blank values', () async {
+        final toolCalls = [
+          _makeToolCall(
+            name: ProjectAgentToolNames.updateProjectReport,
+            args: {
+              'markdown': '# Report',
+              'tldr': 'Summary.',
+              'one_liner': '   ',
+              'health_band': 'watch',
+              'health_rationale': 'Uncertain.',
+            },
+          ),
+        ];
+
+        await strategy.processToolCalls(
+          toolCalls: toolCalls,
+          manager: mockManager,
+        );
+
+        expect(strategy.extractReportOneLiner(), isNull);
       });
 
       test('returns error when markdown is empty', () async {

--- a/test/features/agents/workflow/project_agent_workflow_test.dart
+++ b/test/features/agents/workflow/project_agent_workflow_test.dart
@@ -1483,6 +1483,7 @@ void main() {
                       arguments: jsonEncode({
                         'markdown': '# Status Report\nAll good.',
                         'tldr': 'On track.',
+                        'one_liner': 'Steady progress; API v2 next.',
                         'health_band': 'on_track',
                         'health_rationale': 'Recent work is landing well.',
                         'health_confidence': 0.88,
@@ -1524,6 +1525,7 @@ void main() {
         expect(reports, hasLength(1));
         expect(reports.first.content, '# Status Report\nAll good.');
         expect(reports.first.tldr, 'On track.');
+        expect(reports.first.oneLiner, 'Steady progress; API v2 next.');
         expect(reports.first.provenance, {
           'project_health_band': 'on_track',
           'project_health_rationale': 'Recent work is landing well.',

--- a/test/features/projects/state/project_one_liner_provider_test.dart
+++ b/test/features/projects/state/project_one_liner_provider_test.dart
@@ -1,0 +1,205 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/agents/state/agent_providers.dart';
+import 'package:lotti/features/agents/state/project_agent_providers.dart';
+import 'package:lotti/features/projects/state/project_one_liner_provider.dart';
+
+import '../../../features/agents/test_utils.dart';
+
+void main() {
+  group('projectOneLinerProvider', () {
+    const projectId = 'project-1';
+    const agentId = 'agent-project-1';
+
+    test('returns oneLiner when agent report has one', () async {
+      const expectedOneLiner = 'Steady progress; next milestone is API v2.';
+
+      final container = ProviderContainer(
+        overrides: [
+          projectAgentProvider(
+            projectId,
+          ).overrideWith(
+            (ref) async => makeTestIdentity(agentId: agentId),
+          ),
+          agentReportProvider(
+            agentId,
+          ).overrideWith(
+            (ref) async => makeTestReport(
+              agentId: agentId,
+              oneLiner: expectedOneLiner,
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final result = await container.read(
+        projectOneLinerProvider(projectId).future,
+      );
+
+      expect(result, expectedOneLiner);
+    });
+
+    test('returns null when no project agent exists', () async {
+      final container = ProviderContainer(
+        overrides: [
+          projectAgentProvider(projectId).overrideWith((ref) async => null),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final result = await container.read(
+        projectOneLinerProvider(projectId).future,
+      );
+
+      expect(result, isNull);
+    });
+
+    test(
+      'returns null when agent resolves to a non-identity entity',
+      () async {
+        final container = ProviderContainer(
+          overrides: [
+            projectAgentProvider(
+              projectId,
+            ).overrideWith(
+              (ref) async => makeTestState(agentId: agentId),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final result = await container.read(
+          projectOneLinerProvider(projectId).future,
+        );
+
+        expect(result, isNull);
+      },
+    );
+
+    test('returns null when agent report has no oneLiner', () async {
+      final container = ProviderContainer(
+        overrides: [
+          projectAgentProvider(
+            projectId,
+          ).overrideWith(
+            (ref) async => makeTestIdentity(agentId: agentId),
+          ),
+          agentReportProvider(
+            agentId,
+          ).overrideWith(
+            (ref) async => makeTestReport(agentId: agentId),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final result = await container.read(
+        projectOneLinerProvider(projectId).future,
+      );
+
+      expect(result, isNull);
+    });
+
+    test('returns null when oneLiner is empty', () async {
+      final container = ProviderContainer(
+        overrides: [
+          projectAgentProvider(
+            projectId,
+          ).overrideWith(
+            (ref) async => makeTestIdentity(agentId: agentId),
+          ),
+          agentReportProvider(
+            agentId,
+          ).overrideWith(
+            (ref) async => makeTestReport(
+              agentId: agentId,
+              oneLiner: '',
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final result = await container.read(
+        projectOneLinerProvider(projectId).future,
+      );
+
+      expect(result, isNull);
+    });
+
+    test('returns null when oneLiner is only whitespace', () async {
+      final container = ProviderContainer(
+        overrides: [
+          projectAgentProvider(
+            projectId,
+          ).overrideWith(
+            (ref) async => makeTestIdentity(agentId: agentId),
+          ),
+          agentReportProvider(
+            agentId,
+          ).overrideWith(
+            (ref) async => makeTestReport(
+              agentId: agentId,
+              oneLiner: '   ',
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final result = await container.read(
+        projectOneLinerProvider(projectId).future,
+      );
+
+      expect(result, isNull);
+    });
+
+    test('trims whitespace from oneLiner', () async {
+      final container = ProviderContainer(
+        overrides: [
+          projectAgentProvider(
+            projectId,
+          ).overrideWith(
+            (ref) async => makeTestIdentity(agentId: agentId),
+          ),
+          agentReportProvider(
+            agentId,
+          ).overrideWith(
+            (ref) async => makeTestReport(
+              agentId: agentId,
+              oneLiner: '  Wrapping up the last sprint items.  ',
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final result = await container.read(
+        projectOneLinerProvider(projectId).future,
+      );
+
+      expect(result, 'Wrapping up the last sprint items.');
+    });
+
+    test('returns null when agent report is null', () async {
+      final container = ProviderContainer(
+        overrides: [
+          projectAgentProvider(
+            projectId,
+          ).overrideWith(
+            (ref) async => makeTestIdentity(agentId: agentId),
+          ),
+          agentReportProvider(agentId).overrideWith((ref) async => null),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final result = await container.read(
+        projectOneLinerProvider(projectId).future,
+      );
+
+      expect(result, isNull);
+    });
+  });
+}

--- a/test/features/projects/test_utils.dart
+++ b/test/features/projects/test_utils.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_riverpod/misc.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/journal_entities.dart';
@@ -5,6 +6,7 @@ import 'package:lotti/classes/project_data.dart';
 import 'package:lotti/classes/task.dart';
 import 'package:lotti/features/projects/model/projects_overview_models.dart';
 import 'package:lotti/features/projects/state/project_health_metrics.dart';
+import 'package:lotti/features/projects/state/project_one_liner_provider.dart';
 import 'package:lotti/features/projects/ui/model/project_list_detail_models.dart';
 import 'package:lotti/utils/file_utils.dart';
 
@@ -197,6 +199,13 @@ ReviewSession makeTestReviewSession({
     expanded: expanded,
   );
 }
+
+/// Provider overrides that return null for all project one-liners matching
+/// the given [projectIds].
+List<Override> noOneLinerOverrides(List<String> projectIds) => [
+  for (final id in projectIds)
+    projectOneLinerProvider(id).overrideWith((ref) async => null),
+];
 
 /// Creates a [ProjectListData] for testing with two categories and two
 /// projects.

--- a/test/features/projects/ui/widgets/project_list_pane_test.dart
+++ b/test/features/projects/ui/widgets/project_list_pane_test.dart
@@ -5,7 +5,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/intl.dart';
 import 'package:lotti/features/design_system/theme/design_system_theme.dart';
 import 'package:lotti/features/projects/model/projects_overview_models.dart';
-import 'package:lotti/features/projects/state/project_one_liner_provider.dart';
 import 'package:lotti/features/projects/ui/model/project_list_detail_state.dart';
 import 'package:lotti/features/projects/ui/widgets/project_list_pane.dart';
 import 'package:lotti/l10n/app_localizations.dart';
@@ -13,12 +12,6 @@ import 'package:lotti/l10n/app_localizations.dart';
 import '../../../../helpers/test_finders.dart';
 import '../../../../widget_test_utils.dart';
 import '../../test_utils.dart';
-
-/// Override to return null for all project one-liners matching the given IDs.
-List<Override> _noOneLinerOverrides(List<String> projectIds) => [
-  for (final id in projectIds)
-    projectOneLinerProvider(id).overrideWith((ref) async => null),
-];
 
 void main() {
   Widget wrap(Widget child, {Locale? locale, List<Override>? overrides}) {
@@ -30,7 +23,7 @@ void main() {
     );
 
     return ProviderScope(
-      overrides: overrides ?? _noOneLinerOverrides(['p1', 'p2']),
+      overrides: overrides ?? noOneLinerOverrides(['p1', 'p2']),
       child: makeTestableWidget2(
         Builder(
           builder: (context) => locale == null

--- a/test/features/projects/ui/widgets/project_list_pane_test.dart
+++ b/test/features/projects/ui/widgets/project_list_pane_test.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/intl.dart';
 import 'package:lotti/features/design_system/theme/design_system_theme.dart';
 import 'package:lotti/features/projects/model/projects_overview_models.dart';
+import 'package:lotti/features/projects/state/project_one_liner_provider.dart';
 import 'package:lotti/features/projects/ui/model/project_list_detail_state.dart';
 import 'package:lotti/features/projects/ui/widgets/project_list_pane.dart';
 import 'package:lotti/l10n/app_localizations.dart';
@@ -11,8 +14,14 @@ import '../../../../helpers/test_finders.dart';
 import '../../../../widget_test_utils.dart';
 import '../../test_utils.dart';
 
+/// Override to return null for all project one-liners matching the given IDs.
+List<Override> _noOneLinerOverrides(List<String> projectIds) => [
+  for (final id in projectIds)
+    projectOneLinerProvider(id).overrideWith((ref) async => null),
+];
+
 void main() {
-  Widget wrap(Widget child, {Locale? locale}) {
+  Widget wrap(Widget child, {Locale? locale, List<Override>? overrides}) {
     final themedChild = Theme(
       data: DesignSystemTheme.dark(),
       child: Scaffold(
@@ -20,17 +29,20 @@ void main() {
       ),
     );
 
-    return makeTestableWidget2(
-      Builder(
-        builder: (context) => locale == null
-            ? themedChild
-            : Localizations.override(
-                context: context,
-                locale: locale,
-                child: themedChild,
-              ),
+    return ProviderScope(
+      overrides: overrides ?? _noOneLinerOverrides(['p1', 'p2']),
+      child: makeTestableWidget2(
+        Builder(
+          builder: (context) => locale == null
+              ? themedChild
+              : Localizations.override(
+                  context: context,
+                  locale: locale,
+                  child: themedChild,
+                ),
+        ),
+        mediaQueryData: const MediaQueryData(size: Size(500, 1000)),
       ),
-      mediaQueryData: const MediaQueryData(size: Size(500, 1000)),
     );
   }
 

--- a/test/features/projects/ui/widgets/project_list_shared_test.dart
+++ b/test/features/projects/ui/widgets/project_list_shared_test.dart
@@ -29,12 +29,6 @@ void main() {
     );
   }
 
-  /// Override to return null for all project one-liners matching the given IDs.
-  List<Override> noOneLinerOverrides(List<String> projectIds) => [
-    for (final id in projectIds)
-      projectOneLinerProvider(id).overrideWith((ref) async => null),
-  ];
-
   ProjectCategoryGroup makeGroupedProjectsSection() {
     final workCategory = makeTestProjectListData().categories.first;
     return ProjectCategoryGroup(
@@ -317,12 +311,6 @@ void main() {
   });
 
   group('ProjectRow', () {
-    List<Override> noOneLinerOverride(String projectId) => [
-      projectOneLinerProvider(projectId).overrideWith(
-        (ref) async => null,
-      ),
-    ];
-
     testWidgets('renders title, task progress, and status tag', (tester) async {
       final item = makeTestProjectListItemData();
 
@@ -336,7 +324,7 @@ void main() {
             onHoverChanged: (_) {},
             onTap: () {},
           ),
-          overrides: noOneLinerOverride(item.project.meta.id),
+          overrides: noOneLinerOverrides([item.project.meta.id]),
         ),
       );
       await tester.pump();
@@ -391,7 +379,7 @@ void main() {
             onHoverChanged: (_) {},
             onTap: () {},
           ),
-          overrides: noOneLinerOverride(item.project.meta.id),
+          overrides: noOneLinerOverrides([item.project.meta.id]),
         ),
       );
       await tester.pump();
@@ -419,7 +407,7 @@ void main() {
             onHoverChanged: (_) {},
             onTap: () => tapped = true,
           ),
-          overrides: noOneLinerOverride(item.project.meta.id),
+          overrides: noOneLinerOverrides([item.project.meta.id]),
         ),
       );
       await tester.pump();

--- a/test/features/projects/ui/widgets/project_list_shared_test.dart
+++ b/test/features/projects/ui/widgets/project_list_shared_test.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/design_system/theme/design_system_theme.dart';
 import 'package:lotti/features/projects/model/projects_overview_models.dart';
+import 'package:lotti/features/projects/state/project_one_liner_provider.dart';
 import 'package:lotti/features/projects/ui/model/project_list_detail_state.dart';
 import 'package:lotti/features/projects/ui/widgets/project_list_shared.dart';
 import 'package:lotti/features/projects/ui/widgets/showcase/showcase_palette.dart';
@@ -11,17 +14,26 @@ import '../../../../widget_test_utils.dart';
 import '../../test_utils.dart';
 
 void main() {
-  Widget wrap(Widget child) {
-    return makeTestableWidget2(
-      Theme(
-        data: DesignSystemTheme.dark(),
-        child: Scaffold(
-          body: SizedBox(width: 402, height: 900, child: child),
+  Widget wrap(Widget child, {List<Override> overrides = const []}) {
+    return ProviderScope(
+      overrides: overrides,
+      child: makeTestableWidget2(
+        Theme(
+          data: DesignSystemTheme.dark(),
+          child: Scaffold(
+            body: SizedBox(width: 402, height: 900, child: child),
+          ),
         ),
+        mediaQueryData: const MediaQueryData(size: Size(500, 1000)),
       ),
-      mediaQueryData: const MediaQueryData(size: Size(500, 1000)),
     );
   }
+
+  /// Override to return null for all project one-liners matching the given IDs.
+  List<Override> noOneLinerOverrides(List<String> projectIds) => [
+    for (final id in projectIds)
+      projectOneLinerProvider(id).overrideWith((ref) async => null),
+  ];
 
   ProjectCategoryGroup makeGroupedProjectsSection() {
     final workCategory = makeTestProjectListData().categories.first;
@@ -90,6 +102,7 @@ void main() {
             selectedProjectId: 'p1',
             onProjectSelected: (_) {},
           ),
+          overrides: noOneLinerOverrides(['p1']),
         ),
       );
       await tester.pump();
@@ -113,6 +126,7 @@ void main() {
             selectedProjectId: null,
             onProjectSelected: (_) {},
           ),
+          overrides: noOneLinerOverrides(['p1', 'p2']),
         ),
       );
       await tester.pump();
@@ -144,6 +158,7 @@ void main() {
               selectedProjectId: null,
               onProjectSelected: (_) {},
             ),
+            overrides: noOneLinerOverrides(['p1', 'p2']),
           ),
         );
         await tester.pump();
@@ -174,6 +189,7 @@ void main() {
               selectedProjectId: null,
               onProjectSelected: (_) {},
             ),
+            overrides: noOneLinerOverrides(['p1', 'p2']),
           ),
         );
         await tester.pump();
@@ -234,6 +250,7 @@ void main() {
               selectedProjectId: null,
               onProjectSelected: (_) {},
             ),
+            overrides: noOneLinerOverrides(['p1', 'p2']),
           ),
         );
         await tester.pump();
@@ -282,6 +299,7 @@ void main() {
               selectedProjectId: 'p1',
               onProjectSelected: (_) {},
             ),
+            overrides: noOneLinerOverrides(['p1', 'p2']),
           ),
         );
         await tester.pump();
@@ -299,6 +317,12 @@ void main() {
   });
 
   group('ProjectRow', () {
+    List<Override> noOneLinerOverride(String projectId) => [
+      projectOneLinerProvider(projectId).overrideWith(
+        (ref) async => null,
+      ),
+    ];
+
     testWidgets('renders title, task progress, and status tag', (tester) async {
       final item = makeTestProjectListItemData();
 
@@ -312,6 +336,7 @@ void main() {
             onHoverChanged: (_) {},
             onTap: () {},
           ),
+          overrides: noOneLinerOverride(item.project.meta.id),
         ),
       );
       await tester.pump();
@@ -324,6 +349,60 @@ void main() {
         findsOneWidget,
       );
       expect(find.byIcon(Icons.format_list_bulleted_rounded), findsOneWidget);
+    });
+
+    testWidgets('displays one-liner when available', (tester) async {
+      final item = makeTestProjectListItemData();
+      const oneLiner = 'Steady progress; next milestone is API v2.';
+
+      await tester.pumpWidget(
+        wrap(
+          ProjectRow(
+            item: item,
+            selected: false,
+            topOverlap: 0,
+            bottomOverlap: 0,
+            onHoverChanged: (_) {},
+            onTap: () {},
+          ),
+          overrides: [
+            projectOneLinerProvider(
+              item.project.meta.id,
+            ).overrideWith((ref) async => oneLiner),
+          ],
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text(oneLiner), findsOneWidget);
+      expect(find.text('Test Project'), findsOneWidget);
+    });
+
+    testWidgets('hides one-liner when null', (tester) async {
+      final item = makeTestProjectListItemData();
+
+      await tester.pumpWidget(
+        wrap(
+          ProjectRow(
+            item: item,
+            selected: false,
+            topOverlap: 0,
+            bottomOverlap: 0,
+            onHoverChanged: (_) {},
+            onTap: () {},
+          ),
+          overrides: noOneLinerOverride(item.project.meta.id),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Test Project'), findsOneWidget);
+      // Only title and metadata row — no extra Text widget for one-liner.
+      final textWidgets = tester.widgetList<Text>(find.byType(Text)).toList();
+      final oneLinerTexts = textWidgets.where(
+        (t) => t.maxLines == 3 && t.overflow == TextOverflow.ellipsis,
+      );
+      expect(oneLinerTexts, isEmpty);
     });
 
     testWidgets('calls onTap when tapped', (tester) async {
@@ -340,6 +419,7 @@ void main() {
             onHoverChanged: (_) {},
             onTap: () => tapped = true,
           ),
+          overrides: noOneLinerOverride(item.project.meta.id),
         ),
       );
       await tester.pump();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project list cards now show an AI-generated one-line subtitle (distinct from the longer TLDR) beneath project titles.
* **Documentation**
  * Changelog updated for version 0.9.951 to document the new one-liner subtitle.
* **Tests**
  * Added/updated tests covering one-liner extraction, trimming/blank handling, provider behavior, and widget rendering.
* **Chores**
  * Version/release metadata updated for 0.9.951.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->