### PR TITLE
test: clean up fake time

### DIFF
--- a/test/features/sync/actor/sync_actor_host_test.dart
+++ b/test/features/sync/actor/sync_actor_host_test.dart
@@ -71,6 +71,12 @@ void _testActorInvalidResponseEntrypoint(SendPort readyPort) {
         final eventPort = command['eventPort'] as SendPort?;
         eventPort?.send(123);
         replyTo?.send(<String, Object?>{'ok': true});
+      case 'emitRawThenValidEvent':
+        final eventPort = command['eventPort'] as SendPort?;
+        eventPort
+          ?..send(123)
+          ..send(<String, Object?>{'event': 'afterRaw'});
+        replyTo?.send(<String, Object?>{'ok': true});
       default:
         replyTo?.send(<String, Object?>{'ok': false, 'error': 'bad'});
     }
@@ -162,21 +168,25 @@ void main() {
       host = await SyncActorHost.spawn(
         entrypoint: _testActorInvalidResponseEntrypoint,
       );
+
+      final events = <Map<String, Object?>>[];
+      final validEvent = Completer<Map<String, Object?>>();
+      final sub = host.events.listen((event) {
+        events.add(event);
+        if (!validEvent.isCompleted) {
+          validEvent.complete(event);
+        }
+      });
+
       final eventPortResponse = await host.send(
-        'emitRawEvent',
+        'emitRawThenValidEvent',
         payload: {'eventPort': host.eventSendPort},
       );
       expect(eventPortResponse['ok'], isTrue);
 
-      final events = <Map<String, Object?>>[];
-      final sub = host.events.listen(events.add);
-
-      await host.send(
-        'emitRawEvent',
-        payload: {'eventPort': host.eventSendPort},
-      );
-      await Future<void>.delayed(const Duration(milliseconds: 100));
-      expect(events, isEmpty);
+      final event = await validEvent.future.timeout(const Duration(seconds: 2));
+      expect(event['event'], 'afterRaw');
+      expect(events, hasLength(1));
       await sub.cancel();
     });
 

--- a/test/features/sync/actor/sync_actor_test.dart
+++ b/test/features/sync/actor/sync_actor_test.dart
@@ -640,6 +640,11 @@ void main() {
         final mockTimelineRoom = MockRoom();
         final mockTimelineEvent = MockEvent();
         final incomingEvents = <Map<String, Object?>>[];
+        final verificationSeen = Completer<void>();
+        final toDeviceSeen = Completer<void>();
+        final incomingMessageSeen = Completer<void>();
+        final syncUpdatesSeen = Completer<void>();
+        var syncUpdateCount = 0;
 
         when(() => mockTimelineRoom.id).thenReturn('!room:localhost');
         when(() => mockTimelineEvent.type).thenReturn('m.room.message');
@@ -661,7 +666,27 @@ void main() {
         final eventPort = ReceivePort()
           ..listen((dynamic raw) {
             if (raw is Map) {
-              incomingEvents.add(raw.cast<String, Object?>());
+              final event = raw.cast<String, Object?>();
+              incomingEvents.add(event);
+              switch (event['event']) {
+                case 'verificationState':
+                  if (!verificationSeen.isCompleted) {
+                    verificationSeen.complete();
+                  }
+                case 'toDevice':
+                  if (!toDeviceSeen.isCompleted) {
+                    toDeviceSeen.complete();
+                  }
+                case 'incomingMessage':
+                  if (!incomingMessageSeen.isCompleted) {
+                    incomingMessageSeen.complete();
+                  }
+                case 'syncUpdate':
+                  syncUpdateCount++;
+                  if (syncUpdateCount == 3 && !syncUpdatesSeen.isCompleted) {
+                    syncUpdatesSeen.complete();
+                  }
+              }
             }
           });
 
@@ -691,13 +716,19 @@ void main() {
             content: const <String, dynamic>{},
           ),
         );
-        await Future<void>.delayed(const Duration(milliseconds: 200));
+        await Future.wait<void>([
+          verificationSeen.future,
+          toDeviceSeen.future,
+        ]);
         onSyncController
           ..add(MockSyncUpdate())
           ..add(MockSyncUpdate())
           ..add(MockSyncUpdate());
         timelineController.add(mockTimelineEvent);
-        await Future<void>.delayed(const Duration(milliseconds: 200));
+        await Future.wait<void>([
+          syncUpdatesSeen.future,
+          incomingMessageSeen.future,
+        ]);
 
         final health = await handler.handleCommand(_cmd('getHealth'));
         final syncCount = health['syncCount'];
@@ -1217,6 +1248,7 @@ void main() {
         final initialKeys = MockDeviceKeysList();
         final updatedKeys = MockDeviceKeysList();
         final incomingEvents = <Map<String, Object?>>[];
+        final keyRefreshLogged = Completer<void>();
         var keysUpdated = false;
 
         when(() => ownDevice.deviceId).thenReturn('DEV');
@@ -1239,7 +1271,15 @@ void main() {
         final eventPort = ReceivePort()
           ..listen((dynamic raw) {
             if (raw is Map) {
-              incomingEvents.add(raw.cast<String, Object?>());
+              final event = raw.cast<String, Object?>();
+              incomingEvents.add(event);
+              if (event['event'] == 'log' &&
+                  '${event['message']}'.contains(
+                    'verification device keys updated for',
+                  ) &&
+                  !keyRefreshLogged.isCompleted) {
+                keyRefreshLogged.complete();
+              }
             }
           });
 
@@ -1273,9 +1313,8 @@ void main() {
         );
 
         final first = await handler.handleCommand(_cmd('startVerification'));
-        await Future<void>.delayed(const Duration(milliseconds: 20));
         final second = await handler.handleCommand(_cmd('startVerification'));
-        await Future<void>.delayed(const Duration(milliseconds: 20));
+        await keyRefreshLogged.future;
 
         expect(first['ok'], isTrue);
         expect(first['started'], isFalse);
@@ -1300,11 +1339,18 @@ void main() {
       'startVerification emits key-refresh error event on refresh failure',
       () async {
         final incomingEvents = <Map<String, Object?>>[];
+        final refreshErrorSeen = Completer<void>();
 
         final eventPort = ReceivePort()
           ..listen((dynamic raw) {
             if (raw is Map) {
-              incomingEvents.add(raw.cast<String, Object?>());
+              final event = raw.cast<String, Object?>();
+              incomingEvents.add(event);
+              if (event['event'] == 'verificationKeyRefreshError' &&
+                  '${event['error']}'.contains('refresh failed') &&
+                  !refreshErrorSeen.isCompleted) {
+                refreshErrorSeen.complete();
+              }
             }
           });
 
@@ -1329,7 +1375,7 @@ void main() {
           _initPayload(eventPort: eventPort.sendPort),
         );
         final response = await handler.handleCommand(_cmd('startVerification'));
-        await Future<void>.delayed(const Duration(milliseconds: 20));
+        await refreshErrorSeen.future;
 
         expect(response['ok'], isTrue);
         expect(response['started'], isFalse);

--- a/test/features/sync/backfill/backfill_request_service_test.dart
+++ b/test/features/sync/backfill/backfill_request_service_test.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: cascade_invocations, avoid_redundant_argument_values
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:fake_async/fake_async.dart';
@@ -971,6 +972,7 @@ void main() {
         );
 
         var callCount = 0;
+        final processing = Completer<List<SyncSequenceLogItem>>();
         when(
           () => mockSequenceService.getMissingEntriesWithLimits(
             limit: any(named: 'limit'),
@@ -982,9 +984,7 @@ void main() {
           ),
         ).thenAnswer((_) async {
           callCount++;
-          // Simulate slow processing (longer than interval)
-          await Future<void>.delayed(const Duration(seconds: 8));
-          return [];
+          return processing.future;
         });
 
         service.start();
@@ -998,8 +998,8 @@ void main() {
         async.elapse(const Duration(seconds: 5));
         async.flushMicrotasks();
 
-        // Complete the first processing at 13s (5s + 8s delay)
-        async.elapse(const Duration(seconds: 3));
+        // Complete the first processing.
+        processing.complete([]);
         async.flushMicrotasks();
 
         // Only one call should have been made despite two timer fires
@@ -1674,6 +1674,7 @@ void main() {
           );
 
           var getRequestedCallCount = 0;
+          final requested = Completer<List<SyncSequenceLogItem>>();
           when(
             () => mockSequenceService.getRequestedEntries(
               limit: 50,
@@ -1681,9 +1682,7 @@ void main() {
             ),
           ).thenAnswer((_) async {
             getRequestedCallCount++;
-            // Simulate slow processing
-            await Future<void>.delayed(const Duration(seconds: 2));
-            return [];
+            return requested.future;
           });
 
           // Start first processReRequest
@@ -1699,7 +1698,7 @@ void main() {
           expect(result, 0);
 
           // Complete the first processing
-          async.elapse(const Duration(seconds: 2));
+          requested.complete([]);
           async.flushMicrotasks();
 
           // Only one call to getRequestedEntries (second was rejected)

--- a/test/features/sync/outbox/outbox_service_test.dart
+++ b/test/features/sync/outbox/outbox_service_test.dart
@@ -2250,44 +2250,57 @@ void main() {
 
     test(
       'sendNext aborts second drain when disposed during settle',
-      () async {
+      () {
         // Regression: with `outboxPostDrainSettle = 1500ms`, the disposal
         // window grows. After awaiting the settle, sendNext must not run a
         // second drain on a disposed service.
-        when(
-          () => journalDb.getConfigFlag(enableMatrixFlag),
-        ).thenAnswer((_) async => true);
-        final gate = createGate();
+        fakeAsync((async) {
+          when(
+            () => journalDb.getConfigFlag(enableMatrixFlag),
+          ).thenAnswer((_) async => true);
+          final gate = createGate();
 
-        var calls = 0;
-        when(() => processor.processQueue()).thenAnswer((_) async {
-          calls++;
-          return OutboxProcessingResult.none;
+          var calls = 0;
+          when(() => processor.processQueue()).thenAnswer((_) async {
+            calls++;
+            return OutboxProcessingResult.none;
+          });
+
+          final svc = TestableOutboxService(
+            syncDatabase: syncDatabase,
+            loggingService: loggingService,
+            vectorClockService: vectorClockService,
+            journalDb: journalDb,
+            documentsDirectory: documentsDirectory,
+            userActivityService: userActivityService,
+            repository: repository,
+            messageSender: messageSender,
+            processor: processor,
+            activityGate: gate,
+            ownsActivityGate: false,
+            postDrainSettle: const Duration(milliseconds: 50),
+          );
+
+          var pendingCompleted = false;
+          final pending = svc.sendNext()
+            ..then((_) {
+              pendingCompleted = true;
+            });
+          async.flushMicrotasks();
+          expect(calls, 1);
+
+          // Dispose mid-settle, before the trailing drain runs.
+          async.elapse(const Duration(milliseconds: 10));
+          unawaited(svc.dispose());
+          async
+            ..elapse(const Duration(milliseconds: 40))
+            ..flushMicrotasks();
+          expect(pendingCompleted, isTrue);
+
+          // First drain ran; trailing drain skipped because of disposal.
+          expect(calls, 1);
+          unawaited(pending);
         });
-
-        final svc = TestableOutboxService(
-          syncDatabase: syncDatabase,
-          loggingService: loggingService,
-          vectorClockService: vectorClockService,
-          journalDb: journalDb,
-          documentsDirectory: documentsDirectory,
-          userActivityService: userActivityService,
-          repository: repository,
-          messageSender: messageSender,
-          processor: processor,
-          activityGate: gate,
-          ownsActivityGate: false,
-          postDrainSettle: const Duration(milliseconds: 50),
-        );
-
-        final pending = svc.sendNext();
-        // Dispose mid-settle, before the trailing drain runs.
-        await Future<void>.delayed(const Duration(milliseconds: 10));
-        await svc.dispose();
-        await pending;
-
-        // First drain ran; trailing drain skipped because of disposal.
-        expect(calls, 1);
       },
     );
 
@@ -2530,9 +2543,10 @@ void main() {
       );
       final gate = createGate();
       // Keep the runner busy so queueSize > 0 when watchdog fires
+      late Completer<void> gateReleased;
       when(
         gate.waitUntilIdle,
-      ).thenAnswer((_) => Future<void>.delayed(const Duration(seconds: 30)));
+      ).thenAnswer((_) => gateReleased.future);
       final matrixService = MockMatrixService();
       when(() => matrixService.isLoggedIn()).thenReturn(true);
       final client = MockMatrixClient();
@@ -2551,6 +2565,7 @@ void main() {
       ).thenAnswer((_) => const Stream<int>.empty());
 
       fakeAsync((async) {
+        gateReleased = Completer<void>();
         final svc = OutboxService(
           syncDatabase: syncDatabase,
           loggingService: loggingService,
@@ -2579,6 +2594,8 @@ void main() {
             subDomain: 'watchdog',
           ),
         );
+        gateReleased.complete();
+        async.flushMicrotasks();
         unawaited(svc.dispose());
         async.flushMicrotasks();
       });
@@ -3066,9 +3083,10 @@ void main() {
 
       // Gate delays long enough so watchdog fires while runner is active
       final gate = createGate();
+      late Completer<void> gateReleased;
       when(
         gate.waitUntilIdle,
-      ).thenAnswer((_) => Future<void>.delayed(const Duration(seconds: 12)));
+      ).thenAnswer((_) => gateReleased.future);
 
       final matrixService = MockMatrixService();
       final client = MockMatrixClient();
@@ -3094,6 +3112,7 @@ void main() {
       ).thenAnswer((_) async => OutboxProcessingResult.none);
 
       fakeAsync((async) {
+        gateReleased = Completer<void>();
         final svc = OutboxService(
           syncDatabase: syncDatabase,
           loggingService: loggingService,
@@ -3120,8 +3139,10 @@ void main() {
         async.elapse(const Duration(seconds: 10));
 
         // Let the runner finish and the second drain occur after settle
+        gateReleased.complete();
         async
-          ..elapse(const Duration(seconds: 3))
+          ..flushMicrotasks()
+          ..elapse(Duration.zero)
           ..flushMicrotasks();
 
         // Exactly one runner invocation → two drains
@@ -3169,9 +3190,10 @@ void main() {
 
         // Long wait to keep the queue active till after watchdog
         final gate = createGate();
+        late Completer<void> gateReleased;
         when(
           gate.waitUntilIdle,
-        ).thenAnswer((_) => Future<void>.delayed(const Duration(seconds: 12)));
+        ).thenAnswer((_) => gateReleased.future);
 
         final matrixService = MockMatrixService();
         final client = MockMatrixClient();
@@ -3194,6 +3216,7 @@ void main() {
         ).thenAnswer((_) => const Stream<int>.empty());
 
         fakeAsync((async) {
+          gateReleased = Completer<void>();
           final svc = OutboxService(
             syncDatabase: syncDatabase,
             loggingService: loggingService,
@@ -3223,8 +3246,10 @@ void main() {
           async.elapse(const Duration(seconds: 10));
 
           // Allow runner completion and second drains
+          gateReleased.complete();
           async
-            ..elapse(const Duration(seconds: 3))
+            ..flushMicrotasks()
+            ..elapse(Duration.zero)
             ..flushMicrotasks();
 
           // Upper bound: two drains per runner invocation, at most two runner
@@ -3254,24 +3279,23 @@ void main() {
           () => processor.processQueue(),
         ).thenAnswer((_) async => OutboxProcessingResult.none);
         // Slow fetchPending simulates overlap window with dbNudge
+        late Completer<List<OutboxItem>> fetchPending;
         when(
           () => repository.fetchPending(limit: any(named: 'limit')),
-        ).thenAnswer((_) async {
-          await Future<void>.delayed(const Duration(milliseconds: 50));
-          return [
-            OutboxItem(
-              id: 7,
-              message: '{}',
-              subject: 's',
-              status: OutboxStatus.pending.index,
-              retries: 0,
-              createdAt: DateTime(2024, 3, 15, 10, 30),
-              updatedAt: DateTime(2024, 3, 15, 10, 30),
-              filePath: null,
-              priority: OutboxPriority.low.index,
-            ),
-          ];
-        });
+        ).thenAnswer((_) => fetchPending.future);
+        final pendingItems = [
+          OutboxItem(
+            id: 7,
+            message: '{}',
+            subject: 's',
+            status: OutboxStatus.pending.index,
+            retries: 0,
+            createdAt: DateTime(2024, 3, 15, 10, 30),
+            updatedAt: DateTime(2024, 3, 15, 10, 30),
+            filePath: null,
+            priority: OutboxPriority.low.index,
+          ),
+        ];
 
         // Gate immediate
         final gate = createGate();
@@ -3295,6 +3319,7 @@ void main() {
         ).thenAnswer((_) => countController.stream);
 
         fakeAsync((async) {
+          fetchPending = Completer<List<OutboxItem>>();
           final svc = OutboxService(
             syncDatabase: syncDatabase,
             loggingService: loggingService,
@@ -3320,9 +3345,8 @@ void main() {
           async.flushMicrotasks();
 
           // Allow drains to complete
-          async
-            ..elapse(const Duration(seconds: 1))
-            ..flushMicrotasks();
+          fetchPending.complete(pendingItems);
+          async.flushMicrotasks();
 
           // Should not explode in duplicate processing; 4 drains is an upper bound here
           verify(() => processor.processQueue()).called(lessThanOrEqualTo(4));

--- a/test/features/sync/queue/bridge_coordinator_test.dart
+++ b/test/features/sync/queue/bridge_coordinator_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/features/sync/queue/bridge_coordinator.dart';
@@ -255,8 +256,14 @@ void main() {
     () async {
       final room = _MockRoom();
       when(() => room.id).thenReturn(roomId);
+      final retried = Completer<void>();
+      var callCount = 0;
       final runner = _RecordingRunner()
         ..override = (Room r, BridgeMarker m) async {
+          callCount++;
+          if (callCount >= 2 && !retried.isCompleted) {
+            retried.complete();
+          }
           throw StateError('bootstrap boom');
         };
       final coordinator = buildCoordinator(
@@ -273,8 +280,7 @@ void main() {
           stackTrace: any<StackTrace>(named: 'stackTrace'),
         ),
       ).called(1);
-      // Retry timer should have scheduled a second call after 10ms.
-      await Future<void>.delayed(const Duration(milliseconds: 40));
+      await retried.future.timeout(const Duration(seconds: 2));
       expect(runner.calls.length, greaterThanOrEqualTo(2));
       await coordinator.stop();
     },
@@ -429,9 +435,13 @@ void main() {
       'eventually fires _bridge again',
       () async {
         var callCount = 0;
+        final retryCompleted = Completer<void>();
         final runner = _RecordingRunner()
           ..override = (Room r, BridgeMarker m) async {
             callCount++;
+            if (callCount > 1 && !retryCompleted.isCompleted) {
+              retryCompleted.complete();
+            }
             return callCount > 1; // first call incomplete, then completes.
           };
         final coordinator = buildCoordinator(
@@ -440,7 +450,7 @@ void main() {
           incompleteRetryDelay: const Duration(milliseconds: 10),
         );
         await coordinator.bridgeNow();
-        await Future<void>.delayed(const Duration(milliseconds: 30));
+        await retryCompleted.future.timeout(const Duration(seconds: 2));
         expect(callCount, greaterThanOrEqualTo(2));
         verify(
           () => logging.captureEvent(
@@ -456,6 +466,7 @@ void main() {
       'giving up emits queue.bridge.incomplete.giveUp after '
       'maxIncompleteRetries consecutive incomplete runs',
       () async {
+        final gaveUp = Completer<void>();
         final runner = _RecordingRunner(defaultCompleted: false);
         final coordinator = buildCoordinator(
           resolveRoom: () async => room,
@@ -463,8 +474,17 @@ void main() {
           incompleteRetryDelay: const Duration(milliseconds: 5),
           maxIncompleteRetries: 2,
         );
+        when(
+          () => logging.captureEvent(
+            any<String>(that: contains('queue.bridge.incomplete.giveUp')),
+            domain: any(named: 'domain'),
+            subDomain: any(named: 'subDomain'),
+          ),
+        ).thenAnswer((_) {
+          if (!gaveUp.isCompleted) gaveUp.complete();
+        });
         await coordinator.bridgeNow();
-        await Future<void>.delayed(const Duration(milliseconds: 80));
+        await gaveUp.future.timeout(const Duration(seconds: 2));
         verify(
           () => logging.captureEvent(
             any<String>(that: contains('queue.bridge.incomplete.giveUp')),
@@ -479,18 +499,24 @@ void main() {
     test(
       'stop() cancels a pending incomplete-retry timer so no bridge fires '
       'after shutdown',
-      () async {
-        final runner = _RecordingRunner(defaultCompleted: false);
-        final coordinator = buildCoordinator(
-          resolveRoom: () async => room,
-          runner: runner,
-          incompleteRetryDelay: const Duration(milliseconds: 50),
-        );
-        await coordinator.bridgeNow();
-        final callsAtStop = runner.calls.length;
-        await coordinator.stop();
-        await Future<void>.delayed(const Duration(milliseconds: 120));
-        expect(runner.calls.length, callsAtStop);
+      () {
+        fakeAsync((async) {
+          final runner = _RecordingRunner(defaultCompleted: false);
+          final coordinator = buildCoordinator(
+            resolveRoom: () async => room,
+            runner: runner,
+            incompleteRetryDelay: const Duration(milliseconds: 50),
+          );
+          unawaited(coordinator.bridgeNow());
+          async.flushMicrotasks();
+          final callsAtStop = runner.calls.length;
+          unawaited(coordinator.stop());
+          async
+            ..flushMicrotasks()
+            ..elapse(const Duration(milliseconds: 120))
+            ..flushMicrotasks();
+          expect(runner.calls.length, callsAtStop);
+        });
       },
     );
 
@@ -690,6 +716,7 @@ void main() {
       () async {
         final outcomes = <bool>[false, true];
         var index = 0;
+        final completed = Completer<void>();
         final runner = _RecordingRunner()
           ..override = (Room r, BridgeMarker m) async {
             final result = outcomes[index.clamp(0, outcomes.length - 1)];
@@ -702,15 +729,14 @@ void main() {
           incompleteRetryDelay: const Duration(milliseconds: 10),
         );
         var completions = 0;
-        coordinator.onBridgeCompleted = () => completions++;
+        coordinator.onBridgeCompleted = () {
+          completions++;
+          if (!completed.isCompleted) completed.complete();
+        };
 
         await coordinator.bridgeNow();
 
-        // Drain the retry timer + its bridge pass.
-        for (var i = 0; i < 50; i++) {
-          await Future<void>.delayed(const Duration(milliseconds: 5));
-          if (index >= 2 && completions >= 1) break;
-        }
+        await completed.future.timeout(const Duration(seconds: 2));
         expect(index, 2);
         expect(completions, 1);
 

--- a/test/features/sync/queue/inbound_worker_test.dart
+++ b/test/features/sync/queue/inbound_worker_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:clock/clock.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
@@ -596,9 +598,11 @@ void main() {
       'loop completion',
       () async {
         final applied = <String>[];
+        final appliedDone = Completer<void>();
         final worker = buildWorker(
           apply: (entry) async {
             applied.add(entry.eventId);
+            appliedDone.complete();
             return ApplyOutcome.applied;
           },
         );
@@ -606,11 +610,7 @@ void main() {
         await queue.enqueueLive(
           _buildSyncEvent(eventId: r'$live', roomId: roomId, originTsMs: 1),
         );
-        // Give the loop a turn to observe the depth change and drain.
-        for (var i = 0; i < 20; i++) {
-          await Future<void>.delayed(Duration.zero);
-          if (applied.isNotEmpty) break;
-        }
+        await appliedDone.future;
         expect(applied, [r'$live']);
         await worker.stop();
         expect(worker.isRunning, isFalse);
@@ -622,11 +622,15 @@ void main() {
       'iteration',
       () async {
         final pen = PendingDecryptionPen(logging: logging);
+        final appliedDone = Completer<void>();
         final worker = InboundWorker(
           queue: queue,
           sequenceLogService: sequenceLog,
           resolveRoom: () async => room,
-          apply: (_, _) async => ApplyOutcome.applied,
+          apply: (_, _) async {
+            appliedDone.complete();
+            return ApplyOutcome.applied;
+          },
           logging: logging,
           decryptionPen: pen,
         );
@@ -650,10 +654,7 @@ void main() {
         ).thenAnswer((_) async => decrypted);
 
         await worker.start();
-        for (var i = 0; i < 30; i++) {
-          await Future<void>.delayed(Duration.zero);
-          if (pen.size == 0) break;
-        }
+        await appliedDone.future;
         await worker.stop();
         expect(pen.size, 0);
       },
@@ -665,15 +666,16 @@ void main() {
       'retries were previously rounded up to idleTick)',
       () async {
         var attempt = 0;
+        final appliedDone = Completer<void>();
         final worker = InboundWorker(
           queue: queue,
           sequenceLogService: sequenceLog,
           resolveRoom: () async => room,
           apply: (_, _) async {
             attempt++;
-            return attempt == 1
-                ? ApplyOutcome.decryptionPending
-                : ApplyOutcome.applied;
+            if (attempt == 1) return ApplyOutcome.decryptionPending;
+            appliedDone.complete();
+            return ApplyOutcome.applied;
           },
           logging: logging,
           initialBackoff: const Duration(milliseconds: 10),
@@ -690,18 +692,9 @@ void main() {
             originTsMs: 1,
           ),
         );
-        final stopwatch = Stopwatch()..start();
-        for (var i = 0; i < 500; i++) {
-          await Future<void>.delayed(const Duration(milliseconds: 20));
-          if ((await queue.stats()).total == 0) break;
-        }
-        stopwatch.stop();
+        await appliedDone.future.timeout(const Duration(seconds: 5));
         await worker.stop();
         expect((await queue.stats()).total, 0);
-        // decryptionPending base backoff is 250ms. The loop must wake
-        // near that deadline; anything close to the 30s idleTick would
-        // be a regression back to the rounded-up sleep.
-        expect(stopwatch.elapsed, lessThan(const Duration(seconds: 5)));
       },
     );
 
@@ -710,12 +703,14 @@ void main() {
       'subscription that was attached before peek (no missed signal)',
       () async {
         final applied = <String>[];
+        final appliedDone = Completer<void>();
         final worker = InboundWorker(
           queue: queue,
           sequenceLogService: sequenceLog,
           resolveRoom: () async => room,
           apply: (entry, _) async {
             applied.add(entry.eventId);
+            appliedDone.complete();
             return ApplyOutcome.applied;
           },
           logging: logging,
@@ -733,10 +728,7 @@ void main() {
             originTsMs: 1,
           ),
         );
-        for (var i = 0; i < 200; i++) {
-          await Future<void>.delayed(const Duration(milliseconds: 10));
-          if (applied.isNotEmpty) break;
-        }
+        await appliedDone.future.timeout(const Duration(seconds: 5));
         await worker.stop();
         expect(applied, [r'$race']);
       },
@@ -746,6 +738,7 @@ void main() {
       'an uncaught exception in the loop body is captured by _logging and '
       '_running is cleared so start() can relaunch afterwards',
       () async {
+        final loopErrorCaptured = Completer<void>();
         // Resolve throws on the first call (pen.flushInto path); after
         // that returns the real room so start() can succeed again.
         var resolveCalls = 0;
@@ -764,6 +757,21 @@ void main() {
           logging: logging,
           decryptionPen: decryptionPen,
         );
+        when(
+          () => logging.captureException(
+            any<Object>(),
+            domain: any(named: 'domain'),
+            subDomain: any(
+              named: 'subDomain',
+              that: contains('loop'),
+            ),
+            stackTrace: any<StackTrace>(named: 'stackTrace'),
+          ),
+        ).thenAnswer((_) {
+          if (!loopErrorCaptured.isCompleted) {
+            loopErrorCaptured.complete();
+          }
+        });
         // Holding an encrypted event forces the pen.flushInto branch
         // which calls _resolveRoom() and blows up on the first call.
         final enc = _MockEvent();
@@ -774,10 +782,8 @@ void main() {
         decryptionPen.hold(enc);
 
         await worker.start();
-        for (var i = 0; i < 50; i++) {
-          await Future<void>.delayed(Duration.zero);
-          if (!worker.isRunning) break;
-        }
+        await loopErrorCaptured.future;
+        await worker.stop();
         expect(worker.isRunning, isFalse);
         verify(
           () => logging.captureException(
@@ -814,10 +820,7 @@ void main() {
         await queue.enqueueLive(
           _buildSyncEvent(eventId: r'$gated', roomId: roomId, originTsMs: 1),
         );
-        for (var i = 0; i < 30; i++) {
-          await Future<void>.delayed(Duration.zero);
-          if ((await queue.stats()).total == 0) break;
-        }
+        await queue.waitForDrainAtMostTo(0);
         await worker.stop();
         expect(waitCalls, greaterThanOrEqualTo(1));
       },

--- a/test/features/sync/queue/pending_decryption_pen_test.dart
+++ b/test/features/sync/queue/pending_decryption_pen_test.dart
@@ -486,12 +486,11 @@ void main() {
         () => room.getEventById(r'$sweep'),
       ).thenAnswer((_) async => decrypted);
 
+      final enqueued = queue.depthChanges.firstWhere(
+        (signal) => signal.total == 1,
+      );
       pen.startSweeping(resolveRoom: () async => room, queue: queue);
-      // Wait long enough for the periodic sweep to fire at least once.
-      for (var i = 0; i < 50; i++) {
-        await Future<void>.delayed(const Duration(milliseconds: 5));
-        if (pen.size == 0) break;
-      }
+      await enqueued.timeout(const Duration(seconds: 2));
       expect(pen.size, 0);
       await pen.stop();
       final stats = await queue.stats();

--- a/test/features/sync/queue/queue_apply_adapter_test.dart
+++ b/test/features/sync/queue/queue_apply_adapter_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -341,30 +342,27 @@ void main() {
         final b = _buildEntry(eventId: r'$b', roomId: '!r:x', originTsMs: 2);
         final c = _buildEntry(eventId: r'$c', roomId: '!r:x', originTsMs: 3);
 
-        // Each prepare call holds open for 100 ms. Sequential prepare
-        // would take ~300 ms; parallel prepare caps at ~100 ms plus
-        // tiny scheduling overhead.
         final prepared = _MockPreparedSyncEvent();
+        final allStarted = Completer<void>();
+        final release = Completer<void>();
+        var prepareCalls = 0;
         when(() => processor.prepare(event: any(named: 'event'))).thenAnswer((
           _,
         ) async {
-          await Future<void>.delayed(const Duration(milliseconds: 100));
+          prepareCalls++;
+          if (prepareCalls == 3) {
+            allStarted.complete();
+          }
+          await release.future;
           return prepared;
         });
 
         final adapter = build();
-        final stopwatch = Stopwatch()..start();
-        await adapter.bindPrepareBatch()([a, b, c], room);
-        stopwatch.stop();
-
-        // 200 ms window leaves plenty of headroom for CI jitter but
-        // still fails decisively if prepare went sequential (≥300 ms).
-        expect(
-          stopwatch.elapsed,
-          lessThan(const Duration(milliseconds: 200)),
-          reason:
-              'prepare ran sequentially (${stopwatch.elapsedMilliseconds}ms)',
-        );
+        final prepareBatch = adapter.bindPrepareBatch()([a, b, c], room);
+        await allStarted.future;
+        expect(prepareCalls, 3);
+        release.complete();
+        await prepareBatch;
         verify(() => processor.prepare(event: any(named: 'event'))).called(3);
       },
     );

--- a/test/features/sync/queue/queue_pipeline_coordinator_test.dart
+++ b/test/features/sync/queue/queue_pipeline_coordinator_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:clock/clock.dart';
 import 'package:drift/drift.dart' show Value;
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/database/sync_db.dart';
@@ -57,9 +58,10 @@ class _MockTimeline extends Mock implements Timeline {}
 /// call and optionally throws, without needing mocktail fallbacks for
 /// every named-argument type (Function, LoggingService, nullable refs).
 class _FakeAttachmentIngestor implements AttachmentIngestor {
-  _FakeAttachmentIngestor({this.shouldThrow = false});
+  _FakeAttachmentIngestor({this.shouldThrow = false, this.firstProcessed});
 
   bool shouldThrow;
+  final Completer<Event>? firstProcessed;
   final List<Map<Symbol, Object?>> processCalls = <Map<Symbol, Object?>>[];
 
   @override
@@ -73,6 +75,9 @@ class _FakeAttachmentIngestor implements AttachmentIngestor {
       #event: event,
       #scheduleDownload: scheduleDownload,
     });
+    if (firstProcessed case final completer? when !completer.isCompleted) {
+      completer.complete(event);
+    }
     if (shouldThrow) {
       throw StateError('ingestor boom');
     }
@@ -121,7 +126,7 @@ void main() {
     bridge = _MockBridge();
     pen = _MockPen();
     seeder = _MockSeeder();
-    timelineCtl = StreamController<Event>.broadcast();
+    timelineCtl = StreamController<Event>.broadcast(sync: true);
     syncCtl = CachedStreamController<SyncUpdate>();
     client = _MockClient();
     when(() => client.onSync).thenReturn(syncCtl);
@@ -1177,42 +1182,46 @@ void main() {
       'when UpdateNotifications emits, the coordinator calls '
       'resurrectByReason(missingBase) so any abandoned row waiting '
       'on its base journal entry becomes drainable again',
-      () async {
-        final updateNotifications = UpdateNotifications();
-        addTearDown(updateNotifications.dispose);
-        when(
-          () => queue.resurrectByReason(any<String>()),
-        ).thenAnswer((_) async => 1);
+      () {
+        fakeAsync((async) {
+          final updateNotifications = UpdateNotifications();
+          addTearDown(updateNotifications.dispose);
+          when(
+            () => queue.resurrectByReason(any<String>()),
+          ).thenAnswer((_) async => 1);
 
-        final coordinator = QueuePipelineCoordinator(
-          syncDb: syncDb,
-          settingsDb: settingsDb,
-          journalDb: journalDb,
-          sessionManager: sessionManager,
-          roomManager: roomManager,
-          eventProcessor: processor,
-          sequenceLogService: sequenceLog,
-          activityGate: null,
-          logging: logging,
-          updateNotifications: updateNotifications,
-          queueOverride: queue,
-          workerOverride: worker,
-          bridgeOverride: bridge,
-          penOverride: pen,
-          seederOverride: seeder,
-        );
-        await coordinator.start();
+          final coordinator = QueuePipelineCoordinator(
+            syncDb: syncDb,
+            settingsDb: settingsDb,
+            journalDb: journalDb,
+            sessionManager: sessionManager,
+            roomManager: roomManager,
+            eventProcessor: processor,
+            sequenceLogService: sequenceLog,
+            activityGate: null,
+            logging: logging,
+            updateNotifications: updateNotifications,
+            queueOverride: queue,
+            workerOverride: worker,
+            bridgeOverride: bridge,
+            penOverride: pen,
+            seederOverride: seeder,
+          );
+          addTearDown(() async => coordinator.stop());
+          var started = false;
+          unawaited(coordinator.start().then((_) => started = true));
+          async.flushMicrotasks();
+          expect(started, isTrue);
 
-        updateNotifications.notify({'some-entry-id'});
-        // notify() batches over 100 ms — wait past that so the
-        // debounced controller actually emits.
-        await Future<void>.delayed(const Duration(milliseconds: 200));
+          updateNotifications.notify({'some-entry-id'});
+          async
+            ..elapse(const Duration(milliseconds: 100))
+            ..flushMicrotasks();
 
-        verify(
-          () => queue.resurrectByReason('missingBase'),
-        ).called(greaterThanOrEqualTo(1));
-
-        await coordinator.stop();
+          verify(
+            () => queue.resurrectByReason('missingBase'),
+          ).called(greaterThanOrEqualTo(1));
+        });
       },
     );
   });
@@ -1263,6 +1272,22 @@ void main() {
       'not strand incoming sync-payload events',
       () async {
         final ingestor = _FakeAttachmentIngestor(shouldThrow: true);
+        final ingestorFailureLogged = Completer<void>();
+        when(
+          () => logging.captureException(
+            any<Object>(),
+            domain: any<String>(named: 'domain'),
+            subDomain: any<String>(
+              named: 'subDomain',
+              that: contains('attachmentIngestor'),
+            ),
+            stackTrace: any<StackTrace>(named: 'stackTrace'),
+          ),
+        ).thenAnswer((_) {
+          if (!ingestorFailureLogged.isCompleted) {
+            ingestorFailureLogged.complete();
+          }
+        });
 
         final coordinator = QueuePipelineCoordinator(
           syncDb: syncDb,
@@ -1284,9 +1309,7 @@ void main() {
         await coordinator.start();
 
         timelineCtl.add(buildEvent(EventTypes.Message));
-        // Allow the fire-and-forget `_processAttachment` microtask plus
-        // the enqueue microtask to land.
-        await Future<void>.delayed(const Duration(milliseconds: 10));
+        await ingestorFailureLogged.future;
 
         // The enqueue path still fires despite the ingestor throwing.
         verify(() => queue.enqueueLive(any())).called(1);
@@ -1343,7 +1366,6 @@ void main() {
         registry.register(r'$self-echo');
 
         timelineCtl.add(echoed);
-        await Future<void>.delayed(const Duration(milliseconds: 10));
 
         // Neither the queue nor the attachment ingestor should see the
         // event — it's ours and already on disk.
@@ -1383,9 +1405,14 @@ void main() {
         when(() => peer.roomId).thenReturn(roomId);
         when(() => peer.type).thenReturn(EventTypes.Message);
         when(() => peer.status).thenReturn(EventStatus.synced);
+        final enqueued = Completer<void>();
+        when(() => queue.enqueueLive(peer)).thenAnswer((_) async {
+          enqueued.complete();
+          return EnqueueResult.empty;
+        });
 
         timelineCtl.add(peer);
-        await Future<void>.delayed(const Duration(milliseconds: 10));
+        await enqueued.future;
 
         verify(() => queue.enqueueLive(peer)).called(1);
 
@@ -1452,7 +1479,6 @@ void main() {
           ..add(pending)
           ..add(optimistic)
           ..add(errored);
-        await Future<void>.delayed(const Duration(milliseconds: 10));
 
         // None of these should reach the queue — they are
         // SDK-generated fake-sync emissions, not real inbound events.
@@ -1523,48 +1549,54 @@ void main() {
       'when resurrectByReason throws on a journal-db update notify, '
       'the exception is logged under the resurrectByReason subDomain '
       'so a broken queue never silences the missing-base signal',
-      () async {
-        final updateNotifications = UpdateNotifications();
-        addTearDown(updateNotifications.dispose);
-        when(
-          () => queue.resurrectByReason(any<String>()),
-        ).thenThrow(StateError('queue gone'));
+      () {
+        fakeAsync((async) {
+          final updateNotifications = UpdateNotifications();
+          addTearDown(updateNotifications.dispose);
+          when(
+            () => queue.resurrectByReason(any<String>()),
+          ).thenThrow(StateError('queue gone'));
 
-        final coordinator = QueuePipelineCoordinator(
-          syncDb: syncDb,
-          settingsDb: settingsDb,
-          journalDb: journalDb,
-          sessionManager: sessionManager,
-          roomManager: roomManager,
-          eventProcessor: processor,
-          sequenceLogService: sequenceLog,
-          activityGate: null,
-          logging: logging,
-          updateNotifications: updateNotifications,
-          queueOverride: queue,
-          workerOverride: worker,
-          bridgeOverride: bridge,
-          penOverride: pen,
-          seederOverride: seeder,
-        );
-        await coordinator.start();
+          final coordinator = QueuePipelineCoordinator(
+            syncDb: syncDb,
+            settingsDb: settingsDb,
+            journalDb: journalDb,
+            sessionManager: sessionManager,
+            roomManager: roomManager,
+            eventProcessor: processor,
+            sequenceLogService: sequenceLog,
+            activityGate: null,
+            logging: logging,
+            updateNotifications: updateNotifications,
+            queueOverride: queue,
+            workerOverride: worker,
+            bridgeOverride: bridge,
+            penOverride: pen,
+            seederOverride: seeder,
+          );
+          addTearDown(() async => coordinator.stop());
+          var started = false;
+          unawaited(coordinator.start().then((_) => started = true));
+          async.flushMicrotasks();
+          expect(started, isTrue);
 
-        updateNotifications.notify({'some-entry'});
-        await Future<void>.delayed(const Duration(milliseconds: 200));
+          updateNotifications.notify({'some-entry'});
+          async
+            ..elapse(const Duration(milliseconds: 100))
+            ..flushMicrotasks();
 
-        verify(
-          () => logging.captureException(
-            any<Object>(),
-            domain: any<String>(named: 'domain'),
-            subDomain: any<String>(
-              named: 'subDomain',
-              that: contains('resurrectByReason'),
+          verify(
+            () => logging.captureException(
+              any<Object>(),
+              domain: any<String>(named: 'domain'),
+              subDomain: any<String>(
+                named: 'subDomain',
+                that: contains('resurrectByReason'),
+              ),
+              stackTrace: any<StackTrace>(named: 'stackTrace'),
             ),
-            stackTrace: any<StackTrace>(named: 'stackTrace'),
-          ),
-        ).called(greaterThanOrEqualTo(1));
-
-        await coordinator.stop();
+          ).called(greaterThanOrEqualTo(1));
+        });
       },
     );
   });
@@ -2290,7 +2322,10 @@ void main() {
       () async {
         final realQueue = InboundQueue(db: syncDb, logging: logging);
         addTearDown(realQueue.dispose);
-        final ingestor = _FakeAttachmentIngestor();
+        final firstProcessed = Completer<Event>();
+        final ingestor = _FakeAttachmentIngestor(
+          firstProcessed: firstProcessed,
+        );
 
         final coordinator = QueuePipelineCoordinator(
           syncDb: syncDb,
@@ -2354,9 +2389,7 @@ void main() {
 
         // The forward walk emitted page [e1] (anchor itself is
         // filtered) → ingestor.process must have fired for that event.
-        // `processAttachment` is `unawaited`, so let the microtask
-        // queue drain first.
-        await Future<void>.delayed(const Duration(milliseconds: 10));
+        expect(await firstProcessed.future, same(e1));
         expect(ingestor.processCalls, hasLength(1));
         expect(ingestor.processCalls.single[#event], same(e1));
       },
@@ -2369,7 +2402,10 @@ void main() {
       () async {
         final realQueue = InboundQueue(db: syncDb, logging: logging);
         addTearDown(realQueue.dispose);
-        final ingestor = _FakeAttachmentIngestor();
+        final firstProcessed = Completer<Event>();
+        final ingestor = _FakeAttachmentIngestor(
+          firstProcessed: firstProcessed,
+        );
 
         final coordinator = QueuePipelineCoordinator(
           syncDb: syncDb,
@@ -2420,7 +2456,7 @@ void main() {
         // No anchor id → backward walk runs.
         final completed = await coordinator.runBootstrapForTest(room: room);
         expect(completed, isTrue);
-        await Future<void>.delayed(const Duration(milliseconds: 10));
+        expect(await firstProcessed.future, same(e));
         expect(ingestor.processCalls, hasLength(1));
         expect(ingestor.processCalls.single[#event], same(e));
       },

--- a/test/features/sync/queue/queue_pipeline_integration_test.dart
+++ b/test/features/sync/queue/queue_pipeline_integration_test.dart
@@ -12,6 +12,7 @@ import 'package:lotti/features/sync/matrix/session_manager.dart';
 import 'package:lotti/features/sync/matrix/sync_event_processor.dart';
 import 'package:lotti/features/sync/matrix/sync_room_manager.dart';
 import 'package:lotti/features/sync/queue/bridge_coordinator.dart';
+import 'package:lotti/features/sync/queue/inbound_event_queue.dart';
 import 'package:lotti/features/sync/queue/queue_pipeline_coordinator.dart';
 import 'package:lotti/features/sync/sequence/sync_sequence_log_service.dart';
 import 'package:lotti/services/vector_clock_service.dart';
@@ -69,6 +70,31 @@ Event _buildSyncEvent({
   return event;
 }
 
+Future<void> _waitForQueueStats(
+  InboundQueue queue,
+  bool Function(QueueStats stats) matches,
+) async {
+  final completer = Completer<void>();
+
+  Future<void> check() async {
+    if (completer.isCompleted) return;
+    final stats = await queue.stats();
+    if (matches(stats) && !completer.isCompleted) {
+      completer.complete();
+    }
+  }
+
+  final sub = queue.depthChanges.listen((_) {
+    unawaited(check());
+  });
+  try {
+    await check();
+    await completer.future;
+  } finally {
+    await sub.cancel();
+  }
+}
+
 void main() {
   late SyncDatabase syncDb;
   late JournalDb journalDb;
@@ -106,7 +132,7 @@ void main() {
     logging = MockLoggingService();
     bridge = _MockBridge();
     room = _MockRoom();
-    timelineCtl = StreamController<Event>.broadcast();
+    timelineCtl = StreamController<Event>.broadcast(sync: true);
     syncCtl = CachedStreamController<SyncUpdate>();
     client = _MockClient();
     when(() => client.onSync).thenReturn(syncCtl);
@@ -146,12 +172,18 @@ void main() {
       when(
         () => processor.prepare(event: any(named: 'event')),
       ).thenAnswer((_) async => prepared);
+      final applied = Completer<void>();
       when(
         () => processor.apply(
           prepared: any(named: 'prepared'),
           journalDb: journalDb,
         ),
-      ).thenAnswer((_) async => null);
+      ).thenAnswer((_) async {
+        if (!applied.isCompleted) {
+          applied.complete();
+        }
+        return null;
+      });
 
       final coordinator = QueuePipelineCoordinator(
         syncDb: syncDb,
@@ -179,18 +211,8 @@ void main() {
       );
       timelineCtl.add(event);
 
-      // Let the pipeline finish: enqueue → depth signal → worker
-      // wakeup → apply. Pump until the queue empties or the budget
-      // expires so the test stays deterministic on slow machines.
-      // Budget is generous because a real-timer worker on a loaded
-      // CI runner can take multiple seconds to wake + apply; ending
-      // assertions should still race ahead once the queue is empty.
-      final start = DateTime.now();
-      while (DateTime.now().difference(start) < const Duration(seconds: 10)) {
-        await Future<void>.delayed(const Duration(milliseconds: 20));
-        final stats = await coordinator.queue.stats();
-        if (stats.total == 0) break;
-      }
+      await applied.future;
+      await coordinator.queue.waitForDrainAtMostTo(0);
 
       verify(() => processor.prepare(event: any(named: 'event'))).called(1);
       verify(
@@ -219,12 +241,20 @@ void main() {
       when(
         () => processor.prepare(event: any(named: 'event')),
       ).thenAnswer((_) async => prepared);
+      final bothApplied = Completer<void>();
+      var applyCount = 0;
       when(
         () => processor.apply(
           prepared: any(named: 'prepared'),
           journalDb: journalDb,
         ),
-      ).thenAnswer((_) async => null);
+      ).thenAnswer((_) async {
+        applyCount++;
+        if (applyCount == 2 && !bothApplied.isCompleted) {
+          bothApplied.complete();
+        }
+        return null;
+      });
 
       final coordinator = QueuePipelineCoordinator(
         syncDb: syncDb,
@@ -276,7 +306,6 @@ void main() {
 
       // Step 1: encrypted event arrives — pen holds it, queue stays empty.
       timelineCtl.add(encrypted);
-      await Future<void>.delayed(const Duration(milliseconds: 30));
       final statsAfterHold = await coordinator.queue.stats();
       expect(statsAfterHold.total, 0);
 
@@ -291,12 +320,7 @@ void main() {
       );
       timelineCtl.add(wakeEvent);
 
-      final start = DateTime.now();
-      while (DateTime.now().difference(start) < const Duration(seconds: 10)) {
-        await Future<void>.delayed(const Duration(milliseconds: 30));
-        final stats = await coordinator.queue.stats();
-        if (stats.total == 0) break;
-      }
+      await bothApplied.future;
 
       // Both the wake event and the now-decrypted event applied.
       verify(
@@ -330,12 +354,18 @@ void main() {
         }
         return prepared;
       });
+      final appliedDone = Completer<void>();
       when(
         () => processor.apply(
           prepared: any(named: 'prepared'),
           journalDb: journalDb,
         ),
-      ).thenAnswer((_) async => null);
+      ).thenAnswer((_) async {
+        if (!appliedDone.isCompleted) {
+          appliedDone.complete();
+        }
+        return null;
+      });
 
       final attachmentIndex = AttachmentIndex(logging: MockLoggingService());
       addTearDown(attachmentIndex.dispose);
@@ -392,14 +422,12 @@ void main() {
       // here by manually flipping the row to abandoned once we see
       // the first retry attempt, then `attemptsExhausted` mimics
       // the "worker gave up" terminal state. This keeps the test
-      // deterministic and under the 10s budget.
+      // deterministic without sleeping through the retry ladder.
       {
-        final start = DateTime.now();
-        while (DateTime.now().difference(start) < const Duration(seconds: 10)) {
-          await Future<void>.delayed(const Duration(milliseconds: 30));
-          final stats = await coordinator.queue.stats();
-          if (stats.retrying > 0 || stats.abandoned > 0) break;
-        }
+        await _waitForQueueStats(
+          coordinator.queue,
+          (stats) => stats.retrying > 0 || stats.abandoned > 0,
+        );
         // Transition the retrying row straight to abandoned so we can
         // exercise resurrection without sleeping through the full
         // 30s → 10min ladder.
@@ -413,7 +441,7 @@ void main() {
           InboundEventQueueCompanion(
             status: const Value('abandoned'),
             abandonedAt: Value(
-              DateTime.now().millisecondsSinceEpoch,
+              DateTime(2024, 3, 15, 10, 30).millisecondsSinceEpoch,
             ),
             lastErrorReason: const Value('maxAttempts(pendingAttachment)'),
           ),
@@ -449,14 +477,11 @@ void main() {
       attachmentIndex.record(attachmentEvent);
 
       // Phase 3 — wait for resurrection + apply + marker advance.
-      {
-        final start = DateTime.now();
-        while (DateTime.now().difference(start) < const Duration(seconds: 10)) {
-          await Future<void>.delayed(const Duration(milliseconds: 30));
-          final stats = await coordinator.queue.stats();
-          if (stats.applied > 0) break;
-        }
-      }
+      await appliedDone.future;
+      await _waitForQueueStats(
+        coordinator.queue,
+        (stats) => stats.applied > 0,
+      );
 
       verify(
         () => processor.apply(
@@ -496,12 +521,18 @@ void main() {
         }
         return prepared;
       });
+      final appliedDone = Completer<void>();
       when(
         () => processor.apply(
           prepared: any(named: 'prepared'),
           journalDb: journalDb,
         ),
-      ).thenAnswer((_) async => null);
+      ).thenAnswer((_) async {
+        if (!appliedDone.isCompleted) {
+          appliedDone.complete();
+        }
+        return null;
+      });
 
       final attachmentIndex = AttachmentIndex(logging: MockLoggingService());
       addTearDown(attachmentIndex.dispose);
@@ -561,12 +592,10 @@ void main() {
       // Wait for the row to become retrying; then flip to abandoned
       // (shortcut past the production ladder).
       {
-        final start = DateTime.now();
-        while (DateTime.now().difference(start) < const Duration(seconds: 10)) {
-          await Future<void>.delayed(const Duration(milliseconds: 30));
-          final stats = await coordinator.queue.stats();
-          if (stats.retrying > 0 || stats.abandoned > 0) break;
-        }
+        await _waitForQueueStats(
+          coordinator.queue,
+          (stats) => stats.retrying > 0 || stats.abandoned > 0,
+        );
         final entries = await (syncDb.select(
           syncDb.inboundEventQueue,
         )..where((t) => t.eventId.equals(r'$liveSyncAwaiting'))).get();
@@ -577,7 +606,7 @@ void main() {
           InboundEventQueueCompanion(
             status: const Value('abandoned'),
             abandonedAt: Value(
-              DateTime.now().millisecondsSinceEpoch,
+              DateTime(2024, 3, 15, 10, 30).millisecondsSinceEpoch,
             ),
             lastErrorReason: const Value('maxAttempts(pendingAttachment)'),
           ),
@@ -622,14 +651,11 @@ void main() {
       timelineCtl.add(attachmentEvent);
 
       // Phase 3 — wait for resurrection + apply.
-      {
-        final start = DateTime.now();
-        while (DateTime.now().difference(start) < const Duration(seconds: 10)) {
-          await Future<void>.delayed(const Duration(milliseconds: 30));
-          final stats = await coordinator.queue.stats();
-          if (stats.applied > 0) break;
-        }
-      }
+      await appliedDone.future;
+      await _waitForQueueStats(
+        coordinator.queue,
+        (stats) => stats.applied > 0,
+      );
 
       verify(
         () => processor.apply(

--- a/test/features/sync/state/backfill_stats_controller_test.dart
+++ b/test/features/sync/state/backfill_stats_controller_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -151,11 +153,9 @@ void main() {
         when(
           () => mockSequenceService.getBackfillStats(),
         ).thenAnswer((_) async => testStats);
+        final backfill = Completer<int>();
         when(() => mockBackfillService.processFullBackfill()).thenAnswer(
-          (_) async {
-            await Future<void>.delayed(const Duration(milliseconds: 200));
-            return 5;
-          },
+          (_) => backfill.future,
         );
 
         createAndLoad(async);
@@ -168,9 +168,8 @@ void main() {
         var state = container.read(backfillStatsControllerProvider);
         expect(state.isProcessing, isTrue);
 
-        async
-          ..elapse(const Duration(milliseconds: 200))
-          ..flushMicrotasks();
+        backfill.complete(5);
+        async.flushMicrotasks();
 
         state = container.read(backfillStatsControllerProvider);
         expect(state.isProcessing, isFalse);
@@ -204,11 +203,9 @@ void main() {
         when(
           () => mockSequenceService.getBackfillStats(),
         ).thenAnswer((_) async => testStats);
+        final backfill = Completer<int>();
         when(() => mockBackfillService.processFullBackfill()).thenAnswer(
-          (_) async {
-            await Future<void>.delayed(const Duration(milliseconds: 100));
-            return 5;
-          },
+          (_) => backfill.future,
         );
 
         createAndLoad(async);
@@ -218,9 +215,8 @@ void main() {
         act(async, (c) => c.triggerFullBackfill());
 
         // Complete the first one
-        async
-          ..elapse(const Duration(milliseconds: 100))
-          ..flushMicrotasks();
+        backfill.complete(5);
+        async.flushMicrotasks();
 
         verify(() => mockBackfillService.processFullBackfill()).called(1);
       });
@@ -257,11 +253,9 @@ void main() {
         when(
           () => mockSequenceService.getBackfillStats(),
         ).thenAnswer((_) async => testStats);
+        final reRequest = Completer<int>();
         when(() => mockBackfillService.processReRequest()).thenAnswer(
-          (_) async {
-            await Future<void>.delayed(const Duration(milliseconds: 200));
-            return 8;
-          },
+          (_) => reRequest.future,
         );
 
         createAndLoad(async);
@@ -274,9 +268,8 @@ void main() {
         var state = container.read(backfillStatsControllerProvider);
         expect(state.isReRequesting, isTrue);
 
-        async
-          ..elapse(const Duration(milliseconds: 200))
-          ..flushMicrotasks();
+        reRequest.complete(8);
+        async.flushMicrotasks();
 
         state = container.read(backfillStatsControllerProvider);
         expect(state.isReRequesting, isFalse);
@@ -310,11 +303,9 @@ void main() {
         when(
           () => mockSequenceService.getBackfillStats(),
         ).thenAnswer((_) async => testStats);
+        final reRequest = Completer<int>();
         when(() => mockBackfillService.processReRequest()).thenAnswer(
-          (_) async {
-            await Future<void>.delayed(const Duration(milliseconds: 100));
-            return 5;
-          },
+          (_) => reRequest.future,
         );
 
         createAndLoad(async);
@@ -322,9 +313,8 @@ void main() {
         act(async, (c) => c.triggerReRequest());
         act(async, (c) => c.triggerReRequest());
 
-        async
-          ..elapse(const Duration(milliseconds: 100))
-          ..flushMicrotasks();
+        reRequest.complete(5);
+        async.flushMicrotasks();
 
         verify(() => mockBackfillService.processReRequest()).called(1);
       });
@@ -335,11 +325,9 @@ void main() {
         when(
           () => mockSequenceService.getBackfillStats(),
         ).thenAnswer((_) async => testStats);
+        final backfill = Completer<int>();
         when(() => mockBackfillService.processFullBackfill()).thenAnswer(
-          (_) async {
-            await Future<void>.delayed(const Duration(milliseconds: 100));
-            return 5;
-          },
+          (_) => backfill.future,
         );
 
         createAndLoad(async);
@@ -349,9 +337,8 @@ void main() {
         act(async, (c) => c.triggerReRequest());
 
         // Complete the backfill
-        async
-          ..elapse(const Duration(milliseconds: 100))
-          ..flushMicrotasks();
+        backfill.complete(5);
+        async.flushMicrotasks();
 
         verifyNever(() => mockBackfillService.processReRequest());
       });
@@ -385,11 +372,9 @@ void main() {
         when(
           () => mockSequenceService.getBackfillStats(),
         ).thenAnswer((_) async => testStats);
+        final reset = Completer<int>();
         when(() => mockSequenceService.resetUnresolvableEntries()).thenAnswer(
-          (_) async {
-            await Future<void>.delayed(const Duration(milliseconds: 200));
-            return 10;
-          },
+          (_) => reset.future,
         );
 
         createAndLoad(async);
@@ -399,9 +384,8 @@ void main() {
         var state = container.read(backfillStatsControllerProvider);
         expect(state.isResetting, isTrue);
 
-        async
-          ..elapse(const Duration(milliseconds: 200))
-          ..flushMicrotasks();
+        reset.complete(10);
+        async.flushMicrotasks();
 
         state = container.read(backfillStatsControllerProvider);
         expect(state.isResetting, isFalse);
@@ -432,11 +416,9 @@ void main() {
         when(
           () => mockSequenceService.getBackfillStats(),
         ).thenAnswer((_) async => testStats);
+        final reset = Completer<int>();
         when(() => mockSequenceService.resetUnresolvableEntries()).thenAnswer(
-          (_) async {
-            await Future<void>.delayed(const Duration(milliseconds: 100));
-            return 5;
-          },
+          (_) => reset.future,
         );
 
         createAndLoad(async);
@@ -444,9 +426,8 @@ void main() {
         act(async, (c) => c.resetUnresolvable());
         act(async, (c) => c.resetUnresolvable());
 
-        async
-          ..elapse(const Duration(milliseconds: 100))
-          ..flushMicrotasks();
+        reset.complete(5);
+        async.flushMicrotasks();
 
         verify(() => mockSequenceService.resetUnresolvableEntries()).called(1);
       });
@@ -457,11 +438,9 @@ void main() {
         when(
           () => mockSequenceService.getBackfillStats(),
         ).thenAnswer((_) async => testStats);
+        final backfill = Completer<int>();
         when(() => mockBackfillService.processFullBackfill()).thenAnswer(
-          (_) async {
-            await Future<void>.delayed(const Duration(milliseconds: 100));
-            return 5;
-          },
+          (_) => backfill.future,
         );
 
         createAndLoad(async);
@@ -469,9 +448,8 @@ void main() {
         act(async, (c) => c.triggerFullBackfill());
         act(async, (c) => c.resetUnresolvable());
 
-        async
-          ..elapse(const Duration(milliseconds: 100))
-          ..flushMicrotasks();
+        backfill.complete(5);
+        async.flushMicrotasks();
 
         verifyNever(() => mockSequenceService.resetUnresolvableEntries());
       });
@@ -516,16 +494,12 @@ void main() {
         when(
           () => mockSequenceService.getBackfillStats(),
         ).thenAnswer((_) async => testStats);
+        final retire = Completer<int>();
         when(
           () => mockSequenceService.retireAgedOutRequestedEntries(
             amnestyWindow: any(named: 'amnestyWindow'),
           ),
-        ).thenAnswer(
-          (_) async {
-            await Future<void>.delayed(const Duration(milliseconds: 200));
-            return 3;
-          },
-        );
+        ).thenAnswer((_) => retire.future);
 
         createAndLoad(async);
 
@@ -537,9 +511,8 @@ void main() {
         var state = container.read(backfillStatsControllerProvider);
         expect(state.isRetiringStuck, isTrue);
 
-        async
-          ..elapse(const Duration(milliseconds: 200))
-          ..flushMicrotasks();
+        retire.complete(3);
+        async.flushMicrotasks();
 
         state = container.read(backfillStatsControllerProvider);
         expect(state.isRetiringStuck, isFalse);
@@ -627,11 +600,9 @@ void main() {
           when(
             () => mockSequenceService.getBackfillStats(),
           ).thenAnswer((_) async => testStats);
+          final backfill = Completer<int>();
           when(() => mockBackfillService.processFullBackfill()).thenAnswer(
-            (_) async {
-              await Future<void>.delayed(const Duration(milliseconds: 100));
-              return 2;
-            },
+            (_) => backfill.future,
           );
           when(
             () => mockSequenceService.retireAgedOutRequestedEntries(
@@ -645,9 +616,8 @@ void main() {
           act(async, (c) => c.triggerFullBackfill());
           act(async, (c) => c.retireStuckNow());
 
-          async
-            ..elapse(const Duration(milliseconds: 100))
-            ..flushMicrotasks();
+          backfill.complete(2);
+          async.flushMicrotasks();
 
           verifyNever(
             () => mockSequenceService.retireAgedOutRequestedEntries(

--- a/test/features/sync/state/matrix_room_provider_test.dart
+++ b/test/features/sync/state/matrix_room_provider_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/sync/state/matrix_room_provider.dart';
@@ -103,11 +105,10 @@ void main() {
       ).thenAnswer((_) async => '!room:s');
 
       // Simulate a slow invite
+      final invite = Completer<void>();
       when(
         () => mockMatrixService.inviteToSyncRoom(userId: any(named: 'userId')),
-      ).thenAnswer(
-        (_) async => Future<void>.delayed(const Duration(milliseconds: 50)),
-      );
+      ).thenAnswer((_) => invite.future);
 
       final container = ProviderContainer(
         overrides: [
@@ -124,6 +125,7 @@ void main() {
       // Fire two invites concurrently
       final f1 = controller.inviteToRoom('@user:server');
       final f2 = controller.inviteToRoom('@user:server');
+      invite.complete();
       await Future.wait([f1, f2]);
 
       // Only one should have gone through


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Rewrote many test suites to remove timing-dependent sleeps and polling, replacing them with deterministic synchronization and controlled async advancement. Tests now await explicit signals for retries, lifecycle transitions, concurrency and event-driven behaviors, reducing flakiness and making retry, drain, enqueue, backfill and watchdog scenarios reliably repeatable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->