### PR TITLE
fix: hide duplicate recording indicator on desktop

### DIFF
--- a/lib/beamer/beamer_app.dart
+++ b/lib/beamer/beamer_app.dart
@@ -69,6 +69,21 @@ bool _isRunningInFlatpak() {
           Platform.environment['FLATPAK_ID']!.isNotEmpty);
 }
 
+/// True when the tasks tab is active and the tasks beamer location points
+/// at a `/tasks/<uuid>` task detail. Used by both shells: the mobile shell
+/// hides the bottom nav pill so the page-owned `TaskActionBar` can dock
+/// flush against the home indicator, and the desktop shell hides the
+/// bottom-right floating recording indicator since the action bar already
+/// exposes the same affordance. Pure function of router state, no
+/// widget-lifecycle race.
+bool isTaskDetailRoute(BeamLocation<dynamic>? location, int activeTabIndex) {
+  // Tasks is always the first destination; if any other tab is active
+  // the tasks delegate's current path is irrelevant.
+  if (activeTabIndex != 0) return false;
+  if (location is! TasksLocation) return false;
+  return isUuid(location.state.pathParameters['taskId']);
+}
+
 enum _AppNavigationDestinationKind {
   tasks,
   projects,
@@ -308,43 +323,37 @@ class _AppScreenState extends ConsumerState<AppScreen> {
           Beamer(routerDelegate: navService.settingsDelegate),
         ];
 
-        if (isWide) {
-          return _buildDesktopLayout(
-            context: context,
-            index: index,
-            destinations: destinations,
-            beamerChildren: beamerChildren,
-          );
-        }
-
-        // Listen to the tasks delegate so the mobile shell rebuilds when
-        // its current route changes (push to / pop from task details).
-        // That's how we know whether to hide the bottom nav pill — see
-        // [_isMobileImmersiveRoute].
+        // Listen to the tasks delegate so both shells rebuild when the
+        // tasks route changes (push to / pop from task details). That's how
+        // we know whether to hide:
+        //   - the mobile bottom nav pill; and
+        //   - the desktop bottom-right floating recording indicator, which
+        //     is redundant once the TaskActionBar is on screen.
+        // See [_isTaskDetailRoute].
         return ListenableBuilder(
           listenable: navService.tasksDelegate,
-          builder: (context, _) => _buildMobileLayout(
-            context: context,
-            index: index,
-            destinations: destinations,
-            beamerChildren: beamerChildren,
-          ),
+          builder: (context, _) => isWide
+              ? _buildDesktopLayout(
+                  context: context,
+                  index: index,
+                  destinations: destinations,
+                  beamerChildren: beamerChildren,
+                )
+              : _buildMobileLayout(
+                  context: context,
+                  index: index,
+                  destinations: destinations,
+                  beamerChildren: beamerChildren,
+                ),
         );
       },
     );
   }
 
-  /// True when the active mobile tab's beamer route is one that should
-  /// take over the bottom edge — currently just `/tasks/<uuid>`. Pure
-  /// function of router state, no widget-lifecycle race.
-  bool _isMobileImmersiveRoute(int activeTabIndex) {
-    // Tasks is always the first destination; if any other tab is
-    // active the tasks delegate's current path is irrelevant.
-    if (activeTabIndex != 0) return false;
-    final loc = navService.tasksDelegate.currentBeamLocation;
-    if (loc is! TasksLocation) return false;
-    return isUuid(loc.state.pathParameters['taskId']);
-  }
+  bool _isTaskDetailRoute(int activeTabIndex) => isTaskDetailRoute(
+    navService.tasksDelegate.currentBeamLocation,
+    activeTabIndex,
+  );
 
   Widget _buildDesktopLayout({
     required BuildContext context,
@@ -464,7 +473,11 @@ class _AppScreenState extends ConsumerState<AppScreen> {
                       ),
                   ],
                 ),
-                if (!_isRunningInFlatpak())
+                // Hidden on `/tasks/<uuid>` — the desktop TaskActionBar
+                // already surfaces the recording control there, so the
+                // floating indicator would be redundant. Stays visible on
+                // the tasks list and on every other top-level destination.
+                if (!_isRunningInFlatpak() && !_isTaskDetailRoute(index))
                   const Positioned(
                     right: AppScreenConstants.navigationAudioIndicatorRight,
                     bottom: AppScreenConstants.navigationTimeIndicatorBottom,
@@ -491,7 +504,7 @@ class _AppScreenState extends ConsumerState<AppScreen> {
     // — so the page-owned bar can dock flush against the home
     // indicator. The enclosing ListenableBuilder ensures we rebuild on
     // every route change.
-    final showBottomNav = !_isMobileImmersiveRoute(index);
+    final showBottomNav = !_isTaskDetailRoute(index);
 
     final designSystemBottomNavigationBar = DesignSystemBottomNavigationBar(
       items: [

--- a/lib/features/tasks/README.md
+++ b/lib/features/tasks/README.md
@@ -197,10 +197,12 @@ Checklist content is modeled separately through checklist entities and linked ch
   The page sets `Scaffold.extendBody: true` so body content paints
   behind the bar — that's what the `BackdropFilter` blurs. The mobile
   shell hides its bottom nav pill whenever the active beamer route is
-  `/tasks/<uuid>` (computed in `_AppScreenState._isMobileImmersiveRoute`,
+  `/tasks/<uuid>` (computed in `_AppScreenState._isTaskDetailRoute`,
   no per-page lifecycle plumbing), so the action bar can dock flush
-  against the home indicator. TaskActionBar consumes the safe-area
-  inset internally.
+  against the home indicator. The desktop shell uses the same predicate
+  to hide its bottom-right floating recording indicator on task detail
+  routes, since the action bar already exposes the recording control.
+  TaskActionBar consumes the safe-area inset internally.
 
 ```mermaid
 flowchart TD

--- a/lib/features/tasks/ui/pages/task_details_page.dart
+++ b/lib/features/tasks/ui/pages/task_details_page.dart
@@ -120,7 +120,7 @@ class _TaskDetailsPageState extends ConsumerState<TaskDetailsPage>
       extendBody: true,
       // The mobile shell hides its bottom nav bar whenever the
       // current beamer route is `/tasks/<uuid>` (see
-      // _AppScreenState._isMobileImmersiveRoute), so the action bar
+      // _AppScreenState._isTaskDetailRoute), so the action bar
       // sits flush with the home indicator. TaskActionBar handles its
       // own bottom safe-inset padding.
       bottomNavigationBar: Column(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.998+4051
+version: 0.9.998+4052
 
 msix_config:
   display_name: LottiApp

--- a/test/beamer/beamer_app_test.dart
+++ b/test/beamer/beamer_app_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/beamer/beamer_app.dart';
+import 'package:lotti/beamer/locations/tasks_location.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/features/ai/ui/settings/services/ai_setup_prompt_service.dart';
@@ -30,6 +31,7 @@ import 'package:lotti/widgets/nav_bar/design_system_bottom_navigation_bar.dart';
 import 'package:matrix/encryption.dart';
 import 'package:matrix/matrix.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:uuid/uuid.dart';
 
 import '../mocks/mocks.dart';
 import '../mocks/sync_config_test_mocks.dart';
@@ -734,6 +736,71 @@ void main() {
       await tester.pump();
     });
   });
+
+  group('isTaskDetailRoute', () {
+    // Single source of truth for the drives the predicate: this is the
+    // exact same callsite shape used by both shells in beamer_app.dart
+    // (mobile bottom-nav suppression + desktop floating recording
+    // indicator hiding), so unit-testing it covers both behaviors.
+
+    test('returns false when the active tab is not the tasks tab', () {
+      // Even with a task-detail location, any non-tasks tab keeps the
+      // floating indicator visible — the desktop TaskActionBar only
+      // renders inside the tasks-tab pane.
+      final location = TasksLocation(
+        RouteInformation(uri: Uri.parse('/tasks/${const Uuid().v4()}')),
+      );
+      expect(isTaskDetailRoute(location, 1), isFalse);
+      expect(isTaskDetailRoute(location, 5), isFalse);
+    });
+
+    test('returns false when the location is not a TasksLocation', () {
+      final location = _ArbitraryLocation(
+        RouteInformation(uri: Uri.parse('/tasks/abc')),
+      );
+      expect(isTaskDetailRoute(location, 0), isFalse);
+    });
+
+    test('returns false when the location is null', () {
+      expect(isTaskDetailRoute(null, 0), isFalse);
+    });
+
+    test('returns false on the tasks list route (no taskId in path)', () {
+      final location = TasksLocation(
+        RouteInformation(uri: Uri.parse('/tasks')),
+      );
+      expect(isTaskDetailRoute(location, 0), isFalse);
+    });
+
+    test('returns false when the trailing path segment is not a uuid', () {
+      // A non-uuid segment (legacy/typo path) must not falsely flag the
+      // route as a task detail and hide the indicator.
+      final location = TasksLocation(
+        RouteInformation(uri: Uri.parse('/tasks/not-a-uuid')),
+      );
+      expect(isTaskDetailRoute(location, 0), isFalse);
+    });
+
+    test('returns true on /tasks/<uuid> with the tasks tab active', () {
+      final taskId = const Uuid().v4();
+      final location = TasksLocation(
+        RouteInformation(uri: Uri.parse('/tasks/$taskId')),
+      );
+      expect(isTaskDetailRoute(location, 0), isTrue);
+    });
+  });
+}
+
+class _ArbitraryLocation extends BeamLocation<BeamState> {
+  _ArbitraryLocation(super.routeInformation);
+
+  @override
+  List<BeamPage> buildPages(BuildContext context, BeamState state) => const [
+    BeamPage(key: ValueKey('arbitrary'), child: SizedBox.shrink()),
+  ];
+
+  @override
+  List<Pattern> get pathPatterns => ['*'];
 }
 
 class _StubSavedTaskFiltersController extends SavedTaskFiltersController {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mobile bottom navigation now reliably hides on task detail pages; desktop floating audio indicator is also suppressed on task details. UI shells update correctly when navigating so visibility rules apply immediately.

* **Documentation**
  * Updated task feature docs to reflect unified behavior for hiding controls on task detail views.

* **Tests**
  * Added unit tests validating task-detail route behavior.

* **Chores**
  * Version bumped to 0.9.998+4052
<!-- end of auto-generated comment: release notes by coderabbit.ai -->