### PR TITLE
test: add glados tests for agent wake activity

### DIFF
--- a/lib/features/agents/wake/wake_runner.dart
+++ b/lib/features/agents/wake/wake_runner.dart
@@ -18,8 +18,8 @@ class WakeRunner {
 
   /// Stream that emits the current set of active agent IDs whenever it changes.
   ///
-  /// Emits after every [tryAcquire] and [release] call. Consumers can filter
-  /// for a specific agent ID using `.map((ids) => ids.contains(agentId))`.
+  /// Consumers can filter for a specific agent ID using
+  /// `.map((ids) => ids.contains(agentId))`.
   Stream<Set<String>> get runningAgentIds => _runningController.stream;
 
   /// Attempt to acquire the single-flight lock for [agentId].
@@ -39,7 +39,10 @@ class WakeRunner {
   /// Must be called in a `finally` block after the run finishes (or fails)
   /// to prevent the lock from leaking.
   void release(String agentId) {
-    _activeLocks.remove(agentId)?.complete();
+    final lock = _activeLocks.remove(agentId);
+    if (lock == null) return;
+
+    lock.complete();
     _activeStartedAt.remove(agentId);
     _runningController.add(activeAgentIds);
   }

--- a/test/features/agents/service/feedback_extraction_service_test.dart
+++ b/test/features/agents/service/feedback_extraction_service_test.dart
@@ -1,10 +1,12 @@
 //ignore_for_file: avoid_redundant_argument_values
 import 'package:clock/clock.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:glados/glados.dart' as glados;
 import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/model/change_set.dart';
 import 'package:lotti/features/agents/model/classified_feedback.dart';
 import 'package:lotti/features/agents/model/improver_slot_keys.dart';
 import 'package:lotti/features/agents/service/feedback_extraction_service.dart';
@@ -14,6 +16,366 @@ import 'package:mocktail/mocktail.dart';
 import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
 import '../test_utils.dart';
+
+enum _GeneratedFeedbackDecisionTimeSlot { before, since, inside, until, after }
+
+enum _GeneratedFeedbackDecisionToolSlot {
+  estimate,
+  title,
+  addChecklist,
+  updateChecklist,
+  migrateChecklist,
+}
+
+enum _GeneratedFeedbackDecisionContextSlot {
+  none,
+  rejectionReason,
+  snakeReason,
+  kebabReason,
+  nestedFeedback,
+  notesList,
+  nonExplanatoryArgs,
+  shortReason,
+}
+
+enum _GeneratedFeedbackDecisionSummarySlot {
+  decisionSummary,
+  changeSetSummary,
+  toolNameFallback,
+}
+
+class _GeneratedFeedbackDecisionSpec {
+  const _GeneratedFeedbackDecisionSpec({
+    required this.timeSlot,
+    required this.verdict,
+    required this.toolSlot,
+    required this.contextSlot,
+    required this.summarySlot,
+  });
+
+  final _GeneratedFeedbackDecisionTimeSlot timeSlot;
+  final ChangeDecisionVerdict verdict;
+  final _GeneratedFeedbackDecisionToolSlot toolSlot;
+  final _GeneratedFeedbackDecisionContextSlot contextSlot;
+  final _GeneratedFeedbackDecisionSummarySlot summarySlot;
+
+  bool get isChecklistTool => switch (toolSlot) {
+    _GeneratedFeedbackDecisionToolSlot.addChecklist ||
+    _GeneratedFeedbackDecisionToolSlot.updateChecklist ||
+    _GeneratedFeedbackDecisionToolSlot.migrateChecklist => true,
+    _ => false,
+  };
+
+  bool get hasExplanatoryContext => switch (contextSlot) {
+    _GeneratedFeedbackDecisionContextSlot.rejectionReason ||
+    _GeneratedFeedbackDecisionContextSlot.snakeReason ||
+    _GeneratedFeedbackDecisionContextSlot.kebabReason ||
+    _GeneratedFeedbackDecisionContextSlot.nestedFeedback ||
+    _GeneratedFeedbackDecisionContextSlot.notesList => true,
+    _ => false,
+  };
+
+  bool get suppressesAsBareChecklistRejection =>
+      verdict == ChangeDecisionVerdict.rejected &&
+      isChecklistTool &&
+      !hasExplanatoryContext;
+
+  String get toolName => switch (toolSlot) {
+    _GeneratedFeedbackDecisionToolSlot.estimate => 'update_task_estimate',
+    _GeneratedFeedbackDecisionToolSlot.title => 'update_task_title',
+    _GeneratedFeedbackDecisionToolSlot.addChecklist =>
+      TaskAgentToolNames.addChecklistItem,
+    _GeneratedFeedbackDecisionToolSlot.updateChecklist =>
+      TaskAgentToolNames.updateChecklistItems,
+    _GeneratedFeedbackDecisionToolSlot.migrateChecklist =>
+      TaskAgentToolNames.migrateChecklistItems,
+  };
+
+  FeedbackSentiment get expectedSentiment => switch (verdict) {
+    ChangeDecisionVerdict.confirmed => FeedbackSentiment.positive,
+    ChangeDecisionVerdict.rejected => FeedbackSentiment.negative,
+    ChangeDecisionVerdict.deferred => FeedbackSentiment.neutral,
+    ChangeDecisionVerdict.retracted => FeedbackSentiment.neutral,
+  };
+
+  DateTime createdAt({
+    required DateTime since,
+    required DateTime until,
+  }) {
+    return switch (timeSlot) {
+      _GeneratedFeedbackDecisionTimeSlot.before => since.subtract(
+        const Duration(microseconds: 1),
+      ),
+      _GeneratedFeedbackDecisionTimeSlot.since => since,
+      _GeneratedFeedbackDecisionTimeSlot.inside => since.add(
+        const Duration(days: 2, hours: 3),
+      ),
+      _GeneratedFeedbackDecisionTimeSlot.until => until,
+      _GeneratedFeedbackDecisionTimeSlot.after => until.add(
+        const Duration(microseconds: 1),
+      ),
+    };
+  }
+
+  bool isInWindow({
+    required DateTime since,
+    required DateTime until,
+  }) {
+    final created = createdAt(since: since, until: until);
+    return !created.isBefore(since) && !created.isAfter(until);
+  }
+
+  ChangeDecisionEntity decision({
+    required int index,
+    required DateTime since,
+    required DateTime until,
+  }) {
+    return makeTestChangeDecision(
+      id: _decisionId(index),
+      agentId: _agentId(index),
+      changeSetId: _changeSetId(index),
+      itemIndex: 0,
+      toolName: toolName,
+      verdict: verdict,
+      createdAt: createdAt(since: since, until: until),
+      rejectionReason: rejectionReason(index),
+      humanSummary: decisionSummary(index),
+      args: args(index),
+    );
+  }
+
+  ChangeSetEntity? changeSet({
+    required int index,
+    required DateTime since,
+    required DateTime until,
+  }) {
+    if (summarySlot != _GeneratedFeedbackDecisionSummarySlot.changeSetSummary) {
+      return null;
+    }
+
+    return makeTestChangeSet(
+      id: _changeSetId(index),
+      agentId: _agentId(index),
+      createdAt: createdAt(since: since, until: until),
+      items: [
+        ChangeItem(
+          toolName: toolName,
+          args: args(index) ?? const {},
+          humanSummary: changeSetSummary(index),
+        ),
+      ],
+    );
+  }
+
+  _ExpectedFeedbackDecisionItem expectedItem(int index) {
+    return _ExpectedFeedbackDecisionItem(
+      id: _decisionId(index),
+      agentId: _agentId(index),
+      sentiment: expectedSentiment,
+      detail: expectedDetail(index),
+    );
+  }
+
+  String expectedDetail(int index) {
+    final reason = rejectionReason(index);
+    final suffix = reason == null ? '' : ' — $reason';
+    return '${verdict.name}: ${expectedSummary(index)}$suffix';
+  }
+
+  String expectedSummary(int index) {
+    return switch (summarySlot) {
+      _GeneratedFeedbackDecisionSummarySlot.decisionSummary => decisionSummary(
+        index,
+      )!,
+      _GeneratedFeedbackDecisionSummarySlot.changeSetSummary =>
+        changeSetSummary(index),
+      _GeneratedFeedbackDecisionSummarySlot.toolNameFallback => toolName,
+    };
+  }
+
+  String? decisionSummary(int index) {
+    return switch (summarySlot) {
+      _GeneratedFeedbackDecisionSummarySlot.decisionSummary =>
+        'Generated decision summary $index',
+      _ => null,
+    };
+  }
+
+  String changeSetSummary(int index) => 'Generated change-set summary $index';
+
+  String? rejectionReason(int index) {
+    return switch (contextSlot) {
+      _GeneratedFeedbackDecisionContextSlot.rejectionReason =>
+        'Generated rejection reason $index',
+      _ => null,
+    };
+  }
+
+  Map<String, dynamic>? args(int index) {
+    return switch (contextSlot) {
+      _GeneratedFeedbackDecisionContextSlot.snakeReason => {
+        'rejection_reason': 'Generated snake reason $index',
+      },
+      _GeneratedFeedbackDecisionContextSlot.kebabReason => {
+        'rejection-reason': 'Generated kebab reason $index',
+      },
+      _GeneratedFeedbackDecisionContextSlot.nestedFeedback => {
+        'feedback': {'text': 'Generated nested feedback $index'},
+      },
+      _GeneratedFeedbackDecisionContextSlot.notesList => {
+        'notes': ['Generated note $index', 'Generated follow-up $index'],
+      },
+      _GeneratedFeedbackDecisionContextSlot.nonExplanatoryArgs => {
+        'title': 'Generated checklist item $index',
+        'status': 'open',
+      },
+      _GeneratedFeedbackDecisionContextSlot.shortReason => {'reason': 'ok'},
+      _ => null,
+    };
+  }
+
+  String _decisionId(int index) => 'generated-decision-$index';
+
+  String _agentId(int index) => 'generated-agent-$index';
+
+  String _changeSetId(int index) => 'generated-change-set-$index';
+
+  @override
+  String toString() {
+    return '_GeneratedFeedbackDecisionSpec('
+        'timeSlot: $timeSlot, verdict: $verdict, toolSlot: $toolSlot, '
+        'contextSlot: $contextSlot, summarySlot: $summarySlot)';
+  }
+}
+
+class _GeneratedFeedbackDecisionScenario {
+  const _GeneratedFeedbackDecisionScenario({required this.decisions});
+
+  final List<_GeneratedFeedbackDecisionSpec> decisions;
+
+  _ExpectedFeedbackDecisionModel expectedModel({
+    required DateTime since,
+    required DateTime until,
+  }) {
+    final classifiedItems = <_ExpectedFeedbackDecisionItem>[];
+    var totalDecisionsScanned = 0;
+    var suppressedChecklistRejectionCount = 0;
+
+    for (var index = 0; index < decisions.length; index += 1) {
+      final decision = decisions[index];
+      if (!decision.isInWindow(since: since, until: until)) {
+        continue;
+      }
+
+      totalDecisionsScanned += 1;
+      if (decision.suppressesAsBareChecklistRejection) {
+        suppressedChecklistRejectionCount += 1;
+        continue;
+      }
+
+      classifiedItems.add(decision.expectedItem(index));
+    }
+
+    return _ExpectedFeedbackDecisionModel(
+      classifiedItems: classifiedItems,
+      totalDecisionsScanned: totalDecisionsScanned,
+      suppressedChecklistRejectionCount: suppressedChecklistRejectionCount,
+    );
+  }
+
+  @override
+  String toString() {
+    return '_GeneratedFeedbackDecisionScenario(decisions: $decisions)';
+  }
+}
+
+class _ExpectedFeedbackDecisionModel {
+  const _ExpectedFeedbackDecisionModel({
+    required this.classifiedItems,
+    required this.totalDecisionsScanned,
+    required this.suppressedChecklistRejectionCount,
+  });
+
+  final List<_ExpectedFeedbackDecisionItem> classifiedItems;
+  final int totalDecisionsScanned;
+  final int suppressedChecklistRejectionCount;
+
+  bool get hasAggregateSuppressionItem =>
+      suppressedChecklistRejectionCount >= 2;
+
+  int get totalItemCount =>
+      classifiedItems.length + (hasAggregateSuppressionItem ? 1 : 0);
+}
+
+class _ExpectedFeedbackDecisionItem {
+  const _ExpectedFeedbackDecisionItem({
+    required this.id,
+    required this.agentId,
+    required this.sentiment,
+    required this.detail,
+  });
+
+  final String id;
+  final String agentId;
+  final FeedbackSentiment sentiment;
+  final String detail;
+}
+
+extension _AnyGeneratedFeedbackDecisionScenario on glados.Any {
+  glados.Generator<_GeneratedFeedbackDecisionTimeSlot>
+  get feedbackDecisionTimeSlot =>
+      glados.AnyUtils(this).choose(_GeneratedFeedbackDecisionTimeSlot.values);
+
+  glados.Generator<ChangeDecisionVerdict> get feedbackDecisionVerdict =>
+      glados.AnyUtils(this).choose(ChangeDecisionVerdict.values);
+
+  glados.Generator<_GeneratedFeedbackDecisionToolSlot>
+  get feedbackDecisionToolSlot =>
+      glados.AnyUtils(this).choose(_GeneratedFeedbackDecisionToolSlot.values);
+
+  glados.Generator<_GeneratedFeedbackDecisionContextSlot>
+  get feedbackDecisionContextSlot => glados.AnyUtils(
+    this,
+  ).choose(_GeneratedFeedbackDecisionContextSlot.values);
+
+  glados.Generator<_GeneratedFeedbackDecisionSummarySlot>
+  get feedbackDecisionSummarySlot => glados.AnyUtils(
+    this,
+  ).choose(_GeneratedFeedbackDecisionSummarySlot.values);
+
+  glados.Generator<_GeneratedFeedbackDecisionSpec> get feedbackDecisionSpec =>
+      glados.CombinableAny(this).combine5(
+        feedbackDecisionTimeSlot,
+        feedbackDecisionVerdict,
+        feedbackDecisionToolSlot,
+        feedbackDecisionContextSlot,
+        feedbackDecisionSummarySlot,
+        (
+          _GeneratedFeedbackDecisionTimeSlot timeSlot,
+          ChangeDecisionVerdict verdict,
+          _GeneratedFeedbackDecisionToolSlot toolSlot,
+          _GeneratedFeedbackDecisionContextSlot contextSlot,
+          _GeneratedFeedbackDecisionSummarySlot summarySlot,
+        ) => _GeneratedFeedbackDecisionSpec(
+          timeSlot: timeSlot,
+          verdict: verdict,
+          toolSlot: toolSlot,
+          contextSlot: contextSlot,
+          summarySlot: summarySlot,
+        ),
+      );
+
+  glados.Generator<_GeneratedFeedbackDecisionScenario>
+  get feedbackDecisionScenario =>
+      glados.ListAnys(
+            this,
+          )
+          .listWithLengthInRange(0, 14, feedbackDecisionSpec)
+          .map(
+            (decisions) =>
+                _GeneratedFeedbackDecisionScenario(decisions: decisions),
+          );
+}
 
 void main() {
   late MockAgentRepository mockRepo;
@@ -484,6 +846,101 @@ void main() {
       expect(result.items.first.sourceEntityId, 'cd-inside');
       expect(result.totalDecisionsScanned, 1);
     });
+
+    glados.Glados(
+      glados.any.feedbackDecisionScenario,
+      glados.ExploreConfig(numRuns: 180),
+    ).test(
+      'generated decision extraction preserves window, suppression, '
+      'and fallback semantics',
+      (scenario) async {
+        final decisions = <ChangeDecisionEntity>[];
+        for (var index = 0; index < scenario.decisions.length; index += 1) {
+          decisions.add(
+            scenario.decisions[index].decision(
+              index: index,
+              since: windowStart,
+              until: windowEnd,
+            ),
+          );
+        }
+        stubDecisions(decisions);
+
+        for (var index = 0; index < scenario.decisions.length; index += 1) {
+          final changeSet = scenario.decisions[index].changeSet(
+            index: index,
+            since: windowStart,
+            until: windowEnd,
+          );
+          if (changeSet == null) {
+            continue;
+          }
+          when(() => mockRepo.getEntity(changeSet.id)).thenAnswer(
+            (_) async => changeSet,
+          );
+        }
+
+        final expected = scenario.expectedModel(
+          since: windowStart,
+          until: windowEnd,
+        );
+
+        final result = await service.extract(
+          templateId: kTestTemplateId,
+          since: windowStart,
+          until: windowEnd,
+        );
+
+        expect(result.windowStart, windowStart);
+        expect(result.windowEnd, windowEnd);
+        expect(result.totalObservationsScanned, 0);
+        expect(result.totalDecisionsScanned, expected.totalDecisionsScanned);
+        expect(result.items, hasLength(expected.totalItemCount));
+
+        final decisionItems = result.items
+            .where((item) => item.sourceEntityId != null)
+            .toList();
+        expect(decisionItems, hasLength(expected.classifiedItems.length));
+        for (var index = 0; index < decisionItems.length; index += 1) {
+          final actual = decisionItems[index];
+          final expectedItem = expected.classifiedItems[index];
+
+          expect(actual.source, FeedbackSources.decision);
+          expect(actual.category, FeedbackCategory.accuracy);
+          expect(actual.confidence, 1);
+          expect(actual.sourceEntityId, expectedItem.id);
+          expect(actual.agentId, expectedItem.agentId);
+          expect(actual.sentiment, expectedItem.sentiment);
+          expect(actual.detail, expectedItem.detail);
+        }
+
+        final aggregateItems = result.items
+            .where((item) => item.sourceEntityId == null)
+            .toList();
+        if (expected.hasAggregateSuppressionItem) {
+          expect(aggregateItems, hasLength(1));
+          final aggregate = aggregateItems.single;
+          expect(aggregate.source, FeedbackSources.decision);
+          expect(aggregate.category, FeedbackCategory.prioritization);
+          expect(aggregate.sentiment, FeedbackSentiment.negative);
+          expect(aggregate.agentId, kTestTemplateId);
+          expect(aggregate.confidence, 1);
+          expect(
+            aggregate.detail,
+            contains('Repeated rejected checklist proposals'),
+          );
+          expect(
+            aggregate.detail,
+            contains(
+              '${expected.suppressedChecklistRejectionCount} '
+              'checklist changes',
+            ),
+          );
+        } else {
+          expect(aggregateItems, isEmpty);
+        }
+      },
+    );
 
     test('classifies observations as neutral with default detail', () async {
       stubEmptyData();

--- a/test/features/agents/service/project_activity_monitor_test.dart
+++ b/test/features/agents/service/project_activity_monitor_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:clock/clock.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:glados/glados.dart' as glados;
 import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
@@ -13,6 +14,270 @@ import 'package:mocktail/mocktail.dart';
 import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
 import '../test_utils.dart';
+
+enum _GeneratedProjectActivityAffectedSlot {
+  empty,
+  directProjectToken,
+  taskToken,
+  mixedTokens,
+}
+
+enum _GeneratedProjectActivityLinkSlot {
+  none,
+  single,
+  newerSecond,
+  tieBreakById,
+}
+
+enum _GeneratedProjectActivityStateSlot {
+  missing,
+  activeNoPending,
+  activePastPending,
+  activeAtNowPending,
+  activeFuturePending,
+  deleted,
+}
+
+enum _GeneratedProjectActivityFailureSlot {
+  none,
+  linksThrow,
+  stateThrow,
+  upsertThrow,
+}
+
+final _generatedProjectActivityNow = DateTime(2026, 4, 3, 15, 45);
+
+class _GeneratedProjectActivitySpec {
+  const _GeneratedProjectActivitySpec({
+    required this.linkSlot,
+    required this.stateSlot,
+    required this.failureSlot,
+  });
+
+  final _GeneratedProjectActivityLinkSlot linkSlot;
+  final _GeneratedProjectActivityStateSlot stateSlot;
+  final _GeneratedProjectActivityFailureSlot failureSlot;
+
+  bool get hasPrimaryLink => linkSlot != _GeneratedProjectActivityLinkSlot.none;
+
+  bool get canLoadState =>
+      hasPrimaryLink &&
+      failureSlot != _GeneratedProjectActivityFailureSlot.linksThrow &&
+      failureSlot != _GeneratedProjectActivityFailureSlot.stateThrow;
+
+  bool get hasWritableState {
+    return canLoadState &&
+        switch (stateSlot) {
+          _GeneratedProjectActivityStateSlot.activeNoPending ||
+          _GeneratedProjectActivityStateSlot.activePastPending => true,
+          _GeneratedProjectActivityStateSlot.missing ||
+          _GeneratedProjectActivityStateSlot.activeAtNowPending ||
+          _GeneratedProjectActivityStateSlot.activeFuturePending ||
+          _GeneratedProjectActivityStateSlot.deleted => false,
+        };
+  }
+
+  bool get expectsUiNotification =>
+      hasWritableState &&
+      failureSlot != _GeneratedProjectActivityFailureSlot.upsertThrow;
+
+  String projectId(int index) => 'generated-project-$index';
+
+  String primaryAgentId(int index) {
+    return switch (linkSlot) {
+      _GeneratedProjectActivityLinkSlot.none => 'missing-agent-$index',
+      _GeneratedProjectActivityLinkSlot.single => 'generated-agent-$index-a',
+      _GeneratedProjectActivityLinkSlot.newerSecond =>
+        'generated-agent-$index-new',
+      _GeneratedProjectActivityLinkSlot.tieBreakById =>
+        'generated-agent-$index-z',
+    };
+  }
+
+  List<AgentLink> links(int index) {
+    final projectId = this.projectId(index);
+    return switch (linkSlot) {
+      _GeneratedProjectActivityLinkSlot.none => const <AgentLink>[],
+      _GeneratedProjectActivityLinkSlot.single => [
+        _agentProjectLink(
+          id: 'generated-link-$index-a',
+          fromId: primaryAgentId(index),
+          toId: projectId,
+          createdAt: DateTime(2026, 4),
+        ),
+      ],
+      _GeneratedProjectActivityLinkSlot.newerSecond => [
+        _agentProjectLink(
+          id: 'generated-link-$index-old',
+          fromId: 'generated-agent-$index-old',
+          toId: projectId,
+          createdAt: DateTime(2026, 4),
+        ),
+        _agentProjectLink(
+          id: 'generated-link-$index-new',
+          fromId: primaryAgentId(index),
+          toId: projectId,
+          createdAt: DateTime(2026, 4, 2),
+        ),
+      ],
+      _GeneratedProjectActivityLinkSlot.tieBreakById => [
+        _agentProjectLink(
+          id: 'generated-link-$index-a',
+          fromId: 'generated-agent-$index-a',
+          toId: projectId,
+          createdAt: DateTime(2026, 4),
+        ),
+        _agentProjectLink(
+          id: 'generated-link-$index-z',
+          fromId: primaryAgentId(index),
+          toId: projectId,
+          createdAt: DateTime(2026, 4),
+        ),
+      ],
+    };
+  }
+
+  AgentStateEntity? state(int index) {
+    if (stateSlot == _GeneratedProjectActivityStateSlot.missing) return null;
+
+    final pendingProjectActivityAt = switch (stateSlot) {
+      _GeneratedProjectActivityStateSlot.activePastPending =>
+        _generatedProjectActivityNow.subtract(const Duration(minutes: 5)),
+      _GeneratedProjectActivityStateSlot.activeAtNowPending =>
+        _generatedProjectActivityNow,
+      _GeneratedProjectActivityStateSlot.activeFuturePending =>
+        _generatedProjectActivityNow.add(const Duration(minutes: 5)),
+      _GeneratedProjectActivityStateSlot.missing ||
+      _GeneratedProjectActivityStateSlot.activeNoPending ||
+      _GeneratedProjectActivityStateSlot.deleted => null,
+    };
+
+    final state = makeTestState(
+      id: 'generated-state-$index',
+      agentId: primaryAgentId(index),
+      revision: index + 1,
+      slots: AgentSlots(
+        activeProjectId: projectId(index),
+        pendingProjectActivityAt: pendingProjectActivityAt,
+      ),
+    );
+
+    if (stateSlot == _GeneratedProjectActivityStateSlot.deleted) {
+      return state.copyWith(deletedAt: DateTime(2026, 4, 2));
+    }
+    return state;
+  }
+
+  @override
+  String toString() {
+    return '_GeneratedProjectActivitySpec('
+        'linkSlot: $linkSlot, stateSlot: $stateSlot, '
+        'failureSlot: $failureSlot)';
+  }
+}
+
+class _GeneratedProjectActivityScenario {
+  const _GeneratedProjectActivityScenario({
+    required this.affectedSlot,
+    required this.specs,
+  });
+
+  final _GeneratedProjectActivityAffectedSlot affectedSlot;
+  final List<_GeneratedProjectActivitySpec> specs;
+
+  Set<String> get affectedIds {
+    return switch (affectedSlot) {
+      _GeneratedProjectActivityAffectedSlot.empty => const <String>{},
+      _GeneratedProjectActivityAffectedSlot.directProjectToken =>
+        specs.isEmpty ? {'project-unmapped'} : {'generated-project-0'},
+      _GeneratedProjectActivityAffectedSlot.taskToken => {'generated-task-1'},
+      _GeneratedProjectActivityAffectedSlot.mixedTokens => {
+        'generated-task-1',
+        'generated-project-0',
+        projectNotification,
+      },
+    };
+  }
+
+  Set<String> get resolvedProjectIds {
+    if (affectedSlot == _GeneratedProjectActivityAffectedSlot.empty) {
+      return const <String>{};
+    }
+    return {
+      for (var i = 0; i < specs.length; i++) specs[i].projectId(i),
+    };
+  }
+
+  @override
+  String toString() {
+    return '_GeneratedProjectActivityScenario('
+        'affectedSlot: $affectedSlot, specs: $specs)';
+  }
+}
+
+AgentLink _agentProjectLink({
+  required String id,
+  required String fromId,
+  required String toId,
+  required DateTime createdAt,
+}) {
+  return AgentLink.agentProject(
+    id: id,
+    fromId: fromId,
+    toId: toId,
+    createdAt: createdAt,
+    updatedAt: createdAt,
+    vectorClock: null,
+  );
+}
+
+extension _AnyGeneratedProjectActivityScenario on glados.Any {
+  glados.Generator<_GeneratedProjectActivityAffectedSlot>
+  get projectActivityAffectedSlot => glados.AnyUtils(
+    this,
+  ).choose(_GeneratedProjectActivityAffectedSlot.values);
+
+  glados.Generator<_GeneratedProjectActivityLinkSlot>
+  get projectActivityLinkSlot =>
+      glados.AnyUtils(this).choose(_GeneratedProjectActivityLinkSlot.values);
+
+  glados.Generator<_GeneratedProjectActivityStateSlot>
+  get projectActivityStateSlot =>
+      glados.AnyUtils(this).choose(_GeneratedProjectActivityStateSlot.values);
+
+  glados.Generator<_GeneratedProjectActivityFailureSlot>
+  get projectActivityFailureSlot =>
+      glados.AnyUtils(this).choose(_GeneratedProjectActivityFailureSlot.values);
+
+  glados.Generator<_GeneratedProjectActivitySpec> get projectActivitySpec =>
+      glados.CombinableAny(this).combine3(
+        projectActivityLinkSlot,
+        projectActivityStateSlot,
+        projectActivityFailureSlot,
+        (
+          _GeneratedProjectActivityLinkSlot linkSlot,
+          _GeneratedProjectActivityStateSlot stateSlot,
+          _GeneratedProjectActivityFailureSlot failureSlot,
+        ) => _GeneratedProjectActivitySpec(
+          linkSlot: linkSlot,
+          stateSlot: stateSlot,
+          failureSlot: failureSlot,
+        ),
+      );
+
+  glados.Generator<_GeneratedProjectActivityScenario>
+  get projectActivityScenario => glados.CombinableAny(this).combine2(
+    projectActivityAffectedSlot,
+    glados.ListAnys(this).listWithLengthInRange(0, 5, projectActivitySpec),
+    (
+      _GeneratedProjectActivityAffectedSlot affectedSlot,
+      List<_GeneratedProjectActivitySpec> specs,
+    ) => _GeneratedProjectActivityScenario(
+      affectedSlot: affectedSlot,
+      specs: specs,
+    ),
+  );
+}
 
 void main() {
   setUpAll(registerAllFallbackValues);
@@ -64,6 +329,159 @@ void main() {
   });
 
   group('ProjectActivityMonitor', () {
+    glados.Glados(
+      glados.any.projectActivityScenario,
+      glados.ExploreConfig(numRuns: 180),
+    ).test('matches generated project activity marking semantics', (
+      scenario,
+    ) async {
+      final generatedNotifications = MockUpdateNotifications();
+      final generatedRepository = MockAgentRepository();
+      final generatedProjectRepository = MockProjectRepository();
+      final generatedSyncService = MockAgentSyncService();
+      final generatedController = StreamController<Set<String>>.broadcast();
+      final writtenStates = <AgentStateEntity>[];
+      final uiNotifications = <Set<String>>[];
+
+      when(
+        () => generatedNotifications.localUpdateStream,
+      ).thenAnswer((_) => generatedController.stream);
+      when(() => generatedNotifications.notifyUiOnly(any())).thenAnswer((
+        invocation,
+      ) {
+        uiNotifications.add(
+          Set<String>.from(invocation.positionalArguments.single as Set),
+        );
+      });
+      when(
+        () => generatedProjectRepository.resolveAffectedProjectIds(any()),
+      ).thenAnswer((_) async => scenario.resolvedProjectIds);
+      when(() => generatedSyncService.upsertEntity(any())).thenAnswer((
+        invocation,
+      ) async {
+        final entity =
+            invocation.positionalArguments.single as AgentStateEntity;
+        writtenStates.add(entity);
+        final index = scenario.specs.indexWhere(
+          (spec) =>
+              spec.primaryAgentId(scenario.specs.indexOf(spec)) ==
+              entity.agentId,
+        );
+        if (index >= 0 &&
+            scenario.specs[index].failureSlot ==
+                _GeneratedProjectActivityFailureSlot.upsertThrow) {
+          throw StateError('generated upsert failure');
+        }
+      });
+      when(
+        () => generatedRepository.getLinksTo(
+          any(),
+          type: AgentLinkTypes.agentProject,
+        ),
+      ).thenAnswer((_) async => const <AgentLink>[]);
+      when(
+        () => generatedRepository.getAgentState(any()),
+      ).thenAnswer((_) async => null);
+
+      for (final (index, spec) in scenario.specs.indexed) {
+        final projectId = spec.projectId(index);
+        when(
+          () => generatedRepository.getLinksTo(
+            projectId,
+            type: AgentLinkTypes.agentProject,
+          ),
+        ).thenAnswer((_) async {
+          if (spec.failureSlot ==
+              _GeneratedProjectActivityFailureSlot.linksThrow) {
+            throw StateError('generated links failure');
+          }
+          return spec.links(index);
+        });
+
+        final agentId = spec.primaryAgentId(index);
+        when(() => generatedRepository.getAgentState(agentId)).thenAnswer((
+          _,
+        ) async {
+          if (spec.failureSlot ==
+              _GeneratedProjectActivityFailureSlot.stateThrow) {
+            throw StateError('generated state failure');
+          }
+          return spec.state(index);
+        });
+      }
+
+      final generatedMonitor = ProjectActivityMonitor(
+        notifications: generatedNotifications,
+        agentRepository: generatedRepository,
+        projectRepository: generatedProjectRepository,
+        syncService: generatedSyncService,
+        clock: Clock.fixed(_generatedProjectActivityNow),
+      );
+
+      try {
+        generatedMonitor.start();
+        generatedController.add(scenario.affectedIds);
+        await pumpEventQueue(times: 4);
+
+        final expectedWrittenAgentIds = <String>[
+          for (var i = 0; i < scenario.specs.length; i++)
+            if (scenario.affectedIds.isNotEmpty &&
+                scenario.specs[i].hasWritableState)
+              scenario.specs[i].primaryAgentId(i),
+        ];
+        expect(
+          writtenStates.map((state) => state.agentId).toList(),
+          expectedWrittenAgentIds,
+          reason: '$scenario',
+        );
+
+        for (final state in writtenStates) {
+          final index = scenario.specs.indexWhere(
+            (spec) =>
+                spec.primaryAgentId(scenario.specs.indexOf(spec)) ==
+                state.agentId,
+          );
+          expect(index, isNonNegative, reason: '$scenario');
+          final original = scenario.specs[index].state(index)!;
+          expect(state.revision, original.revision + 1, reason: '$scenario');
+          expect(
+            state.slots.activeProjectId,
+            original.slots.activeProjectId,
+            reason: '$scenario',
+          );
+          expect(
+            state.slots.pendingProjectActivityAt,
+            _generatedProjectActivityNow,
+            reason: '$scenario',
+          );
+          expect(state.updatedAt, _generatedProjectActivityNow);
+        }
+
+        final expectedUiNotifications = <Set<String>>[
+          for (var i = 0; i < scenario.specs.length; i++)
+            if (scenario.affectedIds.isNotEmpty &&
+                scenario.specs[i].expectsUiNotification)
+              {scenario.specs[i].primaryAgentId(i), agentNotification},
+        ];
+        expect(uiNotifications, expectedUiNotifications, reason: '$scenario');
+
+        if (scenario.affectedIds.isEmpty) {
+          verifyNever(
+            () => generatedProjectRepository.resolveAffectedProjectIds(any()),
+          );
+        } else {
+          verify(
+            () => generatedProjectRepository.resolveAffectedProjectIds(
+              scenario.affectedIds,
+            ),
+          ).called(1);
+        }
+      } finally {
+        await generatedMonitor.stop();
+        await generatedController.close();
+      }
+    });
+
     test('marks pending activity for linked project agents', () async {
       final link = AgentLink.agentProject(
         id: 'link-1',
@@ -91,8 +509,7 @@ void main() {
       monitor.start();
 
       updateController.add({'project-1'});
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 2);
 
       final captured =
           verify(
@@ -138,8 +555,7 @@ void main() {
       monitor.start();
 
       updateController.add({'task-1'});
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 2);
 
       final captured =
           verify(
@@ -176,8 +592,7 @@ void main() {
       monitor.start();
 
       updateController.add({'project-1'});
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 2);
 
       verifyNever(() => syncService.upsertEntity(any()));
     });
@@ -205,8 +620,7 @@ void main() {
       monitor.start();
 
       updateController.add({'project-1'});
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 2);
 
       verifyNever(() => syncService.upsertEntity(any()));
     });
@@ -242,8 +656,7 @@ void main() {
       monitor.start();
 
       updateController.add({'project-1'});
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 2);
 
       verifyNever(() => syncService.upsertEntity(any()));
     });
@@ -259,8 +672,7 @@ void main() {
       monitor.start();
 
       updateController.add({'project-err'});
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 2);
 
       // Should not crash — error is caught and logged via developer.log
       verifyNever(() => syncService.upsertEntity(any()));
@@ -297,8 +709,7 @@ void main() {
       loggedMonitor.start();
 
       updateController.add({'project-err2'});
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 2);
 
       verify(
         () => mockLogger.error(
@@ -317,7 +728,7 @@ void main() {
       monitor.start();
 
       updateController.add(<String>{});
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue();
 
       verifyNever(
         () => projectRepository.resolveAffectedProjectIds(any()),
@@ -339,8 +750,7 @@ void main() {
       monitor.start();
 
       updateController.add({projectNotification});
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
+      await pumpEventQueue(times: 2);
 
       verifyNever(() => syncService.upsertEntity(any()));
       verifyNever(

--- a/test/features/agents/service/project_activity_monitor_test.dart
+++ b/test/features/agents/service/project_activity_monitor_test.dart
@@ -200,12 +200,26 @@ class _GeneratedProjectActivityScenario {
   }
 
   Set<String> get resolvedProjectIds {
-    if (affectedSlot == _GeneratedProjectActivityAffectedSlot.empty) {
-      return const <String>{};
-    }
-    return {
-      for (var i = 0; i < specs.length; i++) specs[i].projectId(i),
+    return switch (affectedSlot) {
+      _GeneratedProjectActivityAffectedSlot.empty => const <String>{},
+      _GeneratedProjectActivityAffectedSlot.directProjectToken => {
+        if (specs.isEmpty) 'project-unmapped' else specs[0].projectId(0),
+      },
+      _GeneratedProjectActivityAffectedSlot.taskToken => {
+        if (specs.length > 1) specs[1].projectId(1) else 'generated-project-1',
+      },
+      _GeneratedProjectActivityAffectedSlot.mixedTokens => {
+        if (specs.isEmpty) 'generated-project-0' else specs[0].projectId(0),
+        if (specs.length > 1) specs[1].projectId(1) else 'generated-project-1',
+      },
     };
+  }
+
+  int indexForAgentId(String agentId) {
+    return Iterable<int>.generate(specs.length).firstWhere(
+      (index) => specs[index].primaryAgentId(index) == agentId,
+      orElse: () => -1,
+    );
   }
 
   @override
@@ -279,6 +293,118 @@ extension _AnyGeneratedProjectActivityScenario on glados.Any {
   );
 }
 
+class _GeneratedProjectActivityBench {
+  factory _GeneratedProjectActivityBench(
+    _GeneratedProjectActivityScenario scenario,
+  ) {
+    final notifications = MockUpdateNotifications();
+    final repository = MockAgentRepository();
+    final projectRepository = MockProjectRepository();
+    final syncService = MockAgentSyncService();
+    final controller = StreamController<Set<String>>.broadcast();
+    final writtenStates = <AgentStateEntity>[];
+    final uiNotifications = <Set<String>>[];
+
+    when(
+      () => notifications.localUpdateStream,
+    ).thenAnswer((_) => controller.stream);
+    when(() => notifications.notifyUiOnly(any())).thenAnswer((invocation) {
+      uiNotifications.add(
+        Set<String>.from(invocation.positionalArguments.single as Set),
+      );
+    });
+    when(
+      () => projectRepository.resolveAffectedProjectIds(any()),
+    ).thenAnswer((_) async => scenario.resolvedProjectIds);
+    when(() => syncService.upsertEntity(any())).thenAnswer((invocation) async {
+      final entity = invocation.positionalArguments.single as AgentStateEntity;
+      writtenStates.add(entity);
+      final index = scenario.indexForAgentId(entity.agentId);
+      if (index >= 0 &&
+          scenario.specs[index].failureSlot ==
+              _GeneratedProjectActivityFailureSlot.upsertThrow) {
+        throw StateError('generated upsert failure');
+      }
+    });
+    when(
+      () => repository.getLinksTo(
+        any(),
+        type: AgentLinkTypes.agentProject,
+      ),
+    ).thenAnswer((_) async => const <AgentLink>[]);
+    when(() => repository.getAgentState(any())).thenAnswer((_) async => null);
+
+    for (final (index, spec) in scenario.specs.indexed) {
+      final projectId = spec.projectId(index);
+      when(
+        () => repository.getLinksTo(
+          projectId,
+          type: AgentLinkTypes.agentProject,
+        ),
+      ).thenAnswer((_) async {
+        if (spec.failureSlot ==
+            _GeneratedProjectActivityFailureSlot.linksThrow) {
+          throw StateError('generated links failure');
+        }
+        return spec.links(index);
+      });
+
+      final agentId = spec.primaryAgentId(index);
+      when(() => repository.getAgentState(agentId)).thenAnswer((_) async {
+        if (spec.failureSlot ==
+            _GeneratedProjectActivityFailureSlot.stateThrow) {
+          throw StateError('generated state failure');
+        }
+        return spec.state(index);
+      });
+    }
+
+    final monitor = ProjectActivityMonitor(
+      notifications: notifications,
+      agentRepository: repository,
+      projectRepository: projectRepository,
+      syncService: syncService,
+      clock: Clock.fixed(_generatedProjectActivityNow),
+    );
+
+    return _GeneratedProjectActivityBench._(
+      notifications: notifications,
+      repository: repository,
+      projectRepository: projectRepository,
+      syncService: syncService,
+      controller: controller,
+      monitor: monitor,
+      writtenStates: writtenStates,
+      uiNotifications: uiNotifications,
+    );
+  }
+
+  _GeneratedProjectActivityBench._({
+    required this.notifications,
+    required this.repository,
+    required this.projectRepository,
+    required this.syncService,
+    required this.controller,
+    required this.monitor,
+    required this.writtenStates,
+    required this.uiNotifications,
+  });
+
+  final MockUpdateNotifications notifications;
+  final MockAgentRepository repository;
+  final MockProjectRepository projectRepository;
+  final MockAgentSyncService syncService;
+  final StreamController<Set<String>> controller;
+  final ProjectActivityMonitor monitor;
+  final List<AgentStateEntity> writtenStates;
+  final List<Set<String>> uiNotifications;
+
+  Future<void> dispose() async {
+    await monitor.stop();
+    await controller.close();
+  }
+}
+
 void main() {
   setUpAll(registerAllFallbackValues);
 
@@ -335,112 +461,29 @@ void main() {
     ).test('matches generated project activity marking semantics', (
       scenario,
     ) async {
-      final generatedNotifications = MockUpdateNotifications();
-      final generatedRepository = MockAgentRepository();
-      final generatedProjectRepository = MockProjectRepository();
-      final generatedSyncService = MockAgentSyncService();
-      final generatedController = StreamController<Set<String>>.broadcast();
-      final writtenStates = <AgentStateEntity>[];
-      final uiNotifications = <Set<String>>[];
-
-      when(
-        () => generatedNotifications.localUpdateStream,
-      ).thenAnswer((_) => generatedController.stream);
-      when(() => generatedNotifications.notifyUiOnly(any())).thenAnswer((
-        invocation,
-      ) {
-        uiNotifications.add(
-          Set<String>.from(invocation.positionalArguments.single as Set),
-        );
-      });
-      when(
-        () => generatedProjectRepository.resolveAffectedProjectIds(any()),
-      ).thenAnswer((_) async => scenario.resolvedProjectIds);
-      when(() => generatedSyncService.upsertEntity(any())).thenAnswer((
-        invocation,
-      ) async {
-        final entity =
-            invocation.positionalArguments.single as AgentStateEntity;
-        writtenStates.add(entity);
-        final index = scenario.specs.indexWhere(
-          (spec) =>
-              spec.primaryAgentId(scenario.specs.indexOf(spec)) ==
-              entity.agentId,
-        );
-        if (index >= 0 &&
-            scenario.specs[index].failureSlot ==
-                _GeneratedProjectActivityFailureSlot.upsertThrow) {
-          throw StateError('generated upsert failure');
-        }
-      });
-      when(
-        () => generatedRepository.getLinksTo(
-          any(),
-          type: AgentLinkTypes.agentProject,
-        ),
-      ).thenAnswer((_) async => const <AgentLink>[]);
-      when(
-        () => generatedRepository.getAgentState(any()),
-      ).thenAnswer((_) async => null);
-
-      for (final (index, spec) in scenario.specs.indexed) {
-        final projectId = spec.projectId(index);
-        when(
-          () => generatedRepository.getLinksTo(
-            projectId,
-            type: AgentLinkTypes.agentProject,
-          ),
-        ).thenAnswer((_) async {
-          if (spec.failureSlot ==
-              _GeneratedProjectActivityFailureSlot.linksThrow) {
-            throw StateError('generated links failure');
-          }
-          return spec.links(index);
-        });
-
-        final agentId = spec.primaryAgentId(index);
-        when(() => generatedRepository.getAgentState(agentId)).thenAnswer((
-          _,
-        ) async {
-          if (spec.failureSlot ==
-              _GeneratedProjectActivityFailureSlot.stateThrow) {
-            throw StateError('generated state failure');
-          }
-          return spec.state(index);
-        });
-      }
-
-      final generatedMonitor = ProjectActivityMonitor(
-        notifications: generatedNotifications,
-        agentRepository: generatedRepository,
-        projectRepository: generatedProjectRepository,
-        syncService: generatedSyncService,
-        clock: Clock.fixed(_generatedProjectActivityNow),
-      );
+      final bench = _GeneratedProjectActivityBench(scenario);
 
       try {
-        generatedMonitor.start();
-        generatedController.add(scenario.affectedIds);
+        bench.monitor.start();
+        bench.controller.add(scenario.affectedIds);
         await pumpEventQueue(times: 4);
 
         final expectedWrittenAgentIds = <String>[
           for (var i = 0; i < scenario.specs.length; i++)
-            if (scenario.affectedIds.isNotEmpty &&
+            if (scenario.resolvedProjectIds.contains(
+                  scenario.specs[i].projectId(i),
+                ) &&
                 scenario.specs[i].hasWritableState)
               scenario.specs[i].primaryAgentId(i),
         ];
         expect(
-          writtenStates.map((state) => state.agentId).toList(),
+          bench.writtenStates.map((state) => state.agentId).toList(),
           expectedWrittenAgentIds,
           reason: '$scenario',
         );
 
-        for (final state in writtenStates) {
-          final index = scenario.specs.indexWhere(
-            (spec) =>
-                spec.primaryAgentId(scenario.specs.indexOf(spec)) ==
-                state.agentId,
-          );
+        for (final state in bench.writtenStates) {
+          final index = scenario.indexForAgentId(state.agentId);
           expect(index, isNonNegative, reason: '$scenario');
           final original = scenario.specs[index].state(index)!;
           expect(state.revision, original.revision + 1, reason: '$scenario');
@@ -459,26 +502,31 @@ void main() {
 
         final expectedUiNotifications = <Set<String>>[
           for (var i = 0; i < scenario.specs.length; i++)
-            if (scenario.affectedIds.isNotEmpty &&
+            if (scenario.resolvedProjectIds.contains(
+                  scenario.specs[i].projectId(i),
+                ) &&
                 scenario.specs[i].expectsUiNotification)
               {scenario.specs[i].primaryAgentId(i), agentNotification},
         ];
-        expect(uiNotifications, expectedUiNotifications, reason: '$scenario');
+        expect(
+          bench.uiNotifications,
+          expectedUiNotifications,
+          reason: '$scenario',
+        );
 
         if (scenario.affectedIds.isEmpty) {
           verifyNever(
-            () => generatedProjectRepository.resolveAffectedProjectIds(any()),
+            () => bench.projectRepository.resolveAffectedProjectIds(any()),
           );
         } else {
           verify(
-            () => generatedProjectRepository.resolveAffectedProjectIds(
+            () => bench.projectRepository.resolveAffectedProjectIds(
               scenario.affectedIds,
             ),
           ).called(1);
         }
       } finally {
-        await generatedMonitor.stop();
-        await generatedController.close();
+        await bench.dispose();
       }
     });
 

--- a/test/features/agents/service/project_recommendation_service_test.dart
+++ b/test/features/agents/service/project_recommendation_service_test.dart
@@ -1,4 +1,6 @@
+import 'package:clock/clock.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:glados/glados.dart' as glados;
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
@@ -10,6 +12,338 @@ import 'package:mocktail/mocktail.dart';
 import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
 import '../test_utils.dart';
+
+enum _GeneratedRecommendationRawStepsSlot { missing, nonList, list }
+
+enum _GeneratedRecommendationStepSlot {
+  validTitleOnly,
+  validWithRationale,
+  validWithPriority,
+  validWithEmptyMetadata,
+  blankTitle,
+  missingTitle,
+  nonStringTitle,
+  nonMap,
+}
+
+enum _GeneratedRecommendationExistingSlot {
+  activeSameProject,
+  activeOtherProject,
+  dismissedSameProject,
+  resolvedSameProject,
+  wrongType,
+}
+
+enum _GeneratedRecommendationLookupSlot {
+  missing,
+  wrongType,
+  active,
+  resolved,
+  dismissed,
+  superseded,
+}
+
+enum _GeneratedRecommendationTransitionOperation { resolve, dismiss }
+
+final _generatedRecommendationNow = DateTime(2026, 5, 21, 12, 30);
+
+class _GeneratedRecommendationDraft {
+  const _GeneratedRecommendationDraft({
+    required this.title,
+    this.rationale,
+    this.priority,
+  });
+
+  final String title;
+  final String? rationale;
+  final String? priority;
+}
+
+class _GeneratedRecommendationRecordScenario {
+  const _GeneratedRecommendationRecordScenario({
+    required this.rawStepsSlot,
+    required this.stepSlots,
+    required this.existingSlots,
+  });
+
+  final _GeneratedRecommendationRawStepsSlot rawStepsSlot;
+  final List<_GeneratedRecommendationStepSlot> stepSlots;
+  final List<_GeneratedRecommendationExistingSlot> existingSlots;
+
+  List<Object?> get rawStepValues {
+    return [
+      for (final (index, slot) in stepSlots.indexed) _rawStep(index, slot),
+    ];
+  }
+
+  Map<String, dynamic>? get decisionArgs {
+    return switch (rawStepsSlot) {
+      _GeneratedRecommendationRawStepsSlot.missing => const {},
+      _GeneratedRecommendationRawStepsSlot.nonList => const {'steps': 'nope'},
+      _GeneratedRecommendationRawStepsSlot.list => {'steps': rawStepValues},
+    };
+  }
+
+  List<_GeneratedRecommendationDraft> get validDrafts {
+    if (rawStepsSlot != _GeneratedRecommendationRawStepsSlot.list) {
+      return const [];
+    }
+    return [
+      for (final (index, slot) in stepSlots.indexed)
+        if (_expectedDraft(index, slot) != null) _expectedDraft(index, slot)!,
+    ];
+  }
+
+  List<AgentDomainEntity> get existingEntities {
+    return [
+      for (final (index, slot) in existingSlots.indexed)
+        _existingEntity(index, slot),
+    ];
+  }
+
+  List<ProjectRecommendationEntity> get supersededRecommendations {
+    return [
+      for (final entity in existingEntities)
+        if (entity is ProjectRecommendationEntity &&
+            entity.projectId == 'generated-project' &&
+            entity.status == ProjectRecommendationStatus.active)
+          entity,
+    ];
+  }
+
+  Object? _rawStep(int index, _GeneratedRecommendationStepSlot slot) {
+    return switch (slot) {
+      _GeneratedRecommendationStepSlot.validTitleOnly => {
+        'title': '  Generated step $index  ',
+      },
+      _GeneratedRecommendationStepSlot.validWithRationale => {
+        'title': 'Generated rationale step $index',
+        'rationale': '  Explain step $index  ',
+      },
+      _GeneratedRecommendationStepSlot.validWithPriority => {
+        'title': 'Generated priority step $index',
+        'priority': ' high ',
+      },
+      _GeneratedRecommendationStepSlot.validWithEmptyMetadata => {
+        'title': 'Generated clean step $index',
+        'rationale': '   ',
+        'priority': '',
+      },
+      _GeneratedRecommendationStepSlot.blankTitle => {'title': '   '},
+      _GeneratedRecommendationStepSlot.missingTitle => {
+        'rationale': 'missing title',
+      },
+      _GeneratedRecommendationStepSlot.nonStringTitle => {'title': index},
+      _GeneratedRecommendationStepSlot.nonMap => 'not-a-step-$index',
+    };
+  }
+
+  _GeneratedRecommendationDraft? _expectedDraft(
+    int index,
+    _GeneratedRecommendationStepSlot slot,
+  ) {
+    return switch (slot) {
+      _GeneratedRecommendationStepSlot.validTitleOnly =>
+        _GeneratedRecommendationDraft(title: 'Generated step $index'),
+      _GeneratedRecommendationStepSlot.validWithRationale =>
+        _GeneratedRecommendationDraft(
+          title: 'Generated rationale step $index',
+          rationale: 'Explain step $index',
+        ),
+      _GeneratedRecommendationStepSlot.validWithPriority =>
+        _GeneratedRecommendationDraft(
+          title: 'Generated priority step $index',
+          priority: 'HIGH',
+        ),
+      _GeneratedRecommendationStepSlot.validWithEmptyMetadata =>
+        _GeneratedRecommendationDraft(title: 'Generated clean step $index'),
+      _GeneratedRecommendationStepSlot.blankTitle ||
+      _GeneratedRecommendationStepSlot.missingTitle ||
+      _GeneratedRecommendationStepSlot.nonStringTitle ||
+      _GeneratedRecommendationStepSlot.nonMap => null,
+    };
+  }
+
+  AgentDomainEntity _existingEntity(
+    int index,
+    _GeneratedRecommendationExistingSlot slot,
+  ) {
+    return switch (slot) {
+      _GeneratedRecommendationExistingSlot.activeSameProject =>
+        makeTestProjectRecommendation(
+          id: 'generated-existing-$index',
+          agentId: 'generated-agent',
+          projectId: 'generated-project',
+          title: 'Existing active $index',
+        ),
+      _GeneratedRecommendationExistingSlot.activeOtherProject =>
+        makeTestProjectRecommendation(
+          id: 'generated-existing-$index',
+          agentId: 'generated-agent',
+          projectId: 'other-project',
+          title: 'Other active $index',
+        ),
+      _GeneratedRecommendationExistingSlot.dismissedSameProject =>
+        makeTestProjectRecommendation(
+          id: 'generated-existing-$index',
+          agentId: 'generated-agent',
+          projectId: 'generated-project',
+          status: ProjectRecommendationStatus.dismissed,
+          title: 'Dismissed $index',
+        ),
+      _GeneratedRecommendationExistingSlot.resolvedSameProject =>
+        makeTestProjectRecommendation(
+          id: 'generated-existing-$index',
+          agentId: 'generated-agent',
+          projectId: 'generated-project',
+          status: ProjectRecommendationStatus.resolved,
+          title: 'Resolved $index',
+        ),
+      _GeneratedRecommendationExistingSlot.wrongType => makeTestState(
+        id: 'generated-state-$index',
+        agentId: 'generated-agent',
+      ),
+    };
+  }
+
+  @override
+  String toString() {
+    return '_GeneratedRecommendationRecordScenario('
+        'rawStepsSlot: $rawStepsSlot, stepSlots: $stepSlots, '
+        'existingSlots: $existingSlots)';
+  }
+}
+
+class _GeneratedRecommendationTransitionScenario {
+  const _GeneratedRecommendationTransitionScenario({
+    required this.lookupSlot,
+    required this.operation,
+  });
+
+  final _GeneratedRecommendationLookupSlot lookupSlot;
+  final _GeneratedRecommendationTransitionOperation operation;
+
+  AgentDomainEntity? get lookupEntity {
+    return switch (lookupSlot) {
+      _GeneratedRecommendationLookupSlot.missing => null,
+      _GeneratedRecommendationLookupSlot.wrongType => makeTestState(
+        id: 'generated-rec',
+        agentId: 'generated-agent',
+      ),
+      _GeneratedRecommendationLookupSlot.active =>
+        makeTestProjectRecommendation(
+          id: 'generated-rec',
+          agentId: 'generated-agent',
+          projectId: 'generated-project',
+        ),
+      _GeneratedRecommendationLookupSlot.resolved =>
+        makeTestProjectRecommendation(
+          id: 'generated-rec',
+          agentId: 'generated-agent',
+          projectId: 'generated-project',
+          status: ProjectRecommendationStatus.resolved,
+          resolvedAt: DateTime(2026, 5, 20),
+        ),
+      _GeneratedRecommendationLookupSlot.dismissed =>
+        makeTestProjectRecommendation(
+          id: 'generated-rec',
+          agentId: 'generated-agent',
+          projectId: 'generated-project',
+          status: ProjectRecommendationStatus.dismissed,
+          dismissedAt: DateTime(2026, 5, 20),
+        ),
+      _GeneratedRecommendationLookupSlot.superseded =>
+        makeTestProjectRecommendation(
+          id: 'generated-rec',
+          agentId: 'generated-agent',
+          projectId: 'generated-project',
+          status: ProjectRecommendationStatus.superseded,
+          supersededAt: DateTime(2026, 5, 20),
+        ),
+    };
+  }
+
+  bool get expectsTransition =>
+      lookupSlot == _GeneratedRecommendationLookupSlot.active;
+
+  ProjectRecommendationStatus get expectedStatus {
+    return switch (operation) {
+      _GeneratedRecommendationTransitionOperation.resolve =>
+        ProjectRecommendationStatus.resolved,
+      _GeneratedRecommendationTransitionOperation.dismiss =>
+        ProjectRecommendationStatus.dismissed,
+    };
+  }
+
+  Future<bool> run(ProjectRecommendationService service) {
+    return switch (operation) {
+      _GeneratedRecommendationTransitionOperation.resolve =>
+        service.markResolved('generated-rec'),
+      _GeneratedRecommendationTransitionOperation.dismiss =>
+        service.dismissRecommendation('generated-rec'),
+    };
+  }
+
+  @override
+  String toString() {
+    return '_GeneratedRecommendationTransitionScenario('
+        'lookupSlot: $lookupSlot, operation: $operation)';
+  }
+}
+
+extension _AnyGeneratedProjectRecommendationScenario on glados.Any {
+  glados.Generator<_GeneratedRecommendationRawStepsSlot>
+  get recommendationRawStepsSlot =>
+      glados.AnyUtils(this).choose(_GeneratedRecommendationRawStepsSlot.values);
+
+  glados.Generator<_GeneratedRecommendationStepSlot>
+  get recommendationStepSlot =>
+      glados.AnyUtils(this).choose(_GeneratedRecommendationStepSlot.values);
+
+  glados.Generator<_GeneratedRecommendationExistingSlot>
+  get recommendationExistingSlot =>
+      glados.AnyUtils(this).choose(_GeneratedRecommendationExistingSlot.values);
+
+  glados.Generator<_GeneratedRecommendationLookupSlot>
+  get recommendationLookupSlot =>
+      glados.AnyUtils(this).choose(_GeneratedRecommendationLookupSlot.values);
+
+  glados.Generator<_GeneratedRecommendationTransitionOperation>
+  get recommendationTransitionOperation => glados.AnyUtils(
+    this,
+  ).choose(_GeneratedRecommendationTransitionOperation.values);
+
+  glados.Generator<_GeneratedRecommendationRecordScenario>
+  get recommendationRecordScenario => glados.CombinableAny(this).combine3(
+    recommendationRawStepsSlot,
+    glados.ListAnys(this).listWithLengthInRange(0, 7, recommendationStepSlot),
+    glados.ListAnys(
+      this,
+    ).listWithLengthInRange(0, 5, recommendationExistingSlot),
+    (
+      _GeneratedRecommendationRawStepsSlot rawStepsSlot,
+      List<_GeneratedRecommendationStepSlot> stepSlots,
+      List<_GeneratedRecommendationExistingSlot> existingSlots,
+    ) => _GeneratedRecommendationRecordScenario(
+      rawStepsSlot: rawStepsSlot,
+      stepSlots: stepSlots,
+      existingSlots: existingSlots,
+    ),
+  );
+
+  glados.Generator<_GeneratedRecommendationTransitionScenario>
+  get recommendationTransitionScenario => glados.CombinableAny(this).combine2(
+    recommendationLookupSlot,
+    recommendationTransitionOperation,
+    (
+      _GeneratedRecommendationLookupSlot lookupSlot,
+      _GeneratedRecommendationTransitionOperation operation,
+    ) => _GeneratedRecommendationTransitionScenario(
+      lookupSlot: lookupSlot,
+      operation: operation,
+    ),
+  );
+}
 
 void main() {
   setUpAll(registerAllFallbackValues);
@@ -44,6 +378,208 @@ void main() {
       notifications: mockNotifications,
       domainLogger: mockDomainLogger,
     );
+  });
+
+  glados.Glados(
+    glados.any.recommendationRecordScenario,
+    glados.ExploreConfig(numRuns: 180),
+  ).test('matches generated recommendation recording semantics', (
+    scenario,
+  ) async {
+    final generatedSyncService = MockAgentSyncService();
+    final generatedRepository = MockAgentRepository();
+    final generatedNotifications = MockUpdateNotifications();
+    final generatedLogger = MockDomainLogger();
+    final writtenEntities = <AgentDomainEntity>[];
+    final uiNotifications = <Set<String>>[];
+
+    when(() => generatedSyncService.repository).thenReturn(
+      generatedRepository,
+    );
+    when(
+      () => generatedRepository.getEntitiesByAgentId(
+        'generated-agent',
+        type: AgentEntityTypes.projectRecommendation,
+      ),
+    ).thenAnswer((_) async => scenario.existingEntities);
+    when(() => generatedSyncService.upsertEntity(any())).thenAnswer((
+      invocation,
+    ) async {
+      writtenEntities.add(
+        invocation.positionalArguments.single as AgentDomainEntity,
+      );
+    });
+    when(() => generatedNotifications.notifyUiOnly(any())).thenAnswer((
+      invocation,
+    ) {
+      uiNotifications.add(
+        Set<String>.from(invocation.positionalArguments.single as Set<String>),
+      );
+    });
+    when(
+      () => generatedLogger.log(
+        any(),
+        any(),
+        subDomain: any(named: 'subDomain'),
+      ),
+    ).thenReturn(null);
+
+    final generatedService = ProjectRecommendationService(
+      syncService: generatedSyncService,
+      notifications: generatedNotifications,
+      domainLogger: generatedLogger,
+    );
+    final changeSet = makeTestChangeSet(
+      id: 'generated-change-set',
+      agentId: 'generated-agent',
+      taskId: 'generated-project',
+    );
+    final decision = makeTestChangeDecision(
+      id: 'generated-decision',
+      agentId: 'generated-agent',
+      changeSetId: changeSet.id,
+      toolName: 'recommend_next_steps',
+      taskId: 'generated-project',
+      args: scenario.decisionArgs,
+    );
+
+    await withClock(Clock.fixed(_generatedRecommendationNow), () async {
+      if (scenario.validDrafts.isEmpty) {
+        await expectLater(
+          () => generatedService.recordConfirmedRecommendations(
+            changeSet: changeSet,
+            decision: decision,
+          ),
+          throwsA(isA<ArgumentError>()),
+        );
+        verifyNever(
+          () => generatedRepository.getEntitiesByAgentId(
+            any(),
+            type: any(named: 'type'),
+            limit: any(named: 'limit'),
+          ),
+        );
+        expect(writtenEntities, isEmpty);
+        expect(uiNotifications, isEmpty);
+        return;
+      }
+
+      await generatedService.recordConfirmedRecommendations(
+        changeSet: changeSet,
+        decision: decision,
+      );
+    });
+
+    if (scenario.validDrafts.isEmpty) return;
+
+    final superseded = writtenEntities
+        .take(scenario.supersededRecommendations.length)
+        .cast<ProjectRecommendationEntity>()
+        .toList();
+    expect(
+      superseded.map((entity) => entity.id).toList(),
+      scenario.supersededRecommendations.map((entity) => entity.id).toList(),
+      reason: '$scenario',
+    );
+    for (final entity in superseded) {
+      expect(entity.status, ProjectRecommendationStatus.superseded);
+      expect(entity.updatedAt, _generatedRecommendationNow);
+      expect(entity.supersededAt, _generatedRecommendationNow);
+    }
+
+    final created = writtenEntities
+        .skip(scenario.supersededRecommendations.length)
+        .cast<ProjectRecommendationEntity>()
+        .toList();
+    expect(created, hasLength(scenario.validDrafts.length));
+    for (final (index, draft) in scenario.validDrafts.indexed) {
+      final entity = created[index];
+      expect(entity.agentId, 'generated-agent');
+      expect(entity.projectId, 'generated-project');
+      expect(entity.title, draft.title);
+      expect(entity.position, index);
+      expect(entity.status, ProjectRecommendationStatus.active);
+      expect(entity.createdAt, _generatedRecommendationNow);
+      expect(entity.updatedAt, _generatedRecommendationNow);
+      expect(entity.sourceChangeSetId, changeSet.id);
+      expect(entity.sourceDecisionId, decision.id);
+      expect(entity.rationale, draft.rationale);
+      expect(entity.priority, draft.priority);
+    }
+
+    expect(uiNotifications, [
+      {'generated-agent', 'generated-project', agentNotification},
+    ]);
+  });
+
+  glados.Glados(
+    glados.any.recommendationTransitionScenario,
+    glados.ExploreConfig(numRuns: 120),
+  ).test('matches generated active-only transition semantics', (
+    scenario,
+  ) async {
+    final generatedSyncService = MockAgentSyncService();
+    final generatedRepository = MockAgentRepository();
+    final generatedNotifications = MockUpdateNotifications();
+    final writtenEntities = <AgentDomainEntity>[];
+    final uiNotifications = <Set<String>>[];
+
+    when(() => generatedSyncService.repository).thenReturn(
+      generatedRepository,
+    );
+    when(() => generatedRepository.getEntity('generated-rec')).thenAnswer(
+      (_) async => scenario.lookupEntity,
+    );
+    when(() => generatedSyncService.upsertEntity(any())).thenAnswer((
+      invocation,
+    ) async {
+      writtenEntities.add(
+        invocation.positionalArguments.single as AgentDomainEntity,
+      );
+    });
+    when(() => generatedNotifications.notifyUiOnly(any())).thenAnswer((
+      invocation,
+    ) {
+      uiNotifications.add(
+        Set<String>.from(invocation.positionalArguments.single as Set<String>),
+      );
+    });
+
+    final generatedService = ProjectRecommendationService(
+      syncService: generatedSyncService,
+      notifications: generatedNotifications,
+    );
+
+    final result = await withClock(
+      Clock.fixed(_generatedRecommendationNow),
+      () => scenario.run(generatedService),
+    );
+
+    expect(result, scenario.expectsTransition, reason: '$scenario');
+    if (!scenario.expectsTransition) {
+      expect(writtenEntities, isEmpty);
+      expect(uiNotifications, isEmpty);
+      return;
+    }
+
+    final updated = writtenEntities.single as ProjectRecommendationEntity;
+    expect(updated.status, scenario.expectedStatus);
+    expect(updated.updatedAt, _generatedRecommendationNow);
+    expect(
+      updated.resolvedAt,
+      scenario.expectedStatus == ProjectRecommendationStatus.resolved
+          ? _generatedRecommendationNow
+          : isNull,
+    );
+    expect(
+      updated.dismissedAt,
+      scenario.expectedStatus == ProjectRecommendationStatus.dismissed
+          ? _generatedRecommendationNow
+          : isNull,
+    );
+    expect(uiNotifications, [
+      {'generated-agent', 'generated-project', agentNotification},
+    ]);
   });
 
   test(

--- a/test/features/agents/wake/scheduled_wake_manager_test.dart
+++ b/test/features/agents/wake/scheduled_wake_manager_test.dart
@@ -228,7 +228,7 @@ extension _AnyGeneratedScheduledWakeScenario on glados.Any {
 
   glados.Generator<_GeneratedScheduledWakeManagerLifecycleScenario>
   get scheduledWakeManagerLifecycleScenario => glados.ListAnys(this)
-      .listWithLengthInRange(0, 24, scheduledWakeManagerOperation)
+      .listWithLengthInRange(1, 24, scheduledWakeManagerOperation)
       .map(
         (operations) => _GeneratedScheduledWakeManagerLifecycleScenario(
           operations: operations,

--- a/test/features/agents/wake/scheduled_wake_manager_test.dart
+++ b/test/features/agents/wake/scheduled_wake_manager_test.dart
@@ -1,6 +1,7 @@
 import 'package:clock/clock.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:glados/glados.dart' as glados;
 import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
@@ -10,6 +11,230 @@ import 'package:mocktail/mocktail.dart';
 import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
 import '../test_utils.dart';
+
+enum _GeneratedScheduledWakeStateKind {
+  nonProjectNeverWoken,
+  nonProjectPreviouslyWoken,
+  projectNeverWoken,
+  projectDormant,
+  projectPendingActivity,
+}
+
+enum _GeneratedScheduledWakeTimeSlot {
+  beforeNow,
+  exactlyNow,
+  afterNow,
+  midnight,
+  endOfDay,
+}
+
+enum _GeneratedScheduledWakeFailureSlot {
+  none,
+  firstFastForward,
+  everyFastForward,
+}
+
+enum _GeneratedScheduledWakeManagerOperationKind { start, stop, tick }
+
+final _generatedScheduledWakeNow = DateTime(2026, 5, 20, 10, 30);
+
+class _GeneratedScheduledWakeSpec {
+  const _GeneratedScheduledWakeSpec({
+    required this.kind,
+    required this.timeSlot,
+  });
+
+  final _GeneratedScheduledWakeStateKind kind;
+  final _GeneratedScheduledWakeTimeSlot timeSlot;
+
+  bool get expectsFastForward =>
+      kind == _GeneratedScheduledWakeStateKind.projectDormant;
+
+  bool get expectsEnqueue => !expectsFastForward;
+
+  DateTime get scheduledWakeAt {
+    final (hour, minute) = switch (timeSlot) {
+      _GeneratedScheduledWakeTimeSlot.beforeNow => (6, 15),
+      _GeneratedScheduledWakeTimeSlot.exactlyNow => (10, 30),
+      _GeneratedScheduledWakeTimeSlot.afterNow => (16, 45),
+      _GeneratedScheduledWakeTimeSlot.midnight => (0, 5),
+      _GeneratedScheduledWakeTimeSlot.endOfDay => (23, 55),
+    };
+    return DateTime(2026, 5, 17, hour, minute);
+  }
+
+  DateTime expectedFastForwardWakeAt(DateTime now) {
+    final scheduled = scheduledWakeAt;
+    var nextWake = DateTime(
+      now.year,
+      now.month,
+      now.day,
+      scheduled.hour,
+      scheduled.minute,
+    );
+    if (!nextWake.isAfter(now)) {
+      nextWake = DateTime(
+        now.year,
+        now.month,
+        now.day + 1,
+        scheduled.hour,
+        scheduled.minute,
+      );
+    }
+    return nextWake;
+  }
+
+  AgentStateEntity toState(int index) {
+    final agentId = 'generated-scheduled-agent-$index';
+    final projectId = 'generated-project-$index';
+    return makeTestState(
+      id: 'generated-scheduled-state-$index',
+      agentId: agentId,
+      scheduledWakeAt: scheduledWakeAt,
+      lastWakeAt: switch (kind) {
+        _GeneratedScheduledWakeStateKind.nonProjectNeverWoken ||
+        _GeneratedScheduledWakeStateKind.projectNeverWoken => null,
+        _GeneratedScheduledWakeStateKind.nonProjectPreviouslyWoken ||
+        _GeneratedScheduledWakeStateKind.projectDormant ||
+        _GeneratedScheduledWakeStateKind.projectPendingActivity => DateTime(
+          2026,
+          5,
+          17,
+          11,
+        ),
+      },
+      slots: switch (kind) {
+        _GeneratedScheduledWakeStateKind.nonProjectNeverWoken ||
+        _GeneratedScheduledWakeStateKind.nonProjectPreviouslyWoken =>
+          const AgentSlots(),
+        _GeneratedScheduledWakeStateKind.projectNeverWoken ||
+        _GeneratedScheduledWakeStateKind.projectDormant => AgentSlots(
+          activeProjectId: projectId,
+        ),
+        _GeneratedScheduledWakeStateKind.projectPendingActivity => AgentSlots(
+          activeProjectId: projectId,
+          pendingProjectActivityAt: DateTime(2026, 5, 20, 9),
+        ),
+      },
+    );
+  }
+
+  @override
+  String toString() {
+    return '_GeneratedScheduledWakeSpec('
+        'kind: $kind, timeSlot: $timeSlot)';
+  }
+}
+
+class _GeneratedScheduledWakeBatchScenario {
+  const _GeneratedScheduledWakeBatchScenario({
+    required this.specs,
+    required this.failureSlot,
+  });
+
+  final List<_GeneratedScheduledWakeSpec> specs;
+  final _GeneratedScheduledWakeFailureSlot failureSlot;
+
+  Set<String> failingFastForwardAgentIds(List<AgentStateEntity> states) {
+    final fastForwardIds = <String>[
+      for (var i = 0; i < specs.length; i++)
+        if (specs[i].expectsFastForward) states[i].agentId,
+    ];
+    return switch (failureSlot) {
+      _GeneratedScheduledWakeFailureSlot.none => const <String>{},
+      _GeneratedScheduledWakeFailureSlot.firstFastForward =>
+        fastForwardIds.isEmpty ? const <String>{} : {fastForwardIds.first},
+      _GeneratedScheduledWakeFailureSlot.everyFastForward =>
+        fastForwardIds.toSet(),
+    };
+  }
+
+  @override
+  String toString() {
+    return '_GeneratedScheduledWakeBatchScenario('
+        'specs: $specs, failureSlot: $failureSlot)';
+  }
+}
+
+class _GeneratedScheduledWakeManagerOperation {
+  const _GeneratedScheduledWakeManagerOperation({required this.kind});
+
+  final _GeneratedScheduledWakeManagerOperationKind kind;
+
+  @override
+  String toString() {
+    return '_GeneratedScheduledWakeManagerOperation(kind: $kind)';
+  }
+}
+
+class _GeneratedScheduledWakeManagerLifecycleScenario {
+  const _GeneratedScheduledWakeManagerLifecycleScenario({
+    required this.operations,
+  });
+
+  final List<_GeneratedScheduledWakeManagerOperation> operations;
+
+  @override
+  String toString() {
+    return '_GeneratedScheduledWakeManagerLifecycleScenario('
+        'operations: $operations)';
+  }
+}
+
+extension _AnyGeneratedScheduledWakeScenario on glados.Any {
+  glados.Generator<_GeneratedScheduledWakeStateKind>
+  get scheduledWakeStateKind =>
+      glados.AnyUtils(this).choose(_GeneratedScheduledWakeStateKind.values);
+
+  glados.Generator<_GeneratedScheduledWakeTimeSlot> get scheduledWakeTimeSlot =>
+      glados.AnyUtils(this).choose(_GeneratedScheduledWakeTimeSlot.values);
+
+  glados.Generator<_GeneratedScheduledWakeSpec> get scheduledWakeSpec =>
+      glados.CombinableAny(this).combine2(
+        scheduledWakeStateKind,
+        scheduledWakeTimeSlot,
+        (
+          _GeneratedScheduledWakeStateKind kind,
+          _GeneratedScheduledWakeTimeSlot timeSlot,
+        ) => _GeneratedScheduledWakeSpec(kind: kind, timeSlot: timeSlot),
+      );
+
+  glados.Generator<_GeneratedScheduledWakeFailureSlot>
+  get scheduledWakeFailureSlot =>
+      glados.AnyUtils(this).choose(_GeneratedScheduledWakeFailureSlot.values);
+
+  glados.Generator<_GeneratedScheduledWakeBatchScenario>
+  get scheduledWakeBatchScenario => glados.CombinableAny(this).combine2(
+    glados.ListAnys(this).listWithLengthInRange(0, 8, scheduledWakeSpec),
+    scheduledWakeFailureSlot,
+    (
+      List<_GeneratedScheduledWakeSpec> specs,
+      _GeneratedScheduledWakeFailureSlot failureSlot,
+    ) => _GeneratedScheduledWakeBatchScenario(
+      specs: specs,
+      failureSlot: failureSlot,
+    ),
+  );
+
+  glados.Generator<_GeneratedScheduledWakeManagerOperationKind>
+  get scheduledWakeManagerOperationKind => glados.AnyUtils(
+    this,
+  ).choose(_GeneratedScheduledWakeManagerOperationKind.values);
+
+  glados.Generator<_GeneratedScheduledWakeManagerOperation>
+  get scheduledWakeManagerOperation => scheduledWakeManagerOperationKind.map(
+    (kind) => _GeneratedScheduledWakeManagerOperation(kind: kind),
+  );
+
+  glados.Generator<_GeneratedScheduledWakeManagerLifecycleScenario>
+  get scheduledWakeManagerLifecycleScenario => glados.ListAnys(this)
+      .listWithLengthInRange(0, 24, scheduledWakeManagerOperation)
+      .map(
+        (operations) => _GeneratedScheduledWakeManagerLifecycleScenario(
+          operations: operations,
+        ),
+      );
+}
 
 void main() {
   setUpAll(registerAllFallbackValues);
@@ -36,6 +261,161 @@ void main() {
   }
 
   group('ScheduledWakeManager', () {
+    glados.Glados(
+      glados.any.scheduledWakeBatchScenario,
+      glados.ExploreConfig(numRuns: 180),
+    ).test('matches generated due-batch enqueue and fast-forward semantics', (
+      scenario,
+    ) {
+      final states = [
+        for (final (index, spec) in scenario.specs.indexed) spec.toState(index),
+      ];
+      final failingFastForwardIds = scenario.failingFastForwardAgentIds(states);
+      final generatedRepository = MockAgentRepository();
+      final generatedOrchestrator = MockWakeOrchestrator();
+      final generatedSyncService = MockAgentSyncService();
+      final attemptedFastForwardWrites = <AgentStateEntity>[];
+      final notifiedAgentIds = <String>[];
+
+      fakeAsync((async) {
+        withClock(Clock.fixed(_generatedScheduledWakeNow), () {
+          when(
+            () => generatedRepository.getDueScheduledAgentStates(any()),
+          ).thenAnswer((_) async => states);
+          when(() => generatedSyncService.upsertEntity(any())).thenAnswer((
+            invocation,
+          ) async {
+            final entity =
+                invocation.positionalArguments.single as AgentStateEntity;
+            attemptedFastForwardWrites.add(entity);
+            if (failingFastForwardIds.contains(entity.agentId)) {
+              throw StateError('generated sync failure');
+            }
+          });
+
+          final manager = ScheduledWakeManager(
+            repository: generatedRepository,
+            orchestrator: generatedOrchestrator,
+            syncService: generatedSyncService,
+            checkInterval: const Duration(minutes: 7),
+            onPersistedStateChanged: notifiedAgentIds.add,
+          )..start();
+          async.flushMicrotasks();
+
+          final expectedEnqueuedIds = <String>[
+            for (var i = 0; i < scenario.specs.length; i++)
+              if (scenario.specs[i].expectsEnqueue) states[i].agentId,
+          ];
+          final expectedFastForwardIds = <String>[
+            for (var i = 0; i < scenario.specs.length; i++)
+              if (scenario.specs[i].expectsFastForward) states[i].agentId,
+          ];
+          final expectedNotifiedIds = expectedFastForwardIds
+              .where((agentId) => !failingFastForwardIds.contains(agentId))
+              .toList();
+
+          if (expectedEnqueuedIds.isEmpty) {
+            verifyNever(
+              () => generatedOrchestrator.enqueueManualWake(
+                agentId: any(named: 'agentId'),
+                reason: any(named: 'reason'),
+              ),
+            );
+          } else {
+            final capturedAgentIds = verify(
+              () => generatedOrchestrator.enqueueManualWake(
+                agentId: captureAny(named: 'agentId'),
+                reason: WakeReason.scheduled.name,
+              ),
+            ).captured.cast<String>();
+            expect(capturedAgentIds, expectedEnqueuedIds, reason: '$scenario');
+          }
+
+          expect(
+            attemptedFastForwardWrites.map((state) => state.agentId).toList(),
+            expectedFastForwardIds,
+            reason: '$scenario',
+          );
+
+          for (final write in attemptedFastForwardWrites) {
+            final index = states.indexWhere(
+              (state) => state.agentId == write.agentId,
+            );
+            expect(index, isNonNegative, reason: '$scenario');
+            expect(
+              write.scheduledWakeAt,
+              scenario.specs[index].expectedFastForwardWakeAt(
+                _generatedScheduledWakeNow,
+              ),
+              reason: '$scenario',
+            );
+            expect(write.updatedAt, _generatedScheduledWakeNow);
+          }
+
+          expect(notifiedAgentIds, expectedNotifiedIds, reason: '$scenario');
+
+          manager.stop();
+        });
+      });
+    });
+
+    glados.Glados(
+      glados.any.scheduledWakeManagerLifecycleScenario,
+      glados.ExploreConfig(numRuns: 160),
+    ).test('matches generated start stop and timer replacement semantics', (
+      scenario,
+    ) {
+      const checkInterval = Duration(minutes: 11);
+      final generatedRepository = MockAgentRepository();
+      final generatedOrchestrator = MockWakeOrchestrator();
+      final generatedSyncService = MockAgentSyncService();
+      var repositoryChecks = 0;
+      var expectedChecks = 0;
+      var running = false;
+
+      fakeAsync((async) {
+        withClock(Clock.fixed(_generatedScheduledWakeNow), () {
+          when(
+            () => generatedRepository.getDueScheduledAgentStates(any()),
+          ).thenAnswer((_) async {
+            repositoryChecks++;
+            return <AgentStateEntity>[];
+          });
+
+          final manager = ScheduledWakeManager(
+            repository: generatedRepository,
+            orchestrator: generatedOrchestrator,
+            syncService: generatedSyncService,
+            checkInterval: checkInterval,
+          );
+
+          for (final operation in scenario.operations) {
+            switch (operation.kind) {
+              case _GeneratedScheduledWakeManagerOperationKind.start:
+                manager.start();
+                running = true;
+                expectedChecks++;
+                async.flushMicrotasks();
+
+              case _GeneratedScheduledWakeManagerOperationKind.stop:
+                manager.stop();
+                running = false;
+                async.flushMicrotasks();
+
+              case _GeneratedScheduledWakeManagerOperationKind.tick:
+                async.elapse(checkInterval);
+                if (running) expectedChecks++;
+                async.flushMicrotasks();
+            }
+
+            expect(repositoryChecks, expectedChecks, reason: '$scenario');
+          }
+
+          manager.stop();
+        });
+      });
+    });
+
     test('enqueues wake for agent with scheduledWakeAt in the past', () {
       final now = DateTime(2024, 3, 15, 10, 30);
       final pastSchedule = DateTime(2024, 3, 15, 9);

--- a/test/features/agents/wake/wake_runner_test.dart
+++ b/test/features/agents/wake/wake_runner_test.dart
@@ -1,7 +1,90 @@
 import 'package:clock/clock.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:glados/glados.dart' as glados;
 import 'package:lotti/features/agents/wake/wake_runner.dart';
+
+enum _GeneratedWakeRunnerOperationKind {
+  acquire,
+  release,
+  waitForCompletion,
+}
+
+enum _GeneratedWakeRunnerAgentSlot { first, second, third, fourth }
+
+final _generatedWakeRunnerBase = DateTime(2026, 5, 19, 9);
+
+String _generatedWakeRunnerAgentId(_GeneratedWakeRunnerAgentSlot slot) =>
+    'generated-runner-agent-${slot.name}';
+
+class _GeneratedWakeRunnerOperation {
+  const _GeneratedWakeRunnerOperation({
+    required this.kind,
+    required this.agentSlot,
+  });
+
+  final _GeneratedWakeRunnerOperationKind kind;
+  final _GeneratedWakeRunnerAgentSlot agentSlot;
+
+  String get agentId => _generatedWakeRunnerAgentId(agentSlot);
+
+  @override
+  String toString() {
+    return '_GeneratedWakeRunnerOperation('
+        'kind: $kind, agentSlot: $agentSlot)';
+  }
+}
+
+class _GeneratedWakeRunnerScenario {
+  const _GeneratedWakeRunnerScenario({required this.operations});
+
+  final List<_GeneratedWakeRunnerOperation> operations;
+
+  @override
+  String toString() {
+    return '_GeneratedWakeRunnerScenario(operations: $operations)';
+  }
+}
+
+class _GeneratedWakeRunnerWaiter {
+  _GeneratedWakeRunnerWaiter({
+    required this.agentId,
+    required this.actualCompleted,
+    required this.expectedCompleted,
+  });
+
+  final String agentId;
+  bool actualCompleted;
+  bool expectedCompleted;
+}
+
+extension _AnyGeneratedWakeRunnerScenario on glados.Any {
+  glados.Generator<_GeneratedWakeRunnerOperationKind>
+  get wakeRunnerOperationKind =>
+      glados.AnyUtils(this).choose(_GeneratedWakeRunnerOperationKind.values);
+
+  glados.Generator<_GeneratedWakeRunnerAgentSlot> get wakeRunnerAgentSlot =>
+      glados.AnyUtils(this).choose(_GeneratedWakeRunnerAgentSlot.values);
+
+  glados.Generator<_GeneratedWakeRunnerOperation> get wakeRunnerOperation =>
+      glados.CombinableAny(this).combine2(
+        wakeRunnerOperationKind,
+        wakeRunnerAgentSlot,
+        (
+          _GeneratedWakeRunnerOperationKind kind,
+          _GeneratedWakeRunnerAgentSlot agentSlot,
+        ) => _GeneratedWakeRunnerOperation(kind: kind, agentSlot: agentSlot),
+      );
+
+  glados.Generator<_GeneratedWakeRunnerScenario> get wakeRunnerScenario =>
+      glados.ListAnys(this)
+          .listWithLengthInRange(0, 45, wakeRunnerOperation)
+          .map(
+            (operations) => _GeneratedWakeRunnerScenario(
+              operations: operations,
+            ),
+          );
+}
 
 void main() {
   late WakeRunner runner;
@@ -11,6 +94,114 @@ void main() {
   });
 
   group('WakeRunner', () {
+    glados.Glados(
+      glados.any.wakeRunnerScenario,
+      glados.ExploreConfig(numRuns: 180),
+    ).test('matches generated single-flight operation semantics', (scenario) {
+      final generatedRunner = WakeRunner();
+      final expectedActive = <String, DateTime>{};
+      final expectedEmissions = <Set<String>>[];
+      final emissions = <Set<String>>[];
+      final waiters = <_GeneratedWakeRunnerWaiter>[];
+      var currentTick = 0;
+
+      withClock(
+        Clock(
+          () => _generatedWakeRunnerBase.add(Duration(seconds: currentTick)),
+        ),
+        () {
+          fakeAsync((async) {
+            generatedRunner.runningAgentIds.listen(emissions.add);
+
+            for (final (index, operation) in scenario.operations.indexed) {
+              currentTick = index;
+              final agentId = operation.agentId;
+
+              switch (operation.kind) {
+                case _GeneratedWakeRunnerOperationKind.acquire:
+                  late bool acquired;
+                  generatedRunner
+                      .tryAcquire(agentId)
+                      .then((value) => acquired = value);
+                  async.flushMicrotasks();
+
+                  final expectedAcquired = !expectedActive.containsKey(agentId);
+                  expect(acquired, expectedAcquired, reason: '$scenario');
+                  if (expectedAcquired) {
+                    expectedActive[agentId] = clock.now();
+                    expectedEmissions.add(expectedActive.keys.toSet());
+                  }
+
+                case _GeneratedWakeRunnerOperationKind.release:
+                  generatedRunner.release(agentId);
+                  expectedActive.remove(agentId);
+                  expectedEmissions.add(expectedActive.keys.toSet());
+                  waiters
+                      .where((waiter) => waiter.agentId == agentId)
+                      .forEach((waiter) => waiter.expectedCompleted = true);
+                  async.flushMicrotasks();
+
+                case _GeneratedWakeRunnerOperationKind.waitForCompletion:
+                  final waiter = _GeneratedWakeRunnerWaiter(
+                    agentId: agentId,
+                    actualCompleted: false,
+                    expectedCompleted: !expectedActive.containsKey(agentId),
+                  );
+                  generatedRunner.waitForCompletion(agentId).then((_) {
+                    waiter.actualCompleted = true;
+                  });
+                  async.flushMicrotasks();
+
+                  if (!expectedActive.containsKey(agentId)) {
+                    expect(
+                      waiter.actualCompleted,
+                      isTrue,
+                      reason: '$scenario',
+                    );
+                  } else {
+                    expect(
+                      waiter.actualCompleted,
+                      isFalse,
+                      reason: '$scenario',
+                    );
+                    waiters.add(waiter);
+                  }
+              }
+
+              expect(
+                generatedRunner.activeAgentIds,
+                expectedActive.keys.toSet(),
+                reason: '$scenario',
+              );
+              expect(
+                generatedRunner.activeStartedAtById,
+                expectedActive,
+                reason: '$scenario',
+              );
+              for (final slot in _GeneratedWakeRunnerAgentSlot.values) {
+                final id = _generatedWakeRunnerAgentId(slot);
+                expect(
+                  generatedRunner.startedAt(id),
+                  expectedActive[id],
+                  reason: '$scenario',
+                );
+              }
+              expect(emissions, expectedEmissions, reason: '$scenario');
+              for (final waiter in waiters) {
+                expect(
+                  waiter.actualCompleted,
+                  waiter.expectedCompleted,
+                  reason: '$scenario',
+                );
+              }
+            }
+
+            generatedRunner.dispose();
+          });
+        },
+      );
+    });
+
     group('tryAcquire', () {
       test('returns true and acquires lock when no run is active', () {
         fakeAsync((async) {

--- a/test/features/agents/wake/wake_runner_test.dart
+++ b/test/features/agents/wake/wake_runner_test.dart
@@ -78,7 +78,7 @@ extension _AnyGeneratedWakeRunnerScenario on glados.Any {
 
   glados.Generator<_GeneratedWakeRunnerScenario> get wakeRunnerScenario =>
       glados.ListAnys(this)
-          .listWithLengthInRange(0, 45, wakeRunnerOperation)
+          .listWithLengthInRange(1, 45, wakeRunnerOperation)
           .map(
             (operations) => _GeneratedWakeRunnerScenario(
               operations: operations,
@@ -133,12 +133,14 @@ void main() {
                   }
 
                 case _GeneratedWakeRunnerOperationKind.release:
+                  final removed = expectedActive.remove(agentId) != null;
                   generatedRunner.release(agentId);
-                  expectedActive.remove(agentId);
-                  expectedEmissions.add(expectedActive.keys.toSet());
-                  waiters
-                      .where((waiter) => waiter.agentId == agentId)
-                      .forEach((waiter) => waiter.expectedCompleted = true);
+                  if (removed) {
+                    expectedEmissions.add(expectedActive.keys.toSet());
+                    waiters
+                        .where((waiter) => waiter.agentId == agentId)
+                        .forEach((waiter) => waiter.expectedCompleted = true);
+                  }
                   async.flushMicrotasks();
 
                 case _GeneratedWakeRunnerOperationKind.waitForCompletion:
@@ -263,10 +265,16 @@ void main() {
       });
 
       test('release on non-locked agent is safe (no-op)', () {
-        // Should not throw
-        runner.release('agent-nonexistent');
+        fakeAsync((async) {
+          final emissions = <Set<String>>[];
+          runner.runningAgentIds.listen(emissions.add);
 
-        expect(runner.isRunning('agent-nonexistent'), isFalse);
+          runner.release('agent-nonexistent');
+          async.flushMicrotasks();
+
+          expect(runner.isRunning('agent-nonexistent'), isFalse);
+          expect(emissions, isEmpty);
+        });
       });
     });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added property-based (generative) tests across agent-related suites covering project activity monitoring, scheduled wake manager, wake runner, feedback extraction, and project recommendation service.
  * Validated semantics for state updates, wake enqueue/fast-forward, single-flight concurrency, feedback windowing/suppression, and recommendation lifecycle behaviors.
  * Standardized async settling in tests using a unified pump mechanism.

* **Refactor**
  * Small clarity/refactor in wake-runner release behavior and documentation for the running-agent stream.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matthiasn/lotti/pull/3117)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->