### PR TITLE
refactor: database tweaks

### DIFF
--- a/lib/database/common.dart
+++ b/lib/database/common.dart
@@ -61,11 +61,19 @@ Future<void> createDbBackup(String fileName) async {
 ///
 /// Applied via the `setup` callback so that every connection (including
 /// read-pool isolates) inherits these settings.
+///
+/// `wal_autocheckpoint` is lowered from SQLite's default of 1000 pages to
+/// 200 pages (~800 KB at the default 4 KB page size). A shorter WAL means
+/// smaller, more frequent checkpoints and a narrower window in which a
+/// checkpoint can starve a reader — slow-query capture observed a 9-minute
+/// stall on a `sync_sequence_log` read whose p95 is <60 ms, consistent
+/// with a WAL checkpoint pause rather than a bad plan.
 void _setupDatabase(Database database) {
   database
     ..execute('PRAGMA journal_mode = WAL;')
     ..execute('PRAGMA busy_timeout = 5000;')
-    ..execute('PRAGMA synchronous = NORMAL;');
+    ..execute('PRAGMA synchronous = NORMAL;')
+    ..execute('PRAGMA wal_autocheckpoint = 200;');
 }
 
 /// Opens a database connection with lazy initialization.

--- a/lib/database/common.dart
+++ b/lib/database/common.dart
@@ -91,9 +91,13 @@ void _setupDatabase(Database database) {
 ///   (default: 0). Only effective when [background] is true.
 /// - [slowQueryThreshold]: Threshold used by the shared slow-query interceptor.
 ///   Slow-query writes remain disabled until the corresponding logging domain
-///   is enabled in Settings > Advanced > Logging Domains. Default is 50 ms —
-///   the user-visible jank floor. Tests and deep-dive captures pass
-///   [Duration.zero] or a smaller value to surface every query.
+///   is enabled in Settings > Advanced > Logging Domains. Default is 10 ms —
+///   a fraction of the 16 ms frame budget, so any single query logged here
+///   is already a meaningful slice of a frame. n+1 chains are not caught
+///   by thresholding individual queries (each link is under the bar); they
+///   are caught by the coalescers in `JournalDb` and by counting round-trips
+///   in tests. Pass [Duration.zero] in tests and deep-dive captures to
+///   surface every query.
 /// - [documentsDirectoryProvider]: Optional provider for documents directory (for testing)
 /// - [tempDirectoryProvider]: Optional provider for temp directory (for testing)
 ///
@@ -112,7 +116,7 @@ LazyDatabase openDbConnection(
   bool inMemoryDatabase = false,
   bool background = true,
   int readPool = 0,
-  Duration slowQueryThreshold = const Duration(milliseconds: 50),
+  Duration slowQueryThreshold = const Duration(milliseconds: 10),
   SlowQueryReporter? slowQueryReporter,
   Future<Directory> Function()? documentsDirectoryProvider,
   Future<Directory> Function()? tempDirectoryProvider,

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -2361,12 +2361,61 @@ class JournalDb extends _$JournalDb {
   /// The query orders by `updated_at ASC` so that when multiple ratings
   /// link to the same time entry, the most recently updated one wins
   /// (last-write-wins in the map comprehension).
+  ///
+  /// Concurrent callers within the same microtask (the DailyOS prefetch
+  /// window fires `_fetchAllData` per date) share a single round-trip: the
+  /// wave merges every caller's id set, issues one `ratingsForTimeEntries`
+  /// query, and hands each caller a map restricted to its own ids.
+  ///
+  /// Per-row ordering (`j.updated_at ASC`) is preserved across the wave so
+  /// last-write-wins remains stable within each caller's subset. The
+  /// caller's set is snapshotted before scheduling so the post-query filter
+  /// never reads a mutated view if the caller reuses or clears the set
+  /// before the coalesced wave fires.
   Future<Map<String, String>> getRatingIdsForTimeEntries(
     Set<String> timeEntryIds,
-  ) async {
-    if (timeEntryIds.isEmpty) return {};
-    final rows = await ratingsForTimeEntries(timeEntryIds.toList()).get();
-    return {for (final row in rows) row.timeEntryId: row.ratingId};
+  ) {
+    final snapshot = Set<String>.unmodifiable(timeEntryIds);
+    if (snapshot.isEmpty) return Future.value(const <String, String>{});
+    return _coalesceRatings(snapshot);
+  }
+
+  _PendingRatingsWave? _pendingRatingsWave;
+
+  /// Single-shot query executed by the ratings coalescer. Extracted as a
+  /// protected seam so tests can count DB round-trips without depending on
+  /// a query interceptor.
+  @protected
+  @visibleForTesting
+  Future<List<RatingsForTimeEntriesResult>> runRatingsForTimeEntriesQueryForIds(
+    Set<String> ids,
+  ) {
+    return ratingsForTimeEntries(ids.toList()).get();
+  }
+
+  Future<Map<String, String>> _coalesceRatings(Set<String> ids) {
+    final wave = _pendingRatingsWave ??= _PendingRatingsWave();
+    wave.mergedIds.addAll(ids);
+    if (!wave.scheduled) {
+      wave.scheduled = true;
+      scheduleMicrotask(() async {
+        _pendingRatingsWave = null;
+        try {
+          final rows = await runRatingsForTimeEntriesQueryForIds(
+            wave.mergedIds,
+          );
+          wave.completer.complete(rows);
+        } catch (error, stack) {
+          wave.completer.completeError(error, stack);
+        }
+      });
+    }
+    return wave.completer.future.then(
+      (rows) => {
+        for (final row in rows)
+          if (ids.contains(row.timeEntryId)) row.timeEntryId: row.ratingId,
+      },
+    );
   }
 
   Future<List<JournalEntity>> getQuantitativeByType({
@@ -2834,4 +2883,14 @@ class _PendingLinksWave {
   bool scheduled = false;
   final Completer<List<EntryLink>> completer =
       Completer<List<EntryLink>>.sync();
+}
+
+/// In-flight coalescing wave for `getRatingIdsForTimeEntries`. Mirrors
+/// [_PendingLinksWave] but keeps drift's rating-query result rows so each
+/// caller can reconstruct its own last-write-wins map for its id subset.
+class _PendingRatingsWave {
+  final Set<String> mergedIds = <String>{};
+  bool scheduled = false;
+  final Completer<List<RatingsForTimeEntriesResult>> completer =
+      Completer<List<RatingsForTimeEntriesResult>>.sync();
 }

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -2119,9 +2119,12 @@ class JournalDb extends _$JournalDb {
   /// the day-plan repository so a prefetch window of N dates collapses
   /// into a single round-trip. Chunks inputs to stay under SQLite's
   /// default 999-variable limit even if a caller fans out far past the
-  /// DailyOS prefetch window.
+  /// DailyOS prefetch window. Duplicate ids are removed before chunking
+  /// so the `IN (…)` semantics of the original single-query form are
+  /// preserved — otherwise dupes in different chunks would yield dupe
+  /// rows.
   Future<List<DayPlanEntry>> getDayPlansByIds(Iterable<String> ids) async {
-    final idList = ids.toList(growable: false);
+    final idList = ids.toSet().toList(growable: false);
     if (idList.isEmpty) return const [];
     final out = <DayPlanEntry>[];
     for (var i = 0; i < idList.length; i += _sqliteInListChunk) {
@@ -2397,13 +2400,27 @@ class JournalDb extends _$JournalDb {
 
   /// Single-shot query executed by the ratings coalescer. Extracted as a
   /// protected seam so tests can count DB round-trips without depending on
-  /// a query interceptor.
+  /// a query interceptor. The merged wave set can grow past SQLite's
+  /// 999-variable limit when many prefetched dates converge in one
+  /// microtask; chunk through [_sqliteInListChunk] with a stable
+  /// `updated_at ASC` order preserved across chunks so last-write-wins
+  /// holds at the map-comprehension step.
   @protected
   @visibleForTesting
   Future<List<RatingsForTimeEntriesResult>> runRatingsForTimeEntriesQueryForIds(
     Set<String> ids,
-  ) {
-    return ratingsForTimeEntries(ids.toList()).get();
+  ) async {
+    final idList = ids.toList(growable: false);
+    if (idList.length <= _sqliteInListChunk) {
+      return ratingsForTimeEntries(idList).get();
+    }
+    final combined = <RatingsForTimeEntriesResult>[];
+    for (var i = 0; i < idList.length; i += _sqliteInListChunk) {
+      final end = (i + _sqliteInListChunk).clamp(0, idList.length);
+      final chunk = idList.sublist(i, end);
+      combined.addAll(await ratingsForTimeEntries(chunk).get());
+    }
+    return combined;
   }
 
   Future<Map<String, String>> _coalesceRatings(Set<String> ids) {

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -90,6 +90,11 @@ class JournalDb extends _$JournalDb {
   @override
   int get schemaVersion => 39;
 
+  /// Conservative chunk size for `IN :ids` drift queries to stay under
+  /// SQLite's default `SQLITE_MAX_VARIABLE_NUMBER` of 999 with headroom
+  /// for other variables in the same statement.
+  static const int _sqliteInListChunk = 500;
+
   @override
   MigrationStrategy get migration {
     return MigrationStrategy(
@@ -2112,15 +2117,23 @@ class JournalDb extends _$JournalDb {
 
   /// Batch variant of [getDayPlanById]. Used by the coalescing layer in
   /// the day-plan repository so a prefetch window of N dates collapses
-  /// into a single round-trip.
+  /// into a single round-trip. Chunks inputs to stay under SQLite's
+  /// default 999-variable limit even if a caller fans out far past the
+  /// DailyOS prefetch window.
   Future<List<DayPlanEntry>> getDayPlansByIds(Iterable<String> ids) async {
     final idList = ids.toList(growable: false);
     if (idList.isEmpty) return const [];
-    final res = await _queryWithPrivateFilter(
-      allPrivate: () => dayPlansByIds(idList).get(),
-      filtered: (s) => dayPlansByIdsByPrivateStatuses(idList, s).get(),
-    );
-    return res.map((e) => fromDbEntity(e) as DayPlanEntry).toList();
+    final out = <DayPlanEntry>[];
+    for (var i = 0; i < idList.length; i += _sqliteInListChunk) {
+      final end = (i + _sqliteInListChunk).clamp(0, idList.length);
+      final chunk = idList.sublist(i, end);
+      final res = await _queryWithPrivateFilter(
+        allPrivate: () => dayPlansByIds(chunk).get(),
+        filtered: (s) => dayPlansByIdsByPrivateStatuses(chunk, s).get(),
+      );
+      out.addAll(res.map((e) => fromDbEntity(e) as DayPlanEntry));
+    }
+    return out;
   }
 
   Future<List<DayPlanEntry>> getDayPlansInRange({

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.958+3936
+version: 0.9.958+3937
 
 msix_config:
   display_name: LottiApp

--- a/test/database/batch_chunking_test.dart
+++ b/test/database/batch_chunking_test.dart
@@ -1,0 +1,309 @@
+// ignore_for_file: avoid_redundant_argument_values
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/day_plan.dart';
+import 'package:lotti/classes/entry_link.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/classes/rating_data.dart';
+import 'package:lotti/database/conversions.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/database/journal_db/config_flags.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/logging_service.dart';
+import 'package:lotti/utils/consts.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../mocks/mocks.dart';
+
+DayPlanEntry makePlan(DateTime date) {
+  return DayPlanEntry(
+    meta: Metadata(
+      id: dayPlanId(date),
+      createdAt: date,
+      updatedAt: date,
+      dateFrom: date,
+      dateTo: date.add(const Duration(days: 1)),
+    ),
+    data: DayPlanData(
+      planDate: date,
+      status: const DayPlanStatus.draft(),
+      plannedBlocks: const [],
+    ),
+  );
+}
+
+RatingEntry makeRating({
+  required String id,
+  required DateTime updatedAt,
+}) {
+  return RatingEntry(
+    meta: Metadata(
+      id: id,
+      createdAt: updatedAt,
+      updatedAt: updatedAt,
+      dateFrom: updatedAt,
+      dateTo: updatedAt,
+    ),
+    data: RatingData(
+      targetId: 'te-$id',
+      catalogId: 'session',
+      dimensions: const [],
+    ),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late JournalDb db;
+  late MockLoggingService loggingService;
+  Directory? testDirectory;
+  Directory? previousDirectory;
+  LoggingService? previousLoggingService;
+
+  setUp(() async {
+    if (getIt.isRegistered<Directory>()) {
+      previousDirectory = getIt<Directory>();
+      getIt.unregister<Directory>();
+    }
+    testDirectory = Directory.systemTemp.createTempSync('lotti_chunking_');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (MethodCall methodCall) async {
+            if (methodCall.method == 'getApplicationDocumentsDirectory' ||
+                methodCall.method == 'getApplicationSupportDirectory' ||
+                methodCall.method == 'getTemporaryDirectory') {
+              return testDirectory!.path;
+            }
+            return null;
+          },
+        );
+    getIt.registerSingleton<Directory>(testDirectory!);
+
+    loggingService = MockLoggingService();
+    when(
+      () => loggingService.captureEvent(
+        any<Object>(),
+        domain: any<String>(named: 'domain'),
+        subDomain: any<String?>(named: 'subDomain'),
+      ),
+    ).thenAnswer((_) async {});
+    when(
+      () => loggingService.captureException(
+        any<Object>(),
+        domain: any<String>(named: 'domain'),
+        subDomain: any<String?>(named: 'subDomain'),
+        stackTrace: any<StackTrace?>(named: 'stackTrace'),
+      ),
+    ).thenAnswer((_) async {});
+    if (getIt.isRegistered<LoggingService>()) {
+      previousLoggingService = getIt<LoggingService>();
+      getIt.unregister<LoggingService>();
+    } else {
+      previousLoggingService = null;
+    }
+    getIt.registerSingleton<LoggingService>(loggingService);
+
+    db = JournalDb(
+      inMemoryDatabase: true,
+      background: false,
+      readPool: 0,
+    );
+    await initConfigFlags(db, inMemoryDatabase: true);
+  });
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          null,
+        );
+    await db.close();
+    if (getIt.isRegistered<LoggingService>()) {
+      getIt.unregister<LoggingService>();
+    }
+    if (previousLoggingService != null) {
+      getIt.registerSingleton<LoggingService>(previousLoggingService!);
+    }
+    getIt.unregister<Directory>();
+    if (previousDirectory != null) {
+      getIt.registerSingleton<Directory>(previousDirectory!);
+    }
+    if (testDirectory != null && testDirectory!.existsSync()) {
+      testDirectory!.deleteSync(recursive: true);
+    }
+  });
+
+  group('getDayPlansByIds', () {
+    test('returns empty list for empty input without hitting the DB', () async {
+      final result = await db.getDayPlansByIds(const <String>[]);
+      expect(result, isEmpty);
+    });
+
+    test('returns the matching rows for a small id set', () async {
+      final d1 = DateTime(2026, 4, 1);
+      final d2 = DateTime(2026, 4, 2);
+      final d3 = DateTime(2026, 4, 3);
+      await db.upsertJournalDbEntity(toDbEntity(makePlan(d1)));
+      await db.upsertJournalDbEntity(toDbEntity(makePlan(d2)));
+      await db.upsertJournalDbEntity(toDbEntity(makePlan(d3)));
+
+      final result = await db.getDayPlansByIds({
+        dayPlanId(d1),
+        dayPlanId(d3),
+      });
+
+      expect(result.map((p) => p.meta.id).toSet(), {
+        dayPlanId(d1),
+        dayPlanId(d3),
+      });
+    });
+
+    test(
+      'deduplicates input ids so chunked queries do not return duplicate rows',
+      () async {
+        final d = DateTime(2026, 4, 10);
+        await db.upsertJournalDbEntity(toDbEntity(makePlan(d)));
+
+        // Caller fans duplicates through an Iterable — a Set-backed input
+        // would dedupe up front, but getDayPlansByIds must guard against
+        // List-shaped callers too.
+        final result = await db.getDayPlansByIds([
+          dayPlanId(d),
+          dayPlanId(d),
+          dayPlanId(d),
+        ]);
+
+        expect(result.map((p) => p.meta.id), [dayPlanId(d)]);
+      },
+    );
+
+    test(
+      'excludes private plans when the private flag is off (filtered path)',
+      () async {
+        // Drop the private flag so `_queryWithPrivateFilter` routes through
+        // the `filtered:` branch and uses `dayPlansByIdsByPrivateStatuses`
+        // instead of the all-private fast path.
+        final privateConfig = await db.getConfigFlagByName(privateFlag);
+        await db.upsertConfigFlag(privateConfig!.copyWith(status: false));
+
+        final publicDate = DateTime(2026, 5, 1);
+        final privateDate = DateTime(2026, 5, 2);
+        final publicPlan = makePlan(publicDate);
+        final privatePlan = makePlan(privateDate).copyWith(
+          meta: makePlan(privateDate).meta.copyWith(private: true),
+        );
+        await db.upsertJournalDbEntity(toDbEntity(publicPlan));
+        await db.upsertJournalDbEntity(toDbEntity(privatePlan));
+
+        final result = await db.getDayPlansByIds({
+          dayPlanId(publicDate),
+          dayPlanId(privateDate),
+        });
+
+        expect(result.map((p) => p.meta.id), [dayPlanId(publicDate)]);
+      },
+    );
+
+    test('chunks across the 500-id boundary and returns every match', () async {
+      // 1,200 dates → 3 chunks (500 + 500 + 200). Of those 1,200 ids, only
+      // 3 actually exist in the DB; the others are unmatched. Every stored
+      // row must be returned exactly once across the combined output.
+      final base = DateTime(2026, 1, 1);
+      final stored = [
+        0,
+        600,
+        1100,
+      ].map((offset) => base.add(Duration(days: offset))).toList();
+      for (final d in stored) {
+        await db.upsertJournalDbEntity(toDbEntity(makePlan(d)));
+      }
+
+      final ids = <String>[
+        for (var i = 0; i < 1200; i++) dayPlanId(base.add(Duration(days: i))),
+      ];
+
+      final result = await db.getDayPlansByIds(ids);
+
+      expect(
+        result.map((p) => p.meta.id).toSet(),
+        stored.map(dayPlanId).toSet(),
+      );
+    });
+  });
+
+  group('runRatingsForTimeEntriesQueryForIds chunking', () {
+    test(
+      'a sub-500 id set hits the fast path and returns the stored rating id',
+      () async {
+        final updatedAt = DateTime(2026, 4, 1);
+        await db.upsertJournalDbEntity(
+          toDbEntity(makeRating(id: 'r1', updatedAt: updatedAt)),
+        );
+        await db.upsertEntryLink(
+          EntryLink.rating(
+            id: 'rlink-r1',
+            fromId: 'r1',
+            toId: 'te-A',
+            createdAt: updatedAt,
+            updatedAt: updatedAt,
+            vectorClock: null,
+          ),
+        );
+
+        final rows = await db.runRatingsForTimeEntriesQueryForIds({'te-A'});
+
+        expect(rows, hasLength(1));
+        expect(rows.single.timeEntryId, 'te-A');
+        expect(rows.single.ratingId, 'r1');
+      },
+    );
+
+    test(
+      'a >500 id set exercises the chunk loop and still returns every match',
+      () async {
+        // Three real rating links seeded at positions that land in three
+        // different 500-id chunks of a 1,200-id request (indexes 0, 600,
+        // 1100). The combined loop must concatenate rows from each chunk.
+        final updatedAt = DateTime(2026, 4, 1);
+        for (final idx in [0, 600, 1100]) {
+          await db.upsertJournalDbEntity(
+            toDbEntity(
+              makeRating(
+                id: 'r-$idx',
+                updatedAt: updatedAt.add(Duration(minutes: idx)),
+              ),
+            ),
+          );
+          await db.upsertEntryLink(
+            EntryLink.rating(
+              id: 'rlink-$idx',
+              fromId: 'r-$idx',
+              toId: 'te-$idx',
+              createdAt: updatedAt,
+              updatedAt: updatedAt,
+              vectorClock: null,
+            ),
+          );
+        }
+
+        final ids = <String>{for (var i = 0; i < 1200; i++) 'te-$i'};
+
+        final rows = await db.runRatingsForTimeEntriesQueryForIds(ids);
+
+        expect(rows.map((r) => r.timeEntryId).toSet(), {
+          'te-0',
+          'te-600',
+          'te-1100',
+        });
+        expect(
+          rows.map((r) => r.ratingId).toSet(),
+          {'r-0', 'r-600', 'r-1100'},
+        );
+      },
+    );
+  });
+}

--- a/test/database/open_db_connection_test.dart
+++ b/test/database/open_db_connection_test.dart
@@ -84,6 +84,11 @@ void main() {
     // NORMAL = 1
     expect(syncResult.read<int>('synchronous'), 1);
 
+    final checkpointResult = await db
+        .customSelect('PRAGMA wal_autocheckpoint')
+        .getSingle();
+    expect(checkpointResult.read<int>('wal_autocheckpoint'), 200);
+
     await db.close();
   });
 

--- a/test/database/ratings_coalescing_test.dart
+++ b/test/database/ratings_coalescing_test.dart
@@ -1,0 +1,297 @@
+// ignore_for_file: avoid_redundant_argument_values
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/entry_link.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/classes/rating_data.dart';
+import 'package:lotti/database/conversions.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/database/journal_db/config_flags.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/logging_service.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../mocks/mocks.dart';
+
+/// Spy subclass that counts `runRatingsForTimeEntriesQueryForIds` calls.
+/// The coalescer flushes each wave through exactly one call to this method,
+/// so the counter equals the number of DB round-trips.
+class _CountingJournalDb extends JournalDb {
+  _CountingJournalDb()
+    : super(inMemoryDatabase: true, background: false, readPool: 0);
+
+  int ratingsQueryCount = 0;
+  Set<String>? lastMergedIds;
+
+  @override
+  Future<List<RatingsForTimeEntriesResult>> runRatingsForTimeEntriesQueryForIds(
+    Set<String> ids,
+  ) {
+    ratingsQueryCount += 1;
+    lastMergedIds = Set<String>.from(ids);
+    return super.runRatingsForTimeEntriesQueryForIds(ids);
+  }
+}
+
+class _FailingRatingsJournalDb extends JournalDb {
+  _FailingRatingsJournalDb()
+    : super(inMemoryDatabase: true, background: false, readPool: 0);
+
+  Object failure = StateError('not set');
+  int attempts = 0;
+
+  @override
+  Future<List<RatingsForTimeEntriesResult>> runRatingsForTimeEntriesQueryForIds(
+    Set<String> ids,
+  ) {
+    attempts += 1;
+    return Future<List<RatingsForTimeEntriesResult>>.error(failure);
+  }
+}
+
+RatingEntry makeRating({
+  required String id,
+  required DateTime updatedAt,
+  String catalogId = 'session',
+}) {
+  return RatingEntry(
+    meta: Metadata(
+      id: id,
+      createdAt: updatedAt,
+      updatedAt: updatedAt,
+      dateFrom: updatedAt,
+      dateTo: updatedAt,
+    ),
+    data: RatingData(
+      targetId: 'te-$id',
+      catalogId: catalogId,
+      dimensions: const [],
+    ),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _CountingJournalDb db;
+  late MockLoggingService loggingService;
+  Directory? testDirectory;
+  Directory? previousDirectory;
+
+  setUp(() async {
+    if (getIt.isRegistered<Directory>()) {
+      previousDirectory = getIt<Directory>();
+      getIt.unregister<Directory>();
+    }
+    testDirectory = Directory.systemTemp.createTempSync(
+      'lotti_ratings_coalesce_',
+    );
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (MethodCall methodCall) async {
+            if (methodCall.method == 'getApplicationDocumentsDirectory' ||
+                methodCall.method == 'getApplicationSupportDirectory' ||
+                methodCall.method == 'getTemporaryDirectory') {
+              return testDirectory!.path;
+            }
+            return null;
+          },
+        );
+    getIt.registerSingleton<Directory>(testDirectory!);
+
+    loggingService = MockLoggingService();
+    when(
+      () => loggingService.captureEvent(
+        any<Object>(),
+        domain: any<String>(named: 'domain'),
+        subDomain: any<String?>(named: 'subDomain'),
+      ),
+    ).thenAnswer((_) async {});
+    when(
+      () => loggingService.captureException(
+        any<Object>(),
+        domain: any<String>(named: 'domain'),
+        subDomain: any<String?>(named: 'subDomain'),
+        stackTrace: any<StackTrace?>(named: 'stackTrace'),
+      ),
+    ).thenAnswer((_) async {});
+    if (getIt.isRegistered<LoggingService>()) {
+      getIt.unregister<LoggingService>();
+    }
+    getIt.registerSingleton<LoggingService>(loggingService);
+
+    db = _CountingJournalDb();
+    await initConfigFlags(db, inMemoryDatabase: true);
+  });
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          null,
+        );
+    await db.close();
+    if (getIt.isRegistered<LoggingService>()) {
+      getIt.unregister<LoggingService>();
+    }
+    getIt.unregister<Directory>();
+    if (previousDirectory != null) {
+      getIt.registerSingleton<Directory>(previousDirectory!);
+    }
+    if (testDirectory != null && testDirectory!.existsSync()) {
+      testDirectory!.deleteSync(recursive: true);
+    }
+  });
+
+  Future<void> insertRatingLink({
+    required String ratingId,
+    required String timeEntryId,
+    required DateTime ratingUpdatedAt,
+  }) async {
+    await db.upsertJournalDbEntity(
+      toDbEntity(
+        makeRating(id: ratingId, updatedAt: ratingUpdatedAt),
+      ),
+    );
+    final link = EntryLink.rating(
+      id: 'rlink-$ratingId-$timeEntryId',
+      fromId: ratingId,
+      toId: timeEntryId,
+      createdAt: ratingUpdatedAt,
+      updatedAt: ratingUpdatedAt,
+      vectorClock: null,
+    );
+    await db.upsertEntryLink(link);
+  }
+
+  group('getRatingIdsForTimeEntries microtask coalescing', () {
+    test(
+      'two concurrent callers share one DB query; each receives only its '
+      'own subset mapped to the rating id',
+      () async {
+        await insertRatingLink(
+          ratingId: 'r1',
+          timeEntryId: 'te-A',
+          ratingUpdatedAt: DateTime(2026, 4, 1),
+        );
+        await insertRatingLink(
+          ratingId: 'r2',
+          timeEntryId: 'te-B',
+          ratingUpdatedAt: DateTime(2026, 4, 2),
+        );
+        await insertRatingLink(
+          ratingId: 'r3',
+          timeEntryId: 'te-C',
+          ratingUpdatedAt: DateTime(2026, 4, 3),
+        );
+        db.ratingsQueryCount = 0;
+
+        final futureA = db.getRatingIdsForTimeEntries({'te-A'});
+        final futureBC = db.getRatingIdsForTimeEntries({'te-B', 'te-C'});
+
+        final resultA = await futureA;
+        final resultBC = await futureBC;
+
+        expect(resultA, {'te-A': 'r1'});
+        expect(resultBC, {'te-B': 'r2', 'te-C': 'r3'});
+        expect(db.ratingsQueryCount, 1);
+        expect(db.lastMergedIds, {'te-A', 'te-B', 'te-C'});
+      },
+    );
+
+    test('empty id set short-circuits without issuing a query', () async {
+      final result = await db.getRatingIdsForTimeEntries(const <String>{});
+      expect(result, isEmpty);
+      expect(db.ratingsQueryCount, 0);
+    });
+
+    test('distinct microtask waves issue separate queries', () async {
+      await insertRatingLink(
+        ratingId: 'r1',
+        timeEntryId: 'te-A',
+        ratingUpdatedAt: DateTime(2026, 4, 1),
+      );
+      db.ratingsQueryCount = 0;
+
+      final first = await db.getRatingIdsForTimeEntries({'te-A'});
+      final second = await db.getRatingIdsForTimeEntries({'te-A'});
+
+      expect(first, {'te-A': 'r1'});
+      expect(second, {'te-A': 'r1'});
+      expect(db.ratingsQueryCount, 2);
+    });
+
+    test(
+      'last-write-wins: when multiple ratings link to one time entry the '
+      'most recently updated rating id is returned',
+      () async {
+        await insertRatingLink(
+          ratingId: 'older',
+          timeEntryId: 'te-A',
+          ratingUpdatedAt: DateTime(2026, 4, 1),
+        );
+        await insertRatingLink(
+          ratingId: 'newer',
+          timeEntryId: 'te-A',
+          ratingUpdatedAt: DateTime(2026, 4, 10),
+        );
+        db.ratingsQueryCount = 0;
+
+        final result = await db.getRatingIdsForTimeEntries({'te-A'});
+
+        expect(result, {'te-A': 'newer'});
+        expect(db.ratingsQueryCount, 1);
+      },
+    );
+
+    test(
+      'query error propagates to every caller waiting on the wave',
+      () async {
+        await db.close();
+        final failingDb = _FailingRatingsJournalDb()
+          ..failure = StateError('simulated');
+        await initConfigFlags(failingDb, inMemoryDatabase: true);
+        addTearDown(failingDb.close);
+
+        final futures = [
+          failingDb.getRatingIdsForTimeEntries({'te-A'}),
+          failingDb.getRatingIdsForTimeEntries({'te-B'}),
+        ];
+
+        for (final f in futures) {
+          await expectLater(f, throwsA(same(failingDb.failure)));
+        }
+        expect(failingDb.attempts, 1);
+      },
+    );
+
+    test(
+      "rows outside a caller's id set do not leak into its result map",
+      () async {
+        await insertRatingLink(
+          ratingId: 'r1',
+          timeEntryId: 'te-A',
+          ratingUpdatedAt: DateTime(2026, 4, 1),
+        );
+        await insertRatingLink(
+          ratingId: 'r2',
+          timeEntryId: 'te-B',
+          ratingUpdatedAt: DateTime(2026, 4, 2),
+        );
+        db.ratingsQueryCount = 0;
+
+        // Two callers share a wave. The first must only see te-A even
+        // though the DB returned both te-A and te-B to the merged query.
+        final narrow = db.getRatingIdsForTimeEntries({'te-A'});
+        final wide = db.getRatingIdsForTimeEntries({'te-A', 'te-B'});
+
+        expect(await narrow, {'te-A': 'r1'});
+        expect(await wide, {'te-A': 'r1', 'te-B': 'r2'});
+        expect(db.ratingsQueryCount, 1);
+      },
+    );
+  });
+}

--- a/test/database/ratings_coalescing_test.dart
+++ b/test/database/ratings_coalescing_test.dart
@@ -79,6 +79,7 @@ void main() {
   late MockLoggingService loggingService;
   Directory? testDirectory;
   Directory? previousDirectory;
+  LoggingService? previousLoggingService;
 
   setUp(() async {
     if (getIt.isRegistered<Directory>()) {
@@ -119,7 +120,10 @@ void main() {
       ),
     ).thenAnswer((_) async {});
     if (getIt.isRegistered<LoggingService>()) {
+      previousLoggingService = getIt<LoggingService>();
       getIt.unregister<LoggingService>();
+    } else {
+      previousLoggingService = null;
     }
     getIt.registerSingleton<LoggingService>(loggingService);
 
@@ -136,6 +140,9 @@ void main() {
     await db.close();
     if (getIt.isRegistered<LoggingService>()) {
       getIt.unregister<LoggingService>();
+    }
+    if (previousLoggingService != null) {
+      getIt.registerSingleton<LoggingService>(previousLoggingService!);
     }
     getIt.unregister<Directory>();
     if (previousDirectory != null) {
@@ -261,9 +268,14 @@ void main() {
           failingDb.getRatingIdsForTimeEntries({'te-B'}),
         ];
 
-        for (final f in futures) {
-          await expectLater(f, throwsA(same(failingDb.failure)));
-        }
+        // Register expectLater on every future before awaiting: the
+        // coalesced wave completes both with the same error in one
+        // microtask, so a sequential `await` would leave the second
+        // future briefly unhandled.
+        await Future.wait([
+          for (final f in futures)
+            expectLater(f, throwsA(same(failingDb.failure))),
+        ]);
         expect(failingDb.attempts, 1);
       },
     );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Concurrent rating lookups are coalesced into a single shared query, reducing redundant DB work and speeding responses.
  * WAL autocheckpoint threshold set to 200 pages; default slow-query threshold reduced from 50ms to 10ms.

* **Bug Fixes**
  * Empty rating requests return immediately; errors from a coalesced query propagate to all awaiting callers.
  * Query results are correctly partitioned per caller to prevent cross-request leakage.

* **Tests**
  * New tests cover coalescing behavior, error propagation, ordering, empty-request handling, and multi-wave execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->