### PR TITLE
fix: btm nav indicator spacing

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -9,13 +9,13 @@
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		4016230B4975ED50F0A482EF /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92D91E266C343C8D4FB2CAB2 /* Pods_Runner.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
-		AA0000011ED2DC5600515810 /* AudioConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000001ED2DC5600515810 /* AudioConverter.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		AA0000011ED2DC5600515810 /* AudioConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000001ED2DC5600515810 /* AudioConverter.swift */; };
 		ADB650B7270B3C4300B98C66 /* HealthKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADB650B6270B3C4300B98C66 /* HealthKit.framework */; };
-		FD4BDDFBB85CAB6754042A0B /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08CACAFD56E1EF268BBD8C5 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -32,15 +32,14 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		11F41E38CE9E80A57ADA494E /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
-		685F4B202801BD667A32A474 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		6E256A90A1AFDDA032DC9C3A /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		AA0000001ED2DC5600515810 /* AudioConverter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioConverter.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		92D91E266C343C8D4FB2CAB2 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -48,13 +47,14 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AA0000001ED2DC5600515810 /* AudioConverter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioConverter.swift; sourceTree = "<group>"; };
 		AD0869BB271438AF00225DF9 /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Base.xcconfig; path = Flutter/Base.xcconfig; sourceTree = "<group>"; };
 		ADAEC2742738A8F200996377 /* RunnerRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RunnerRelease.entitlements; sourceTree = "<group>"; };
 		ADB650B5270B3C4300B98C66 /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 		ADB650B6270B3C4300B98C66 /* HealthKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = HealthKit.framework; path = System/Library/Frameworks/HealthKit.framework; sourceTree = SDKROOT; };
 		ADEF534728103FDF00F29D25 /* RunnerDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RunnerDebug.entitlements; sourceTree = "<group>"; };
-		E08CACAFD56E1EF268BBD8C5 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		F9EF5E47E2CAAE216BAF45A3 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		BC40E945F234D175636388AB /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		EDEED4B2A55A1A98CCDDCF61 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -62,8 +62,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FD4BDDFBB85CAB6754042A0B /* Pods_Runner.framework in Frameworks */,
 				ADB650B7270B3C4300B98C66 /* HealthKit.framework in Frameworks */,
+				4016230B4975ED50F0A482EF /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -74,7 +74,7 @@
 			isa = PBXGroup;
 			children = (
 				ADB650B6270B3C4300B98C66 /* HealthKit.framework */,
-				E08CACAFD56E1EF268BBD8C5 /* Pods_Runner.framework */,
+				92D91E266C343C8D4FB2CAB2 /* Pods_Runner.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -132,9 +132,9 @@
 		DF94D6CF0EC47B3F5E5BE83B /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				F9EF5E47E2CAAE216BAF45A3 /* Pods-Runner.debug.xcconfig */,
-				685F4B202801BD667A32A474 /* Pods-Runner.release.xcconfig */,
-				11F41E38CE9E80A57ADA494E /* Pods-Runner.profile.xcconfig */,
+				6E256A90A1AFDDA032DC9C3A /* Pods-Runner.debug.xcconfig */,
+				EDEED4B2A55A1A98CCDDCF61 /* Pods-Runner.release.xcconfig */,
+				BC40E945F234D175636388AB /* Pods-Runner.profile.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -146,15 +146,15 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
-				3598D2361899188EA78E35FC /* [CP] Check Pods Manifest.lock */,
+				8F29E1474F0DC19574F2FC87 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
-				0FE883801761399A3CC470E1 /* [CP] Embed Pods Frameworks */,
-				637C45752F004DA6891FA4AA /* [CP] Copy Pods Resources */,
+				2926CBC8C9AB102C25753DEF /* [CP] Embed Pods Frameworks */,
+				ED55F12E71A54B2F4F51B1BD /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -213,7 +213,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		0FE883801761399A3CC470E1 /* [CP] Embed Pods Frameworks */ = {
+		2926CBC8C9AB102C25753DEF /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -230,7 +230,23 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		3598D2361899188EA78E35FC /* [CP] Check Pods Manifest.lock */ = {
+		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
+			);
+			name = "Thin Binary";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
+		};
+		8F29E1474F0DC19574F2FC87 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -252,23 +268,22 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
+		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
-				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
-			name = "Thin Binary";
+			name = "Run Script";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
 		};
-		637C45752F004DA6891FA4AA /* [CP] Copy Pods Resources */ = {
+		ED55F12E71A54B2F4F51B1BD /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -284,21 +299,6 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
 			showEnvVarsInLog = 0;
-		};
-		9740EEB61CF901F6004384FC /* Run Script */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Run Script";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -468,7 +468,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
-				ONLY_ACTIVE_ARCH = NO;
+				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/lib/beamer/beamer_app.dart
+++ b/lib/beamer/beamer_app.dart
@@ -51,10 +51,6 @@ class AppScreenConstants {
   static const double navigationPadding = 34;
   static const double navigationTimeIndicatorBottom = 0;
   static const double navigationAudioIndicatorRight = 100;
-
-  /// Amount by which the recording indicators visually overlap the top edge
-  /// of the bottom-nav pill so their flat bottoms tuck into it.
-  static const double navigationIndicatorPillOverlap = 6;
 }
 
 /// Check if the app is running inside Flatpak sandbox
@@ -456,9 +452,17 @@ class _AppScreenState extends ConsumerState<AppScreen> {
             onTap: () => navService.tapIndex(i),
           ),
       ],
+      overlay: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const TimeRecordingIndicator(),
+          const SizedBox(width: 4),
+          // Audio indicator is omitted on Flatpak builds (MediaKit
+          // compatibility issues).
+          if (!_isRunningInFlatpak()) const AudioRecordingIndicator(),
+        ],
+      ),
     );
-    final overlayBottomInset =
-        DesignSystemBottomNavigationBar.pillTopFromScreenBottom(context);
 
     return Scaffold(
       extendBody: true,
@@ -475,25 +479,6 @@ class _AppScreenState extends ConsumerState<AppScreen> {
             bottom: 0,
             child: designSystemBottomNavigationBar,
           ),
-          Positioned(
-            left: AppScreenConstants.navigationPadding,
-            bottom:
-                AppScreenConstants.navigationTimeIndicatorBottom +
-                overlayBottomInset -
-                AppScreenConstants.navigationIndicatorPillOverlap,
-            child: const TimeRecordingIndicator(),
-          ),
-          // Only show AudioRecordingIndicator when not running in Flatpak
-          // Flatpak builds have MediaKit compatibility issues
-          if (!_isRunningInFlatpak())
-            Positioned(
-              right: AppScreenConstants.navigationAudioIndicatorRight,
-              bottom:
-                  AppScreenConstants.navigationTimeIndicatorBottom +
-                  overlayBottomInset -
-                  AppScreenConstants.navigationIndicatorPillOverlap,
-              child: const AudioRecordingIndicator(),
-            ),
         ],
       ),
     );

--- a/lib/beamer/beamer_app.dart
+++ b/lib/beamer/beamer_app.dart
@@ -456,10 +456,13 @@ class _AppScreenState extends ConsumerState<AppScreen> {
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           const TimeRecordingIndicator(),
-          const SizedBox(width: 4),
           // Audio indicator is omitted on Flatpak builds (MediaKit
-          // compatibility issues).
-          if (!_isRunningInFlatpak()) const AudioRecordingIndicator(),
+          // compatibility issues). Spacer lives inside the same conditional
+          // so it doesn't dangle when only the time indicator is visible.
+          if (!_isRunningInFlatpak()) ...[
+            const SizedBox(width: 4),
+            const AudioRecordingIndicator(),
+          ],
         ],
       ),
     );

--- a/lib/widgets/misc/time_recording_indicator.dart
+++ b/lib/widgets/misc/time_recording_indicator.dart
@@ -67,8 +67,7 @@ class TimeRecordingIndicator extends ConsumerWidget {
               },
               child: MouseRegion(
                 cursor: SystemMouseCursors.click,
-                child: Material(
-                  elevation: 5,
+                child: ClipRRect(
                   borderRadius: borderRadius,
                   child: Container(
                     decoration: BoxDecoration(

--- a/lib/widgets/nav_bar/design_system_bottom_navigation_bar.dart
+++ b/lib/widgets/nav_bar/design_system_bottom_navigation_bar.dart
@@ -8,10 +8,17 @@ import 'package:lotti/features/design_system/theme/design_tokens.dart';
 class DesignSystemBottomNavigationBar extends StatelessWidget {
   const DesignSystemBottomNavigationBar({
     required this.items,
+    this.overlay,
     super.key,
   });
 
   final List<DesignSystemNavigationTabBarItem> items;
+
+  /// Optional widget rendered immediately above the pill, sized to the same
+  /// width as the pill. The overlay scales with the pill via the same
+  /// `FittedBox`, so its position stays tied to the rendered nav bar
+  /// regardless of how many tabs are visible.
+  final Widget? overlay;
 
   static EdgeInsets padding(BuildContext context) {
     final tokens = context.designTokens;
@@ -44,12 +51,23 @@ class DesignSystemBottomNavigationBar extends StatelessWidget {
         itemHeight;
   }
 
-  /// Distance from the bottom of the screen to the top edge of the visible
-  /// nav-bar pill. Used by overlays (e.g. recording indicators) that should
-  /// dock flush against the pill rather than float above the outer bounds.
-  static double pillTopFromScreenBottom(BuildContext context) {
+  /// Distance from the top of the system bottom safe-area inset to the visual
+  /// top of the nav-bar pill. Overlays (e.g. recording indicators) that wrap
+  /// themselves in `SafeArea(top: false)` should add this offset to dock flush
+  /// against the pill. Excludes `MediaQuery.paddingOf(context).bottom` so the
+  /// SafeArea at the overlay site is the single source of truth for the
+  /// home-indicator inset on iOS.
+  static double pillTopFromNavBarBottom(BuildContext context) {
     if (isDesktopLayout(context)) return 0;
-    return occupiedHeight(context) - padding(context).top;
+    final tokens = context.designTokens;
+    final itemHeight = math.max(
+      DesignSystemNavigationTabBar.defaultItemMinHeight,
+      tokens.spacing.step3 * 2 +
+          DesignSystemNavigationTabBar.defaultIconSize +
+          tokens.spacing.step1 +
+          tokens.typography.lineHeight.caption,
+    );
+    return padding(context).bottom + tokens.spacing.step2 * 2 + itemHeight;
   }
 
   @override
@@ -61,7 +79,18 @@ class DesignSystemBottomNavigationBar extends StatelessWidget {
         child: Align(
           child: FittedBox(
             fit: BoxFit.scaleDown,
-            child: DesignSystemNavigationTabBar(items: items),
+            // IntrinsicWidth bounds the inner Column so the overlay row can
+            // stretch to the pill's natural width.
+            child: IntrinsicWidth(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  ?overlay,
+                  DesignSystemNavigationTabBar(items: items),
+                ],
+              ),
+            ),
           ),
         ),
       ),

--- a/lib/widgets/nav_bar/design_system_bottom_navigation_bar.dart
+++ b/lib/widgets/nav_bar/design_system_bottom_navigation_bar.dart
@@ -30,6 +30,20 @@ class DesignSystemBottomNavigationBar extends StatelessWidget {
     );
   }
 
+  /// Intrinsic height of a single nav-bar item row (icon + caption with the
+  /// design-system minimum), shared by the height calculations below so the
+  /// numbers can't drift apart.
+  static double _itemHeight(BuildContext context) {
+    final tokens = context.designTokens;
+    return math.max(
+      DesignSystemNavigationTabBar.defaultItemMinHeight,
+      tokens.spacing.step3 * 2 +
+          DesignSystemNavigationTabBar.defaultIconSize +
+          tokens.spacing.step1 +
+          tokens.typography.lineHeight.caption,
+    );
+  }
+
   static double occupiedHeight(BuildContext context) {
     // In desktop layout the bottom navigation bar is not shown;
     // the sidebar replaces it, so no bottom inset is needed.
@@ -37,18 +51,11 @@ class DesignSystemBottomNavigationBar extends StatelessWidget {
 
     final tokens = context.designTokens;
     final bottomSafeInset = MediaQuery.paddingOf(context).bottom;
-    final itemHeight = math.max(
-      DesignSystemNavigationTabBar.defaultItemMinHeight,
-      tokens.spacing.step3 * 2 +
-          DesignSystemNavigationTabBar.defaultIconSize +
-          tokens.spacing.step1 +
-          tokens.typography.lineHeight.caption,
-    );
 
     return bottomSafeInset +
         padding(context).vertical +
         tokens.spacing.step2 * 2 +
-        itemHeight;
+        _itemHeight(context);
   }
 
   /// Distance from the top of the system bottom safe-area inset to the visual
@@ -60,14 +67,9 @@ class DesignSystemBottomNavigationBar extends StatelessWidget {
   static double pillTopFromNavBarBottom(BuildContext context) {
     if (isDesktopLayout(context)) return 0;
     final tokens = context.designTokens;
-    final itemHeight = math.max(
-      DesignSystemNavigationTabBar.defaultItemMinHeight,
-      tokens.spacing.step3 * 2 +
-          DesignSystemNavigationTabBar.defaultIconSize +
-          tokens.spacing.step1 +
-          tokens.typography.lineHeight.caption,
-    );
-    return padding(context).bottom + tokens.spacing.step2 * 2 + itemHeight;
+    return padding(context).bottom +
+        tokens.spacing.step2 * 2 +
+        _itemHeight(context);
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.983+4013
+version: 0.9.983+4014
 
 msix_config:
   display_name: LottiApp

--- a/test/beamer/beamer_app_test.dart
+++ b/test/beamer/beamer_app_test.dart
@@ -13,7 +13,6 @@ import 'package:lotti/features/design_system/components/navigation/desktop_navig
 import 'package:lotti/features/journal/state/journal_page_state.dart';
 import 'package:lotti/features/speech/state/recorder_controller.dart';
 import 'package:lotti/features/speech/state/recorder_state.dart';
-import 'package:lotti/features/speech/ui/widgets/recording/audio_recording_indicator.dart';
 import 'package:lotti/features/sync/matrix/key_verification_runner.dart';
 import 'package:lotti/features/sync/state/matrix_login_controller.dart';
 import 'package:lotti/features/tasks/state/saved_filters/saved_task_filter.dart';
@@ -410,7 +409,7 @@ void main() {
       });
     }
 
-    testWidgets('docks recording indicators to the design-system nav pill', (
+    testWidgets('renders recording indicators inside the nav bar overlay', (
       tester,
     ) async {
       final mockNavService = MockNavService();
@@ -431,33 +430,35 @@ void main() {
         navService: mockNavService,
       );
 
-      final context = tester.element(find.byType(AppScreen));
-      final pillTop = DesignSystemBottomNavigationBar.pillTopFromScreenBottom(
-        context,
+      // The indicators are passed in as the nav bar's `overlay` so they
+      // share the same FittedBox/Column as the pill — sized to the pill's
+      // width and stacked above it via spaceBetween.
+      final navBar = tester.widget<DesignSystemBottomNavigationBar>(
+        find.byType(DesignSystemBottomNavigationBar),
       );
-      final expectedTimeBottom =
-          AppScreenConstants.navigationTimeIndicatorBottom +
-          pillTop -
-          AppScreenConstants.navigationIndicatorPillOverlap;
-      final expectedAudioBottom =
-          AppScreenConstants.navigationTimeIndicatorBottom +
-          pillTop -
-          AppScreenConstants.navigationIndicatorPillOverlap;
-      final timeIndicatorPositioned = tester.widget<Positioned>(
-        find.ancestor(
-          of: find.byType(TimeRecordingIndicator),
-          matching: find.byType(Positioned),
+      expect(navBar.overlay, isNotNull);
+
+      // The TimeRecordingIndicator must be inside the nav bar widget, not
+      // in a separate Positioned.
+      expect(
+        find.descendant(
+          of: find.byType(DesignSystemBottomNavigationBar),
+          matching: find.byType(TimeRecordingIndicator),
         ),
-      );
-      final audioIndicatorPositioned = tester.widget<Positioned>(
-        find.ancestor(
-          of: find.byType(AudioRecordingIndicator),
-          matching: find.byType(Positioned),
-        ),
+        findsOneWidget,
       );
 
-      expect(timeIndicatorPositioned.bottom, expectedTimeBottom);
-      expect(audioIndicatorPositioned.bottom, expectedAudioBottom);
+      // The closest enclosing Row uses center so the indicators meet in
+      // the middle of the pill rather than spreading to its edges.
+      final overlayRow = tester.widget<Row>(
+        find
+            .ancestor(
+              of: find.byType(TimeRecordingIndicator),
+              matching: find.byType(Row),
+            )
+            .first,
+      );
+      expect(overlayRow.mainAxisAlignment, MainAxisAlignment.center);
     });
   });
 

--- a/test/widgets/nav_bar/design_system_bottom_navigation_bar_test.dart
+++ b/test/widgets/nav_bar/design_system_bottom_navigation_bar_test.dart
@@ -114,5 +114,176 @@ void main() {
         );
       },
     );
+
+    testWidgets('occupiedHeight returns 0 in desktop layout', (tester) async {
+      const desktop = MediaQueryData(size: Size(1280, 800));
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const SizedBox.shrink(),
+          theme: DesignSystemTheme.light(),
+          mediaQueryData: desktop,
+        ),
+      );
+
+      expect(
+        DesignSystemBottomNavigationBar.occupiedHeight(
+          tester.element(find.byType(Scaffold)),
+        ),
+        0,
+      );
+    });
+
+    testWidgets('pillTopFromNavBarBottom returns 0 in desktop layout', (
+      tester,
+    ) async {
+      const desktop = MediaQueryData(size: Size(1280, 800));
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const SizedBox.shrink(),
+          theme: DesignSystemTheme.light(),
+          mediaQueryData: desktop,
+        ),
+      );
+
+      expect(
+        DesignSystemBottomNavigationBar.pillTopFromNavBarBottom(
+          tester.element(find.byType(Scaffold)),
+        ),
+        0,
+      );
+    });
+
+    testWidgets(
+      'pillTopFromNavBarBottom equals occupiedHeight minus the bottom inset '
+      'and the top outer padding',
+      (tester) async {
+        const withInset = MediaQueryData(
+          size: Size(390, 844),
+          padding: EdgeInsets.only(bottom: 34),
+        );
+
+        await tester.pumpWidget(
+          makeTestableWidgetWithScaffold(
+            const SizedBox.shrink(),
+            theme: DesignSystemTheme.light(),
+            mediaQueryData: withInset,
+          ),
+        );
+
+        final context = tester.element(find.byType(Scaffold));
+        final occupied = DesignSystemBottomNavigationBar.occupiedHeight(
+          context,
+        );
+        final pillTop = DesignSystemBottomNavigationBar.pillTopFromNavBarBottom(
+          context,
+        );
+        final outerPadding = DesignSystemBottomNavigationBar.padding(context);
+
+        // pillTopFromNavBarBottom intentionally drops both the bottom safe
+        // inset (consumed by SafeArea at the overlay site) and the top half
+        // of the outer padding (above the pill).
+        expect(
+          pillTop,
+          occupied - withInset.padding.bottom - outerPadding.top,
+        );
+      },
+    );
+
+    testWidgets(
+      'renders the overlay above the pill in the same Column when provided',
+      (tester) async {
+        const overlayKey = ValueKey('overlay');
+
+        await tester.pumpWidget(
+          makeTestableWidgetWithScaffold(
+            const SizedBox(
+              width: 402,
+              child: DesignSystemBottomNavigationBar(
+                items: [
+                  DesignSystemNavigationTabBarItem(
+                    label: 'Tasks',
+                    icon: Icon(Icons.check_circle_outline),
+                    active: true,
+                  ),
+                  DesignSystemNavigationTabBarItem(
+                    label: 'Projects',
+                    icon: Icon(Icons.folder_outlined),
+                  ),
+                ],
+                overlay: SizedBox(key: overlayKey, height: 24),
+              ),
+            ),
+            theme: DesignSystemTheme.light(),
+          ),
+        );
+
+        // Overlay is mounted.
+        expect(find.byKey(overlayKey), findsOneWidget);
+
+        // It shares the same Column as the pill (so it scales/centers
+        // with the pill via the FittedBox + IntrinsicWidth above it).
+        final column = tester.widget<Column>(
+          find
+              .ancestor(
+                of: find.byKey(overlayKey),
+                matching: find.byType(Column),
+              )
+              .first,
+        );
+        expect(column.crossAxisAlignment, CrossAxisAlignment.stretch);
+        expect(column.mainAxisSize, MainAxisSize.min);
+        expect(
+          column.children.whereType<DesignSystemNavigationTabBar>(),
+          hasLength(1),
+        );
+
+        // Overlay is the first child, pill is the second — overlay is
+        // visually above the pill.
+        final overlayCenter = tester.getCenter(find.byKey(overlayKey));
+        final pillCenter = tester.getCenter(
+          find.byType(DesignSystemNavigationTabBar),
+        );
+        expect(overlayCenter.dy, lessThan(pillCenter.dy));
+      },
+    );
+
+    testWidgets('omits the overlay slot when none is provided', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const SizedBox(
+            width: 402,
+            child: DesignSystemBottomNavigationBar(
+              items: [
+                DesignSystemNavigationTabBarItem(
+                  label: 'Tasks',
+                  icon: Icon(Icons.check_circle_outline),
+                  active: true,
+                ),
+              ],
+            ),
+          ),
+          theme: DesignSystemTheme.light(),
+        ),
+      );
+
+      // The outermost Column inside the nav bar is the one that hosts the
+      // pill (and would host the overlay if provided). Inner Columns belong
+      // to each tab item.
+      final column = tester
+          .widgetList<Column>(
+            find.descendant(
+              of: find.byType(DesignSystemBottomNavigationBar),
+              matching: find.byType(Column),
+            ),
+          )
+          .first;
+      // Only the pill — no overlay child contributes to the Column.
+      expect(column.children, hasLength(1));
+      expect(column.children.first, isA<DesignSystemNavigationTabBar>());
+    });
   });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recording indicators are now rendered via the bottom navigation bar overlay for improved placement and alignment.

* **Style**
  * Updated recording indicator visuals to use rounded clipping (removed elevation) and refined nav bar layout/math for consistent sizing.

* **Tests**
  * Tests updated to assert overlay usage and centered layout for recording indicators.

* **Chores**
  * Version bumped to 0.9.983+4014.
  * Updated iOS project/build configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->