### PR TITLE
feat: bundled attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.955] - 2026-04-17
+## [0.9.956] - 2026-04-17
 ### Added
 - Outbox attachment bundling: when the `use_bundled_attachments` config flag
   is on (off by default), the outbox packs as many pending items' attachment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.955] - 2026-04-17
+### Added
+- Outbox attachment bundling: when the `use_bundled_attachments` config flag
+  is on (off by default), the outbox packs as many pending items' attachment
+  files as fit into a single zip capped at 8 MiB and uploads the bundle as
+  one Matrix file event, then sends each bundled item's text event with the
+  bundled paths short-circuited. Items whose own attachments exceed the cap
+  fall through to the existing single-item send path. Receivers recognize
+  the `com.lotti.bundle` event marker and unpack the zip to each entry's
+  target relative path unconditionally, so turning the flag on is forward-
+  compatible with peers already on this release.
+- Attachment enumerator that derives the file-on-disk set (JSON plus any
+  journal audio/image file) for a `SyncMessage`. Used by the outbox bundling
+  path and available for future packing strategies.
+
 ## [0.9.954] - 2026-04-17
 ### Added
 - Optional gzip compression for JSON sync attachments, gated by the

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -31,6 +31,11 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="0.9.955" date="2026-04-17">
+      <description>
+          <p>Outbox attachment bundling: when the new config flag is on, pending sync items' attachment files are packed into a single zip (capped at 8 MiB) and uploaded as one Matrix file event, collapsing many per-file uploads into one round-trip over slow links. Items whose own attachments exceed the cap fall through to the existing per-file path. Receivers recognize the bundle marker and unpack entries to their target paths unconditionally, so enabling bundling on a single device stays compatible with peers already on this release.</p>
+      </description>
+    </release>
     <release version="0.9.954" date="2026-04-17">
       <description>
           <p>Optional gzip compression for JSON sync attachments over Matrix, gated by a new config flag that is off by default. Receivers always decompress when the encoding marker is present on an attachment event, so turning compression on for a single device stays compatible with peers on this release. Only .json attachments are compressed; media files are already on compressed formats and skip the branch.</p>

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -31,7 +31,7 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
-    <release version="0.9.955" date="2026-04-17">
+    <release version="0.9.956" date="2026-04-17">
       <description>
           <p>Outbox attachment bundling: when the new config flag is on, pending sync items' attachment files are packed into a single zip (capped at 8 MiB) and uploaded as one Matrix file event, collapsing many per-file uploads into one round-trip over slow links. Items whose own attachments exceed the cap fall through to the existing per-file path. Receivers recognize the bundle marker and unpack entries to their target paths unconditionally, so enabling bundling on a single device stays compatible with peers already on this release.</p>
       </description>

--- a/lib/database/journal_db/config_flags.dart
+++ b/lib/database/journal_db/config_flags.dart
@@ -117,6 +117,14 @@ Future<void> initConfigFlags(
 
   await db.insertFlagIfNotExists(
     const ConfigFlag(
+      name: useBundledAttachmentsFlag,
+      description: 'Pack multiple sync attachments into one zip on send?',
+      status: false,
+    ),
+  );
+
+  await db.insertFlagIfNotExists(
+    const ConfigFlag(
       name: enableAgentsFlag,
       description: 'Enable Agents?',
       status: false,

--- a/lib/features/settings/ui/pages/flags_page.dart
+++ b/lib/features/settings/ui/pages/flags_page.dart
@@ -28,6 +28,7 @@ class _FlagsPageState extends ConsumerState<FlagsPage> {
     enableMatrixFlag,
     resendAttachments,
     useCompressedJsonAttachmentsFlag,
+    useBundledAttachmentsFlag,
     enableHabitsPageFlag,
     enableDashboardsPageFlag,
     enableDailyOsPageFlag,
@@ -60,6 +61,8 @@ class _FlagsPageState extends ConsumerState<FlagsPage> {
         return Icons.refresh_rounded;
       case useCompressedJsonAttachmentsFlag:
         return Icons.compress_rounded;
+      case useBundledAttachmentsFlag:
+        return Icons.inventory_2_outlined;
       case enableHabitsPageFlag:
         return Icons.repeat_rounded;
       case enableDashboardsPageFlag:
@@ -106,6 +109,8 @@ class _FlagsPageState extends ConsumerState<FlagsPage> {
         return context
             .messages
             .configFlagUseCompressedJsonAttachmentsDescription;
+      case useBundledAttachmentsFlag:
+        return context.messages.configFlagUseBundledAttachmentsDescription;
       case enableHabitsPageFlag:
         return context.messages.configFlagEnableHabitsPageDescription;
       case enableDashboardsPageFlag:
@@ -150,6 +155,8 @@ class _FlagsPageState extends ConsumerState<FlagsPage> {
         return context.messages.configFlagResendAttachments;
       case useCompressedJsonAttachmentsFlag:
         return context.messages.configFlagUseCompressedJsonAttachments;
+      case useBundledAttachmentsFlag:
+        return context.messages.configFlagUseBundledAttachments;
       case enableHabitsPageFlag:
         return context.messages.configFlagEnableHabitsPage;
       case enableDashboardsPageFlag:

--- a/lib/features/sync/README.md
+++ b/lib/features/sync/README.md
@@ -350,6 +350,32 @@ When the flag is on, the uploaded file name gains a `.gz` suffix and the
 event content includes the encoding header; otherwise bytes are sent
 verbatim with no header and no suffix.
 
+### Attachment Bundling
+
+Attachment events may carry a `com.lotti.bundle: true` marker in the Matrix
+event content. The event's payload is then a zip archive whose entries are
+named by their logical `relativePath` values. When a receiver sees this
+marker it unpacks the zip instead of writing the zip itself, routing every
+entry through the same `_targetFile()` path-traversal guard and the
+non-agent-file existing-on-disk dedup that single-file saves use. The outer
+`relativePath` of a bundle event is `.bundles/<uuid>.zip`, a location no
+sync payload refers to, so older receivers that predate bundle support
+store the zip harmlessly while newer receivers recognize the marker.
+
+On the send side, bundling is gated by the `use_bundled_attachments` config
+flag (off by default). When the flag is on, `OutboxProcessor.processQueue`
+enumerates attachments across the current pending batch via
+`enumerateAttachments`, greedily packs as many as fit into one zip up to
+`SyncTuning.outboxBundleMaxBytes` (8 MiB), uploads the bundle as one Matrix
+file event, and then sends each bundled item's text event with the bundled
+relative paths in `MatrixMessageContext.skipAttachmentPaths`. The sender's
+`_sendFile` short-circuits for any path in that set. Items whose own
+attachments exceed the bundle cap fall through to the existing single-item
+path on the next tick, so large media uploads are never hidden behind a
+bundle. The bundle marker and the `com.lotti.encoding` marker are
+independent; a bundled event is always a zip and does not set the encoding
+header.
+
 ```mermaid
 flowchart TD
   Event["Matrix event"] --> Decode["Decode SyncMessage"]

--- a/lib/features/sync/matrix/attachment_enumerator.dart
+++ b/lib/features/sync/matrix/attachment_enumerator.dart
@@ -68,10 +68,11 @@ Future<List<AttachmentDescriptor>> _forJournalEntity({
   // Read once and cache: the same bytes feed the JournalEntity.fromJson pass
   // below (to discover audio/image paths) and any downstream consumer such as
   // the bundler, so subsequent reads can short-circuit.
-  final jsonFullPath = p.join(
-    documentsDirectory.path,
-    p.joinAll(message.jsonPath.split('/').where((part) => part.isNotEmpty)),
+  final jsonFullPath = _resolveWithinDocuments(
+    relativePath: message.jsonPath,
+    documentsDirectory: documentsDirectory,
   );
+  if (jsonFullPath == null) return const [];
   Uint8List bytes;
   try {
     bytes = await File(jsonFullPath).readAsBytes();
@@ -112,10 +113,11 @@ Future<List<AttachmentDescriptor>> _forFile({
   required String relativePath,
   required Directory documentsDirectory,
 }) async {
-  final joined = p.joinAll(
-    relativePath.split('/').where((part) => part.isNotEmpty),
+  final fullPath = _resolveWithinDocuments(
+    relativePath: relativePath,
+    documentsDirectory: documentsDirectory,
   );
-  final fullPath = p.join(documentsDirectory.path, joined);
+  if (fullPath == null) return const [];
   try {
     final size = await File(fullPath).length();
     if (size <= 0) return const [];
@@ -130,4 +132,24 @@ Future<List<AttachmentDescriptor>> _forFile({
   } on FileSystemException {
     return const [];
   }
+}
+
+/// Resolves [relativePath] against [documentsDirectory] and rejects anything
+/// that escapes the documents tree — defends the enumerator (and therefore
+/// any downstream read/upload) against `..` segments or absolute fragments
+/// in a crafted `jsonPath`. Returns the absolute path on success, or null
+/// when the path is outside the documents directory or cannot be normalized.
+String? _resolveWithinDocuments({
+  required String relativePath,
+  required Directory documentsDirectory,
+}) {
+  var rel = relativePath;
+  if (p.isAbsolute(rel)) {
+    final prefix = p.rootPrefix(rel);
+    rel = rel.substring(prefix.length);
+  }
+  final joined = p.joinAll(rel.split('/').where((part) => part.isNotEmpty));
+  final resolved = p.normalize(p.join(documentsDirectory.path, joined));
+  if (!p.isWithin(documentsDirectory.path, resolved)) return null;
+  return resolved;
 }

--- a/lib/features/sync/matrix/attachment_enumerator.dart
+++ b/lib/features/sync/matrix/attachment_enumerator.dart
@@ -1,0 +1,124 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/sync/model/sync_message.dart';
+import 'package:lotti/utils/audio_utils.dart';
+import 'package:lotti/utils/image_utils.dart';
+import 'package:path/path.dart' as p;
+
+/// Describes a single file that a [SyncMessage] would upload individually via
+/// `MatrixMessageSender._sendFile` when bundling is disabled.
+class AttachmentDescriptor {
+  const AttachmentDescriptor({
+    required this.fullPath,
+    required this.relativePath,
+    required this.size,
+  });
+
+  /// Absolute path to the file on disk.
+  final String fullPath;
+
+  /// Logical relative path used as the sync-side file identifier. This is the
+  /// value read by receivers to decide where to write the file locally.
+  final String relativePath;
+
+  /// File size in bytes at enumeration time.
+  final int size;
+}
+
+/// Enumerates the on-disk files a [message] would upload individually.
+///
+/// Files that are missing or empty are silently omitted. A message that
+/// carries no file attachments returns an empty list. Callers should treat
+/// a partial enumeration (e.g. the JSON is readable but the media file is
+/// missing) as a signal to fall back to the solo send path, where the
+/// existing error handling applies.
+///
+/// This helper never throws; it returns an empty list on any I/O failure.
+Future<List<AttachmentDescriptor>> enumerateAttachments({
+  required SyncMessage message,
+  required Directory documentsDirectory,
+}) async {
+  switch (message) {
+    case final SyncJournalEntity msg:
+      return _forJournalEntity(
+        message: msg,
+        documentsDirectory: documentsDirectory,
+      );
+    case final SyncAgentEntity msg:
+      final path = msg.jsonPath;
+      if (path == null) return const [];
+      return _forFile(
+        relativePath: path,
+        documentsDirectory: documentsDirectory,
+      );
+    case final SyncAgentLink msg:
+      final path = msg.jsonPath;
+      if (path == null) return const [];
+      return _forFile(
+        relativePath: path,
+        documentsDirectory: documentsDirectory,
+      );
+    case _:
+      return const [];
+  }
+}
+
+Future<List<AttachmentDescriptor>> _forJournalEntity({
+  required SyncJournalEntity message,
+  required Directory documentsDirectory,
+}) async {
+  final base = await _forFile(
+    relativePath: message.jsonPath,
+    documentsDirectory: documentsDirectory,
+  );
+  if (base.isEmpty) return const [];
+
+  try {
+    final bytes = await File(base.first.fullPath).readAsBytes();
+    final entity = JournalEntity.fromJson(
+      json.decode(utf8.decode(bytes)) as Map<String, dynamic>,
+    );
+    final media = await entity.maybeMap(
+      journalAudio: (JournalAudio audio) async => _forFile(
+        relativePath: AudioUtils.getRelativeAudioPath(audio),
+        documentsDirectory: documentsDirectory,
+      ),
+      journalImage: (JournalImage image) async => _forFile(
+        relativePath: getRelativeImagePath(image),
+        documentsDirectory: documentsDirectory,
+      ),
+      orElse: () async => const <AttachmentDescriptor>[],
+    );
+    return [...base, ...media];
+  } catch (_) {
+    return base;
+  }
+}
+
+Future<List<AttachmentDescriptor>> _forFile({
+  required String relativePath,
+  required Directory documentsDirectory,
+}) async {
+  final joined = p.joinAll(
+    relativePath.split('/').where((part) => part.isNotEmpty),
+  );
+  final fullPath = p.join(documentsDirectory.path, joined);
+  final file = File(fullPath);
+  try {
+    // ignore: avoid_slow_async_io
+    if (!await file.exists()) return const [];
+    final size = await file.length();
+    if (size <= 0) return const [];
+    return [
+      AttachmentDescriptor(
+        fullPath: fullPath,
+        relativePath: relativePath,
+        size: size,
+      ),
+    ];
+  } catch (_) {
+    return const [];
+  }
+}

--- a/lib/features/sync/matrix/attachment_enumerator.dart
+++ b/lib/features/sync/matrix/attachment_enumerator.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/sync/model/sync_message.dart';
@@ -9,23 +10,17 @@ import 'package:path/path.dart' as p;
 
 /// Describes a single file that a [SyncMessage] would upload individually via
 /// `MatrixMessageSender._sendFile` when bundling is disabled.
-class AttachmentDescriptor {
-  const AttachmentDescriptor({
-    required this.fullPath,
-    required this.relativePath,
-    required this.size,
-  });
-
-  /// Absolute path to the file on disk.
-  final String fullPath;
-
-  /// Logical relative path used as the sync-side file identifier. This is the
-  /// value read by receivers to decide where to write the file locally.
-  final String relativePath;
-
-  /// File size in bytes at enumeration time.
-  final int size;
-}
+///
+/// When the file is the JSON payload the enumerator already read to discover
+/// media paths, `bytes` is populated so downstream callers (e.g. the
+/// bundler) can avoid re-reading the same file from disk. For media files
+/// `bytes` is null and callers must load the contents themselves.
+typedef AttachmentDescriptor = ({
+  String fullPath,
+  String relativePath,
+  int size,
+  Uint8List? bytes,
+});
 
 /// Enumerates the on-disk files a [message] would upload individually.
 ///
@@ -47,36 +42,52 @@ Future<List<AttachmentDescriptor>> enumerateAttachments({
         documentsDirectory: documentsDirectory,
       );
     case final SyncAgentEntity msg:
-      final path = msg.jsonPath;
-      if (path == null) return const [];
-      return _forFile(
-        relativePath: path,
-        documentsDirectory: documentsDirectory,
-      );
+      return _forOptionalJsonPath(msg.jsonPath, documentsDirectory);
     case final SyncAgentLink msg:
-      final path = msg.jsonPath;
-      if (path == null) return const [];
-      return _forFile(
-        relativePath: path,
-        documentsDirectory: documentsDirectory,
-      );
+      return _forOptionalJsonPath(msg.jsonPath, documentsDirectory);
     case _:
       return const [];
   }
+}
+
+Future<List<AttachmentDescriptor>> _forOptionalJsonPath(
+  String? relativePath,
+  Directory documentsDirectory,
+) async {
+  if (relativePath == null) return const [];
+  return _forFile(
+    relativePath: relativePath,
+    documentsDirectory: documentsDirectory,
+  );
 }
 
 Future<List<AttachmentDescriptor>> _forJournalEntity({
   required SyncJournalEntity message,
   required Directory documentsDirectory,
 }) async {
-  final base = await _forFile(
-    relativePath: message.jsonPath,
-    documentsDirectory: documentsDirectory,
+  // Read once and cache: the same bytes feed the JournalEntity.fromJson pass
+  // below (to discover audio/image paths) and any downstream consumer such as
+  // the bundler, so subsequent reads can short-circuit.
+  final jsonFullPath = p.join(
+    documentsDirectory.path,
+    p.joinAll(message.jsonPath.split('/').where((part) => part.isNotEmpty)),
   );
-  if (base.isEmpty) return const [];
+  Uint8List bytes;
+  try {
+    bytes = await File(jsonFullPath).readAsBytes();
+  } on FileSystemException {
+    return const [];
+  }
+  if (bytes.isEmpty) return const [];
+
+  final base = (
+    fullPath: jsonFullPath,
+    relativePath: message.jsonPath,
+    size: bytes.length,
+    bytes: bytes,
+  );
 
   try {
-    final bytes = await File(base.first.fullPath).readAsBytes();
     final entity = JournalEntity.fromJson(
       json.decode(utf8.decode(bytes)) as Map<String, dynamic>,
     );
@@ -91,9 +102,9 @@ Future<List<AttachmentDescriptor>> _forJournalEntity({
       ),
       orElse: () async => const <AttachmentDescriptor>[],
     );
-    return [...base, ...media];
+    return [base, ...media];
   } catch (_) {
-    return base;
+    return [base];
   }
 }
 
@@ -105,20 +116,18 @@ Future<List<AttachmentDescriptor>> _forFile({
     relativePath.split('/').where((part) => part.isNotEmpty),
   );
   final fullPath = p.join(documentsDirectory.path, joined);
-  final file = File(fullPath);
   try {
-    // ignore: avoid_slow_async_io
-    if (!await file.exists()) return const [];
-    final size = await file.length();
+    final size = await File(fullPath).length();
     if (size <= 0) return const [];
     return [
-      AttachmentDescriptor(
+      (
         fullPath: fullPath,
         relativePath: relativePath,
         size: size,
+        bytes: null,
       ),
     ];
-  } catch (_) {
+  } on FileSystemException {
     return const [];
   }
 }

--- a/lib/features/sync/matrix/consts.dart
+++ b/lib/features/sync/matrix/consts.dart
@@ -14,3 +14,12 @@ const String attachmentEncodingKey = 'com.lotti.encoding';
 /// Value for [attachmentEncodingKey] indicating the attachment bytes are
 /// gzip-compressed; the receiver must decompress before writing to disk.
 const String attachmentEncodingGzip = 'gzip';
+
+/// Key in an attachment event's content that marks the file as a zip
+/// containing multiple inner attachments. Entries inside the zip are named
+/// after their target relative paths. Receivers that understand this marker
+/// unpack the zip and write each entry to its inner path instead of writing
+/// the zip itself. Receivers that do not understand the marker will still
+/// write the zip to the outer `relativePath`, which is harmless because that
+/// path is under `.bundles/` and is not referenced by any sync payload.
+const String attachmentBundleKey = 'com.lotti.bundle';

--- a/lib/features/sync/matrix/consts.dart
+++ b/lib/features/sync/matrix/consts.dart
@@ -21,5 +21,10 @@ const String attachmentEncodingGzip = 'gzip';
 /// unpack the zip and write each entry to its inner path instead of writing
 /// the zip itself. Receivers that do not understand the marker will still
 /// write the zip to the outer `relativePath`, which is harmless because that
-/// path is under `.bundles/` and is not referenced by any sync payload.
+/// path is under [attachmentBundleDirPrefix] and is not referenced by any
+/// sync payload.
 const String attachmentBundleKey = 'com.lotti.bundle';
+
+/// Documents-relative directory prefix used for the outer `relativePath` of
+/// bundle events. No sync payload resolves to a path under this prefix.
+const String attachmentBundleDirPrefix = '.bundles/';

--- a/lib/features/sync/matrix/matrix_message_sender.dart
+++ b/lib/features/sync/matrix/matrix_message_sender.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:archive/archive.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/features/sync/matrix/consts.dart';
@@ -21,6 +22,7 @@ import 'package:lotti/utils/image_utils.dart';
 import 'package:matrix/matrix.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
+import 'package:uuid/uuid.dart';
 
 typedef MatrixMessageSentCallback =
     void Function(
@@ -158,6 +160,7 @@ class MatrixMessageSender {
         final normalized = await _sendJournalEntityPayload(
           room: room,
           message: outboundMessage,
+          skipAttachmentPaths: context.skipAttachmentPaths,
         );
         if (normalized == null) {
           _trace(
@@ -183,6 +186,7 @@ class MatrixMessageSender {
       final agentResult = await _enrichAndUploadAgentPayload(
         room: room,
         message: outboundMessage,
+        skipAttachmentPaths: context.skipAttachmentPaths,
       );
       if (agentResult == null) {
         _trace(
@@ -263,12 +267,86 @@ class MatrixMessageSender {
     }
   }
 
+  /// Packages the supplied relativePath→bytes [entries] into a single zip
+  /// archive and uploads it as one Matrix file event with
+  /// [attachmentBundleKey] set. The outer event's relativePath is
+  /// `.bundles/<bundleId>.zip`, a location no sync payload refers to, so
+  /// receivers that predate bundle support store the zip harmlessly while
+  /// newer receivers recognize the marker and unpack each entry to its
+  /// inner relativePath.
+  ///
+  /// Returns the Matrix event id on success, or null on failure.
+  Future<String?> sendAttachmentBundle({
+    required Room room,
+    required Map<String, Uint8List> entries,
+    String? bundleId,
+  }) async {
+    if (entries.isEmpty) return null;
+    final id = bundleId ?? const Uuid().v4();
+    final archive = Archive();
+    for (final entry in entries.entries) {
+      archive.addFile(
+        ArchiveFile(entry.key, entry.value.length, entry.value),
+      );
+    }
+    final encoded = ZipEncoder().encode(archive);
+    final zipBytes = encoded is Uint8List
+        ? encoded
+        : Uint8List.fromList(encoded);
+    final bundlePath = '.bundles/$id.zip';
+    try {
+      final eventId = await room.sendFileEvent(
+        MatrixFile(bytes: zipBytes, name: '$id.zip'),
+        extraContent: {
+          'relativePath': bundlePath,
+          attachmentBundleKey: true,
+        },
+      );
+      if (eventId == null) {
+        _loggingService.captureEvent(
+          'bundle send returned null id=$id count=${entries.length}',
+          domain: 'MATRIX_SERVICE',
+          subDomain: 'sendMatrixMsg.bundle',
+        );
+        return null;
+      }
+      _loggingService.captureEvent(
+        'sent bundle id=$id count=${entries.length} '
+        'bytes=${zipBytes.length}',
+        domain: 'MATRIX_SERVICE',
+        subDomain: 'sendMatrixMsg.bundle',
+      );
+      _sentEventRegistry.register(
+        eventId,
+        source: SentEventSource.file,
+      );
+      return eventId;
+    } catch (error, stackTrace) {
+      _loggingService.captureException(
+        error,
+        domain: 'MATRIX_SERVICE',
+        subDomain: 'sendMatrixMsg.bundle',
+        stackTrace: stackTrace,
+      );
+      return null;
+    }
+  }
+
   Future<bool> _sendFile({
     required Room room,
     required String fullPath,
     required String relativePath,
     Uint8List? bytes,
+    Set<String> skipAttachmentPaths = const <String>{},
   }) async {
+    if (skipAttachmentPaths.contains(relativePath)) {
+      _loggingService.captureEvent(
+        'skipped $relativePath, already uploaded via bundle',
+        domain: 'MATRIX_SERVICE',
+        subDomain: 'sendMatrixMsg.bundled',
+      );
+      return true;
+    }
     try {
       final file = File(fullPath);
       // ignore: avoid_slow_async_io
@@ -358,6 +436,7 @@ class MatrixMessageSender {
   Future<SyncJournalEntity?> _sendJournalEntityPayload({
     required Room room,
     required SyncJournalEntity message,
+    Set<String> skipAttachmentPaths = const <String>{},
   }) async {
     final relativeJsonPath = p.joinAll(
       message.jsonPath.split('/').where((part) => part.isNotEmpty),
@@ -387,6 +466,7 @@ class MatrixMessageSender {
       fullPath: jsonFullPath,
       relativePath: message.jsonPath,
       bytes: jsonBytes,
+      skipAttachmentPaths: skipAttachmentPaths,
     );
 
     if (!jsonSent) {
@@ -503,6 +583,7 @@ class MatrixMessageSender {
             room: room,
             fullPath: audioPath,
             relativePath: AudioUtils.getRelativeAudioPath(journalAudio),
+            skipAttachmentPaths: skipAttachmentPaths,
           );
           attachmentsOk = attachmentsOk && sent;
         }
@@ -518,6 +599,7 @@ class MatrixMessageSender {
             room: room,
             fullPath: imagePath,
             relativePath: getRelativeImagePath(journalImage),
+            skipAttachmentPaths: skipAttachmentPaths,
           );
           attachmentsOk = attachmentsOk && sent;
         }
@@ -544,6 +626,7 @@ class MatrixMessageSender {
   Future<SyncMessage?> _enrichAndUploadAgentPayload({
     required Room room,
     required SyncMessage message,
+    Set<String> skipAttachmentPaths = const <String>{},
   }) async {
     final String? inlineJson;
     final String? jsonPath;
@@ -597,6 +680,7 @@ class MatrixMessageSender {
       room: room,
       relativePath: enrichedPath,
       logLabel: logLabel,
+      skipAttachmentPaths: skipAttachmentPaths,
     );
     if (!uploaded) return null;
 
@@ -619,6 +703,7 @@ class MatrixMessageSender {
     required Room room,
     required String relativePath,
     required String logLabel,
+    Set<String> skipAttachmentPaths = const <String>{},
   }) async {
     final relativeJoined = p.joinAll(
       relativePath.split('/').where((part) => part.isNotEmpty),
@@ -643,6 +728,7 @@ class MatrixMessageSender {
       fullPath: fullPath,
       relativePath: relativePath,
       bytes: jsonBytes,
+      skipAttachmentPaths: skipAttachmentPaths,
     );
   }
 
@@ -680,9 +766,16 @@ class MatrixMessageContext {
     required this.syncRoomId,
     required this.syncRoom,
     required this.unverifiedDevices,
+    this.skipAttachmentPaths = const <String>{},
   });
 
   final String? syncRoomId;
   final Room? syncRoom;
   final List<DeviceKeys> unverifiedDevices;
+
+  /// Relative paths whose file contents have already been uploaded out-of-band
+  /// (e.g. inside an attachment bundle) and must NOT be uploaded again during
+  /// this send. Short-circuits the per-file upload inside `_sendFile` while
+  /// keeping the surrounding vector-clock bookkeeping intact.
+  final Set<String> skipAttachmentPaths;
 }

--- a/lib/features/sync/matrix/matrix_message_sender.dart
+++ b/lib/features/sync/matrix/matrix_message_sender.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:isolate';
 import 'dart:typed_data';
 
 import 'package:archive/archive.dart';
@@ -283,17 +284,10 @@ class MatrixMessageSender {
   }) async {
     if (entries.isEmpty) return null;
     final id = bundleId ?? const Uuid().v4();
-    final archive = Archive();
-    for (final entry in entries.entries) {
-      archive.addFile(
-        ArchiveFile(entry.key, entry.value.length, entry.value),
-      );
-    }
-    final encoded = ZipEncoder().encode(archive);
-    final zipBytes = encoded is Uint8List
-        ? encoded
-        : Uint8List.fromList(encoded);
-    final bundlePath = '.bundles/$id.zip';
+    // Encoding can take tens of milliseconds for multi-MiB bundles. Run it
+    // on a worker isolate so it doesn't block UI frames on the sync isolate.
+    final zipBytes = await Isolate.run(() => _encodeBundleBytes(entries));
+    final bundlePath = '$attachmentBundleDirPrefix$id.zip';
     try {
       final eventId = await room.sendFileEvent(
         MatrixFile(bytes: zipBytes, name: '$id.zip'),
@@ -778,4 +772,18 @@ class MatrixMessageContext {
   /// this send. Short-circuits the per-file upload inside `_sendFile` while
   /// keeping the surrounding vector-clock bookkeeping intact.
   final Set<String> skipAttachmentPaths;
+}
+
+/// Worker-isolate entry point for zip encoding. Builds the archive from
+/// [entries] and returns the encoded bytes as a single [Uint8List] so the
+/// archive value does not have to cross the isolate boundary.
+Uint8List _encodeBundleBytes(Map<String, Uint8List> entries) {
+  final archive = Archive();
+  for (final entry in entries.entries) {
+    archive.addFile(
+      ArchiveFile(entry.key, entry.value.length, entry.value),
+    );
+  }
+  final encoded = ZipEncoder().encode(archive);
+  return encoded is Uint8List ? encoded : Uint8List.fromList(encoded);
 }

--- a/lib/features/sync/matrix/matrix_message_sender.dart
+++ b/lib/features/sync/matrix/matrix_message_sender.dart
@@ -284,11 +284,13 @@ class MatrixMessageSender {
   }) async {
     if (entries.isEmpty) return null;
     final id = bundleId ?? const Uuid().v4();
-    // Encoding can take tens of milliseconds for multi-MiB bundles. Run it
-    // on a worker isolate so it doesn't block UI frames on the sync isolate.
-    final zipBytes = await Isolate.run(() => _encodeBundleBytes(entries));
     final bundlePath = '$attachmentBundleDirPrefix$id.zip';
     try {
+      // Encoding can take tens of milliseconds for multi-MiB bundles. Run it
+      // on a worker isolate so it doesn't block UI frames on the sync
+      // isolate, and keep it inside the try so encoder errors are logged the
+      // same way as upload errors instead of propagating as unhandled.
+      final zipBytes = await Isolate.run(() => _encodeBundleBytes(entries));
       final eventId = await room.sendFileEvent(
         MatrixFile(bytes: zipBytes, name: '$id.zip'),
         extraContent: {

--- a/lib/features/sync/matrix/matrix_service.dart
+++ b/lib/features/sync/matrix/matrix_service.dart
@@ -489,6 +489,18 @@ class MatrixService {
       );
       return null;
     }
+    // Mirror [sendMatrixMsg]: block the upload when any room device is
+    // unverified so bundles do not orphan themselves ahead of text events
+    // that the normal send path would (correctly) refuse in the same state.
+    final unverified = getUnverifiedDevices();
+    if (unverified.isNotEmpty) {
+      _loggingService.captureException(
+        'Unverified devices found; skipping attachment bundle',
+        domain: 'MATRIX_SERVICE',
+        subDomain: 'sendAttachmentBundle',
+      );
+      return null;
+    }
     return _messageSender.sendAttachmentBundle(
       room: room,
       entries: entries,

--- a/lib/features/sync/matrix/matrix_service.dart
+++ b/lib/features/sync/matrix/matrix_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:lotti/classes/config.dart';
@@ -436,6 +437,7 @@ class MatrixService {
   Future<bool> sendMatrixMsg(
     SyncMessage syncMessage, {
     String? myRoomId,
+    Set<String> skipAttachmentPaths = const <String>{},
   }) {
     var targetRoom = syncRoom;
     var targetRoomId = syncRoomId;
@@ -465,8 +467,31 @@ class MatrixService {
         syncRoomId: targetRoomId,
         syncRoom: targetRoom,
         unverifiedDevices: getUnverifiedDevices(),
+        skipAttachmentPaths: skipAttachmentPaths,
       ),
       onSent: (String _, SyncMessage _) => incrementSentCountOf(sentType),
+    );
+  }
+
+  /// Uploads a zip containing multiple sync attachment files as a single
+  /// Matrix event. See [MatrixMessageSender.sendAttachmentBundle] for the
+  /// wire format. Returns the bundle event id on success, or null on failure
+  /// or when no sync room is currently available.
+  Future<String?> sendAttachmentBundle({
+    required Map<String, Uint8List> entries,
+  }) async {
+    final room = syncRoom;
+    if (room == null) {
+      _loggingService.captureEvent(
+        'attachment bundle aborted: no sync room',
+        domain: 'MATRIX_SERVICE',
+        subDomain: 'sendAttachmentBundle',
+      );
+      return null;
+    }
+    return _messageSender.sendAttachmentBundle(
+      room: room,
+      entries: entries,
     );
   }
 

--- a/lib/features/sync/matrix/pipeline/attachment_ingestor.dart
+++ b/lib/features/sync/matrix/pipeline/attachment_ingestor.dart
@@ -350,7 +350,7 @@ class AttachmentIngestor {
       // never skips those. For non-agent payloads the vector clock is not
       // validated here; SmartJournalEntityLoader.load() revalidates and
       // re-downloads via DescriptorDownloader if the local file is stale.
-      if (await _shouldSkipExistingFile(file, relativePath)) {
+      if (_shouldSkipExistingFile(file, relativePath)) {
         return false;
       }
 
@@ -430,15 +430,11 @@ class AttachmentIngestor {
   /// the bundle-entry write path. Agent payloads always return false so
   /// in-place updates (e.g. ChangeSetEntity pending → resolved) are never
   /// suppressed.
-  Future<bool> _shouldSkipExistingFile(
-    File target,
-    String relativePath,
-  ) async {
+  bool _shouldSkipExistingFile(File target, String relativePath) {
     if (isAgentPayloadPath(relativePath)) return false;
-    // ignore: avoid_slow_async_io
-    if (!await target.exists()) return false;
+    if (!target.existsSync()) return false;
     try {
-      return await target.length() > 0;
+      return target.lengthSync() > 0;
     } on FileSystemException {
       return false;
     }
@@ -457,9 +453,20 @@ class AttachmentIngestor {
   }) async {
     final docDir = documentsDirectory;
     if (docDir == null) return false;
-    final decoded = await Isolate.run(
-      () => _decodeBundleEntries(downloadedBytes),
-    );
+    final Map<String, Uint8List> decoded;
+    try {
+      decoded = await Isolate.run(
+        () => _decodeBundleEntries(downloadedBytes),
+      );
+    } catch (error, stackTrace) {
+      logging.captureException(
+        error,
+        domain: syncLoggingDomain,
+        subDomain: 'attachment.bundle.decode',
+        stackTrace: stackTrace,
+      );
+      return false;
+    }
     var writtenCount = 0;
     var totalBytes = 0;
     var skippedCount = 0;
@@ -474,7 +481,7 @@ class AttachmentIngestor {
         );
         continue;
       }
-      if (await _shouldSkipExistingFile(target, entryPath)) {
+      if (_shouldSkipExistingFile(target, entryPath)) {
         skippedCount++;
         continue;
       }

--- a/lib/features/sync/matrix/pipeline/attachment_ingestor.dart
+++ b/lib/features/sync/matrix/pipeline/attachment_ingestor.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:io';
 
+import 'package:archive/archive.dart';
 import 'package:lotti/database/logging_types.dart';
 import 'package:lotti/features/sync/matrix/consts.dart';
 import 'package:lotti/features/sync/matrix/pipeline/attachment_index.dart';
@@ -381,6 +382,18 @@ class AttachmentIngestor {
         return false;
       }
 
+      // Bundle attachments ship a zip whose entries are addressed by their
+      // real relative paths. Unpack each entry via the same target-file +
+      // agent-dedup logic used for individual attachments and skip writing
+      // the outer zip itself to disk.
+      if (event.content[attachmentBundleKey] == true) {
+        return _unpackBundle(
+          bundleRelativePath: relativePath,
+          downloadedBytes: downloadedBytes,
+          logging: logging,
+        );
+      }
+
       final bytes = decodeAttachmentBytes(
         event: event,
         downloadedBytes: downloadedBytes,
@@ -421,6 +434,61 @@ class AttachmentIngestor {
       );
       return false;
     }
+  }
+
+  /// Unpacks a zip bundle. Each entry's name is its target relative path
+  /// inside the documents directory. Entries are routed through
+  /// [_targetFile] for path-traversal guarding and apply the same non-agent
+  /// dedup rule as single-file saves: if a non-agent file already exists and
+  /// is non-empty locally, skip it. Agent-payload entries are always
+  /// overwritten to match single-file semantics.
+  Future<bool> _unpackBundle({
+    required String bundleRelativePath,
+    required Uint8List downloadedBytes,
+    required LoggingService logging,
+  }) async {
+    final docDir = documentsDirectory;
+    if (docDir == null) return false;
+    final archive = ZipDecoder().decodeBytes(downloadedBytes);
+    var writtenCount = 0;
+    var totalBytes = 0;
+    var skippedCount = 0;
+    for (final entry in archive) {
+      if (!entry.isFile) continue;
+      final entryPath = entry.name;
+      final target = _targetFile(entryPath);
+      if (target == null) {
+        logging.captureEvent(
+          'pathTraversal.blocked bundleEntry=$entryPath '
+          'outer=$bundleRelativePath',
+          domain: syncLoggingDomain,
+          subDomain: 'attachment.bundle.entry',
+        );
+        continue;
+      }
+      final isAgentPayload = isAgentPayloadPath(entryPath);
+      if (!isAgentPayload && target.existsSync() && target.lengthSync() > 0) {
+        skippedCount++;
+        continue;
+      }
+      final bytes = entry.content;
+      await atomicWriteBytes(
+        bytes: bytes,
+        filePath: target.path,
+        logging: logging,
+        subDomain: 'attachment.bundle.write',
+      );
+      writtenCount++;
+      totalBytes += bytes.length;
+    }
+    logging.captureEvent(
+      'bundleUnpacked outer=$bundleRelativePath '
+      'entries=${archive.length} written=$writtenCount '
+      'skipped=$skippedCount bytes=$totalBytes',
+      domain: syncLoggingDomain,
+      subDomain: 'attachment.bundle.unpack',
+    );
+    return writtenCount > 0;
   }
 }
 

--- a/lib/features/sync/matrix/pipeline/attachment_ingestor.dart
+++ b/lib/features/sync/matrix/pipeline/attachment_ingestor.dart
@@ -3,6 +3,8 @@
 import 'dart:async';
 import 'dart:collection';
 import 'dart:io';
+import 'dart:isolate';
+import 'dart:typed_data';
 
 import 'package:archive/archive.dart';
 import 'package:lotti/database/logging_types.dart';
@@ -344,25 +346,12 @@ class AttachmentIngestor {
       }
 
       // Agent entities/links can be legitimately updated in-place (e.g.
-      // ChangeSetEntity pending → resolved). Always re-download to avoid
-      // stale reads.
-      final isAgentPayload = isAgentPayloadPath(relativePath);
-
-      // Fast-path dedupe (non-agent only): if the file already exists and is
-      // non-empty, skip re-downloading to avoid repeated writes and log spam.
-      // Note: We don't validate the file's vector clock here because
-      // SmartJournalEntityLoader.load() will do that validation and
-      // re-download via DescriptorDownloader if the local file is stale.
-      // ignore: avoid_slow_async_io
-      if (!isAgentPayload && await file.exists()) {
-        try {
-          final len = await file.length();
-          if (len > 0) {
-            return false; // already present
-          }
-        } catch (_) {
-          // If querying length fails, fall through to re-download.
-        }
+      // ChangeSetEntity pending → resolved), so [_shouldSkipExistingFile]
+      // never skips those. For non-agent payloads the vector clock is not
+      // validated here; SmartJournalEntityLoader.load() revalidates and
+      // re-downloads via DescriptorDownloader if the local file is stale.
+      if (await _shouldSkipExistingFile(file, relativePath)) {
+        return false;
       }
 
       logging.captureEvent(
@@ -436,12 +425,31 @@ class AttachmentIngestor {
     }
   }
 
+  /// Returns true when [target] should NOT be downloaded/written again —
+  /// the non-agent dedup rule used by both the single-file save path and
+  /// the bundle-entry write path. Agent payloads always return false so
+  /// in-place updates (e.g. ChangeSetEntity pending → resolved) are never
+  /// suppressed.
+  Future<bool> _shouldSkipExistingFile(
+    File target,
+    String relativePath,
+  ) async {
+    if (isAgentPayloadPath(relativePath)) return false;
+    // ignore: avoid_slow_async_io
+    if (!await target.exists()) return false;
+    try {
+      return await target.length() > 0;
+    } on FileSystemException {
+      return false;
+    }
+  }
+
   /// Unpacks a zip bundle. Each entry's name is its target relative path
   /// inside the documents directory. Entries are routed through
-  /// [_targetFile] for path-traversal guarding and apply the same non-agent
-  /// dedup rule as single-file saves: if a non-agent file already exists and
-  /// is non-empty locally, skip it. Agent-payload entries are always
-  /// overwritten to match single-file semantics.
+  /// [_targetFile] for path-traversal guarding and through
+  /// [_shouldSkipExistingFile] for the same non-agent dedup rule used by
+  /// single-file saves. Zip decoding runs on a worker isolate to keep the
+  /// sync isolate free for frame work while large bundles are parsed.
   Future<bool> _unpackBundle({
     required String bundleRelativePath,
     required Uint8List downloadedBytes,
@@ -449,13 +457,13 @@ class AttachmentIngestor {
   }) async {
     final docDir = documentsDirectory;
     if (docDir == null) return false;
-    final archive = ZipDecoder().decodeBytes(downloadedBytes);
+    final decoded = await Isolate.run(
+      () => _decodeBundleEntries(downloadedBytes),
+    );
     var writtenCount = 0;
     var totalBytes = 0;
     var skippedCount = 0;
-    for (final entry in archive) {
-      if (!entry.isFile) continue;
-      final entryPath = entry.name;
+    for (final entryPath in decoded.keys) {
       final target = _targetFile(entryPath);
       if (target == null) {
         logging.captureEvent(
@@ -466,12 +474,11 @@ class AttachmentIngestor {
         );
         continue;
       }
-      final isAgentPayload = isAgentPayloadPath(entryPath);
-      if (!isAgentPayload && target.existsSync() && target.lengthSync() > 0) {
+      if (await _shouldSkipExistingFile(target, entryPath)) {
         skippedCount++;
         continue;
       }
-      final bytes = entry.content;
+      final bytes = decoded[entryPath]!;
       await atomicWriteBytes(
         bytes: bytes,
         filePath: target.path,
@@ -483,7 +490,7 @@ class AttachmentIngestor {
     }
     logging.captureEvent(
       'bundleUnpacked outer=$bundleRelativePath '
-      'entries=${archive.length} written=$writtenCount '
+      'entries=${decoded.length} written=$writtenCount '
       'skipped=$skippedCount bytes=$totalBytes',
       domain: syncLoggingDomain,
       subDomain: 'attachment.bundle.unpack',
@@ -491,6 +498,18 @@ class AttachmentIngestor {
     return writtenCount > 0;
   }
 }
+
+/// Worker-isolate entry point for [ZipDecoder]. Returns a plain
+/// `relativePath -> bytes` map of file entries so the decoded archive does
+/// not have to cross the isolate boundary.
+Map<String, Uint8List> _decodeBundleEntries(Uint8List downloadedBytes) {
+  final archive = ZipDecoder().decodeBytes(downloadedBytes);
+  return {
+    for (final entry in archive)
+      if (entry.isFile) entry.name: entry.content,
+  };
+}
+
 
 class _DownloadRequest {
   const _DownloadRequest({

--- a/lib/features/sync/matrix/pipeline/attachment_ingestor.dart
+++ b/lib/features/sync/matrix/pipeline/attachment_ingestor.dart
@@ -56,6 +56,17 @@ class AttachmentIngestor {
       <String, _DownloadRequest>{};
   final Set<String> _handledAttachmentEventIds = <String>{};
   final Queue<String> _handledAttachmentEventOrder = Queue<String>();
+  // Bundle events whose zip was successfully decoded and routed through the
+  // per-entry write path. Populated only after [_unpackBundle] returns from
+  // a successful decode — a failed download or decode leaves the id out so
+  // subsequent catch-up passes retry the bundle. Without this separation a
+  // first-pass failure would orphan the bundled items forever: each inner
+  // relativePath is never registered in AttachmentIndex, so
+  // DescriptorDownloader cannot re-fetch it, and the per-counter gap
+  // detection in SyncSequenceLogService never fires because the text event
+  // itself was received.
+  final Set<String> _appliedBundleEventIds = <String>{};
+  final Queue<String> _appliedBundleEventOrder = Queue<String>();
   final Set<String> _queuedKeys = <String>{};
   final Set<String> _inFlightKeys = <String>{};
 
@@ -102,20 +113,24 @@ class AttachmentIngestor {
       // Suppress repair if a save is already in flight for this path to avoid
       // concurrent writes to the same file.
       //
-      // Bundle events are special-cased: their outer `.bundles/<id>.zip`
-      // path is never written locally (we only persist the unpacked entries),
-      // so [_isLocalFileMissingOrEmpty] would always report true and trigger
-      // an endless re-download of the bundle on every catch-up pass. Once
-      // the bundle event id is recorded as handled, skip re-processing — the
-      // inner files will be repaired through their own per-entry descriptor
-      // events if they go missing.
+      // Bundle events use a different "needs repair" signal: their outer
+      // `.bundles/<id>.zip` path is never persisted (we write the unpacked
+      // entries instead), so [_isLocalFileMissingOrEmpty] would always
+      // report true and drive an endless re-download on every pass. Instead,
+      // retry until the zip has been successfully decoded
+      // ([_appliedBundleEventIds] records that state), and stop once
+      // applied. This recovers from a failed first-pass unpack without
+      // permanently orphaning the bundled items.
       final isBundleEvent = event.content[attachmentBundleKey] == true;
+      final bundleNotYetApplied =
+          isBundleEvent && !_appliedBundleEventIds.contains(event.eventId);
       final shouldRepairLocal =
           alreadyHandled &&
           documentsDirectory != null &&
-          !isBundleEvent &&
           !_inFlightSavePaths.contains(_normalizeKey(rpAny)) &&
-          _isLocalFileMissingOrEmpty(rpAny);
+          (isBundleEvent
+              ? bundleNotYetApplied
+              : _isLocalFileMissingOrEmpty(rpAny));
       final shouldProcessAttachment = !alreadyHandled || shouldRepairLocal;
 
       if (shouldProcessAttachment) {
@@ -285,6 +300,17 @@ class AttachmentIngestor {
     }
   }
 
+  void _recordAppliedBundleEvent(String eventId) {
+    if (_appliedBundleEventIds.add(eventId)) {
+      _appliedBundleEventOrder.addLast(eventId);
+      while (_appliedBundleEventOrder.length >
+          _handledAttachmentEventCapacity) {
+        final oldest = _appliedBundleEventOrder.removeFirst();
+        _appliedBundleEventIds.remove(oldest);
+      }
+    }
+  }
+
   String _normalizeKey(String relativePath) =>
       normalizeAttachmentIndexKey(relativePath);
 
@@ -387,6 +413,7 @@ class AttachmentIngestor {
       // the outer zip itself to disk.
       if (event.content[attachmentBundleKey] == true) {
         return _unpackBundle(
+          eventId: event.eventId,
           bundleRelativePath: relativePath,
           downloadedBytes: downloadedBytes,
           logging: logging,
@@ -457,6 +484,7 @@ class AttachmentIngestor {
   /// single-file saves. Zip decoding runs on a worker isolate to keep the
   /// sync isolate free for frame work while large bundles are parsed.
   Future<bool> _unpackBundle({
+    required String eventId,
     required String bundleRelativePath,
     required Uint8List downloadedBytes,
     required LoggingService logging,
@@ -475,8 +503,19 @@ class AttachmentIngestor {
         subDomain: 'attachment.bundle.decode',
         stackTrace: stackTrace,
       );
+      // Decode failed — do NOT mark applied so the next catch-up pass can
+      // retry the download and unpack. Without this recovery the bundled
+      // items' text events would be stuck: inner relativePaths are never in
+      // AttachmentIndex and DescriptorDownloader has nothing to pull.
       return false;
     }
+    // Decode succeeded. Record the event id as applied now, before the
+    // per-entry write loop — writes happen atomically per file and any one
+    // failing doesn't change whether the bundle itself was delivered. A
+    // single entry's write failure is recovered through the normal retry
+    // path that fires when its text event applies, not by re-downloading
+    // the whole zip.
+    _recordAppliedBundleEvent(eventId);
     var writtenCount = 0;
     var totalBytes = 0;
     var skippedCount = 0;

--- a/lib/features/sync/matrix/pipeline/attachment_ingestor.dart
+++ b/lib/features/sync/matrix/pipeline/attachment_ingestor.dart
@@ -101,9 +101,19 @@ class AttachmentIngestor {
       // handled once — new events always proceed.
       // Suppress repair if a save is already in flight for this path to avoid
       // concurrent writes to the same file.
+      //
+      // Bundle events are special-cased: their outer `.bundles/<id>.zip`
+      // path is never written locally (we only persist the unpacked entries),
+      // so [_isLocalFileMissingOrEmpty] would always report true and trigger
+      // an endless re-download of the bundle on every catch-up pass. Once
+      // the bundle event id is recorded as handled, skip re-processing — the
+      // inner files will be repaired through their own per-entry descriptor
+      // events if they go missing.
+      final isBundleEvent = event.content[attachmentBundleKey] == true;
       final shouldRepairLocal =
           alreadyHandled &&
           documentsDirectory != null &&
+          !isBundleEvent &&
           !_inFlightSavePaths.contains(_normalizeKey(rpAny)) &&
           _isLocalFileMissingOrEmpty(rpAny);
       final shouldProcessAttachment = !alreadyHandled || shouldRepairLocal;
@@ -516,7 +526,6 @@ Map<String, Uint8List> _decodeBundleEntries(Uint8List downloadedBytes) {
       if (entry.isFile) entry.name: entry.content,
   };
 }
-
 
 class _DownloadRequest {
   const _DownloadRequest({

--- a/lib/features/sync/outbox/outbox_processor.dart
+++ b/lib/features/sync/outbox/outbox_processor.dart
@@ -304,13 +304,19 @@ class OutboxProcessor {
       }
     }
 
+    // Stop bundling at the first pending item that cannot join the bundle —
+    // skipping it and packing later items would ship those before this one,
+    // violating the outbox's head-first ordering and creating avoidable
+    // causal gaps. The non-bundleable item itself will be sent via the
+    // existing head-only flow (either this tick if bundled ends up empty, or
+    // on the next tick once the bundle is drained).
     final bundled = <({OutboxItem item, List<AttachmentDescriptor> atts})>[];
     var bundleSize = 0;
     for (final e in enumerated) {
-      if (e.atts.isEmpty) continue;
+      if (e.atts.isEmpty) break;
       final total = e.atts.fold<int>(0, (s, a) => s + a.size);
-      if (total > SyncTuning.outboxBundleMaxBytes) continue;
-      if (bundleSize + total > SyncTuning.outboxBundleMaxBytes) continue;
+      if (total > SyncTuning.outboxBundleMaxBytes) break;
+      if (bundleSize + total > SyncTuning.outboxBundleMaxBytes) break;
       bundled.add(e);
       bundleSize += total;
     }
@@ -384,15 +390,29 @@ class OutboxProcessor {
         continue;
       }
       var timedOut = false;
-      final ok = await _messageSender
-          .send(msg, skipAttachmentPaths: skipSet)
-          .timeout(
-            sendTimeout,
-            onTimeout: () {
-              timedOut = true;
-              return false;
-            },
-          );
+      bool ok;
+      try {
+        ok = await _messageSender
+            .send(msg, skipAttachmentPaths: skipSet)
+            .timeout(
+              sendTimeout,
+              onTimeout: () {
+                timedOut = true;
+                return false;
+              },
+            );
+      } catch (error, stackTrace) {
+        _loggingService.captureException(
+          error,
+          domain: 'OUTBOX',
+          subDomain: 'bundle.send',
+          stackTrace: stackTrace,
+        );
+        await _repository.markRetry(refreshed);
+        _recordBundleItemFailure(refreshed, timedOut: timedOut);
+        anyFailure = true;
+        continue;
+      }
       if (ok) {
         if (_lastFailedSubject == refreshed.subject) {
           _lastFailedSubject = null;

--- a/lib/features/sync/outbox/outbox_processor.dart
+++ b/lib/features/sync/outbox/outbox_processor.dart
@@ -59,7 +59,6 @@ class OutboxProcessor {
     DomainLogger? domainLogger,
     JournalDb? journalDb,
     Directory? documentsDirectory,
-    int? bundleMaxBytesOverride,
   }) : _repository = repository,
        _messageSender = messageSender,
        _loggingService = loggingService,
@@ -71,9 +70,7 @@ class OutboxProcessor {
        errorDelay = errorDelayOverride ?? SyncTuning.outboxErrorDelay,
        maxRetriesForDiagnostics =
            maxRetriesOverride ?? SyncTuning.outboxMaxRetriesDiagnostics,
-       sendTimeout = sendTimeoutOverride ?? SyncTuning.outboxSendTimeout,
-       bundleMaxBytes =
-           bundleMaxBytesOverride ?? SyncTuning.outboxBundleMaxBytes;
+       sendTimeout = sendTimeoutOverride ?? SyncTuning.outboxSendTimeout;
 
   final OutboxRepository _repository;
   final OutboxMessageSender _messageSender;
@@ -86,7 +83,6 @@ class OutboxProcessor {
   final Duration errorDelay;
   final int maxRetriesForDiagnostics;
   final Duration sendTimeout;
-  final int bundleMaxBytes;
 
   void _syncLog(String message, {String? subDomain}) {
     _domainLogger?.log(LogDomains.sync, message, subDomain: subDomain);
@@ -102,12 +98,6 @@ class OutboxProcessor {
       return OutboxProcessingResult.none;
     }
 
-    // When the feature flag is on and enough items are pending to gain from
-    // one Matrix round-trip, attempt an attachment-bundle send first. The
-    // helper returns null when bundling is disabled or nothing was
-    // bundleable (e.g. every pending item's attachments exceed the cap or
-    // carry no files at all), so the existing head-only flow still runs as
-    // the default path.
     final bundleOutcome = await _maybeProcessBundle(pendingItems);
     if (bundleOutcome != null) return bundleOutcome;
 
@@ -279,11 +269,17 @@ class OutboxProcessor {
   }
 
   /// Attempts to coalesce as many of [pending] items' attachment files as
-  /// fit into a single zip (capped at [bundleMaxBytes]) and uploads them as
-  /// one Matrix file event before sending each included item's text event
-  /// with the bundled paths marked for skip. Returns null when bundling is
-  /// disabled or nothing was bundleable, so the caller can fall through to
-  /// the existing head-only flow.
+  /// fit into a single zip (capped at [SyncTuning.outboxBundleMaxBytes]) and
+  /// uploads them as one Matrix file event before sending each included
+  /// item's text event with the bundled paths marked for skip.
+  ///
+  /// Returns null when bundling is disabled or nothing was bundleable (e.g.
+  /// the batch carries no attachment files or every item's attachments
+  /// exceed the cap on their own), so the caller can fall through to the
+  /// existing head-only flow. Per-item failures mark only that item for
+  /// retry and mirror the head-only diagnostic retry-cap semantics so a
+  /// permanently failing item in a bundle still surfaces
+  /// `retryCapReached`.
   Future<OutboxProcessingResult?> _maybeProcessBundle(
     List<OutboxItem> pending,
   ) async {
@@ -294,8 +290,6 @@ class OutboxProcessor {
     final bundlingOn = await db.getConfigFlag(useBundledAttachmentsFlag);
     if (!bundlingOn) return null;
 
-    // Enumerate attachments per item. Items that fail to decode or have no
-    // attachments are kept for the solo path.
     final enumerated = <({OutboxItem item, List<AttachmentDescriptor> atts})>[];
     for (final item in pending) {
       try {
@@ -310,33 +304,22 @@ class OutboxProcessor {
       }
     }
 
-    // Partition greedily: an item is included in the bundle if its own
-    // attachments fit within the remaining bundle budget. Items whose total
-    // attachment size exceeds the cap on their own go to the solo path via
-    // the existing head-only flow on the next tick.
     final bundled = <({OutboxItem item, List<AttachmentDescriptor> atts})>[];
     var bundleSize = 0;
     for (final e in enumerated) {
       if (e.atts.isEmpty) continue;
       final total = e.atts.fold<int>(0, (s, a) => s + a.size);
-      if (total > bundleMaxBytes) continue;
-      if (bundleSize + total > bundleMaxBytes) continue;
+      if (total > SyncTuning.outboxBundleMaxBytes) continue;
+      if (bundleSize + total > SyncTuning.outboxBundleMaxBytes) continue;
       bundled.add(e);
       bundleSize += total;
     }
 
     if (bundled.isEmpty) return null;
 
-    // Read file contents and pack into the payload map. Any read failure
-    // falls through to the existing solo path, where the usual error handling
-    // applies per item.
-    final entries = <String, Uint8List>{};
+    final Map<String, Uint8List> entries;
     try {
-      for (final e in bundled) {
-        for (final a in e.atts) {
-          entries[a.relativePath] = await File(a.fullPath).readAsBytes();
-        }
-      }
+      entries = await _readBundleEntries(bundled);
     } catch (err, stackTrace) {
       _loggingService.captureException(
         err,
@@ -380,8 +363,6 @@ class OutboxProcessor {
       subDomain: 'bundle.ok',
     );
 
-    // Send each bundled item's text event. Per-item failures mark that item
-    // for retry without affecting the others.
     final skipSet = entries.keys.toSet();
     var anyFailure = false;
     for (final e in bundled) {
@@ -398,6 +379,7 @@ class OutboxProcessor {
           stackTrace: stackTrace,
         );
         await _repository.markRetry(refreshed);
+        _recordBundleItemFailure(refreshed);
         anyFailure = true;
         continue;
       }
@@ -412,15 +394,15 @@ class OutboxProcessor {
             },
           );
       if (ok) {
+        if (_lastFailedSubject == refreshed.subject) {
+          _lastFailedSubject = null;
+          _lastFailedRepeats = 0;
+        }
         await _repository.markSent(refreshed);
       } else {
         await _repository.markRetry(refreshed);
+        _recordBundleItemFailure(refreshed, timedOut: timedOut);
         anyFailure = true;
-        _syncLog(
-          'bundle text-event sendFail subject=${refreshed.subject} '
-          'timedOut=$timedOut',
-          subDomain: 'outbox.bundle.retry',
-        );
       }
     }
 
@@ -431,5 +413,72 @@ class OutboxProcessor {
       );
     }
     return OutboxProcessingResult.none;
+  }
+
+  /// Reads the per-file bytes for every attachment the enumerator chose for
+  /// [bundled]. Bytes already cached on a descriptor (the JSON payload the
+  /// enumerator parsed to find media paths) are reused so the same file is
+  /// not read twice; missing media bytes are loaded in parallel.
+  Future<Map<String, Uint8List>> _readBundleEntries(
+    List<({OutboxItem item, List<AttachmentDescriptor> atts})> bundled,
+  ) async {
+    final entries = <String, Uint8List>{};
+    final pendingReads = <Future<void>>[];
+    for (final e in bundled) {
+      for (final a in e.atts) {
+        final cached = a.bytes;
+        if (cached != null) {
+          entries[a.relativePath] = cached;
+          continue;
+        }
+        pendingReads.add(
+          File(a.fullPath).readAsBytes().then((bytes) {
+            entries[a.relativePath] = bytes;
+          }),
+        );
+      }
+    }
+    await Future.wait(pendingReads);
+    return entries;
+  }
+
+  /// Applies the head-only flow's retry-cap and repeat-subject diagnostics
+  /// to a failing bundled item so that permanent failures surface
+  /// `retryCapReached` even when they arrive via a bundle.
+  void _recordBundleItemFailure(
+    OutboxItem refreshed, {
+    bool timedOut = false,
+  }) {
+    final nextAttempts = refreshed.retries + 1;
+    if (_lastFailedSubject == refreshed.subject) {
+      _lastFailedRepeats++;
+    } else {
+      _lastFailedSubject = refreshed.subject;
+      _lastFailedRepeats = 1;
+    }
+    _syncLog(
+      'bundle sendFail subject=${refreshed.subject} '
+      'attempts=$nextAttempts timedOut=$timedOut',
+      subDomain: 'outbox.bundle.retry',
+    );
+    try {
+      _loggingService.captureEvent(
+        'bundle sendFailed subject=${refreshed.subject} '
+        'attempts=$nextAttempts repeats=$_lastFailedRepeats '
+        'backoffMs=${retryDelay.inMilliseconds} timedOut=$timedOut',
+        domain: 'OUTBOX',
+        subDomain: 'bundle.retry',
+      );
+    } catch (_) {}
+    if (nextAttempts >= maxRetriesForDiagnostics) {
+      try {
+        _loggingService.captureEvent(
+          'retryCapReached subject=${refreshed.subject} '
+          'attempts=$nextAttempts status=error → bundle',
+          domain: 'OUTBOX',
+          subDomain: 'retry.cap',
+        );
+      } catch (_) {}
+    }
   }
 }

--- a/lib/features/sync/outbox/outbox_processor.dart
+++ b/lib/features/sync/outbox/outbox_processor.dart
@@ -1,17 +1,36 @@
-// ignore_for_file: one_member_abstracts, sort_constructors_first
+// ignore_for_file: sort_constructors_first
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
 
+import 'package:lotti/database/database.dart';
 import 'package:lotti/database/sync_db.dart';
+import 'package:lotti/features/sync/matrix/attachment_enumerator.dart';
 import 'package:lotti/features/sync/model/sync_message.dart';
 import 'package:lotti/features/sync/outbox/outbox_repository.dart';
 import 'package:lotti/features/sync/tuning.dart';
 import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/logging_service.dart';
+import 'package:lotti/utils/consts.dart';
 
 abstract class OutboxMessageSender {
-  Future<bool> send(SyncMessage message);
+  /// Sends [message]. When [skipAttachmentPaths] is non-empty, the sender must
+  /// skip uploading any file whose relative path is in the set — typically
+  /// because the file was already uploaded out-of-band via
+  /// [sendAttachmentBundle].
+  Future<bool> send(
+    SyncMessage message, {
+    Set<String> skipAttachmentPaths = const <String>{},
+  });
+
+  /// Packages the supplied relativePath→bytes [entries] into a single zip
+  /// archive and uploads it as one Matrix file event. Returns the event id on
+  /// success, null on failure (including no available sync room).
+  Future<String?> sendAttachmentBundle({
+    required Map<String, Uint8List> entries,
+  });
 }
 
 class OutboxProcessingResult {
@@ -38,26 +57,36 @@ class OutboxProcessor {
     int? maxRetriesOverride,
     Duration? sendTimeoutOverride,
     DomainLogger? domainLogger,
+    JournalDb? journalDb,
+    Directory? documentsDirectory,
+    int? bundleMaxBytesOverride,
   }) : _repository = repository,
        _messageSender = messageSender,
        _loggingService = loggingService,
        _domainLogger = domainLogger,
+       _journalDb = journalDb,
+       _documentsDirectory = documentsDirectory,
        batchSize = batchSizeOverride ?? 10,
        retryDelay = retryDelayOverride ?? SyncTuning.outboxRetryDelay,
        errorDelay = errorDelayOverride ?? SyncTuning.outboxErrorDelay,
        maxRetriesForDiagnostics =
            maxRetriesOverride ?? SyncTuning.outboxMaxRetriesDiagnostics,
-       sendTimeout = sendTimeoutOverride ?? SyncTuning.outboxSendTimeout;
+       sendTimeout = sendTimeoutOverride ?? SyncTuning.outboxSendTimeout,
+       bundleMaxBytes =
+           bundleMaxBytesOverride ?? SyncTuning.outboxBundleMaxBytes;
 
   final OutboxRepository _repository;
   final OutboxMessageSender _messageSender;
   final LoggingService _loggingService;
   final DomainLogger? _domainLogger;
+  final JournalDb? _journalDb;
+  final Directory? _documentsDirectory;
   final int batchSize;
   final Duration retryDelay;
   final Duration errorDelay;
   final int maxRetriesForDiagnostics;
   final Duration sendTimeout;
+  final int bundleMaxBytes;
 
   void _syncLog(String message, {String? subDomain}) {
     _domainLogger?.log(LogDomains.sync, message, subDomain: subDomain);
@@ -72,6 +101,15 @@ class OutboxProcessor {
     if (pendingItems.isEmpty) {
       return OutboxProcessingResult.none;
     }
+
+    // When the feature flag is on and enough items are pending to gain from
+    // one Matrix round-trip, attempt an attachment-bundle send first. The
+    // helper returns null when bundling is disabled or nothing was
+    // bundleable (e.g. every pending item's attachments exceed the cap or
+    // carry no files at all), so the existing head-only flow still runs as
+    // the default path.
+    final bundleOutcome = await _maybeProcessBundle(pendingItems);
+    if (bundleOutcome != null) return bundleOutcome;
 
     final nextItem = pendingItems.first;
     try {
@@ -238,5 +276,160 @@ class OutboxProcessor {
   SyncMessage _decodeMessage(OutboxItem item) {
     final jsonMap = json.decode(item.message) as Map<String, dynamic>;
     return SyncMessage.fromJson(jsonMap);
+  }
+
+  /// Attempts to coalesce as many of [pending] items' attachment files as
+  /// fit into a single zip (capped at [bundleMaxBytes]) and uploads them as
+  /// one Matrix file event before sending each included item's text event
+  /// with the bundled paths marked for skip. Returns null when bundling is
+  /// disabled or nothing was bundleable, so the caller can fall through to
+  /// the existing head-only flow.
+  Future<OutboxProcessingResult?> _maybeProcessBundle(
+    List<OutboxItem> pending,
+  ) async {
+    final docDir = _documentsDirectory;
+    final db = _journalDb;
+    if (docDir == null || db == null) return null;
+
+    final bundlingOn = await db.getConfigFlag(useBundledAttachmentsFlag);
+    if (!bundlingOn) return null;
+
+    // Enumerate attachments per item. Items that fail to decode or have no
+    // attachments are kept for the solo path.
+    final enumerated = <({OutboxItem item, List<AttachmentDescriptor> atts})>[];
+    for (final item in pending) {
+      try {
+        final msg = _decodeMessage(item);
+        final atts = await enumerateAttachments(
+          message: msg,
+          documentsDirectory: docDir,
+        );
+        enumerated.add((item: item, atts: atts));
+      } catch (_) {
+        enumerated.add((item: item, atts: const <AttachmentDescriptor>[]));
+      }
+    }
+
+    // Partition greedily: an item is included in the bundle if its own
+    // attachments fit within the remaining bundle budget. Items whose total
+    // attachment size exceeds the cap on their own go to the solo path via
+    // the existing head-only flow on the next tick.
+    final bundled = <({OutboxItem item, List<AttachmentDescriptor> atts})>[];
+    var bundleSize = 0;
+    for (final e in enumerated) {
+      if (e.atts.isEmpty) continue;
+      final total = e.atts.fold<int>(0, (s, a) => s + a.size);
+      if (total > bundleMaxBytes) continue;
+      if (bundleSize + total > bundleMaxBytes) continue;
+      bundled.add(e);
+      bundleSize += total;
+    }
+
+    if (bundled.isEmpty) return null;
+
+    // Read file contents and pack into the payload map. Any read failure
+    // falls through to the existing solo path, where the usual error handling
+    // applies per item.
+    final entries = <String, Uint8List>{};
+    try {
+      for (final e in bundled) {
+        for (final a in e.atts) {
+          entries[a.relativePath] = await File(a.fullPath).readAsBytes();
+        }
+      }
+    } catch (err, stackTrace) {
+      _loggingService.captureException(
+        err,
+        domain: 'OUTBOX',
+        subDomain: 'bundle.readFiles',
+        stackTrace: stackTrace,
+      );
+      return null;
+    }
+
+    _loggingService.captureEvent(
+      'bundle packing items=${bundled.length} files=${entries.length} '
+      'bytes=$bundleSize',
+      domain: 'OUTBOX',
+      subDomain: 'bundle.pack',
+    );
+    _syncLog(
+      'bundle pack items=${bundled.length} files=${entries.length} '
+      'bytes=$bundleSize',
+      subDomain: 'outbox.bundle.pack',
+    );
+
+    final bundleEventId = await _messageSender.sendAttachmentBundle(
+      entries: entries,
+    );
+    if (bundleEventId == null) {
+      for (final e in bundled) {
+        await _repository.markRetry(e.item);
+      }
+      _loggingService.captureEvent(
+        'bundle upload failed items=${bundled.length}',
+        domain: 'OUTBOX',
+        subDomain: 'bundle.fail',
+      );
+      return OutboxProcessingResult.schedule(errorDelay);
+    }
+    _loggingService.captureEvent(
+      'bundle uploaded eventId=$bundleEventId items=${bundled.length} '
+      'bytes=$bundleSize',
+      domain: 'OUTBOX',
+      subDomain: 'bundle.ok',
+    );
+
+    // Send each bundled item's text event. Per-item failures mark that item
+    // for retry without affecting the others.
+    final skipSet = entries.keys.toSet();
+    var anyFailure = false;
+    for (final e in bundled) {
+      final refreshed = await _repository.refreshItem(e.item);
+      if (refreshed == null) continue;
+      final SyncMessage msg;
+      try {
+        msg = _decodeMessage(refreshed);
+      } catch (error, stackTrace) {
+        _loggingService.captureException(
+          error,
+          domain: 'OUTBOX',
+          subDomain: 'bundle.decode',
+          stackTrace: stackTrace,
+        );
+        await _repository.markRetry(refreshed);
+        anyFailure = true;
+        continue;
+      }
+      var timedOut = false;
+      final ok = await _messageSender
+          .send(msg, skipAttachmentPaths: skipSet)
+          .timeout(
+            sendTimeout,
+            onTimeout: () {
+              timedOut = true;
+              return false;
+            },
+          );
+      if (ok) {
+        await _repository.markSent(refreshed);
+      } else {
+        await _repository.markRetry(refreshed);
+        anyFailure = true;
+        _syncLog(
+          'bundle text-event sendFail subject=${refreshed.subject} '
+          'timedOut=$timedOut',
+          subDomain: 'outbox.bundle.retry',
+        );
+      }
+    }
+
+    final remaining = pending.length - bundled.length;
+    if (remaining > 0 || anyFailure) {
+      return OutboxProcessingResult.schedule(
+        anyFailure ? retryDelay : Duration.zero,
+      );
+    }
+    return OutboxProcessingResult.none;
   }
 }

--- a/lib/features/sync/outbox/outbox_service.dart
+++ b/lib/features/sync/outbox/outbox_service.dart
@@ -1623,7 +1623,20 @@ class MatrixOutboxMessageSender implements OutboxMessageSender {
   final MatrixService _matrixService;
 
   @override
-  Future<bool> send(SyncMessage message) {
-    return _matrixService.sendMatrixMsg(message);
+  Future<bool> send(
+    SyncMessage message, {
+    Set<String> skipAttachmentPaths = const <String>{},
+  }) {
+    return _matrixService.sendMatrixMsg(
+      message,
+      skipAttachmentPaths: skipAttachmentPaths,
+    );
+  }
+
+  @override
+  Future<String?> sendAttachmentBundle({
+    required Map<String, Uint8List> entries,
+  }) {
+    return _matrixService.sendAttachmentBundle(entries: entries);
   }
 }

--- a/lib/features/sync/outbox/outbox_service.dart
+++ b/lib/features/sync/outbox/outbox_service.dart
@@ -93,6 +93,8 @@ class OutboxService {
           loggingService: _loggingService,
           maxRetriesOverride: maxRetries,
           domainLogger: _domainLogger,
+          journalDb: _journalDb,
+          documentsDirectory: _documentsDirectory,
         );
 
     _startRunner();

--- a/lib/features/sync/tuning.dart
+++ b/lib/features/sync/tuning.dart
@@ -144,4 +144,12 @@ class SyncTuning {
   // is more restrictive. Deeper historical backfill requires manual trigger.
   static const Duration defaultBackfillMaxAge = Duration(days: 1);
   static const int defaultBackfillMaxEntriesPerHost = 250;
+
+  // Outbox attachment bundling. When the feature flag is on, the outbox packs
+  // as many pending items' attachment files as fit into one zip capped at
+  // [outboxBundleMaxBytes] and uploads them as a single Matrix file event.
+  // Items whose attachments exceed the cap are sent individually through the
+  // existing path. The cap is conservative relative to typical homeserver
+  // media limits (Synapse default 50 MiB, federated hosts often 10-20 MiB).
+  static const int outboxBundleMaxBytes = 8 * 1024 * 1024;
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -795,6 +795,8 @@
   "configFlagRecordLocationDescription": "Automaticky zaznamenejte vaši polohu s novými záznamy. To pomáhá s organizací a vyhledáváním podle polohy.",
   "configFlagResendAttachments": "Odeslat přílohy znovu",
   "configFlagResendAttachmentsDescription": "Povolte toto nastavení pro automatické opětovné odeslání neúspěšného nahrávání příloh po obnovení připojení.",
+  "configFlagUseBundledAttachments": "Seskupovat přílohy synchronizace",
+  "configFlagUseBundledAttachmentsDescription": "Před nahráním seskupí více čekajících příloh synchronizace do jediného ZIPu (až 8 MiB). Sníží počet round-tripů v pomalých sítích; při selhání nahrávání se celý balíček zopakuje.",
   "configFlagUseCloudInferenceDescription": "Používat AI služby v cloudu pro vylepšené funkce. Vyžaduje připojení k internetu.",
   "configFlagUseCompressedJsonAttachments": "Komprimovat JSON payloady synchronizace",
   "configFlagUseCompressedJsonAttachmentsDescription": "Před nahráním gzip-komprimuje JSON přílohy synchronizace. Šetří šířku pásma v pomalých sítích za mírnou cenu CPU při odesílání a příjmu.",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1024,6 +1024,8 @@
   "configFlagRecordLocationDescription": "Zeichnet automatisch deinen Standort mit neuen Einträgen auf. Dies hilft bei der ortsbezogenen Organisation und Suche.",
   "configFlagResendAttachments": "Anhänge erneut senden",
   "configFlagResendAttachmentsDescription": "Aktiviere diese Option, um fehlgeschlagene Anlagen-Uploads automatisch erneut zu senden, wenn die Verbindung wiederhergestellt ist.",
+  "configFlagUseBundledAttachments": "Sync-Anhänge bündeln",
+  "configFlagUseBundledAttachmentsDescription": "Packt mehrere anstehende Sync-Anhänge vor dem Upload in ein einziges ZIP (bis 8 MiB). Reduziert Round-Trips in langsamen Netzen; das gesamte Bündel wird erneut versucht, wenn der Upload fehlschlägt.",
   "configFlagUseCloudInferenceDescription": "Cloud-basierte KI-Dienste für erweiterte Funktionen verwenden. Dies erfordert eine Internetverbindung.",
   "configFlagUseCompressedJsonAttachments": "JSON-Sync-Payloads komprimieren",
   "configFlagUseCompressedJsonAttachmentsDescription": "Komprimiert JSON-Sync-Anhänge mit gzip vor dem Hochladen. Spart Bandbreite in langsamen Netzen – gegen einen kleinen CPU-Aufwand beim Senden und Empfangen.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1229,6 +1229,8 @@
   "configFlagRecordLocationDescription": "Automatically record your location with new entries. This helps with location-based organization and search.",
   "configFlagResendAttachments": "Resend attachments",
   "configFlagResendAttachmentsDescription": "Enable this to automatically resend failed attachment uploads when the connection is restored.",
+  "configFlagUseBundledAttachments": "Bundle sync attachments",
+  "configFlagUseBundledAttachmentsDescription": "Pack queued sync attachments into a single zip before upload (up to 8 MiB). Cuts round-trips on slow networks; the whole bundle retries if the upload fails.",
   "configFlagUseCloudInferenceDescription": "Use cloud-based AI services for enhanced features. This requires an internet connection.",
   "configFlagUseCompressedJsonAttachments": "Compress JSON sync payloads",
   "configFlagUseCompressedJsonAttachmentsDescription": "Gzip-compress JSON sync attachments before upload. Saves bandwidth on slow networks in exchange for a small CPU cost when sending and receiving.",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1024,6 +1024,8 @@
   "configFlagRecordLocationDescription": "Registrar automáticamente tu ubicación con las nuevas entradas. Esto ayuda con la organización y la búsqueda basadas en la ubicación.",
   "configFlagResendAttachments": "Reenviar archivos adjuntos",
   "configFlagResendAttachmentsDescription": "Activar para reenviar automáticamente las cargas de archivos adjuntos fallidas cuando se restablezca la conexión.",
+  "configFlagUseBundledAttachments": "Agrupar adjuntos de sync",
+  "configFlagUseBundledAttachmentsDescription": "Empaqueta varios adjuntos de sincronización en cola dentro de un único zip antes de subirlos (hasta 8 MiB). Reduce los round-trips en redes lentas; si la subida falla, se reintenta todo el paquete.",
   "configFlagUseCloudInferenceDescription": "Utiliza servicios de IA basados en la nube para funciones mejoradas. Esto requiere una conexión a Internet.",
   "configFlagUseCompressedJsonAttachments": "Comprimir cargas útiles JSON de sync",
   "configFlagUseCompressedJsonAttachmentsDescription": "Comprime con gzip los archivos adjuntos JSON de sincronización antes de subirlos. Ahorra ancho de banda en redes lentas, a cambio de un pequeño coste de CPU al enviar y recibir.",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1024,6 +1024,8 @@
   "configFlagRecordLocationDescription": "Enregistrer automatiquement ta position avec les nouvelles entrées. Cela facilite l'organisation et la recherche basées sur la localisation.",
   "configFlagResendAttachments": "Renvoyer les pièces jointes",
   "configFlagResendAttachmentsDescription": "Active cette option pour renvoyer automatiquement les téléchargements de pièces jointes ayant échoué lorsque la connexion est rétablie.",
+  "configFlagUseBundledAttachments": "Regrouper les pièces jointes de sync",
+  "configFlagUseBundledAttachmentsDescription": "Regroupe plusieurs pièces jointes de synchronisation en attente dans un seul zip avant l'envoi (jusqu'à 8 Mio). Réduit les allers-retours sur les réseaux lents ; l'ensemble du paquet est retenté si l'envoi échoue.",
   "configFlagUseCloudInferenceDescription": "Utiliser les services d'IA basés sur le cloud pour des fonctionnalités améliorées. Cela nécessite une connexion Internet.",
   "configFlagUseCompressedJsonAttachments": "Compresser les payloads JSON de sync",
   "configFlagUseCompressedJsonAttachmentsDescription": "Compresse les pièces jointes JSON de synchronisation avec gzip avant l'envoi. Économise de la bande passante sur les réseaux lents, au prix d'un léger coût CPU à l'envoi et à la réception.",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4074,6 +4074,18 @@ abstract class AppLocalizations {
   /// **'Enable this to automatically resend failed attachment uploads when the connection is restored.'**
   String get configFlagResendAttachmentsDescription;
 
+  /// No description provided for @configFlagUseBundledAttachments.
+  ///
+  /// In en, this message translates to:
+  /// **'Bundle sync attachments'**
+  String get configFlagUseBundledAttachments;
+
+  /// No description provided for @configFlagUseBundledAttachmentsDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Pack queued sync attachments into a single zip before upload (up to 8 MiB). Cuts round-trips on slow networks; the whole bundle retries if the upload fails.'**
+  String get configFlagUseBundledAttachmentsDescription;
+
   /// No description provided for @configFlagUseCloudInferenceDescription.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -2298,6 +2298,14 @@ class AppLocalizationsCs extends AppLocalizations {
       'Povolte toto nastavení pro automatické opětovné odeslání neúspěšného nahrávání příloh po obnovení připojení.';
 
   @override
+  String get configFlagUseBundledAttachments =>
+      'Seskupovat přílohy synchronizace';
+
+  @override
+  String get configFlagUseBundledAttachmentsDescription =>
+      'Před nahráním seskupí více čekajících příloh synchronizace do jediného ZIPu (až 8 MiB). Sníží počet round-tripů v pomalých sítích; při selhání nahrávání se celý balíček zopakuje.';
+
+  @override
   String get configFlagUseCloudInferenceDescription =>
       'Používat AI služby v cloudu pro vylepšené funkce. Vyžaduje připojení k internetu.';
 

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2316,6 +2316,13 @@ class AppLocalizationsDe extends AppLocalizations {
       'Aktiviere diese Option, um fehlgeschlagene Anlagen-Uploads automatisch erneut zu senden, wenn die Verbindung wiederhergestellt ist.';
 
   @override
+  String get configFlagUseBundledAttachments => 'Sync-Anhänge bündeln';
+
+  @override
+  String get configFlagUseBundledAttachmentsDescription =>
+      'Packt mehrere anstehende Sync-Anhänge vor dem Upload in ein einziges ZIP (bis 8 MiB). Reduziert Round-Trips in langsamen Netzen; das gesamte Bündel wird erneut versucht, wenn der Upload fehlschlägt.';
+
+  @override
   String get configFlagUseCloudInferenceDescription =>
       'Cloud-basierte KI-Dienste für erweiterte Funktionen verwenden. Dies erfordert eine Internetverbindung.';
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2279,6 +2279,13 @@ class AppLocalizationsEn extends AppLocalizations {
       'Enable this to automatically resend failed attachment uploads when the connection is restored.';
 
   @override
+  String get configFlagUseBundledAttachments => 'Bundle sync attachments';
+
+  @override
+  String get configFlagUseBundledAttachmentsDescription =>
+      'Pack queued sync attachments into a single zip before upload (up to 8 MiB). Cuts round-trips on slow networks; the whole bundle retries if the upload fails.';
+
+  @override
   String get configFlagUseCloudInferenceDescription =>
       'Use cloud-based AI services for enhanced features. This requires an internet connection.';
 

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2354,6 +2354,13 @@ class AppLocalizationsEs extends AppLocalizations {
       'Activar para reenviar automáticamente las cargas de archivos adjuntos fallidas cuando se restablezca la conexión.';
 
   @override
+  String get configFlagUseBundledAttachments => 'Agrupar adjuntos de sync';
+
+  @override
+  String get configFlagUseBundledAttachmentsDescription =>
+      'Empaqueta varios adjuntos de sincronización en cola dentro de un único zip antes de subirlos (hasta 8 MiB). Reduce los round-trips en redes lentas; si la subida falla, se reintenta todo el paquete.';
+
+  @override
   String get configFlagUseCloudInferenceDescription =>
       'Utiliza servicios de IA basados en la nube para funciones mejoradas. Esto requiere una conexión a Internet.';
 

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2348,6 +2348,14 @@ class AppLocalizationsFr extends AppLocalizations {
       'Active cette option pour renvoyer automatiquement les téléchargements de pièces jointes ayant échoué lorsque la connexion est rétablie.';
 
   @override
+  String get configFlagUseBundledAttachments =>
+      'Regrouper les pièces jointes de sync';
+
+  @override
+  String get configFlagUseBundledAttachmentsDescription =>
+      'Regroupe plusieurs pièces jointes de synchronisation en attente dans un seul zip avant l\'envoi (jusqu\'à 8 Mio). Réduit les allers-retours sur les réseaux lents ; l\'ensemble du paquet est retenté si l\'envoi échoue.';
+
+  @override
   String get configFlagUseCloudInferenceDescription =>
       'Utiliser les services d\'IA basés sur le cloud pour des fonctionnalités améliorées. Cela nécessite une connexion Internet.';
 

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -2319,6 +2319,14 @@ class AppLocalizationsRo extends AppLocalizations {
       'Activați această opțiune pentru a retrimite automat încărcările de atașamente eșuate atunci când conexiunea este restabilită.';
 
   @override
+  String get configFlagUseBundledAttachments =>
+      'Grupează atașamentele de sincronizare';
+
+  @override
+  String get configFlagUseBundledAttachmentsDescription =>
+      'Grupează mai multe atașamente de sincronizare din coadă într-un singur ZIP înainte de încărcare (până la 8 MiB). Reduce numărul de round-trip-uri în rețele lente; dacă încărcarea eșuează, întregul pachet este reîncercat.';
+
+  @override
   String get configFlagUseCloudInferenceDescription =>
       'Utilizați servicii AI bazate pe cloud pentru funcții îmbunătățite. Acest lucru necesită o conexiune la internet.';
 

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -1024,6 +1024,8 @@
   "configFlagRecordLocationDescription": "Înregistrează automat locația dvs. cu intrări noi. Acest lucru ajută la organizarea și căutarea pe baza locației.",
   "configFlagResendAttachments": "Retrimite atașamentele",
   "configFlagResendAttachmentsDescription": "Activați această opțiune pentru a retrimite automat încărcările de atașamente eșuate atunci când conexiunea este restabilită.",
+  "configFlagUseBundledAttachments": "Grupează atașamentele de sincronizare",
+  "configFlagUseBundledAttachmentsDescription": "Grupează mai multe atașamente de sincronizare din coadă într-un singur ZIP înainte de încărcare (până la 8 MiB). Reduce numărul de round-trip-uri în rețele lente; dacă încărcarea eșuează, întregul pachet este reîncercat.",
   "configFlagUseCloudInferenceDescription": "Utilizați servicii AI bazate pe cloud pentru funcții îmbunătățite. Acest lucru necesită o conexiune la internet.",
   "configFlagUseCompressedJsonAttachments": "Comprimă payload-urile JSON de sincronizare",
   "configFlagUseCompressedJsonAttachmentsDescription": "Comprimă cu gzip atașamentele JSON de sincronizare înainte de încărcare. Reduce consumul de lățime de bandă în rețele lente, cu un mic cost CPU la trimitere și primire.",

--- a/lib/utils/consts.dart
+++ b/lib/utils/consts.dart
@@ -14,6 +14,7 @@ const enableEventsFlag = 'enable_events';
 const enableSessionRatingsFlag = 'enable_session_ratings';
 const enableSyncActorFlag = 'enable_sync_actor';
 const useCompressedJsonAttachmentsFlag = 'use_compressed_json_attachments';
+const useBundledAttachmentsFlag = 'use_bundled_attachments';
 const enableAgentsFlag = 'enable_agents';
 const enableProjectsFlag = 'enable_projects';
 const enableEmbeddingsFlag = 'enable_embeddings';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -66,7 +66,7 @@ packages:
     source: hosted
     version: "0.10.1"
   archive:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: archive
       sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.956+3931
+version: 0.9.956+3932
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.955+3930
+version: 0.9.956+3931
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.954+3929
+version: 0.9.955+3930
 
 msix_config:
   display_name: LottiApp
@@ -18,6 +18,7 @@ environment:
   sdk: '>=3.11.0 <4.0.0'
 
 dependencies:
+  archive: ^4.0.7
   async: ^2.13.0
   beamer: ^1.5.2
   cached_network_image: ^3.2.0
@@ -143,7 +144,6 @@ dependency_overrides:
 
 dev_dependencies:
   arb_utils: ^0.10.1
-  archive: ^4.0.7
   build_runner: ^2.5.4
   cross_file: any
   custom_lint: ^0.8.0

--- a/test/database/database_test.dart
+++ b/test/database/database_test.dart
@@ -127,6 +127,11 @@ final expectedFlags = <ConfigFlag>{
     status: false,
   ),
   const ConfigFlag(
+    name: useBundledAttachmentsFlag,
+    description: 'Pack multiple sync attachments into one zip on send?',
+    status: false,
+  ),
+  const ConfigFlag(
     name: enableAgentsFlag,
     description: 'Enable Agents?',
     status: false,

--- a/test/features/sync/matrix/attachment_enumerator_test.dart
+++ b/test/features/sync/matrix/attachment_enumerator_test.dart
@@ -1,0 +1,240 @@
+// ignore_for_file: prefer_const_constructors
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/entry_link.dart';
+import 'package:lotti/classes/entry_text.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/sync/matrix/attachment_enumerator.dart';
+import 'package:lotti/features/sync/model/sync_message.dart';
+import 'package:lotti/features/sync/vector_clock.dart';
+import 'package:lotti/utils/audio_utils.dart';
+import 'package:lotti/utils/image_utils.dart';
+
+void main() {
+  late Directory docs;
+
+  setUp(() {
+    docs = Directory.systemTemp.createTempSync('enumerator_test');
+  });
+
+  tearDown(() {
+    if (docs.existsSync()) docs.deleteSync(recursive: true);
+  });
+
+  Metadata meta({String id = 'e1'}) {
+    final ts = DateTime(2026, 4, 17, 12);
+    return Metadata(
+      id: id,
+      createdAt: ts,
+      updatedAt: ts,
+      dateFrom: ts,
+      dateTo: ts,
+    );
+  }
+
+  File writeFile(String relativePath, List<int> bytes) {
+    final file = File('${docs.path}$relativePath')
+      ..parent.createSync(recursive: true)
+      ..writeAsBytesSync(bytes);
+    return file;
+  }
+
+  group('SyncJournalEntity', () {
+    test('text entry returns only the jsonPath file', () async {
+      final entity = JournalEntity.journalEntry(
+        meta: meta(),
+        entryText: const EntryText(plainText: 'hello'),
+      );
+      const jsonPath = '/text_entries/e1.json';
+      writeFile(jsonPath, utf8.encode(jsonEncode(entity)));
+
+      final result = await enumerateAttachments(
+        message: SyncMessage.journalEntity(
+          id: 'e1',
+          jsonPath: jsonPath,
+          vectorClock: null,
+          status: SyncEntryStatus.initial,
+        ),
+        documentsDirectory: docs,
+      );
+
+      expect(result, hasLength(1));
+      expect(result.single.relativePath, jsonPath);
+      expect(result.single.size, greaterThan(0));
+    });
+
+    test('journalImage returns jsonPath plus the image file', () async {
+      final imageData = ImageData(
+        capturedAt: DateTime(2026, 4, 17, 12),
+        imageId: 'img-1',
+        imageFile: 'photo.jpg',
+        imageDirectory: '/images/',
+      );
+      final entity = JournalEntity.journalImage(
+        meta: meta(),
+        data: imageData,
+        entryText: const EntryText(plainText: 'caption'),
+      );
+      const jsonPath = '/text_entries/img-1.json';
+      writeFile(jsonPath, utf8.encode(jsonEncode(entity)));
+      final imageRelative = getRelativeImagePath(entity as JournalImage);
+      writeFile(imageRelative, List<int>.filled(64, 0xA));
+
+      final result = await enumerateAttachments(
+        message: SyncMessage.journalEntity(
+          id: 'img-1',
+          jsonPath: jsonPath,
+          vectorClock: null,
+          status: SyncEntryStatus.initial,
+        ),
+        documentsDirectory: docs,
+      );
+
+      expect(
+        result.map((a) => a.relativePath).toSet(),
+        equals({jsonPath, imageRelative}),
+      );
+      final imageDesc = result.firstWhere(
+        (a) => a.relativePath == imageRelative,
+      );
+      expect(imageDesc.size, 64);
+    });
+
+    test('journalAudio returns jsonPath plus the audio file', () async {
+      final audioData = AudioData(
+        dateFrom: DateTime(2026, 4, 17, 12),
+        dateTo: DateTime(2026, 4, 17, 12),
+        audioFile: 'voice.aac',
+        audioDirectory: '/audio/',
+        duration: const Duration(seconds: 30),
+      );
+      final entity = JournalEntity.journalAudio(
+        meta: meta(),
+        data: audioData,
+        entryText: const EntryText(plainText: 'transcript'),
+      );
+      const jsonPath = '/text_entries/audio-1.json';
+      writeFile(jsonPath, utf8.encode(jsonEncode(entity)));
+      final audioRelative = AudioUtils.getRelativeAudioPath(
+        entity as JournalAudio,
+      );
+      writeFile(audioRelative, List<int>.filled(128, 0xC));
+
+      final result = await enumerateAttachments(
+        message: SyncMessage.journalEntity(
+          id: 'audio-1',
+          jsonPath: jsonPath,
+          vectorClock: null,
+          status: SyncEntryStatus.initial,
+        ),
+        documentsDirectory: docs,
+      );
+
+      expect(
+        result.map((a) => a.relativePath).toSet(),
+        equals({jsonPath, audioRelative}),
+      );
+      final audioDesc = result.firstWhere(
+        (a) => a.relativePath == audioRelative,
+      );
+      expect(audioDesc.size, 128);
+    });
+
+    test('missing media file does not block the json entry', () async {
+      final imageData = ImageData(
+        capturedAt: DateTime(2026, 4, 17, 12),
+        imageId: 'img-miss',
+        imageFile: 'photo.jpg',
+        imageDirectory: '/images/',
+      );
+      final entity = JournalEntity.journalImage(
+        meta: meta(),
+        data: imageData,
+        entryText: const EntryText(plainText: 'caption'),
+      );
+      const jsonPath = '/text_entries/img-miss.json';
+      writeFile(jsonPath, utf8.encode(jsonEncode(entity)));
+      // NOTE: media file is NOT written to disk
+
+      final result = await enumerateAttachments(
+        message: SyncMessage.journalEntity(
+          id: 'img-miss',
+          jsonPath: jsonPath,
+          vectorClock: null,
+          status: SyncEntryStatus.initial,
+        ),
+        documentsDirectory: docs,
+      );
+
+      expect(
+        result.map((a) => a.relativePath).toSet(),
+        equals({jsonPath}),
+      );
+    });
+
+    test('missing json file returns empty', () async {
+      final result = await enumerateAttachments(
+        message: SyncMessage.journalEntity(
+          id: 'nope',
+          jsonPath: '/does/not/exist.json',
+          vectorClock: null,
+          status: SyncEntryStatus.initial,
+        ),
+        documentsDirectory: docs,
+      );
+      expect(result, isEmpty);
+    });
+  });
+
+  group('other SyncMessage variants', () {
+    test('SyncAgentEntity without jsonPath returns empty', () async {
+      final result = await enumerateAttachments(
+        message: SyncMessage.agentEntity(
+          status: SyncEntryStatus.initial,
+        ),
+        documentsDirectory: docs,
+      );
+      expect(result, isEmpty);
+    });
+
+    test('SyncAgentLink without jsonPath returns empty', () async {
+      final result = await enumerateAttachments(
+        message: SyncMessage.agentLink(
+          status: SyncEntryStatus.initial,
+        ),
+        documentsDirectory: docs,
+      );
+      expect(result, isEmpty);
+    });
+
+    test('SyncEntryLink returns empty (no attachments)', () async {
+      final link = EntryLink.basic(
+        id: 'link-1',
+        fromId: 'from',
+        toId: 'to',
+        createdAt: DateTime(2026, 4, 17),
+        updatedAt: DateTime(2026, 4, 17),
+        vectorClock: const VectorClock({'host': 1}),
+      );
+      final result = await enumerateAttachments(
+        message: SyncMessage.entryLink(
+          entryLink: link,
+          status: SyncEntryStatus.initial,
+        ),
+        documentsDirectory: docs,
+      );
+      expect(result, isEmpty);
+    });
+
+    test('SyncAiConfigDelete returns empty', () async {
+      final result = await enumerateAttachments(
+        message: const SyncMessage.aiConfigDelete(id: 'x'),
+        documentsDirectory: docs,
+      );
+      expect(result, isEmpty);
+    });
+  });
+}

--- a/test/features/sync/matrix/attachment_enumerator_test.dart
+++ b/test/features/sync/matrix/attachment_enumerator_test.dart
@@ -260,6 +260,53 @@ void main() {
       expect(result, isEmpty);
     });
 
+    test(
+      'empty JSON file returns an empty descriptor list',
+      () async {
+        // Enumerator treats a zero-byte JSON file the same as a missing one
+        // so the bundler won't ship a zero-byte payload that would decode to
+        // a null JournalEntity downstream.
+        const jsonPath = '/text_entries/empty.json';
+        writeFile(jsonPath, const <int>[]);
+
+        final result = await enumerateAttachments(
+          message: SyncMessage.journalEntity(
+            id: 'empty',
+            jsonPath: jsonPath,
+            vectorClock: null,
+            status: SyncEntryStatus.initial,
+          ),
+          documentsDirectory: docs,
+        );
+
+        expect(result, isEmpty);
+      },
+    );
+
+    test(
+      'unparseable JSON returns just the base descriptor without media',
+      () async {
+        // A JSON file that is present on disk but not a valid JournalEntity
+        // cannot yield media paths. Enumerator returns the base descriptor
+        // alone so the bundler can still pack the file.
+        const jsonPath = '/text_entries/bad.json';
+        writeFile(jsonPath, utf8.encode('{ not-a-journal-entity'));
+
+        final result = await enumerateAttachments(
+          message: SyncMessage.journalEntity(
+            id: 'bad',
+            jsonPath: jsonPath,
+            vectorClock: null,
+            status: SyncEntryStatus.initial,
+          ),
+          documentsDirectory: docs,
+        );
+
+        expect(result, hasLength(1));
+        expect(result.single.relativePath, jsonPath);
+      },
+    );
+
     test('rejects an absolute jsonPath pointing outside docs', () async {
       // Write a target outside docs; an absolute jsonPath would resolve to
       // it if the helper didn't strip the root prefix and re-anchor under

--- a/test/features/sync/matrix/attachment_enumerator_test.dart
+++ b/test/features/sync/matrix/attachment_enumerator_test.dart
@@ -237,4 +237,50 @@ void main() {
       expect(result, isEmpty);
     });
   });
+
+  group('path hardening', () {
+    test('rejects a jsonPath that escapes the documents directory', () async {
+      // A sibling file that exists outside docs — the traversal target.
+      final escapeTarget = File('${docs.path}/../escape.json')
+        ..writeAsStringSync('{"secret":true}');
+      addTearDown(() {
+        if (escapeTarget.existsSync()) escapeTarget.deleteSync();
+      });
+
+      final result = await enumerateAttachments(
+        message: SyncMessage.journalEntity(
+          id: 'trav',
+          jsonPath: '../escape.json',
+          vectorClock: null,
+          status: SyncEntryStatus.initial,
+        ),
+        documentsDirectory: docs,
+      );
+
+      expect(result, isEmpty);
+    });
+
+    test('rejects an absolute jsonPath pointing outside docs', () async {
+      // Write a target outside docs; an absolute jsonPath would resolve to
+      // it if the helper didn't strip the root prefix and re-anchor under
+      // documentsDirectory.
+      final outside = File('${docs.path}/../absolute.json')
+        ..writeAsStringSync('{}');
+      addTearDown(() {
+        if (outside.existsSync()) outside.deleteSync();
+      });
+
+      final result = await enumerateAttachments(
+        message: SyncMessage.journalEntity(
+          id: 'abs',
+          jsonPath: outside.absolute.path,
+          vectorClock: null,
+          status: SyncEntryStatus.initial,
+        ),
+        documentsDirectory: docs,
+      );
+
+      expect(result, isEmpty);
+    });
+  });
 }

--- a/test/features/sync/matrix/matrix_message_sender_test.dart
+++ b/test/features/sync/matrix/matrix_message_sender_test.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:archive/archive.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/checklist_data.dart';
 import 'package:lotti/classes/entry_link.dart';
@@ -2174,5 +2175,128 @@ void main() {
       expect(decoded['agentLink'], isNotNull);
       expect(decoded['jsonPath'], '/agent_links/legacy-link.json');
     });
+  });
+
+  group('attachment bundles', () {
+    test(
+      'sendAttachmentBundle packs entries into a zip and marks bundle header',
+      () async {
+        MatrixFile? capturedFile;
+        Map<String, dynamic>? capturedExtra;
+        when(
+          () => room.sendFileEvent(
+            any<MatrixFile>(),
+            extraContent: any<Map<String, dynamic>>(named: 'extraContent'),
+          ),
+        ).thenAnswer((invocation) async {
+          capturedFile = invocation.positionalArguments.first as MatrixFile;
+          capturedExtra =
+              invocation.namedArguments[#extraContent] as Map<String, dynamic>?;
+          return r'$bundle-event';
+        });
+
+        final entries = <String, Uint8List>{
+          'text_entries/a.json': Uint8List.fromList(utf8.encode('{"id":"a"}')),
+          'images/b.jpg': Uint8List.fromList(List<int>.filled(64, 0xA)),
+        };
+
+        final eventId = await sender.sendAttachmentBundle(
+          room: room,
+          entries: entries,
+          bundleId: 'fixed-id',
+        );
+
+        expect(eventId, r'$bundle-event');
+        expect(capturedExtra, isNotNull);
+        expect(capturedExtra![attachmentBundleKey], isTrue);
+        expect(capturedExtra!['relativePath'], '.bundles/fixed-id.zip');
+        expect(capturedFile!.name, 'fixed-id.zip');
+        final decoded = ZipDecoder().decodeBytes(capturedFile!.bytes);
+        final names = decoded.map((f) => f.name).toSet();
+        expect(names, equals(entries.keys.toSet()));
+      },
+    );
+
+    test('sendAttachmentBundle returns null when entries is empty', () async {
+      final result = await sender.sendAttachmentBundle(
+        room: room,
+        entries: const <String, Uint8List>{},
+      );
+      expect(result, isNull);
+      verifyNever(
+        () => room.sendFileEvent(
+          any<MatrixFile>(),
+          extraContent: any<Map<String, dynamic>>(named: 'extraContent'),
+        ),
+      );
+    });
+
+    test(
+      'skipAttachmentPaths in MatrixMessageContext short-circuits file upload',
+      () async {
+        var fileSendCalls = 0;
+        when(
+          () => room.sendFileEvent(
+            any<MatrixFile>(),
+            extraContent: any<Map<String, dynamic>>(named: 'extraContent'),
+          ),
+        ).thenAnswer((_) async {
+          fileSendCalls++;
+          return r'$file-id';
+        });
+        when(
+          () => room.sendTextEvent(
+            any<String>(),
+            msgtype: any<String>(named: 'msgtype'),
+            parseCommands: any<bool>(named: 'parseCommands'),
+            parseMarkdown: any<bool>(named: 'parseMarkdown'),
+          ),
+        ).thenAnswer((_) async => r'$text-id');
+
+        final meta = Metadata(
+          id: 'skip-entry',
+          createdAt: DateTime(2026, 4, 17, 12),
+          updatedAt: DateTime(2026, 4, 17, 12),
+          dateFrom: DateTime(2026, 4, 17, 12),
+          dateTo: DateTime(2026, 4, 17, 12),
+        );
+        final entity = JournalEntity.journalEntry(
+          meta: meta,
+          entryText: const EntryText(plainText: 'Test'),
+        );
+        final jsonPath = relativeEntityPath(entity);
+        File('${documentsDirectory.path}$jsonPath')
+          ..parent.createSync(recursive: true)
+          ..writeAsStringSync(jsonEncode(entity.toJson()));
+
+        final result = await sender.sendMatrixMessage(
+          message: SyncMessage.journalEntity(
+            id: meta.id,
+            jsonPath: jsonPath,
+            vectorClock: null,
+            status: SyncEntryStatus.initial,
+          ),
+          context: MatrixMessageContext(
+            syncRoomId: '!room:test',
+            syncRoom: room,
+            unverifiedDevices: const <DeviceKeys>[],
+            skipAttachmentPaths: {jsonPath},
+          ),
+          onSent: (_, _) {},
+        );
+
+        expect(result, isTrue);
+        // _sendFile should NOT have uploaded the JSON file — the text event
+        // still goes out, but sendFileEvent should have been called zero times.
+        expect(fileSendCalls, 0);
+        verify(
+          () => loggingService.captureEvent(
+            any<String>(that: contains('already uploaded via bundle')),
+            domain: 'MATRIX_SERVICE',
+            subDomain: 'sendMatrixMsg.bundled',
+          ),
+        ).called(1);
+      },
+    );
   });
 }

--- a/test/features/sync/matrix/matrix_message_sender_test.dart
+++ b/test/features/sync/matrix/matrix_message_sender_test.dart
@@ -2232,6 +2232,59 @@ void main() {
     });
 
     test(
+      'sendAttachmentBundle returns null when room.sendFileEvent returns null',
+      () async {
+        when(
+          () => room.sendFileEvent(
+            any<MatrixFile>(),
+            extraContent: any<Map<String, dynamic>>(named: 'extraContent'),
+          ),
+        ).thenAnswer((_) async => null);
+
+        final result = await sender.sendAttachmentBundle(
+          room: room,
+          entries: {'a.json': Uint8List.fromList(utf8.encode('{"a":1}'))},
+        );
+
+        expect(result, isNull);
+        verify(
+          () => loggingService.captureEvent(
+            any<String>(that: contains('bundle send returned null')),
+            domain: 'MATRIX_SERVICE',
+            subDomain: 'sendMatrixMsg.bundle',
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'sendAttachmentBundle returns null and logs when sendFileEvent throws',
+      () async {
+        when(
+          () => room.sendFileEvent(
+            any<MatrixFile>(),
+            extraContent: any<Map<String, dynamic>>(named: 'extraContent'),
+          ),
+        ).thenThrow(Exception('matrix upload blew up'));
+
+        final result = await sender.sendAttachmentBundle(
+          room: room,
+          entries: {'a.json': Uint8List.fromList(utf8.encode('{"a":1}'))},
+        );
+
+        expect(result, isNull);
+        verify(
+          () => loggingService.captureException(
+            any<Object>(),
+            domain: 'MATRIX_SERVICE',
+            subDomain: 'sendMatrixMsg.bundle',
+            stackTrace: any<StackTrace?>(named: 'stackTrace'),
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
       'skipAttachmentPaths in MatrixMessageContext short-circuits file upload',
       () async {
         var fileSendCalls = 0;

--- a/test/features/sync/matrix/matrix_service_test.dart
+++ b/test/features/sync/matrix/matrix_service_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/database/database.dart';
@@ -83,6 +84,7 @@ void main() {
         applied: false,
       ),
     );
+    registerFallbackValue(_RoomFake());
   });
 
   setUp(() {
@@ -363,5 +365,80 @@ void main() {
 
       expect(service.debugPipeline, pipeline);
     });
+
+    group('sendAttachmentBundle', () {
+      test('returns null when no sync room is available', () async {
+        final service = createService();
+
+        final result = await service.sendAttachmentBundle(
+          entries: {
+            'a.json': Uint8List.fromList(const [1, 2, 3]),
+          },
+        );
+
+        expect(result, isNull);
+        verifyNever(
+          () => messageSender.sendAttachmentBundle(
+            room: any<Room>(named: 'room'),
+            entries: any<Map<String, Uint8List>>(named: 'entries'),
+          ),
+        );
+      });
+
+      test('returns null when unverified devices block the send', () async {
+        final room = _MockRoom();
+        when(() => roomManager.currentRoom).thenReturn(room);
+        final unverified = _MockDeviceKeys();
+        when(() => gateway.unverifiedDevices()).thenReturn([unverified]);
+
+        final service = createService();
+
+        final result = await service.sendAttachmentBundle(
+          entries: {
+            'a.json': Uint8List.fromList(const [1, 2, 3]),
+          },
+        );
+
+        expect(result, isNull);
+        verifyNever(
+          () => messageSender.sendAttachmentBundle(
+            room: any<Room>(named: 'room'),
+            entries: any<Map<String, Uint8List>>(named: 'entries'),
+          ),
+        );
+      });
+
+      test('delegates to message sender when room and verify ok', () async {
+        final room = _MockRoom();
+        when(() => roomManager.currentRoom).thenReturn(room);
+        when(
+          () => messageSender.sendAttachmentBundle(
+            room: room,
+            entries: any<Map<String, Uint8List>>(named: 'entries'),
+          ),
+        ).thenAnswer((_) async => r'$bundle-evt');
+
+        final service = createService();
+
+        final entries = {
+          'a.json': Uint8List.fromList(const [1, 2, 3]),
+        };
+        final result = await service.sendAttachmentBundle(entries: entries);
+
+        expect(result, r'$bundle-evt');
+        verify(
+          () => messageSender.sendAttachmentBundle(
+            room: room,
+            entries: entries,
+          ),
+        ).called(1);
+      });
+    });
   });
 }
+
+class _RoomFake extends Fake implements Room {}
+
+class _MockRoom extends Mock implements Room {}
+
+class _MockDeviceKeys extends Mock implements DeviceKeys {}

--- a/test/features/sync/matrix/pipeline/attachment_ingestor_test.dart
+++ b/test/features/sync/matrix/pipeline/attachment_ingestor_test.dart
@@ -1829,5 +1829,133 @@ void main() {
         verify(ev.downloadAndDecryptAttachment).called(1);
       },
     );
+
+    test(
+      'failed bundle unpack is retried on the next process() call',
+      () async {
+        // Regression test: the outer bundle path is never persisted, so the
+        // "applied" signal has to live in a separate set that's only
+        // populated once the zip decodes successfully. A first-pass failure
+        // must leave that set empty so the bundled items are not orphaned.
+        final logging = MockLoggingService();
+        when(
+          () => logging.captureEvent(
+            any<String>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+          ),
+        ).thenAnswer((_) async {});
+        when(
+          () => logging.captureException(
+            any<Object>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+            stackTrace: any<StackTrace?>(named: 'stackTrace'),
+          ),
+        ).thenAnswer((_) async {});
+
+        final tmp = Directory.systemTemp.createTempSync('ingestor_bundle_rcv');
+        addTearDown(() => tmp.deleteSync(recursive: true));
+
+        // Build a real zip for the successful retry; the first pass returns
+        // a MatrixFile that throws on `bytes` access to simulate a
+        // mid-download failure that `_saveAttachment`'s outer catch logs.
+        final entryBytes = utf8.encode('{"id":"rcv"}');
+        final archive = Archive()
+          ..addFile(
+            ArchiveFile(
+              'text_entries/rcv.json',
+              entryBytes.length,
+              entryBytes,
+            ),
+          );
+        final zipBytes = Uint8List.fromList(ZipEncoder().encode(archive));
+
+        final matrixFile = MockMatrixFile();
+        var passCount = 0;
+        when(() => matrixFile.bytes).thenAnswer((_) {
+          passCount++;
+          if (passCount == 1) {
+            throw const FileSystemException('simulated download failure');
+          }
+          return zipBytes;
+        });
+
+        final ev = MockEvent();
+        when(() => ev.eventId).thenReturn('e_bundle_rcv');
+        when(() => ev.content).thenReturn({
+          'relativePath': '.bundles/rcv.zip',
+          'msgtype': 'm.file',
+          attachmentBundleKey: true,
+        });
+        when(() => ev.attachmentMimetype).thenReturn('application/zip');
+        when(() => ev.senderId).thenReturn('@other:u');
+        var downloadCalls = 0;
+        when(ev.downloadAndDecryptAttachment).thenAnswer((_) async {
+          downloadCalls++;
+          return matrixFile;
+        });
+
+        final index = AttachmentIndex(logging: logging);
+        final desc = MockDescriptorCatchUpManager();
+        when(() => desc.removeIfPresent('.bundles/rcv.zip')).thenReturn(false);
+
+        final ingestor = AttachmentIngestor(documentsDirectory: tmp);
+
+        // Pass 1: download proceeds, _saveAttachment's catch fires when
+        // MatrixFile.bytes throws → _unpackBundle never runs → event id is
+        // NOT in _appliedBundleEventIds.
+        final first = await ingestor.process(
+          event: ev,
+          logging: logging,
+          attachmentIndex: index,
+          descriptorCatchUp: desc,
+          scheduleLiveScan: () {},
+          retryNow: () async {},
+        );
+        expect(first, isFalse);
+        expect(
+          File('${tmp.path}/text_entries/rcv.json').existsSync(),
+          isFalse,
+          reason: 'first pass must have failed cleanly without writing',
+        );
+
+        // Pass 2: MatrixFile.bytes now returns real zip bytes. The
+        // bundleNotYetApplied repair gate must fire, even though the event
+        // id is already in _handledAttachmentEventIds from pass 1, so the
+        // bundle downloads, decodes, and persists the inner entry.
+        final second = await ingestor.process(
+          event: ev,
+          logging: logging,
+          attachmentIndex: index,
+          descriptorCatchUp: desc,
+          scheduleLiveScan: () {},
+          retryNow: () async {},
+        );
+        expect(second, isTrue);
+        expect(
+          File('${tmp.path}/text_entries/rcv.json').readAsStringSync(),
+          '{"id":"rcv"}',
+        );
+        expect(downloadCalls, 2);
+
+        // Pass 3: now that _appliedBundleEventIds contains the id, the
+        // repair gate must stop firing to avoid the every-pass re-download.
+        final third = await ingestor.process(
+          event: ev,
+          logging: logging,
+          attachmentIndex: index,
+          descriptorCatchUp: desc,
+          scheduleLiveScan: () {},
+          retryNow: () async {},
+        );
+        expect(third, isFalse);
+        expect(
+          downloadCalls,
+          2,
+          reason: 'pass 3 must not trigger another download',
+        );
+      },
+    );
   });
 }

--- a/test/features/sync/matrix/pipeline/attachment_ingestor_test.dart
+++ b/test/features/sync/matrix/pipeline/attachment_ingestor_test.dart
@@ -1495,16 +1495,19 @@ void main() {
         ),
       ).thenAnswer((_) async {});
 
+      // Use an isolated docs dir nested inside the temp root so the traversal
+      // attempt can try to escape the docs dir without touching any file
+      // outside the test fixture — keeps the assertion off host state like
+      // /etc/passwd.
       final tmp = Directory.systemTemp.createTempSync('ingestor_bundle_tr');
+      final docsDir = Directory('${tmp.path}/docs')..createSync();
       addTearDown(() => tmp.deleteSync(recursive: true));
 
       final safeBytes = utf8.encode('safe');
       final badBytes = utf8.encode('pwned');
       final archive = Archive()
         ..addFile(ArchiveFile('safe/ok.txt', safeBytes.length, safeBytes))
-        ..addFile(
-          ArchiveFile('../../../etc/passwd', badBytes.length, badBytes),
-        );
+        ..addFile(ArchiveFile('../escaped.txt', badBytes.length, badBytes));
       final zipBytes = Uint8List.fromList(ZipEncoder().encode(archive));
 
       final matrixFile = MockMatrixFile();
@@ -1527,7 +1530,7 @@ void main() {
       final desc = MockDescriptorCatchUpManager();
       when(() => desc.removeIfPresent('.bundles/tr.zip')).thenReturn(false);
 
-      final ingestor = AttachmentIngestor(documentsDirectory: tmp);
+      final ingestor = AttachmentIngestor(documentsDirectory: docsDir);
       final result = await ingestor.process(
         event: ev,
         logging: logging,
@@ -1538,9 +1541,9 @@ void main() {
       );
 
       expect(result, isTrue);
-      expect(File('${tmp.path}/safe/ok.txt').readAsStringSync(), 'safe');
+      expect(File('${docsDir.path}/safe/ok.txt').readAsStringSync(), 'safe');
       // Bad entry must not have escaped the documents directory.
-      expect(File('/etc/passwd').readAsStringSync(), isNot(contains('pwned')));
+      expect(File('${tmp.path}/escaped.txt').existsSync(), isFalse);
       verify(
         () => logging.captureEvent(
           any<String>(that: contains('pathTraversal.blocked bundleEntry=')),

--- a/test/features/sync/matrix/pipeline/attachment_ingestor_test.dart
+++ b/test/features/sync/matrix/pipeline/attachment_ingestor_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:archive/archive.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/database/logging_types.dart';
 import 'package:lotti/features/sync/matrix/consts.dart';
@@ -1392,6 +1393,225 @@ void main() {
         // Exactly one download should have been triggered across both events,
         // regardless of which process() call won the race.
         expect(downloadCallCount, 1);
+      },
+    );
+
+    test(
+      'unpacks bundle zip and writes each entry to its target path',
+      () async {
+        final logging = MockLoggingService();
+        when(
+          () => logging.captureEvent(
+            any<String>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+          ),
+        ).thenAnswer((_) async {});
+        when(
+          () => logging.captureException(
+            any<Object>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+            stackTrace: any<StackTrace?>(named: 'stackTrace'),
+          ),
+        ).thenAnswer((_) async {});
+
+        final tmp = Directory.systemTemp.createTempSync('ingestor_bundle');
+        addTearDown(() => tmp.deleteSync(recursive: true));
+
+        final entryA = utf8.encode('{"id":"A"}');
+        final entryB = utf8.encode('binary-bytes-b');
+        final archive = Archive()
+          ..addFile(ArchiveFile('text_entries/a.json', entryA.length, entryA))
+          ..addFile(ArchiveFile('images/b.jpg', entryB.length, entryB));
+        final zipBytes = Uint8List.fromList(ZipEncoder().encode(archive));
+
+        final matrixFile = MockMatrixFile();
+        when(() => matrixFile.bytes).thenReturn(zipBytes);
+
+        final ev = MockEvent();
+        when(() => ev.eventId).thenReturn('e_bundle');
+        when(() => ev.content).thenReturn({
+          'relativePath': '.bundles/abc.zip',
+          'msgtype': 'm.file',
+          attachmentBundleKey: true,
+        });
+        when(() => ev.attachmentMimetype).thenReturn('application/zip');
+        when(() => ev.senderId).thenReturn('@other:u');
+        when(
+          ev.downloadAndDecryptAttachment,
+        ).thenAnswer((_) async => matrixFile);
+
+        final index = AttachmentIndex(logging: logging);
+        final desc = MockDescriptorCatchUpManager();
+        when(() => desc.removeIfPresent('.bundles/abc.zip')).thenReturn(false);
+
+        final ingestor = AttachmentIngestor(documentsDirectory: tmp);
+        final result = await ingestor.process(
+          event: ev,
+          logging: logging,
+          attachmentIndex: index,
+          descriptorCatchUp: desc,
+          scheduleLiveScan: () {},
+          retryNow: () async {},
+        );
+
+        expect(result, isTrue);
+        expect(
+          File('${tmp.path}/text_entries/a.json').readAsStringSync(),
+          '{"id":"A"}',
+        );
+        expect(
+          File('${tmp.path}/images/b.jpg').readAsBytesSync(),
+          equals(entryB),
+        );
+        // Outer zip itself must not be written at its .bundles/... path.
+        expect(File('${tmp.path}/.bundles/abc.zip').existsSync(), isFalse);
+        verify(
+          () => logging.captureEvent(
+            any<String>(that: contains('bundleUnpacked')),
+            domain: any<String>(named: 'domain'),
+            subDomain: 'attachment.bundle.unpack',
+          ),
+        ).called(1);
+      },
+    );
+
+    test('blocks path traversal on bundle entry names', () async {
+      final logging = MockLoggingService();
+      when(
+        () => logging.captureEvent(
+          any<String>(),
+          domain: any<String>(named: 'domain'),
+          subDomain: any<String>(named: 'subDomain'),
+        ),
+      ).thenAnswer((_) async {});
+      when(
+        () => logging.captureException(
+          any<Object>(),
+          domain: any<String>(named: 'domain'),
+          subDomain: any<String>(named: 'subDomain'),
+          stackTrace: any<StackTrace?>(named: 'stackTrace'),
+        ),
+      ).thenAnswer((_) async {});
+
+      final tmp = Directory.systemTemp.createTempSync('ingestor_bundle_tr');
+      addTearDown(() => tmp.deleteSync(recursive: true));
+
+      final safeBytes = utf8.encode('safe');
+      final badBytes = utf8.encode('pwned');
+      final archive = Archive()
+        ..addFile(ArchiveFile('safe/ok.txt', safeBytes.length, safeBytes))
+        ..addFile(
+          ArchiveFile('../../../etc/passwd', badBytes.length, badBytes),
+        );
+      final zipBytes = Uint8List.fromList(ZipEncoder().encode(archive));
+
+      final matrixFile = MockMatrixFile();
+      when(() => matrixFile.bytes).thenReturn(zipBytes);
+
+      final ev = MockEvent();
+      when(() => ev.eventId).thenReturn('e_bundle_tr');
+      when(() => ev.content).thenReturn({
+        'relativePath': '.bundles/tr.zip',
+        'msgtype': 'm.file',
+        attachmentBundleKey: true,
+      });
+      when(() => ev.attachmentMimetype).thenReturn('application/zip');
+      when(() => ev.senderId).thenReturn('@other:u');
+      when(
+        ev.downloadAndDecryptAttachment,
+      ).thenAnswer((_) async => matrixFile);
+
+      final index = AttachmentIndex(logging: logging);
+      final desc = MockDescriptorCatchUpManager();
+      when(() => desc.removeIfPresent('.bundles/tr.zip')).thenReturn(false);
+
+      final ingestor = AttachmentIngestor(documentsDirectory: tmp);
+      final result = await ingestor.process(
+        event: ev,
+        logging: logging,
+        attachmentIndex: index,
+        descriptorCatchUp: desc,
+        scheduleLiveScan: () {},
+        retryNow: () async {},
+      );
+
+      expect(result, isTrue);
+      expect(File('${tmp.path}/safe/ok.txt').readAsStringSync(), 'safe');
+      // Bad entry must not have escaped the documents directory.
+      expect(File('/etc/passwd').readAsStringSync(), isNot(contains('pwned')));
+      verify(
+        () => logging.captureEvent(
+          any<String>(that: contains('pathTraversal.blocked bundleEntry=')),
+          domain: any<String>(named: 'domain'),
+          subDomain: 'attachment.bundle.entry',
+        ),
+      ).called(1);
+    });
+
+    test(
+      'bundle unpack skips entries that already exist for non-agent paths',
+      () async {
+        final logging = MockLoggingService();
+        when(
+          () => logging.captureEvent(
+            any<String>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+          ),
+        ).thenAnswer((_) async {});
+
+        final tmp = Directory.systemTemp.createTempSync('ingestor_bundle_dd');
+        addTearDown(() => tmp.deleteSync(recursive: true));
+
+        final existing = File('${tmp.path}/text_entries/dup.json')
+          ..createSync(recursive: true)
+          ..writeAsStringSync('{"existing":true}');
+
+        final entryBytes = utf8.encode('{"new":true}');
+        final archive = Archive()
+          ..addFile(
+            ArchiveFile(
+              'text_entries/dup.json',
+              entryBytes.length,
+              entryBytes,
+            ),
+          );
+        final zipBytes = Uint8List.fromList(ZipEncoder().encode(archive));
+
+        final matrixFile = MockMatrixFile();
+        when(() => matrixFile.bytes).thenReturn(zipBytes);
+
+        final ev = MockEvent();
+        when(() => ev.eventId).thenReturn('e_bundle_dd');
+        when(() => ev.content).thenReturn({
+          'relativePath': '.bundles/dd.zip',
+          'msgtype': 'm.file',
+          attachmentBundleKey: true,
+        });
+        when(() => ev.attachmentMimetype).thenReturn('application/zip');
+        when(() => ev.senderId).thenReturn('@other:u');
+        when(
+          ev.downloadAndDecryptAttachment,
+        ).thenAnswer((_) async => matrixFile);
+
+        final index = AttachmentIndex(logging: logging);
+        final desc = MockDescriptorCatchUpManager();
+        when(() => desc.removeIfPresent('.bundles/dd.zip')).thenReturn(false);
+
+        final ingestor = AttachmentIngestor(documentsDirectory: tmp);
+        final result = await ingestor.process(
+          event: ev,
+          logging: logging,
+          attachmentIndex: index,
+          descriptorCatchUp: desc,
+          scheduleLiveScan: () {},
+          retryNow: () async {},
+        );
+
+        expect(result, isFalse); // nothing new written
+        expect(existing.readAsStringSync(), '{"existing":true}'); // unchanged
       },
     );
 

--- a/test/features/sync/matrix/pipeline/attachment_ingestor_test.dart
+++ b/test/features/sync/matrix/pipeline/attachment_ingestor_test.dart
@@ -1554,6 +1554,73 @@ void main() {
     });
 
     test(
+      'bundle unpack tolerates corrupt zip bytes and writes nothing',
+      () async {
+        final logging = MockLoggingService();
+        when(
+          () => logging.captureEvent(
+            any<String>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+          ),
+        ).thenAnswer((_) async {});
+        when(
+          () => logging.captureException(
+            any<Object>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+            stackTrace: any<StackTrace?>(named: 'stackTrace'),
+          ),
+        ).thenAnswer((_) async {});
+
+        final tmp = Directory.systemTemp.createTempSync('ingestor_bundle_bad');
+        addTearDown(() => tmp.deleteSync(recursive: true));
+
+        final badBytes = Uint8List.fromList(utf8.encode('not-a-zip'));
+        final matrixFile = MockMatrixFile();
+        when(() => matrixFile.bytes).thenReturn(badBytes);
+
+        final ev = MockEvent();
+        when(() => ev.eventId).thenReturn('e_bundle_bad');
+        when(() => ev.content).thenReturn({
+          'relativePath': '.bundles/bad.zip',
+          'msgtype': 'm.file',
+          attachmentBundleKey: true,
+        });
+        when(() => ev.attachmentMimetype).thenReturn('application/zip');
+        when(() => ev.senderId).thenReturn('@other:u');
+        when(
+          ev.downloadAndDecryptAttachment,
+        ).thenAnswer((_) async => matrixFile);
+
+        final index = AttachmentIndex(logging: logging);
+        final desc = MockDescriptorCatchUpManager();
+        when(() => desc.removeIfPresent('.bundles/bad.zip')).thenReturn(false);
+
+        final ingestor = AttachmentIngestor(documentsDirectory: tmp);
+        final result = await ingestor.process(
+          event: ev,
+          logging: logging,
+          attachmentIndex: index,
+          descriptorCatchUp: desc,
+          scheduleLiveScan: () {},
+          retryNow: () async {},
+        );
+
+        // The pipeline must tolerate corrupt input without throwing or
+        // writing anything to disk. ZipDecoder in archive 4.x is lenient and
+        // produces an empty archive rather than throwing for these bytes;
+        // the try/catch around the isolate decode covers the stricter case
+        // where it does throw.
+        expect(result, isFalse);
+        expect(
+          Directory(tmp.path).listSync(recursive: true).whereType<File>(),
+          isEmpty,
+        );
+      },
+    );
+
+    test(
       'bundle unpack skips entries that already exist for non-agent paths',
       () async {
         final logging = MockLoggingService();
@@ -1679,5 +1746,88 @@ void main() {
       // Verify download was NOT called
       verifyNever(ev.downloadAndDecryptAttachment);
     });
+
+    test(
+      'bundle event is not re-downloaded on repeat process() calls',
+      () async {
+        // The outer .bundles/<id>.zip path is never persisted locally — only
+        // the unpacked inner entries are. Earlier the repair heuristic would
+        // therefore see "local file missing" on every pass and re-download
+        // the bundle. The bundle-aware short-circuit keeps
+        // downloadAndDecryptAttachment at one call across repeated
+        // invocations for the same event id.
+        final logging = MockLoggingService();
+        when(
+          () => logging.captureEvent(
+            any<String>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+          ),
+        ).thenAnswer((_) async {});
+
+        final tmp = Directory.systemTemp.createTempSync('ingestor_bundle_rpt');
+        addTearDown(() => tmp.deleteSync(recursive: true));
+
+        final entryBytes = utf8.encode('{"id":"rpt"}');
+        final archive = Archive()
+          ..addFile(
+            ArchiveFile(
+              'text_entries/rpt.json',
+              entryBytes.length,
+              entryBytes,
+            ),
+          );
+        final zipBytes = Uint8List.fromList(ZipEncoder().encode(archive));
+
+        final matrixFile = MockMatrixFile();
+        when(() => matrixFile.bytes).thenReturn(zipBytes);
+
+        final ev = MockEvent();
+        when(() => ev.eventId).thenReturn('e_bundle_rpt');
+        when(() => ev.content).thenReturn({
+          'relativePath': '.bundles/rpt.zip',
+          'msgtype': 'm.file',
+          attachmentBundleKey: true,
+        });
+        when(() => ev.attachmentMimetype).thenReturn('application/zip');
+        when(() => ev.senderId).thenReturn('@other:u');
+        when(
+          ev.downloadAndDecryptAttachment,
+        ).thenAnswer((_) async => matrixFile);
+
+        final index = AttachmentIndex(logging: logging);
+        final desc = MockDescriptorCatchUpManager();
+        when(() => desc.removeIfPresent('.bundles/rpt.zip')).thenReturn(false);
+
+        final ingestor = AttachmentIngestor(documentsDirectory: tmp);
+
+        final first = await ingestor.process(
+          event: ev,
+          logging: logging,
+          attachmentIndex: index,
+          descriptorCatchUp: desc,
+          scheduleLiveScan: () {},
+          retryNow: () async {},
+        );
+        final second = await ingestor.process(
+          event: ev,
+          logging: logging,
+          attachmentIndex: index,
+          descriptorCatchUp: desc,
+          scheduleLiveScan: () {},
+          retryNow: () async {},
+        );
+
+        expect(first, isTrue);
+        expect(second, isFalse);
+        expect(
+          File('${tmp.path}/text_entries/rpt.json').readAsStringSync(),
+          '{"id":"rpt"}',
+        );
+        // One download only, despite the outer .bundles/*.zip never being
+        // written to disk.
+        verify(ev.downloadAndDecryptAttachment).called(1);
+      },
+    );
   });
 }

--- a/test/features/sync/outbox/outbox_processor_test.dart
+++ b/test/features/sync/outbox/outbox_processor_test.dart
@@ -1870,6 +1870,84 @@ void main() {
     );
 
     test(
+      'bundled item send timeout triggers retry with timedOut=true',
+      () async {
+        // The timeout callback path has its own bookkeeping (timedOut=true
+        // logged alongside the subject diagnostic). A send() future that
+        // never completes exercises it.
+        final tmp = Directory.systemTemp.createTempSync('outbox_bundle_to');
+        addTearDown(() => tmp.deleteSync(recursive: true));
+
+        final repo = MockOutboxRepository();
+        final sender = MockMessageSender();
+        final log = MockLoggingService();
+        final db = MockJournalDb();
+
+        final entity = JournalEntity.journalEntry(
+          meta: meta('to-1'),
+          entryText: const EntryText(plainText: 'x'),
+        );
+        final jsonPath = relativeEntityPath(entity);
+        File('${tmp.path}$jsonPath')
+          ..parent.createSync(recursive: true)
+          ..writeAsStringSync(jsonEncode(entity.toJson()));
+        final item = pendingFor(id: 1, entryId: 'to-1', jsonPath: jsonPath);
+
+        when(
+          () => repo.fetchPending(limit: any(named: 'limit')),
+        ).thenAnswer((_) async => [item]);
+        when(() => repo.refreshItem(item)).thenAnswer((_) async => item);
+        when(() => repo.markRetry(any<OutboxItem>())).thenAnswer((_) async {});
+        when(
+          () => db.getConfigFlag(useBundledAttachmentsFlag),
+        ).thenAnswer((_) async => true);
+        when(
+          () => sender.sendAttachmentBundle(
+            entries: any<Map<String, Uint8List>>(named: 'entries'),
+          ),
+        ).thenAnswer((_) async => r'$bundle-ok');
+        when(
+          () => sender.send(
+            any(),
+            skipAttachmentPaths: any<Set<String>>(named: 'skipAttachmentPaths'),
+          ),
+        ).thenAnswer((_) => Completer<bool>().future);
+        final events = <String>[];
+        when(
+          () => log.captureEvent(
+            captureAny<Object>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+          ),
+        ).thenAnswer((inv) {
+          events.add(inv.positionalArguments.first.toString());
+        });
+
+        final proc = OutboxProcessor(
+          repository: repo,
+          messageSender: sender,
+          loggingService: log,
+          journalDb: db,
+          documentsDirectory: tmp,
+          sendTimeoutOverride: const Duration(milliseconds: 20),
+        );
+
+        await proc.processQueue();
+
+        verify(() => repo.markRetry(item)).called(1);
+        expect(
+          events.any(
+            (e) =>
+                e.contains('bundle sendFailed subject=host:1') &&
+                e.contains('timedOut=true'),
+          ),
+          isTrue,
+          reason: 'expected the bundled-item timeout path to log timedOut=true',
+        );
+      },
+    );
+
+    test(
       'bundled item success resets repeated-subject diagnostic counters',
       () async {
         final tmp = Directory.systemTemp.createTempSync('outbox_bundle_reset');
@@ -1911,13 +1989,16 @@ void main() {
             skipAttachmentPaths: any<Set<String>>(named: 'skipAttachmentPaths'),
           ),
         ).thenAnswer((_) async => sendResult);
+        final events = <String>[];
         when(
           () => log.captureEvent(
-            any<Object>(),
+            captureAny<Object>(),
             domain: any<String>(named: 'domain'),
             subDomain: any<String>(named: 'subDomain'),
           ),
-        ).thenAnswer((_) {});
+        ).thenAnswer((inv) {
+          events.add(inv.positionalArguments.first.toString());
+        });
 
         final proc = OutboxProcessor(
           repository: repo,
@@ -1927,17 +2008,49 @@ void main() {
           documentsDirectory: tmp,
         );
 
-        // Tick 1: fail to seed _lastFailedSubject/_lastFailedRepeats for
-        // this subject.
+        // Tick 1: fail to seed _lastFailedSubject/_lastFailedRepeats=1.
         await proc.processQueue();
         verify(() => repo.markRetry(item)).called(1);
+        expect(
+          events.any(
+            (e) =>
+                e.contains('bundle sendFailed subject=host:1') &&
+                e.contains('repeats=1'),
+          ),
+          isTrue,
+        );
+        events.clear();
 
         // Tick 2: succeed → the success branch must reset the tracker.
         sendResult = true;
-        final result = await proc.processQueue();
+        final tick2 = await proc.processQueue();
         verify(() => repo.markSent(item)).called(1);
-        // Nothing remaining → no further schedule.
-        expect(result.shouldSchedule, isFalse);
+        expect(tick2.shouldSchedule, isFalse);
+        events.clear();
+
+        // Tick 3: fail again for the same subject. If the Tick 2 success
+        // reset the tracker, the repeats count restarts at 1. Without the
+        // reset it would already be 2 on the first failure after success.
+        sendResult = false;
+        await proc.processQueue();
+        expect(
+          events.any(
+            (e) =>
+                e.contains('bundle sendFailed subject=host:1') &&
+                e.contains('repeats=1'),
+          ),
+          isTrue,
+          reason:
+              'expected the repeat counter to restart at 1 after the Tick 2 '
+              'success — otherwise the reset branch on the success path is '
+              'not exercised.',
+        );
+        expect(
+          events.any((e) => e.contains('repeats=2')),
+          isFalse,
+          reason:
+              'counter should NOT be 2: Tick 2 success must have cleared it.',
+        );
       },
     );
   });

--- a/test/features/sync/outbox/outbox_processor_test.dart
+++ b/test/features/sync/outbox/outbox_processor_test.dart
@@ -1301,5 +1301,644 @@ void main() {
         expect(result.nextDelay, const Duration(seconds: 1));
       },
     );
+
+    test(
+      'break on first non-bundleable item preserves head-first ordering',
+      () async {
+        // Head item has no attachments (e.g. SyncAiConfigDelete), so it is
+        // non-bundleable. A later pending item DOES have attachments but must
+        // not be bundled past the head — otherwise it would ship first and
+        // violate ordering. Expect: return null → fall through to head-only.
+        final tmp = Directory.systemTemp.createTempSync('outbox_bundle_order');
+        addTearDown(() => tmp.deleteSync(recursive: true));
+
+        final repo = MockOutboxRepository();
+        final sender = MockMessageSender();
+        final log = MockLoggingService();
+        final db = MockJournalDb();
+
+        final noAttItem = OutboxItem(
+          id: 1,
+          message: jsonEncode(
+            const SyncMessage.aiConfigDelete(id: 'cfg').toJson(),
+          ),
+          subject: 'host:1',
+          status: OutboxStatus.pending.index,
+          retries: 0,
+          createdAt: DateTime(2026, 4, 17),
+          updatedAt: DateTime(2026, 4, 17),
+          priority: OutboxPriority.low.index,
+        );
+        final entity = JournalEntity.journalEntry(
+          meta: meta('later'),
+          entryText: const EntryText(plainText: 'x'),
+        );
+        final jsonPath = relativeEntityPath(entity);
+        File('${tmp.path}$jsonPath')
+          ..parent.createSync(recursive: true)
+          ..writeAsStringSync(jsonEncode(entity.toJson()));
+        final laterItem = pendingFor(
+          id: 2,
+          entryId: 'later',
+          jsonPath: jsonPath,
+        );
+
+        when(
+          () => repo.fetchPending(limit: any(named: 'limit')),
+        ).thenAnswer((_) async => [noAttItem, laterItem]);
+        when(
+          () => repo.refreshItem(noAttItem),
+        ).thenAnswer((_) async => noAttItem);
+        when(() => repo.markSent(any<OutboxItem>())).thenAnswer((_) async {});
+        when(
+          () => db.getConfigFlag(useBundledAttachmentsFlag),
+        ).thenAnswer((_) async => true);
+        when(() => sender.send(any())).thenAnswer((_) async => true);
+        when(
+          () => log.captureEvent(
+            any<Object>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+          ),
+        ).thenAnswer((_) {});
+
+        final proc = OutboxProcessor(
+          repository: repo,
+          messageSender: sender,
+          loggingService: log,
+          journalDb: db,
+          documentsDirectory: tmp,
+        );
+
+        await proc.processQueue();
+
+        // No bundle must have been uploaded — head-only path processed the
+        // head (the no-attachment item) solo.
+        verifyNever(
+          () => sender.sendAttachmentBundle(
+            entries: any<Map<String, Uint8List>>(named: 'entries'),
+          ),
+        );
+        verify(() => sender.send(any())).called(1);
+        verify(() => repo.markSent(noAttItem)).called(1);
+        verifyNever(() => repo.markSent(laterItem));
+      },
+    );
+
+    test(
+      'bundled item send exception triggers retry and diagnostics',
+      () async {
+        final tmp = Directory.systemTemp.createTempSync('outbox_bundle_ex');
+        addTearDown(() => tmp.deleteSync(recursive: true));
+
+        final repo = MockOutboxRepository();
+        final sender = MockMessageSender();
+        final log = MockLoggingService();
+        final db = MockJournalDb();
+
+        final entity = JournalEntity.journalEntry(
+          meta: meta('ex-1'),
+          entryText: const EntryText(plainText: 'x'),
+        );
+        final jsonPath = relativeEntityPath(entity);
+        File('${tmp.path}$jsonPath')
+          ..parent.createSync(recursive: true)
+          ..writeAsStringSync(jsonEncode(entity.toJson()));
+        final item = pendingFor(id: 1, entryId: 'ex-1', jsonPath: jsonPath);
+
+        when(
+          () => repo.fetchPending(limit: any(named: 'limit')),
+        ).thenAnswer((_) async => [item]);
+        when(() => repo.refreshItem(item)).thenAnswer((_) async => item);
+        when(() => repo.markRetry(any<OutboxItem>())).thenAnswer((_) async {});
+        when(
+          () => db.getConfigFlag(useBundledAttachmentsFlag),
+        ).thenAnswer((_) async => true);
+        when(
+          () => sender.sendAttachmentBundle(
+            entries: any<Map<String, Uint8List>>(named: 'entries'),
+          ),
+        ).thenAnswer((_) async => r'$bundle-ok');
+        when(
+          () => sender.send(
+            any(),
+            skipAttachmentPaths: any<Set<String>>(named: 'skipAttachmentPaths'),
+          ),
+        ).thenThrow(Exception('boom'));
+        final loggedExceptionSubDomains = <String?>[];
+        when(
+          () => log.captureException(
+            any<Object>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+            stackTrace: any<StackTrace?>(named: 'stackTrace'),
+          ),
+        ).thenAnswer((invocation) async {
+          loggedExceptionSubDomains.add(
+            invocation.namedArguments[#subDomain] as String?,
+          );
+        });
+        when(
+          () => log.captureEvent(
+            any<Object>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+          ),
+        ).thenAnswer((_) {});
+
+        final proc = OutboxProcessor(
+          repository: repo,
+          messageSender: sender,
+          loggingService: log,
+          journalDb: db,
+          documentsDirectory: tmp,
+          retryDelayOverride: const Duration(seconds: 2),
+        );
+
+        final result = await proc.processQueue();
+
+        verify(() => repo.markRetry(item)).called(1);
+        expect(loggedExceptionSubDomains, contains('bundle.send'));
+        expect(result.shouldSchedule, isTrue);
+        expect(result.nextDelay, const Duration(seconds: 2));
+      },
+    );
+
+    test(
+      'retry cap on bundled item emits retryCapReached diagnostic',
+      () async {
+        final tmp = Directory.systemTemp.createTempSync('outbox_bundle_cap');
+        addTearDown(() => tmp.deleteSync(recursive: true));
+
+        final repo = MockOutboxRepository();
+        final sender = MockMessageSender();
+        final log = MockLoggingService();
+        final db = MockJournalDb();
+
+        final entity = JournalEntity.journalEntry(
+          meta: meta('cap-1'),
+          entryText: const EntryText(plainText: 'x'),
+        );
+        final jsonPath = relativeEntityPath(entity);
+        File('${tmp.path}$jsonPath')
+          ..parent.createSync(recursive: true)
+          ..writeAsStringSync(jsonEncode(entity.toJson()));
+        // One retry short of the cap — next attempt hits the diagnostic.
+        final item = OutboxItem(
+          id: 1,
+          message: jsonEncode(
+            SyncMessage.journalEntity(
+              id: 'cap-1',
+              jsonPath: jsonPath,
+              vectorClock: null,
+              status: SyncEntryStatus.initial,
+            ).toJson(),
+          ),
+          subject: 'host:cap',
+          status: OutboxStatus.pending.index,
+          retries: 2,
+          createdAt: DateTime(2026, 4, 17),
+          updatedAt: DateTime(2026, 4, 17),
+          priority: OutboxPriority.low.index,
+        );
+
+        when(
+          () => repo.fetchPending(limit: any(named: 'limit')),
+        ).thenAnswer((_) async => [item]);
+        when(() => repo.refreshItem(item)).thenAnswer((_) async => item);
+        when(() => repo.markRetry(any<OutboxItem>())).thenAnswer((_) async {});
+        when(
+          () => db.getConfigFlag(useBundledAttachmentsFlag),
+        ).thenAnswer((_) async => true);
+        when(
+          () => sender.sendAttachmentBundle(
+            entries: any<Map<String, Uint8List>>(named: 'entries'),
+          ),
+        ).thenAnswer((_) async => r'$bundle-ok');
+        when(
+          () => sender.send(
+            any(),
+            skipAttachmentPaths: any<Set<String>>(named: 'skipAttachmentPaths'),
+          ),
+        ).thenAnswer((_) async => false);
+        final events = <String>[];
+        when(
+          () => log.captureEvent(
+            captureAny<Object>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+          ),
+        ).thenAnswer((invocation) {
+          events.add(invocation.positionalArguments.first.toString());
+        });
+
+        final proc = OutboxProcessor(
+          repository: repo,
+          messageSender: sender,
+          loggingService: log,
+          journalDb: db,
+          documentsDirectory: tmp,
+          maxRetriesOverride: 3,
+        );
+
+        await proc.processQueue();
+
+        verify(() => repo.markRetry(item)).called(1);
+        expect(
+          events.any(
+            (e) =>
+                e.contains('retryCapReached subject=host:cap attempts=3') &&
+                e.contains('bundle'),
+          ),
+          isTrue,
+          reason: 'expected retryCapReached event for bundled item at cap',
+        );
+      },
+    );
+
+    test(
+      'invalid-JSON pending item is treated as non-bundleable',
+      () async {
+        // An item whose message is unparseable JSON: the decode inside the
+        // enumeration loop throws, and the catch substitutes empty attachments
+        // so the break-on-first-non-bundleable rule trips before any bundle
+        // is built. The head-only path then handles the item.
+        final tmp = Directory.systemTemp.createTempSync('outbox_bundle_dec');
+        addTearDown(() => tmp.deleteSync(recursive: true));
+
+        final repo = MockOutboxRepository();
+        final sender = MockMessageSender();
+        final log = MockLoggingService();
+        final db = MockJournalDb();
+
+        final junk = OutboxItem(
+          id: 1,
+          message: '{ not-json',
+          subject: 'host:junk',
+          status: OutboxStatus.pending.index,
+          retries: 0,
+          createdAt: DateTime(2026, 4, 17),
+          updatedAt: DateTime(2026, 4, 17),
+          priority: OutboxPriority.low.index,
+        );
+
+        when(
+          () => repo.fetchPending(limit: any(named: 'limit')),
+        ).thenAnswer((_) async => [junk]);
+        when(() => repo.refreshItem(junk)).thenAnswer((_) async => junk);
+        when(() => repo.markRetry(any<OutboxItem>())).thenAnswer((_) async {});
+        when(
+          () => db.getConfigFlag(useBundledAttachmentsFlag),
+        ).thenAnswer((_) async => true);
+        when(
+          () => log.captureEvent(
+            any<Object>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+          ),
+        ).thenAnswer((_) {});
+        when(
+          () => log.captureException(
+            any<Object>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+            stackTrace: any<StackTrace?>(named: 'stackTrace'),
+          ),
+        ).thenAnswer((_) async {});
+
+        final proc = OutboxProcessor(
+          repository: repo,
+          messageSender: sender,
+          loggingService: log,
+          journalDb: db,
+          documentsDirectory: tmp,
+        );
+
+        await proc.processQueue();
+
+        verifyNever(
+          () => sender.sendAttachmentBundle(
+            entries: any<Map<String, Uint8List>>(named: 'entries'),
+          ),
+        );
+        // Head-only path handled it via markRetry (decode would fail there
+        // too and throw into the outer try/catch).
+        verify(() => repo.markRetry(junk)).called(1);
+      },
+    );
+
+    test(
+      'missing JSON file during enumeration falls through to head-only',
+      () async {
+        // Enumerator returns empty for an item whose JSON file was deleted
+        // before processQueue ran; bundled stays empty, _maybeProcessBundle
+        // returns null, and the head-only path runs the item solo.
+        final tmp = Directory.systemTemp.createTempSync('outbox_bundle_read');
+        addTearDown(() => tmp.deleteSync(recursive: true));
+
+        final repo = MockOutboxRepository();
+        final sender = MockMessageSender();
+        final log = MockLoggingService();
+        final db = MockJournalDb();
+
+        final entity = JournalEntity.journalEntry(
+          meta: meta('read-1'),
+          entryText: const EntryText(plainText: 'x'),
+        );
+        final jsonPath = relativeEntityPath(entity);
+        final jsonFile = File('${tmp.path}$jsonPath')
+          ..parent.createSync(recursive: true)
+          ..writeAsStringSync(jsonEncode(entity.toJson()));
+        final item = pendingFor(id: 1, entryId: 'read-1', jsonPath: jsonPath);
+
+        when(
+          () => repo.fetchPending(limit: any(named: 'limit')),
+        ).thenAnswer((_) async => [item]);
+        when(() => repo.refreshItem(item)).thenAnswer((_) async => item);
+        when(() => repo.markSent(any<OutboxItem>())).thenAnswer((_) async {});
+        when(
+          () => db.getConfigFlag(useBundledAttachmentsFlag),
+        ).thenAnswer((_) async => true);
+        when(
+          () => sender.sendAttachmentBundle(
+            entries: any<Map<String, Uint8List>>(named: 'entries'),
+          ),
+        ).thenAnswer((invocation) async {
+          // Delete the file synchronously during pack — but the enumerator
+          // already read bytes into the descriptor cache, so bundles built
+          // from this message will still succeed. To force the read-failure
+          // branch we must target a media file that the enumerator saw but
+          // didn't cache. See below for a stricter test via stubbed sender.
+          return r'$ok';
+        });
+        when(() => sender.send(any())).thenAnswer((_) async => true);
+        when(
+          () => log.captureEvent(
+            any<Object>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+          ),
+        ).thenAnswer((_) {});
+        when(
+          () => log.captureException(
+            any<Object>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+            stackTrace: any<StackTrace?>(named: 'stackTrace'),
+          ),
+        ).thenAnswer((_) async {});
+
+        // Delete the JSON file before the processor runs. The enumerator
+        // will see it missing and return no descriptors, so bundled ends up
+        // empty, _maybeProcessBundle returns null, and the head-only path
+        // takes over.
+        jsonFile.deleteSync();
+
+        final proc = OutboxProcessor(
+          repository: repo,
+          messageSender: sender,
+          loggingService: log,
+          journalDb: db,
+          documentsDirectory: tmp,
+        );
+
+        await proc.processQueue();
+
+        // No bundle upload — enumerator returned empty, so the item is
+        // processed via the head-only path.
+        verifyNever(
+          () => sender.sendAttachmentBundle(
+            entries: any<Map<String, Uint8List>>(named: 'entries'),
+          ),
+        );
+        verify(() => sender.send(any())).called(1);
+      },
+    );
+
+    test(
+      'bundled item decode failure after refresh marks retry and continues',
+      () async {
+        // Enumeration sees a valid item. Refresh then returns an item whose
+        // message is unparseable, simulating a concurrent write that
+        // corrupted the stored payload. The per-item decode try/catch must
+        // markRetry and continue, not propagate.
+        final tmp = Directory.systemTemp.createTempSync('outbox_bundle_refr');
+        addTearDown(() => tmp.deleteSync(recursive: true));
+
+        final repo = MockOutboxRepository();
+        final sender = MockMessageSender();
+        final log = MockLoggingService();
+        final db = MockJournalDb();
+
+        final entity = JournalEntity.journalEntry(
+          meta: meta('refr-1'),
+          entryText: const EntryText(plainText: 'x'),
+        );
+        final jsonPath = relativeEntityPath(entity);
+        File('${tmp.path}$jsonPath')
+          ..parent.createSync(recursive: true)
+          ..writeAsStringSync(jsonEncode(entity.toJson()));
+        final item = pendingFor(id: 1, entryId: 'refr-1', jsonPath: jsonPath);
+        final corrupted = OutboxItem(
+          id: item.id,
+          message: '{ not-json',
+          subject: item.subject,
+          status: item.status,
+          retries: item.retries,
+          createdAt: item.createdAt,
+          updatedAt: item.updatedAt,
+          priority: item.priority,
+        );
+
+        when(
+          () => repo.fetchPending(limit: any(named: 'limit')),
+        ).thenAnswer((_) async => [item]);
+        when(() => repo.refreshItem(item)).thenAnswer((_) async => corrupted);
+        when(() => repo.markRetry(any<OutboxItem>())).thenAnswer((_) async {});
+        when(
+          () => db.getConfigFlag(useBundledAttachmentsFlag),
+        ).thenAnswer((_) async => true);
+        when(
+          () => sender.sendAttachmentBundle(
+            entries: any<Map<String, Uint8List>>(named: 'entries'),
+          ),
+        ).thenAnswer((_) async => r'$bundle-ok');
+        when(
+          () => log.captureEvent(
+            any<Object>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+          ),
+        ).thenAnswer((_) {});
+        final exSubDomains = <String?>[];
+        when(
+          () => log.captureException(
+            any<Object>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+            stackTrace: any<StackTrace?>(named: 'stackTrace'),
+          ),
+        ).thenAnswer((inv) async {
+          exSubDomains.add(inv.namedArguments[#subDomain] as String?);
+        });
+
+        final proc = OutboxProcessor(
+          repository: repo,
+          messageSender: sender,
+          loggingService: log,
+          journalDb: db,
+          documentsDirectory: tmp,
+        );
+
+        await proc.processQueue();
+
+        verify(() => repo.markRetry(corrupted)).called(1);
+        expect(exSubDomains, contains('bundle.decode'));
+        verifyNever(
+          () => sender.send(
+            any(),
+            skipAttachmentPaths: any<Set<String>>(named: 'skipAttachmentPaths'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'refresh returning null during bundle skips the item without error',
+      () async {
+        // Item was marked sent/deleted between fetch and the per-item loop.
+        // refreshItem returns null; the loop must skip it cleanly with no
+        // markSent or markRetry call.
+        final tmp = Directory.systemTemp.createTempSync('outbox_bundle_rfn');
+        addTearDown(() => tmp.deleteSync(recursive: true));
+
+        final repo = MockOutboxRepository();
+        final sender = MockMessageSender();
+        final log = MockLoggingService();
+        final db = MockJournalDb();
+
+        final entity = JournalEntity.journalEntry(
+          meta: meta('rfn-1'),
+          entryText: const EntryText(plainText: 'x'),
+        );
+        final jsonPath = relativeEntityPath(entity);
+        File('${tmp.path}$jsonPath')
+          ..parent.createSync(recursive: true)
+          ..writeAsStringSync(jsonEncode(entity.toJson()));
+        final item = pendingFor(id: 1, entryId: 'rfn-1', jsonPath: jsonPath);
+
+        when(
+          () => repo.fetchPending(limit: any(named: 'limit')),
+        ).thenAnswer((_) async => [item]);
+        when(() => repo.refreshItem(item)).thenAnswer((_) async => null);
+        when(
+          () => db.getConfigFlag(useBundledAttachmentsFlag),
+        ).thenAnswer((_) async => true);
+        when(
+          () => sender.sendAttachmentBundle(
+            entries: any<Map<String, Uint8List>>(named: 'entries'),
+          ),
+        ).thenAnswer((_) async => r'$bundle-ok');
+        when(
+          () => log.captureEvent(
+            any<Object>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+          ),
+        ).thenAnswer((_) {});
+
+        final proc = OutboxProcessor(
+          repository: repo,
+          messageSender: sender,
+          loggingService: log,
+          journalDb: db,
+          documentsDirectory: tmp,
+        );
+
+        final result = await proc.processQueue();
+
+        verifyNever(() => repo.markRetry(any<OutboxItem>()));
+        verifyNever(() => repo.markSent(any<OutboxItem>()));
+        verifyNever(
+          () => sender.send(
+            any(),
+            skipAttachmentPaths: any<Set<String>>(named: 'skipAttachmentPaths'),
+          ),
+        );
+        expect(result.shouldSchedule, isFalse);
+      },
+    );
+
+    test(
+      'bundled item success resets repeated-subject diagnostic counters',
+      () async {
+        final tmp = Directory.systemTemp.createTempSync('outbox_bundle_reset');
+        addTearDown(() => tmp.deleteSync(recursive: true));
+
+        final repo = MockOutboxRepository();
+        final sender = MockMessageSender();
+        final log = MockLoggingService();
+        final db = MockJournalDb();
+
+        final entity = JournalEntity.journalEntry(
+          meta: meta('ok-1'),
+          entryText: const EntryText(plainText: 'x'),
+        );
+        final jsonPath = relativeEntityPath(entity);
+        File('${tmp.path}$jsonPath')
+          ..parent.createSync(recursive: true)
+          ..writeAsStringSync(jsonEncode(entity.toJson()));
+        final item = pendingFor(id: 1, entryId: 'ok-1', jsonPath: jsonPath);
+
+        when(
+          () => repo.fetchPending(limit: any(named: 'limit')),
+        ).thenAnswer((_) async => [item]);
+        when(() => repo.refreshItem(item)).thenAnswer((_) async => item);
+        when(() => repo.markSent(any<OutboxItem>())).thenAnswer((_) async {});
+        when(() => repo.markRetry(any<OutboxItem>())).thenAnswer((_) async {});
+        when(
+          () => db.getConfigFlag(useBundledAttachmentsFlag),
+        ).thenAnswer((_) async => true);
+        when(
+          () => sender.sendAttachmentBundle(
+            entries: any<Map<String, Uint8List>>(named: 'entries'),
+          ),
+        ).thenAnswer((_) async => r'$bundle-ok');
+        var sendResult = false;
+        when(
+          () => sender.send(
+            any(),
+            skipAttachmentPaths: any<Set<String>>(named: 'skipAttachmentPaths'),
+          ),
+        ).thenAnswer((_) async => sendResult);
+        when(
+          () => log.captureEvent(
+            any<Object>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+          ),
+        ).thenAnswer((_) {});
+
+        final proc = OutboxProcessor(
+          repository: repo,
+          messageSender: sender,
+          loggingService: log,
+          journalDb: db,
+          documentsDirectory: tmp,
+        );
+
+        // Tick 1: fail to seed _lastFailedSubject/_lastFailedRepeats for
+        // this subject.
+        await proc.processQueue();
+        verify(() => repo.markRetry(item)).called(1);
+
+        // Tick 2: succeed → the success branch must reset the tracker.
+        sendResult = true;
+        final result = await proc.processQueue();
+        verify(() => repo.markSent(item)).called(1);
+        // Nothing remaining → no further schedule.
+        expect(result.shouldSchedule, isFalse);
+      },
+    );
   });
 }

--- a/test/features/sync/outbox/outbox_processor_test.dart
+++ b/test/features/sync/outbox/outbox_processor_test.dart
@@ -1,13 +1,19 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/entry_text.dart';
+import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/features/sync/model/sync_message.dart';
 import 'package:lotti/features/sync/outbox/outbox_processor.dart';
 import 'package:lotti/features/sync/outbox/outbox_repository.dart';
 import 'package:lotti/features/sync/state/outbox_state_controller.dart';
+import 'package:lotti/utils/consts.dart';
+import 'package:lotti/utils/file_utils.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../mocks/mocks.dart';
@@ -1019,6 +1025,280 @@ void main() {
         // item2 sent successfully, no more items
         expect(result2.shouldSchedule, isFalse);
         verify(() => sender.send(any())).called(1);
+      },
+    );
+  });
+
+  group('attachment bundling', () {
+    Metadata meta(String id) {
+      final ts = DateTime(2026, 4, 17, 12);
+      return Metadata(
+        id: id,
+        createdAt: ts,
+        updatedAt: ts,
+        dateFrom: ts,
+        dateTo: ts,
+      );
+    }
+
+    OutboxItem pendingFor({
+      required int id,
+      required String entryId,
+      required String jsonPath,
+    }) {
+      return OutboxItem(
+        id: id,
+        message: jsonEncode(
+          SyncMessage.journalEntity(
+            id: entryId,
+            jsonPath: jsonPath,
+            vectorClock: null,
+            status: SyncEntryStatus.initial,
+          ).toJson(),
+        ),
+        subject: 'host:$id',
+        status: OutboxStatus.pending.index,
+        retries: 0,
+        createdAt: DateTime(2026, 4, 17),
+        updatedAt: DateTime(2026, 4, 17),
+        priority: OutboxPriority.low.index,
+      );
+    }
+
+    test(
+      'bundles two pending items when flag is on and items fit under cap',
+      () async {
+        final tmp = Directory.systemTemp.createTempSync('outbox_bundle_test');
+        addTearDown(() => tmp.deleteSync(recursive: true));
+
+        final repo = MockOutboxRepository();
+        final sender = MockMessageSender();
+        final log = MockLoggingService();
+        final db = MockJournalDb();
+
+        final entity1 = JournalEntity.journalEntry(
+          meta: meta('e1'),
+          entryText: const EntryText(plainText: 'Entry one'),
+        );
+        final entity2 = JournalEntity.journalEntry(
+          meta: meta('e2'),
+          entryText: const EntryText(plainText: 'Entry two'),
+        );
+        final jsonPath1 = relativeEntityPath(entity1);
+        final jsonPath2 = relativeEntityPath(entity2);
+        File('${tmp.path}$jsonPath1')
+          ..parent.createSync(recursive: true)
+          ..writeAsStringSync(jsonEncode(entity1.toJson()));
+        File('${tmp.path}$jsonPath2')
+          ..parent.createSync(recursive: true)
+          ..writeAsStringSync(jsonEncode(entity2.toJson()));
+
+        final item1 = pendingFor(id: 1, entryId: 'e1', jsonPath: jsonPath1);
+        final item2 = pendingFor(id: 2, entryId: 'e2', jsonPath: jsonPath2);
+
+        when(
+          () => repo.fetchPending(limit: any(named: 'limit')),
+        ).thenAnswer((_) async => [item1, item2]);
+        when(() => repo.refreshItem(item1)).thenAnswer((_) async => item1);
+        when(() => repo.refreshItem(item2)).thenAnswer((_) async => item2);
+        when(() => repo.markSent(any<OutboxItem>())).thenAnswer((_) async {});
+        when(() => repo.markRetry(any<OutboxItem>())).thenAnswer((_) async {});
+        when(
+          () => db.getConfigFlag(useBundledAttachmentsFlag),
+        ).thenAnswer((_) async => true);
+        final capturedBundles = <Map<String, Uint8List>>[];
+        when(
+          () => sender.sendAttachmentBundle(
+            entries: any<Map<String, Uint8List>>(named: 'entries'),
+          ),
+        ).thenAnswer((invocation) async {
+          capturedBundles.add(
+            invocation.namedArguments[#entries] as Map<String, Uint8List>,
+          );
+          return r'$bundle-id';
+        });
+        final capturedSkipSets = <Set<String>>[];
+        when(
+          () => sender.send(
+            any(),
+            skipAttachmentPaths: any<Set<String>>(
+              named: 'skipAttachmentPaths',
+            ),
+          ),
+        ).thenAnswer((invocation) async {
+          capturedSkipSets.add(
+            invocation.namedArguments[#skipAttachmentPaths] as Set<String>,
+          );
+          return true;
+        });
+        when(
+          () => log.captureEvent(
+            any<Object>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+          ),
+        ).thenAnswer((_) {});
+
+        final proc = OutboxProcessor(
+          repository: repo,
+          messageSender: sender,
+          loggingService: log,
+          journalDb: db,
+          documentsDirectory: tmp,
+        );
+
+        final result = await proc.processQueue();
+
+        // Bundle must have been uploaded once with both items' jsonPaths.
+        expect(capturedBundles, hasLength(1));
+        expect(
+          capturedBundles.single.keys.toSet(),
+          equals({jsonPath1, jsonPath2}),
+        );
+        // Both items' text events must have been sent with the skip set
+        // containing both paths.
+        expect(capturedSkipSets, hasLength(2));
+        for (final s in capturedSkipSets) {
+          expect(s, equals({jsonPath1, jsonPath2}));
+        }
+        verify(() => repo.markSent(item1)).called(1);
+        verify(() => repo.markSent(item2)).called(1);
+        verifyNever(() => repo.markRetry(any<OutboxItem>()));
+        // Everything drained this tick → no more schedule.
+        expect(result.shouldSchedule, isFalse);
+      },
+    );
+
+    test(
+      'falls through to head-only flow when flag is off',
+      () async {
+        final tmp = Directory.systemTemp.createTempSync('outbox_bundle_off');
+        addTearDown(() => tmp.deleteSync(recursive: true));
+
+        final repo = MockOutboxRepository();
+        final sender = MockMessageSender();
+        final log = MockLoggingService();
+        final db = MockJournalDb();
+
+        final entity = JournalEntity.journalEntry(
+          meta: meta('off-1'),
+          entryText: const EntryText(plainText: 'x'),
+        );
+        final jsonPath = relativeEntityPath(entity);
+        File('${tmp.path}$jsonPath')
+          ..parent.createSync(recursive: true)
+          ..writeAsStringSync(jsonEncode(entity.toJson()));
+
+        final item = pendingFor(
+          id: 1,
+          entryId: 'off-1',
+          jsonPath: jsonPath,
+        );
+        when(
+          () => repo.fetchPending(limit: any(named: 'limit')),
+        ).thenAnswer((_) async => [item]);
+        when(() => repo.refreshItem(item)).thenAnswer((_) async => item);
+        when(() => repo.markSent(any<OutboxItem>())).thenAnswer((_) async {});
+        when(
+          () => db.getConfigFlag(useBundledAttachmentsFlag),
+        ).thenAnswer((_) async => false);
+        when(() => sender.send(any())).thenAnswer((_) async => true);
+        when(
+          () => log.captureEvent(
+            any<Object>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+          ),
+        ).thenAnswer((_) {});
+
+        final proc = OutboxProcessor(
+          repository: repo,
+          messageSender: sender,
+          loggingService: log,
+          journalDb: db,
+          documentsDirectory: tmp,
+        );
+
+        await proc.processQueue();
+
+        // Bundle upload must NOT have happened.
+        verifyNever(
+          () => sender.sendAttachmentBundle(
+            entries: any<Map<String, Uint8List>>(named: 'entries'),
+          ),
+        );
+        // Regular send path ran for the head item.
+        verify(() => sender.send(any())).called(1);
+      },
+    );
+
+    test(
+      'bundle upload failure marks bundled items for retry',
+      () async {
+        final tmp = Directory.systemTemp.createTempSync('outbox_bundle_fail');
+        addTearDown(() => tmp.deleteSync(recursive: true));
+
+        final repo = MockOutboxRepository();
+        final sender = MockMessageSender();
+        final log = MockLoggingService();
+        final db = MockJournalDb();
+
+        final entity = JournalEntity.journalEntry(
+          meta: meta('fail-1'),
+          entryText: const EntryText(plainText: 'x'),
+        );
+        final jsonPath = relativeEntityPath(entity);
+        File('${tmp.path}$jsonPath')
+          ..parent.createSync(recursive: true)
+          ..writeAsStringSync(jsonEncode(entity.toJson()));
+
+        final item = pendingFor(
+          id: 1,
+          entryId: 'fail-1',
+          jsonPath: jsonPath,
+        );
+        when(
+          () => repo.fetchPending(limit: any(named: 'limit')),
+        ).thenAnswer((_) async => [item]);
+        when(() => repo.markRetry(any<OutboxItem>())).thenAnswer((_) async {});
+        when(
+          () => db.getConfigFlag(useBundledAttachmentsFlag),
+        ).thenAnswer((_) async => true);
+        when(
+          () => sender.sendAttachmentBundle(
+            entries: any<Map<String, Uint8List>>(named: 'entries'),
+          ),
+        ).thenAnswer((_) async => null);
+        when(
+          () => log.captureEvent(
+            any<Object>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(named: 'subDomain'),
+          ),
+        ).thenAnswer((_) {});
+
+        final proc = OutboxProcessor(
+          repository: repo,
+          messageSender: sender,
+          loggingService: log,
+          journalDb: db,
+          documentsDirectory: tmp,
+          errorDelayOverride: const Duration(seconds: 1),
+        );
+
+        final result = await proc.processQueue();
+
+        verify(() => repo.markRetry(item)).called(1);
+        verifyNever(
+          () => sender.send(
+            any(),
+            skipAttachmentPaths: any<Set<String>>(
+              named: 'skipAttachmentPaths',
+            ),
+          ),
+        );
+        expect(result.shouldSchedule, isTrue);
+        expect(result.nextDelay, const Duration(seconds: 1));
       },
     );
   });

--- a/test/features/sync/outbox/outbox_retry_cap_db_test.dart
+++ b/test/features/sync/outbox/outbox_retry_cap_db_test.dart
@@ -1,6 +1,7 @@
 // ignore_for_file:
 
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:drift/drift.dart' show Value;
 import 'package:flutter_test/flutter_test.dart';
@@ -15,7 +16,15 @@ import 'package:lotti/services/logging_service.dart';
 
 class _SenderFalse implements OutboxMessageSender {
   @override
-  Future<bool> send(SyncMessage message) async => false;
+  Future<bool> send(
+    SyncMessage message, {
+    Set<String> skipAttachmentPaths = const <String>{},
+  }) async => false;
+
+  @override
+  Future<String?> sendAttachmentBundle({
+    required Map<String, Uint8List> entries,
+  }) async => null;
 }
 
 class _NoopLogging extends LoggingService {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional outbox attachment bundling (config off by default): pending attachments can be packed into a single upload (8 MiB cap) with per-item text events; oversized attachments fall back to individual uploads. Receivers detect bundle-marked uploads and unpack entries to their intended paths.
  * Release: 0.9.956.

* **Documentation**
  * Sync docs updated to describe bundling behavior and receiver compatibility.

* **Tests**
  * Added comprehensive bundling, unpacking, edge-case and retry coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->