### PR TITLE
fix: route every attachment download through the gzip decoder

### DIFF
--- a/lib/features/sync/matrix/matrix_message_sender.dart
+++ b/lib/features/sync/matrix/matrix_message_sender.dart
@@ -7,6 +7,7 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/features/sync/matrix/consts.dart';
 import 'package:lotti/features/sync/matrix/sent_event_registry.dart';
+import 'package:lotti/features/sync/matrix/utils/attachment_decoding.dart';
 import 'package:lotti/features/sync/model/sync_message.dart';
 import 'package:lotti/features/sync/vector_clock.dart';
 import 'package:lotti/features/sync/vector_clock_logging.dart';
@@ -326,7 +327,7 @@ class MatrixMessageSender {
         shouldCompress
             ? 'sent $relativePath file message (gzip '
                   '${fileBytes.length}→${uploadBytes.length} bytes, '
-                  'ratio=${_formatCompressionRatio(raw: fileBytes.length, compressed: uploadBytes.length)}) '
+                  'ratio=${formatCompressionRatio(raw: fileBytes.length, compressed: uploadBytes.length)}) '
                   'to $room, event ID $eventId'
             : 'sent $relativePath file message to $room, event ID $eventId',
         domain: 'MATRIX_SERVICE',
@@ -684,12 +685,4 @@ class MatrixMessageContext {
   final String? syncRoomId;
   final Room? syncRoom;
   final List<DeviceKeys> unverifiedDevices;
-}
-
-/// Formats a gzip compression ratio as `compressed / raw` to 3 decimals.
-/// Returns `'-'` when [raw] is 0 so the log line stays well-formed on the
-/// (unreachable but defensively handled) empty-payload path.
-String _formatCompressionRatio({required int raw, required int compressed}) {
-  if (raw <= 0) return '-';
-  return (compressed / raw).toStringAsFixed(3);
 }

--- a/lib/features/sync/matrix/pipeline/attachment_ingestor.dart
+++ b/lib/features/sync/matrix/pipeline/attachment_ingestor.dart
@@ -3,13 +3,13 @@
 import 'dart:async';
 import 'dart:collection';
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:lotti/database/logging_types.dart';
 import 'package:lotti/features/sync/matrix/consts.dart';
 import 'package:lotti/features/sync/matrix/pipeline/attachment_index.dart';
 import 'package:lotti/features/sync/matrix/pipeline/descriptor_catch_up_manager.dart';
 import 'package:lotti/features/sync/matrix/utils/atomic_write.dart';
+import 'package:lotti/features/sync/matrix/utils/attachment_decoding.dart';
 import 'package:lotti/features/sync/tuning.dart';
 import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/utils/fd_limits.dart';
@@ -381,7 +381,7 @@ class AttachmentIngestor {
         return false;
       }
 
-      final bytes = _decodeAttachmentBytes(
+      final bytes = decodeAttachmentBytes(
         event: event,
         downloadedBytes: downloadedBytes,
         relativePath: relativePath,
@@ -422,37 +422,6 @@ class AttachmentIngestor {
       return false;
     }
   }
-}
-
-/// Decodes the raw downloaded attachment bytes according to any encoding
-/// declared in the Matrix event content. Currently supports gzip. Unknown
-/// encodings fall through and return the bytes unchanged so older fields that
-/// we might add later do not accidentally corrupt files on legacy clients.
-Uint8List _decodeAttachmentBytes({
-  required Event event,
-  required Uint8List downloadedBytes,
-  required String relativePath,
-  required LoggingService logging,
-}) {
-  final encoding = event.content[attachmentEncodingKey];
-  if (encoding != attachmentEncodingGzip) return downloadedBytes;
-  final decoded = gzip.decode(downloadedBytes);
-  logging.captureEvent(
-    'gzipDecoded path=$relativePath '
-    'compressed=${downloadedBytes.length} decoded=${decoded.length} '
-    'ratio=${_formatCompressionRatio(raw: decoded.length, compressed: downloadedBytes.length)}',
-    domain: syncLoggingDomain,
-    subDomain: 'attachment.decode',
-  );
-  return decoded is Uint8List ? decoded : Uint8List.fromList(decoded);
-}
-
-/// Formats a gzip compression ratio as `compressed / raw` to 3 decimals,
-/// matching the sender-side rendering so log lines on both ends of a sync
-/// can be aggregated with the same `ratio=` grep.
-String _formatCompressionRatio({required int raw, required int compressed}) {
-  if (raw <= 0) return '-';
-  return (compressed / raw).toStringAsFixed(3);
 }
 
 class _DownloadRequest {

--- a/lib/features/sync/matrix/sync_event_processor.dart
+++ b/lib/features/sync/matrix/sync_event_processor.dart
@@ -25,6 +25,7 @@ import 'package:lotti/features/settings/constants/theming_settings_keys.dart';
 import 'package:lotti/features/sync/backfill/backfill_response_handler.dart';
 import 'package:lotti/features/sync/matrix/pipeline/attachment_index.dart';
 import 'package:lotti/features/sync/matrix/utils/atomic_write.dart';
+import 'package:lotti/features/sync/matrix/utils/attachment_decoding.dart';
 import 'package:lotti/features/sync/model/sync_message.dart';
 import 'package:lotti/features/sync/sequence/sync_sequence_log_service.dart';
 import 'package:lotti/features/sync/sequence/sync_sequence_payload_type.dart';
@@ -140,10 +141,16 @@ class DescriptorDownloader {
   }) async {
     for (var attempt = 0; attempt < maxDescriptorDownloadAttempts; attempt++) {
       final matrixFile = await descriptorEvent.downloadAndDecryptAttachment();
-      final bytes = matrixFile.bytes;
-      if (bytes.isEmpty) {
+      final downloadedBytes = matrixFile.bytes;
+      if (downloadedBytes.isEmpty) {
         throw const FileSystemException('empty attachment bytes');
       }
+      final bytes = decodeAttachmentBytes(
+        event: descriptorEvent,
+        downloadedBytes: downloadedBytes,
+        relativePath: jsonPath,
+        logging: _logging,
+      );
       final candidateJson = utf8.decode(bytes);
       final decoded = json.decode(candidateJson) as Map<String, dynamic>;
       final candidate = JournalEntity.fromJson(decoded);
@@ -388,10 +395,16 @@ class SmartJournalEntityLoader implements SyncJournalEntityLoader {
         }
         try {
           final matrixFile = await eventForPath.downloadAndDecryptAttachment();
-          final bytes = matrixFile.bytes;
-          if (bytes.isEmpty) {
+          final downloadedBytes = matrixFile.bytes;
+          if (downloadedBytes.isEmpty) {
             throw const FileSystemException('empty attachment bytes');
           }
+          final bytes = decodeAttachmentBytes(
+            event: eventForPath,
+            downloadedBytes: downloadedBytes,
+            relativePath: jsonPath,
+            logging: _logging,
+          );
           final jsonString = utf8.decode(bytes);
           await saveJson(targetFile.path, jsonString);
           _logging.captureEvent(
@@ -477,10 +490,16 @@ class SmartJournalEntityLoader implements SyncJournalEntityLoader {
     }
     try {
       final file = await ev.downloadAndDecryptAttachment();
-      final bytes = file.bytes;
-      if (bytes.isEmpty) {
+      final downloadedBytes = file.bytes;
+      if (downloadedBytes.isEmpty) {
         throw const FileSystemException('empty attachment bytes');
       }
+      final bytes = decodeAttachmentBytes(
+        event: ev,
+        downloadedBytes: downloadedBytes,
+        relativePath: rp,
+        logging: _logging,
+      );
       await atomicWriteBytes(
         bytes: bytes,
         filePath: fp,
@@ -1221,10 +1240,16 @@ class SyncEventProcessor {
 
     try {
       final matrixFile = await descriptorEvent.downloadAndDecryptAttachment();
-      final bytes = matrixFile.bytes;
-      if (bytes.isEmpty) {
+      final downloadedBytes = matrixFile.bytes;
+      if (downloadedBytes.isEmpty) {
         throw const FileSystemException('empty attachment bytes');
       }
+      final bytes = decodeAttachmentBytes(
+        event: descriptorEvent,
+        downloadedBytes: downloadedBytes,
+        relativePath: jsonPath,
+        logging: _loggingService,
+      );
       final jsonString = utf8.decode(bytes);
       await saveJson(targetFile.path, jsonString);
       _trace(

--- a/lib/features/sync/matrix/utils/attachment_decoding.dart
+++ b/lib/features/sync/matrix/utils/attachment_decoding.dart
@@ -1,0 +1,47 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:lotti/features/sync/matrix/consts.dart';
+import 'package:lotti/services/logging_service.dart';
+import 'package:matrix/matrix.dart';
+
+/// Decodes the raw downloaded attachment bytes according to any encoding
+/// declared in the Matrix event content. Currently only gzip is recognized.
+///
+/// Returns the bytes unchanged when no `com.lotti.encoding` header is present,
+/// so the decoder is a safe no-op on non-encoded attachments and on every
+/// attachment produced by senders that predate this feature.
+///
+/// Must wrap every caller of `event.downloadAndDecryptAttachment()` that
+/// treats the bytes as a concrete payload (JSON, media file, etc.), otherwise
+/// a gzipped `.json` attachment reaches `utf8.decode` as `0x1f 0x8b ...` and
+/// explodes with `FormatException: Unexpected extension byte`.
+Uint8List decodeAttachmentBytes({
+  required Event event,
+  required Uint8List downloadedBytes,
+  required String relativePath,
+  required LoggingService logging,
+}) {
+  final encoding = event.content[attachmentEncodingKey];
+  if (encoding != attachmentEncodingGzip) return downloadedBytes;
+  final decoded = gzip.decode(downloadedBytes);
+  logging.captureEvent(
+    'gzipDecoded path=$relativePath '
+    'compressed=${downloadedBytes.length} decoded=${decoded.length} '
+    'ratio=${formatCompressionRatio(raw: decoded.length, compressed: downloadedBytes.length)}',
+    domain: syncLoggingDomain,
+    subDomain: 'attachment.decode',
+  );
+  return decoded is Uint8List ? decoded : Uint8List.fromList(decoded);
+}
+
+/// Formats a gzip compression ratio as `compressed / raw` to 3 decimals.
+///
+/// Rendered identically on both ends of a sync (sender and receiver) so that
+/// `grep 'ratio=' sync-*.log` aggregates cleanly across peers.
+/// Returns `'-'` when [raw] is 0 to keep the log line well-formed on the
+/// defensively-handled empty-payload path.
+String formatCompressionRatio({required int raw, required int compressed}) {
+  if (raw <= 0) return '-';
+  return (compressed / raw).toStringAsFixed(3);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.954+3928
+version: 0.9.954+3929
 
 msix_config:
   display_name: LottiApp

--- a/test/features/sync/matrix/utils/attachment_decoding_test.dart
+++ b/test/features/sync/matrix/utils/attachment_decoding_test.dart
@@ -1,0 +1,174 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/sync/matrix/consts.dart';
+import 'package:lotti/features/sync/matrix/utils/attachment_decoding.dart';
+import 'package:matrix/matrix.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../mocks/mocks.dart';
+
+class _MockEvent extends Mock implements Event {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(StackTrace.empty);
+  });
+
+  group('decodeAttachmentBytes', () {
+    test(
+      'returns bytes verbatim when no encoding header is present',
+      () {
+        final logging = MockLoggingService();
+        final event = _MockEvent();
+        when(() => event.content).thenReturn(<String, dynamic>{});
+
+        final payload = Uint8List.fromList([1, 2, 3, 4, 5]);
+        final decoded = decodeAttachmentBytes(
+          event: event,
+          downloadedBytes: payload,
+          relativePath: '/foo.json',
+          logging: logging,
+        );
+
+        expect(decoded, same(payload));
+        verifyNever(
+          () => logging.captureEvent(
+            any<String>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'returns bytes verbatim for unknown encoding values',
+      () {
+        // Forward-compat: a future sender might add a new encoding; older
+        // receivers must pass the bytes through untouched rather than
+        // panic or corrupt the file.
+        final logging = MockLoggingService();
+        final event = _MockEvent();
+        when(() => event.content).thenReturn(<String, dynamic>{
+          attachmentEncodingKey: 'brotli',
+        });
+
+        final payload = Uint8List.fromList([9, 8, 7]);
+        final decoded = decodeAttachmentBytes(
+          event: event,
+          downloadedBytes: payload,
+          relativePath: '/bar.json',
+          logging: logging,
+        );
+
+        expect(decoded, same(payload));
+      },
+    );
+
+    test(
+      'decompresses a gzipped payload when encoding=gzip and logs ratio',
+      () {
+        final logging = MockLoggingService();
+        when(
+          () => logging.captureEvent(
+            any<String>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+          ),
+        ).thenAnswer((_) async {});
+
+        final event = _MockEvent();
+        when(() => event.content).thenReturn(<String, dynamic>{
+          attachmentEncodingKey: attachmentEncodingGzip,
+        });
+
+        // A repetitive JSON-shaped payload so gzip has something to crunch.
+        final original = List<String>.filled(
+          64,
+          '{"k":"value"},',
+        ).join().codeUnits;
+        final compressed = Uint8List.fromList(gzip.encode(original));
+
+        final decoded = decodeAttachmentBytes(
+          event: event,
+          downloadedBytes: compressed,
+          relativePath: '/agent_entities/foo.json',
+          logging: logging,
+        );
+
+        expect(decoded, equals(original));
+
+        final captured = verify(
+          () => logging.captureEvent(
+            captureAny<String>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: 'attachment.decode',
+          ),
+        ).captured;
+        expect(captured, hasLength(1));
+        final line = captured.single as String;
+        expect(line, contains('gzipDecoded'));
+        expect(line, contains('path=/agent_entities/foo.json'));
+        expect(line, contains('compressed=${compressed.length}'));
+        expect(line, contains('decoded=${original.length}'));
+        expect(line, contains('ratio='));
+      },
+    );
+
+    test(
+      'regression: gzipped JSON no longer explodes a downstream utf8.decode',
+      () {
+        // This is the exact shape of the production bug that this helper
+        // exists to prevent. Pre-fix, a caller would receive the raw gzip
+        // bytes (0x1f 0x8b ...) and feed them to utf8.decode, which throws
+        // `FormatException: Unexpected extension byte (at offset 1)`.
+        final logging = MockLoggingService();
+        when(
+          () => logging.captureEvent(
+            any<String>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+          ),
+        ).thenAnswer((_) async {});
+
+        final event = _MockEvent();
+        when(() => event.content).thenReturn(<String, dynamic>{
+          attachmentEncodingKey: attachmentEncodingGzip,
+        });
+        const originalJson = '{"hello":"world","n":42}';
+        final compressed = Uint8List.fromList(
+          gzip.encode(originalJson.codeUnits),
+        );
+
+        final decoded = decodeAttachmentBytes(
+          event: event,
+          downloadedBytes: compressed,
+          relativePath: '/agent_entities/x.json',
+          logging: logging,
+        );
+
+        expect(String.fromCharCodes(decoded), originalJson);
+      },
+    );
+  });
+
+  group('formatCompressionRatio', () {
+    test('formats to 3 decimals', () {
+      expect(
+        formatCompressionRatio(raw: 1000, compressed: 250),
+        '0.250',
+      );
+      expect(
+        formatCompressionRatio(raw: 7, compressed: 2),
+        '0.286',
+      );
+    });
+
+    test('returns - for raw<=0 rather than dividing by zero', () {
+      expect(formatCompressionRatio(raw: 0, compressed: 10), '-');
+      expect(formatCompressionRatio(raw: -1, compressed: 10), '-');
+    });
+  });
+}


### PR DESCRIPTION
The gzip-on-send feature decoded only on the AttachmentIngestor path. Four other sites in SyncEventProcessor (DescriptorDownloader.download, SmartLoader.fetchJson.noVc, SmartLoader.fetchMedia, _fetchFromDescriptor) went straight from event.downloadAndDecryptAttachment().bytes to utf8.decode or atomicWriteBytes without honoring the com.lotti.encoding header.

With the flag on, this produced a FormatException: Unexpected extension byte (at offset 1) at _Utf8Decoder.convertSingle on every agent-entity descriptor re-fetch — gzip magic 0x1f 0x8b is not valid UTF-8 at offset 1. The failed fetch then retried, which is why the sync log bloated to 3.7 MB in 25 minutes.

Extracted decodeAttachmentBytes + formatCompressionRatio to lib/features/sync/matrix/utils/attachment_decoding.dart so every caller of downloadAndDecryptAttachment shares one decoding seam. Removed the duplicated private helpers in attachment_ingestor.dart and matrix_message_sender.dart. Added unit tests including an explicit regression for the 0x1f 0x8b → utf8.decode crash shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated attachment decoding and compression-ratio formatting into a shared utility and updated attachment handling to use it
  * Enhanced logging for attachment decompression metrics

* **Tests**
  * Added comprehensive tests for attachment decoding workflows and compression-ratio formatting

* **Chores**
  * Version bump to 0.9.954+3929
<!-- end of auto-generated comment: release notes by coderabbit.ai -->