### PR TITLE
feat: add data layer for persisted filter settings

### DIFF
--- a/lib/features/tasks/state/saved_filters/saved_task_filter.dart
+++ b/lib/features/tasks/state/saved_filters/saved_task_filter.dart
@@ -1,0 +1,23 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:lotti/features/journal/state/journal_page_state.dart';
+
+part 'saved_task_filter.freezed.dart';
+part 'saved_task_filter.g.dart';
+
+/// A user-saved Tasks filter pinned to the sidebar under Tasks.
+///
+/// Position in the persisted list is the sort order. The ephemeral
+/// search query is intentionally NOT part of [filter] — it stays on
+/// the live page state and is preserved across saved-filter activations.
+@Freezed(toJson: true, fromJson: true)
+abstract class SavedTaskFilter with _$SavedTaskFilter {
+  @JsonSerializable(explicitToJson: true)
+  const factory SavedTaskFilter({
+    required String id,
+    required String name,
+    required TasksFilter filter,
+  }) = _SavedTaskFilter;
+
+  factory SavedTaskFilter.fromJson(Map<String, dynamic> json) =>
+      _$SavedTaskFilterFromJson(json);
+}

--- a/lib/features/tasks/state/saved_filters/saved_task_filter.freezed.dart
+++ b/lib/features/tasks/state/saved_filters/saved_task_filter.freezed.dart
@@ -1,0 +1,301 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'saved_task_filter.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$SavedTaskFilter {
+
+ String get id; String get name; TasksFilter get filter;
+/// Create a copy of SavedTaskFilter
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SavedTaskFilterCopyWith<SavedTaskFilter> get copyWith => _$SavedTaskFilterCopyWithImpl<SavedTaskFilter>(this as SavedTaskFilter, _$identity);
+
+  /// Serializes this SavedTaskFilter to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SavedTaskFilter&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.filter, filter) || other.filter == filter));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,name,filter);
+
+@override
+String toString() {
+  return 'SavedTaskFilter(id: $id, name: $name, filter: $filter)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SavedTaskFilterCopyWith<$Res>  {
+  factory $SavedTaskFilterCopyWith(SavedTaskFilter value, $Res Function(SavedTaskFilter) _then) = _$SavedTaskFilterCopyWithImpl;
+@useResult
+$Res call({
+ String id, String name, TasksFilter filter
+});
+
+
+$TasksFilterCopyWith<$Res> get filter;
+
+}
+/// @nodoc
+class _$SavedTaskFilterCopyWithImpl<$Res>
+    implements $SavedTaskFilterCopyWith<$Res> {
+  _$SavedTaskFilterCopyWithImpl(this._self, this._then);
+
+  final SavedTaskFilter _self;
+  final $Res Function(SavedTaskFilter) _then;
+
+/// Create a copy of SavedTaskFilter
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? filter = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,filter: null == filter ? _self.filter : filter // ignore: cast_nullable_to_non_nullable
+as TasksFilter,
+  ));
+}
+/// Create a copy of SavedTaskFilter
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$TasksFilterCopyWith<$Res> get filter {
+  
+  return $TasksFilterCopyWith<$Res>(_self.filter, (value) {
+    return _then(_self.copyWith(filter: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [SavedTaskFilter].
+extension SavedTaskFilterPatterns on SavedTaskFilter {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _SavedTaskFilter value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _SavedTaskFilter() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _SavedTaskFilter value)  $default,){
+final _that = this;
+switch (_that) {
+case _SavedTaskFilter():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _SavedTaskFilter value)?  $default,){
+final _that = this;
+switch (_that) {
+case _SavedTaskFilter() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  TasksFilter filter)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _SavedTaskFilter() when $default != null:
+return $default(_that.id,_that.name,_that.filter);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  TasksFilter filter)  $default,) {final _that = this;
+switch (_that) {
+case _SavedTaskFilter():
+return $default(_that.id,_that.name,_that.filter);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  TasksFilter filter)?  $default,) {final _that = this;
+switch (_that) {
+case _SavedTaskFilter() when $default != null:
+return $default(_that.id,_that.name,_that.filter);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+@JsonSerializable(explicitToJson: true)
+class _SavedTaskFilter implements SavedTaskFilter {
+  const _SavedTaskFilter({required this.id, required this.name, required this.filter});
+  factory _SavedTaskFilter.fromJson(Map<String, dynamic> json) => _$SavedTaskFilterFromJson(json);
+
+@override final  String id;
+@override final  String name;
+@override final  TasksFilter filter;
+
+/// Create a copy of SavedTaskFilter
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SavedTaskFilterCopyWith<_SavedTaskFilter> get copyWith => __$SavedTaskFilterCopyWithImpl<_SavedTaskFilter>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SavedTaskFilterToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SavedTaskFilter&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.filter, filter) || other.filter == filter));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,name,filter);
+
+@override
+String toString() {
+  return 'SavedTaskFilter(id: $id, name: $name, filter: $filter)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$SavedTaskFilterCopyWith<$Res> implements $SavedTaskFilterCopyWith<$Res> {
+  factory _$SavedTaskFilterCopyWith(_SavedTaskFilter value, $Res Function(_SavedTaskFilter) _then) = __$SavedTaskFilterCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String name, TasksFilter filter
+});
+
+
+@override $TasksFilterCopyWith<$Res> get filter;
+
+}
+/// @nodoc
+class __$SavedTaskFilterCopyWithImpl<$Res>
+    implements _$SavedTaskFilterCopyWith<$Res> {
+  __$SavedTaskFilterCopyWithImpl(this._self, this._then);
+
+  final _SavedTaskFilter _self;
+  final $Res Function(_SavedTaskFilter) _then;
+
+/// Create a copy of SavedTaskFilter
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? filter = null,}) {
+  return _then(_SavedTaskFilter(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,filter: null == filter ? _self.filter : filter // ignore: cast_nullable_to_non_nullable
+as TasksFilter,
+  ));
+}
+
+/// Create a copy of SavedTaskFilter
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$TasksFilterCopyWith<$Res> get filter {
+  
+  return $TasksFilterCopyWith<$Res>(_self.filter, (value) {
+    return _then(_self.copyWith(filter: value));
+  });
+}
+}
+
+// dart format on

--- a/lib/features/tasks/state/saved_filters/saved_task_filter.g.dart
+++ b/lib/features/tasks/state/saved_filters/saved_task_filter.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'saved_task_filter.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_SavedTaskFilter _$SavedTaskFilterFromJson(Map<String, dynamic> json) =>
+    _SavedTaskFilter(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      filter: TasksFilter.fromJson(json['filter'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$SavedTaskFilterToJson(_SavedTaskFilter instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'filter': instance.filter.toJson(),
+    };

--- a/lib/features/tasks/state/saved_filters/saved_task_filters_controller.dart
+++ b/lib/features/tasks/state/saved_filters/saved_task_filters_controller.dart
@@ -1,0 +1,107 @@
+import 'package:lotti/database/settings_db.dart';
+import 'package:lotti/features/journal/state/journal_page_state.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filters_persistence.dart';
+import 'package:lotti/get_it.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:uuid/uuid.dart';
+
+part 'saved_task_filters_controller.g.dart';
+
+/// Riverpod controller backing the user's pinned task-filter list.
+///
+/// State is the ordered list of [SavedTaskFilter]s. Position in the list is
+/// the sort order. Mutations write through to [SavedTaskFiltersPersistence]
+/// after each operation.
+@Riverpod(keepAlive: true)
+class SavedTaskFiltersController extends _$SavedTaskFiltersController {
+  late final SavedTaskFiltersPersistence _persistence;
+  final Uuid _uuid = const Uuid();
+
+  @override
+  Future<List<SavedTaskFilter>> build() async {
+    _persistence = SavedTaskFiltersPersistence(getIt<SettingsDb>());
+    return _persistence.load();
+  }
+
+  /// Appends a new saved filter built from [filter] with the given [name].
+  ///
+  /// Returns the newly-created [SavedTaskFilter] so callers can mark it as
+  /// the currently-active saved view in the page state.
+  Future<SavedTaskFilter> create({
+    required String name,
+    required TasksFilter filter,
+  }) async {
+    final saved = SavedTaskFilter(
+      id: _uuid.v4(),
+      name: name,
+      filter: filter,
+    );
+    final current = state.value ?? const <SavedTaskFilter>[];
+    final next = [...current, saved];
+    state = AsyncData(next);
+    await _persistence.save(next);
+    return saved;
+  }
+
+  /// Renames the saved filter with [id]. No-op when [id] is missing or the
+  /// trimmed name is empty / unchanged.
+  Future<void> rename(String id, String name) async {
+    final trimmed = name.trim();
+    if (trimmed.isEmpty) return;
+
+    final current = state.value ?? const <SavedTaskFilter>[];
+    final idx = current.indexWhere((SavedTaskFilter f) => f.id == id);
+    if (idx < 0) return;
+    if (current[idx].name == trimmed) return;
+
+    final next = [...current];
+    next[idx] = current[idx].copyWith(name: trimmed);
+    state = AsyncData(next);
+    await _persistence.save(next);
+  }
+
+  /// Replaces the filter payload of the saved filter with [id].
+  ///
+  /// Used when "Update '`<name>`'" is invoked from the modal — the saved view
+  /// keeps its name and id but takes on the currently-active filter shape.
+  Future<void> updateFilter(String id, TasksFilter filter) async {
+    final current = state.value ?? const <SavedTaskFilter>[];
+    final idx = current.indexWhere((SavedTaskFilter f) => f.id == id);
+    if (idx < 0) return;
+
+    final next = [...current];
+    next[idx] = current[idx].copyWith(filter: filter);
+    state = AsyncData(next);
+    await _persistence.save(next);
+  }
+
+  /// Removes the saved filter with [id]. No-op when missing.
+  Future<void> delete(String id) async {
+    final current = state.value ?? const <SavedTaskFilter>[];
+    if (!current.any((SavedTaskFilter f) => f.id == id)) return;
+    final next = current
+        .where((SavedTaskFilter f) => f.id != id)
+        .toList(growable: false);
+    state = AsyncData(next);
+    await _persistence.save(next);
+  }
+
+  /// Moves the saved filter [dragId] to the position currently held by
+  /// [targetId]. The dragged row is inserted at the target's index, shifting
+  /// the rest. No-op when ids match or are missing.
+  Future<void> reorder(String dragId, String targetId) async {
+    if (dragId == targetId) return;
+
+    final current = state.value ?? const <SavedTaskFilter>[];
+    final fromIdx = current.indexWhere((SavedTaskFilter f) => f.id == dragId);
+    final toIdx = current.indexWhere((SavedTaskFilter f) => f.id == targetId);
+    if (fromIdx < 0 || toIdx < 0) return;
+
+    final next = [...current];
+    final item = next.removeAt(fromIdx);
+    next.insert(toIdx, item);
+    state = AsyncData(next);
+    await _persistence.save(next);
+  }
+}

--- a/lib/features/tasks/state/saved_filters/saved_task_filters_controller.dart
+++ b/lib/features/tasks/state/saved_filters/saved_task_filters_controller.dart
@@ -32,12 +32,12 @@ class SavedTaskFiltersController extends _$SavedTaskFiltersController {
     required String name,
     required TasksFilter filter,
   }) async {
+    final current = await future;
     final saved = SavedTaskFilter(
       id: _uuid.v4(),
       name: name,
       filter: filter,
     );
-    final current = state.value ?? const <SavedTaskFilter>[];
     final next = [...current, saved];
     state = AsyncData(next);
     await _persistence.save(next);
@@ -50,7 +50,7 @@ class SavedTaskFiltersController extends _$SavedTaskFiltersController {
     final trimmed = name.trim();
     if (trimmed.isEmpty) return;
 
-    final current = state.value ?? const <SavedTaskFilter>[];
+    final current = await future;
     final idx = current.indexWhere((SavedTaskFilter f) => f.id == id);
     if (idx < 0) return;
     if (current[idx].name == trimmed) return;
@@ -66,7 +66,7 @@ class SavedTaskFiltersController extends _$SavedTaskFiltersController {
   /// Used when "Update '`<name>`'" is invoked from the modal — the saved view
   /// keeps its name and id but takes on the currently-active filter shape.
   Future<void> updateFilter(String id, TasksFilter filter) async {
-    final current = state.value ?? const <SavedTaskFilter>[];
+    final current = await future;
     final idx = current.indexWhere((SavedTaskFilter f) => f.id == id);
     if (idx < 0) return;
 
@@ -78,7 +78,7 @@ class SavedTaskFiltersController extends _$SavedTaskFiltersController {
 
   /// Removes the saved filter with [id]. No-op when missing.
   Future<void> delete(String id) async {
-    final current = state.value ?? const <SavedTaskFilter>[];
+    final current = await future;
     if (!current.any((SavedTaskFilter f) => f.id == id)) return;
     final next = current
         .where((SavedTaskFilter f) => f.id != id)
@@ -93,7 +93,7 @@ class SavedTaskFiltersController extends _$SavedTaskFiltersController {
   Future<void> reorder(String dragId, String targetId) async {
     if (dragId == targetId) return;
 
-    final current = state.value ?? const <SavedTaskFilter>[];
+    final current = await future;
     final fromIdx = current.indexWhere((SavedTaskFilter f) => f.id == dragId);
     final toIdx = current.indexWhere((SavedTaskFilter f) => f.id == targetId);
     if (fromIdx < 0 || toIdx < 0) return;

--- a/lib/features/tasks/state/saved_filters/saved_task_filters_controller.g.dart
+++ b/lib/features/tasks/state/saved_filters/saved_task_filters_controller.g.dart
@@ -1,0 +1,87 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'saved_task_filters_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Riverpod controller backing the user's pinned task-filter list.
+///
+/// State is the ordered list of [SavedTaskFilter]s. Position in the list is
+/// the sort order. Mutations write through to [SavedTaskFiltersPersistence]
+/// after each operation.
+
+@ProviderFor(SavedTaskFiltersController)
+final savedTaskFiltersControllerProvider =
+    SavedTaskFiltersControllerProvider._();
+
+/// Riverpod controller backing the user's pinned task-filter list.
+///
+/// State is the ordered list of [SavedTaskFilter]s. Position in the list is
+/// the sort order. Mutations write through to [SavedTaskFiltersPersistence]
+/// after each operation.
+final class SavedTaskFiltersControllerProvider
+    extends
+        $AsyncNotifierProvider<
+          SavedTaskFiltersController,
+          List<SavedTaskFilter>
+        > {
+  /// Riverpod controller backing the user's pinned task-filter list.
+  ///
+  /// State is the ordered list of [SavedTaskFilter]s. Position in the list is
+  /// the sort order. Mutations write through to [SavedTaskFiltersPersistence]
+  /// after each operation.
+  SavedTaskFiltersControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'savedTaskFiltersControllerProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$savedTaskFiltersControllerHash();
+
+  @$internal
+  @override
+  SavedTaskFiltersController create() => SavedTaskFiltersController();
+}
+
+String _$savedTaskFiltersControllerHash() =>
+    r'4b7cbbf71b29ae2167345e22369a8f1424ed1cd0';
+
+/// Riverpod controller backing the user's pinned task-filter list.
+///
+/// State is the ordered list of [SavedTaskFilter]s. Position in the list is
+/// the sort order. Mutations write through to [SavedTaskFiltersPersistence]
+/// after each operation.
+
+abstract class _$SavedTaskFiltersController
+    extends $AsyncNotifier<List<SavedTaskFilter>> {
+  FutureOr<List<SavedTaskFilter>> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref =
+        this.ref
+            as $Ref<AsyncValue<List<SavedTaskFilter>>, List<SavedTaskFilter>>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<
+                AsyncValue<List<SavedTaskFilter>>,
+                List<SavedTaskFilter>
+              >,
+              AsyncValue<List<SavedTaskFilter>>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/lib/features/tasks/state/saved_filters/saved_task_filters_persistence.dart
+++ b/lib/features/tasks/state/saved_filters/saved_task_filters_persistence.dart
@@ -1,0 +1,85 @@
+import 'dart:convert';
+
+import 'package:lotti/database/settings_db.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter.dart';
+import 'package:lotti/services/dev_logger.dart';
+
+/// Persists the ordered list of [SavedTaskFilter]s as a single JSON blob in
+/// [SettingsDb].
+///
+/// The list is small (typical user has a handful of saved filters) so a
+/// single-blob approach mirrors `JournalFilterPersistence` and keeps reorder
+/// trivial: position in the list is the sort order.
+class SavedTaskFiltersPersistence {
+  SavedTaskFiltersPersistence(this._settingsDb);
+
+  /// Storage key under which the JSON list of saved filters is persisted.
+  static const storageKey = 'SAVED_TASK_FILTERS';
+
+  final SettingsDb _settingsDb;
+
+  // Dedup state — avoids redundant DB writes when the encoded value is
+  // unchanged. Mirrors the pattern in JournalFilterPersistence.
+  String? _persistedValue;
+  bool _hasLoaded = false;
+
+  /// Loads the persisted list. Returns an empty list when nothing is stored
+  /// or the stored payload cannot be decoded.
+  Future<List<SavedTaskFilter>> load() async {
+    final raw = await _settingsDb.itemByKey(storageKey);
+    if (raw == null) {
+      _persistedValue = null;
+      _hasLoaded = true;
+      return const <SavedTaskFilter>[];
+    }
+
+    try {
+      final list = (jsonDecode(raw) as List<dynamic>)
+          .map((e) => SavedTaskFilter.fromJson(e as Map<String, dynamic>))
+          .toList(growable: false);
+      _persistedValue = _encode(list);
+      _hasLoaded = true;
+      return list;
+    } catch (e) {
+      _persistedValue = raw;
+      _hasLoaded = true;
+      DevLogger.warning(
+        name: 'SavedTaskFiltersPersistence',
+        message: 'Error decoding saved task filters: $e',
+      );
+      return const <SavedTaskFilter>[];
+    }
+  }
+
+  /// Persists [filters] (preserving order). Skips the DB write when the
+  /// encoded value matches the last-persisted value.
+  Future<void> save(List<SavedTaskFilter> filters) async {
+    final encoded = _encode(filters);
+
+    if (!_hasLoaded) {
+      _persistedValue = _normalize(await _settingsDb.itemByKey(storageKey));
+      _hasLoaded = true;
+    }
+
+    if (_persistedValue == encoded) return;
+
+    await _settingsDb.saveSettingsItem(storageKey, encoded);
+    _persistedValue = encoded;
+  }
+
+  String _encode(List<SavedTaskFilter> filters) {
+    return jsonEncode(filters.map((f) => f.toJson()).toList(growable: false));
+  }
+
+  String? _normalize(String? value) {
+    if (value == null) return null;
+    try {
+      final list = (jsonDecode(value) as List<dynamic>)
+          .map((e) => SavedTaskFilter.fromJson(e as Map<String, dynamic>))
+          .toList(growable: false);
+      return _encode(list);
+    } catch (_) {
+      return value;
+    }
+  }
+}

--- a/test/features/tasks/state/saved_filters/saved_task_filter_test.dart
+++ b/test/features/tasks/state/saved_filters/saved_task_filter_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/journal/state/journal_page_state.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter.dart';
+
+void main() {
+  group('SavedTaskFilter JSON', () {
+    test('round-trips a populated filter through fromJson/toJson', () {
+      const original = SavedTaskFilter(
+        id: 'sv-abc',
+        name: 'Blocked or on hold',
+        filter: TasksFilter(
+          selectedCategoryIds: {'cat-1'},
+          selectedTaskStatuses: {'BLOCKED', 'ON_HOLD'},
+          selectedPriorities: {'P1'},
+          sortOption: TaskSortOption.byDueDate,
+          showCreationDate: true,
+          showDueDate: false,
+          agentAssignmentFilter: AgentAssignmentFilter.hasAgent,
+        ),
+      );
+
+      final restored = SavedTaskFilter.fromJson(original.toJson());
+
+      expect(restored, original);
+    });
+
+    test('preserves id, name, and filter equality across encode/decode', () {
+      const original = SavedTaskFilter(
+        id: 'sv-1',
+        name: 'In progress · P0–P1',
+        filter: TasksFilter(
+          selectedTaskStatuses: {'IN_PROGRESS'},
+          selectedPriorities: {'P0', 'P1'},
+        ),
+      );
+
+      final restored = SavedTaskFilter.fromJson(original.toJson());
+
+      expect(restored.id, 'sv-1');
+      expect(restored.name, 'In progress · P0–P1');
+      expect(restored.filter.selectedPriorities, {'P0', 'P1'});
+      expect(restored.filter.selectedTaskStatuses, {'IN_PROGRESS'});
+    });
+  });
+}

--- a/test/features/tasks/state/saved_filters/saved_task_filters_controller_test.dart
+++ b/test/features/tasks/state/saved_filters/saved_task_filters_controller_test.dart
@@ -1,0 +1,366 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/journal/state/journal_page_state.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filters_controller.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filters_persistence.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../widget_test_utils.dart';
+
+const _filterA = TasksFilter(
+  selectedTaskStatuses: {'IN_PROGRESS'},
+  selectedPriorities: {'P0', 'P1'},
+);
+
+const _filterB = TasksFilter(
+  agentAssignmentFilter: AgentAssignmentFilter.noAgent,
+);
+
+const _filterC = TasksFilter(
+  selectedTaskStatuses: {'BLOCKED', 'ON_HOLD'},
+);
+
+void main() {
+  late TestGetItMocks mocks;
+
+  setUp(() async {
+    mocks = await setUpTestGetIt();
+  });
+
+  tearDown(tearDownTestGetIt);
+
+  // Helper: stub the persisted list at the storage key.
+  void stubPersisted(List<SavedTaskFilter> items) {
+    when(
+      () => mocks.settingsDb.itemByKey(
+        SavedTaskFiltersPersistence.storageKey,
+      ),
+    ).thenAnswer(
+      (_) async => jsonEncode(
+        items.map((e) => e.toJson()).toList(growable: false),
+      ),
+    );
+  }
+
+  ProviderContainer makeContainer() {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  group('build', () {
+    test('returns empty list when nothing is persisted', () async {
+      final container = makeContainer();
+
+      final list = await container.read(
+        savedTaskFiltersControllerProvider.future,
+      );
+
+      expect(list, isEmpty);
+    });
+
+    test('loads persisted filters in stored order', () async {
+      stubPersisted(const [
+        SavedTaskFilter(id: 'sv-1', name: 'A', filter: _filterA),
+        SavedTaskFilter(id: 'sv-2', name: 'B', filter: _filterB),
+      ]);
+      final container = makeContainer();
+
+      final list = await container.read(
+        savedTaskFiltersControllerProvider.future,
+      );
+
+      expect(list.map((e) => e.id), ['sv-1', 'sv-2']);
+      expect(list[0].filter, _filterA);
+    });
+  });
+
+  group('create', () {
+    test('appends a new saved filter and persists', () async {
+      final container = makeContainer();
+      await container.read(savedTaskFiltersControllerProvider.future);
+
+      final created = await container
+          .read(savedTaskFiltersControllerProvider.notifier)
+          .create(name: 'New view', filter: _filterA);
+
+      expect(created.name, 'New view');
+      expect(created.id, isNotEmpty);
+
+      final list = container.read(savedTaskFiltersControllerProvider).value!;
+      expect(list, hasLength(1));
+      expect(list.first.id, created.id);
+      expect(list.first.filter, _filterA);
+
+      verify(
+        () => mocks.settingsDb.saveSettingsItem(
+          SavedTaskFiltersPersistence.storageKey,
+          any(),
+        ),
+      ).called(1);
+    });
+
+    test('preserves existing entries when appending', () async {
+      stubPersisted(const [
+        SavedTaskFilter(id: 'sv-1', name: 'A', filter: _filterA),
+      ]);
+      final container = makeContainer();
+      await container.read(savedTaskFiltersControllerProvider.future);
+
+      await container
+          .read(savedTaskFiltersControllerProvider.notifier)
+          .create(name: 'B', filter: _filterB);
+
+      final list = container.read(savedTaskFiltersControllerProvider).value!;
+      expect(list.map((e) => e.name), ['A', 'B']);
+    });
+  });
+
+  group('rename', () {
+    test('renames an existing filter and persists', () async {
+      stubPersisted(const [
+        SavedTaskFilter(id: 'sv-1', name: 'Old', filter: _filterA),
+      ]);
+      final container = makeContainer();
+      await container.read(savedTaskFiltersControllerProvider.future);
+
+      await container
+          .read(savedTaskFiltersControllerProvider.notifier)
+          .rename('sv-1', 'New');
+
+      expect(
+        container.read(savedTaskFiltersControllerProvider).value!.single.name,
+        'New',
+      );
+    });
+
+    test('trims whitespace before applying', () async {
+      stubPersisted(const [
+        SavedTaskFilter(id: 'sv-1', name: 'Old', filter: _filterA),
+      ]);
+      final container = makeContainer();
+      await container.read(savedTaskFiltersControllerProvider.future);
+
+      await container
+          .read(savedTaskFiltersControllerProvider.notifier)
+          .rename('sv-1', '   Padded   ');
+
+      expect(
+        container.read(savedTaskFiltersControllerProvider).value!.single.name,
+        'Padded',
+      );
+    });
+
+    test('is a no-op for empty / whitespace name', () async {
+      stubPersisted(const [
+        SavedTaskFilter(id: 'sv-1', name: 'Keep', filter: _filterA),
+      ]);
+      final container = makeContainer();
+      await container.read(savedTaskFiltersControllerProvider.future);
+      // Reset mock invocation count after the load.
+      clearInteractions(mocks.settingsDb);
+
+      await container
+          .read(savedTaskFiltersControllerProvider.notifier)
+          .rename('sv-1', '   ');
+
+      expect(
+        container.read(savedTaskFiltersControllerProvider).value!.single.name,
+        'Keep',
+      );
+      verifyNever(
+        () => mocks.settingsDb.saveSettingsItem(any(), any()),
+      );
+    });
+
+    test('is a no-op when id is unknown', () async {
+      stubPersisted(const [
+        SavedTaskFilter(id: 'sv-1', name: 'Keep', filter: _filterA),
+      ]);
+      final container = makeContainer();
+      await container.read(savedTaskFiltersControllerProvider.future);
+      clearInteractions(mocks.settingsDb);
+
+      await container
+          .read(savedTaskFiltersControllerProvider.notifier)
+          .rename('missing', 'Whatever');
+
+      verifyNever(
+        () => mocks.settingsDb.saveSettingsItem(any(), any()),
+      );
+    });
+
+    test('is a no-op when name is unchanged', () async {
+      stubPersisted(const [
+        SavedTaskFilter(id: 'sv-1', name: 'Same', filter: _filterA),
+      ]);
+      final container = makeContainer();
+      await container.read(savedTaskFiltersControllerProvider.future);
+      clearInteractions(mocks.settingsDb);
+
+      await container
+          .read(savedTaskFiltersControllerProvider.notifier)
+          .rename('sv-1', 'Same');
+
+      verifyNever(
+        () => mocks.settingsDb.saveSettingsItem(any(), any()),
+      );
+    });
+  });
+
+  group('updateFilter', () {
+    test('replaces the filter payload while preserving id and name', () async {
+      stubPersisted(const [
+        SavedTaskFilter(id: 'sv-1', name: 'View', filter: _filterA),
+      ]);
+      final container = makeContainer();
+      await container.read(savedTaskFiltersControllerProvider.future);
+
+      await container
+          .read(savedTaskFiltersControllerProvider.notifier)
+          .updateFilter('sv-1', _filterB);
+
+      final updated = container
+          .read(savedTaskFiltersControllerProvider)
+          .value!
+          .single;
+      expect(updated.id, 'sv-1');
+      expect(updated.name, 'View');
+      expect(updated.filter, _filterB);
+    });
+
+    test('is a no-op when id is unknown', () async {
+      stubPersisted(const [
+        SavedTaskFilter(id: 'sv-1', name: 'View', filter: _filterA),
+      ]);
+      final container = makeContainer();
+      await container.read(savedTaskFiltersControllerProvider.future);
+      clearInteractions(mocks.settingsDb);
+
+      await container
+          .read(savedTaskFiltersControllerProvider.notifier)
+          .updateFilter('missing', _filterB);
+
+      expect(
+        container.read(savedTaskFiltersControllerProvider).value!.single.filter,
+        _filterA,
+      );
+      verifyNever(
+        () => mocks.settingsDb.saveSettingsItem(any(), any()),
+      );
+    });
+  });
+
+  group('delete', () {
+    test('removes the filter and persists', () async {
+      stubPersisted(const [
+        SavedTaskFilter(id: 'sv-1', name: 'A', filter: _filterA),
+        SavedTaskFilter(id: 'sv-2', name: 'B', filter: _filterB),
+      ]);
+      final container = makeContainer();
+      await container.read(savedTaskFiltersControllerProvider.future);
+
+      await container
+          .read(savedTaskFiltersControllerProvider.notifier)
+          .delete('sv-1');
+
+      final list = container.read(savedTaskFiltersControllerProvider).value!;
+      expect(list.map((e) => e.id), ['sv-2']);
+    });
+
+    test('is a no-op when id is unknown', () async {
+      stubPersisted(const [
+        SavedTaskFilter(id: 'sv-1', name: 'A', filter: _filterA),
+      ]);
+      final container = makeContainer();
+      await container.read(savedTaskFiltersControllerProvider.future);
+      clearInteractions(mocks.settingsDb);
+
+      await container
+          .read(savedTaskFiltersControllerProvider.notifier)
+          .delete('missing');
+
+      expect(
+        container.read(savedTaskFiltersControllerProvider).value,
+        hasLength(1),
+      );
+      verifyNever(
+        () => mocks.settingsDb.saveSettingsItem(any(), any()),
+      );
+    });
+  });
+
+  group('reorder', () {
+    test('moves a filter to the target position', () async {
+      stubPersisted(const [
+        SavedTaskFilter(id: 'sv-1', name: 'A', filter: _filterA),
+        SavedTaskFilter(id: 'sv-2', name: 'B', filter: _filterB),
+        SavedTaskFilter(id: 'sv-3', name: 'C', filter: _filterC),
+      ]);
+      final container = makeContainer();
+      await container.read(savedTaskFiltersControllerProvider.future);
+
+      await container
+          .read(savedTaskFiltersControllerProvider.notifier)
+          .reorder('sv-3', 'sv-1');
+
+      final list = container.read(savedTaskFiltersControllerProvider).value!;
+      expect(list.map((e) => e.id), ['sv-3', 'sv-1', 'sv-2']);
+    });
+
+    test('handles dragging downward (reverse direction)', () async {
+      stubPersisted(const [
+        SavedTaskFilter(id: 'sv-1', name: 'A', filter: _filterA),
+        SavedTaskFilter(id: 'sv-2', name: 'B', filter: _filterB),
+        SavedTaskFilter(id: 'sv-3', name: 'C', filter: _filterC),
+      ]);
+      final container = makeContainer();
+      await container.read(savedTaskFiltersControllerProvider.future);
+
+      await container
+          .read(savedTaskFiltersControllerProvider.notifier)
+          .reorder('sv-1', 'sv-3');
+
+      final list = container.read(savedTaskFiltersControllerProvider).value!;
+      expect(list.map((e) => e.id), ['sv-2', 'sv-3', 'sv-1']);
+    });
+
+    test('is a no-op when dragId equals targetId', () async {
+      stubPersisted(const [
+        SavedTaskFilter(id: 'sv-1', name: 'A', filter: _filterA),
+        SavedTaskFilter(id: 'sv-2', name: 'B', filter: _filterB),
+      ]);
+      final container = makeContainer();
+      await container.read(savedTaskFiltersControllerProvider.future);
+      clearInteractions(mocks.settingsDb);
+
+      await container
+          .read(savedTaskFiltersControllerProvider.notifier)
+          .reorder('sv-1', 'sv-1');
+
+      verifyNever(
+        () => mocks.settingsDb.saveSettingsItem(any(), any()),
+      );
+    });
+
+    test('is a no-op when either id is unknown', () async {
+      stubPersisted(const [
+        SavedTaskFilter(id: 'sv-1', name: 'A', filter: _filterA),
+      ]);
+      final container = makeContainer();
+      await container.read(savedTaskFiltersControllerProvider.future);
+      clearInteractions(mocks.settingsDb);
+
+      await container
+          .read(savedTaskFiltersControllerProvider.notifier)
+          .reorder('sv-1', 'missing');
+
+      verifyNever(
+        () => mocks.settingsDb.saveSettingsItem(any(), any()),
+      );
+    });
+  });
+}

--- a/test/features/tasks/state/saved_filters/saved_task_filters_controller_test.dart
+++ b/test/features/tasks/state/saved_filters/saved_task_filters_controller_test.dart
@@ -117,6 +117,26 @@ void main() {
       final list = container.read(savedTaskFiltersControllerProvider).value!;
       expect(list.map((e) => e.name), ['A', 'B']);
     });
+
+    test(
+      'waits for initial load before mutating to avoid wiping data',
+      () async {
+        stubPersisted(const [
+          SavedTaskFilter(id: 'sv-1', name: 'A', filter: _filterA),
+        ]);
+        final container = makeContainer();
+
+        // Invoke create() without awaiting the build future first; the mutation
+        // must internally await it so the persisted entry is preserved.
+        final notifier = container.read(
+          savedTaskFiltersControllerProvider.notifier,
+        );
+        await notifier.create(name: 'B', filter: _filterB);
+
+        final list = container.read(savedTaskFiltersControllerProvider).value!;
+        expect(list.map((e) => e.name), ['A', 'B']);
+      },
+    );
   });
 
   group('rename', () {

--- a/test/features/tasks/state/saved_filters/saved_task_filters_persistence_test.dart
+++ b/test/features/tasks/state/saved_filters/saved_task_filters_persistence_test.dart
@@ -1,0 +1,224 @@
+// ignore_for_file: avoid_redundant_argument_values
+
+import 'dart:convert';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/journal/state/journal_page_state.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filters_persistence.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../mocks/mocks.dart';
+
+const _sampleFilter = TasksFilter(
+  selectedCategoryIds: {'cat-1'},
+  selectedProjectIds: <String>{},
+  selectedTaskStatuses: {'IN_PROGRESS'},
+  selectedLabelIds: <String>{},
+  selectedPriorities: {'P0', 'P1'},
+  sortOption: TaskSortOption.byPriority,
+  showCreationDate: false,
+  showDueDate: true,
+  showCoverArt: true,
+  showDistances: false,
+  agentAssignmentFilter: AgentAssignmentFilter.all,
+);
+
+const _saved = [
+  SavedTaskFilter(
+    id: 'sv-1',
+    name: 'In progress · P0–P1',
+    filter: _sampleFilter,
+  ),
+  SavedTaskFilter(
+    id: 'sv-2',
+    name: 'No agent assigned',
+    filter: TasksFilter(agentAssignmentFilter: AgentAssignmentFilter.noAgent),
+  ),
+];
+
+void main() {
+  late MockSettingsDb mockSettingsDb;
+  late SavedTaskFiltersPersistence sut;
+
+  setUp(() {
+    mockSettingsDb = MockSettingsDb();
+    sut = SavedTaskFiltersPersistence(mockSettingsDb);
+
+    when(() => mockSettingsDb.itemByKey(any())).thenAnswer((_) async => null);
+    when(
+      () => mockSettingsDb.saveSettingsItem(any(), any()),
+    ).thenAnswer((_) async => 1);
+  });
+
+  group('storageKey', () {
+    test('has expected canonical value', () {
+      expect(SavedTaskFiltersPersistence.storageKey, 'SAVED_TASK_FILTERS');
+    });
+  });
+
+  group('load', () {
+    test('returns empty list when nothing is stored', () {
+      fakeAsync((async) {
+        List<SavedTaskFilter>? result;
+        sut.load().then((v) => result = v);
+        async.flushMicrotasks();
+
+        expect(result, isEmpty);
+        verify(
+          () => mockSettingsDb.itemByKey(
+            SavedTaskFiltersPersistence.storageKey,
+          ),
+        ).called(1);
+      });
+    });
+
+    test('decodes a persisted ordered list of saved filters', () {
+      fakeAsync((async) {
+        final stored = jsonEncode(
+          _saved.map((e) => e.toJson()).toList(growable: false),
+        );
+        when(
+          () => mockSettingsDb.itemByKey(any()),
+        ).thenAnswer((_) async => stored);
+
+        List<SavedTaskFilter>? result;
+        sut.load().then((v) => result = v);
+        async.flushMicrotasks();
+
+        expect(result, hasLength(2));
+        expect(result![0].id, 'sv-1');
+        expect(result![0].name, 'In progress · P0–P1');
+        expect(result![0].filter.selectedPriorities, {'P0', 'P1'});
+        expect(
+          result![1].filter.agentAssignmentFilter,
+          AgentAssignmentFilter.noAgent,
+        );
+      });
+    });
+
+    test('returns empty list when stored payload is malformed', () {
+      fakeAsync((async) {
+        when(
+          () => mockSettingsDb.itemByKey(any()),
+        ).thenAnswer((_) async => '{not-json');
+
+        List<SavedTaskFilter>? result;
+        sut.load().then((v) => result = v);
+        async.flushMicrotasks();
+
+        expect(result, isEmpty);
+      });
+    });
+  });
+
+  group('save', () {
+    test('encodes the list as a JSON array preserving order', () {
+      fakeAsync((async) {
+        sut.save(_saved);
+        async.flushMicrotasks();
+
+        final captured = verify(
+          () => mockSettingsDb.saveSettingsItem(
+            SavedTaskFiltersPersistence.storageKey,
+            captureAny(),
+          ),
+        ).captured;
+
+        expect(captured, hasLength(1));
+        final decoded = jsonDecode(captured.first as String) as List<dynamic>;
+        expect(decoded, hasLength(2));
+        expect(
+          (decoded[0] as Map<String, dynamic>)['id'],
+          'sv-1',
+        );
+        expect(
+          (decoded[1] as Map<String, dynamic>)['name'],
+          'No agent assigned',
+        );
+      });
+    });
+
+    test('writes empty array when list is empty', () {
+      fakeAsync((async) {
+        sut.save(const <SavedTaskFilter>[]);
+        async.flushMicrotasks();
+
+        final captured = verify(
+          () => mockSettingsDb.saveSettingsItem(
+            SavedTaskFiltersPersistence.storageKey,
+            captureAny(),
+          ),
+        ).captured;
+
+        expect(captured, hasLength(1));
+        expect(captured.first, '[]');
+      });
+    });
+
+    test('skips write when encoded value matches the loaded value', () {
+      fakeAsync((async) {
+        final stored = jsonEncode(
+          _saved.map((e) => e.toJson()).toList(growable: false),
+        );
+        when(
+          () => mockSettingsDb.itemByKey(any()),
+        ).thenAnswer((_) async => stored);
+
+        sut.load();
+        async.flushMicrotasks();
+
+        sut.save(_saved);
+        async.flushMicrotasks();
+
+        verifyNever(
+          () => mockSettingsDb.saveSettingsItem(any(), any()),
+        );
+      });
+    });
+
+    test('writes when list differs from loaded value', () {
+      fakeAsync((async) {
+        final stored = jsonEncode(
+          _saved.take(1).map((e) => e.toJson()).toList(growable: false),
+        );
+        when(
+          () => mockSettingsDb.itemByKey(any()),
+        ).thenAnswer((_) async => stored);
+
+        sut.load();
+        async.flushMicrotasks();
+
+        sut.save(_saved);
+        async.flushMicrotasks();
+
+        verify(
+          () => mockSettingsDb.saveSettingsItem(
+            SavedTaskFiltersPersistence.storageKey,
+            any(),
+          ),
+        ).called(1);
+      });
+    });
+
+    test('fetches DB value when saving without a prior load', () {
+      fakeAsync((async) {
+        sut.save(_saved);
+        async.flushMicrotasks();
+
+        verify(
+          () => mockSettingsDb.itemByKey(
+            SavedTaskFiltersPersistence.storageKey,
+          ),
+        ).called(1);
+        verify(
+          () => mockSettingsDb.saveSettingsItem(
+            SavedTaskFiltersPersistence.storageKey,
+            any(),
+          ),
+        ).called(1);
+      });
+    });
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Save and pin task filters in the sidebar for quick access
  * Create, rename (trimmed input), update filter criteria, delete, and reorder saved filters
  * Saved filters persist across sessions and preserve order; redundant writes are avoided

* **Tests**
  * Added unit tests covering JSON serialization, controller operations, persistence behavior, and reordering edge cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->