### PR TITLE
test: add more glados tests for sync

### DIFF
--- a/test/features/sync/backfill/backfill_request_service_test.dart
+++ b/test/features/sync/backfill/backfill_request_service_test.dart
@@ -119,6 +119,81 @@ class _BackfillSelectionScenario {
   }
 }
 
+class _AutomaticBackfillSelectionScenario {
+  const _AutomaticBackfillSelectionScenario({
+    required this.maxBatchSize,
+    required this.bypassDebounce,
+    required this.bridgeInFlight,
+    required this.candidates,
+  });
+
+  final int maxBatchSize;
+  final bool bypassDebounce;
+  final bool bridgeInFlight;
+  final List<_GeneratedBackfillCandidate> candidates;
+
+  List<SyncSequenceLogItem> missingItems({
+    required String aliceHostId,
+    required String bobHostId,
+  }) {
+    return [
+      for (var index = 0; index < candidates.length; index++)
+        _createMissingLogItem(
+          candidates[index].hostId(
+            aliceHostId: aliceHostId,
+            bobHostId: bobHostId,
+          ),
+          index + 1,
+        ),
+    ];
+  }
+
+  Set<({String hostId, int counter})> queuedEntries({
+    required String aliceHostId,
+    required String bobHostId,
+  }) {
+    return {
+      for (var index = 0; index < candidates.length; index++)
+        if (candidates[index].alreadyQueued)
+          (
+            hostId: candidates[index].hostId(
+              aliceHostId: aliceHostId,
+              bobHostId: bobHostId,
+            ),
+            counter: index + 1,
+          ),
+    };
+  }
+
+  List<({String hostId, int counter})> expectedRequested({
+    required String aliceHostId,
+    required String bobHostId,
+  }) {
+    if (bridgeInFlight) return const [];
+    return [
+      for (var index = 0; index < candidates.length; index++)
+        if (!candidates[index].alreadyQueued)
+          (
+            hostId: candidates[index].hostId(
+              aliceHostId: aliceHostId,
+              bobHostId: bobHostId,
+            ),
+            counter: index + 1,
+          ),
+    ].take(maxBatchSize).toList();
+  }
+
+  @override
+  String toString() {
+    return '_AutomaticBackfillSelectionScenario('
+        'maxBatchSize: $maxBatchSize, '
+        'bypassDebounce: $bypassDebounce, '
+        'bridgeInFlight: $bridgeInFlight, '
+        'candidates: $candidates'
+        ')';
+  }
+}
+
 extension _AnyBackfillSelectionScenario on glados.Any {
   glados.Generator<_GeneratedBackfillCandidate>
   get generatedBackfillCandidate => glados.CombinableAny(this).combine2(
@@ -144,6 +219,27 @@ extension _AnyBackfillSelectionScenario on glados.Any {
           candidates: candidates,
         ),
       );
+
+  glados.Generator<_AutomaticBackfillSelectionScenario>
+  get automaticBackfillSelectionScenario => glados.CombinableAny(this).combine4(
+    glados.IntAnys(this).intInRange(1, 7),
+    glados.BoolAny(this).bool,
+    glados.BoolAny(this).bool,
+    glados.ListAnys(
+      this,
+    ).listWithLengthInRange(1, 15, generatedBackfillCandidate),
+    (
+      int maxBatchSize,
+      bool bypassDebounce,
+      bool bridgeInFlight,
+      List<_GeneratedBackfillCandidate> candidates,
+    ) => _AutomaticBackfillSelectionScenario(
+      maxBatchSize: maxBatchSize,
+      bypassDebounce: bypassDebounce,
+      bridgeInFlight: bridgeInFlight,
+      candidates: candidates,
+    ),
+  );
 }
 
 void main() {
@@ -592,6 +688,130 @@ void main() {
         } finally {
           service.dispose();
         }
+      },
+    );
+
+    glados.Glados(
+      _AnyBackfillSelectionScenario(
+        glados.any,
+      ).automaticBackfillSelectionScenario,
+      glados.ExploreConfig(numRuns: 120),
+    ).test(
+      'automatic backfill requests the generated first unqueued bounded batch',
+      (scenario) {
+        fakeAsync((async) {
+          final coordinator = _MockQueuePipelineCoordinator();
+          when(
+            () => coordinator.isBridgeInFlight,
+          ).thenReturn(scenario.bridgeInFlight);
+
+          final service = BackfillRequestService(
+            sequenceLogService: mockSequenceService,
+            syncDatabase: mockSyncDatabase,
+            outboxService: mockOutboxService,
+            vectorClockService: mockVcService,
+            loggingService: mockLogging,
+            queueCoordinator: coordinator,
+            maxBatchSize: scenario.maxBatchSize,
+            missingDebounce: const Duration(minutes: 7),
+          );
+
+          final missingItems = scenario.missingItems(
+            aliceHostId: aliceHostId,
+            bobHostId: bobHostId,
+          );
+          final expected = scenario.expectedRequested(
+            aliceHostId: aliceHostId,
+            bobHostId: bobHostId,
+          );
+          final enqueuedRequests = <SyncBackfillRequest>[];
+          final markedRequested = <List<({String hostId, int counter})>>[];
+          final minAges = <Duration>[];
+
+          when(
+            () => mockSequenceService.getMissingEntriesWithLimits(
+              limit: any(named: 'limit'),
+              maxRequestCount: any(named: 'maxRequestCount'),
+              maxAge: any(named: 'maxAge'),
+              minAge: any(named: 'minAge'),
+              maxPerHost: any(named: 'maxPerHost'),
+              offset: any(named: 'offset'),
+            ),
+          ).thenAnswer((invocation) async {
+            final limit = invocation.namedArguments[#limit] as int;
+            final offset = invocation.namedArguments[#offset] as int;
+            minAges.add(invocation.namedArguments[#minAge] as Duration);
+            return missingItems.skip(offset).take(limit).toList();
+          });
+          when(() => mockSyncDatabase.getPendingBackfillEntries()).thenAnswer(
+            (_) async => scenario.queuedEntries(
+              aliceHostId: aliceHostId,
+              bobHostId: bobHostId,
+            ),
+          );
+          when(() => mockOutboxService.enqueueMessage(any())).thenAnswer((
+            invocation,
+          ) async {
+            enqueuedRequests.add(
+              invocation.positionalArguments.single as SyncBackfillRequest,
+            );
+          });
+          when(() => mockSequenceService.markAsRequested(any())).thenAnswer((
+            invocation,
+          ) async {
+            markedRequested.add(
+              (invocation.positionalArguments.single
+                      as List<({String hostId, int counter})>)
+                  .toList(),
+            );
+          });
+
+          try {
+            if (scenario.bypassDebounce) {
+              service.nudgeAfterDrain();
+            } else {
+              service.nudge();
+            }
+            async.flushMicrotasks();
+
+            if (scenario.bridgeInFlight || expected.isEmpty) {
+              expect(enqueuedRequests, isEmpty);
+              expect(markedRequested, isEmpty);
+            } else {
+              expect(enqueuedRequests, hasLength(1));
+              expect(enqueuedRequests.single.requesterId, myHostId);
+              expect(
+                enqueuedRequests.single.entries
+                    .map(
+                      (entry) => (
+                        hostId: entry.hostId,
+                        counter: entry.counter,
+                      ),
+                    )
+                    .toList(),
+                expected,
+              );
+              expect(markedRequested, [expected]);
+            }
+
+            if (scenario.bridgeInFlight) {
+              expect(minAges, isEmpty);
+            } else {
+              expect(minAges, isNotEmpty);
+              expect(
+                minAges.toSet(),
+                {
+                  if (scenario.bypassDebounce)
+                    Duration.zero
+                  else
+                    const Duration(minutes: 7),
+                },
+              );
+            }
+          } finally {
+            service.dispose();
+          }
+        });
       },
     );
 

--- a/test/features/sync/matrix/pipeline/attachment_ingestor_test.dart
+++ b/test/features/sync/matrix/pipeline/attachment_ingestor_test.dart
@@ -1,8 +1,12 @@
+import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:glados/glados.dart' as glados;
 import 'package:lotti/features/sync/matrix/pipeline/attachment_index.dart';
 import 'package:lotti/features/sync/matrix/pipeline/attachment_ingestor.dart';
+import 'package:lotti/features/sync/vector_clock.dart';
 import 'package:matrix/matrix.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -15,6 +19,9 @@ Event _makeEvent({
   String? relativePath,
   String mime = '', // empty mime → _saveAttachment short-circuits before
   // touching the (mocked) Matrix download stack
+  String text = '',
+  List<int>? downloadBytes,
+  void Function()? onDownload,
   Map<String, dynamic>? content,
 }) {
   final e = _MockEvent();
@@ -26,8 +33,236 @@ Event _makeEvent({
           'relativePath': ?relativePath,
         },
   );
-  when(() => e.text).thenReturn('');
+  when(() => e.text).thenReturn(text);
+  if (downloadBytes != null) {
+    when(e.downloadAndDecryptAttachment).thenAnswer((_) async {
+      onDownload?.call();
+      return MatrixFile(
+        bytes: Uint8List.fromList(downloadBytes),
+        name: 'generated.json',
+      );
+    });
+  }
   return e;
+}
+
+class _GeneratedAttachmentObservation {
+  const _GeneratedAttachmentObservation({
+    required this.eventSlot,
+    required this.pathSlot,
+    required this.withLeadingSlash,
+  });
+
+  final int eventSlot;
+  final int pathSlot;
+  final bool withLeadingSlash;
+
+  String get eventId => 'generated-attachment-$eventSlot';
+
+  String get canonicalPath => '/attachments/path-$pathSlot.json';
+
+  String get rawPath =>
+      withLeadingSlash ? canonicalPath : canonicalPath.substring(1);
+
+  @override
+  String toString() {
+    return '_GeneratedAttachmentObservation('
+        'eventSlot: $eventSlot, '
+        'pathSlot: $pathSlot, '
+        'withLeadingSlash: $withLeadingSlash'
+        ')';
+  }
+}
+
+class _GeneratedAttachmentReplayScenario {
+  const _GeneratedAttachmentReplayScenario({required this.observations});
+
+  final List<_GeneratedAttachmentObservation> observations;
+
+  List<String> expectedPathSignals() {
+    final seen = <String>{};
+    final paths = <String>[];
+    for (final observation in observations) {
+      if (seen.add(observation.eventId)) {
+        paths.add(observation.canonicalPath);
+      }
+    }
+    return paths;
+  }
+
+  Map<String, String> expectedLatestEventByPath() {
+    final seen = <String>{};
+    final latest = <String, String>{};
+    for (final observation in observations) {
+      if (seen.add(observation.eventId)) {
+        latest[observation.canonicalPath] = observation.eventId;
+      }
+    }
+    return latest;
+  }
+
+  @override
+  String toString() {
+    return '_GeneratedAttachmentReplayScenario('
+        'observations: $observations'
+        ')';
+  }
+}
+
+class _GeneratedDominanceObservation {
+  const _GeneratedDominanceObservation({
+    required this.eventSlot,
+    required this.pathSlot,
+    required this.agentPayload,
+    required this.dominates,
+    required this.counter,
+  });
+
+  final int eventSlot;
+  final int pathSlot;
+  final bool agentPayload;
+  final bool dominates;
+  final int counter;
+
+  String get eventId => 'generated-dominance-$eventSlot';
+
+  String get canonicalPath => agentPayload
+      ? '/agent_entities/generated-$pathSlot.json'
+      : '/attachments/generated-$pathSlot.json';
+
+  String get text {
+    return base64.encode(
+      utf8.encode(
+        json.encode(<String, dynamic>{
+          'runtimeType': agentPayload ? 'agentEntity' : 'journalEntity',
+          'vectorClock': <String, int>{'host-a': counter},
+        }),
+      ),
+    );
+  }
+
+  @override
+  String toString() {
+    return '_GeneratedDominanceObservation('
+        'eventSlot: $eventSlot, '
+        'pathSlot: $pathSlot, '
+        'agentPayload: $agentPayload, '
+        'dominates: $dominates, '
+        'counter: $counter'
+        ')';
+  }
+}
+
+class _GeneratedDominanceScenario {
+  const _GeneratedDominanceScenario({required this.observations});
+
+  final List<_GeneratedDominanceObservation> observations;
+
+  List<
+    ({String eventId, String path, VectorClock? vectorClock, bool dominates})
+  >
+  expectedDominanceCalls() {
+    final seen = <String>{};
+    return [
+      for (final observation in observations)
+        if (seen.add(observation.eventId) && observation.agentPayload)
+          (
+            eventId: observation.eventId,
+            path: observation.canonicalPath,
+            vectorClock: VectorClock({'host-a': observation.counter}),
+            dominates: observation.dominates,
+          ),
+    ];
+  }
+
+  @override
+  String toString() {
+    return '_GeneratedDominanceScenario(observations: $observations)';
+  }
+}
+
+extension _AnyAttachmentIngestorScenario on glados.Any {
+  glados.Generator<_GeneratedAttachmentObservation> get attachmentObservation =>
+      glados.CombinableAny(this).combine3(
+        glados.IntAnys(this).intInRange(0, 5),
+        glados.IntAnys(this).intInRange(0, 3),
+        glados.BoolAny(this).bool,
+        (
+          int eventSlot,
+          int pathSlot,
+          bool withLeadingSlash,
+        ) => _GeneratedAttachmentObservation(
+          eventSlot: eventSlot,
+          pathSlot: pathSlot,
+          withLeadingSlash: withLeadingSlash,
+        ),
+      );
+
+  glados.Generator<_GeneratedAttachmentReplayScenario>
+  get attachmentReplayScenario =>
+      glados.ListAnys(
+            this,
+          )
+          .listWithLengthInRange(1, 14, attachmentObservation)
+          .map(
+            (observations) =>
+                _GeneratedAttachmentReplayScenario(observations: observations),
+          );
+
+  glados.Generator<_GeneratedDominanceObservation> get dominanceObservation =>
+      glados.CombinableAny(this).combine5(
+        glados.IntAnys(this).intInRange(0, 7),
+        glados.IntAnys(this).intInRange(0, 3),
+        glados.BoolAny(this).bool,
+        glados.BoolAny(this).bool,
+        glados.IntAnys(this).intInRange(1, 8),
+        (
+          int eventSlot,
+          int pathSlot,
+          bool agentPayload,
+          bool dominates,
+          int counter,
+        ) => _GeneratedDominanceObservation(
+          eventSlot: eventSlot,
+          pathSlot: pathSlot,
+          agentPayload: agentPayload,
+          dominates: dominates,
+          counter: counter,
+        ),
+      );
+
+  glados.Generator<_GeneratedDominanceScenario> get dominanceScenario =>
+      glados.ListAnys(
+            this,
+          )
+          .listWithLengthInRange(1, 14, dominanceObservation)
+          .map(
+            (observations) =>
+                _GeneratedDominanceScenario(observations: observations),
+          );
+}
+
+Future<void> _withFreshAttachmentIngestorState(
+  Future<void> Function(
+    MockLoggingService logging,
+    AttachmentIndex index,
+    Directory tempDir,
+  )
+  body,
+) async {
+  final logging = MockLoggingService();
+  stubLoggingService(logging);
+  final index = AttachmentIndex(logging: logging, verboseLogging: false);
+  final tempDir = Directory.systemTemp.createTempSync('lotti_attach_ingest_');
+
+  try {
+    await body(logging, index, tempDir);
+  } finally {
+    await index.dispose();
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  }
 }
 
 void main() {
@@ -165,6 +400,47 @@ void main() {
       // index.find returns the latest event for the path.
       expect(index.find('images/a.jpg')!.eventId, 'ev2');
     });
+
+    glados.Glados(
+      glados.any.attachmentReplayScenario,
+    ).test(
+      'generated descriptor replay emits one path signal per new event id',
+      (scenario) async {
+        await _withFreshAttachmentIngestorState((logging, index, _) async {
+          final ingestor = AttachmentIngestor(verboseLogging: false);
+          final recordedPaths = <String>[];
+          final subscription = index.pathRecorded.listen(recordedPaths.add);
+
+          try {
+            for (final observation in scenario.observations) {
+              final event = _makeEvent(
+                eventId: observation.eventId,
+                relativePath: observation.rawPath,
+              );
+
+              final wrote = await ingestor.process(
+                event: event,
+                logging: logging,
+                attachmentIndex: index,
+              );
+              expect(wrote, isFalse);
+            }
+
+            await pumpEventQueue();
+
+            expect(recordedPaths, scenario.expectedPathSignals());
+
+            final expectedLatestByPath = scenario.expectedLatestEventByPath();
+            for (var slot = 0; slot <= 3; slot++) {
+              final path = '/attachments/path-$slot.json';
+              expect(index.find(path)?.eventId, expectedLatestByPath[path]);
+            }
+          } finally {
+            await subscription.cancel();
+          }
+        });
+      },
+    );
   });
 
   group('AttachmentIngestor.process — path traversal & download skip', () {
@@ -298,6 +574,121 @@ void main() {
         ),
       ).called(1);
     });
+
+    glados.Glados(
+      glados.any.dominanceScenario,
+    ).test(
+      'generated agent observations consult VC dominance once per new event',
+      (scenario) async {
+        await _withFreshAttachmentIngestorState((
+          logging,
+          index,
+          tempDir,
+        ) async {
+          final expectedCalls = scenario.expectedDominanceCalls();
+          final dominanceCalls =
+              <({String path, VectorClock? vectorClock, bool dominates})>[];
+          final downloadedEventIds = <String>[];
+          final skipLogs = <String>[];
+
+          when(
+            () => logging.captureEvent(
+              any<Object>(),
+              domain: any<String>(named: 'domain'),
+              subDomain: any<String>(named: 'subDomain'),
+              level: any(named: 'level'),
+              type: any(named: 'type'),
+            ),
+          ).thenAnswer((invocation) {
+            if (invocation.namedArguments[#subDomain] ==
+                'attachment.download.skip') {
+              skipLogs.add(invocation.positionalArguments.single.toString());
+            }
+          });
+
+          for (final observation in scenario.observations) {
+            File(
+                '${tempDir.path}/${observation.canonicalPath.substring(1)}',
+              )
+              ..createSync(recursive: true)
+              ..writeAsStringSync('local-copy');
+          }
+
+          final ingestor = AttachmentIngestor(
+            documentsDirectory: tempDir,
+            localVcDominates: (path, vectorClock) async {
+              final expected = expectedCalls[dominanceCalls.length];
+              dominanceCalls.add(
+                (
+                  path: path,
+                  vectorClock: vectorClock,
+                  dominates: expected.dominates,
+                ),
+              );
+              return expected.dominates;
+            },
+          );
+
+          final seenForWrite = <String>{};
+          for (final observation in scenario.observations) {
+            final event = _makeEvent(
+              eventId: observation.eventId,
+              relativePath: observation.canonicalPath,
+              mime: 'application/json',
+              text: observation.text,
+              downloadBytes: utf8.encode(
+                'downloaded:${observation.eventId}:${observation.counter}',
+              ),
+              onDownload: () => downloadedEventIds.add(observation.eventId),
+            );
+
+            final wrote = await ingestor.process(
+              event: event,
+              logging: logging,
+              attachmentIndex: index,
+            );
+            final expectedWrite =
+                seenForWrite.add(observation.eventId) &&
+                observation.agentPayload &&
+                !observation.dominates;
+            expect(wrote, expectedWrite);
+          }
+
+          expect(
+            dominanceCalls
+                .map(
+                  (call) => (
+                    path: call.path,
+                    vectorClock: call.vectorClock,
+                  ),
+                )
+                .toList(),
+            expectedCalls
+                .map(
+                  (call) => (
+                    path: call.path,
+                    vectorClock: call.vectorClock,
+                  ),
+                )
+                .toList(),
+          );
+          expect(
+            downloadedEventIds,
+            [
+              for (final call in expectedCalls)
+                if (!call.dominates) call.eventId,
+            ],
+          );
+          expect(
+            skipLogs,
+            [
+              for (final call in expectedCalls)
+                if (call.dominates) 'skip.localVcDominates path=${call.path}',
+            ],
+          );
+        });
+      },
+    );
   });
 
   group('AttachmentIngestor.scheduleDownload', () {

--- a/test/features/sync/queue/inbound_event_queue_test.dart
+++ b/test/features/sync/queue/inbound_event_queue_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:clock/clock.dart';
 import 'package:drift/drift.dart' show Value;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:glados/glados.dart' as glados;
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/features/sync/matrix/consts.dart';
 import 'package:lotti/features/sync/queue/inbound_event_queue.dart';
@@ -40,6 +41,248 @@ Event _buildSyncEvent({
     'content': eventContent,
   });
   return event;
+}
+
+enum _GeneratedTerminalAction { commit, skip }
+
+class _GeneratedInboundQueueRow {
+  const _GeneratedInboundQueueRow({
+    required this.timestampBucket,
+    required this.processingBucket,
+    required this.terminalAction,
+  });
+
+  final int timestampBucket;
+  final int processingBucket;
+  final _GeneratedTerminalAction terminalAction;
+
+  int get originTsMs => 1000 + timestampBucket;
+
+  @override
+  String toString() {
+    return '_GeneratedInboundQueueRow('
+        'timestampBucket: $timestampBucket, '
+        'processingBucket: $processingBucket, '
+        'terminalAction: $terminalAction'
+        ')';
+  }
+}
+
+class _GeneratedInboundQueueMarkerScenario {
+  const _GeneratedInboundQueueMarkerScenario({required this.rows});
+
+  final List<_GeneratedInboundQueueRow> rows;
+
+  String eventIdFor(int index) => '\$generated-marker-$index';
+
+  Map<String, _GeneratedTerminalAction> get actionByEventId => {
+    for (var index = 0; index < rows.length; index++)
+      eventIdFor(index): rows[index].terminalAction,
+  };
+
+  List<int> processingOrder() {
+    final indexed =
+        <({int index, _GeneratedInboundQueueRow row})>[
+          for (var index = 0; index < rows.length; index++)
+            (index: index, row: rows[index]),
+        ]..sort((a, b) {
+          final bucketCompare = a.row.processingBucket.compareTo(
+            b.row.processingBucket,
+          );
+          if (bucketCompare != 0) return bucketCompare;
+          return a.index.compareTo(b.index);
+        });
+
+    return [for (final item in indexed) item.index];
+  }
+
+  @override
+  String toString() {
+    return '_GeneratedInboundQueueMarkerScenario(rows: $rows)';
+  }
+}
+
+class _GeneratedResurrectionRow {
+  const _GeneratedResurrectionRow({
+    required this.pathSlot,
+    required this.timestampBucket,
+    required this.withLeadingSlash,
+  });
+
+  final int pathSlot;
+  final int timestampBucket;
+  final bool withLeadingSlash;
+
+  int get originTsMs => 2000 + timestampBucket;
+
+  String get canonicalPath => '/generated/path-$pathSlot.json';
+
+  String get rawPath =>
+      withLeadingSlash ? canonicalPath : canonicalPath.substring(1);
+
+  @override
+  String toString() {
+    return '_GeneratedResurrectionRow('
+        'pathSlot: $pathSlot, '
+        'timestampBucket: $timestampBucket, '
+        'withLeadingSlash: $withLeadingSlash'
+        ')';
+  }
+}
+
+class _GeneratedResurrectionScenario {
+  const _GeneratedResurrectionScenario({
+    required this.targetSlot,
+    required this.rows,
+  });
+
+  final int targetSlot;
+  final List<_GeneratedResurrectionRow> rows;
+
+  String get targetPath => '/generated/path-$targetSlot.json';
+
+  String eventIdFor(int index) => '\$generated-resurrect-$index';
+
+  List<String> expectedResurrectedEventIds() {
+    final indexed =
+        <({int index, _GeneratedResurrectionRow row})>[
+          for (var index = 0; index < rows.length; index++)
+            (index: index, row: rows[index]),
+        ]..sort((a, b) {
+          final tsCompare = a.row.originTsMs.compareTo(b.row.originTsMs);
+          if (tsCompare != 0) return tsCompare;
+          return a.index.compareTo(b.index);
+        });
+
+    return [
+      for (final item in indexed)
+        if (item.row.canonicalPath == targetPath) eventIdFor(item.index),
+    ];
+  }
+
+  @override
+  String toString() {
+    return '_GeneratedResurrectionScenario('
+        'targetSlot: $targetSlot, '
+        'rows: $rows'
+        ')';
+  }
+}
+
+class _ExpectedQueueMarker {
+  int lastAppliedTs = 0;
+  String? lastAppliedEventId;
+  int lastAppliedCommitSeq = 0;
+
+  void process(
+    InboundQueueEntry entry,
+    Iterable<InboundQueueEntry> activeAfter,
+  ) {
+    int? oldestActiveTs;
+    for (final active in activeAfter) {
+      if (oldestActiveTs == null || active.originTs < oldestActiveTs) {
+        oldestActiveTs = active.originTs;
+      }
+    }
+
+    final candidateTs = oldestActiveTs == null
+        ? entry.originTs
+        : entry.originTs < oldestActiveTs
+        ? entry.originTs
+        : oldestActiveTs - 1;
+
+    final shouldAdvance =
+        lastAppliedTs == 0 ||
+        candidateTs > lastAppliedTs ||
+        (candidateTs == entry.originTs &&
+            entry.originTs == lastAppliedTs &&
+            (lastAppliedEventId == null ||
+                entry.eventId.compareTo(lastAppliedEventId!) > 0));
+
+    if (!shouldAdvance) return;
+
+    if (candidateTs == entry.originTs && entry.eventId.startsWith(r'$')) {
+      lastAppliedEventId = entry.eventId;
+    }
+    lastAppliedTs = candidateTs;
+    lastAppliedCommitSeq++;
+  }
+}
+
+extension _AnyInboundQueueScenario on glados.Any {
+  glados.Generator<_GeneratedTerminalAction> get terminalAction =>
+      glados.AnyUtils(this).choose(_GeneratedTerminalAction.values);
+
+  glados.Generator<_GeneratedInboundQueueRow> get inboundQueueRow =>
+      glados.CombinableAny(this).combine3(
+        glados.IntAnys(this).intInRange(0, 5),
+        glados.IntAnys(this).intInRange(0, 7),
+        terminalAction,
+        (
+          int timestampBucket,
+          int processingBucket,
+          _GeneratedTerminalAction terminalAction,
+        ) => _GeneratedInboundQueueRow(
+          timestampBucket: timestampBucket,
+          processingBucket: processingBucket,
+          terminalAction: terminalAction,
+        ),
+      );
+
+  glados.Generator<_GeneratedInboundQueueMarkerScenario>
+  get inboundQueueMarkerScenario =>
+      glados.ListAnys(
+            this,
+          )
+          .listWithLengthInRange(1, 8, inboundQueueRow)
+          .map(
+            (rows) => _GeneratedInboundQueueMarkerScenario(rows: rows),
+          );
+
+  glados.Generator<_GeneratedResurrectionRow> get resurrectionRow =>
+      glados.CombinableAny(this).combine3(
+        glados.IntAnys(this).intInRange(0, 3),
+        glados.IntAnys(this).intInRange(0, 8),
+        glados.BoolAny(this).bool,
+        (
+          int pathSlot,
+          int timestampBucket,
+          bool withLeadingSlash,
+        ) => _GeneratedResurrectionRow(
+          pathSlot: pathSlot,
+          timestampBucket: timestampBucket,
+          withLeadingSlash: withLeadingSlash,
+        ),
+      );
+
+  glados.Generator<_GeneratedResurrectionScenario> get resurrectionScenario =>
+      glados.CombinableAny(this).combine2(
+        glados.IntAnys(this).intInRange(0, 3),
+        glados.ListAnys(this).listWithLengthInRange(1, 10, resurrectionRow),
+        (int targetSlot, List<_GeneratedResurrectionRow> rows) =>
+            _GeneratedResurrectionScenario(
+              targetSlot: targetSlot,
+              rows: rows,
+            ),
+      );
+}
+
+Future<void> _withFreshInboundQueue(
+  Future<void> Function(SyncDatabase db, InboundQueue queue) body,
+) async {
+  final db = SyncDatabase(inMemoryDatabase: true);
+  final queue = InboundQueue(
+    db: db,
+    logging: MockLoggingService(),
+    leaseDuration: const Duration(seconds: 1),
+  );
+
+  try {
+    await body(db, queue);
+  } finally {
+    await queue.dispose();
+    await db.close();
+  }
 }
 
 void main() {
@@ -294,6 +537,132 @@ void main() {
         expect(marker.lastAppliedEventId, r'$zzz');
         expect(marker.lastAppliedTs, 1000);
         expect(marker.lastAppliedCommitSeq, 2);
+      },
+    );
+  });
+
+  group('generated queue ledger properties', () {
+    glados.Glados(
+      glados.any.inboundQueueMarkerScenario,
+    ).test(
+      'marker clamping matches the model for generated commit/skip order',
+      (scenario) async {
+        await _withFreshInboundQueue((db, queue) async {
+          await queue.enqueueBatch(
+            [
+              for (var index = 0; index < scenario.rows.length; index++)
+                _buildSyncEvent(
+                  eventId: scenario.eventIdFor(index),
+                  roomId: roomA,
+                  originTsMs: scenario.rows[index].originTsMs,
+                ),
+            ],
+            producer: InboundEventProducer.live,
+          );
+
+          final batch = await queue.peekBatchReady(
+            maxBatch: scenario.rows.length,
+          );
+          expect(batch, hasLength(scenario.rows.length));
+
+          final actionByEventId = scenario.actionByEventId;
+          final activeByEventId = {
+            for (final entry in batch) entry.eventId: entry,
+          };
+          final expectedMarker = _ExpectedQueueMarker();
+          var expectedApplied = 0;
+          var expectedAbandoned = 0;
+
+          final processOrder = scenario.processingOrder();
+
+          for (final index in processOrder) {
+            final entry = batch[index];
+            final action = actionByEventId[entry.eventId]!;
+
+            activeByEventId.remove(entry.eventId);
+            expectedMarker.process(entry, activeByEventId.values);
+
+            switch (action) {
+              case _GeneratedTerminalAction.commit:
+                await queue.commitApplied(entry);
+                expectedApplied++;
+              case _GeneratedTerminalAction.skip:
+                await queue.markSkipped(entry, reason: 'generatedSkip');
+                expectedAbandoned++;
+            }
+          }
+
+          final marker = await (db.select(
+            db.queueMarkers,
+          )..where((t) => t.roomId.equals(roomA))).getSingle();
+          expect(marker.lastAppliedTs, expectedMarker.lastAppliedTs);
+          expect(
+            marker.lastAppliedEventId,
+            expectedMarker.lastAppliedEventId,
+          );
+          expect(
+            marker.lastAppliedCommitSeq,
+            expectedMarker.lastAppliedCommitSeq,
+          );
+
+          final stats = await queue.stats();
+          expect(stats.total, 0);
+          expect(stats.applied, expectedApplied);
+          expect(stats.abandoned, expectedAbandoned);
+        });
+      },
+    );
+
+    glados.Glados(
+      glados.any.resurrectionScenario,
+    ).test(
+      'resurrectByPath only reopens generated abandoned rows for that path',
+      (scenario) async {
+        await _withFreshInboundQueue((_, queue) async {
+          await queue.enqueueBatch(
+            [
+              for (var index = 0; index < scenario.rows.length; index++)
+                _buildSyncEvent(
+                  eventId: scenario.eventIdFor(index),
+                  roomId: roomA,
+                  originTsMs: scenario.rows[index].originTsMs,
+                  content: <String, dynamic>{
+                    'msgtype': syncMessageType,
+                    'jsonPath': scenario.rows[index].rawPath,
+                  },
+                ),
+            ],
+            producer: InboundEventProducer.live,
+          );
+
+          final batch = await queue.peekBatchReady(
+            maxBatch: scenario.rows.length,
+          );
+          for (final entry in batch) {
+            await queue.markSkipped(entry, reason: 'pendingAttachmentTimeout');
+          }
+
+          final expectedEventIds = scenario.expectedResurrectedEventIds();
+          final resurrected = await queue.resurrectByPath(scenario.targetPath);
+
+          expect(resurrected, expectedEventIds.length);
+
+          final stats = await queue.stats();
+          expect(stats.total, expectedEventIds.length);
+          expect(stats.readyNow, expectedEventIds.length);
+          expect(
+            stats.abandoned,
+            scenario.rows.length - expectedEventIds.length,
+          );
+
+          final ready = await queue.peekBatchReady(
+            maxBatch: scenario.rows.length,
+          );
+          expect(
+            ready.map((entry) => entry.eventId).toList(),
+            expectedEventIds,
+          );
+        });
       },
     );
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added property-based tests for automatic backfill request behavior covering debounce bypass and bridge-in-flight suppression.
  * Added generated tests for attachment processing validating descriptor replay signals, download/skip behavior, and vector-clock dominance decisions.
  * Added property-based tests for inbound queue invariants, marker advancement, resurrection by path, and batch/ledger stats under randomized scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->