### PR TITLE
feat: add sync activity indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.985]
+### Added
+- Sidebar **Sync activity indicator** (variant D4a). When the new
+  `show_sync_activity_indicator` config flag is enabled, the desktop
+  sidebar gains an ambient two-row monospace strip just above
+  Settings: `tx <outbox-depth>` / `rx <inbox-depth>`, each with a
+  5×5 LED that flashes for ~140 ms per packet committed on that
+  channel (TX = events uploaded to the homeserver, RX = inbound
+  events applied locally). Tap navigates to Settings → Sync. When
+  the flag is on, the legacy red `289` Settings badge is suppressed
+  so the count is shown in exactly one place. Hidden in the
+  collapsed sidebar — the strip is too narrow there. Default off;
+  opt in via Settings → Config Flags.
+
 ## [0.9.984]
 ### Added
 - Task agents can now propose user-reviewed edits to historical time

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -31,6 +31,11 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="0.9.985" date="2026-05-02">
+      <description>
+          <p>New sidebar Sync activity indicator (variant D4a). When the show_sync_activity_indicator config flag is enabled, the desktop sidebar gains an ambient two-row monospace strip just above Settings: tx &lt;outbox-depth&gt; / rx &lt;inbox-depth&gt;, each with a 5×5 LED that flashes for ~140 ms per packet committed on that channel. Tap navigates to Settings → Sync; while the flag is on the legacy red Settings badge is suppressed so the count is shown in exactly one place. Default off; opt in via Settings → Config Flags.</p>
+      </description>
+    </release>
     <release version="0.9.984" date="2026-05-02">
       <description>
           <p>Task agents can now propose user-reviewed edits to historical time entries linked from the current task. The wake prompt exposes editable non-running entry IDs with their current time range and text, the new update_time_entry tool validates task ownership and excludes the live timer, and the suggestion row renders a current-to-proposed diff before confirmation.</p>

--- a/lib/beamer/beamer_app.dart
+++ b/lib/beamer/beamer_app.dart
@@ -7,6 +7,7 @@ import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:form_builder_validators/localization/l10n.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/database/state/config_flag_provider.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/ai/ui/settings/ai_settings_navigation_service.dart';
 import 'package:lotti/features/ai/ui/settings/services/ai_setup_prompt_service.dart';
@@ -25,6 +26,7 @@ import 'package:lotti/features/settings/ui/pages/outbox/outbox_trailing_badge.da
 import 'package:lotti/features/speech/ui/widgets/recording/audio_recording_indicator.dart';
 import 'package:lotti/features/sync/state/matrix_login_controller.dart';
 import 'package:lotti/features/sync/ui/widgets/matrix/incoming_verification_modal.dart';
+import 'package:lotti/features/sync/ui/widgets/sync_activity_indicator.dart';
 import 'package:lotti/features/tasks/ui/saved_filters/tasks_saved_filters_tree.dart';
 import 'package:lotti/features/tasks/ui/tasks_badge_icon.dart';
 import 'package:lotti/features/tasks/ui/tasks_trailing_badge.dart';
@@ -39,6 +41,7 @@ import 'package:lotti/pages/empty_scaffold.dart';
 import 'package:lotti/providers/service_providers.dart';
 import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/nav_service.dart';
+import 'package:lotti/utils/consts.dart';
 import 'package:lotti/widgets/misc/desktop_menu.dart';
 import 'package:lotti/widgets/misc/time_recording_indicator.dart';
 import 'package:lotti/widgets/misc/zoom_wrapper.dart';
@@ -359,6 +362,9 @@ class _AppScreenState extends ConsumerState<AppScreen> {
 
     final paneWidths = ref.watch(paneWidthControllerProvider);
     final isCollapsed = paneWidths.sidebarCollapsed;
+    final showSyncIndicator =
+        ref.watch(configFlagProvider(showSyncActivityIndicatorFlag)).value ??
+        false;
 
     return Scaffold(
       // Scaffold fills behind the outer ResizableDivider's 3 px reserved
@@ -404,6 +410,9 @@ class _AppScreenState extends ConsumerState<AppScreen> {
             onToggleCollapsed: () => ref
                 .read(paneWidthControllerProvider.notifier)
                 .toggleSidebarCollapsed(),
+            aboveSettings: showSyncIndicator
+                ? const SyncActivityIndicator()
+                : null,
           ),
           ResizableDivider(
             enabled: !isCollapsed,

--- a/lib/database/journal_db/config_flags.dart
+++ b/lib/database/journal_db/config_flags.dart
@@ -197,5 +197,13 @@ Future<void> initConfigFlags(
     ),
   );
 
+  await db.insertFlagIfNotExists(
+    const ConfigFlag(
+      name: showSyncActivityIndicatorFlag,
+      description: 'Show live sync activity in the sidebar.',
+      status: false,
+    ),
+  );
+
   // No additional flags for label guardrails: always-on behavior.
 }

--- a/lib/features/design_system/components/navigation/desktop_navigation_sidebar.dart
+++ b/lib/features/design_system/components/navigation/desktop_navigation_sidebar.dart
@@ -63,6 +63,7 @@ class DesktopNavigationSidebar extends StatelessWidget {
     this.collapsed = false,
     this.collapsedWidth = 72,
     this.onToggleCollapsed,
+    this.aboveSettings,
     super.key,
   });
 
@@ -96,6 +97,13 @@ class DesktopNavigationSidebar extends StatelessWidget {
   /// Called when the toggle icon next to the logo is tapped. When null, the
   /// toggle icon is rendered but not interactive.
   final VoidCallback? onToggleCollapsed;
+
+  /// Optional widget rendered between the scrollable nav and the
+  /// Settings row in the expanded layout. The Lotti app uses this slot
+  /// to host the ambient sync activity indicator (variant D4a). The
+  /// slot is intentionally suppressed in [collapsed] mode — its monospace
+  /// LED strip would not fit the icon-only column.
+  final Widget? aboveSettings;
 
   @override
   Widget build(BuildContext context) {
@@ -159,6 +167,14 @@ class DesktopNavigationSidebar extends StatelessWidget {
               ),
             ),
           ),
+
+          // Optional ambient indicator slot (e.g. sync activity).
+          // Hidden in collapsed mode because the strip is too narrow
+          // to display readable monospace counters.
+          if (!collapsed && aboveSettings != null) ...[
+            aboveSettings!,
+            SizedBox(height: tokens.spacing.step3),
+          ],
 
           // Settings at the bottom
           if (settingsDestination != null)

--- a/lib/features/settings/ui/pages/flags_page.dart
+++ b/lib/features/settings/ui/pages/flags_page.dart
@@ -109,6 +109,7 @@ class FlagsBody extends ConsumerStatefulWidget {
     enableEmbeddingsFlag,
     enableVectorSearchFlag,
     enableWhatsNewFlag,
+    showSyncActivityIndicatorFlag,
   ];
 
   @override
@@ -166,6 +167,8 @@ class _FlagsBodyState extends ConsumerState<FlagsBody> {
         return Icons.manage_search_rounded;
       case enableWhatsNewFlag:
         return Icons.new_releases_outlined;
+      case showSyncActivityIndicatorFlag:
+        return Icons.network_check_rounded;
       default:
         return Icons.settings;
     }
@@ -215,6 +218,8 @@ class _FlagsBodyState extends ConsumerState<FlagsBody> {
         return context.messages.configFlagEnableVectorSearchDescription;
       case enableWhatsNewFlag:
         return context.messages.configFlagEnableWhatsNewDescription;
+      case showSyncActivityIndicatorFlag:
+        return context.messages.configFlagShowSyncActivityIndicatorDescription;
       default:
         return flag.description;
     }
@@ -262,6 +267,8 @@ class _FlagsBodyState extends ConsumerState<FlagsBody> {
         return context.messages.configFlagEnableVectorSearch;
       case enableWhatsNewFlag:
         return context.messages.configFlagEnableWhatsNew;
+      case showSyncActivityIndicatorFlag:
+        return context.messages.configFlagShowSyncActivityIndicator;
       default:
         return flag.name;
     }

--- a/lib/features/settings/ui/pages/outbox/outbox_trailing_badge.dart
+++ b/lib/features/settings/ui/pages/outbox/outbox_trailing_badge.dart
@@ -1,17 +1,28 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/database/state/config_flag_provider.dart';
 import 'package:lotti/features/design_system/components/badges/design_system_badge.dart';
 import 'package:lotti/features/sync/state/outbox_state_controller.dart';
+import 'package:lotti/utils/consts.dart';
 
 /// Standalone count pill for pending outbox items, rendered in a trailing slot
 /// (e.g. alongside Settings on the desktop navigation sidebar).
 ///
-/// Only renders when sync is enabled and there are pending items.
+/// Only renders when sync is enabled and there are pending items. The
+/// pill is also suppressed when the sidebar sync activity indicator is
+/// active — the indicator already shows the outbox depth, so showing
+/// both would double up.
 class OutboxTrailingBadge extends ConsumerWidget {
   const OutboxTrailingBadge({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final indicatorEnabled =
+        ref.watch(configFlagProvider(showSyncActivityIndicatorFlag)).value ??
+        false;
+    if (indicatorEnabled) {
+      return const SizedBox.shrink();
+    }
     final connectionState = ref.watch(outboxConnectionStateProvider).value;
     if (connectionState != OutboxConnectionState.online) {
       return const SizedBox.shrink();

--- a/lib/features/sync/README.md
+++ b/lib/features/sync/README.md
@@ -641,6 +641,32 @@ Pipeline-tagged log lines let a log analyzer compare apply rates:
 
 The Phase-2 ±15% gate compares event/sec rates between the two.
 
+### Sidebar activity indicator (D4a)
+
+`SyncActivitySignaler` (`state/sync_activity_signaler.dart`) is a
+broadcast pulse emitter wired into the two committal chokepoints:
+
+- **TX** — `DatabaseOutboxRepository.markSent` and `markSentBatch` pulse
+  one event per row that actually transitioned to `status=sent`.
+- **RX** — `InboundQueue.commitApplied` pulses one event per row that
+  flipped to `status=applied`.
+
+The signaler is registered as a `getIt` singleton and exposed to the UI
+via `syncActivityTxPulsesProvider` / `syncActivityRxPulsesProvider`.
+The sidebar `SyncActivityIndicator` (`ui/widgets/sync_activity_indicator.dart`,
+gated behind the `show_sync_activity_indicator` config flag) listens
+to both streams to drive a 140 ms LED flash per packet, alongside live
+counts pulled from `outboxPendingCountProvider` (existing) and
+`inboundQueueDepthProvider` (new — sourced from
+`InboundQueue.depthChanges` via `MatrixService.queueCoordinator`).
+Tapping the strip beams to `/settings/sync` (Settings → Sync), where
+the outbox monitor, queue depth card, backfill, and sync stats live.
+
+The signaler is fire-and-forget and carries no payload; correctness
+still lives in the underlying queue/outbox state. Producers tolerate a
+null signaler (constructors take `SyncActivitySignaler?`) so tests that
+do not need the indicator can omit it without modifying call sites.
+
 ## Sequence Log And Backfill
 
 `SyncSequenceLogService` is the causal accounting layer. It records which

--- a/lib/features/sync/outbox/outbox_repository.dart
+++ b/lib/features/sync/outbox/outbox_repository.dart
@@ -1,6 +1,7 @@
 import 'package:drift/drift.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/features/sync/state/outbox_state_controller.dart';
+import 'package:lotti/features/sync/state/sync_activity_signaler.dart';
 import 'package:lotti/features/sync/tuning.dart';
 
 abstract class OutboxRepository {
@@ -67,10 +68,12 @@ class DatabaseOutboxRepository implements OutboxRepository {
   DatabaseOutboxRepository(
     this._database, {
     this.maxRetries = 10,
-  });
+    SyncActivitySignaler? activitySignaler,
+  }) : _activitySignaler = activitySignaler;
 
   final SyncDatabase _database;
   final int maxRetries;
+  final SyncActivitySignaler? _activitySignaler;
 
   @override
   Future<List<OutboxItem>> fetchPending({int limit = 10}) {
@@ -110,6 +113,7 @@ class DatabaseOutboxRepository implements OutboxRepository {
         updatedAt: Value(DateTime.now()),
       ),
     );
+    _activitySignaler?.pulseTx();
   }
 
   @override
@@ -121,6 +125,7 @@ class DatabaseOutboxRepository implements OutboxRepository {
     await _database.markOutboxItemsSent(
       ids: items.map((item) => item.id).toList(growable: false),
     );
+    _activitySignaler?.pulseTx(count: items.length);
   }
 
   @override

--- a/lib/features/sync/outbox/outbox_repository.dart
+++ b/lib/features/sync/outbox/outbox_repository.dart
@@ -125,7 +125,7 @@ class DatabaseOutboxRepository implements OutboxRepository {
     await _database.markOutboxItemsSent(
       ids: items.map((item) => item.id).toList(growable: false),
     );
-    _activitySignaler?.pulseTx(count: items.length);
+    _activitySignaler?.pulseTx();
   }
 
   @override

--- a/lib/features/sync/outbox/outbox_service.dart
+++ b/lib/features/sync/outbox/outbox_service.dart
@@ -16,6 +16,7 @@ import 'package:lotti/features/sync/outbox/outbox_repository.dart';
 import 'package:lotti/features/sync/sequence/sync_sequence_log_service.dart';
 import 'package:lotti/features/sync/sequence/sync_sequence_payload_type.dart';
 import 'package:lotti/features/sync/state/outbox_state_controller.dart';
+import 'package:lotti/features/sync/state/sync_activity_signaler.dart';
 import 'package:lotti/features/sync/tuning.dart';
 import 'package:lotti/features/sync/vector_clock.dart';
 import 'package:lotti/features/sync/vector_clock_logging.dart';
@@ -53,7 +54,9 @@ class OutboxService {
     SyncSequenceLogService? sequenceLogService,
     Duration postDrainSettle = _defaultPostDrainSettle,
     DomainLogger? domainLogger,
+    SyncActivitySignaler? activitySignaler,
   }) : _postDrainSettle = postDrainSettle,
+       _activitySignaler = activitySignaler,
        _syncDatabase = syncDatabase,
        _loggingService = loggingService,
        _vectorClockService = vectorClockService,
@@ -83,6 +86,7 @@ class OutboxService {
         DatabaseOutboxRepository(
           syncDatabase,
           maxRetries: maxRetries,
+          activitySignaler: _activitySignaler,
         );
     _messageSender = messageSender ?? MatrixOutboxMessageSender(matrixService!);
     _processor =
@@ -226,6 +230,7 @@ class OutboxService {
 
   final LoggingService _loggingService;
   final DomainLogger? _domainLogger;
+  final SyncActivitySignaler? _activitySignaler;
   final SyncDatabase _syncDatabase;
   final VectorClockService _vectorClockService;
   final JournalDb _journalDb;

--- a/lib/features/sync/queue/inbound_event_queue.dart
+++ b/lib/features/sync/queue/inbound_event_queue.dart
@@ -5,6 +5,7 @@ import 'package:clock/clock.dart';
 import 'package:drift/drift.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/features/sync/matrix/pipeline/matrix_event_classifier.dart';
+import 'package:lotti/features/sync/state/sync_activity_signaler.dart';
 import 'package:lotti/features/sync/tuning.dart';
 import 'package:lotti/services/logging_service.dart';
 import 'package:matrix/matrix.dart';
@@ -204,12 +205,15 @@ class InboundQueue {
     required SyncDatabase db,
     required LoggingService logging,
     Duration? leaseDuration,
+    SyncActivitySignaler? activitySignaler,
   }) : _db = db,
        _logging = logging,
+       _activitySignaler = activitySignaler,
        _leaseDuration = leaseDuration ?? SyncTuning.inboundWorkerLeaseDuration;
 
   final SyncDatabase _db;
   final LoggingService _logging;
+  final SyncActivitySignaler? _activitySignaler;
   final Duration _leaseDuration;
 
   final StreamController<QueueDepthSignal> _depthCtl =
@@ -542,6 +546,7 @@ class InboundQueue {
       domain: _logDomain,
       subDomain: _logSubCommit,
     );
+    _activitySignaler?.pulseRx();
     _scheduleDepthEmit();
   }
 

--- a/lib/features/sync/queue/queue_pipeline_coordinator.dart
+++ b/lib/features/sync/queue/queue_pipeline_coordinator.dart
@@ -22,6 +22,7 @@ import 'package:lotti/features/sync/queue/pending_decryption_pen.dart';
 import 'package:lotti/features/sync/queue/queue_apply_adapter.dart';
 import 'package:lotti/features/sync/queue/queue_marker_seeder.dart';
 import 'package:lotti/features/sync/sequence/sync_sequence_log_service.dart';
+import 'package:lotti/features/sync/state/sync_activity_signaler.dart';
 import 'package:lotti/features/user_activity/state/user_activity_gate.dart';
 import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/logging_service.dart';
@@ -61,6 +62,7 @@ class QueuePipelineCoordinator {
     UpdateNotifications? updateNotifications,
     AttachmentIngestor? attachmentIngestor,
     SentEventRegistry? sentEventRegistry,
+    SyncActivitySignaler? activitySignaler,
     InboundQueue? queueOverride,
     InboundWorker? workerOverride,
     BridgeCoordinator? bridgeOverride,
@@ -77,7 +79,13 @@ class QueuePipelineCoordinator {
        _updateNotifications = updateNotifications,
        _attachmentIngestor = attachmentIngestor,
        _sentEventRegistry = sentEventRegistry,
-       _queue = queueOverride ?? InboundQueue(db: syncDb, logging: logging),
+       _queue =
+           queueOverride ??
+           InboundQueue(
+             db: syncDb,
+             logging: logging,
+             activitySignaler: activitySignaler,
+           ),
        _pen = penOverride ?? PendingDecryptionPen(logging: logging),
        _seeder =
            seederOverride ??

--- a/lib/features/sync/state/outbox_state_controller.dart
+++ b/lib/features/sync/state/outbox_state_controller.dart
@@ -1,4 +1,7 @@
 import 'package:lotti/features/sync/outbox/outbox_daily_volume.dart';
+import 'package:lotti/features/sync/queue/inbound_event_queue.dart';
+import 'package:lotti/features/sync/state/sync_activity_signaler.dart';
+import 'package:lotti/get_it.dart';
 import 'package:lotti/providers/service_providers.dart';
 import 'package:lotti/utils/consts.dart';
 import 'package:lotti/widgets/charts/utils.dart';
@@ -64,4 +67,47 @@ Future<List<Observation>> outboxDailyVolume(Ref ref) async {
   final syncDb = ref.watch(syncDatabaseProvider);
   final volumes = await syncDb.getDailyOutboxVolume(days: kOutboxVolumeDays);
   return volumes.map((v) => Observation(v.date, v.totalBytes / 1024)).toList();
+}
+
+/// Looks up the global [SyncActivitySignaler]. Resolved through `getIt`
+/// so tests that swap in a custom signaler do not need a parallel
+/// override in every consumer.
+@riverpod
+SyncActivitySignaler syncActivitySignaler(Ref ref) =>
+    getIt<SyncActivitySignaler>();
+
+/// Per-packet TX pulses for the sidebar sync activity indicator. Emits
+/// once per outbound event committed to the homeserver.
+@riverpod
+Stream<DateTime> syncActivityTxPulses(Ref ref) =>
+    ref.watch(syncActivitySignalerProvider).txPulses;
+
+/// Per-packet RX pulses for the sidebar sync activity indicator. Emits
+/// once per inbound event applied locally.
+@riverpod
+Stream<DateTime> syncActivityRxPulses(Ref ref) =>
+    ref.watch(syncActivitySignalerProvider).rxPulses;
+
+/// Live depth of the inbound queue (active rows the worker can still
+/// drain). Used by the sidebar sync activity indicator. Resolves the
+/// queue lazily via `MatrixService.queueCoordinator` because the
+/// coordinator is created during app boot, not during provider
+/// construction.
+@riverpod
+Stream<int> inboundQueueDepth(Ref ref) {
+  final matrixService = ref.watch(matrixServiceProvider);
+  return _inboundQueueDepthStream(matrixService.queueCoordinator.queue);
+}
+
+Stream<int> _inboundQueueDepthStream(InboundQueue queue) async* {
+  // Seed the stream with the current depth so the UI does not have to
+  // wait for the next emission to render a non-zero count.
+  try {
+    final stats = await queue.stats();
+    yield stats.total;
+  } catch (_) {
+    // Initial paint failures are non-fatal; the live signal will
+    // provide a count on the next emission.
+  }
+  yield* queue.depthChanges.map((signal) => signal.total);
 }

--- a/lib/features/sync/state/outbox_state_controller.dart
+++ b/lib/features/sync/state/outbox_state_controller.dart
@@ -104,27 +104,59 @@ Stream<int> inboundQueueDepth(Ref ref) {
 
 @visibleForTesting
 Stream<int> inboundQueueDepthStream(InboundQueue queue) async* {
-  // Subscribe BEFORE awaiting `stats()` so any depth signal that fires
-  // while we're computing the initial snapshot is queued in `relay`
-  // rather than dropped — `depthChanges` is a broadcast stream with no
-  // buffering of its own, so a naive seed-then-yield* sequence would
-  // miss every signal that lands during the await.
-  final relay = StreamController<int>();
+  // Two ordering hazards must be handled together:
+  //
+  // (1) `depthChanges` is a broadcast stream with no buffering, so we
+  //     must subscribe BEFORE awaiting `stats()` — otherwise a signal
+  //     that fires during the snapshot computation is dropped and the
+  //     UI shows a stale count until the next packet.
+  //
+  // (2) The `stats()` snapshot we just awaited is older than any live
+  //     signal that arrived during the await, so emitting `stats.total`
+  //     unconditionally and then replaying buffered live values would
+  //     step the consumer backwards (e.g. `2 → 1 → 2`). The fix: buffer
+  //     live values until `stats()` resolves, emit the snapshot ONLY
+  //     when the buffer is still empty, otherwise drop the stale
+  //     snapshot and emit the buffered live sequence in arrival order
+  //     before switching to forwarding the live tail.
+  final buffered = <int>[];
+  final relay = StreamController<int>.broadcast();
   final sub = queue.depthChanges
       .map((signal) => signal.total)
       .listen(
-        relay.add,
-        onError: relay.addError,
-        onDone: relay.close,
+        (value) {
+          if (relay.hasListener) {
+            relay.add(value);
+          } else {
+            buffered.add(value);
+          }
+        },
+        onError: (Object error, StackTrace stack) {
+          if (relay.hasListener) relay.addError(error, stack);
+        },
       );
   try {
+    int? snapshot;
     try {
       final stats = await queue.stats();
-      yield stats.total;
+      snapshot = stats.total;
     } catch (_) {
       // Initial paint failures are non-fatal; the live signal below
       // will provide a count on the next emission.
     }
+
+    if (buffered.isEmpty && snapshot != null) {
+      yield snapshot;
+    } else {
+      // A live signal beat the snapshot to the queue; trust the live
+      // sequence over the now-stale `stats()` result and replay every
+      // buffered value in arrival order before draining the tail.
+      for (final value in buffered) {
+        yield value;
+      }
+      buffered.clear();
+    }
+
     yield* relay.stream;
   } finally {
     await sub.cancel();

--- a/lib/features/sync/state/outbox_state_controller.dart
+++ b/lib/features/sync/state/outbox_state_controller.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:lotti/features/sync/outbox/outbox_daily_volume.dart';
 import 'package:lotti/features/sync/queue/inbound_event_queue.dart';
 import 'package:lotti/features/sync/state/sync_activity_signaler.dart';
@@ -100,14 +102,30 @@ Stream<int> inboundQueueDepth(Ref ref) {
 }
 
 Stream<int> _inboundQueueDepthStream(InboundQueue queue) async* {
-  // Seed the stream with the current depth so the UI does not have to
-  // wait for the next emission to render a non-zero count.
+  // Subscribe BEFORE awaiting `stats()` so any depth signal that fires
+  // while we're computing the initial snapshot is queued in `relay`
+  // rather than dropped — `depthChanges` is a broadcast stream with no
+  // buffering of its own, so a naive seed-then-yield* sequence would
+  // miss every signal that lands during the await.
+  final relay = StreamController<int>();
+  final sub = queue.depthChanges
+      .map((signal) => signal.total)
+      .listen(
+        relay.add,
+        onError: relay.addError,
+        onDone: relay.close,
+      );
   try {
-    final stats = await queue.stats();
-    yield stats.total;
-  } catch (_) {
-    // Initial paint failures are non-fatal; the live signal will
-    // provide a count on the next emission.
+    try {
+      final stats = await queue.stats();
+      yield stats.total;
+    } catch (_) {
+      // Initial paint failures are non-fatal; the live signal below
+      // will provide a count on the next emission.
+    }
+    yield* relay.stream;
+  } finally {
+    await sub.cancel();
+    if (!relay.isClosed) await relay.close();
   }
-  yield* queue.depthChanges.map((signal) => signal.total);
 }

--- a/lib/features/sync/state/outbox_state_controller.dart
+++ b/lib/features/sync/state/outbox_state_controller.dart
@@ -7,6 +7,7 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/providers/service_providers.dart';
 import 'package:lotti/utils/consts.dart';
 import 'package:lotti/widgets/charts/utils.dart';
+import 'package:meta/meta.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'outbox_state_controller.g.dart';
@@ -98,10 +99,11 @@ Stream<DateTime> syncActivityRxPulses(Ref ref) =>
 @riverpod
 Stream<int> inboundQueueDepth(Ref ref) {
   final matrixService = ref.watch(matrixServiceProvider);
-  return _inboundQueueDepthStream(matrixService.queueCoordinator.queue);
+  return inboundQueueDepthStream(matrixService.queueCoordinator.queue);
 }
 
-Stream<int> _inboundQueueDepthStream(InboundQueue queue) async* {
+@visibleForTesting
+Stream<int> inboundQueueDepthStream(InboundQueue queue) async* {
   // Subscribe BEFORE awaiting `stats()` so any depth signal that fires
   // while we're computing the initial snapshot is queued in `relay`
   // rather than dropped — `depthChanges` is a broadcast stream with no

--- a/lib/features/sync/state/outbox_state_controller.g.dart
+++ b/lib/features/sync/state/outbox_state_controller.g.dart
@@ -145,3 +145,198 @@ final class OutboxDailyVolumeProvider
 }
 
 String _$outboxDailyVolumeHash() => r'4b860d94f32e31ae0ac6377ddb62e63baf8a55bc';
+
+/// Looks up the global [SyncActivitySignaler]. Resolved through `getIt`
+/// so tests that swap in a custom signaler do not need a parallel
+/// override in every consumer.
+
+@ProviderFor(syncActivitySignaler)
+final syncActivitySignalerProvider = SyncActivitySignalerProvider._();
+
+/// Looks up the global [SyncActivitySignaler]. Resolved through `getIt`
+/// so tests that swap in a custom signaler do not need a parallel
+/// override in every consumer.
+
+final class SyncActivitySignalerProvider
+    extends
+        $FunctionalProvider<
+          SyncActivitySignaler,
+          SyncActivitySignaler,
+          SyncActivitySignaler
+        >
+    with $Provider<SyncActivitySignaler> {
+  /// Looks up the global [SyncActivitySignaler]. Resolved through `getIt`
+  /// so tests that swap in a custom signaler do not need a parallel
+  /// override in every consumer.
+  SyncActivitySignalerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'syncActivitySignalerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$syncActivitySignalerHash();
+
+  @$internal
+  @override
+  $ProviderElement<SyncActivitySignaler> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  SyncActivitySignaler create(Ref ref) {
+    return syncActivitySignaler(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(SyncActivitySignaler value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<SyncActivitySignaler>(value),
+    );
+  }
+}
+
+String _$syncActivitySignalerHash() =>
+    r'fe8cc1cd49a6214320ad6ad4b946879cba7f7b42';
+
+/// Per-packet TX pulses for the sidebar sync activity indicator. Emits
+/// once per outbound event committed to the homeserver.
+
+@ProviderFor(syncActivityTxPulses)
+final syncActivityTxPulsesProvider = SyncActivityTxPulsesProvider._();
+
+/// Per-packet TX pulses for the sidebar sync activity indicator. Emits
+/// once per outbound event committed to the homeserver.
+
+final class SyncActivityTxPulsesProvider
+    extends
+        $FunctionalProvider<AsyncValue<DateTime>, DateTime, Stream<DateTime>>
+    with $FutureModifier<DateTime>, $StreamProvider<DateTime> {
+  /// Per-packet TX pulses for the sidebar sync activity indicator. Emits
+  /// once per outbound event committed to the homeserver.
+  SyncActivityTxPulsesProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'syncActivityTxPulsesProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$syncActivityTxPulsesHash();
+
+  @$internal
+  @override
+  $StreamProviderElement<DateTime> $createElement($ProviderPointer pointer) =>
+      $StreamProviderElement(pointer);
+
+  @override
+  Stream<DateTime> create(Ref ref) {
+    return syncActivityTxPulses(ref);
+  }
+}
+
+String _$syncActivityTxPulsesHash() =>
+    r'7692edbba85b9f0705b31c6d74dd809c48c94eb8';
+
+/// Per-packet RX pulses for the sidebar sync activity indicator. Emits
+/// once per inbound event applied locally.
+
+@ProviderFor(syncActivityRxPulses)
+final syncActivityRxPulsesProvider = SyncActivityRxPulsesProvider._();
+
+/// Per-packet RX pulses for the sidebar sync activity indicator. Emits
+/// once per inbound event applied locally.
+
+final class SyncActivityRxPulsesProvider
+    extends
+        $FunctionalProvider<AsyncValue<DateTime>, DateTime, Stream<DateTime>>
+    with $FutureModifier<DateTime>, $StreamProvider<DateTime> {
+  /// Per-packet RX pulses for the sidebar sync activity indicator. Emits
+  /// once per inbound event applied locally.
+  SyncActivityRxPulsesProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'syncActivityRxPulsesProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$syncActivityRxPulsesHash();
+
+  @$internal
+  @override
+  $StreamProviderElement<DateTime> $createElement($ProviderPointer pointer) =>
+      $StreamProviderElement(pointer);
+
+  @override
+  Stream<DateTime> create(Ref ref) {
+    return syncActivityRxPulses(ref);
+  }
+}
+
+String _$syncActivityRxPulsesHash() =>
+    r'd177376085ba2f61b55a117e7e0b24e14e140d92';
+
+/// Live depth of the inbound queue (active rows the worker can still
+/// drain). Used by the sidebar sync activity indicator. Resolves the
+/// queue lazily via `MatrixService.queueCoordinator` because the
+/// coordinator is created during app boot, not during provider
+/// construction.
+
+@ProviderFor(inboundQueueDepth)
+final inboundQueueDepthProvider = InboundQueueDepthProvider._();
+
+/// Live depth of the inbound queue (active rows the worker can still
+/// drain). Used by the sidebar sync activity indicator. Resolves the
+/// queue lazily via `MatrixService.queueCoordinator` because the
+/// coordinator is created during app boot, not during provider
+/// construction.
+
+final class InboundQueueDepthProvider
+    extends $FunctionalProvider<AsyncValue<int>, int, Stream<int>>
+    with $FutureModifier<int>, $StreamProvider<int> {
+  /// Live depth of the inbound queue (active rows the worker can still
+  /// drain). Used by the sidebar sync activity indicator. Resolves the
+  /// queue lazily via `MatrixService.queueCoordinator` because the
+  /// coordinator is created during app boot, not during provider
+  /// construction.
+  InboundQueueDepthProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'inboundQueueDepthProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$inboundQueueDepthHash();
+
+  @$internal
+  @override
+  $StreamProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $StreamProviderElement(pointer);
+
+  @override
+  Stream<int> create(Ref ref) {
+    return inboundQueueDepth(ref);
+  }
+}
+
+String _$inboundQueueDepthHash() => r'c7efe154cf8deca99752a30387edaee2fbc97a34';

--- a/lib/features/sync/state/outbox_state_controller.g.dart
+++ b/lib/features/sync/state/outbox_state_controller.g.dart
@@ -339,4 +339,4 @@ final class InboundQueueDepthProvider
   }
 }
 
-String _$inboundQueueDepthHash() => r'c7efe154cf8deca99752a30387edaee2fbc97a34';
+String _$inboundQueueDepthHash() => r'6fba40d4284e5aabc28e5752f2bff2d5b3be3955';

--- a/lib/features/sync/state/sync_activity_signaler.dart
+++ b/lib/features/sync/state/sync_activity_signaler.dart
@@ -1,0 +1,48 @@
+import 'dart:async';
+
+/// Lightweight pulse emitter for the sidebar's sync activity indicator
+/// (variant D4a in `docs/design/`). Emits once per Matrix packet that
+/// the local sync engine actually transmitted (TX) or applied (RX) so
+/// the UI can flash an LED for ~140 ms per event.
+///
+/// The signaler is intentionally diagnostic-only: it carries no payload,
+/// no ordering guarantees, and is fire-and-forget at the producer side.
+/// Listeners use it as a hint to drive ambient UI; correctness lives
+/// in the underlying queue/outbox state.
+class SyncActivitySignaler {
+  SyncActivitySignaler();
+
+  final StreamController<DateTime> _txCtl =
+      StreamController<DateTime>.broadcast();
+  final StreamController<DateTime> _rxCtl =
+      StreamController<DateTime>.broadcast();
+
+  /// Pulses for outbound packets that committed to the homeserver.
+  Stream<DateTime> get txPulses => _txCtl.stream;
+
+  /// Pulses for inbound packets that were applied locally.
+  Stream<DateTime> get rxPulses => _rxCtl.stream;
+
+  /// Emits [count] TX pulses. Used by the outbox path after a single
+  /// send (`count == 1`) or a successful bundle send (one pulse per
+  /// committed item).
+  void pulseTx({int count = 1}) {
+    if (count <= 0 || _txCtl.isClosed) return;
+    final now = DateTime.now();
+    for (var i = 0; i < count; i++) {
+      _txCtl.add(now);
+    }
+  }
+
+  /// Emits one RX pulse. Used by the inbound queue after each
+  /// `commitApplied`.
+  void pulseRx() {
+    if (_rxCtl.isClosed) return;
+    _rxCtl.add(DateTime.now());
+  }
+
+  Future<void> dispose() async {
+    await _txCtl.close();
+    await _rxCtl.close();
+  }
+}

--- a/lib/features/sync/state/sync_activity_signaler.dart
+++ b/lib/features/sync/state/sync_activity_signaler.dart
@@ -23,15 +23,16 @@ class SyncActivitySignaler {
   /// Pulses for inbound packets that were applied locally.
   Stream<DateTime> get rxPulses => _rxCtl.stream;
 
-  /// Emits [count] TX pulses. Used by the outbox path after a single
-  /// send (`count == 1`) or a successful bundle send (one pulse per
-  /// committed item).
-  void pulseTx({int count = 1}) {
-    if (count <= 0 || _txCtl.isClosed) return;
-    final now = DateTime.now();
-    for (var i = 0; i < count; i++) {
-      _txCtl.add(now);
-    }
+  /// Emits a single TX pulse. Used by the outbox path after a single
+  /// send or a successful bundle send. The indicator widget coalesces
+  /// rapid pulses into a single ~140 ms LED hold (the spec says
+  /// "multiple fires within the hold window simply extend it"), so
+  /// emitting once per batch is visually identical to emitting once per
+  /// committed row — and avoids walking a tight per-item loop on hot
+  /// drain paths.
+  void pulseTx() {
+    if (_txCtl.isClosed) return;
+    _txCtl.add(DateTime.now());
   }
 
   /// Emits one RX pulse. Used by the inbound queue after each

--- a/lib/features/sync/ui/widgets/sync_activity_indicator.dart
+++ b/lib/features/sync/ui/widgets/sync_activity_indicator.dart
@@ -1,0 +1,286 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/features/sync/state/outbox_state_controller.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/services/nav_service.dart';
+import 'package:lotti/ui/app_fonts.dart';
+
+/// Test hook used by widget tests to invoke the indicator's tap action
+/// without depending on the live router.
+@visibleForTesting
+class SyncActivityIndicatorTestHooks {
+  const SyncActivityIndicatorTestHooks._();
+
+  /// Override the navigation callback the indicator triggers on tap.
+  /// Setting to `null` restores the default `beamToNamed` behaviour.
+  static void Function(String path)? navigatorOverride;
+}
+
+/// Route the indicator navigates to on tap. Lands on the Sync
+/// Settings landing page (Settings → Sync), where the user can drill
+/// into the outbox monitor, queue depth, backfill, and sync stats.
+const String kSyncOutboxRoute = '/settings/sync';
+
+/// Hold duration for an LED flash. Per the design handoff the LED is
+/// on for roughly 140 ms per packet, then fades to its idle state.
+const Duration kSyncActivityLedHold = Duration(milliseconds: 140);
+
+/// LED active background colors. Sourced directly from the design
+/// handoff in `docs/design/README.md` (variant D4a) — the spec calls
+/// these out as intentionally outside the normal `--fg-*` ramp because
+/// the indicator must read quieter than disabled text.
+const Color kSyncActivityTxColor = Color(0xFFC99A4E); // muted amber
+const Color kSyncActivityRxColor = Color(0xFF5ED4B7); // Lotti teal-light
+
+const Color _ledIdle = Color(0x1AFFFFFF); // 10% white
+const Color _labelColor = Color(0x4DFFFFFF); // 30% white
+const Color _valueActive = Color(0x8CFFFFFF); // 55% white
+const Color _valueIdle = Color(0x52FFFFFF); // 32% white
+const Color _hoverWash = Color(0x0AFFFFFF); // 4% white
+const Color _focusRing = Color(0xFF5ED4B7); // matches Lotti teal-light
+
+/// Ambient sidebar indicator showing live Matrix sync traffic. Two
+/// stacked monospace rows (`tx <count>` / `rx <count>`) each with a
+/// 5×5 LED that flashes briefly per packet committed on that channel.
+///
+/// Variant **D4a** in `docs/design/`. Visual semantics — colors,
+/// timings, sizes — are pinned to the handoff and reproduced
+/// pixel-for-pixel.
+class SyncActivityIndicator extends ConsumerStatefulWidget {
+  const SyncActivityIndicator({super.key});
+
+  @override
+  ConsumerState<SyncActivityIndicator> createState() =>
+      _SyncActivityIndicatorState();
+}
+
+class _SyncActivityIndicatorState extends ConsumerState<SyncActivityIndicator> {
+  bool _txOn = false;
+  bool _rxOn = false;
+  bool _hovered = false;
+  Timer? _txTimer;
+  Timer? _rxTimer;
+  ProviderSubscription<AsyncValue<DateTime>>? _txSub;
+  ProviderSubscription<AsyncValue<DateTime>>? _rxSub;
+
+  @override
+  void initState() {
+    super.initState();
+    // listenManual lets us subscribe outside of build() so each pulse
+    // (a new AsyncData emission from the stream provider) triggers
+    // exactly one LED flash regardless of how often the widget rebuilds.
+    _txSub = ref.listenManual<AsyncValue<DateTime>>(
+      syncActivityTxPulsesProvider,
+      (_, next) {
+        if (next is AsyncData<DateTime>) _flashTx();
+      },
+    );
+    _rxSub = ref.listenManual<AsyncValue<DateTime>>(
+      syncActivityRxPulsesProvider,
+      (_, next) {
+        if (next is AsyncData<DateTime>) _flashRx();
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _txTimer?.cancel();
+    _rxTimer?.cancel();
+    _txSub?.close();
+    _rxSub?.close();
+    super.dispose();
+  }
+
+  void _flashTx() {
+    if (!mounted) return;
+    setState(() => _txOn = true);
+    _txTimer?.cancel();
+    _txTimer = Timer(kSyncActivityLedHold, () {
+      if (!mounted) return;
+      setState(() => _txOn = false);
+    });
+  }
+
+  void _flashRx() {
+    if (!mounted) return;
+    setState(() => _rxOn = true);
+    _rxTimer?.cancel();
+    _rxTimer = Timer(kSyncActivityLedHold, () {
+      if (!mounted) return;
+      setState(() => _rxOn = false);
+    });
+  }
+
+  void _handleTap() {
+    final override = SyncActivityIndicatorTestHooks.navigatorOverride;
+    if (override != null) {
+      override(kSyncOutboxRoute);
+      return;
+    }
+    beamToNamed(kSyncOutboxRoute);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final outbox = ref.watch(outboxPendingCountProvider).value ?? 0;
+    final inbox = ref.watch(inboundQueueDepthProvider).value ?? 0;
+    final semanticsLabel = context.messages.syncActivityIndicatorSemantics(
+      outbox,
+      inbox,
+    );
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4),
+      child: Semantics(
+        button: true,
+        label: semanticsLabel,
+        child: FocusableActionDetector(
+          mouseCursor: SystemMouseCursors.click,
+          onShowHoverHighlight: (hovered) {
+            if (!mounted) return;
+            setState(() => _hovered = hovered);
+          },
+          actions: <Type, Action<Intent>>{
+            ActivateIntent: CallbackAction<ActivateIntent>(
+              onInvoke: (_) {
+                _handleTap();
+                return null;
+              },
+            ),
+          },
+          child: Builder(
+            builder: (context) {
+              final focused = Focus.of(context).hasFocus;
+              return GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: _handleTap,
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 180),
+                  curve: Curves.easeOut,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 14,
+                    vertical: 8,
+                  ),
+                  decoration: BoxDecoration(
+                    color: _hovered ? _hoverWash : Colors.transparent,
+                    borderRadius: BorderRadius.circular(8),
+                    border: focused
+                        ? Border.all(color: _focusRing, width: 2)
+                        : null,
+                  ),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      _SyncActivityRow(
+                        label: 'tx',
+                        on: _txOn,
+                        color: kSyncActivityTxColor,
+                        value: outbox,
+                      ),
+                      const SizedBox(height: 3),
+                      _SyncActivityRow(
+                        label: 'rx',
+                        on: _rxOn,
+                        color: kSyncActivityRxColor,
+                        value: inbox,
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SyncActivityRow extends StatelessWidget {
+  const _SyncActivityRow({
+    required this.label,
+    required this.on,
+    required this.color,
+    required this.value,
+  });
+
+  final String label;
+  final bool on;
+  final Color color;
+  final int value;
+
+  @override
+  Widget build(BuildContext context) {
+    final valueStyle =
+        AppFonts.inconsolata(
+          fontSize: 10,
+          fontWeight: FontWeight.w400,
+          color: value > 0 ? _valueActive : _valueIdle,
+          letterSpacing: 0.3,
+        ).copyWith(
+          fontFeatures: const [FontFeature.tabularFigures()],
+          height: 1.4,
+        );
+    final labelStyle = AppFonts.inconsolata(
+      fontSize: 10,
+      fontWeight: FontWeight.w400,
+      color: _labelColor,
+      letterSpacing: 0.3,
+    ).copyWith(height: 1.4);
+
+    return SizedBox(
+      height: 14,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _SyncActivityLed(on: on, color: color),
+          const SizedBox(width: 6),
+          SizedBox(
+            width: 14,
+            child: ExcludeSemantics(child: Text(label, style: labelStyle)),
+          ),
+          const SizedBox(width: 6),
+          if (value > 0)
+            ExcludeSemantics(
+              child: Text(
+                '$value',
+                style: valueStyle,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SyncActivityLed extends StatelessWidget {
+  const _SyncActivityLed({required this.on, required this.color});
+
+  final bool on;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 90),
+      width: 5,
+      height: 5,
+      decoration: BoxDecoration(
+        color: on ? color : _ledIdle,
+        shape: BoxShape.circle,
+        boxShadow: on
+            ? [
+                BoxShadow(
+                  color: color,
+                  blurRadius: 5,
+                ),
+              ]
+            : null,
+      ),
+    );
+  }
+}

--- a/lib/features/sync/ui/widgets/sync_activity_indicator.dart
+++ b/lib/features/sync/ui/widgets/sync_activity_indicator.dart
@@ -2,10 +2,12 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/sync/state/outbox_state_controller.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/services/nav_service.dart';
+import 'package:lotti/themes/theme.dart' show numericBadgeFontFeatures;
 import 'package:lotti/ui/app_fonts.dart';
 
 /// Test hook used by widget tests to invoke the indicator's tap action
@@ -31,16 +33,22 @@ const Duration kSyncActivityLedHold = Duration(milliseconds: 140);
 /// LED active background colors. Sourced directly from the design
 /// handoff in `docs/design/README.md` (variant D4a) — the spec calls
 /// these out as intentionally outside the normal `--fg-*` ramp because
-/// the indicator must read quieter than disabled text.
+/// the indicator must read quieter than disabled text. The TX amber
+/// has no design-system equivalent (the closest token, `warning`, is
+/// far more saturated) so it stays as a literal pending a token
+/// decision; RX is `interactive.enabled` and the focus ring follows
+/// it (resolved from the active theme at build time).
 const Color kSyncActivityTxColor = Color(0xFFC99A4E); // muted amber
-const Color kSyncActivityRxColor = Color(0xFF5ED4B7); // Lotti teal-light
 
+/// Pure-white-with-alpha values for the muted "ambient awareness, not
+/// notification" feel. The handoff calls for these to stay quieter
+/// than the softest design-system text token (64% white), so they are
+/// intentionally below the existing token ramp.
 const Color _ledIdle = Color(0x1AFFFFFF); // 10% white
 const Color _labelColor = Color(0x4DFFFFFF); // 30% white
 const Color _valueActive = Color(0x8CFFFFFF); // 55% white
 const Color _valueIdle = Color(0x52FFFFFF); // 32% white
 const Color _hoverWash = Color(0x0AFFFFFF); // 4% white
-const Color _focusRing = Color(0xFF5ED4B7); // matches Lotti teal-light
 
 /// Ambient sidebar indicator showing live Matrix sync traffic. Two
 /// stacked monospace rows (`tx <count>` / `rx <count>`) each with a
@@ -132,6 +140,11 @@ class _SyncActivityIndicatorState extends ConsumerState<SyncActivityIndicator> {
       inbox,
     );
 
+    // RX dot and focus ring follow the active theme's interactive
+    // accent (`#5ED4B7` in dark mode), so they read consistently with
+    // every other primary affordance in the sidebar.
+    final rxColor = context.designTokens.colors.interactive.enabled;
+
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 4),
       child: Semantics(
@@ -172,7 +185,7 @@ class _SyncActivityIndicatorState extends ConsumerState<SyncActivityIndicator> {
                     // stable so neighbouring rows don't jump on
                     // focus-in / focus-out.
                     border: Border.all(
-                      color: focused ? _focusRing : Colors.transparent,
+                      color: focused ? rxColor : Colors.transparent,
                       width: 2,
                     ),
                   ),
@@ -190,7 +203,7 @@ class _SyncActivityIndicatorState extends ConsumerState<SyncActivityIndicator> {
                       _SyncActivityRow(
                         label: 'rx',
                         on: _rxOn,
-                        color: kSyncActivityRxColor,
+                        color: rxColor,
                         value: inbox,
                       ),
                     ],
@@ -227,7 +240,7 @@ class _SyncActivityRow extends StatelessWidget {
           color: value > 0 ? _valueActive : _valueIdle,
           letterSpacing: 0.3,
         ).copyWith(
-          fontFeatures: const [FontFeature.tabularFigures()],
+          fontFeatures: numericBadgeFontFeatures,
           height: 1.4,
         );
     final labelStyle = AppFonts.inconsolata(

--- a/lib/features/sync/ui/widgets/sync_activity_indicator.dart
+++ b/lib/features/sync/ui/widgets/sync_activity_indicator.dart
@@ -11,11 +11,10 @@ import 'package:lotti/themes/theme.dart' show numericBadgeFontFeatures;
 import 'package:lotti/ui/app_fonts.dart';
 
 /// Test hook used by widget tests to invoke the indicator's tap action
-/// without depending on the live router.
+/// without depending on the live router. Has no instances — its only
+/// purpose is to namespace the static [navigatorOverride] hook.
 @visibleForTesting
-class SyncActivityIndicatorTestHooks {
-  const SyncActivityIndicatorTestHooks._();
-
+abstract final class SyncActivityIndicatorTestHooks {
   /// Override the navigation callback the indicator triggers on tap.
   /// Setting to `null` restores the default `beamToNamed` behaviour.
   static void Function(String path)? navigatorOverride;

--- a/lib/features/sync/ui/widgets/sync_activity_indicator.dart
+++ b/lib/features/sync/ui/widgets/sync_activity_indicator.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/sync/state/outbox_state_controller.dart';
+import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/ui/app_fonts.dart';
@@ -62,35 +63,11 @@ class _SyncActivityIndicatorState extends ConsumerState<SyncActivityIndicator> {
   bool _hovered = false;
   Timer? _txTimer;
   Timer? _rxTimer;
-  ProviderSubscription<AsyncValue<DateTime>>? _txSub;
-  ProviderSubscription<AsyncValue<DateTime>>? _rxSub;
-
-  @override
-  void initState() {
-    super.initState();
-    // listenManual lets us subscribe outside of build() so each pulse
-    // (a new AsyncData emission from the stream provider) triggers
-    // exactly one LED flash regardless of how often the widget rebuilds.
-    _txSub = ref.listenManual<AsyncValue<DateTime>>(
-      syncActivityTxPulsesProvider,
-      (_, next) {
-        if (next is AsyncData<DateTime>) _flashTx();
-      },
-    );
-    _rxSub = ref.listenManual<AsyncValue<DateTime>>(
-      syncActivityRxPulsesProvider,
-      (_, next) {
-        if (next is AsyncData<DateTime>) _flashRx();
-      },
-    );
-  }
 
   @override
   void dispose() {
     _txTimer?.cancel();
     _rxTimer?.cancel();
-    _txSub?.close();
-    _rxSub?.close();
     super.dispose();
   }
 
@@ -120,11 +97,34 @@ class _SyncActivityIndicatorState extends ConsumerState<SyncActivityIndicator> {
       override(kSyncOutboxRoute);
       return;
     }
-    beamToNamed(kSyncOutboxRoute);
+    // Switch to the Settings tab AND beam the inner Settings Beamer
+    // delegate to the Sync sub-route. Going through the global
+    // `beamToNamed` helper alone races with the IndexedStack mount
+    // cycle when the user is currently on a different tab — by the
+    // time the Settings Beamer mounts it has fallen back to its
+    // `/settings` initial path, so the user lands on Settings instead
+    // of Settings → Sync. The two-step pattern matches the project
+    // detail page's category-deep-link flow.
+    final navService = getIt<NavService>();
+    navService.tapIndex(navService.settingsIndex);
+    navService.settingsDelegate.beamToNamed(kSyncOutboxRoute);
+    unawaited(navService.persistNamedRoute(kSyncOutboxRoute));
   }
 
   @override
   Widget build(BuildContext context) {
+    // ref.listen handles the subscription lifecycle and reacts to
+    // provider overrides automatically — preferable to the manual
+    // initState subscription, which would stay tied to whatever
+    // provider instance was current when the widget first mounted.
+    ref
+      ..listen<AsyncValue<DateTime>>(syncActivityTxPulsesProvider, (_, next) {
+        if (next is AsyncData<DateTime>) _flashTx();
+      })
+      ..listen<AsyncValue<DateTime>>(syncActivityRxPulsesProvider, (_, next) {
+        if (next is AsyncData<DateTime>) _flashRx();
+      });
+
     final outbox = ref.watch(outboxPendingCountProvider).value ?? 0;
     final inbox = ref.watch(inboundQueueDepthProvider).value ?? 0;
     final semanticsLabel = context.messages.syncActivityIndicatorSemantics(
@@ -167,9 +167,14 @@ class _SyncActivityIndicatorState extends ConsumerState<SyncActivityIndicator> {
                   decoration: BoxDecoration(
                     color: _hovered ? _hoverWash : Colors.transparent,
                     borderRadius: BorderRadius.circular(8),
-                    border: focused
-                        ? Border.all(color: _focusRing, width: 2)
-                        : null,
+                    // Always render a 2 px border and toggle its color
+                    // on focus — keeps the strip's outer dimensions
+                    // stable so neighbouring rows don't jump on
+                    // focus-in / focus-out.
+                    border: Border.all(
+                      color: focused ? _focusRing : Colors.transparent,
+                      width: 2,
+                    ),
                   ),
                   child: Column(
                     mainAxisSize: MainAxisSize.min,

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -45,6 +45,7 @@ import 'package:lotti/features/sync/outbox/outbox_service.dart';
 import 'package:lotti/features/sync/queue/queue_pipeline_coordinator.dart';
 import 'package:lotti/features/sync/secure_storage.dart';
 import 'package:lotti/features/sync/sequence/sync_sequence_log_service.dart';
+import 'package:lotti/features/sync/state/sync_activity_signaler.dart';
 import 'package:lotti/features/sync/tuning.dart';
 import 'package:lotti/features/user_activity/state/user_activity_gate.dart';
 import 'package:lotti/features/user_activity/state/user_activity_service.dart';
@@ -174,6 +175,7 @@ Future<void> registerSingletons() async {
       ),
     )
     ..registerSingleton<UpdateNotifications>(UpdateNotifications())
+    ..registerSingleton<SyncActivitySignaler>(SyncActivitySignaler())
     ..registerSingleton<JournalDb>(JournalDb())
     ..registerSingleton<AgentDatabase>(AgentDatabase())
     ..registerSingleton<EditorDb>(EditorDb())
@@ -315,6 +317,7 @@ Future<void> registerSingletons() async {
     updateNotifications: getIt<UpdateNotifications>(),
     attachmentIngestor: queueAttachmentIngestor,
     sentEventRegistry: sentEventRegistry,
+    activitySignaler: getIt<SyncActivitySignaler>(),
   );
 
   final matrixService = MatrixService(
@@ -352,6 +355,7 @@ Future<void> registerSingletons() async {
         matrixService: matrixService,
         sequenceLogService: syncSequenceLogService,
         domainLogger: domainLogger,
+        activitySignaler: getIt<SyncActivitySignaler>(),
       ),
     );
 

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -881,6 +881,8 @@
   "configFlagRecordLocationDescription": "Automaticky zaznamenejte vaši polohu s novými záznamy. To pomáhá s organizací a vyhledáváním podle polohy.",
   "configFlagResendAttachments": "Odeslat přílohy znovu",
   "configFlagResendAttachmentsDescription": "Povolte toto nastavení pro automatické opětovné odeslání neúspěšného nahrávání příloh po obnovení připojení.",
+  "configFlagShowSyncActivityIndicator": "Zobrazit indikátor aktivity synchronizace",
+  "configFlagShowSyncActivityIndicatorDescription": "Zobrazit živou aktivitu synchronizace v postranním panelu — tx/rx LED proužek s hloubkou odchozí a příchozí fronty.",
   "configFlagUseCloudInferenceDescription": "Používat AI služby v cloudu pro vylepšené funkce. Vyžaduje připojení k internetu.",
   "configFlagUseCompressedJsonAttachments": "Komprimovat JSON payloady synchronizace",
   "configFlagUseCompressedJsonAttachmentsDescription": "Před nahráním gzip-komprimuje JSON přílohy synchronizace. Šetří šířku pásma v pomalých sítích za mírnou cenu CPU při odesílání a příjmu.",
@@ -2291,6 +2293,17 @@
   "speechModalSelectLanguage": "Vyberte jazyk",
   "speechModalTitle": "Rozpoznávání řeči",
   "speechModalTranscriptionProgress": "Pokrok přepisu",
+  "syncActivityIndicatorSemantics": "Aktivita synchronizace. Odchozí: {outbox}. Příchozí: {inbox}. Otevřít odchozí frontu synchronizace.",
+  "@syncActivityIndicatorSemantics": {
+    "placeholders": {
+      "outbox": {
+        "type": "int"
+      },
+      "inbox": {
+        "type": "int"
+      }
+    }
+  },
   "syncCreateNewRoom": "Vytvořit novou místnost",
   "syncCreateNewRoomInstead": "Místo toho vytvořit novou místnost",
   "syncDeleteConfigConfirm": "ANO, JSEM SI JISTÝ",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1118,6 +1118,8 @@
   "configFlagRecordLocationDescription": "Zeichnet automatisch deinen Standort mit neuen Einträgen auf. Dies hilft bei der ortsbezogenen Organisation und Suche.",
   "configFlagResendAttachments": "Anhänge erneut senden",
   "configFlagResendAttachmentsDescription": "Aktiviere diese Option, um fehlgeschlagene Anlagen-Uploads automatisch erneut zu senden, wenn die Verbindung wiederhergestellt ist.",
+  "configFlagShowSyncActivityIndicator": "Sync-Aktivitätsanzeige einblenden",
+  "configFlagShowSyncActivityIndicatorDescription": "Live-Sync-Aktivität in der Seitenleiste anzeigen — eine tx/rx-LED-Leiste mit Outbox- und Inbox-Tiefe.",
   "configFlagUseCloudInferenceDescription": "Cloud-basierte KI-Dienste für erweiterte Funktionen verwenden. Dies erfordert eine Internetverbindung.",
   "configFlagUseCompressedJsonAttachments": "JSON-Sync-Payloads komprimieren",
   "configFlagUseCompressedJsonAttachmentsDescription": "Komprimiert JSON-Sync-Anhänge mit gzip vor dem Hochladen. Spart Bandbreite in langsamen Netzen – gegen einen kleinen CPU-Aufwand beim Senden und Empfangen.",
@@ -2561,6 +2563,17 @@
   "speechModalSelectLanguage": "Sprache auswählen",
   "speechModalTitle": "Spracherkennung",
   "speechModalTranscriptionProgress": "Transkriptionsfortschritt",
+  "syncActivityIndicatorSemantics": "Sync-Aktivität. Outbox: {outbox}. Inbox: {inbox}. Sync-Outbox öffnen.",
+  "@syncActivityIndicatorSemantics": {
+    "placeholders": {
+      "outbox": {
+        "type": "int"
+      },
+      "inbox": {
+        "type": "int"
+      }
+    }
+  },
   "syncCreateNewRoom": "Neuen Raum erstellen",
   "syncCreateNewRoomInstead": "Stattdessen neuen Raum erstellen",
   "syncDeleteConfigConfirm": "JA, ICH BIN SICHER",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1359,6 +1359,8 @@
   "configFlagRecordLocationDescription": "Automatically record your location with new entries. This helps with location-based organization and search.",
   "configFlagResendAttachments": "Resend attachments",
   "configFlagResendAttachmentsDescription": "Enable this to automatically resend failed attachment uploads when the connection is restored.",
+  "configFlagShowSyncActivityIndicator": "Show sync activity indicator",
+  "configFlagShowSyncActivityIndicatorDescription": "Show live sync activity in the sidebar — a tx/rx LED strip with outbox and inbox depth.",
   "configFlagUseCloudInferenceDescription": "Use cloud-based AI services for enhanced features. This requires an internet connection.",
   "configFlagUseCompressedJsonAttachments": "Compress JSON sync payloads",
   "configFlagUseCompressedJsonAttachmentsDescription": "Gzip-compress JSON sync attachments before upload. Saves bandwidth on slow networks in exchange for a small CPU cost when sending and receiving.",
@@ -2866,6 +2868,17 @@
   "speechModalSelectLanguage": "Select Language",
   "speechModalTitle": "Speech Recognition",
   "speechModalTranscriptionProgress": "Transcription Progress",
+  "syncActivityIndicatorSemantics": "Sync activity. Outbox: {outbox}. Inbox: {inbox}. Open sync outbox.",
+  "@syncActivityIndicatorSemantics": {
+    "placeholders": {
+      "outbox": {
+        "type": "int"
+      },
+      "inbox": {
+        "type": "int"
+      }
+    }
+  },
   "syncCreateNewRoom": "Create New Room",
   "syncCreateNewRoomInstead": "Create New Room Instead",
   "syncDeleteConfigConfirm": "YES, I'M SURE",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1118,6 +1118,8 @@
   "configFlagRecordLocationDescription": "Registrar automáticamente tu ubicación con las nuevas entradas. Esto ayuda con la organización y la búsqueda basadas en la ubicación.",
   "configFlagResendAttachments": "Reenviar archivos adjuntos",
   "configFlagResendAttachmentsDescription": "Activar para reenviar automáticamente las cargas de archivos adjuntos fallidas cuando se restablezca la conexión.",
+  "configFlagShowSyncActivityIndicator": "Mostrar indicador de actividad de sincronización",
+  "configFlagShowSyncActivityIndicatorDescription": "Muestra la actividad de sincronización en directo en la barra lateral — una franja LED tx/rx con la profundidad de bandejas de entrada y salida.",
   "configFlagUseCloudInferenceDescription": "Utiliza servicios de IA basados en la nube para funciones mejoradas. Esto requiere una conexión a Internet.",
   "configFlagUseCompressedJsonAttachments": "Comprimir cargas útiles JSON de sync",
   "configFlagUseCompressedJsonAttachmentsDescription": "Comprime con gzip los archivos adjuntos JSON de sincronización antes de subirlos. Ahorra ancho de banda en redes lentas, a cambio de un pequeño coste de CPU al enviar y recibir.",
@@ -2561,6 +2563,17 @@
   "speechModalSelectLanguage": "Seleccionar idioma",
   "speechModalTitle": "Reconocimiento de voz",
   "speechModalTranscriptionProgress": "Progreso de la transcripción",
+  "syncActivityIndicatorSemantics": "Actividad de sincronización. Bandeja de salida: {outbox}. Bandeja de entrada: {inbox}. Abrir bandeja de salida de sincronización.",
+  "@syncActivityIndicatorSemantics": {
+    "placeholders": {
+      "outbox": {
+        "type": "int"
+      },
+      "inbox": {
+        "type": "int"
+      }
+    }
+  },
   "syncCreateNewRoom": "Crear nueva sala",
   "syncCreateNewRoomInstead": "Crear nueva sala en su lugar",
   "syncDeleteConfigConfirm": "SÍ, ESTOY SEGURO",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1118,6 +1118,8 @@
   "configFlagRecordLocationDescription": "Enregistrer automatiquement ta position avec les nouvelles entrées. Cela facilite l'organisation et la recherche basées sur la localisation.",
   "configFlagResendAttachments": "Renvoyer les pièces jointes",
   "configFlagResendAttachmentsDescription": "Active cette option pour renvoyer automatiquement les téléchargements de pièces jointes ayant échoué lorsque la connexion est rétablie.",
+  "configFlagShowSyncActivityIndicator": "Afficher l'indicateur d'activité de synchronisation",
+  "configFlagShowSyncActivityIndicatorDescription": "Affiche l'activité de synchronisation en direct dans la barre latérale — une bande LED tx/rx avec la profondeur des files entrante et sortante.",
   "configFlagUseCloudInferenceDescription": "Utiliser les services d'IA basés sur le cloud pour des fonctionnalités améliorées. Cela nécessite une connexion Internet.",
   "configFlagUseCompressedJsonAttachments": "Compresser les payloads JSON de sync",
   "configFlagUseCompressedJsonAttachmentsDescription": "Compresse les pièces jointes JSON de synchronisation avec gzip avant l'envoi. Économise de la bande passante sur les réseaux lents, au prix d'un léger coût CPU à l'envoi et à la réception.",
@@ -2561,6 +2563,17 @@
   "speechModalSelectLanguage": "Sélectionner la langue",
   "speechModalTitle": "Reconnaissance vocale",
   "speechModalTranscriptionProgress": "Progression de la transcription",
+  "syncActivityIndicatorSemantics": "Activité de synchronisation. Boîte d'envoi : {outbox}. Boîte de réception : {inbox}. Ouvrir la boîte d'envoi de synchronisation.",
+  "@syncActivityIndicatorSemantics": {
+    "placeholders": {
+      "outbox": {
+        "type": "int"
+      },
+      "inbox": {
+        "type": "int"
+      }
+    }
+  },
   "syncCreateNewRoom": "Créer une nouvelle salle",
   "syncCreateNewRoomInstead": "Créer une nouvelle salle à la place",
   "syncDeleteConfigConfirm": "OUI, JE SUIS SÛR",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1119,7 +1119,7 @@
   "configFlagResendAttachments": "Renvoyer les pièces jointes",
   "configFlagResendAttachmentsDescription": "Active cette option pour renvoyer automatiquement les téléchargements de pièces jointes ayant échoué lorsque la connexion est rétablie.",
   "configFlagShowSyncActivityIndicator": "Afficher l'indicateur d'activité de synchronisation",
-  "configFlagShowSyncActivityIndicatorDescription": "Affiche l'activité de synchronisation en direct dans la barre latérale — une bande LED tx/rx avec la profondeur des files entrante et sortante.",
+  "configFlagShowSyncActivityIndicatorDescription": "Affiche l'activité de synchronisation en direct dans la barre latérale — une bande LED tx/rx avec la profondeur des files d'entrée et de sortie.",
   "configFlagUseCloudInferenceDescription": "Utiliser les services d'IA basés sur le cloud pour des fonctionnalités améliorées. Cela nécessite une connexion Internet.",
   "configFlagUseCompressedJsonAttachments": "Compresser les payloads JSON de sync",
   "configFlagUseCompressedJsonAttachmentsDescription": "Compresse les pièces jointes JSON de synchronisation avec gzip avant l'envoi. Économise de la bande passante sur les réseaux lents, au prix d'un léger coût CPU à l'envoi et à la réception.",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4302,6 +4302,18 @@ abstract class AppLocalizations {
   /// **'Enable this to automatically resend failed attachment uploads when the connection is restored.'**
   String get configFlagResendAttachmentsDescription;
 
+  /// No description provided for @configFlagShowSyncActivityIndicator.
+  ///
+  /// In en, this message translates to:
+  /// **'Show sync activity indicator'**
+  String get configFlagShowSyncActivityIndicator;
+
+  /// No description provided for @configFlagShowSyncActivityIndicatorDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Show live sync activity in the sidebar — a tx/rx LED strip with outbox and inbox depth.'**
+  String get configFlagShowSyncActivityIndicatorDescription;
+
   /// No description provided for @configFlagUseCloudInferenceDescription.
   ///
   /// In en, this message translates to:
@@ -10464,6 +10476,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Transcription Progress'**
   String get speechModalTranscriptionProgress;
+
+  /// No description provided for @syncActivityIndicatorSemantics.
+  ///
+  /// In en, this message translates to:
+  /// **'Sync activity. Outbox: {outbox}. Inbox: {inbox}. Open sync outbox.'**
+  String syncActivityIndicatorSemantics(int outbox, int inbox);
 
   /// No description provided for @syncCreateNewRoom.
   ///

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -2496,6 +2496,14 @@ class AppLocalizationsCs extends AppLocalizations {
       'Povolte toto nastavení pro automatické opětovné odeslání neúspěšného nahrávání příloh po obnovení připojení.';
 
   @override
+  String get configFlagShowSyncActivityIndicator =>
+      'Zobrazit indikátor aktivity synchronizace';
+
+  @override
+  String get configFlagShowSyncActivityIndicatorDescription =>
+      'Zobrazit živou aktivitu synchronizace v postranním panelu — tx/rx LED proužek s hloubkou odchozí a příchozí fronty.';
+
+  @override
   String get configFlagUseCloudInferenceDescription =>
       'Používat AI služby v cloudu pro vylepšené funkce. Vyžaduje připojení k internetu.';
 
@@ -6087,6 +6095,11 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get speechModalTranscriptionProgress => 'Pokrok přepisu';
+
+  @override
+  String syncActivityIndicatorSemantics(int outbox, int inbox) {
+    return 'Aktivita synchronizace. Odchozí: $outbox. Příchozí: $inbox. Otevřít odchozí frontu synchronizace.';
+  }
 
   @override
   String get syncCreateNewRoom => 'Vytvořit novou místnost';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2506,6 +2506,14 @@ class AppLocalizationsDe extends AppLocalizations {
       'Aktiviere diese Option, um fehlgeschlagene Anlagen-Uploads automatisch erneut zu senden, wenn die Verbindung wiederhergestellt ist.';
 
   @override
+  String get configFlagShowSyncActivityIndicator =>
+      'Sync-Aktivitätsanzeige einblenden';
+
+  @override
+  String get configFlagShowSyncActivityIndicatorDescription =>
+      'Live-Sync-Aktivität in der Seitenleiste anzeigen — eine tx/rx-LED-Leiste mit Outbox- und Inbox-Tiefe.';
+
+  @override
   String get configFlagUseCloudInferenceDescription =>
       'Cloud-basierte KI-Dienste für erweiterte Funktionen verwenden. Dies erfordert eine Internetverbindung.';
 
@@ -6074,6 +6082,11 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get speechModalTranscriptionProgress => 'Transkriptionsfortschritt';
+
+  @override
+  String syncActivityIndicatorSemantics(int outbox, int inbox) {
+    return 'Sync-Aktivität. Outbox: $outbox. Inbox: $inbox. Sync-Outbox öffnen.';
+  }
 
   @override
   String get syncCreateNewRoom => 'Neuen Raum erstellen';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2468,6 +2468,14 @@ class AppLocalizationsEn extends AppLocalizations {
       'Enable this to automatically resend failed attachment uploads when the connection is restored.';
 
   @override
+  String get configFlagShowSyncActivityIndicator =>
+      'Show sync activity indicator';
+
+  @override
+  String get configFlagShowSyncActivityIndicatorDescription =>
+      'Show live sync activity in the sidebar — a tx/rx LED strip with outbox and inbox depth.';
+
+  @override
   String get configFlagUseCloudInferenceDescription =>
       'Use cloud-based AI services for enhanced features. This requires an internet connection.';
 
@@ -5985,6 +5993,11 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get speechModalTranscriptionProgress => 'Transcription Progress';
+
+  @override
+  String syncActivityIndicatorSemantics(int outbox, int inbox) {
+    return 'Sync activity. Outbox: $outbox. Inbox: $inbox. Open sync outbox.';
+  }
 
   @override
   String get syncCreateNewRoom => 'Create New Room';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2544,6 +2544,14 @@ class AppLocalizationsEs extends AppLocalizations {
       'Activar para reenviar automáticamente las cargas de archivos adjuntos fallidas cuando se restablezca la conexión.';
 
   @override
+  String get configFlagShowSyncActivityIndicator =>
+      'Mostrar indicador de actividad de sincronización';
+
+  @override
+  String get configFlagShowSyncActivityIndicatorDescription =>
+      'Muestra la actividad de sincronización en directo en la barra lateral — una franja LED tx/rx con la profundidad de bandejas de entrada y salida.';
+
+  @override
   String get configFlagUseCloudInferenceDescription =>
       'Utiliza servicios de IA basados en la nube para funciones mejoradas. Esto requiere una conexión a Internet.';
 
@@ -6173,6 +6181,11 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get speechModalTranscriptionProgress => 'Progreso de la transcripción';
+
+  @override
+  String syncActivityIndicatorSemantics(int outbox, int inbox) {
+    return 'Actividad de sincronización. Bandeja de salida: $outbox. Bandeja de entrada: $inbox. Abrir bandeja de salida de sincronización.';
+  }
 
   @override
   String get syncCreateNewRoom => 'Crear nueva sala';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2544,7 +2544,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get configFlagShowSyncActivityIndicatorDescription =>
-      'Affiche l\'activité de synchronisation en direct dans la barre latérale — une bande LED tx/rx avec la profondeur des files entrante et sortante.';
+      'Affiche l\'activité de synchronisation en direct dans la barre latérale — une bande LED tx/rx avec la profondeur des files d\'entrée et de sortie.';
 
   @override
   String get configFlagUseCloudInferenceDescription =>

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2539,6 +2539,14 @@ class AppLocalizationsFr extends AppLocalizations {
       'Active cette option pour renvoyer automatiquement les téléchargements de pièces jointes ayant échoué lorsque la connexion est rétablie.';
 
   @override
+  String get configFlagShowSyncActivityIndicator =>
+      'Afficher l\'indicateur d\'activité de synchronisation';
+
+  @override
+  String get configFlagShowSyncActivityIndicatorDescription =>
+      'Affiche l\'activité de synchronisation en direct dans la barre latérale — une bande LED tx/rx avec la profondeur des files entrante et sortante.';
+
+  @override
   String get configFlagUseCloudInferenceDescription =>
       'Utiliser les services d\'IA basés sur le cloud pour des fonctionnalités améliorées. Cela nécessite une connexion Internet.';
 
@@ -6182,6 +6190,11 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get speechModalTranscriptionProgress =>
       'Progression de la transcription';
+
+  @override
+  String syncActivityIndicatorSemantics(int outbox, int inbox) {
+    return 'Activité de synchronisation. Boîte d\'envoi : $outbox. Boîte de réception : $inbox. Ouvrir la boîte d\'envoi de synchronisation.';
+  }
 
   @override
   String get syncCreateNewRoom => 'Créer une nouvelle salle';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -2520,7 +2520,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get configFlagShowSyncActivityIndicatorDescription =>
-      'Afișați activitatea de sincronizare live în bara laterală — o bandă LED tx/rx cu adâncimea cozilor de ieșire și intrare.';
+      'Afișează activitatea de sincronizare live în bara laterală — o bandă LED tx/rx cu adâncimea cozilor de ieșire și intrare.';
 
   @override
   String get configFlagUseCloudInferenceDescription =>

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -2515,6 +2515,14 @@ class AppLocalizationsRo extends AppLocalizations {
       'Activați această opțiune pentru a retrimite automat încărcările de atașamente eșuate atunci când conexiunea este restabilită.';
 
   @override
+  String get configFlagShowSyncActivityIndicator =>
+      'Afișează indicatorul de activitate de sincronizare';
+
+  @override
+  String get configFlagShowSyncActivityIndicatorDescription =>
+      'Afișați activitatea de sincronizare live în bara laterală — o bandă LED tx/rx cu adâncimea cozilor de ieșire și intrare.';
+
+  @override
   String get configFlagUseCloudInferenceDescription =>
       'Utilizați servicii AI bazate pe cloud pentru funcții îmbunătățite. Acest lucru necesită o conexiune la internet.';
 
@@ -6125,6 +6133,11 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get speechModalTranscriptionProgress => 'Progresul transcrierii';
+
+  @override
+  String syncActivityIndicatorSemantics(int outbox, int inbox) {
+    return 'Activitate sincronizare. Coadă de ieșire: $outbox. Coadă de intrare: $inbox. Deschide coada de ieșire pentru sincronizare.';
+  }
 
   @override
   String get syncCreateNewRoom => 'Creează cameră nouă';

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -1119,7 +1119,7 @@
   "configFlagResendAttachments": "Retrimite atașamentele",
   "configFlagResendAttachmentsDescription": "Activați această opțiune pentru a retrimite automat încărcările de atașamente eșuate atunci când conexiunea este restabilită.",
   "configFlagShowSyncActivityIndicator": "Afișează indicatorul de activitate de sincronizare",
-  "configFlagShowSyncActivityIndicatorDescription": "Afișați activitatea de sincronizare live în bara laterală — o bandă LED tx/rx cu adâncimea cozilor de ieșire și intrare.",
+  "configFlagShowSyncActivityIndicatorDescription": "Afișează activitatea de sincronizare live în bara laterală — o bandă LED tx/rx cu adâncimea cozilor de ieșire și intrare.",
   "configFlagUseCloudInferenceDescription": "Utilizați servicii AI bazate pe cloud pentru funcții îmbunătățite. Acest lucru necesită o conexiune la internet.",
   "configFlagUseCompressedJsonAttachments": "Comprimă payload-urile JSON de sincronizare",
   "configFlagUseCompressedJsonAttachmentsDescription": "Comprimă cu gzip atașamentele JSON de sincronizare înainte de încărcare. Reduce consumul de lățime de bandă în rețele lente, cu un mic cost CPU la trimitere și primire.",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -1118,6 +1118,8 @@
   "configFlagRecordLocationDescription": "Înregistrează automat locația dvs. cu intrări noi. Acest lucru ajută la organizarea și căutarea pe baza locației.",
   "configFlagResendAttachments": "Retrimite atașamentele",
   "configFlagResendAttachmentsDescription": "Activați această opțiune pentru a retrimite automat încărcările de atașamente eșuate atunci când conexiunea este restabilită.",
+  "configFlagShowSyncActivityIndicator": "Afișează indicatorul de activitate de sincronizare",
+  "configFlagShowSyncActivityIndicatorDescription": "Afișați activitatea de sincronizare live în bara laterală — o bandă LED tx/rx cu adâncimea cozilor de ieșire și intrare.",
   "configFlagUseCloudInferenceDescription": "Utilizați servicii AI bazate pe cloud pentru funcții îmbunătățite. Acest lucru necesită o conexiune la internet.",
   "configFlagUseCompressedJsonAttachments": "Comprimă payload-urile JSON de sincronizare",
   "configFlagUseCompressedJsonAttachmentsDescription": "Comprimă cu gzip atașamentele JSON de sincronizare înainte de încărcare. Reduce consumul de lățime de bandă în rețele lente, cu un mic cost CPU la trimitere și primire.",
@@ -2561,6 +2563,17 @@
   "speechModalSelectLanguage": "Selectați limba",
   "speechModalTitle": "Recunoaștere vocală",
   "speechModalTranscriptionProgress": "Progresul transcrierii",
+  "syncActivityIndicatorSemantics": "Activitate sincronizare. Coadă de ieșire: {outbox}. Coadă de intrare: {inbox}. Deschide coada de ieșire pentru sincronizare.",
+  "@syncActivityIndicatorSemantics": {
+    "placeholders": {
+      "outbox": {
+        "type": "int"
+      },
+      "inbox": {
+        "type": "int"
+      }
+    }
+  },
   "syncCreateNewRoom": "Creează cameră nouă",
   "syncCreateNewRoomInstead": "Creează cameră nouă în schimb",
   "syncDeleteConfigConfirm": "DA, SUNT SIGUR",

--- a/lib/themes/theme.dart
+++ b/lib/themes/theme.dart
@@ -414,15 +414,18 @@ TextStyle monoTabularStyle({
   );
 }
 
-/// OpenType features applied to every count-style badge so digit shapes
-/// stay visually steady across renders:
+/// OpenType features applied to every count-style numeric surface
+/// (badges, sidebar sync activity strip, etc.) so digit shapes stay
+/// visually steady across renders:
 ///
 /// - `tnum` / [FontFeature.tabularFigures] — every digit advances by the
 ///   same width; counts ticking from `9` → `10` → `99` no longer twitch.
 /// - `cv02` / `cv03` / `cv04` — Inter's open-digit character variants
 ///   (open four, open six, open nine). The default Inter forms have
 ///   closed counters that read as smudges at small badge sizes; the open
-///   variants stay legible at 11–12 px.
+///   variants stay legible at 11–12 px. Fonts that don't define these
+///   variants (e.g. Inconsolata on the sync activity strip) silently
+///   ignore them, so the constant is safe to share.
 /// - `zero` / [FontFeature.slashedZero] — slashed zero so it cannot be
 ///   confused with `O` or `8` on dense badges.
 const numericBadgeFontFeatures = <FontFeature>[

--- a/lib/utils/consts.dart
+++ b/lib/utils/consts.dart
@@ -21,6 +21,7 @@ const enableEmbeddingsFlag = 'enable_embeddings';
 const enableVectorSearchFlag = 'enable_vector_search';
 
 const enableWhatsNewFlag = 'enable_whats_new';
+const showSyncActivityIndicatorFlag = 'show_sync_activity_indicator';
 
 const logAgentRuntimeFlag = 'log_agent_runtime';
 const logAgentWorkflowFlag = 'log_agent_workflow';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.984+4023
+version: 0.9.985+4024
 
 msix_config:
   display_name: LottiApp

--- a/test/database/database_test.dart
+++ b/test/database/database_test.dart
@@ -177,6 +177,11 @@ final expectedFlags = <ConfigFlag>{
     description: "Enable What's New feature?",
     status: false,
   ),
+  const ConfigFlag(
+    name: showSyncActivityIndicatorFlag,
+    description: 'Show live sync activity in the sidebar.',
+    status: false,
+  ),
 };
 
 void main() {

--- a/test/features/design_system/components/navigation/desktop_navigation_sidebar_test.dart
+++ b/test/features/design_system/components/navigation/desktop_navigation_sidebar_test.dart
@@ -559,6 +559,54 @@ void main() {
 
       expect(toggleCount, 1);
     });
+
+    testWidgets(
+      'aboveSettings slot renders between the nav and the Settings row '
+      'in expanded mode and stays hidden in collapsed mode',
+      (tester) async {
+        const slotKey = Key('above-settings-slot');
+        const slot = SizedBox(
+          key: slotKey,
+          height: 24,
+          child: Text('sync activity'),
+        );
+        final settings = DesktopSidebarDestination(
+          label: 'Settings',
+          iconBuilder: ({required bool active}) => const Icon(Icons.settings),
+        );
+
+        await tester.pumpWidget(
+          wrap(
+            DesktopNavigationSidebar(
+              destinations: buildDestinations(),
+              activeIndex: 0,
+              onDestinationSelected: (_) {},
+              settingsDestination: settings,
+              aboveSettings: slot,
+            ),
+          ),
+        );
+        await tester.pump();
+        expect(find.byKey(slotKey), findsOneWidget);
+
+        // Collapsed mode — slot is suppressed because the strip is too
+        // narrow to display readable monospace counters.
+        await tester.pumpWidget(
+          wrap(
+            DesktopNavigationSidebar(
+              destinations: buildDestinations(),
+              activeIndex: 0,
+              onDestinationSelected: (_) {},
+              settingsDestination: settings,
+              aboveSettings: slot,
+              collapsed: true,
+            ),
+          ),
+        );
+        await tester.pump();
+        expect(find.byKey(slotKey), findsNothing);
+      },
+    );
   });
 
   group('DesktopNavigationSidebar collapsed', () {

--- a/test/features/design_system/components/navigation/desktop_navigation_sidebar_test.dart
+++ b/test/features/design_system/components/navigation/desktop_navigation_sidebar_test.dart
@@ -561,8 +561,8 @@ void main() {
     });
 
     testWidgets(
-      'aboveSettings slot renders between the nav and the Settings row '
-      'in expanded mode and stays hidden in collapsed mode',
+      'aboveSettings slot renders BETWEEN the last nav item and the '
+      'Settings row in expanded mode and stays hidden in collapsed mode',
       (tester) async {
         const slotKey = Key('above-settings-slot');
         const slot = SizedBox(
@@ -588,6 +588,17 @@ void main() {
         );
         await tester.pump();
         expect(find.byKey(slotKey), findsOneWidget);
+
+        // Verify vertical placement: the slot must sit between the
+        // last nav row ("Habits") and the Settings row. A regression
+        // that hoisted the slot into the nav list or pushed it below
+        // Settings would still satisfy `findsOneWidget`, so these
+        // placement asserts are the load-bearing check.
+        final habitsY = tester.getCenter(find.text('Habits')).dy;
+        final slotY = tester.getCenter(find.byKey(slotKey)).dy;
+        final settingsY = tester.getCenter(find.text('Settings')).dy;
+        expect(slotY, greaterThan(habitsY));
+        expect(slotY, lessThan(settingsY));
 
         // Collapsed mode — slot is suppressed because the strip is too
         // narrow to display readable monospace counters.

--- a/test/features/settings/ui/pages/flags_page_test.dart
+++ b/test/features/settings/ui/pages/flags_page_test.dart
@@ -94,6 +94,11 @@ void main() {
             description: 'Bundle text-only outbox messages',
             status: false,
           ),
+          const ConfigFlag(
+            name: showSyncActivityIndicatorFlag,
+            description: 'Show live sync activity in the sidebar.',
+            status: false,
+          ),
         },
       ]),
     );
@@ -124,8 +129,9 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      // 10 flags in the mock data (8 originals + whats-new + outbox-bundling).
-      expect(find.byType(DesignSystemListItem), findsNWidgets(10));
+      // 11 flags in the mock data (8 originals + whats-new +
+      // outbox-bundling + sync-activity-indicator).
+      expect(find.byType(DesignSystemListItem), findsNWidgets(11));
     });
 
     testWidgets('uses SettingsIcon as leading widget', (tester) async {
@@ -134,7 +140,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(find.byType(SettingsIcon), findsNWidgets(10));
+      expect(find.byType(SettingsIcon), findsNWidgets(11));
     });
 
     testWidgets('shows correct title and description for private flag', (
@@ -365,6 +371,72 @@ void main() {
     });
   });
 
+  group('FlagsPage — sync activity indicator flag', () {
+    testWidgets(
+      'renders the sync activity indicator flag with its localized '
+      'title, description, and the network-check icon — covers the per-flag '
+      'arms in _iconForFlag/_titleForFlag/_subtitleForFlag',
+      (tester) async {
+        await tester.pumpWidget(
+          makeTestableWidgetWithScaffold(const FlagsPage()),
+        );
+        await tester.pumpAndSettle();
+
+        final context = tester.element(find.byType(FlagsPage));
+        final indicatorItem = find.widgetWithText(
+          DesignSystemListItem,
+          context.messages.configFlagShowSyncActivityIndicator,
+        );
+        await tester.ensureVisible(indicatorItem);
+        await tester.pumpAndSettle();
+        expect(indicatorItem, findsOneWidget);
+        expect(
+          find.text(
+            context.messages.configFlagShowSyncActivityIndicatorDescription,
+          ),
+          findsOneWidget,
+        );
+        expect(
+          find.descendant(
+            of: indicatorItem,
+            matching: find.byIcon(Icons.network_check_rounded),
+          ),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'toggling persists the sync activity indicator flag via '
+      'PersistenceLogic',
+      (tester) async {
+        await tester.pumpWidget(
+          makeTestableWidgetWithScaffold(const FlagsPage()),
+        );
+        await tester.pumpAndSettle();
+
+        final context = tester.element(find.byType(FlagsPage));
+        final indicatorItem = find.widgetWithText(
+          DesignSystemListItem,
+          context.messages.configFlagShowSyncActivityIndicator,
+        );
+        await tester.ensureVisible(indicatorItem);
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.descendant(of: indicatorItem, matching: find.byType(Switch)),
+        );
+        await tester.pump();
+
+        const expected = ConfigFlag(
+          name: showSyncActivityIndicatorFlag,
+          description: 'Show live sync activity in the sidebar.',
+          status: true,
+        );
+        verify(() => mockPersistenceLogic.setConfigFlag(expected)).called(1);
+      },
+    );
+  });
+
   group('FlagsPage — search bar', () {
     testWidgets('renders a single DesignSystemSearch above the list', (
       tester,
@@ -474,7 +546,7 @@ void main() {
         await tester.tap(clearIcon);
         await tester.pumpAndSettle();
 
-        expect(find.byType(DesignSystemListItem), findsNWidgets(10));
+        expect(find.byType(DesignSystemListItem), findsNWidgets(11));
       },
     );
 
@@ -495,7 +567,7 @@ void main() {
         // "list is restored" outcome.
         await tester.enterText(find.byType(DesignSystemSearch), '');
         await tester.pumpAndSettle();
-        expect(find.byType(DesignSystemListItem), findsNWidgets(10));
+        expect(find.byType(DesignSystemListItem), findsNWidgets(11));
       },
     );
 
@@ -512,7 +584,7 @@ void main() {
 
         // Whitespace-trimming inside `filterDisplayedFlags` keeps the
         // list intact rather than producing a "no match" empty state.
-        expect(find.byType(DesignSystemListItem), findsNWidgets(10));
+        expect(find.byType(DesignSystemListItem), findsNWidgets(11));
       },
     );
   });

--- a/test/features/settings/ui/pages/outbox/outbox_trailing_badge_test.dart
+++ b/test/features/settings/ui/pages/outbox/outbox_trailing_badge_test.dart
@@ -1,7 +1,9 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/database/state/config_flag_provider.dart';
 import 'package:lotti/features/design_system/components/badges/design_system_badge.dart';
 import 'package:lotti/features/settings/ui/pages/outbox/outbox_trailing_badge.dart';
 import 'package:lotti/providers/service_providers.dart';
+import 'package:lotti/utils/consts.dart';
 
 import '../../../../../mocks/mocks.dart';
 import '../../../../../mocks/sync_config_test_mocks.dart';
@@ -69,5 +71,34 @@ void main() {
 
       expect(find.byType(DesignSystemBadge), findsNothing);
     });
+
+    testWidgets(
+      'renders nothing when sidebar sync activity indicator is enabled',
+      (tester) async {
+        // Even with sync online and a non-zero count, the badge must
+        // disappear once the sidebar sync activity indicator is on —
+        // the indicator already surfaces the same number, so doubling
+        // up would be visual noise.
+        final syncDbMock = mockSyncDatabaseWithCount(7);
+        final dbMock = mockJournalDbWithSyncFlag(enabled: true);
+
+        await tester.pumpWidget(
+          makeTestableWidgetWithScaffold(
+            const OutboxTrailingBadge(),
+            overrides: [
+              journalDbProvider.overrideWithValue(dbMock),
+              syncDatabaseProvider.overrideWithValue(syncDbMock),
+              configFlagProvider(
+                showSyncActivityIndicatorFlag,
+              ).overrideWith((_) => Stream<bool>.value(true)),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(DesignSystemBadge), findsNothing);
+        expect(find.text('7'), findsNothing);
+      },
+    );
   });
 }

--- a/test/features/sync/state/outbox_state_controller_test.dart
+++ b/test/features/sync/state/outbox_state_controller_test.dart
@@ -402,13 +402,15 @@ void main() {
 
     test('syncActivityTxPulsesProvider forwards every TX pulse', () async {
       final received = <DateTime>[];
-      final sub = container
-          .listen<AsyncValue<DateTime>>(syncActivityTxPulsesProvider, (
-            _,
-            next,
-          ) {
-            if (next is AsyncData<DateTime>) received.add(next.value);
-          });
+      final sub = container.listen<AsyncValue<DateTime>>(
+        syncActivityTxPulsesProvider,
+        (
+          _,
+          next,
+        ) {
+          if (next is AsyncData<DateTime>) received.add(next.value);
+        },
+      );
 
       signaler
         ..pulseTx()
@@ -421,13 +423,15 @@ void main() {
 
     test('syncActivityRxPulsesProvider forwards every RX pulse', () async {
       final received = <DateTime>[];
-      final sub = container
-          .listen<AsyncValue<DateTime>>(syncActivityRxPulsesProvider, (
-            _,
-            next,
-          ) {
-            if (next is AsyncData<DateTime>) received.add(next.value);
-          });
+      final sub = container.listen<AsyncValue<DateTime>>(
+        syncActivityRxPulsesProvider,
+        (
+          _,
+          next,
+        ) {
+          if (next is AsyncData<DateTime>) received.add(next.value);
+        },
+      );
 
       signaler.pulseRx();
       await Future<void>.delayed(Duration.zero);
@@ -462,10 +466,9 @@ void main() {
     });
 
     test(
-      'seeds with the snapshot from queue.stats() then forwards live '
-      'depthChanges signals — covers the subscribe-before-await ordering '
-      'that prevents signals from being dropped during the initial '
-      'snapshot computation',
+      'seeds with the snapshot from queue.stats() — covers the '
+      'subscribe-before-await ordering that prevents signals from being '
+      'dropped during the initial snapshot computation',
       () async {
         const roomId = '!room:example.org';
         // Insert one active row so stats().total reports 1 on seed.
@@ -483,41 +486,47 @@ void main() {
               ),
             );
 
-        final emitted = <int>[];
-        final sub = inboundQueueDepthStream(queue).listen(emitted.add);
-
-        // Wait for the initial seed to land.
-        await Future<void>.delayed(const Duration(milliseconds: 20));
-        expect(emitted, isNotEmpty, reason: 'initial snapshot should emit');
-        expect(emitted.first, 1);
-
-        await sub.cancel();
+        // Synchronise on the first emission directly — `.first`
+        // resolves the moment the snapshot is yielded, so we don't
+        // have to guess at a wall-clock budget for `stats()`.
+        final firstEmission = await inboundQueueDepthStream(queue).first;
+        expect(firstEmission, 1);
       },
     );
 
     test(
-      'closes the relay cleanly when the consumer cancels, so a leaking '
-      'depthChanges subscription does not survive after the provider '
-      'auto-disposes',
+      'forwards a live depthChanges signal that arrives after the '
+      'snapshot — covers the steady-state `relay.add` path once the '
+      'generator has switched into draining mode',
       () async {
-        final emitted = <int>[];
-        final sub = inboundQueueDepthStream(queue).listen(emitted.add);
+        const roomId = '!room:example.org';
+        final stream = inboundQueueDepthStream(queue);
+        // expectLater + emitsThrough waits for the matched value
+        // without polling — synchronises on the actual event we care
+        // about (a depth change of `1`) and times out cleanly on
+        // regression rather than hanging the test runner.
+        final matched = expectLater(stream, emitsThrough(1));
 
-        await Future<void>.delayed(const Duration(milliseconds: 5));
-        await sub.cancel();
+        // Trigger a live depth signal by inserting an active row and
+        // letting the queue emit through `_scheduleDepthEmit`.
+        await db
+            .into(db.inboundEventQueue)
+            .insert(
+              InboundEventQueueCompanion.insert(
+                eventId: r'$live',
+                roomId: roomId,
+                originTs: 2000,
+                producer: InboundEventProducer.live.name,
+                rawJson: jsonEncode(<String, dynamic>{}),
+                enqueuedAt: clock.now().millisecondsSinceEpoch,
+                status: const Value('enqueued'),
+              ),
+            );
+        // The queue's internal `_emitDepth` runs on a microtask boundary.
+        // Nudge it so `expectLater` resolves without a wall-clock wait.
+        await Future<void>.value();
 
-        // Re-subscribe — if the previous relay had leaked an active
-        // listener on `queue.depthChanges`, this second subscription
-        // would still need to fire the initial seed independently.
-        // (Implicit: no exception thrown on cancel.)
-        final secondEmitted = <int>[];
-        final secondSub = inboundQueueDepthStream(queue).listen(
-          secondEmitted.add,
-        );
-        await Future<void>.delayed(const Duration(milliseconds: 5));
-        await secondSub.cancel();
-
-        expect(secondEmitted, isNotEmpty);
+        await matched.timeout(const Duration(seconds: 2));
       },
     );
   });

--- a/test/features/sync/state/outbox_state_controller_test.dart
+++ b/test/features/sync/state/outbox_state_controller_test.dart
@@ -1,10 +1,17 @@
 import 'dart:async';
+import 'dart:convert';
 
+import 'package:clock/clock.dart';
+import 'package:drift/drift.dart' show Value;
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/features/sync/outbox/outbox_daily_volume.dart';
+import 'package:lotti/features/sync/queue/inbound_event_queue.dart';
 import 'package:lotti/features/sync/state/outbox_state_controller.dart';
+import 'package:lotti/features/sync/state/sync_activity_signaler.dart';
 import 'package:lotti/providers/service_providers.dart';
 import 'package:lotti/utils/consts.dart';
 import 'package:lotti/widgets/charts/utils.dart';
@@ -362,5 +369,156 @@ void main() {
         );
       });
     });
+  });
+
+  group('Sync activity providers', () {
+    late SyncActivitySignaler signaler;
+    late ProviderContainer container;
+
+    setUp(() {
+      signaler = SyncActivitySignaler();
+      // Reset getIt because the syncActivitySignalerProvider resolves
+      // through it; the OutboxStateController group above doesn't
+      // touch getIt so this is the first registration.
+      if (GetIt.I.isRegistered<SyncActivitySignaler>()) {
+        GetIt.I.unregister<SyncActivitySignaler>();
+      }
+      GetIt.I.registerSingleton<SyncActivitySignaler>(signaler);
+      container = ProviderContainer();
+    });
+
+    tearDown(() async {
+      container.dispose();
+      await signaler.dispose();
+      if (GetIt.I.isRegistered<SyncActivitySignaler>()) {
+        GetIt.I.unregister<SyncActivitySignaler>();
+      }
+    });
+
+    test('syncActivitySignalerProvider returns the getIt singleton', () {
+      final resolved = container.read(syncActivitySignalerProvider);
+      expect(identical(resolved, signaler), isTrue);
+    });
+
+    test('syncActivityTxPulsesProvider forwards every TX pulse', () async {
+      final received = <DateTime>[];
+      final sub = container
+          .listen<AsyncValue<DateTime>>(syncActivityTxPulsesProvider, (
+            _,
+            next,
+          ) {
+            if (next is AsyncData<DateTime>) received.add(next.value);
+          });
+
+      signaler
+        ..pulseTx()
+        ..pulseTx();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, hasLength(2));
+      sub.close();
+    });
+
+    test('syncActivityRxPulsesProvider forwards every RX pulse', () async {
+      final received = <DateTime>[];
+      final sub = container
+          .listen<AsyncValue<DateTime>>(syncActivityRxPulsesProvider, (
+            _,
+            next,
+          ) {
+            if (next is AsyncData<DateTime>) received.add(next.value);
+          });
+
+      signaler.pulseRx();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, hasLength(1));
+      sub.close();
+    });
+  });
+
+  group('inboundQueueDepthProvider — _inboundQueueDepthStream', () {
+    late SyncDatabase db;
+    late MockLoggingService logging;
+    late InboundQueue queue;
+
+    setUpAll(() {
+      registerFallbackValue(StackTrace.empty);
+    });
+
+    setUp(() {
+      db = SyncDatabase(inMemoryDatabase: true);
+      logging = MockLoggingService();
+      queue = InboundQueue(
+        db: db,
+        logging: logging,
+        leaseDuration: const Duration(seconds: 1),
+      );
+    });
+
+    tearDown(() async {
+      await queue.dispose();
+      await db.close();
+    });
+
+    test(
+      'seeds with the snapshot from queue.stats() then forwards live '
+      'depthChanges signals — covers the subscribe-before-await ordering '
+      'that prevents signals from being dropped during the initial '
+      'snapshot computation',
+      () async {
+        const roomId = '!room:example.org';
+        // Insert one active row so stats().total reports 1 on seed.
+        await db
+            .into(db.inboundEventQueue)
+            .insert(
+              InboundEventQueueCompanion.insert(
+                eventId: r'$seed',
+                roomId: roomId,
+                originTs: 1000,
+                producer: InboundEventProducer.live.name,
+                rawJson: jsonEncode(<String, dynamic>{}),
+                enqueuedAt: clock.now().millisecondsSinceEpoch,
+                status: const Value('enqueued'),
+              ),
+            );
+
+        final emitted = <int>[];
+        final sub = inboundQueueDepthStream(queue).listen(emitted.add);
+
+        // Wait for the initial seed to land.
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(emitted, isNotEmpty, reason: 'initial snapshot should emit');
+        expect(emitted.first, 1);
+
+        await sub.cancel();
+      },
+    );
+
+    test(
+      'closes the relay cleanly when the consumer cancels, so a leaking '
+      'depthChanges subscription does not survive after the provider '
+      'auto-disposes',
+      () async {
+        final emitted = <int>[];
+        final sub = inboundQueueDepthStream(queue).listen(emitted.add);
+
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+        await sub.cancel();
+
+        // Re-subscribe — if the previous relay had leaked an active
+        // listener on `queue.depthChanges`, this second subscription
+        // would still need to fire the initial seed independently.
+        // (Implicit: no exception thrown on cancel.)
+        final secondEmitted = <int>[];
+        final secondSub = inboundQueueDepthStream(queue).listen(
+          secondEmitted.add,
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+        await secondSub.cancel();
+
+        expect(secondEmitted, isNotEmpty);
+      },
+    );
   });
 }

--- a/test/features/sync/state/outbox_state_controller_test.dart
+++ b/test/features/sync/state/outbox_state_controller_test.dart
@@ -10,6 +10,7 @@ import 'package:get_it/get_it.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/features/sync/outbox/outbox_daily_volume.dart';
 import 'package:lotti/features/sync/queue/inbound_event_queue.dart';
+import 'package:lotti/features/sync/queue/queue_pipeline_coordinator.dart';
 import 'package:lotti/features/sync/state/outbox_state_controller.dart';
 import 'package:lotti/features/sync/state/sync_activity_signaler.dart';
 import 'package:lotti/providers/service_providers.dart';
@@ -497,37 +498,133 @@ void main() {
     test(
       'forwards a live depthChanges signal that arrives after the '
       'snapshot — covers the steady-state `relay.add` path once the '
-      'generator has switched into draining mode',
+      'consumer is listening',
       () async {
-        const roomId = '!room:example.org';
-        final stream = inboundQueueDepthStream(queue);
-        // expectLater + emitsThrough waits for the matched value
-        // without polling — synchronises on the actual event we care
-        // about (a depth change of `1`) and times out cleanly on
-        // regression rather than hanging the test runner.
-        final matched = expectLater(stream, emitsThrough(1));
-
-        // Trigger a live depth signal by inserting an active row and
-        // letting the queue emit through `_scheduleDepthEmit`.
+        const roomA = '!a:example.org';
+        const roomB = '!b:example.org';
+        // Insert one row in roomA so the snapshot reports total: 1.
         await db
             .into(db.inboundEventQueue)
             .insert(
               InboundEventQueueCompanion.insert(
-                eventId: r'$live',
-                roomId: roomId,
-                originTs: 2000,
+                eventId: r'$seed',
+                roomId: roomA,
+                originTs: 1000,
                 producer: InboundEventProducer.live.name,
                 rawJson: jsonEncode(<String, dynamic>{}),
                 enqueuedAt: clock.now().millisecondsSinceEpoch,
                 status: const Value('enqueued'),
               ),
             );
-        // The queue's internal `_emitDepth` runs on a microtask boundary.
-        // Nudge it so `expectLater` resolves without a wall-clock wait.
+
+        // `emitsInOrder` waits for the snapshot (1) and then a live
+        // depth signal of (0). The live signal fires when we prune the
+        // stranded row in roomA — `pruneStrandedEntries(roomB)` flips
+        // every active row that doesn't belong to roomB to abandoned
+        // and calls `_scheduleDepthEmit`, exercising the
+        // `relay.hasListener → relay.add(value)` branch.
+        final stream = inboundQueueDepthStream(queue);
+        final matched = expectLater(stream, emitsInOrder(<int>[1, 0]));
+
+        // Yield once so the generator has time to subscribe AND run
+        // its initial `stats()` fetch before we trigger the live emit.
         await Future<void>.value();
+        await Future<void>.value();
+        await queue.pruneStrandedEntries(roomB);
 
         await matched.timeout(const Duration(seconds: 2));
       },
     );
+
+    test(
+      'replays buffered live signals in arrival order when they beat the '
+      '`stats()` snapshot — covers the `else` branch of the '
+      'buffered/snapshot decision in `inboundQueueDepthStream`',
+      () async {
+        // Insert two rows so a future prune emits a depth-of-zero
+        // signal that lands during the generator's `stats()` await.
+        const roomA = '!a:example.org';
+        const roomB = '!b:example.org';
+        for (var i = 0; i < 2; i++) {
+          await db
+              .into(db.inboundEventQueue)
+              .insert(
+                InboundEventQueueCompanion.insert(
+                  eventId: '\$row-$i',
+                  roomId: roomA,
+                  originTs: 1000 + i,
+                  producer: InboundEventProducer.live.name,
+                  rawJson: jsonEncode(<String, dynamic>{}),
+                  enqueuedAt: clock.now().millisecondsSinceEpoch,
+                  status: const Value('enqueued'),
+                ),
+              );
+        }
+
+        // Subscribe to the stream and IMMEDIATELY trigger a depth emit
+        // before the generator's `stats()` await resolves. The signal
+        // lands while the consumer hasn't started listening to the
+        // relay yet (`relay.hasListener == false`), so the value is
+        // captured into the `buffered` list. Once `stats()` settles,
+        // the snapshot branch is skipped (`buffered.isEmpty == false`)
+        // and the buffered values are replayed instead.
+        final received = <int>[];
+        final completer = Completer<void>();
+        final sub = inboundQueueDepthStream(queue).listen((value) {
+          received.add(value);
+          if (received.contains(0) && !completer.isCompleted) {
+            completer.complete();
+          }
+        });
+
+        // Fire the live signal synchronously (no `await` between the
+        // listen() call and the prune) so it races the generator's
+        // `stats()` await.
+        unawaited(queue.pruneStrandedEntries(roomB));
+
+        await completer.future.timeout(const Duration(seconds: 2));
+        await sub.cancel();
+        // The replay path emitted `0` (the post-prune depth). A
+        // regression that emitted `2` (the stale snapshot) before
+        // `0` would still pass `received.contains(0)`, so we also
+        // assert there is no stale `2` ahead of the `0`.
+        expect(received, contains(0));
+        final indexOfZero = received.indexOf(0);
+        expect(received.sublist(0, indexOfZero), isNot(contains(2)));
+      },
+    );
+
+    test(
+      'inboundQueueDepthProvider resolves the queue via MatrixService and '
+      'streams the seeded depth — covers the provider entry point',
+      () async {
+        final mockMatrix = MockMatrixService();
+        final mockCoordinator = _MockQueueCoordinator();
+        when(() => mockMatrix.queueCoordinator).thenReturn(mockCoordinator);
+        when(() => mockCoordinator.queue).thenReturn(queue);
+
+        final container = ProviderContainer(
+          overrides: [matrixServiceProvider.overrideWithValue(mockMatrix)],
+        );
+        addTearDown(container.dispose);
+
+        final completer = Completer<int>();
+        container.listen<AsyncValue<int>>(inboundQueueDepthProvider, (
+          _,
+          next,
+        ) {
+          if (next is AsyncData<int> && !completer.isCompleted) {
+            completer.complete(next.value);
+          }
+        }, fireImmediately: true);
+
+        final value = await completer.future.timeout(
+          const Duration(seconds: 2),
+        );
+        expect(value, 0);
+      },
+    );
   });
 }
+
+class _MockQueueCoordinator extends Mock implements QueuePipelineCoordinator {}

--- a/test/features/sync/state/sync_activity_signaler_test.dart
+++ b/test/features/sync/state/sync_activity_signaler_test.dart
@@ -13,7 +13,7 @@ void main() {
       await signaler.dispose();
     });
 
-    test('emits one TX pulse per pulseTx call by default', () async {
+    test('emits one TX pulse per pulseTx call', () async {
       final pulses = <DateTime>[];
       final sub = signaler.txPulses.listen(pulses.add);
 
@@ -24,29 +24,24 @@ void main() {
       await sub.cancel();
     });
 
-    test('emits N TX pulses when count > 1 (bundle send)', () async {
-      final pulses = <DateTime>[];
-      final sub = signaler.txPulses.listen(pulses.add);
+    test(
+      'pulseTx coalesces a batch into one emission — '
+      'the LED hold window is per pulse, not per packet, so '
+      'emitting once per batch produces an identical visual',
+      () async {
+        final pulses = <DateTime>[];
+        final sub = signaler.txPulses.listen(pulses.add);
 
-      signaler.pulseTx(count: 5);
-      await Future<void>.delayed(Duration.zero);
+        signaler
+          ..pulseTx()
+          ..pulseTx()
+          ..pulseTx();
+        await Future<void>.delayed(Duration.zero);
 
-      expect(pulses, hasLength(5));
-      await sub.cancel();
-    });
-
-    test('drops invalid TX counts (zero / negative)', () async {
-      final pulses = <DateTime>[];
-      final sub = signaler.txPulses.listen(pulses.add);
-
-      signaler
-        ..pulseTx(count: 0)
-        ..pulseTx(count: -1);
-      await Future<void>.delayed(Duration.zero);
-
-      expect(pulses, isEmpty);
-      await sub.cancel();
-    });
+        expect(pulses, hasLength(3));
+        await sub.cancel();
+      },
+    );
 
     test('emits one RX pulse per pulseRx call', () async {
       final pulses = <DateTime>[];

--- a/test/features/sync/state/sync_activity_signaler_test.dart
+++ b/test/features/sync/state/sync_activity_signaler_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/sync/state/sync_activity_signaler.dart';
+
+void main() {
+  group('SyncActivitySignaler', () {
+    late SyncActivitySignaler signaler;
+
+    setUp(() {
+      signaler = SyncActivitySignaler();
+    });
+
+    tearDown(() async {
+      await signaler.dispose();
+    });
+
+    test('emits one TX pulse per pulseTx call by default', () async {
+      final pulses = <DateTime>[];
+      final sub = signaler.txPulses.listen(pulses.add);
+
+      signaler.pulseTx();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(pulses, hasLength(1));
+      await sub.cancel();
+    });
+
+    test('emits N TX pulses when count > 1 (bundle send)', () async {
+      final pulses = <DateTime>[];
+      final sub = signaler.txPulses.listen(pulses.add);
+
+      signaler.pulseTx(count: 5);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(pulses, hasLength(5));
+      await sub.cancel();
+    });
+
+    test('drops invalid TX counts (zero / negative)', () async {
+      final pulses = <DateTime>[];
+      final sub = signaler.txPulses.listen(pulses.add);
+
+      signaler
+        ..pulseTx(count: 0)
+        ..pulseTx(count: -1);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(pulses, isEmpty);
+      await sub.cancel();
+    });
+
+    test('emits one RX pulse per pulseRx call', () async {
+      final pulses = <DateTime>[];
+      final sub = signaler.rxPulses.listen(pulses.add);
+
+      signaler
+        ..pulseRx()
+        ..pulseRx();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(pulses, hasLength(2));
+      await sub.cancel();
+    });
+
+    test('TX and RX channels are independent', () async {
+      final tx = <DateTime>[];
+      final rx = <DateTime>[];
+      final txSub = signaler.txPulses.listen(tx.add);
+      final rxSub = signaler.rxPulses.listen(rx.add);
+
+      signaler
+        ..pulseTx()
+        ..pulseRx()
+        ..pulseTx();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(tx, hasLength(2));
+      expect(rx, hasLength(1));
+      await txSub.cancel();
+      await rxSub.cancel();
+    });
+
+    test(
+      'streams are broadcast — late subscriber misses earlier events',
+      () async {
+        signaler.pulseTx();
+        await Future<void>.delayed(Duration.zero);
+
+        final pulses = <DateTime>[];
+        final sub = signaler.txPulses.listen(pulses.add);
+        signaler.pulseTx();
+        await Future<void>.delayed(Duration.zero);
+
+        // Late subscriber should only see the second pulse (broadcast).
+        expect(pulses, hasLength(1));
+        await sub.cancel();
+      },
+    );
+
+    test('after dispose, further pulses are no-ops', () async {
+      await signaler.dispose();
+      // Re-subscribing on a closed broadcast stream throws, so we just
+      // verify pulseTx/pulseRx do not throw post-close.
+      expect(signaler.pulseTx, returnsNormally);
+      expect(signaler.pulseRx, returnsNormally);
+    });
+  });
+}

--- a/test/features/sync/ui/widgets/sync_activity_indicator_test.dart
+++ b/test/features/sync/ui/widgets/sync_activity_indicator_test.dart
@@ -162,9 +162,15 @@ void main() {
       await tester.pump();
 
       final colors = ledColors(tester);
-      // First LED is TX, second is RX (column order).
+      // First LED is TX, second is RX (column order). The RX color is
+      // resolved from `tokens.colors.interactive.enabled` at build
+      // time — assert against "active" rather than against an
+      // imported literal so a token tweak doesn't silently fail this
+      // assertion.
       expect(colors[0], isNot(equals(kSyncActivityTxColor)));
-      expect(colors[1], equals(kSyncActivityRxColor));
+      expect(colors[1], isNotNull);
+      expect(colors[1], isNot(equals(const Color(0x1AFFFFFF))));
+      expect(colors[1], isNot(equals(kSyncActivityTxColor)));
 
       await tester.pump(
         kSyncActivityLedHold + const Duration(milliseconds: 5),
@@ -193,5 +199,28 @@ void main() {
         kSyncActivityLedHold + const Duration(milliseconds: 5),
       );
     });
+
+    testWidgets(
+      'idle background is transparent — sanity check that the hover wash '
+      'is opt-in (the `_hovered = true` path is exercised in manual smoke '
+      'tests; FocusableActionDetector hover hooks do not fire reliably '
+      'under flutter_test pointer simulation, so we do not assert on the '
+      'hovered state here)',
+      (tester) async {
+        await pumpIndicator(tester, outbox: 1);
+
+        final container = tester
+            .widgetList<AnimatedContainer>(find.byType(AnimatedContainer))
+            .firstWhere(
+              (c) =>
+                  c.padding ==
+                  const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+            );
+        expect(
+          (container.decoration! as BoxDecoration).color,
+          Colors.transparent,
+        );
+      },
+    );
   });
 }

--- a/test/features/sync/ui/widgets/sync_activity_indicator_test.dart
+++ b/test/features/sync/ui/widgets/sync_activity_indicator_test.dart
@@ -1,10 +1,15 @@
 import 'dart:async';
 
+import 'package:beamer/beamer.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/sync/state/outbox_state_controller.dart';
 import 'package:lotti/features/sync/ui/widgets/sync_activity_indicator.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/nav_service.dart';
+import 'package:mocktail/mocktail.dart';
 
+import '../../../../mocks/mocks.dart';
 import '../../../../widget_test_utils.dart';
 
 void main() {
@@ -125,6 +130,44 @@ void main() {
       expect(navigated, [kSyncOutboxRoute]);
     });
 
+    testWidgets(
+      'tapping with no override switches the Settings tab and beams the '
+      'settings delegate to the sync sub-route — covers the production '
+      'NavService path in `_handleTap`',
+      (tester) async {
+        // Production path: no test override registered, so `_handleTap`
+        // resolves the real NavService via getIt. Register a mock that
+        // records the call sequence; we don't need a real beamer.
+        SyncActivityIndicatorTestHooks.navigatorOverride = null;
+
+        final mockNav = MockNavService();
+        final mockDelegate = _RecordingBeamerDelegate();
+        when(() => mockNav.settingsIndex).thenReturn(6);
+        when(() => mockNav.tapIndex(any())).thenReturn(null);
+        when(() => mockNav.settingsDelegate).thenReturn(mockDelegate);
+        when(
+          () => mockNav.persistNamedRoute(any()),
+        ).thenAnswer((_) async {});
+        if (getIt.isRegistered<NavService>()) {
+          getIt.unregister<NavService>();
+        }
+        getIt.registerSingleton<NavService>(mockNav);
+        addTearDown(() {
+          if (getIt.isRegistered<NavService>()) {
+            getIt.unregister<NavService>();
+          }
+        });
+
+        await pumpIndicator(tester, outbox: 5);
+        await tester.tap(find.byType(SyncActivityIndicator));
+        await tester.pump();
+
+        verify(() => mockNav.tapIndex(6)).called(1);
+        verify(() => mockNav.persistNamedRoute(kSyncOutboxRoute)).called(1);
+        expect(mockDelegate.beamed, [kSyncOutboxRoute]);
+      },
+    );
+
     /// Returns every LED background colour in widget tree order
     /// (tx first, rx second). LEDs are the only `AnimatedContainer`s
     /// whose decoration uses `BoxShape.circle`, so we filter on that.
@@ -232,4 +275,33 @@ void main() {
       },
     );
   });
+}
+
+/// Captures `beamToNamed` calls without spinning up a real Beamer
+/// router. Used to verify the production `_handleTap` path forwards
+/// the sync outbox route to the Settings delegate.
+class _RecordingBeamerDelegate extends BeamerDelegate {
+  _RecordingBeamerDelegate()
+    : super(
+        locationBuilder: RoutesLocationBuilder(
+          routes: {'*': (_, _, _) => const SizedBox.shrink()},
+        ).call,
+      );
+
+  final List<String> beamed = <String>[];
+
+  @override
+  void beamToNamed(
+    String uri, {
+    Object? data,
+    Object? routeState,
+    bool beamBackOnPop = false,
+    bool popBeamLocationOnPop = false,
+    bool stacked = true,
+    bool replaceRouteInformation = false,
+    TransitionDelegate<dynamic>? transitionDelegate,
+    String? popToNamed,
+  }) {
+    beamed.add(uri);
+  }
 }

--- a/test/features/sync/ui/widgets/sync_activity_indicator_test.dart
+++ b/test/features/sync/ui/widgets/sync_activity_indicator_test.dart
@@ -1,0 +1,203 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/sync/state/outbox_state_controller.dart';
+import 'package:lotti/features/sync/ui/widgets/sync_activity_indicator.dart';
+
+import '../../../../widget_test_utils.dart';
+
+void main() {
+  group('SyncActivityIndicator', () {
+    late StreamController<DateTime> txCtl;
+    late StreamController<DateTime> rxCtl;
+    late StreamController<int> outboxCtl;
+    late StreamController<int> inboxCtl;
+
+    setUp(() {
+      txCtl = StreamController<DateTime>.broadcast();
+      rxCtl = StreamController<DateTime>.broadcast();
+      outboxCtl = StreamController<int>.broadcast();
+      inboxCtl = StreamController<int>.broadcast();
+      SyncActivityIndicatorTestHooks.navigatorOverride = null;
+    });
+
+    tearDown(() async {
+      SyncActivityIndicatorTestHooks.navigatorOverride = null;
+      await txCtl.close();
+      await rxCtl.close();
+      await outboxCtl.close();
+      await inboxCtl.close();
+    });
+
+    Future<void> pumpIndicator(
+      WidgetTester tester, {
+      int outbox = 0,
+      int inbox = 0,
+    }) async {
+      await tester.pumpWidget(
+        makeTestableWidget(
+          const SyncActivityIndicator(),
+          overrides: [
+            syncActivityTxPulsesProvider.overrideWith((_) => txCtl.stream),
+            syncActivityRxPulsesProvider.overrideWith((_) => rxCtl.stream),
+            outboxPendingCountProvider.overrideWith(
+              (_) => Stream<int>.value(outbox),
+            ),
+            inboundQueueDepthProvider.overrideWith(
+              (_) => Stream<int>.value(inbox),
+            ),
+          ],
+        ),
+      );
+      await tester.pump();
+    }
+
+    testWidgets('renders both tx and rx rows with their counts', (
+      tester,
+    ) async {
+      await pumpIndicator(tester, outbox: 289, inbox: 14);
+
+      expect(find.text('tx'), findsOneWidget);
+      expect(find.text('rx'), findsOneWidget);
+      expect(find.text('289'), findsOneWidget);
+      expect(find.text('14'), findsOneWidget);
+    });
+
+    testWidgets('hides numeric values when both queues are empty', (
+      tester,
+    ) async {
+      await pumpIndicator(tester);
+
+      // Rows still render so the affordance stays clickable, but the
+      // numeric "0" is suppressed — the LEDs alone carry the idle state.
+      expect(find.text('tx'), findsOneWidget);
+      expect(find.text('rx'), findsOneWidget);
+      expect(find.text('0'), findsNothing);
+    });
+
+    testWidgets('hides only the zero row when one channel is non-zero', (
+      tester,
+    ) async {
+      await pumpIndicator(tester, outbox: 12);
+
+      expect(find.text('12'), findsOneWidget);
+      expect(find.text('0'), findsNothing);
+    });
+
+    testWidgets('exposes a button-role semantics label with both counts', (
+      tester,
+    ) async {
+      await pumpIndicator(tester, outbox: 289, inbox: 14);
+
+      final semantics = tester.getSemantics(
+        find.byType(SyncActivityIndicator),
+      );
+      // Walk the semantics subtree looking for a button node whose
+      // label mentions both counts.
+      final nodes = <String>[];
+      semantics.visitChildren((child) {
+        nodes.add(child.label);
+        return true;
+      });
+      final label = [semantics.label, ...nodes].firstWhere(
+        (l) => l.contains('289') && l.contains('14'),
+        orElse: () => '',
+      );
+      expect(label, isNotEmpty);
+      expect(label.toLowerCase(), contains('outbox'));
+      expect(label.toLowerCase(), contains('inbox'));
+    });
+
+    testWidgets('tapping invokes navigator override with sync outbox route', (
+      tester,
+    ) async {
+      final navigated = <String>[];
+      SyncActivityIndicatorTestHooks.navigatorOverride = navigated.add;
+
+      await pumpIndicator(tester, outbox: 5);
+      await tester.tap(find.byType(SyncActivityIndicator));
+      await tester.pump();
+
+      expect(navigated, [kSyncOutboxRoute]);
+    });
+
+    /// Returns every LED background colour in widget tree order
+    /// (tx first, rx second). LEDs are the only `AnimatedContainer`s
+    /// whose decoration uses `BoxShape.circle`, so we filter on that.
+    List<Color?> ledColors(WidgetTester tester) {
+      return tester
+          .widgetList<AnimatedContainer>(find.byType(AnimatedContainer))
+          .where((c) {
+            final decoration = c.decoration;
+            return decoration is BoxDecoration &&
+                decoration.shape == BoxShape.circle;
+          })
+          .map((c) => (c.decoration! as BoxDecoration).color)
+          .toList();
+    }
+
+    testWidgets('TX pulse turns the LED on, then off after the hold window', (
+      tester,
+    ) async {
+      await pumpIndicator(tester, outbox: 1);
+
+      // Idle: neither LED is amber.
+      expect(ledColors(tester).first, isNot(equals(kSyncActivityTxColor)));
+
+      txCtl.add(DateTime(2026, 5, 2, 10));
+      await tester.pump();
+      await tester.pump();
+
+      expect(ledColors(tester).first, equals(kSyncActivityTxColor));
+
+      await tester.pump(
+        kSyncActivityLedHold + const Duration(milliseconds: 5),
+      );
+
+      expect(ledColors(tester).first, isNot(equals(kSyncActivityTxColor)));
+    });
+
+    testWidgets('RX pulse only lights the RX LED, leaving TX dark', (
+      tester,
+    ) async {
+      await pumpIndicator(tester, inbox: 3);
+
+      rxCtl.add(DateTime(2026, 5, 2, 10));
+      await tester.pump();
+      await tester.pump();
+
+      final colors = ledColors(tester);
+      // First LED is TX, second is RX (column order).
+      expect(colors[0], isNot(equals(kSyncActivityTxColor)));
+      expect(colors[1], equals(kSyncActivityRxColor));
+
+      await tester.pump(
+        kSyncActivityLedHold + const Duration(milliseconds: 5),
+      );
+    });
+
+    testWidgets('rapid pulses extend the LED hold window', (tester) async {
+      await pumpIndicator(tester, outbox: 5);
+
+      txCtl.add(DateTime(2026, 5, 2, 10));
+      await tester.pump();
+      await tester.pump();
+      // Halfway through the hold window, fire another pulse.
+      await tester.pump(const Duration(milliseconds: 70));
+      txCtl.add(DateTime(2026, 5, 2, 10, 0, 0, 100));
+      await tester.pump();
+      await tester.pump();
+
+      // After the original hold window would have expired (140 ms), the
+      // LED is still on because the second pulse re-armed the timer.
+      await tester.pump(const Duration(milliseconds: 80));
+      expect(ledColors(tester).first, equals(kSyncActivityTxColor));
+
+      // Drain the timer so the test exits clean.
+      await tester.pump(
+        kSyncActivityLedHold + const Duration(milliseconds: 5),
+      );
+    });
+  });
+}

--- a/test/features/sync/ui/widgets/sync_activity_indicator_test.dart
+++ b/test/features/sync/ui/widgets/sync_activity_indicator_test.dart
@@ -11,14 +11,10 @@ void main() {
   group('SyncActivityIndicator', () {
     late StreamController<DateTime> txCtl;
     late StreamController<DateTime> rxCtl;
-    late StreamController<int> outboxCtl;
-    late StreamController<int> inboxCtl;
 
     setUp(() {
       txCtl = StreamController<DateTime>.broadcast();
       rxCtl = StreamController<DateTime>.broadcast();
-      outboxCtl = StreamController<int>.broadcast();
-      inboxCtl = StreamController<int>.broadcast();
       SyncActivityIndicatorTestHooks.navigatorOverride = null;
     });
 
@@ -26,8 +22,6 @@ void main() {
       SyncActivityIndicatorTestHooks.navigatorOverride = null;
       await txCtl.close();
       await rxCtl.close();
-      await outboxCtl.close();
-      await inboxCtl.close();
     });
 
     Future<void> pumpIndicator(

--- a/test/features/sync/ui/widgets/sync_activity_indicator_test.dart
+++ b/test/features/sync/ui/widgets/sync_activity_indicator_test.dart
@@ -82,6 +82,13 @@ void main() {
     testWidgets('exposes a button-role semantics label with both counts', (
       tester,
     ) async {
+      // Semantics are off by default in widget tests; opt them in so
+      // `tester.getSemantics(...)` does not throw a StateError on a
+      // strict Flutter version. The handle must be disposed inline
+      // (not via addTearDown) — the tester verifies that all handles
+      // are released before the test body finishes.
+      final semanticsHandle = tester.ensureSemantics();
+
       await pumpIndicator(tester, outbox: 289, inbox: 14);
 
       final semantics = tester.getSemantics(
@@ -101,6 +108,8 @@ void main() {
       expect(label, isNotEmpty);
       expect(label.toLowerCase(), contains('outbox'));
       expect(label.toLowerCase(), contains('inbox'));
+
+      semanticsHandle.dispose();
     });
 
     testWidgets('tapping invokes navigator override with sync outbox route', (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional desktop sidebar sync activity indicator: compact two-row monospace TX/RX strip with flashing LEDs and live outbox/inbox counts; appears above Settings when enabled (defaults off). Tap the strip to open the sync outbox. Suppresses the legacy red Settings badge so the sync count appears in one place.

* **Documentation**
  * Changelog and sync docs updated.

* **Localization**
  * New translations added for the indicator.

* **Tests**
  * Added unit and widget tests covering indicator behavior and navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->