### PR TITLE
feat: desktop sidebar navigation tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.958] - 2026-04-18
+### Changed
+- Desktop navigation sidebar: the Tasks and Settings notification counts now
+  render as a design-system number badge in a dedicated trailing slot on the
+  right of each row (instead of a Material `Badge` overlapping the icon and
+  label). The vertical spacing between sidebar items is now 24 px to match
+  the Figma layout. Sidebar rows are no longer pinned to a fixed 48 px
+  height — each row grows with its label, so increasing the OS/app text
+  scale no longer vertically clips "Projects", "DailyOS", "Insights",
+  "Logbook" or "Settings". The mobile bottom-nav preserves its existing
+  overlay badge.
+
 ## [0.9.957] - 2026-04-18
 ### Changed
 - Database schema bumped to v39 with two new partial indexes on the

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -31,6 +31,11 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="0.9.958" date="2026-04-18">
+      <description>
+          <p>Desktop navigation sidebar: the Tasks and Settings notification counts now render as a design-system number badge in a dedicated trailing slot on the right of each row instead of a Material Badge overlapping the icon and label. Vertical spacing between sidebar items is now 24 px to match the Figma layout. Sidebar rows are no longer pinned to a fixed 48 px height — each row grows with its label, so increasing the OS or app text scale no longer vertically clips "Projects", "DailyOS", "Insights", "Logbook" or "Settings". The mobile bottom-nav preserves its existing overlay badge.</p>
+      </description>
+    </release>
     <release version="0.9.957" date="2026-04-18">
       <description>
           <p>Database schema bumped to v39 with two new partial indexes on the journal table. idx_journal_tasks_due_open is keyed on the JSON-extracted due date for open tasks so the due-date query streams straight from the index without an external sort, and idx_journal_task_status_private covers countInProgressTasks and similar global task-status counts with a narrow index instead of scanning the full task set. Both partials carry type = 'Task' AND task = 1 AND deleted = FALSE so they stay consistent with the other task indexes and SQLite's theorem prover reliably proves coverage for the paired queries.</p>

--- a/lib/beamer/beamer_app.dart
+++ b/lib/beamer/beamer_app.dart
@@ -19,10 +19,12 @@ import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/settings/state/zoom_controller.dart';
 import 'package:lotti/features/settings/ui/pages/outbox/outbox_badge.dart';
+import 'package:lotti/features/settings/ui/pages/outbox/outbox_trailing_badge.dart';
 import 'package:lotti/features/speech/ui/widgets/recording/audio_recording_indicator.dart';
 import 'package:lotti/features/sync/state/matrix_login_controller.dart';
 import 'package:lotti/features/sync/ui/widgets/matrix/incoming_verification_modal.dart';
 import 'package:lotti/features/tasks/ui/tasks_badge_icon.dart';
+import 'package:lotti/features/tasks/ui/tasks_trailing_badge.dart';
 import 'package:lotti/features/theming/state/theming_controller.dart';
 import 'package:lotti/features/user_activity/state/user_activity_service.dart';
 import 'package:lotti/features/whats_new/state/whats_new_controller.dart';
@@ -70,11 +72,29 @@ class _AppNavigationDestination {
     required this.kind,
     required this.label,
     required this.iconBuilder,
+    this.mobileIconWrapper,
+    this.trailingBuilder,
   });
 
   final _AppNavigationDestinationKind kind;
   final String label;
+
+  /// Plain icon (no badge overlay). Used directly in the desktop sidebar,
+  /// where the count lives in [trailingBuilder].
   final Widget Function({required bool active}) iconBuilder;
+
+  /// Optional wrapper applied to the icon in compact (mobile) contexts where
+  /// the count must overlay the icon rather than sit in its own row slot.
+  final Widget Function(Widget icon)? mobileIconWrapper;
+
+  /// Optional trailing widget shown on the right side of the desktop sidebar
+  /// row. Typically a count pill.
+  final Widget Function({required bool active})? trailingBuilder;
+
+  Widget _mobileIcon({required bool active}) {
+    final icon = iconBuilder(active: active);
+    return mobileIconWrapper?.call(icon) ?? icon;
+  }
 
   DesignSystemNavigationTabBarItem toDesignSystemItem({
     required bool active,
@@ -82,8 +102,8 @@ class _AppNavigationDestination {
   }) {
     return DesignSystemNavigationTabBarItem(
       label: label,
-      icon: iconBuilder(active: false),
-      activeIcon: iconBuilder(active: true),
+      icon: _mobileIcon(active: false),
+      activeIcon: _mobileIcon(active: true),
       active: active,
       onTap: onTap,
     );
@@ -93,6 +113,7 @@ class _AppNavigationDestination {
     return DesktopSidebarDestination(
       label: label,
       iconBuilder: iconBuilder,
+      trailingBuilder: trailingBuilder,
     );
   }
 }
@@ -472,11 +493,10 @@ class _AppScreenState extends ConsumerState<AppScreen> {
       _AppNavigationDestination(
         kind: _AppNavigationDestinationKind.tasks,
         label: context.messages.navTabTitleTasks,
-        iconBuilder: ({required active}) => TasksBadge(
-          child: Icon(
-            active ? Icons.list_rounded : Icons.list_outlined,
-          ),
-        ),
+        iconBuilder: ({required active}) =>
+            Icon(active ? Icons.list_rounded : Icons.list_outlined),
+        mobileIconWrapper: (icon) => TasksBadge(child: icon),
+        trailingBuilder: ({required active}) => const TasksTrailingBadge(),
       ),
       _AppNavigationDestination(
         kind: _AppNavigationDestinationKind.projects,
@@ -514,8 +534,9 @@ class _AppScreenState extends ConsumerState<AppScreen> {
       _AppNavigationDestination(
         kind: _AppNavigationDestinationKind.settings,
         label: context.messages.navTabTitleSettings,
-        iconBuilder: ({required active}) =>
-            const OutboxBadgeIcon(icon: Icon(Icons.settings_rounded)),
+        iconBuilder: ({required active}) => const Icon(Icons.settings_rounded),
+        mobileIconWrapper: (icon) => OutboxBadgeIcon(icon: icon),
+        trailingBuilder: ({required active}) => const OutboxTrailingBadge(),
       ),
     ];
 

--- a/lib/features/design_system/components/navigation/desktop_navigation_sidebar.dart
+++ b/lib/features/design_system/components/navigation/desktop_navigation_sidebar.dart
@@ -7,6 +7,7 @@ class DesktopSidebarDestination {
   const DesktopSidebarDestination({
     required this.label,
     required this.iconBuilder,
+    this.trailingBuilder,
   });
 
   /// Display label for this destination.
@@ -14,6 +15,10 @@ class DesktopSidebarDestination {
 
   /// Builder that returns an icon widget based on the active state.
   final Widget Function({required bool active}) iconBuilder;
+
+  /// Optional builder for a trailing widget (e.g. a count badge) rendered
+  /// on the right side of the row, aligned with the label.
+  final Widget Function({required bool active})? trailingBuilder;
 }
 
 /// Persistent left-hand navigation sidebar for the desktop layout.
@@ -104,7 +109,8 @@ class DesktopNavigationSidebar extends StatelessWidget {
                       active: i == activeIndex && !isSettingsActive,
                       onTap: () => onDestinationSelected(i),
                     ),
-                    if (i < destinations.length - 1) const SizedBox(height: 4),
+                    if (i < destinations.length - 1)
+                      SizedBox(height: tokens.spacing.step6),
                   ],
                 ],
               ),
@@ -149,7 +155,6 @@ class _DesktopSidebarNavItem extends StatelessWidget {
           borderRadius: BorderRadius.circular(tokens.radii.m),
           onTap: onTap,
           child: Ink(
-            height: 48,
             decoration: BoxDecoration(
               color: active ? tokens.colors.surface.active : Colors.transparent,
               borderRadius: BorderRadius.circular(tokens.radii.m),
@@ -157,12 +162,12 @@ class _DesktopSidebarNavItem extends StatelessWidget {
             child: Padding(
               padding: EdgeInsets.symmetric(
                 horizontal: tokens.spacing.step5,
+                vertical: tokens.spacing.step4,
               ),
               child: Row(
                 children: [
                   SizedBox(
                     width: 32,
-                    height: 20,
                     child: Align(
                       alignment: Alignment.centerLeft,
                       child: IconTheme(
@@ -180,9 +185,12 @@ class _DesktopSidebarNavItem extends StatelessWidget {
                       style: tokens.typography.styles.body.bodyMedium.copyWith(
                         color: tokens.colors.text.highEmphasis,
                       ),
-                      overflow: TextOverflow.ellipsis,
                     ),
                   ),
+                  if (destination.trailingBuilder != null) ...[
+                    SizedBox(width: tokens.spacing.step3),
+                    destination.trailingBuilder!(active: active),
+                  ],
                 ],
               ),
             ),

--- a/lib/features/design_system/components/navigation/desktop_navigation_sidebar.dart
+++ b/lib/features/design_system/components/navigation/desktop_navigation_sidebar.dart
@@ -165,17 +165,20 @@ class _DesktopSidebarNavItem extends StatelessWidget {
                 vertical: tokens.spacing.step4,
               ),
               child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   SizedBox(
                     width: 32,
                     child: Align(
                       alignment: Alignment.centerLeft,
-                      child: IconTheme(
-                        data: IconThemeData(
-                          size: 20,
-                          color: tokens.colors.text.mediumEmphasis,
+                      child: ExcludeSemantics(
+                        child: IconTheme(
+                          data: IconThemeData(
+                            size: 20,
+                            color: tokens.colors.text.mediumEmphasis,
+                          ),
+                          child: destination.iconBuilder(active: active),
                         ),
-                        child: destination.iconBuilder(active: active),
                       ),
                     ),
                   ),

--- a/lib/features/settings/ui/pages/outbox/outbox_trailing_badge.dart
+++ b/lib/features/settings/ui/pages/outbox/outbox_trailing_badge.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/features/design_system/components/badges/design_system_badge.dart';
+import 'package:lotti/features/sync/state/outbox_state_controller.dart';
+
+/// Standalone count pill for pending outbox items, rendered in a trailing slot
+/// (e.g. alongside Settings on the desktop navigation sidebar).
+///
+/// Only renders when sync is enabled and there are pending items.
+class OutboxTrailingBadge extends ConsumerWidget {
+  const OutboxTrailingBadge({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final connectionState = ref.watch(outboxConnectionStateProvider).value;
+    if (connectionState != OutboxConnectionState.online) {
+      return const SizedBox.shrink();
+    }
+    final count = ref.watch(outboxPendingCountProvider).value ?? 0;
+    if (count == 0) {
+      return const SizedBox.shrink();
+    }
+    return DesignSystemBadge.number(
+      value: '$count',
+      tone: DesignSystemBadgeTone.danger,
+    );
+  }
+}

--- a/lib/features/tasks/ui/tasks_badge_icon.dart
+++ b/lib/features/tasks/ui/tasks_badge_icon.dart
@@ -3,6 +3,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/tasks/state/tasks_count_controller.dart';
 import 'package:lotti/themes/theme.dart';
 
+/// Icon wrapper that overlays the open-task count as a Material [Badge].
+///
+/// Used in compact contexts like the mobile bottom navigation bar, where the
+/// count needs to ride on the icon. The desktop sidebar uses
+/// `TasksTrailingBadge` instead, which places the count in its own row slot.
 class TasksBadge extends ConsumerWidget {
   const TasksBadge({
     required this.child,

--- a/lib/features/tasks/ui/tasks_trailing_badge.dart
+++ b/lib/features/tasks/ui/tasks_trailing_badge.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/features/design_system/components/badges/design_system_badge.dart';
+import 'package:lotti/features/tasks/state/tasks_count_controller.dart';
+
+/// Standalone count pill for the open-task count, rendered in a trailing slot
+/// (e.g. on the desktop navigation sidebar). Shows nothing when the count is 0.
+class TasksTrailingBadge extends ConsumerWidget {
+  const TasksTrailingBadge({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final count = ref.watch(tasksCountControllerProvider).value ?? 0;
+    if (count == 0) {
+      return const SizedBox.shrink();
+    }
+    return DesignSystemBadge.number(
+      value: '$count',
+      tone: DesignSystemBadgeTone.danger,
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.957+3935
+version: 0.9.958+3936
 
 msix_config:
   display_name: LottiApp

--- a/test/features/design_system/components/navigation/desktop_navigation_sidebar_test.dart
+++ b/test/features/design_system/components/navigation/desktop_navigation_sidebar_test.dart
@@ -267,6 +267,153 @@ void main() {
       },
     );
 
+    testWidgets(
+      'renders trailingBuilder widget on the right side of the row, '
+      'to the right of the label',
+      (tester) async {
+        const trailingKey = Key('trailing-badge');
+
+        await tester.pumpWidget(
+          wrap(
+            DesktopNavigationSidebar(
+              destinations: [
+                DesktopSidebarDestination(
+                  label: 'Tasks',
+                  iconBuilder: ({required bool active}) =>
+                      const Icon(Icons.list_outlined),
+                  trailingBuilder: ({required bool active}) => const SizedBox(
+                    key: trailingKey,
+                    width: 32,
+                    height: 24,
+                  ),
+                ),
+              ],
+              activeIndex: 0,
+              onDestinationSelected: (_) {},
+            ),
+          ),
+        );
+        await tester.pump();
+
+        final trailingFinder = find.byKey(trailingKey);
+        expect(trailingFinder, findsOneWidget);
+
+        // Trailing sits to the right of the label.
+        final trailingLeft = tester.getTopLeft(trailingFinder).dx;
+        final labelRight = tester.getTopRight(find.text('Tasks')).dx;
+        expect(
+          trailingLeft,
+          greaterThanOrEqualTo(labelRight),
+          reason: 'Trailing badge should be to the right of the label',
+        );
+      },
+    );
+
+    testWidgets('label text is rendered without forced single-line clipping', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        wrap(
+          DesktopNavigationSidebar(
+            destinations: [
+              DesktopSidebarDestination(
+                label: 'Insights',
+                iconBuilder: ({required bool active}) =>
+                    const Icon(Icons.insert_chart_outlined),
+              ),
+            ],
+            activeIndex: 0,
+            onDestinationSelected: (_) {},
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // The label uses the Text defaults so the row can grow with the
+      // text scaler instead of getting clipped to a fixed 48 px item.
+      final text = tester.widget<Text>(find.text('Insights'));
+      expect(text.overflow, isNull);
+      expect(text.softWrap, isNull);
+      expect(text.maxLines, isNull);
+    });
+
+    testWidgets(
+      'item grows vertically to fit the label when the text scaler is large',
+      (tester) async {
+        Widget buildSidebar(double scale) {
+          return makeTestableWidget2(
+            Theme(
+              data: DesignSystemTheme.dark(),
+              child: MediaQuery(
+                data: MediaQueryData(textScaler: TextScaler.linear(scale)),
+                child: Scaffold(
+                  body: SizedBox(
+                    width: 320,
+                    height: 900,
+                    child: DesktopNavigationSidebar(
+                      destinations: [
+                        DesktopSidebarDestination(
+                          label: 'Projects',
+                          iconBuilder: ({required bool active}) =>
+                              const Icon(Icons.folder_outlined),
+                        ),
+                      ],
+                      activeIndex: 0,
+                      onDestinationSelected: (_) {},
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          );
+        }
+
+        await tester.pumpWidget(buildSidebar(1));
+        await tester.pump();
+        final baseHeight = tester.getSize(find.text('Projects')).height;
+        final baseRow = tester
+            .getSize(
+              find
+                  .ancestor(
+                    of: find.text('Projects'),
+                    matching: find.byType(Row),
+                  )
+                  .first,
+            )
+            .height;
+
+        await tester.pumpWidget(buildSidebar(2));
+        await tester.pump();
+        final largeHeight = tester.getSize(find.text('Projects')).height;
+        final largeRow = tester
+            .getSize(
+              find
+                  .ancestor(
+                    of: find.text('Projects'),
+                    matching: find.byType(Row),
+                  )
+                  .first,
+            )
+            .height;
+
+        expect(
+          largeHeight,
+          greaterThan(baseHeight),
+          reason: 'Scaled-up label should take more vertical space',
+        );
+        expect(
+          largeRow,
+          greaterThanOrEqualTo(largeHeight),
+          reason: 'Row must grow to fit the scaled label, not clip it',
+        );
+        expect(
+          largeRow,
+          greaterThan(baseRow),
+          reason: 'The row should grow with the label',
+        );
+      },
+    );
+
     testWidgets('sidebar does not render a "+ New" quick action', (
       tester,
     ) async {

--- a/test/features/settings/ui/pages/outbox/outbox_trailing_badge_test.dart
+++ b/test/features/settings/ui/pages/outbox/outbox_trailing_badge_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/components/badges/design_system_badge.dart';
+import 'package:lotti/features/settings/ui/pages/outbox/outbox_trailing_badge.dart';
+import 'package:lotti/providers/service_providers.dart';
+
+import '../../../../../mocks/mocks.dart';
+import '../../../../../mocks/sync_config_test_mocks.dart';
+import '../../../../../widget_test_utils.dart';
+
+void main() {
+  group('OutboxTrailingBadge', () {
+    testWidgets('renders a danger-tone number badge when count > 0', (
+      tester,
+    ) async {
+      final syncDbMock = mockSyncDatabaseWithCount(4);
+      final dbMock = mockJournalDbWithSyncFlag(enabled: true);
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const OutboxTrailingBadge(),
+          overrides: [
+            journalDbProvider.overrideWithValue(dbMock),
+            syncDatabaseProvider.overrideWithValue(syncDbMock),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('4'), findsOneWidget);
+      final badge = tester.widget<DesignSystemBadge>(
+        find.byType(DesignSystemBadge),
+      );
+      expect(badge.tone, DesignSystemBadgeTone.danger);
+    });
+
+    testWidgets('renders nothing when sync is disabled', (tester) async {
+      final syncDbMock = mockSyncDatabaseWithCount(9);
+      final dbMock = mockJournalDbWithSyncFlag(enabled: false);
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const OutboxTrailingBadge(),
+          overrides: [
+            journalDbProvider.overrideWithValue(dbMock),
+            syncDatabaseProvider.overrideWithValue(syncDbMock),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(DesignSystemBadge), findsNothing);
+      expect(find.text('9'), findsNothing);
+    });
+
+    testWidgets('renders nothing when count is 0', (tester) async {
+      final syncDbMock = mockSyncDatabaseWithCount(0);
+      final dbMock = mockJournalDbWithSyncFlag(enabled: true);
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const OutboxTrailingBadge(),
+          overrides: [
+            journalDbProvider.overrideWithValue(dbMock),
+            syncDatabaseProvider.overrideWithValue(syncDbMock),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(DesignSystemBadge), findsNothing);
+    });
+  });
+}

--- a/test/features/tasks/ui/tasks_trailing_badge_test.dart
+++ b/test/features/tasks/ui/tasks_trailing_badge_test.dart
@@ -1,0 +1,65 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/components/badges/design_system_badge.dart';
+import 'package:lotti/features/tasks/ui/tasks_trailing_badge.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../widget_test_utils.dart';
+
+void main() {
+  group('TasksTrailingBadge', () {
+    late TestGetItMocks mocks;
+
+    setUp(() async {
+      mocks = await setUpTestGetIt();
+    });
+
+    tearDown(tearDownTestGetIt);
+
+    testWidgets('renders a danger-tone number badge when count > 0', (
+      tester,
+    ) async {
+      when(mocks.journalDb.getTasksCount).thenAnswer((_) async => 7);
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(const TasksTrailingBadge()),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('7'), findsOneWidget);
+      final badge = tester.widget<DesignSystemBadge>(
+        find.byType(DesignSystemBadge),
+      );
+      expect(badge.tone, DesignSystemBadgeTone.danger);
+    });
+
+    testWidgets('renders nothing when count is 0', (tester) async {
+      when(mocks.journalDb.getTasksCount).thenAnswer((_) async => 0);
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(const TasksTrailingBadge()),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(DesignSystemBadge), findsNothing);
+      expect(find.text('0'), findsNothing);
+    });
+
+    testWidgets('renders nothing while the count is still loading', (
+      tester,
+    ) async {
+      // Never-completing future keeps the provider in loading state.
+      when(mocks.journalDb.getTasksCount).thenAnswer(
+        (_) => Completer<int>().future,
+      );
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(const TasksTrailingBadge()),
+      );
+      await tester.pump();
+
+      expect(find.byType(DesignSystemBadge), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop sidebar now shows Tasks and Settings notification counts as design-system trailing number badges.

* **Bug Fixes**
  * Sidebar rows no longer clip label text at larger text scales; rows expand with content.

* **Improvements**
  * Increased vertical spacing between sidebar items for visual balance; mobile bottom-navigation badge behavior unchanged.

* **Tests / Docs**
  * Added widget tests for sidebar and trailing badges; changelog and release metadata updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->