### PR TITLE
feat: run wake cycle when audio transcribed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.978]
+### Changed
+- Task agents now react immediately to recorded audio. Brand-new task agents
+  on a blank task no longer surface a "wake in 2:00" countdown — the
+  orchestrator skips the throttle deadline while the agent is awaiting
+  content, and the content gate keeps the agent from running until real
+  content arrives. The moment a transcription finishes (cloud or realtime),
+  the task agent is nudged via a manual wake that bypasses the standard
+  throttle, so the user does not wait through a 2-minute window after
+  speaking. Subsequent typing edits still go through the normal 2-minute
+  coalescing throttle. Implemented via a new `WakeReason.transcriptionComplete`
+  and an `awaitingContent` mirror in `WakeOrchestrator`, populated by
+  `TaskAgentService` on creation and restoration.
+
 ## [0.9.977] - 2026-04-25
 ### Fixed
 - Bottom navigation bar polish: the sync outbox badge on the Settings tab now

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -31,6 +31,11 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="0.9.978" date="2026-04-27">
+      <description>
+          <p>Task agents now react immediately to recorded audio. Brand-new task agents on a blank task no longer surface a "wake in 2:00" countdown — the orchestrator skips the throttle deadline while the agent is awaiting content, and the content gate keeps the agent from running until real content arrives. The moment a transcription finishes (cloud or realtime), the task agent is nudged via a manual wake that bypasses the standard throttle, so the user does not wait through a 2-minute window after speaking. Subsequent typing edits still go through the normal 2-minute coalescing throttle. Implemented via a new WakeReason.transcriptionComplete and an awaitingContent mirror in WakeOrchestrator, populated by TaskAgentService on creation and restoration.</p>
+      </description>
+    </release>
     <release version="0.9.977" date="2026-04-25">
       <description>
           <p>Bottom navigation bar polish: the sync outbox badge on the Settings tab now sits in the top-right of the icon to match the Tasks badge, and the audio and time recording indicators dock flush against the visible nav-bar pill instead of floating above it.</p>

--- a/lib/features/agents/model/agent_enums.dart
+++ b/lib/features/agents/model/agent_enums.dart
@@ -114,6 +114,11 @@ enum WakeReason {
 
   /// Triggered by a scheduled timer (e.g., weekly one-on-one ritual).
   scheduled,
+
+  /// Triggered immediately after speech transcription completes for an
+  /// audio entry linked to a task — bypasses the throttle so the user
+  /// does not wait through a 2-minute countdown after speaking.
+  transcriptionComplete,
 }
 
 /// Status of an evolution session.

--- a/lib/features/agents/service/task_agent_service.dart
+++ b/lib/features/agents/service/task_agent_service.dart
@@ -160,15 +160,21 @@ class TaskAgentService {
     // Register subscription for changes to this task.
     _registerTaskSubscription(identity.agentId, taskId);
 
+    // Mirror the persisted awaitingContent flag in the orchestrator so that
+    // subscription notifications for a brand-new blank task do not surface a
+    // 2-minute throttle countdown in the UI.
+    //
     // Always enqueue the creation wake. The content gate in
     // WakeOrchestrator._shouldSkipForAwaitingContent() will defer execution
     // for blank tasks and immediately activate agents whose task already has
     // meaningful content.
-    orchestrator.enqueueManualWake(
-      agentId: identity.agentId,
-      reason: WakeReason.creation.name,
-      triggerTokens: {taskId},
-    );
+    orchestrator
+      ..setAwaitingContent(identity.agentId, awaiting: awaitContent)
+      ..enqueueManualWake(
+        agentId: identity.agentId,
+        reason: WakeReason.creation.name,
+        triggerTokens: {taskId},
+      );
 
     domainLogger?.log(
       LogDomains.agentRuntime,
@@ -292,12 +298,20 @@ class TaskAgentService {
 
   /// Read the persisted `nextWakeAt` from the agent's state entity and
   /// restore it into the orchestrator's in-memory throttle cache.
+  ///
+  /// Also mirrors the persisted `awaitingContent` flag so the orchestrator
+  /// can skip surfacing a 2-minute countdown for blank tasks across app
+  /// restarts.
   Future<void> _hydrateThrottleDeadline(String agentId) async {
     final state = await repository.getAgentState(agentId);
     final deadline = state?.nextWakeAt;
     if (deadline != null) {
       orchestrator.setThrottleDeadline(agentId, deadline);
     }
+    orchestrator.setAwaitingContent(
+      agentId,
+      awaiting: state?.awaitingContent ?? false,
+    );
     // Note: we intentionally do NOT call clearThrottle when nextWakeAt is
     // null. A concurrent _onBatch notification may have already scheduled a
     // deferred drain timer for this agent (between _registerTaskSubscription

--- a/lib/features/agents/wake/wake_orchestrator.dart
+++ b/lib/features/agents/wake/wake_orchestrator.dart
@@ -129,6 +129,16 @@ class WakeOrchestrator {
   final _suppression = WakeSuppressionTracker();
   late final WakeThrottleCoordinator _throttle;
 
+  /// In-memory mirror of the persisted `awaitingContent` flag for each agent.
+  ///
+  /// Populated by the task-agent service when agents are created or their
+  /// subscriptions are restored, and cleared by [_shouldSkipForAwaitingContent]
+  /// once meaningful task content arrives. Used in [_onBatch] to suppress the
+  /// 2-minute throttle countdown for blank tasks — there is no point surfacing
+  /// a "wake in 2:00" timer when the content gate is going to skip the run
+  /// anyway.
+  final _agentsAwaitingContent = <String>{};
+
   // ── Throttle state ──────────────────────────────────────────────────────
 
   /// The minimum interval between subscription-triggered wakes for the
@@ -231,8 +241,28 @@ class WakeOrchestrator {
     _subscriptions.removeWhere((s) => s.agentId == agentId);
     _suppression.clearAgent(agentId);
     _wakeCounters.remove(agentId);
+    _agentsAwaitingContent.remove(agentId);
     clearThrottle(agentId);
   }
+
+  /// Mark [agentId] as awaiting-content (or not).
+  ///
+  /// While the flag is set, [_onBatch] will not call [_setThrottleDeadline]
+  /// for this agent — so subscription notifications coming in for a blank
+  /// task do not surface a 2-minute countdown timer in the UI. The job is
+  /// still enqueued and will be picked up by the safety-net drain or a
+  /// later notification once content arrives.
+  void setAwaitingContent(String agentId, {required bool awaiting}) {
+    if (awaiting) {
+      _agentsAwaitingContent.add(agentId);
+    } else {
+      _agentsAwaitingContent.remove(agentId);
+    }
+  }
+
+  /// Returns `true` when [agentId] is currently awaiting content.
+  bool isAwaitingContent(String agentId) =>
+      _agentsAwaitingContent.contains(agentId);
 
   // ── Self-notification suppression ──────────────────────────────────────────
 
@@ -503,6 +533,22 @@ class WakeOrchestrator {
         queue.enqueue(job);
       }
 
+      // Awaiting-content agents (newly-created task agents on blank tasks)
+      // do not get a throttle deadline — surfacing a 2-minute countdown for
+      // a task with nothing to analyze is just noise. The job stays in the
+      // queue and the content gate will skip it until real content arrives.
+      // Once content does arrive, _shouldSkipForAwaitingContent clears the
+      // flag and from then on the normal throttle applies.
+      if (_agentsAwaitingContent.contains(sub.agentId)) {
+        _log(
+          'skipping throttle deadline for '
+          '${DomainLogger.sanitizeId(sub.agentId)} '
+          '(awaiting content, no countdown surfaced)',
+          subDomain: 'awaitContent',
+        );
+        continue;
+      }
+
       // Defer-first: instead of dispatching immediately, set a throttle
       // deadline and schedule a deferred drain. This allows bursty edits
       // to coalesce into a single wake cycle.
@@ -592,6 +638,9 @@ class WakeOrchestrator {
       } else {
         await repository.upsertEntity(cleared);
       }
+      // Drop the in-memory mirror so subsequent subscription notifications
+      // get the normal throttle countdown.
+      _agentsAwaitingContent.remove(job.agentId);
       return false;
     } catch (e, s) {
       // Don't let content-check errors block the wake — proceed normally.

--- a/lib/features/agents/wake/wake_orchestrator.dart
+++ b/lib/features/agents/wake/wake_orchestrator.dart
@@ -598,16 +598,39 @@ class WakeOrchestrator {
   ///
   /// When content IS found, clears the `awaitingContent` flag on the agent
   /// state so subsequent wakes proceed normally.
+  ///
+  /// Whenever this method returns `false` because the persisted state shows
+  /// the agent is no longer awaiting content (state missing, flag already
+  /// cleared, or no active task to gate on), the in-memory mirror is dropped
+  /// so it cannot stay falsely `true` and silence countdowns indefinitely.
+  /// Truly indeterminate paths (no `taskContentChecker`, exceptions) leave
+  /// the mirror untouched — they fail open without lying about state.
   Future<bool> _shouldSkipForAwaitingContent(WakeJob job) async {
     try {
       final state = await repository.getAgentState(job.agentId);
-      if (state == null || !state.awaitingContent) return false;
+      if (state == null || !state.awaitingContent) {
+        // Persisted state says not awaiting — drop any stale mirror entry
+        // so future notifications surface the normal countdown.
+        _agentsAwaitingContent.remove(job.agentId);
+        return false;
+      }
 
       final taskId = state.slots.activeTaskId;
-      if (taskId == null) return false;
+      if (taskId == null) {
+        // Awaiting flag is set but there is no task to gate on. The agent
+        // is about to run; drop the mirror so subsequent notifications use
+        // the normal throttle.
+        _agentsAwaitingContent.remove(job.agentId);
+        return false;
+      }
 
       final checker = taskContentChecker;
-      if (checker == null) return false;
+      if (checker == null) {
+        // Indeterminate — we can't verify content state. Fail open and
+        // leave the mirror as-is so the persisted flag still drives the
+        // countdown suppression.
+        return false;
+      }
 
       final hasContent = await checker(taskId);
       if (!hasContent) {
@@ -644,6 +667,9 @@ class WakeOrchestrator {
       return false;
     } catch (e, s) {
       // Don't let content-check errors block the wake — proceed normally.
+      // Mirror is intentionally left untouched: we don't know whether the
+      // persisted flag still applies, so we fail open without rewriting
+      // local state.
       _logError(
         'content-gate: error checking content for '
         '${DomainLogger.sanitizeId(job.agentId)}',

--- a/lib/features/speech/helpers/automatic_prompt_trigger.dart
+++ b/lib/features/speech/helpers/automatic_prompt_trigger.dart
@@ -1,4 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/state/agent_providers.dart';
+import 'package:lotti/features/agents/state/task_agent_providers.dart';
 import 'package:lotti/features/ai/services/skill_inference_runner.dart';
 import 'package:lotti/features/ai/state/profile_automation_providers.dart';
 import 'package:lotti/features/speech/state/recorder_state.dart';
@@ -54,6 +57,15 @@ class AutomaticPromptTrigger {
           domain: 'automatic_prompt_trigger',
           subDomain: 'triggerAutomaticPrompts',
         );
+        // A realtime transcript is still a completed transcription — nudge
+        // the agent so it processes the freshly-spoken content immediately
+        // instead of waiting through the standard 2-minute throttle.
+        if (realtimeTranscriptProvided) {
+          await _nudgeTaskAgent(
+            entryId: entryId,
+            linkedTaskId: linkedTaskId,
+          );
+        }
         return;
       }
 
@@ -70,11 +82,59 @@ class AutomaticPromptTrigger {
         automationResult: result,
         linkedTaskId: linkedTaskId,
       );
+
+      // Transcription added real content to the task — nudge the task agent
+      // immediately so it processes the new transcript without waiting out
+      // the standard 2-minute throttle. The manual wake clears any pending
+      // throttle deadline (and its UI countdown) and supersedes any queued
+      // subscription job.
+      await _nudgeTaskAgent(
+        entryId: entryId,
+        linkedTaskId: linkedTaskId,
+      );
     } catch (exception, stackTrace) {
       loggingService.captureException(
         exception,
         domain: 'automatic_prompt_trigger',
         subDomain: 'triggerAutomaticPrompts',
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  /// Enqueue a manual wake on the task's agent so a freshly-completed
+  /// transcription is processed immediately, bypassing the 2-minute
+  /// subscription throttle.
+  ///
+  /// No-op when no task agent is registered for [linkedTaskId]. Failures
+  /// are logged but never propagate — a missed nudge is recoverable via
+  /// the standard subscription path; throwing here would abort the caller.
+  Future<void> _nudgeTaskAgent({
+    required String entryId,
+    required String linkedTaskId,
+  }) async {
+    try {
+      final taskAgentService = ref.read(taskAgentServiceProvider);
+      final agent = await taskAgentService.getTaskAgentForTask(linkedTaskId);
+      if (agent == null) return;
+      ref
+          .read(wakeOrchestratorProvider)
+          .enqueueManualWake(
+            agentId: agent.agentId,
+            reason: WakeReason.transcriptionComplete.name,
+            triggerTokens: {linkedTaskId, entryId},
+          );
+      loggingService.captureEvent(
+        'Nudged task agent ${agent.agentId} after transcription '
+        'completion (task $linkedTaskId, entry $entryId)',
+        domain: 'automatic_prompt_trigger',
+        subDomain: 'nudgeTaskAgent',
+      );
+    } catch (exception, stackTrace) {
+      loggingService.captureException(
+        exception,
+        domain: 'automatic_prompt_trigger',
+        subDomain: 'nudgeTaskAgent',
         stackTrace: stackTrace,
       );
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.977+3989
+version: 0.9.978+3990
 
 msix_config:
   display_name: LottiApp

--- a/test/features/agents/service/task_agent_service_test.dart
+++ b/test/features/agents/service/task_agent_service_test.dart
@@ -299,6 +299,103 @@ void main() {
           throwsStateError,
         );
       });
+
+      test(
+        'mirrors awaitContent flag onto orchestrator awaiting-content cache',
+        () async {
+          final identity = makeIdentity();
+          when(
+            () => mockRepository.getLinksTo('task-blank', type: 'agent_task'),
+          ).thenAnswer((_) async => []);
+          when(
+            () => mockAgentService.createAgent(
+              kind: any(named: 'kind'),
+              displayName: any(named: 'displayName'),
+              config: any(named: 'config'),
+              allowedCategoryIds: any(named: 'allowedCategoryIds'),
+            ),
+          ).thenAnswer((_) async => identity);
+          when(
+            () => mockRepository.getAgentState('agent-1'),
+          ).thenAnswer((_) async => makeState());
+          when(() => mockOrchestrator.addSubscription(any())).thenReturn(null);
+          when(
+            () => mockOrchestrator.enqueueManualWake(
+              agentId: any(named: 'agentId'),
+              reason: any(named: 'reason'),
+              triggerTokens: any(named: 'triggerTokens'),
+            ),
+          ).thenReturn(null);
+          when(
+            () => mockOrchestrator.setAwaitingContent(
+              any(),
+              awaiting: any(named: 'awaiting'),
+            ),
+          ).thenReturn(null);
+
+          await service.createTaskAgent(
+            taskId: 'task-blank',
+            templateId: kTestTemplateId,
+            allowedCategoryIds: const {},
+            awaitContent: true,
+          );
+
+          verify(
+            () => mockOrchestrator.setAwaitingContent(
+              'agent-1',
+              awaiting: true,
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'clears awaiting-content cache when task already has content',
+        () async {
+          final identity = makeIdentity();
+          when(
+            () => mockRepository.getLinksTo('task-warm', type: 'agent_task'),
+          ).thenAnswer((_) async => []);
+          when(
+            () => mockAgentService.createAgent(
+              kind: any(named: 'kind'),
+              displayName: any(named: 'displayName'),
+              config: any(named: 'config'),
+              allowedCategoryIds: any(named: 'allowedCategoryIds'),
+            ),
+          ).thenAnswer((_) async => identity);
+          when(
+            () => mockRepository.getAgentState('agent-1'),
+          ).thenAnswer((_) async => makeState());
+          when(() => mockOrchestrator.addSubscription(any())).thenReturn(null);
+          when(
+            () => mockOrchestrator.enqueueManualWake(
+              agentId: any(named: 'agentId'),
+              reason: any(named: 'reason'),
+              triggerTokens: any(named: 'triggerTokens'),
+            ),
+          ).thenReturn(null);
+          when(
+            () => mockOrchestrator.setAwaitingContent(
+              any(),
+              awaiting: any(named: 'awaiting'),
+            ),
+          ).thenReturn(null);
+
+          await service.createTaskAgent(
+            taskId: 'task-warm',
+            templateId: kTestTemplateId,
+            allowedCategoryIds: const {},
+          );
+
+          verify(
+            () => mockOrchestrator.setAwaitingContent(
+              'agent-1',
+              awaiting: false,
+            ),
+          ).called(1);
+        },
+      );
     });
 
     group('getTaskAgentForTask', () {
@@ -491,6 +588,35 @@ void main() {
           () => mockOrchestrator.setThrottleDeadline(any(), any()),
         );
       });
+
+      test(
+        'hydrates awaiting-content cache from persisted state',
+        () async {
+          final stateAwaiting = makeState().copyWith(awaitingContent: true);
+          when(
+            () => mockRepository.getLinksFrom('agent-1', type: 'agent_task'),
+          ).thenAnswer((_) async => []);
+          when(() => mockOrchestrator.addSubscription(any())).thenReturn(null);
+          when(
+            () => mockRepository.getAgentState('agent-1'),
+          ).thenAnswer((_) async => stateAwaiting);
+          when(
+            () => mockOrchestrator.setAwaitingContent(
+              any(),
+              awaiting: any(named: 'awaiting'),
+            ),
+          ).thenReturn(null);
+
+          await service.restoreSubscriptionsForAgent('agent-1');
+
+          verify(
+            () => mockOrchestrator.setAwaitingContent(
+              'agent-1',
+              awaiting: true,
+            ),
+          ).called(1);
+        },
+      );
     });
 
     group('restoreSubscriptions', () {

--- a/test/features/agents/wake/wake_orchestrator_test.dart
+++ b/test/features/agents/wake/wake_orchestrator_test.dart
@@ -3200,6 +3200,161 @@ void main() {
           cg.stop();
         });
       });
+
+      test(
+        'drops mirror when persisted state shows the agent is no longer '
+        'awaiting content',
+        () {
+          fakeAsync((async) {
+            // Simulate a divergence: the in-memory mirror still says
+            // awaiting, but the persisted state has been cleared (e.g.,
+            // by another device via sync). The gate must drop the mirror
+            // so future notifications surface the normal countdown.
+            final clearedState = makeTestState(
+              agentId: 'agent-cg-stale',
+              slots: const AgentSlots(activeTaskId: 'task-stale'),
+            );
+            when(
+              () => mockRepository.getAgentState('agent-cg-stale'),
+            ).thenAnswer((_) async => clearedState);
+
+            final cg =
+                WakeOrchestrator(
+                    repository: mockRepository,
+                    queue: queue,
+                    runner: WakeRunner(),
+                    taskContentChecker: (taskId) async => true,
+                    wakeExecutor: (agentId, runKey, triggers, threadId) async =>
+                        null,
+                  )
+                  ..setAwaitingContent('agent-cg-stale', awaiting: true)
+                  ..enqueueManualWake(
+                    agentId: 'agent-cg-stale',
+                    reason: 'subscription',
+                  );
+
+            async
+              ..elapse(WakeOrchestrator.throttleWindow)
+              ..flushMicrotasks();
+
+            expect(cg.isAwaitingContent('agent-cg-stale'), isFalse);
+
+            cg.stop();
+          });
+        },
+      );
+
+      test('drops mirror when no agent state is persisted', () {
+        fakeAsync((async) {
+          when(
+            () => mockRepository.getAgentState('agent-cg-missing'),
+          ).thenAnswer((_) async => null);
+
+          final cg =
+              WakeOrchestrator(
+                  repository: mockRepository,
+                  queue: queue,
+                  runner: WakeRunner(),
+                  taskContentChecker: (taskId) async => true,
+                  wakeExecutor: (agentId, runKey, triggers, threadId) async =>
+                      null,
+                )
+                ..setAwaitingContent('agent-cg-missing', awaiting: true)
+                ..enqueueManualWake(
+                  agentId: 'agent-cg-missing',
+                  reason: 'subscription',
+                );
+
+          async
+            ..elapse(WakeOrchestrator.throttleWindow)
+            ..flushMicrotasks();
+
+          expect(cg.isAwaitingContent('agent-cg-missing'), isFalse);
+
+          cg.stop();
+        });
+      });
+
+      test(
+        'drops mirror when awaiting flag is set but no activeTaskId can '
+        'be gated on',
+        () {
+          fakeAsync((async) {
+            final state = makeTestState(
+              agentId: 'agent-cg-no-task',
+              awaitingContent: true,
+            );
+            when(
+              () => mockRepository.getAgentState('agent-cg-no-task'),
+            ).thenAnswer((_) async => state);
+
+            final cg =
+                WakeOrchestrator(
+                    repository: mockRepository,
+                    queue: queue,
+                    runner: WakeRunner(),
+                    taskContentChecker: (taskId) async => false,
+                    wakeExecutor: (agentId, runKey, triggers, threadId) async =>
+                        null,
+                  )
+                  ..setAwaitingContent('agent-cg-no-task', awaiting: true)
+                  ..enqueueManualWake(
+                    agentId: 'agent-cg-no-task',
+                    reason: 'creation',
+                  );
+
+            async
+              ..elapse(WakeOrchestrator.throttleWindow)
+              ..flushMicrotasks();
+
+            expect(cg.isAwaitingContent('agent-cg-no-task'), isFalse);
+
+            cg.stop();
+          });
+        },
+      );
+
+      test(
+        'leaves mirror untouched when taskContentChecker is null (fail-open)',
+        () {
+          fakeAsync((async) {
+            final state = makeTestState(
+              agentId: 'agent-cg-fail-open',
+              awaitingContent: true,
+              slots: const AgentSlots(activeTaskId: 'task-fail-open'),
+            );
+            when(
+              () => mockRepository.getAgentState('agent-cg-fail-open'),
+            ).thenAnswer((_) async => state);
+
+            final cg =
+                WakeOrchestrator(
+                    repository: mockRepository,
+                    queue: queue,
+                    runner: WakeRunner(),
+                    // taskContentChecker is null
+                    wakeExecutor: (agentId, runKey, triggers, threadId) async =>
+                        null,
+                  )
+                  ..setAwaitingContent('agent-cg-fail-open', awaiting: true)
+                  ..enqueueManualWake(
+                    agentId: 'agent-cg-fail-open',
+                    reason: 'subscription',
+                  );
+
+            async
+              ..elapse(WakeOrchestrator.throttleWindow)
+              ..flushMicrotasks();
+
+            // Indeterminate path — persisted flag still says awaiting, so
+            // the mirror should remain so that countdown suppression keeps
+            // matching the persisted truth.
+            expect(cg.isAwaitingContent('agent-cg-fail-open'), isTrue);
+
+            cg.stop();
+          });
+        },
+      );
     });
 
     group('agent execution zone', () {

--- a/test/features/agents/wake/wake_orchestrator_test.dart
+++ b/test/features/agents/wake/wake_orchestrator_test.dart
@@ -2199,6 +2199,109 @@ void main() {
       );
     });
 
+    group('awaiting-content cache', () {
+      test(
+        'setAwaitingContent suppresses throttle deadline on subscription wakes',
+        () {
+          fakeAsync((async) {
+            orchestrator
+              ..addSubscription(makeSub())
+              ..setAwaitingContent('agent-1', awaiting: true)
+              ..wakeExecutor = noOpExecutor;
+
+            final controller = StreamController<Set<String>>.broadcast();
+            orchestrator.start(controller.stream);
+
+            emitTokens(async, controller, {'entity-1'});
+
+            // Advance just shy of the safety-net interval. With no deferred
+            // drain timer scheduled (the throttle was skipped), nothing has
+            // surfaced a countdown via persisted nextWakeAt and the wake has
+            // not been dispatched.
+            async
+              ..elapse(
+                WakeOrchestrator.safetyNetInterval - const Duration(seconds: 1),
+              )
+              ..flushMicrotasks();
+
+            verifyNever(
+              () => mockRepository.insertWakeRun(entry: any(named: 'entry')),
+            );
+            verifyNever(
+              () => mockRepository.upsertEntity(
+                any(
+                  that: isA<AgentStateEntity>().having(
+                    (s) => s.nextWakeAt,
+                    'nextWakeAt',
+                    isNotNull,
+                  ),
+                ),
+              ),
+            );
+            expect(orchestrator.isAwaitingContent('agent-1'), isTrue);
+
+            controller.close();
+          });
+        },
+      );
+
+      test(
+        'content-gate clears the cache once real content arrives',
+        () {
+          fakeAsync((async) {
+            final state = makeTestState(
+              agentId: 'agent-cg-cache',
+              awaitingContent: true,
+              slots: const AgentSlots(activeTaskId: 'task-cache'),
+            );
+            when(
+              () => mockRepository.getAgentState('agent-cg-cache'),
+            ).thenAnswer((_) async => state);
+
+            final cg =
+                WakeOrchestrator(
+                    repository: mockRepository,
+                    queue: queue,
+                    runner: WakeRunner(),
+                    taskContentChecker: (taskId) async => true,
+                    wakeExecutor: (agentId, runKey, triggers, threadId) async {
+                      return null;
+                    },
+                  )
+                  ..setAwaitingContent('agent-cg-cache', awaiting: true)
+                  ..enqueueManualWake(
+                    agentId: 'agent-cg-cache',
+                    reason: 'creation',
+                  );
+
+            expect(cg.isAwaitingContent('agent-cg-cache'), isTrue);
+
+            async
+              ..elapse(WakeOrchestrator.throttleWindow)
+              ..flushMicrotasks();
+
+            // After the content gate finds content, the cache is cleared so
+            // subsequent subscription wakes get the normal countdown again.
+            expect(cg.isAwaitingContent('agent-cg-cache'), isFalse);
+
+            cg.stop();
+          });
+        },
+      );
+
+      test('removeSubscriptions drops the awaiting-content entry', () {
+        orchestrator
+          ..addSubscription(makeSub())
+          ..setAwaitingContent('agent-1', awaiting: true);
+
+        expect(orchestrator.isAwaitingContent('agent-1'), isTrue);
+
+        orchestrator.removeSubscriptions('agent-1');
+
+        expect(orchestrator.isAwaitingContent('agent-1'), isFalse);
+      });
+    });
+
     group('_scheduleDeferredDrain edge cases', () {
       test(
         'setThrottleDeadline with past deadline does not throttle agent',

--- a/test/features/speech/helpers/automatic_prompt_trigger_test.dart
+++ b/test/features/speech/helpers/automatic_prompt_trigger_test.dart
@@ -1,5 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/agents/state/agent_providers.dart';
+import 'package:lotti/features/agents/state/task_agent_providers.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/services/profile_automation_service.dart';
 import 'package:lotti/features/ai/services/skill_inference_runner.dart';
@@ -11,15 +13,20 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/services/logging_service.dart';
 import 'package:mocktail/mocktail.dart';
 
+import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
+import '../../agents/test_data/entity_factories.dart';
 
 void main() {
   late MockLoggingService mockLoggingService;
   late MockProfileAutomationService mockProfileAutomationService;
   late MockSkillInferenceRunner mockRunner;
+  late MockTaskAgentService mockTaskAgentService;
+  late MockWakeOrchestrator mockWakeOrchestrator;
   late ProviderContainer container;
 
   setUpAll(() {
+    registerAllFallbackValues();
     registerFallbackValue(AutomationResult.notHandled);
   });
 
@@ -52,6 +59,8 @@ void main() {
     mockLoggingService = MockLoggingService();
     mockProfileAutomationService = MockProfileAutomationService();
     mockRunner = MockSkillInferenceRunner();
+    mockTaskAgentService = MockTaskAgentService();
+    mockWakeOrchestrator = MockWakeOrchestrator();
 
     if (getIt.isRegistered<LoggingService>()) {
       getIt.unregister<LoggingService>();
@@ -82,12 +91,26 @@ void main() {
       ),
     ).thenAnswer((_) async => AutomationResult.notHandled);
 
+    when(
+      () => mockTaskAgentService.getTaskAgentForTask(any()),
+    ).thenAnswer((_) async => null);
+
+    when(
+      () => mockWakeOrchestrator.enqueueManualWake(
+        agentId: any(named: 'agentId'),
+        reason: any(named: 'reason'),
+        triggerTokens: any(named: 'triggerTokens'),
+      ),
+    ).thenReturn(null);
+
     container = ProviderContainer(
       overrides: [
         profileAutomationServiceProvider.overrideWithValue(
           mockProfileAutomationService,
         ),
         skillInferenceRunnerProvider.overrideWithValue(mockRunner),
+        taskAgentServiceProvider.overrideWithValue(mockTaskAgentService),
+        wakeOrchestratorProvider.overrideWithValue(mockWakeOrchestrator),
       ],
     );
   });
@@ -295,6 +318,173 @@ void main() {
           ),
         ).called(1);
       });
+    });
+
+    group('agent nudge on transcription completion', () {
+      test(
+        'enqueues a manual wake after a successful profile-driven '
+        'transcription so the user does not wait through the throttle',
+        () async {
+          const taskId = 'task-nudge';
+          const entryId = 'entry-nudge';
+          final skill = testSkill();
+          final result = AutomationResult(handled: true, skill: skill);
+          final agent = makeTestIdentity(agentId: 'agent-nudge');
+
+          when(
+            () => mockProfileAutomationService.tryTranscribe(
+              taskId: taskId,
+              enableSpeechRecognition: any(named: 'enableSpeechRecognition'),
+            ),
+          ).thenAnswer((_) async => result);
+          when(
+            () => mockRunner.runTranscription(
+              audioEntryId: entryId,
+              automationResult: result,
+              linkedTaskId: taskId,
+            ),
+          ).thenAnswer((_) async {});
+          when(
+            () => mockTaskAgentService.getTaskAgentForTask(taskId),
+          ).thenAnswer((_) async => agent);
+
+          final trigger = container.read(automaticPromptTriggerProvider);
+
+          await trigger.triggerAutomaticPrompts(
+            entryId,
+            stoppedState(),
+            linkedTaskId: taskId,
+          );
+
+          verify(
+            () => mockWakeOrchestrator.enqueueManualWake(
+              agentId: 'agent-nudge',
+              reason: 'transcriptionComplete',
+              triggerTokens: {taskId, entryId},
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'still nudges the agent when the realtime transcript was already '
+        'provided (cloud transcription is skipped, but the content is fresh)',
+        () async {
+          const taskId = 'task-rt';
+          const entryId = 'entry-rt';
+          final skill = testSkill();
+          final result = AutomationResult(handled: true, skill: skill);
+          final agent = makeTestIdentity(agentId: 'agent-rt');
+
+          when(
+            () => mockProfileAutomationService.tryTranscribe(
+              taskId: taskId,
+              enableSpeechRecognition: any(named: 'enableSpeechRecognition'),
+            ),
+          ).thenAnswer((_) async => result);
+          when(
+            () => mockTaskAgentService.getTaskAgentForTask(taskId),
+          ).thenAnswer((_) async => agent);
+
+          final trigger = container.read(automaticPromptTriggerProvider);
+
+          await trigger.triggerAutomaticPrompts(
+            entryId,
+            stoppedState(),
+            linkedTaskId: taskId,
+            realtimeTranscriptProvided: true,
+          );
+
+          verifyNever(
+            () => mockRunner.runTranscription(
+              audioEntryId: any(named: 'audioEntryId'),
+              automationResult: any(named: 'automationResult'),
+              linkedTaskId: any(named: 'linkedTaskId'),
+            ),
+          );
+          verify(
+            () => mockWakeOrchestrator.enqueueManualWake(
+              agentId: 'agent-rt',
+              reason: 'transcriptionComplete',
+              triggerTokens: {taskId, entryId},
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'does not nudge when no task agent is registered for the task',
+        () async {
+          const taskId = 'task-orphan';
+          const entryId = 'entry-orphan';
+          final skill = testSkill();
+          final result = AutomationResult(handled: true, skill: skill);
+
+          when(
+            () => mockProfileAutomationService.tryTranscribe(
+              taskId: taskId,
+              enableSpeechRecognition: any(named: 'enableSpeechRecognition'),
+            ),
+          ).thenAnswer((_) async => result);
+          when(
+            () => mockRunner.runTranscription(
+              audioEntryId: entryId,
+              automationResult: result,
+              linkedTaskId: taskId,
+            ),
+          ).thenAnswer((_) async {});
+          when(
+            () => mockTaskAgentService.getTaskAgentForTask(taskId),
+          ).thenAnswer((_) async => null);
+
+          final trigger = container.read(automaticPromptTriggerProvider);
+
+          await trigger.triggerAutomaticPrompts(
+            entryId,
+            stoppedState(),
+            linkedTaskId: taskId,
+          );
+
+          verifyNever(
+            () => mockWakeOrchestrator.enqueueManualWake(
+              agentId: any(named: 'agentId'),
+              reason: any(named: 'reason'),
+              triggerTokens: any(named: 'triggerTokens'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'does not nudge when transcription was not handled by automation',
+        () async {
+          const taskId = 'task-skip';
+          const entryId = 'entry-skip';
+
+          when(
+            () => mockProfileAutomationService.tryTranscribe(
+              taskId: taskId,
+              enableSpeechRecognition: any(named: 'enableSpeechRecognition'),
+            ),
+          ).thenAnswer((_) async => AutomationResult.notHandled);
+
+          final trigger = container.read(automaticPromptTriggerProvider);
+
+          await trigger.triggerAutomaticPrompts(
+            entryId,
+            stoppedState(),
+            linkedTaskId: taskId,
+          );
+
+          verifyNever(
+            () => mockWakeOrchestrator.enqueueManualWake(
+              agentId: any(named: 'agentId'),
+              reason: any(named: 'reason'),
+              triggerTokens: any(named: 'triggerTokens'),
+            ),
+          );
+        },
+      );
     });
   });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agents now wake immediately when audio transcription completes on blank tasks, bypassing the 2-minute UI countdown; typing/edits still use the standard 2-minute throttle.

* **Tests**
  * Added coverage for transcription-complete nudges, awaiting-content caching, mirror-drop semantics, and related subscription behaviors.

* **Documentation**
  * Changelog and release metadata updated for version 0.9.978.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->