### PR TITLE
fix: navigation between task details pages in desktop mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sits in the top-right of the icon to match the Tasks badge, and the audio
   and time recording indicators dock flush against the visible nav-bar pill
   instead of floating above it.
+- Desktop linked-task navigation no longer takes over the full window. Tapping
+  a linked task from a task's details now pushes onto a per-pane stack inside
+  the right-hand details area, leaving the task list pane visible. The back
+  arrow at the top of the task details only appears on desktop when a linked
+  task is on top of the stack, and clicking it pops back to the previous task
+  instead of being a no-op. Mobile navigation is unchanged.
 
 ### Added
 - Saved filters for the Tasks tab. Build a filter (status, priority,

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -35,6 +35,7 @@
       <description>
           <p>Bottom navigation bar polish: the sync outbox badge on the Settings tab now sits in the top-right of the icon to match the Tasks badge, and the audio and time recording indicators dock flush against the visible nav-bar pill instead of floating above it.</p>
           <p>Saved filters for the Tasks tab. Build a filter (status, priority, category, agent, etc.) in the Tasks Filter modal, tap the new Save button next to Apply, give it a name, and pin it under "Tasks" in the expanded sidebar. Saved filters live in SavedTaskFiltersController (Riverpod, keepAlive: true), persist as a JSON list under SAVED_TASK_FILTERS in SettingsDb, and surface as a treeview with active-state highlight, hover-revealed two-tap delete, double-click inline rename, drag-to-reorder, and a "Tasks · {filter name}" indicator in the tasks pane header. Activating a saved filter applies it via JournalPageController.applyBatchFilterUpdate while preserving the ephemeral search query.</p>
+          <p>Desktop linked-task navigation no longer takes over the full window. Tapping a linked task from a task's details now pushes onto a per-pane stack inside the right-hand details area, leaving the task list pane visible. The back arrow at the top of the task details only appears on desktop when a linked task is on top of the stack, and clicking it pops back to the previous task instead of being a no-op. Mobile navigation is unchanged.</p>
       </description>
     </release>
     <release version="0.9.976" date="2026-04-25">

--- a/lib/beamer/locations/tasks_location.dart
+++ b/lib/beamer/locations/tasks_location.dart
@@ -22,7 +22,7 @@ class TasksLocation extends BeamLocation<BeamState> {
     final isDesktop = navService.isDesktopMode;
 
     if (isDesktop) {
-      navService.desktopSelectedTaskId.value = isUuid(taskId) ? taskId : null;
+      navService.resetDesktopTaskDetail(isUuid(taskId) ? taskId : null);
     }
 
     return [

--- a/lib/features/tasks/README.md
+++ b/lib/features/tasks/README.md
@@ -81,6 +81,38 @@ the detail pane is keyed by the selected task ID. That gives each task detail
 surface its own state lifetime instead of reusing the previous task's
 stateful page internals across selection changes.
 
+### Desktop task detail stack
+
+On desktop, the right-hand task detail pane is backed by a per-pane stack
+held on `NavService.desktopTaskDetailStack` (`ValueNotifier<List<String>>`).
+
+- `TasksLocation` calls `resetDesktopTaskDetail(taskId)` when the URL
+  changes, seeding the stack with one entry — the task selected from the
+  list pane (the "base").
+- Tapping a `LinkedTaskCard` from inside a task's details calls
+  `pushDesktopTaskDetail(linkedId)` so the linked task is shown on top of
+  the base, *strictly inside* the right-hand pane. The list pane on the
+  left remains visible. Mobile keeps using `Navigator.push` with a
+  `MaterialPageRoute` because the navigator stack and the visible
+  navigation stack are the same thing on mobile.
+- The back arrow in `TaskCompactAppBar` / `TaskExpandableAppBar` is only
+  rendered on desktop when `desktopTaskDetailStack.length > 1`. The base
+  task hides the arrow because the list pane already lets the user
+  return to a sibling task. Pressing the arrow on desktop calls
+  `popDesktopTaskDetail()` instead of `NavService.beamBack()`.
+- `desktopSelectedTaskId` is kept in sync with `stack.last` so existing
+  list-pane highlight listeners keep working without changes.
+
+```mermaid
+stateDiagram-v2
+  [*] --> Empty
+  Empty --> Base: URL → resetDesktopTaskDetail(taskId)
+  Base --> Linked: tap LinkedTaskCard → pushDesktopTaskDetail(otherId)
+  Linked --> Linked: tap LinkedTaskCard → push another
+  Linked --> Base: back arrow → popDesktopTaskDetail()
+  Base --> Empty: URL clears task → resetDesktopTaskDetail(null)
+```
+
 At runtime the browse page does three specific things:
 
 1. it converts paged `JournalEntity` results into `TaskBrowseEntry` rows via `buildTaskBrowseEntries`

--- a/lib/features/tasks/ui/linked_tasks/linked_task_card.dart
+++ b/lib/features/tasks/ui/linked_tasks/linked_task_card.dart
@@ -1,11 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
-import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
-import 'package:lotti/features/tasks/ui/pages/task_details_page.dart';
-import 'package:lotti/get_it.dart';
-import 'package:lotti/services/nav_service.dart';
+import 'package:lotti/features/tasks/util/task_navigation.dart';
 import 'package:lotti/themes/colors.dart';
 import 'package:lotti/themes/theme.dart';
 
@@ -39,20 +36,7 @@ class LinkedTaskCard extends StatelessWidget {
     final statusColor = _getStatusColor(context, task.data.status);
 
     return GestureDetector(
-      onTap: () {
-        if (isDesktopLayout(context)) {
-          // Desktop: push within the right-pane stack so the list pane
-          // on the left stays visible. Avoids the root Navigator push
-          // that would otherwise cover the entire window.
-          getIt<NavService>().pushDesktopTaskDetail(task.id);
-        } else {
-          Navigator.of(context).push(
-            MaterialPageRoute<void>(
-              builder: (context) => TaskDetailsPage(taskId: task.id),
-            ),
-          );
-        }
-      },
+      onTap: () => openLinkedTaskDetail(context: context, taskId: task.id),
       behavior: HitTestBehavior.opaque,
       child: Padding(
         padding: const EdgeInsets.only(left: 4, top: 4, bottom: 4),

--- a/lib/features/tasks/ui/linked_tasks/linked_task_card.dart
+++ b/lib/features/tasks/ui/linked_tasks/linked_task_card.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
+import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/tasks/ui/pages/task_details_page.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/themes/colors.dart';
 import 'package:lotti/themes/theme.dart';
 
@@ -36,11 +39,20 @@ class LinkedTaskCard extends StatelessWidget {
     final statusColor = _getStatusColor(context, task.data.status);
 
     return GestureDetector(
-      onTap: () => Navigator.of(context).push(
-        MaterialPageRoute<void>(
-          builder: (context) => TaskDetailsPage(taskId: task.id),
-        ),
-      ),
+      onTap: () {
+        if (isDesktopLayout(context)) {
+          // Desktop: push within the right-pane stack so the list pane
+          // on the left stays visible. Avoids the root Navigator push
+          // that would otherwise cover the entire window.
+          getIt<NavService>().pushDesktopTaskDetail(task.id);
+        } else {
+          Navigator.of(context).push(
+            MaterialPageRoute<void>(
+              builder: (context) => TaskDetailsPage(taskId: task.id),
+            ),
+          );
+        }
+      },
       behavior: HitTestBehavior.opaque,
       child: Padding(
         padding: const EdgeInsets.only(left: 4, top: 4, bottom: 4),

--- a/lib/features/tasks/ui/pages/tasks_root_page.dart
+++ b/lib/features/tasks/ui/pages/tasks_root_page.dart
@@ -44,7 +44,7 @@ class TasksRootPage extends ConsumerWidget {
                 final selectedTaskId = stack.isEmpty ? null : stack.last;
                 final child = selectedTaskId != null
                     ? TaskDetailsPage(
-                        key: ValueKey('${selectedTaskId}_${stack.length}'),
+                        key: ValueKey(selectedTaskId),
                         taskId: selectedTaskId,
                       )
                     : DesktopDetailEmptyState(

--- a/lib/features/tasks/ui/pages/tasks_root_page.dart
+++ b/lib/features/tasks/ui/pages/tasks_root_page.dart
@@ -38,12 +38,13 @@ class TasksRootPage extends ConsumerWidget {
                 .updateListPaneWidth(delta),
           ),
           Expanded(
-            child: ValueListenableBuilder<String?>(
-              valueListenable: getIt<NavService>().desktopSelectedTaskId,
-              builder: (context, selectedTaskId, _) {
+            child: ValueListenableBuilder<List<String>>(
+              valueListenable: getIt<NavService>().desktopTaskDetailStack,
+              builder: (context, stack, _) {
+                final selectedTaskId = stack.isEmpty ? null : stack.last;
                 final child = selectedTaskId != null
                     ? TaskDetailsPage(
-                        key: ValueKey(selectedTaskId),
+                        key: ValueKey('${selectedTaskId}_${stack.length}'),
                         taskId: selectedTaskId,
                       )
                     : DesktopDetailEmptyState(

--- a/lib/features/tasks/ui/task_compact_app_bar.dart
+++ b/lib/features/tasks/ui/task_compact_app_bar.dart
@@ -2,11 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/ai/ui/unified_ai_popup_menu.dart';
+import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/journal/ui/widgets/entry_details/header/extended_header_modal.dart';
 import 'package:lotti/features/tasks/state/task_app_bar_controller.dart';
 import 'package:lotti/features/tasks/ui/widgets/task_showcase_palette.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/themes/theme.dart';
+import 'package:lotti/widgets/app_bar/glass_back_button.dart';
 import 'package:lotti/widgets/app_bar/title_app_bar.dart';
 
 /// Scroll offset at which the compact app bar surfaces the task title in
@@ -41,14 +45,20 @@ class TaskCompactAppBar extends ConsumerWidget {
     final offset =
         ref.watch(taskAppBarControllerProvider(id: task.id)).value ?? 0;
     final showTitle = offset >= _persistentTitleScrollThreshold;
+    final isDesktop = isDesktopLayout(context);
+    // On desktop the back arrow is only rendered while a linked task
+    // sits on top of the detail stack — at that point we use the same
+    // glass-styled button (and matching 48px leading width) as the
+    // expandable bar so the affordance stays visually identical
+    // whether the task has cover art or not.
     return SliverAppBar(
       backgroundColor: context.designTokens.colors.background.level01,
-      leadingWidth: 100,
+      leadingWidth: isDesktop ? 48 : 100,
       titleSpacing: 0,
       toolbarHeight: 45,
       scrolledUnderElevation: 0,
       elevation: 0,
-      leading: const BackWidget(),
+      leading: _TaskBackLeading(isDesktop: isDesktop),
       centerTitle: true,
       title: AnimatedSwitcher(
         duration: const Duration(milliseconds: 160),
@@ -83,6 +93,43 @@ class TaskCompactAppBar extends ConsumerWidget {
       ),
       const SizedBox(width: 10),
     ];
+  }
+}
+
+/// Leading widget for the compact task app bar.
+///
+/// Mobile: always renders [BackWidget] which beams back to the task list.
+/// Desktop: renders a [GlassBackButton] only when the task detail stack
+/// has more than one entry (i.e. a linked task is currently shown on top
+/// of the base task). The base task on desktop hides the back arrow
+/// because the list pane is already visible to the left. The glass
+/// styling matches the expandable variant so the back affordance looks
+/// the same whether the task has cover art or not. When pressed on
+/// desktop, pops the desktop detail stack instead of beaming back.
+class _TaskBackLeading extends StatelessWidget {
+  const _TaskBackLeading({required this.isDesktop});
+
+  final bool isDesktop;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!isDesktop) {
+      return const BackWidget();
+    }
+    return ValueListenableBuilder<List<String>>(
+      valueListenable: getIt<NavService>().desktopTaskDetailStack,
+      builder: (context, stack, _) {
+        if (stack.length <= 1) {
+          return const SizedBox.shrink();
+        }
+        return Padding(
+          padding: const EdgeInsets.only(left: 8),
+          child: GlassBackButton(
+            onPressed: () => getIt<NavService>().popDesktopTaskDetail(),
+          ),
+        );
+      },
+    );
   }
 }
 

--- a/lib/features/tasks/ui/task_compact_app_bar.dart
+++ b/lib/features/tasks/ui/task_compact_app_bar.dart
@@ -6,11 +6,9 @@ import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/journal/ui/widgets/entry_details/header/extended_header_modal.dart';
 import 'package:lotti/features/tasks/state/task_app_bar_controller.dart';
+import 'package:lotti/features/tasks/ui/widgets/task_detail_back_leading.dart';
 import 'package:lotti/features/tasks/ui/widgets/task_showcase_palette.dart';
-import 'package:lotti/get_it.dart';
-import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/themes/theme.dart';
-import 'package:lotti/widgets/app_bar/glass_back_button.dart';
 import 'package:lotti/widgets/app_bar/title_app_bar.dart';
 
 /// Scroll offset at which the compact app bar surfaces the task title in
@@ -99,13 +97,9 @@ class TaskCompactAppBar extends ConsumerWidget {
 /// Leading widget for the compact task app bar.
 ///
 /// Mobile: always renders [BackWidget] which beams back to the task list.
-/// Desktop: renders a [GlassBackButton] only when the task detail stack
-/// has more than one entry (i.e. a linked task is currently shown on top
-/// of the base task). The base task on desktop hides the back arrow
-/// because the list pane is already visible to the left. The glass
-/// styling matches the expandable variant so the back affordance looks
-/// the same whether the task has cover art or not. When pressed on
-/// desktop, pops the desktop detail stack instead of beaming back.
+/// Desktop: delegates to [TaskDetailDesktopBackLeading], shared with the
+/// expandable bar so the back affordance is visually identical whether
+/// the task has cover art or not.
 class _TaskBackLeading extends StatelessWidget {
   const _TaskBackLeading({required this.isDesktop});
 
@@ -116,20 +110,7 @@ class _TaskBackLeading extends StatelessWidget {
     if (!isDesktop) {
       return const BackWidget();
     }
-    return ValueListenableBuilder<List<String>>(
-      valueListenable: getIt<NavService>().desktopTaskDetailStack,
-      builder: (context, stack, _) {
-        if (stack.length <= 1) {
-          return const SizedBox.shrink();
-        }
-        return Padding(
-          padding: const EdgeInsets.only(left: 8),
-          child: GlassBackButton(
-            onPressed: () => getIt<NavService>().popDesktopTaskDetail(),
-          ),
-        );
-      },
-    );
+    return const TaskDetailDesktopBackLeading();
   }
 }
 

--- a/lib/features/tasks/ui/task_expandable_app_bar.dart
+++ b/lib/features/tasks/ui/task_expandable_app_bar.dart
@@ -7,9 +7,8 @@ import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/journal/ui/widgets/entry_details/header/extended_header_modal.dart';
 import 'package:lotti/features/tasks/state/task_app_bar_controller.dart';
 import 'package:lotti/features/tasks/ui/cover_art_background.dart';
+import 'package:lotti/features/tasks/ui/widgets/task_detail_back_leading.dart';
 import 'package:lotti/features/tasks/ui/widgets/task_showcase_palette.dart';
-import 'package:lotti/get_it.dart';
-import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/widgets/app_bar/glass_action_button.dart';
 import 'package:lotti/widgets/app_bar/glass_back_button.dart';
 
@@ -56,11 +55,8 @@ class TaskExpandableAppBar extends ConsumerWidget {
           toolbarHeight: 40,
           scrolledUnderElevation: 0,
           elevation: 0,
-          leading: Padding(
-            padding: const EdgeInsets.only(left: 8),
-            child: _GlassTaskBackLeading(
-              isDesktop: isDesktopLayout(context),
-            ),
+          leading: _GlassTaskBackLeading(
+            isDesktop: isDesktopLayout(context),
           ),
           centerTitle: true,
           title: AnimatedSwitcher(
@@ -113,10 +109,9 @@ class TaskExpandableAppBar extends ConsumerWidget {
 /// Glass-styled back button leading for the expandable task app bar.
 ///
 /// Mobile: always renders [GlassBackButton] which pops the navigator.
-/// Desktop: only renders when more than one task sits on the desktop
-/// detail stack, and pops that stack instead of the navigator. The base
-/// task hides the back arrow because the list pane is visible to the
-/// left.
+/// Desktop: delegates to [TaskDetailDesktopBackLeading], shared with the
+/// compact bar so the back affordance is visually identical whether the
+/// task has cover art or not.
 class _GlassTaskBackLeading extends StatelessWidget {
   const _GlassTaskBackLeading({required this.isDesktop});
 
@@ -125,19 +120,12 @@ class _GlassTaskBackLeading extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (!isDesktop) {
-      return const GlassBackButton();
+      return const Padding(
+        padding: EdgeInsets.only(left: 8),
+        child: GlassBackButton(),
+      );
     }
-    return ValueListenableBuilder<List<String>>(
-      valueListenable: getIt<NavService>().desktopTaskDetailStack,
-      builder: (context, stack, _) {
-        if (stack.length <= 1) {
-          return const SizedBox.shrink();
-        }
-        return GlassBackButton(
-          onPressed: () => getIt<NavService>().popDesktopTaskDetail(),
-        );
-      },
-    );
+    return const TaskDetailDesktopBackLeading();
   }
 }
 

--- a/lib/features/tasks/ui/task_expandable_app_bar.dart
+++ b/lib/features/tasks/ui/task_expandable_app_bar.dart
@@ -2,11 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/ai/ui/unified_ai_popup_menu.dart';
+import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/journal/ui/widgets/entry_details/header/extended_header_modal.dart';
 import 'package:lotti/features/tasks/state/task_app_bar_controller.dart';
 import 'package:lotti/features/tasks/ui/cover_art_background.dart';
 import 'package:lotti/features/tasks/ui/widgets/task_showcase_palette.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/widgets/app_bar/glass_action_button.dart';
 import 'package:lotti/widgets/app_bar/glass_back_button.dart';
 
@@ -53,9 +56,11 @@ class TaskExpandableAppBar extends ConsumerWidget {
           toolbarHeight: 40,
           scrolledUnderElevation: 0,
           elevation: 0,
-          leading: const Padding(
-            padding: EdgeInsets.only(left: 8),
-            child: GlassBackButton(),
+          leading: Padding(
+            padding: const EdgeInsets.only(left: 8),
+            child: _GlassTaskBackLeading(
+              isDesktop: isDesktopLayout(context),
+            ),
           ),
           centerTitle: true,
           title: AnimatedSwitcher(
@@ -102,6 +107,37 @@ class TaskExpandableAppBar extends ConsumerWidget {
       ),
       const SizedBox(width: 10),
     ];
+  }
+}
+
+/// Glass-styled back button leading for the expandable task app bar.
+///
+/// Mobile: always renders [GlassBackButton] which pops the navigator.
+/// Desktop: only renders when more than one task sits on the desktop
+/// detail stack, and pops that stack instead of the navigator. The base
+/// task hides the back arrow because the list pane is visible to the
+/// left.
+class _GlassTaskBackLeading extends StatelessWidget {
+  const _GlassTaskBackLeading({required this.isDesktop});
+
+  final bool isDesktop;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!isDesktop) {
+      return const GlassBackButton();
+    }
+    return ValueListenableBuilder<List<String>>(
+      valueListenable: getIt<NavService>().desktopTaskDetailStack,
+      builder: (context, stack, _) {
+        if (stack.length <= 1) {
+          return const SizedBox.shrink();
+        }
+        return GlassBackButton(
+          onPressed: () => getIt<NavService>().popDesktopTaskDetail(),
+        );
+      },
+    );
   }
 }
 

--- a/lib/features/tasks/ui/widgets/task_detail_back_leading.dart
+++ b/lib/features/tasks/ui/widgets/task_detail_back_leading.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/nav_service.dart';
+import 'package:lotti/widgets/app_bar/glass_back_button.dart';
+
+/// Shared desktop "back" leading for the task detail app bars.
+///
+/// Renders a [GlassBackButton] only when more than one task sits on the
+/// `NavService.desktopTaskDetailStack` — i.e. a linked task is currently
+/// layered on top of the base task selected from the list pane. The base
+/// task hides the arrow on desktop because the list pane on the left
+/// already exposes sibling tasks. Tapping the button pops the desktop
+/// detail stack so the previous task is restored.
+///
+/// Used by both `TaskCompactAppBar` and `TaskExpandableAppBar` so the
+/// affordance is visually identical regardless of whether the task has
+/// cover art.
+class TaskDetailDesktopBackLeading extends StatelessWidget {
+  const TaskDetailDesktopBackLeading({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<List<String>>(
+      valueListenable: getIt<NavService>().desktopTaskDetailStack,
+      builder: (context, stack, _) {
+        if (stack.length <= 1) {
+          return const SizedBox.shrink();
+        }
+        return Padding(
+          padding: const EdgeInsets.only(left: 8),
+          child: GlassBackButton(
+            onPressed: () => getIt<NavService>().popDesktopTaskDetail(),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/tasks/util/task_navigation.dart
+++ b/lib/features/tasks/util/task_navigation.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/features/design_system/theme/breakpoints.dart';
+import 'package:lotti/features/tasks/ui/pages/task_details_page.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/nav_service.dart';
+
+/// Navigation helper used when the user taps a linked task from inside
+/// another task's details surface.
+///
+/// Desktop: pushes onto `NavService.desktopTaskDetailStack` so the
+/// linked task is shown on top of the base task *strictly within the
+/// right-hand details pane*. The list pane on the left stays visible.
+///
+/// Mobile: pushes a [MaterialPageRoute] onto the navigator. On mobile
+/// the navigator stack and the visible navigation stack are the same
+/// thing, so this is the natural way to layer the linked task.
+void openLinkedTaskDetail({
+  required BuildContext context,
+  required String taskId,
+}) {
+  if (isDesktopLayout(context)) {
+    getIt<NavService>().pushDesktopTaskDetail(taskId);
+    return;
+  }
+  Navigator.of(context).push(
+    MaterialPageRoute<void>(
+      builder: (context) => TaskDetailsPage(taskId: taskId),
+    ),
+  );
+}

--- a/lib/services/nav_service.dart
+++ b/lib/services/nav_service.dart
@@ -64,9 +64,19 @@ class NavService {
   /// Set by `AppScreen` based on the current window width.
   bool isDesktopMode = false;
 
-  /// Selected item IDs for desktop split-pane views.
-  /// Updated by Beamer locations when the route contains an item ID.
-  /// Root pages listen to these to show the detail pane reactively.
+  /// Desktop split-pane task detail stack.
+  ///
+  /// Index 0 is the task selected from the list pane (the "base"). Tapping
+  /// a linked task from within a task's details pushes onto the stack so
+  /// the detail pane shows it without covering the list pane. Popping
+  /// returns to the previous task. URL-driven changes (Beamer location)
+  /// reset the stack to a single entry.
+  final ValueNotifier<List<String>> desktopTaskDetailStack =
+      ValueNotifier<List<String>>(const <String>[]);
+
+  /// Convenience notifier mirroring `desktopTaskDetailStack.last` (or
+  /// `null` when the stack is empty). Kept as a separate notifier so
+  /// existing listeners (selected-row highlighting, etc.) keep working.
   final ValueNotifier<String?> desktopSelectedTaskId = ValueNotifier<String?>(
     null,
   );
@@ -264,6 +274,40 @@ class NavService {
     return indexStreamController.stream;
   }
 
+  /// Reset the desktop task detail stack to either `[taskId]` or empty.
+  /// Called from `TasksLocation` when the URL changes so the stack stays
+  /// in sync with the route.
+  void resetDesktopTaskDetail(String? taskId) {
+    final next = taskId == null ? const <String>[] : <String>[taskId];
+    if (!listEquals(desktopTaskDetailStack.value, next)) {
+      desktopTaskDetailStack.value = next;
+    }
+    if (desktopSelectedTaskId.value != taskId) {
+      desktopSelectedTaskId.value = taskId;
+    }
+  }
+
+  /// Push a linked task onto the desktop detail stack so the right pane
+  /// shows it without covering the task list pane.
+  void pushDesktopTaskDetail(String taskId) {
+    desktopTaskDetailStack.value = <String>[
+      ...desktopTaskDetailStack.value,
+      taskId,
+    ];
+    desktopSelectedTaskId.value = taskId;
+  }
+
+  /// Pop the top of the desktop detail stack. No-op when the stack has
+  /// at most one entry — the base task always stays visible because the
+  /// list pane is still on screen.
+  void popDesktopTaskDetail() {
+    final stack = desktopTaskDetailStack.value;
+    if (stack.length <= 1) return;
+    final next = stack.sublist(0, stack.length - 1);
+    desktopTaskDetailStack.value = next;
+    desktopSelectedTaskId.value = next.last;
+  }
+
   void beamToNamed(String path, {Object? data}) {
     final normalizedPath = _normalizePath(path);
     setPath(normalizedPath);
@@ -285,6 +329,7 @@ class NavService {
   }
 
   Future<void> dispose() async {
+    desktopTaskDetailStack.dispose();
     desktopSelectedTaskId.dispose();
     desktopSelectedProjectId.dispose();
     desktopSelectedDashboardId.dispose();

--- a/lib/services/nav_service.dart
+++ b/lib/services/nav_service.dart
@@ -277,11 +277,34 @@ class NavService {
   /// Reset the desktop task detail stack to either `[taskId]` or empty.
   /// Called from `TasksLocation` when the URL changes so the stack stays
   /// in sync with the route.
+  ///
+  /// Idempotent across Beamer rebuilds: if the stack is already anchored
+  /// at the given `taskId` (i.e. `stack.first == taskId`), the stack is
+  /// left untouched so a `pushDesktopTaskDetail`-built linked-task stack
+  /// is preserved when `buildPages` re-runs for the same URL (theme
+  /// changes, provider rebuilds, etc.).
   void resetDesktopTaskDetail(String? taskId) {
-    final next = taskId == null ? const <String>[] : <String>[taskId];
-    if (!listEquals(desktopTaskDetailStack.value, next)) {
-      desktopTaskDetailStack.value = next;
+    final current = desktopTaskDetailStack.value;
+    if (taskId == null) {
+      if (current.isNotEmpty) {
+        desktopTaskDetailStack.value = const <String>[];
+      }
+      if (desktopSelectedTaskId.value != null) {
+        desktopSelectedTaskId.value = null;
+      }
+      return;
     }
+
+    if (current.isNotEmpty && current.first == taskId) {
+      // Stack is already anchored at this base task — preserve any
+      // linked-task pushes layered on top of it.
+      if (desktopSelectedTaskId.value != current.last) {
+        desktopSelectedTaskId.value = current.last;
+      }
+      return;
+    }
+
+    desktopTaskDetailStack.value = <String>[taskId];
     if (desktopSelectedTaskId.value != taskId) {
       desktopSelectedTaskId.value = taskId;
     }

--- a/lib/widgets/app_bar/title_app_bar.dart
+++ b/lib/widgets/app_bar/title_app_bar.dart
@@ -76,20 +76,21 @@ class TitleWidgetAppBar extends StatelessWidget implements PreferredSizeWidget {
 class BackWidget extends StatelessWidget {
   const BackWidget({
     super.key,
+    this.onPressed,
   });
+
+  /// Optional override for the back action. Defaults to
+  /// `NavService.beamBack()`.
+  final VoidCallback? onPressed;
 
   @override
   Widget build(BuildContext context) {
-    void onPressed() {
-      getIt<NavService>().beamBack();
-    }
-
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
         const SizedBox(width: 2),
         IconButton(
-          onPressed: onPressed,
+          onPressed: onPressed ?? () => getIt<NavService>().beamBack(),
           icon: Icon(
             Icons.chevron_left,
             size: 30,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.977+3988
+version: 0.9.977+3989
 
 msix_config:
   display_name: LottiApp

--- a/test/beamer/locations/tasks_location_test.dart
+++ b/test/beamer/locations/tasks_location_test.dart
@@ -88,12 +88,11 @@ void main() {
       'and does not push detail page',
       () {
         final taskId = const Uuid().v4();
-        final desktopSelectedTaskId = ValueNotifier<String?>(null);
 
         when(() => mockNavService.isDesktopMode).thenReturn(true);
         when(
-          () => mockNavService.desktopSelectedTaskId,
-        ).thenReturn(desktopSelectedTaskId);
+          () => mockNavService.resetDesktopTaskDetail(any()),
+        ).thenAnswer((_) {});
 
         final routeInformation = RouteInformation(
           uri: Uri.parse('/tasks/$taskId'),
@@ -115,15 +114,14 @@ void main() {
     );
 
     test(
-      'in desktop mode, buildPages updates desktopSelectedTaskId',
+      'in desktop mode, buildPages resets the desktop task detail stack',
       () {
         final taskId = const Uuid().v4();
-        final desktopSelectedTaskId = ValueNotifier<String?>(null);
 
         when(() => mockNavService.isDesktopMode).thenReturn(true);
         when(
-          () => mockNavService.desktopSelectedTaskId,
-        ).thenReturn(desktopSelectedTaskId);
+          () => mockNavService.resetDesktopTaskDetail(any()),
+        ).thenAnswer((_) {});
 
         final routeInformation = RouteInformation(
           uri: Uri.parse('/tasks/$taskId'),
@@ -139,7 +137,25 @@ void main() {
 
         location.buildPages(mockBuildContext, newBeamState);
 
-        expect(desktopSelectedTaskId.value, taskId);
+        verify(() => mockNavService.resetDesktopTaskDetail(taskId)).called(1);
+      },
+    );
+
+    test(
+      'in desktop mode without a task id, buildPages clears the stack',
+      () {
+        when(() => mockNavService.isDesktopMode).thenReturn(true);
+        when(
+          () => mockNavService.resetDesktopTaskDetail(any()),
+        ).thenAnswer((_) {});
+
+        final routeInformation = RouteInformation(uri: Uri.parse('/tasks'));
+        final location = TasksLocation(routeInformation);
+        final beamState = BeamState.fromRouteInformation(routeInformation);
+
+        location.buildPages(mockBuildContext, beamState);
+
+        verify(() => mockNavService.resetDesktopTaskDetail(null)).called(1);
       },
     );
   });

--- a/test/features/tasks/ui/linked_tasks/linked_task_card_test.dart
+++ b/test/features/tasks/ui/linked_tasks/linked_task_card_test.dart
@@ -1,11 +1,28 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
 import 'package:lotti/features/tasks/ui/linked_tasks/linked_task_card.dart';
+import 'package:lotti/features/tasks/ui/pages/task_details_page.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/l10n/app_localizations.dart';
+import 'package:lotti/services/nav_service.dart';
+import 'package:mocktail/mocktail.dart';
 
+import '../../../../mocks/mocks.dart';
 import '../../../../test_helper.dart';
+import '../../../../widget_test_utils.dart';
+
+class _RoutePushObserver extends NavigatorObserver {
+  final List<Route<dynamic>> pushedRoutes = [];
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    pushedRoutes.add(route);
+  }
+}
 
 void main() {
   group('LinkedTaskCard', () {
@@ -283,6 +300,102 @@ void main() {
 
       expect(find.byType(Row), findsWidgets);
       expect(find.byType(Expanded), findsOneWidget);
+    });
+
+    group('navigation on tap', () {
+      late MockNavService mockNavService;
+
+      setUp(() {
+        mockNavService = MockNavService();
+        when(
+          () => mockNavService.pushDesktopTaskDetail(any()),
+        ).thenAnswer((_) {});
+        if (getIt.isRegistered<NavService>()) {
+          getIt.unregister<NavService>();
+        }
+        getIt
+          ..allowReassignment = true
+          ..registerSingleton<NavService>(mockNavService);
+      });
+
+      tearDown(() {
+        if (getIt.isRegistered<NavService>()) {
+          getIt.unregister<NavService>();
+        }
+      });
+
+      testWidgets(
+        'desktop tap pushes onto NavService desktop detail stack',
+        (tester) async {
+          final task = buildTask(id: 'task-target');
+
+          await tester.pumpWidget(
+            ProviderScope(
+              child: WidgetTestBench(
+                mediaQueryData: const MediaQueryData(size: Size(1280, 800)),
+                child: LinkedTaskCard(task: task),
+              ),
+            ),
+          );
+
+          await tester.tap(find.byType(GestureDetector));
+          await tester.pump();
+
+          verify(
+            () => mockNavService.pushDesktopTaskDetail('task-target'),
+          ).called(1);
+          // Desktop must NOT push a MaterialPageRoute that would cover both
+          // panes — verify no TaskDetailsPage was pushed onto the navigator.
+          expect(find.byType(TaskDetailsPage), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'mobile tap pushes a MaterialPageRoute onto the navigator',
+        (tester) async {
+          final task = buildTask(id: 'task-mobile');
+          final observer = _RoutePushObserver();
+
+          await tester.pumpWidget(
+            ProviderScope(
+              child: MediaQuery(
+                data: const MediaQueryData(size: Size(400, 800)),
+                child: MaterialApp(
+                  theme: resolveTestTheme(),
+                  localizationsDelegates: const [
+                    AppLocalizations.delegate,
+                    GlobalMaterialLocalizations.delegate,
+                    GlobalWidgetsLocalizations.delegate,
+                    GlobalCupertinoLocalizations.delegate,
+                  ],
+                  supportedLocales: AppLocalizations.supportedLocales,
+                  navigatorObservers: [observer],
+                  home: Scaffold(
+                    body: LinkedTaskCard(task: task),
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          await tester.tap(find.byType(GestureDetector));
+          // Don't pumpAndSettle — TaskDetailsPage tries to read services
+          // from getIt that are intentionally not wired up here.
+
+          verifyNever(
+            () => mockNavService.pushDesktopTaskDetail(any()),
+          );
+          // Initial push of the home route + the linked task push.
+          expect(observer.pushedRoutes.length, 2);
+          final pushed = observer.pushedRoutes.last;
+          expect(pushed, isA<MaterialPageRoute<void>>());
+          final builder = (pushed as MaterialPageRoute<void>).builder;
+          expect(
+            builder(tester.element(find.byType(Scaffold))),
+            isA<TaskDetailsPage>(),
+          );
+        },
+      );
     });
   });
 }

--- a/test/features/tasks/ui/pages/tasks_root_page_test.dart
+++ b/test/features/tasks/ui/pages/tasks_root_page_test.dart
@@ -37,6 +37,9 @@ void main() {
         when(
           () => mockNavService.desktopSelectedTaskId,
         ).thenReturn(ValueNotifier<String?>(null));
+        when(
+          () => mockNavService.desktopTaskDetailStack,
+        ).thenReturn(ValueNotifier<List<String>>(const <String>[]));
         getIt
           ..registerSingleton<NavService>(mockNavService)
           ..registerSingleton<EntitiesCacheService>(
@@ -116,10 +119,10 @@ void main() {
     fakeController = FakeJournalPageController(state());
 
     final navService = getIt<NavService>() as MockNavService;
-    final selectedNotifier = ValueNotifier<String?>('task-42');
+    final stackNotifier = ValueNotifier<List<String>>(<String>['task-42']);
     when(
-      () => navService.desktopSelectedTaskId,
-    ).thenReturn(selectedNotifier);
+      () => navService.desktopTaskDetailStack,
+    ).thenReturn(stackNotifier);
 
     await tester.pumpWidget(
       makeTestableWidgetNoScroll(
@@ -139,8 +142,8 @@ void main() {
     expect(find.byType(DesktopDetailEmptyState), findsNothing);
     expect(find.byType(TaskDetailsPage), findsOneWidget);
     expect(
-      tester.widget<TaskDetailsPage>(find.byType(TaskDetailsPage)).key,
-      const ValueKey('task-42'),
+      tester.widget<TaskDetailsPage>(find.byType(TaskDetailsPage)).taskId,
+      'task-42',
     );
 
     // Dispose the widget tree and flush pending timers from
@@ -155,10 +158,10 @@ void main() {
       fakeController = FakeJournalPageController(state());
 
       final navService = getIt<NavService>() as MockNavService;
-      final selectedNotifier = ValueNotifier<String?>('task-a');
+      final stackNotifier = ValueNotifier<List<String>>(<String>['task-a']);
       when(
-        () => navService.desktopSelectedTaskId,
-      ).thenReturn(selectedNotifier);
+        () => navService.desktopTaskDetailStack,
+      ).thenReturn(stackNotifier);
 
       await tester.pumpWidget(
         makeTestableWidgetNoScroll(
@@ -177,12 +180,12 @@ void main() {
       expect(find.byType(AnimatedSwitcher), findsOneWidget);
       expect(find.byType(TaskDetailsPage), findsOneWidget);
       expect(
-        tester.widget<TaskDetailsPage>(find.byType(TaskDetailsPage)).key,
-        const ValueKey('task-a'),
+        tester.widget<TaskDetailsPage>(find.byType(TaskDetailsPage)).taskId,
+        'task-a',
       );
 
-      // Switch to a different task id — mid-transition both pages coexist.
-      selectedNotifier.value = 'task-b';
+      // Replace base task — mid-transition both pages coexist.
+      stackNotifier.value = <String>['task-b'];
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 200));
 
@@ -192,8 +195,8 @@ void main() {
       await tester.pump(const Duration(milliseconds: 360));
       expect(find.byType(TaskDetailsPage), findsOneWidget);
       expect(
-        tester.widget<TaskDetailsPage>(find.byType(TaskDetailsPage)).key,
-        const ValueKey('task-b'),
+        tester.widget<TaskDetailsPage>(find.byType(TaskDetailsPage)).taskId,
+        'task-b',
       );
 
       await tester.pumpWidget(const SizedBox.shrink());
@@ -202,15 +205,73 @@ void main() {
   );
 
   testWidgets(
-    'does not animate when the selected task id stays the same',
+    'pushing onto the stack swaps to the linked task and crossfades',
     (tester) async {
       fakeController = FakeJournalPageController(state());
 
       final navService = getIt<NavService>() as MockNavService;
-      final selectedNotifier = ValueNotifier<String?>('task-stable');
+      final stackNotifier = ValueNotifier<List<String>>(<String>['base-task']);
       when(
-        () => navService.desktopSelectedTaskId,
-      ).thenReturn(selectedNotifier);
+        () => navService.desktopTaskDetailStack,
+      ).thenReturn(stackNotifier);
+
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          const TasksRootPage(),
+          mediaQueryData: const MediaQueryData(size: Size(1280, 800)),
+          overrides: [
+            journalPageScopeProvider.overrideWithValue(true),
+            journalPageControllerProvider(
+              true,
+            ).overrideWith(() => fakeController),
+          ],
+        ),
+      );
+      await tester.pump();
+
+      expect(
+        tester.widget<TaskDetailsPage>(find.byType(TaskDetailsPage)).taskId,
+        'base-task',
+      );
+
+      // Simulate pushing a linked task onto the desktop stack.
+      stackNotifier.value = <String>['base-task', 'linked-task'];
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 600));
+
+      expect(find.byType(TaskDetailsPage), findsOneWidget);
+      expect(
+        tester.widget<TaskDetailsPage>(find.byType(TaskDetailsPage)).taskId,
+        'linked-task',
+      );
+
+      // Pop returns to the base task.
+      stackNotifier.value = <String>['base-task'];
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 600));
+
+      expect(
+        tester.widget<TaskDetailsPage>(find.byType(TaskDetailsPage)).taskId,
+        'base-task',
+      );
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpAndSettle();
+    },
+  );
+
+  testWidgets(
+    'does not animate when the stack stays the same',
+    (tester) async {
+      fakeController = FakeJournalPageController(state());
+
+      final navService = getIt<NavService>() as MockNavService;
+      final stackNotifier = ValueNotifier<List<String>>(
+        <String>['task-stable'],
+      );
+      when(
+        () => navService.desktopTaskDetailStack,
+      ).thenReturn(stackNotifier);
 
       await tester.pumpWidget(
         makeTestableWidgetNoScroll(
@@ -228,17 +289,17 @@ void main() {
 
       expect(find.byType(TaskDetailsPage), findsOneWidget);
 
-      // Re-emit the same id — simulates a data-reload code path that
+      // Re-emit the same stack — simulates a data-reload code path that
       // happens to rebuild the outer ValueListenableBuilder.
-      selectedNotifier.notifyListeners();
+      stackNotifier.notifyListeners();
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 200));
 
       // Still exactly one TaskDetailsPage — no crossfade in flight.
       expect(find.byType(TaskDetailsPage), findsOneWidget);
       expect(
-        tester.widget<TaskDetailsPage>(find.byType(TaskDetailsPage)).key,
-        const ValueKey('task-stable'),
+        tester.widget<TaskDetailsPage>(find.byType(TaskDetailsPage)).taskId,
+        'task-stable',
       );
 
       await tester.pumpWidget(const SizedBox.shrink());

--- a/test/features/tasks/ui/task_compact_app_bar_test.dart
+++ b/test/features/tasks/ui/task_compact_app_bar_test.dart
@@ -7,7 +7,13 @@ import 'package:lotti/classes/task.dart';
 import 'package:lotti/features/design_system/theme/design_system_theme.dart';
 import 'package:lotti/features/tasks/state/task_app_bar_controller.dart';
 import 'package:lotti/features/tasks/ui/task_compact_app_bar.dart';
+import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations.dart';
+import 'package:lotti/services/nav_service.dart';
+import 'package:lotti/widgets/app_bar/glass_back_button.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../mocks/mocks.dart';
 
 /// Test-only TaskAppBarController that emits a pinned scroll offset so the
 /// persistent-title threshold check can be exercised deterministically.
@@ -181,6 +187,79 @@ void main() {
         );
         await tester.pumpAndSettle();
         expect(find.text('Test Task'), findsOneWidget);
+      },
+    );
+  });
+
+  group('TaskCompactAppBar desktop back-arrow visibility', () {
+    late MockNavService mockNavService;
+    late ValueNotifier<List<String>> stackNotifier;
+
+    setUp(() {
+      mockNavService = MockNavService();
+      stackNotifier = ValueNotifier<List<String>>(<String>['task-base']);
+      when(
+        () => mockNavService.desktopTaskDetailStack,
+      ).thenReturn(stackNotifier);
+      when(() => mockNavService.popDesktopTaskDetail()).thenAnswer((_) {});
+      if (getIt.isRegistered<NavService>()) {
+        getIt.unregister<NavService>();
+      }
+      getIt
+        ..allowReassignment = true
+        ..registerSingleton<NavService>(mockNavService);
+    });
+
+    tearDown(() {
+      stackNotifier.dispose();
+      if (getIt.isRegistered<NavService>()) {
+        getIt.unregister<NavService>();
+      }
+    });
+
+    testWidgets(
+      'desktop with single-entry stack hides the back arrow',
+      (tester) async {
+        tester.view
+          ..physicalSize = const Size(1280, 800)
+          ..devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        final task = buildTask();
+        await tester.pumpWidget(buildTestWidget(task));
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.chevron_left), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'desktop with multi-entry stack shows a glass back button '
+      'and pops on tap',
+      (tester) async {
+        tester.view
+          ..physicalSize = const Size(1280, 800)
+          ..devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        stackNotifier.value = <String>['task-base', 'task-linked'];
+
+        final task = buildTask(id: 'task-linked');
+        await tester.pumpWidget(buildTestWidget(task));
+        await tester.pumpAndSettle();
+
+        // Compact bar uses the same GlassBackButton style as the
+        // expandable bar on desktop pop, so the affordance stays
+        // visually consistent across linked-task navigation.
+        expect(find.byType(GlassBackButton), findsOneWidget);
+
+        await tester.tap(find.byType(GlassBackButton));
+        await tester.pump();
+
+        verify(() => mockNavService.popDesktopTaskDetail()).called(1);
+        verifyNever(() => mockNavService.beamBack(data: any(named: 'data')));
       },
     );
   });

--- a/test/features/tasks/ui/task_expandable_app_bar_test.dart
+++ b/test/features/tasks/ui/task_expandable_app_bar_test.dart
@@ -15,6 +15,7 @@ import 'package:lotti/l10n/app_localizations.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/editor_state_service.dart';
+import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/widgets/app_bar/glass_action_button.dart';
 import 'package:lotti/widgets/app_bar/glass_back_button.dart';
 import 'package:mocktail/mocktail.dart';
@@ -316,6 +317,66 @@ void main() {
         // The modal surfaces the shared "entryActions" title — find it to
         // prove the modal opened without asserting on internal item wiring.
         expect(find.text('Actions'), findsOneWidget);
+      },
+    );
+  });
+
+  group('TaskExpandableAppBar desktop back-arrow visibility', () {
+    late MockNavService mockNavService;
+    late ValueNotifier<List<String>> stackNotifier;
+
+    setUp(() {
+      mockNavService = MockNavService();
+      stackNotifier = ValueNotifier<List<String>>(<String>['task-base']);
+      when(
+        () => mockNavService.desktopTaskDetailStack,
+      ).thenReturn(stackNotifier);
+      when(() => mockNavService.popDesktopTaskDetail()).thenAnswer((_) {});
+      getIt.registerSingleton<NavService>(mockNavService);
+    });
+
+    tearDown(() {
+      stackNotifier.dispose();
+    });
+
+    testWidgets(
+      'desktop with single-entry stack hides the GlassBackButton',
+      (tester) async {
+        tester.view
+          ..physicalSize = const Size(1280, 800)
+          ..devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        final task = buildTask();
+        await tester.pumpWidget(buildTestWidget(task, 'image-1'));
+        await tester.pump();
+
+        expect(find.byType(GlassBackButton), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'desktop with multi-entry stack shows GlassBackButton and pops on tap',
+      (tester) async {
+        tester.view
+          ..physicalSize = const Size(1280, 800)
+          ..devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        stackNotifier.value = <String>['task-base', 'task-linked'];
+
+        final task = buildTask(id: 'task-linked');
+        await tester.pumpWidget(buildTestWidget(task, 'image-1'));
+        await tester.pump();
+
+        expect(find.byType(GlassBackButton), findsOneWidget);
+
+        await tester.tap(find.byType(GlassBackButton));
+        await tester.pump();
+
+        verify(() => mockNavService.popDesktopTaskDetail()).called(1);
       },
     );
   });

--- a/test/services/nav_service_test.dart
+++ b/test/services/nav_service_test.dart
@@ -323,6 +323,51 @@ void main() {
       expect(id, '123e4567-e89b-12d3-a456-426614174000');
     });
 
+    group('desktop task detail stack', () {
+      test('resetDesktopTaskDetail seeds the stack with one entry', () {
+        final navService = getIt<NavService>()
+          ..resetDesktopTaskDetail('task-a');
+        expect(navService.desktopTaskDetailStack.value, ['task-a']);
+        expect(navService.desktopSelectedTaskId.value, 'task-a');
+
+        navService.resetDesktopTaskDetail(null);
+        expect(navService.desktopTaskDetailStack.value, isEmpty);
+        expect(navService.desktopSelectedTaskId.value, isNull);
+      });
+
+      test('pushDesktopTaskDetail appends and updates selected id', () {
+        final navService = getIt<NavService>()
+          ..resetDesktopTaskDetail('base')
+          ..pushDesktopTaskDetail('linked');
+
+        expect(navService.desktopTaskDetailStack.value, ['base', 'linked']);
+        expect(navService.desktopSelectedTaskId.value, 'linked');
+      });
+
+      test('popDesktopTaskDetail removes the top and restores selected id', () {
+        final navService = getIt<NavService>()
+          ..resetDesktopTaskDetail('base')
+          ..pushDesktopTaskDetail('linked-1')
+          ..pushDesktopTaskDetail('linked-2')
+          ..popDesktopTaskDetail();
+
+        expect(navService.desktopTaskDetailStack.value, ['base', 'linked-1']);
+        expect(navService.desktopSelectedTaskId.value, 'linked-1');
+      });
+
+      test(
+        'popDesktopTaskDetail is a no-op when only one entry remains',
+        () {
+          final navService = getIt<NavService>()
+            ..resetDesktopTaskDetail('only')
+            ..popDesktopTaskDetail();
+
+          expect(navService.desktopTaskDetailStack.value, ['only']);
+          expect(navService.desktopSelectedTaskId.value, 'only');
+        },
+      );
+    });
+
     group('global beamToNamed', () {
       test('uses override when set', () {
         String? calledPath;

--- a/test/services/nav_service_test.dart
+++ b/test/services/nav_service_test.dart
@@ -324,6 +324,14 @@ void main() {
     });
 
     group('desktop task detail stack', () {
+      setUp(() {
+        // The NavService singleton is shared across tests. Clear the
+        // stack first so each test starts from a clean state and the
+        // idempotency guard in `resetDesktopTaskDetail` does not pick
+        // up state from a sibling test.
+        getIt<NavService>().resetDesktopTaskDetail(null);
+      });
+
       test('resetDesktopTaskDetail seeds the stack with one entry', () {
         final navService = getIt<NavService>()
           ..resetDesktopTaskDetail('task-a');
@@ -364,6 +372,23 @@ void main() {
 
           expect(navService.desktopTaskDetailStack.value, ['only']);
           expect(navService.desktopSelectedTaskId.value, 'only');
+        },
+      );
+
+      test(
+        'resetDesktopTaskDetail preserves a pushed linked-task stack '
+        'when the base task id is unchanged',
+        () {
+          // Simulates Beamer rebuilding `buildPages` for the same URL
+          // (theme change, provider change). The trailing reset must not
+          // clobber the linked-task layered on top of the base.
+          final navService = getIt<NavService>()
+            ..resetDesktopTaskDetail('base')
+            ..pushDesktopTaskDetail('linked')
+            ..resetDesktopTaskDetail('base');
+
+          expect(navService.desktopTaskDetailStack.value, ['base', 'linked']);
+          expect(navService.desktopSelectedTaskId.value, 'linked');
         },
       );
     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Desktop linked-task taps now open inside the right-hand details pane using a navigable stack, preserving the task list pane.
  * Desktop back-arrow is shown only when there is history and pops the details stack to go back; mobile navigation unchanged.

* **Documentation**
  * Updated release notes and README to describe the desktop detail-pane stack and back-arrow behavior.

* **Tests**
  * Added/updated widget and unit tests covering stack push/pop and back-arrow visibility/behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->