### PR TITLE
feat: proactively broadcast burnt VC counters

### DIFF
--- a/lib/features/journal/repository/journal_repository.dart
+++ b/lib/features/journal/repository/journal_repository.dart
@@ -10,6 +10,7 @@ import 'package:lotti/features/sync/outbox/outbox_service.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/db_notification.dart';
+import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/notification_service.dart';
 import 'package:lotti/services/time_service.dart';
@@ -269,24 +270,44 @@ class JournalRepository {
     final existing = await journalDb.entryLinkById(link.id);
 
     if (existing != null && !_hasChange(existing, link)) {
+      // No VC reserved yet — fast path.
       return false;
     }
 
-    final updated = link.copyWith(
-      updatedAt: DateTime.now(),
-      vectorClock: await getIt<VectorClockService>().getNextVectorClock(),
-    );
+    // Wrap in VC scope: if upsertEntryLink returns 0 (identical row already
+    // exists), release the reservation and let the burn handler broadcast
+    // an unresolvable hint so peers skip the gap instead of round-tripping
+    // via backfill.
+    return getIt<VectorClockService>().withVcScope<bool>(
+      () async {
+        final updated = link.copyWith(
+          updatedAt: DateTime.now(),
+          vectorClock: await getIt<VectorClockService>().getNextVectorClock(),
+        );
 
-    final res = await journalDb.upsertEntryLink(updated);
-    getIt<UpdateNotifications>().notify({link.fromId, link.toId});
-
-    await getIt<OutboxService>().enqueueMessage(
-      SyncMessage.entryLink(
-        entryLink: updated,
-        status: SyncEntryStatus.update,
-      ),
+        final res = await journalDb.upsertEntryLink(updated);
+        if (res == 0) return false;
+        getIt<UpdateNotifications>().notify({link.fromId, link.toId});
+        try {
+          await getIt<OutboxService>().enqueueMessage(
+            SyncMessage.entryLink(
+              entryLink: updated,
+              status: SyncEntryStatus.update,
+            ),
+          );
+        } catch (error, stackTrace) {
+          getIt<DomainLogger>().error(
+            LogDomains.sync,
+            'outbox enqueue failed after updateLink; VC already committed',
+            error: error,
+            stackTrace: stackTrace,
+            subDomain: 'updateLink.enqueue',
+          );
+        }
+        return true;
+      },
+      commitWhen: (ok) => ok,
     );
-    return res != 0;
   }
 
   bool _hasChange(EntryLink existing, EntryLink incoming) {

--- a/lib/features/projects/repository/project_repository.dart
+++ b/lib/features/projects/repository/project_repository.dart
@@ -9,6 +9,7 @@ import 'package:lotti/features/sync/outbox/outbox_service.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/db_notification.dart';
+import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/services/vector_clock_service.dart';
 import 'package:lotti/utils/file_utils.dart';
@@ -293,28 +294,52 @@ class ProjectRepository {
       );
     }
 
-    // No existing link — just create the new project link
-    final now = DateTime.now();
-    final link = EntryLink.project(
-      id: uuid.v1(),
-      fromId: projectId,
-      toId: taskId,
-      createdAt: now,
-      updatedAt: now,
-      vectorClock: await _vectorClockService.getNextVectorClock(),
-    );
+    // No existing link — just create the new project link.
+    //
+    // Wrapped in a VC scope: if [upsertEntryLink] returns 0 (no-op / unchanged
+    // row) the scope releases, the burn handler broadcasts a proactive
+    // `SyncBackfillResponse(unresolvable=true)`, and peers close the gap on
+    // the live event stream. Without this wrap, the reserved counter would
+    // burn silently and receivers would only converge via reactive backfill.
+    return _vectorClockService.withVcScope<bool>(
+      () async {
+        final now = DateTime.now();
+        final link = EntryLink.project(
+          id: uuid.v1(),
+          fromId: projectId,
+          toId: taskId,
+          createdAt: now,
+          updatedAt: now,
+          vectorClock: await _vectorClockService.getNextVectorClock(),
+        );
 
-    final res = await _journalDb.upsertEntryLink(link);
-    if (res != 0) {
-      _updateNotifications.notify({
-        projectId,
-        taskId,
-        projectNotification,
-        projectEntityUpdateNotification(projectId),
-      });
-      await _enqueueLinkSync(link, SyncEntryStatus.initial);
-    }
-    return res != 0;
+        final res = await _journalDb.upsertEntryLink(link);
+        if (res == 0) return false;
+        _updateNotifications.notify({
+          projectId,
+          taskId,
+          projectNotification,
+          projectEntityUpdateNotification(projectId),
+        });
+        try {
+          await _enqueueLinkSync(link, SyncEntryStatus.initial);
+        } catch (error, stackTrace) {
+          // Commit-on-write invariant: the link row is already persisted, so
+          // the VC counter is claimed on disk — an outbox failure must not
+          // release the reservation.
+          getIt<DomainLogger>().error(
+            LogDomains.sync,
+            'outbox enqueue failed after linkTaskToProject; '
+            'VC already committed',
+            error: error,
+            stackTrace: stackTrace,
+            subDomain: 'linkTaskToProject.enqueue',
+          );
+        }
+        return true;
+      },
+      commitWhen: (ok) => ok,
+    );
   }
 
   /// Removes a task from its project.
@@ -386,57 +411,93 @@ class ProjectRepository {
     required String projectId,
     required String taskId,
   }) async {
-    final now = DateTime.now();
-    final deletedLink = await _prepareDeletedLink(oldLink, now);
-    final newLink = EntryLink.project(
-      id: uuid.v1(),
-      fromId: projectId,
-      toId: taskId,
-      createdAt: now,
-      updatedAt: now,
-      vectorClock: await _vectorClockService.getNextVectorClock(),
+    // Wrap BOTH reservations (delete-link VC + new-link VC) in a single
+    // scope so a rolled-back transaction releases both. Nested reservations
+    // from [_prepareDeletedLink] attach automatically via the zone-local
+    // scope.
+    return _vectorClockService.withVcScope<bool>(
+      () async {
+        final now = DateTime.now();
+        final deletedLink = await _prepareDeletedLink(oldLink, now);
+        final newLink = EntryLink.project(
+          id: uuid.v1(),
+          fromId: projectId,
+          toId: taskId,
+          createdAt: now,
+          updatedAt: now,
+          vectorClock: await _vectorClockService.getNextVectorClock(),
+        );
+
+        // Both writes in one transaction — if either fails, both roll back.
+        final success = await _journalDb.transaction(() async {
+          final deleteRes = await _journalDb.upsertEntryLink(deletedLink);
+          if (deleteRes == 0) return false;
+          final insertRes = await _journalDb.upsertEntryLink(newLink);
+          return insertRes != 0;
+        });
+
+        if (!success) return false;
+
+        _updateNotifications.notify({
+          oldLink.fromId,
+          oldLink.toId,
+          projectId,
+          taskId,
+          projectNotification,
+          projectEntityUpdateNotification(oldLink.fromId),
+          projectEntityUpdateNotification(projectId),
+        });
+        try {
+          await _enqueueLinkSync(deletedLink, SyncEntryStatus.update);
+          await _enqueueLinkSync(newLink, SyncEntryStatus.initial);
+        } catch (error, stackTrace) {
+          getIt<DomainLogger>().error(
+            LogDomains.sync,
+            'outbox enqueue failed after _relinkTask; VCs already committed',
+            error: error,
+            stackTrace: stackTrace,
+            subDomain: '_relinkTask.enqueue',
+          );
+        }
+        return true;
+      },
+      commitWhen: (ok) => ok,
     );
-
-    // Both writes in one transaction — if either fails, both roll back
-    final success = await _journalDb.transaction(() async {
-      final deleteRes = await _journalDb.upsertEntryLink(deletedLink);
-      if (deleteRes == 0) return false;
-      final insertRes = await _journalDb.upsertEntryLink(newLink);
-      return insertRes != 0;
-    });
-
-    if (!success) return false;
-
-    // Side effects only after successful commit
-    _updateNotifications.notify({
-      oldLink.fromId,
-      oldLink.toId,
-      projectId,
-      taskId,
-      projectNotification,
-      projectEntityUpdateNotification(oldLink.fromId),
-      projectEntityUpdateNotification(projectId),
-    });
-    await _enqueueLinkSync(deletedLink, SyncEntryStatus.update);
-    await _enqueueLinkSync(newLink, SyncEntryStatus.initial);
-    return true;
   }
 
   Future<bool> _softDeleteLink(EntryLink link) async {
-    final now = DateTime.now();
-    final deleted = await _prepareDeletedLink(link, now);
-    final res = await _journalDb.upsertEntryLink(deleted);
-    if (res == 0) return false;
-    _updateNotifications.notify({
-      link.fromId,
-      link.toId,
-      projectNotification,
-      projectEntityUpdateNotification(link.fromId),
-    });
-    await _enqueueLinkSync(deleted, SyncEntryStatus.update);
-    return true;
+    return _vectorClockService.withVcScope<bool>(
+      () async {
+        final now = DateTime.now();
+        final deleted = await _prepareDeletedLink(link, now);
+        final res = await _journalDb.upsertEntryLink(deleted);
+        if (res == 0) return false;
+        _updateNotifications.notify({
+          link.fromId,
+          link.toId,
+          projectNotification,
+          projectEntityUpdateNotification(link.fromId),
+        });
+        try {
+          await _enqueueLinkSync(deleted, SyncEntryStatus.update);
+        } catch (error, stackTrace) {
+          getIt<DomainLogger>().error(
+            LogDomains.sync,
+            'outbox enqueue failed after _softDeleteLink; VC already committed',
+            error: error,
+            stackTrace: stackTrace,
+            subDomain: '_softDeleteLink.enqueue',
+          );
+        }
+        return true;
+      },
+      commitWhen: (ok) => ok,
+    );
   }
 
+  /// Reserves a VC for the soft-deleted link. Callers invoke this inside a
+  /// [VectorClockService.withVcScope] so the reservation is bound to the
+  /// enclosing write outcome.
   Future<EntryLink> _prepareDeletedLink(EntryLink link, DateTime now) async {
     return link.copyWith(
       deletedAt: now,

--- a/lib/features/ratings/repository/rating_repository.dart
+++ b/lib/features/ratings/repository/rating_repository.dart
@@ -10,6 +10,7 @@ import 'package:lotti/features/sync/outbox/outbox_service.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/db_notification.dart';
+import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/vector_clock_service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -163,39 +164,54 @@ class RatingRepository {
     required String fromId,
     required String toId,
   }) async {
-    final now = DateTime.now();
     final vectorClockService = getIt<VectorClockService>();
 
-    final link = EntryLink.rating(
-      id: _uuid.v1(),
-      fromId: fromId,
-      toId: toId,
-      createdAt: now,
-      updatedAt: now,
-      hidden: false,
-      vectorClock: await vectorClockService.getNextVectorClock(),
+    // Wrap the VC reservation in a scope: if upsertEntryLink turns out to be
+    // a no-op (row already exists unchanged), the scope releases and the
+    // burn handler proactively broadcasts an unresolvable hint for the
+    // reserved counter — peers skip the gap without a backfill round-trip.
+    await vectorClockService.withVcScope<bool>(
+      () async {
+        final now = DateTime.now();
+        final link = EntryLink.rating(
+          id: _uuid.v1(),
+          fromId: fromId,
+          toId: toId,
+          createdAt: now,
+          updatedAt: now,
+          hidden: false,
+          vectorClock: await vectorClockService.getNextVectorClock(),
+        );
+
+        final res = await _journalDb.upsertEntryLink(link);
+        if (res == 0) return false;
+        getIt<UpdateNotifications>().notify({fromId, toId});
+
+        // Enqueue sync message separately so a sync failure doesn't
+        // cause the caller to roll back an otherwise consistent local
+        // state — and doesn't trigger a VC release (the link is already
+        // persisted; the reserved counter is baked into disk).
+        try {
+          await getIt<OutboxService>().enqueueMessage(
+            SyncMessage.entryLink(
+              entryLink: link,
+              status: SyncEntryStatus.initial,
+            ),
+          );
+        } catch (e, stackTrace) {
+          getIt<DomainLogger>().error(
+            LogDomains.sync,
+            'outbox enqueue failed after _createRatingLink; '
+            'VC already committed',
+            error: e,
+            stackTrace: stackTrace,
+            subDomain: '_createRatingLink.enqueue',
+          );
+        }
+        return true;
+      },
+      commitWhen: (ok) => ok,
     );
-
-    await _journalDb.upsertEntryLink(link);
-    getIt<UpdateNotifications>().notify({fromId, toId});
-
-    // Enqueue sync message separately so a sync failure doesn't
-    // cause the caller to roll back an otherwise consistent local state.
-    try {
-      await getIt<OutboxService>().enqueueMessage(
-        SyncMessage.entryLink(
-          entryLink: link,
-          status: SyncEntryStatus.initial,
-        ),
-      );
-    } catch (e, stackTrace) {
-      getIt<LoggingService>().captureException(
-        e,
-        domain: 'RatingRepository',
-        subDomain: '_createRatingLink.enqueue',
-        stackTrace: stackTrace,
-      );
-    }
   }
 
   /// Soft-deletes a journal entity by setting its deletedAt timestamp.

--- a/lib/features/sync/backfill/backfill_response_handler.dart
+++ b/lib/features/sync/backfill/backfill_response_handler.dart
@@ -130,12 +130,24 @@ class BackfillResponseHandler {
   }
 
   /// Send an "unresolvable" backfill response indicating the originating host
-  /// cannot resolve its own counter (e.g., it was superseded before being recorded).
+  /// cannot resolve its own counter (e.g., it was superseded before being
+  /// recorded, burnt, or the payload VC regressed below the counter).
+  ///
+  /// Always called on our own host — the callers in [_processBackfillEntry]
+  /// and [_sendHintOrUnresolvable] gate on `hostId == myHost`. The self-log
+  /// upsert mirrors the broadcast so our own sequence log agrees with what
+  /// peers will write after receiving it (self-echoes are suppressed on the
+  /// Matrix pipeline, so `handleBackfillResponse` never fires for us).
   Future<void> _sendUnresolvableResponse({
     required String hostId,
     required int counter,
     SyncSequencePayloadType? payloadType,
   }) async {
+    await _sequenceLogService.markOwnCounterUnresolvable(
+      hostId: hostId,
+      counter: counter,
+      payloadType: payloadType ?? SyncSequencePayloadType.journalEntity,
+    );
     await _outboxService.enqueueMessage(
       SyncMessage.backfillResponse(
         hostId: hostId,

--- a/lib/features/sync/backfill/backfill_response_handler.dart
+++ b/lib/features/sync/backfill/backfill_response_handler.dart
@@ -434,6 +434,19 @@ class BackfillResponseHandler {
       counter,
     );
 
+    // Own-host requests can ONLY be answered from a direct exact-match row
+    // whose payload VC currently covers the requested counter. Covering by a
+    // later entity is unsound for own-host burns: a burnt counter has no
+    // recorded entity, so any "covering" candidate is necessarily a
+    // DIFFERENT entity and its payload does not carry whatever the burnt
+    // write would have mutated. Attributing that payload to the burnt
+    // counter silently mis-maps state on the requester's side. For own-host
+    // misses we therefore send `unresolvable` immediately — our sequence
+    // log is authoritative for our own counters, so any miss is
+    // definitively a burn.
+    final myHost = await _vectorClockService.getHost();
+    final isOwnHost = myHost != null && hostId == myHost;
+
     if (logEntry != null && logEntry.entryId != null) {
       final payloadType = SyncSequencePayloadType.values.elementAt(
         logEntry.payloadType,
@@ -445,8 +458,7 @@ class BackfillResponseHandler {
       final vcCounter = payloadVc?.vclock[hostId];
 
       // An exact row is only safe to answer from when the current payload VC
-      // still covers the requested counter. Otherwise the row is stale and
-      // should fall back to a verified covering entry, not resend first.
+      // still covers the requested counter. Otherwise the row is stale.
       if (payloadVc != null && (vcCounter == null || vcCounter < counter)) {
         _trace(
           'exact entry VC does not cover counter, rejecting '
@@ -455,6 +467,17 @@ class BackfillResponseHandler {
           'vcCounter=$vcCounter',
           subDomain: 'backfill.exactRejected',
         );
+        if (isOwnHost) {
+          // Own-host: do not attempt covering. The stale row means the VC
+          // regressed or the payload is orphaned — either way, the
+          // counter is unresolvable from our authoritative position.
+          await _sendUnresolvableResponse(
+            hostId: hostId,
+            counter: counter,
+            payloadType: payloadType,
+          );
+          return true;
+        }
         logEntry = await _findVerifiedCoveringEntry(
           hostId: hostId,
           requestedCounter: counter,
@@ -462,22 +485,12 @@ class BackfillResponseHandler {
         );
 
         if (logEntry == null) {
-          final myHost = await _vectorClockService.getHost();
-          if (myHost != null && hostId == myHost) {
-            await _sendUnresolvableResponse(
-              hostId: hostId,
-              counter: counter,
-              payloadType: payloadType,
-            );
-            return true;
-          }
           return false;
         }
       }
     }
 
     if (logEntry == null || logEntry.entryId == null) {
-      // Log whether the entry exists at all vs exists without entryId
       _trace(
         'directLookup miss hostId=$hostId counter=$counter '
         'exists=${logEntry != null} entryId=${logEntry?.entryId} '
@@ -485,10 +498,25 @@ class BackfillResponseHandler {
         subDomain: 'backfill.directLookup',
       );
 
-      // Exact counter not found — try to find a covering entry (a higher
-      // counter for the same host that has a resolved payload). This handles
-      // the superseded scenario: counter 5 was superseded by counter 7, so
-      // we only have (host, 7) in our log, not (host, 5).
+      if (isOwnHost) {
+        // Burn: our sequence log has no entry for this own-host counter,
+        // so no write ever carried it. Covering by a later (necessarily
+        // different) entity would misattribute unrelated state to this
+        // counter on the requester's side — always wrong for own-host
+        // burns. Send unresolvable so the requester marks `status=5` and
+        // skips the covering lookup entirely.
+        _trace(
+          'own-host miss → unresolvable (no covering attempted) '
+          'hostId=$hostId counter=$counter',
+          subDomain: 'backfill.unresolvable',
+        );
+        await _sendUnresolvableResponse(hostId: hostId, counter: counter);
+        return true;
+      }
+
+      // Foreign-host counter: we are only a relay, not the originator. A
+      // best-effort covering hint can still help the requester close the
+      // gap if the covering entity coincidentally matches; otherwise skip.
       final covering = await _findVerifiedCoveringEntry(
         hostId: hostId,
         requestedCounter: counter,
@@ -498,20 +526,8 @@ class BackfillResponseHandler {
       if (covering != null) {
         logEntry = covering;
       } else {
-        // No covering entry found either
-        final myHost = await _vectorClockService.getHost();
-        if (myHost != null && hostId == myHost) {
-          _trace(
-            'own counter not found, sending unresolvable '
-            'hostId=$hostId counter=$counter',
-            subDomain: 'backfill.unresolvable',
-          );
-          await _sendUnresolvableResponse(hostId: hostId, counter: counter);
-          return true;
-        }
-        // Not our counter - ignore, another device might have it
         _trace(
-          'counter not found and not our host, skipping '
+          'foreign-host counter not found, skipping '
           'hostId=$hostId counter=$counter myHost=$myHost',
           subDomain: 'backfill.notFound',
         );

--- a/lib/features/sync/repository/sync_maintenance_repository.dart
+++ b/lib/features/sync/repository/sync_maintenance_repository.dart
@@ -211,21 +211,29 @@ class SyncMaintenanceRepository {
 
         var processed = 0;
         for (final entity in entities) {
-          final stamped = entity.copyWith(
-            vectorClock: await _vectorClockService.getNextVectorClock(
-              previous: entity.vectorClock,
-            ),
-          );
-          // Enqueue before persisting so the entity still has a null
-          // vector clock on disk if enqueueMessage throws — making the
-          // row retryable on the next backfill run.
-          await _outboxService.enqueueMessage(
-            SyncMessage.agentEntity(
-              agentEntity: stamped,
-              status: SyncEntryStatus.update,
-            ),
-          );
-          await _agentRepository.upsertEntity(stamped);
+          // Each stamping is its own scope — if the outbox enqueue throws
+          // before the upsertEntity commits to disk, the reservation
+          // releases and the burn handler broadcasts an unresolvable hint.
+          // Once upsertEntity lands, the scope commits regardless of later
+          // failures (commit-on-write invariant).
+          await _vectorClockService.withVcScope<void>(() async {
+            final stamped = entity.copyWith(
+              vectorClock: await _vectorClockService.getNextVectorClock(
+                previous: entity.vectorClock,
+              ),
+            );
+            // Enqueue before persisting so the entity still has a null
+            // vector clock on disk if enqueueMessage throws — making the
+            // row retryable on the next backfill run. Any throw here will
+            // propagate and release the reservation via the scope.
+            await _outboxService.enqueueMessage(
+              SyncMessage.agentEntity(
+                agentEntity: stamped,
+                status: SyncEntryStatus.update,
+              ),
+            );
+            await _agentRepository.upsertEntity(stamped);
+          });
 
           processed++;
           onDetailedProgress?.call(processed, total);
@@ -258,19 +266,22 @@ class SyncMaintenanceRepository {
 
         var processed = 0;
         for (final link in links) {
-          final stamped = link.copyWith(
-            vectorClock: await _vectorClockService.getNextVectorClock(
-              previous: link.vectorClock,
-            ),
-          );
-          // Enqueue before persisting — see backfillAgentEntityClocks.
-          await _outboxService.enqueueMessage(
-            SyncMessage.agentLink(
-              agentLink: stamped,
-              status: SyncEntryStatus.update,
-            ),
-          );
-          await _agentRepository.upsertLink(stamped);
+          await _vectorClockService.withVcScope<void>(() async {
+            final stamped = link.copyWith(
+              vectorClock: await _vectorClockService.getNextVectorClock(
+                previous: link.vectorClock,
+              ),
+            );
+            // Enqueue before persisting — see backfillAgentEntityClocks.
+            // A throw here propagates and releases the reservation.
+            await _outboxService.enqueueMessage(
+              SyncMessage.agentLink(
+                agentLink: stamped,
+                status: SyncEntryStatus.update,
+              ),
+            );
+            await _agentRepository.upsertLink(stamped);
+          });
 
           processed++;
           onDetailedProgress?.call(processed, total);

--- a/lib/features/sync/sequence/sync_sequence_log_service.dart
+++ b/lib/features/sync/sequence/sync_sequence_log_service.dart
@@ -972,6 +972,12 @@ class SyncSequenceLogService {
       SyncSequenceLogCompanion(
         hostId: Value(hostId),
         counter: Value(counter),
+        // Explicitly clear any stale entry_id on an existing row (e.g. one
+        // inserted earlier via a covered-VC hint referring to a different
+        // entity). The unresolvable marker must stand alone — a lingering
+        // entry_id would let later reset/verify paths treat the counter as
+        // if it had a known payload and reopen it.
+        entryId: const Value(null),
         payloadType: Value(payloadType.index),
         status: Value(SyncSequenceStatus.unresolvable.index),
         createdAt: Value(now),
@@ -1008,12 +1014,51 @@ class SyncSequenceLogService {
     }
 
     if (unresolvable) {
-      // Mark as unresolvable - the originating host cannot resolve its own
-      // counter. This is permanent; the entry will never be backfilled.
-      await _syncDatabase.updateSequenceStatus(
+      // Mark as unresolvable. Upsert (not update-only) because a proactive
+      // burn broadcast from the originator frequently arrives on a peer
+      // that has not yet materialized `(hostId, counter)` — gap detection
+      // hasn't run for this host yet, no covered-VC hint has referenced
+      // the counter, and so on. An `updateSequenceStatus` call would
+      // silently no-op in that common case and drop the authoritative
+      // marker, sending the peer back into reactive backfill later when
+      // the gap eventually surfaces.
+      //
+      // Do NOT downgrade rows that already have an authoritative success
+      // state (received / backfilled / deleted) — if the peer obtained
+      // the payload through another route, that's strictly better than
+      // the originator's unresolvable hint and should win.
+      final existing = await _syncDatabase.getEntryByHostAndCounter(
         hostId,
         counter,
-        SyncSequenceStatus.unresolvable,
+      );
+      if (existing != null &&
+          (existing.status == SyncSequenceStatus.received.index ||
+              existing.status == SyncSequenceStatus.backfilled.index ||
+              existing.status == SyncSequenceStatus.deleted.index)) {
+        _trace(
+          'handleBackfillResponse: unresolvable ignored for '
+          'hostId=$hostId counter=$counter — existing status='
+          '${SyncSequenceStatus.values[existing.status]}',
+          subDomain: 'sequence.backfillResponse',
+        );
+        return;
+      }
+
+      final now = DateTime.now();
+      await _syncDatabase.recordSequenceEntry(
+        SyncSequenceLogCompanion(
+          hostId: Value(hostId),
+          counter: Value(counter),
+          // Clear any stale payload mapping for the same reason as in
+          // [markOwnCounterUnresolvable]: the unresolvable marker asserts
+          // no entity is bound to this counter, and a lingering entry_id
+          // would let later reset/verify paths reopen it.
+          entryId: const Value(null),
+          payloadType: Value(payloadType.index),
+          status: Value(SyncSequenceStatus.unresolvable.index),
+          createdAt: Value(existing?.createdAt ?? now),
+          updatedAt: Value(now),
+        ),
       );
 
       _trace(

--- a/lib/features/sync/sequence/sync_sequence_log_service.dart
+++ b/lib/features/sync/sequence/sync_sequence_log_service.dart
@@ -938,6 +938,52 @@ class SyncSequenceLogService {
   ///
   /// This two-phase approach ensures we don't mark entries as backfilled
   /// until we actually have the data locally.
+  /// Mark one of OUR OWN host's counters as permanently unresolvable.
+  ///
+  /// Called by paths that know authoritatively that a counter was assigned by
+  /// our [VectorClockService] but will never carry a Matrix event — burns
+  /// from [VectorClockService.reserveNextVectorClock] that released without
+  /// a matching write, and own-host miss/stale cases in
+  /// `backfill_response_handler` that answer peers with `unresolvable`.
+  ///
+  /// Why an upsert (not just [SyncDatabase.updateSequenceStatus]): the burn
+  /// case usually has no row in our sequence log at all (we never
+  /// `recordSentEntry`-ed the counter), so an update-only call would silently
+  /// no-op. Insert-or-update pins the row to `status=unresolvable` with
+  /// `entry_id` explicitly null — asserting "no entity was ever bound to this
+  /// counter on this host." Subsequent paths that might have otherwise
+  /// inserted the row with the wrong entity_id (covered-VC hints referring
+  /// to our own host, if any skip is ever relaxed) will then see an existing
+  /// authoritative row and leave it alone.
+  ///
+  /// Not wired through [handleBackfillResponse] because that is the handler
+  /// for INCOMING responses, and own-host broadcasts never flow through it
+  /// on the originator — self-echoes are suppressed in the Matrix pipeline.
+  /// Going through the receiver handler on the sender side would misrepresent
+  /// the call's intent and break the moment someone tightens the handler
+  /// contract (e.g. gates it on a pending request).
+  Future<void> markOwnCounterUnresolvable({
+    required String hostId,
+    required int counter,
+    SyncSequencePayloadType payloadType = SyncSequencePayloadType.journalEntity,
+  }) async {
+    final now = DateTime.now();
+    await _syncDatabase.recordSequenceEntry(
+      SyncSequenceLogCompanion(
+        hostId: Value(hostId),
+        counter: Value(counter),
+        payloadType: Value(payloadType.index),
+        status: Value(SyncSequenceStatus.unresolvable.index),
+        createdAt: Value(now),
+        updatedAt: Value(now),
+      ),
+    );
+    _trace(
+      'markOwnCounterUnresolvable hostId=$hostId counter=$counter',
+      subDomain: 'sequence.ownUnresolvable',
+    );
+  }
+
   Future<void> handleBackfillResponse({
     required String hostId,
     required int counter,

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -367,14 +367,24 @@ Future<void> registerSingletons() async {
   // fire-and-forget by design: it must never throw and must never block the
   // caller — see VectorClockService._onReleaseBurn.
   vectorClockService.setBurnHandler((counter) {
-    // Fire-and-forget: schedule the enqueue, swallow failures at the handler
-    // boundary. `unawaited` would still surface errors to the zone; we catch
-    // explicitly so a transient outbox issue doesn't poison the write path
-    // that triggered the burn.
+    // Fire-and-forget: schedule the local-log write + broadcast, swallow
+    // failures at the handler boundary. `unawaited` would still surface
+    // errors to the zone; we catch explicitly so a transient sequence-log
+    // or outbox issue doesn't poison the write path that triggered the
+    // burn.
     Future<void>(() async {
       try {
         final host = await vectorClockService.getHost();
         if (host == null) return;
+        // Record in our OWN sequence log first so our local state matches
+        // what peers will see after receiving the broadcast below. We do
+        // NOT route through handleBackfillResponse because self-echoes are
+        // suppressed on the Matrix pipeline — that handler never fires for
+        // our own message on our own side.
+        await syncSequenceLogService.markOwnCounterUnresolvable(
+          hostId: host,
+          counter: counter,
+        );
         await outboxService.enqueueMessage(
           SyncMessage.backfillResponse(
             hostId: host,
@@ -391,8 +401,8 @@ Future<void> registerSingletons() async {
       } catch (error, stackTrace) {
         domainLogger.error(
           LogDomains.sync,
-          'vc burn broadcast enqueue failed; counter $counter will fall '
-          'back to reactive backfill resolution',
+          'vc burn broadcast failed; counter $counter will fall back to '
+          'reactive backfill resolution',
           error: error,
           stackTrace: stackTrace,
           subDomain: 'vc.burn.broadcast',

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -40,6 +40,7 @@ import 'package:lotti/features/sync/matrix/session_manager.dart';
 import 'package:lotti/features/sync/matrix/sync_event_processor.dart';
 import 'package:lotti/features/sync/matrix/sync_room_discovery.dart';
 import 'package:lotti/features/sync/matrix/sync_room_manager.dart';
+import 'package:lotti/features/sync/model/sync_message.dart';
 import 'package:lotti/features/sync/outbox/outbox_service.dart';
 import 'package:lotti/features/sync/queue/queue_pipeline_coordinator.dart';
 import 'package:lotti/features/sync/secure_storage.dart';
@@ -357,6 +358,48 @@ Future<void> registerSingletons() async {
 
   // Self-healing sync: create backfill services after OutboxService is available
   final outboxService = getIt<OutboxService>();
+
+  // Proactive VC burn broadcast: when a reservation releases (write rejected,
+  // scope threw, commitWhen=false), enqueue a SyncBackfillResponse with
+  // unresolvable=true so peers close the gap on arrival instead of having to
+  // issue a backfill request first. Registered here because the handler has
+  // to fire into OutboxService, which is only now available. The handler is
+  // fire-and-forget by design: it must never throw and must never block the
+  // caller — see VectorClockService._onReleaseBurn.
+  vectorClockService.setBurnHandler((counter) {
+    // Fire-and-forget: schedule the enqueue, swallow failures at the handler
+    // boundary. `unawaited` would still surface errors to the zone; we catch
+    // explicitly so a transient outbox issue doesn't poison the write path
+    // that triggered the burn.
+    Future<void>(() async {
+      try {
+        final host = await vectorClockService.getHost();
+        if (host == null) return;
+        await outboxService.enqueueMessage(
+          SyncMessage.backfillResponse(
+            hostId: host,
+            counter: counter,
+            deleted: false,
+            unresolvable: true,
+          ),
+        );
+        domainLogger.log(
+          LogDomains.sync,
+          'vc.burn.broadcast host=$host counter=$counter',
+          subDomain: 'vc.burn.broadcast',
+        );
+      } catch (error, stackTrace) {
+        domainLogger.error(
+          LogDomains.sync,
+          'vc burn broadcast enqueue failed; counter $counter will fall '
+          'back to reactive backfill resolution',
+          error: error,
+          stackTrace: stackTrace,
+          subDomain: 'vc.burn.broadcast',
+        );
+      }
+    });
+  });
   final backfillResponseHandler = BackfillResponseHandler(
     journalDb: journalDb,
     sequenceLogService: syncSequenceLogService,

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -366,28 +366,33 @@ Future<void> registerSingletons() async {
   // to fire into OutboxService, which is only now available. The handler is
   // fire-and-forget by design: it must never throw and must never block the
   // caller — see VectorClockService._onReleaseBurn.
-  vectorClockService.setBurnHandler((counter) {
+  vectorClockService.setBurnHandler((hostId, counter) {
     // Fire-and-forget: schedule the local-log write + broadcast, swallow
     // failures at the handler boundary. `unawaited` would still surface
     // errors to the zone; we catch explicitly so a transient sequence-log
     // or outbox issue doesn't poison the write path that triggered the
     // burn.
+    //
+    // [hostId] is the host captured at reservation time, not whatever
+    // [VectorClockService.getHost] returns now — if setNewHost ran between
+    // reserve and release the broadcast would otherwise be attributed to
+    // the new host, producing a phantom unresolvable on the new host's
+    // counter space and leaving the actual burnt counter on the old host
+    // unannounced.
     Future<void>(() async {
       try {
-        final host = await vectorClockService.getHost();
-        if (host == null) return;
         // Record in our OWN sequence log first so our local state matches
         // what peers will see after receiving the broadcast below. We do
         // NOT route through handleBackfillResponse because self-echoes are
         // suppressed on the Matrix pipeline — that handler never fires for
         // our own message on our own side.
         await syncSequenceLogService.markOwnCounterUnresolvable(
-          hostId: host,
+          hostId: hostId,
           counter: counter,
         );
         await outboxService.enqueueMessage(
           SyncMessage.backfillResponse(
-            hostId: host,
+            hostId: hostId,
             counter: counter,
             deleted: false,
             unresolvable: true,
@@ -395,7 +400,7 @@ Future<void> registerSingletons() async {
         );
         domainLogger.log(
           LogDomains.sync,
-          'vc.burn.broadcast host=$host counter=$counter',
+          'vc.burn.broadcast host=$hostId counter=$counter',
           subDomain: 'vc.burn.broadcast',
         );
       } catch (error, stackTrace) {

--- a/lib/services/vector_clock_service.dart
+++ b/lib/services/vector_clock_service.dart
@@ -6,18 +6,39 @@ import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/features/sync/utils.dart';
 import 'package:lotti/features/sync/vector_clock.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/utils/file_utils.dart';
 import 'package:meta/meta.dart';
 
 /// A reservation for the next vector clock counter.
 ///
-/// Every counter advance flows through a reservation. The in-memory watermark
-/// is bumped synchronously at [VectorClockService.reserveNextVectorClock] time
-/// so concurrent reservations do not collide, but the persistent watermark
-/// only moves on [commit]. [release] leaves the persistent state untouched.
+/// **Persistence is eager (collision-safe, burn-accepting).** The persisted
+/// watermark in [SettingsDb] is advanced synchronously at
+/// [VectorClockService.reserveNextVectorClock] time, BEFORE any entity write
+/// can commit with the returned counter.
+///
+/// The VC counter lives in `SettingsDb` while entity writes hit other Drift
+/// databases (`JournalDb`, `AgentDatabase`) and outbox writes hit a third
+/// (`SyncDatabase`) — no transaction spans any two of those files. If we
+/// persisted the counter AFTER the entity write, a crash between the entity
+/// commit and the counter persist would let the next reservation re-hand an
+/// already-used counter: **cross-entity VC collision on disk — permanent,
+/// unrecoverable, breaks vector-clock semantics.** Persist-first makes the
+/// opposite tradeoff: a crash (or a rejected/failed write) can burn a
+/// counter — no entity carries it — which IS recoverable.
+///
+/// Recovery of burnt counters:
+/// - [release] logs the burn and emits a proactive `unresolvable` broadcast
+///   (when a handler is registered — see
+///   [VectorClockService.setBurnHandler]) so receivers mark the counter as
+///   `unresolvable` on arrival instead of waiting for a backfill round-trip.
+/// - If the broadcast is missed (offline, crash before enqueue), the
+///   fallback is the existing backfill path: the originator answers
+///   `unresolvable` when a peer eventually requests the missing counter via
+///   `backfill_response_handler.dart`'s "own counter not found" branch.
 ///
 /// A reservation must be finalized exactly once. [VectorClockService.withVcScope]
-/// handles this for nested callers automatically; callers of
+/// handles this for nested callers automatically; direct callers of
 /// [VectorClockService.reserveNextVectorClock] outside a scope must finalize
 /// the returned reservation themselves.
 class VcReservation {
@@ -32,31 +53,24 @@ class VcReservation {
   /// Whether the reservation is still pending (neither committed nor released).
   bool get isPending => !_finalized;
 
-  /// Persist the counter advance. Idempotent: subsequent calls are no-ops.
-  ///
-  /// Call this only after the entire write+enqueue pipeline that is supposed
-  /// to carry the counter has completed successfully. A burnt commit means a
-  /// counter is consumed on disk but no Matrix event was emitted carrying it,
-  /// producing a gap on receivers.
+  /// Acknowledge the reservation on a successful write. No-op — the counter
+  /// was already persisted at [VectorClockService.reserveNextVectorClock]
+  /// time. Retained for API stability so [VectorClockService.withVcScope] can
+  /// drive a single finalization path. Idempotent.
   Future<void> commit() async {
     if (_finalized) return;
     _finalized = true;
-    await _service._commitReservation(_counter);
   }
 
-  /// Roll back the reservation without persisting. Idempotent.
-  ///
-  /// The in-memory watermark will rewind only when this was the most-recent
-  /// reservation AND no other reservations are outstanding. Otherwise the
-  /// counter is abandoned in-memory (no persisted burn), which means the
-  /// next reservation may skip past it — a receiver that observes a later
-  /// Matrix event from this host will detect the gap, and the originator
-  /// will answer any backfill request for the abandoned counter with
-  /// `unresolvable` via the sequence log's "own counter not found" path.
+  /// Acknowledge that the reservation will not carry an entity/Matrix event.
+  /// The counter is already persisted on disk; this call logs the burn and
+  /// asks the registered burn handler (if any) to broadcast an
+  /// `unresolvable` hint to peers so they can resolve the gap immediately
+  /// instead of waiting for the next backfill round-trip. Idempotent.
   void release() {
     if (_finalized) return;
     _finalized = true;
-    _service._releaseReservation(_counter);
+    _service._onReleaseBurn(_counter);
   }
 }
 
@@ -67,6 +81,16 @@ class _VcScope {
   final List<VcReservation> reservations = [];
 }
 
+/// Handler invoked synchronously when a reserved counter is released without
+/// a matching write (a "burn"). Implementations typically enqueue a proactive
+/// `SyncBackfillResponse(unresolvable=true)` for the given counter so peers
+/// close the gap without waiting for the reactive backfill-request path.
+///
+/// The handler MUST NOT throw. Errors are the handler's responsibility to log
+/// and swallow — the VC counter is already persisted and cannot be rewound,
+/// so a handler exception would be uselessly destructive.
+typedef VcBurnHandler = void Function(int counter);
+
 class VectorClockService {
   VectorClockService() {
     _initialized = init();
@@ -75,22 +99,33 @@ class VectorClockService {
   static const Symbol _zoneKey = #_vcScope;
 
   /// The maximum counter that has been persisted to [SettingsDb].
-  /// Always `<= _nextAvailableCounter`.
+  /// Under persist-on-reserve semantics [_persistedCounter] and
+  /// [_nextAvailableCounter] are always equal outside of the tiny window
+  /// inside [reserveNextVectorClock] where the in-memory bump and the
+  /// [_persistCounter] write are not yet complete.
   late int _persistedCounter;
 
-  /// The next counter to hand out. Advanced synchronously by
-  /// [reserveNextVectorClock] before any persistence so concurrent reservations
-  /// see distinct counters; rewound by [_releaseReservation] only when this
-  /// was the most-recent reservation with no siblings outstanding.
+  /// The next counter to hand out. Advanced synchronously inside
+  /// [reserveNextVectorClock]; see [_persistedCounter] for the persistence
+  /// invariant.
   late int _nextAvailableCounter;
 
   late String _host;
 
-  /// Set of counters reserved but not yet committed or released. Used by
-  /// release to decide whether a rewind is safe.
-  final Set<int> _outstanding = <int>{};
-
   late final Future<void> _initialized;
+
+  /// Serializes [reserveNextVectorClock] so the in-memory bump, the
+  /// [SettingsDb] write, and the return of the reservation happen atomically
+  /// from the caller's perspective. Concurrent reservations then see
+  /// monotonically increasing counters without ever racing past each other.
+  Future<void>? _reserveLock;
+
+  /// Proactive "this counter is unresolvable" broadcast hook. Set by the
+  /// composition root via [setBurnHandler]; not wired by default so unit tests
+  /// and bootstrap paths (pre-outbox) do not blow up on a null handler. When
+  /// absent, burns still log and the backfill responder's reactive path
+  /// covers the gap on peer request.
+  VcBurnHandler? _burnHandler;
 
   /// Future that completes when initialization is done.
   /// Await this before using the service to ensure it's ready.
@@ -125,7 +160,6 @@ class VectorClockService {
     _host = host;
     _persistedCounter = 0;
     _nextAvailableCounter = 0;
-    _outstanding.clear();
     await _persistCounter(0);
     return host;
   }
@@ -146,64 +180,81 @@ class VectorClockService {
     return digest.toString();
   }
 
-  /// Reserve the next vector clock counter.
-  ///
-  /// The reservation bumps the in-memory watermark but does not persist. The
-  /// caller is responsible for finalizing the reservation via
-  /// [VcReservation.commit] (advance the persisted watermark) or
-  /// [VcReservation.release] (roll back).
-  ///
-  /// When called inside [withVcScope], the reservation is automatically
-  /// attached to the scope and the scope handles the finalization based on
-  /// the action's outcome.
-  Future<VcReservation> reserveNextVectorClock({VectorClock? previous}) async {
-    await _initialized;
-    // Synchronous block — no await between read and write of
-    // _nextAvailableCounter, so Dart's single-threaded execution model makes
-    // the arithmetic atomic.
-    final previousHostCounter = previous?.vclock[_host];
-    final int effectiveCounter;
-    if (previousHostCounter != null &&
-        previousHostCounter >= _nextAvailableCounter) {
-      // Previous clock has a counter >= ours for our host - catch up.
-      effectiveCounter = previousHostCounter + 1;
-    } else {
-      effectiveCounter = _nextAvailableCounter;
-    }
-    _nextAvailableCounter = effectiveCounter + 1;
-    _outstanding.add(effectiveCounter);
-
-    final reservation = VcReservation._(
-      VectorClock({...?previous?.vclock, _host: effectiveCounter}),
-      effectiveCounter,
-      this,
-    );
-
-    final scope = Zone.current[_zoneKey] as _VcScope?;
-    if (scope != null) {
-      scope.reservations.add(reservation);
-    }
-
-    return reservation;
+  /// Register the proactive burn-broadcast handler. Call this from the
+  /// composition root after `OutboxService` is ready. Passing `null` clears
+  /// the handler (useful in tests).
+  // ignore: use_setters_to_change_properties
+  void setBurnHandler(VcBurnHandler? handler) {
+    _burnHandler = handler;
   }
 
-  /// Obtain the next vector clock with scope-aware auto-commit semantics.
+  /// Reserve the next vector clock counter.
   ///
-  /// - Outside a [withVcScope]: the reservation is committed immediately
-  ///   (legacy behavior — a burnt counter if the caller's write fails).
-  /// - Inside a [withVcScope]: the reservation is attached to the scope and
-  ///   finalized according to the action's outcome (commit on success, release
-  ///   on failure or `commitWhen == false`).
-  ///
-  /// Prefer wrapping a failable write path in [withVcScope] so the counter
-  /// rolls back when the write rejects (e.g., `applied=false`).
+  /// Persists the advance to [SettingsDb] BEFORE returning — see the
+  /// [VcReservation] class doc for why. The returned reservation must still
+  /// be finalized via [VcReservation.commit] on success or
+  /// [VcReservation.release] on failure (commit is a no-op; release logs +
+  /// broadcasts the burn). When called inside [withVcScope] the finalization
+  /// is automatic.
+  Future<VcReservation> reserveNextVectorClock({VectorClock? previous}) async {
+    await _initialized;
+
+    // Serialize so concurrent reservers never observe the same
+    // _nextAvailableCounter between the in-memory bump and the [_persistCounter]
+    // flush. Dart's single-threaded execution guards synchronous code, but
+    // [_persistCounter] awaits a Drift write, and without this lock another
+    // reserver could overtake us between the await points.
+    while (_reserveLock != null) {
+      await _reserveLock;
+    }
+    final completer = Completer<void>();
+    _reserveLock = completer.future;
+    try {
+      final previousHostCounter = previous?.vclock[_host];
+      final int effectiveCounter;
+      if (previousHostCounter != null &&
+          previousHostCounter >= _nextAvailableCounter) {
+        // Previous clock has a counter >= ours for our host — catch up.
+        effectiveCounter = previousHostCounter + 1;
+      } else {
+        effectiveCounter = _nextAvailableCounter;
+      }
+      final newWatermark = effectiveCounter + 1;
+      _nextAvailableCounter = newWatermark;
+      if (_persistedCounter < newWatermark) {
+        _persistedCounter = newWatermark;
+        await _persistCounter(newWatermark);
+      }
+
+      final reservation = VcReservation._(
+        VectorClock({...?previous?.vclock, _host: effectiveCounter}),
+        effectiveCounter,
+        this,
+      );
+
+      final scope = Zone.current[_zoneKey] as _VcScope?;
+      if (scope != null) {
+        scope.reservations.add(reservation);
+      }
+
+      return reservation;
+    } finally {
+      _reserveLock = null;
+      completer.complete();
+    }
+  }
+
+  /// Obtain the next vector clock, attaching to an ambient [withVcScope] when
+  /// one is present (so a burn-broadcast fires on action failure) and
+  /// otherwise committing immediately (counter already persisted on reserve,
+  /// so a non-scoped caller that never runs a matching write will burn a
+  /// counter — prefer [withVcScope] for failable writes).
   Future<VectorClock> getNextVectorClock({VectorClock? previous}) async {
     final reservation = await reserveNextVectorClock(previous: previous);
     final scope = Zone.current[_zoneKey] as _VcScope?;
     if (scope == null) {
       await reservation.commit();
     }
-    // Inside a scope, the scope finalizes the reservation.
     return reservation.vc;
   }
 
@@ -211,19 +262,19 @@ class VectorClockService {
   ///
   /// Every call to [reserveNextVectorClock] / [getNextVectorClock] made
   /// inside [action] (or transitively, including through other services such
-  /// as `MetadataService`) attaches its reservation to this scope instead of
-  /// committing immediately.
+  /// as `MetadataService`) attaches its reservation to this scope.
   ///
   /// On completion:
   /// - [action] returns normally AND ([commitWhen] is null OR
-  ///   `commitWhen(result)` is true) → all reservations in this scope commit.
-  /// - [action] throws → all reservations release. The exception rethrows.
+  ///   `commitWhen(result)` is true) → all reservations commit (no-op;
+  ///   counters already persisted).
+  /// - [action] throws → all reservations release → each burn is logged and
+  ///   broadcast via the burn handler. The exception rethrows.
   /// - `commitWhen(result)` is false → all reservations release; [action]'s
   ///   result is still returned.
   ///
-  /// Nested scopes are supported: an inner [withVcScope] call delegates to
-  /// the existing outer scope (no new scope is created), so a single
-  /// commit/release decision covers the whole nested chain.
+  /// Nested scopes delegate to the outermost scope so a single commit/release
+  /// decision covers the whole nested chain.
   Future<T> withVcScope<T>(
     Future<T> Function() action, {
     bool Function(T result)? commitWhen,
@@ -244,9 +295,6 @@ class VectorClockService {
           await reservation.commit();
         }
       } else {
-        // Release in reverse order so the rewind heuristic in
-        // [_releaseReservation] can collapse a contiguous tail back to the
-        // pre-reservation watermark.
         for (final reservation in scope.reservations.reversed) {
           reservation.release();
         }
@@ -260,25 +308,36 @@ class VectorClockService {
     }
   }
 
-  Future<void> _commitReservation(int counter) async {
-    _outstanding.remove(counter);
-    final target = counter + 1;
-    if (_persistedCounter < target) {
-      _persistedCounter = target;
-      await _persistCounter(target);
+  /// Called by [VcReservation.release]. Logs the burn and invokes the
+  /// registered broadcast handler (if any). Swallows handler exceptions —
+  /// the counter is already on disk, so a throw here would be destructive
+  /// for no benefit.
+  void _onReleaseBurn(int counter) {
+    // DomainLogger may not be registered in some test harnesses / bootstrap
+    // paths; use the `isRegistered` guard so a release on a minimally-wired
+    // service (e.g. unit test seeding the SettingsDb counter) does not crash.
+    if (getIt.isRegistered<DomainLogger>()) {
+      getIt<DomainLogger>().error(
+        LogDomains.sync,
+        'VC counter burnt (reservation released; counter already persisted)',
+        subDomain: 'vc.burn',
+      );
     }
-  }
-
-  void _releaseReservation(int counter) {
-    _outstanding.remove(counter);
-    // Rewind the in-memory watermark only when this release targets the
-    // most-recent reservation (`counter + 1 == _nextAvailableCounter`).
-    // Callers that release in reverse chronological order (including the
-    // [withVcScope] finalizer) collapse a contiguous tail back to the
-    // pre-scope watermark. A middle-release leaves a gap that sibling
-    // reservations already committed past — that counter is abandoned.
-    if (_nextAvailableCounter == counter + 1) {
-      _nextAvailableCounter = counter;
+    final handler = _burnHandler;
+    if (handler == null) return;
+    try {
+      handler(counter);
+    } catch (error, stackTrace) {
+      if (getIt.isRegistered<DomainLogger>()) {
+        getIt<DomainLogger>().error(
+          LogDomains.sync,
+          'VC burn broadcast handler threw — counter $counter will fall back '
+          'to reactive backfill resolution',
+          error: error,
+          stackTrace: stackTrace,
+          subDomain: 'vc.burn.handler',
+        );
+      }
     }
   }
 
@@ -302,7 +361,6 @@ class VectorClockService {
   Future<void> setNextAvailableCounter(int counter) async {
     _nextAvailableCounter = counter;
     _persistedCounter = counter;
-    _outstanding.clear();
     await _persistCounter(counter);
   }
 

--- a/lib/services/vector_clock_service.dart
+++ b/lib/services/vector_clock_service.dart
@@ -42,11 +42,17 @@ import 'package:meta/meta.dart';
 /// [VectorClockService.reserveNextVectorClock] outside a scope must finalize
 /// the returned reservation themselves.
 class VcReservation {
-  VcReservation._(this.vc, this._counter, this._service);
+  VcReservation._(this.vc, this._counter, this._hostId, this._service);
 
   /// The reserved vector clock.
   final VectorClock vc;
   final int _counter;
+
+  /// The host ID at the time of reservation. Captured so that a later burn
+  /// broadcast attributes the counter to the correct host even if
+  /// [VectorClockService.setNewHost] swaps the service's host between
+  /// reservation and release.
+  final String _hostId;
   final VectorClockService _service;
   bool _finalized = false;
 
@@ -70,7 +76,7 @@ class VcReservation {
   void release() {
     if (_finalized) return;
     _finalized = true;
-    _service._onReleaseBurn(_counter);
+    _service._onReleaseBurn(_hostId, _counter);
   }
 }
 
@@ -83,13 +89,20 @@ class _VcScope {
 
 /// Handler invoked synchronously when a reserved counter is released without
 /// a matching write (a "burn"). Implementations typically enqueue a proactive
-/// `SyncBackfillResponse(unresolvable=true)` for the given counter so peers
-/// close the gap without waiting for the reactive backfill-request path.
+/// `SyncBackfillResponse(unresolvable=true)` for the given `(hostId, counter)`
+/// so peers close the gap without waiting for the reactive backfill-request
+/// path.
+///
+/// [hostId] is the host captured at reservation time, NOT the service's
+/// current host at broadcast time. These can differ if
+/// [VectorClockService.setNewHost] runs between reservation and release —
+/// the broadcast must attribute the burnt counter to the host that actually
+/// reserved it.
 ///
 /// The handler MUST NOT throw. Errors are the handler's responsibility to log
 /// and swallow — the VC counter is already persisted and cannot be rewound,
 /// so a handler exception would be uselessly destructive.
-typedef VcBurnHandler = void Function(int counter);
+typedef VcBurnHandler = void Function(String hostId, int counter);
 
 class VectorClockService {
   VectorClockService() {
@@ -229,6 +242,7 @@ class VectorClockService {
       final reservation = VcReservation._(
         VectorClock({...?previous?.vclock, _host: effectiveCounter}),
         effectiveCounter,
+        _host,
         this,
       );
 
@@ -312,7 +326,12 @@ class VectorClockService {
   /// registered broadcast handler (if any). Swallows handler exceptions —
   /// the counter is already on disk, so a throw here would be destructive
   /// for no benefit.
-  void _onReleaseBurn(int counter) {
+  ///
+  /// [hostId] is the host captured at reservation time; may differ from the
+  /// service's current [_host] if [setNewHost] ran between reserve and
+  /// release. The broadcast must attribute the burnt counter to the host
+  /// that actually reserved it.
+  void _onReleaseBurn(String hostId, int counter) {
     // DomainLogger may not be registered in some test harnesses / bootstrap
     // paths; use the `isRegistered` guard so a release on a minimally-wired
     // service (e.g. unit test seeding the SettingsDb counter) does not crash.
@@ -326,7 +345,7 @@ class VectorClockService {
     final handler = _burnHandler;
     if (handler == null) return;
     try {
-      handler(counter);
+      handler(hostId, counter);
     } catch (error, stackTrace) {
       if (getIt.isRegistered<DomainLogger>()) {
         getIt<DomainLogger>().error(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.973+3976
+version: 0.9.973+3977
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.973+3975
+version: 0.9.973+3976
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.973+3974
+version: 0.9.973+3975
 
 msix_config:
   display_name: LottiApp

--- a/test/features/sync/backfill/backfill_response_handler_test.dart
+++ b/test/features/sync/backfill/backfill_response_handler_test.dart
@@ -436,11 +436,15 @@ void main() {
     );
 
     test(
-      'skips stale covering entry and uses next valid covering entry',
+      'own-host miss sends unresolvable immediately — does NOT attempt '
+      'covering. A covering entity is a DIFFERENT entity whose VC '
+      'monotonically dominates the requested counter only on the same '
+      'host axis, which is not true VC dominance (would require same '
+      'entity). For our own host the sequence log is authoritative, so '
+      'a miss is definitively a burn and the correct answer is '
+      'unresolvable — otherwise the requester mis-attributes the '
+      "covering entity's payload to a counter it never carried.",
       () async {
-        // Request for our own counter 100. First covering entry at counter 200
-        // has a stale VC ({aliceHostId: 50}). Second covering entry at counter
-        // 300 has a valid VC ({aliceHostId: 100}).
         const staleEntryId = 'stale-entry-id';
         const validEntryId = 'valid-entry-id';
         const request = SyncBackfillRequest(
@@ -454,7 +458,8 @@ void main() {
           () => mockSequenceService.getEntryByHostAndCounter(aliceHostId, 100),
         ).thenAnswer((_) async => null);
 
-        // First covering entry at counter 200 — stale VC
+        // Even if a covering entity were available, own-host burns must
+        // not take that path — these stubs model what USED to happen.
         when(
           () => mockSequenceService.getNearestCoveringEntry(aliceHostId, 100),
         ).thenAnswer(
@@ -465,8 +470,6 @@ void main() {
             originatingHostId: aliceHostId,
           ),
         );
-
-        // Second covering entry at counter 300 — valid VC
         when(
           () => mockSequenceService.getNearestCoveringEntry(aliceHostId, 201),
         ).thenAnswer(
@@ -477,8 +480,6 @@ void main() {
             originatingHostId: aliceHostId,
           ),
         );
-
-        // Stale entry: VC is behind
         when(
           () => mockJournalDb.journalEntityById(staleEntryId),
         ).thenAnswer(
@@ -487,8 +488,6 @@ void main() {
             vectorClock: const VectorClock({aliceHostId: 50}),
           ),
         );
-
-        // Valid entry: VC covers the requested counter
         when(
           () => mockJournalDb.journalEntityById(validEntryId),
         ).thenAnswer(
@@ -504,20 +503,20 @@ void main() {
 
         await handler.handleBackfillRequest(request);
 
-        // Capture all enqueued messages and verify the valid entry was sent
         final captured = verify(
           () => mockOutboxService.enqueueMessage(captureAny()),
         ).captured.cast<SyncMessage>();
 
-        // The journal entity must reference the valid entry, not the stale one
-        final journalMsg = captured.whereType<SyncJournalEntity>().single;
-        expect(journalMsg.id, validEntryId);
-
-        // No unresolvable response should have been sent
-        final unresolvable = captured.whereType<SyncBackfillResponse>().where(
-          (r) => r.unresolvable ?? false,
+        // Exactly one response — unresolvable. No covering entity sent.
+        expect(captured.length, 1);
+        expect(
+          captured.single,
+          isA<SyncBackfillResponse>()
+              .having((r) => r.hostId, 'hostId', aliceHostId)
+              .having((r) => r.counter, 'counter', 100)
+              .having((r) => r.unresolvable, 'unresolvable', true),
         );
-        expect(unresolvable, isEmpty);
+        expect(captured.whereType<SyncJournalEntity>(), isEmpty);
       },
     );
 
@@ -702,7 +701,13 @@ void main() {
     });
 
     test(
-      'falls back to verified covering entry when exact own counter VC is behind',
+      'own-host exact row with stale VC sends unresolvable — does NOT '
+      'fall back to covering. Stale here means our authoritative '
+      "sequence-log row exists but the payload's current VC has "
+      'regressed below the requested counter, so the row is orphaned. '
+      'Covering by a later (necessarily different) entity would silently '
+      "mis-attribute its payload to this counter on the requester's "
+      'side — the only safe answer from the originator is unresolvable.',
       () async {
         const coveringEntryId = 'covering-entry-id';
         const request = SyncBackfillRequest(
@@ -718,6 +723,8 @@ void main() {
           (_) async => _createLogItem(aliceHostId, 3, entryId: entryId),
         );
 
+        // Covering stub retained to prove the handler does NOT consult it
+        // for own-host misses.
         when(
           () => mockSequenceService.getNearestCoveringEntry(aliceHostId, 4),
         ).thenAnswer(
@@ -729,6 +736,8 @@ void main() {
           ),
         );
 
+        // Exact row's payload has a stale VC ({alice: 0}) that does not
+        // cover counter 3.
         when(
           () => mockJournalDb.journalEntityById(entryId),
         ).thenAnswer((_) async => _createJournalEntry(entryId));
@@ -752,23 +761,18 @@ void main() {
           () => mockOutboxService.enqueueMessage(captureAny()),
         ).captured;
 
-        expect(captured.length, 2);
+        expect(captured.length, 1);
         expect(
-          captured[0],
-          isA<SyncJournalEntity>().having(
-            (message) => message.id,
-            'id',
-            coveringEntryId,
-          ),
-        );
-        expect(
-          captured[1],
+          captured.single,
           isA<SyncBackfillResponse>()
               .having((r) => r.hostId, 'hostId', aliceHostId)
               .having((r) => r.counter, 'counter', 3)
-              .having((r) => r.deleted, 'deleted', false)
-              .having((r) => r.payloadId, 'payloadId', coveringEntryId)
-              .having((r) => r.unresolvable, 'unresolvable', isNull),
+              .having((r) => r.unresolvable, 'unresolvable', true),
+        );
+        expect(
+          captured.whereType<SyncJournalEntity>(),
+          isEmpty,
+          reason: 'No covering payload must be sent for own-host stale rows',
         );
       },
     );

--- a/test/features/sync/backfill/backfill_response_handler_test.dart
+++ b/test/features/sync/backfill/backfill_response_handler_test.dart
@@ -99,6 +99,18 @@ void main() {
       () => mockSequenceService.getNearestCoveringEntry(any(), any()),
     ).thenAnswer((_) async => null);
 
+    // `_sendUnresolvableResponse` now also writes to our own sequence log so
+    // the local state matches what peers will see after receiving the
+    // broadcast. Stub as a no-op for every test — assertions that care can
+    // still verify the call via `verify(...)`.
+    when(
+      () => mockSequenceService.markOwnCounterUnresolvable(
+        hostId: any(named: 'hostId'),
+        counter: any(named: 'counter'),
+        payloadType: any(named: 'payloadType'),
+      ),
+    ).thenAnswer((_) async {});
+
     handler = BackfillResponseHandler(
       journalDb: mockJournalDb,
       sequenceLogService: mockSequenceService,

--- a/test/features/sync/sequence/sync_sequence_log_service_test.dart
+++ b/test/features/sync/sequence/sync_sequence_log_service_test.dart
@@ -1427,30 +1427,117 @@ void main() {
       ).called(1);
     });
 
-    test('marks entry as unresolvable when unresolvable=true', () async {
-      when(
-        () => mockDb.updateSequenceStatus(
-          any(),
-          any(),
-          any(),
-        ),
-      ).thenAnswer((_) async => 1);
+    test(
+      'upserts an unresolvable row when unresolvable=true and no row '
+      'exists yet — proactive burn broadcasts must land on peers that '
+      'never materialized (hostId, counter)',
+      () async {
+        when(
+          () => mockDb.getEntryByHostAndCounter(aliceHostId, 3),
+        ).thenAnswer((_) async => null);
+        when(
+          () => mockDb.recordSequenceEntry(any()),
+        ).thenAnswer((_) async => 1);
 
-      await service.handleBackfillResponse(
-        hostId: aliceHostId,
-        counter: 3,
-        deleted: false,
-        unresolvable: true,
-      );
+        await service.handleBackfillResponse(
+          hostId: aliceHostId,
+          counter: 3,
+          deleted: false,
+          unresolvable: true,
+        );
 
-      verify(
-        () => mockDb.updateSequenceStatus(
-          aliceHostId,
-          3,
-          SyncSequenceStatus.unresolvable,
-        ),
-      ).called(1);
-    });
+        verifyNever(() => mockDb.updateSequenceStatus(any(), any(), any()));
+        verify(
+          () => mockDb.recordSequenceEntry(
+            any(
+              that: isA<SyncSequenceLogCompanion>()
+                  .having((c) => c.hostId, 'hostId', const Value(aliceHostId))
+                  .having((c) => c.counter, 'counter', const Value(3))
+                  .having(
+                    (c) => c.entryId,
+                    'entryId',
+                    const Value<String?>(null),
+                  )
+                  .having(
+                    (c) => c.status,
+                    'status',
+                    Value(SyncSequenceStatus.unresolvable.index),
+                  ),
+            ),
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'unresolvable upsert ignores rows with authoritative success state '
+      "(received / backfilled / deleted) — the originator's hint must "
+      'never downgrade a better outcome obtained through another route',
+      () async {
+        when(() => mockDb.getEntryByHostAndCounter(aliceHostId, 3)).thenAnswer(
+          (_) async => _createLogItem(
+            aliceHostId,
+            3,
+            entryId: 'existing',
+            status: SyncSequenceStatus.received,
+          ),
+        );
+
+        await service.handleBackfillResponse(
+          hostId: aliceHostId,
+          counter: 3,
+          deleted: false,
+          unresolvable: true,
+        );
+
+        verifyNever(() => mockDb.recordSequenceEntry(any()));
+        verifyNever(() => mockDb.updateSequenceStatus(any(), any(), any()));
+      },
+    );
+
+    test(
+      'unresolvable upsert clears a stale entryId on an existing row — '
+      'so a lingering covered-VC mapping does not let later verify/reset '
+      'paths reopen the counter',
+      () async {
+        when(() => mockDb.getEntryByHostAndCounter(aliceHostId, 3)).thenAnswer(
+          (_) async => _createLogItem(
+            aliceHostId,
+            3,
+            entryId: 'stale-entity',
+            status: SyncSequenceStatus.missing,
+          ),
+        );
+        when(
+          () => mockDb.recordSequenceEntry(any()),
+        ).thenAnswer((_) async => 1);
+
+        await service.handleBackfillResponse(
+          hostId: aliceHostId,
+          counter: 3,
+          deleted: false,
+          unresolvable: true,
+        );
+
+        verify(
+          () => mockDb.recordSequenceEntry(
+            any(
+              that: isA<SyncSequenceLogCompanion>()
+                  .having(
+                    (c) => c.entryId,
+                    'entryId',
+                    const Value<String?>(null),
+                  )
+                  .having(
+                    (c) => c.status,
+                    'status',
+                    Value(SyncSequenceStatus.unresolvable.index),
+                  ),
+            ),
+          ),
+        ).called(1);
+      },
+    );
 
     test(
       'stores entryId hint on missing entry but does not change status',
@@ -4442,6 +4529,45 @@ void main() {
         expect(gaps.length, 2);
         expect(gaps[0], (hostId: aliceHostId, counter: 3));
         expect(gaps[1], (hostId: aliceHostId, counter: 4));
+      },
+    );
+  });
+
+  group('markOwnCounterUnresolvable', () {
+    test(
+      'upserts a row with status=unresolvable and entryId explicitly null '
+      '— clears any stale payload mapping (e.g. from a covered-VC hint) '
+      'so later reset/verify paths do not treat the counter as if it had '
+      'a known payload',
+      () async {
+        when(
+          () => mockDb.recordSequenceEntry(any()),
+        ).thenAnswer((_) async => 1);
+
+        await service.markOwnCounterUnresolvable(
+          hostId: aliceHostId,
+          counter: 42,
+        );
+
+        verify(
+          () => mockDb.recordSequenceEntry(
+            any(
+              that: isA<SyncSequenceLogCompanion>()
+                  .having((c) => c.hostId, 'hostId', const Value(aliceHostId))
+                  .having((c) => c.counter, 'counter', const Value(42))
+                  .having(
+                    (c) => c.entryId,
+                    'entryId',
+                    const Value<String?>(null),
+                  )
+                  .having(
+                    (c) => c.status,
+                    'status',
+                    Value(SyncSequenceStatus.unresolvable.index),
+                  ),
+            ),
+          ),
+        ).called(1);
       },
     );
   });

--- a/test/services/vector_clock_service_test.dart
+++ b/test/services/vector_clock_service_test.dart
@@ -202,72 +202,55 @@ void main() {
   });
 
   group('VectorClockService reservations', () {
-    test('commit persists the counter advance', () async {
-      await service.setNextAvailableCounter(10);
+    test(
+      'reserveNextVectorClock persists the advance eagerly — a crash '
+      'between reserve and any subsequent entity write can only burn the '
+      'counter, never re-hand it (collision-safe across DB files)',
+      () async {
+        await service.setNextAvailableCounter(10);
 
-      final reservation = await service.reserveNextVectorClock();
-      final host = await service.getHost();
-      expect(reservation.vc.vclock[host], 10);
-      // In-memory bumped synchronously on reserve.
-      expect(await service.getNextAvailableCounter(), 11);
+        final reservation = await service.reserveNextVectorClock();
+        final host = await service.getHost();
+        expect(reservation.vc.vclock[host], 10);
 
-      await reservation.commit();
+        // Counter already persisted BEFORE the caller can run any write.
+        final reloaded = VectorClockService();
+        await reloaded.initialized;
+        expect(await reloaded.getNextAvailableCounter(), 11);
 
-      // Fresh service instance should observe the committed watermark.
-      final reloaded = VectorClockService();
-      await reloaded.initialized;
-      expect(await reloaded.getNextAvailableCounter(), 11);
-    });
+        // commit is a no-op under persist-on-reserve semantics.
+        await reservation.commit();
+        expect(reservation.isPending, isFalse);
+      },
+    );
 
     test(
-      'release rewinds the in-memory watermark and does not persist — '
-      'the next reservation reuses the slot so a rejected write never '
-      'burns a VC counter',
+      'release logs the burn and notifies the burn handler — the counter '
+      'is already on disk (cannot rewind) so proactive broadcast is the '
+      'only way for peers to skip gap detection',
       () async {
         await service.setNextAvailableCounter(20);
+        final burnt = <int>[];
+        service.setBurnHandler(burnt.add);
 
-        final first = await service.reserveNextVectorClock();
-        expect(first.vc.vclock[await service.getHost()], 20);
+        final reservation = await service.reserveNextVectorClock();
+        reservation.release();
+
+        expect(burnt, [20]);
+
+        // In-memory watermark did NOT rewind.
         expect(await service.getNextAvailableCounter(), 21);
 
-        first.release();
-
-        // In-memory rewinds because this was the latest reservation.
-        expect(await service.getNextAvailableCounter(), 20);
-
-        // SettingsDb still reports 20 — nothing was persisted.
+        // Persisted watermark held at 21 through the release.
         final reloaded = VectorClockService();
         await reloaded.initialized;
-        expect(await reloaded.getNextAvailableCounter(), 20);
+        expect(await reloaded.getNextAvailableCounter(), 21);
 
-        // Next reservation reuses counter 20.
-        final second = await service.reserveNextVectorClock();
-        expect(second.vc.vclock[await service.getHost()], 20);
+        service.setBurnHandler(null);
       },
     );
 
-    test(
-      'release does not rewind when a sibling reservation is outstanding — '
-      'the counter is abandoned in-memory so siblings stay intact',
-      () async {
-        await service.setNextAvailableCounter(30);
-
-        final first = await service.reserveNextVectorClock(); // 30
-        final second = await service.reserveNextVectorClock(); // 31
-
-        first.release();
-        // In-memory stays at 32 (second is still outstanding at 31).
-        expect(await service.getNextAvailableCounter(), 32);
-
-        await second.commit();
-        // Commit persists target = 32.
-        final reloaded = VectorClockService();
-        await reloaded.initialized;
-        expect(await reloaded.getNextAvailableCounter(), 32);
-      },
-    );
-
-    test('commit is idempotent', () async {
+    test('commit is idempotent and safe to call before release', () async {
       await service.setNextAvailableCounter(40);
       final reservation = await service.reserveNextVectorClock();
       await reservation.commit();
@@ -275,16 +258,50 @@ void main() {
       expect(reservation.isPending, isFalse);
     });
 
-    test('release after commit is a no-op', () async {
-      await service.setNextAvailableCounter(50);
-      final reservation = await service.reserveNextVectorClock();
-      await reservation.commit();
-      reservation.release(); // no-op
+    test(
+      'release after commit is a no-op — a late release path does not '
+      'double-broadcast a burn for a counter that actually carried a write',
+      () async {
+        await service.setNextAvailableCounter(50);
+        final burnt = <int>[];
+        service.setBurnHandler(burnt.add);
 
-      final reloaded = VectorClockService();
-      await reloaded.initialized;
-      expect(await reloaded.getNextAvailableCounter(), 51);
-    });
+        final reservation = await service.reserveNextVectorClock();
+        await reservation.commit();
+        reservation.release(); // no-op — already finalized by commit
+
+        expect(burnt, isEmpty);
+        final reloaded = VectorClockService();
+        await reloaded.initialized;
+        expect(await reloaded.getNextAvailableCounter(), 51);
+
+        service.setBurnHandler(null);
+      },
+    );
+
+    test(
+      'concurrent reservations serialize — no two concurrent callers ever '
+      'observe the same counter between reserve and persist',
+      () async {
+        await service.setNextAvailableCounter(1000);
+
+        final futures = List.generate(
+          10,
+          (_) => service.reserveNextVectorClock(),
+        );
+        final reservations = await Future.wait(futures);
+        final host = await service.getHost();
+
+        final counters = reservations.map((r) => r.vc.vclock[host]!).toList()
+          ..sort();
+        expect(counters, List.generate(10, (i) => 1000 + i));
+        expect(counters.toSet().length, 10); // no duplicates
+
+        for (final r in reservations) {
+          await r.commit();
+        }
+      },
+    );
   });
 
   group('VectorClockService withVcScope', () {
@@ -305,11 +322,13 @@ void main() {
     });
 
     test(
-      'releases every nested reservation on throw — covers the '
-      'applied=false-style burn by rewinding the counter so the next '
-      'write reuses the same slot',
+      'throw inside scope broadcasts a burn for every reserved counter '
+      '— peers can mark them unresolvable on arrival instead of hitting '
+      'the reactive backfill-request round-trip',
       () async {
         await service.setNextAvailableCounter(200);
+        final burnt = <int>[];
+        service.setBurnHandler(burnt.add);
 
         expect(
           () => service.withVcScope<void>(() async {
@@ -319,42 +338,48 @@ void main() {
           }),
           throwsA(isA<StateError>()),
         );
-
-        // Let microtasks drain.
         await Future<void>.delayed(Duration.zero);
 
-        // All reservations released — in-memory watermark rewound to 200.
-        expect(await service.getNextAvailableCounter(), 200);
+        // Both counters burnt — broadcast in reverse (latest first) so
+        // the handler's ordering matches the release order.
+        expect(burnt, [201, 200]);
 
-        // Nothing persisted past the pre-scope watermark.
+        // Persisted watermark stays at 202 (counters already on disk).
         final reloaded = VectorClockService();
         await reloaded.initialized;
-        expect(await reloaded.getNextAvailableCounter(), 200);
+        expect(await reloaded.getNextAvailableCounter(), 202);
+
+        service.setBurnHandler(null);
       },
     );
 
     test(
-      'releases reservations when commitWhen returns false — this is the '
-      'applied=false path from persistence_logic.updateDbEntity where a '
-      'VC comparison rejects an update as stale',
+      'commitWhen=false broadcasts a burn for every reserved counter — '
+      'this is the applied=false path from persistence_logic.updateDbEntity '
+      'when a VC comparison rejects an update as stale',
       () async {
         await service.setNextAvailableCounter(300);
+        final burnt = <int>[];
+        service.setBurnHandler(burnt.add);
 
         final applied = await service.withVcScope<bool>(
           () async {
             await service.getNextVectorClock();
             await service.getNextVectorClock();
-            return false; // simulates applied=false
+            return false;
           },
           commitWhen: (applied) => applied,
         );
 
         expect(applied, isFalse);
-        expect(await service.getNextAvailableCounter(), 300);
+        expect(burnt, [301, 300]);
 
+        // Persisted watermark stays at 302 — nothing we can rewind.
         final reloaded = VectorClockService();
         await reloaded.initialized;
-        expect(await reloaded.getNextAvailableCounter(), 300);
+        expect(await reloaded.getNextAvailableCounter(), 302);
+
+        service.setBurnHandler(null);
       },
     );
 
@@ -362,9 +387,8 @@ void main() {
       await service.setNextAvailableCounter(400);
       final host = await service.getHost();
 
-      // Outer scope commits on success; inner scope with commitWhen=false
-      // would normally release, but because the outer scope controls
-      // finalization here, both reservations commit together.
+      // Outer scope commits on success; inner scope's own commitWhen=false
+      // does not fire because the outermost scope owns finalization.
       final result = await service.withVcScope<int>(() async {
         final outer = await service.getNextVectorClock();
         final innerCounter = await service.withVcScope<int>(
@@ -384,8 +408,8 @@ void main() {
     });
 
     test(
-      'getNextVectorClock outside a scope auto-commits — preserves the '
-      'legacy single-shot behavior for low-stakes callers',
+      'getNextVectorClock outside a scope auto-commits — legacy callers '
+      'that do not opt into a scope still get the eager persist semantics',
       () async {
         await service.setNextAvailableCounter(500);
         await service.getNextVectorClock();
@@ -397,14 +421,13 @@ void main() {
     );
 
     test(
-      'commit-on-write invariant: if the body observes a successful DB '
-      'write and returns normally — even though a sync enqueue after it '
-      'was supposed to throw but was swallowed — the counter commits. '
-      'Rewinding here would let the next reservation re-hand the same '
-      'counter to a different entity, producing a cross-entity collision '
-      'because the first entity already persists the counter on disk.',
+      'commit-on-write invariant: a scoped action that swallows a '
+      'post-DB-write exception still commits — the counter is already '
+      'on disk and the write carried it, so no burn broadcast',
       () async {
         await service.setNextAvailableCounter(600);
+        final burnt = <int>[];
+        service.setBurnHandler(burnt.add);
 
         final applied = await service.withVcScope<bool>(
           () async {
@@ -413,9 +436,8 @@ void main() {
             try {
               throw StateError('transient outbox failure');
             } catch (_) {
-              // Swallow — simulates the commit-on-write pattern in
-              // persistence_logic where the DB write already claimed the
-              // counter on disk.
+              // Swallow — simulates the pattern in persistence_logic where
+              // the DB write already committed the counter to disk.
             }
             return dbWriteSucceeded;
           },
@@ -423,16 +445,36 @@ void main() {
         );
 
         expect(applied, isTrue);
+        expect(burnt, isEmpty);
 
         final reloaded = VectorClockService();
         await reloaded.initialized;
-        expect(
-          await reloaded.getNextAvailableCounter(),
-          601,
-          reason:
-              'write landed — counter must persist despite the swallowed '
-              'enqueue failure',
+        expect(await reloaded.getNextAvailableCounter(), 601);
+
+        service.setBurnHandler(null);
+      },
+    );
+
+    test(
+      'burn handler exception does not propagate into the scope finalizer '
+      '— the counter is already burnt; a handler throw must not cascade',
+      () async {
+        await service.setNextAvailableCounter(700);
+        service.setBurnHandler((_) {
+          throw StateError('handler boom');
+        });
+
+        // Should not rethrow the handler's StateError.
+        final applied = await service.withVcScope<bool>(
+          () async {
+            await service.getNextVectorClock();
+            return false;
+          },
+          commitWhen: (applied) => applied,
         );
+        expect(applied, isFalse);
+
+        service.setBurnHandler(null);
       },
     );
   });

--- a/test/services/vector_clock_service_test.dart
+++ b/test/services/vector_clock_service_test.dart
@@ -231,7 +231,7 @@ void main() {
       () async {
         await service.setNextAvailableCounter(20);
         final burnt = <int>[];
-        service.setBurnHandler(burnt.add);
+        service.setBurnHandler((_, counter) => burnt.add(counter));
 
         final reservation = await service.reserveNextVectorClock();
         reservation.release();
@@ -264,7 +264,7 @@ void main() {
       () async {
         await service.setNextAvailableCounter(50);
         final burnt = <int>[];
-        service.setBurnHandler(burnt.add);
+        service.setBurnHandler((_, counter) => burnt.add(counter));
 
         final reservation = await service.reserveNextVectorClock();
         await reservation.commit();
@@ -328,7 +328,7 @@ void main() {
       () async {
         await service.setNextAvailableCounter(200);
         final burnt = <int>[];
-        service.setBurnHandler(burnt.add);
+        service.setBurnHandler((_, counter) => burnt.add(counter));
 
         expect(
           () => service.withVcScope<void>(() async {
@@ -360,7 +360,7 @@ void main() {
       () async {
         await service.setNextAvailableCounter(300);
         final burnt = <int>[];
-        service.setBurnHandler(burnt.add);
+        service.setBurnHandler((_, counter) => burnt.add(counter));
 
         final applied = await service.withVcScope<bool>(
           () async {
@@ -427,7 +427,7 @@ void main() {
       () async {
         await service.setNextAvailableCounter(600);
         final burnt = <int>[];
-        service.setBurnHandler(burnt.add);
+        service.setBurnHandler((_, counter) => burnt.add(counter));
 
         final applied = await service.withVcScope<bool>(
           () async {
@@ -456,11 +456,40 @@ void main() {
     );
 
     test(
+      'burn handler receives the host captured at reserve time, not the '
+      "service's current host at release time — setNewHost between "
+      'reserve and release must not re-attribute the burn to the new host',
+      () async {
+        await service.setNextAvailableCounter(800);
+        final burnt = <({String hostId, int counter})>[];
+        service.setBurnHandler((hostId, counter) {
+          burnt.add((hostId: hostId, counter: counter));
+        });
+
+        final originalHost = await service.getHost();
+        final reservation = await service.reserveNextVectorClock();
+
+        // Swap to a brand-new host identity BEFORE releasing — simulates
+        // a user re-linking to a different Matrix account.
+        final newHost = await service.setNewHost();
+        expect(newHost, isNot(originalHost));
+
+        reservation.release();
+
+        expect(burnt, hasLength(1));
+        expect(burnt.single.hostId, originalHost);
+        expect(burnt.single.counter, 800);
+
+        service.setBurnHandler(null);
+      },
+    );
+
+    test(
       'burn handler exception does not propagate into the scope finalizer '
       '— the counter is already burnt; a handler throw must not cascade',
       () async {
         await service.setNextAvailableCounter(700);
-        service.setBurnHandler((_) {
+        service.setBurnHandler((_, _) {
           throw StateError('handler boom');
         });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped build version to 0.9.973+3977

* **New Features**
  * Vector clocks now persist at reservation time and support a configurable burn handler to emit non-blocking burn broadcasts.
  * Backfill now marks own-host counters as unresolvable and treats own-host misses as authoritative (no covering fallback).

* **Behavior Changes**
  * Commit no longer advances persisted counters; release triggers burn processing.
  * Many repo/backfill operations run inside per-item VC scopes and now catch/log enqueue failures.
  * Sequence log exposes an API to mark own counters unresolvable.

* **Tests**
  * Updated for reserve-time persistence, burn semantics, concurrency, and own-host backfill behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->