### PR TITLE
refactor: eliminate n+1 queries

### DIFF
--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -2547,9 +2547,14 @@ class JournalDb extends _$JournalDb {
   /// window firing `_fetchAllData` per date) share a single round-trip: the
   /// wave merges every caller's id set, issues one `to_id IN (…)` query, and
   /// hands each caller the subset matching its own ids.
+  ///
+  /// The caller's set is snapshotted before scheduling so the post-query
+  /// filter never reads a mutated view if the caller reuses or clears the
+  /// set before the coalesced wave fires.
   Future<List<EntryLink>> basicLinksForEntryIds(Set<String> ids) {
-    if (ids.isEmpty) return Future.value(const <EntryLink>[]);
-    return _coalesceBasicLinks(ids);
+    final snapshot = Set<String>.unmodifiable(ids);
+    if (snapshot.isEmpty) return Future.value(const <EntryLink>[]);
+    return _coalesceBasicLinks(snapshot);
   }
 
   _PendingLinksWave? _pendingBasicLinksWave;

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -892,6 +892,42 @@ class JournalDb extends _$JournalDb {
     return dbEntities.map(fromDbEntity).toList();
   }
 
+  /// Lean metadata-only fetch: returns the denormalized `category` column for
+  /// each id, without loading or deserializing the fat `serialized` JSON
+  /// payload. Intended for callers that only need the category-id lookup
+  /// (e.g. time-history header aggregation) — any caller that also needs
+  /// `meta.categoryId` as the source of truth can use this without losing
+  /// information because `conversions.toDbEntity` keeps the column in lock-
+  /// step with the JSON on every upsert.
+  ///
+  /// Entries filtered out by the private-status gate are simply absent from
+  /// the returned map. An empty category value in the `journal.category`
+  /// column is returned as `null` so callers can treat "no category" and
+  /// "not present" uniformly.
+  Future<Map<String, String?>> getCategoryIdsForEntryIds(
+    Iterable<String> ids,
+  ) async {
+    final idList = ids.toSet().toList(growable: false);
+    if (idList.isEmpty) return const <String, String?>{};
+    final pairs = await _queryWithPrivateFilter<List<MapEntry<String, String>>>(
+      allPrivate: () async {
+        final rows = await journalCategoriesByIds(idList).get();
+        return [for (final row in rows) MapEntry(row.id, row.category)];
+      },
+      filtered: (s) async {
+        final rows = await journalCategoriesByIdsByPrivateStatuses(
+          idList,
+          s,
+        ).get();
+        return [for (final row in rows) MapEntry(row.id, row.category)];
+      },
+    );
+    return {
+      for (final pair in pairs)
+        pair.key: pair.value.isEmpty ? null : pair.value,
+    };
+  }
+
   Future<List<String>> getJournalEntityIdsSortedByDateFromDesc(
     Iterable<String> ids,
   ) {
@@ -2074,6 +2110,19 @@ class JournalDb extends _$JournalDb {
     return fromDbEntity(res.first) as DayPlanEntry;
   }
 
+  /// Batch variant of [getDayPlanById]. Used by the coalescing layer in
+  /// the day-plan repository so a prefetch window of N dates collapses
+  /// into a single round-trip.
+  Future<List<DayPlanEntry>> getDayPlansByIds(Iterable<String> ids) async {
+    final idList = ids.toList(growable: false);
+    if (idList.isEmpty) return const [];
+    final res = await _queryWithPrivateFilter(
+      allPrivate: () => dayPlansByIds(idList).get(),
+      filtered: (s) => dayPlansByIdsByPrivateStatuses(idList, s).get(),
+    );
+    return res.map((e) => fromDbEntity(e) as DayPlanEntry).toList();
+  }
+
   Future<List<DayPlanEntry>> getDayPlansInRange({
     required DateTime rangeStart,
     required DateTime rangeEnd,
@@ -2131,15 +2180,13 @@ class JournalDb extends _$JournalDb {
   /// Excludes completed (DONE) and rejected (REJECTED) tasks.
   /// This includes both tasks due on the specified day and overdue tasks.
   Future<List<Task>> getTasksDueOnOrBefore(DateTime date) async {
-    // Use end of day to capture tasks due on this day
     final endOfDay = DateTime(date.year, date.month, date.day, 23, 59, 59, 999);
-    final endIso = endOfDay.toIso8601String();
-
-    final res = await _selectTasksDue(
-      endIso: endIso,
-      privateStatuses: await _visiblePrivateStatuses(),
+    final privateStatuses = await _visiblePrivateStatuses();
+    final superset = await _coalesceOpenTasksDueUpTo(endOfDay, privateStatuses);
+    return _filterTasks(
+      superset,
+      endInclusive: endOfDay,
     );
-    return res.map(fromDbEntity).whereType<Task>().toList();
   }
 
   /// Returns tasks that are due on the specified date only.
@@ -2148,15 +2195,93 @@ class JournalDb extends _$JournalDb {
   Future<List<Task>> getTasksDueOn(DateTime date) async {
     final startOfDay = DateTime(date.year, date.month, date.day);
     final endOfDay = DateTime(date.year, date.month, date.day, 23, 59, 59, 999);
-    final startIso = startOfDay.toIso8601String();
-    final endIso = endOfDay.toIso8601String();
-
-    final res = await _selectTasksDue(
-      startIso: startIso,
-      endIso: endIso,
-      privateStatuses: await _visiblePrivateStatuses(),
+    final privateStatuses = await _visiblePrivateStatuses();
+    final superset = await _coalesceOpenTasksDueUpTo(endOfDay, privateStatuses);
+    return _filterTasks(
+      superset,
+      startInclusive: startOfDay,
+      endInclusive: endOfDay,
     );
-    return res.map(fromDbEntity).whereType<Task>().toList();
+  }
+
+  // Microtask-coalescing state for `_coalesceOpenTasksDueUpTo`.
+  //
+  // The DailyOS prefetch window fires `getTasksDueOn` / `getTasksDueOnOrBefore`
+  // once per date in a synchronous sweep. Instead of N round-trips through
+  // `_selectTasksDue`, we share the widest `due <= max(endOfDay)` superset
+  // across the whole wave and let each caller filter its own range
+  // client-side from the in-memory list.
+  //
+  // The coalescer is keyed by the private-status shape so that private-filter
+  // changes mid-wave (very rare but theoretically possible) still produce a
+  // correct batch per shape.
+  final Map<String, _PendingDueWave> _pendingDueWaves = {};
+
+  /// Single-shot query executed by the tasks-due coalescer. Extracted as a
+  /// protected seam so tests can count round-trips and inject failures
+  /// without depending on a query interceptor.
+  @protected
+  @visibleForTesting
+  Future<List<Task>> runTasksDueFetch({
+    required DateTime endInclusive,
+    required List<bool> privateStatuses,
+  }) async {
+    final rows = await _selectTasksDue(
+      endIso: endInclusive.toIso8601String(),
+      privateStatuses: privateStatuses,
+    );
+    return rows.map(fromDbEntity).whereType<Task>().toList(growable: false);
+  }
+
+  Future<List<Task>> _coalesceOpenTasksDueUpTo(
+    DateTime endInclusive,
+    List<bool> privateStatuses,
+  ) {
+    final key = privateStatuses.join(',');
+    final existing = _pendingDueWaves[key];
+    if (existing != null) {
+      // Extend the existing wave's upper bound so the superset covers the
+      // latest caller as well. Filtering happens per caller, so a slightly
+      // wider range is free.
+      if (endInclusive.isAfter(existing.endInclusive)) {
+        existing.endInclusive = endInclusive;
+      }
+      return existing.completer.future;
+    }
+
+    final wave = _PendingDueWave(
+      endInclusive: endInclusive,
+      privateStatuses: List<bool>.unmodifiable(privateStatuses),
+    );
+    _pendingDueWaves[key] = wave;
+    scheduleMicrotask(() async {
+      _pendingDueWaves.remove(key);
+      try {
+        final tasks = await runTasksDueFetch(
+          endInclusive: wave.endInclusive,
+          privateStatuses: wave.privateStatuses,
+        );
+        wave.completer.complete(tasks);
+      } catch (error, stack) {
+        wave.completer.completeError(error, stack);
+      }
+    });
+    return wave.completer.future;
+  }
+
+  static List<Task> _filterTasks(
+    List<Task> superset, {
+    required DateTime endInclusive,
+    DateTime? startInclusive,
+  }) {
+    return [
+      for (final task in superset)
+        if (task.data.due != null &&
+            !task.data.due!.isAfter(endInclusive) &&
+            (startInclusive == null ||
+                !task.data.due!.isBefore(startInclusive)))
+          task,
+    ];
   }
 
   // Drift SQL doesn't support `INDEXED BY`, so keep the due-date hot path in
@@ -2417,14 +2542,53 @@ class JournalDb extends _$JournalDb {
 
   /// Returns only [BasicLink] entries for the given [ids], filtering out
   /// RatingLinks at the SQL level using the `type` column.
-  Future<List<EntryLink>> basicLinksForEntryIds(Set<String> ids) async {
-    if (ids.isEmpty) return <EntryLink>[];
-    final entryLinks =
+  ///
+  /// Concurrent callers within the same microtask (e.g. the DailyOS prefetch
+  /// window firing `_fetchAllData` per date) share a single round-trip: the
+  /// wave merges every caller's id set, issues one `to_id IN (…)` query, and
+  /// hands each caller the subset matching its own ids.
+  Future<List<EntryLink>> basicLinksForEntryIds(Set<String> ids) {
+    if (ids.isEmpty) return Future.value(const <EntryLink>[]);
+    return _coalesceBasicLinks(ids);
+  }
+
+  _PendingLinksWave? _pendingBasicLinksWave;
+
+  /// Single-shot query executed by the basic-links coalescer. Extracted as a
+  /// protected seam so tests can count DB round-trips without depending on
+  /// a query interceptor.
+  @protected
+  @visibleForTesting
+  Future<List<EntryLink>> runBasicLinksQueryForIds(Set<String> ids) async {
+    final rows =
         await (select(linkedEntries)..where(
               (t) => t.toId.isIn(ids.toList()) & t.type.equals('BasicLink'),
             ))
             .get();
-    return entryLinks.map(entryLinkFromLinkedDbEntry).toList();
+    return rows.map(entryLinkFromLinkedDbEntry).toList();
+  }
+
+  Future<List<EntryLink>> _coalesceBasicLinks(Set<String> ids) {
+    final wave = _pendingBasicLinksWave ??= _PendingLinksWave();
+    wave.mergedIds.addAll(ids);
+    if (!wave.scheduled) {
+      wave.scheduled = true;
+      scheduleMicrotask(() async {
+        _pendingBasicLinksWave = null;
+        try {
+          final links = await runBasicLinksQueryForIds(wave.mergedIds);
+          wave.completer.complete(links);
+        } catch (error, stack) {
+          wave.completer.completeError(error, stack);
+        }
+      });
+    }
+    return wave.completer.future.then(
+      (links) => [
+        for (final link in links)
+          if (ids.contains(link.toId)) link,
+      ],
+    );
   }
 
   Future<List<EntryLink>> linksForEntryIdsBidirectional(Set<String> ids) async {
@@ -2639,4 +2803,30 @@ WHERE EXISTS (
 
     return null;
   }
+}
+
+/// In-flight coalescing wave for the open-task-due-date superset fetch.
+/// Every caller in the same microtask wave that shares a private-status
+/// shape joins the same wave; the wave issues a single `_selectTasksDue`
+/// covering the widest `endInclusive` seen before the microtask fires.
+class _PendingDueWave {
+  _PendingDueWave({
+    required this.endInclusive,
+    required this.privateStatuses,
+  });
+
+  DateTime endInclusive;
+  final List<bool> privateStatuses;
+  final Completer<List<Task>> completer = Completer<List<Task>>.sync();
+}
+
+/// In-flight coalescing wave for `basicLinksForEntryIds`. Concurrent callers
+/// within the same microtask merge their id sets; the wave fires one
+/// `to_id IN (…)` query and each caller filters the full result down to
+/// its own ids.
+class _PendingLinksWave {
+  final Set<String> mergedIds = <String>{};
+  bool scheduled = false;
+  final Completer<List<EntryLink>> completer =
+      Completer<List<EntryLink>>.sync();
 }

--- a/lib/database/database.drift
+++ b/lib/database/database.drift
@@ -1007,6 +1007,20 @@ SELECT * FROM journal
   WHERE deleted = false
   AND id IN :ids;
 
+-- Lean projection returning only (id, category) for callers that just need
+-- the denormalized category column to build a lookup map. Skips the
+-- serialized JSON blob and the fromDbEntity deserialization pass.
+journalCategoriesByIds:
+SELECT id, category FROM journal
+  WHERE deleted = false
+  AND id IN :ids;
+
+journalCategoriesByIdsByPrivateStatuses:
+SELECT id, category FROM journal
+  WHERE deleted = false
+  AND id IN :ids
+  AND private IN :privateStatuses;
+
 linkedJournalEntityIds:
 SELECT to_id FROM linked_entries WHERE from_id = :from_id AND hidden IN :hidden;
 
@@ -1067,6 +1081,22 @@ dayPlanByIdByPrivateStatuses:
 SELECT * FROM journal
   WHERE type = 'DayPlanEntry'
   AND id = :id
+  AND deleted = false
+  AND private IN :privateStatuses;
+
+-- Batch fetch variants: used by the microtask-coalescing layer in
+-- DayPlanRepositoryImpl so a prefetch window of N dates collapses into a
+-- single round-trip instead of N single-row SELECTs.
+dayPlansByIds:
+SELECT * FROM journal
+  WHERE type = 'DayPlanEntry'
+  AND id IN :ids
+  AND deleted = false;
+
+dayPlansByIdsByPrivateStatuses:
+SELECT * FROM journal
+  WHERE type = 'DayPlanEntry'
+  AND id IN :ids
   AND deleted = false
   AND private IN :privateStatuses;
 

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -7244,6 +7244,52 @@ abstract class _$JournalDb extends GeneratedDatabase {
     ).asyncMap(journal.mapFromRow);
   }
 
+  Selectable<JournalCategoriesByIdsResult> journalCategoriesByIds(
+    List<String> ids,
+  ) {
+    var $arrayStartIndex = 1;
+    final expandedids = $expandVar($arrayStartIndex, ids.length);
+    $arrayStartIndex += ids.length;
+    return customSelect(
+      'SELECT id, category FROM journal WHERE deleted = FALSE AND id IN ($expandedids)',
+      variables: [for (var $ in ids) Variable<String>($)],
+      readsFrom: {journal},
+    ).map(
+      (QueryRow row) => JournalCategoriesByIdsResult(
+        id: row.read<String>('id'),
+        category: row.read<String>('category'),
+      ),
+    );
+  }
+
+  Selectable<JournalCategoriesByIdsByPrivateStatusesResult>
+  journalCategoriesByIdsByPrivateStatuses(
+    List<String> ids,
+    List<bool> privateStatuses,
+  ) {
+    var $arrayStartIndex = 1;
+    final expandedids = $expandVar($arrayStartIndex, ids.length);
+    $arrayStartIndex += ids.length;
+    final expandedprivateStatuses = $expandVar(
+      $arrayStartIndex,
+      privateStatuses.length,
+    );
+    $arrayStartIndex += privateStatuses.length;
+    return customSelect(
+      'SELECT id, category FROM journal WHERE deleted = FALSE AND id IN ($expandedids) AND private IN ($expandedprivateStatuses)',
+      variables: [
+        for (var $ in ids) Variable<String>($),
+        for (var $ in privateStatuses) Variable<bool>($),
+      ],
+      readsFrom: {journal},
+    ).map(
+      (QueryRow row) => JournalCategoriesByIdsByPrivateStatusesResult(
+        id: row.read<String>('id'),
+        category: row.read<String>('category'),
+      ),
+    );
+  }
+
   Selectable<String> linkedJournalEntityIds(String fromId, List<bool?> hidden) {
     var $arrayStartIndex = 2;
     final expandedhidden = $expandVar($arrayStartIndex, hidden.length);
@@ -7365,6 +7411,39 @@ abstract class _$JournalDb extends GeneratedDatabase {
       'SELECT * FROM journal WHERE type = \'DayPlanEntry\' AND id = ?1 AND deleted = FALSE AND private IN ($expandedprivateStatuses)',
       variables: [
         Variable<String>(id),
+        for (var $ in privateStatuses) Variable<bool>($),
+      ],
+      readsFrom: {journal},
+    ).asyncMap(journal.mapFromRow);
+  }
+
+  Selectable<JournalDbEntity> dayPlansByIds(List<String> ids) {
+    var $arrayStartIndex = 1;
+    final expandedids = $expandVar($arrayStartIndex, ids.length);
+    $arrayStartIndex += ids.length;
+    return customSelect(
+      'SELECT * FROM journal WHERE type = \'DayPlanEntry\' AND id IN ($expandedids) AND deleted = FALSE',
+      variables: [for (var $ in ids) Variable<String>($)],
+      readsFrom: {journal},
+    ).asyncMap(journal.mapFromRow);
+  }
+
+  Selectable<JournalDbEntity> dayPlansByIdsByPrivateStatuses(
+    List<String> ids,
+    List<bool> privateStatuses,
+  ) {
+    var $arrayStartIndex = 1;
+    final expandedids = $expandVar($arrayStartIndex, ids.length);
+    $arrayStartIndex += ids.length;
+    final expandedprivateStatuses = $expandVar(
+      $arrayStartIndex,
+      privateStatuses.length,
+    );
+    $arrayStartIndex += privateStatuses.length;
+    return customSelect(
+      'SELECT * FROM journal WHERE type = \'DayPlanEntry\' AND id IN ($expandedids) AND deleted = FALSE AND private IN ($expandedprivateStatuses)',
+      variables: [
+        for (var $ in ids) Variable<String>($),
         for (var $ in privateStatuses) Variable<bool>($),
       ],
       readsFrom: {journal},
@@ -10331,6 +10410,21 @@ class CountTasksGroupedByCategoryResult {
   CountTasksGroupedByCategoryResult({
     required this.category,
     required this.taskCount,
+  });
+}
+
+class JournalCategoriesByIdsResult {
+  final String id;
+  final String category;
+  JournalCategoriesByIdsResult({required this.id, required this.category});
+}
+
+class JournalCategoriesByIdsByPrivateStatusesResult {
+  final String id;
+  final String category;
+  JournalCategoriesByIdsByPrivateStatusesResult({
+    required this.id,
+    required this.category,
   });
 }
 

--- a/lib/features/daily_os/repository/day_plan_repository.dart
+++ b/lib/features/daily_os/repository/day_plan_repository.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:lotti/classes/day_plan.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
@@ -51,15 +53,52 @@ class DayPlanRepositoryImpl implements DayPlanRepository {
   final PersistenceLogic _persistenceLogic;
   final UpdateNotifications _updateNotifications;
 
+  // Microtask-coalescing batch for concurrent getDayPlan calls. When the
+  // time-history header prefetches a window of dates, each date fires a
+  // provider which each calls getDayPlan(date) inside the same synchronous
+  // sweep. Before the first microtask flushes we collect all requested ids
+  // and turn them into a single dayPlansByIds round-trip.
+  Set<String>? _pendingIds;
+  Completer<Map<String, DayPlanEntry>>? _pendingBatch;
+
   @override
-  Future<DayPlanEntry?> getDayPlan(DateTime date) async {
+  Future<DayPlanEntry?> getDayPlan(DateTime date) {
     final id = dayPlanId(date);
-    return _journalDb.getDayPlanById(id);
+    final completer = _pendingBatch ??=
+        Completer<Map<String, DayPlanEntry>>.sync();
+    var ids = _pendingIds;
+    if (ids == null) {
+      ids = <String>{};
+      _pendingIds = ids;
+    }
+    ids.add(id);
+
+    if (ids.length == 1) {
+      // First enqueued id owns the flush: schedule a microtask that batches
+      // every id enqueued before the event loop yields. `sync` completer so
+      // awaits in callers don't reorder relative to the DB future.
+      scheduleMicrotask(() async {
+        final toFetch = _pendingIds;
+        final target = _pendingBatch;
+        _pendingIds = null;
+        _pendingBatch = null;
+        if (toFetch == null || target == null) return;
+        try {
+          final rows = await _journalDb.getDayPlansByIds(toFetch);
+          target.complete({for (final row in rows) row.meta.id: row});
+        } catch (error, stack) {
+          target.completeError(error, stack);
+        }
+      });
+    }
+
+    return completer.future.then((map) => map[id]);
   }
 
   @override
   Future<DayPlanEntry> save(DayPlanEntry plan) async {
-    // Check if this is an update or a new create
+    // Check if this is an update or a new create. Bypass the batch path —
+    // saves run in their own call chains and the latency win doesn't apply.
     final existing = await _journalDb.getDayPlanById(plan.meta.id);
 
     if (existing == null) {

--- a/lib/features/daily_os/state/time_history_header_controller.dart
+++ b/lib/features/daily_os/state/time_history_header_controller.dart
@@ -309,17 +309,20 @@ class TimeHistoryHeaderController extends _$TimeHistoryHeaderController {
 
     entryIdFromLinkedIds.values.forEach(linkedIds.addAll);
 
-    // Batch fetch linked entities
-    final linkedEntries = await _batchedGetEntitiesForIds(db, linkedIds);
-    final linkedEntriesMap = <String, JournalEntity>{
-      for (final entry in linkedEntries) entry.meta.id: entry,
-    };
+    // Batch fetch ONLY the categoryId for each linked entry. The aggregation
+    // step needs nothing else from those rows, so this lean projection skips
+    // the `serialized` JSON blob and avoids the fromDbEntity deserialization
+    // pass entirely — meaningful on hot paths with hundreds of linked ids.
+    final linkedCategoryIds = await _batchedGetCategoryIdsForIds(
+      db,
+      linkedIds,
+    );
 
     // Aggregate by day and category
     return _aggregateEntries(
       entries,
       entryIdFromLinkedIds,
-      linkedEntriesMap,
+      linkedCategoryIds,
       start,
       end,
     );
@@ -353,16 +356,30 @@ class TimeHistoryHeaderController extends _$TimeHistoryHeaderController {
     Set<String> ids,
   ) => _runBatchedQuery(ids, db.linksForEntryIds);
 
-  /// Batch fetch entities to avoid SQLite variable limits.
-  Future<List<JournalEntity>> _batchedGetEntitiesForIds(
+  /// Batch fetch entry → categoryId pairs to avoid SQLite variable limits.
+  /// Uses the lean `journalCategoriesByIds` drift query to skip the fat
+  /// serialized payload that the aggregation doesn't read.
+  Future<Map<String, String?>> _batchedGetCategoryIdsForIds(
     JournalDb db,
     Set<String> ids,
-  ) => _runBatchedQuery(ids, db.getJournalEntitiesForIdsUnordered);
+  ) async {
+    if (ids.isEmpty) return const <String, String?>{};
+    final merged = <String, String?>{};
+    final idList = ids.toList();
+    for (var i = 0; i < idList.length; i += _batchSize) {
+      final batch = idList.sublist(
+        i,
+        (i + _batchSize).clamp(0, idList.length),
+      );
+      merged.addAll(await db.getCategoryIdsForEntryIds(batch.toSet()));
+    }
+    return merged;
+  }
 
   TimeHistoryData _aggregateEntries(
     List<JournalEntity> entries,
     Map<String, Set<String>> entryIdFromLinkedIds,
-    Map<String, JournalEntity> linkedEntriesMap,
+    Map<String, String?> linkedCategoryIds,
     DateTime start,
     DateTime end,
   ) {
@@ -399,16 +416,18 @@ class TimeHistoryHeaderController extends _$TimeHistoryHeaderController {
       final duration = entryDuration(journalEntity);
       if (duration <= Duration.zero) continue;
 
-      // Find category through linked entries
-      final linkedTo =
-          (entryIdFromLinkedIds[journalEntity.meta.id] ?? <String>{})
-              .map((id) => linkedEntriesMap[id])
-              .nonNulls;
-
-      final categoryId = linkedTo
-          .map((item) => item.meta.categoryId)
-          .nonNulls
-          .firstOrNull;
+      // Find category through linked entries. `linkedCategoryIds` is the
+      // lean projection returned by `_batchedGetCategoryIdsForIds`, so this
+      // is a direct map lookup — no JournalEntity deserialization needed.
+      final linkedIds = entryIdFromLinkedIds[journalEntity.meta.id] ?? const {};
+      String? categoryId;
+      for (final linkedId in linkedIds) {
+        final resolved = linkedCategoryIds[linkedId];
+        if (resolved != null) {
+          categoryId = resolved;
+          break;
+        }
+      }
 
       final noon = journalEntity.meta.dateFrom.dayAtNoon;
       final dataByDay = data[noon];

--- a/test/database/basic_links_coalescing_test.dart
+++ b/test/database/basic_links_coalescing_test.dart
@@ -214,9 +214,13 @@ void main() {
           failingDb.basicLinksForEntryIds({'b'}),
         ];
 
-        for (final f in futures) {
-          await expectLater(f, throwsA(same(failure)));
-        }
+        // Register expectLater on every future before awaiting: the
+        // coalesced wave completes both with the same error in one
+        // microtask, so a sequential `await` would leave the second
+        // future briefly unhandled.
+        await Future.wait([
+          for (final f in futures) expectLater(f, throwsA(same(failure))),
+        ]);
         expect(failingDb.attempts, 1);
       },
     );

--- a/test/database/basic_links_coalescing_test.dart
+++ b/test/database/basic_links_coalescing_test.dart
@@ -1,0 +1,240 @@
+// ignore_for_file: avoid_redundant_argument_values
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/entry_link.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/database/journal_db/config_flags.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/logging_service.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../mocks/mocks.dart';
+
+/// [JournalDb] subclass that spies on the protected single-shot query the
+/// coalescer delegates to. Counts how many real DB round-trips occur — the
+/// coalescer flushes one wave through exactly one call to this method.
+class _CountingJournalDb extends JournalDb {
+  _CountingJournalDb()
+    : super(inMemoryDatabase: true, background: false, readPool: 0);
+
+  int basicLinkQueryCount = 0;
+  Set<String>? lastMergedIds;
+
+  @override
+  Future<List<EntryLink>> runBasicLinksQueryForIds(Set<String> ids) {
+    basicLinkQueryCount += 1;
+    lastMergedIds = Set<String>.from(ids);
+    return super.runBasicLinksQueryForIds(ids);
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _CountingJournalDb db;
+  late MockLoggingService loggingService;
+  Directory? testDirectory;
+  Directory? previousDirectory;
+
+  setUp(() async {
+    if (getIt.isRegistered<Directory>()) {
+      previousDirectory = getIt<Directory>();
+      getIt.unregister<Directory>();
+    }
+    testDirectory = Directory.systemTemp.createTempSync(
+      'lotti_basic_links_coalesce_',
+    );
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (MethodCall methodCall) async {
+            if (methodCall.method == 'getApplicationDocumentsDirectory' ||
+                methodCall.method == 'getApplicationSupportDirectory' ||
+                methodCall.method == 'getTemporaryDirectory') {
+              return testDirectory!.path;
+            }
+            return null;
+          },
+        );
+    getIt.registerSingleton<Directory>(testDirectory!);
+
+    loggingService = MockLoggingService();
+    when(
+      () => loggingService.captureEvent(
+        any<Object>(),
+        domain: any<String>(named: 'domain'),
+        subDomain: any<String?>(named: 'subDomain'),
+      ),
+    ).thenAnswer((_) async {});
+    when(
+      () => loggingService.captureException(
+        any<Object>(),
+        domain: any<String>(named: 'domain'),
+        subDomain: any<String?>(named: 'subDomain'),
+        stackTrace: any<StackTrace?>(named: 'stackTrace'),
+      ),
+    ).thenAnswer((_) async {});
+    if (getIt.isRegistered<LoggingService>()) {
+      getIt.unregister<LoggingService>();
+    }
+    getIt.registerSingleton<LoggingService>(loggingService);
+
+    db = _CountingJournalDb();
+    await initConfigFlags(db, inMemoryDatabase: true);
+  });
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          null,
+        );
+    await db.close();
+    if (getIt.isRegistered<LoggingService>()) {
+      getIt.unregister<LoggingService>();
+    }
+    getIt.unregister<Directory>();
+    if (previousDirectory != null) {
+      getIt.registerSingleton<Directory>(previousDirectory!);
+    }
+    if (testDirectory != null && testDirectory!.existsSync()) {
+      testDirectory!.deleteSync(recursive: true);
+    }
+  });
+
+  Future<void> insertBasicLink({
+    required String fromId,
+    required String toId,
+  }) async {
+    final link = EntryLink.basic(
+      id: 'link-$fromId-$toId',
+      fromId: fromId,
+      toId: toId,
+      createdAt: DateTime(2026, 4, 1),
+      updatedAt: DateTime(2026, 4, 1),
+      vectorClock: null,
+    );
+    await db.upsertEntryLink(link);
+  }
+
+  group('basicLinksForEntryIds microtask coalescing', () {
+    test(
+      'two concurrent callers share one DB query and each receives only '
+      'the links whose to_id matches its own set',
+      () async {
+        await insertBasicLink(fromId: 'parent-A', toId: 'child-A');
+        await insertBasicLink(fromId: 'parent-B', toId: 'child-B');
+        await insertBasicLink(fromId: 'parent-C', toId: 'child-C');
+        db.basicLinkQueryCount = 0;
+
+        final futureA = db.basicLinksForEntryIds({'child-A'});
+        final futureB = db.basicLinksForEntryIds({'child-B', 'child-C'});
+
+        final resultA = await futureA;
+        final resultB = await futureB;
+
+        expect(resultA.map((l) => l.toId), ['child-A']);
+        expect(
+          resultB.map((l) => l.toId).toSet(),
+          {'child-B', 'child-C'},
+        );
+        expect(db.basicLinkQueryCount, 1);
+      },
+    );
+
+    test('empty id set short-circuits without issuing a query', () async {
+      final result = await db.basicLinksForEntryIds(const <String>{});
+      expect(result, isEmpty);
+      expect(db.basicLinkQueryCount, 0);
+    });
+
+    test('distinct microtask waves issue separate queries', () async {
+      await insertBasicLink(fromId: 'p', toId: 'child');
+
+      db.basicLinkQueryCount = 0;
+
+      final first = await db.basicLinksForEntryIds({'child'});
+      final second = await db.basicLinksForEntryIds({'child'});
+
+      expect(first.map((l) => l.toId), ['child']);
+      expect(second.map((l) => l.toId), ['child']);
+      expect(db.basicLinkQueryCount, 2);
+    });
+
+    test('RatingLink rows are not returned', () async {
+      await insertBasicLink(fromId: 'task-1', toId: 'te-1');
+      final rating = EntryLink.rating(
+        id: 'rating-link',
+        fromId: 'rating-1',
+        toId: 'te-1',
+        createdAt: DateTime(2026, 4, 1),
+        updatedAt: DateTime(2026, 4, 1),
+        vectorClock: null,
+      );
+      await db.upsertEntryLink(rating);
+
+      db.basicLinkQueryCount = 0;
+      final links = await db.basicLinksForEntryIds({'te-1'});
+
+      expect(links.map((l) => l.id), ['link-task-1-te-1']);
+      expect(db.basicLinkQueryCount, 1);
+    });
+
+    test(
+      'same id requested twice in one wave issues exactly one query',
+      () async {
+        await insertBasicLink(fromId: 'p', toId: 'target');
+        db.basicLinkQueryCount = 0;
+
+        final results = await Future.wait([
+          db.basicLinksForEntryIds({'target'}),
+          db.basicLinksForEntryIds({'target'}),
+        ]);
+
+        expect(results[0].map((l) => l.toId), ['target']);
+        expect(results[1].map((l) => l.toId), ['target']);
+        expect(db.basicLinkQueryCount, 1);
+      },
+    );
+
+    test(
+      'query error propagates to every caller waiting on the wave',
+      () async {
+        await db.close();
+        final failingDb = _FailingLinksJournalDb();
+        final failure = StateError('simulated');
+        failingDb.failure = failure;
+        await initConfigFlags(failingDb, inMemoryDatabase: true);
+        addTearDown(failingDb.close);
+
+        final futures = [
+          failingDb.basicLinksForEntryIds({'a'}),
+          failingDb.basicLinksForEntryIds({'b'}),
+        ];
+
+        for (final f in futures) {
+          await expectLater(f, throwsA(same(failure)));
+        }
+        expect(failingDb.attempts, 1);
+      },
+    );
+  });
+}
+
+/// Subclass whose `runBasicLinksQueryForIds` throws, so the coalescer's
+/// error-propagation branch can be covered deterministically.
+class _FailingLinksJournalDb extends JournalDb {
+  _FailingLinksJournalDb()
+    : super(inMemoryDatabase: true, background: false, readPool: 0);
+
+  Object failure = StateError('not set');
+  int attempts = 0;
+
+  @override
+  Future<List<EntryLink>> runBasicLinksQueryForIds(Set<String> ids) {
+    attempts += 1;
+    return Future<List<EntryLink>>.error(failure);
+  }
+}

--- a/test/database/database_test.dart
+++ b/test/database/database_test.dart
@@ -2125,6 +2125,209 @@ void main() {
           expect(allPlans, hasLength(2));
         },
       );
+
+      test('getDayPlansByIds returns empty list for empty input', () async {
+        expect(await db!.getDayPlansByIds(const <String>[]), isEmpty);
+      });
+
+      test(
+        'getDayPlansByIds batch-fetches matching plans and honors private flag',
+        () async {
+          final baseDate = DateTime(2026, 2, 10);
+          final publicA = DayPlanEntry(
+            meta: Metadata(
+              id: dayPlanId(baseDate),
+              createdAt: baseDate,
+              updatedAt: baseDate,
+              dateFrom: baseDate,
+              dateTo: baseDate.add(const Duration(days: 1)),
+            ),
+            data: DayPlanData(
+              planDate: baseDate,
+              status: const DayPlanStatus.draft(),
+              plannedBlocks: const [],
+            ),
+          );
+          final publicB = DayPlanEntry(
+            meta: Metadata(
+              id: dayPlanId(baseDate.add(const Duration(days: 1))),
+              createdAt: baseDate.add(const Duration(days: 1)),
+              updatedAt: baseDate.add(const Duration(days: 1)),
+              dateFrom: baseDate.add(const Duration(days: 1)),
+              dateTo: baseDate.add(const Duration(days: 2)),
+            ),
+            data: DayPlanData(
+              planDate: baseDate.add(const Duration(days: 1)),
+              status: const DayPlanStatus.draft(),
+              plannedBlocks: const [],
+            ),
+          );
+          final privatePlan = DayPlanEntry(
+            meta: Metadata(
+              id: dayPlanId(baseDate.add(const Duration(days: 2))),
+              createdAt: baseDate.add(const Duration(days: 2)),
+              updatedAt: baseDate.add(const Duration(days: 2)),
+              dateFrom: baseDate.add(const Duration(days: 2)),
+              dateTo: baseDate.add(const Duration(days: 3)),
+              private: true,
+            ),
+            data: DayPlanData(
+              planDate: baseDate.add(const Duration(days: 2)),
+              status: const DayPlanStatus.draft(),
+              plannedBlocks: const [],
+            ),
+          );
+
+          await db!.upsertJournalDbEntity(toDbEntity(publicA));
+          await db!.upsertJournalDbEntity(toDbEntity(publicB));
+          await db!.upsertJournalDbEntity(toDbEntity(privatePlan));
+
+          // Filtered path: privateFlag = false → private plan is excluded
+          // from the batch, missing ids are silently skipped, and the two
+          // public plans come back.
+          await db!.upsertConfigFlag(
+            const ConfigFlag(
+              name: privateFlag,
+              description: 'Show private entries?',
+              status: false,
+            ),
+          );
+
+          final filtered = await db!.getDayPlansByIds([
+            publicA.meta.id,
+            publicB.meta.id,
+            privatePlan.meta.id,
+            'dayplan-does-not-exist',
+          ]);
+          expect(
+            filtered.map((e) => e.meta.id).toSet(),
+            {publicA.meta.id, publicB.meta.id},
+          );
+
+          // allPrivate path: privateFlag = true → all three plans come back.
+          await db!.upsertConfigFlag(
+            const ConfigFlag(
+              name: privateFlag,
+              description: 'Show private entries?',
+              status: true,
+            ),
+          );
+
+          final all = await db!.getDayPlansByIds([
+            publicA.meta.id,
+            publicB.meta.id,
+            privatePlan.meta.id,
+          ]);
+          expect(
+            all.map((e) => e.meta.id).toSet(),
+            {publicA.meta.id, publicB.meta.id, privatePlan.meta.id},
+          );
+        },
+      );
+    });
+
+    group('getCategoryIdsForEntryIds -', () {
+      test(
+        'returns empty map for empty input without hitting the db',
+        () async {
+          expect(
+            await db!.getCategoryIdsForEntryIds(const <String>[]),
+            isEmpty,
+          );
+        },
+      );
+
+      test(
+        'returns denormalized category per id and maps empty column to null',
+        () async {
+          final base = DateTime(2026, 3, 1);
+          final withCategory = buildJournalEntry(
+            id: 'cat-id-entry-1',
+            timestamp: base,
+            text: 'has category',
+            categoryId: 'cat-alpha',
+          );
+          final withoutCategory = buildJournalEntry(
+            id: 'cat-id-entry-2',
+            timestamp: base.add(const Duration(minutes: 1)),
+            text: 'no category',
+          );
+
+          await db!.upsertJournalDbEntity(toDbEntity(withCategory));
+          await db!.upsertJournalDbEntity(toDbEntity(withoutCategory));
+
+          final result = await db!.getCategoryIdsForEntryIds([
+            withCategory.meta.id,
+            withoutCategory.meta.id,
+            // Duplicate id is deduplicated via toSet() before the query.
+            withCategory.meta.id,
+            // Missing ids are simply absent from the returned map.
+            'cat-id-missing',
+          ]);
+
+          expect(result, hasLength(2));
+          expect(result[withCategory.meta.id], 'cat-alpha');
+          // Empty column value is normalized to null so callers can treat
+          // "no category" and "not present" uniformly.
+          expect(result.containsKey(withoutCategory.meta.id), isTrue);
+          expect(result[withoutCategory.meta.id], isNull);
+          expect(result.containsKey('cat-id-missing'), isFalse);
+        },
+      );
+
+      test(
+        'filtered path drops private entries when privateFlag is off',
+        () async {
+          final base = DateTime(2026, 3, 2);
+          final publicEntry = buildJournalEntry(
+            id: 'cat-id-public',
+            timestamp: base,
+            text: 'public',
+            categoryId: 'cat-public',
+          );
+          final privateEntry = buildJournalEntry(
+            id: 'cat-id-private',
+            timestamp: base.add(const Duration(minutes: 1)),
+            text: 'private',
+            privateFlag: true,
+            categoryId: 'cat-private',
+          );
+
+          await db!.upsertJournalDbEntity(toDbEntity(publicEntry));
+          await db!.upsertJournalDbEntity(toDbEntity(privateEntry));
+
+          await db!.upsertConfigFlag(
+            const ConfigFlag(
+              name: privateFlag,
+              description: 'Show private entries?',
+              status: false,
+            ),
+          );
+
+          final filtered = await db!.getCategoryIdsForEntryIds([
+            publicEntry.meta.id,
+            privateEntry.meta.id,
+          ]);
+          expect(filtered, {publicEntry.meta.id: 'cat-public'});
+
+          await db!.upsertConfigFlag(
+            const ConfigFlag(
+              name: privateFlag,
+              description: 'Show private entries?',
+              status: true,
+            ),
+          );
+
+          final all = await db!.getCategoryIdsForEntryIds([
+            publicEntry.meta.id,
+            privateEntry.meta.id,
+          ]);
+          expect(all, {
+            publicEntry.meta.id: 'cat-public',
+            privateEntry.meta.id: 'cat-private',
+          });
+        },
+      );
     });
 
     group('Label definition queries -', () {

--- a/test/database/tasks_due_coalescing_test.dart
+++ b/test/database/tasks_due_coalescing_test.dart
@@ -1,0 +1,311 @@
+// ignore_for_file: avoid_redundant_argument_values
+import 'dart:io';
+
+import 'package:drift/drift.dart' as drift;
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/classes/task.dart';
+import 'package:lotti/database/conversions.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/database/journal_db/config_flags.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/logging_service.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../mocks/mocks.dart';
+
+/// Subclass of [JournalDb] whose `runTasksDueFetch` throws, so the
+/// coalescer's error-propagation branch can be exercised deterministically.
+class _FailingTasksDueJournalDb extends JournalDb {
+  _FailingTasksDueJournalDb()
+    : super(inMemoryDatabase: true, background: false, readPool: 0);
+
+  Object failure = StateError('not set');
+  int attempts = 0;
+
+  @override
+  Future<List<Task>> runTasksDueFetch({
+    required DateTime endInclusive,
+    required List<bool> privateStatuses,
+  }) {
+    attempts += 1;
+    return Future<List<Task>>.error(failure);
+  }
+}
+
+/// Subclass of [JournalDb] that counts `customSelect` invocations whose
+/// raw SQL pins the partial open-task due-date index. The coalescer flushes
+/// the whole wave through that one statement, so the counter equals the
+/// number of DB round-trips for due-task fetches.
+class _CountingJournalDb extends JournalDb {
+  _CountingJournalDb()
+    : super(inMemoryDatabase: true, background: false, readPool: 0);
+
+  int tasksDueQueryCount = 0;
+
+  @override
+  drift.Selectable<drift.QueryRow> customSelect(
+    String query, {
+    List<drift.Variable<Object>> variables = const [],
+    Set<drift.ResultSetImplementation<dynamic, dynamic>> readsFrom = const {},
+  }) {
+    if (query.contains('INDEXED BY idx_journal_tasks_due_open')) {
+      tasksDueQueryCount += 1;
+    }
+    return super.customSelect(
+      query,
+      variables: variables,
+      readsFrom: readsFrom,
+    );
+  }
+}
+
+Task makeTask({
+  required String id,
+  required DateTime due,
+  TaskStatus? status,
+}) {
+  final createdAt = due.subtract(const Duration(days: 1));
+  return Task(
+    meta: Metadata(
+      id: id,
+      createdAt: createdAt,
+      updatedAt: createdAt,
+      dateFrom: due,
+      dateTo: due,
+    ),
+    data: TaskData(
+      status:
+          status ??
+          TaskStatus.open(
+            id: '$id-status',
+            createdAt: createdAt,
+            utcOffset: 0,
+          ),
+      dateFrom: due,
+      dateTo: due,
+      statusHistory: const [],
+      title: id,
+      due: due,
+    ),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _CountingJournalDb db;
+  late MockLoggingService loggingService;
+  Directory? testDirectory;
+  Directory? previousDirectory;
+
+  setUp(() async {
+    if (getIt.isRegistered<Directory>()) {
+      previousDirectory = getIt<Directory>();
+      getIt.unregister<Directory>();
+    }
+    testDirectory = Directory.systemTemp.createTempSync('lotti_due_coalesce_');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (MethodCall methodCall) async {
+            if (methodCall.method == 'getApplicationDocumentsDirectory' ||
+                methodCall.method == 'getApplicationSupportDirectory' ||
+                methodCall.method == 'getTemporaryDirectory') {
+              return testDirectory!.path;
+            }
+            return null;
+          },
+        );
+    getIt.registerSingleton<Directory>(testDirectory!);
+
+    loggingService = MockLoggingService();
+    when(
+      () => loggingService.captureEvent(
+        any<Object>(),
+        domain: any<String>(named: 'domain'),
+        subDomain: any<String?>(named: 'subDomain'),
+      ),
+    ).thenAnswer((_) async {});
+    when(
+      () => loggingService.captureException(
+        any<Object>(),
+        domain: any<String>(named: 'domain'),
+        subDomain: any<String?>(named: 'subDomain'),
+        stackTrace: any<StackTrace?>(named: 'stackTrace'),
+      ),
+    ).thenAnswer((_) async {});
+    if (getIt.isRegistered<LoggingService>()) {
+      getIt.unregister<LoggingService>();
+    }
+    getIt.registerSingleton<LoggingService>(loggingService);
+
+    db = _CountingJournalDb();
+    await initConfigFlags(db, inMemoryDatabase: true);
+  });
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          null,
+        );
+    await db.close();
+    if (getIt.isRegistered<LoggingService>()) {
+      getIt.unregister<LoggingService>();
+    }
+    getIt.unregister<Directory>();
+    if (previousDirectory != null) {
+      getIt.registerSingleton<Directory>(previousDirectory!);
+    }
+    if (testDirectory != null && testDirectory!.existsSync()) {
+      testDirectory!.deleteSync(recursive: true);
+    }
+  });
+
+  Future<void> insertTask(Task task) async {
+    await db.upsertJournalDbEntity(toDbEntity(task));
+  }
+
+  group('tasks-due microtask coalescing', () {
+    test(
+      'three concurrent getTasksDueOnOrBefore calls share one DB query '
+      'and each returns the correct filtered subset',
+      () async {
+        final t1 = makeTask(id: 't1', due: DateTime(2026, 4, 10));
+        final t2 = makeTask(id: 't2', due: DateTime(2026, 4, 12));
+        final t3 = makeTask(id: 't3', due: DateTime(2026, 4, 15));
+        await insertTask(t1);
+        await insertTask(t2);
+        await insertTask(t3);
+        db.tasksDueQueryCount = 0;
+
+        final futures = [
+          db.getTasksDueOnOrBefore(DateTime(2026, 4, 10)),
+          db.getTasksDueOnOrBefore(DateTime(2026, 4, 12)),
+          db.getTasksDueOnOrBefore(DateTime(2026, 4, 15)),
+        ];
+        final results = await Future.wait(futures);
+
+        expect(results[0].map((t) => t.meta.id), ['t1']);
+        expect(results[1].map((t) => t.meta.id).toSet(), {'t1', 't2'});
+        expect(results[2].map((t) => t.meta.id).toSet(), {'t1', 't2', 't3'});
+        expect(db.tasksDueQueryCount, 1);
+      },
+    );
+
+    test(
+      'mixed getTasksDueOn + getTasksDueOnOrBefore in the same wave hits '
+      'the DB once and filters each range correctly',
+      () async {
+        final past = makeTask(id: 'past', due: DateTime(2026, 4, 10));
+        final today = makeTask(id: 'today', due: DateTime(2026, 4, 15, 14));
+        final future = makeTask(id: 'future', due: DateTime(2026, 4, 20, 10));
+        await insertTask(past);
+        await insertTask(today);
+        await insertTask(future);
+        db.tasksDueQueryCount = 0;
+
+        final cumulative = db.getTasksDueOnOrBefore(DateTime(2026, 4, 15));
+        final futureDay = db.getTasksDueOn(DateTime(2026, 4, 20));
+
+        final cumulativeResult = await cumulative;
+        final futureDayResult = await futureDay;
+
+        expect(cumulativeResult.map((t) => t.meta.id).toSet(), {
+          'past',
+          'today',
+        });
+        expect(futureDayResult.map((t) => t.meta.id), ['future']);
+        expect(db.tasksDueQueryCount, 1);
+      },
+    );
+
+    test('distinct microtask waves issue separate queries', () async {
+      final t = makeTask(id: 'only', due: DateTime(2026, 4, 10));
+      await insertTask(t);
+      db.tasksDueQueryCount = 0;
+
+      final first = await db.getTasksDueOnOrBefore(DateTime(2026, 4, 10));
+      final second = await db.getTasksDueOnOrBefore(DateTime(2026, 4, 11));
+
+      expect(first.map((t) => t.meta.id), ['only']);
+      expect(second.map((t) => t.meta.id), ['only']);
+      expect(db.tasksDueQueryCount, 2);
+    });
+
+    test('DONE tasks are still excluded after coalescing', () async {
+      final open = makeTask(id: 'open', due: DateTime(2026, 4, 10));
+      final done = Task(
+        meta: Metadata(
+          id: 'done',
+          createdAt: DateTime(2026, 4, 1),
+          updatedAt: DateTime(2026, 4, 1),
+          dateFrom: DateTime(2026, 4, 10),
+          dateTo: DateTime(2026, 4, 10),
+        ),
+        data: TaskData(
+          status: TaskStatus.done(
+            id: 'done-s',
+            createdAt: DateTime(2026, 4, 1),
+            utcOffset: 0,
+          ),
+          dateFrom: DateTime(2026, 4, 10),
+          dateTo: DateTime(2026, 4, 10),
+          statusHistory: const [],
+          title: 'done',
+          due: DateTime(2026, 4, 10),
+        ),
+      );
+      await insertTask(open);
+      await insertTask(done);
+      db.tasksDueQueryCount = 0;
+
+      final results = await db.getTasksDueOnOrBefore(DateTime(2026, 4, 10));
+
+      expect(results.map((t) => t.meta.id), ['open']);
+    });
+
+    test(
+      'query error propagates to every caller waiting on the wave',
+      () async {
+        await db.close();
+        final failingDb = _FailingTasksDueJournalDb()
+          ..failure = StateError('simulated');
+        await initConfigFlags(failingDb, inMemoryDatabase: true);
+        addTearDown(failingDb.close);
+
+        final futures = [
+          failingDb.getTasksDueOnOrBefore(DateTime(2026, 4, 10)),
+          failingDb.getTasksDueOnOrBefore(DateTime(2026, 4, 12)),
+        ];
+
+        for (final f in futures) {
+          await expectLater(f, throwsA(same(failingDb.failure)));
+        }
+        expect(failingDb.attempts, 1);
+      },
+    );
+
+    test(
+      'tasks whose due falls after the caller end-of-day are filtered out',
+      () async {
+        final tEarly = makeTask(id: 'early', due: DateTime(2026, 4, 10, 8));
+        final tLate = makeTask(id: 'late', due: DateTime(2026, 4, 12, 10));
+        await insertTask(tEarly);
+        await insertTask(tLate);
+        db.tasksDueQueryCount = 0;
+
+        // Two concurrent callers share a single query (widest end = 4/12).
+        // The caller asking about 4/10 must not see `late`.
+        final narrow = db.getTasksDueOnOrBefore(DateTime(2026, 4, 10));
+        final wide = db.getTasksDueOnOrBefore(DateTime(2026, 4, 12));
+
+        expect((await narrow).map((t) => t.meta.id), ['early']);
+        expect((await wide).map((t) => t.meta.id).toSet(), {'early', 'late'});
+        expect(db.tasksDueQueryCount, 1);
+      },
+    );
+  });
+}

--- a/test/database/tasks_due_coalescing_test.dart
+++ b/test/database/tasks_due_coalescing_test.dart
@@ -281,9 +281,14 @@ void main() {
           failingDb.getTasksDueOnOrBefore(DateTime(2026, 4, 12)),
         ];
 
-        for (final f in futures) {
-          await expectLater(f, throwsA(same(failingDb.failure)));
-        }
+        // Register expectLater on every future before awaiting: the
+        // coalesced wave completes both with the same error in one
+        // microtask, so a sequential `await` would leave the second
+        // future briefly unhandled.
+        await Future.wait([
+          for (final f in futures)
+            expectLater(f, throwsA(same(failingDb.failure))),
+        ]);
         expect(failingDb.attempts, 1);
       },
     );

--- a/test/features/daily_os/repository/day_plan_repository_test.dart
+++ b/test/features/daily_os/repository/day_plan_repository_test.dart
@@ -1,0 +1,181 @@
+// ignore_for_file: avoid_redundant_argument_values
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/day_plan.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/daily_os/repository/day_plan_repository.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../mocks/mocks.dart';
+
+void main() {
+  DayPlanEntry makePlan(DateTime date) {
+    return DayPlanEntry(
+      meta: Metadata(
+        id: dayPlanId(date),
+        createdAt: date,
+        updatedAt: date,
+        dateFrom: date,
+        dateTo: date.add(const Duration(days: 1)),
+      ),
+      data: DayPlanData(
+        planDate: date,
+        status: const DayPlanStatus.draft(),
+        plannedBlocks: const [],
+      ),
+    );
+  }
+
+  late MockJournalDb journalDb;
+  late MockPersistenceLogic persistenceLogic;
+  late MockUpdateNotifications updateNotifications;
+  late DayPlanRepositoryImpl repository;
+
+  setUp(() {
+    journalDb = MockJournalDb();
+    persistenceLogic = MockPersistenceLogic();
+    updateNotifications = MockUpdateNotifications();
+    repository = DayPlanRepositoryImpl(
+      journalDb: journalDb,
+      persistenceLogic: persistenceLogic,
+      updateNotifications: updateNotifications,
+    );
+  });
+
+  group('getDayPlan microtask coalescing', () {
+    test(
+      'collapses concurrent calls in the same microtask into one batch '
+      'round-trip and returns the right plan for each date',
+      () async {
+        final d1 = DateTime(2026, 4, 1);
+        final d2 = DateTime(2026, 4, 2);
+        final d3 = DateTime(2026, 4, 3);
+        final p1 = makePlan(d1);
+        final p3 = makePlan(d3);
+
+        when(() => journalDb.getDayPlansByIds(any())).thenAnswer(
+          // Returns only p1 and p3 — d2 has no plan, verifying nulls flow.
+          (_) async => [p1, p3],
+        );
+
+        // Fire three requests in the same synchronous sweep (simulating the
+        // prefetch-window loop in time_history_header_widget).
+        final futures = [
+          repository.getDayPlan(d1),
+          repository.getDayPlan(d2),
+          repository.getDayPlan(d3),
+        ];
+        final results = await Future.wait(futures);
+
+        expect(results[0], p1);
+        expect(results[1], isNull);
+        expect(results[2], p3);
+
+        // Exactly one batch call against the DB for all three dates.
+        final captured =
+            verify(
+                  () => journalDb.getDayPlansByIds(captureAny()),
+                ).captured.single
+                as Iterable<String>;
+        expect(captured.toSet(), {
+          dayPlanId(d1),
+          dayPlanId(d2),
+          dayPlanId(d3),
+        });
+        verifyNever(() => journalDb.getDayPlanById(any()));
+      },
+    );
+
+    test('distinct microtask waves issue separate batch calls', () async {
+      final d1 = DateTime(2026, 4, 5);
+      final d2 = DateTime(2026, 4, 6);
+      final p1 = makePlan(d1);
+      final p2 = makePlan(d2);
+
+      when(
+        () => journalDb.getDayPlansByIds(any()),
+      ).thenAnswer((invocation) async {
+        final ids = (invocation.positionalArguments.first as Iterable<String>)
+            .toSet();
+        return [
+          if (ids.contains(p1.meta.id)) p1,
+          if (ids.contains(p2.meta.id)) p2,
+        ];
+      });
+
+      final first = await repository.getDayPlan(d1);
+      final second = await repository.getDayPlan(d2);
+
+      expect(first, p1);
+      expect(second, p2);
+      verify(() => journalDb.getDayPlansByIds(any())).called(2);
+    });
+
+    test('requesting the same date twice hits the DB once', () async {
+      final d = DateTime(2026, 4, 7);
+      final plan = makePlan(d);
+      when(
+        () => journalDb.getDayPlansByIds(any()),
+      ).thenAnswer((_) async => [plan]);
+
+      final results = await Future.wait([
+        repository.getDayPlan(d),
+        repository.getDayPlan(d),
+      ]);
+
+      expect(results[0], plan);
+      expect(results[1], plan);
+      final captured =
+          verify(
+                () => journalDb.getDayPlansByIds(captureAny()),
+              ).captured.single
+              as Iterable<String>;
+      expect(captured.toSet(), {dayPlanId(d)});
+    });
+
+    test(
+      'batch error propagates to every caller waiting on that wave',
+      () async {
+        final d1 = DateTime(2026, 4, 8);
+        final d2 = DateTime(2026, 4, 9);
+        final failure = StateError('db blew up');
+        when(
+          () => journalDb.getDayPlansByIds(any()),
+        ).thenThrow(failure);
+
+        final f1 = repository.getDayPlan(d1);
+        final f2 = repository.getDayPlan(d2);
+
+        await expectLater(f1, throwsA(same(failure)));
+        await expectLater(f2, throwsA(same(failure)));
+        verify(() => journalDb.getDayPlansByIds(any())).called(1);
+      },
+    );
+
+    test(
+      'a failed wave does not poison the next: the subsequent call succeeds',
+      () async {
+        final d1 = DateTime(2026, 4, 10);
+        final d2 = DateTime(2026, 4, 11);
+        final plan = makePlan(d2);
+
+        var calls = 0;
+        when(
+          () => journalDb.getDayPlansByIds(any()),
+        ).thenAnswer((_) async {
+          calls += 1;
+          if (calls == 1) throw StateError('transient');
+          return [plan];
+        });
+
+        await expectLater(
+          repository.getDayPlan(d1),
+          throwsA(isA<StateError>()),
+        );
+        final second = await repository.getDayPlan(d2);
+
+        expect(second, plan);
+        expect(calls, 2);
+      },
+    );
+  });
+}

--- a/test/features/daily_os/repository/day_plan_repository_test.dart
+++ b/test/features/daily_os/repository/day_plan_repository_test.dart
@@ -145,8 +145,13 @@ void main() {
         final f1 = repository.getDayPlan(d1);
         final f2 = repository.getDayPlan(d2);
 
-        await expectLater(f1, throwsA(same(failure)));
-        await expectLater(f2, throwsA(same(failure)));
+        // Register both expectations before awaiting: the shared batch
+        // completes both futures with the same error in one microtask,
+        // so sequential awaits would leave the second one unhandled.
+        await Future.wait([
+          expectLater(f1, throwsA(same(failure))),
+          expectLater(f2, throwsA(same(failure))),
+        ]);
         verify(() => journalDb.getDayPlansByIds(any())).called(1);
       },
     );

--- a/test/features/daily_os/state/time_history_header_controller_test.dart
+++ b/test/features/daily_os/state/time_history_header_controller_test.dart
@@ -129,6 +129,13 @@ void main() {
       createCategory('cat-personal', 'Personal'),
     ]);
 
+    // Default blanket stub for the lean category projection used during
+    // time-history aggregation. Individual tests override with the
+    // specific id→categoryId map they need.
+    when(
+      () => mockDb.getCategoryIdsForEntryIds(any()),
+    ).thenAnswer((_) async => const <String, String?>{});
+
     getIt
       ..registerSingleton<JournalDb>(mockDb)
       ..registerSingleton<UpdateNotifications>(mockUpdateNotifications)
@@ -205,6 +212,9 @@ void main() {
         when(
           () => mockDb.getJournalEntitiesForIdsUnordered(any()),
         ).thenAnswer((_) async => [task]);
+        when(() => mockDb.getCategoryIdsForEntryIds(any())).thenAnswer(
+          (_) async => {'task-1': 'cat-work'},
+        );
 
         final result = await container.read(
           timeHistoryHeaderControllerProvider.future,
@@ -355,6 +365,9 @@ void main() {
         when(
           () => mockDb.getJournalEntitiesForIdsUnordered(any()),
         ).thenAnswer((_) async => [task1, task2]);
+        when(() => mockDb.getCategoryIdsForEntryIds(any())).thenAnswer(
+          (_) async => {'task-1': 'cat-work', 'task-2': 'cat-personal'},
+        );
 
         final result = await container.read(
           timeHistoryHeaderControllerProvider.future,
@@ -599,6 +612,9 @@ void main() {
           when(
             () => mockDb.getJournalEntitiesForIdsUnordered(any()),
           ).thenAnswer((_) async => [task1]);
+          when(() => mockDb.getCategoryIdsForEntryIds(any())).thenAnswer(
+            (_) async => {'task-1': 'cat-work'},
+          );
 
           // Initial load
           await container.read(timeHistoryHeaderControllerProvider.future);
@@ -649,6 +665,9 @@ void main() {
           when(
             () => mockDb.getJournalEntitiesForIdsUnordered(any()),
           ).thenAnswer((_) async => [task2]);
+          when(() => mockDb.getCategoryIdsForEntryIds(any())).thenAnswer(
+            (_) async => {'task-2': 'cat-work'},
+          );
 
           final notifier = container.read(
             timeHistoryHeaderControllerProvider.notifier,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced redundant database round-trips by coalescing concurrent requests, improving responsiveness for day plans, task due queries, and linked-entry category lookups.
  * Ensured correct per-request filtering and consistent error propagation so concurrent callers receive properly bounded results or shared errors.

* **Tests**
  * Added comprehensive tests validating coalescing, batching correctness, filtering behavior, and error propagation across concurrent callers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->