### PR TITLE
feat: reduce eagerness of the backfill trigger

### DIFF
--- a/lib/database/sync_db.dart
+++ b/lib/database/sync_db.dart
@@ -1020,26 +1020,41 @@ class SyncDatabase extends _$SyncDatabase {
   }) async {
     final effectiveNow = now ?? DateTime.now();
     final minAgeCutoff = effectiveNow.subtract(minAge);
-    // Get all missing/requested entries respecting request count and the
-    // debounce window. Holding `minAge` in the query (not post-filter)
-    // avoids loading rows we immediately discard on every process cycle.
+    // All three time/count gates (`minAge`, `maxAge`, `maxRequestCount`) are
+    // pushed into the SQL WHERE so we never materialise rows we'd
+    // immediately discard. The per-host cap is still post-processed because
+    // SQLite plain selects don't have a window-function-free way to
+    // express "top N rows per host"; that post-processing runs on the
+    // bounded result set below.
     final baseQuery = select(syncSequenceLog)
-      ..where(
-        (t) =>
+      ..where((t) {
+        var predicate =
             (t.status.equals(SyncSequenceStatus.missing.index) |
                 t.status.equals(SyncSequenceStatus.requested.index)) &
             t.requestCount.isSmallerThanValue(maxRequestCount) &
-            t.createdAt.isSmallerOrEqualValue(minAgeCutoff),
-      )
+            t.createdAt.isSmallerOrEqualValue(minAgeCutoff);
+        if (maxAge != null) {
+          final maxAgeCutoff = effectiveNow.subtract(maxAge);
+          predicate = predicate & t.createdAt.isBiggerThanValue(maxAgeCutoff);
+        }
+        return predicate;
+      })
       ..orderBy([(t) => OrderingTerm(expression: t.createdAt)]);
 
-    var entries = await baseQuery.get();
+    // Cap the SQL fetch so a pathologically large missing-row backlog does
+    // not blow up memory. Without `maxPerHost` the tight `offset + limit`
+    // bound is exactly what the caller wants. With `maxPerHost`, the Dart
+    // post-filter needs to see enough rows per host to pick the first N
+    // per host while still honouring `offset + limit` across hosts — so
+    // we fall back to a generous fixed cap. At production tuning
+    // (`backfillProcessingBatchSize = 100`, `defaultBackfillMaxEntriesPerHost
+    // = 250`), this cap is >> any realistic per-cycle working set; if it
+    // ever saturates, the next periodic cycle picks up the remainder.
+    const perHostFetchCap = 10000;
+    final sqlFetchLimit = maxPerHost != null ? perHostFetchCap : offset + limit;
+    baseQuery.limit(sqlFetchLimit);
 
-    // Apply age filter if specified
-    if (maxAge != null) {
-      final cutoff = effectiveNow.subtract(maxAge);
-      entries = entries.where((e) => e.createdAt.isAfter(cutoff)).toList();
-    }
+    var entries = await baseQuery.get();
 
     // Apply per-host limit if specified
     if (maxPerHost != null) {

--- a/lib/database/sync_db.dart
+++ b/lib/database/sync_db.dart
@@ -680,17 +680,29 @@ class SyncDatabase extends _$SyncDatabase {
 
   /// Get entries with status 'missing' or 'requested' that haven't
   /// exceeded maxRequestCount, ordered by creation time (oldest first).
+  /// Return rows in `missing` / `requested` state that are still eligible
+  /// for a backfill request.
+  ///
+  /// [minAge] holds rows freshly detected as missing back for a grace window,
+  /// so a short-lived gap caused by out-of-order priority messages resolves
+  /// naturally via the standard sync path before backfill fires. Only rows
+  /// whose `created_at` is at or before `now - minAge` are returned. Pass
+  /// `Duration.zero` to disable (manual / "request now" paths).
   Future<List<SyncSequenceLogItem>> getMissingEntries({
     int limit = 50,
     int maxRequestCount = 10,
     int offset = 0,
+    Duration minAge = Duration.zero,
+    DateTime? now,
   }) {
+    final cutoff = (now ?? DateTime.now()).subtract(minAge);
     return (select(syncSequenceLog)
           ..where(
             (t) =>
                 (t.status.equals(SyncSequenceStatus.missing.index) |
                     t.status.equals(SyncSequenceStatus.requested.index)) &
-                t.requestCount.isSmallerThanValue(maxRequestCount),
+                t.requestCount.isSmallerThanValue(maxRequestCount) &
+                t.createdAt.isSmallerOrEqualValue(cutoff),
           )
           ..orderBy([(t) => OrderingTerm(expression: t.createdAt)])
           ..limit(limit, offset: offset))
@@ -991,22 +1003,33 @@ class SyncDatabase extends _$SyncDatabase {
 
   /// Get missing entries with age and per-host limits for automatic backfill.
   /// [maxAge] - Only include entries created within this duration
+  /// [minAge] - Debounce window: rows freshly flagged as missing are held back
+  ///           until their `created_at` is at or before `now - minAge`. This
+  ///           lets short-lived gaps caused by out-of-order priority messages
+  ///           resolve via the standard sync path before backfill fires. Pass
+  ///           `Duration.zero` to disable (default).
   /// [maxPerHost] - Maximum entries to include per host
   Future<List<SyncSequenceLogItem>> getMissingEntriesWithLimits({
     int limit = 50,
     int maxRequestCount = 10,
     Duration? maxAge,
+    Duration minAge = Duration.zero,
     int? maxPerHost,
     DateTime? now,
     int offset = 0,
   }) async {
-    // Get all missing/requested entries respecting request count
+    final effectiveNow = now ?? DateTime.now();
+    final minAgeCutoff = effectiveNow.subtract(minAge);
+    // Get all missing/requested entries respecting request count and the
+    // debounce window. Holding `minAge` in the query (not post-filter)
+    // avoids loading rows we immediately discard on every process cycle.
     final baseQuery = select(syncSequenceLog)
       ..where(
         (t) =>
             (t.status.equals(SyncSequenceStatus.missing.index) |
                 t.status.equals(SyncSequenceStatus.requested.index)) &
-            t.requestCount.isSmallerThanValue(maxRequestCount),
+            t.requestCount.isSmallerThanValue(maxRequestCount) &
+            t.createdAt.isSmallerOrEqualValue(minAgeCutoff),
       )
       ..orderBy([(t) => OrderingTerm(expression: t.createdAt)]);
 
@@ -1014,7 +1037,7 @@ class SyncDatabase extends _$SyncDatabase {
 
     // Apply age filter if specified
     if (maxAge != null) {
-      final cutoff = (now ?? DateTime.now()).subtract(maxAge);
+      final cutoff = effectiveNow.subtract(maxAge);
       entries = entries.where((e) => e.createdAt.isAfter(cutoff)).toList();
     }
 

--- a/lib/features/sync/backfill/backfill_request_service.dart
+++ b/lib/features/sync/backfill/backfill_request_service.dart
@@ -34,6 +34,7 @@ class BackfillRequestService {
     int? maxBatchSize,
     int? maxRequestCount,
     Duration? maxAge,
+    Duration? missingDebounce,
     int? maxPerHost,
     Duration? amnestyWindow,
   }) : _sequenceLogService = sequenceLogService,
@@ -48,6 +49,7 @@ class BackfillRequestService {
        _maxBatchSize = maxBatchSize ?? SyncTuning.backfillProcessingBatchSize,
        _maxRequestCount = maxRequestCount ?? SyncTuning.backfillMaxRequestCount,
        _maxAge = maxAge ?? SyncTuning.defaultBackfillMaxAge,
+       _missingDebounce = missingDebounce ?? SyncTuning.backfillMissingDebounce,
        _maxPerHost = maxPerHost ?? SyncTuning.defaultBackfillMaxEntriesPerHost,
        _amnestyWindow = amnestyWindow ?? SyncTuning.backfillAmnestyWindow;
 
@@ -75,6 +77,15 @@ class BackfillRequestService {
   final int _maxBatchSize;
   final int _maxRequestCount;
   final Duration _maxAge;
+
+  /// Grace window after a row is first flagged `missing` by gap detection
+  /// before it becomes eligible for an automatic backfill request — see
+  /// [SyncTuning.backfillMissingDebounce] for the rationale. Applied only
+  /// to the bounded automatic path (the periodic timer and `nudge()`,
+  /// which both pass `useLimits: true`). A user-initiated full backfill
+  /// via [processFullBackfill] explicitly bypasses the debounce so
+  /// "request now" is not silently held back for 10 minutes.
+  final Duration _missingDebounce;
   final int _maxPerHost;
   final Duration _amnestyWindow;
 
@@ -435,11 +446,17 @@ class BackfillRequestService {
 
     while (selected.length < _maxBatchSize) {
       final remaining = _maxBatchSize - selected.length;
+      // `useLimits` doubles as the automatic/manual switch: the periodic
+      // timer and `nudge()` both pass `true`; only `processFullBackfill`'s
+      // explicit user-triggered path passes `false`. Apply the debounce
+      // only on automatic paths so a user who presses "request missing
+      // now" is not silently held back for 10 minutes.
       final page = useLimits
           ? await _sequenceLogService.getMissingEntriesWithLimits(
               limit: remaining,
               maxRequestCount: _maxRequestCount,
               maxAge: _maxAge,
+              minAge: _missingDebounce,
               maxPerHost: _maxPerHost,
               offset: offset,
             )

--- a/lib/features/sync/sequence/sync_sequence_log_service.dart
+++ b/lib/features/sync/sequence/sync_sequence_log_service.dart
@@ -903,15 +903,20 @@ class SyncSequenceLogService {
 
   /// Get entries marked as missing or requested that haven't exceeded
   /// the maximum request count, for sending backfill requests.
+  ///
+  /// [minAge] defers returning rows freshly flagged as missing for that long
+  /// — see [SyncDatabase.getMissingEntries] for the rationale.
   Future<List<SyncSequenceLogItem>> getMissingEntries({
     int limit = 50,
     int maxRequestCount = 10,
     int offset = 0,
+    Duration minAge = Duration.zero,
   }) {
     return _syncDatabase.getMissingEntries(
       limit: limit,
       maxRequestCount: maxRequestCount,
       offset: offset,
+      minAge: minAge,
     );
   }
 
@@ -1369,10 +1374,14 @@ class SyncSequenceLogService {
 
   /// Get missing entries with age and per-host limits for automatic backfill.
   /// This is used for bounded automatic backfill that only looks at recent gaps.
+  ///
+  /// [minAge] defers rows freshly flagged as missing — see
+  /// [SyncDatabase.getMissingEntriesWithLimits] for the rationale.
   Future<List<SyncSequenceLogItem>> getMissingEntriesWithLimits({
     int limit = 50,
     int maxRequestCount = 10,
     Duration? maxAge,
+    Duration minAge = Duration.zero,
     int? maxPerHost,
     int offset = 0,
   }) {
@@ -1380,6 +1389,7 @@ class SyncSequenceLogService {
       limit: limit,
       maxRequestCount: maxRequestCount,
       maxAge: maxAge,
+      minAge: minAge,
       maxPerHost: maxPerHost,
       offset: offset,
     );

--- a/lib/features/sync/tuning.dart
+++ b/lib/features/sync/tuning.dart
@@ -127,6 +127,25 @@ class SyncTuning {
   static const Duration backfillRequestInterval = Duration(minutes: 2);
   static const int backfillMaxRequestCount = 10;
 
+  /// Grace window between a row being first flagged as `missing` by gap
+  /// detection and the first backfill request firing for it.
+  ///
+  /// Baseline sync is now reliable (0 missing after a 460-entry offline
+  /// catch-up with backfill disabled), so any "missing" row is almost
+  /// always a transient reordering artifact — priority messages can jump
+  /// ahead of standard ones and briefly make them look missing. Without
+  /// this delay, a single priority message arriving out of sequence can
+  /// cause hundreds of backfill requests that duplicate traffic already
+  /// in flight. With the delay, the normal sync path gets a chance to
+  /// deliver the older messages first; only rows that are STILL missing
+  /// after the window become eligible for a backfill request.
+  ///
+  /// Enforced at query time in `SyncDatabase.getMissingEntries` and
+  /// `SyncDatabase.getMissingEntriesWithLimits` — rows that transition
+  /// out of `missing` during the window are no longer returned (no
+  /// cancellation logic needed).
+  static const Duration backfillMissingDebounce = Duration(minutes: 10);
+
   // Large-gap logging threshold.
   // Gaps larger than this are still fully materialized so backfill can recover
   // them, but they are logged explicitly for diagnostics.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.973+3977
+version: 0.9.973+3978
 
 msix_config:
   display_name: LottiApp

--- a/test/database/sync_db_test.dart
+++ b/test/database/sync_db_test.dart
@@ -1054,6 +1054,87 @@ void main() {
       expect(missing.first.counter, 1);
     });
 
+    test(
+      'getMissingEntries honors minAge — rows created more recently '
+      'than now-minAge are held back so a short-lived gap caused by '
+      'out-of-order priority messages can resolve via standard sync '
+      'before backfill fires',
+      () async {
+        final database = db!;
+        const hostId = 'host-1';
+        final now = DateTime(2024, 1, 2, 12);
+
+        // Fresh: 1 minute old — within the 10-minute debounce window.
+        await database.recordSequenceEntry(
+          SyncSequenceLogCompanion(
+            hostId: const Value(hostId),
+            counter: const Value(1),
+            status: Value(SyncSequenceStatus.missing.index),
+            createdAt: Value(now.subtract(const Duration(minutes: 1))),
+            updatedAt: Value(now.subtract(const Duration(minutes: 1))),
+          ),
+        );
+        // Ripe: 15 minutes old — past the window.
+        await database.recordSequenceEntry(
+          SyncSequenceLogCompanion(
+            hostId: const Value(hostId),
+            counter: const Value(2),
+            status: Value(SyncSequenceStatus.missing.index),
+            createdAt: Value(now.subtract(const Duration(minutes: 15))),
+            updatedAt: Value(now.subtract(const Duration(minutes: 15))),
+          ),
+        );
+
+        final ripe = await database.getMissingEntries(
+          minAge: const Duration(minutes: 10),
+          now: now,
+        );
+        expect(ripe, hasLength(1));
+        expect(ripe.single.counter, 2);
+
+        // Without debounce, both rows are eligible. Ordering is by
+        // created_at ASC, so the older row (counter 2) comes first.
+        final all = await database.getMissingEntries(now: now);
+        expect(all.map((e) => e.counter), [2, 1]);
+      },
+    );
+
+    test(
+      'getMissingEntriesWithLimits honors minAge alongside the maxAge / '
+      'maxPerHost gates',
+      () async {
+        final database = db!;
+        const hostId = 'host-1';
+        final now = DateTime(2024, 1, 2, 12);
+
+        await database.recordSequenceEntry(
+          SyncSequenceLogCompanion(
+            hostId: const Value(hostId),
+            counter: const Value(1),
+            status: Value(SyncSequenceStatus.missing.index),
+            createdAt: Value(now.subtract(const Duration(minutes: 1))),
+            updatedAt: Value(now.subtract(const Duration(minutes: 1))),
+          ),
+        );
+        await database.recordSequenceEntry(
+          SyncSequenceLogCompanion(
+            hostId: const Value(hostId),
+            counter: const Value(2),
+            status: Value(SyncSequenceStatus.missing.index),
+            createdAt: Value(now.subtract(const Duration(minutes: 15))),
+            updatedAt: Value(now.subtract(const Duration(minutes: 15))),
+          ),
+        );
+
+        final ripe = await database.getMissingEntriesWithLimits(
+          minAge: const Duration(minutes: 10),
+          now: now,
+        );
+        expect(ripe, hasLength(1));
+        expect(ripe.single.counter, 2);
+      },
+    );
+
     test('updateSequenceStatus updates status', () async {
       final database = db!;
       const hostId = 'host-1';

--- a/test/features/sync/backfill/backfill_request_service_test.dart
+++ b/test/features/sync/backfill/backfill_request_service_test.dart
@@ -10,6 +10,7 @@ import 'package:lotti/features/sync/model/sync_message.dart';
 import 'package:lotti/features/sync/queue/queue_pipeline_coordinator.dart';
 import 'package:lotti/features/sync/sequence/sync_sequence_log_service.dart';
 import 'package:lotti/features/sync/sequence/sync_sequence_payload_type.dart';
+import 'package:lotti/features/sync/tuning.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
 import 'package:shared_preferences/shared_preferences.dart';
@@ -188,6 +189,7 @@ void main() {
             limit: any(named: 'limit'),
             maxRequestCount: any(named: 'maxRequestCount'),
             maxAge: any(named: 'maxAge'),
+            minAge: any(named: 'minAge'),
             maxPerHost: any(named: 'maxPerHost'),
             offset: any(named: 'offset'),
           ),
@@ -205,6 +207,7 @@ void main() {
             limit: any(named: 'limit'),
             maxRequestCount: any(named: 'maxRequestCount'),
             maxAge: any(named: 'maxAge'),
+            minAge: any(named: 'minAge'),
             maxPerHost: any(named: 'maxPerHost'),
             offset: any(named: 'offset'),
           ),
@@ -219,6 +222,7 @@ void main() {
             limit: any(named: 'limit'),
             maxRequestCount: any(named: 'maxRequestCount'),
             maxAge: any(named: 'maxAge'),
+            minAge: any(named: 'minAge'),
             maxPerHost: any(named: 'maxPerHost'),
             offset: any(named: 'offset'),
           ),
@@ -227,6 +231,98 @@ void main() {
         service.dispose();
       });
     });
+
+    test(
+      'passes missingDebounce (from SyncTuning) to the sequence log so '
+      'rows freshly detected as missing are held back for 10 minutes — '
+      'lets the standard sync path deliver out-of-order entries before '
+      'backfill fires',
+      () {
+        fakeAsync((async) {
+          final service = BackfillRequestService(
+            sequenceLogService: mockSequenceService,
+            syncDatabase: mockSyncDatabase,
+            outboxService: mockOutboxService,
+            vectorClockService: mockVcService,
+            loggingService: mockLogging,
+            requestInterval: const Duration(seconds: 10),
+          );
+
+          when(
+            () => mockSequenceService.getMissingEntriesWithLimits(
+              limit: any(named: 'limit'),
+              maxRequestCount: any(named: 'maxRequestCount'),
+              maxAge: any(named: 'maxAge'),
+              minAge: any(named: 'minAge'),
+              maxPerHost: any(named: 'maxPerHost'),
+              offset: any(named: 'offset'),
+            ),
+          ).thenAnswer((_) async => []);
+
+          service.start();
+          async
+            ..elapse(const Duration(seconds: 10))
+            ..flushMicrotasks();
+
+          verify(
+            () => mockSequenceService.getMissingEntriesWithLimits(
+              limit: any(named: 'limit'),
+              maxRequestCount: any(named: 'maxRequestCount'),
+              maxAge: any(named: 'maxAge'),
+              minAge: SyncTuning.backfillMissingDebounce,
+              maxPerHost: any(named: 'maxPerHost'),
+              offset: any(named: 'offset'),
+            ),
+          ).called(1);
+
+          service.dispose();
+        });
+      },
+    );
+
+    test(
+      'processFullBackfill bypasses the debounce — a user-initiated '
+      'full backfill must not be silently held back for 10 minutes',
+      () async {
+        final service = BackfillRequestService(
+          sequenceLogService: mockSequenceService,
+          syncDatabase: mockSyncDatabase,
+          outboxService: mockOutboxService,
+          vectorClockService: mockVcService,
+          loggingService: mockLogging,
+        );
+
+        when(
+          () => mockSequenceService.getMissingEntries(
+            limit: any(named: 'limit'),
+            maxRequestCount: any(named: 'maxRequestCount'),
+            offset: any(named: 'offset'),
+          ),
+        ).thenAnswer((_) async => []);
+
+        await service.processFullBackfill();
+
+        // getMissingEntries (not the WithLimits variant) is called without
+        // any minAge — the manual path does NOT debounce.
+        verify(
+          () => mockSequenceService.getMissingEntries(
+            limit: any(named: 'limit'),
+            maxRequestCount: any(named: 'maxRequestCount'),
+            offset: any(named: 'offset'),
+          ),
+        ).called(1);
+        verifyNever(
+          () => mockSequenceService.getMissingEntriesWithLimits(
+            limit: any(named: 'limit'),
+            maxRequestCount: any(named: 'maxRequestCount'),
+            maxAge: any(named: 'maxAge'),
+            minAge: any(named: 'minAge'),
+            maxPerHost: any(named: 'maxPerHost'),
+            offset: any(named: 'offset'),
+          ),
+        );
+      },
+    );
 
     test('sends backfill requests for missing entries', () {
       fakeAsync((async) {
@@ -249,6 +345,7 @@ void main() {
             limit: any(named: 'limit'),
             maxRequestCount: any(named: 'maxRequestCount'),
             maxAge: any(named: 'maxAge'),
+            minAge: any(named: 'minAge'),
             maxPerHost: any(named: 'maxPerHost'),
             offset: any(named: 'offset'),
           ),
@@ -308,6 +405,7 @@ void main() {
             limit: any(named: 'limit'),
             maxRequestCount: any(named: 'maxRequestCount'),
             maxAge: any(named: 'maxAge'),
+            minAge: any(named: 'minAge'),
             maxPerHost: any(named: 'maxPerHost'),
             offset: any(named: 'offset'),
           ),
@@ -349,6 +447,7 @@ void main() {
             limit: maxBatch,
             maxRequestCount: any(named: 'maxRequestCount'),
             maxAge: any(named: 'maxAge'),
+            minAge: any(named: 'minAge'),
             maxPerHost: any(named: 'maxPerHost'),
             offset: any(named: 'offset'),
           ),
@@ -377,6 +476,7 @@ void main() {
             limit: maxBatch,
             maxRequestCount: any(named: 'maxRequestCount'),
             maxAge: any(named: 'maxAge'),
+            minAge: any(named: 'minAge'),
             maxPerHost: any(named: 'maxPerHost'),
             offset: any(named: 'offset'),
           ),
@@ -402,6 +502,7 @@ void main() {
             limit: any(named: 'limit'),
             maxRequestCount: any(named: 'maxRequestCount'),
             maxAge: any(named: 'maxAge'),
+            minAge: any(named: 'minAge'),
             maxPerHost: any(named: 'maxPerHost'),
             offset: any(named: 'offset'),
           ),
@@ -444,6 +545,7 @@ void main() {
             limit: any(named: 'limit'),
             maxRequestCount: any(named: 'maxRequestCount'),
             maxAge: any(named: 'maxAge'),
+            minAge: any(named: 'minAge'),
             maxPerHost: any(named: 'maxPerHost'),
             offset: any(named: 'offset'),
           ),
@@ -492,6 +594,7 @@ void main() {
             limit: any(named: 'limit'),
             maxRequestCount: any(named: 'maxRequestCount'),
             maxAge: any(named: 'maxAge'),
+            minAge: any(named: 'minAge'),
             maxPerHost: any(named: 'maxPerHost'),
             offset: any(named: 'offset'),
           ),
@@ -515,6 +618,7 @@ void main() {
             limit: any(named: 'limit'),
             maxRequestCount: any(named: 'maxRequestCount'),
             maxAge: any(named: 'maxAge'),
+            minAge: any(named: 'minAge'),
             maxPerHost: any(named: 'maxPerHost'),
             offset: any(named: 'offset'),
           ),
@@ -538,6 +642,7 @@ void main() {
             limit: any(named: 'limit'),
             maxRequestCount: any(named: 'maxRequestCount'),
             maxAge: any(named: 'maxAge'),
+            minAge: any(named: 'minAge'),
             maxPerHost: any(named: 'maxPerHost'),
             offset: any(named: 'offset'),
           ),
@@ -627,6 +732,7 @@ void main() {
             limit: any(named: 'limit'),
             maxRequestCount: any(named: 'maxRequestCount'),
             maxAge: any(named: 'maxAge'),
+            minAge: any(named: 'minAge'),
             maxPerHost: any(named: 'maxPerHost'),
             offset: any(named: 'offset'),
           ),
@@ -662,6 +768,7 @@ void main() {
             limit: any(named: 'limit'),
             maxRequestCount: any(named: 'maxRequestCount'),
             maxAge: any(named: 'maxAge'),
+            minAge: any(named: 'minAge'),
             maxPerHost: any(named: 'maxPerHost'),
             offset: any(named: 'offset'),
           ),
@@ -693,6 +800,7 @@ void main() {
             limit: any(named: 'limit'),
             maxRequestCount: any(named: 'maxRequestCount'),
             maxAge: any(named: 'maxAge'),
+            minAge: any(named: 'minAge'),
             maxPerHost: any(named: 'maxPerHost'),
             offset: any(named: 'offset'),
           ),
@@ -750,6 +858,7 @@ void main() {
             limit: any(named: 'limit'),
             maxRequestCount: any(named: 'maxRequestCount'),
             maxAge: any(named: 'maxAge'),
+            minAge: any(named: 'minAge'),
             maxPerHost: any(named: 'maxPerHost'),
             offset: any(named: 'offset'),
           ),
@@ -798,6 +907,7 @@ void main() {
             limit: any(named: 'limit'),
             maxRequestCount: any(named: 'maxRequestCount'),
             maxAge: any(named: 'maxAge'),
+            minAge: any(named: 'minAge'),
             maxPerHost: any(named: 'maxPerHost'),
             offset: any(named: 'offset'),
           ),
@@ -1476,6 +1586,7 @@ void main() {
             limit: any(named: 'limit'),
             maxRequestCount: any(named: 'maxRequestCount'),
             maxAge: any(named: 'maxAge'),
+            minAge: any(named: 'minAge'),
             maxPerHost: any(named: 'maxPerHost'),
             offset: any(named: 'offset'),
           ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a 10-minute debounce for newly detected missing entries so automatic backfill waits before requesting recent gaps.

* **Tests**
  * Added unit tests covering age-gating behavior for both automatic (debounced) and manual (immediate) backfill paths.

* **Chores**
  * Version bumped to 0.9.973+3978.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->