### PR TITLE
refactor: drop priority from determining next outbox items to send

### DIFF
--- a/lib/database/sync_db.dart
+++ b/lib/database/sync_db.dart
@@ -531,8 +531,8 @@ class SyncDatabase extends _$SyncDatabase {
     return (select(outbox)
           ..where((t) => t.status.equals(OutboxStatus.pending.index))
           ..orderBy([
-            (t) => OrderingTerm(expression: t.priority),
             (t) => OrderingTerm(expression: t.createdAt),
+            (t) => OrderingTerm(expression: t.id),
           ])
           ..limit(limit))
         .get();
@@ -555,8 +555,8 @@ class SyncDatabase extends _$SyncDatabase {
                           t.updatedAt.isSmallerThanValue(reclaimWindow)),
                 )
                 ..orderBy([
-                  (t) => OrderingTerm(expression: t.priority),
                   (t) => OrderingTerm(expression: t.createdAt),
+                  (t) => OrderingTerm(expression: t.id),
                 ])
                 ..limit(1))
               .getSingleOrNull();
@@ -601,9 +601,9 @@ class SyncDatabase extends _$SyncDatabase {
     });
   }
 
-  /// Atomically claim a batch of consecutive outbox rows in priority/createdAt
-  /// order, transitioning each from `pending` (or an expired `sending` lease)
-  /// to `sending` under one transaction.
+  /// Atomically claim a batch of consecutive outbox rows in createdAt order,
+  /// transitioning each from `pending` (or an expired `sending` lease) to
+  /// `sending` under one transaction.
   ///
   /// Boundary rule for `OutboxProcessor` bundling:
   ///  - If the head row has `filePath != null` (media attachment), the
@@ -617,7 +617,7 @@ class SyncDatabase extends _$SyncDatabase {
   /// If a CAS race causes any per-row update to fail mid-batch, the walk
   /// stops there. The returned list is always a contiguous prefix of the
   /// query order — never a non-contiguous gap, which would otherwise
-  /// violate `(priority, createdAt)` send ordering.
+  /// violate `createdAt` send ordering.
   Future<List<OutboxItem>> claimNextOutboxBatch({
     required int maxSize,
     Duration leaseDuration = const Duration(minutes: 1),
@@ -633,23 +633,20 @@ class SyncDatabase extends _$SyncDatabase {
       // predicate prevented the planner from matching either of the
       // existing outbox indices and forced a SCAN (218 ms in the
       // super-slow log). Each branch is now a clean equality on
-      // `status` so the planner picks the partial
-      // `idx_outbox_actionable_priority_created_at` (pending + sending,
-      // ordered by `(priority, created_at)`) and walks it index-only.
-      // The merge in Dart is bounded by `2 × maxSize` rows; trivial.
-      // `id` is the third sort key so the merged batch matches the
-      // contiguous-prefix ordering contract `OutboxRepository.
-      // claimNextBatch` and `OutboxProcessor._processBundle` rely on:
-      // when (priority, createdAt) tie, picking a stable order keeps
-      // the first `filePath != null` boundary deterministic across
-      // repeated calls.
+      // `status`. The merge in Dart is bounded by `2 × maxSize` rows;
+      // trivial. `id` is the secondary sort key so the merged batch
+      // matches the contiguous-prefix ordering contract that
+      // `OutboxRepository.claimNextBatch` and
+      // `OutboxProcessor._processBundle` rely on: when `createdAt`
+      // ties, picking a stable order keeps the first
+      // `filePath != null` boundary deterministic across repeated
+      // calls.
       final pendingRows =
           await (select(outbox)
                 ..where(
                   (t) => t.status.equals(OutboxStatus.pending.index),
                 )
                 ..orderBy([
-                  (t) => OrderingTerm(expression: t.priority),
                   (t) => OrderingTerm(expression: t.createdAt),
                   (t) => OrderingTerm(expression: t.id),
                 ])
@@ -663,7 +660,6 @@ class SyncDatabase extends _$SyncDatabase {
                       t.updatedAt.isSmallerThanValue(reclaimWindow),
                 )
                 ..orderBy([
-                  (t) => OrderingTerm(expression: t.priority),
                   (t) => OrderingTerm(expression: t.createdAt),
                   (t) => OrderingTerm(expression: t.id),
                 ])
@@ -671,8 +667,6 @@ class SyncDatabase extends _$SyncDatabase {
               .get();
       final candidates = <OutboxItem>[...pendingRows, ...expiredSendingRows]
         ..sort((a, b) {
-          final p = a.priority.compareTo(b.priority);
-          if (p != 0) return p;
           final created = a.createdAt.compareTo(b.createdAt);
           if (created != 0) return created;
           return a.id.compareTo(b.id);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.993+4042
+version: 0.9.993+4043
 
 msix_config:
   display_name: LottiApp

--- a/test/database/sync_db_migration_test.dart
+++ b/test/database/sync_db_migration_test.dart
@@ -397,13 +397,15 @@ void main() {
         ),
       );
 
-      // The high-priority item should appear first
+      // Polling is FIFO by createdAt — the older v5 row comes first,
+      // and the newly inserted v6 row's high priority is round-tripped
+      // through the new column.
       final allItems = await db.oldestOutboxItems(10);
       expect(allItems, hasLength(2));
-      expect(allItems.first.subject, 'v6-high');
-      expect(allItems.first.priority, OutboxPriority.high.index);
-      expect(allItems.last.subject, 'v5-subject');
-      expect(allItems.last.priority, OutboxPriority.low.index);
+      expect(allItems.first.subject, 'v5-subject');
+      expect(allItems.first.priority, OutboxPriority.low.index);
+      expect(allItems.last.subject, 'v6-high');
+      expect(allItems.last.priority, OutboxPriority.high.index);
 
       await db.close();
     });

--- a/test/database/sync_db_test.dart
+++ b/test/database/sync_db_test.dart
@@ -305,14 +305,14 @@ void main() {
       expect(results.last.createdAt, DateTime(2024, 4, 2));
     });
 
-    test('oldestOutboxItems uses the queue index', () async {
+    test('oldestOutboxItems avoids a full table scan', () async {
       final plan = await db!
           .customSelect(
             '''
         EXPLAIN QUERY PLAN
         SELECT * FROM outbox
         WHERE status = ?1
-        ORDER BY priority ASC, created_at ASC
+        ORDER BY created_at ASC
         LIMIT 1
         ''',
             variables: [Variable<int>(OutboxStatus.pending.index)],
@@ -320,7 +320,7 @@ void main() {
           .get();
 
       final details = plan.map((row) => row.read<String>('detail')).join(' ');
-      expect(details, contains('idx_outbox_status_priority_created_at'));
+      expect(details, isNot(contains('SCAN outbox')));
     });
 
     test('claimNextOutboxItem claims oldest eligible item', () async {
@@ -452,8 +452,8 @@ void main() {
       });
 
       test(
-        'claims up to maxSize consecutive text rows in priority/createdAt '
-        'order and transitions each to sending',
+        'claims up to maxSize consecutive text rows in createdAt order '
+        'and transitions each to sending',
         () async {
           final database = db!;
           for (var i = 0; i < 5; i++) {
@@ -558,7 +558,7 @@ void main() {
       );
 
       test(
-        'bundles freely across priority tiers in (priority, createdAt) order',
+        'bundles in createdAt order regardless of priority tier',
         () async {
           final database = db!;
           await database.addOutboxItem(
@@ -3673,7 +3673,7 @@ void main() {
     );
   });
 
-  group('Outbox Priority Ordering - ', () {
+  group('Outbox Polling Ordering - ', () {
     late SyncDatabase database;
 
     setUp(() async {
@@ -3685,7 +3685,7 @@ void main() {
     });
 
     test(
-      'oldestOutboxItems returns high-priority before low even if low is older',
+      'oldestOutboxItems returns items in createdAt order regardless of priority',
       () async {
         // Insert low-priority item first (older)
         await database.addOutboxItem(
@@ -3725,48 +3725,47 @@ void main() {
 
         final items = await database.oldestOutboxItems(10);
         expect(items, hasLength(3));
-        expect(items[0].subject, 'high-new');
-        expect(items[0].priority, OutboxPriority.high.index);
+        expect(items[0].subject, 'low-old');
         expect(items[1].subject, 'normal-mid');
-        expect(items[1].priority, OutboxPriority.normal.index);
-        expect(items[2].subject, 'low-old');
-        expect(items[2].priority, OutboxPriority.low.index);
+        expect(items[2].subject, 'high-new');
       },
     );
 
-    test('claimNextOutboxItem claims highest-priority item first', () async {
-      // Insert low-priority item first (older)
-      await database.addOutboxItem(
-        OutboxCompanion(
-          status: Value(OutboxStatus.pending.index),
-          subject: const Value('low-old'),
-          message: const Value('{}'),
-          createdAt: Value(DateTime(2024, 1, 1, 10)),
-          updatedAt: Value(DateTime(2024, 1, 1, 10)),
-          priority: Value(OutboxPriority.low.index),
-        ),
-      );
+    test(
+      'claimNextOutboxItem claims oldest item first regardless of priority',
+      () async {
+        // Insert low-priority item first (older)
+        await database.addOutboxItem(
+          OutboxCompanion(
+            status: Value(OutboxStatus.pending.index),
+            subject: const Value('low-old'),
+            message: const Value('{}'),
+            createdAt: Value(DateTime(2024, 1, 1, 10)),
+            updatedAt: Value(DateTime(2024, 1, 1, 10)),
+            priority: Value(OutboxPriority.low.index),
+          ),
+        );
 
-      // Insert high-priority item second (newer)
-      await database.addOutboxItem(
-        OutboxCompanion(
-          status: Value(OutboxStatus.pending.index),
-          subject: const Value('high-new'),
-          message: const Value('{}'),
-          createdAt: Value(DateTime(2024, 1, 1, 12)),
-          updatedAt: Value(DateTime(2024, 1, 1, 12)),
-          priority: Value(OutboxPriority.high.index),
-        ),
-      );
+        // Insert high-priority item second (newer)
+        await database.addOutboxItem(
+          OutboxCompanion(
+            status: Value(OutboxStatus.pending.index),
+            subject: const Value('high-new'),
+            message: const Value('{}'),
+            createdAt: Value(DateTime(2024, 1, 1, 12)),
+            updatedAt: Value(DateTime(2024, 1, 1, 12)),
+            priority: Value(OutboxPriority.high.index),
+          ),
+        );
 
-      final claimed = await database.claimNextOutboxItem(
-        now: DateTime(2024, 1, 1, 13),
-      );
+        final claimed = await database.claimNextOutboxItem(
+          now: DateTime(2024, 1, 1, 13),
+        );
 
-      expect(claimed, isNotNull);
-      expect(claimed!.subject, 'high-new');
-      expect(claimed.priority, OutboxPriority.high.index);
-    });
+        expect(claimed, isNotNull);
+        expect(claimed!.subject, 'low-old');
+      },
+    );
 
     test('within same priority, oldest item is processed first', () async {
       await database.addOutboxItem(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sync processing now uses creation-time FIFO ordering for outbox items instead of priority-first ordering.

* **Tests**
  * Updated tests to assert and document FIFO (created-at) ordering and related bundling/claiming behavior.

* **Chores**
  * Incremented package version for this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->