### PR TITLE
refactor: prevent duplicate sync work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.961] - 2026-04-18
+### Changed
+- Sync pipeline: removed duplicate-work in inbox attachment handling and
+  sync-family logging. `AttachmentIndex.record` now dedupes per eventId so
+  repeated observations from live scan + catch-up + backfill passes become
+  no-ops instead of thrashing the per-path slot between events sharing one
+  `relativePath`. `SyncEventProcessor` and `SyncSequenceLogService` no
+  longer emit each log line twice (once via `DomainLogger`, once via a
+  paired direct `LoggingService.captureEvent` to a sync-file domain) —
+  `DomainLogger` is the single emitter and falls back to a direct
+  `sync`-domain capture when no domain logger is wired. Descriptor catch-up
+  skips events whose `relativePath` is not in the pending set, so the
+  per-run scan no longer records ~1000 unrelated events into the
+  attachment index. Removed the per-tick `OUTBOX enqueueRequest() done`
+  log, which fired on every debounced wake and carried no signal.
+
 ## [0.9.959] - 2026-04-18
 ### Changed
 - Desktop task switcher: switching between open tasks in the desktop split

--- a/docs/implementation_plans/2026-04-18_sync_slice_invalidation_coalescing.md
+++ b/docs/implementation_plans/2026-04-18_sync_slice_invalidation_coalescing.md
@@ -8,7 +8,7 @@ Not started. Scoping only — do not implement without further agreement.
 
 Slow query log for 2026-04-18 shows sync-driven UI-controller thrash:
 
-```
+```text
 256 855 ms  / 409 calls   SELECT * FROM journal WHERE deleted = FALSE AND id IN (?…)
 134 220 ms  / 272 calls   SELECT le.from_id, le.to_id FROM linked_entries le
                            INNER JOIN journal j ON j.id = le.from_id WHERE le.to_id IN (?…)
@@ -135,7 +135,7 @@ coalesce before the expensive query re-runs.
 3. Apply the chosen fix (start with Option A using `batch`).
 4. Re-run. Target: ≤1 query execution per controller per slice.
 5. **Slow query budget:** re-enable slow-query logging on a real
-   device, apply a real catchup, confirm the cumulative time in the
+   device, apply a real catch-up, confirm the cumulative time in the
    top-3 query fingerprints drops by at least an order of magnitude.
 
 ## Out of scope

--- a/docs/implementation_plans/2026-04-18_sync_slice_invalidation_coalescing.md
+++ b/docs/implementation_plans/2026-04-18_sync_slice_invalidation_coalescing.md
@@ -1,0 +1,176 @@
+# Sync Slice Invalidation Coalescing (Pattern 3)
+
+## Status
+
+Not started. Scoping only — do not implement without further agreement.
+
+## Problem
+
+Slow query log for 2026-04-18 shows sync-driven UI-controller thrash:
+
+```
+256 855 ms  / 409 calls   SELECT * FROM journal WHERE deleted = FALSE AND id IN (?…)
+134 220 ms  / 272 calls   SELECT le.from_id, le.to_id FROM linked_entries le
+                           INNER JOIN journal j ON j.id = le.from_id WHERE le.to_id IN (?…)
+ 10 239 ms  / 299 calls   SELECT * FROM journal WHERE type = 'Task' AND deleted = FALSE
+                           AND task = 1 AND task_status IN (?…) AND category IN (?…)
+```
+
+Worst single sample: a 9-id primary-key `IN` lookup took **4.2 s**. The
+PK path itself cannot cost that — the measured time is wait/queue time
+behind the writer lock, not execution time. So the DB was already
+saturated by a sync slice's per-event writes, and the readers piled up
+behind it.
+
+The query sites themselves are already batched (single `IN (?…)` per
+caller invocation):
+
+- `lib/database/database.dart:865-916` — `getJournalEntitiesForIds[Unordered]`
+- `lib/features/journal/state/entry_controller.dart:503`
+- `lib/features/ai_chat/repository/task_summary_repository.dart:119`
+- `lib/features/daily_os/state/unified_daily_os_data_controller.dart:351`
+- `lib/features/ai/repository/vector_search_repository.dart:139, 256, 284`
+- `lib/database/database.dart:1637` (`getLinkedEntities`)
+
+None of them sit inside a per-event loop. What multiplies the call
+count is **how often each controller rebuilds** during a sync slice.
+With ~800 sync events processed in one replay, each controller's
+stream subscription fires once per journal row write, re-running its
+single batched query every time.
+
+## Mechanism
+
+`SyncEventProcessor.process(...)` is awaited per event in
+`matrix_stream_processor.dart:267`. Each call writes into
+`JournalDb` via `_handleMessage`, which fires Drift stream listeners.
+Every Riverpod controller that has a `watch(...)` on the journal table
+re-runs its body on every write.
+
+Observed Drift watchers triggered by journal writes:
+
+- `unified_daily_os_data_controller` — day-plan + linked-from lookups
+- `task_summary_repository` — linked entities per task
+- `entry_controller` — single-entry reads, linked entries
+- `ai_chat` / `vector_search_repository` — linked entities for chat RAG
+- `time_history_header_controller` — category lookups
+
+For a typical 800-event slice these UIs can rebuild tens to hundreds
+of times in rapid succession. Each rebuild is itself batched, but the
+DB sees the sum of all rebuilds stacked up.
+
+## Options — in preference order
+
+### A. Wrap the slice apply in a Drift transaction
+
+```dart
+await _journalDb.transaction(() async {
+  for (final e in ordered) {
+    await _eventProcessor.process(event: e, journalDb: _journalDb);
+  }
+});
+```
+
+Drift coalesces stream emissions at transaction boundaries, so all
+subscribed controllers fire once per slice instead of once per event.
+
+- **Pros:** simplest code change; biggest lock-contention win; UI
+  ends up reflecting the full slice atomically.
+- **Cons:** behavioural change to error handling. Today a single
+  event failing retries independently; inside a transaction the
+  whole slice rolls back. Retry semantics in `matrix_stream_processor`
+  (`_retryTracker`, `_missingBaseEventIds`, `schedule(...)`) must
+  still function — at minimum catch per-event errors inside the
+  transaction, record retry state, and continue without rolling back.
+  Alternative: wrap in `batch(...)` instead of `transaction(...)`
+  (Drift `Batch` API) for writes only, which coalesces listener
+  notifications without the all-or-nothing rollback.
+
+**Open questions before implementing:**
+- Does `Batch` coalesce stream listeners the same way a transaction
+  does? Verify with a focused test.
+- Are there any writes in `_handleMessage` that happen outside the
+  journal DB and couldn't be rolled back cleanly (file writes,
+  attachment saves, agent DB writes)? Those must be reordered or
+  kept outside the transaction.
+- Does `SyncSequenceLogService.recordReceivedEntry` need its own
+  transaction scope, or should it be inside the slice transaction?
+
+### B. Debounce downstream controllers on a single "slice complete" signal
+
+Instead of changing the apply path, subscribe the expensive
+controllers to a `sliceComplete` stream from
+`matrix_stream_processor` rather than to raw Drift journal updates.
+Emit one signal per ordered-processing burst. Controllers refresh
+once per slice.
+
+- **Pros:** no transactional semantics change; each controller
+  decides how to react.
+- **Cons:** every controller that cares about journal state has to
+  migrate to the new signal — ~5+ call sites. Easy to miss one and
+  end up with stale UI. Needs a deprecation path for the raw Drift
+  watch.
+
+### C. Per-controller debounce on the existing `UpdateNotifications`
+
+Controllers already receive `UpdateNotifications.notify(...)` calls.
+Add a debounce (e.g. 50 ms) on their reactive side so rapid bursts
+coalesce before the expensive query re-runs.
+
+- **Pros:** most local change; each controller can choose whether
+  to debounce.
+- **Cons:** introduces perceived UI staleness under normal (non-sync)
+  single-user edits. Must tune per controller. Does not help the
+  DB writer contention during the slice itself — only reduces how
+  many times the query runs.
+
+## Verification plan
+
+1. **Reproduce the storm** in a test: use the `FakeMatrixStream` +
+   `SyncEventProcessor` wiring already used in
+   `test/features/sync/matrix/pipeline/matrix_stream_processor_test.dart`
+   to feed a 500-event slice. Instrument the test DB to count
+   `journal id IN (?)` query executions during the slice.
+2. Baseline: current code should show hundreds of query executions
+   for ~5 active controllers.
+3. Apply the chosen fix (start with Option A using `batch`).
+4. Re-run. Target: ≤1 query execution per controller per slice.
+5. **Slow query budget:** re-enable slow-query logging on a real
+   device, apply a real catchup, confirm the cumulative time in the
+   top-3 query fingerprints drops by at least an order of magnitude.
+
+## Out of scope
+
+- Query-plan changes on the individual SQL statements. The problem
+  is **frequency**, not per-call cost. Any partial-index work on
+  `journal WHERE type IN ('JournalEntry','WorkoutEntry')` is a
+  separate concern and does not belong in this plan.
+- UI refresh latency tuning (the debounce in Option C). If A lands,
+  C becomes unnecessary.
+- Rewriting `UpdateNotifications` into a bus. The current fan-out
+  works; we are only changing when it fires.
+
+## Risks
+
+- **Transaction rollback semantics** breaking partial-slice retry
+  behaviour. Mitigation: keep the `_retryTracker` outside the
+  transaction, catch-and-log per-event errors inside it, never let
+  an individual event failure abort the slice.
+- **Sync-sequence log writes** are in the same DB family as the
+  journal. Confirm they coalesce with journal writes under the same
+  transaction/batch. If not, wrap them separately.
+- **AgentDb writes** (different Drift DB instance) will not be
+  covered by a `JournalDb` transaction. Confirm they don't create
+  cross-DB consistency gaps.
+
+## References
+
+- `lib/features/sync/matrix/sync_event_processor.dart:599-673` —
+  per-event `process()` entry point.
+- `lib/features/sync/matrix/pipeline/matrix_stream_processor.dart:260-320` —
+  the per-event await loop where a transaction boundary would go.
+- `lib/database/database.dart:865-916` — batched id-lookup queries.
+- `logs/slow_queries-2026-04-18.log` — evidence for the 409-call
+  storm and the 4.2 s worst case.
+- `docs/implementation_plans/2026-03-12_sync_inbox_attachment_dedupe_and_logging.md`
+  — prior pass that fixed a different sync-volume class
+  (attachment dedupe), confirms the pipeline wiring conventions.

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -31,6 +31,11 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="0.9.961" date="2026-04-18">
+      <description>
+          <p>Sync pipeline: removed duplicate-work in inbox attachment handling and sync-family logging. AttachmentIndex.record now dedupes per eventId so repeated observations from live scan, catch-up, and backfill passes become no-ops instead of thrashing the per-path slot between events sharing one relativePath. SyncEventProcessor and SyncSequenceLogService no longer emit each log line twice — DomainLogger is the single emitter and falls back to a direct sync-domain capture when no domain logger is wired. Descriptor catch-up skips events whose relativePath is not in the pending set, so the per-run scan no longer records ~1000 unrelated events into the attachment index. Removed the per-tick OUTBOX enqueueRequest() done log, which fired on every debounced wake and carried no signal.</p>
+      </description>
+    </release>
     <release version="0.9.959" date="2026-04-18">
       <description>
           <p>Desktop task switcher: switching between open tasks in the desktop split layout now crossfades the detail pane instead of cutting abruptly. The transition is a 480 ms easeInOutCubic fade driven by an AnimatedSwitcher keyed on the selected task id, so it fires only when a genuinely different task is opened — reloads and in-place data updates for the currently open task do not trigger the animation.</p>

--- a/lib/features/sync/matrix/pipeline/attachment_index.dart
+++ b/lib/features/sync/matrix/pipeline/attachment_index.dart
@@ -14,6 +14,12 @@ class AttachmentIndex {
 
   final Map<String, Event> _byPath = <String, Event>{};
 
+  // Per-eventId idempotency guard. Keyed by eventId so repeated observations
+  // of the same Matrix event (from live scan + catch-up + backfill passes)
+  // are no-ops, even when several events share one relativePath and would
+  // otherwise thrash the _byPath slot back and forth between them.
+  final Set<String> _seenEventIds = <String>{};
+
   /// Records an attachment event keyed by its relativePath. Later events
   /// overwrite earlier ones for the same path.
   ///
@@ -23,10 +29,16 @@ class AttachmentIndex {
       final mimetype = e.attachmentMimetype;
       final rp = e.content['relativePath'];
       if (rp is String && rp.isNotEmpty) {
+        final eventId = _safeEventId(e);
+        if (eventId != null && !_seenEventIds.add(eventId)) {
+          return false;
+        }
         final key = rp.startsWith('/') ? rp : '/$rp';
         final noSlash = rp.startsWith('/') ? rp.substring(1) : rp;
         final existing = _byPath[key] ?? _byPath[noSlash];
-        if (existing != null && existing.eventId == e.eventId) {
+        if (existing != null &&
+            eventId != null &&
+            _safeEventId(existing) == eventId) {
           return false;
         }
         _byPath[key] = e;
@@ -34,7 +46,7 @@ class AttachmentIndex {
         // case callers use that form.
         _byPath[noSlash] = e;
         _logging?.captureEvent(
-          'attachmentIndex.record path=$key mime=$mimetype id=${e.eventId}',
+          'attachmentIndex.record path=$key mime=$mimetype id=${eventId ?? '?'}',
           domain: syncLoggingDomain,
           subDomain: 'attachmentIndex.record',
         );
@@ -48,6 +60,18 @@ class AttachmentIndex {
       );
     }
     return false;
+  }
+
+  // Safe access to [Event.eventId]. Returns null when the field is missing or
+  // empty, so callers can treat the event as "not known yet" instead of
+  // failing the whole record path.
+  static String? _safeEventId(Event e) {
+    try {
+      final id = e.eventId;
+      return id.isEmpty ? null : id;
+    } catch (_) {
+      return null;
+    }
   }
 
   /// Returns the last-seen attachment event for [relativePath], or null.

--- a/lib/features/sync/matrix/pipeline/attachment_index.dart
+++ b/lib/features/sync/matrix/pipeline/attachment_index.dart
@@ -35,12 +35,6 @@ class AttachmentIndex {
         }
         final key = rp.startsWith('/') ? rp : '/$rp';
         final noSlash = rp.startsWith('/') ? rp.substring(1) : rp;
-        final existing = _byPath[key] ?? _byPath[noSlash];
-        if (existing != null &&
-            eventId != null &&
-            _safeEventId(existing) == eventId) {
-          return false;
-        }
         _byPath[key] = e;
         // For robustness, also record a variant without the leading slash in
         // case callers use that form.

--- a/lib/features/sync/matrix/pipeline/descriptor_catch_up_manager.dart
+++ b/lib/features/sync/matrix/pipeline/descriptor_catch_up_manager.dart
@@ -196,7 +196,14 @@ class DescriptorCatchUpManager {
         domain: syncLoggingDomain,
         subDomain: 'descriptorCatchUp',
       );
-      if (freshHits > 0) {
+      // Gate the retry/live-scan nudge on pendingHits (not freshHits): the
+      // AttachmentIndex per-eventId dedup returns false when the live stream
+      // has already indexed the descriptor, so freshHits stays zero for
+      // pending paths that are in fact now resolvable. We want the nudge
+      // whenever a pending path has at least one matching event in the
+      // scanned window, regardless of whether this pass was the first to
+      // record it.
+      if (pendingHits > 0) {
         await _retryNow();
         _scheduleLiveScan();
       }

--- a/lib/features/sync/matrix/pipeline/descriptor_catch_up_manager.dart
+++ b/lib/features/sync/matrix/pipeline/descriptor_catch_up_manager.dart
@@ -162,16 +162,19 @@ class DescriptorCatchUpManager {
         );
         for (final e in events) {
           final rp = e.content['relativePath'];
-          if (rp is String && rp.isNotEmpty) {
-            final changed = _attachmentIndex.record(e);
-            recorded++;
-            if (changed) newRecords++;
-            if (contains(rp)) {
-              pendingHits++;
-              if (changed) {
-                freshHits++;
-              }
-            }
+          if (rp is! String || rp.isEmpty) continue;
+          // Skip non-pending paths — the live stream is responsible for
+          // populating the AttachmentIndex for general traffic; this
+          // catch-up exists specifically to unblock pending descriptors.
+          // Scanning non-pending events would do ~1000 wasted map writes
+          // per run on large rooms.
+          if (!contains(rp)) continue;
+          final changed = _attachmentIndex.record(e);
+          recorded++;
+          pendingHits++;
+          if (changed) {
+            newRecords++;
+            freshHits++;
           }
         }
       } finally {

--- a/lib/features/sync/matrix/sync_event_processor.dart
+++ b/lib/features/sync/matrix/sync_event_processor.dart
@@ -575,10 +575,19 @@ class SyncEventProcessor {
   num? startupTimestamp;
 
   void _trace(String message, {String? subDomain}) {
-    _domainLogger?.log(
-      LogDomains.sync,
+    final sub = subDomain ?? 'processor';
+    final domainLogger = _domainLogger;
+    if (domainLogger != null) {
+      domainLogger.log(LogDomains.sync, message, subDomain: sub);
+      return;
+    }
+    // Fallback for callers that did not inject a DomainLogger (e.g. tests).
+    // Emitting directly under the `sync` domain keeps sync-file routing in
+    // LoggingService working so the log line still lands in the sync file.
+    _loggingService.captureEvent(
       message,
-      subDomain: subDomain ?? 'processor',
+      domain: LogDomains.sync,
+      subDomain: sub,
     );
   }
 
@@ -621,12 +630,6 @@ class SyncEventProcessor {
           'eventId=${event.eventId}',
           subDomain: 'processor.skipUnrecoverable',
         );
-        _loggingService.captureEvent(
-          'skipping undeserializable sync message: $e '
-          'eventId=${event.eventId}',
-          domain: 'MATRIX_SYNC',
-          subDomain: 'skipUnrecoverable',
-        );
         return;
       }
 
@@ -643,11 +646,6 @@ class SyncEventProcessor {
       _trace(
         'processing ${event.originServerTs} ${event.eventId}',
         subDomain: 'processor.SyncEventProcessor',
-      );
-      _loggingService.captureEvent(
-        'processing ${event.originServerTs} ${event.eventId}',
-        domain: 'MATRIX_SERVICE',
-        subDomain: 'SyncEventProcessor',
       );
 
       final diag = await _handleMessage(
@@ -725,11 +723,6 @@ class SyncEventProcessor {
             'apply entryLink.embedded from=${link.fromId} to=${link.toId} rows=$linkRows',
             subDomain: 'processor.apply.entryLink.embedded',
           );
-          _loggingService.captureEvent(
-            'apply entryLink.embedded from=${link.fromId} to=${link.toId} rows=$linkRows',
-            domain: 'MATRIX_SERVICE',
-            subDomain: 'apply.entryLink.embedded',
-          );
         }
         affectedIds.addAll({link.fromId, link.toId});
       } catch (e, st) {
@@ -806,11 +799,6 @@ class SyncEventProcessor {
       'apply journalEntity skipped staleDescriptor eventId=${event.eventId} id=${syncMessage.id} status=${diag.conflictStatus} embeddedLinks=$processedLinksCount/${entryLinks?.length ?? 0}',
       subDomain: 'processor.apply',
     );
-    _loggingService.captureEvent(
-      'apply journalEntity skipped staleDescriptor eventId=${event.eventId} id=${syncMessage.id} status=${diag.conflictStatus} embeddedLinks=$processedLinksCount/${entryLinks?.length ?? 0}',
-      domain: 'MATRIX_SERVICE',
-      subDomain: 'apply',
-    );
 
     if (_sequenceLogService != null && syncMessage.originatingHostId != null) {
       try {
@@ -825,11 +813,6 @@ class SyncEventProcessor {
           _trace(
             'apply.gapsDetected count=${gaps.length} for entity=${syncMessage.id}',
             subDomain: 'processor.gapDetection',
-          );
-          _loggingService.captureEvent(
-            'apply.gapsDetected count=${gaps.length} for entity=${syncMessage.id}',
-            domain: 'SYNC_SEQUENCE',
-            subDomain: 'gapDetection',
           );
         }
       } catch (e, st) {
@@ -901,12 +884,6 @@ class SyncEventProcessor {
         'id=${syncMessage.id}',
         subDomain: 'processor.apply',
       );
-      _loggingService.captureEvent(
-        'apply journalEntity skipped duplicate eventId=${event.eventId} '
-        'id=${syncMessage.id}',
-        domain: 'MATRIX_SERVICE',
-        subDomain: 'apply',
-      );
       return diag;
     }
 
@@ -966,15 +943,6 @@ class SyncEventProcessor {
       'embeddedLinks=$processedLinksCount/${entryLinks?.length ?? 0}',
       subDomain: 'processor.apply',
     );
-    _loggingService.captureEvent(
-      'apply journalEntity eventId=${event.eventId} id=${journalEntity.meta.id} '
-      'rowsWritten=$rows applied=${updateResult.applied} '
-      'skip=${updateResult.skipReason?.label ?? 'none'} '
-      'status=${diag.conflictStatus} '
-      'embeddedLinks=$processedLinksCount/${entryLinks?.length ?? 0}',
-      domain: 'MATRIX_SERVICE',
-      subDomain: 'apply',
-    );
     _markJournalEntityProcessed(
       journalEntity.meta.id,
       vcB ?? syncMessage.vectorClock,
@@ -1005,12 +973,6 @@ class SyncEventProcessor {
               'apply.gapsDetected count=${gaps.length} '
               'for entity=${journalEntity.meta.id}',
               subDomain: 'processor.gapDetection',
-            );
-            _loggingService.captureEvent(
-              'apply.gapsDetected count=${gaps.length} '
-              'for entity=${journalEntity.meta.id}',
-              domain: 'SYNC_SEQUENCE',
-              subDomain: 'gapDetection',
             );
           }
         } catch (e, st) {
@@ -1044,12 +1006,6 @@ class SyncEventProcessor {
           'apply entryLink from=${entryLink.fromId} to=${entryLink.toId} '
           'rows=$rows',
           subDomain: 'processor.apply.entryLink',
-        );
-        _loggingService.captureEvent(
-          'apply entryLink from=${entryLink.fromId} to=${entryLink.toId} '
-          'rows=$rows',
-          domain: 'MATRIX_SERVICE',
-          subDomain: 'apply.entryLink',
         );
       }
     } catch (_) {
@@ -1097,12 +1053,6 @@ class SyncEventProcessor {
               'for link=${entryLink.id}',
               subDomain: 'processor.gapDetection',
             );
-            _loggingService.captureEvent(
-              'apply.entryLink.gapsDetected count=${gaps.length} '
-              'for link=${entryLink.id}',
-              domain: 'SYNC_SEQUENCE',
-              subDomain: 'gapDetection',
-            );
           }
         } catch (e, st) {
           _loggingService.captureException(
@@ -1143,11 +1093,6 @@ class SyncEventProcessor {
       _trace(
         '$typeName.skipped no payload and no jsonPath',
         subDomain: 'processor.resolve',
-      );
-      _loggingService.captureEvent(
-        '$typeName.skipped no payload and no jsonPath',
-        domain: 'AGENT_SYNC',
-        subDomain: 'resolve',
       );
       return null;
     }
@@ -1230,11 +1175,6 @@ class SyncEventProcessor {
         '$typeName.descriptor.miss path=$jsonPath key=$indexKey',
         subDomain: 'processor.resolve',
       );
-      _loggingService.captureEvent(
-        '$typeName.descriptor.miss path=$jsonPath key=$indexKey',
-        domain: 'AGENT_SYNC',
-        subDomain: 'resolve',
-      );
       return null;
     }
 
@@ -1255,11 +1195,6 @@ class SyncEventProcessor {
       _trace(
         '$typeName.descriptor.fetched path=$jsonPath bytes=${bytes.length}',
         subDomain: 'processor.resolve',
-      );
-      _loggingService.captureEvent(
-        '$typeName.descriptor.fetched path=$jsonPath bytes=${bytes.length}',
-        domain: 'AGENT_SYNC',
-        subDomain: 'resolve',
       );
       return jsonString;
     } catch (e, st) {
@@ -1452,11 +1387,6 @@ class SyncEventProcessor {
             'backfillRequest.ignored no handler configured',
             subDomain: 'processor.apply',
           );
-          _loggingService.captureEvent(
-            'backfillRequest.ignored no handler configured',
-            domain: 'SYNC_BACKFILL',
-            subDomain: 'apply',
-          );
         }
         return null;
       case SyncBackfillResponse():
@@ -1467,11 +1397,6 @@ class SyncEventProcessor {
           _trace(
             'backfillResponse.ignored no handler configured',
             subDomain: 'processor.apply',
-          );
-          _loggingService.captureEvent(
-            'backfillResponse.ignored no handler configured',
-            domain: 'SYNC_BACKFILL',
-            subDomain: 'apply',
           );
         }
         return null;
@@ -1532,11 +1457,6 @@ class SyncEventProcessor {
             'apply agentEntity id=${resolvedEntity.id}',
             subDomain: 'processor.apply',
           );
-          _loggingService.captureEvent(
-            'apply agentEntity id=${resolvedEntity.id}',
-            domain: 'AGENT_SYNC',
-            subDomain: 'apply',
-          );
 
           // Record in sequence log for gap detection (self-healing sync)
           if (_sequenceLogService != null &&
@@ -1557,12 +1477,6 @@ class SyncEventProcessor {
                   'for entity=${resolvedEntity.id}',
                   subDomain: 'processor.gapDetection',
                 );
-                _loggingService.captureEvent(
-                  'apply.agentEntity.gapsDetected count=${gaps.length} '
-                  'for entity=${resolvedEntity.id}',
-                  domain: 'SYNC_SEQUENCE',
-                  subDomain: 'gapDetection',
-                );
               }
             } catch (e, st) {
               _loggingService.captureException(
@@ -1577,11 +1491,6 @@ class SyncEventProcessor {
           _trace(
             'agentEntity.ignored no repository',
             subDomain: 'processor.apply',
-          );
-          _loggingService.captureEvent(
-            'agentEntity.ignored no repository',
-            domain: 'AGENT_SYNC',
-            subDomain: 'apply',
           );
         }
         return null;
@@ -1622,11 +1531,6 @@ class SyncEventProcessor {
             'apply agentLink id=${resolvedLink.id}',
             subDomain: 'processor.apply',
           );
-          _loggingService.captureEvent(
-            'apply agentLink id=${resolvedLink.id}',
-            domain: 'AGENT_SYNC',
-            subDomain: 'apply',
-          );
 
           // Record in sequence log for gap detection (self-healing sync)
           if (_sequenceLogService != null &&
@@ -1647,12 +1551,6 @@ class SyncEventProcessor {
                   'for link=${resolvedLink.id}',
                   subDomain: 'processor.gapDetection',
                 );
-                _loggingService.captureEvent(
-                  'apply.agentLink.gapsDetected count=${gaps.length} '
-                  'for link=${resolvedLink.id}',
-                  domain: 'SYNC_SEQUENCE',
-                  subDomain: 'gapDetection',
-                );
               }
             } catch (e, st) {
               _loggingService.captureException(
@@ -1667,11 +1565,6 @@ class SyncEventProcessor {
           _trace(
             'agentLink.ignored no repository',
             subDomain: 'processor.apply',
-          );
-          _loggingService.captureEvent(
-            'agentLink.ignored no repository',
-            domain: 'AGENT_SYNC',
-            subDomain: 'apply',
           );
         }
         return null;

--- a/lib/features/sync/outbox/outbox_service.dart
+++ b/lib/features/sync/outbox/outbox_service.dart
@@ -554,7 +554,6 @@ class OutboxService {
       Future<void>.delayed(adjustedDelay).then((_) {
         if (_isDisposed) return;
         _clientRunner.enqueueRequest(DateTime.now().millisecondsSinceEpoch);
-        _loggingService.captureEvent('enqueueRequest() done', domain: 'OUTBOX');
       }),
     );
   }

--- a/lib/features/sync/sequence/sync_sequence_log_service.dart
+++ b/lib/features/sync/sequence/sync_sequence_log_service.dart
@@ -124,10 +124,19 @@ class SyncSequenceLogService {
   bool _pendingMissingEntriesDetected = false;
 
   void _trace(String message, {String? subDomain}) {
-    _domainLogger?.log(
-      LogDomains.sync,
+    final sub = subDomain ?? 'sequence';
+    final domainLogger = _domainLogger;
+    if (domainLogger != null) {
+      domainLogger.log(LogDomains.sync, message, subDomain: sub);
+      return;
+    }
+    // Fallback for callers that did not inject a DomainLogger (e.g. tests).
+    // Emitting directly under the `sync` domain keeps sync-file routing in
+    // LoggingService working so the log line still lands in the sync file.
+    _loggingService.captureEvent(
       message,
-      subDomain: subDomain ?? 'sequence',
+      domain: LogDomains.sync,
+      subDomain: sub,
     );
   }
 
@@ -254,11 +263,6 @@ class SyncSequenceLogService {
         'recordSentEntry type=$payloadType hostId=$hostId counter=$counter entryId=$entryId',
         subDomain: 'sequence.recordSent',
       );
-      _loggingService.captureEvent(
-        'recordSentEntry type=$payloadType hostId=$hostId counter=$counter entryId=$entryId',
-        domain: 'SYNC_SEQUENCE',
-        subDomain: 'recordSent',
-      );
     }
   }
 
@@ -375,11 +379,6 @@ class SyncSequenceLogService {
           'skipGapDetection hostId=$hostId counter=$counter - host never seen online',
           subDomain: 'sequence.skipGap',
         );
-        _loggingService.captureEvent(
-          'skipGapDetection hostId=$hostId counter=$counter - host never seen online',
-          domain: 'SYNC_SEQUENCE',
-          subDomain: 'skipGap',
-        );
       }
 
       final lastSeen = await _getCachedLastCounterForHost(hostId);
@@ -404,11 +403,6 @@ class SyncSequenceLogService {
             'largeGapDetected hostId=$hostId gapSize=$gapSize (lastSeen=$gapBaseline, counter=$counter) - recording full gap',
             subDomain: 'sequence.largeGap',
           );
-          _loggingService.captureEvent(
-            'largeGapDetected hostId=$hostId gapSize=$gapSize (lastSeen=$gapBaseline, counter=$counter) - recording full gap',
-            domain: 'SYNC_SEQUENCE',
-            subDomain: 'largeGap',
-          );
           final insertedCount = await _materializeLargeGap(
             hostId: hostId,
             startCounter: startCounter,
@@ -425,12 +419,6 @@ class SyncSequenceLogService {
             'gapDetectedRange hostId=$hostId start=$startCounter end=${counter - 1} '
             'inserted=$insertedCount (last seen: $gapBaseline, observed: $counter) from=$originatingHostId',
             subDomain: 'sequence.gapDetected',
-          );
-          _loggingService.captureEvent(
-            'gapDetectedRange hostId=$hostId start=$startCounter end=${counter - 1} '
-            'inserted=$insertedCount (last seen: $gapBaseline, observed: $counter) from=$originatingHostId',
-            domain: 'SYNC_SEQUENCE',
-            subDomain: 'gapDetected',
           );
         } else {
           final existingCounters = await _syncDatabase
@@ -459,11 +447,6 @@ class SyncSequenceLogService {
               _trace(
                 'gapDetected hostId=$hostId counter=$i (last seen: $gapBaseline, observed: $counter) from=$originatingHostId',
                 subDomain: 'sequence.gapDetected',
-              );
-              _loggingService.captureEvent(
-                'gapDetected hostId=$hostId counter=$i (last seen: $gapBaseline, observed: $counter) from=$originatingHostId',
-                domain: 'SYNC_SEQUENCE',
-                subDomain: 'gapDetected',
               );
             }
           }
@@ -524,17 +507,6 @@ class SyncSequenceLogService {
             'recordReceivedEntry: requestedResolved hostId=$hostId counter=$counter entryId=$entryId type=$payloadType',
             subDomain: 'sequence.requestedResolved',
           );
-          _loggingService
-            ..captureEvent(
-              'recordReceivedEntry: backfilled hostId=$hostId counter=$counter entryId=$entryId',
-              domain: 'SYNC_SEQUENCE',
-              subDomain: 'backfillArrived',
-            )
-            ..captureEvent(
-              'recordReceivedEntry: requestedResolved hostId=$hostId counter=$counter entryId=$entryId type=$payloadType',
-              domain: 'SYNC_SEQUENCE',
-              subDomain: 'requestedResolved',
-            );
         }
       } else {
         // For other hosts in the VC, also record with entryId.
@@ -588,17 +560,6 @@ class SyncSequenceLogService {
             'recordReceivedEntry: requestedResolved (non-originator) hostId=$hostId counter=$counter entryId=$entryId type=$payloadType',
             subDomain: 'sequence.requestedResolved',
           );
-          _loggingService
-            ..captureEvent(
-              'recordReceivedEntry: backfilled (non-originator) hostId=$hostId counter=$counter entryId=$entryId',
-              domain: 'SYNC_SEQUENCE',
-              subDomain: 'backfillArrived',
-            )
-            ..captureEvent(
-              'recordReceivedEntry: requestedResolved (non-originator) hostId=$hostId counter=$counter entryId=$entryId type=$payloadType',
-              domain: 'SYNC_SEQUENCE',
-              subDomain: 'requestedResolved',
-            );
         }
       }
 
@@ -610,11 +571,6 @@ class SyncSequenceLogService {
       _trace(
         'recordReceivedEntry type=$payloadType entryId=$entryId detected ${gaps.count} gaps',
         subDomain: 'sequence.recordReceived',
-      );
-      _loggingService.captureEvent(
-        'recordReceivedEntry type=$payloadType entryId=$entryId detected ${gaps.count} gaps',
-        domain: 'SYNC_SEQUENCE',
-        subDomain: 'recordReceived',
       );
     }
 
@@ -659,13 +615,6 @@ class SyncSequenceLogService {
         'start=$startCounter end=$endCounter '
         'chunkSize=${SyncTuning.gapMaterializationChunkSize}',
         subDomain: 'sequence.extremeGap',
-      );
-      _loggingService.captureEvent(
-        'extremeGapDetected hostId=$hostId gapSize=$gapSize '
-        'start=$startCounter end=$endCounter '
-        'chunkSize=${SyncTuning.gapMaterializationChunkSize}',
-        domain: 'SYNC_SEQUENCE',
-        subDomain: 'extremeGap',
       );
     }
 
@@ -815,11 +764,6 @@ class SyncSequenceLogService {
               'recordReceivedEntry: requestedResolved (covered) hostId=$hostId counter=$counter entryId=$entryId type=$payloadType',
               subDomain: 'sequence.requestedResolved',
             );
-            _loggingService.captureEvent(
-              'recordReceivedEntry: requestedResolved (covered) hostId=$hostId counter=$counter entryId=$entryId type=$payloadType',
-              domain: 'SYNC_SEQUENCE',
-              subDomain: 'requestedResolved',
-            );
           }
         }
         // If already received/backfilled, skip - don't downgrade status
@@ -835,11 +779,6 @@ class SyncSequenceLogService {
       _trace(
         'markCoveredCountersAsReceived: marked $markedCount counters as received for entry=$entryId',
         subDomain: 'sequence.coveredClocks',
-      );
-      _loggingService.captureEvent(
-        'markCoveredCountersAsReceived: marked $markedCount counters as received for entry=$entryId',
-        domain: 'SYNC_SEQUENCE',
-        subDomain: 'coveredClocks',
       );
     }
   }
@@ -901,11 +840,6 @@ class SyncSequenceLogService {
         'handleBackfillResponse hostId=$hostId counter=$counter deleted=true',
         subDomain: 'sequence.backfillResponse',
       );
-      _loggingService.captureEvent(
-        'handleBackfillResponse hostId=$hostId counter=$counter deleted=true',
-        domain: 'SYNC_SEQUENCE',
-        subDomain: 'backfillResponse',
-      );
       return;
     }
 
@@ -921,11 +855,6 @@ class SyncSequenceLogService {
       _trace(
         'handleBackfillResponse hostId=$hostId counter=$counter unresolvable=true',
         subDomain: 'sequence.backfillResponse',
-      );
-      _loggingService.captureEvent(
-        'handleBackfillResponse hostId=$hostId counter=$counter unresolvable=true',
-        domain: 'SYNC_SEQUENCE',
-        subDomain: 'backfillResponse',
       );
       return;
     }
@@ -958,11 +887,6 @@ class SyncSequenceLogService {
         'handleBackfillResponse: stored hint hostId=$hostId counter=$counter entryId=$entryId (new entry)',
         subDomain: 'sequence.backfillHint',
       );
-      _loggingService.captureEvent(
-        'handleBackfillResponse: stored hint hostId=$hostId counter=$counter entryId=$entryId (new entry)',
-        domain: 'SYNC_SEQUENCE',
-        subDomain: 'backfillHint',
-      );
       return;
     }
 
@@ -973,11 +897,6 @@ class SyncSequenceLogService {
       _trace(
         'handleBackfillResponse: entry already has status=${SyncSequenceStatus.values[existing.status]} hostId=$hostId counter=$counter',
         subDomain: 'sequence.backfillResponse',
-      );
-      _loggingService.captureEvent(
-        'handleBackfillResponse: entry already has status=${SyncSequenceStatus.values[existing.status]} hostId=$hostId counter=$counter',
-        domain: 'SYNC_SEQUENCE',
-        subDomain: 'backfillResponse',
       );
       return;
     }
@@ -1013,11 +932,6 @@ class SyncSequenceLogService {
       'handleBackfillResponse: stored hint hostId=$hostId counter=$counter entryId=$entryId (status=${SyncSequenceStatus.values[newStatus]})',
       subDomain: 'sequence.backfillHint',
     );
-    _loggingService.captureEvent(
-      'handleBackfillResponse: stored hint hostId=$hostId counter=$counter entryId=$entryId (status=${SyncSequenceStatus.values[newStatus]})',
-      domain: 'SYNC_SEQUENCE',
-      subDomain: 'backfillHint',
-    );
   }
 
   /// Verify that we have an entry locally and its VC covers the requested
@@ -1037,11 +951,6 @@ class SyncSequenceLogService {
       _trace(
         'verifyAndMarkBackfilled: entry $entryId VC does not cover $hostId:$counter (vc[$hostId]=$vcCounter)',
         subDomain: 'sequence.backfillVerify',
-      );
-      _loggingService.captureEvent(
-        'verifyAndMarkBackfilled: entry $entryId VC does not cover $hostId:$counter (vc[$hostId]=$vcCounter)',
-        domain: 'SYNC_SEQUENCE',
-        subDomain: 'backfillVerify',
       );
       return false;
     }
@@ -1076,11 +985,6 @@ class SyncSequenceLogService {
     _trace(
       'verifyAndMarkBackfilled: confirmed hostId=$hostId counter=$counter entryId=$entryId',
       subDomain: 'sequence.backfillVerified',
-    );
-    _loggingService.captureEvent(
-      'verifyAndMarkBackfilled: confirmed hostId=$hostId counter=$counter entryId=$entryId',
-      domain: 'SYNC_SEQUENCE',
-      subDomain: 'backfillVerified',
     );
     return true;
   }
@@ -1117,11 +1021,6 @@ class SyncSequenceLogService {
         'resolvePendingHints: resolved $resolved pending entries for type=$payloadType id=$payloadId',
         subDomain: 'sequence.backfillResolved',
       );
-      _loggingService.captureEvent(
-        'resolvePendingHints: resolved $resolved pending entries for type=$payloadType id=$payloadId',
-        domain: 'SYNC_SEQUENCE',
-        subDomain: 'backfillResolved',
-      );
     }
 
     return resolved;
@@ -1137,11 +1036,6 @@ class SyncSequenceLogService {
       _trace(
         'resetUnresolvableEntries: reset $count entries back to missing',
         subDomain: 'sequence.resetUnresolvable',
-      );
-      _loggingService.captureEvent(
-        'resetUnresolvableEntries: reset $count entries back to missing',
-        domain: 'SYNC_SEQUENCE',
-        subDomain: 'resetUnresolvable',
       );
     }
 
@@ -1206,11 +1100,6 @@ class SyncSequenceLogService {
     _trace(
       'resetRequestCounts: reset ${entries.length} entries for re-request',
       subDomain: 'sequence.reRequest',
-    );
-    _loggingService.captureEvent(
-      'resetRequestCounts: reset ${entries.length} entries for re-request',
-      domain: 'SYNC_SEQUENCE',
-      subDomain: 'reRequest',
     );
   }
 
@@ -1373,11 +1262,6 @@ class SyncSequenceLogService {
       _trace(
         '$label: added $populated sequence log entries',
         subDomain: 'sequence.populate',
-      );
-      _loggingService.captureEvent(
-        '$label: added $populated sequence log entries',
-        domain: 'SYNC_SEQUENCE',
-        subDomain: 'populate',
       );
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.959+3937
+version: 0.9.960+3938
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.960+3938
+version: 0.9.961+3939
 
 msix_config:
   display_name: LottiApp

--- a/test/features/sync/matrix/pipeline/attachment_index_test.dart
+++ b/test/features/sync/matrix/pipeline/attachment_index_test.dart
@@ -12,6 +12,67 @@ void main() {
     registerFallbackValue(StackTrace.empty);
   });
 
+  Event makeEvent({
+    required String eventId,
+    required String relativePath,
+    String mime = 'image/jpeg',
+  }) {
+    final e = MockEvent();
+    when(() => e.eventId).thenReturn(eventId);
+    when(() => e.attachmentMimetype).thenReturn(mime);
+    when(() => e.content).thenReturn({'relativePath': relativePath});
+    return e;
+  }
+
+  test(
+    'record is idempotent per eventId — repeat observations are no-ops '
+    'and emit no log',
+    () {
+      final logging = MockLoggingService();
+      final index = AttachmentIndex(logging: logging);
+      final e = makeEvent(eventId: 'ev1', relativePath: 'images/a.jpg');
+
+      expect(index.record(e), isTrue);
+      expect(index.record(e), isFalse);
+      expect(index.record(e), isFalse);
+
+      verify(
+        () => logging.captureEvent(
+          any<String>(that: contains('attachmentIndex.record')),
+          domain: any<String>(named: 'domain'),
+          subDomain: 'attachmentIndex.record',
+        ),
+      ).called(1);
+    },
+  );
+
+  test(
+    'record does not thrash when multiple events share one relativePath — '
+    'each eventId logs exactly once regardless of interleaving',
+    () {
+      final logging = MockLoggingService();
+      final index = AttachmentIndex(logging: logging);
+      final a = makeEvent(eventId: 'A', relativePath: 'audio/x.m4a');
+      final b = makeEvent(eventId: 'B', relativePath: 'audio/x.m4a');
+
+      // Interleave observations like catch-up + live-scan would.
+      expect(index.record(a), isTrue);
+      expect(index.record(b), isTrue);
+      expect(index.record(a), isFalse);
+      expect(index.record(b), isFalse);
+      expect(index.record(a), isFalse);
+      expect(index.record(b), isFalse);
+
+      verify(
+        () => logging.captureEvent(
+          any<String>(that: contains('attachmentIndex.record')),
+          domain: any<String>(named: 'domain'),
+          subDomain: 'attachmentIndex.record',
+        ),
+      ).called(2);
+    },
+  );
+
   test('record and find works with and without leading slash', () {
     final logging = MockLoggingService();
     final index = AttachmentIndex(logging: logging);

--- a/test/features/sync/matrix/pipeline/descriptor_catch_up_manager_test.dart
+++ b/test/features/sync/matrix/pipeline/descriptor_catch_up_manager_test.dart
@@ -249,7 +249,9 @@ void main() {
   });
 
   test(
-    'pending hit with unchanged descriptor does not trigger callbacks',
+    'pending hit with already-indexed descriptor still triggers callbacks — '
+    'retry is gated on pendingHits, not freshHits, so pending paths whose '
+    'descriptor the live stream already indexed still get nudged',
     () async {
       final logging = MockLoggingService();
       when(
@@ -277,6 +279,8 @@ void main() {
       when(() => ev.content).thenReturn(<String, dynamic>{
         'relativePath': '/p.json',
       });
+      // Pre-record via the live-stream path so the catch-up pass sees an
+      // already-known eventId and record() returns false.
       index.record(ev);
 
       when(() => timeline.events).thenReturn(<Event>[ev]);
@@ -298,8 +302,8 @@ void main() {
       )..addPending('/p.json');
       await manager.debugRunNow();
       expect(manager.runs, 1);
-      expect(liveScanCalls, 0);
-      expect(retryNowCalls, 0);
+      expect(liveScanCalls, 1);
+      expect(retryNowCalls, 1);
     },
   );
 

--- a/test/features/sync/matrix/sync_event_processor_test.dart
+++ b/test/features/sync/matrix/sync_event_processor_test.dart
@@ -10,6 +10,7 @@ import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/journal_update_result.dart';
+import 'package:lotti/database/logging_types.dart';
 import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
@@ -5742,4 +5743,56 @@ void main() {
   // Note: Sequence log integration tests for the sync processor are covered
   // by sync_sequence_log_service_test.dart which tests recordReceivedEntry
   // behavior including gap detection and status transitions.
+
+  group('_trace routing', () {
+    test(
+      'routes through DomainLogger when one is injected and skips the '
+      'direct captureEvent fallback',
+      () async {
+        final domainLogger = MockDomainLogger();
+        when(
+          () => domainLogger.log(
+            any<String>(),
+            any<String>(),
+            subDomain: any<String>(named: 'subDomain'),
+            level: any<InsightLevel>(named: 'level'),
+          ),
+        ).thenReturn(null);
+
+        final proc = SyncEventProcessor(
+          loggingService: loggingService,
+          domainLogger: domainLogger,
+          updateNotifications: updateNotifications,
+          aiConfigRepository: aiConfigRepository,
+          settingsDb: settingsDb,
+          journalEntityLoader: journalEntityLoader,
+        );
+
+        // Trigger a _trace emission via the undeserializable-skip path.
+        when(() => event.text).thenReturn(
+          base64.encode(utf8.encode(json.encode(<String, dynamic>{}))),
+        );
+        await proc.process(event: event, journalDb: journalDb);
+
+        verify(
+          () => domainLogger.log(
+            LogDomains.sync,
+            any<String>(
+              that: contains('skipping undeserializable sync message'),
+            ),
+            subDomain: 'processor.skipUnrecoverable',
+          ),
+        ).called(1);
+        verifyNever(
+          () => loggingService.captureEvent(
+            any<String>(
+              that: contains('skipping undeserializable sync message'),
+            ),
+            domain: LogDomains.sync,
+            subDomain: 'processor.skipUnrecoverable',
+          ),
+        );
+      },
+    );
+  });
 }

--- a/test/features/sync/matrix/sync_event_processor_test.dart
+++ b/test/features/sync/matrix/sync_event_processor_test.dart
@@ -25,6 +25,7 @@ import 'package:lotti/features/sync/sequence/sync_sequence_payload_type.dart';
 import 'package:lotti/features/sync/vector_clock.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/db_notification.dart';
+import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/utils/audio_utils.dart';
 import 'package:lotti/utils/image_utils.dart';
 import 'package:matrix/matrix.dart';
@@ -885,8 +886,8 @@ void main() {
       verify(
         () => loggingService.captureEvent(
           any<Object>(that: contains('agentEntity')),
-          domain: 'AGENT_SYNC',
-          subDomain: 'apply',
+          domain: LogDomains.sync,
+          subDomain: 'processor.apply',
         ),
       ).called(1);
       verify(
@@ -1090,8 +1091,8 @@ void main() {
       verify(
         () => loggingService.captureEvent(
           any<Object>(that: contains('agentLink')),
-          domain: 'AGENT_SYNC',
-          subDomain: 'apply',
+          domain: LogDomains.sync,
+          subDomain: 'processor.apply',
         ),
       ).called(1);
       verify(
@@ -1195,8 +1196,8 @@ void main() {
       verify(
         () => loggingService.captureEvent(
           any<Object>(that: contains('ignored')),
-          domain: 'AGENT_SYNC',
-          subDomain: 'apply',
+          domain: LogDomains.sync,
+          subDomain: 'processor.apply',
         ),
       ).called(1);
     });
@@ -1225,8 +1226,8 @@ void main() {
       verify(
         () => loggingService.captureEvent(
           any<Object>(that: contains('ignored')),
-          domain: 'AGENT_SYNC',
-          subDomain: 'apply',
+          domain: LogDomains.sync,
+          subDomain: 'processor.apply',
         ),
       ).called(1);
     });
@@ -1428,8 +1429,8 @@ void main() {
         verify(
           () => loggingService.captureEvent(
             contains('apply.agentEntity.gapsDetected count=1'),
-            domain: 'SYNC_SEQUENCE',
-            subDomain: 'gapDetection',
+            domain: LogDomains.sync,
+            subDomain: 'processor.gapDetection',
           ),
         ).called(1);
       });
@@ -2067,8 +2068,8 @@ void main() {
         verify(
           () => loggingService.captureEvent(
             any<Object>(that: contains('no payload and no jsonPath')),
-            domain: 'AGENT_SYNC',
-            subDomain: 'resolve',
+            domain: LogDomains.sync,
+            subDomain: 'processor.resolve',
           ),
         ).called(1);
       });
@@ -2085,8 +2086,8 @@ void main() {
         verify(
           () => loggingService.captureEvent(
             any<Object>(that: contains('no payload and no jsonPath')),
-            domain: 'AGENT_SYNC',
-            subDomain: 'resolve',
+            domain: LogDomains.sync,
+            subDomain: 'processor.resolve',
           ),
         ).called(1);
       });
@@ -2523,8 +2524,8 @@ void main() {
         any<Object>(
           that: contains('skipping undeserializable sync message'),
         ),
-        domain: 'MATRIX_SYNC',
-        subDomain: 'skipUnrecoverable',
+        domain: LogDomains.sync,
+        subDomain: 'processor.skipUnrecoverable',
       ),
     ).called(1);
   });
@@ -2577,8 +2578,8 @@ void main() {
         any<String>(
           that: contains('skipping undeserializable sync message'),
         ),
-        domain: 'MATRIX_SYNC',
-        subDomain: 'skipUnrecoverable',
+        domain: LogDomains.sync,
+        subDomain: 'processor.skipUnrecoverable',
       ),
     ).called(1);
   });
@@ -4100,8 +4101,8 @@ void main() {
     verify(
       () => loggingService.captureEvent(
         contains('apply entryLink from=from-id to=to-id rows=1'),
-        domain: 'MATRIX_SERVICE',
-        subDomain: 'apply.entryLink',
+        domain: LogDomains.sync,
+        subDomain: 'processor.apply.entryLink',
       ),
     ).called(1);
   });
@@ -4308,8 +4309,8 @@ void main() {
       verify(
         () => loggingService.captureEvent(
           contains('apply.gapsDetected count=1'),
-          domain: 'SYNC_SEQUENCE',
-          subDomain: 'gapDetection',
+          domain: LogDomains.sync,
+          subDomain: 'processor.gapDetection',
         ),
       ).called(1);
       verifyNever(() => journalDb.updateJournalEntity(any()));
@@ -4646,8 +4647,8 @@ void main() {
             contains(
               'apply entryLink.embedded from=${link1.fromId} to=${link1.toId}',
             ),
-            domain: 'MATRIX_SERVICE',
-            subDomain: 'apply.entryLink.embedded',
+            domain: LogDomains.sync,
+            subDomain: 'processor.apply.entryLink.embedded',
           ),
         ).called(1);
 
@@ -4656,8 +4657,8 @@ void main() {
             contains(
               'apply entryLink.embedded from=${link2.fromId} to=${link2.toId}',
             ),
-            domain: 'MATRIX_SERVICE',
-            subDomain: 'apply.entryLink.embedded',
+            domain: LogDomains.sync,
+            subDomain: 'processor.apply.entryLink.embedded',
           ),
         ).called(1);
 
@@ -4665,8 +4666,8 @@ void main() {
         verify(
           () => loggingService.captureEvent(
             contains('embeddedLinks=2/2'),
-            domain: 'MATRIX_SERVICE',
-            subDomain: 'apply',
+            domain: LogDomains.sync,
+            subDomain: 'processor.apply',
           ),
         ).called(1);
 
@@ -4744,8 +4745,8 @@ void main() {
           contains(
             'apply entryLink.embedded from=${link.fromId} to=${link.toId}',
           ),
-          domain: 'MATRIX_SERVICE',
-          subDomain: 'apply.entryLink.embedded',
+          domain: LogDomains.sync,
+          subDomain: 'processor.apply.entryLink.embedded',
         ),
       ).called(1);
 
@@ -4753,8 +4754,8 @@ void main() {
       verify(
         () => loggingService.captureEvent(
           contains('embeddedLinks=1/1'),
-          domain: 'MATRIX_SERVICE',
-          subDomain: 'apply',
+          domain: LogDomains.sync,
+          subDomain: 'processor.apply',
         ),
       ).called(1);
 
@@ -4827,8 +4828,8 @@ void main() {
           contains(
             'apply entryLink.embedded from=${link2.fromId} to=${link2.toId}',
           ),
-          domain: 'MATRIX_SERVICE',
-          subDomain: 'apply.entryLink.embedded',
+          domain: LogDomains.sync,
+          subDomain: 'processor.apply.entryLink.embedded',
         ),
       ).called(1);
 
@@ -4836,8 +4837,8 @@ void main() {
       verify(
         () => loggingService.captureEvent(
           contains('embeddedLinks=1/2'),
-          domain: 'MATRIX_SERVICE',
-          subDomain: 'apply',
+          domain: LogDomains.sync,
+          subDomain: 'processor.apply',
         ),
       ).called(1);
     });
@@ -4865,8 +4866,8 @@ void main() {
       verify(
         () => loggingService.captureEvent(
           contains('embeddedLinks=0/0'),
-          domain: 'MATRIX_SERVICE',
-          subDomain: 'apply',
+          domain: LogDomains.sync,
+          subDomain: 'processor.apply',
         ),
       ).called(1);
     });
@@ -4905,7 +4906,7 @@ void main() {
         () => loggingService.captureEvent(
           contains('apply entryLink.embedded'),
           domain: any(named: 'domain'),
-          subDomain: 'apply.entryLink.embedded',
+          subDomain: 'processor.apply.entryLink.embedded',
         ),
       );
 
@@ -4913,8 +4914,8 @@ void main() {
       verify(
         () => loggingService.captureEvent(
           contains('embeddedLinks=0/1'),
-          domain: 'MATRIX_SERVICE',
-          subDomain: 'apply',
+          domain: LogDomains.sync,
+          subDomain: 'processor.apply',
         ),
       ).called(1);
 
@@ -4985,8 +4986,8 @@ void main() {
       verify(
         () => loggingService.captureEvent(
           any<Object>(),
-          domain: 'SYNC_BACKFILL',
-          subDomain: 'apply',
+          domain: LogDomains.sync,
+          subDomain: 'processor.apply',
         ),
       ).called(1);
     });
@@ -5009,8 +5010,8 @@ void main() {
         verify(
           () => loggingService.captureEvent(
             any<Object>(),
-            domain: 'SYNC_BACKFILL',
-            subDomain: 'apply',
+            domain: LogDomains.sync,
+            subDomain: 'processor.apply',
           ),
         ).called(1);
       },
@@ -5388,8 +5389,8 @@ void main() {
         verify(
           () => loggingService.captureEvent(
             contains('apply.entryLink.gapsDetected count=2'),
-            domain: 'SYNC_SEQUENCE',
-            subDomain: 'gapDetection',
+            domain: LogDomains.sync,
+            subDomain: 'processor.gapDetection',
           ),
         ).called(1);
       },

--- a/test/features/sync/outbox/outbox_service_test.dart
+++ b/test/features/sync/outbox/outbox_service_test.dart
@@ -2757,13 +2757,6 @@ void main() {
             subDomain: 'dbNudge',
           ),
         ).called(1);
-        verify(
-          () => loggingService.captureEvent(
-            'enqueueRequest() done',
-            domain: 'OUTBOX',
-            subDomain: any(named: 'subDomain'),
-          ),
-        ).called(1);
         unawaited(svc.dispose());
         async.flushMicrotasks();
       });
@@ -2807,13 +2800,6 @@ void main() {
           () => loggingService.captureEvent(
             startsWith('dbNudge'),
             domain: any(named: 'domain'),
-            subDomain: any(named: 'subDomain'),
-          ),
-        );
-        verifyNever(
-          () => loggingService.captureEvent(
-            'enqueueRequest() done',
-            domain: 'OUTBOX',
             subDomain: any(named: 'subDomain'),
           ),
         );

--- a/test/features/sync/sequence/sync_sequence_log_service_test.dart
+++ b/test/features/sync/sequence/sync_sequence_log_service_test.dart
@@ -2,6 +2,7 @@
 
 import 'package:drift/drift.dart' hide isNotNull, isNull;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/database/logging_types.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/features/sync/sequence/sync_sequence_log_service.dart';
 import 'package:lotti/features/sync/sequence/sync_sequence_payload_type.dart';
@@ -3721,6 +3722,57 @@ void main() {
         expect(gaps.length, 2);
         expect(gaps[0], (hostId: aliceHostId, counter: 3));
         expect(gaps[1], (hostId: aliceHostId, counter: 4));
+      },
+    );
+  });
+
+  group('_trace routing', () {
+    test(
+      'routes through DomainLogger when one is injected and skips the '
+      'direct captureEvent fallback',
+      () async {
+        final mockDomainLogger = MockDomainLogger();
+        when(
+          () => mockDomainLogger.log(
+            any<String>(),
+            any<String>(),
+            subDomain: any<String>(named: 'subDomain'),
+            level: any<InsightLevel>(named: 'level'),
+          ),
+        ).thenReturn(null);
+
+        final svc = SyncSequenceLogService(
+          syncDatabase: mockDb,
+          vectorClockService: mockVcService,
+          loggingService: mockLogging,
+          domainLogger: mockDomainLogger,
+        );
+
+        when(
+          () => mockDb.resetUnresolvableWithKnownPayload(),
+        ).thenAnswer((_) async => 3);
+
+        // resetUnresolvableEntries emits exactly one _trace when count > 0.
+        await svc.resetUnresolvableEntries();
+
+        verify(
+          () => mockDomainLogger.log(
+            LogDomains.sync,
+            any<String>(
+              that: contains('resetUnresolvableEntries: reset 3 entries'),
+            ),
+            subDomain: 'sequence.resetUnresolvable',
+          ),
+        ).called(1);
+        verifyNever(
+          () => mockLogging.captureEvent(
+            any<String>(
+              that: contains('resetUnresolvableEntries: reset 3 entries'),
+            ),
+            domain: LogDomains.sync,
+            subDomain: 'sequence.resetUnresolvable',
+          ),
+        );
       },
     );
   });

--- a/test/features/sync/sequence/sync_sequence_log_service_test.dart
+++ b/test/features/sync/sequence/sync_sequence_log_service_test.dart
@@ -7,6 +7,7 @@ import 'package:lotti/features/sync/sequence/sync_sequence_log_service.dart';
 import 'package:lotti/features/sync/sequence/sync_sequence_payload_type.dart';
 import 'package:lotti/features/sync/tuning.dart';
 import 'package:lotti/features/sync/vector_clock.dart';
+import 'package:lotti/services/domain_logging.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../mocks/mocks.dart';
@@ -398,8 +399,8 @@ void main() {
       verify(
         () => mockLogging.captureEvent(
           any<String>(that: contains('backfilled hostId=$aliceHostId')),
-          domain: 'SYNC_SEQUENCE',
-          subDomain: 'backfillArrived',
+          domain: LogDomains.sync,
+          subDomain: 'sequence.backfillArrived',
         ),
       ).called(1);
     });
@@ -561,8 +562,8 @@ void main() {
       verify(
         () => mockLogging.captureEvent(
           any<String>(that: contains('backfilled (non-originator)')),
-          domain: 'SYNC_SEQUENCE',
-          subDomain: 'backfillArrived',
+          domain: LogDomains.sync,
+          subDomain: 'sequence.backfillArrived',
         ),
       ).called(1);
     });
@@ -659,8 +660,8 @@ void main() {
       verify(
         () => mockLogging.captureEvent(
           any<String>(that: contains('largeGapDetected')),
-          domain: 'SYNC_SEQUENCE',
-          subDomain: 'largeGap',
+          domain: LogDomains.sync,
+          subDomain: 'sequence.largeGap',
         ),
       ).called(1);
     });
@@ -732,8 +733,8 @@ void main() {
       verify(
         () => mockLogging.captureEvent(
           any<String>(that: contains('extremeGapDetected')),
-          domain: 'SYNC_SEQUENCE',
-          subDomain: 'extremeGap',
+          domain: LogDomains.sync,
+          subDomain: 'sequence.extremeGap',
         ),
       ).called(1);
     });
@@ -815,8 +816,8 @@ void main() {
       verifyNever(
         () => mockLogging.captureEvent(
           any<String>(that: contains('largeGapDetected')),
-          domain: 'SYNC_SEQUENCE',
-          subDomain: 'largeGap',
+          domain: LogDomains.sync,
+          subDomain: 'sequence.largeGap',
         ),
       );
     });
@@ -867,8 +868,8 @@ void main() {
       verify(
         () => mockLogging.captureEvent(
           any<String>(that: contains('skipGapDetection')),
-          domain: 'SYNC_SEQUENCE',
-          subDomain: 'skipGap',
+          domain: LogDomains.sync,
+          subDomain: 'sequence.skipGap',
         ),
       ).called(1);
 
@@ -1015,8 +1016,8 @@ void main() {
         verify(
           () => mockLogging.captureEvent(
             any<String>(that: contains('skipGapDetection')),
-            domain: 'SYNC_SEQUENCE',
-            subDomain: 'skipGap',
+            domain: LogDomains.sync,
+            subDomain: 'sequence.skipGap',
           ),
         ).called(1);
       },
@@ -1627,8 +1628,8 @@ void main() {
       verify(
         () => mockLogging.captureEvent(
           any<String>(that: contains('reset 2 entries')),
-          domain: 'SYNC_SEQUENCE',
-          subDomain: 'reRequest',
+          domain: LogDomains.sync,
+          subDomain: 'sequence.reRequest',
         ),
       ).called(1);
     });
@@ -3138,8 +3139,8 @@ void main() {
       verify(
         () => mockLogging.captureEvent(
           any<String>(that: contains('markCoveredCountersAsReceived')),
-          domain: 'SYNC_SEQUENCE',
-          subDomain: 'coveredClocks',
+          domain: LogDomains.sync,
+          subDomain: 'sequence.coveredClocks',
         ),
       ).called(1);
     });
@@ -3358,8 +3359,8 @@ void main() {
       verify(
         () => mockLogging.captureEvent(
           any<String>(that: contains('reset 5 entries')),
-          domain: 'SYNC_SEQUENCE',
-          subDomain: 'resetUnresolvable',
+          domain: LogDomains.sync,
+          subDomain: 'sequence.resetUnresolvable',
         ),
       ).called(1);
     });
@@ -3374,8 +3375,8 @@ void main() {
       verifyNever(
         () => mockLogging.captureEvent(
           any<String>(),
-          domain: 'SYNC_SEQUENCE',
-          subDomain: 'resetUnresolvable',
+          domain: LogDomains.sync,
+          subDomain: 'sequence.resetUnresolvable',
         ),
       );
     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sync pipeline now deduplicates attachment processing, avoids redundant work, skips unrelated descriptor events, and no longer emits duplicate sync/sequence/outbox log lines.

* **Documentation**
  * Added implementation plan for sync slice invalidation coalescing.

* **Chores**
  * Version bumped to 0.9.961 and release notes/Flatpak metainfo added.

* **Tests**
  * Updated logging-related tests and added idempotency tests for attachment indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->