### PR TITLE
fix: crash on hot reload

### DIFF
--- a/lib/features/ai/repository/dashscope_inference_repository.g.dart
+++ b/lib/features/ai/repository/dashscope_inference_repository.g.dart
@@ -56,4 +56,4 @@ final class DashScopeInferenceRepositoryProvider
 }
 
 String _$dashScopeInferenceRepositoryHash() =>
-    r'e3f21359d72ce546f12ec732f65b69e814ee397f';
+    r'aca72583bc6f5f03c9610a1c17e82f82a478d71d';

--- a/lib/features/speech/state/audio_player_controller.dart
+++ b/lib/features/speech/state/audio_player_controller.dart
@@ -35,6 +35,15 @@ PlayerFactory playerFactory(Ref ref) {
 /// Notifier managing audio player state.
 /// Marked as keepAlive since audio state should persist for the entire app
 /// lifecycle.
+///
+/// The underlying media_kit [Player] is created lazily on the first
+/// `setAudioNote`/`play` call and torn down again when playback completes.
+/// Keeping the native mpv core thread out of memory between active sessions
+/// makes Flutter hot restart safe whenever audio is not actively playing.
+/// (mpv's `core_thread` invokes FFI callbacks asynchronously; if the Dart
+/// VM is torn down by hot restart while the thread is alive, the trampolines
+/// it calls into are gone and the process aborts with
+/// "Callback invoked after it has been deleted".)
 @Riverpod(keepAlive: true)
 class AudioPlayerController extends _$AudioPlayerController {
   /// Tracks the active Player instance so the shutdown path can dispose it
@@ -43,6 +52,7 @@ class AudioPlayerController extends _$AudioPlayerController {
   static Player? _activePlayer;
 
   Player? _audioPlayer;
+  bool _hasOpenAudio = false;
   LoggingService? _loggingService;
   Duration _completionDelay = const Duration(
     milliseconds: AudioPlayerConstants.completionDelayMs,
@@ -59,17 +69,13 @@ class AudioPlayerController extends _$AudioPlayerController {
   @override
   AudioPlayerState build() {
     ref.onDispose(_cleanup);
-    _init();
+    _initLogging();
     return const AudioPlayerState();
   }
 
-  void _init() {
+  void _initLogging() {
     try {
-      final factory = ref.read(playerFactoryProvider);
-      _audioPlayer = factory();
-      _activePlayer = _audioPlayer;
       _loggingService = getIt<LoggingService>();
-      _setupSubscriptions();
     } catch (exception, stackTrace) {
       _loggingService?.captureException(
         exception,
@@ -80,10 +86,41 @@ class AudioPlayerController extends _$AudioPlayerController {
     }
   }
 
-  void _setupSubscriptions() {
-    final player = _audioPlayer;
-    if (player == null) return;
+  /// Lazily constructs the underlying media_kit [Player] and wires its event
+  /// streams. Returns the existing instance if one is already alive.
+  ///
+  /// Player construction spins up mpv's native `core_thread`. Deferring it
+  /// until the user actually triggers playback keeps Flutter hot restart
+  /// safe in any session where audio is never opened.
+  Player? _ensurePlayer() {
+    final existing = _audioPlayer;
+    if (existing != null) return existing;
+    try {
+      final factory = ref.read(playerFactoryProvider);
+      final player = factory();
+      _audioPlayer = player;
+      _activePlayer = player;
+      _setupSubscriptions(player);
+      return player;
+    } catch (exception, stackTrace) {
+      _loggingService?.captureException(
+        exception,
+        domain: 'audio_player_controller',
+        subDomain: 'ensurePlayer',
+        stackTrace: stackTrace,
+      );
+      return null;
+    }
+  }
 
+  /// Test hook for triggering lazy player construction without having to
+  /// invoke a stateful action method (which would emit additional states).
+  @visibleForTesting
+  void ensurePlayerForTest() {
+    _ensurePlayer();
+  }
+
+  void _setupSubscriptions(Player player) {
     _positionSubscription = player.stream.position.listen(updateProgress);
     _bufferSubscription = player.stream.buffer.listen(_updateBuffered);
     _completedSubscription = player.stream.completed.listen(
@@ -94,15 +131,33 @@ class AudioPlayerController extends _$AudioPlayerController {
   void _cleanup() {
     _completionTimer?.cancel();
     _completionTimer = null;
+    _tearDownActivePlayer();
+  }
+
+  /// Tears down the live [Player] and its stream subscriptions. State (such
+  /// as the currently selected [AudioPlayerState.audioNote]) is preserved
+  /// so callers can transparently re-open the file on the next play.
+  ///
+  /// Stays synchronous so callers (Riverpod's `onDispose`, the completion
+  /// timer) can rely on the [Player.dispose] call being issued before they
+  /// return — only the resulting `Future` is unawaited.
+  void _tearDownActivePlayer() {
+    final player = _audioPlayer;
+    if (player == null) return;
     _positionSubscription?.cancel();
+    _positionSubscription = null;
     _bufferSubscription?.cancel();
+    _bufferSubscription = null;
     _completedSubscription?.cancel();
+    _completedSubscription = null;
     // Only clear the static pointer if we own it — a newer controller may
     // have already replaced it, and nulling would break the shutdown path.
-    if (identical(_activePlayer, _audioPlayer)) {
+    if (identical(_activePlayer, player)) {
       _activePlayer = null;
     }
-    _audioPlayer?.dispose();
+    _audioPlayer = null;
+    _hasOpenAudio = false;
+    unawaited(player.dispose());
   }
 
   /// Disposes the active media_kit Player for graceful shutdown.
@@ -148,7 +203,7 @@ class AudioPlayerController extends _$AudioPlayerController {
   /// Sets the audio note to play and opens the media file.
   Future<void> setAudioNote(JournalAudio audioNote) async {
     try {
-      if (state.audioNote == audioNote) {
+      if (state.audioNote == audioNote && _hasOpenAudio) {
         return;
       }
 
@@ -156,7 +211,7 @@ class AudioPlayerController extends _$AudioPlayerController {
       _completionTimer?.cancel();
       _completionTimer = null;
 
-      final player = _audioPlayer;
+      final player = _ensurePlayer();
       if (player == null) return;
 
       final localPath = await AudioUtils.getFullAudioPath(audioNote);
@@ -167,6 +222,7 @@ class AudioPlayerController extends _$AudioPlayerController {
       );
       state = newState;
       await player.open(Media(localPath), play: false);
+      _hasOpenAudio = true;
       final totalDuration = player.state.duration;
       state = state.copyWith(totalDuration: totalDuration);
     } catch (exception, stackTrace) {
@@ -182,8 +238,20 @@ class AudioPlayerController extends _$AudioPlayerController {
   /// Starts or resumes playback.
   Future<void> play() async {
     try {
-      final player = _audioPlayer;
+      final player = _ensurePlayer();
       if (player == null) return;
+
+      // After a completion-driven teardown the Player will have been
+      // recreated above without any media loaded. Reopen the previously
+      // selected audio note so the user can transparently replay.
+      if (!_hasOpenAudio) {
+        final audioNote = state.audioNote;
+        if (audioNote != null) {
+          final localPath = await AudioUtils.getFullAudioPath(audioNote);
+          await player.open(Media(localPath), play: false);
+          _hasOpenAudio = true;
+        }
+      }
 
       await player.setRate(state.speed);
       await player.play();
@@ -201,7 +269,7 @@ class AudioPlayerController extends _$AudioPlayerController {
   /// Seeks to the specified position.
   Future<void> seek(Duration newPosition) async {
     try {
-      final player = _audioPlayer;
+      final player = _ensurePlayer();
       if (player == null) return;
 
       await player.seek(newPosition);
@@ -232,7 +300,7 @@ class AudioPlayerController extends _$AudioPlayerController {
   /// Sets the playback speed.
   Future<void> setSpeed(double speed) async {
     try {
-      final player = _audioPlayer;
+      final player = _ensurePlayer();
       if (player == null) return;
 
       await player.setRate(speed);
@@ -250,7 +318,7 @@ class AudioPlayerController extends _$AudioPlayerController {
   /// Pauses playback.
   Future<void> pause() async {
     try {
-      final player = _audioPlayer;
+      final player = _ensurePlayer();
       if (player == null) return;
 
       await player.pause();
@@ -290,8 +358,15 @@ class AudioPlayerController extends _$AudioPlayerController {
         _completionTimer = null;
         // Verify the audio note hasn't been replaced before updating progress
         if (state.audioNote?.meta.id == capturedId) {
-          state = state.copyWith(progress: duration);
+          state = state.copyWith(
+            progress: duration,
+            status: AudioPlayerStatus.stopped,
+          );
         }
+        // Tear down the live Player after playback completes so mpv's
+        // core thread shuts down. State (audioNote/totalDuration) is
+        // preserved so the next play() transparently reopens the file.
+        _tearDownActivePlayer();
       },
     );
   }

--- a/lib/features/speech/state/audio_player_controller.dart
+++ b/lib/features/speech/state/audio_player_controller.dart
@@ -76,13 +76,11 @@ class AudioPlayerController extends _$AudioPlayerController {
   void _initLogging() {
     try {
       _loggingService = getIt<LoggingService>();
-    } catch (exception, stackTrace) {
-      _loggingService?.captureException(
-        exception,
-        domain: 'audio_player_controller',
-        subDomain: 'init',
-        stackTrace: stackTrace,
-      );
+    } catch (_) {
+      // No LoggingService registered — nothing we can log this miss to.
+      // Production startup always registers it, so this catch is purely
+      // defensive against test/dev edge cases where the controller is
+      // constructed before service wiring.
     }
   }
 
@@ -92,17 +90,25 @@ class AudioPlayerController extends _$AudioPlayerController {
   /// Player construction spins up mpv's native `core_thread`. Deferring it
   /// until the user actually triggers playback keeps Flutter hot restart
   /// safe in any session where audio is never opened.
+  ///
+  /// Subscriptions are wired *before* caching the instance so a failure
+  /// midway through never leaves a half-initialized player visible to later
+  /// callers; on failure the partially-constructed player is disposed.
   Player? _ensurePlayer() {
     final existing = _audioPlayer;
     if (existing != null) return existing;
+    Player? createdPlayer;
     try {
       final factory = ref.read(playerFactoryProvider);
-      final player = factory();
+      final player = createdPlayer = factory();
+      _setupSubscriptions(player);
       _audioPlayer = player;
       _activePlayer = player;
-      _setupSubscriptions(player);
       return player;
     } catch (exception, stackTrace) {
+      if (createdPlayer != null) {
+        unawaited(createdPlayer.dispose());
+      }
       _loggingService?.captureException(
         exception,
         domain: 'audio_player_controller',
@@ -238,6 +244,12 @@ class AudioPlayerController extends _$AudioPlayerController {
   /// Starts or resumes playback.
   Future<void> play() async {
     try {
+      // If a completion-delay timer from the previous run is still pending
+      // it would otherwise fire mid-replay, tearing down the freshly
+      // resumed player and flipping state back to stopped.
+      _completionTimer?.cancel();
+      _completionTimer = null;
+
       final player = _ensurePlayer();
       if (player == null) return;
 
@@ -250,6 +262,20 @@ class AudioPlayerController extends _$AudioPlayerController {
           final localPath = await AudioUtils.getFullAudioPath(audioNote);
           await player.open(Media(localPath), play: false);
           _hasOpenAudio = true;
+
+          // Sync total duration from the actual media file in case it
+          // diverges from the metadata stored on the audio note.
+          final totalDuration = player.state.duration;
+          state = state.copyWith(totalDuration: totalDuration);
+
+          // Restore mid-track progress so a seek performed while the
+          // player was torn down (or a partial-listen pause) is preserved
+          // on replay. Progress at the very end of the track is treated
+          // as a request to restart from the beginning.
+          final progress = state.progress;
+          if (progress > Duration.zero && progress < state.totalDuration) {
+            await player.seek(progress);
+          }
         }
       }
 
@@ -272,7 +298,13 @@ class AudioPlayerController extends _$AudioPlayerController {
       final player = _ensurePlayer();
       if (player == null) return;
 
-      await player.seek(newPosition);
+      // After a completion-driven teardown the Player has no media loaded
+      // yet; calling player.seek before player.open is undefined. The
+      // requested position is still recorded in state and will be applied
+      // when play() reopens the file (see the reopen branch in play).
+      if (_hasOpenAudio) {
+        await player.seek(newPosition);
+      }
       final newBuffered = newPosition > state.buffered
           ? newPosition
           : state.buffered;
@@ -390,5 +422,14 @@ class AudioPlayerController extends _$AudioPlayerController {
   @visibleForTesting
   set stateForTest(AudioPlayerState newState) {
     state = newState;
+  }
+
+  /// Pretends an audio file is already opened on the underlying Player so
+  /// methods that gate on [_hasOpenAudio] (e.g. [seek]) exercise their
+  /// file-loaded path without going through [setAudioNote] (which requires
+  /// a real path resolvable by [AudioUtils.getFullAudioPath]).
+  @visibleForTesting
+  set hasOpenAudioForTest(bool value) {
+    _hasOpenAudio = value;
   }
 }

--- a/lib/features/speech/state/audio_player_controller.g.dart
+++ b/lib/features/speech/state/audio_player_controller.g.dart
@@ -57,6 +57,15 @@ String _$playerFactoryHash() => r'97fc3a12db5c97e405602b8ed38fdb574808a6ca';
 /// Notifier managing audio player state.
 /// Marked as keepAlive since audio state should persist for the entire app
 /// lifecycle.
+///
+/// The underlying media_kit [Player] is created lazily on the first
+/// `setAudioNote`/`play` call and torn down again when playback completes.
+/// Keeping the native mpv core thread out of memory between active sessions
+/// makes Flutter hot restart safe whenever audio is not actively playing.
+/// (mpv's `core_thread` invokes FFI callbacks asynchronously; if the Dart
+/// VM is torn down by hot restart while the thread is alive, the trampolines
+/// it calls into are gone and the process aborts with
+/// "Callback invoked after it has been deleted".)
 
 @ProviderFor(AudioPlayerController)
 final audioPlayerControllerProvider = AudioPlayerControllerProvider._();
@@ -64,11 +73,29 @@ final audioPlayerControllerProvider = AudioPlayerControllerProvider._();
 /// Notifier managing audio player state.
 /// Marked as keepAlive since audio state should persist for the entire app
 /// lifecycle.
+///
+/// The underlying media_kit [Player] is created lazily on the first
+/// `setAudioNote`/`play` call and torn down again when playback completes.
+/// Keeping the native mpv core thread out of memory between active sessions
+/// makes Flutter hot restart safe whenever audio is not actively playing.
+/// (mpv's `core_thread` invokes FFI callbacks asynchronously; if the Dart
+/// VM is torn down by hot restart while the thread is alive, the trampolines
+/// it calls into are gone and the process aborts with
+/// "Callback invoked after it has been deleted".)
 final class AudioPlayerControllerProvider
     extends $NotifierProvider<AudioPlayerController, AudioPlayerState> {
   /// Notifier managing audio player state.
   /// Marked as keepAlive since audio state should persist for the entire app
   /// lifecycle.
+  ///
+  /// The underlying media_kit [Player] is created lazily on the first
+  /// `setAudioNote`/`play` call and torn down again when playback completes.
+  /// Keeping the native mpv core thread out of memory between active sessions
+  /// makes Flutter hot restart safe whenever audio is not actively playing.
+  /// (mpv's `core_thread` invokes FFI callbacks asynchronously; if the Dart
+  /// VM is torn down by hot restart while the thread is alive, the trampolines
+  /// it calls into are gone and the process aborts with
+  /// "Callback invoked after it has been deleted".)
   AudioPlayerControllerProvider._()
     : super(
         from: null,
@@ -97,11 +124,20 @@ final class AudioPlayerControllerProvider
 }
 
 String _$audioPlayerControllerHash() =>
-    r'c601610d29f1729eb71ee51d7c7678e3c4ad249b';
+    r'20ac72444988e23f4319261fba05b43f15ff0f9f';
 
 /// Notifier managing audio player state.
 /// Marked as keepAlive since audio state should persist for the entire app
 /// lifecycle.
+///
+/// The underlying media_kit [Player] is created lazily on the first
+/// `setAudioNote`/`play` call and torn down again when playback completes.
+/// Keeping the native mpv core thread out of memory between active sessions
+/// makes Flutter hot restart safe whenever audio is not actively playing.
+/// (mpv's `core_thread` invokes FFI callbacks asynchronously; if the Dart
+/// VM is torn down by hot restart while the thread is alive, the trampolines
+/// it calls into are gone and the process aborts with
+/// "Callback invoked after it has been deleted".)
 
 abstract class _$AudioPlayerController extends $Notifier<AudioPlayerState> {
   AudioPlayerState build();

--- a/lib/features/speech/state/recorder_controller.dart
+++ b/lib/features/speech/state/recorder_controller.dart
@@ -686,7 +686,16 @@ class AudioRecorderController extends _$AudioRecorderController {
 
   /// Pauses any currently playing audio. Shared between [record] and
   /// [recordRealtime].
+  ///
+  /// Skips reading the provider if it hasn't been initialized yet — reading it
+  /// would eagerly construct a media_kit `Player` (and its native mpv core
+  /// thread) just to observe that nothing is playing. That makes every
+  /// subsequent hot restart crash on macOS, since mpv's core thread outlives
+  /// the Dart isolate teardown.
   Future<void> _pauseAudioPlayer() async {
+    if (!ref.exists(audioPlayerControllerProvider)) {
+      return;
+    }
     try {
       final playerState = ref.read(audioPlayerControllerProvider);
       if (playerState.status == AudioPlayerStatus.playing) {

--- a/lib/features/speech/state/recorder_controller.g.dart
+++ b/lib/features/speech/state/recorder_controller.g.dart
@@ -69,7 +69,7 @@ final class AudioRecorderControllerProvider
 }
 
 String _$audioRecorderControllerHash() =>
-    r'15607fb0393f0b0ff7d9a249c76f3f130e17c3a8';
+    r'12e85c27a573e8c00ea67694ba33ca29c4c5fa0c';
 
 /// Main controller for audio recording functionality.
 ///

--- a/test/features/speech/state/audio_player_controller_test.dart
+++ b/test/features/speech/state/audio_player_controller_test.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: cascade_invocations
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -57,6 +58,12 @@ void main() {
       getIt.unregister<LoggingService>();
     }
     getIt.registerSingleton<LoggingService>(mockLoggingService);
+
+    // AudioUtils.getFullAudioPath -> getDocumentsDirectory() -> getIt<Directory>
+    if (getIt.isRegistered<Directory>()) {
+      getIt.unregister<Directory>();
+    }
+    getIt.registerSingleton<Directory>(Directory.systemTemp);
 
     // Setup mock player state
     when(() => mockPlayer.state).thenReturn(mockPlayerState);
@@ -246,6 +253,40 @@ void main() {
       verify(() => mockPlayerStream.buffer).called(1);
       verify(() => mockPlayerStream.completed).called(1);
     });
+
+    test(
+      'disposes the player and does not cache it when subscription wiring '
+      'throws',
+      () async {
+        final brokenStream = MockPlayerStream();
+        final brokenPlayer = MockPlayer();
+        when(() => brokenPlayer.stream).thenReturn(brokenStream);
+        when(brokenPlayer.dispose).thenAnswer((_) async {});
+        // First stream access during _setupSubscriptions throws — simulating
+        // a wiring failure midway through construction.
+        when(() => brokenStream.position).thenThrow(
+          Exception('stream wiring failure'),
+        );
+
+        final brokenContainer = ProviderContainer(
+          overrides: [
+            playerFactoryProvider.overrideWithValue(() => brokenPlayer),
+          ],
+        );
+        addTearDown(brokenContainer.dispose);
+
+        final controller = brokenContainer.read(
+          audioPlayerControllerProvider.notifier,
+        )..ensurePlayerForTest();
+
+        // The partially-constructed player must be disposed so no native mpv
+        // core thread is leaked, and a follow-up call must NOT see the
+        // half-initialized instance — it should retry the factory.
+        verify(brokenPlayer.dispose).called(1);
+        controller.ensurePlayerForTest();
+        verify(() => brokenStream.position).called(2);
+      },
+    );
   });
 
   group('AudioPlayerController - Stream Updates', () {
@@ -397,6 +438,172 @@ void main() {
 
       verify(() => mockPlayer.play()).called(1);
     });
+
+    test('cancels a pending completion timer to avoid race', () {
+      fakeAsync((async) {
+        final controller = container.read(
+          audioPlayerControllerProvider.notifier,
+        )..ensurePlayerForTest();
+
+        // Use a delay long enough that we can definitively observe it has
+        // been cancelled (rather than races vs. the play() future).
+        controller.completionDelayForTest = const Duration(seconds: 1);
+
+        // State with an audioNote so the completion handler arms its timer.
+        controller.stateForTest = AudioPlayerState(
+          status: AudioPlayerStatus.playing,
+          totalDuration: const Duration(minutes: 5),
+          audioNote: JournalAudio(
+            meta: Metadata(
+              id: 'race-audio-id',
+              createdAt: DateTime(2024, 1, 15),
+              updatedAt: DateTime(2024, 1, 15),
+              dateFrom: DateTime(2024, 1, 15),
+              dateTo: DateTime(2024, 1, 15),
+            ),
+            data: AudioData(
+              audioFile: 'race.m4a',
+              audioDirectory: '/test/path',
+              duration: const Duration(minutes: 3),
+              dateTo: DateTime(2024, 1, 15),
+              dateFrom: DateTime(2024, 1, 15),
+            ),
+          ),
+        );
+
+        controller.handleCompletedForTest(isCompleted: true);
+        async.flushMicrotasks();
+
+        // User taps play before the completion-delay timer has fired.
+        controller.play();
+        async.flushMicrotasks();
+
+        // Advance well past the delay; the cancelled timer must NOT fire,
+        // so neither the "stopped" status flip nor the player teardown
+        // happens, and playback remains alive.
+        async.elapse(const Duration(seconds: 2));
+
+        final state = container.read(audioPlayerControllerProvider);
+        expect(state.status, equals(AudioPlayerStatus.playing));
+        verifyNever(() => mockPlayer.dispose());
+      });
+    });
+
+    test('reopens media and restores progress after teardown', () async {
+      final controller = container.read(audioPlayerControllerProvider.notifier);
+      final audioNote = JournalAudio(
+        meta: Metadata(
+          id: 'restore-audio-id',
+          createdAt: DateTime(2024, 1, 15),
+          updatedAt: DateTime(2024, 1, 15),
+          dateFrom: DateTime(2024, 1, 15),
+          dateTo: DateTime(2024, 1, 15),
+        ),
+        data: AudioData(
+          audioFile: 'restore.m4a',
+          audioDirectory: '/test/path',
+          duration: const Duration(minutes: 5),
+          dateTo: DateTime(2024, 1, 15),
+          dateFrom: DateTime(2024, 1, 15),
+        ),
+      );
+
+      // Simulate the post-teardown state: an audio note is selected, mid-track
+      // progress is recorded, but the underlying Player has not been built.
+      controller.stateForTest = AudioPlayerState(
+        status: AudioPlayerStatus.stopped,
+        totalDuration: const Duration(minutes: 5),
+        progress: const Duration(seconds: 90),
+        audioNote: audioNote,
+      );
+
+      await controller.play();
+
+      // Reopen happens, total duration is synced from the (mocked) file, and
+      // the recorded progress is restored before playback resumes.
+      verify(
+        () => mockPlayer.open(any(), play: false),
+      ).called(1);
+      verify(() => mockPlayer.seek(const Duration(seconds: 90))).called(1);
+      verify(() => mockPlayer.play()).called(1);
+    });
+
+    test('does not seek when reopened progress is at the very end', () async {
+      final controller = container.read(audioPlayerControllerProvider.notifier);
+      final audioNote = JournalAudio(
+        meta: Metadata(
+          id: 'finished-audio-id',
+          createdAt: DateTime(2024, 1, 15),
+          updatedAt: DateTime(2024, 1, 15),
+          dateFrom: DateTime(2024, 1, 15),
+          dateTo: DateTime(2024, 1, 15),
+        ),
+        data: AudioData(
+          audioFile: 'finished.m4a',
+          audioDirectory: '/test/path',
+          duration: const Duration(minutes: 5),
+          dateTo: DateTime(2024, 1, 15),
+          dateFrom: DateTime(2024, 1, 15),
+        ),
+      );
+
+      // Mock state.duration is 5 minutes (see the shared setUp). After natural
+      // completion progress equals totalDuration; replay should restart from
+      // the beginning, NOT seek to the end.
+      controller.stateForTest = AudioPlayerState(
+        status: AudioPlayerStatus.stopped,
+        totalDuration: const Duration(minutes: 5),
+        progress: const Duration(minutes: 5),
+        audioNote: audioNote,
+      );
+
+      await controller.play();
+
+      verify(() => mockPlayer.open(any(), play: false)).called(1);
+      verifyNever(() => mockPlayer.seek(any()));
+    });
+  });
+
+  group('AudioPlayerController - setAudioNote()', () {
+    final audioNote = JournalAudio(
+      meta: Metadata(
+        id: 'open-audio-id',
+        createdAt: DateTime(2024, 1, 15),
+        updatedAt: DateTime(2024, 1, 15),
+        dateFrom: DateTime(2024, 1, 15),
+        dateTo: DateTime(2024, 1, 15),
+      ),
+      data: AudioData(
+        audioFile: 'open.m4a',
+        audioDirectory: '/test/path',
+        duration: const Duration(minutes: 3),
+        dateTo: DateTime(2024, 1, 15),
+        dateFrom: DateTime(2024, 1, 15),
+      ),
+    );
+
+    test('opens the media and syncs duration from the player', () async {
+      final controller = container.read(audioPlayerControllerProvider.notifier);
+
+      await controller.setAudioNote(audioNote);
+
+      verify(() => mockPlayer.open(any(), play: false)).called(1);
+      final state = container.read(audioPlayerControllerProvider);
+      // mockPlayer.state.duration is wired to 5 minutes in setUp; that
+      // value should win over the metadata-supplied 3 minutes.
+      expect(state.audioNote, equals(audioNote));
+      expect(state.totalDuration, equals(const Duration(minutes: 5)));
+      expect(state.status, equals(AudioPlayerStatus.stopped));
+    });
+
+    test('skips reopening when the same note is already loaded', () async {
+      final controller = container.read(audioPlayerControllerProvider.notifier);
+
+      await controller.setAudioNote(audioNote);
+      await controller.setAudioNote(audioNote);
+
+      verify(() => mockPlayer.open(any(), play: false)).called(1);
+    });
   });
 
   group('AudioPlayerController - pause()', () {
@@ -438,7 +645,8 @@ void main() {
 
   group('AudioPlayerController - seek()', () {
     test('updates progress to seek position', () async {
-      final controller = container.read(audioPlayerControllerProvider.notifier);
+      final controller = container.read(audioPlayerControllerProvider.notifier)
+        ..hasOpenAudioForTest = true;
 
       await controller.seek(const Duration(seconds: 90));
 
@@ -447,7 +655,8 @@ void main() {
     });
 
     test('updates pausedAt to seek position', () async {
-      final controller = container.read(audioPlayerControllerProvider.notifier);
+      final controller = container.read(audioPlayerControllerProvider.notifier)
+        ..hasOpenAudioForTest = true;
 
       await controller.seek(const Duration(seconds: 90));
 
@@ -456,7 +665,8 @@ void main() {
     });
 
     test('updates buffered when seeking beyond current buffered', () async {
-      final controller = container.read(audioPlayerControllerProvider.notifier);
+      final controller = container.read(audioPlayerControllerProvider.notifier)
+        ..hasOpenAudioForTest = true;
 
       // Current buffered is 0, seeking to 90 should update buffered
       await controller.seek(const Duration(seconds: 90));
@@ -467,9 +677,12 @@ void main() {
 
     test('preserves buffered when seeking backward', () {
       fakeAsync((async) {
-        final controller = container.read(
-          audioPlayerControllerProvider.notifier,
-        )..ensurePlayerForTest();
+        final controller =
+            container.read(
+                audioPlayerControllerProvider.notifier,
+              )
+              ..ensurePlayerForTest()
+              ..hasOpenAudioForTest = true;
 
         // Set buffer ahead
         bufferController.add(const Duration(seconds: 120));
@@ -486,11 +699,27 @@ void main() {
     });
 
     test('calls player.seek()', () async {
-      final controller = container.read(audioPlayerControllerProvider.notifier);
+      final controller = container.read(audioPlayerControllerProvider.notifier)
+        ..hasOpenAudioForTest = true;
 
       await controller.seek(const Duration(seconds: 90));
 
       verify(() => mockPlayer.seek(const Duration(seconds: 90))).called(1);
+    });
+
+    test('skips player.seek when no audio is open', () async {
+      final controller = container.read(audioPlayerControllerProvider.notifier);
+
+      // _hasOpenAudio defaults to false (no setAudioNote yet). seek() should
+      // still record the new position in state so play()'s reopen branch can
+      // restore it, but it must not call player.seek on a fileless player.
+      await controller.seek(const Duration(seconds: 30));
+
+      verifyNever(() => mockPlayer.seek(any()));
+      expect(
+        container.read(audioPlayerControllerProvider).progress,
+        equals(const Duration(seconds: 30)),
+      );
     });
 
     test('does not emit when all values unchanged', () async {
@@ -502,16 +731,11 @@ void main() {
         fireImmediately: true,
       );
 
-      await container
-          .read(audioPlayerControllerProvider.notifier)
-          .seek(
-            const Duration(seconds: 45),
-          );
-      await container
-          .read(audioPlayerControllerProvider.notifier)
-          .seek(
-            const Duration(seconds: 45),
-          );
+      final controller = container.read(audioPlayerControllerProvider.notifier)
+        ..hasOpenAudioForTest = true;
+
+      await controller.seek(const Duration(seconds: 45));
+      await controller.seek(const Duration(seconds: 45));
 
       // Should have: initial + first seek = 2 states
       // Second seek with same values should not emit
@@ -1188,7 +1412,7 @@ void main() {
 
       final controller = localContainer.read(
         audioPlayerControllerProvider.notifier,
-      );
+      )..hasOpenAudioForTest = true;
       await controller.seek(const Duration(seconds: 30));
 
       verify(

--- a/test/features/speech/state/audio_player_controller_test.dart
+++ b/test/features/speech/state/audio_player_controller_test.dart
@@ -215,11 +215,33 @@ void main() {
       expect(state.buffered, equals(Duration.zero));
     });
 
-    test('creates player using factory', () {
-      // Reading provider triggers initialization
+    test('creates player and wires streams on first ensure', () {
+      // Reading the provider alone does NOT create a player — the Player
+      // is constructed lazily so that the native mpv core thread is not
+      // spun up in sessions that never actually trigger playback.
       container.read(audioPlayerControllerProvider);
+      verifyNever(() => mockPlayerStream.position);
+      verifyNever(() => mockPlayerStream.buffer);
+      verifyNever(() => mockPlayerStream.completed);
 
-      // Verify streams were accessed for subscriptions
+      // Triggering lazy construction wires the subscriptions.
+      container
+          .read(audioPlayerControllerProvider.notifier)
+          .ensurePlayerForTest();
+      verify(() => mockPlayerStream.position).called(1);
+      verify(() => mockPlayerStream.buffer).called(1);
+      verify(() => mockPlayerStream.completed).called(1);
+    });
+
+    test('ensurePlayerForTest is idempotent', () {
+      final controller = container.read(
+        audioPlayerControllerProvider.notifier,
+      );
+      controller
+        ..ensurePlayerForTest()
+        ..ensurePlayerForTest()
+        ..ensurePlayerForTest();
+      // Subscriptions should only be wired once even across repeated calls.
       verify(() => mockPlayerStream.position).called(1);
       verify(() => mockPlayerStream.buffer).called(1);
       verify(() => mockPlayerStream.completed).called(1);
@@ -229,8 +251,11 @@ void main() {
   group('AudioPlayerController - Stream Updates', () {
     test('position stream updates progress', () {
       fakeAsync((async) {
-        // Initialize controller
-        container.read(audioPlayerControllerProvider);
+        // Initialize controller and force lazy player construction so the
+        // streams are subscribed.
+        container
+            .read(audioPlayerControllerProvider.notifier)
+            .ensurePlayerForTest();
 
         // Emit position update
         positionController.add(const Duration(seconds: 30));
@@ -246,7 +271,7 @@ void main() {
         // Initialize controller and set total duration
         final controller = container.read(
           audioPlayerControllerProvider.notifier,
-        );
+        )..ensurePlayerForTest();
         controller.updateProgress(Duration.zero); // Trigger initial state
 
         // Emit very large position (should not clamp when totalDuration is zero)
@@ -261,8 +286,10 @@ void main() {
 
     test('buffer stream updates buffered amount', () {
       fakeAsync((async) {
-        // Initialize controller
-        container.read(audioPlayerControllerProvider);
+        // Initialize controller and force lazy player construction.
+        container
+            .read(audioPlayerControllerProvider.notifier)
+            .ensurePlayerForTest();
 
         // Emit buffer update
         bufferController.add(const Duration(seconds: 60));
@@ -275,8 +302,10 @@ void main() {
 
     test('buffer stream clamps to totalDuration when exceeding', () {
       fakeAsync((async) {
-        // Initialize controller
-        container.read(audioPlayerControllerProvider);
+        // Initialize controller and force lazy player construction.
+        container
+            .read(audioPlayerControllerProvider.notifier)
+            .ensurePlayerForTest();
 
         // When totalDuration is zero, no clamping occurs
         bufferController.add(const Duration(hours: 5));
@@ -296,6 +325,11 @@ void main() {
           (previous, next) => states.add(next),
           fireImmediately: true,
         );
+
+        // Force lazy player construction to wire stream subscriptions.
+        container
+            .read(audioPlayerControllerProvider.notifier)
+            .ensurePlayerForTest();
 
         // Emit same progress twice
         positionController.add(const Duration(seconds: 30));
@@ -319,6 +353,11 @@ void main() {
           (previous, next) => states.add(next),
           fireImmediately: true,
         );
+
+        // Force lazy player construction to wire stream subscriptions.
+        container
+            .read(audioPlayerControllerProvider.notifier)
+            .ensurePlayerForTest();
 
         // Emit same buffer twice
         bufferController.add(const Duration(seconds: 60));
@@ -374,7 +413,7 @@ void main() {
       fakeAsync((async) {
         final controller = container.read(
           audioPlayerControllerProvider.notifier,
-        );
+        )..ensurePlayerForTest();
 
         // Set progress first
         positionController.add(const Duration(seconds: 45));
@@ -430,7 +469,7 @@ void main() {
       fakeAsync((async) {
         final controller = container.read(
           audioPlayerControllerProvider.notifier,
-        );
+        )..ensurePlayerForTest();
 
         // Set buffer ahead
         bufferController.add(const Duration(seconds: 120));
@@ -532,7 +571,8 @@ void main() {
 
   group('AudioPlayerController - completion handling', () {
     test('handles completion event with delay', () async {
-      final controller = container.read(audioPlayerControllerProvider.notifier);
+      final controller = container.read(audioPlayerControllerProvider.notifier)
+        ..ensurePlayerForTest();
 
       // Set a short delay for testing
       controller.completionDelayForTest = const Duration(milliseconds: 10);
@@ -542,8 +582,10 @@ void main() {
       expect(controller.completedSubscription, isNotNull);
     });
 
-    test('completion subscription is set up', () {
-      container.read(audioPlayerControllerProvider);
+    test('completion subscription is set up after lazy ensure', () {
+      container
+          .read(audioPlayerControllerProvider.notifier)
+          .ensurePlayerForTest();
 
       verify(() => mockPlayerStream.completed).called(1);
     });
@@ -610,7 +652,7 @@ void main() {
       fakeAsync((async) {
         final controller = container.read(
           audioPlayerControllerProvider.notifier,
-        );
+        )..ensurePlayerForTest();
 
         positionController.add(Duration.zero);
         bufferController.add(Duration.zero);
@@ -627,8 +669,10 @@ void main() {
 
     test('handles very large durations', () {
       fakeAsync((async) {
-        // Initialize controller first
-        container.read(audioPlayerControllerProvider);
+        // Initialize controller and force lazy player construction.
+        container
+            .read(audioPlayerControllerProvider.notifier)
+            .ensurePlayerForTest();
 
         positionController.add(const Duration(hours: 999));
         async.flushMicrotasks();
@@ -642,8 +686,10 @@ void main() {
 
     test('clamps progress to totalDuration when exceeding', () {
       fakeAsync((async) {
-        // Initialize controller
-        container.read(audioPlayerControllerProvider);
+        // Initialize controller and force lazy player construction.
+        container
+            .read(audioPlayerControllerProvider.notifier)
+            .ensurePlayerForTest();
 
         // The test verifies the clamping logic in updateProgress
         // When position exceeds totalDuration and totalDuration > 0, it clamps
@@ -660,8 +706,10 @@ void main() {
 
     test('clamps buffer to totalDuration when exceeding', () {
       fakeAsync((async) {
-        // Initialize controller
-        container.read(audioPlayerControllerProvider);
+        // Initialize controller and force lazy player construction.
+        container
+            .read(audioPlayerControllerProvider.notifier)
+            .ensurePlayerForTest();
 
         // Emit buffer updates
         bufferController.add(const Duration(seconds: 60));
@@ -676,8 +724,10 @@ void main() {
   group('AudioPlayerController - Completion Timer', () {
     test('handleCompleted ignores when isCompleted is false', () {
       fakeAsync((async) {
-        // Initialize controller
-        container.read(audioPlayerControllerProvider);
+        // Initialize controller and force lazy player construction.
+        container
+            .read(audioPlayerControllerProvider.notifier)
+            .ensurePlayerForTest();
 
         // Emit completed = false
         completedController.add(false);
@@ -719,8 +769,10 @@ void main() {
 
     test('handleCompleted ignores when audioNote duration is null', () {
       fakeAsync((async) {
-        // Initialize controller - no audioNote set, so duration is null
-        container.read(audioPlayerControllerProvider);
+        // Initialize controller and force lazy player construction.
+        container
+            .read(audioPlayerControllerProvider.notifier)
+            .ensurePlayerForTest();
 
         // Emit completion
         completedController.add(true);
@@ -849,7 +901,7 @@ void main() {
       fakeAsync((async) {
         final controller = container.read(
           audioPlayerControllerProvider.notifier,
-        );
+        )..ensurePlayerForTest();
 
         // Set state with totalDuration using test helper
         controller.stateForTest = const AudioPlayerState(
@@ -871,7 +923,7 @@ void main() {
       fakeAsync((async) {
         final controller = container.read(
           audioPlayerControllerProvider.notifier,
-        );
+        )..ensurePlayerForTest();
 
         // Set state with totalDuration using test helper
         controller.stateForTest = const AudioPlayerState(
@@ -893,7 +945,7 @@ void main() {
       fakeAsync((async) {
         final controller = container.read(
           audioPlayerControllerProvider.notifier,
-        );
+        )..ensurePlayerForTest();
 
         // Set state with totalDuration using test helper
         controller.stateForTest = const AudioPlayerState(
@@ -915,7 +967,7 @@ void main() {
       fakeAsync((async) {
         final controller = container.read(
           audioPlayerControllerProvider.notifier,
-        );
+        )..ensurePlayerForTest();
 
         // Set state with totalDuration using test helper
         controller.stateForTest = const AudioPlayerState(
@@ -998,22 +1050,41 @@ void main() {
       localContainer.dispose();
     });
 
-    test('init catches and logs exceptions when factory throws', () async {
-      final errorContainer = ProviderContainer(
-        overrides: [
-          playerFactoryProvider.overrideWithValue(() {
-            throw Exception('Factory failed');
-          }),
-        ],
-      );
+    test(
+      'ensurePlayer catches and logs exceptions when factory throws',
+      () async {
+        final localLoggingService = MockLoggingService();
+        if (getIt.isRegistered<LoggingService>()) {
+          getIt.unregister<LoggingService>();
+        }
+        getIt.registerSingleton<LoggingService>(localLoggingService);
 
-      // Reading the provider should trigger init which will catch the error
-      errorContainer.read(audioPlayerControllerProvider);
+        final errorContainer = ProviderContainer(
+          overrides: [
+            playerFactoryProvider.overrideWithValue(() {
+              throw Exception('Factory failed');
+            }),
+          ],
+        );
 
-      // Note: The exception is caught silently since _loggingService may be null
-      // before it's initialized. This is expected behavior.
-      errorContainer.dispose();
-    });
+        // build() no longer eagerly creates the Player, so the throw happens
+        // when we trigger lazy construction.
+        errorContainer
+            .read(audioPlayerControllerProvider.notifier)
+            .ensurePlayerForTest();
+
+        verify(
+          () => localLoggingService.captureException(
+            any<Object>(),
+            domain: 'audio_player_controller',
+            subDomain: 'ensurePlayer',
+            stackTrace: any<StackTrace>(named: 'stackTrace'),
+          ),
+        ).called(1);
+
+        errorContainer.dispose();
+      },
+    );
 
     test('pause catches and logs exceptions', () async {
       // Create isolated mocks for this test
@@ -1280,8 +1351,11 @@ void main() {
 
   group('AudioPlayerController - disposeActivePlayer', () {
     test('disposes the active player', () async {
-      // Initialize controller — sets _activePlayer
-      container.read(audioPlayerControllerProvider);
+      // Initialize controller and force lazy construction so _activePlayer
+      // is set.
+      container
+          .read(audioPlayerControllerProvider.notifier)
+          .ensurePlayerForTest();
 
       await AudioPlayerController.disposeActivePlayer();
 
@@ -1289,7 +1363,9 @@ void main() {
     });
 
     test('is idempotent — second call is a no-op', () async {
-      container.read(audioPlayerControllerProvider);
+      container
+          .read(audioPlayerControllerProvider.notifier)
+          .ensurePlayerForTest();
 
       await AudioPlayerController.disposeActivePlayer();
       await AudioPlayerController.disposeActivePlayer();
@@ -1349,13 +1425,15 @@ void main() {
         ],
       );
 
-      // Initialize the controller
-      testContainer.read(audioPlayerControllerProvider);
+      // Initialize the controller and force lazy player construction.
+      testContainer
+          .read(audioPlayerControllerProvider.notifier)
+          .ensurePlayerForTest();
 
       // Dispose the container
       testContainer.dispose();
 
-      // Verify player was disposed
+      // Verify player was disposed (via _cleanup → _disposeActivePlayer).
       verify(() => mockPlayer.dispose()).called(1);
     });
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Player is now created lazily and torn down more reliably, preventing lingering native threads, avoiding unnecessary player creation when pausing, and better preserving playback progress when reopening audio — improving stability and resource usage.

* **Tests**
  * Added and updated tests to cover lazy player lifecycle, subscription wiring, seek behavior when no audio is open, completion/reopen cases, and explicit test helpers for controlled player setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->