### PR TITLE
fix: time recording proposal creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.956] - 2026-04-18
+### Fixed
+- AI-proposed time entries can now be confirmed from the task "Proposed
+  changes" panel. The approval-time validator previously rejected any
+  `create_time_entry` whose `startTime` or `endTime` fell after the
+  originating wake timestamp, which left suggestions like 11:13–11:48 or
+  11:00–13:00 stuck as pending with a "Failed to apply change" toast
+  whenever the agent rounded or estimated a session past the wake instant.
+  The wake timestamp is still used for the same-day check (so
+  after-midnight approvals keep working), but the "not in the future"
+  cutoff no longer applies at approval time — the user is the authority
+  when confirming. `endTime` must still land on the same day as
+  `startTime`. Direct agent-time tool calls (if ever wired) still refuse
+  fabricated future times.
+
 ## [0.9.955] - 2026-04-17
 ### Changed
 - Align the desktop tasks and projects surfaces with the Figma design system.

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -31,6 +31,11 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="0.9.956" date="2026-04-18">
+      <description>
+          <p>Fix a P0 bug that prevented AI-proposed time entries from being confirmed from the task "Proposed changes" panel. The approval-time validator previously rejected any create_time_entry whose startTime or endTime fell after the originating wake timestamp, which left suggestions like 11:13–11:48 or 11:00–13:00 stuck as pending with a "Failed to apply change" toast whenever the agent rounded or estimated a session past the wake instant. The wake timestamp is still used for the same-day check (so after-midnight approvals keep working), but the "not in the future" cutoff no longer applies at approval time — the user is the authority when confirming. endTime must still land on the same day as startTime.</p>
+      </description>
+    </release>
     <release version="0.9.955" date="2026-04-17">
       <description>
           <p>Desktop tasks and projects surfaces are aligned with the Figma design system. Sidebar, task list, task details and projects list share the deeper background/01 surface while task cards sit on background/02, and dark-mode text tokens were raised to the Figma-specified opacities (high 100%, medium 80%, low 64%) so headlines, subtitles and timestamps read with the correct contrast without changing type weights. The selected task row now uses the Figma surface/selected token for a subtler highlight, and task group headers and counts use the caption token for a lighter hierarchy. The task title strip and its sliver app bars render on background/01 with no elevation so the header no longer reads darker than the body.</p>

--- a/lib/features/agents/tools/time_entry_handler.dart
+++ b/lib/features/agents/tools/time_entry_handler.dart
@@ -139,7 +139,12 @@ class TimeEntryHandler {
           errorMessage: 'startTime is not on ${completedReference.label} day',
         );
       }
-      if (startTime.isAfter(completedReference.timestamp)) {
+      // At approval time (deferred execution), the user is the authority and
+      // may intentionally confirm an entry whose start/end drifted past the
+      // wake timestamp (e.g. a meeting the agent estimated would end at
+      // 13:00). Only enforce the "not in the future" cutoff at wake time.
+      if (completedReference.enforceFutureCutoff &&
+          startTime.isAfter(completedReference.timestamp)) {
         return ToolExecutionResult(
           success: false,
           output:
@@ -165,7 +170,8 @@ class TimeEntryHandler {
           errorMessage: 'endTime is on a different day',
         );
       }
-      if (endTime.isAfter(completedReference.timestamp)) {
+      if (completedReference.enforceFutureCutoff &&
+          endTime.isAfter(completedReference.timestamp)) {
         return ToolExecutionResult(
           success: false,
           output:
@@ -278,23 +284,46 @@ class TimeEntryHandler {
     return a.year == b.year && a.month == b.month && a.day == b.day;
   }
 
-  static ({DateTime timestamp, String label}) _resolveCompletedSessionReference(
+  /// Resolves the reference timestamp used for same-day and future-cutoff
+  /// validation.
+  ///
+  /// When called directly by the agent at wake time, no `_referenceTimestamp`
+  /// arg is injected so [fallback] (clock.now()) is used and
+  /// [enforceFutureCutoff] is true — the agent cannot fabricate times after
+  /// the current instant.
+  ///
+  /// At approval time, `ChangeSetConfirmationService` injects the originating
+  /// wake timestamp. The same-day check still runs against that timestamp so
+  /// after-midnight approvals of same-day-as-wake entries still work, but the
+  /// future cutoff is disabled so the user can confirm entries the agent
+  /// estimated to extend past the wake instant (e.g. an ongoing meeting).
+  static ({DateTime timestamp, String label, bool enforceFutureCutoff})
+  _resolveCompletedSessionReference(
     Map<String, dynamic> args,
     DateTime fallback,
   ) {
     final raw = args[timeEntryReferenceTimestampArg];
     if (raw is! String) {
-      return (timestamp: fallback, label: 'current time');
+      return (
+        timestamp: fallback,
+        label: 'current time',
+        enforceFutureCutoff: true,
+      );
     }
 
     final parsed = DateTime.tryParse(raw);
     if (parsed == null) {
-      return (timestamp: fallback, label: 'current time');
+      return (
+        timestamp: fallback,
+        label: 'current time',
+        enforceFutureCutoff: true,
+      );
     }
 
     return (
       timestamp: parsed.isUtc ? parsed.toLocal() : parsed,
       label: 'wake timestamp',
+      enforceFutureCutoff: false,
     );
   }
 

--- a/lib/features/agents/tools/time_entry_handler.dart
+++ b/lib/features/agents/tools/time_entry_handler.dart
@@ -287,10 +287,10 @@ class TimeEntryHandler {
   /// Resolves the reference timestamp used for same-day and future-cutoff
   /// validation.
   ///
-  /// When called directly by the agent at wake time, no `_referenceTimestamp`
-  /// arg is injected so [fallback] (clock.now()) is used and
-  /// [enforceFutureCutoff] is true — the agent cannot fabricate times after
-  /// the current instant.
+  /// When called directly by the agent at wake time, no
+  /// `_referenceTimestamp` arg is injected so `fallback` (clock.now()) is
+  /// used and `enforceFutureCutoff` is `true` — the agent cannot fabricate
+  /// times after the current instant.
   ///
   /// At approval time, `ChangeSetConfirmationService` injects the originating
   /// wake timestamp. The same-day check still runs against that timestamp so
@@ -303,15 +303,8 @@ class TimeEntryHandler {
     DateTime fallback,
   ) {
     final raw = args[timeEntryReferenceTimestampArg];
-    if (raw is! String) {
-      return (
-        timestamp: fallback,
-        label: 'current time',
-        enforceFutureCutoff: true,
-      );
-    }
+    final parsed = raw is String ? DateTime.tryParse(raw) : null;
 
-    final parsed = DateTime.tryParse(raw);
     if (parsed == null) {
       return (
         timestamp: fallback,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.955+3933
+version: 0.9.956+3934
 
 msix_config:
   display_name: LottiApp

--- a/test/features/agents/tools/time_entry_handler_test.dart
+++ b/test/features/agents/tools/time_entry_handler_test.dart
@@ -538,22 +538,90 @@ void main() {
       );
 
       test(
-        'returns failure when completed session ends after wake timestamp',
+        'accepts completed session whose endTime extends past the wake '
+        'timestamp (user is the authority at approval time)',
         () async {
-          await withClock(Clock.fixed(DateTime(2026, 3, 18, 0, 5)), () async {
+          // Reproduces the P0 scenario: agent wakes at 11:48:23, model
+          // rounds/estimates endTime past wake, user approves later. The
+          // "not in the future" cutoff must not apply at approval time.
+          await withClock(Clock.fixed(DateTime(2026, 4, 18, 12, 54)), () async {
             final result = await handler.handle(
               sourceTaskId,
               {
-                'startTime': '2026-03-17T23:00:00',
-                'endTime': '2026-03-17T23:59:00',
-                'summary': 'Late session',
-                timeEntryReferenceTimestampArg: '2026-03-17T23:55:00',
+                'startTime': '2026-04-18T11:13:50',
+                'endTime': '2026-04-18T11:48:50',
+                'summary': 'Design walkthrough',
+                timeEntryReferenceTimestampArg: '2026-04-18T11:48:23.029723',
+              },
+            );
+
+            expect(result.success, isTrue);
+            expect(result.output, contains('11:13–11:48'));
+          });
+        },
+      );
+
+      test(
+        'accepts completed session whose endTime is in the actual future at '
+        'approval time as long as it stays on the same day',
+        () async {
+          // Item 23 from the P0 logs: end=13:00, wake=11:48, approval<13:00.
+          await withClock(Clock.fixed(DateTime(2026, 4, 18, 12, 57)), () async {
+            final result = await handler.handle(
+              sourceTaskId,
+              {
+                'startTime': '2026-04-18T11:00:00',
+                'endTime': '2026-04-18T13:00:00',
+                'summary': 'Comprehensive walkthrough',
+                timeEntryReferenceTimestampArg: '2026-04-18T11:48:23.029723',
+              },
+            );
+
+            expect(result.success, isTrue);
+            expect(result.output, contains('11:00–13:00'));
+          });
+        },
+      );
+
+      test(
+        'still rejects completed session when endTime spills into the next '
+        'day (same-day constraint is preserved)',
+        () async {
+          await withClock(Clock.fixed(DateTime(2026, 4, 18, 23, 0)), () async {
+            final result = await handler.handle(
+              sourceTaskId,
+              {
+                'startTime': '2026-04-18T23:30:00',
+                'endTime': '2026-04-19T00:30:00',
+                'summary': 'Crossing midnight',
+                timeEntryReferenceTimestampArg: '2026-04-18T22:00:00',
               },
             );
 
             expect(result.success, isFalse);
-            expect(result.output, contains('wake timestamp'));
-            expect(result.errorMessage, 'endTime is after wake timestamp');
+            expect(result.output, contains('same day'));
+            expect(result.errorMessage, 'endTime is on a different day');
+          });
+        },
+      );
+
+      test(
+        'at wake time (no reference timestamp injected) still rejects '
+        'completed session with endTime in the future',
+        () async {
+          // testNow = 2026-03-17T15:30 — endTime 16:00 is in the future.
+          await withClock(Clock.fixed(testNow), () async {
+            final result = await handler.handle(
+              sourceTaskId,
+              {
+                'startTime': '2026-03-17T14:00:00',
+                'endTime': '2026-03-17T16:00:00',
+                'summary': 'Would be hallucinated',
+              },
+            );
+
+            expect(result.success, isFalse);
+            expect(result.errorMessage, 'endTime is after current time');
           });
         },
       );

--- a/test/features/agents/tools/time_entry_handler_test.dart
+++ b/test/features/agents/tools/time_entry_handler_test.dart
@@ -587,7 +587,7 @@ void main() {
         'still rejects completed session when endTime spills into the next '
         'day (same-day constraint is preserved)',
         () async {
-          await withClock(Clock.fixed(DateTime(2026, 4, 18, 23, 0)), () async {
+          await withClock(Clock.fixed(DateTime(2026, 4, 18, 23)), () async {
             final result = await handler.handle(
               sourceTaskId,
               {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inability to confirm AI-proposed time entries from the "Proposed changes" panel. Approval now accepts entries whose start/end extend past the originating event time, treating the user as authority at confirmation while still enforcing that start and end fall on the same day. Direct agent time-tool calls continue to refuse fabricated future times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->