### PR TITLE
fix: bring back task title affordance when empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.969] - 2026-04-21
+### Fixed
+- Task title edit affordance restored. The new `DesktopTaskHeader`
+  rendered the title as plain read-only text and showed nothing when a
+  task had no title, leaving users with no obvious way to tap into the
+  inline editor. The read-only title now renders a trailing pencil
+  (`Icons.edit_outlined`) next to the label, and empty titles display a
+  localized "No title" placeholder in the same tappable slot. Task list
+  rows in turn render the existing `taskUntitled` "(untitled)" label in
+  the design-system error color + italic so missing titles stand out
+  rather than silently collapsing the row.
+
 ## [0.9.968] - 2026-04-20
 ### Added
 - Phase 0 sync diagnostic observability (additive logs only; no behaviour

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -31,6 +31,11 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="0.9.969" date="2026-04-21">
+      <description>
+          <p>Restores the task title edit affordance in the new DesktopTaskHeader. The read-only title now renders a trailing pencil icon next to the label, and empty titles display a localized "No title" placeholder in the same tappable slot so users have an obvious target to open the inline editor. Task list rows render the existing "(untitled)" label in the design-system error color and italic so missing titles stand out rather than silently collapsing the row.</p>
+      </description>
+    </release>
     <release version="0.9.968" date="2026-04-20">
       <description>
           <p>Adds Phase 0 sync observability for the planned Inbound Event Queue redesign. MatrixStreamSignalBinder now records two additive probes on the sync room: a sync.limited log line with prevBatch, event count, and the time gap since the previous sync response whenever the Matrix server returns timeline.limited == true, and an onTimelineEvent.ordering summary every 100 events tracking strict reorderings and same-timestamp ties. Both route through the MATRIX_SYNC log domain into the dated sync log file. No behaviour change; data from ~48 hours of real use validates the two load-bearing SDK assumptions before the queue refactor starts.</p>

--- a/lib/features/tasks/ui/header/desktop_task_header.dart
+++ b/lib/features/tasks/ui/header/desktop_task_header.dart
@@ -386,12 +386,21 @@ class _TitleReadOnly extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final isEmpty = title.trim().isEmpty;
+    final displayText = isEmpty ? context.messages.taskTitleEmpty : title;
+    final effectiveStyle = isEmpty
+        ? style.copyWith(
+            color: TaskShowcasePalette.mediumText(context),
+            fontStyle: FontStyle.italic,
+          )
+        : style;
     return Semantics(
       label: context.messages.taskEditTitleLabel,
       button: true,
       container: true,
       child: FocusableActionDetector(
-        mouseCursor: SystemMouseCursors.text,
+        mouseCursor: SystemMouseCursors.click,
         actions: <Type, Action<Intent>>{
           ActivateIntent: CallbackAction<ActivateIntent>(
             onInvoke: (_) {
@@ -403,7 +412,27 @@ class _TitleReadOnly extends StatelessWidget {
         child: GestureDetector(
           behavior: HitTestBehavior.opaque,
           onTap: onTap,
-          child: Text(title, softWrap: true, style: style),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Text(
+                  displayText,
+                  softWrap: true,
+                  style: effectiveStyle,
+                ),
+              ),
+              SizedBox(width: tokens.spacing.step2),
+              Padding(
+                padding: EdgeInsets.only(top: tokens.spacing.step1),
+                child: Icon(
+                  Icons.edit_outlined,
+                  size: 18,
+                  color: TaskShowcasePalette.mediumText(context),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/tasks/ui/widgets/task_browse_list_item.dart
+++ b/lib/features/tasks/ui/widgets/task_browse_list_item.dart
@@ -370,14 +370,9 @@ class _TaskRowContent extends ConsumerWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(
-                liveTask.data.title,
+              _TaskBrowseTitle(
+                title: liveTask.data.title,
                 maxLines: coverArtId == null ? 2 : 3,
-                overflow: TextOverflow.ellipsis,
-                style: tokens.typography.styles.subtitle.subtitle2.copyWith(
-                  color: TaskShowcasePalette.highText(context),
-                  fontWeight: FontWeight.w600,
-                ),
               ),
               if (oneLiner != null && oneLiner.isNotEmpty) ...[
                 SizedBox(height: tokens.spacing.step1),
@@ -455,6 +450,34 @@ class _TaskRowContent extends ConsumerWidget {
     }
 
     return widgets;
+  }
+}
+
+/// Title line for the task row. When the task has no title, renders a
+/// localized `(untitled)` warning in the error color so the gap is obvious
+/// in the list rather than silently collapsing to an empty row.
+class _TaskBrowseTitle extends StatelessWidget {
+  const _TaskBrowseTitle({required this.title, required this.maxLines});
+
+  final String title;
+  final int maxLines;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final isEmpty = title.trim().isEmpty;
+    return Text(
+      isEmpty ? context.messages.taskUntitled : title,
+      maxLines: maxLines,
+      overflow: TextOverflow.ellipsis,
+      style: tokens.typography.styles.subtitle.subtitle2.copyWith(
+        color: isEmpty
+            ? TaskShowcasePalette.error(context)
+            : TaskShowcasePalette.highText(context),
+        fontWeight: FontWeight.w600,
+        fontStyle: isEmpty ? FontStyle.italic : FontStyle.normal,
+      ),
+    );
   }
 }
 

--- a/lib/features/tasks/ui/widgets/task_browse_list_item.dart
+++ b/lib/features/tasks/ui/widgets/task_browse_list_item.dart
@@ -465,9 +465,10 @@ class _TaskBrowseTitle extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
-    final isEmpty = title.trim().isEmpty;
+    final trimmed = title.trim();
+    final isEmpty = trimmed.isEmpty;
     return Text(
-      isEmpty ? context.messages.taskUntitled : title,
+      isEmpty ? context.messages.taskUntitled : trimmed,
       maxLines: maxLines,
       overflow: TextOverflow.ellipsis,
       style: tokens.typography.styles.subtitle.subtitle2.copyWith(

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -2368,6 +2368,7 @@
   "taskStatusOpen": "Otevřeno",
   "taskStatusRejected": "Odmítnuto",
   "taskSummaries": "Souhrny úkolů",
+  "taskTitleEmpty": "Bez názvu",
   "taskUntitled": "(bez názvu)",
   "thinkingDisclosureCopied": "Úvaha zkopírována",
   "thinkingDisclosureCopy": "Kopírovat úvahu",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2631,6 +2631,7 @@
   "taskStatusOpen": "Offen",
   "taskStatusRejected": "Abgelehnt",
   "taskSummaries": "Aufgabenzusammenfassungen",
+  "taskTitleEmpty": "Kein Titel",
   "taskUntitled": "(ohne Titel)",
   "thinkingDisclosureCopied": "Begründung kopiert",
   "thinkingDisclosureCopy": "Begründung kopieren",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2895,6 +2895,7 @@
   "taskStatusOpen": "Open",
   "taskStatusRejected": "Rejected",
   "taskSummaries": "Task Summaries",
+  "taskTitleEmpty": "No title",
   "taskUntitled": "(untitled)",
   "thinkingDisclosureCopied": "Reasoning copied",
   "thinkingDisclosureCopy": "Copy reasoning",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2631,6 +2631,7 @@
   "taskStatusOpen": "Abierto",
   "taskStatusRejected": "Rechazado",
   "taskSummaries": "Resúmenes de tareas",
+  "taskTitleEmpty": "Sin título",
   "taskUntitled": "(sin título)",
   "thinkingDisclosureCopied": "Razonamiento copiado",
   "thinkingDisclosureCopy": "Copiar razonamiento",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -2631,6 +2631,7 @@
   "taskStatusOpen": "OUVERTE",
   "taskStatusRejected": "REJETÉE",
   "taskSummaries": "Résumés de tâches",
+  "taskTitleEmpty": "Sans titre",
   "taskUntitled": "(sans titre)",
   "thinkingDisclosureCopied": "Raisonnement copié",
   "thinkingDisclosureCopy": "Copier le raisonnement",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -11077,6 +11077,12 @@ abstract class AppLocalizations {
   /// **'Task Summaries'**
   String get taskSummaries;
 
+  /// No description provided for @taskTitleEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'No title'**
+  String get taskTitleEmpty;
+
   /// No description provided for @taskUntitled.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -6275,6 +6275,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get taskSummaries => 'Souhrny úkolů';
 
   @override
+  String get taskTitleEmpty => 'Bez názvu';
+
+  @override
   String get taskUntitled => '(bez názvu)';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -6287,6 +6287,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get taskSummaries => 'Aufgabenzusammenfassungen';
 
   @override
+  String get taskTitleEmpty => 'Kein Titel';
+
+  @override
   String get taskUntitled => '(ohne Titel)';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -6199,6 +6199,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get taskSummaries => 'Task Summaries';
 
   @override
+  String get taskTitleEmpty => 'No title';
+
+  @override
   String get taskUntitled => '(untitled)';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -6386,6 +6386,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get taskSummaries => 'Resúmenes de tareas';
 
   @override
+  String get taskTitleEmpty => 'Sin título';
+
+  @override
   String get taskUntitled => '(sin título)';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -6401,6 +6401,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get taskSummaries => 'Résumés de tâches';
 
   @override
+  String get taskTitleEmpty => 'Sans titre';
+
+  @override
   String get taskUntitled => '(sans titre)';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -6313,6 +6313,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get taskSummaries => 'Rezumate sarcini';
 
   @override
+  String get taskTitleEmpty => 'Fără titlu';
+
+  @override
   String get taskUntitled => '(fără titlu)';
 
   @override

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -2631,6 +2631,7 @@
   "taskStatusOpen": "DESCHIS",
   "taskStatusRejected": "RESPINS",
   "taskSummaries": "Rezumate sarcini",
+  "taskTitleEmpty": "Fără titlu",
   "taskUntitled": "(fără titlu)",
   "thinkingDisclosureCopied": "Raționament copiat",
   "thinkingDisclosureCopy": "Copiază raționamentul",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.968+3957
+version: 0.9.971+3960
 
 msix_config:
   display_name: LottiApp

--- a/test/features/tasks/ui/header/desktop_task_header_test.dart
+++ b/test/features/tasks/ui/header/desktop_task_header_test.dart
@@ -200,6 +200,41 @@ void main() {
       expect(find.byIcon(Icons.close_rounded), findsOneWidget);
     });
 
+    testWidgets('read-only title renders a pencil edit affordance', (
+      tester,
+    ) async {
+      await _pumpDesktop(
+        tester,
+        DesktopTaskHeader(
+          data: _fixture(),
+          onTitleSaved: (_) {},
+        ),
+      );
+      expect(find.byIcon(Icons.edit_outlined), findsOneWidget);
+    });
+
+    testWidgets(
+      'empty title renders "No title" placeholder + pencil and opens editor on tap',
+      (tester) async {
+        await _pumpDesktop(
+          tester,
+          DesktopTaskHeader(
+            data: _fixture(title: ''),
+            onTitleSaved: (_) {},
+          ),
+        );
+
+        expect(find.text('No title'), findsOneWidget);
+        expect(find.byIcon(Icons.edit_outlined), findsOneWidget);
+        expect(find.byType(TextField), findsNothing);
+
+        await tester.tap(find.text('No title'));
+        await tester.pump();
+
+        expect(find.byType(TextField), findsOneWidget);
+      },
+    );
+
     testWidgets(
       'read-only title exposes an accessible button via Semantics',
       (tester) async {

--- a/test/features/tasks/ui/widgets/task_browse_list_item_test.dart
+++ b/test/features/tasks/ui/widgets/task_browse_list_item_test.dart
@@ -15,6 +15,7 @@ import 'package:lotti/features/tasks/ui/cover_art_thumbnail.dart';
 import 'package:lotti/features/tasks/ui/model/task_browse_models.dart';
 import 'package:lotti/features/tasks/ui/time_recording_icon.dart';
 import 'package:lotti/features/tasks/ui/widgets/task_browse_list_item.dart';
+import 'package:lotti/features/tasks/ui/widgets/task_showcase_palette.dart';
 import 'package:lotti/features/tasks/ui/widgets/task_showcase_shared_widgets.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/entities_cache_service.dart';
@@ -909,6 +910,33 @@ void main() {
       expect(find.text('Updated Title'), findsOneWidget);
       expect(find.text('Original Title'), findsNothing);
     });
+
+    testWidgets(
+      'renders localized "(untitled)" warning in red when title is empty',
+      (tester) async {
+        final task = TestTaskFactory.create(
+          id: 'task-empty-title',
+          title: '',
+          dateFrom: DateTime(2026, 4, 8),
+        );
+
+        await tester.pumpWidget(
+          makeTestableWidget(_makeWidget(task)),
+        );
+        await tester.pump();
+
+        final finder = find.text('(untitled)');
+        expect(finder, findsOneWidget);
+
+        final textWidget = tester.widget<Text>(finder);
+        final style = textWidget.style!;
+        expect(style.fontStyle, FontStyle.italic);
+        // Warning color comes from the design-system error token, not from
+        // colorScheme. Assert the same resolution the widget uses.
+        final element = tester.element(finder);
+        expect(style.color, TaskShowcasePalette.error(element));
+      },
+    );
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored task title editing UI: read-only titles now show a trailing edit icon and are tappable to open the inline editor.
  * Empty task titles display a localized "No title" placeholder instead of disappearing.
  * Task list rows now surface missing titles with an error-colored, italic "(untitled)" label to prevent silent collapse.

* **Localization**
  * Added translations for the empty-title label in Czech, German, Spanish, French, Romanian, and English.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->