### PR TITLE
refactor: wrap sync slice apply in journalDb transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   per-run scan no longer records ~1000 unrelated events into the
   attachment index. Removed the per-tick `OUTBOX enqueueRequest() done`
   log, which fired on every debounced wake and carried no signal.
+- Sync pipeline: the per-event apply loop in `MatrixStreamProcessor` now
+  runs inside a single `JournalDb.transaction`, so a slice of N sync
+  events commits once instead of N times. Drift coalesces the journal
+  table stream emissions to one notification per slice, collapsing the
+  reader/writer lock contention that produced multi-second waits behind
+  otherwise-cheap `id IN (?)` lookups during large catch-up replays.
+  Per-event error handling is unchanged: individual apply failures are
+  still caught locally and scheduled for retry, so the transaction only
+  rolls back when a commit genuinely fails.
 
 ## [0.9.959] - 2026-04-18
 ### Changed

--- a/docs/implementation_plans/2026-04-18_sync_slice_invalidation_coalescing.md
+++ b/docs/implementation_plans/2026-04-18_sync_slice_invalidation_coalescing.md
@@ -2,7 +2,15 @@
 
 ## Status
 
-Not started. Scoping only — do not implement without further agreement.
+Implemented (Option A, transaction wrap). The second-pass apply loop in
+`MatrixStreamProcessor._processOrderedInternal` now runs inside a single
+`_journalDb.transaction(() async {...})`. Per-event error handling is
+unchanged — exceptions raised by `_eventProcessor.process(...)` are caught
+inside `_processSyncPayloadEvent` and converted into retry-tracker entries,
+so the transaction commits the whole slice and only rolls back if the
+commit itself fails. Verified by
+`test/features/sync/matrix/pipeline/matrix_stream_processor_test.dart`
+→ `coalesces per-event writes into a single journalDb transaction`.
 
 ## Problem
 

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -34,6 +34,7 @@
     <release version="0.9.961" date="2026-04-18">
       <description>
           <p>Sync pipeline: removed duplicate-work in inbox attachment handling and sync-family logging. AttachmentIndex.record now dedupes per eventId so repeated observations from live scan, catch-up, and backfill passes become no-ops instead of thrashing the per-path slot between events sharing one relativePath. SyncEventProcessor and SyncSequenceLogService no longer emit each log line twice — DomainLogger is the single emitter and falls back to a direct sync-domain capture when no domain logger is wired. Descriptor catch-up skips events whose relativePath is not in the pending set, so the per-run scan no longer records ~1000 unrelated events into the attachment index. Removed the per-tick OUTBOX enqueueRequest() done log, which fired on every debounced wake and carried no signal.</p>
+          <p>Sync pipeline: the per-event apply loop in MatrixStreamProcessor now runs inside a single JournalDb.transaction, so a slice of N sync events commits once instead of N times. Drift coalesces journal-table stream emissions to one notification per slice, collapsing the reader/writer lock contention that produced multi-second waits behind otherwise-cheap id IN (?) lookups during large catch-up replays. Per-event error handling is unchanged: individual apply failures are still caught locally and scheduled for retry, so the transaction only rolls back when a commit genuinely fails.</p>
       </description>
     </release>
     <release version="0.9.959" date="2026-04-18">

--- a/lib/features/sync/README.md
+++ b/lib/features/sync/README.md
@@ -322,6 +322,12 @@ The important runtime rules are:
 - client-stream and timeline callbacks act as scheduling signals, not as the
   payload-processing path
 - marker advancement happens inside ordered batches, not per callback
+- the per-event apply loop in `MatrixStreamProcessor._processOrderedInternal`
+  runs inside a single `JournalDb.transaction`, so a slice of N events
+  commits once and Drift emits one journal-table stream notification per
+  slice instead of N. Per-event errors are still caught locally and
+  converted to retry-tracker entries, so the transaction only rolls back
+  when a commit itself fails.
 
 `SyncEventProcessor` decodes `SyncMessage`, resolves file-backed payloads,
 applies them to local stores, records sequence state, and delegates backfill

--- a/lib/features/sync/matrix/pipeline/matrix_stream_processor.dart
+++ b/lib/features/sync/matrix/pipeline/matrix_stream_processor.dart
@@ -447,6 +447,12 @@ class MatrixStreamProcessor {
     // `_processSyncPayloadEvent`, so the transaction only sees an
     // uncaught throw if commit itself fails — in which case rolling back
     // the slice is the correct behaviour.
+    //
+    // IDs to record as completed *after* the transaction commits. Recording
+    // inside the transaction would leave these in `_completedSyncIds` even
+    // if the commit rolls back, causing later ingestion paths to skip
+    // events whose DB writes never persisted.
+    final completedSyncIds = <String>[];
     await _journalDb.transaction(() async {
       for (final e in ordered) {
         final ts = TimelineEventOrdering.timestamp(e);
@@ -516,6 +522,7 @@ class MatrixStreamProcessor {
               isSyncPayloadEvent = true;
               processedOk = true;
               treatAsHandled = true;
+              syncPayloadsSkippedCompleted++;
             } else {
               isSyncPayloadEvent = true;
               syncPayloadEventsSeen++;
@@ -527,6 +534,7 @@ class MatrixStreamProcessor {
                 );
                 processedOk = outcome.processedOk;
                 treatAsHandled = outcome.treatAsHandled;
+                if (processedOk) syncPayloadsApplied++;
                 if (outcome.hadFailure) hadFailure = true;
                 if (outcome.failureDelta > 0) {
                   batchFailures += outcome.failureDelta;
@@ -570,13 +578,15 @@ class MatrixStreamProcessor {
           latestTs = ts;
           latestEventId = id;
         }
-        // Record completed sync payloads to suppress duplicate applies across
-        // overlapping ingestion paths (e.g., live scan + client stream).
+        // Defer the completion bookkeeping until the transaction commits —
+        // see the comment above the transaction block.
         if ((processedOk || treatAsHandled) && isSyncPayloadEvent) {
-          _recordCompletedSync(id);
+          completedSyncIds.add(id);
         }
       }
     });
+
+    completedSyncIds.forEach(_recordCompletedSync);
 
     // Log batch processing summary for diagnostics
     _loggingService.captureEvent(

--- a/lib/features/sync/matrix/pipeline/matrix_stream_processor.dart
+++ b/lib/features/sync/matrix/pipeline/matrix_stream_processor.dart
@@ -437,130 +437,146 @@ class MatrixStreamProcessor {
     var syncPayloadEventsSeen = 0;
     var syncPayloadsApplied = 0;
     var syncPayloadsSkippedCompleted = 0;
-    for (final e in ordered) {
-      final ts = TimelineEventOrdering.timestamp(e);
-      final id = e.eventId;
-      final content = e.content;
-      var processedOk = true;
-      var treatAsHandled =
-          false; // allow advancement even if skipped by retry cap
-      var isSyncPayloadEvent = false;
 
-      // If this looks like a sync payload and another ingestion path is already
-      // processing it, skip to avoid duplicate applies.
-      final isPotentialSync = ec.MatrixEventClassifier.isSyncPayloadEvent(e);
-      final wasSuppressed = suppressedIds.contains(id);
-      if (!wasSuppressed && isPotentialSync && _inFlightSyncIds.contains(id)) {
-        // Defer; the completing path will record completion and advancement.
-        continue;
-      }
+    // Wrap the per-event apply loop in a single JournalDb transaction so
+    // that Drift coalesces the stream emissions produced by per-event
+    // writes into one notification per slice. Without this, a slice of N
+    // events fires N separate writer commits, each of which wakes every
+    // journal watcher/controller and queues up readers behind the writer
+    // lock. Per-event errors are already caught inside
+    // `_processSyncPayloadEvent`, so the transaction only sees an
+    // uncaught throw if commit itself fails — in which case rolling back
+    // the slice is the correct behaviour.
+    await _journalDb.transaction(() async {
+      for (final e in ordered) {
+        final ts = TimelineEventOrdering.timestamp(e);
+        final id = e.eventId;
+        final content = e.content;
+        var processedOk = true;
+        var treatAsHandled =
+            false; // allow advancement even if skipped by retry cap
+        var isSyncPayloadEvent = false;
 
-      if (wasSuppressed) {
-        isSyncPayloadEvent = isPotentialSync;
-        processedOk = true;
-        treatAsHandled = true;
-      } else if (ec.MatrixEventClassifier.isSyncPayloadEvent(e) &&
-          content['msgtype'] == syncMessageType) {
-        // Skip already-completed sync events to avoid redundant logging
-        // and DB checks.
-        if (wasCompletedSync(id)) {
-          isSyncPayloadEvent = true;
+        // If this looks like a sync payload and another ingestion path is already
+        // processing it, skip to avoid duplicate applies.
+        final isPotentialSync = ec.MatrixEventClassifier.isSyncPayloadEvent(e);
+        final wasSuppressed = suppressedIds.contains(id);
+        if (!wasSuppressed &&
+            isPotentialSync &&
+            _inFlightSyncIds.contains(id)) {
+          // Defer; the completing path will record completion and advancement.
+          continue;
+        }
+
+        if (wasSuppressed) {
+          isSyncPayloadEvent = isPotentialSync;
           processedOk = true;
           treatAsHandled = true;
-          syncPayloadsSkippedCompleted++;
-        } else {
-          isSyncPayloadEvent = true;
-          syncPayloadEventsSeen++;
-          _inFlightSyncIds.add(id);
-          try {
-            final outcome = await _processSyncPayloadEvent(e);
-            processedOk = outcome.processedOk;
-            treatAsHandled = outcome.treatAsHandled;
-            if (processedOk) syncPayloadsApplied++;
-            if (outcome.hadFailure) hadFailure = true;
-            if (outcome.failureDelta > 0) batchFailures += outcome.failureDelta;
-            if (outcome.nextDue != null &&
-                (earliestNextDue == null ||
-                    outcome.nextDue!.isBefore(earliestNextDue))) {
-              earliestNextDue = outcome.nextDue;
-            }
-          } finally {
-            _inFlightSyncIds.remove(id);
-          }
-        }
-      } else {
-        // Fallback: attempt to decode base64 JSON and detect a SyncMessage.
-        final validFallback =
-            ec.MatrixEventClassifier.isSyncPayloadEvent(e) &&
-            content['msgtype'] != syncMessageType;
-
-        if (validFallback) {
+        } else if (ec.MatrixEventClassifier.isSyncPayloadEvent(e) &&
+            content['msgtype'] == syncMessageType) {
           // Skip already-completed sync events to avoid redundant logging
           // and DB checks.
           if (wasCompletedSync(id)) {
             isSyncPayloadEvent = true;
             processedOk = true;
             treatAsHandled = true;
+            syncPayloadsSkippedCompleted++;
           } else {
             isSyncPayloadEvent = true;
             syncPayloadEventsSeen++;
             _inFlightSyncIds.add(id);
             try {
-              final outcome = await _processSyncPayloadEvent(
-                e,
-                dropSuffix: ' (no-msgtype)',
-              );
+              final outcome = await _processSyncPayloadEvent(e);
               processedOk = outcome.processedOk;
               treatAsHandled = outcome.treatAsHandled;
+              if (processedOk) syncPayloadsApplied++;
               if (outcome.hadFailure) hadFailure = true;
               if (outcome.failureDelta > 0) {
                 batchFailures += outcome.failureDelta;
               }
-              if (outcome.nextDue != null &&
-                  (earliestNextDue == null ||
-                      outcome.nextDue!.isBefore(earliestNextDue))) {
-                earliestNextDue = outcome.nextDue;
-              }
-              if (processedOk && _collectMetrics) {
-                _loggingService.captureEvent(
-                  'processed via no-msgtype fallback: $id',
-                  domain: syncLoggingDomain,
-                  subDomain: 'fallback',
-                );
+              final due = outcome.nextDue;
+              final prev = earliestNextDue;
+              if (due != null && (prev == null || due.isBefore(prev))) {
+                earliestNextDue = due;
               }
             } finally {
               _inFlightSyncIds.remove(id);
             }
           }
         } else {
-          // Do not count attachment events as "skipped" - they are part of
-          // the sync flow.
-          if (!ec.MatrixEventClassifier.isAttachment(e)) {
-            if (_collectMetrics) _metrics.incSkipped();
+          // Fallback: attempt to decode base64 JSON and detect a SyncMessage.
+          final validFallback =
+              ec.MatrixEventClassifier.isSyncPayloadEvent(e) &&
+              content['msgtype'] != syncMessageType;
+
+          if (validFallback) {
+            // Skip already-completed sync events to avoid redundant logging
+            // and DB checks.
+            if (wasCompletedSync(id)) {
+              isSyncPayloadEvent = true;
+              processedOk = true;
+              treatAsHandled = true;
+            } else {
+              isSyncPayloadEvent = true;
+              syncPayloadEventsSeen++;
+              _inFlightSyncIds.add(id);
+              try {
+                final outcome = await _processSyncPayloadEvent(
+                  e,
+                  dropSuffix: ' (no-msgtype)',
+                );
+                processedOk = outcome.processedOk;
+                treatAsHandled = outcome.treatAsHandled;
+                if (outcome.hadFailure) hadFailure = true;
+                if (outcome.failureDelta > 0) {
+                  batchFailures += outcome.failureDelta;
+                }
+                final due = outcome.nextDue;
+                final prev = earliestNextDue;
+                if (due != null && (prev == null || due.isBefore(prev))) {
+                  earliestNextDue = due;
+                }
+                if (processedOk && _collectMetrics) {
+                  _loggingService.captureEvent(
+                    'processed via no-msgtype fallback: $id',
+                    domain: syncLoggingDomain,
+                    subDomain: 'fallback',
+                  );
+                }
+              } finally {
+                _inFlightSyncIds.remove(id);
+              }
+            }
+          } else {
+            // Do not count attachment events as "skipped" - they are part of
+            // the sync flow.
+            if (!ec.MatrixEventClassifier.isAttachment(e)) {
+              if (_collectMetrics) _metrics.incSkipped();
+            }
           }
         }
+        if (!processedOk && !treatAsHandled) {
+          blockedByFailure = true;
+        }
+        if (!blockedByFailure &&
+            (processedOk || treatAsHandled) &&
+            isSyncPayloadEvent &&
+            TimelineEventOrdering.isNewer(
+              candidateTimestamp: ts,
+              candidateEventId: id,
+              latestTimestamp: latestTs,
+              latestEventId: latestEventId,
+            )) {
+          latestTs = ts;
+          latestEventId = id;
+        }
+        // Record completed sync payloads to suppress duplicate applies across
+        // overlapping ingestion paths (e.g., live scan + client stream).
+        if ((processedOk || treatAsHandled) && isSyncPayloadEvent) {
+          _recordCompletedSync(id);
+        }
       }
-      if (!processedOk && !treatAsHandled) {
-        blockedByFailure = true;
-      }
-      if (!blockedByFailure &&
-          (processedOk || treatAsHandled) &&
-          isSyncPayloadEvent &&
-          TimelineEventOrdering.isNewer(
-            candidateTimestamp: ts,
-            candidateEventId: id,
-            latestTimestamp: latestTs,
-            latestEventId: latestEventId,
-          )) {
-        latestTs = ts;
-        latestEventId = id;
-      }
-      // Record completed sync payloads to suppress duplicate applies across
-      // overlapping ingestion paths (e.g., live scan + client stream).
-      if ((processedOk || treatAsHandled) && isSyncPayloadEvent) {
-        _recordCompletedSync(id);
-      }
-    }
+    });
 
     // Log batch processing summary for diagnostics
     _loggingService.captureEvent(
@@ -569,19 +585,21 @@ class MatrixStreamProcessor {
       subDomain: 'batch',
     );
 
-    if (latestEventId != null && latestTs != null) {
+    final advancedEventId = latestEventId;
+    final advancedTs = latestTs;
+    if (advancedEventId != null && advancedTs != null) {
       final shouldAdvance = msh.shouldAdvanceMarker(
-        candidateTimestamp: latestTs,
-        candidateEventId: latestEventId,
+        candidateTimestamp: advancedTs,
+        candidateEventId: advancedEventId,
         lastTimestamp: _lastProcessedTs,
         lastEventId: _lastProcessedEventId,
       );
       if (shouldAdvance) {
-        final isDurableMarker = isServerAssignedMatrixEventId(latestEventId);
+        final isDurableMarker = isServerAssignedMatrixEventId(advancedEventId);
         if (isDurableMarker) {
-          _lastProcessedEventId = latestEventId;
+          _lastProcessedEventId = advancedEventId;
         }
-        _lastProcessedTs = latestTs;
+        _lastProcessedTs = advancedTs;
         // Persist locally immediately to avoid losing progress if the app
         // backgrounds or exits before the debounced remote flush fires. Only
         // durable server event ids are safe to reuse as restart anchors; local
@@ -589,14 +607,14 @@ class MatrixStreamProcessor {
         // into the persisted read marker.
         try {
           if (isDurableMarker) {
-            await setLastReadMatrixEventId(latestEventId, _settingsDb);
+            await setLastReadMatrixEventId(advancedEventId, _settingsDb);
           }
-          await setLastReadMatrixEventTs(latestTs.toInt(), _settingsDb);
+          await setLastReadMatrixEventTs(advancedTs.toInt(), _settingsDb);
           if (_collectMetrics) {
             _loggingService.captureEvent(
               isDurableMarker
-                  ? 'marker.local id=$latestEventId ts=${latestTs.toInt()}'
-                  : 'marker.local.skip(nonServerId) id=$latestEventId ts=${latestTs.toInt()}',
+                  ? 'marker.local id=$advancedEventId ts=${advancedTs.toInt()}'
+                  : 'marker.local.skip(nonServerId) id=$advancedEventId ts=${advancedTs.toInt()}',
               domain: syncLoggingDomain,
               subDomain: 'marker.local',
             );
@@ -610,7 +628,7 @@ class MatrixStreamProcessor {
           );
         }
         if (isDurableMarker) {
-          _readMarkerManager.schedule(room, latestEventId);
+          _readMarkerManager.schedule(room, advancedEventId);
         }
         _circuit.reset(); // reset on successful advancement
         // Nudge a quick tail rescan to catch immediately subsequent events

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.961+3939
+version: 0.9.961+3940
 
 msix_config:
   display_name: LottiApp

--- a/test/features/sync/matrix/pipeline/matrix_stream_processor_test.dart
+++ b/test/features/sync/matrix/pipeline/matrix_stream_processor_test.dart
@@ -166,52 +166,13 @@ void main() {
       test(
         'coalesces per-event writes into a single journalDb transaction',
         () async {
-          registerFallbackValue(_MockEvent());
-          registerFallbackValue(_MockJournalDb());
-
-          final mockRoom = _MockRoom();
-          when(() => roomManager.currentRoom).thenReturn(mockRoom);
-          when(sentEventRegistry.prune).thenReturn(null);
-          when(
-            () => sentEventRegistry.consume(any<String>()),
-          ).thenReturn(false);
-          when(
-            () => settingsDb.saveSettingsItem(any<String>(), any<String>()),
-          ).thenAnswer((_) async => 1);
-
-          // Track whether eventProcessor.process calls happen while the
-          // journalDb transaction callback is running.
-          var insideTransaction = false;
-          var processCallsInsideTransaction = 0;
-          var processCallsOutsideTransaction = 0;
-          var transactionInvocations = 0;
-
-          when(
-            () => journalDb.transaction<Null>(any<Future<Null> Function()>()),
-          ).thenAnswer((invocation) async {
-            transactionInvocations += 1;
-            final action =
-                invocation.positionalArguments.first as Future<void> Function();
-            insideTransaction = true;
-            try {
-              await action();
-            } finally {
-              insideTransaction = false;
-            }
-          });
-
-          when(
-            () => eventProcessor.process(
-              event: any<Event>(named: 'event'),
-              journalDb: any<JournalDb>(named: 'journalDb'),
-            ),
-          ).thenAnswer((_) async {
-            if (insideTransaction) {
-              processCallsInsideTransaction += 1;
-            } else {
-              processCallsOutsideTransaction += 1;
-            }
-          });
+          final txn = _stubCommonProcessOrdered(
+            roomManager: roomManager,
+            sentEventRegistry: sentEventRegistry,
+            settingsDb: settingsDb,
+            journalDb: journalDb,
+            eventProcessor: eventProcessor,
+          );
 
           final events = List<Event>.generate(
             5,
@@ -227,16 +188,248 @@ void main() {
           await processor.processOrdered(events);
 
           expect(
-            transactionInvocations,
+            txn.transactionInvocations,
             1,
             reason: 'slice must commit via a single journalDb transaction',
           );
           expect(
-            processCallsInsideTransaction,
+            txn.processCallsInsideTransaction,
             events.length,
             reason: 'every per-event apply must run inside the transaction',
           );
-          expect(processCallsOutsideTransaction, 0);
+          expect(txn.processCallsOutsideTransaction, 0);
+        },
+      );
+
+      test(
+        'defers _recordCompletedSync until after transaction commits',
+        () async {
+          final processor = createProcessor();
+          var wasCompletedInsideTxn = false;
+
+          final txn = _stubCommonProcessOrdered(
+            roomManager: roomManager,
+            sentEventRegistry: sentEventRegistry,
+            settingsDb: settingsDb,
+            journalDb: journalDb,
+            eventProcessor: eventProcessor,
+            onBeforeCommit: () {
+              wasCompletedInsideTxn |= processor.wasCompletedSync(r'$ev1');
+            },
+          );
+
+          final event = _createMockSyncEvent(
+            r'$ev1',
+            1000,
+            content: <String, dynamic>{'msgtype': syncMessageType},
+          );
+          await processor.processOrdered([event]);
+
+          expect(txn.transactionInvocations, 1);
+          expect(
+            wasCompletedInsideTxn,
+            isFalse,
+            reason: 'completion must not be recorded inside the transaction',
+          );
+          expect(
+            processor.wasCompletedSync(r'$ev1'),
+            isTrue,
+            reason: 'completion must be recorded after a successful commit',
+          );
+        },
+      );
+
+      test(
+        'does not record completion when the transaction throws',
+        () async {
+          registerFallbackValue(_MockEvent());
+          registerFallbackValue(_MockJournalDb());
+
+          final mockRoom = _MockRoom();
+          when(() => roomManager.currentRoom).thenReturn(mockRoom);
+          when(sentEventRegistry.prune).thenReturn(null);
+          when(
+            () => sentEventRegistry.consume(any<String>()),
+          ).thenReturn(false);
+          when(
+            () => settingsDb.saveSettingsItem(any<String>(), any<String>()),
+          ).thenAnswer((_) async => 1);
+          when(
+            () => eventProcessor.process(
+              event: any<Event>(named: 'event'),
+              journalDb: any<JournalDb>(named: 'journalDb'),
+            ),
+          ).thenAnswer((_) async {});
+          when(
+            () => journalDb.transaction<Null>(any<Future<Null> Function()>()),
+          ).thenAnswer((invocation) async {
+            final action =
+                invocation.positionalArguments.first as Future<void> Function();
+            await action();
+            // Simulate commit failure after the callback ran. The whole slice
+            // rolls back, so any in-memory flags we set inside the callback
+            // must NOT be applied to long-lived processor state.
+            throw StateError('simulated commit failure');
+          });
+
+          final processor = createProcessor();
+          final event = _createMockSyncEvent(
+            r'$ev1',
+            1000,
+            content: <String, dynamic>{'msgtype': syncMessageType},
+          );
+
+          await expectLater(
+            () => processor.processOrdered([event]),
+            throwsA(isA<StateError>()),
+          );
+
+          expect(
+            processor.wasCompletedSync(r'$ev1'),
+            isFalse,
+            reason:
+                'a rolled-back slice must not leave events flagged as completed',
+          );
+        },
+      );
+
+      test(
+        'processes valid no-msgtype fallback sync events in the transaction',
+        () async {
+          final txn = _stubCommonProcessOrdered(
+            roomManager: roomManager,
+            sentEventRegistry: sentEventRegistry,
+            settingsDb: settingsDb,
+            journalDb: journalDb,
+            eventProcessor: eventProcessor,
+          );
+
+          // Base64 of {"runtimeType":"journalEntity"} — classifies as a Lotti
+          // sync payload via runtimeType presence, without the `msgtype`
+          // header that the primary path keys off.
+          const fallbackBody = 'eyJydW50aW1lVHlwZSI6ImpvdXJuYWxFbnRpdHkifQ==';
+          final event = _createMockSyncEvent(
+            r'$fallbackEv',
+            2000,
+            content: <String, dynamic>{'body': fallbackBody},
+          );
+
+          final processor = createProcessor();
+          await processor.processOrdered([event]);
+
+          expect(
+            txn.transactionInvocations,
+            1,
+            reason: 'fallback path must still apply inside a transaction',
+          );
+          expect(
+            txn.processCallsInsideTransaction,
+            1,
+            reason: 'fallback sync payload must be handed to the processor',
+          );
+          expect(
+            processor.wasCompletedSync(r'$fallbackEv'),
+            isTrue,
+            reason: 'fallback completion must be recorded after commit',
+          );
+        },
+      );
+
+      test(
+        'skips events already flagged as completed by an earlier pass',
+        () async {
+          final txn = _stubCommonProcessOrdered(
+            roomManager: roomManager,
+            sentEventRegistry: sentEventRegistry,
+            settingsDb: settingsDb,
+            journalDb: journalDb,
+            eventProcessor: eventProcessor,
+          );
+
+          final processor = createProcessor();
+          final event = _createMockSyncEvent(
+            r'$repeatEv',
+            3000,
+            content: <String, dynamic>{'msgtype': syncMessageType},
+          );
+
+          // First pass records completion after commit.
+          await processor.processOrdered([event]);
+          expect(processor.wasCompletedSync(r'$repeatEv'), isTrue);
+          expect(txn.processCallsInsideTransaction, 1);
+
+          // Second pass must short-circuit — no new process() call, and the
+          // skip path must increment its own counter (verified indirectly via
+          // the non-increasing processor call count).
+          await processor.processOrdered([event]);
+          expect(
+            txn.processCallsInsideTransaction,
+            1,
+            reason: 'completed events must not be handed to the processor',
+          );
+          expect(
+            txn.transactionInvocations,
+            2,
+            reason: 'the slice still opens a transaction to flush side-effects',
+          );
+        },
+      );
+
+      test(
+        'suppresses events the registry marks as our own sends',
+        () async {
+          registerFallbackValue(_MockEvent());
+          registerFallbackValue(_MockJournalDb());
+
+          final mockRoom = _MockRoom();
+          when(() => roomManager.currentRoom).thenReturn(mockRoom);
+          when(sentEventRegistry.prune).thenReturn(null);
+          when(
+            () => settingsDb.saveSettingsItem(any<String>(), any<String>()),
+          ).thenAnswer((_) async => 1);
+          // This eventId is flagged as something we sent ourselves.
+          when(
+            () => sentEventRegistry.consume(r'$selfEv'),
+          ).thenReturn(true);
+          when(
+            () => journalDb.transaction<Null>(any<Future<Null> Function()>()),
+          ).thenAnswer((invocation) async {
+            final action =
+                invocation.positionalArguments.first as Future<void> Function();
+            await action();
+          });
+
+          var processCalls = 0;
+          when(
+            () => eventProcessor.process(
+              event: any<Event>(named: 'event'),
+              journalDb: any<JournalDb>(named: 'journalDb'),
+            ),
+          ).thenAnswer((_) async {
+            processCalls += 1;
+          });
+
+          final processor = createProcessor();
+          final event = _createMockSyncEvent(
+            r'$selfEv',
+            4000,
+            content: <String, dynamic>{'msgtype': syncMessageType},
+          );
+          await processor.processOrdered([event]);
+
+          expect(
+            processCalls,
+            0,
+            reason: 'suppressed events must not be handed to the processor',
+          );
+          expect(
+            processor.wasCompletedSync(r'$selfEv'),
+            isTrue,
+            reason:
+                'suppressed events are still marked completed so that '
+                'overlapping ingestion paths do not reprocess them',
+          );
+          expect(metrics.selfEventsSuppressed, 1);
         },
       );
     });
@@ -253,20 +446,111 @@ void main() {
 
 class _MockRoom extends Mock implements Room {}
 
+class _StubbedTransaction {
+  _StubbedTransaction();
+
+  int transactionInvocations = 0;
+  int processCallsInsideTransaction = 0;
+  int processCallsOutsideTransaction = 0;
+}
+
+/// Installs the common `processOrdered` stub set:
+///
+/// - `roomManager.currentRoom` returns a live room
+/// - `sentEventRegistry.prune` / `.consume` are no-ops
+/// - `settingsDb.saveSettingsItem` succeeds
+/// - `journalDb.transaction` runs the callback and tracks inside/outside
+///   status
+/// - `eventProcessor.process` increments the inside/outside counters
+///
+/// Returns a handle whose counters tests can assert on. Optionally runs
+/// [onBeforeCommit] after the callback body finishes but before the
+/// transaction itself returns, to assert on transient in-transaction state.
+_StubbedTransaction _stubCommonProcessOrdered({
+  required _MockRoomManager roomManager,
+  required _MockSentEventRegistry sentEventRegistry,
+  required _MockSettingsDb settingsDb,
+  required _MockJournalDb journalDb,
+  required _MockEventProcessor eventProcessor,
+  void Function()? onBeforeCommit,
+}) {
+  registerFallbackValue(_MockEvent());
+  registerFallbackValue(_MockJournalDb());
+
+  final handle = _StubbedTransaction();
+  var insideTransaction = false;
+
+  final mockRoom = _MockRoom();
+  when(() => roomManager.currentRoom).thenReturn(mockRoom);
+  when(sentEventRegistry.prune).thenReturn(null);
+  when(() => sentEventRegistry.consume(any<String>())).thenReturn(false);
+  when(
+    () => settingsDb.saveSettingsItem(any<String>(), any<String>()),
+  ).thenAnswer((_) async => 1);
+
+  // Dart infers `T = Null` for `transaction(() async { ... })` when the
+  // closure has no explicit return — hence the `<Null>` stub here matches the
+  // production invocation.
+  when(
+    () => journalDb.transaction<Null>(any<Future<Null> Function()>()),
+  ).thenAnswer((invocation) async {
+    handle.transactionInvocations += 1;
+    final action =
+        invocation.positionalArguments.first as Future<void> Function();
+    insideTransaction = true;
+    try {
+      await action();
+      onBeforeCommit?.call();
+    } finally {
+      insideTransaction = false;
+    }
+  });
+
+  when(
+    () => eventProcessor.process(
+      event: any<Event>(named: 'event'),
+      journalDb: any<JournalDb>(named: 'journalDb'),
+    ),
+  ).thenAnswer((_) async {
+    if (insideTransaction) {
+      handle.processCallsInsideTransaction += 1;
+    } else {
+      handle.processCallsOutsideTransaction += 1;
+    }
+  });
+
+  return handle;
+}
+
 Event _createMockSyncEvent(
   String eventId,
   int tsMs, {
   Map<String, dynamic>? content,
+  String? text,
 }) {
   final event = _MockEvent();
   when(() => event.eventId).thenReturn(eventId);
   when(
     () => event.originServerTs,
   ).thenReturn(DateTime.fromMillisecondsSinceEpoch(tsMs));
-  when(() => event.content).thenReturn(content ?? <String, dynamic>{});
+  final effectiveContent = content ?? <String, dynamic>{};
+  when(() => event.content).thenReturn(effectiveContent);
   when(() => event.roomId).thenReturn('!room:server');
   when(() => event.type).thenReturn('m.room.message');
   when(() => event.senderId).thenReturn('@user:server');
+  // Non-null by construction so the attachment classifier never blows up on a
+  // plain sync payload mock. Tests that want an attachment set this via
+  // [content].
+  when(() => event.attachmentMimetype).thenReturn('');
+  // `text` is used by the no-msgtype fallback classifier to detect sync
+  // payloads via base64-encoded runtimeType; default to the body field when
+  // present so tests can drive both paths from one factory.
+  final bodyText =
+      text ??
+      (effectiveContent['body'] is String
+          ? effectiveContent['body'] as String
+          : '');
+  when(() => event.text).thenReturn(bodyText);
   return event;
 }
 

--- a/test/features/sync/matrix/pipeline/matrix_stream_processor_test.dart
+++ b/test/features/sync/matrix/pipeline/matrix_stream_processor_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/settings_db.dart';
+import 'package:lotti/features/sync/matrix/consts.dart';
 import 'package:lotti/features/sync/matrix/pipeline/matrix_stream_processor.dart';
 import 'package:lotti/features/sync/matrix/pipeline/metrics_counters.dart';
 import 'package:lotti/features/sync/matrix/read_marker_service.dart';
@@ -161,6 +162,83 @@ void main() {
 
         await processor.processOrdered([]);
       });
+
+      test(
+        'coalesces per-event writes into a single journalDb transaction',
+        () async {
+          registerFallbackValue(_MockEvent());
+          registerFallbackValue(_MockJournalDb());
+
+          final mockRoom = _MockRoom();
+          when(() => roomManager.currentRoom).thenReturn(mockRoom);
+          when(sentEventRegistry.prune).thenReturn(null);
+          when(
+            () => sentEventRegistry.consume(any<String>()),
+          ).thenReturn(false);
+          when(
+            () => settingsDb.saveSettingsItem(any<String>(), any<String>()),
+          ).thenAnswer((_) async => 1);
+
+          // Track whether eventProcessor.process calls happen while the
+          // journalDb transaction callback is running.
+          var insideTransaction = false;
+          var processCallsInsideTransaction = 0;
+          var processCallsOutsideTransaction = 0;
+          var transactionInvocations = 0;
+
+          when(
+            () => journalDb.transaction<Null>(any<Future<Null> Function()>()),
+          ).thenAnswer((invocation) async {
+            transactionInvocations += 1;
+            final action =
+                invocation.positionalArguments.first as Future<void> Function();
+            insideTransaction = true;
+            try {
+              await action();
+            } finally {
+              insideTransaction = false;
+            }
+          });
+
+          when(
+            () => eventProcessor.process(
+              event: any<Event>(named: 'event'),
+              journalDb: any<JournalDb>(named: 'journalDb'),
+            ),
+          ).thenAnswer((_) async {
+            if (insideTransaction) {
+              processCallsInsideTransaction += 1;
+            } else {
+              processCallsOutsideTransaction += 1;
+            }
+          });
+
+          final events = List<Event>.generate(
+            5,
+            (i) => _createMockSyncEvent(
+              r'$ev'
+              '${i + 1}',
+              1000 + i,
+              content: <String, dynamic>{'msgtype': syncMessageType},
+            ),
+          );
+
+          final processor = createProcessor();
+          await processor.processOrdered(events);
+
+          expect(
+            transactionInvocations,
+            1,
+            reason: 'slice must commit via a single journalDb transaction',
+          );
+          expect(
+            processCallsInsideTransaction,
+            events.length,
+            reason: 'every per-event apply must run inside the transaction',
+          );
+          expect(processCallsOutsideTransaction, 0);
+        },
+      );
     });
 
     group('retryNow', () {
@@ -175,13 +253,17 @@ void main() {
 
 class _MockRoom extends Mock implements Room {}
 
-Event _createMockSyncEvent(String eventId, int tsMs) {
+Event _createMockSyncEvent(
+  String eventId,
+  int tsMs, {
+  Map<String, dynamic>? content,
+}) {
   final event = _MockEvent();
   when(() => event.eventId).thenReturn(eventId);
   when(
     () => event.originServerTs,
   ).thenReturn(DateTime.fromMillisecondsSinceEpoch(tsMs));
-  when(() => event.content).thenReturn(<String, dynamic>{});
+  when(() => event.content).thenReturn(content ?? <String, dynamic>{});
   when(() => event.roomId).thenReturn('!room:server');
   when(() => event.type).thenReturn('m.room.message');
   when(() => event.senderId).thenReturn('@user:server');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Sync processing now batches apply work and coalesces stream notifications per slice, reducing lock contention and speeding large catch-up replays. Per-event error handling and retry behavior are unchanged.
* **Documentation**
  * Updated release notes and sync docs to describe the new batched apply and notification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->