### PR TITLE
feat: adaptively hide time recording indicator in sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.997]
 ### Changed
-- Sidebar running-timer card now hides itself when the timer's parent
-  task is the same task currently open in the desktop task-details
-  pane. The detail page's sticky action bar already shows a running
-  indicator, so duplicating the title in the sidebar was just noise.
-  The card returns the moment a different task (or none) is selected.
-- The show/hide flip runs through a combined `AnimatedSwitcher` +
-  `AnimatedSize` (~220 ms, `Curves.easeInOut`) so the card fades and
-  the surrounding sidebar collapses smoothly instead of popping.
+- Sidebar running-timer card now hides itself only when the timer's
+  parent task is the same task currently open in the desktop task-
+  details pane *and* the user is actually on a `/tasks/<uuid>` route.
+  The detail page's sticky action bar already shows a running
+  indicator, so duplicating the title in the sidebar would be noise —
+  but the card still surfaces on every other tab (Habits, Settings,
+  …) because `desktopSelectedTaskId` is sticky across tab switches and
+  the action bar isn't visible there. The show/hide flip runs through
+  a combined `AnimatedSwitcher` + `AnimatedSize` (~220 ms,
+  `Curves.easeInOut`) so the card fades and the surrounding sidebar
+  collapses smoothly instead of popping. The stream is seeded with
+  `TimeService.getCurrent()` so a session already running is rendered
+  on first frame instead of flashing through a hidden state.
 - Sticky action bar's running "Track time" pill gets a touch more
   breathing room on the leading edge: the inset stop circle now sits
   8 px from the pill border (was 4 px) so it no longer crowds the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.997]
+### Changed
+- Sidebar running-timer card now hides itself when the timer's parent
+  task is the same task currently open in the desktop task-details
+  pane. The detail page's sticky action bar already shows a running
+  indicator, so duplicating the title in the sidebar was just noise.
+  The card returns the moment a different task (or none) is selected.
+- The show/hide flip runs through a combined `AnimatedSwitcher` +
+  `AnimatedSize` (~220 ms, `Curves.easeInOut`) so the card fades and
+  the surrounding sidebar collapses smoothly instead of popping.
+- Sticky action bar's running "Track time" pill gets a touch more
+  breathing room on the leading edge: the inset stop circle now sits
+  8 px from the pill border (was 4 px) so it no longer crowds the
+  edge while the elapsed digits tick.
+
 ## [0.9.996]
 ### Changed
 - Audio recording player restyled to match the green Figma audio card.

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -33,7 +33,7 @@
   <releases>
     <release version="0.9.997" date="2026-05-06">
       <description>
-          <p>Sidebar running-timer card now hides itself when the timer's parent task is the same task currently open in the desktop task-details pane. The detail page's sticky action bar already shows a running indicator, so duplicating the title in the sidebar was just noise. The card returns the moment a different task (or none) is selected. The show/hide flip runs through a combined AnimatedSwitcher + AnimatedSize (~220 ms, easeInOut) so the card fades and the surrounding sidebar collapses smoothly instead of popping.</p>
+          <p>Sidebar running-timer card now hides itself only when the timer's parent task is the same task currently open in the desktop task-details pane and the user is actually on a /tasks/&lt;uuid&gt; route. The detail page's sticky action bar already shows a running indicator, so duplicating the title in the sidebar would be noise — but the card still surfaces on every other tab (Habits, Settings, …) because the selected-task notifier is sticky across tab switches and the action bar isn't visible there. The show/hide flip runs through a combined AnimatedSwitcher + AnimatedSize (~220 ms, easeInOut) so the card fades and the surrounding sidebar collapses smoothly instead of popping. The stream is seeded with the current running entity so a session already running is rendered on first frame instead of flashing through a hidden state.</p>
           <p>Sticky action bar's running "Track time" pill gets a touch more breathing room on the leading edge: the inset stop circle now sits 8 px from the pill border (was 4 px) so it no longer crowds the edge while the elapsed digits tick.</p>
       </description>
     </release>

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -31,6 +31,12 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="0.9.997" date="2026-05-06">
+      <description>
+          <p>Sidebar running-timer card now hides itself when the timer's parent task is the same task currently open in the desktop task-details pane. The detail page's sticky action bar already shows a running indicator, so duplicating the title in the sidebar was just noise. The card returns the moment a different task (or none) is selected. The show/hide flip runs through a combined AnimatedSwitcher + AnimatedSize (~220 ms, easeInOut) so the card fades and the surrounding sidebar collapses smoothly instead of popping.</p>
+          <p>Sticky action bar's running "Track time" pill gets a touch more breathing room on the leading edge: the inset stop circle now sits 8 px from the pill border (was 4 px) so it no longer crowds the edge while the elapsed digits tick.</p>
+      </description>
+    </release>
     <release version="0.9.996" date="2026-05-06">
       <description>
           <p>Audio recording player restyled to match the green Figma audio card. The play/pause control is now a soft circular pill drawn on the design-system surface token with the high-emphasis text color for the glyph; the previous gradient + drop shadow + animated progress ring are gone. The waveform's played bars use the brand teal interactive token (#2BA184 in light mode, #5ED4B7 in dark mode), with a thin teal scrubber line drawn at the playhead and bars widened to 4 px with 3 px spacing for parity with the Figma reference. The fallback progress bar (used while the waveform is still resolving) follows the same tokens, with the unplayed track now reading from the decorative level02 token instead of an alpha overlay on onSurfaceVariant. The play/pause button drops a step in size (40 px compact / 48 px standard) so it no longer dominates the card.</p>

--- a/lib/features/tasks/README.md
+++ b/lib/features/tasks/README.md
@@ -222,6 +222,42 @@ flowchart TD
 
 This page is not just "show task fields." It is the task workspace where task metadata, linked content, time tracking, and AI-adjacent affordances meet.
 
+### Sidebar timer coordination
+
+`SidebarTimerSection` (desktop, `aboveSettings` slot — see `lib/widgets/README.md` for the visual contract) and `TaskActionBar`'s running pill both render the same live `TimeService` session. To avoid duplicating the task title on screen, the sidebar card hides itself when the action bar is already showing the indicator — but only when the action bar is actually visible.
+
+The hide condition is the conjunction of:
+
+- the running timer's `linkedFrom` is a `Task`,
+- `linkedFrom.meta.id == NavService.desktopSelectedTaskId`, and
+- `NavService.currentPath` starts with `/tasks/` (i.e. user is on a task-detail route).
+
+The route check matters because `desktopSelectedTaskId` is sticky across tab switches: it's only mutated by `tasks_location.dart` (via `NavService.resetDesktopTaskDetail` / `pushDesktopTaskDetail` / `popDesktopTaskDetail`). Without the path guard, switching from a task to e.g. Habits would leave the sidebar card hidden even though the action bar is no longer on screen.
+
+Reactivity sources composed inside the card:
+
+- `TimeService.getStream()` — running entity + duration. Seeded with `TimeService.getCurrent()` as `initialData` so an already-running session renders on first frame instead of flashing through a hidden state.
+- `NavService.desktopSelectedTaskId` (`ValueListenableBuilder`) — selection changes inside the tasks pane.
+- `NavService.getIndexStream()` (`StreamBuilder`) — top-level tab/route changes; `currentPath` is read synchronously when the stream emits.
+
+The show/hide flip runs through an `AnimatedSwitcher` + `AnimatedSize` (`SidebarTimerSection.animationDuration` ≈ 220 ms, `Curves.easeInOut`) so the card fades and the surrounding sidebar collapses smoothly instead of popping.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Hidden
+    Hidden --> Visible: TimeService emits a running entity\nand hide-condition is false
+    Visible --> Hidden: TimeService emits null (timer stopped)
+    Visible --> Hidden: linkedFrom.task.id == openTaskId\nAND currentPath startsWith /tasks/
+    Hidden --> Visible: openTaskId changes (different task selected)
+    Hidden --> Visible: currentPath leaves /tasks/<uuid>\n(tab switch / nav away)
+    note right of Hidden
+      AnimatedSwitcher fades the
+      outgoing card; AnimatedSize
+      collapses the surrounding column
+      (~220 ms, Curves.easeInOut).
+    end note
+```
+
 Inside `TaskForm`, the composition is also fairly opinionated:
 
 - `DesktopTaskHeaderConnector` for the interactive header: inline multi-line title edit, priority badge, project reference (with a "No project" placeholder when none is linked), work-category chip (or "unassigned" placeholder), due-date chip (or "No due date" placeholder), estimate chip (with progress bar when set), assigned label chips (or "Add Label" placeholder), and status dropdown. Extended actions (share, speech modal, etc.) are owned by the pinned app bar's `more_vert` button, not the header itself. The connector watches `entryControllerProvider`, `projectForTaskProvider` and the labels stream, maps the task to an immutable `DesktopTaskHeaderData` plus a Riverpod-aware `estimateSlot`, and forwards callbacks to the existing modal pickers (`TaskStatusModalContent`, `showDueDatePicker`, `showEstimatePicker`, `CategorySelectionModalContent`, `ProjectSelectionModalContent`, `LabelSelectionModalUtils`) plus `EntryController.save / updateTaskStatus / updateTaskPriority / updateCategoryId`

--- a/lib/features/tasks/ui/widgets/task_action_bar.dart
+++ b/lib/features/tasks/ui/widgets/task_action_bar.dart
@@ -385,12 +385,6 @@ class _TrackTimePill extends StatelessWidget {
           onTap: isTracking ? onNavigateToRunningEntry : onStartTimer,
           child: Container(
             height: TaskActionBar.buttonSize,
-            // While tracking, the leading edge holds the inset stop
-            // circle. step3 keeps it visually balanced inside the pill;
-            // step2 (the prior value) crowded the circle against the
-            // edge. The trailing edge keeps step2 because the digits
-            // already get extra breathing room from the inner Padding
-            // (right: step3) below.
             padding: EdgeInsets.symmetric(horizontal: spacing.step5),
             decoration: BoxDecoration(
               color: fillColor,

--- a/lib/features/tasks/ui/widgets/task_action_bar.dart
+++ b/lib/features/tasks/ui/widgets/task_action_bar.dart
@@ -385,9 +385,13 @@ class _TrackTimePill extends StatelessWidget {
           onTap: isTracking ? onNavigateToRunningEntry : onStartTimer,
           child: Container(
             height: TaskActionBar.buttonSize,
-            padding: EdgeInsets.symmetric(
-              horizontal: isTracking ? spacing.step2 : spacing.step5,
-            ),
+            // While tracking, the leading edge holds the inset stop
+            // circle. step3 keeps it visually balanced inside the pill;
+            // step2 (the prior value) crowded the circle against the
+            // edge. The trailing edge keeps step2 because the digits
+            // already get extra breathing room from the inner Padding
+            // (right: step3) below.
+            padding: EdgeInsets.symmetric(horizontal: spacing.step5),
             decoration: BoxDecoration(
               color: fillColor,
               borderRadius: pillRadius,
@@ -417,9 +421,7 @@ class _TrackTimePill extends StatelessWidget {
                       // (open 4/6/9), matching the sidebar timer pill so
                       // the elapsed digits don't shift width as they
                       // tick.
-                      fontFeatures: isTracking
-                          ? numericBadgeFontFeatures
-                          : null,
+                      fontFeatures: numericBadgeFontFeatures,
                     ),
                   ),
                 ),

--- a/lib/widgets/README.md
+++ b/lib/widgets/README.md
@@ -193,8 +193,6 @@ Inline panel surfaced in the desktop sidebar's `aboveSettings` slot whenever a t
 - Layout: title row (briefcase icon + task title) over a body row with timer icon, monospaced HH:MM:SS, and a circular stop button.
 - Typography: Inter with `numericBadgeFontFeatures` (tabular figures, slashed zero, `cv02`/`cv03`/`cv04` open digits) so 4/6/9 stay legible at small sizes and digits do not breathe.
 - Interactions: tapping the body navigates to the running task (or the timer's journal entry, if not task-linked); tapping the stop button calls `TimeService.stop()`.
-- Visibility: hides when the running timer's parent task matches `NavService.desktopSelectedTaskId` — the open task already shows its own running indicator in the sticky action bar, so duplicating the title in the sidebar would just be noise. Surfaces again the moment a different task (or none) is selected.
-- Transitions: the show/hide flip runs through an `AnimatedSwitcher` + `AnimatedSize` (`SidebarTimerSection.animationDuration` ≈ 220 ms, `Curves.easeInOut`) so the card fades and the surrounding sidebar collapses smoothly instead of popping.
 - Idle state: collapses to `SizedBox.shrink` so the slot consumes no vertical space.
 
 ### TimeRecordingIndicator

--- a/lib/widgets/README.md
+++ b/lib/widgets/README.md
@@ -193,6 +193,8 @@ Inline panel surfaced in the desktop sidebar's `aboveSettings` slot whenever a t
 - Layout: title row (briefcase icon + task title) over a body row with timer icon, monospaced HH:MM:SS, and a circular stop button.
 - Typography: Inter with `numericBadgeFontFeatures` (tabular figures, slashed zero, `cv02`/`cv03`/`cv04` open digits) so 4/6/9 stay legible at small sizes and digits do not breathe.
 - Interactions: tapping the body navigates to the running task (or the timer's journal entry, if not task-linked); tapping the stop button calls `TimeService.stop()`.
+- Visibility: hides when the running timer's parent task matches `NavService.desktopSelectedTaskId` — the open task already shows its own running indicator in the sticky action bar, so duplicating the title in the sidebar would just be noise. Surfaces again the moment a different task (or none) is selected.
+- Transitions: the show/hide flip runs through an `AnimatedSwitcher` + `AnimatedSize` (`SidebarTimerSection.animationDuration` ≈ 220 ms, `Curves.easeInOut`) so the card fades and the surrounding sidebar collapses smoothly instead of popping.
 - Idle state: collapses to `SizedBox.shrink` so the slot consumes no vertical space.
 
 ### TimeRecordingIndicator

--- a/lib/widgets/misc/sidebar_timer_section.dart
+++ b/lib/widgets/misc/sidebar_timer_section.dart
@@ -7,6 +7,7 @@ import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/journal/util/entry_tools.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/services/time_service.dart';
 import 'package:lotti/themes/theme.dart' show numericBadgeFontFeatures;
 import 'package:lotti/widgets/misc/timer_navigation.dart';
@@ -16,33 +17,92 @@ import 'package:lotti/widgets/misc/timer_navigation.dart';
 ///
 /// Tapping anywhere on the body navigates to the running task (or the
 /// timer's journal entry, if not linked to a task). Tapping the stop
-/// button stops the timer. The panel collapses to [SizedBox.shrink] when
-/// no timer is running, so it consumes no space in the idle state.
+/// button stops the timer.
+///
+/// The card is hidden in two situations, each producing a smooth
+/// fade-and-collapse transition rather than a hard pop:
+///
+/// * No timer is running. There is nothing to show.
+/// * The running timer is linked to the same task that is currently
+///   open in the desktop task-details pane (tracked via
+///   [NavService.desktopSelectedTaskId]). The task page already shows a
+///   running indicator in its sticky action bar, so duplicating the
+///   title in the sidebar is just noise.
 class SidebarTimerSection extends ConsumerWidget {
   const SidebarTimerSection({super.key});
+
+  /// Duration used for both the fade and the surrounding collapse.
+  /// Short enough to feel responsive, long enough to read as a
+  /// transition rather than a flicker.
+  @visibleForTesting
+  static const Duration animationDuration = Duration(milliseconds: 220);
+
+  /// Stable key used by the hidden state. Sharing one key across all
+  /// hidden variants keeps [AnimatedSwitcher] from running an extra
+  /// transition when we toggle between "no timer" and
+  /// "timer hidden because the task is open".
+  static const Key _hiddenKey = ValueKey('sidebar-timer-hidden');
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final timeService = getIt<TimeService>();
+    final selectedTaskId = getIt<NavService>().desktopSelectedTaskId;
 
     return StreamBuilder<JournalEntity?>(
       stream: timeService.getStream(),
       builder: (context, snapshot) {
         final current = snapshot.data;
-        if (current == null) {
-          return const SizedBox.shrink();
-        }
-        return _SidebarTimerCard(
-          current: current,
-          linkedFrom: timeService.linkedFrom,
-          onStop: () => unawaited(timeService.stop()),
-          onTapBody: () => navigateToTimerTarget(
-            ref: ref,
-            current: current,
-            linkedFrom: timeService.linkedFrom,
-          ),
+        return ValueListenableBuilder<String?>(
+          valueListenable: selectedTaskId,
+          builder: (context, openTaskId, _) {
+            final child = _resolveChild(
+              ref: ref,
+              timeService: timeService,
+              current: current,
+              openTaskId: openTaskId,
+            );
+            return AnimatedSize(
+              duration: animationDuration,
+              curve: Curves.easeInOut,
+              alignment: Alignment.bottomCenter,
+              child: AnimatedSwitcher(
+                duration: animationDuration,
+                switchInCurve: Curves.easeIn,
+                switchOutCurve: Curves.easeOut,
+                child: child,
+              ),
+            );
+          },
         );
       },
+    );
+  }
+
+  Widget _resolveChild({
+    required WidgetRef ref,
+    required TimeService timeService,
+    required JournalEntity? current,
+    required String? openTaskId,
+  }) {
+    if (current == null) {
+      return const SizedBox.shrink(key: _hiddenKey);
+    }
+    final linkedFrom = timeService.linkedFrom;
+    if (linkedFrom is Task &&
+        openTaskId != null &&
+        linkedFrom.meta.id == openTaskId) {
+      return const SizedBox.shrink(key: _hiddenKey);
+    }
+    return _SidebarTimerCard(
+      key: ValueKey('sidebar-timer-${current.meta.id}'),
+      current: current,
+      linkedFrom: linkedFrom,
+      onStop: () => unawaited(timeService.stop()),
+      onTapBody: () => navigateToTimerTarget(
+        ref: ref,
+        current: current,
+        linkedFrom: linkedFrom,
+      ),
     );
   }
 }
@@ -53,6 +113,7 @@ class _SidebarTimerCard extends StatelessWidget {
     required this.linkedFrom,
     required this.onStop,
     required this.onTapBody,
+    super.key,
   });
 
   final JournalEntity current;

--- a/lib/widgets/misc/sidebar_timer_section.dart
+++ b/lib/widgets/misc/sidebar_timer_section.dart
@@ -25,9 +25,22 @@ import 'package:lotti/widgets/misc/timer_navigation.dart';
 /// * No timer is running. There is nothing to show.
 /// * The running timer is linked to the same task that is currently
 ///   open in the desktop task-details pane (tracked via
-///   [NavService.desktopSelectedTaskId]). The task page already shows a
+///   [NavService.desktopSelectedTaskId]) AND the user is actually
+///   viewing a task-detail route. The detail page already shows a
 ///   running indicator in its sticky action bar, so duplicating the
-///   title in the sidebar is just noise.
+///   title in the sidebar is just noise. The route check matters
+///   because [NavService.desktopSelectedTaskId] is sticky across tab
+///   switches — without it, switching from a task to e.g. Habits would
+///   leave the sidebar timer hidden even though the user can no longer
+///   see the action-bar indicator.
+///
+/// Reactivity:
+///
+/// * [TimeService.getStream] drives running/duration updates.
+/// * [NavService.desktopSelectedTaskId] drives selection changes inside
+///   the tasks pane.
+/// * [NavService.getIndexStream] drives top-level tab/route changes;
+///   we read [NavService.currentPath] synchronously when it fires.
 class SidebarTimerSection extends ConsumerWidget {
   const SidebarTimerSection({super.key});
 
@@ -43,34 +56,49 @@ class SidebarTimerSection extends ConsumerWidget {
   /// "timer hidden because the task is open".
   static const Key _hiddenKey = ValueKey('sidebar-timer-hidden');
 
+  /// True when [path] points at an individual task-detail route
+  /// (e.g. `/tasks/<uuid>`), as opposed to the tasks list root or any
+  /// other top-level tab.
+  static bool _isTaskDetailRoute(String path) => path.startsWith('/tasks/');
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final timeService = getIt<TimeService>();
-    final selectedTaskId = getIt<NavService>().desktopSelectedTaskId;
+    final navService = getIt<NavService>();
 
     return StreamBuilder<JournalEntity?>(
       stream: timeService.getStream(),
+      initialData: timeService.getCurrent(),
       builder: (context, snapshot) {
         final current = snapshot.data;
         return ValueListenableBuilder<String?>(
-          valueListenable: selectedTaskId,
+          valueListenable: navService.desktopSelectedTaskId,
           builder: (context, openTaskId, _) {
-            final child = _resolveChild(
-              ref: ref,
-              timeService: timeService,
-              current: current,
-              openTaskId: openTaskId,
-            );
-            return AnimatedSize(
-              duration: animationDuration,
-              curve: Curves.easeInOut,
-              alignment: Alignment.bottomCenter,
-              child: AnimatedSwitcher(
-                duration: animationDuration,
-                switchInCurve: Curves.easeIn,
-                switchOutCurve: Curves.easeOut,
-                child: child,
-              ),
+            return StreamBuilder<int>(
+              // Tab/route switches don't otherwise rebuild this widget;
+              // subscribe to the nav index stream so we re-evaluate the
+              // active path when the user moves between top-level tabs.
+              stream: navService.getIndexStream(),
+              builder: (context, _) {
+                final child = _resolveChild(
+                  ref: ref,
+                  timeService: timeService,
+                  navService: navService,
+                  current: current,
+                  openTaskId: openTaskId,
+                );
+                return AnimatedSize(
+                  duration: animationDuration,
+                  curve: Curves.easeInOut,
+                  alignment: Alignment.bottomCenter,
+                  child: AnimatedSwitcher(
+                    duration: animationDuration,
+                    switchInCurve: Curves.easeIn,
+                    switchOutCurve: Curves.easeOut,
+                    child: child,
+                  ),
+                );
+              },
             );
           },
         );
@@ -81,6 +109,7 @@ class SidebarTimerSection extends ConsumerWidget {
   Widget _resolveChild({
     required WidgetRef ref,
     required TimeService timeService,
+    required NavService navService,
     required JournalEntity? current,
     required String? openTaskId,
   }) {
@@ -90,7 +119,8 @@ class SidebarTimerSection extends ConsumerWidget {
     final linkedFrom = timeService.linkedFrom;
     if (linkedFrom is Task &&
         openTaskId != null &&
-        linkedFrom.meta.id == openTaskId) {
+        linkedFrom.meta.id == openTaskId &&
+        _isTaskDetailRoute(navService.currentPath)) {
       return const SizedBox.shrink(key: _hiddenKey);
     }
     return _SidebarTimerCard(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.996+4048
+version: 0.9.997+4049
 
 msix_config:
   display_name: LottiApp

--- a/test/beamer/beamer_app_test.dart
+++ b/test/beamer/beamer_app_test.dart
@@ -153,6 +153,12 @@ Future<void> _stubNavService(
   );
   when(() => navService.tapIndex(any())).thenReturn(null);
   when(() => navService.isDesktopMode).thenReturn(false);
+  // SidebarTimerSection reads this notifier to decide whether to hide
+  // when the running task matches the open task. Empty selection in
+  // these tests so the sidebar timer surfaces normally.
+  when(
+    () => navService.desktopSelectedTaskId,
+  ).thenReturn(ValueNotifier<String?>(null));
 }
 
 Future<void> _pumpAppScreen(

--- a/test/beamer/beamer_app_test.dart
+++ b/test/beamer/beamer_app_test.dart
@@ -131,7 +131,14 @@ Future<void> _stubNavService(
   final journalDelegate = await _createEmptyDelegate('/journal');
   final settingsDelegate = await _createEmptyDelegate('/settings');
 
-  when(() => navService.getIndexStream()).thenAnswer((_) => indexStream);
+  // Real NavService.getIndexStream returns a broadcast stream (multiple
+  // listeners — e.g. AppScreen + SidebarTimerSection — subscribe). Wrap
+  // the test-supplied stream so single-subscription inputs like
+  // Stream.value still satisfy multi-listener consumers.
+  final broadcastIndex = indexStream.isBroadcast
+      ? indexStream
+      : indexStream.asBroadcastStream();
+  when(() => navService.getIndexStream()).thenAnswer((_) => broadcastIndex);
   when(() => navService.tasksDelegate).thenReturn(tasksDelegate);
   when(() => navService.projectsDelegate).thenReturn(projectsDelegate);
   when(() => navService.calendarDelegate).thenReturn(calendarDelegate);
@@ -153,12 +160,13 @@ Future<void> _stubNavService(
   );
   when(() => navService.tapIndex(any())).thenReturn(null);
   when(() => navService.isDesktopMode).thenReturn(false);
-  // SidebarTimerSection reads this notifier to decide whether to hide
-  // when the running task matches the open task. Empty selection in
-  // these tests so the sidebar timer surfaces normally.
+  // SidebarTimerSection reads these to decide whether to hide when the
+  // running task matches the open task. Empty selection + a non-task
+  // root path in these tests so the sidebar timer surfaces normally.
   when(
     () => navService.desktopSelectedTaskId,
   ).thenReturn(ValueNotifier<String?>(null));
+  when(() => navService.currentPath).thenReturn('/');
 }
 
 Future<void> _pumpAppScreen(
@@ -244,6 +252,9 @@ Future<void> _pumpAppScreen(
 Future<void> _registerAppScreenGetIt(MockNavService navService) async {
   final mockTimeService = MockTimeService();
   when(mockTimeService.getStream).thenAnswer(_emptyTimeStream);
+  // SidebarTimerSection seeds its StreamBuilder with getCurrent() so it
+  // doesn't flicker on first frame when a timer is already running.
+  when(mockTimeService.getCurrent).thenReturn(null);
 
   await setUpTestGetIt(
     additionalSetup: () {

--- a/test/widgets/misc/sidebar_timer_section_test.dart
+++ b/test/widgets/misc/sidebar_timer_section_test.dart
@@ -53,17 +53,34 @@ void main() {
   late _FakeTimeService timeService;
   late MockNavService navService;
   late ValueNotifier<String?> desktopSelectedTaskId;
+  late StreamController<int> indexStreamController;
+
+  /// Push a new currentPath into the stubbed [NavService] and emit on
+  /// the index stream so subscribed widgets re-evaluate.
+  void setCurrentPath(String path) {
+    when(() => navService.currentPath).thenReturn(path);
+    indexStreamController.add(0);
+  }
 
   setUp(() async {
     timeService = _FakeTimeService();
     navService = MockNavService();
     desktopSelectedTaskId = ValueNotifier<String?>(null);
+    indexStreamController = StreamController<int>.broadcast();
     // Mocktail records every call by default; nav routes are inspected
     // via `verify(...).captured` in the assertion phase.
     when(() => navService.beamToNamed(any())).thenAnswer((_) {});
     when(
       () => navService.desktopSelectedTaskId,
     ).thenReturn(desktopSelectedTaskId);
+    when(
+      () => navService.getIndexStream(),
+    ).thenAnswer((_) => indexStreamController.stream);
+    // Default to a task-detail route so the existing tests, which
+    // expect the sidebar to render the running card, hit the
+    // common-path branch. Tests exercising tab-switch behavior
+    // override this via [setCurrentPath].
+    when(() => navService.currentPath).thenReturn('/tasks/some-task');
 
     await setUpTestGetIt(
       additionalSetup: () {
@@ -77,6 +94,7 @@ void main() {
   tearDown(() async {
     timeService.disposeController();
     desktopSelectedTaskId.dispose();
+    await indexStreamController.close();
     await tearDownTestGetIt();
   });
 
@@ -313,6 +331,39 @@ void main() {
       await tester.pump(SidebarTimerSection.animationDuration);
 
       expect(find.text('Tracked'), findsOneWidget);
+      expect(find.byIcon(Icons.stop_rounded), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'stays visible when on a non-task route, even if selected task matches',
+    (tester) async {
+      // Sticky state: user opened a task, started a timer, then
+      // switched tabs. desktopSelectedTaskId is still pointing at the
+      // task, but the user is now on /habits, so the sticky action bar
+      // is no longer visible — the sidebar must keep showing the
+      // running indicator.
+      final task = makeTask('task-sticky', title: 'Sticky');
+      final timer = makeTimerEntry('timer-sticky');
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(const SidebarTimerSection()),
+      );
+
+      timeService.emit(timer, linkedFrom: task);
+      desktopSelectedTaskId.value = 'task-sticky';
+      await tester.pump();
+      await tester.pump(SidebarTimerSection.animationDuration);
+      // Sanity: while on the task route, the card is hidden.
+      expect(find.text('Sticky'), findsNothing);
+
+      // User switches to the Habits tab — currentPath is no longer a
+      // task-detail route. The card must come back.
+      setCurrentPath('/habits');
+      await tester.pump();
+      await tester.pump(SidebarTimerSection.animationDuration);
+
+      expect(find.text('Sticky'), findsOneWidget);
       expect(find.byIcon(Icons.stop_rounded), findsOneWidget);
     },
   );

--- a/test/widgets/misc/sidebar_timer_section_test.dart
+++ b/test/widgets/misc/sidebar_timer_section_test.dart
@@ -52,13 +52,18 @@ void main() {
 
   late _FakeTimeService timeService;
   late MockNavService navService;
+  late ValueNotifier<String?> desktopSelectedTaskId;
 
   setUp(() async {
     timeService = _FakeTimeService();
     navService = MockNavService();
+    desktopSelectedTaskId = ValueNotifier<String?>(null);
     // Mocktail records every call by default; nav routes are inspected
     // via `verify(...).captured` in the assertion phase.
     when(() => navService.beamToNamed(any())).thenAnswer((_) {});
+    when(
+      () => navService.desktopSelectedTaskId,
+    ).thenReturn(desktopSelectedTaskId);
 
     await setUpTestGetIt(
       additionalSetup: () {
@@ -71,6 +76,7 @@ void main() {
 
   tearDown(() async {
     timeService.disposeController();
+    desktopSelectedTaskId.dispose();
     await tearDownTestGetIt();
   });
 
@@ -126,6 +132,7 @@ void main() {
 
     timeService.emit(null);
     await tester.pump();
+    await tester.pump(SidebarTimerSection.animationDuration);
 
     expect(find.byType(InkWell), findsNothing);
     expect(find.byIcon(Icons.timer_outlined), findsNothing);
@@ -147,6 +154,7 @@ void main() {
 
     timeService.emit(timer, linkedFrom: task);
     await tester.pump();
+    await tester.pump(SidebarTimerSection.animationDuration);
 
     expect(find.text('Payment confirmation'), findsOneWidget);
     expect(find.text('01:23:45'), findsOneWidget);
@@ -169,6 +177,7 @@ void main() {
 
     timeService.emit(timer, linkedFrom: task);
     await tester.pump();
+    await tester.pump(SidebarTimerSection.animationDuration);
 
     final timeWidget = tester.widget<Text>(find.text('00:04:09'));
     final features = timeWidget.style?.fontFeatures ?? const <FontFeature>[];
@@ -198,10 +207,11 @@ void main() {
 
     timeService.emit(timer, linkedFrom: task);
     await tester.pump();
+    await tester.pump(SidebarTimerSection.animationDuration);
 
     // Tap on the title text to ensure body taps (not the stop button) navigate
     await tester.tap(find.text('Implement sidebar timer'));
-    await tester.pumpAndSettle();
+    await tester.pump();
 
     expect(lastBeamedPath(), equals('/tasks/task-3'));
     final intent = container.read(taskFocusControllerProvider(id: 'task-3'));
@@ -222,8 +232,12 @@ void main() {
 
     timeService.emit(timer, linkedFrom: task);
     await tester.pump();
+    await tester.pump(SidebarTimerSection.animationDuration);
 
     await tester.tap(find.byIcon(Icons.stop_rounded));
+    // Two pumps for the broadcast stream + rebuild, then settle the
+    // fade-out so the outgoing card is removed from the tree.
+    await tester.pump();
     await tester.pumpAndSettle();
 
     expect(timeService.stopCalls, equals(1));
@@ -244,10 +258,86 @@ void main() {
 
     timeService.emit(timer, linkedFrom: task);
     await tester.pump();
+    await tester.pump(SidebarTimerSection.animationDuration);
 
     // Falls back to plainText when title is empty
     expect(find.text('task plain text'), findsOneWidget);
   });
+
+  testWidgets(
+    'hides the card when the running task is open in the details pane',
+    (tester) async {
+      final task = makeTask('task-open', title: 'Refine sidebar visibility');
+      final timer = makeTimerEntry(
+        'timer-open',
+        elapsed: const Duration(minutes: 12),
+      );
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(const SidebarTimerSection()),
+      );
+
+      timeService.emit(timer, linkedFrom: task);
+      await tester.pump();
+      expect(find.text('Refine sidebar visibility'), findsOneWidget);
+
+      desktopSelectedTaskId.value = 'task-open';
+      // Pump past the fade+collapse animation.
+      await tester.pump();
+      await tester.pump(SidebarTimerSection.animationDuration);
+
+      expect(find.text('Refine sidebar visibility'), findsNothing);
+      expect(find.byIcon(Icons.timer_outlined), findsNothing);
+      expect(find.byIcon(Icons.stop_rounded), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'reappears when navigating away from the running task',
+    (tester) async {
+      final task = makeTask('task-here', title: 'Tracked');
+      final timer = makeTimerEntry('timer-here');
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(const SidebarTimerSection()),
+      );
+
+      timeService.emit(timer, linkedFrom: task);
+      desktopSelectedTaskId.value = 'task-here';
+      await tester.pump();
+      await tester.pump(SidebarTimerSection.animationDuration);
+      expect(find.text('Tracked'), findsNothing);
+
+      desktopSelectedTaskId.value = 'some-other-task';
+      await tester.pump();
+      await tester.pump(SidebarTimerSection.animationDuration);
+
+      expect(find.text('Tracked'), findsOneWidget);
+      expect(find.byIcon(Icons.stop_rounded), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'stays visible when the running timer is not linked to a task',
+    (tester) async {
+      // A bare journal-entry timer (no Task linkedFrom) should never be
+      // hidden by the open-task check, even if a task happens to be
+      // selected in the details pane.
+      final linked = makeTimerEntry('linked-loose');
+      final timer = makeTimerEntry('timer-loose');
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(const SidebarTimerSection()),
+      );
+
+      timeService.emit(timer, linkedFrom: linked);
+      desktopSelectedTaskId.value = 'unrelated-task';
+      await tester.pump();
+      await tester.pump(SidebarTimerSection.animationDuration);
+
+      expect(find.byIcon(Icons.timer_outlined), findsOneWidget);
+    },
+  );
 
   testWidgets('non-task linkedFrom navigates to journal entry', (tester) async {
     final linked = makeTimerEntry('linked-6');
@@ -259,9 +349,10 @@ void main() {
 
     timeService.emit(timer, linkedFrom: linked);
     await tester.pump();
+    await tester.pump(SidebarTimerSection.animationDuration);
 
     await tester.tap(find.byIcon(Icons.timer_outlined));
-    await tester.pumpAndSettle();
+    await tester.pump();
 
     expect(lastBeamedPath(), equals('/journal/linked-6'));
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar timer card now intelligently hides when the running task is open in the details pane.

* **UI/UX Improvements**
  * Added smooth fade and collapse animations (~220 ms) for timer visibility changes.
  * Increased spacing on the Track time pill for improved visual balance.

* **Documentation**
  * Added sidebar timer coordination documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->