### PR TITLE
fix: slow ratings query

### DIFF
--- a/lib/features/daily_os/README.md
+++ b/lib/features/daily_os/README.md
@@ -59,7 +59,6 @@ flowchart LR
 
   Unified --> TimelineData["DailyTimelineData"]
   Unified --> BudgetData["TimeBudgetProgress"]
-  Unified --> Ratings["ratingIds"]
 
   Header --> HeaderCtl["TimeHistoryHeaderController"]
   HeaderCtl --> DB
@@ -135,7 +134,7 @@ It:
 - listens to `UpdateNotifications.updateStream`
 - listens to `TimeService` for the currently running timer
 - returns a transient empty `DayPlanEntry` when the day has no persisted plan yet
-- fetches the day plan, calendar entries, due tasks, entry links, linked parent entities, and rating IDs
+- fetches the day plan, calendar entries, due tasks, entry links, and linked parent entities
 - recomputes timeline data, budget progress, and synthetic zero-budget rows together
 - refetches after plan mutations so derived state stays consistent
 
@@ -152,7 +151,6 @@ sequenceDiagram
   Unified->>DB: sortedCalendarEntries(day)
   Unified->>DB: getTasksDueOn / getTasksDueOnOrBefore(day)
   Unified->>DB: resolve links and linked parent entities
-  Unified->>DB: getRatingIdsForTimeEntries(entryIds)
   Unified->>Unified: build timeline + budgets + synthetic budget rows
   Unified-->>UI: DailyOsData
 

--- a/lib/features/daily_os/state/unified_daily_os_data_controller.dart
+++ b/lib/features/daily_os/state/unified_daily_os_data_controller.dart
@@ -32,17 +32,12 @@ class DailyOsData {
     required this.dayPlan,
     required this.timelineData,
     required this.budgetProgress,
-    this.ratingIds = const {},
   });
 
   final DateTime date;
   final DayPlanEntry dayPlan;
   final DailyTimelineData timelineData;
   final List<TimeBudgetProgress> budgetProgress;
-
-  /// Maps time entry IDs to their rating entity IDs.
-  /// Empty if no ratings exist for the day's entries.
-  final Map<String, String> ratingIds;
 }
 
 /// Unified data controller for the Daily OS view.
@@ -286,7 +281,6 @@ class UnifiedDailyOsDataController extends _$UnifiedDailyOsDataController {
         dayPlan: currentState.dayPlan,
         timelineData: currentState.timelineData,
         budgetProgress: updatedBudgets,
-        ratingIds: currentState.ratingIds,
       ),
     );
   }
@@ -373,24 +367,18 @@ class UnifiedDailyOsDataController extends _$UnifiedDailyOsDataController {
       dueTasks: dueTasks,
     );
 
-    // Bulk fetch ratings for all time entries (avoids N+1)
-    final ratingIds = await db.getRatingIdsForTimeEntries(entryIds);
-
     _trackedRefreshKeys
       ..clear()
       ..add(dayPlan.meta.id)
       ..addAll(entryIds)
       ..addAll(linkedFromIds)
-      ..addAll(dueTasks.map((task) => task.meta.id))
-      ..addAll(ratingIds.keys)
-      ..addAll(ratingIds.values);
+      ..addAll(dueTasks.map((task) => task.meta.id));
 
     return DailyOsData(
       date: _date,
       dayPlan: dayPlan,
       timelineData: timelineData,
       budgetProgress: budgetProgress,
-      ratingIds: ratingIds,
     );
   }
 

--- a/lib/features/daily_os/ui/widgets/time_history_header/time_history_header_widget.dart
+++ b/lib/features/daily_os/ui/widgets/time_history_header/time_history_header_widget.dart
@@ -60,13 +60,22 @@ class _TimeHistoryHeaderState extends ConsumerState<TimeHistoryHeader> {
   // Whether we've set the initial scroll position to center on today
   bool _hasSetInitialScroll = false;
 
-  // Number of days to prefetch in each direction beyond visible
+  // Off-screen prefetch is currently disabled to keep the SQLite read pool
+  // out of the multi-second-hang regime under heavy fan-out. Flip this to
+  // `true` (and tune `_prefetchBuffer` / `_invalidateMargin`) once the
+  // DailyOS query path is cheap enough to warm warm neighbours without
+  // starving the selected day.
+  static const bool _prefetchEnabled = false;
+
+  // Number of days to prefetch in each direction beyond visible.
+  // Only takes effect when `_prefetchEnabled` is true.
   static const int _prefetchBuffer = 5;
 
   // Number of days to render beyond visible range for smoother transitions
   static const int _chartBuffer = 2;
 
-  // Margin for invalidation (2x buffer to avoid thrashing)
+  // Margin for invalidation (2x buffer to avoid thrashing).
+  // Only takes effect when `_prefetchEnabled` is true.
   static const int _invalidateMargin = _prefetchBuffer * 2;
 
   @override
@@ -203,7 +212,13 @@ class _TimeHistoryHeaderState extends ConsumerState<TimeHistoryHeader> {
   }
 
   /// Update the prefetch window based on visible indices.
+  ///
+  /// No-op while `_prefetchEnabled` is false: the visible-only mode relies
+  /// on `dailyOsSelectedDateProvider` to drive a single
+  /// `unifiedDailyOsDataControllerProvider` build per navigation.
   void _updatePrefetchWindow() {
+    if (!_prefetchEnabled) return;
+
     final historyData = ref.read(timeHistoryHeaderControllerProvider).value;
     if (historyData == null || historyData.days.isEmpty) return;
 
@@ -298,8 +313,14 @@ class _TimeHistoryHeaderState extends ConsumerState<TimeHistoryHeader> {
       }
     }
 
-    // Prefetch today's data in background (fire-and-forget)
-    ref.read(unifiedDailyOsDataControllerProvider(date: today));
+    // Prefetch today's data in background (fire-and-forget).
+    // Gated on the same flag as the scroll-window prefetch so disabling
+    // off-screen warming also disables this redundant warm-up — the
+    // selected-date provider drives the actual load when `goToToday`
+    // moves the selection.
+    if (_prefetchEnabled) {
+      ref.read(unifiedDailyOsDataControllerProvider(date: today));
+    }
   }
 
   /// Center the scroll view on today when data first loads.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.983+4014
+version: 0.9.983+4015
 
 msix_config:
   display_name: LottiApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.983+4015
+version: 0.9.983+4016
 
 msix_config:
   display_name: LottiApp

--- a/test/features/daily_os/state/unified_daily_os_data_controller_test.dart
+++ b/test/features/daily_os/state/unified_daily_os_data_controller_test.dart
@@ -179,10 +179,6 @@ void main() {
 
     when(() => mockDb.basicLinksForEntryIds(any())).thenAnswer((_) async => []);
 
-    when(
-      () => mockDb.getRatingIdsForTimeEntries(any()),
-    ).thenAnswer((_) async => <String, String>{});
-
     when(() => mockDb.getTasksDueOnOrBefore(any())).thenAnswer((_) async => []);
     when(() => mockDb.getTasksDueOn(any())).thenAnswer((_) async => []);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Daily OS architecture docs to reflect simplified data flow (removed rating-id linkage).

* **Refactor**
  * Removed rating ID tracking from Daily OS state; refresh now focuses on core data dependencies.
  * Disabled off-screen prefetch for the time history header by default.

* **Tests**
  * Adjusted test fixtures to match state management changes.

* **Chores**
  * Version bump to 0.9.983+4016.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->