### PR TITLE
feat(tasks): saved filters for the tasks tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.977] - 2026-04-25
+### Added
+- Saved filters for the Tasks tab. Build a filter (status, priority,
+  category, agent, etc.) in the Tasks Filter modal, tap the new **Save**
+  button next to Apply, give it a name, and pin it under "Tasks" in the
+  expanded sidebar. Saved filters live in `SavedTaskFiltersController`
+  (Riverpod, `keepAlive: true`), persist as a JSON list under
+  `SAVED_TASK_FILTERS` in `SettingsDb`, and surface as a treeview with
+  active-state highlight, hover-revealed two-tap delete, double-click
+  inline rename, drag-to-reorder, and a "Tasks · {filter name}" indicator
+  in the tasks pane header. Activating a saved filter applies it via
+  `JournalPageController.applyBatchFilterUpdate` while preserving the
+  ephemeral search query.
+
 ## [0.9.976] - 2026-04-25
 ### Changed
 - Agent wake cycles now sync as one bundled Matrix payload instead of emitting

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -31,6 +31,11 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="0.9.977" date="2026-04-25">
+      <description>
+          <p>Saved filters for the Tasks tab. Build a filter (status, priority, category, agent, etc.) in the Tasks Filter modal, tap the new Save button next to Apply, give it a name, and pin it under "Tasks" in the expanded sidebar. Saved filters live in SavedTaskFiltersController (Riverpod, keepAlive: true), persist as a JSON list under SAVED_TASK_FILTERS in SettingsDb, and surface as a treeview with active-state highlight, hover-revealed two-tap delete, double-click inline rename, drag-to-reorder, and a "Tasks · {filter name}" indicator in the tasks pane header. Activating a saved filter applies it via JournalPageController.applyBatchFilterUpdate while preserving the ephemeral search query.</p>
+      </description>
+    </release>
     <release version="0.9.976" date="2026-04-25">
       <description>
           <p>Agent wake cycles now sync as one bundled Matrix payload instead of emitting one outbox row per agent entity/link mutation. AgentSyncService wraps wake execution in a zone-local AgentWakeSyncInterceptor keyed by the wake run, buffers only agent entity/link messages, deduplicates by id, preserves superseded child vector clocks via coveredVectorClocks, and flushes a descriptor-backed SyncAgentBundle to the outbox when the wake exits. Receivers resolve the bundle attachment, apply entities before links through the existing agent sync handlers, and record each child payload in the sequence log so the convergence and backfill contract stays unchanged while wake traffic collapses to one Matrix message.</p>

--- a/lib/beamer/beamer_app.dart
+++ b/lib/beamer/beamer_app.dart
@@ -23,6 +23,7 @@ import 'package:lotti/features/settings/ui/pages/outbox/outbox_trailing_badge.da
 import 'package:lotti/features/speech/ui/widgets/recording/audio_recording_indicator.dart';
 import 'package:lotti/features/sync/state/matrix_login_controller.dart';
 import 'package:lotti/features/sync/ui/widgets/matrix/incoming_verification_modal.dart';
+import 'package:lotti/features/tasks/ui/saved_filters/tasks_saved_filters_tree.dart';
 import 'package:lotti/features/tasks/ui/tasks_badge_icon.dart';
 import 'package:lotti/features/tasks/ui/tasks_trailing_badge.dart';
 import 'package:lotti/features/theming/state/theming_controller.dart';
@@ -74,6 +75,7 @@ class _AppNavigationDestination {
     required this.iconBuilder,
     this.mobileIconWrapper,
     this.trailingBuilder,
+    this.expandedChildBuilder,
   });
 
   final _AppNavigationDestinationKind kind;
@@ -90,6 +92,11 @@ class _AppNavigationDestination {
   /// Optional trailing widget shown on the right side of the desktop sidebar
   /// row. Typically a count pill.
   final Widget Function({required bool active})? trailingBuilder;
+
+  /// Optional builder for a subtree rendered immediately under the
+  /// destination row when it is the active tab and the sidebar is expanded.
+  /// The Tasks destination uses this to host the saved-filters treeview.
+  final Widget Function()? expandedChildBuilder;
 
   Widget _mobileIcon({required bool active}) {
     final icon = iconBuilder(active: active);
@@ -114,6 +121,7 @@ class _AppNavigationDestination {
       label: label,
       iconBuilder: iconBuilder,
       trailingBuilder: trailingBuilder,
+      expandedChildBuilder: expandedChildBuilder,
     );
   }
 }
@@ -503,6 +511,7 @@ class _AppScreenState extends ConsumerState<AppScreen> {
             Icon(active ? Icons.list_rounded : Icons.list_outlined),
         mobileIconWrapper: (icon) => TasksBadge(child: icon),
         trailingBuilder: ({required active}) => const TasksTrailingBadge(),
+        expandedChildBuilder: () => const TasksSavedFiltersTree(),
       ),
       _AppNavigationDestination(
         kind: _AppNavigationDestinationKind.projects,

--- a/lib/features/design_system/components/headers/tab_section_header.dart
+++ b/lib/features/design_system/components/headers/tab_section_header.dart
@@ -79,7 +79,7 @@ class TabSectionHeader extends StatelessWidget {
                         ),
                       ),
                       if (titleSuffix != null) ...[
-                        const SizedBox(width: 8),
+                        SizedBox(width: tokens.spacing.step3),
                         Flexible(child: titleSuffix!),
                       ],
                     ],

--- a/lib/features/design_system/components/headers/tab_section_header.dart
+++ b/lib/features/design_system/components/headers/tab_section_header.dart
@@ -22,6 +22,7 @@ class TabSectionHeader extends StatelessWidget {
     required this.onFilterPressed,
     required this.filterTooltip,
     this.titleTrailing,
+    this.titleSuffix,
     super.key,
   });
 
@@ -34,6 +35,10 @@ class TabSectionHeader extends StatelessWidget {
   final VoidCallback onFilterPressed;
   final String filterTooltip;
   final Widget? titleTrailing;
+
+  /// Optional inline suffix rendered after [title] — used by Tasks to show
+  /// "Tasks · {savedFilterName}" when a saved filter is active.
+  final Widget? titleSuffix;
 
   @override
   Widget build(BuildContext context) {
@@ -62,11 +67,22 @@ class TabSectionHeader extends StatelessWidget {
             child: Row(
               children: [
                 Expanded(
-                  child: Text(
-                    title,
-                    style: tokens.typography.styles.heading.heading3.copyWith(
-                      color: highText,
-                    ),
+                  child: Row(
+                    children: [
+                      Flexible(
+                        child: Text(
+                          title,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: tokens.typography.styles.heading.heading3
+                              .copyWith(color: highText),
+                        ),
+                      ),
+                      if (titleSuffix != null) ...[
+                        const SizedBox(width: 8),
+                        Flexible(child: titleSuffix!),
+                      ],
+                    ],
                   ),
                 ),
                 effectiveTitleTrailing,

--- a/lib/features/design_system/components/navigation/desktop_navigation_sidebar.dart
+++ b/lib/features/design_system/components/navigation/desktop_navigation_sidebar.dart
@@ -15,6 +15,7 @@ class DesktopSidebarDestination {
     required this.label,
     required this.iconBuilder,
     this.trailingBuilder,
+    this.expandedChildBuilder,
   });
 
   /// Display label for this destination.
@@ -26,6 +27,16 @@ class DesktopSidebarDestination {
   /// Optional builder for a trailing widget (e.g. a count badge) rendered
   /// on the right side of the row, aligned with the label.
   final Widget Function({required bool active})? trailingBuilder;
+
+  /// Optional builder for a subtree rendered immediately below the
+  /// destination row when the sidebar is in its expanded layout.
+  ///
+  /// The builder is only invoked while the destination is the active tab —
+  /// the design system uses this to host the Tasks "Saved filters" treeview
+  /// without having to special-case the tasks destination in every consumer.
+  /// Subtrees stay collapsed when the sidebar is in its narrow icon-only
+  /// layout.
+  final Widget Function()? expandedChildBuilder;
 }
 
 /// Persistent left-hand navigation sidebar for the desktop layout.
@@ -131,6 +142,16 @@ class DesktopNavigationSidebar extends StatelessWidget {
                       collapsed: collapsed,
                       onTap: () => onDestinationSelected(i),
                     ),
+                    // Render the destination's expanded subtree only when
+                    // the destination is active and the sidebar is not
+                    // collapsed — keeps icon-only mode visually stable.
+                    if (!collapsed &&
+                        i == activeIndex &&
+                        !isSettingsActive &&
+                        destinations[i].expandedChildBuilder != null) ...[
+                      SizedBox(height: tokens.spacing.step3),
+                      destinations[i].expandedChildBuilder!(),
+                    ],
                     if (i < destinations.length - 1)
                       SizedBox(height: tokens.spacing.step6),
                   ],

--- a/lib/features/design_system/components/task_filters/design_system_filter_modal.dart
+++ b/lib/features/design_system/components/task_filters/design_system_filter_modal.dart
@@ -19,12 +19,20 @@ typedef DesignSystemFilterFieldHandler =
 /// The action bar (Clear All + Apply) is rendered as a sticky action bar that
 /// remains visible while the filter sections scroll. State is shared between
 /// the scrollable content and the sticky action bar via a [ValueNotifier].
+///
+/// When [onSavePressed] is supplied, an additional Save affordance is rendered
+/// next to Apply. Tapping it opens an inline name popup; the entered name is
+/// passed to [onSavePressed]. The button is disabled when [canSave] is false
+/// (typically because the filter has no clauses to save).
 Future<void> showDesignSystemFilterModal({
   required BuildContext context,
   required DesignSystemTaskFilterState initialState,
   required ValueChanged<DesignSystemTaskFilterState> onApplied,
   DesignSystemFilterFieldHandler? onFieldPressed,
   Widget Function(Widget)? modalDecorator,
+  ValueChanged<String>? onSavePressed,
+  bool canSave = false,
+  String? initialSaveName,
 }) async {
   final stateNotifier = ValueNotifier(initialState);
 
@@ -47,6 +55,9 @@ Future<void> showDesignSystemFilterModal({
                 Navigator.of(ctx).pop();
               },
               onClearAllPressed: (next) => stateNotifier.value = next,
+              onSavePressed: onSavePressed,
+              canSave: canSave,
+              initialSaveName: initialSaveName,
             );
           },
         );

--- a/lib/features/design_system/components/task_filters/design_system_task_filter_sheet.dart
+++ b/lib/features/design_system/components/task_filters/design_system_task_filter_sheet.dart
@@ -898,33 +898,35 @@ class _DesignSystemTaskFilterActionBarState
           ),
           if (showSaveButton) ...[
             SizedBox(width: spacing.step5),
-            MenuAnchor(
-              controller: _saveMenu,
-              alignmentOffset: const Offset(0, -8),
-              menuChildren: [
-                _SaveNamePopup(
-                  key: DesignSystemTaskFilterActionBar.saveNamePopupKey,
-                  initialValue: widget.initialSaveName ?? '',
-                  activeFilterCount: widget.state.appliedCount,
-                  tokens: tokens,
-                  messages: messages,
-                  onCancel: _saveMenu.close,
-                  onCommit: (name) {
-                    _saveMenu.close();
-                    widget.onSavePressed?.call(name);
-                  },
-                ),
-              ],
-              builder: (ctx, controller, child) {
-                return DesignSystemFilterActionButton(
-                  key: DesignSystemTaskFilterActionBar.saveButtonKey,
-                  label: messages.tasksSavedFiltersSaveButtonLabel,
-                  palette: palette,
-                  highlighted: false,
-                  textStyle: tokens.typography.styles.subtitle.subtitle1,
-                  onTap: _openSavePopup,
-                );
-              },
+            Expanded(
+              child: MenuAnchor(
+                controller: _saveMenu,
+                alignmentOffset: const Offset(0, -8),
+                menuChildren: [
+                  _SaveNamePopup(
+                    key: DesignSystemTaskFilterActionBar.saveNamePopupKey,
+                    initialValue: widget.initialSaveName ?? '',
+                    activeFilterCount: widget.state.appliedCount,
+                    tokens: tokens,
+                    messages: messages,
+                    onCancel: _saveMenu.close,
+                    onCommit: (name) {
+                      _saveMenu.close();
+                      widget.onSavePressed?.call(name);
+                    },
+                  ),
+                ],
+                builder: (ctx, controller, child) {
+                  return DesignSystemFilterActionButton(
+                    key: DesignSystemTaskFilterActionBar.saveButtonKey,
+                    label: messages.tasksSavedFiltersSaveButtonLabel,
+                    palette: palette,
+                    highlighted: false,
+                    textStyle: tokens.typography.styles.subtitle.subtitle1,
+                    onTap: _openSavePopup,
+                  );
+                },
+              ),
             ),
           ],
           SizedBox(width: spacing.step5),

--- a/lib/features/design_system/components/task_filters/design_system_task_filter_sheet.dart
+++ b/lib/features/design_system/components/task_filters/design_system_task_filter_sheet.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:lotti/features/design_system/components/task_filters/design_system_filter_shared.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/l10n/app_localizations.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
 
 List<T> _parseJsonList<T>(
   dynamic jsonList,
@@ -791,12 +794,15 @@ class DesignSystemTaskFilterSheet extends StatelessWidget {
 /// Sticky action bar for the filter sheet — Clear All + Apply buttons.
 ///
 /// Designed to be used as the `stickyActionBar` in a Wolt modal page.
-class DesignSystemTaskFilterActionBar extends StatelessWidget {
+class DesignSystemTaskFilterActionBar extends StatefulWidget {
   const DesignSystemTaskFilterActionBar({
     required this.state,
     required this.onChanged,
     this.onApplyPressed,
     this.onClearAllPressed,
+    this.onSavePressed,
+    this.canSave = false,
+    this.initialSaveName,
     super.key,
   });
 
@@ -805,11 +811,67 @@ class DesignSystemTaskFilterActionBar extends StatelessWidget {
   final ValueChanged<DesignSystemTaskFilterState>? onApplyPressed;
   final ValueChanged<DesignSystemTaskFilterState>? onClearAllPressed;
 
+  /// When supplied, a Save affordance is rendered between Clear All and
+  /// Apply. Tapping it opens an inline name popup; the trimmed name is
+  /// passed to this callback when the user commits.
+  final ValueChanged<String>? onSavePressed;
+
+  /// Whether the Save affordance is currently enabled.
+  final bool canSave;
+
+  /// Optional initial value for the Save name popup — typically the name
+  /// of the currently active saved filter, when the user is editing it.
+  final String? initialSaveName;
+
+  /// Stable test key for the Save action button.
+  @visibleForTesting
+  static const Key saveButtonKey = ValueKey(
+    'design-system-task-filter-save',
+  );
+
+  /// Stable test key for the Save name popup card.
+  @visibleForTesting
+  static const Key saveNamePopupKey = ValueKey(
+    'design-system-task-filter-save-popup',
+  );
+
+  /// Stable test key for the Save name popup text field.
+  @visibleForTesting
+  static const Key saveNamePopupFieldKey = ValueKey(
+    'design-system-task-filter-save-popup-field',
+  );
+
+  /// Stable test key for the popup commit button.
+  @visibleForTesting
+  static const Key saveNamePopupCommitKey = ValueKey(
+    'design-system-task-filter-save-popup-commit',
+  );
+
+  @override
+  State<DesignSystemTaskFilterActionBar> createState() =>
+      _DesignSystemTaskFilterActionBarState();
+}
+
+class _DesignSystemTaskFilterActionBarState
+    extends State<DesignSystemTaskFilterActionBar> {
+  final MenuController _saveMenu = MenuController();
+
+  void _openSavePopup() {
+    if (!widget.canSave) return;
+    if (_saveMenu.isOpen) {
+      _saveMenu.close();
+    } else {
+      _saveMenu.open();
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final palette = DesignSystemFilterPalette.fromTokens(tokens);
     final spacing = tokens.spacing;
+    final messages = context.messages;
+    final showSaveButton = widget.onSavePressed != null;
 
     return Padding(
       padding: EdgeInsets.symmetric(
@@ -823,30 +885,226 @@ class DesignSystemTaskFilterActionBar extends StatelessWidget {
               key: const ValueKey(
                 'design-system-task-filter-clear',
               ),
-              label: state.clearAllLabel,
+              label: widget.state.clearAllLabel,
               palette: palette,
               highlighted: false,
               textStyle: tokens.typography.styles.subtitle.subtitle1,
               onTap: () {
-                final clearedState = state.clearAll();
-                onChanged(clearedState);
-                onClearAllPressed?.call(clearedState);
+                final clearedState = widget.state.clearAll();
+                widget.onChanged(clearedState);
+                widget.onClearAllPressed?.call(clearedState);
               },
             ),
           ),
+          if (showSaveButton) ...[
+            SizedBox(width: spacing.step5),
+            MenuAnchor(
+              controller: _saveMenu,
+              alignmentOffset: const Offset(0, -8),
+              menuChildren: [
+                _SaveNamePopup(
+                  key: DesignSystemTaskFilterActionBar.saveNamePopupKey,
+                  initialValue: widget.initialSaveName ?? '',
+                  activeFilterCount: widget.state.appliedCount,
+                  tokens: tokens,
+                  messages: messages,
+                  onCancel: _saveMenu.close,
+                  onCommit: (name) {
+                    _saveMenu.close();
+                    widget.onSavePressed?.call(name);
+                  },
+                ),
+              ],
+              builder: (ctx, controller, child) {
+                return DesignSystemFilterActionButton(
+                  key: DesignSystemTaskFilterActionBar.saveButtonKey,
+                  label: messages.tasksSavedFiltersSaveButtonLabel,
+                  palette: palette,
+                  highlighted: false,
+                  textStyle: tokens.typography.styles.subtitle.subtitle1,
+                  onTap: _openSavePopup,
+                );
+              },
+            ),
+          ],
           SizedBox(width: spacing.step5),
           Expanded(
             child: DesignSystemFilterActionButton(
               key: const ValueKey(
                 'design-system-task-filter-apply',
               ),
-              label: state.applyLabel,
+              label: widget.state.applyLabel,
               palette: palette,
               highlighted: true,
-              counter: state.appliedCount,
+              counter: widget.state.appliedCount,
               textStyle: tokens.typography.styles.subtitle.subtitle1,
-              onTap: () => onApplyPressed?.call(state),
+              onTap: () => widget.onApplyPressed?.call(widget.state),
             ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SaveNamePopup extends StatefulWidget {
+  const _SaveNamePopup({
+    required this.initialValue,
+    required this.activeFilterCount,
+    required this.tokens,
+    required this.messages,
+    required this.onCancel,
+    required this.onCommit,
+    super.key,
+  });
+
+  final String initialValue;
+  final int activeFilterCount;
+  final DsTokens tokens;
+  final AppLocalizations messages;
+  final VoidCallback onCancel;
+  final ValueChanged<String> onCommit;
+
+  @override
+  State<_SaveNamePopup> createState() => _SaveNamePopupState();
+}
+
+class _SaveNamePopupState extends State<_SaveNamePopup> {
+  late final TextEditingController _controller = TextEditingController(
+    text: widget.initialValue,
+  );
+  final FocusNode _focusNode = FocusNode();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _controller.selection = TextSelection(
+        baseOffset: 0,
+        extentOffset: _controller.text.length,
+      );
+      _focusNode.requestFocus();
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  void _commit() {
+    final trimmed = _controller.text.trim();
+    if (trimmed.isEmpty) return;
+    widget.onCommit(trimmed);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = widget.tokens;
+    final messages = widget.messages;
+    return Container(
+      width: 270,
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: tokens.colors.background.level02,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: tokens.colors.decorative.level01),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            messages.tasksSavedFiltersSavePopupTitle,
+            style: tokens.typography.styles.body.bodySmall.copyWith(
+              color: tokens.colors.text.mediumEmphasis,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Focus(
+            onKeyEvent: (node, event) {
+              if (event is KeyDownEvent &&
+                  event.logicalKey == LogicalKeyboardKey.escape) {
+                widget.onCancel();
+                return KeyEventResult.handled;
+              }
+              return KeyEventResult.ignored;
+            },
+            child: TextField(
+              key: DesignSystemTaskFilterActionBar.saveNamePopupFieldKey,
+              controller: _controller,
+              focusNode: _focusNode,
+              textInputAction: TextInputAction.done,
+              onSubmitted: (_) => _commit(),
+              style: tokens.typography.styles.body.bodyMedium.copyWith(
+                color: tokens.colors.text.highEmphasis,
+              ),
+              decoration: InputDecoration(
+                isDense: true,
+                hintText: messages.tasksSavedFiltersSavePopupHint,
+                hintStyle: tokens.typography.styles.body.bodyMedium.copyWith(
+                  color: tokens.colors.text.lowEmphasis,
+                ),
+                contentPadding: const EdgeInsets.symmetric(
+                  horizontal: 10,
+                  vertical: 8,
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  borderSide: BorderSide(
+                    color: tokens.colors.interactive.enabled,
+                  ),
+                ),
+                focusedBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  borderSide: BorderSide(
+                    color: tokens.colors.interactive.enabled,
+                  ),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            messages.tasksSavedFiltersSavePopupHelper(
+              widget.activeFilterCount,
+            ),
+            style: tokens.typography.styles.body.bodySmall.copyWith(
+              color: tokens.colors.text.lowEmphasis,
+            ),
+          ),
+          const SizedBox(height: 10),
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: widget.onCancel,
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: tokens.colors.text.mediumEmphasis,
+                    side: BorderSide(color: tokens.colors.decorative.level01),
+                    padding: const EdgeInsets.symmetric(vertical: 8),
+                  ),
+                  child: Text(messages.tasksSavedFiltersSavePopupCancel),
+                ),
+              ),
+              const SizedBox(width: 6),
+              Expanded(
+                child: FilledButton(
+                  key: DesignSystemTaskFilterActionBar.saveNamePopupCommitKey,
+                  onPressed: _commit,
+                  style: FilledButton.styleFrom(
+                    backgroundColor: tokens.colors.interactive.enabled,
+                    foregroundColor: tokens.colors.text.onInteractiveAlert,
+                    padding: const EdgeInsets.symmetric(vertical: 8),
+                  ),
+                  child: Text(messages.tasksSavedFiltersSavePopupSave),
+                ),
+              ),
+            ],
           ),
         ],
       ),

--- a/lib/features/design_system/components/task_filters/design_system_task_filter_sheet.dart
+++ b/lib/features/design_system/components/task_filters/design_system_task_filter_sheet.dart
@@ -974,10 +974,12 @@ class _SaveNamePopupState extends State<_SaveNamePopup> {
     text: widget.initialValue,
   );
   final FocusNode _focusNode = FocusNode();
+  late bool _canCommit = _controller.text.trim().isNotEmpty;
 
   @override
   void initState() {
     super.initState();
+    _controller.addListener(_handleTextChanged);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       _controller.selection = TextSelection(
@@ -990,15 +992,23 @@ class _SaveNamePopupState extends State<_SaveNamePopup> {
 
   @override
   void dispose() {
-    _controller.dispose();
+    _controller
+      ..removeListener(_handleTextChanged)
+      ..dispose();
     _focusNode.dispose();
     super.dispose();
   }
 
+  void _handleTextChanged() {
+    final next = _controller.text.trim().isNotEmpty;
+    if (next != _canCommit) {
+      setState(() => _canCommit = next);
+    }
+  }
+
   void _commit() {
-    final trimmed = _controller.text.trim();
-    if (trimmed.isEmpty) return;
-    widget.onCommit(trimmed);
+    if (!_canCommit) return;
+    widget.onCommit(_controller.text.trim());
   }
 
   @override
@@ -1095,7 +1105,7 @@ class _SaveNamePopupState extends State<_SaveNamePopup> {
               Expanded(
                 child: FilledButton(
                   key: DesignSystemTaskFilterActionBar.saveNamePopupCommitKey,
-                  onPressed: _commit,
+                  onPressed: _canCommit ? _commit : null,
                   style: FilledButton.styleFrom(
                     backgroundColor: tokens.colors.interactive.enabled,
                     foregroundColor: tokens.colors.text.onInteractiveAlert,

--- a/lib/features/tasks/README.md
+++ b/lib/features/tasks/README.md
@@ -374,7 +374,7 @@ which keeps tasks-tab filter state separate from the journal tab. One subtle bou
 
 The tasks tab also supports user-saved filters surfaced as a treeview under the Tasks destination in the desktop sidebar. The model lives in `lib/features/tasks/state/saved_filters/`:
 
-- `SavedTaskFilter` (`{id, name, filter: TasksFilter}`) is a freezed JSON-serialisable model. The ephemeral `query` / `match` field on `JournalPageState` is intentionally NOT part of the saved payload — it stays on the live page state and is preserved across saved-filter activations.
+- `SavedTaskFilter` (`{id, name, filter: TasksFilter}`) is a Freezed JSON-serializable model. The ephemeral `query` / `match` field on `JournalPageState` is intentionally NOT part of the saved payload — it stays on the live page state and is preserved across saved-filter activations.
 - `SavedTaskFiltersPersistence` writes the ordered list as a single JSON blob to `SettingsDb` under the `SAVED_TASK_FILTERS` key. Position in the list IS the sort order. Mirrors the dedup-on-write pattern of `JournalFilterPersistence`.
 - `savedTaskFiltersControllerProvider` (Riverpod `keepAlive: true` async notifier) exposes `create`, `rename`, `updateFilter`, `delete`, `reorder`. Each mutation persists.
 - `SavedTaskFilterActivator` applies a `SavedTaskFilter` to the live `JournalPageController` via `applyBatchFilterUpdate`.

--- a/lib/features/tasks/README.md
+++ b/lib/features/tasks/README.md
@@ -370,6 +370,42 @@ Persistence uses:
 
 which keeps tasks-tab filter state separate from the journal tab. One subtle boundary here: project filtering is persisted in the same controller state, but the visible project filter controls are rendered by shared/project widgets rather than `lib/features/tasks/ui/filtering/`.
 
+### Saved Filters
+
+The tasks tab also supports user-saved filters surfaced as a treeview under the Tasks destination in the desktop sidebar. The model lives in `lib/features/tasks/state/saved_filters/`:
+
+- `SavedTaskFilter` (`{id, name, filter: TasksFilter}`) is a freezed JSON-serialisable model. The ephemeral `query` / `match` field on `JournalPageState` is intentionally NOT part of the saved payload — it stays on the live page state and is preserved across saved-filter activations.
+- `SavedTaskFiltersPersistence` writes the ordered list as a single JSON blob to `SettingsDb` under the `SAVED_TASK_FILTERS` key. Position in the list IS the sort order. Mirrors the dedup-on-write pattern of `JournalFilterPersistence`.
+- `savedTaskFiltersControllerProvider` (Riverpod `keepAlive: true` async notifier) exposes `create`, `rename`, `updateFilter`, `delete`, `reorder`. Each mutation persists.
+- `SavedTaskFilterActivator` applies a `SavedTaskFilter` to the live `JournalPageController` via `applyBatchFilterUpdate`.
+
+Three derived providers wire the UI to the live page state:
+
+- `currentSavedTaskFilterIdProvider` — id of the saved filter whose persisted shape matches the live filter (display-only fields like `showCoverArt`/`showProjectsHeader`/`showDistances` are ignored when matching), or `null` when nothing matches.
+- `tasksFilterHasUnsavedClausesProvider` — `true` when the live filter has clauses but doesn't match any saved filter; gates the sidebar `+` and modal Save button.
+- `liveTasksFilterProvider` — snapshot of the live `TasksFilter` shape; used by the Save flow to capture exactly what the user sees.
+
+Surfaces:
+
+1. Sidebar treeview (`TasksSavedFiltersTree` → `SavedTaskFiltersSection` + `SavedTaskFilterRow`) — rendered via `DesktopSidebarDestination.expandedChildBuilder` only when the Tasks destination is active and the sidebar is expanded. Hover-trash with two-tap confirm delete, double-click rename, drag-to-reorder via `ReorderableListView.builder`. Empty state is a dashed pill instructing the user to adjust the filter and tap Save.
+2. Filter modal Save flow — `DesignSystemTaskFilterActionBar` gained an optional Save button next to Apply. Tapping it opens an inline name popup (`MenuAnchor`-anchored) with autofocus, Enter-to-commit, Escape-to-cancel, click-outside dismiss. The name is passed to `showTaskFilterModal`'s `onSavePressed` handler, which calls `create()` for new saves and `updateFilter()` when the user edits and re-saves the currently active filter under the same name.
+3. Tasks pane named-filter indicator — `TabSectionHeader.titleSuffix` renders `· {savedFilterName}` next to "Tasks" when a saved filter is active.
+4. Save / update / delete confirmation toasts via `SnackBar` (`saved_task_filter_toast.dart`).
+
+```mermaid
+stateDiagram-v2
+  [*] --> NoMatch
+  NoMatch: live filter has no saved match
+  Saved: live filter matches saved view
+  NoMatch --> Saved: activate saved row\n· filter applies\n· currentSavedId set
+  Saved --> NoMatch: user edits any field\n· currentSavedId clears
+  NoMatch --> Saved: user re-edits into\nan existing saved shape
+  NoMatch --> NoMatch: Save button →\nname popup → create
+  Saved --> Saved: Save with same name →\nupdateFilter (no rename)
+```
+
+Counts in the saved-filter rows are surfaced through the optional `counts: Map<String, int>?` parameter on `SavedTaskFiltersSection`. The current desktop wiring leaves this null pending a per-saved-filter task-count provider — the row hides the count when none is supplied.
+
 The redesigned browse page also preserves the existing non-filter runtime behavior:
 
 - pull-to-refresh

--- a/lib/features/tasks/state/saved_filters/saved_task_filter_activator.dart
+++ b/lib/features/tasks/state/saved_filters/saved_task_filter_activator.dart
@@ -55,66 +55,17 @@ TasksFilter _liveFilterFor(JournalPageState pageState) {
 /// Treat two [TasksFilter]s as equivalent when their saved-filter-relevant
 /// fields agree. Display-only and persistence-only fields are ignored.
 bool _matches(TasksFilter saved, TasksFilter live) {
-  return saved.selectedCategoryIds
-          .toSet()
-          .difference(
-            live.selectedCategoryIds.toSet(),
-          )
-          .isEmpty &&
-      live.selectedCategoryIds
-          .toSet()
-          .difference(
-            saved.selectedCategoryIds.toSet(),
-          )
-          .isEmpty &&
-      saved.selectedProjectIds
-          .toSet()
-          .difference(
-            live.selectedProjectIds.toSet(),
-          )
-          .isEmpty &&
-      live.selectedProjectIds
-          .toSet()
-          .difference(
-            saved.selectedProjectIds.toSet(),
-          )
-          .isEmpty &&
-      saved.selectedTaskStatuses
-          .toSet()
-          .difference(
-            live.selectedTaskStatuses.toSet(),
-          )
-          .isEmpty &&
-      live.selectedTaskStatuses
-          .toSet()
-          .difference(
-            saved.selectedTaskStatuses.toSet(),
-          )
-          .isEmpty &&
-      saved.selectedLabelIds
-          .toSet()
-          .difference(
-            live.selectedLabelIds.toSet(),
-          )
-          .isEmpty &&
-      live.selectedLabelIds
-          .toSet()
-          .difference(
-            saved.selectedLabelIds.toSet(),
-          )
-          .isEmpty &&
-      saved.selectedPriorities
-          .toSet()
-          .difference(
-            live.selectedPriorities.toSet(),
-          )
-          .isEmpty &&
-      live.selectedPriorities
-          .toSet()
-          .difference(
-            saved.selectedPriorities.toSet(),
-          )
-          .isEmpty &&
+  bool eq(Iterable<String> a, Iterable<String> b) {
+    final sA = a.toSet();
+    final sB = b.toSet();
+    return sA.length == sB.length && sA.containsAll(sB);
+  }
+
+  return eq(saved.selectedCategoryIds, live.selectedCategoryIds) &&
+      eq(saved.selectedProjectIds, live.selectedProjectIds) &&
+      eq(saved.selectedTaskStatuses, live.selectedTaskStatuses) &&
+      eq(saved.selectedLabelIds, live.selectedLabelIds) &&
+      eq(saved.selectedPriorities, live.selectedPriorities) &&
       saved.sortOption == live.sortOption &&
       saved.showCreationDate == live.showCreationDate &&
       saved.showDueDate == live.showDueDate &&
@@ -124,13 +75,18 @@ bool _matches(TasksFilter saved, TasksFilter live) {
 /// Returns true when the live tasks filter has at least one active clause
 /// — non-empty selection sets, a non-default agent mode, or a non-default
 /// sort. Display toggles do not count.
+///
+/// Sort is included because [_matches] also compares it: a saved filter that
+/// differs only by sort would otherwise leave Save disabled even though the
+/// live shape doesn't match any saved entry.
 bool _hasActiveClauses(TasksFilter live) {
   return live.selectedTaskStatuses.isNotEmpty ||
       live.selectedCategoryIds.isNotEmpty ||
       live.selectedProjectIds.isNotEmpty ||
       live.selectedLabelIds.isNotEmpty ||
       live.selectedPriorities.isNotEmpty ||
-      live.agentAssignmentFilter != AgentAssignmentFilter.all;
+      live.agentAssignmentFilter != AgentAssignmentFilter.all ||
+      live.sortOption != TaskSortOption.byPriority;
 }
 
 /// id of the saved filter whose persisted shape matches the live tasks-page

--- a/lib/features/tasks/state/saved_filters/saved_task_filter_activator.dart
+++ b/lib/features/tasks/state/saved_filters/saved_task_filter_activator.dart
@@ -1,0 +1,170 @@
+import 'package:lotti/features/journal/state/journal_page_controller.dart';
+import 'package:lotti/features/journal/state/journal_page_state.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filters_controller.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'saved_task_filter_activator.g.dart';
+
+/// Applies a [SavedTaskFilter] to the live tasks page state.
+///
+/// The ephemeral search query is intentionally preserved across activations —
+/// it is never part of a saved filter (the design treats it as a separate
+/// concern from the persisted filter shape).
+class SavedTaskFilterActivator {
+  const SavedTaskFilterActivator(this._controller);
+
+  final JournalPageController _controller;
+
+  Future<void> activate(SavedTaskFilter saved) {
+    final f = saved.filter;
+    return _controller.applyBatchFilterUpdate(
+      statuses: f.selectedTaskStatuses,
+      categoryIds: f.selectedCategoryIds,
+      labelIds: f.selectedLabelIds,
+      projectIds: f.selectedProjectIds,
+      priorities: f.selectedPriorities,
+      sortOption: f.sortOption,
+      agentAssignmentFilter: f.agentAssignmentFilter,
+      showCreationDate: f.showCreationDate,
+      showDueDate: f.showDueDate,
+    );
+  }
+}
+
+/// Builds a [TasksFilter] snapshot from the live tasks-page state for
+/// comparison against persisted saved filters.
+///
+/// Mirrors the field set in [JournalPageController._persistTasksFilterWithoutRefresh],
+/// minus the display-only `showCoverArt` / `showProjectsHeader` / `showDistances`
+/// flags which the saved-filter UX intentionally ignores when matching.
+TasksFilter _liveFilterFor(JournalPageState pageState) {
+  return TasksFilter(
+    selectedCategoryIds: pageState.selectedCategoryIds,
+    selectedProjectIds: pageState.selectedProjectIds,
+    selectedTaskStatuses: pageState.selectedTaskStatuses,
+    selectedLabelIds: pageState.selectedLabelIds,
+    selectedPriorities: pageState.selectedPriorities,
+    sortOption: pageState.sortOption,
+    showCreationDate: pageState.showCreationDate,
+    showDueDate: pageState.showDueDate,
+    agentAssignmentFilter: pageState.agentAssignmentFilter,
+  );
+}
+
+/// Treat two [TasksFilter]s as equivalent when their saved-filter-relevant
+/// fields agree. Display-only and persistence-only fields are ignored.
+bool _matches(TasksFilter saved, TasksFilter live) {
+  return saved.selectedCategoryIds
+          .toSet()
+          .difference(
+            live.selectedCategoryIds.toSet(),
+          )
+          .isEmpty &&
+      live.selectedCategoryIds
+          .toSet()
+          .difference(
+            saved.selectedCategoryIds.toSet(),
+          )
+          .isEmpty &&
+      saved.selectedProjectIds
+          .toSet()
+          .difference(
+            live.selectedProjectIds.toSet(),
+          )
+          .isEmpty &&
+      live.selectedProjectIds
+          .toSet()
+          .difference(
+            saved.selectedProjectIds.toSet(),
+          )
+          .isEmpty &&
+      saved.selectedTaskStatuses
+          .toSet()
+          .difference(
+            live.selectedTaskStatuses.toSet(),
+          )
+          .isEmpty &&
+      live.selectedTaskStatuses
+          .toSet()
+          .difference(
+            saved.selectedTaskStatuses.toSet(),
+          )
+          .isEmpty &&
+      saved.selectedLabelIds
+          .toSet()
+          .difference(
+            live.selectedLabelIds.toSet(),
+          )
+          .isEmpty &&
+      live.selectedLabelIds
+          .toSet()
+          .difference(
+            saved.selectedLabelIds.toSet(),
+          )
+          .isEmpty &&
+      saved.selectedPriorities
+          .toSet()
+          .difference(
+            live.selectedPriorities.toSet(),
+          )
+          .isEmpty &&
+      live.selectedPriorities
+          .toSet()
+          .difference(
+            saved.selectedPriorities.toSet(),
+          )
+          .isEmpty &&
+      saved.sortOption == live.sortOption &&
+      saved.showCreationDate == live.showCreationDate &&
+      saved.showDueDate == live.showDueDate &&
+      saved.agentAssignmentFilter == live.agentAssignmentFilter;
+}
+
+/// Returns true when the live tasks filter has at least one active clause
+/// — non-empty selection sets, a non-default agent mode, or a non-default
+/// sort. Display toggles do not count.
+bool _hasActiveClauses(TasksFilter live) {
+  return live.selectedTaskStatuses.isNotEmpty ||
+      live.selectedCategoryIds.isNotEmpty ||
+      live.selectedProjectIds.isNotEmpty ||
+      live.selectedLabelIds.isNotEmpty ||
+      live.selectedPriorities.isNotEmpty ||
+      live.agentAssignmentFilter != AgentAssignmentFilter.all;
+}
+
+/// id of the saved filter whose persisted shape matches the live tasks-page
+/// filter, or null when no saved filter matches.
+@riverpod
+String? currentSavedTaskFilterId(Ref ref) {
+  final pageState = ref.watch(journalPageControllerProvider(true));
+  final saved =
+      ref.watch(savedTaskFiltersControllerProvider).value ??
+      const <SavedTaskFilter>[];
+  if (saved.isEmpty) return null;
+  final live = _liveFilterFor(pageState);
+  for (final v in saved) {
+    if (_matches(v.filter, live)) return v.id;
+  }
+  return null;
+}
+
+/// True when the live filter has clauses that don't match any saved filter
+/// — the sidebar `+` and the modal Save button use this to decide whether
+/// they're enabled.
+@riverpod
+bool tasksFilterHasUnsavedClauses(Ref ref) {
+  final pageState = ref.watch(journalPageControllerProvider(true));
+  final live = _liveFilterFor(pageState);
+  if (!_hasActiveClauses(live)) return false;
+  final matchedId = ref.watch(currentSavedTaskFilterIdProvider);
+  return matchedId == null;
+}
+
+/// Snapshot of the live tasks filter shape — used by the modal save flow to
+/// build a new [SavedTaskFilter] payload.
+@riverpod
+TasksFilter liveTasksFilter(Ref ref) {
+  final pageState = ref.watch(journalPageControllerProvider(true));
+  return _liveFilterFor(pageState);
+}

--- a/lib/features/tasks/state/saved_filters/saved_task_filter_activator.g.dart
+++ b/lib/features/tasks/state/saved_filters/saved_task_filter_activator.g.dart
@@ -1,0 +1,162 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'saved_task_filter_activator.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// id of the saved filter whose persisted shape matches the live tasks-page
+/// filter, or null when no saved filter matches.
+
+@ProviderFor(currentSavedTaskFilterId)
+final currentSavedTaskFilterIdProvider = CurrentSavedTaskFilterIdProvider._();
+
+/// id of the saved filter whose persisted shape matches the live tasks-page
+/// filter, or null when no saved filter matches.
+
+final class CurrentSavedTaskFilterIdProvider
+    extends $FunctionalProvider<String?, String?, String?>
+    with $Provider<String?> {
+  /// id of the saved filter whose persisted shape matches the live tasks-page
+  /// filter, or null when no saved filter matches.
+  CurrentSavedTaskFilterIdProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'currentSavedTaskFilterIdProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$currentSavedTaskFilterIdHash();
+
+  @$internal
+  @override
+  $ProviderElement<String?> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String? create(Ref ref) {
+    return currentSavedTaskFilterId(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(String? value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<String?>(value),
+    );
+  }
+}
+
+String _$currentSavedTaskFilterIdHash() =>
+    r'00920e878c33b99fac210d31d1f942916a3d2dae';
+
+/// True when the live filter has clauses that don't match any saved filter
+/// — the sidebar `+` and the modal Save button use this to decide whether
+/// they're enabled.
+
+@ProviderFor(tasksFilterHasUnsavedClauses)
+final tasksFilterHasUnsavedClausesProvider =
+    TasksFilterHasUnsavedClausesProvider._();
+
+/// True when the live filter has clauses that don't match any saved filter
+/// — the sidebar `+` and the modal Save button use this to decide whether
+/// they're enabled.
+
+final class TasksFilterHasUnsavedClausesProvider
+    extends $FunctionalProvider<bool, bool, bool>
+    with $Provider<bool> {
+  /// True when the live filter has clauses that don't match any saved filter
+  /// — the sidebar `+` and the modal Save button use this to decide whether
+  /// they're enabled.
+  TasksFilterHasUnsavedClausesProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'tasksFilterHasUnsavedClausesProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$tasksFilterHasUnsavedClausesHash();
+
+  @$internal
+  @override
+  $ProviderElement<bool> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  bool create(Ref ref) {
+    return tasksFilterHasUnsavedClauses(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
+  }
+}
+
+String _$tasksFilterHasUnsavedClausesHash() =>
+    r'fb0290d76c1b5ebf734e036790c899e6981813a8';
+
+/// Snapshot of the live tasks filter shape — used by the modal save flow to
+/// build a new [SavedTaskFilter] payload.
+
+@ProviderFor(liveTasksFilter)
+final liveTasksFilterProvider = LiveTasksFilterProvider._();
+
+/// Snapshot of the live tasks filter shape — used by the modal save flow to
+/// build a new [SavedTaskFilter] payload.
+
+final class LiveTasksFilterProvider
+    extends $FunctionalProvider<TasksFilter, TasksFilter, TasksFilter>
+    with $Provider<TasksFilter> {
+  /// Snapshot of the live tasks filter shape — used by the modal save flow to
+  /// build a new [SavedTaskFilter] payload.
+  LiveTasksFilterProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'liveTasksFilterProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$liveTasksFilterHash();
+
+  @$internal
+  @override
+  $ProviderElement<TasksFilter> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  TasksFilter create(Ref ref) {
+    return liveTasksFilter(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(TasksFilter value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<TasksFilter>(value),
+    );
+  }
+}
+
+String _$liveTasksFilterHash() => r'831f9654b8014123c249c9555cf9b947ddae8afe';

--- a/lib/features/tasks/state/saved_filters/saved_task_filters_controller.g.dart
+++ b/lib/features/tasks/state/saved_filters/saved_task_filters_controller.g.dart
@@ -54,7 +54,7 @@ final class SavedTaskFiltersControllerProvider
 }
 
 String _$savedTaskFiltersControllerHash() =>
-    r'4b7cbbf71b29ae2167345e22369a8f1424ed1cd0';
+    r'9b4871c872a517e08789775bd7b8a29781247592';
 
 /// Riverpod controller backing the user's pinned task-filter list.
 ///

--- a/lib/features/tasks/ui/filtering/task_filter_modal.dart
+++ b/lib/features/tasks/ui/filtering/task_filter_modal.dart
@@ -8,8 +8,12 @@ import 'package:lotti/features/design_system/components/task_filters/design_syst
 import 'package:lotti/features/journal/state/journal_page_controller.dart';
 import 'package:lotti/features/journal/state/journal_page_scope.dart';
 import 'package:lotti/features/journal/state/journal_page_state.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter_activator.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filters_controller.dart';
 import 'package:lotti/features/tasks/ui/filtering/task_project_selection_modal.dart';
 import 'package:lotti/features/tasks/ui/filtering/tasks_filter_sheet_state.dart';
+import 'package:lotti/features/tasks/ui/saved_filters/saved_task_filter_toast.dart';
 import 'package:lotti/features/tasks/ui/utils.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/entities_cache_service.dart';
@@ -51,9 +55,68 @@ Future<void> showTaskFilterModal(
     projectsWithCategories: allProjectsWithCategories,
   );
 
+  // Snapshot the saved-filter state for the Save flow. Wrapped in a guard so
+  // narrowly-scoped tests (and any environment without the saved-filter
+  // dependencies wired up) gracefully fall back to "no save UX" rather than
+  // blocking the whole filter modal from opening.
+  var canSave = false;
+  String? currentSavedId;
+  String? currentSavedName;
+  try {
+    final savedFilters =
+        container.read(savedTaskFiltersControllerProvider).value ??
+        const <SavedTaskFilter>[];
+    currentSavedId = container.read(currentSavedTaskFilterIdProvider);
+    final hasUnsavedClauses = container.read(
+      tasksFilterHasUnsavedClausesProvider,
+    );
+    canSave = hasUnsavedClauses || currentSavedId != null;
+    currentSavedName = currentSavedId == null
+        ? null
+        : savedFilters
+              .firstWhere(
+                (f) => f.id == currentSavedId,
+                orElse: () => savedFilters.first,
+              )
+              .name;
+  } on Object {
+    // Fall back to no-save UX when saved-filter providers can't initialise.
+    canSave = false;
+    currentSavedId = null;
+    currentSavedName = null;
+  }
+  final initialSavedId = currentSavedId;
+  final initialSavedName = currentSavedName;
+
   await showDesignSystemFilterModal(
     context: context,
     initialState: initialState,
+    canSave: showTasks && canSave,
+    initialSaveName: initialSavedName,
+    onSavePressed: !showTasks
+        ? null
+        : (rawName) async {
+            // The modal stays open after save (only the popup closes); the
+            // user can still tap Apply to commit the draft state.
+            final liveFilter = container.read(liveTasksFilterProvider);
+            final notifier = container.read(
+              savedTaskFiltersControllerProvider.notifier,
+            );
+            if (initialSavedId != null && rawName == initialSavedName) {
+              await notifier.updateFilter(initialSavedId, liveFilter);
+              if (context.mounted) {
+                showSavedTaskFilterUpdatedToast(context, name: rawName);
+              }
+            } else {
+              final created = await notifier.create(
+                name: rawName,
+                filter: liveFilter,
+              );
+              if (context.mounted) {
+                showSavedTaskFilterSavedToast(context, name: created.name);
+              }
+            }
+          },
     onApplied: (sheetState) {
       _applyFilterState(
         sheetState,

--- a/lib/features/tasks/ui/filtering/task_filter_modal.dart
+++ b/lib/features/tasks/ui/filtering/task_filter_modal.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/entity_definitions.dart';
@@ -55,38 +56,26 @@ Future<void> showTaskFilterModal(
     projectsWithCategories: allProjectsWithCategories,
   );
 
-  // Snapshot the saved-filter state for the Save flow. Wrapped in a guard so
-  // narrowly-scoped tests (and any environment without the saved-filter
-  // dependencies wired up) gracefully fall back to "no save UX" rather than
-  // blocking the whole filter modal from opening.
-  var canSave = false;
-  String? currentSavedId;
-  String? currentSavedName;
-  try {
-    final savedFilters =
-        container.read(savedTaskFiltersControllerProvider).value ??
-        const <SavedTaskFilter>[];
-    currentSavedId = container.read(currentSavedTaskFilterIdProvider);
-    final hasUnsavedClauses = container.read(
-      tasksFilterHasUnsavedClausesProvider,
-    );
-    canSave = hasUnsavedClauses || currentSavedId != null;
-    currentSavedName = currentSavedId == null
-        ? null
-        : savedFilters
-              .firstWhere(
-                (f) => f.id == currentSavedId,
-                orElse: () => savedFilters.first,
-              )
-              .name;
-  } on Object {
-    // Fall back to no-save UX when saved-filter providers can't initialise.
-    canSave = false;
-    currentSavedId = null;
-    currentSavedName = null;
-  }
-  final initialSavedId = currentSavedId;
-  final initialSavedName = currentSavedName;
+  // Snapshot the saved-filter state for the Save flow.
+  final savedFilters =
+      container.read(savedTaskFiltersControllerProvider).value ??
+      const <SavedTaskFilter>[];
+  final matchedId = container.read(currentSavedTaskFilterIdProvider);
+  final hasUnsavedClauses = container.read(
+    tasksFilterHasUnsavedClausesProvider,
+  );
+  // Resolve the active id to a name. If the id no longer points at any saved
+  // filter (concurrent delete/rename), degrade to the create flow rather than
+  // updating a stale id.
+  final matchedName = matchedId == null
+      ? null
+      : savedFilters
+            .where((f) => f.id == matchedId)
+            .map((f) => f.name)
+            .firstOrNull;
+  final initialSavedId = matchedName == null ? null : matchedId;
+  final initialSavedName = matchedName;
+  final canSave = hasUnsavedClauses || initialSavedId != null;
 
   await showDesignSystemFilterModal(
     context: context,

--- a/lib/features/tasks/ui/pages/tasks_tab_page.dart
+++ b/lib/features/tasks/ui/pages/tasks_tab_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:clock/clock.dart';
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
@@ -16,7 +17,6 @@ import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/journal/state/journal_page_controller.dart';
 import 'package:lotti/features/journal/state/journal_page_scope.dart';
 import 'package:lotti/features/projects/ui/widgets/projects_overview_list.dart';
-import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter.dart';
 import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter_activator.dart';
 import 'package:lotti/features/tasks/state/saved_filters/saved_task_filters_controller.dart';
 import 'package:lotti/features/tasks/ui/filtering/task_filter_modal.dart';
@@ -514,10 +514,7 @@ class _SavedFilterTitleSuffix extends ConsumerWidget {
     if (activeId == null) return const SizedBox.shrink();
     final saved =
         ref.watch(savedTaskFiltersControllerProvider).value ?? const [];
-    final match = saved
-        .where((f) => f.id == activeId)
-        .cast<SavedTaskFilter?>()
-        .firstWhere((_) => true, orElse: () => null);
+    final match = saved.firstWhereOrNull((f) => f.id == activeId);
     if (match == null) return const SizedBox.shrink();
     final tokens = context.designTokens;
     return Text(

--- a/lib/features/tasks/ui/pages/tasks_tab_page.dart
+++ b/lib/features/tasks/ui/pages/tasks_tab_page.dart
@@ -16,6 +16,9 @@ import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/journal/state/journal_page_controller.dart';
 import 'package:lotti/features/journal/state/journal_page_scope.dart';
 import 'package:lotti/features/projects/ui/widgets/projects_overview_list.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter_activator.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filters_controller.dart';
 import 'package:lotti/features/tasks/ui/filtering/task_filter_modal.dart';
 import 'package:lotti/features/tasks/ui/filtering/task_label_quick_filter.dart';
 import 'package:lotti/features/tasks/ui/model/task_browse_models.dart';
@@ -132,6 +135,7 @@ class _TasksTabPageBodyState extends ConsumerState<_TasksTabPageBody> {
             children: [
               TabSectionHeader(
                 title: context.messages.navTabTitleTasks,
+                titleSuffix: _SavedFilterTitleSuffix(),
                 query: state.match,
                 searchHint: context.messages.searchTasksHint,
                 filterTooltip: context.messages.tasksFilterTitle,
@@ -498,5 +502,32 @@ Future<void> _defaultCreateTaskPressed(
   if (task != null) {
     unawaited(autoAssignCategoryAgentWith(agentService, task));
     getIt<NavService>().beamToNamed('/tasks/${task.meta.id}');
+  }
+}
+
+/// Inline "· {savedFilterName}" suffix appended to the Tasks header when an
+/// active saved filter matches the live filter shape.
+class _SavedFilterTitleSuffix extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final activeId = ref.watch(currentSavedTaskFilterIdProvider);
+    if (activeId == null) return const SizedBox.shrink();
+    final saved =
+        ref.watch(savedTaskFiltersControllerProvider).value ?? const [];
+    final match = saved
+        .where((f) => f.id == activeId)
+        .cast<SavedTaskFilter?>()
+        .firstWhere((_) => true, orElse: () => null);
+    if (match == null) return const SizedBox.shrink();
+    final tokens = context.designTokens;
+    return Text(
+      '· ${match.name}',
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+      style: tokens.typography.styles.body.bodyMedium.copyWith(
+        color: tokens.colors.text.mediumEmphasis,
+        fontWeight: FontWeight.w500,
+      ),
+    );
   }
 }

--- a/lib/features/tasks/ui/saved_filters/saved_task_filter_row.dart
+++ b/lib/features/tasks/ui/saved_filters/saved_task_filter_row.dart
@@ -172,14 +172,17 @@ class _SavedTaskFilterRowState extends State<SavedTaskFilterRow> {
         ? tokens.colors.interactive.enabled
         : tokens.colors.text.lowEmphasis;
 
-    // When the saved filter scopes to exactly one category, surface that
-    // category's color as a small dot left of the title. Multi-category and
-    // category-less filters get no dot — the visual would imply an
-    // ambiguous category.
+    // Surface each selected category's color as a small dot left of the
+    // title. Capped at three dots so the leading gutter stays compact;
+    // categories whose colour cannot be resolved (deleted, no colour set)
+    // are skipped.
     final categoryIds = widget.view.filter.selectedCategoryIds;
-    final categoryDotColor = categoryIds.length == 1
-        ? _categoryColor(categoryIds.first)
-        : null;
+    final categoryDotColors = <Color>[];
+    for (final id in categoryIds) {
+      if (categoryDotColors.length == 3) break;
+      final c = _categoryColor(id);
+      if (c != null) categoryDotColors.add(c);
+    }
 
     return MouseRegion(
       onEnter: (_) => _setHover(true),
@@ -220,24 +223,37 @@ class _SavedTaskFilterRowState extends State<SavedTaskFilterRow> {
                   ),
                   child: Row(
                     children: [
-                      // Reserve the dot's column even when absent so the
-                      // label stays vertically aligned across rows. The
-                      // category dot is enlarged to step3 (8). Stays
-                      // visible on hover — the drag handle lives in its
-                      // own narrow column at the row's leading edge and
-                      // is bounded so the two glyphs do not overlap.
-                      SizedBox(
-                        width: tokens.spacing.step3,
-                        height: tokens.spacing.step3,
-                        child: categoryDotColor != null && !_editing
-                            ? DecoratedBox(
-                                decoration: BoxDecoration(
-                                  shape: BoxShape.circle,
-                                  color: categoryDotColor,
+                      // Reserve the dot column even when absent so the
+                      // label stays vertically aligned across rows. Each
+                      // dot is step3 (8) with a step1 (2) gap between
+                      // them; the column expands when multiple categories
+                      // are selected, which is the desired behaviour
+                      // (more dots = wider gutter).
+                      if (categoryDotColors.isEmpty || _editing)
+                        SizedBox(
+                          width: tokens.spacing.step3,
+                          height: tokens.spacing.step3,
+                        )
+                      else
+                        SizedBox(
+                          height: tokens.spacing.step3,
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              for (var i = 0; i < categoryDotColors.length; i++) ...[
+                                if (i > 0) SizedBox(width: tokens.spacing.step1),
+                                Container(
+                                  width: tokens.spacing.step3,
+                                  height: tokens.spacing.step3,
+                                  decoration: BoxDecoration(
+                                    shape: BoxShape.circle,
+                                    color: categoryDotColors[i],
+                                  ),
                                 ),
-                              )
-                            : null,
-                      ),
+                              ],
+                            ],
+                          ),
+                        ),
                       SizedBox(width: tokens.spacing.step3),
                       Expanded(
                         child: _editing

--- a/lib/features/tasks/ui/saved_filters/saved_task_filter_row.dart
+++ b/lib/features/tasks/ui/saved_filters/saved_task_filter_row.dart
@@ -2,7 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter.dart';
+import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/services/entities_cache_service.dart';
+import 'package:lotti/utils/color.dart';
 
 /// Stable test keys for the saved-filter row internals.
 @visibleForTesting
@@ -142,23 +145,41 @@ class _SavedTaskFilterRowState extends State<SavedTaskFilterRow> {
     setState(() => _confirmDelete = true);
   }
 
+  /// Resolves the color stored on the `CategoryDefinition` keyed by [id], or
+  /// `null` when the category has been deleted or carries no color string.
+  Color? _categoryColor(String id) {
+    final hex = getIt<EntitiesCacheService>().getCategoryById(id)?.color;
+    if (hex == null || hex.isEmpty) return null;
+    return colorFromCssHex(hex);
+  }
+
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final messages = context.messages;
     final showDeleteAffordance = _hover && !_editing;
-    final showDragHandle =
-        (_hover || widget.active) && widget.dragHandle != null;
+    // Drag handle is hidden until the row is hovered — desktop-native pattern,
+    // matches macOS list affordances (no persistent grip on the active row).
+    final showDragHandle = _hover && widget.dragHandle != null;
 
     final background = widget.active
         ? tokens.colors.surface.selected
         : (_hover ? tokens.colors.surface.hover : Colors.transparent);
     final labelColor = widget.active
-        ? tokens.colors.text.highEmphasis
-        : tokens.colors.text.mediumEmphasis;
+        ? tokens.colors.text.mediumEmphasis
+        : tokens.colors.text.lowEmphasis;
     final countColor = widget.active
         ? tokens.colors.interactive.enabled
         : tokens.colors.text.lowEmphasis;
+
+    // When the saved filter scopes to exactly one category, surface that
+    // category's color as a small dot left of the title. Multi-category and
+    // category-less filters get no dot — the visual would imply an
+    // ambiguous category.
+    final categoryIds = widget.view.filter.selectedCategoryIds;
+    final categoryDotColor = categoryIds.length == 1
+        ? _categoryColor(categoryIds.first)
+        : null;
 
     return MouseRegion(
       onEnter: (_) => _setHover(true),
@@ -173,8 +194,11 @@ class _SavedTaskFilterRowState extends State<SavedTaskFilterRow> {
           onDoubleTap: _editing ? null : _enterEditMode,
           child: Container(
             key: SavedTaskFilterRowKeys.root(widget.view.id),
-            margin: const EdgeInsetsDirectional.only(start: 4),
-            constraints: const BoxConstraints(minHeight: 32),
+            margin: EdgeInsetsDirectional.only(start: tokens.spacing.step2),
+            constraints: BoxConstraints(
+              // step6 + step1 → 26: same row min-height as before.
+              minHeight: tokens.spacing.step6 + tokens.spacing.step1,
+            ),
             decoration: BoxDecoration(
               color: background,
               borderRadius: BorderRadius.circular(tokens.radii.m),
@@ -182,48 +206,39 @@ class _SavedTaskFilterRowState extends State<SavedTaskFilterRow> {
             child: Stack(
               clipBehavior: Clip.none,
               children: [
-                if (widget.active)
-                  Positioned.directional(
-                    textDirection: Directionality.of(context),
-                    start: 14,
-                    top: 7,
-                    bottom: 7,
-                    child: Container(
-                      width: 2,
-                      decoration: BoxDecoration(
-                        color: tokens.colors.interactive.enabled,
-                        borderRadius: BorderRadius.circular(2),
-                      ),
-                    ),
-                  ),
-                if (!widget.active && !_hover)
-                  Positioned.directional(
-                    textDirection: Directionality.of(context),
-                    start: 9,
-                    top: 0,
-                    bottom: 0,
-                    child: Center(
-                      child: Container(
-                        width: 3,
-                        height: 3,
-                        decoration: BoxDecoration(
-                          shape: BoxShape.circle,
-                          color: tokens.colors.interactive.enabled.withValues(
-                            alpha: 0.4,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
                 Padding(
-                  padding: const EdgeInsetsDirectional.only(
-                    start: 30,
-                    end: 8,
-                    top: 7,
-                    bottom: 7,
+                  // start: step5 + step2 + step1 → 22 (restored to the
+                  // pre-refactor pill geometry the user signed off on).
+                  padding: EdgeInsetsDirectional.only(
+                    start:
+                        tokens.spacing.step5 +
+                        tokens.spacing.step2 +
+                        tokens.spacing.step1,
+                    end: tokens.spacing.step3,
+                    top: tokens.spacing.step2,
+                    bottom: tokens.spacing.step2,
                   ),
                   child: Row(
                     children: [
+                      // Reserve the dot's column even when absent so the
+                      // label stays vertically aligned across rows. The
+                      // category dot is enlarged to step3 (8). Stays
+                      // visible on hover — the drag handle lives in its
+                      // own narrow column at the row's leading edge and
+                      // is bounded so the two glyphs do not overlap.
+                      SizedBox(
+                        width: tokens.spacing.step3,
+                        height: tokens.spacing.step3,
+                        child: categoryDotColor != null && !_editing
+                            ? DecoratedBox(
+                                decoration: BoxDecoration(
+                                  shape: BoxShape.circle,
+                                  color: categoryDotColor,
+                                ),
+                              )
+                            : null,
+                      ),
+                      SizedBox(width: tokens.spacing.step3),
                       Expanded(
                         child: _editing
                             ? _RenameField(
@@ -242,13 +257,8 @@ class _SavedTaskFilterRowState extends State<SavedTaskFilterRow> {
                                 widget.view.name,
                                 maxLines: 1,
                                 overflow: TextOverflow.ellipsis,
-                                style: tokens.typography.styles.body.bodyMedium
-                                    .copyWith(
-                                      color: labelColor,
-                                      fontWeight: widget.active
-                                          ? FontWeight.w600
-                                          : FontWeight.w500,
-                                    ),
+                                style: tokens.typography.styles.others.caption
+                                    .copyWith(color: labelColor),
                               ),
                       ),
                       if (!_editing)
@@ -262,8 +272,8 @@ class _SavedTaskFilterRowState extends State<SavedTaskFilterRow> {
                                 opacity: showDeleteAffordance ? 0 : 1,
                                 duration: const Duration(milliseconds: 120),
                                 child: Padding(
-                                  padding: const EdgeInsetsDirectional.only(
-                                    start: 6,
+                                  padding: EdgeInsetsDirectional.only(
+                                    start: tokens.spacing.step2,
                                   ),
                                   child: Text(
                                     '${widget.count}',
@@ -312,9 +322,13 @@ class _SavedTaskFilterRowState extends State<SavedTaskFilterRow> {
                 if (showDragHandle)
                   Positioned.directional(
                     textDirection: Directionality.of(context),
-                    start: 4,
+                    start: tokens.spacing.step1,
                     top: 0,
                     bottom: 0,
+                    // Bound the handle to its own narrow column so it never
+                    // visually creeps into the dot's space (dot starts at
+                    // step5 + step2 + step1 = 22 from the row's left edge).
+                    width: tokens.spacing.step5,
                     child: Center(
                       child: KeyedSubtree(
                         key: SavedTaskFilterRowKeys.dragHandle(widget.view.id),

--- a/lib/features/tasks/ui/saved_filters/saved_task_filter_toast.dart
+++ b/lib/features/tasks/ui/saved_filters/saved_task_filter_toast.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+
+/// Shows a transient confirmation that the named filter was saved.
+void showSavedTaskFilterSavedToast(
+  BuildContext context, {
+  required String name,
+}) {
+  _showToast(
+    context,
+    context.messages.tasksSavedFilterToastSaved(name),
+  );
+}
+
+/// Shows a transient confirmation that an existing saved filter was updated.
+void showSavedTaskFilterUpdatedToast(
+  BuildContext context, {
+  required String name,
+}) {
+  _showToast(
+    context,
+    context.messages.tasksSavedFilterToastUpdated(name),
+  );
+}
+
+/// Shows a transient confirmation that a saved filter was deleted.
+void showSavedTaskFilterDeletedToast(BuildContext context) {
+  _showToast(context, context.messages.tasksSavedFilterToastDeleted);
+}
+
+void _showToast(BuildContext context, String message) {
+  final tokens = context.designTokens;
+  final messenger = ScaffoldMessenger.maybeOf(context);
+  if (messenger == null) return;
+  messenger
+    ..clearSnackBars()
+    ..showSnackBar(
+      SnackBar(
+        behavior: SnackBarBehavior.floating,
+        backgroundColor: tokens.colors.background.level02,
+        content: Row(
+          children: [
+            Icon(
+              Icons.check_rounded,
+              size: 16,
+              color: tokens.colors.interactive.enabled,
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                message,
+                style: tokens.typography.styles.body.bodyMedium.copyWith(
+                  color: tokens.colors.text.highEmphasis,
+                ),
+              ),
+            ),
+          ],
+        ),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(999),
+          side: BorderSide(
+            color: tokens.colors.interactive.enabled.withValues(alpha: 0.32),
+          ),
+        ),
+        duration: const Duration(milliseconds: 2000),
+      ),
+    );
+}

--- a/lib/features/tasks/ui/saved_filters/saved_task_filters_section.dart
+++ b/lib/features/tasks/ui/saved_filters/saved_task_filters_section.dart
@@ -12,24 +12,20 @@ class SavedTaskFiltersSectionKeys {
   const SavedTaskFiltersSectionKeys._();
 
   static const Key root = Key('saved-filters-section');
-  static const Key header = Key('saved-filters-section-header');
   static const Key emptyState = Key('saved-filters-empty-state');
   static const Key list = Key('saved-filters-list');
-  static const Key addButton = Key('saved-filters-add-button');
 }
 
-/// Renders the "Saved filters" subtree under the Tasks destination.
+/// Renders the saved-filters subtree under the Tasks destination.
 ///
-/// Composition:
-/// - [SavedTaskFiltersSectionKeys.header] — overline label + add affordance
-/// - either [SavedTaskFiltersSectionKeys.emptyState] (dashed pill) or
-///   [SavedTaskFiltersSectionKeys.list] (reorderable rows)
+/// The section is rendered as a [SavedTaskFiltersSectionKeys.list] when at
+/// least one filter is persisted, or a `SizedBox.shrink` otherwise. There is
+/// no header — new filters are saved via the Save button in the Tasks Filter
+/// modal, not from the sidebar.
 class SavedTaskFiltersSection extends ConsumerWidget {
   const SavedTaskFiltersSection({
     required this.activeId,
     required this.onActivate,
-    required this.onAddPressed,
-    this.canAdd = false,
     this.counts,
     this.onDeleted,
     super.key,
@@ -43,14 +39,6 @@ class SavedTaskFiltersSection extends ConsumerWidget {
   /// activated filter so the caller can apply it to the live page state.
   final ValueChanged<SavedTaskFilter> onActivate;
 
-  /// Called when the `+` add affordance in the section header is tapped.
-  /// Typically opens the Tasks Filter modal at the save-name popup.
-  final VoidCallback onAddPressed;
-
-  /// Whether the add affordance is enabled. Pass `true` only when there is
-  /// an active filter that doesn't match any existing saved filter.
-  final bool canAdd;
-
   /// Optional live counts keyed by saved-filter id. Missing ids are rendered
   /// without a count.
   final Map<String, int>? counts;
@@ -63,154 +51,53 @@ class SavedTaskFiltersSection extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final tokens = context.designTokens;
-    final messages = context.messages;
     final asyncList = ref.watch(savedTaskFiltersControllerProvider);
     // Treat loading and error states as "no data yet" so the section header
     // renders without flashing the empty state. Once data resolves, the body
     // switches between empty state and list.
     final list = asyncList.value;
 
+    // Hide the section entirely while the data is loading or when there are
+    // no saved filters — the user reaches the save flow through the Tasks
+    // Filter modal, so an empty placeholder in the sidebar adds noise
+    // without value.
+    if (list == null || list.isEmpty) {
+      return const SizedBox.shrink(key: SavedTaskFiltersSectionKeys.root);
+    }
+
     return Column(
       key: SavedTaskFiltersSectionKeys.root,
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
       children: [
-        _SectionHeader(
-          title: messages.tasksSavedFiltersSectionTitle,
-          tooltip: messages.tasksSavedFiltersAddTooltip,
-          enabled: canAdd,
-          onPressed: onAddPressed,
-          tokens: tokens,
+        // Small step1 (2px) breathing room above the first row, in lieu of
+        // the previous "Saved filters" overline header — the rows live
+        // immediately under the Tasks destination and need no extra label.
+        SizedBox(height: tokens.spacing.step1),
+        _ReorderableList(
+          key: SavedTaskFiltersSectionKeys.list,
+          items: list,
+          activeId: activeId,
+          counts: counts,
+          onActivate: onActivate,
+          onRename: (id, name) async {
+            await ref
+                .read(savedTaskFiltersControllerProvider.notifier)
+                .rename(id, name);
+          },
+          onDelete: (id) async {
+            await ref
+                .read(savedTaskFiltersControllerProvider.notifier)
+                .delete(id);
+            onDeleted?.call();
+          },
+          onReorder: (dragId, targetId) async {
+            await ref
+                .read(savedTaskFiltersControllerProvider.notifier)
+                .reorder(dragId, targetId);
+          },
         ),
-        if (list == null)
-          const SizedBox.shrink()
-        else if (list.isEmpty)
-          Padding(
-            key: SavedTaskFiltersSectionKeys.emptyState,
-            padding: const EdgeInsetsDirectional.only(
-              start: 30,
-              end: 8,
-              top: 4,
-              bottom: 4,
-            ),
-            child: Container(
-              padding: const EdgeInsets.symmetric(
-                horizontal: 12,
-                vertical: 10,
-              ),
-              decoration: BoxDecoration(
-                color: tokens.colors.surface.enabled,
-                borderRadius: BorderRadius.circular(tokens.radii.m),
-                border: Border.all(
-                  color: tokens.colors.decorative.level01,
-                ),
-              ),
-              child: Text(
-                messages.tasksSavedFiltersEmpty,
-                style: tokens.typography.styles.body.bodySmall.copyWith(
-                  color: tokens.colors.text.lowEmphasis,
-                  height: 1.4,
-                ),
-              ),
-            ),
-          )
-        else
-          _ReorderableList(
-            key: SavedTaskFiltersSectionKeys.list,
-            items: list,
-            activeId: activeId,
-            counts: counts,
-            onActivate: onActivate,
-            onRename: (id, name) async {
-              await ref
-                  .read(savedTaskFiltersControllerProvider.notifier)
-                  .rename(id, name);
-            },
-            onDelete: (id) async {
-              await ref
-                  .read(savedTaskFiltersControllerProvider.notifier)
-                  .delete(id);
-              onDeleted?.call();
-            },
-            onReorder: (dragId, targetId) async {
-              await ref
-                  .read(savedTaskFiltersControllerProvider.notifier)
-                  .reorder(dragId, targetId);
-            },
-          ),
       ],
-    );
-  }
-}
-
-class _SectionHeader extends StatelessWidget {
-  const _SectionHeader({
-    required this.title,
-    required this.tooltip,
-    required this.enabled,
-    required this.onPressed,
-    required this.tokens,
-  });
-
-  final String title;
-  final String tooltip;
-  final bool enabled;
-  final VoidCallback onPressed;
-  final DsTokens tokens;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      key: SavedTaskFiltersSectionKeys.header,
-      padding: const EdgeInsetsDirectional.only(
-        start: 30,
-        end: 12,
-        top: 4,
-        bottom: 4,
-      ),
-      child: Row(
-        children: [
-          Expanded(
-            child: Text(
-              title.toUpperCase(),
-              style: tokens.typography.styles.others.overline.copyWith(
-                color: tokens.colors.text.lowEmphasis,
-                fontWeight: FontWeight.w700,
-                letterSpacing: 1.3,
-              ),
-            ),
-          ),
-          Tooltip(
-            message: tooltip,
-            child: SizedBox(
-              width: 18,
-              height: 18,
-              child: Material(
-                key: SavedTaskFiltersSectionKeys.addButton,
-                color: enabled
-                    ? tokens.colors.surface.selected
-                    : Colors.transparent,
-                borderRadius: BorderRadius.circular(tokens.radii.s),
-                child: InkWell(
-                  borderRadius: BorderRadius.circular(tokens.radii.s),
-                  onTap: enabled ? onPressed : null,
-                  child: Center(
-                    child: Icon(
-                      Icons.add_rounded,
-                      size: 12,
-                      color: enabled
-                          ? tokens.colors.interactive.enabled
-                          : tokens.colors.text.lowEmphasis.withValues(
-                              alpha: 0.5,
-                            ),
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ],
-      ),
     );
   }
 }
@@ -256,22 +143,29 @@ class _ReorderableList extends StatelessWidget {
       ),
       itemBuilder: (context, index) {
         final view = items[index];
-        return SavedTaskFilterRow(
+        // step2 (4px) breathing room between rows; the last row also gets it
+        // so the section has a small trailing gap before whatever follows in
+        // the sidebar column.
+        final tokens = context.designTokens;
+        return Padding(
           key: ValueKey(view.id),
-          view: view,
-          active: view.id == activeId,
-          count: counts?[view.id],
-          onActivate: () => onActivate(view),
-          onRename: (name) => onRename(view.id, name),
-          onDelete: () => onDelete(view.id),
-          dragHandle: Semantics(
-            button: true,
-            label: context.messages.tasksSavedFilterDragHandleSemantics,
-            child: ReorderableDragStartListener(
-              index: index,
-              child: const Icon(
-                Icons.drag_indicator,
-                size: 14,
+          padding: EdgeInsetsDirectional.only(bottom: tokens.spacing.step2),
+          child: SavedTaskFilterRow(
+            view: view,
+            active: view.id == activeId,
+            count: counts?[view.id],
+            onActivate: () => onActivate(view),
+            onRename: (name) => onRename(view.id, name),
+            onDelete: () => onDelete(view.id),
+            dragHandle: Semantics(
+              button: true,
+              label: context.messages.tasksSavedFilterDragHandleSemantics,
+              child: ReorderableDragStartListener(
+                index: index,
+                child: const Icon(
+                  Icons.drag_indicator,
+                  size: 14,
+                ),
               ),
             ),
           ),

--- a/lib/features/tasks/ui/saved_filters/saved_task_filters_section.dart
+++ b/lib/features/tasks/ui/saved_filters/saved_task_filters_section.dart
@@ -31,6 +31,7 @@ class SavedTaskFiltersSection extends ConsumerWidget {
     required this.onAddPressed,
     this.canAdd = false,
     this.counts,
+    this.onDeleted,
     super.key,
   });
 
@@ -53,6 +54,11 @@ class SavedTaskFiltersSection extends ConsumerWidget {
   /// Optional live counts keyed by saved-filter id. Missing ids are rendered
   /// without a count.
   final Map<String, int>? counts;
+
+  /// Fired after a saved filter is deleted. The caller typically uses this to
+  /// show a transient confirmation toast — the section itself only handles
+  /// the controller mutation.
+  final VoidCallback? onDeleted;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -124,6 +130,7 @@ class SavedTaskFiltersSection extends ConsumerWidget {
               await ref
                   .read(savedTaskFiltersControllerProvider.notifier)
                   .delete(id);
+              onDeleted?.call();
             },
             onReorder: (dragId, targetId) async {
               await ref

--- a/lib/features/tasks/ui/saved_filters/tasks_saved_filters_tree.dart
+++ b/lib/features/tasks/ui/saved_filters/tasks_saved_filters_tree.dart
@@ -34,8 +34,19 @@ class TasksSavedFiltersTree extends ConsumerWidget {
         );
         await SavedTaskFilterActivator(controller).activate(saved);
       },
-      onAddPressed: () => showTaskFilterModal(context, showTasks: true),
-      onDeleted: () => showSavedTaskFilterDeletedToast(context),
+      // The section's onAddPressed fires synchronously from a button press, so
+      // the mounted guard is technically redundant — kept for symmetry with
+      // onDeleted, which fires after an awaited controller mutation and could
+      // re-enter this closure with a defunct context if the user navigated
+      // away mid-flight.
+      onAddPressed: () {
+        if (!context.mounted) return;
+        showTaskFilterModal(context, showTasks: true);
+      },
+      onDeleted: () {
+        if (!context.mounted) return;
+        showSavedTaskFilterDeletedToast(context);
+      },
     );
   }
 }

--- a/lib/features/tasks/ui/saved_filters/tasks_saved_filters_tree.dart
+++ b/lib/features/tasks/ui/saved_filters/tasks_saved_filters_tree.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/features/journal/state/journal_page_controller.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter_activator.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filters_controller.dart';
+import 'package:lotti/features/tasks/ui/filtering/task_filter_modal.dart';
+import 'package:lotti/features/tasks/ui/saved_filters/saved_task_filter_toast.dart';
+import 'package:lotti/features/tasks/ui/saved_filters/saved_task_filters_section.dart';
+
+/// Sidebar subtree under the Tasks destination.
+///
+/// Wires:
+/// - [savedTaskFiltersControllerProvider] for the persisted list,
+/// - [currentSavedTaskFilterIdProvider] to highlight the active row,
+/// - [tasksFilterHasUnsavedClausesProvider] to enable the `+` button,
+/// - [SavedTaskFilterActivator] to apply a saved filter to the live page,
+/// - [showTaskFilterModal] to open the modal when `+` is pressed (where
+///   the user names and saves the current filter).
+class TasksSavedFiltersTree extends ConsumerWidget {
+  const TasksSavedFiltersTree({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final activeId = ref.watch(currentSavedTaskFilterIdProvider);
+    final canAdd = ref.watch(tasksFilterHasUnsavedClausesProvider);
+
+    return SavedTaskFiltersSection(
+      activeId: activeId,
+      canAdd: canAdd,
+      onActivate: (SavedTaskFilter saved) async {
+        final controller = ref.read(
+          journalPageControllerProvider(true).notifier,
+        );
+        await SavedTaskFilterActivator(controller).activate(saved);
+      },
+      onAddPressed: () => showTaskFilterModal(context, showTasks: true),
+      onDeleted: () => showSavedTaskFilterDeletedToast(context),
+    );
+  }
+}

--- a/lib/features/tasks/ui/saved_filters/tasks_saved_filters_tree.dart
+++ b/lib/features/tasks/ui/saved_filters/tasks_saved_filters_tree.dart
@@ -4,7 +4,6 @@ import 'package:lotti/features/journal/state/journal_page_controller.dart';
 import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter.dart';
 import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter_activator.dart';
 import 'package:lotti/features/tasks/state/saved_filters/saved_task_filters_controller.dart';
-import 'package:lotti/features/tasks/ui/filtering/task_filter_modal.dart';
 import 'package:lotti/features/tasks/ui/saved_filters/saved_task_filter_toast.dart';
 import 'package:lotti/features/tasks/ui/saved_filters/saved_task_filters_section.dart';
 
@@ -13,36 +12,27 @@ import 'package:lotti/features/tasks/ui/saved_filters/saved_task_filters_section
 /// Wires:
 /// - [savedTaskFiltersControllerProvider] for the persisted list,
 /// - [currentSavedTaskFilterIdProvider] to highlight the active row,
-/// - [tasksFilterHasUnsavedClausesProvider] to enable the `+` button,
-/// - [SavedTaskFilterActivator] to apply a saved filter to the live page,
-/// - [showTaskFilterModal] to open the modal when `+` is pressed (where
-///   the user names and saves the current filter).
+/// - [SavedTaskFilterActivator] to apply a saved filter to the live page.
+///
+/// New filters are saved through the Save button in the Tasks Filter modal,
+/// not from the sidebar — so the section deliberately has no `+` affordance.
 class TasksSavedFiltersTree extends ConsumerWidget {
   const TasksSavedFiltersTree({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final activeId = ref.watch(currentSavedTaskFilterIdProvider);
-    final canAdd = ref.watch(tasksFilterHasUnsavedClausesProvider);
 
     return SavedTaskFiltersSection(
       activeId: activeId,
-      canAdd: canAdd,
       onActivate: (SavedTaskFilter saved) async {
         final controller = ref.read(
           journalPageControllerProvider(true).notifier,
         );
         await SavedTaskFilterActivator(controller).activate(saved);
       },
-      // The section's onAddPressed fires synchronously from a button press, so
-      // the mounted guard is technically redundant — kept for symmetry with
-      // onDeleted, which fires after an awaited controller mutation and could
-      // re-enter this closure with a defunct context if the user navigated
-      // away mid-flight.
-      onAddPressed: () {
-        if (!context.mounted) return;
-        showTaskFilterModal(context, showTasks: true);
-      },
+      // onDeleted fires after an awaited controller mutation, so guard against
+      // a defunct context (the user could have navigated away mid-flight).
       onDeleted: () {
         if (!context.mounted) return;
         showSavedTaskFilterDeletedToast(context);

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -2439,7 +2439,6 @@
   "tasksSavedFiltersSavePopupHint": "např. Blokované nebo pozastavené",
   "tasksSavedFiltersSavePopupSave": "Uložit",
   "tasksSavedFiltersSavePopupTitle": "Pojmenuj tento filtr",
-  "tasksSavedFiltersSectionTitle": "Uložené filtry",
   "tasksSavedFilterToastDeleted": "Filtr smazán",
   "tasksSavedFilterToastSaved": "Uloženo „{name}“",
   "@tasksSavedFilterToastSaved": {

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -2428,7 +2428,7 @@
   "tasksSavedFiltersEmpty": "Zatím žádné uložené filtry. Uprav filtr úkolů a klepni na Uložit.",
   "tasksSavedFiltersSaveButtonLabel": "Uložit",
   "tasksSavedFiltersSavePopupCancel": "Zrušit",
-  "tasksSavedFiltersSavePopupHelper": "{count, plural, =1{Aktivní 1 filtr. Uloženo na boční panel pod Úkoly.} other{Aktivních {count} filtrů. Uloženo na boční panel pod Úkoly.}}",
+  "tasksSavedFiltersSavePopupHelper": "{count, plural, =1{Aktivní 1 filtr. Uloženo na boční panel pod Úkoly.} few{Aktivní {count} filtry. Uloženo na boční panel pod Úkoly.} other{Aktivních {count} filtrů. Uloženo na boční panel pod Úkoly.}}",
   "@tasksSavedFiltersSavePopupHelper": {
     "placeholders": {
       "count": {

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -2426,7 +2426,37 @@
   "tasksSavedFilterRenameSemantics": "Přejmenovat uložený filtr",
   "tasksSavedFiltersAddTooltip": "Uložit aktuální filtr",
   "tasksSavedFiltersEmpty": "Zatím žádné uložené filtry. Uprav filtr úkolů a klepni na Uložit.",
+  "tasksSavedFiltersSaveButtonLabel": "Uložit",
+  "tasksSavedFiltersSavePopupCancel": "Zrušit",
+  "tasksSavedFiltersSavePopupHelper": "{count, plural, =1{Aktivní 1 filtr. Uloženo na boční panel pod Úkoly.} other{Aktivních {count} filtrů. Uloženo na boční panel pod Úkoly.}}",
+  "@tasksSavedFiltersSavePopupHelper": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "tasksSavedFiltersSavePopupHint": "např. Blokované nebo pozastavené",
+  "tasksSavedFiltersSavePopupSave": "Uložit",
+  "tasksSavedFiltersSavePopupTitle": "Pojmenuj tento filtr",
   "tasksSavedFiltersSectionTitle": "Uložené filtry",
+  "tasksSavedFilterToastDeleted": "Filtr smazán",
+  "tasksSavedFilterToastSaved": "Uloženo „{name}“",
+  "@tasksSavedFilterToastSaved": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "tasksSavedFilterToastUpdated": "Aktualizováno „{name}“",
+  "@tasksSavedFilterToastUpdated": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
   "tasksSearchModeLabel": "Režim hledání",
   "tasksShowCoverArt": "Zobrazit obal na kartách",
   "tasksShowCreationDate": "Zobrazit datum vytvoření na kartách",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2689,7 +2689,37 @@
   "tasksSavedFilterRenameSemantics": "Gespeicherten Filter umbenennen",
   "tasksSavedFiltersAddTooltip": "Aktuellen Filter speichern",
   "tasksSavedFiltersEmpty": "Noch keine gespeicherten Filter. Pass den Aufgabenfilter an und tippe auf Speichern.",
+  "tasksSavedFiltersSaveButtonLabel": "Speichern",
+  "tasksSavedFiltersSavePopupCancel": "Abbrechen",
+  "tasksSavedFiltersSavePopupHelper": "{count, plural, =1{1 Filter aktiv. In der Seitenleiste unter „Aufgaben“ gespeichert.} other{{count} Filter aktiv. In der Seitenleiste unter „Aufgaben“ gespeichert.}}",
+  "@tasksSavedFiltersSavePopupHelper": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "tasksSavedFiltersSavePopupHint": "z. B. Blockiert oder pausiert",
+  "tasksSavedFiltersSavePopupSave": "Speichern",
+  "tasksSavedFiltersSavePopupTitle": "Diesen Filter benennen",
   "tasksSavedFiltersSectionTitle": "Gespeicherte Filter",
+  "tasksSavedFilterToastDeleted": "Filter gelöscht",
+  "tasksSavedFilterToastSaved": "„{name}“ gespeichert",
+  "@tasksSavedFilterToastSaved": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "tasksSavedFilterToastUpdated": "„{name}“ aktualisiert",
+  "@tasksSavedFilterToastUpdated": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
   "tasksSearchModeLabel": "Suchmodus",
   "tasksShowCoverArt": "Titelbild auf Karten anzeigen",
   "tasksShowCreationDate": "Erstellungsdatum auf Karten anzeigen",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2702,7 +2702,6 @@
   "tasksSavedFiltersSavePopupHint": "z. B. Blockiert oder pausiert",
   "tasksSavedFiltersSavePopupSave": "Speichern",
   "tasksSavedFiltersSavePopupTitle": "Diesen Filter benennen",
-  "tasksSavedFiltersSectionTitle": "Gespeicherte Filter",
   "tasksSavedFilterToastDeleted": "Filter gelöscht",
   "tasksSavedFilterToastSaved": "„{name}“ gespeichert",
   "@tasksSavedFilterToastSaved": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2995,7 +2995,6 @@
   "tasksSavedFiltersSavePopupHint": "e.g. Blocked or on hold",
   "tasksSavedFiltersSavePopupSave": "Save",
   "tasksSavedFiltersSavePopupTitle": "Name this filter",
-  "tasksSavedFiltersSectionTitle": "Saved filters",
   "tasksSavedFilterToastDeleted": "Filter deleted",
   "tasksSavedFilterToastSaved": "Saved '{name}'",
   "@tasksSavedFilterToastSaved": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2982,7 +2982,37 @@
   "tasksSavedFilterRenameSemantics": "Rename saved filter",
   "tasksSavedFiltersAddTooltip": "Save current filter",
   "tasksSavedFiltersEmpty": "No saved filters yet. Adjust the task filter, then tap Save.",
+  "tasksSavedFiltersSaveButtonLabel": "Save",
+  "tasksSavedFiltersSavePopupCancel": "Cancel",
+  "tasksSavedFiltersSavePopupHelper": "{count, plural, =1{1 filter active. Saved to sidebar under Tasks.} other{{count} filters active. Saved to sidebar under Tasks.}}",
+  "@tasksSavedFiltersSavePopupHelper": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "tasksSavedFiltersSavePopupHint": "e.g. Blocked or on hold",
+  "tasksSavedFiltersSavePopupSave": "Save",
+  "tasksSavedFiltersSavePopupTitle": "Name this filter",
   "tasksSavedFiltersSectionTitle": "Saved filters",
+  "tasksSavedFilterToastDeleted": "Filter deleted",
+  "tasksSavedFilterToastSaved": "Saved '{name}'",
+  "@tasksSavedFilterToastSaved": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "tasksSavedFilterToastUpdated": "Updated '{name}'",
+  "@tasksSavedFilterToastUpdated": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
   "tasksSearchModeLabel": "Search mode",
   "tasksShowCoverArt": "Show cover art on cards",
   "tasksShowCreationDate": "Show creation date on cards",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2689,7 +2689,37 @@
   "tasksSavedFilterRenameSemantics": "Renombrar filtro guardado",
   "tasksSavedFiltersAddTooltip": "Guardar filtro actual",
   "tasksSavedFiltersEmpty": "Aún no tienes filtros guardados. Ajusta el filtro de tareas y toca Guardar.",
+  "tasksSavedFiltersSaveButtonLabel": "Guardar",
+  "tasksSavedFiltersSavePopupCancel": "Cancelar",
+  "tasksSavedFiltersSavePopupHelper": "{count, plural, =1{1 filtro activo. Guardado en la barra lateral, bajo Tareas.} other{{count} filtros activos. Guardados en la barra lateral, bajo Tareas.}}",
+  "@tasksSavedFiltersSavePopupHelper": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "tasksSavedFiltersSavePopupHint": "p. ej. Bloqueadas o en pausa",
+  "tasksSavedFiltersSavePopupSave": "Guardar",
+  "tasksSavedFiltersSavePopupTitle": "Asigna un nombre a este filtro",
   "tasksSavedFiltersSectionTitle": "Filtros guardados",
+  "tasksSavedFilterToastDeleted": "Filtro eliminado",
+  "tasksSavedFilterToastSaved": "Guardado «{name}»",
+  "@tasksSavedFilterToastSaved": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "tasksSavedFilterToastUpdated": "Actualizado «{name}»",
+  "@tasksSavedFilterToastUpdated": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
   "tasksSearchModeLabel": "Modo de búsqueda",
   "tasksShowCoverArt": "Mostrar imagen de portada en tarjetas",
   "tasksShowCreationDate": "Mostrar fecha de creación en tarjetas",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2702,7 +2702,6 @@
   "tasksSavedFiltersSavePopupHint": "p. ej. Bloqueadas o en pausa",
   "tasksSavedFiltersSavePopupSave": "Guardar",
   "tasksSavedFiltersSavePopupTitle": "Asigna un nombre a este filtro",
-  "tasksSavedFiltersSectionTitle": "Filtros guardados",
   "tasksSavedFilterToastDeleted": "Filtro eliminado",
   "tasksSavedFilterToastSaved": "Guardado «{name}»",
   "@tasksSavedFilterToastSaved": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -2689,7 +2689,37 @@
   "tasksSavedFilterRenameSemantics": "Renommer le filtre enregistré",
   "tasksSavedFiltersAddTooltip": "Enregistrer le filtre actuel",
   "tasksSavedFiltersEmpty": "Aucun filtre enregistré pour l'instant. Ajuste le filtre des tâches, puis appuie sur Enregistrer.",
+  "tasksSavedFiltersSaveButtonLabel": "Enregistrer",
+  "tasksSavedFiltersSavePopupCancel": "Annuler",
+  "tasksSavedFiltersSavePopupHelper": "{count, plural, =1{1 filtre actif. Enregistré dans la barre latérale, sous Tâches.} other{{count} filtres actifs. Enregistrés dans la barre latérale, sous Tâches.}}",
+  "@tasksSavedFiltersSavePopupHelper": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "tasksSavedFiltersSavePopupHint": "ex. : Bloquées ou en pause",
+  "tasksSavedFiltersSavePopupSave": "Enregistrer",
+  "tasksSavedFiltersSavePopupTitle": "Nomme ce filtre",
   "tasksSavedFiltersSectionTitle": "Filtres enregistrés",
+  "tasksSavedFilterToastDeleted": "Filtre supprimé",
+  "tasksSavedFilterToastSaved": "« {name} » enregistré",
+  "@tasksSavedFilterToastSaved": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "tasksSavedFilterToastUpdated": "« {name} » mis à jour",
+  "@tasksSavedFilterToastUpdated": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
   "tasksSearchModeLabel": "Mode de recherche",
   "tasksShowCoverArt": "Afficher la couverture sur les cartes",
   "tasksShowCreationDate": "Afficher la date de création sur les cartes",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -2702,7 +2702,6 @@
   "tasksSavedFiltersSavePopupHint": "ex. : Bloquées ou en pause",
   "tasksSavedFiltersSavePopupSave": "Enregistrer",
   "tasksSavedFiltersSavePopupTitle": "Nomme ce filtre",
-  "tasksSavedFiltersSectionTitle": "Filtres enregistrés",
   "tasksSavedFilterToastDeleted": "Filtre supprimé",
   "tasksSavedFilterToastSaved": "« {name} » enregistré",
   "@tasksSavedFilterToastSaved": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -11257,12 +11257,6 @@ abstract class AppLocalizations {
   /// **'Name this filter'**
   String get tasksSavedFiltersSavePopupTitle;
 
-  /// No description provided for @tasksSavedFiltersSectionTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Saved filters'**
-  String get tasksSavedFiltersSectionTitle;
-
   /// No description provided for @tasksSavedFilterToastDeleted.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -11221,11 +11221,65 @@ abstract class AppLocalizations {
   /// **'No saved filters yet. Adjust the task filter, then tap Save.'**
   String get tasksSavedFiltersEmpty;
 
+  /// No description provided for @tasksSavedFiltersSaveButtonLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Save'**
+  String get tasksSavedFiltersSaveButtonLabel;
+
+  /// No description provided for @tasksSavedFiltersSavePopupCancel.
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel'**
+  String get tasksSavedFiltersSavePopupCancel;
+
+  /// No description provided for @tasksSavedFiltersSavePopupHelper.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 filter active. Saved to sidebar under Tasks.} other{{count} filters active. Saved to sidebar under Tasks.}}'**
+  String tasksSavedFiltersSavePopupHelper(int count);
+
+  /// No description provided for @tasksSavedFiltersSavePopupHint.
+  ///
+  /// In en, this message translates to:
+  /// **'e.g. Blocked or on hold'**
+  String get tasksSavedFiltersSavePopupHint;
+
+  /// No description provided for @tasksSavedFiltersSavePopupSave.
+  ///
+  /// In en, this message translates to:
+  /// **'Save'**
+  String get tasksSavedFiltersSavePopupSave;
+
+  /// No description provided for @tasksSavedFiltersSavePopupTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Name this filter'**
+  String get tasksSavedFiltersSavePopupTitle;
+
   /// No description provided for @tasksSavedFiltersSectionTitle.
   ///
   /// In en, this message translates to:
   /// **'Saved filters'**
   String get tasksSavedFiltersSectionTitle;
+
+  /// No description provided for @tasksSavedFilterToastDeleted.
+  ///
+  /// In en, this message translates to:
+  /// **'Filter deleted'**
+  String get tasksSavedFilterToastDeleted;
+
+  /// No description provided for @tasksSavedFilterToastSaved.
+  ///
+  /// In en, this message translates to:
+  /// **'Saved \'{name}\''**
+  String tasksSavedFilterToastSaved(String name);
+
+  /// No description provided for @tasksSavedFilterToastUpdated.
+  ///
+  /// In en, this message translates to:
+  /// **'Updated \'{name}\''**
+  String tasksSavedFilterToastUpdated(String name);
 
   /// No description provided for @tasksSearchModeLabel.
   ///

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -6450,6 +6450,7 @@ class AppLocalizationsCs extends AppLocalizations {
       count,
       locale: localeName,
       other: 'Aktivních $count filtrů. Uloženo na boční panel pod Úkoly.',
+      few: 'Aktivní $count filtry. Uloženo na boční panel pod Úkoly.',
       one: 'Aktivní 1 filtr. Uloženo na boční panel pod Úkoly.',
     );
     return '$_temp0';

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -6439,7 +6439,47 @@ class AppLocalizationsCs extends AppLocalizations {
       'Zatím žádné uložené filtry. Uprav filtr úkolů a klepni na Uložit.';
 
   @override
+  String get tasksSavedFiltersSaveButtonLabel => 'Uložit';
+
+  @override
+  String get tasksSavedFiltersSavePopupCancel => 'Zrušit';
+
+  @override
+  String tasksSavedFiltersSavePopupHelper(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Aktivních $count filtrů. Uloženo na boční panel pod Úkoly.',
+      one: 'Aktivní 1 filtr. Uloženo na boční panel pod Úkoly.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get tasksSavedFiltersSavePopupHint =>
+      'např. Blokované nebo pozastavené';
+
+  @override
+  String get tasksSavedFiltersSavePopupSave => 'Uložit';
+
+  @override
+  String get tasksSavedFiltersSavePopupTitle => 'Pojmenuj tento filtr';
+
+  @override
   String get tasksSavedFiltersSectionTitle => 'Uložené filtry';
+
+  @override
+  String get tasksSavedFilterToastDeleted => 'Filtr smazán';
+
+  @override
+  String tasksSavedFilterToastSaved(String name) {
+    return 'Uloženo „$name“';
+  }
+
+  @override
+  String tasksSavedFilterToastUpdated(String name) {
+    return 'Aktualizováno „$name“';
+  }
 
   @override
   String get tasksSearchModeLabel => 'Režim hledání';

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -6467,9 +6467,6 @@ class AppLocalizationsCs extends AppLocalizations {
   String get tasksSavedFiltersSavePopupTitle => 'Pojmenuj tento filtr';
 
   @override
-  String get tasksSavedFiltersSectionTitle => 'Uložené filtry';
-
-  @override
   String get tasksSavedFilterToastDeleted => 'Filtr smazán';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -6439,7 +6439,47 @@ class AppLocalizationsDe extends AppLocalizations {
       'Noch keine gespeicherten Filter. Pass den Aufgabenfilter an und tippe auf Speichern.';
 
   @override
+  String get tasksSavedFiltersSaveButtonLabel => 'Speichern';
+
+  @override
+  String get tasksSavedFiltersSavePopupCancel => 'Abbrechen';
+
+  @override
+  String tasksSavedFiltersSavePopupHelper(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          '$count Filter aktiv. In der Seitenleiste unter „Aufgaben“ gespeichert.',
+      one: '1 Filter aktiv. In der Seitenleiste unter „Aufgaben“ gespeichert.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get tasksSavedFiltersSavePopupHint => 'z. B. Blockiert oder pausiert';
+
+  @override
+  String get tasksSavedFiltersSavePopupSave => 'Speichern';
+
+  @override
+  String get tasksSavedFiltersSavePopupTitle => 'Diesen Filter benennen';
+
+  @override
   String get tasksSavedFiltersSectionTitle => 'Gespeicherte Filter';
+
+  @override
+  String get tasksSavedFilterToastDeleted => 'Filter gelöscht';
+
+  @override
+  String tasksSavedFilterToastSaved(String name) {
+    return '„$name“ gespeichert';
+  }
+
+  @override
+  String tasksSavedFilterToastUpdated(String name) {
+    return '„$name“ aktualisiert';
+  }
 
   @override
   String get tasksSearchModeLabel => 'Suchmodus';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -6466,9 +6466,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get tasksSavedFiltersSavePopupTitle => 'Diesen Filter benennen';
 
   @override
-  String get tasksSavedFiltersSectionTitle => 'Gespeicherte Filter';
-
-  @override
   String get tasksSavedFilterToastDeleted => 'Filter gelöscht';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -6344,7 +6344,46 @@ class AppLocalizationsEn extends AppLocalizations {
       'No saved filters yet. Adjust the task filter, then tap Save.';
 
   @override
+  String get tasksSavedFiltersSaveButtonLabel => 'Save';
+
+  @override
+  String get tasksSavedFiltersSavePopupCancel => 'Cancel';
+
+  @override
+  String tasksSavedFiltersSavePopupHelper(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count filters active. Saved to sidebar under Tasks.',
+      one: '1 filter active. Saved to sidebar under Tasks.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get tasksSavedFiltersSavePopupHint => 'e.g. Blocked or on hold';
+
+  @override
+  String get tasksSavedFiltersSavePopupSave => 'Save';
+
+  @override
+  String get tasksSavedFiltersSavePopupTitle => 'Name this filter';
+
+  @override
   String get tasksSavedFiltersSectionTitle => 'Saved filters';
+
+  @override
+  String get tasksSavedFilterToastDeleted => 'Filter deleted';
+
+  @override
+  String tasksSavedFilterToastSaved(String name) {
+    return 'Saved \'$name\'';
+  }
+
+  @override
+  String tasksSavedFilterToastUpdated(String name) {
+    return 'Updated \'$name\'';
+  }
 
   @override
   String get tasksSearchModeLabel => 'Search mode';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -6370,9 +6370,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get tasksSavedFiltersSavePopupTitle => 'Name this filter';
 
   @override
-  String get tasksSavedFiltersSectionTitle => 'Saved filters';
-
-  @override
   String get tasksSavedFilterToastDeleted => 'Filter deleted';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -6538,7 +6538,48 @@ class AppLocalizationsEs extends AppLocalizations {
       'Aún no tienes filtros guardados. Ajusta el filtro de tareas y toca Guardar.';
 
   @override
+  String get tasksSavedFiltersSaveButtonLabel => 'Guardar';
+
+  @override
+  String get tasksSavedFiltersSavePopupCancel => 'Cancelar';
+
+  @override
+  String tasksSavedFiltersSavePopupHelper(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          '$count filtros activos. Guardados en la barra lateral, bajo Tareas.',
+      one: '1 filtro activo. Guardado en la barra lateral, bajo Tareas.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get tasksSavedFiltersSavePopupHint => 'p. ej. Bloqueadas o en pausa';
+
+  @override
+  String get tasksSavedFiltersSavePopupSave => 'Guardar';
+
+  @override
+  String get tasksSavedFiltersSavePopupTitle =>
+      'Asigna un nombre a este filtro';
+
+  @override
   String get tasksSavedFiltersSectionTitle => 'Filtros guardados';
+
+  @override
+  String get tasksSavedFilterToastDeleted => 'Filtro eliminado';
+
+  @override
+  String tasksSavedFilterToastSaved(String name) {
+    return 'Guardado «$name»';
+  }
+
+  @override
+  String tasksSavedFilterToastUpdated(String name) {
+    return 'Actualizado «$name»';
+  }
 
   @override
   String get tasksSearchModeLabel => 'Modo de búsqueda';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -6566,9 +6566,6 @@ class AppLocalizationsEs extends AppLocalizations {
       'Asigna un nombre a este filtro';
 
   @override
-  String get tasksSavedFiltersSectionTitle => 'Filtros guardados';
-
-  @override
   String get tasksSavedFilterToastDeleted => 'Filtro eliminado';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -6579,9 +6579,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get tasksSavedFiltersSavePopupTitle => 'Nomme ce filtre';
 
   @override
-  String get tasksSavedFiltersSectionTitle => 'Filtres enregistrés';
-
-  @override
   String get tasksSavedFilterToastDeleted => 'Filtre supprimé';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -6552,7 +6552,47 @@ class AppLocalizationsFr extends AppLocalizations {
       'Aucun filtre enregistré pour l\'instant. Ajuste le filtre des tâches, puis appuie sur Enregistrer.';
 
   @override
+  String get tasksSavedFiltersSaveButtonLabel => 'Enregistrer';
+
+  @override
+  String get tasksSavedFiltersSavePopupCancel => 'Annuler';
+
+  @override
+  String tasksSavedFiltersSavePopupHelper(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          '$count filtres actifs. Enregistrés dans la barre latérale, sous Tâches.',
+      one: '1 filtre actif. Enregistré dans la barre latérale, sous Tâches.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get tasksSavedFiltersSavePopupHint => 'ex. : Bloquées ou en pause';
+
+  @override
+  String get tasksSavedFiltersSavePopupSave => 'Enregistrer';
+
+  @override
+  String get tasksSavedFiltersSavePopupTitle => 'Nomme ce filtre';
+
+  @override
   String get tasksSavedFiltersSectionTitle => 'Filtres enregistrés';
+
+  @override
+  String get tasksSavedFilterToastDeleted => 'Filtre supprimé';
+
+  @override
+  String tasksSavedFilterToastSaved(String name) {
+    return '« $name » enregistré';
+  }
+
+  @override
+  String tasksSavedFilterToastUpdated(String name) {
+    return '« $name » mis à jour';
+  }
 
   @override
   String get tasksSearchModeLabel => 'Mode de recherche';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -6480,7 +6480,46 @@ class AppLocalizationsRo extends AppLocalizations {
       'Niciun filtru salvat încă. Ajustați filtrul de sarcini, apoi apăsați Salvați.';
 
   @override
+  String get tasksSavedFiltersSaveButtonLabel => 'Salvați';
+
+  @override
+  String get tasksSavedFiltersSavePopupCancel => 'Anulați';
+
+  @override
+  String tasksSavedFiltersSavePopupHelper(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count filtre active. Salvate în bara laterală, sub Sarcini.',
+      one: '1 filtru activ. Salvat în bara laterală, sub Sarcini.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get tasksSavedFiltersSavePopupHint => 'ex.: Blocate sau în așteptare';
+
+  @override
+  String get tasksSavedFiltersSavePopupSave => 'Salvați';
+
+  @override
+  String get tasksSavedFiltersSavePopupTitle => 'Denumiți acest filtru';
+
+  @override
   String get tasksSavedFiltersSectionTitle => 'Filtre salvate';
+
+  @override
+  String get tasksSavedFilterToastDeleted => 'Filtru șters';
+
+  @override
+  String tasksSavedFilterToastSaved(String name) {
+    return 'Salvat „$name”';
+  }
+
+  @override
+  String tasksSavedFilterToastUpdated(String name) {
+    return 'Actualizat „$name”';
+  }
 
   @override
   String get tasksSearchModeLabel => 'Mod de căutare';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -6490,7 +6490,8 @@ class AppLocalizationsRo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count filtre active. Salvate în bara laterală, sub Sarcini.',
+      other: '$count de filtre active. Salvate în bara laterală, sub Sarcini.',
+      few: '$count filtre active. Salvate în bara laterală, sub Sarcini.',
       one: '1 filtru activ. Salvat în bara laterală, sub Sarcini.',
     );
     return '$_temp0';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -6507,9 +6507,6 @@ class AppLocalizationsRo extends AppLocalizations {
   String get tasksSavedFiltersSavePopupTitle => 'Denumiți acest filtru';
 
   @override
-  String get tasksSavedFiltersSectionTitle => 'Filtre salvate';
-
-  @override
   String get tasksSavedFilterToastDeleted => 'Filtru șters';
 
   @override

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -2689,7 +2689,37 @@
   "tasksSavedFilterRenameSemantics": "Redenumiți filtrul salvat",
   "tasksSavedFiltersAddTooltip": "Salvați filtrul curent",
   "tasksSavedFiltersEmpty": "Niciun filtru salvat încă. Ajustați filtrul de sarcini, apoi apăsați Salvați.",
+  "tasksSavedFiltersSaveButtonLabel": "Salvați",
+  "tasksSavedFiltersSavePopupCancel": "Anulați",
+  "tasksSavedFiltersSavePopupHelper": "{count, plural, =1{1 filtru activ. Salvat în bara laterală, sub Sarcini.} other{{count} filtre active. Salvate în bara laterală, sub Sarcini.}}",
+  "@tasksSavedFiltersSavePopupHelper": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "tasksSavedFiltersSavePopupHint": "ex.: Blocate sau în așteptare",
+  "tasksSavedFiltersSavePopupSave": "Salvați",
+  "tasksSavedFiltersSavePopupTitle": "Denumiți acest filtru",
   "tasksSavedFiltersSectionTitle": "Filtre salvate",
+  "tasksSavedFilterToastDeleted": "Filtru șters",
+  "tasksSavedFilterToastSaved": "Salvat „{name}”",
+  "@tasksSavedFilterToastSaved": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "tasksSavedFilterToastUpdated": "Actualizat „{name}”",
+  "@tasksSavedFilterToastUpdated": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
   "tasksSearchModeLabel": "Mod de căutare",
   "tasksShowCoverArt": "Afișează coperta pe carduri",
   "tasksShowCreationDate": "Afișează data creării pe carduri",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -2691,7 +2691,7 @@
   "tasksSavedFiltersEmpty": "Niciun filtru salvat încă. Ajustați filtrul de sarcini, apoi apăsați Salvați.",
   "tasksSavedFiltersSaveButtonLabel": "Salvați",
   "tasksSavedFiltersSavePopupCancel": "Anulați",
-  "tasksSavedFiltersSavePopupHelper": "{count, plural, =1{1 filtru activ. Salvat în bara laterală, sub Sarcini.} other{{count} filtre active. Salvate în bara laterală, sub Sarcini.}}",
+  "tasksSavedFiltersSavePopupHelper": "{count, plural, =1{1 filtru activ. Salvat în bara laterală, sub Sarcini.} few{{count} filtre active. Salvate în bara laterală, sub Sarcini.} other{{count} de filtre active. Salvate în bara laterală, sub Sarcini.}}",
   "@tasksSavedFiltersSavePopupHelper": {
     "placeholders": {
       "count": {

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -2702,7 +2702,6 @@
   "tasksSavedFiltersSavePopupHint": "ex.: Blocate sau în așteptare",
   "tasksSavedFiltersSavePopupSave": "Salvați",
   "tasksSavedFiltersSavePopupTitle": "Denumiți acest filtru",
-  "tasksSavedFiltersSectionTitle": "Filtre salvate",
   "tasksSavedFilterToastDeleted": "Filtru șters",
   "tasksSavedFilterToastSaved": "Salvat „{name}”",
   "@tasksSavedFilterToastSaved": {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.976+3984
+version: 0.9.977+3985
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.977+3985
+version: 0.9.977+3986
 
 msix_config:
   display_name: LottiApp

--- a/test/beamer/beamer_app_test.dart
+++ b/test/beamer/beamer_app_test.dart
@@ -10,11 +10,15 @@ import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/features/ai/ui/settings/services/ai_setup_prompt_service.dart';
 import 'package:lotti/features/design_system/components/navigation/design_system_navigation_tab_bar.dart';
 import 'package:lotti/features/design_system/components/navigation/desktop_navigation_sidebar.dart';
+import 'package:lotti/features/journal/state/journal_page_state.dart';
 import 'package:lotti/features/speech/state/recorder_controller.dart';
 import 'package:lotti/features/speech/state/recorder_state.dart';
 import 'package:lotti/features/speech/ui/widgets/recording/audio_recording_indicator.dart';
 import 'package:lotti/features/sync/matrix/key_verification_runner.dart';
 import 'package:lotti/features/sync/state/matrix_login_controller.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter_activator.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filters_controller.dart';
 import 'package:lotti/features/whats_new/state/whats_new_controller.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations.dart';
@@ -206,6 +210,16 @@ Future<void> _pumpAppScreen(
           ),
         ),
         shouldAutoShowWhatsNewProvider.overrideWith((ref) async => false),
+        // The Tasks destination's expanded subtree (TasksSavedFiltersTree)
+        // watches saved-filter providers. Override them with safe defaults so
+        // this test doesn't transitively trigger the real JournalPageController
+        // build chain (which needs Fts5Db etc. that aren't wired up here).
+        savedTaskFiltersControllerProvider.overrideWith(
+          () => _StubSavedTaskFiltersController(const []),
+        ),
+        currentSavedTaskFilterIdProvider.overrideWith((ref) => null),
+        tasksFilterHasUnsavedClausesProvider.overrideWith((ref) => false),
+        liveTasksFilterProvider.overrideWith((ref) => const TasksFilter()),
       ],
       child: MaterialApp.router(
         theme: withOverrides(ThemeData.dark(useMaterial3: true)),
@@ -634,4 +648,12 @@ void main() {
       await tester.pump();
     });
   });
+}
+
+class _StubSavedTaskFiltersController extends SavedTaskFiltersController {
+  _StubSavedTaskFiltersController(this._seed);
+  final List<SavedTaskFilter> _seed;
+
+  @override
+  Future<List<SavedTaskFilter>> build() async => _seed;
 }

--- a/test/features/design_system/components/navigation/desktop_navigation_sidebar_test.dart
+++ b/test/features/design_system/components/navigation/desktop_navigation_sidebar_test.dart
@@ -476,6 +476,68 @@ void main() {
       expect(find.byIcon(Icons.add_rounded), findsNothing);
     });
 
+    testWidgets(
+      'expandedChildBuilder renders below the active destination row',
+      (tester) async {
+        const childKey = Key('expanded-subtree');
+        final destinations = [
+          DesktopSidebarDestination(
+            label: 'Journal',
+            iconBuilder: ({required bool active}) => const Icon(Icons.book),
+          ),
+          DesktopSidebarDestination(
+            label: 'Tasks',
+            iconBuilder: ({required bool active}) => const Icon(Icons.task_alt),
+            expandedChildBuilder: () => const Padding(
+              key: childKey,
+              padding: EdgeInsets.all(4),
+              child: Text('saved-filters'),
+            ),
+          ),
+        ];
+
+        // Inactive destination — subtree must not render.
+        await tester.pumpWidget(
+          wrap(
+            DesktopNavigationSidebar(
+              destinations: destinations,
+              activeIndex: 0,
+              onDestinationSelected: (_) {},
+            ),
+          ),
+        );
+        await tester.pump();
+        expect(find.byKey(childKey), findsNothing);
+
+        // Active destination — subtree renders.
+        await tester.pumpWidget(
+          wrap(
+            DesktopNavigationSidebar(
+              destinations: destinations,
+              activeIndex: 1,
+              onDestinationSelected: (_) {},
+            ),
+          ),
+        );
+        await tester.pump();
+        expect(find.byKey(childKey), findsOneWidget);
+
+        // Collapsed mode — subtree stays hidden even when active.
+        await tester.pumpWidget(
+          wrap(
+            DesktopNavigationSidebar(
+              destinations: destinations,
+              activeIndex: 1,
+              onDestinationSelected: (_) {},
+              collapsed: true,
+            ),
+          ),
+        );
+        await tester.pump();
+        expect(find.byKey(childKey), findsNothing);
+      },
+    );
+
     testWidgets('toggle icon is tappable and fires onToggleCollapsed', (
       tester,
     ) async {

--- a/test/features/design_system/components/task_filters/design_system_task_filter_action_bar_save_test.dart
+++ b/test/features/design_system/components/task_filters/design_system_task_filter_action_bar_save_test.dart
@@ -1,0 +1,186 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/components/task_filters/design_system_task_filter_sheet.dart';
+
+import '../../../../widget_test_utils.dart';
+
+DesignSystemTaskFilterState _state() {
+  return DesignSystemTaskFilterState(
+    title: 'Apply filter',
+    clearAllLabel: 'Clear all',
+    applyLabel: 'Apply',
+    sortLabel: 'Sort by',
+    sortOptions: const <DesignSystemTaskFilterOption>[
+      DesignSystemTaskFilterOption(id: 'priority', label: 'Priority'),
+    ],
+    selectedSortId: 'priority',
+  );
+}
+
+Future<void> _pumpBar(
+  WidgetTester tester, {
+  ValueChanged<String>? onSavePressed,
+  bool canSave = false,
+  String? initialSaveName,
+}) async {
+  final state = _state();
+  await tester.pumpWidget(
+    makeTestableWidget(
+      Material(
+        child: DesignSystemTaskFilterActionBar(
+          state: state,
+          onChanged: (_) {},
+          onApplyPressed: (_) {},
+          onSavePressed: onSavePressed,
+          canSave: canSave,
+          initialSaveName: initialSaveName,
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  setUp(() async {
+    await setUpTestGetIt();
+  });
+
+  tearDown(tearDownTestGetIt);
+
+  testWidgets('Save button is hidden when onSavePressed is not supplied', (
+    tester,
+  ) async {
+    await _pumpBar(tester);
+
+    expect(
+      find.byKey(DesignSystemTaskFilterActionBar.saveButtonKey),
+      findsNothing,
+    );
+  });
+
+  testWidgets('Save button is rendered when onSavePressed is supplied', (
+    tester,
+  ) async {
+    await _pumpBar(
+      tester,
+      onSavePressed: (_) {},
+    );
+
+    expect(
+      find.byKey(DesignSystemTaskFilterActionBar.saveButtonKey),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('tapping Save when canSave=false does not open the popup', (
+    tester,
+  ) async {
+    await _pumpBar(
+      tester,
+      onSavePressed: (_) {},
+    );
+
+    await tester.tap(
+      find.byKey(DesignSystemTaskFilterActionBar.saveButtonKey),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(DesignSystemTaskFilterActionBar.saveNamePopupFieldKey),
+      findsNothing,
+    );
+  });
+
+  testWidgets('tapping Save when canSave=true opens the popup with the field', (
+    tester,
+  ) async {
+    await _pumpBar(
+      tester,
+      onSavePressed: (_) {},
+      canSave: true,
+    );
+
+    await tester.tap(
+      find.byKey(DesignSystemTaskFilterActionBar.saveButtonKey),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(DesignSystemTaskFilterActionBar.saveNamePopupFieldKey),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('popup commits trimmed name and invokes onSavePressed', (
+    tester,
+  ) async {
+    String? saved;
+    await _pumpBar(
+      tester,
+      onSavePressed: (name) => saved = name,
+      canSave: true,
+    );
+
+    await tester.tap(
+      find.byKey(DesignSystemTaskFilterActionBar.saveButtonKey),
+    );
+    await tester.pumpAndSettle();
+
+    final field = find.byKey(
+      DesignSystemTaskFilterActionBar.saveNamePopupFieldKey,
+    );
+    await tester.enterText(field, '  My filter  ');
+    await tester.tap(
+      find.byKey(DesignSystemTaskFilterActionBar.saveNamePopupCommitKey),
+    );
+    await tester.pumpAndSettle();
+
+    expect(saved, 'My filter');
+  });
+
+  testWidgets('popup does not invoke onSavePressed when name is empty', (
+    tester,
+  ) async {
+    var saveCount = 0;
+    await _pumpBar(
+      tester,
+      onSavePressed: (_) => saveCount++,
+      canSave: true,
+    );
+
+    await tester.tap(
+      find.byKey(DesignSystemTaskFilterActionBar.saveButtonKey),
+    );
+    await tester.pumpAndSettle();
+
+    final field = find.byKey(
+      DesignSystemTaskFilterActionBar.saveNamePopupFieldKey,
+    );
+    await tester.enterText(field, '   ');
+    await tester.tap(
+      find.byKey(DesignSystemTaskFilterActionBar.saveNamePopupCommitKey),
+    );
+    await tester.pumpAndSettle();
+
+    expect(saveCount, 0);
+  });
+
+  testWidgets('popup pre-fills with initialSaveName when supplied', (
+    tester,
+  ) async {
+    await _pumpBar(
+      tester,
+      onSavePressed: (_) {},
+      canSave: true,
+      initialSaveName: 'In progress · P0',
+    );
+
+    await tester.tap(
+      find.byKey(DesignSystemTaskFilterActionBar.saveButtonKey),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('In progress · P0'), findsOneWidget);
+  });
+}

--- a/test/features/design_system/components/task_filters/design_system_task_filter_action_bar_save_test.dart
+++ b/test/features/design_system/components/task_filters/design_system_task_filter_action_bar_save_test.dart
@@ -131,6 +131,9 @@ void main() {
       DesignSystemTaskFilterActionBar.saveNamePopupFieldKey,
     );
     await tester.enterText(field, '  My filter  ');
+    // Pump so the controller listener flips _canCommit to true and the
+    // FilledButton re-enables before we tap it.
+    await tester.pump();
     await tester.tap(
       find.byKey(DesignSystemTaskFilterActionBar.saveNamePopupCommitKey),
     );

--- a/test/features/design_system/components/task_filters/design_system_task_filter_action_bar_save_test.dart
+++ b/test/features/design_system/components/task_filters/design_system_task_filter_action_bar_save_test.dart
@@ -186,4 +186,68 @@ void main() {
 
     expect(find.text('In progress · P0'), findsOneWidget);
   });
+
+  testWidgets(
+    'commit button disables when the field is cleared after typing',
+    (tester) async {
+      await _pumpBar(
+        tester,
+        onSavePressed: (_) {},
+        canSave: true,
+      );
+
+      await tester.tap(
+        find.byKey(DesignSystemTaskFilterActionBar.saveButtonKey),
+      );
+      await tester.pumpAndSettle();
+
+      final field = find.byKey(
+        DesignSystemTaskFilterActionBar.saveNamePopupFieldKey,
+      );
+      // Type a name → enabled.
+      await tester.enterText(field, 'Filter');
+      await tester.pump();
+      var commit = tester.widget<FilledButton>(
+        find.byKey(DesignSystemTaskFilterActionBar.saveNamePopupCommitKey),
+      );
+      expect(commit.onPressed, isNotNull);
+
+      // Clear the field → listener flips _canCommit back to false.
+      await tester.enterText(field, '');
+      await tester.pump();
+      commit = tester.widget<FilledButton>(
+        find.byKey(DesignSystemTaskFilterActionBar.saveNamePopupCommitKey),
+      );
+      expect(commit.onPressed, isNull);
+    },
+  );
+
+  testWidgets(
+    'closing the popup disposes the inner controller / focus node cleanly',
+    (tester) async {
+      await _pumpBar(
+        tester,
+        onSavePressed: (_) {},
+        canSave: true,
+      );
+
+      await tester.tap(
+        find.byKey(DesignSystemTaskFilterActionBar.saveButtonKey),
+      );
+      await tester.pumpAndSettle();
+
+      // Tap the action button again to toggle the menu closed; this routes
+      // through the popup's State.dispose which removes the controller
+      // listener and disposes the controller + focus node.
+      await tester.tap(
+        find.byKey(DesignSystemTaskFilterActionBar.saveButtonKey),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(DesignSystemTaskFilterActionBar.saveNamePopupFieldKey),
+        findsNothing,
+      );
+    },
+  );
 }

--- a/test/features/tasks/state/saved_filters/saved_task_filter_activator_test.dart
+++ b/test/features/tasks/state/saved_filters/saved_task_filter_activator_test.dart
@@ -1,0 +1,220 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/journal/state/journal_page_controller.dart';
+import 'package:lotti/features/journal/state/journal_page_state.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter_activator.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filters_controller.dart';
+
+import '../../../../test_utils/fake_journal_page_controller.dart';
+import '../../../../widget_test_utils.dart';
+
+const _filterA = TasksFilter(
+  selectedTaskStatuses: {'IN_PROGRESS'},
+  selectedPriorities: {'P0', 'P1'},
+);
+
+const _filterB = TasksFilter(
+  agentAssignmentFilter: AgentAssignmentFilter.noAgent,
+);
+
+ProviderContainer _buildContainer({
+  required FakeJournalPageController fakeController,
+  List<SavedTaskFilter> savedSeed = const <SavedTaskFilter>[],
+}) {
+  final container = ProviderContainer(
+    overrides: [
+      journalPageControllerProvider(true).overrideWith(() => fakeController),
+      savedTaskFiltersControllerProvider.overrideWith(
+        () => _StubSavedFiltersController(savedSeed),
+      ),
+    ],
+  );
+  return container;
+}
+
+class _StubSavedFiltersController extends SavedTaskFiltersController {
+  _StubSavedFiltersController(this._seed);
+  final List<SavedTaskFilter> _seed;
+
+  @override
+  Future<List<SavedTaskFilter>> build() async => _seed;
+}
+
+void main() {
+  setUp(() async {
+    await setUpTestGetIt();
+  });
+
+  tearDown(tearDownTestGetIt);
+
+  group('SavedTaskFilterActivator.activate', () {
+    test(
+      'forwards every saved-filter field to applyBatchFilterUpdate',
+      () async {
+        final fake = FakeJournalPageController(const JournalPageState());
+        final activator = SavedTaskFilterActivator(fake);
+
+        await activator.activate(
+          const SavedTaskFilter(
+            id: 'sv-1',
+            name: 'P0/P1 in progress',
+            filter: _filterA,
+          ),
+        );
+
+        expect(fake.applyBatchFilterUpdateCalled, 1);
+        expect(fake.setSelectedTaskStatusesCalls.single, {'IN_PROGRESS'});
+        expect(fake.setSelectedPrioritiesCalls.single, {'P0', 'P1'});
+        // agent default is `all` — gets forwarded.
+        expect(
+          fake.agentAssignmentFilterCalls.single,
+          AgentAssignmentFilter.all,
+        );
+        // Display flags are passed through with their saved values.
+        expect(fake.showCreationDateCalls.single, false);
+        expect(fake.showDueDateCalls.single, true);
+      },
+    );
+  });
+
+  group('currentSavedTaskFilterIdProvider', () {
+    test('returns null when no saved filter matches the live state', () async {
+      final fake = FakeJournalPageController(
+        const JournalPageState(
+          selectedTaskStatuses: {'OPEN'},
+        ),
+      );
+      final container = _buildContainer(
+        fakeController: fake,
+        savedSeed: const [
+          SavedTaskFilter(id: 'sv-1', name: 'A', filter: _filterA),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // Wait for the stub controller to load.
+      await container.read(savedTaskFiltersControllerProvider.future);
+
+      expect(
+        container.read(currentSavedTaskFilterIdProvider),
+        isNull,
+      );
+    });
+
+    test(
+      'returns the matching saved id when the live filter matches',
+      () async {
+        final fake = FakeJournalPageController(
+          const JournalPageState(
+            selectedTaskStatuses: {'IN_PROGRESS'},
+            selectedPriorities: {'P0', 'P1'},
+          ),
+        );
+        final container = _buildContainer(
+          fakeController: fake,
+          savedSeed: const [
+            SavedTaskFilter(id: 'sv-1', name: 'In progress', filter: _filterA),
+            SavedTaskFilter(id: 'sv-2', name: 'No agent', filter: _filterB),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await container.read(savedTaskFiltersControllerProvider.future);
+
+        expect(
+          container.read(currentSavedTaskFilterIdProvider),
+          'sv-1',
+        );
+      },
+    );
+  });
+
+  group('tasksFilterHasUnsavedClausesProvider', () {
+    test('false when the live filter has no clauses', () async {
+      final fake = FakeJournalPageController(const JournalPageState());
+      final container = _buildContainer(fakeController: fake);
+      addTearDown(container.dispose);
+
+      await container.read(savedTaskFiltersControllerProvider.future);
+
+      expect(
+        container.read(tasksFilterHasUnsavedClausesProvider),
+        isFalse,
+      );
+    });
+
+    test(
+      'false when the live filter matches an existing saved filter',
+      () async {
+        final fake = FakeJournalPageController(
+          const JournalPageState(
+            selectedTaskStatuses: {'IN_PROGRESS'},
+            selectedPriorities: {'P0', 'P1'},
+          ),
+        );
+        final container = _buildContainer(
+          fakeController: fake,
+          savedSeed: const [
+            SavedTaskFilter(id: 'sv-1', name: 'A', filter: _filterA),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await container.read(savedTaskFiltersControllerProvider.future);
+
+        expect(
+          container.read(tasksFilterHasUnsavedClausesProvider),
+          isFalse,
+        );
+      },
+    );
+
+    test(
+      'true when the live filter has clauses and matches no saved filter',
+      () async {
+        final fake = FakeJournalPageController(
+          const JournalPageState(
+            selectedTaskStatuses: {'BLOCKED'},
+          ),
+        );
+        final container = _buildContainer(
+          fakeController: fake,
+          savedSeed: const [
+            SavedTaskFilter(id: 'sv-1', name: 'A', filter: _filterA),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await container.read(savedTaskFiltersControllerProvider.future);
+
+        expect(
+          container.read(tasksFilterHasUnsavedClausesProvider),
+          isTrue,
+        );
+      },
+    );
+  });
+
+  group('liveTasksFilterProvider', () {
+    test('builds a TasksFilter snapshot from the live page state', () async {
+      final fake = FakeJournalPageController(
+        const JournalPageState(
+          selectedTaskStatuses: {'BLOCKED', 'ON_HOLD'},
+          selectedPriorities: {'P0'},
+          showCreationDate: true,
+        ),
+      );
+      final container = _buildContainer(fakeController: fake);
+      addTearDown(container.dispose);
+
+      final live = container.read(liveTasksFilterProvider);
+
+      expect(live.selectedTaskStatuses, {'BLOCKED', 'ON_HOLD'});
+      expect(live.selectedPriorities, {'P0'});
+      expect(live.showCreationDate, isTrue);
+      expect(live.showDueDate, isTrue); // default
+      expect(live.agentAssignmentFilter, AgentAssignmentFilter.all);
+    });
+  });
+}

--- a/test/features/tasks/ui/filtering/task_filter_icon_test.dart
+++ b/test/features/tasks/ui/filtering/task_filter_icon_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/features/design_system/components/task_filters/design_system_task_filter_sheet.dart';
 import 'package:lotti/features/journal/state/journal_page_controller.dart';
 import 'package:lotti/features/journal/state/journal_page_scope.dart';
@@ -90,9 +91,15 @@ void main() {
     ).thenAnswer((_) async => <ProjectEntry>[]);
 
     getIt.allowReassignment = true;
+    final mockSettingsDb = MockSettingsDb();
+    when(() => mockSettingsDb.itemByKey(any())).thenAnswer((_) async => null);
+    when(
+      () => mockSettingsDb.saveSettingsItem(any(), any()),
+    ).thenAnswer((_) async => 1);
     getIt
       ..registerSingleton<EntitiesCacheService>(mockEntitiesCacheService)
-      ..registerSingleton<JournalDb>(mockJournalDb);
+      ..registerSingleton<JournalDb>(mockJournalDb)
+      ..registerSingleton<SettingsDb>(mockSettingsDb);
   });
 
   tearDown(getIt.reset);

--- a/test/features/tasks/ui/filtering/task_filter_icon_test.dart
+++ b/test/features/tasks/ui/filtering/task_filter_icon_test.dart
@@ -12,6 +12,9 @@ import 'package:lotti/features/design_system/components/task_filters/design_syst
 import 'package:lotti/features/journal/state/journal_page_controller.dart';
 import 'package:lotti/features/journal/state/journal_page_scope.dart';
 import 'package:lotti/features/journal/state/journal_page_state.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter_activator.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filters_controller.dart';
 import 'package:lotti/features/tasks/ui/filtering/task_filter_icon.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/entities_cache_service.dart';
@@ -115,6 +118,14 @@ void main() {
             journalPageControllerProvider(
               true,
             ).overrideWith(() => fakeController),
+            savedTaskFiltersControllerProvider.overrideWith(
+              () => _StubSavedTaskFiltersController(const []),
+            ),
+            currentSavedTaskFilterIdProvider.overrideWith((ref) => null),
+            tasksFilterHasUnsavedClausesProvider.overrideWith((ref) => false),
+            liveTasksFilterProvider.overrideWith(
+              (ref) => const TasksFilter(),
+            ),
           ],
           child: const Scaffold(
             body: TaskFilterIcon(),
@@ -174,4 +185,12 @@ void main() {
       expect(find.text('Tasks Filter'), findsNothing);
     });
   });
+}
+
+class _StubSavedTaskFiltersController extends SavedTaskFiltersController {
+  _StubSavedTaskFiltersController(this._seed);
+  final List<SavedTaskFilter> _seed;
+
+  @override
+  Future<List<SavedTaskFilter>> build() async => _seed;
 }

--- a/test/features/tasks/ui/filtering/task_filter_modal_save_flow_test.dart
+++ b/test/features/tasks/ui/filtering/task_filter_modal_save_flow_test.dart
@@ -1,0 +1,293 @@
+// ignore_for_file: avoid_redundant_argument_values
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/database/settings_db.dart';
+import 'package:lotti/features/design_system/components/task_filters/design_system_task_filter_sheet.dart';
+import 'package:lotti/features/journal/state/journal_page_controller.dart';
+import 'package:lotti/features/journal/state/journal_page_scope.dart';
+import 'package:lotti/features/journal/state/journal_page_state.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter_activator.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filters_controller.dart';
+import 'package:lotti/features/tasks/ui/filtering/task_filter_modal.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/entities_cache_service.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../mocks/mocks.dart';
+import '../../../../test_helper.dart';
+import '../../../../test_utils/fake_journal_page_controller.dart';
+
+/// Recorder controller — captures `create` and `updateFilter` calls so we can
+/// assert which save-flow branch ran.
+class _RecordingSavedFiltersController extends SavedTaskFiltersController {
+  _RecordingSavedFiltersController(this._seed);
+
+  final List<SavedTaskFilter> _seed;
+  final List<({String name, TasksFilter filter})> creates = [];
+  final List<({String id, TasksFilter filter})> updates = [];
+
+  @override
+  Future<List<SavedTaskFilter>> build() async => _seed;
+
+  @override
+  Future<SavedTaskFilter> create({
+    required String name,
+    required TasksFilter filter,
+  }) async {
+    creates.add((name: name, filter: filter));
+    final created = SavedTaskFilter(
+      id: 'sv-${creates.length}',
+      name: name,
+      filter: filter,
+    );
+    state = AsyncData([..._seed, created]);
+    return created;
+  }
+
+  @override
+  Future<void> updateFilter(String id, TasksFilter filter) async {
+    updates.add((id: id, filter: filter));
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FakeJournalPageController fakeController;
+  late JournalPageState mockState;
+  late MockEntitiesCacheService mockCache;
+  late MockJournalDb mockJournalDb;
+
+  setUp(() {
+    mockCache = MockEntitiesCacheService();
+    mockJournalDb = MockJournalDb();
+
+    when(() => mockCache.sortedCategories).thenReturn(const []);
+    when(() => mockCache.sortedLabels).thenReturn(const []);
+    when(
+      () => mockJournalDb.getProjectsForCategory(any()),
+    ).thenAnswer((_) async => <ProjectEntry>[]);
+
+    mockState = const JournalPageState(
+      taskStatuses: ['OPEN', 'IN PROGRESS'],
+      selectedTaskStatuses: {'OPEN'},
+      selectedCategoryIds: {},
+      selectedLabelIds: {},
+      selectedPriorities: {},
+    );
+
+    final mockSettingsDb = MockSettingsDb();
+    when(() => mockSettingsDb.itemByKey(any())).thenAnswer((_) async => null);
+    when(
+      () => mockSettingsDb.saveSettingsItem(any(), any()),
+    ).thenAnswer((_) async => 1);
+
+    getIt.allowReassignment = true;
+    getIt
+      ..registerSingleton<EntitiesCacheService>(mockCache)
+      ..registerSingleton<JournalDb>(mockJournalDb)
+      ..registerSingleton<SettingsDb>(mockSettingsDb);
+  });
+
+  tearDown(getIt.reset);
+
+  Widget buildSubject({
+    required _RecordingSavedFiltersController recorder,
+    String? activeId,
+    bool hasUnsavedClauses = true,
+    TasksFilter live = const TasksFilter(),
+  }) {
+    fakeController = FakeJournalPageController(mockState);
+
+    return WidgetTestBench(
+      child: ProviderScope(
+        overrides: [
+          journalPageScopeProvider.overrideWithValue(true),
+          journalPageControllerProvider(
+            true,
+          ).overrideWith(() => fakeController),
+          savedTaskFiltersControllerProvider.overrideWith(() => recorder),
+          currentSavedTaskFilterIdProvider.overrideWith((ref) => activeId),
+          tasksFilterHasUnsavedClausesProvider.overrideWith(
+            (ref) => hasUnsavedClauses,
+          ),
+          liveTasksFilterProvider.overrideWith((ref) => live),
+        ],
+        child: Scaffold(
+          body: Builder(
+            builder: (context) => ElevatedButton(
+              key: const ValueKey('open-filter-modal'),
+              onPressed: () => showTaskFilterModal(context, showTasks: true),
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> openModalAndSave(
+    WidgetTester tester, {
+    required String typedName,
+  }) async {
+    await tester.tap(find.byKey(const ValueKey('open-filter-modal')));
+    await tester.pumpAndSettle();
+
+    // Open the Save popup.
+    await tester.tap(find.byKey(DesignSystemTaskFilterActionBar.saveButtonKey));
+    await tester.pumpAndSettle();
+
+    // Type the name and commit.
+    await tester.enterText(
+      find.byKey(DesignSystemTaskFilterActionBar.saveNamePopupFieldKey),
+      typedName,
+    );
+    // Allow the controller listener to flip _canCommit.
+    await tester.pump();
+    await tester.tap(
+      find.byKey(DesignSystemTaskFilterActionBar.saveNamePopupCommitKey),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  group('save flow', () {
+    testWidgets(
+      'creates a new saved filter when no active id is set',
+      (tester) async {
+        final recorder = _RecordingSavedFiltersController(const []);
+        await tester.pumpWidget(
+          buildSubject(
+            recorder: recorder,
+            live: const TasksFilter(
+              selectedTaskStatuses: {'IN_PROGRESS'},
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await openModalAndSave(tester, typedName: '  My filter  ');
+
+        expect(recorder.creates, hasLength(1));
+        expect(recorder.creates.single.name, 'My filter');
+        expect(
+          recorder.creates.single.filter.selectedTaskStatuses,
+          {'IN_PROGRESS'},
+        );
+        expect(recorder.updates, isEmpty);
+      },
+    );
+
+    testWidgets(
+      'updates the active saved filter when typed name matches the active name',
+      (tester) async {
+        final recorder = _RecordingSavedFiltersController(
+          const [
+            SavedTaskFilter(
+              id: 'sv-1',
+              name: 'In progress',
+              filter: TasksFilter(),
+            ),
+          ],
+        );
+        await tester.pumpWidget(
+          buildSubject(
+            recorder: recorder,
+            activeId: 'sv-1',
+            live: const TasksFilter(
+              selectedTaskStatuses: {'BLOCKED'},
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Prime the AsyncNotifier so its initial seed has resolved before
+        // the modal reads `.value` — otherwise the modal sees an empty list
+        // and routes to the create branch.
+        final container = ProviderScope.containerOf(
+          tester.element(find.byKey(const ValueKey('open-filter-modal'))),
+        );
+        await container.read(savedTaskFiltersControllerProvider.future);
+        await tester.pumpAndSettle();
+
+        await openModalAndSave(tester, typedName: 'In progress');
+
+        expect(recorder.updates, hasLength(1));
+        expect(recorder.updates.single.id, 'sv-1');
+        expect(
+          recorder.updates.single.filter.selectedTaskStatuses,
+          {'BLOCKED'},
+        );
+        expect(recorder.creates, isEmpty);
+      },
+    );
+
+    testWidgets(
+      'creates a new saved filter when active id has no resolved name',
+      (tester) async {
+        // Stale-id case: provider says sv-1 is active but the list does not
+        // contain it (concurrent delete). The save flow must degrade to the
+        // create branch rather than calling updateFilter on a stale id.
+        final recorder = _RecordingSavedFiltersController(const []);
+        await tester.pumpWidget(
+          buildSubject(
+            recorder: recorder,
+            activeId: 'sv-1', // no matching entry in seed
+            live: const TasksFilter(
+              selectedTaskStatuses: {'OPEN'},
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await openModalAndSave(tester, typedName: 'Whatever');
+
+        expect(recorder.creates, hasLength(1));
+        expect(recorder.creates.single.name, 'Whatever');
+        expect(recorder.updates, isEmpty);
+      },
+    );
+
+    testWidgets(
+      'creates a new saved filter when typed name differs from active name',
+      (tester) async {
+        final recorder = _RecordingSavedFiltersController(
+          const [
+            SavedTaskFilter(
+              id: 'sv-1',
+              name: 'Existing',
+              filter: TasksFilter(),
+            ),
+          ],
+        );
+        await tester.pumpWidget(
+          buildSubject(
+            recorder: recorder,
+            activeId: 'sv-1',
+            live: const TasksFilter(
+              selectedTaskStatuses: {'BLOCKED'},
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final container = ProviderScope.containerOf(
+          tester.element(find.byKey(const ValueKey('open-filter-modal'))),
+        );
+        await container.read(savedTaskFiltersControllerProvider.future);
+        await tester.pumpAndSettle();
+
+        await openModalAndSave(tester, typedName: 'Different');
+
+        // User typed a new name → create branch fires, no update.
+        expect(recorder.creates, hasLength(1));
+        expect(recorder.creates.single.name, 'Different');
+        expect(recorder.updates, isEmpty);
+      },
+    );
+  });
+}

--- a/test/features/tasks/ui/filtering/task_filter_modal_test.dart
+++ b/test/features/tasks/ui/filtering/task_filter_modal_test.dart
@@ -12,6 +12,9 @@ import 'package:lotti/features/design_system/components/task_filters/design_syst
 import 'package:lotti/features/journal/state/journal_page_controller.dart';
 import 'package:lotti/features/journal/state/journal_page_scope.dart';
 import 'package:lotti/features/journal/state/journal_page_state.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter_activator.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filters_controller.dart';
 import 'package:lotti/features/tasks/ui/filtering/task_filter_modal.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/entities_cache_service.dart';
@@ -131,6 +134,15 @@ void main() {
           journalPageControllerProvider(true).overrideWith(
             () => fakeController,
           ),
+          // Saved-filter providers depend on the live JournalPageController.
+          // Override them with safe defaults so this test exercises the
+          // existing filter UI without spinning up the saved-filter stack.
+          savedTaskFiltersControllerProvider.overrideWith(
+            () => _StubSavedTaskFiltersController(const []),
+          ),
+          currentSavedTaskFilterIdProvider.overrideWith((ref) => null),
+          tasksFilterHasUnsavedClausesProvider.overrideWith((ref) => false),
+          liveTasksFilterProvider.overrideWith((ref) => const TasksFilter()),
         ],
         child: Scaffold(
           body: Builder(
@@ -393,4 +405,12 @@ void main() {
       expect(showCreation, findsOneWidget);
     });
   });
+}
+
+class _StubSavedTaskFiltersController extends SavedTaskFiltersController {
+  _StubSavedTaskFiltersController(this._seed);
+  final List<SavedTaskFilter> _seed;
+
+  @override
+  Future<List<SavedTaskFilter>> build() async => _seed;
 }

--- a/test/features/tasks/ui/filtering/task_filter_modal_test.dart
+++ b/test/features/tasks/ui/filtering/task_filter_modal_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/features/design_system/components/task_filters/design_system_task_filter_sheet.dart';
 import 'package:lotti/features/journal/state/journal_page_controller.dart';
 import 'package:lotti/features/journal/state/journal_page_scope.dart';
@@ -107,9 +108,15 @@ void main() {
     ).thenAnswer((_) async => <ProjectEntry>[]);
 
     getIt.allowReassignment = true;
+    final mockSettingsDb = MockSettingsDb();
+    when(() => mockSettingsDb.itemByKey(any())).thenAnswer((_) async => null);
+    when(
+      () => mockSettingsDb.saveSettingsItem(any(), any()),
+    ).thenAnswer((_) async => 1);
     getIt
       ..registerSingleton<EntitiesCacheService>(mockEntitiesCacheService)
-      ..registerSingleton<JournalDb>(mockJournalDb);
+      ..registerSingleton<JournalDb>(mockJournalDb)
+      ..registerSingleton<SettingsDb>(mockSettingsDb);
   });
 
   tearDown(getIt.reset);

--- a/test/features/tasks/ui/pages/tasks_tab_page_test.dart
+++ b/test/features/tasks/ui/pages/tasks_tab_page_test.dart
@@ -13,6 +13,9 @@ import 'package:lotti/features/design_system/components/headers/tab_section_head
 import 'package:lotti/features/journal/state/journal_page_controller.dart';
 import 'package:lotti/features/journal/state/journal_page_scope.dart';
 import 'package:lotti/features/journal/state/journal_page_state.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter_activator.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filters_controller.dart';
 import 'package:lotti/features/tasks/ui/pages/tasks_tab_page.dart';
 import 'package:lotti/features/user_activity/state/user_activity_service.dart';
 import 'package:lotti/get_it.dart';
@@ -655,4 +658,91 @@ void main() {
       },
     );
   });
+
+  group('Tasks header saved-filter suffix', () {
+    Widget buildSubjectWithSavedFilter({
+      required String? activeId,
+      required List<SavedTaskFilter> seed,
+    }) {
+      fakeController = FakeJournalPageController(state());
+
+      return makeTestableWidgetNoScroll(
+        const TasksTabPage(),
+        overrides: [
+          journalPageScopeProvider.overrideWithValue(true),
+          journalPageControllerProvider(
+            true,
+          ).overrideWith(() => fakeController),
+          taskAgentServiceProvider.overrideWithValue(MockTaskAgentService()),
+          savedTaskFiltersControllerProvider.overrideWith(
+            () => _StubSavedTaskFiltersController(seed),
+          ),
+          currentSavedTaskFilterIdProvider.overrideWith((ref) => activeId),
+          tasksFilterHasUnsavedClausesProvider.overrideWith((ref) => false),
+          liveTasksFilterProvider.overrideWith((ref) => const TasksFilter()),
+        ],
+      );
+    }
+
+    testWidgets('renders no suffix when no saved filter is active', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildSubjectWithSavedFilter(
+          activeId: null,
+          seed: const [],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('· '), findsNothing);
+    });
+
+    testWidgets(
+      'renders the "· {name}" suffix when activeId resolves to a saved view',
+      (tester) async {
+        await tester.pumpWidget(
+          buildSubjectWithSavedFilter(
+            activeId: 'sv-1',
+            seed: const [
+              SavedTaskFilter(
+                id: 'sv-1',
+                name: 'In progress · P0',
+                filter: TasksFilter(),
+              ),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('· In progress · P0'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'renders no suffix when activeId does not resolve to any saved view',
+      (tester) async {
+        // Stale-id case: provider says sv-1 is active, but the list does not
+        // contain it (e.g. concurrent delete). The suffix must degrade to
+        // empty rather than throwing.
+        await tester.pumpWidget(
+          buildSubjectWithSavedFilter(
+            activeId: 'sv-1',
+            seed: const [],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.textContaining('· '), findsNothing);
+      },
+    );
+  });
+}
+
+class _StubSavedTaskFiltersController extends SavedTaskFiltersController {
+  _StubSavedTaskFiltersController(this._seed);
+  final List<SavedTaskFilter> _seed;
+
+  @override
+  Future<List<SavedTaskFilter>> build() async => _seed;
 }

--- a/test/features/tasks/ui/saved_filters/saved_task_filter_row_test.dart
+++ b/test/features/tasks/ui/saved_filters/saved_task_filter_row_test.dart
@@ -2,10 +2,15 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/features/journal/state/journal_page_state.dart';
 import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter.dart';
 import 'package:lotti/features/tasks/ui/saved_filters/saved_task_filter_row.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/entities_cache_service.dart';
+import 'package:mocktail/mocktail.dart';
 
+import '../../../../mocks/mocks.dart';
 import '../../../../widget_test_utils.dart';
 
 const _view = SavedTaskFilter(
@@ -409,5 +414,175 @@ void main() {
     await tester.pump();
     expect(find.text('New Name'), findsOneWidget);
     expect(find.text('In progress · P0'), findsNothing);
+  });
+
+  group('category color dots', () {
+    late MockEntitiesCacheService mockCache;
+
+    CategoryDefinition makeCategory(String id, String? color) =>
+        CategoryDefinition(
+          id: id,
+          createdAt: DateTime(2024),
+          updatedAt: DateTime(2024),
+          name: 'Cat $id',
+          vectorClock: null,
+          private: false,
+          active: true,
+          color: color,
+        );
+
+    setUp(() {
+      mockCache = MockEntitiesCacheService();
+      if (!getIt.isRegistered<EntitiesCacheService>()) {
+        getIt.registerSingleton<EntitiesCacheService>(mockCache);
+      }
+    });
+
+    SavedTaskFilter viewWithCategories(Set<String> ids) => SavedTaskFilter(
+      id: 'sv-x',
+      name: 'Multi-cat',
+      filter: TasksFilter(selectedCategoryIds: ids),
+    );
+
+    testWidgets(
+      'renders one circular dot when exactly one category is selected',
+      (tester) async {
+        when(
+          () => mockCache.getCategoryById('cat-1'),
+        ).thenReturn(makeCategory('cat-1', '#FF0000'));
+
+        await tester.pumpWidget(
+          makeTestableWidget(
+            SavedTaskFilterRow(
+              view: viewWithCategories(const {'cat-1'}),
+              active: false,
+              onActivate: () {},
+              onRename: (_) {},
+              onDelete: () {},
+            ),
+          ),
+        );
+        await tester.pump();
+
+        // Exactly one circular DecoratedBox in the row's leading column.
+        final circles = find.byWidgetPredicate(
+          (w) =>
+              w is DecoratedBox &&
+              w.decoration is BoxDecoration &&
+              (w.decoration as BoxDecoration).shape == BoxShape.circle,
+        );
+        expect(circles, findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'renders multiple dots (capped at three) when many categories are selected',
+      (tester) async {
+        when(
+          () => mockCache.getCategoryById('cat-1'),
+        ).thenReturn(makeCategory('cat-1', '#FF0000'));
+        when(
+          () => mockCache.getCategoryById('cat-2'),
+        ).thenReturn(makeCategory('cat-2', '#00FF00'));
+        when(
+          () => mockCache.getCategoryById('cat-3'),
+        ).thenReturn(makeCategory('cat-3', '#0000FF'));
+        when(
+          () => mockCache.getCategoryById('cat-4'),
+        ).thenReturn(makeCategory('cat-4', '#FFFF00'));
+
+        // LinkedHashSet preserves insertion order: cat-1..cat-4.
+        await tester.pumpWidget(
+          makeTestableWidget(
+            SavedTaskFilterRow(
+              view: viewWithCategories(const {
+                'cat-1',
+                'cat-2',
+                'cat-3',
+                'cat-4',
+              }),
+              active: false,
+              onActivate: () {},
+              onRename: (_) {},
+              onDelete: () {},
+            ),
+          ),
+        );
+        await tester.pump();
+
+        final circles = find.byWidgetPredicate(
+          (w) =>
+              w is DecoratedBox &&
+              w.decoration is BoxDecoration &&
+              (w.decoration as BoxDecoration).shape == BoxShape.circle,
+        );
+        expect(circles, findsNWidgets(3));
+      },
+    );
+
+    testWidgets(
+      'skips categories whose colour cannot be resolved',
+      (tester) async {
+        when(
+          () => mockCache.getCategoryById('cat-1'),
+        ).thenReturn(makeCategory('cat-1', null));
+        when(
+          () => mockCache.getCategoryById('cat-2'),
+        ).thenReturn(makeCategory('cat-2', '#00FF00'));
+        when(() => mockCache.getCategoryById('cat-missing')).thenReturn(null);
+
+        await tester.pumpWidget(
+          makeTestableWidget(
+            SavedTaskFilterRow(
+              view: viewWithCategories(const {
+                'cat-1',
+                'cat-missing',
+                'cat-2',
+              }),
+              active: false,
+              onActivate: () {},
+              onRename: (_) {},
+              onDelete: () {},
+            ),
+          ),
+        );
+        await tester.pump();
+
+        // Only the one category with a usable colour renders a dot.
+        final circles = find.byWidgetPredicate(
+          (w) =>
+              w is DecoratedBox &&
+              w.decoration is BoxDecoration &&
+              (w.decoration as BoxDecoration).shape == BoxShape.circle,
+        );
+        expect(circles, findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'renders no dot column content when no categories are selected',
+      (tester) async {
+        await tester.pumpWidget(
+          makeTestableWidget(
+            SavedTaskFilterRow(
+              view: viewWithCategories(const {}),
+              active: false,
+              onActivate: () {},
+              onRename: (_) {},
+              onDelete: () {},
+            ),
+          ),
+        );
+        await tester.pump();
+
+        final circles = find.byWidgetPredicate(
+          (w) =>
+              w is DecoratedBox &&
+              w.decoration is BoxDecoration &&
+              (w.decoration as BoxDecoration).shape == BoxShape.circle,
+        );
+        expect(circles, findsNothing);
+      },
+    );
   });
 }

--- a/test/features/tasks/ui/saved_filters/saved_task_filter_row_test.dart
+++ b/test/features/tasks/ui/saved_filters/saved_task_filter_row_test.dart
@@ -99,29 +99,32 @@ void main() {
     expect(find.text('In progress · P0'), findsOneWidget);
   });
 
-  testWidgets('renders the drag handle slot when one is supplied', (
-    tester,
-  ) async {
-    const handle = Icon(Icons.drag_indicator, size: 14, key: Key('handle'));
-    await tester.pumpWidget(
-      makeTestableWidget(
-        SavedTaskFilterRow(
-          view: _view,
-          active: true,
-          onActivate: () {},
-          onRename: (_) {},
-          onDelete: () {},
-          dragHandle: handle,
+  testWidgets(
+    'drag handle is hidden by default — even on the active row',
+    (tester) async {
+      const handle = Icon(Icons.drag_indicator, size: 14, key: Key('handle'));
+      await tester.pumpWidget(
+        makeTestableWidget(
+          SavedTaskFilterRow(
+            view: _view,
+            active: true,
+            onActivate: () {},
+            onRename: (_) {},
+            onDelete: () {},
+            dragHandle: handle,
+          ),
         ),
-      ),
-    );
+      );
 
-    expect(
-      find.byKey(SavedTaskFilterRowKeys.dragHandle('sv-1')),
-      findsOneWidget,
-    );
-    expect(find.byKey(const Key('handle')), findsOneWidget);
-  });
+      // Desktop-native pattern: the grip only surfaces while the row is
+      // hovered. The active row gets its own surface tint, no persistent
+      // grip needed.
+      expect(
+        find.byKey(SavedTaskFilterRowKeys.dragHandle('sv-1')),
+        findsNothing,
+      );
+    },
+  );
 
   testWidgets('hover reveals the delete affordance and drag handle', (
     tester,

--- a/test/features/tasks/ui/saved_filters/saved_task_filter_toast_test.dart
+++ b/test/features/tasks/ui/saved_filters/saved_task_filter_toast_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/tasks/ui/saved_filters/saved_task_filter_toast.dart';
+
+import '../../../../widget_test_utils.dart';
+
+const _wideMq = MediaQueryData(
+  size: Size(900, 700),
+  textScaler: TextScaler.noScaling,
+);
+
+/// Pumps a Scaffold whose body builds a button that, on tap, invokes [trigger]
+/// with the surrounding [BuildContext]. Uses [makeTestableWidget2] which does
+/// NOT wrap in a SingleChildScrollView — `ScaffoldMessenger` and the Scaffold
+/// need a bounded vertical extent for the floating SnackBar to lay out.
+Future<void> _pumpHarness(
+  WidgetTester tester,
+  void Function(BuildContext context) trigger,
+) async {
+  await tester.pumpWidget(
+    makeTestableWidget2(
+      Scaffold(
+        body: Builder(
+          builder: (context) {
+            return Center(
+              child: ElevatedButton(
+                onPressed: () => trigger(context),
+                child: const Text('fire'),
+              ),
+            );
+          },
+        ),
+      ),
+      mediaQueryData: _wideMq,
+    ),
+  );
+}
+
+void main() {
+  setUp(() async {
+    await setUpTestGetIt();
+  });
+
+  tearDown(tearDownTestGetIt);
+
+  testWidgets('showSavedTaskFilterSavedToast surfaces the localised label', (
+    tester,
+  ) async {
+    await _pumpHarness(
+      tester,
+      (context) => showSavedTaskFilterSavedToast(context, name: 'My filter'),
+    );
+
+    await tester.tap(find.text('fire'));
+    await tester.pumpAndSettle();
+
+    expect(find.text("Saved 'My filter'"), findsOneWidget);
+    expect(find.byType(SnackBar), findsOneWidget);
+  });
+
+  testWidgets('showSavedTaskFilterUpdatedToast surfaces the localised label', (
+    tester,
+  ) async {
+    await _pumpHarness(
+      tester,
+      (context) => showSavedTaskFilterUpdatedToast(context, name: 'My filter'),
+    );
+
+    await tester.tap(find.text('fire'));
+    await tester.pumpAndSettle();
+
+    expect(find.text("Updated 'My filter'"), findsOneWidget);
+  });
+
+  testWidgets('showSavedTaskFilterDeletedToast surfaces the localised label', (
+    tester,
+  ) async {
+    await _pumpHarness(
+      tester,
+      showSavedTaskFilterDeletedToast,
+    );
+
+    await tester.tap(find.text('fire'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Filter deleted'), findsOneWidget);
+  });
+
+  testWidgets('renders the success check icon inside the SnackBar', (
+    tester,
+  ) async {
+    await _pumpHarness(
+      tester,
+      (context) => showSavedTaskFilterSavedToast(context, name: 'A'),
+    );
+
+    await tester.tap(find.text('fire'));
+    await tester.pumpAndSettle();
+
+    final inSnackBar = find.descendant(
+      of: find.byType(SnackBar),
+      matching: find.byIcon(Icons.check_rounded),
+    );
+    expect(inSnackBar, findsOneWidget);
+  });
+}

--- a/test/features/tasks/ui/saved_filters/saved_task_filters_section_test.dart
+++ b/test/features/tasks/ui/saved_filters/saved_task_filters_section_test.dart
@@ -9,7 +9,6 @@ import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter.dart'
 import 'package:lotti/features/tasks/state/saved_filters/saved_task_filters_persistence.dart';
 import 'package:lotti/features/tasks/ui/saved_filters/saved_task_filter_row.dart';
 import 'package:lotti/features/tasks/ui/saved_filters/saved_task_filters_section.dart';
-import 'package:lotti/l10n/app_localizations.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../../widget_test_utils.dart';
@@ -26,19 +25,15 @@ const _afterDoubleTapTimeout = Duration(milliseconds: 350);
 Future<void> _pumpSection(
   WidgetTester tester, {
   required ValueChanged<SavedTaskFilter> onActivate,
-  required VoidCallback onAddPressed,
   String? activeId,
-  bool canAdd = false,
   Map<String, int>? counts,
 }) async {
   await tester.pumpWidget(
     makeTestableWidgetWithScaffold(
       SavedTaskFiltersSection(
         activeId: activeId,
-        canAdd: canAdd,
         counts: counts,
         onActivate: onActivate,
-        onAddPressed: onAddPressed,
       ),
     ),
   );
@@ -66,22 +61,18 @@ void main() {
     );
   }
 
-  testWidgets('renders the empty state when no saved filters exist', (
-    tester,
-  ) async {
-    await _pumpSection(
-      tester,
-      onActivate: (_) {},
-      onAddPressed: () {},
-    );
+  testWidgets(
+    'renders nothing when no saved filters exist (header is hidden too)',
+    (tester) async {
+      await _pumpSection(tester, onActivate: (_) {});
 
-    final emptyFinder = find.byKey(SavedTaskFiltersSectionKeys.emptyState);
-    expect(emptyFinder, findsOneWidget);
-
-    final messages = AppLocalizations.of(tester.element(emptyFinder))!;
-    expect(find.text(messages.tasksSavedFiltersEmpty), findsOneWidget);
-    expect(find.byKey(SavedTaskFiltersSectionKeys.list), findsNothing);
-  });
+      // Section root is still in the tree as a SizedBox.shrink — no header,
+      // no list, no empty-state pill. New filters are saved through the
+      // modal's Save button, so an empty placeholder adds noise.
+      expect(find.byKey(SavedTaskFiltersSectionKeys.root), findsOneWidget);
+      expect(find.byKey(SavedTaskFiltersSectionKeys.list), findsNothing);
+    },
+  );
 
   testWidgets('renders rows for each persisted saved filter', (tester) async {
     stubPersisted(const [
@@ -89,11 +80,7 @@ void main() {
       SavedTaskFilter(id: 'sv-2', name: 'B', filter: _filterB),
     ]);
 
-    await _pumpSection(
-      tester,
-      onActivate: (_) {},
-      onAddPressed: () {},
-    );
+    await _pumpSection(tester, onActivate: (_) {});
 
     expect(find.byKey(SavedTaskFiltersSectionKeys.list), findsOneWidget);
     expect(find.byKey(SavedTaskFilterRowKeys.root('sv-1')), findsOneWidget);
@@ -110,50 +97,12 @@ void main() {
     ]);
 
     SavedTaskFilter? activated;
-    await _pumpSection(
-      tester,
-      onActivate: (f) => activated = f,
-      onAddPressed: () {},
-    );
+    await _pumpSection(tester, onActivate: (f) => activated = f);
 
     await tester.tap(find.byKey(SavedTaskFilterRowKeys.root('sv-1')));
     await tester.pump(_afterDoubleTapTimeout);
 
     expect(activated?.id, 'sv-1');
-  });
-
-  testWidgets(
-    'add button is disabled and skips onAddPressed when canAdd=false',
-    (tester) async {
-      var pressed = 0;
-      await _pumpSection(
-        tester,
-        onActivate: (_) {},
-        onAddPressed: () => pressed++,
-      );
-
-      await tester.tap(find.byKey(SavedTaskFiltersSectionKeys.addButton));
-      await tester.pump();
-
-      expect(pressed, 0);
-    },
-  );
-
-  testWidgets('add button invokes onAddPressed when canAdd=true', (
-    tester,
-  ) async {
-    var pressed = 0;
-    await _pumpSection(
-      tester,
-      onActivate: (_) {},
-      onAddPressed: () => pressed++,
-      canAdd: true,
-    );
-
-    await tester.tap(find.byKey(SavedTaskFiltersSectionKeys.addButton));
-    await tester.pump();
-
-    expect(pressed, 1);
   });
 
   testWidgets('passes counts through to rows', (tester) async {
@@ -164,7 +113,6 @@ void main() {
     await _pumpSection(
       tester,
       onActivate: (_) {},
-      onAddPressed: () {},
       counts: const {'sv-1': 12},
     );
 
@@ -178,11 +126,7 @@ void main() {
       SavedTaskFilter(id: 'sv-1', name: 'Alpha', filter: _filterA),
     ]);
 
-    await _pumpSection(
-      tester,
-      onActivate: (_) {},
-      onAddPressed: () {},
-    );
+    await _pumpSection(tester, onActivate: (_) {});
 
     // Double-tap the row to enter rename mode.
     final rowFinder = find.byKey(SavedTaskFilterRowKeys.root('sv-1'));
@@ -220,11 +164,7 @@ void main() {
       SavedTaskFilter(id: 'sv-2', name: 'Bravo', filter: _filterB),
     ]);
 
-    await _pumpSection(
-      tester,
-      onActivate: (_) {},
-      onAddPressed: () {},
-    );
+    await _pumpSection(tester, onActivate: (_) {});
 
     // Reveal the delete button via hover, then two-tap to commit.
     final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
@@ -265,7 +205,6 @@ void main() {
     await _pumpSection(
       tester,
       onActivate: (_) {},
-      onAddPressed: () {},
       activeId: 'sv-2',
     );
 

--- a/test/features/tasks/ui/saved_filters/tasks_saved_filters_tree_test.dart
+++ b/test/features/tasks/ui/saved_filters/tasks_saved_filters_tree_test.dart
@@ -69,19 +69,23 @@ void main() {
     );
   }
 
-  testWidgets('renders the saved-filters section', (tester) async {
-    final fake = FakeJournalPageController(const JournalPageState());
+  testWidgets(
+    'renders nothing when no saved filters are persisted',
+    (tester) async {
+      final fake = FakeJournalPageController(const JournalPageState());
 
-    await _pumpTree(
-      tester,
-      fakeController: fake,
-      seed: const [],
-    );
+      await _pumpTree(
+        tester,
+        fakeController: fake,
+        seed: const [],
+      );
 
-    expect(find.byKey(SavedTaskFiltersSectionKeys.root), findsOneWidget);
-    // Empty state is visible when nothing is persisted.
-    expect(find.byKey(SavedTaskFiltersSectionKeys.emptyState), findsOneWidget);
-  });
+      // The section collapses to a SizedBox.shrink when the list is empty —
+      // there is no header, no list, no empty-state pill.
+      expect(find.byKey(SavedTaskFiltersSectionKeys.root), findsOneWidget);
+      expect(find.byKey(SavedTaskFiltersSectionKeys.list), findsNothing);
+    },
+  );
 
   testWidgets(
     'tapping a saved-filter row activates the filter on the page controller',
@@ -182,8 +186,11 @@ void main() {
   );
 
   testWidgets(
-    'localised section header title is rendered',
+    'renders a list (no header) when at least one saved filter is persisted',
     (tester) async {
+      stubPersisted(const [
+        SavedTaskFilter(id: 'sv-1', name: 'A', filter: _filterA),
+      ]);
       final fake = FakeJournalPageController(const JournalPageState());
 
       await _pumpTree(
@@ -192,13 +199,10 @@ void main() {
         seed: const [],
       );
 
-      final messages = AppLocalizations.of(
-        tester.element(find.byKey(SavedTaskFiltersSectionKeys.root)),
-      )!;
-      expect(
-        find.text(messages.tasksSavedFiltersSectionTitle.toUpperCase()),
-        findsOneWidget,
-      );
+      // No section header — the rows live directly under the Tasks
+      // destination. The list and at least one row must be present.
+      expect(find.byKey(SavedTaskFiltersSectionKeys.list), findsOneWidget);
+      expect(find.byKey(SavedTaskFilterRowKeys.root('sv-1')), findsOneWidget);
     },
   );
 }

--- a/test/features/tasks/ui/saved_filters/tasks_saved_filters_tree_test.dart
+++ b/test/features/tasks/ui/saved_filters/tasks_saved_filters_tree_test.dart
@@ -113,7 +113,7 @@ void main() {
     },
   );
 
-  testWidgets('shows the deleted-toast when the controller delete completes', (
+  testWidgets('forwards onDeleted from the section into a toast', (
     tester,
   ) async {
     stubPersisted(const [
@@ -131,27 +131,55 @@ void main() {
       seed: const [],
     );
 
-    // The actual delete is exercised through the section's controller call.
-    // We invoke it directly via the controller since the row's hover-driven
-    // gesture is brittle in widget tests; the tree's job here is to forward
-    // the resulting onDeleted callback into a toast.
-    final container = ProviderScope.containerOf(
-      tester.element(find.byType(TasksSavedFiltersTree)),
+    // Drive the deletion-completed path the same way the row's two-tap delete
+    // would: invoke the section's `onDeleted` closure that the tree wired up.
+    // This exercises the tree's actual wiring (capturing the build context
+    // and dispatching to the toast helper) without depending on the row's
+    // brittle hover-driven gesture.
+    final section = tester.widget<SavedTaskFiltersSection>(
+      find.byType(SavedTaskFiltersSection),
     );
-    await container
-        .read(savedTaskFiltersControllerProvider.notifier)
-        .delete(
-          'sv-1',
-        );
-    // The section's onDelete is wired to the row, not the controller — so we
-    // simulate the completion by triggering the row's delete affordance via
-    // its public interface. For this coverage test, we instead drive
-    // onDeleted directly through a fresh widget that calls the toast helper
-    // from this BuildContext; covered by saved_task_filter_toast_test.dart.
-    // Here we just assert the controller mutation propagates into state.
-    final list = container.read(savedTaskFiltersControllerProvider).value!;
-    expect(list, isEmpty);
+    expect(section.onDeleted, isNotNull);
+    section.onDeleted!.call();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    final messages = AppLocalizations.of(
+      tester.element(find.byType(TasksSavedFiltersTree)),
+    )!;
+    expect(find.text(messages.tasksSavedFilterToastDeleted), findsOneWidget);
+    expect(find.byType(SnackBar), findsOneWidget);
   });
+
+  testWidgets(
+    'controller delete mutation propagates into provider state',
+    (tester) async {
+      stubPersisted(const [
+        SavedTaskFilter(id: 'sv-1', name: 'A', filter: _filterA),
+      ]);
+      when(
+        () => mocks.settingsDb.saveSettingsItem(any(), any()),
+      ).thenAnswer((_) async => 1);
+
+      final fake = FakeJournalPageController(const JournalPageState());
+
+      await _pumpTree(
+        tester,
+        fakeController: fake,
+        seed: const [],
+      );
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(TasksSavedFiltersTree)),
+      );
+      await container
+          .read(savedTaskFiltersControllerProvider.notifier)
+          .delete('sv-1');
+
+      final list = container.read(savedTaskFiltersControllerProvider).value!;
+      expect(list, isEmpty);
+    },
+  );
 
   testWidgets(
     'localised section header title is rendered',

--- a/test/features/tasks/ui/saved_filters/tasks_saved_filters_tree_test.dart
+++ b/test/features/tasks/ui/saved_filters/tasks_saved_filters_tree_test.dart
@@ -1,0 +1,176 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/journal/state/journal_page_controller.dart';
+import 'package:lotti/features/journal/state/journal_page_state.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filters_controller.dart';
+import 'package:lotti/features/tasks/state/saved_filters/saved_task_filters_persistence.dart';
+import 'package:lotti/features/tasks/ui/saved_filters/saved_task_filter_row.dart';
+import 'package:lotti/features/tasks/ui/saved_filters/saved_task_filters_section.dart';
+import 'package:lotti/features/tasks/ui/saved_filters/tasks_saved_filters_tree.dart';
+import 'package:lotti/l10n/app_localizations.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../test_utils/fake_journal_page_controller.dart';
+import '../../../../widget_test_utils.dart';
+
+const _filterA = TasksFilter(
+  selectedTaskStatuses: {'IN_PROGRESS'},
+  selectedPriorities: {'P0', 'P1'},
+);
+
+const _wideMq = MediaQueryData(
+  size: Size(900, 700),
+  textScaler: TextScaler.noScaling,
+);
+
+Future<void> _pumpTree(
+  WidgetTester tester, {
+  required FakeJournalPageController fakeController,
+  required List<SavedTaskFilter> seed,
+}) async {
+  await tester.pumpWidget(
+    makeTestableWidget2(
+      ProviderScope(
+        overrides: [
+          journalPageControllerProvider(
+            true,
+          ).overrideWith(() => fakeController),
+        ],
+        child: const Scaffold(body: TasksSavedFiltersTree()),
+      ),
+      mediaQueryData: _wideMq,
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  late TestGetItMocks mocks;
+
+  setUp(() async {
+    mocks = await setUpTestGetIt();
+  });
+
+  tearDown(tearDownTestGetIt);
+
+  void stubPersisted(List<SavedTaskFilter> items) {
+    when(
+      () => mocks.settingsDb.itemByKey(
+        SavedTaskFiltersPersistence.storageKey,
+      ),
+    ).thenAnswer(
+      (_) async => jsonEncode(
+        items.map((e) => e.toJson()).toList(growable: false),
+      ),
+    );
+  }
+
+  testWidgets('renders the saved-filters section', (tester) async {
+    final fake = FakeJournalPageController(const JournalPageState());
+
+    await _pumpTree(
+      tester,
+      fakeController: fake,
+      seed: const [],
+    );
+
+    expect(find.byKey(SavedTaskFiltersSectionKeys.root), findsOneWidget);
+    // Empty state is visible when nothing is persisted.
+    expect(find.byKey(SavedTaskFiltersSectionKeys.emptyState), findsOneWidget);
+  });
+
+  testWidgets(
+    'tapping a saved-filter row activates the filter on the page controller',
+    (tester) async {
+      stubPersisted(const [
+        SavedTaskFilter(
+          id: 'sv-1',
+          name: 'P0/P1 in progress',
+          filter: _filterA,
+        ),
+      ]);
+      final fake = FakeJournalPageController(const JournalPageState());
+
+      await _pumpTree(
+        tester,
+        fakeController: fake,
+        seed: const [],
+      );
+
+      // Tap the row body. GestureDetector defers single-tap by 300ms when
+      // onDoubleTap is also wired, so we pump past kDoubleTapTimeout.
+      await tester.tap(find.byKey(SavedTaskFilterRowKeys.root('sv-1')));
+      await tester.pump(const Duration(milliseconds: 350));
+      await tester.pumpAndSettle();
+
+      expect(fake.applyBatchFilterUpdateCalled, 1);
+      expect(fake.setSelectedTaskStatusesCalls.single, {'IN_PROGRESS'});
+      expect(fake.setSelectedPrioritiesCalls.single, {'P0', 'P1'});
+    },
+  );
+
+  testWidgets('shows the deleted-toast when the controller delete completes', (
+    tester,
+  ) async {
+    stubPersisted(const [
+      SavedTaskFilter(id: 'sv-1', name: 'A', filter: _filterA),
+    ]);
+    when(
+      () => mocks.settingsDb.saveSettingsItem(any(), any()),
+    ).thenAnswer((_) async => 1);
+
+    final fake = FakeJournalPageController(const JournalPageState());
+
+    await _pumpTree(
+      tester,
+      fakeController: fake,
+      seed: const [],
+    );
+
+    // The actual delete is exercised through the section's controller call.
+    // We invoke it directly via the controller since the row's hover-driven
+    // gesture is brittle in widget tests; the tree's job here is to forward
+    // the resulting onDeleted callback into a toast.
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(TasksSavedFiltersTree)),
+    );
+    await container
+        .read(savedTaskFiltersControllerProvider.notifier)
+        .delete(
+          'sv-1',
+        );
+    // The section's onDelete is wired to the row, not the controller — so we
+    // simulate the completion by triggering the row's delete affordance via
+    // its public interface. For this coverage test, we instead drive
+    // onDeleted directly through a fresh widget that calls the toast helper
+    // from this BuildContext; covered by saved_task_filter_toast_test.dart.
+    // Here we just assert the controller mutation propagates into state.
+    final list = container.read(savedTaskFiltersControllerProvider).value!;
+    expect(list, isEmpty);
+  });
+
+  testWidgets(
+    'localised section header title is rendered',
+    (tester) async {
+      final fake = FakeJournalPageController(const JournalPageState());
+
+      await _pumpTree(
+        tester,
+        fakeController: fake,
+        seed: const [],
+      );
+
+      final messages = AppLocalizations.of(
+        tester.element(find.byKey(SavedTaskFiltersSectionKeys.root)),
+      )!;
+      expect(
+        find.text(messages.tasksSavedFiltersSectionTitle.toUpperCase()),
+        findsOneWidget,
+      );
+    },
+  );
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Save task filters from the filter modal (Save button + naming popup); persisted, reorderable, activatable from a sidebar tree; applying a saved filter preserves current ephemeral search.
  * Active saved filter name shown inline in the Tasks header
* **Notifications**
  * Toasts for saved / updated / deleted filter events
* **Localization**
  * Added translations for the saved-filters flow
* **Documentation**
  * Updated docs/changelog describing saved filters
* **Tests**
  * Widget and state tests covering save UI, activator, and sidebar behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->