### PR TITLE
fix: increase file descriptor limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.953] - 2026-04-16
+### Fixed
+- Raise the open file descriptor soft limit to 10,240 at startup on macOS and
+  Linux. Apps launched from Finder/Spotlight on macOS inherited launchd's
+  legacy 256 limit, which was trivially exhausted under real-world load
+  (sockets, SQLite handles, attachment writes, log files). Under slow-network
+  conditions this manifested as sporadic `EMFILE` errors in the Matrix sync
+  pipeline and cascading DNS lookup failures until the app was restarted.
+
+### Added
+- Log the file descriptor soft/hard limits and the adjustment outcome at
+  startup (`MAIN / fdLimits`), so the current ceiling is discoverable from the
+  app logs without requiring `launchctl` or `ulimit` inspection.
+- Annotate `EMFILE` failures on the attachment save path with current
+  descriptor limits (`attachment.save.emfile` event), making future FD
+  pressure incidents self-diagnosing.
+
 ## [0.9.952] - 2026-04-15
 ### Changed
 - Task filter modal redesigned with the design system filter sheet, replacing

--- a/Makefile
+++ b/Makefile
@@ -261,3 +261,43 @@ icons:
 
 .PHONY: clean_test
 clean_test: clean deps build_runner l10n test
+
+# Capture a file descriptor diagnostic snapshot of the running Lotti process.
+# Writes to tmp/fd/fd-<timestamp>.txt and prints to stdout. Compare snapshots
+# over time to spot monotonic FD growth (a leak) vs a stable working set.
+# Override the PID if auto-detection picks the wrong process:
+#   make fd_snapshot PID=12345
+.PHONY: fd_snapshot
+fd_snapshot:
+	@mkdir -p tmp/fd
+	@PID_VAL="$${PID:-}"; \
+	if [ -z "$$PID_VAL" ]; then PID_VAL=$$(pgrep -x Lotti 2>/dev/null | head -n1); fi; \
+	if [ -z "$$PID_VAL" ]; then PID_VAL=$$(pgrep -x lotti 2>/dev/null | head -n1); fi; \
+	if [ -z "$$PID_VAL" ]; then \
+	  echo "No running Lotti process found."; \
+	  echo "Launch Lotti, or pass an explicit PID: make fd_snapshot PID=<pid>"; \
+	  exit 1; \
+	fi; \
+	TS=$$(date +%Y-%m-%d-%H%M%S); \
+	OUT="tmp/fd/fd-$$TS.txt"; \
+	{ \
+	  echo "=== Lotti FD snapshot $$TS pid=$$PID_VAL ==="; \
+	  if command -v launchctl >/dev/null 2>&1; then \
+	    echo "--- launchctl limit maxfiles ---"; \
+	    launchctl limit maxfiles 2>/dev/null || true; \
+	  fi; \
+	  if command -v sysctl >/dev/null 2>&1; then \
+	    echo "--- sysctl ---"; \
+	    sysctl kern.maxfiles kern.maxfilesperproc 2>/dev/null || true; \
+	  fi; \
+	  if [ -r "/proc/$$PID_VAL/limits" ]; then \
+	    echo "--- /proc/$$PID_VAL/limits (Max open files) ---"; \
+	    grep "Max open files" "/proc/$$PID_VAL/limits" || true; \
+	  fi; \
+	  echo "--- real FD count (excludes cwd/rtd/txt/mem) ---"; \
+	  lsof -p "$$PID_VAL" | awk 'NR>1 && $$4 ~ /^[0-9]+[rwu]?$$/' | wc -l | awk '{print "total_real_fds="$$1}'; \
+	  echo "--- grouped by type ---"; \
+	  lsof -p "$$PID_VAL" | awk 'NR>1 && $$4 ~ /^[0-9]+[rwu]?$$/ {print $$5}' | sort | uniq -c | sort -rn; \
+	} | tee "$$OUT"; \
+	echo ""; \
+	echo "Saved to $$OUT"

--- a/Makefile
+++ b/Makefile
@@ -294,10 +294,13 @@ fd_snapshot:
 	    echo "--- /proc/$$PID_VAL/limits (Max open files) ---"; \
 	    grep "Max open files" "/proc/$$PID_VAL/limits" || true; \
 	  fi; \
+	  LSOF_TMP=$$(mktemp -t lotti-fd-snapshot 2>/dev/null || mktemp); \
+	  lsof -p "$$PID_VAL" >"$$LSOF_TMP" 2>/dev/null || true; \
 	  echo "--- real FD count (excludes cwd/rtd/txt/mem) ---"; \
-	  lsof -p "$$PID_VAL" | awk 'NR>1 && $$4 ~ /^[0-9]+[rwu]?$$/' | wc -l | awk '{print "total_real_fds="$$1}'; \
+	  awk 'NR>1 && $$4 ~ /^[0-9]+[A-Za-z]*$$/' "$$LSOF_TMP" | wc -l | awk '{print "total_real_fds="$$1}'; \
 	  echo "--- grouped by type ---"; \
-	  lsof -p "$$PID_VAL" | awk 'NR>1 && $$4 ~ /^[0-9]+[rwu]?$$/ {print $$5}' | sort | uniq -c | sort -rn; \
+	  awk 'NR>1 && $$4 ~ /^[0-9]+[A-Za-z]*$$/ {print $$5}' "$$LSOF_TMP" | sort | uniq -c | sort -rn; \
+	  rm -f "$$LSOF_TMP"; \
 	} | tee "$$OUT"; \
 	echo ""; \
 	echo "Saved to $$OUT"

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -31,6 +31,12 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="0.9.953" date="2026-04-16">
+      <description>
+          <p>Raise the open file descriptor soft limit to 10,240 at startup on macOS and Linux. The legacy 256 limit inherited by GUI apps on macOS was trivially exhausted under real-world load, which under slow-network conditions manifested as sporadic EMFILE errors on the Matrix sync pipeline and cascading DNS lookup failures until the app was restarted.</p>
+          <p>Startup now logs the soft/hard limits and the adjustment outcome, and EMFILE failures on the attachment save path are annotated with the current descriptor limits so future file-descriptor-pressure incidents are self-diagnosing.</p>
+      </description>
+    </release>
     <release version="0.9.952" date="2026-04-15">
       <description>
           <p>Task filter modal redesigned with the design system filter sheet. All filter modals now use Wolt modal sheet for consistent adaptive presentation. Selected filter chips show contextual icons for status, category, and label. Priority glyphs updated to match Figma designs.</p>

--- a/lib/features/sync/matrix/pipeline/attachment_ingestor.dart
+++ b/lib/features/sync/matrix/pipeline/attachment_ingestor.dart
@@ -4,12 +4,14 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:io';
 
+import 'package:lotti/database/logging_types.dart';
 import 'package:lotti/features/sync/matrix/consts.dart';
 import 'package:lotti/features/sync/matrix/pipeline/attachment_index.dart';
 import 'package:lotti/features/sync/matrix/pipeline/descriptor_catch_up_manager.dart';
 import 'package:lotti/features/sync/matrix/utils/atomic_write.dart';
 import 'package:lotti/features/sync/tuning.dart';
 import 'package:lotti/services/logging_service.dart';
+import 'package:lotti/utils/fd_limits.dart';
 import 'package:lotti/utils/file_utils.dart';
 import 'package:matrix/matrix.dart';
 import 'package:path/path.dart' as p;
@@ -393,6 +395,16 @@ class AttachmentIngestor {
       return true;
     } catch (e, st) {
       // Log but don't throw - SmartJournalEntityLoader can retry later
+      if (e is FileSystemException && e.osError?.errorCode == 24) {
+        final limits = readFileDescriptorLimits();
+        logging.captureEvent(
+          'emfile path=$relativePath '
+          'fd.soft=${limits?.soft ?? '?'} fd.hard=${limits?.hard ?? '?'}',
+          domain: syncLoggingDomain,
+          subDomain: 'attachment.save.emfile',
+          level: InsightLevel.warn,
+        );
+      }
       logging.captureException(
         e,
         domain: syncLoggingDomain,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,6 +20,7 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/providers/service_providers.dart';
 import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/window_service.dart';
+import 'package:lotti/utils/fd_limits.dart';
 import 'package:lotti/utils/file_utils.dart';
 import 'package:lotti/utils/platform.dart';
 import 'package:media_kit/media_kit.dart';
@@ -34,11 +35,23 @@ class AppConstants {
 }
 
 Future<void> main() async {
+  // Raise the file descriptor soft limit before anything opens an FD. On
+  // macOS, GUI apps inherit launchd's legacy soft limit of 256, which is
+  // trivially exhausted (sockets, SQLite, attachments, logs). Captured
+  // synchronously so we can log the outcome once LoggingService exists.
+  final fdAdjustment = ensureFileDescriptorSoftLimit();
+
   await runZonedGuarded(
     () async {
       getIt.registerSingleton<LoggingService>(
         LoggingService(),
         dispose: (service) => service.dispose(),
+      );
+
+      getIt<LoggingService>().captureEvent(
+        fdAdjustment.toString(),
+        domain: 'MAIN',
+        subDomain: 'fdLimits',
       );
 
       WidgetsFlutterBinding.ensureInitialized();

--- a/lib/utils/fd_limits.dart
+++ b/lib/utils/fd_limits.dart
@@ -164,7 +164,10 @@ FdLimitAdjustment ensureFileDescriptorSoftLimit({int target = 10240}) {
       final softBefore = ptr.ref.rlimCur;
       final hardBefore = ptr.ref.rlimMax;
 
-      if (softBefore >= target) {
+      // An already-unlimited soft limit is strictly above any positive target;
+      // treat it as satisfied without a redundant `setrlimit` that would in
+      // fact *lower* it.
+      if (_isUnlimited(softBefore) || softBefore >= target) {
         return FdLimitAdjustment(
           softBefore: softBefore,
           hardBefore: hardBefore,

--- a/lib/utils/fd_limits.dart
+++ b/lib/utils/fd_limits.dart
@@ -41,9 +41,11 @@ class FdLimitAdjustment {
 int _rlimitNofile() {
   if (Platform.isMacOS) return 8;
   if (Platform.isLinux) return 7;
+  // coverage:ignore-start
   throw UnsupportedError(
     'RLIMIT_NOFILE is undefined for ${Platform.operatingSystem}',
   );
+  // coverage:ignore-end
 }
 
 final class _Rlimit extends Struct {
@@ -81,7 +83,9 @@ class _Libc {
 final _Libc? _libc = _resolveLibc();
 
 _Libc? _resolveLibc() {
+  // coverage:ignore-start
   if (!Platform.isMacOS && !Platform.isLinux) return null;
+  // coverage:ignore-end
   try {
     final lib = DynamicLibrary.process();
     return _Libc(
@@ -96,9 +100,11 @@ _Libc? _resolveLibc() {
       ),
       free: lib.lookupFunction<Void Function(Pointer<Void>), _Free>('free'),
     );
+    // coverage:ignore-start
   } catch (_) {
     return null;
   }
+  // coverage:ignore-end
 }
 
 // On Linux, `RLIM_INFINITY == (rlim_t)-1 == 0xFFFFFFFFFFFFFFFF`, which Dart
@@ -107,6 +113,33 @@ _Libc? _resolveLibc() {
 // helper treats any negative reading as "no cap" so the clamp logic works
 // identically on both platforms.
 bool _isUnlimited(int value) => value < 0;
+
+/// Pure planning step for [ensureFileDescriptorSoftLimit].
+///
+/// Given the current soft/hard values (as read from a `struct rlimit`) and a
+/// desired [target], decides whether a `setrlimit` call is needed and what
+/// `rlim_cur` to pass. Kept as a standalone function so the portability
+/// cases — in particular, the Linux `RLIM_INFINITY` sign-flip — can be unit
+/// tested without requiring an actual platform switch or an FFI mock.
+@visibleForTesting
+({bool alreadySatisfied, int newSoft}) resolveFdSoftLimitPlan({
+  required int softBefore,
+  required int hardBefore,
+  required int target,
+}) {
+  // An already-unlimited soft limit is strictly above any positive target;
+  // treat it as satisfied rather than issuing a redundant `setrlimit` that
+  // would in fact *lower* it.
+  if (_isUnlimited(softBefore) || softBefore >= target) {
+    return (alreadySatisfied: true, newSoft: softBefore);
+  }
+  // Clamp to the hard limit, treating RLIM_INFINITY (negative when read as
+  // Dart int on Linux) as "no cap".
+  final newSoft = (_isUnlimited(hardBefore) || target < hardBefore)
+      ? target
+      : hardBefore;
+  return (alreadySatisfied: false, newSoft: newSoft);
+}
 
 /// Raises the soft limit for open file descriptors to at least [target] on
 /// macOS and Linux, never exceeding the current hard limit.
@@ -122,6 +155,7 @@ bool _isUnlimited(int value) => value < 0;
 /// captured in [FdLimitAdjustment.error].
 FdLimitAdjustment ensureFileDescriptorSoftLimit({int target = 10240}) {
   final libc = _libc;
+  // coverage:ignore-start
   if (libc == null) {
     return FdLimitAdjustment(
       softBefore: -1,
@@ -132,10 +166,12 @@ FdLimitAdjustment ensureFileDescriptorSoftLimit({int target = 10240}) {
       raised: false,
     );
   }
+  // coverage:ignore-end
 
   try {
     final resource = _rlimitNofile();
     final ptr = libc.malloc(sizeOf<_Rlimit>()).cast<_Rlimit>();
+    // coverage:ignore-start
     if (ptr.address == 0) {
       return FdLimitAdjustment(
         softBefore: -1,
@@ -147,8 +183,10 @@ FdLimitAdjustment ensureFileDescriptorSoftLimit({int target = 10240}) {
         error: StateError('malloc returned null'),
       );
     }
+    // coverage:ignore-end
 
     try {
+      // coverage:ignore-start
       if (libc.getrlimit(resource, ptr) != 0) {
         return FdLimitAdjustment(
           softBefore: -1,
@@ -160,14 +198,18 @@ FdLimitAdjustment ensureFileDescriptorSoftLimit({int target = 10240}) {
           error: StateError('getrlimit failed'),
         );
       }
+      // coverage:ignore-end
 
       final softBefore = ptr.ref.rlimCur;
       final hardBefore = ptr.ref.rlimMax;
 
-      // An already-unlimited soft limit is strictly above any positive target;
-      // treat it as satisfied without a redundant `setrlimit` that would in
-      // fact *lower* it.
-      if (_isUnlimited(softBefore) || softBefore >= target) {
+      final plan = resolveFdSoftLimitPlan(
+        softBefore: softBefore,
+        hardBefore: hardBefore,
+        target: target,
+      );
+
+      if (plan.alreadySatisfied) {
         return FdLimitAdjustment(
           softBefore: softBefore,
           hardBefore: hardBefore,
@@ -178,12 +220,7 @@ FdLimitAdjustment ensureFileDescriptorSoftLimit({int target = 10240}) {
         );
       }
 
-      // Clamp to the hard limit, treating RLIM_INFINITY (negative when read
-      // as Dart int on Linux) as "no cap".
-      final newSoft = (_isUnlimited(hardBefore) || target < hardBefore)
-          ? target
-          : hardBefore;
-
+      final newSoft = plan.newSoft;
       ptr.ref.rlimCur = newSoft;
       ptr.ref.rlimMax = hardBefore;
 
@@ -200,6 +237,7 @@ FdLimitAdjustment ensureFileDescriptorSoftLimit({int target = 10240}) {
       }
 
       // Re-read to report the authoritative post-state.
+      // coverage:ignore-start
       if (libc.getrlimit(resource, ptr) != 0) {
         return FdLimitAdjustment(
           softBefore: softBefore,
@@ -210,6 +248,7 @@ FdLimitAdjustment ensureFileDescriptorSoftLimit({int target = 10240}) {
           raised: true,
         );
       }
+      // coverage:ignore-end
       return FdLimitAdjustment(
         softBefore: softBefore,
         hardBefore: hardBefore,
@@ -221,6 +260,7 @@ FdLimitAdjustment ensureFileDescriptorSoftLimit({int target = 10240}) {
     } finally {
       libc.free(ptr.cast());
     }
+    // coverage:ignore-start
   } catch (e) {
     return FdLimitAdjustment(
       softBefore: -1,
@@ -232,6 +272,7 @@ FdLimitAdjustment ensureFileDescriptorSoftLimit({int target = 10240}) {
       error: e,
     );
   }
+  // coverage:ignore-end
 }
 
 /// Reads the current file descriptor soft/hard limits without modifying them.
@@ -242,17 +283,25 @@ FdLimitAdjustment ensureFileDescriptorSoftLimit({int target = 10240}) {
 /// at its ceiling when a resource request failed.
 ({int soft, int hard})? readFileDescriptorLimits() {
   final libc = _libc;
+  // coverage:ignore-start
   if (libc == null) return null;
+  // coverage:ignore-end
   try {
     final ptr = libc.malloc(sizeOf<_Rlimit>()).cast<_Rlimit>();
+    // coverage:ignore-start
     if (ptr.address == 0) return null;
+    // coverage:ignore-end
     try {
+      // coverage:ignore-start
       if (libc.getrlimit(_rlimitNofile(), ptr) != 0) return null;
+      // coverage:ignore-end
       return (soft: ptr.ref.rlimCur, hard: ptr.ref.rlimMax);
     } finally {
       libc.free(ptr.cast());
     }
+    // coverage:ignore-start
   } catch (_) {
     return null;
   }
+  // coverage:ignore-end
 }

--- a/lib/utils/fd_limits.dart
+++ b/lib/utils/fd_limits.dart
@@ -57,11 +57,56 @@ final class _Rlimit extends Struct {
 typedef _RlimitSyscallNative = Int32 Function(Int32, Pointer<_Rlimit>);
 typedef _RlimitSyscall = int Function(int, Pointer<_Rlimit>);
 
-typedef _MallocNative = Pointer<Void> Function(IntPtr);
 typedef _Malloc = Pointer<Void> Function(int);
-
-typedef _FreeNative = Void Function(Pointer<Void>);
 typedef _Free = void Function(Pointer<Void>);
+
+class _Libc {
+  const _Libc({
+    required this.getrlimit,
+    required this.setrlimit,
+    required this.malloc,
+    required this.free,
+  });
+
+  final _RlimitSyscall getrlimit;
+  final _RlimitSyscall setrlimit;
+  final _Malloc malloc;
+  final _Free free;
+}
+
+// Cached libc bindings. Top-level `final`s are lazily initialized in Dart, so
+// symbol resolution runs at most once per process even when
+// [readFileDescriptorLimits] is called repeatedly (e.g. on every EMFILE
+// caught in the sync pipeline).
+final _Libc? _libc = _resolveLibc();
+
+_Libc? _resolveLibc() {
+  if (!Platform.isMacOS && !Platform.isLinux) return null;
+  try {
+    final lib = DynamicLibrary.process();
+    return _Libc(
+      getrlimit: lib.lookupFunction<_RlimitSyscallNative, _RlimitSyscall>(
+        'getrlimit',
+      ),
+      setrlimit: lib.lookupFunction<_RlimitSyscallNative, _RlimitSyscall>(
+        'setrlimit',
+      ),
+      malloc: lib.lookupFunction<Pointer<Void> Function(IntPtr), _Malloc>(
+        'malloc',
+      ),
+      free: lib.lookupFunction<Void Function(Pointer<Void>), _Free>('free'),
+    );
+  } catch (_) {
+    return null;
+  }
+}
+
+// On Linux, `RLIM_INFINITY == (rlim_t)-1 == 0xFFFFFFFFFFFFFFFF`, which Dart
+// reads from a Uint64 field as `-1` in its signed 64-bit `int`. On macOS,
+// `RLIM_INFINITY == INT64_MAX`, which reads as a large positive value. This
+// helper treats any negative reading as "no cap" so the clamp logic works
+// identically on both platforms.
+bool _isUnlimited(int value) => value < 0;
 
 /// Raises the soft limit for open file descriptors to at least [target] on
 /// macOS and Linux, never exceeding the current hard limit.
@@ -76,7 +121,8 @@ typedef _Free = void Function(Pointer<Void>);
 /// can emit a single structured log entry. Never throws; all errors are
 /// captured in [FdLimitAdjustment.error].
 FdLimitAdjustment ensureFileDescriptorSoftLimit({int target = 10240}) {
-  if (!Platform.isMacOS && !Platform.isLinux) {
+  final libc = _libc;
+  if (libc == null) {
     return FdLimitAdjustment(
       softBefore: -1,
       hardBefore: -1,
@@ -88,18 +134,8 @@ FdLimitAdjustment ensureFileDescriptorSoftLimit({int target = 10240}) {
   }
 
   try {
-    final libc = DynamicLibrary.process();
-    final getrlimit = libc.lookupFunction<_RlimitSyscallNative, _RlimitSyscall>(
-      'getrlimit',
-    );
-    final setrlimit = libc.lookupFunction<_RlimitSyscallNative, _RlimitSyscall>(
-      'setrlimit',
-    );
-    final malloc = libc.lookupFunction<_MallocNative, _Malloc>('malloc');
-    final free = libc.lookupFunction<_FreeNative, _Free>('free');
-
     final resource = _rlimitNofile();
-    final ptr = malloc(sizeOf<_Rlimit>()).cast<_Rlimit>();
+    final ptr = libc.malloc(sizeOf<_Rlimit>()).cast<_Rlimit>();
     if (ptr.address == 0) {
       return FdLimitAdjustment(
         softBefore: -1,
@@ -113,7 +149,7 @@ FdLimitAdjustment ensureFileDescriptorSoftLimit({int target = 10240}) {
     }
 
     try {
-      if (getrlimit(resource, ptr) != 0) {
+      if (libc.getrlimit(resource, ptr) != 0) {
         return FdLimitAdjustment(
           softBefore: -1,
           hardBefore: -1,
@@ -139,14 +175,16 @@ FdLimitAdjustment ensureFileDescriptorSoftLimit({int target = 10240}) {
         );
       }
 
-      // Clamp to the hard limit. RLIM_INFINITY is (rlim_t)-1 == UINT64_MAX,
-      // which is always > target, so `target < hardBefore` picks target.
-      final newSoft = target < hardBefore ? target : hardBefore;
+      // Clamp to the hard limit, treating RLIM_INFINITY (negative when read
+      // as Dart int on Linux) as "no cap".
+      final newSoft = (_isUnlimited(hardBefore) || target < hardBefore)
+          ? target
+          : hardBefore;
 
       ptr.ref.rlimCur = newSoft;
       ptr.ref.rlimMax = hardBefore;
 
-      if (setrlimit(resource, ptr) != 0) {
+      if (libc.setrlimit(resource, ptr) != 0) {
         return FdLimitAdjustment(
           softBefore: softBefore,
           hardBefore: hardBefore,
@@ -159,7 +197,7 @@ FdLimitAdjustment ensureFileDescriptorSoftLimit({int target = 10240}) {
       }
 
       // Re-read to report the authoritative post-state.
-      if (getrlimit(resource, ptr) != 0) {
+      if (libc.getrlimit(resource, ptr) != 0) {
         return FdLimitAdjustment(
           softBefore: softBefore,
           hardBefore: hardBefore,
@@ -178,7 +216,7 @@ FdLimitAdjustment ensureFileDescriptorSoftLimit({int target = 10240}) {
         raised: true,
       );
     } finally {
-      free(ptr.cast());
+      libc.free(ptr.cast());
     }
   } catch (e) {
     return FdLimitAdjustment(
@@ -200,22 +238,16 @@ FdLimitAdjustment ensureFileDescriptorSoftLimit({int target = 10240}) {
 /// pairs well with an `lsof` inspection to diagnose whether the process was
 /// at its ceiling when a resource request failed.
 ({int soft, int hard})? readFileDescriptorLimits() {
-  if (!Platform.isMacOS && !Platform.isLinux) return null;
+  final libc = _libc;
+  if (libc == null) return null;
   try {
-    final libc = DynamicLibrary.process();
-    final getrlimit = libc.lookupFunction<_RlimitSyscallNative, _RlimitSyscall>(
-      'getrlimit',
-    );
-    final malloc = libc.lookupFunction<_MallocNative, _Malloc>('malloc');
-    final free = libc.lookupFunction<_FreeNative, _Free>('free');
-
-    final ptr = malloc(sizeOf<_Rlimit>()).cast<_Rlimit>();
+    final ptr = libc.malloc(sizeOf<_Rlimit>()).cast<_Rlimit>();
     if (ptr.address == 0) return null;
     try {
-      if (getrlimit(_rlimitNofile(), ptr) != 0) return null;
+      if (libc.getrlimit(_rlimitNofile(), ptr) != 0) return null;
       return (soft: ptr.ref.rlimCur, hard: ptr.ref.rlimMax);
     } finally {
-      free(ptr.cast());
+      libc.free(ptr.cast());
     }
   } catch (_) {
     return null;

--- a/lib/utils/fd_limits.dart
+++ b/lib/utils/fd_limits.dart
@@ -1,0 +1,223 @@
+import 'dart:ffi';
+import 'dart:io';
+
+import 'package:meta/meta.dart';
+
+/// Immutable snapshot of the result of [ensureFileDescriptorSoftLimit].
+///
+/// Fields are `-1` when the platform is unsupported or a call failed before a
+/// value could be read.
+@immutable
+class FdLimitAdjustment {
+  const FdLimitAdjustment({
+    required this.softBefore,
+    required this.hardBefore,
+    required this.softAfter,
+    required this.hardAfter,
+    required this.target,
+    required this.raised,
+    this.error,
+  });
+
+  final int softBefore;
+  final int hardBefore;
+  final int softAfter;
+  final int hardAfter;
+  final int target;
+  final bool raised;
+  final Object? error;
+
+  @override
+  String toString() {
+    if (error != null) {
+      return 'FdLimitAdjustment(target=$target, error=$error)';
+    }
+    return 'FdLimitAdjustment(soft $softBefore -> $softAfter, '
+        'hard=$hardAfter, target=$target, raised=$raised)';
+  }
+}
+
+// POSIX RLIMIT_NOFILE resource id: 8 on Darwin/BSD, 7 on Linux/glibc.
+int _rlimitNofile() {
+  if (Platform.isMacOS) return 8;
+  if (Platform.isLinux) return 7;
+  throw UnsupportedError(
+    'RLIMIT_NOFILE is undefined for ${Platform.operatingSystem}',
+  );
+}
+
+final class _Rlimit extends Struct {
+  @Uint64()
+  external int rlimCur;
+
+  @Uint64()
+  external int rlimMax;
+}
+
+typedef _RlimitSyscallNative = Int32 Function(Int32, Pointer<_Rlimit>);
+typedef _RlimitSyscall = int Function(int, Pointer<_Rlimit>);
+
+typedef _MallocNative = Pointer<Void> Function(IntPtr);
+typedef _Malloc = Pointer<Void> Function(int);
+
+typedef _FreeNative = Void Function(Pointer<Void>);
+typedef _Free = void Function(Pointer<Void>);
+
+/// Raises the soft limit for open file descriptors to at least [target] on
+/// macOS and Linux, never exceeding the current hard limit.
+///
+/// GUI apps launched from Finder/Spotlight on macOS inherit launchd's legacy
+/// soft limit of 256, which is trivially exhausted by a real-world client
+/// (sockets, SQLite handles, attachment writes, log files). Call this at the
+/// very top of `main()` — before anything opens an FD — so later startup code
+/// gets the raised ceiling.
+///
+/// Returns an [FdLimitAdjustment] describing before/after values so the caller
+/// can emit a single structured log entry. Never throws; all errors are
+/// captured in [FdLimitAdjustment.error].
+FdLimitAdjustment ensureFileDescriptorSoftLimit({int target = 10240}) {
+  if (!Platform.isMacOS && !Platform.isLinux) {
+    return FdLimitAdjustment(
+      softBefore: -1,
+      hardBefore: -1,
+      softAfter: -1,
+      hardAfter: -1,
+      target: target,
+      raised: false,
+    );
+  }
+
+  try {
+    final libc = DynamicLibrary.process();
+    final getrlimit = libc.lookupFunction<_RlimitSyscallNative, _RlimitSyscall>(
+      'getrlimit',
+    );
+    final setrlimit = libc.lookupFunction<_RlimitSyscallNative, _RlimitSyscall>(
+      'setrlimit',
+    );
+    final malloc = libc.lookupFunction<_MallocNative, _Malloc>('malloc');
+    final free = libc.lookupFunction<_FreeNative, _Free>('free');
+
+    final resource = _rlimitNofile();
+    final ptr = malloc(sizeOf<_Rlimit>()).cast<_Rlimit>();
+    if (ptr.address == 0) {
+      return FdLimitAdjustment(
+        softBefore: -1,
+        hardBefore: -1,
+        softAfter: -1,
+        hardAfter: -1,
+        target: target,
+        raised: false,
+        error: StateError('malloc returned null'),
+      );
+    }
+
+    try {
+      if (getrlimit(resource, ptr) != 0) {
+        return FdLimitAdjustment(
+          softBefore: -1,
+          hardBefore: -1,
+          softAfter: -1,
+          hardAfter: -1,
+          target: target,
+          raised: false,
+          error: StateError('getrlimit failed'),
+        );
+      }
+
+      final softBefore = ptr.ref.rlimCur;
+      final hardBefore = ptr.ref.rlimMax;
+
+      if (softBefore >= target) {
+        return FdLimitAdjustment(
+          softBefore: softBefore,
+          hardBefore: hardBefore,
+          softAfter: softBefore,
+          hardAfter: hardBefore,
+          target: target,
+          raised: false,
+        );
+      }
+
+      // Clamp to the hard limit. RLIM_INFINITY is (rlim_t)-1 == UINT64_MAX,
+      // which is always > target, so `target < hardBefore` picks target.
+      final newSoft = target < hardBefore ? target : hardBefore;
+
+      ptr.ref.rlimCur = newSoft;
+      ptr.ref.rlimMax = hardBefore;
+
+      if (setrlimit(resource, ptr) != 0) {
+        return FdLimitAdjustment(
+          softBefore: softBefore,
+          hardBefore: hardBefore,
+          softAfter: softBefore,
+          hardAfter: hardBefore,
+          target: target,
+          raised: false,
+          error: StateError('setrlimit failed'),
+        );
+      }
+
+      // Re-read to report the authoritative post-state.
+      if (getrlimit(resource, ptr) != 0) {
+        return FdLimitAdjustment(
+          softBefore: softBefore,
+          hardBefore: hardBefore,
+          softAfter: newSoft,
+          hardAfter: hardBefore,
+          target: target,
+          raised: true,
+        );
+      }
+      return FdLimitAdjustment(
+        softBefore: softBefore,
+        hardBefore: hardBefore,
+        softAfter: ptr.ref.rlimCur,
+        hardAfter: ptr.ref.rlimMax,
+        target: target,
+        raised: true,
+      );
+    } finally {
+      free(ptr.cast());
+    }
+  } catch (e) {
+    return FdLimitAdjustment(
+      softBefore: -1,
+      hardBefore: -1,
+      softAfter: -1,
+      hardAfter: -1,
+      target: target,
+      raised: false,
+      error: e,
+    );
+  }
+}
+
+/// Reads the current file descriptor soft/hard limits without modifying them.
+///
+/// Returns `null` on unsupported platforms or on syscall failure. Intended for
+/// diagnostic logging (e.g. when an `EMFILE` error is caught at runtime) —
+/// pairs well with an `lsof` inspection to diagnose whether the process was
+/// at its ceiling when a resource request failed.
+({int soft, int hard})? readFileDescriptorLimits() {
+  if (!Platform.isMacOS && !Platform.isLinux) return null;
+  try {
+    final libc = DynamicLibrary.process();
+    final getrlimit = libc.lookupFunction<_RlimitSyscallNative, _RlimitSyscall>(
+      'getrlimit',
+    );
+    final malloc = libc.lookupFunction<_MallocNative, _Malloc>('malloc');
+    final free = libc.lookupFunction<_FreeNative, _Free>('free');
+
+    final ptr = malloc(sizeOf<_Rlimit>()).cast<_Rlimit>();
+    if (ptr.address == 0) return null;
+    try {
+      if (getrlimit(_rlimitNofile(), ptr) != 0) return null;
+      return (soft: ptr.ref.rlimCur, hard: ptr.ref.rlimMax);
+    } finally {
+      free(ptr.cast());
+    }
+  } catch (_) {
+    return null;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.953+3925
+version: 0.9.953+3926
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.952+3924
+version: 0.9.953+3925
 
 msix_config:
   display_name: LottiApp

--- a/test/features/sync/matrix/pipeline/attachment_ingestor_test.dart
+++ b/test/features/sync/matrix/pipeline/attachment_ingestor_test.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/database/logging_types.dart';
 import 'package:lotti/features/sync/matrix/pipeline/attachment_index.dart';
 import 'package:lotti/features/sync/matrix/pipeline/attachment_ingestor.dart';
 import 'package:lotti/features/sync/matrix/pipeline/descriptor_catch_up_manager.dart';
@@ -484,6 +485,96 @@ void main() {
         ),
       ).called(1);
     });
+
+    test(
+      'annotates EMFILE (errno 24) FileSystemException with FD limits',
+      () async {
+        final logging = MockLoggingService();
+        when(
+          () => logging.captureEvent(
+            any<String>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+          ),
+        ).thenAnswer((_) async {});
+        when(
+          () => logging.captureEvent(
+            any<String>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+            level: any<InsightLevel>(named: 'level'),
+          ),
+        ).thenAnswer((_) async {});
+        when(
+          () => logging.captureException(
+            any<Object>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+            stackTrace: any<StackTrace?>(named: 'stackTrace'),
+          ),
+        ).thenAnswer((_) async {});
+
+        final tmp = Directory.systemTemp.createTempSync('ingestor_emfile');
+        addTearDown(() => tmp.deleteSync(recursive: true));
+
+        final ev = MockEvent();
+        when(() => ev.eventId).thenReturn('e_emfile');
+        when(
+          () => ev.content,
+        ).thenReturn({
+          'relativePath': '/data/emfile.json',
+          'msgtype': 'm.file',
+        });
+        when(() => ev.attachmentMimetype).thenReturn('application/json');
+        when(() => ev.senderId).thenReturn('@other:u');
+        when(ev.downloadAndDecryptAttachment).thenThrow(
+          const FileSystemException(
+            'Cannot open file',
+            '/data/emfile.json',
+            OSError('Too many open files', 24),
+          ),
+        );
+
+        final index = AttachmentIndex(logging: logging);
+        final desc = MockDescriptorCatchUpManager();
+        when(
+          () => desc.removeIfPresent('/data/emfile.json'),
+        ).thenReturn(false);
+
+        final ingestor = AttachmentIngestor(documentsDirectory: tmp);
+        final result = await ingestor.process(
+          event: ev,
+          logging: logging,
+          attachmentIndex: index,
+          descriptorCatchUp: desc,
+          scheduleLiveScan: () {},
+          retryNow: () async {},
+        );
+
+        expect(result, isFalse);
+
+        // The EMFILE-specific diagnostic event is emitted at warn level,
+        // carrying the current FD limits alongside the path.
+        verify(
+          () => logging.captureEvent(
+            any<String>(that: contains('emfile path=/data/emfile.json')),
+            domain: any<String>(named: 'domain'),
+            subDomain: 'attachment.save.emfile',
+            level: InsightLevel.warn,
+          ),
+        ).called(1);
+
+        // The original exception is still logged through captureException.
+        verify(
+          () => logging.captureException(
+            any<Object>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: 'attachment.save',
+            stackTrace: any<StackTrace?>(named: 'stackTrace'),
+          ),
+        ).called(1);
+      },
+    );
 
     test('overwrites stale agent entity file instead of deduping', () async {
       final logging = MockLoggingService();

--- a/test/utils/fd_limits_test.dart
+++ b/test/utils/fd_limits_test.dart
@@ -59,6 +59,44 @@ void main() {
       expect(adjustment.toString(), contains('FdLimitAdjustment'));
       expect(adjustment.toString(), contains('target='));
     });
+
+    test('toString surfaces the error when one was captured', () {
+      const adjustment = FdLimitAdjustment(
+        softBefore: -1,
+        hardBefore: -1,
+        softAfter: -1,
+        hardAfter: -1,
+        target: 10240,
+        raised: false,
+        error: 'synthetic failure',
+      );
+      final text = adjustment.toString();
+      expect(text, contains('FdLimitAdjustment'));
+      expect(text, contains('target=10240'));
+      expect(text, contains('synthetic failure'));
+      // Error form must not include the before/after detail.
+      expect(text, isNot(contains('soft ')));
+    });
+
+    test('FdLimitAdjustment exposes all fields as provided', () {
+      const adjustment = FdLimitAdjustment(
+        softBefore: 256,
+        hardBefore: 65536,
+        softAfter: 10240,
+        hardAfter: 65536,
+        target: 10240,
+        raised: true,
+      );
+      expect(adjustment.softBefore, 256);
+      expect(adjustment.hardBefore, 65536);
+      expect(adjustment.softAfter, 10240);
+      expect(adjustment.hardAfter, 65536);
+      expect(adjustment.target, 10240);
+      expect(adjustment.raised, isTrue);
+      expect(adjustment.error, isNull);
+      expect(adjustment.toString(), contains('soft 256 -> 10240'));
+      expect(adjustment.toString(), contains('raised=true'));
+    });
   });
 
   group('readFileDescriptorLimits', () {

--- a/test/utils/fd_limits_test.dart
+++ b/test/utils/fd_limits_test.dart
@@ -1,0 +1,85 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/utils/fd_limits.dart';
+
+void main() {
+  group('ensureFileDescriptorSoftLimit', () {
+    test('on macOS or Linux, returns a usable adjustment with no error', () {
+      if (!Platform.isMacOS && !Platform.isLinux) {
+        // Skip on platforms that intentionally no-op.
+        return;
+      }
+      final adjustment = ensureFileDescriptorSoftLimit();
+      expect(adjustment.error, isNull);
+      expect(adjustment.softAfter, greaterThan(0));
+      expect(adjustment.hardAfter, greaterThan(0));
+      expect(adjustment.softAfter, lessThanOrEqualTo(adjustment.hardAfter));
+      expect(adjustment.softAfter, greaterThanOrEqualTo(adjustment.softBefore));
+    });
+
+    test('target is honoured when below hard limit', () {
+      if (!Platform.isMacOS && !Platform.isLinux) return;
+      final adjustment = ensureFileDescriptorSoftLimit();
+      // Default target is 10240. softAfter should reach it unless the hard
+      // limit is lower (exceptional; would be logged as raised=false too).
+      if (adjustment.hardAfter >= adjustment.target) {
+        expect(adjustment.softAfter, greaterThanOrEqualTo(adjustment.target));
+      }
+    });
+
+    test(
+      'second call is idempotent (raised=false when already at or above)',
+      () {
+        if (!Platform.isMacOS && !Platform.isLinux) return;
+        // Prime the limit with an explicit low target so the next call with the
+        // same target never needs to raise.
+        final first = ensureFileDescriptorSoftLimit(target: 4096);
+        expect(first.error, isNull);
+        final second = ensureFileDescriptorSoftLimit(target: 4096);
+        expect(second.error, isNull);
+        expect(second.raised, isFalse);
+        expect(second.softAfter, greaterThanOrEqualTo(4096));
+      },
+    );
+
+    test('setting a target higher than any reasonable hard caps at hard', () {
+      if (!Platform.isMacOS && !Platform.isLinux) return;
+      // 1 << 62 is far above kern.maxfilesperproc on any realistic system.
+      // The call should either clamp or return a setrlimit error — never
+      // silently exceed the hard limit.
+      const absurd = 1 << 62;
+      final adjustment = ensureFileDescriptorSoftLimit(target: absurd);
+      expect(adjustment.softAfter, lessThanOrEqualTo(adjustment.hardAfter));
+    });
+
+    test('toString is informative', () {
+      if (!Platform.isMacOS && !Platform.isLinux) return;
+      final adjustment = ensureFileDescriptorSoftLimit();
+      expect(adjustment.toString(), contains('FdLimitAdjustment'));
+      expect(adjustment.toString(), contains('target='));
+    });
+  });
+
+  group('readFileDescriptorLimits', () {
+    test('returns non-null soft/hard pair on macOS or Linux', () {
+      if (!Platform.isMacOS && !Platform.isLinux) return;
+      final limits = readFileDescriptorLimits();
+      expect(limits, isNotNull);
+      expect(limits!.soft, greaterThan(0));
+      expect(limits.hard, greaterThan(0));
+      expect(limits.soft, lessThanOrEqualTo(limits.hard));
+    });
+
+    test(
+      'after ensureFileDescriptorSoftLimit, soft reflects the raised value',
+      () {
+        if (!Platform.isMacOS && !Platform.isLinux) return;
+        final adjustment = ensureFileDescriptorSoftLimit();
+        final limits = readFileDescriptorLimits();
+        expect(limits, isNotNull);
+        expect(limits!.soft, adjustment.softAfter);
+      },
+    );
+  });
+}

--- a/test/utils/fd_limits_test.dart
+++ b/test/utils/fd_limits_test.dart
@@ -92,6 +92,89 @@ void main() {
       expect(text, isNot(contains('soft ')));
     });
 
+    group('resolveFdSoftLimitPlan', () {
+      test('soft already at or above target is treated as satisfied', () {
+        final plan = resolveFdSoftLimitPlan(
+          softBefore: 10240,
+          hardBefore: 65536,
+          target: 10240,
+        );
+        expect(plan.alreadySatisfied, isTrue);
+        expect(plan.newSoft, 10240);
+      });
+
+      test('soft comfortably above target is still satisfied', () {
+        final plan = resolveFdSoftLimitPlan(
+          softBefore: 20000,
+          hardBefore: 65536,
+          target: 10240,
+        );
+        expect(plan.alreadySatisfied, isTrue);
+        expect(plan.newSoft, 20000);
+      });
+
+      test(
+        'soft reading as RLIM_INFINITY (negative) is treated as satisfied, '
+        'never *lowered* to target',
+        () {
+          // Linux RLIM_INFINITY reads as -1 through a Uint64 struct field.
+          final plan = resolveFdSoftLimitPlan(
+            softBefore: -1,
+            hardBefore: -1,
+            target: 10240,
+          );
+          expect(plan.alreadySatisfied, isTrue);
+          expect(plan.newSoft, -1);
+        },
+      );
+
+      test('soft below target is raised to target when hard has room', () {
+        final plan = resolveFdSoftLimitPlan(
+          softBefore: 256,
+          hardBefore: 65536,
+          target: 10240,
+        );
+        expect(plan.alreadySatisfied, isFalse);
+        expect(plan.newSoft, 10240);
+      });
+
+      test(
+        'hard reading as RLIM_INFINITY (negative on Linux) is treated '
+        'as no cap, so target wins',
+        () {
+          final plan = resolveFdSoftLimitPlan(
+            softBefore: 256,
+            hardBefore: -1,
+            target: 10240,
+          );
+          expect(plan.alreadySatisfied, isFalse);
+          expect(plan.newSoft, 10240);
+        },
+      );
+
+      test('target above hard is clamped to hard', () {
+        final plan = resolveFdSoftLimitPlan(
+          softBefore: 256,
+          hardBefore: 4096,
+          target: 10240,
+        );
+        expect(plan.alreadySatisfied, isFalse);
+        expect(plan.newSoft, 4096);
+      });
+
+      test('target equal to hard still takes target (no off-by-one)', () {
+        final plan = resolveFdSoftLimitPlan(
+          softBefore: 256,
+          hardBefore: 10240,
+          target: 10240,
+        );
+        expect(plan.alreadySatisfied, isFalse);
+        // target == hardBefore: `target < hardBefore` is false, so we pick
+        // hardBefore. Either choice yields 10240; verify we settle on one.
+        expect(plan.newSoft, 10240);
+      });
+    });
+
     test('FdLimitAdjustment exposes all fields as provided', () {
       const adjustment = FdLimitAdjustment(
         softBefore: 256,

--- a/test/utils/fd_limits_test.dart
+++ b/test/utils/fd_limits_test.dart
@@ -12,10 +12,24 @@ void main() {
       }
       final adjustment = ensureFileDescriptorSoftLimit();
       expect(adjustment.error, isNull);
+      // A positive-value check rejects the RLIM_INFINITY sign-flip regression
+      // (-1 signed readback of UINT64_MAX from a Uint64 field).
       expect(adjustment.softAfter, greaterThan(0));
       expect(adjustment.hardAfter, greaterThan(0));
+      expect(adjustment.softBefore, greaterThan(0));
+      expect(adjustment.hardBefore, greaterThan(0));
       expect(adjustment.softAfter, lessThanOrEqualTo(adjustment.hardAfter));
       expect(adjustment.softAfter, greaterThanOrEqualTo(adjustment.softBefore));
+      // When no error occurred, softAfter must reach the target (or the hard
+      // cap if that is lower — always a positive number in practice).
+      expect(
+        adjustment.softAfter,
+        greaterThanOrEqualTo(
+          adjustment.target < adjustment.hardAfter
+              ? adjustment.target
+              : adjustment.hardAfter,
+        ),
+      );
     });
 
     test('target is honoured when below hard limit', () {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Raises the process open-file soft limit to 10,240 at startup on macOS and Linux; emits startup logs/events capturing pre/post descriptor limits

* **Bug Fixes**
  * Attachment save failures due to "Too many open files" (EMFILE) now include annotated descriptor limits for easier diagnosis

* **Documentation**
  * Updated release notes, packaging metadata, and Flatpak changelog for 0.9.953

* **Chores**
  * Added a Make target to capture timestamped FD snapshots and summaries

* **Tests**
  * Added tests validating FD-limit behavior and EMFILE observability/logging
<!-- end of auto-generated comment: release notes by coderabbit.ai -->