### PR TITLE
feat: move task details toaster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.998]
+### Changed
+- Toast notifications triggered from the desktop task details page
+  (e.g. "Change applied" after confirming a proposed change) now float
+  above the sticky `TaskActionBar` instead of pinned to the bottom edge
+  of the app window, so the confirmation reads as belonging to the task
+  view it came from. The page now wraps its `Scaffold` in a nested
+  `ScaffoldMessenger` on macOS / Linux / Windows, scoping
+  `context.showToast()` calls fired from inside the subtree to that
+  messenger — Flutter then floats the `SnackBar` above the
+  `bottomNavigationBar` slot automatically. Mobile (iOS / Android) is
+  unchanged: no nested wrapper is added, toasts continue to bubble up
+  to the root messenger and render at the screen bottom as before.
+
 ## [0.9.997]
 ### Changed
 - Sidebar running-timer card now hides itself only when the timer's

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -31,6 +31,11 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="0.9.998" date="2026-05-07">
+      <description>
+          <p>Toast notifications triggered from the desktop task details page (e.g. "Change applied" after confirming a proposed change) now float above the sticky action bar instead of pinned to the bottom edge of the app window, so the confirmation reads as belonging to the task view it came from. The page now wraps its Scaffold in a nested ScaffoldMessenger on macOS / Linux / Windows, scoping toast calls fired from inside the subtree to that messenger — Flutter then floats the SnackBar above the bottomNavigationBar slot automatically. Mobile (iOS / Android) is unchanged: no nested wrapper is added, toasts continue to bubble up to the root messenger and render at the screen bottom as before.</p>
+      </description>
+    </release>
     <release version="0.9.997" date="2026-05-06">
       <description>
           <p>Sidebar running-timer card now hides itself only when the timer's parent task is the same task currently open in the desktop task-details pane and the user is actually on a /tasks/&lt;uuid&gt; route. The detail page's sticky action bar already shows a running indicator, so duplicating the title in the sidebar would be noise — but the card still surfaces on every other tab (Habits, Settings, …) because the selected-task notifier is sticky across tab switches and the action bar isn't visible there. The show/hide flip runs through a combined AnimatedSwitcher + AnimatedSize (~220 ms, easeInOut) so the card fades and the surrounding sidebar collapses smoothly instead of popping. The stream is seeded with the current running entity so a session already running is rendered on first frame instead of flashing through a hidden state.</p>

--- a/lib/features/tasks/ui/pages/task_details_page.dart
+++ b/lib/features/tasks/ui/pages/task_details_page.dart
@@ -20,6 +20,7 @@ import 'package:lotti/features/user_activity/state/user_activity_service.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/media_import.dart';
 import 'package:lotti/pages/empty_scaffold.dart';
+import 'package:lotti/utils/platform.dart';
 
 class TaskDetailsPage extends ConsumerStatefulWidget {
   const TaskDetailsPage({
@@ -109,6 +110,101 @@ class _TaskDetailsPageState extends ConsumerState<TaskDetailsPage>
       return const EmptyScaffoldWithTitle('');
     }
 
+    final scaffold = Scaffold(
+      backgroundColor: context.designTokens.colors.background.level01,
+      // extendBody so the BackdropFilter inside [TaskActionBar]'s
+      // glass strip has body content underneath to actually blur. The
+      // body's bottom inset is reserved automatically for the
+      // bottomNavigationBar slot, so we don't need a magic-number
+      // bottom padding on the slivers.
+      extendBody: true,
+      // The mobile shell hides its bottom nav bar whenever the
+      // current beamer route is `/tasks/<uuid>` (see
+      // _AppScreenState._isMobileImmersiveRoute), so the action bar
+      // sits flush with the home indicator. TaskActionBar handles its
+      // own bottom safe-inset padding.
+      bottomNavigationBar: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          AiRunningAnimationWrapperCard(
+            entryId: widget.taskId,
+            height: 50,
+            isInteractive: true,
+            responseTypes: const {
+              AiResponseType.imageAnalysis,
+              AiResponseType.audioTranscription,
+              AiResponseType.promptGeneration,
+              AiResponseType.imageGeneration,
+            },
+          ),
+          TaskActionBar(task: task),
+        ],
+      ),
+      // Builder so MediaQuery.paddingOf reads the Scaffold-modified
+      // value: with extendBody: true, Scaffold adds the
+      // bottomNavigationBar slot height (action bar + AI overlay when
+      // running) to padding.bottom on the body's MediaQuery. The
+      // trailing SliverPadding consumes that inset so the last entry
+      // can scroll fully above the bar instead of being hidden behind.
+      body: Builder(
+        builder: (context) => CustomScrollView(
+          controller: _scrollController,
+          slivers: [
+            TaskSliverAppBar(taskId: widget.taskId),
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.only(
+                  left: 15,
+                  right: 15,
+                  top: 10,
+                ),
+                child: TaskForm(taskId: widget.taskId),
+              ),
+            ),
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.only(
+                  top: 8,
+                  left: 10,
+                  right: 10,
+                ),
+                child:
+                    Column(
+                      mainAxisAlignment: MainAxisAlignment.end,
+                      children: <Widget>[
+                        LinkedEntriesWithTimer(
+                          item: task,
+                          entryKeyBuilder: _getEntryKey,
+                          highlightedEntryId: highlightedEntryId,
+                          hideTaskEntries: true,
+                        ),
+                        LinkedFromEntriesWidget(
+                          task,
+                          hideTaskEntries: true,
+                        ),
+                      ],
+                    ).animate().fadeIn(
+                      duration: const Duration(milliseconds: 100),
+                    ),
+              ),
+            ),
+            SliverPadding(
+              padding: EdgeInsets.only(
+                bottom: MediaQuery.paddingOf(context).bottom,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    // On desktop, scope toasts triggered from inside the task details
+    // subtree to a nested ScaffoldMessenger so SnackBars float above the
+    // sticky [TaskActionBar] (the Scaffold's bottomNavigationBar) instead
+    // of the app window's bottom edge. Mobile keeps the root messenger so
+    // toasts continue to appear at the screen bottom as before.
+    final body = isDesktop ? ScaffoldMessenger(child: scaffold) : scaffold;
+
     return DropTarget(
       onDragDone: (data) {
         handleDroppedMedia(
@@ -118,93 +214,7 @@ class _TaskDetailsPageState extends ConsumerState<TaskDetailsPage>
           analysisTrigger: ref.read(automaticImageAnalysisTriggerProvider),
         );
       },
-      child: Scaffold(
-        backgroundColor: context.designTokens.colors.background.level01,
-        // extendBody so the BackdropFilter inside [TaskActionBar]'s
-        // glass strip has body content underneath to actually blur. The
-        // body's bottom inset is reserved automatically for the
-        // bottomNavigationBar slot, so we don't need a magic-number
-        // bottom padding on the slivers.
-        extendBody: true,
-        // The mobile shell hides its bottom nav bar whenever the
-        // current beamer route is `/tasks/<uuid>` (see
-        // _AppScreenState._isMobileImmersiveRoute), so the action bar
-        // sits flush with the home indicator. TaskActionBar handles its
-        // own bottom safe-inset padding.
-        bottomNavigationBar: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            AiRunningAnimationWrapperCard(
-              entryId: widget.taskId,
-              height: 50,
-              isInteractive: true,
-              responseTypes: const {
-                AiResponseType.imageAnalysis,
-                AiResponseType.audioTranscription,
-                AiResponseType.promptGeneration,
-                AiResponseType.imageGeneration,
-              },
-            ),
-            TaskActionBar(task: task),
-          ],
-        ),
-        // Builder so MediaQuery.paddingOf reads the Scaffold-modified
-        // value: with extendBody: true, Scaffold adds the
-        // bottomNavigationBar slot height (action bar + AI overlay when
-        // running) to padding.bottom on the body's MediaQuery. The
-        // trailing SliverPadding consumes that inset so the last entry
-        // can scroll fully above the bar instead of being hidden behind.
-        body: Builder(
-          builder: (context) => CustomScrollView(
-            controller: _scrollController,
-            slivers: [
-              TaskSliverAppBar(taskId: widget.taskId),
-              SliverToBoxAdapter(
-                child: Padding(
-                  padding: const EdgeInsets.only(
-                    left: 15,
-                    right: 15,
-                    top: 10,
-                  ),
-                  child: TaskForm(taskId: widget.taskId),
-                ),
-              ),
-              SliverToBoxAdapter(
-                child: Padding(
-                  padding: const EdgeInsets.only(
-                    top: 8,
-                    left: 10,
-                    right: 10,
-                  ),
-                  child:
-                      Column(
-                        mainAxisAlignment: MainAxisAlignment.end,
-                        children: <Widget>[
-                          LinkedEntriesWithTimer(
-                            item: task,
-                            entryKeyBuilder: _getEntryKey,
-                            highlightedEntryId: highlightedEntryId,
-                            hideTaskEntries: true,
-                          ),
-                          LinkedFromEntriesWidget(
-                            task,
-                            hideTaskEntries: true,
-                          ),
-                        ],
-                      ).animate().fadeIn(
-                        duration: const Duration(milliseconds: 100),
-                      ),
-                ),
-              ),
-              SliverPadding(
-                padding: EdgeInsets.only(
-                  bottom: MediaQuery.paddingOf(context).bottom,
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
+      child: body,
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.997+4050
+version: 0.9.998+4051
 
 msix_config:
   display_name: LottiApp

--- a/test/features/tasks/ui/pages/task_details_page_test.dart
+++ b/test/features/tasks/ui/pages/task_details_page_test.dart
@@ -22,6 +22,7 @@ import 'package:lotti/services/editor_state_service.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/services/link_service.dart';
 import 'package:lotti/services/time_service.dart';
+import 'package:lotti/utils/platform.dart' as platform;
 import 'package:mocktail/mocktail.dart';
 import 'package:path_provider/path_provider.dart';
 
@@ -202,6 +203,81 @@ void main() {
       // Stack so it stacks correctly with the AI overlay above it.
       expect(scaffold.floatingActionButton, isNull);
     });
+
+    testWidgets(
+      'desktop wraps task scaffold in nested ScaffoldMessenger so toasts '
+      'float above the sticky action bar instead of the app window bottom',
+      (tester) async {
+        final originalIsDesktop = platform.isDesktop;
+        platform.isDesktop = true;
+        addTearDown(() => platform.isDesktop = originalIsDesktop);
+
+        when(
+          () => mockJournalDb.journalEntityById(testTask.meta.id),
+        ).thenAnswer((_) async => testTask);
+
+        await tester.pumpWidget(
+          makeTestableWidgetWithScaffold(
+            TaskDetailsPage(taskId: testTask.id),
+            overrides: _taskDetailsPageOverrides(),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // The nested messenger is mounted inside the TaskDetailsPage
+        // subtree, so a context resolving via ScaffoldMessenger.of from
+        // within the page (e.g. from TaskActionBar) hits the nested one
+        // and SnackBars float above the sticky action bar — not at the
+        // app window bottom owned by the outer/root messenger.
+        final nestedFinder = find.descendant(
+          of: find.byType(TaskDetailsPage),
+          matching: find.byType(ScaffoldMessenger),
+        );
+        expect(nestedFinder, findsOneWidget);
+
+        final nestedMessengerState =
+            tester.state<ScaffoldMessengerState>(nestedFinder);
+        final innerContext = tester.element(find.byType(TaskActionBar));
+        expect(
+          ScaffoldMessenger.of(innerContext),
+          same(nestedMessengerState),
+        );
+      },
+    );
+
+    testWidgets(
+      'mobile keeps using the root ScaffoldMessenger so toasts continue to '
+      'appear at the screen bottom unchanged',
+      (tester) async {
+        final originalIsDesktop = platform.isDesktop;
+        platform.isDesktop = false;
+        addTearDown(() => platform.isDesktop = originalIsDesktop);
+
+        when(
+          () => mockJournalDb.journalEntityById(testTask.meta.id),
+        ).thenAnswer((_) async => testTask);
+
+        await tester.pumpWidget(
+          makeTestableWidgetWithScaffold(
+            TaskDetailsPage(taskId: testTask.id),
+            overrides: _taskDetailsPageOverrides(),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // On mobile no nested wrapper is added: the only ScaffoldMessenger
+        // in the tree is the one MaterialApp installs above the page, so
+        // toasts continue to bubble up to it and render at the screen
+        // bottom — the existing iOS behaviour.
+        expect(
+          find.descendant(
+            of: find.byType(TaskDetailsPage),
+            matching: find.byType(ScaffoldMessenger),
+          ),
+          findsNothing,
+        );
+      },
+    );
   });
 
   group('TaskDetailsPage Auto-Scroll Tests - ', () {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.9.998

* **Bug Fixes**
  * Fixed toast/snack-bar notifications on desktop to appear above the task action bar instead of at the bottom of the screen. Mobile notifications remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->