### PR TITLE
fix: self echo prevention mechanism

### DIFF
--- a/lib/features/sync/matrix/sync_event_processor.dart
+++ b/lib/features/sync/matrix/sync_event_processor.dart
@@ -1019,7 +1019,11 @@ class SyncEventProcessor {
         'selfEcho.skip type=${syncMessage.runtimeType}',
         subDomain: 'processor.selfEcho',
       );
-      return PreparedSyncEvent._(event: event, syncMessage: syncMessage);
+      return PreparedSyncEvent._(
+        event: event,
+        syncMessage: syncMessage,
+        isSelfEcho: true,
+      );
     }
     switch (syncMessage) {
       case final SyncJournalEntity msg:
@@ -2157,6 +2161,22 @@ class SyncEventProcessor {
   }) async {
     final event = prepared.event;
     final syncMessage = prepared.syncMessage;
+    // Self-echo short-circuit. Prepare flagged this event as one the local
+    // host originated; the journal/agent/outbox payload was written locally
+    // before the message was sent, so apply has nothing to do for any
+    // family. Returning null commits the queue row cleanly (marker
+    // advances, no skip count, no retry) and — critically — avoids
+    // dereferencing the unpopulated `journalEntity` / `resolvedAgentBundle`
+    // / `resolvedOutboxBundle` slots that would otherwise null-bang in the
+    // per-family branches below.
+    if (prepared.isSelfEcho) {
+      _trace(
+        'apply selfEcho.skip type=${syncMessage.runtimeType} '
+        'eventId=${event.eventId}',
+        subDomain: 'processor.apply',
+      );
+      return null;
+    }
     switch (syncMessage) {
       case final SyncJournalEntity msg:
         return _applyJournalEntity(
@@ -2389,6 +2409,7 @@ class PreparedSyncEvent {
     required this.syncMessage,
     this.journalEntity,
     this.isDuplicateJournalEntity = false,
+    this.isSelfEcho = false,
     this.deferredStaleDescriptorError,
     this.resolvedAgentEntity,
     this.resolvedAgentLink,
@@ -2401,6 +2422,7 @@ class PreparedSyncEvent {
     required this.syncMessage,
     this.journalEntity,
     this.isDuplicateJournalEntity = false,
+    this.isSelfEcho = false,
     this.deferredStaleDescriptorError,
     this.resolvedAgentEntity,
     this.resolvedAgentLink,
@@ -2420,6 +2442,17 @@ class PreparedSyncEvent {
   /// and skipped the loader call. Apply still records the duplicate in the
   /// sequence log so hint resolution runs.
   final bool isDuplicateJournalEntity;
+
+  /// True when prepare identified the event as a self-echo (its
+  /// `originatingHostId` matches the local host). Self-echoes are events the
+  /// local host already wrote before sending; apply has nothing to do for
+  /// any message family. The flag is the explicit contract that the
+  /// per-family apply branches in [SyncEventProcessor._applyMessage] check
+  /// before they expect their resolved-payload slots to be populated. None
+  /// of the other slots (`journalEntity`, `resolvedAgentBundle`, …) are
+  /// populated when this is true, so per-family apply must short-circuit
+  /// rather than dereference them.
+  final bool isSelfEcho;
 
   /// Captured stale-descriptor error from the loader. Apply first checks
   /// whether the local version already supersedes the incoming one; if not,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.983+4020
+version: 0.9.983+4021
 
 msix_config:
   display_name: LottiApp

--- a/test/features/sync/matrix/sync_event_processor_test.dart
+++ b/test/features/sync/matrix/sync_event_processor_test.dart
@@ -6720,5 +6720,205 @@ void main() {
         verify(localVcService.getHost).called(1);
       },
     );
+
+    test(
+      'SyncJournalEntity self-echo applies as a no-op — regression for the '
+      'crash where prepare flagged self-echo but apply still dereferenced '
+      'the unpopulated journalEntity slot and threw `Null check operator '
+      'used on a null value`. The crash classified retriable in the queue '
+      'adapter and pinned the inbound read marker until maxAttempts gave '
+      'up, surfacing as the 29 skipped entries on the Backfill screen. '
+      'Apply must short-circuit before _applyJournalEntity bangs on '
+      '`preloaded!`.',
+      () async {
+        final localVcService = MockVectorClockService();
+        when(localVcService.getHost).thenAnswer((_) async => 'host-self');
+
+        final processorWithVc = SyncEventProcessor(
+          loggingService: loggingService,
+          updateNotifications: updateNotifications,
+          aiConfigRepository: aiConfigRepository,
+          settingsDb: settingsDb,
+          journalEntityLoader: journalEntityLoader,
+          vectorClockService: localVcService,
+        );
+
+        const message = SyncMessage.journalEntity(
+          id: 'entity-self',
+          jsonPath: '/entity-self.json',
+          vectorClock: VectorClock({'host-self': 1}),
+          status: SyncEntryStatus.update,
+          originatingHostId: 'host-self',
+        );
+        when(() => event.text).thenReturn(encodeMessage(message));
+
+        final diags = <SyncApplyDiagnostics>[];
+        processorWithVc.applyObserver = diags.add;
+
+        // The prior bug raised `Null check operator used on a null value`
+        // here. expectLater would mask future regressions; assert no throw
+        // by simply awaiting and then asserting on the side effects.
+        await processorWithVc.process(event: event, journalDb: journalDb);
+
+        // Self-echo must skip the loader entirely (we already wrote the
+        // entity locally before sending) and must not touch the DB.
+        verifyNever(
+          () => journalEntityLoader.load(
+            jsonPath: any<String>(named: 'jsonPath'),
+            incomingVectorClock: any<VectorClock>(named: 'incomingVectorClock'),
+          ),
+        );
+        verifyNever(
+          () => journalDb.updateJournalEntity(any<JournalEntity>()),
+        );
+        // No diagnostics emitted: self-echo is neither applied nor a
+        // duplicate skip — the queue commits cleanly so the marker
+        // advances.
+        expect(diags, isEmpty);
+      },
+    );
+
+    test(
+      'apply() returns null for an isSelfEcho-flagged SyncJournalEntity '
+      'even when the journalEntity slot is null — locks the apply-side '
+      'invariant so a future refactor cannot reintroduce the null-bang '
+      'on `preloaded!`. Driven directly through apply() to keep the '
+      'test independent of prepare wiring.',
+      () async {
+        const message = SyncMessage.journalEntity(
+          id: 'entity-self',
+          jsonPath: '/entity-self.json',
+          vectorClock: VectorClock({'host-self': 1}),
+          status: SyncEntryStatus.update,
+          originatingHostId: 'host-self',
+        );
+        final prepared = PreparedSyncEvent.forTesting(
+          event: event,
+          syncMessage: message,
+          isSelfEcho: true,
+          // journalEntity intentionally left null — that was the crash
+          // shape in production.
+        );
+
+        final result = await processor.apply(
+          prepared: prepared,
+          journalDb: journalDb,
+        );
+
+        expect(result, isNull);
+        verifyNever(
+          () => journalDb.updateJournalEntity(any<JournalEntity>()),
+        );
+      },
+    );
+
+    test(
+      'apply() returns null for an isSelfEcho-flagged SyncOutboxBundle '
+      'whose resolvedOutboxBundle is null — guards against a future '
+      'refactor that could otherwise null-bang in the bundle apply '
+      'branch. Self-echo bundles must short-circuit before the per-child '
+      'recursion because none of their children were resolved.',
+      () async {
+        const message = SyncOutboxBundle(
+          children: [SyncMessage.aiConfigDelete(id: 'cfg-self')],
+          jsonPath: '/outbox_bundles/self.json',
+          originatingHostId: 'host-self',
+        );
+        final prepared = PreparedSyncEvent.forTesting(
+          event: event,
+          syncMessage: message,
+          isSelfEcho: true,
+          // resolvedOutboxBundle intentionally left null.
+        );
+
+        final result = await processor.apply(
+          prepared: prepared,
+          journalDb: journalDb,
+        );
+
+        expect(result, isNull);
+        verifyNever(
+          () => aiConfigRepository.deleteConfig(
+            any<String>(),
+            fromSync: any<bool>(named: 'fromSync'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'apply() returns null for an isSelfEcho-flagged SyncAgentBundle '
+      'whose resolvedAgentBundle is null — symmetric guarantee to the '
+      'outbox-bundle case so every family is covered by the apply-side '
+      'self-echo short-circuit.',
+      () async {
+        const message = SyncMessage.agentBundle(
+          agentId: 'agent-self',
+          wakeRunKey: 'wake-self',
+          jsonPath: '/agent_bundles/self.json',
+          originatingHostId: 'host-self',
+        );
+        final prepared = PreparedSyncEvent.forTesting(
+          event: event,
+          syncMessage: message,
+          isSelfEcho: true,
+          // resolvedAgentBundle intentionally left null.
+        );
+
+        final result = await processor.apply(
+          prepared: prepared,
+          journalDb: journalDb,
+        );
+
+        expect(result, isNull);
+      },
+    );
+
+    test(
+      'peer-originated SyncJournalEntity still flows through the normal '
+      'apply path — the apply-side self-echo guard must not eat '
+      'legitimate inbound work. Without this regression-guard test, a '
+      'mis-set isSelfEcho default could silently drop every peer event.',
+      () async {
+        final localVcService = MockVectorClockService();
+        when(localVcService.getHost).thenAnswer((_) async => 'host-self');
+
+        final processorWithVc = SyncEventProcessor(
+          loggingService: loggingService,
+          updateNotifications: updateNotifications,
+          aiConfigRepository: aiConfigRepository,
+          settingsDb: settingsDb,
+          journalEntityLoader: journalEntityLoader,
+          vectorClockService: localVcService,
+        );
+
+        const message = SyncMessage.journalEntity(
+          id: 'entity-peer',
+          jsonPath: '/entity-peer.json',
+          vectorClock: VectorClock({'host-peer': 1}),
+          status: SyncEntryStatus.update,
+          originatingHostId: 'host-peer',
+        );
+        when(
+          () => journalEntityLoader.load(
+            jsonPath: '/entity-peer.json',
+            incomingVectorClock: const VectorClock({'host-peer': 1}),
+          ),
+        ).thenAnswer((_) async => fallbackJournalEntity);
+        when(() => event.text).thenReturn(encodeMessage(message));
+
+        await processorWithVc.process(event: event, journalDb: journalDb);
+
+        verify(
+          () => journalEntityLoader.load(
+            jsonPath: '/entity-peer.json',
+            incomingVectorClock: const VectorClock({'host-peer': 1}),
+          ),
+        ).called(1);
+        verify(
+          () => journalDb.updateJournalEntity(fallbackJournalEntity),
+        ).called(1);
+      },
+    );
   });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced synchronization to properly handle locally-sent messages that echo back from the server. This prevents redundant processing of already-sent messages and eliminates potential errors that could occur during the sync cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->