### PR TITLE
feat: use design system list items for sync settings and sync maintenance pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   items in a grouped container, consistent with categories and labels.
 - Maintenance and logging domain settings pages now use design system list items
   in a grouped container, consistent with the rest of the settings pages.
+- Sync settings and sync maintenance pages now use design system list items
+  in a grouped container, consistent with the rest of the settings pages.
 - Settings page uses a 3-column desktop layout for wider screens.
 
 ## [0.9.951] - 2026-04-13

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -34,7 +34,7 @@
     <release version="0.9.952" date="2026-04-15">
       <description>
           <p>Task filter modal redesigned with the design system filter sheet. All filter modals now use Wolt modal sheet for consistent adaptive presentation. Selected filter chips show contextual icons for status, category, and label. Priority glyphs updated to match Figma designs.</p>
-          <p>Categories, labels, dashboards, measurables, and habits list pages now use design system list items in a grouped container, matching the settings page visual style. Maintenance and logging domain settings pages likewise updated to use design system list items. Settings page uses a 3-column desktop layout for wider screens.</p>
+          <p>Categories, labels, dashboards, measurables, and habits list pages now use design system list items in a grouped container, matching the settings page visual style. Maintenance, logging domain, sync settings, and sync maintenance pages likewise updated. Settings page uses a 3-column desktop layout for wider screens.</p>
       </description>
     </release>
     <release version="0.9.951" date="2026-04-13">

--- a/lib/features/settings/ui/pages/flags_page.dart
+++ b/lib/features/settings/ui/pages/flags_page.dart
@@ -224,10 +224,7 @@ class _FlagsPageState extends ConsumerState<FlagsPage> {
                             );
                           },
                           showDivider: index < orderedFlags.length - 1,
-                          dividerIndent:
-                              tokens.spacing.step5 +
-                              SettingsIcon.containerSize +
-                              tokens.spacing.step3,
+                          dividerIndent: SettingsIcon.dividerIndent(tokens),
                         ),
                     ],
                   ),

--- a/lib/features/settings/ui/widgets/settings_icon.dart
+++ b/lib/features/settings/ui/widgets/settings_icon.dart
@@ -7,13 +7,13 @@ class SettingsIcon extends StatelessWidget {
   static const containerSize = 36.0;
   static const _iconSize = 20.0;
 
-  /// Matches the surface.hover / decorative.level01 opacity from tokens.json.
-  static const _kBackgroundAlpha = 0.12;
-
-  /// Divider indent that aligns with the start of the title text, skipping
-  /// the leading padding, icon container, and gap.
+  /// Standard divider indent for settings list items with a leading
+  /// [SettingsIcon]. Aligns the divider to the start of the title text.
   static double dividerIndent(DsTokens tokens) =>
       tokens.spacing.step5 + containerSize + tokens.spacing.step3;
+
+  /// Matches the surface.hover / decorative.level01 opacity from tokens.json.
+  static const _kBackgroundAlpha = 0.12;
 
   /// Standard trailing chevron used on navigable settings rows.
   static Widget trailingChevron(DsTokens tokens) => Icon(

--- a/lib/features/sync/ui/matrix_sync_maintenance_page.dart
+++ b/lib/features/sync/ui/matrix_sync_maintenance_page.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:lotti/database/maintenance.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_grouped_list.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/settings/ui/pages/sliver_box_adapter_page.dart';
-import 'package:lotti/features/settings/ui/widgets/animated_settings_cards.dart';
+import 'package:lotti/features/settings/ui/widgets/settings_icon.dart';
 import 'package:lotti/features/sync/ui/re_sync_modal.dart';
 import 'package:lotti/features/sync/ui/sequence_log_populate_modal.dart';
 import 'package:lotti/features/sync/ui/sync_modal.dart';
@@ -15,52 +18,71 @@ class MatrixSyncMaintenancePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = context.designTokens;
     final maintenance = getIt<Maintenance>();
+
+    final items =
+        <({String title, String subtitle, IconData icon, VoidCallback onTap})>[
+          (
+            title: context.messages.maintenanceDeleteSyncDb,
+            subtitle: context.messages.maintenanceDeleteSyncDbDescription,
+            icon: Icons.sync_rounded,
+            onTap: () async {
+              final confirmed = await showConfirmationModal(
+                context: context,
+                message: context.messages.maintenanceDeleteDatabaseQuestion(
+                  'Sync',
+                ),
+                confirmLabel: context.messages.maintenanceDeleteDatabaseConfirm,
+              );
+              if (confirmed && context.mounted) {
+                await maintenance.deleteSyncDb();
+              }
+            },
+          ),
+          (
+            title: context.messages.maintenanceSyncDefinitions,
+            subtitle: context.messages.maintenanceSyncDefinitionsDescription,
+            icon: Icons.sync_alt_rounded,
+            onTap: () => SyncModal.show(context),
+          ),
+          (
+            title: context.messages.maintenanceReSync,
+            subtitle: context.messages.maintenanceReSyncDescription,
+            icon: Icons.refresh_rounded,
+            onTap: () => ReSyncModal.show(context),
+          ),
+          (
+            title: context.messages.maintenancePopulateSequenceLog,
+            subtitle:
+                context.messages.maintenancePopulateSequenceLogDescription,
+            icon: Icons.playlist_add_check_rounded,
+            onTap: () => SequenceLogPopulateModal.show(context),
+          ),
+        ];
 
     return SyncFeatureGate(
       child: SliverBoxAdapterPage(
         title: context.messages.settingsMatrixMaintenanceTitle,
         subtitle: context.messages.settingsMatrixMaintenanceSubtitle,
         showBackButton: true,
-        child: Column(
+        padding: EdgeInsets.symmetric(vertical: tokens.spacing.step4),
+        child: DesignSystemGroupedList(
           children: [
-            AnimatedModernSettingsCardWithIcon(
-              title: context.messages.maintenanceDeleteSyncDb,
-              subtitle: context.messages.maintenanceDeleteSyncDbDescription,
-              icon: Icons.sync_rounded,
-              onTap: () async {
-                final confirmed = await showConfirmationModal(
-                  context: context,
-                  message: context.messages.maintenanceDeleteDatabaseQuestion(
-                    'Sync',
-                  ),
-                  confirmLabel:
-                      context.messages.maintenanceDeleteDatabaseConfirm,
-                );
-                if (confirmed && context.mounted) {
-                  await maintenance.deleteSyncDb();
-                }
-              },
-            ),
-            AnimatedModernSettingsCardWithIcon(
-              title: context.messages.maintenanceSyncDefinitions,
-              subtitle: context.messages.maintenanceSyncDefinitionsDescription,
-              icon: Icons.sync_alt_rounded,
-              onTap: () => SyncModal.show(context),
-            ),
-            AnimatedModernSettingsCardWithIcon(
-              title: context.messages.maintenanceReSync,
-              subtitle: context.messages.maintenanceReSyncDescription,
-              icon: Icons.refresh_rounded,
-              onTap: () => ReSyncModal.show(context),
-            ),
-            AnimatedModernSettingsCardWithIcon(
-              title: context.messages.maintenancePopulateSequenceLog,
-              subtitle:
-                  context.messages.maintenancePopulateSequenceLogDescription,
-              icon: Icons.playlist_add_check_rounded,
-              onTap: () => SequenceLogPopulateModal.show(context),
-            ),
+            for (final (index, item) in items.indexed)
+              DesignSystemListItem(
+                title: item.title,
+                subtitle: item.subtitle,
+                leading: SettingsIcon(icon: item.icon),
+                trailing: Icon(
+                  Icons.chevron_right_rounded,
+                  size: tokens.spacing.step6,
+                  color: tokens.colors.text.lowEmphasis,
+                ),
+                showDivider: index < items.length - 1,
+                dividerIndent: SettingsIcon.dividerIndent(tokens),
+                onTap: item.onTap,
+              ),
           ],
         ),
       ),

--- a/lib/features/sync/ui/provisioned/provisioned_sync_modal.dart
+++ b/lib/features/sync/ui/provisioned/provisioned_sync_modal.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:lotti/features/settings/ui/widgets/animated_settings_cards.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/settings/ui/widgets/settings_icon.dart';
 import 'package:lotti/features/sync/ui/provisioned/bundle_import_page.dart';
 import 'package:lotti/features/sync/ui/provisioned/provisioned_config_page.dart';
 import 'package:lotti/features/sync/ui/provisioned/provisioned_status_page.dart';
@@ -9,7 +11,12 @@ import 'package:lotti/providers/service_providers.dart';
 import 'package:lotti/widgets/modal/modal_utils.dart';
 
 class ProvisionedSyncSettingsCard extends ConsumerStatefulWidget {
-  const ProvisionedSyncSettingsCard({super.key});
+  const ProvisionedSyncSettingsCard({
+    required this.showDivider,
+    super.key,
+  });
+
+  final bool showDivider;
 
   @override
   ConsumerState<ProvisionedSyncSettingsCard> createState() =>
@@ -34,10 +41,19 @@ class _ProvisionedSyncSettingsCardState
 
   @override
   Widget build(BuildContext context) {
-    return AnimatedModernSettingsCardWithIcon(
+    final tokens = context.designTokens;
+
+    return DesignSystemListItem(
       title: context.messages.provisionedSyncTitle,
       subtitle: context.messages.provisionedSyncSubtitle,
-      icon: Icons.qr_code_scanner,
+      leading: const SettingsIcon(icon: Icons.qr_code_scanner),
+      trailing: Icon(
+        Icons.chevron_right_rounded,
+        size: tokens.spacing.step6,
+        color: tokens.colors.text.lowEmphasis,
+      ),
+      showDivider: widget.showDivider,
+      dividerIndent: SettingsIcon.dividerIndent(tokens),
       onTap: () {
         final matrixService = ref.read(matrixServiceProvider);
         final isConfigured =

--- a/lib/features/sync/ui/sync_settings_page.dart
+++ b/lib/features/sync/ui/sync_settings_page.dart
@@ -1,8 +1,11 @@
 import 'package:beamer/beamer.dart';
 import 'package:flutter/material.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_grouped_list.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/settings/ui/pages/outbox/outbox_badge.dart';
 import 'package:lotti/features/settings/ui/pages/sliver_box_adapter_page.dart';
-import 'package:lotti/features/settings/ui/widgets/animated_settings_cards.dart';
+import 'package:lotti/features/settings/ui/widgets/settings_icon.dart';
 import 'package:lotti/features/sync/ui/provisioned/provisioned_sync_modal.dart';
 import 'package:lotti/features/sync/ui/widgets/sync_feature_gate.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
@@ -13,62 +16,93 @@ class SyncSettingsPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+
+    final chevron = Icon(
+      Icons.chevron_right_rounded,
+      size: tokens.spacing.step6,
+      color: tokens.colors.text.lowEmphasis,
+    );
+
+    final items =
+        <
+          ({
+            String title,
+            String subtitle,
+            IconData icon,
+            Widget trailing,
+            VoidCallback onTap,
+          })
+        >[
+          (
+            title: context.messages.settingsMatrixMaintenanceTitle,
+            subtitle: context.messages.settingsMatrixMaintenanceSubtitle,
+            icon: Icons.build_outlined,
+            trailing: chevron,
+            onTap: () =>
+                context.beamToNamed('/settings/sync/matrix/maintenance'),
+          ),
+          (
+            title: context.messages.settingsSyncOutboxTitle,
+            subtitle: context.messages.settingsAdvancedOutboxSubtitle,
+            icon: Icons.mail,
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                OutboxBadgeIcon(
+                  icon: Icon(
+                    MdiIcons.mailboxOutline,
+                    color: tokens.colors.interactive.enabled,
+                  ),
+                ),
+                SizedBox(width: tokens.spacing.step2),
+                chevron,
+              ],
+            ),
+            onTap: () => context.beamToNamed('/settings/sync/outbox'),
+          ),
+          (
+            title: context.messages.settingsConflictsTitle,
+            subtitle: context.messages.settingsAdvancedConflictsSubtitle,
+            icon: Icons.warning_rounded,
+            trailing: chevron,
+            onTap: () => context.beamToNamed('/settings/advanced/conflicts'),
+          ),
+          (
+            title: context.messages.settingsMatrixStatsTitle,
+            subtitle: context.messages.settingsSyncStatsSubtitle,
+            icon: Icons.bar_chart_rounded,
+            trailing: chevron,
+            onTap: () => context.beamToNamed('/settings/sync/stats'),
+          ),
+          (
+            title: context.messages.backfillSettingsTitle,
+            subtitle: context.messages.backfillSettingsSubtitle,
+            icon: Icons.history_rounded,
+            trailing: chevron,
+            onTap: () => context.beamToNamed('/settings/sync/backfill'),
+          ),
+        ];
+
     return SyncFeatureGate(
       child: SliverBoxAdapterPage(
         title: context.messages.settingsMatrixTitle,
         showBackButton: true,
         subtitle: context.messages.settingsSyncSubtitle,
-        child: Column(
+        padding: EdgeInsets.symmetric(vertical: tokens.spacing.step4),
+        child: DesignSystemGroupedList(
           children: [
-            // 1) Provisioned sync setup modal (top-level)
-            const ProvisionedSyncSettingsCard(),
-            AnimatedModernSettingsCardWithIcon(
-              title: context.messages.settingsMatrixMaintenanceTitle,
-              subtitle: context.messages.settingsMatrixMaintenanceSubtitle,
-              icon: Icons.build_outlined,
-              onTap: () =>
-                  context.beamToNamed('/settings/sync/matrix/maintenance'),
-            ),
-
-            // 2) Outbox Monitor
-            AnimatedModernSettingsCardWithIcon(
-              title: context.messages.settingsSyncOutboxTitle,
-              subtitle: context.messages.settingsAdvancedOutboxSubtitle,
-              icon: Icons.mail,
-              onTap: () => context.beamToNamed('/settings/sync/outbox'),
-              trailing: OutboxBadgeIcon(
-                icon: Icon(
-                  MdiIcons.mailboxOutline,
-                  color: Theme.of(
-                    context,
-                  ).colorScheme.primary.withValues(alpha: 0.9),
-                ),
+            const ProvisionedSyncSettingsCard(showDivider: true),
+            for (final (index, item) in items.indexed)
+              DesignSystemListItem(
+                title: item.title,
+                subtitle: item.subtitle,
+                leading: SettingsIcon(icon: item.icon),
+                trailing: item.trailing,
+                showDivider: index < items.length - 1,
+                dividerIndent: SettingsIcon.dividerIndent(tokens),
+                onTap: item.onTap,
               ),
-            ),
-
-            // 3) Conflicts (routes remain under advanced for now)
-            AnimatedModernSettingsCardWithIcon(
-              title: context.messages.settingsConflictsTitle,
-              subtitle: context.messages.settingsAdvancedConflictsSubtitle,
-              icon: Icons.warning_rounded,
-              onTap: () => context.beamToNamed('/settings/advanced/conflicts'),
-            ),
-
-            // 4) Sync Stats (full page)
-            AnimatedModernSettingsCardWithIcon(
-              title: context.messages.settingsMatrixStatsTitle,
-              subtitle: context.messages.settingsSyncStatsSubtitle,
-              icon: Icons.bar_chart_rounded,
-              onTap: () => context.beamToNamed('/settings/sync/stats'),
-            ),
-
-            // 5) Backfill Settings
-            AnimatedModernSettingsCardWithIcon(
-              title: context.messages.backfillSettingsTitle,
-              subtitle: context.messages.backfillSettingsSubtitle,
-              icon: Icons.history_rounded,
-              onTap: () => context.beamToNamed('/settings/sync/backfill'),
-            ),
           ],
         ),
       ),

--- a/test/features/sync/ui/matrix_sync_maintenance_page_test.dart
+++ b/test/features/sync/ui/matrix_sync_maintenance_page_test.dart
@@ -3,6 +3,9 @@ import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/maintenance.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_grouped_list.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
+import 'package:lotti/features/settings/ui/widgets/settings_icon.dart';
 import 'package:lotti/features/sync/models/sync_models.dart';
 import 'package:lotti/features/sync/state/sync_maintenance_controller.dart';
 import 'package:lotti/features/sync/ui/matrix_sync_maintenance_page.dart';
@@ -152,6 +155,69 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Re-sync entries'), findsOneWidget);
+    });
+
+    testWidgets('populate sequence log card opens modal', (tester) async {
+      await tester.pumpWidget(buildPage());
+      await tester.pumpAndSettle();
+
+      final context = tester.element(find.byType(MatrixSyncMaintenancePage));
+      await tester.tap(
+        find.text(context.messages.maintenancePopulateSequenceLog),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text(context.messages.maintenancePopulateSequenceLogConfirm),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('uses design system grouped list layout', (tester) async {
+      await tester.pumpWidget(buildPage());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(DesignSystemGroupedList), findsOneWidget);
+      expect(find.byType(DesignSystemListItem), findsNWidgets(4));
+      expect(find.byType(SettingsIcon), findsNWidgets(4));
+    });
+
+    testWidgets('shows chevron trailing icon on each item', (tester) async {
+      await tester.pumpWidget(buildPage());
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.chevron_right_rounded), findsNWidgets(4));
+    });
+
+    testWidgets('shows correct settings icons', (tester) async {
+      await tester.pumpWidget(buildPage());
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.sync_rounded), findsOneWidget);
+      expect(find.byIcon(Icons.sync_alt_rounded), findsOneWidget);
+      expect(find.byIcon(Icons.refresh_rounded), findsOneWidget);
+      expect(find.byIcon(Icons.playlist_add_check_rounded), findsOneWidget);
+    });
+
+    testWidgets('shows dividers between items but not after last', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildPage());
+      await tester.pumpAndSettle();
+
+      final items = tester.widgetList<DesignSystemListItem>(
+        find.byType(DesignSystemListItem),
+      );
+      final dividerFlags = items.map((item) => item.showDivider).toList();
+
+      for (var i = 0; i < dividerFlags.length - 1; i++) {
+        expect(
+          dividerFlags[i],
+          isTrue,
+          reason: 'Item $i should show divider',
+        );
+      }
+      expect(dividerFlags.last, isFalse, reason: 'Last item has no divider');
     });
 
     testWidgets('hides content when Matrix flag disabled', (tester) async {

--- a/test/features/sync/ui/provisioned/provisioned_sync_modal_test.dart
+++ b/test/features/sync/ui/provisioned/provisioned_sync_modal_test.dart
@@ -40,7 +40,7 @@ void main() {
     testWidgets('displays correct title and subtitle', (tester) async {
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(
-          const ProvisionedSyncSettingsCard(),
+          const ProvisionedSyncSettingsCard(showDivider: false),
           overrides: [
             matrixServiceProvider.overrideWithValue(mockMatrixService),
           ],
@@ -61,7 +61,7 @@ void main() {
     testWidgets('displays QR code scanner icon', (tester) async {
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(
-          const ProvisionedSyncSettingsCard(),
+          const ProvisionedSyncSettingsCard(showDivider: false),
           overrides: [
             matrixServiceProvider.overrideWithValue(mockMatrixService),
           ],
@@ -74,7 +74,7 @@ void main() {
     testWidgets('card is tappable', (tester) async {
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(
-          const ProvisionedSyncSettingsCard(),
+          const ProvisionedSyncSettingsCard(showDivider: false),
           overrides: [
             matrixServiceProvider.overrideWithValue(mockMatrixService),
           ],
@@ -96,7 +96,7 @@ void main() {
     testWidgets('renders without errors', (tester) async {
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(
-          const ProvisionedSyncSettingsCard(),
+          const ProvisionedSyncSettingsCard(showDivider: false),
           overrides: [
             matrixServiceProvider.overrideWithValue(mockMatrixService),
           ],
@@ -115,7 +115,7 @@ void main() {
 
           await tester.pumpWidget(
             makeTestableWidgetWithScaffold(
-              const ProvisionedSyncSettingsCard(),
+              const ProvisionedSyncSettingsCard(showDivider: false),
               overrides: [
                 matrixServiceProvider.overrideWithValue(mockMatrixService),
               ],
@@ -148,7 +148,7 @@ void main() {
 
           await tester.pumpWidget(
             makeTestableWidgetWithScaffold(
-              const ProvisionedSyncSettingsCard(),
+              const ProvisionedSyncSettingsCard(showDivider: false),
               overrides: [
                 matrixServiceProvider.overrideWithValue(mockMatrixService),
               ],
@@ -191,7 +191,7 @@ void main() {
 
           await tester.pumpWidget(
             makeTestableWidgetWithScaffold(
-              const ProvisionedSyncSettingsCard(),
+              const ProvisionedSyncSettingsCard(showDivider: false),
               overrides: [
                 matrixServiceProvider.overrideWithValue(mockMatrixService),
               ],
@@ -223,7 +223,7 @@ void main() {
 
           await tester.pumpWidget(
             makeTestableWidgetWithScaffold(
-              const ProvisionedSyncSettingsCard(),
+              const ProvisionedSyncSettingsCard(showDivider: false),
               overrides: [
                 matrixServiceProvider.overrideWithValue(mockMatrixService),
               ],

--- a/test/features/sync/ui/sync_settings_page_test.dart
+++ b/test/features/sync/ui/sync_settings_page_test.dart
@@ -1,7 +1,12 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/sync_db.dart';
-import 'package:lotti/features/settings/ui/widgets/animated_settings_cards.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_grouped_list.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
+import 'package:lotti/features/settings/ui/pages/outbox/outbox_badge.dart';
+import 'package:lotti/features/settings/ui/widgets/settings_icon.dart';
+import 'package:lotti/features/sync/ui/provisioned/provisioned_sync_modal.dart';
 import 'package:lotti/features/sync/ui/sync_settings_page.dart';
 import 'package:lotti/features/user_activity/state/user_activity_service.dart';
 import 'package:lotti/get_it.dart';
@@ -39,34 +44,43 @@ void main() {
     tearDown(getIt.reset);
 
     testWidgets(
-      'renders provisioned setup, outbox, conflicts, and stats cards',
+      'renders provisioned setup, maintenance, outbox, conflicts, stats, '
+      'and backfill items',
       (tester) async {
         await tester.pumpWidget(
           makeTestableWidgetWithScaffold(const SyncSettingsPage()),
         );
-
         await tester.pumpAndSettle();
 
-        // Assert the setup card title specifically (not the page app bar)
-        final pageContext = tester.element(find.byType(SyncSettingsPage));
+        final context = tester.element(find.byType(SyncSettingsPage));
         expect(
-          find.descendant(
-            of: find.byType(AnimatedModernSettingsCardWithIcon),
-            matching: find.text(pageContext.messages.provisionedSyncTitle),
-          ),
+          find.text(context.messages.provisionedSyncTitle),
           findsOneWidget,
         );
         expect(
-          find.text(pageContext.messages.settingsMatrixMaintenanceTitle),
+          find.text(context.messages.settingsMatrixMaintenanceTitle),
           findsOneWidget,
         );
-        expect(find.text('Sync Outbox'), findsOneWidget);
-        expect(find.text('Matrix Stats'), findsOneWidget);
+        expect(
+          find.text(context.messages.settingsSyncOutboxTitle),
+          findsOneWidget,
+        );
+        expect(
+          find.text(context.messages.settingsConflictsTitle),
+          findsOneWidget,
+        );
+        expect(
+          find.text(context.messages.settingsMatrixStatsTitle),
+          findsOneWidget,
+        );
+        expect(
+          find.text(context.messages.backfillSettingsTitle),
+          findsOneWidget,
+        );
       },
     );
 
     testWidgets('gate hides page when Matrix flag is OFF', (tester) async {
-      // Re-register with flag disabled
       await getIt.reset();
       mockJournalDb = MockJournalDb();
       mockSyncDb = MockSyncDatabase();
@@ -83,16 +97,123 @@ void main() {
       );
       await tester.pump();
 
-      final pageContext = tester.element(find.byType(SyncSettingsPage));
+      final context = tester.element(find.byType(SyncSettingsPage));
       expect(
-        find.text(pageContext.messages.provisionedSyncTitle),
+        find.text(context.messages.provisionedSyncTitle),
         findsNothing,
       );
       expect(
-        find.text(pageContext.messages.settingsMatrixMaintenanceTitle),
+        find.text(context.messages.settingsMatrixMaintenanceTitle),
         findsNothing,
       );
-      expect(find.text('Matrix Stats'), findsNothing);
+      expect(
+        find.text(context.messages.settingsMatrixStatsTitle),
+        findsNothing,
+      );
+    });
+
+    testWidgets('uses design system grouped list layout', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(const SyncSettingsPage()),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(DesignSystemGroupedList), findsOneWidget);
+      // 1 ProvisionedSyncSettingsCard (contains a DesignSystemListItem)
+      // + 5 regular DesignSystemListItems = 6
+      expect(find.byType(DesignSystemListItem), findsNWidgets(6));
+      expect(find.byType(ProvisionedSyncSettingsCard), findsOneWidget);
+    });
+
+    testWidgets('shows settings icons for each item', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(const SyncSettingsPage()),
+      );
+      await tester.pumpAndSettle();
+
+      // 5 regular items + 1 provisioned card = 6 SettingsIcon
+      expect(find.byType(SettingsIcon), findsNWidgets(6));
+      expect(find.byIcon(Icons.qr_code_scanner), findsOneWidget);
+      expect(find.byIcon(Icons.build_outlined), findsOneWidget);
+      expect(find.byIcon(Icons.mail), findsOneWidget);
+      expect(find.byIcon(Icons.warning_rounded), findsOneWidget);
+      expect(find.byIcon(Icons.bar_chart_rounded), findsOneWidget);
+      expect(find.byIcon(Icons.history_rounded), findsOneWidget);
+    });
+
+    testWidgets('shows chevron trailing icon on each item', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(const SyncSettingsPage()),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.chevron_right_rounded), findsNWidgets(6));
+    });
+
+    testWidgets('shows dividers between items but not after last', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(const SyncSettingsPage()),
+      );
+      await tester.pumpAndSettle();
+
+      final items = tester.widgetList<DesignSystemListItem>(
+        find.byType(DesignSystemListItem),
+      );
+      final dividerFlags = items.map((item) => item.showDivider).toList();
+
+      // All except last should show divider
+      for (var i = 0; i < dividerFlags.length - 1; i++) {
+        expect(
+          dividerFlags[i],
+          isTrue,
+          reason: 'Item $i should show divider',
+        );
+      }
+      expect(dividerFlags.last, isFalse, reason: 'Last item has no divider');
+    });
+
+    testWidgets('outbox item shows mailbox badge icon', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(const SyncSettingsPage()),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(OutboxBadgeIcon), findsOneWidget);
+    });
+
+    testWidgets('renders subtitles for all items', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(const SyncSettingsPage()),
+      );
+      await tester.pumpAndSettle();
+
+      final context = tester.element(find.byType(SyncSettingsPage));
+      expect(
+        find.text(context.messages.provisionedSyncSubtitle),
+        findsOneWidget,
+      );
+      expect(
+        find.text(context.messages.settingsMatrixMaintenanceSubtitle),
+        findsOneWidget,
+      );
+      expect(
+        find.text(context.messages.settingsAdvancedOutboxSubtitle),
+        findsOneWidget,
+      );
+      expect(
+        find.text(context.messages.settingsAdvancedConflictsSubtitle),
+        findsOneWidget,
+      );
+      expect(
+        find.text(context.messages.settingsSyncStatsSubtitle),
+        findsOneWidget,
+      );
+      expect(
+        find.text(context.messages.backfillSettingsSubtitle),
+        findsOneWidget,
+      );
     });
   });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Sync settings and sync maintenance pages now use design system list items within grouped containers for improved visual consistency with other settings pages.
  * Enhanced list item styling with design tokens, including dividers and trailing chevrons.

* **Tests**
  * Added comprehensive test coverage for updated sync settings and maintenance pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->