### PR TITLE
ci: add GitHub Action for macOS DMG release

### DIFF
--- a/.github/workflows/flutter-macos-release.yml
+++ b/.github/workflows/flutter-macos-release.yml
@@ -1,0 +1,230 @@
+name: Flutter macOS Release
+
+on:
+  push:
+    tags:
+      - '**'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-macos:
+    name: Build macOS
+    runs-on: macos-14
+    timeout-minutes: 90
+    env:
+      KEYCHAIN_NAME: build.keychain-db
+      ARCHIVE_PATH: build/macos/archive/Runner.xcarchive
+      EXPORT_PATH: build/macos/export
+      DMG_PATH: build/macos/Lotti.dmg
+    steps:
+      - name: Record build start time
+        id: start_time
+        run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v5
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_15.4.app
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: x86_64-apple-darwin,aarch64-apple-darwin
+
+      - uses: kuhnroyal/flutter-fvm-config-action@v2
+        id: fvm-config-action
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          cache: true
+
+      - name: Flutter pub get
+        run: flutter pub get
+
+      - name: Import code signing certificate
+        env:
+          MACOS_CERTIFICATE_BASE64: ${{ secrets.MACOS_CERTIFICATE_BASE64 }}
+          MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          CERT_PATH="$RUNNER_TEMP/cert.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/$KEYCHAIN_NAME"
+
+          echo "$MACOS_CERTIFICATE_BASE64" | base64 --decode > "$CERT_PATH"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          security import "$CERT_PATH" \
+            -P "$MACOS_CERTIFICATE_PASSWORD" \
+            -t cert -f pkcs12 -k "$KEYCHAIN_PATH" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security \
+            -T /usr/bin/xcodebuild
+
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Prepend the build keychain to the user search list so xcodebuild finds it.
+          security list-keychain -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+          security default-keychain -s "$KEYCHAIN_PATH"
+
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
+          rm -f "$CERT_PATH"
+
+      - name: Install provisioning profile
+        env:
+          MACOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.MACOS_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          set -euo pipefail
+          PROFILE_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
+          mkdir -p "$PROFILE_DIR"
+          echo "$MACOS_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$PROFILE_DIR/lotti_developerid.provisionprofile"
+          ls -la "$PROFILE_DIR"
+
+      - name: Write Developer ID exportOptions.plist
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          mkdir -p build/macos
+          cat > build/macos/exportOptions-developerid.plist <<PLIST
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>method</key>
+            <string>developer-id</string>
+            <key>teamID</key>
+            <string>${APPLE_TEAM_ID}</string>
+            <key>signingStyle</key>
+            <string>manual</string>
+            <key>destination</key>
+            <string>export</string>
+          </dict>
+          </plist>
+          PLIST
+
+      - name: Flutter build macOS (compile Dart + pods)
+        run: flutter build macos --release --no-codesign
+
+      - name: Archive with Xcode
+        run: |
+          set -euo pipefail
+          xcodebuild -workspace macos/Runner.xcworkspace \
+            -config Release \
+            -scheme Runner \
+            -archivePath "$ARCHIVE_PATH" \
+            archive
+
+      - name: Export signed .app (Developer ID)
+        run: |
+          set -euo pipefail
+          xcodebuild -exportArchive \
+            -archivePath "$ARCHIVE_PATH" \
+            -exportOptionsPlist build/macos/exportOptions-developerid.plist \
+            -exportPath "$EXPORT_PATH"
+          ls -la "$EXPORT_PATH"
+
+      - name: Notarize and staple .app
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          APP_PATH="$(find "$EXPORT_PATH" -maxdepth 2 -name '*.app' -print -quit)"
+          if [ -z "$APP_PATH" ]; then
+            echo "No .app found under $EXPORT_PATH" >&2
+            exit 1
+          fi
+          ZIP_PATH="$RUNNER_TEMP/Lotti-notarize.zip"
+          /usr/bin/ditto -c -k --keepParent "$APP_PATH" "$ZIP_PATH"
+          xcrun notarytool submit "$ZIP_PATH" \
+            --apple-id "$APPLE_ID" \
+            --team-id "$APPLE_TEAM_ID" \
+            --password "$APPLE_APP_PASSWORD" \
+            --wait
+          xcrun stapler staple "$APP_PATH"
+          rm -f "$ZIP_PATH"
+
+      - name: Build DMG
+        run: |
+          set -euo pipefail
+          APP_PATH="$(find "$EXPORT_PATH" -maxdepth 2 -name '*.app' -print -quit)"
+          DMG_STAGE="$RUNNER_TEMP/dmg-stage"
+          mkdir -p "$DMG_STAGE"
+          cp -R "$APP_PATH" "$DMG_STAGE/"
+          ln -s /Applications "$DMG_STAGE/Applications"
+          hdiutil create \
+            -volname "Lotti" \
+            -srcfolder "$DMG_STAGE" \
+            -ov -format UDZO \
+            "$DMG_PATH"
+
+      - name: Notarize and staple DMG
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          xcrun notarytool submit "$DMG_PATH" \
+            --apple-id "$APPLE_ID" \
+            --team-id "$APPLE_TEAM_ID" \
+            --password "$APPLE_APP_PASSWORD" \
+            --wait
+          xcrun stapler staple "$DMG_PATH"
+          spctl -a -vv -t install "$DMG_PATH" || true
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: macos-dmg
+          path: ${{ env.DMG_PATH }}
+
+      - name: Create GitHub Release
+        run: |
+          set -euo pipefail
+          if ! gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release create -p --generate-notes --target "$GITHUB_SHA" "$GITHUB_REF_NAME"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload DMG to GitHub Release
+        run: gh release upload "$GITHUB_REF_NAME" "$DMG_PATH" --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cleanup keychain
+        if: always()
+        run: |
+          security delete-keychain "$RUNNER_TEMP/$KEYCHAIN_NAME" || true
+          rm -f "$HOME/Library/MobileDevice/Provisioning Profiles/lotti_developerid.provisionprofile" || true
+
+      - name: Report build duration
+        if: always()
+        run: |
+          end=$(date +%s)
+          start=${{ steps.start_time.outputs.start }}
+          duration=$((end - start))
+          mins=$((duration / 60))
+          secs=$((duration % 60))
+          echo "Total build time: ${mins}m ${secs}s (${duration}s)"
+          echo "::notice title=macOS Build Duration::${mins}m ${secs}s"
+          echo "## macOS build duration" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**${mins}m ${secs}s** (${duration} seconds)" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/macos-release.md
+++ b/docs/macos-release.md
@@ -1,0 +1,128 @@
+# macOS Release
+
+This document covers the **GitHub Release** distribution path for Lotti macOS — a Developer ID signed and notarized `.dmg` produced automatically by `.github/workflows/flutter-macos-release.yml` whenever a tag is pushed.
+
+This is **separate** from the Mac App Store / TestFlight path, which is driven by `macos/fastlane/Fastfile` (`do_build` / `do_upload`) and uses an App Store distribution certificate via `match`. Do not mix the two — they use different certificates, different provisioning profiles, and different `exportOptions.plist` settings.
+
+| Path | Cert type | Profile type | Driver |
+|---|---|---|---|
+| GitHub Release `.dmg` | Developer ID Application | Developer ID | `flutter-macos-release.yml` |
+| TestFlight / MAS | Mac App Distribution | Mac App Store | `fastlane do_upload` |
+
+## Prerequisites
+
+- Apple Developer Program membership for team `7DN35ABWYL`.
+- Access to the developer portal at <https://developer.apple.com/account>.
+- A Mac with Xcode and Keychain Access for exporting credentials.
+
+## One-time setup
+
+### 1. Developer ID Application certificate
+
+If you don't already have a Developer ID Application certificate in the **login** keychain:
+
+1. In **Keychain Access**, choose `Certificate Assistant → Request a Certificate from a Certificate Authority`. Save the CSR to disk.
+2. In the developer portal, create a new certificate of type **Developer ID Application**. Upload the CSR. Download the resulting `.cer` and double-click to install.
+
+Export as `.p12`:
+
+1. Open **Keychain Access**, search for `Developer ID Application: Matthias Nehlsen (7DN35ABWYL)`.
+2. Expand the entry so the **private key** is visible.
+3. Select **both** the certificate and its private key (⌘-click).
+4. Right-click → **Export 2 items…** → save as `lotti-developerid.p12`.
+5. Set a strong password. This becomes `MACOS_CERTIFICATE_PASSWORD`.
+
+### 2. Developer ID provisioning profile
+
+In the developer portal:
+
+1. Navigate to **Profiles** → **+** → **Developer ID** (under Distribution, macOS).
+2. App ID: `com.matthiasn.lotti`.
+3. Include the application group `SS586VG7L7.lottiobx` (matches `macos/Runner/Release.entitlements`).
+4. Select the Developer ID Application certificate from step 1.
+5. Download as `lotti_developerid.provisionprofile`.
+
+### 3. App-specific password for notarytool
+
+1. Open <https://appleid.apple.com/account/manage>.
+2. Under **App-Specific Passwords**, generate a new password labelled e.g. `lotti-notary-ci`.
+3. Copy the value. This becomes `APPLE_APP_PASSWORD`.
+
+### 4. Base64 encode for GitHub Secrets
+
+Encode each file as a single unwrapped line. macOS BSD `base64` does not wrap by default; `-b 0` makes that intent explicit (and is harmless on systems whose `base64` does wrap):
+
+```bash
+base64 -b 0 -i lotti-developerid.p12              -o lotti-developerid.p12.b64
+base64 -b 0 -i lotti_developerid.provisionprofile -o lotti_developerid.provisionprofile.b64
+```
+
+To copy a value to the clipboard for pasting into the GitHub secret editor:
+
+```bash
+pbcopy < lotti-developerid.p12.b64
+```
+
+### 5. GitHub Secrets
+
+In the repository: **Settings → Secrets and variables → Actions → New repository secret**.
+
+| Secret name | Value |
+|---|---|
+| `MACOS_CERTIFICATE_BASE64` | contents of `lotti-developerid.p12.b64` |
+| `MACOS_CERTIFICATE_PASSWORD` | password used when exporting the `.p12` |
+| `MACOS_PROVISIONING_PROFILE_BASE64` | contents of `lotti_developerid.provisionprofile.b64` |
+| `MACOS_KEYCHAIN_PASSWORD` | any random string — only locks the temp keychain on the runner. Generate with `openssl rand -hex 24` |
+| `APPLE_ID` | Apple ID email used for notarization |
+| `APPLE_APP_PASSWORD` | app-specific password from step 3 |
+| `APPLE_TEAM_ID` | `7DN35ABWYL` |
+
+### 6. Local verification before pushing a tag
+
+```bash
+# Confirm the exported cert really is Developer ID Application:
+security find-certificate -c "Developer ID Application" -p login.keychain-db \
+  | openssl x509 -noout -subject -issuer
+
+# Inspect the provisioning profile:
+security cms -D -i lotti_developerid.provisionprofile | plutil -p - | head -40
+```
+
+Both should reference team `7DN35ABWYL` and bundle id `com.matthiasn.lotti`.
+
+After verification, **delete the unencoded `.p12` and `.provisionprofile` files from disk** — the encoded copies in GitHub Secrets are now the source of truth for CI.
+
+## Triggering a release
+
+Push a tag (any tag matches the workflow trigger):
+
+```bash
+git tag v0.X.Y
+git push origin v0.X.Y
+```
+
+The workflow will:
+
+1. Import the certificate into a temp keychain on the runner.
+2. Drop the provisioning profile into `~/Library/MobileDevice/Provisioning Profiles/`.
+3. Run `flutter build macos --release --no-codesign`, then `xcodebuild archive`, then `xcodebuild -exportArchive` with a generated `developer-id` `exportOptions.plist`.
+4. Notarize the `.app` with `notarytool submit --wait` and staple the ticket.
+5. Build `Lotti.dmg` via `hdiutil`.
+6. Notarize and staple the `.dmg`.
+7. Create a prerelease GitHub Release (`gh release create -p`) and upload the `.dmg`.
+8. Print the total build duration to logs and the job summary.
+
+The release is created as a **prerelease**. After all platform workflows (Android, Linux, macOS, …) finish, manually mark it as **latest** in the GitHub UI.
+
+## Rotating credentials
+
+- **Certificate expires** (every ~5 years for Developer ID): redo step 1, re-encode, update `MACOS_CERTIFICATE_BASE64` and `MACOS_CERTIFICATE_PASSWORD`.
+- **Provisioning profile expires**: redo step 2, re-encode, update `MACOS_PROVISIONING_PROFILE_BASE64`.
+- **App-specific password lost or revoked**: redo step 3, update `APPLE_APP_PASSWORD`.
+
+## Troubleshooting
+
+- **`errSecInternalComponent` during `xcodebuild archive`** — the imported key wasn't authorized for `codesign`. The workflow handles this via `security set-key-partition-list`; check that step's logs.
+- **`No matching profiles found`** — bundle id, team, or entitlements (notably `application-groups`) on the profile don't match `macos/Runner/Release.entitlements`. Recreate the profile.
+- **Notarization status `Invalid`** — fetch the log with `xcrun notarytool log <submission-id> --apple-id … --team-id … --password …`. Common causes: hardened runtime not enabled, unsigned helper binaries inside the app bundle, or use of disallowed entitlements for Developer ID.
+- **Gatekeeper still warns after install** — confirm the staple succeeded: `xcrun stapler validate Lotti.dmg` and `spctl -a -vv -t install Lotti.dmg`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated macOS release workflow that builds, signs, notarizes, packages (DMG), and publishes macOS app releases on tag push; uploads artifacts and creates GitHub Releases.
* **Documentation**
  * Added a macOS release guide covering prerequisites, one‑time setup, required secrets, verification steps, release triggering, credential rotation, and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->