### PR TITLE
refactor: use device pixel ratio

### DIFF
--- a/.github/workflows/flutter-linux-release.yml
+++ b/.github/workflows/flutter-linux-release.yml
@@ -42,6 +42,8 @@ jobs:
         run: gh release create -p --generate-notes --target $GITHUB_SHA $GITHUB_REF_NAME || true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Activate very_good_cli
+        run: dart pub global activate very_good_cli
       - name: Test
         run: make l10n test
       - name: Build

--- a/lib/features/journal/ui/widgets/entry_image_widget.dart
+++ b/lib/features/journal/ui/widgets/entry_image_widget.dart
@@ -45,8 +45,14 @@ class EntryImageWidget extends ConsumerWidget {
               file,
               width: screenWidth,
               fit: BoxFit.contain,
-              cacheWidth: (screenWidth * devicePixelRatio).round(),
-              cacheHeight: (maxHeight * devicePixelRatio).round(),
+              cacheWidth: (screenWidth * devicePixelRatio).round().clamp(
+                1,
+                10000,
+              ),
+              cacheHeight: (maxHeight * devicePixelRatio).round().clamp(
+                1,
+                10000,
+              ),
               errorBuilder: (context, error, stackTrace) {
                 imageCache.evict(FileImage(file));
                 return const SizedBox.shrink();

--- a/lib/features/journal/ui/widgets/entry_image_widget.dart
+++ b/lib/features/journal/ui/widgets/entry_image_widget.dart
@@ -21,6 +21,7 @@ class EntryImageWidget extends ConsumerWidget {
     final file = File(getFullImagePath(journalImage));
     final focusNode = notifier.focusNode;
     final screenWidth = MediaQuery.sizeOf(context).width;
+    final devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
     final maxHeight = isMobile ? 400.0 : screenWidth;
 
     return GestureDetector(
@@ -44,7 +45,8 @@ class EntryImageWidget extends ConsumerWidget {
               file,
               width: screenWidth,
               fit: BoxFit.contain,
-              cacheHeight: (maxHeight * 3).toInt(),
+              cacheWidth: (screenWidth * devicePixelRatio).round(),
+              cacheHeight: (maxHeight * devicePixelRatio).round(),
               errorBuilder: (context, error, stackTrace) {
                 imageCache.evict(FileImage(file));
                 return const SizedBox.shrink();

--- a/lib/features/journal/ui/widgets/list_cards/card_image_widget.dart
+++ b/lib/features/journal/ui/widgets/list_cards/card_image_widget.dart
@@ -47,12 +47,13 @@ class _CardImageWidgetState extends State<CardImageWidget>
     }
 
     final size = widget.height.toDouble();
+    final devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
     return SizedBox(
       width: size,
       height: size,
       child: Image.file(
         File(path),
-        cacheHeight: widget.height * 3,
+        cacheHeight: (size * devicePixelRatio).round(),
         fit: widget.fit,
       ),
     );

--- a/lib/features/journal/ui/widgets/list_cards/card_image_widget.dart
+++ b/lib/features/journal/ui/widgets/list_cards/card_image_widget.dart
@@ -48,12 +48,16 @@ class _CardImageWidgetState extends State<CardImageWidget>
 
     final size = widget.height.toDouble();
     final devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
+    final cap = size > 0
+        ? (size * devicePixelRatio).round().clamp(1, 10000)
+        : null;
     return SizedBox(
       width: size,
       height: size,
       child: Image.file(
         File(path),
-        cacheHeight: (size * devicePixelRatio).round(),
+        cacheWidth: cap,
+        cacheHeight: cap,
         fit: widget.fit,
       ),
     );

--- a/lib/features/tasks/ui/cover_art_background.dart
+++ b/lib/features/tasks/ui/cover_art_background.dart
@@ -62,6 +62,9 @@ class _CoverArtBackgroundState extends ConsumerState<CoverArtBackground>
               File(path),
               fit: BoxFit.cover,
               alignment: Alignment.topCenter,
+              cacheWidth: constraints.hasBoundedWidth
+                  ? (constraints.maxWidth * devicePixelRatio).round()
+                  : null,
               cacheHeight: constraints.hasBoundedHeight
                   ? (constraints.maxHeight * devicePixelRatio).round()
                   : null,

--- a/lib/features/tasks/ui/cover_art_background.dart
+++ b/lib/features/tasks/ui/cover_art_background.dart
@@ -56,16 +56,21 @@ class _CoverArtBackgroundState extends ConsumerState<CoverArtBackground>
       fit: StackFit.expand,
       children: [
         LayoutBuilder(
-          builder: (context, constraints) => Image.file(
-            File(path),
-            fit: BoxFit.cover,
-            alignment: Alignment.topCenter,
-            cacheHeight: (constraints.maxHeight * 3).toInt(),
-            errorBuilder: (context, error, stackTrace) {
-              imageCache.evict(FileImage(File(path)));
-              return const SizedBox.shrink();
-            },
-          ),
+          builder: (context, constraints) {
+            final devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
+            return Image.file(
+              File(path),
+              fit: BoxFit.cover,
+              alignment: Alignment.topCenter,
+              cacheHeight: constraints.hasBoundedHeight
+                  ? (constraints.maxHeight * devicePixelRatio).round()
+                  : null,
+              errorBuilder: (context, error, stackTrace) {
+                imageCache.evict(FileImage(File(path)));
+                return const SizedBox.shrink();
+              },
+            );
+          },
         ),
         const DecoratedBox(
           decoration: BoxDecoration(

--- a/lib/features/tasks/ui/cover_art_background.dart
+++ b/lib/features/tasks/ui/cover_art_background.dart
@@ -58,15 +58,26 @@ class _CoverArtBackgroundState extends ConsumerState<CoverArtBackground>
         LayoutBuilder(
           builder: (context, constraints) {
             final devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
+            // ResizeImage asserts width/height > 0; SliverAppBar collapse
+            // can briefly drive the constraint to 0 mid-animation, so guard
+            // and clamp the rounded value to a sensible band.
             return Image.file(
               File(path),
               fit: BoxFit.cover,
               alignment: Alignment.topCenter,
-              cacheWidth: constraints.hasBoundedWidth
-                  ? (constraints.maxWidth * devicePixelRatio).round()
+              cacheWidth:
+                  constraints.hasBoundedWidth && constraints.maxWidth > 0
+                  ? (constraints.maxWidth * devicePixelRatio).round().clamp(
+                      1,
+                      10000,
+                    )
                   : null,
-              cacheHeight: constraints.hasBoundedHeight
-                  ? (constraints.maxHeight * devicePixelRatio).round()
+              cacheHeight:
+                  constraints.hasBoundedHeight && constraints.maxHeight > 0
+                  ? (constraints.maxHeight * devicePixelRatio).round().clamp(
+                      1,
+                      10000,
+                    )
                   : null,
               errorBuilder: (context, error, stackTrace) {
                 imageCache.evict(FileImage(File(path)));

--- a/lib/features/tasks/ui/cover_art_thumbnail.dart
+++ b/lib/features/tasks/ui/cover_art_thumbnail.dart
@@ -59,6 +59,7 @@ class _CoverArtThumbnailState extends ConsumerState<CoverArtThumbnail>
     }
 
     final alignmentX = (widget.cropX * 2) - 1;
+    final devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
 
     return SizedBox(
       width: widget.size,
@@ -69,7 +70,7 @@ class _CoverArtThumbnailState extends ConsumerState<CoverArtThumbnail>
           alignment: Alignment(alignmentX, 0),
           child: Image.file(
             File(path),
-            cacheHeight: (widget.size * 3).toInt(),
+            cacheHeight: (widget.size * devicePixelRatio).round(),
           ),
         ),
       ),

--- a/lib/features/tasks/ui/cover_art_thumbnail.dart
+++ b/lib/features/tasks/ui/cover_art_thumbnail.dart
@@ -60,6 +60,9 @@ class _CoverArtThumbnailState extends ConsumerState<CoverArtThumbnail>
 
     final alignmentX = (widget.cropX * 2) - 1;
     final devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
+    final cap = widget.size > 0
+        ? (widget.size * devicePixelRatio).round().clamp(1, 10000)
+        : null;
 
     return SizedBox(
       width: widget.size,
@@ -70,7 +73,8 @@ class _CoverArtThumbnailState extends ConsumerState<CoverArtThumbnail>
           alignment: Alignment(alignmentX, 0),
           child: Image.file(
             File(path),
-            cacheHeight: (widget.size * devicePixelRatio).round(),
+            cacheWidth: cap,
+            cacheHeight: cap,
           ),
         ),
       ),

--- a/test/features/journal/ui/widgets/entry_image_widget_test.dart
+++ b/test/features/journal/ui/widgets/entry_image_widget_test.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/journal/ui/widgets/entry_image_widget.dart';
@@ -74,11 +73,10 @@ void main() {
     });
 
     Widget makeSubject(JournalImage image) {
-      return ProviderScope(
+      return makeTestableWidget(
+        EntryImageWidget(image),
         overrides: [createEntryControllerOverride(image)],
-        child: MaterialApp(
-          home: Scaffold(body: EntryImageWidget(image)),
-        ),
+        mediaQueryData: phoneMediaQueryData.copyWith(devicePixelRatio: 3),
       );
     }
 

--- a/test/features/journal/ui/widgets/entry_image_widget_test.dart
+++ b/test/features/journal/ui/widgets/entry_image_widget_test.dart
@@ -95,12 +95,14 @@ void main() {
       expect(imageWidget.fit, BoxFit.contain);
       expect(imageWidget.errorBuilder, isNotNull);
 
-      // The cacheHeight cap is applied by wrapping the FileImage in a
-      // ResizeImage. A bounded height ensures the decoded bitmap stays
-      // proportional to display size instead of the source resolution
-      // (which can be 10000×10000 per image_utils.compressAndSave limits).
+      // Both cacheWidth and cacheHeight cap the decoded bitmap (via
+      // ResizeImage) so extreme aspect ratios — e.g. panoramas — can't
+      // balloon along the unconstrained axis. Source images can be up to
+      // 10000×10000 per image_utils.compressAndSave limits.
       expect(imageWidget.image, isA<ResizeImage>());
       final resize = imageWidget.image as ResizeImage;
+      expect(resize.width, isNotNull);
+      expect(resize.width, greaterThan(0));
       expect(resize.height, isNotNull);
       expect(resize.height, greaterThan(0));
       expect(resize.imageProvider, isA<FileImage>());

--- a/test/features/tasks/ui/cover_art_background_test.dart
+++ b/test/features/tasks/ui/cover_art_background_test.dart
@@ -86,57 +86,54 @@ void main() {
         }
       });
 
+      Widget buildSubject(
+        JournalImage image, {
+        double height = 100,
+        double width = 100,
+      }) {
+        // Align gives the SizedBox loose constraints so it keeps its
+        // specified dimensions, and the SizedBox bounds CoverArtBackground's
+        // Stack(StackFit.expand) — without explicit bounds, the surrounding
+        // SingleChildScrollView would leave the Stack with an unbounded
+        // vertical constraint.
+        return makeTestableWidget(
+          Align(
+            alignment: Alignment.topLeft,
+            child: SizedBox(
+              height: height,
+              width: width,
+              child: CoverArtBackground(imageId: image.meta.id),
+            ),
+          ),
+          overrides: [createEntryControllerOverride(image)],
+          mediaQueryData: phoneMediaQueryData.copyWith(devicePixelRatio: 3),
+        );
+      }
+
       testWidgets('errorBuilder triggers when image file is invalid', (
         tester,
       ) async {
         final image = buildJournalImage();
         final filePath = createInvalidImageFile(image);
 
-        // Verify file exists before test
         expect(File(filePath).existsSync(), isTrue);
 
-        await tester.pumpWidget(
-          ProviderScope(
-            overrides: [
-              createEntryControllerOverride(image),
-            ],
-            child: const MaterialApp(
-              home: Scaffold(
-                body: CoverArtBackground(imageId: 'image-1'),
-              ),
-            ),
-          ),
-        );
-
-        // Pump multiple times to allow error handling
+        await tester.pumpWidget(buildSubject(image));
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 100));
         await tester.pumpAndSettle();
 
-        // The errorBuilder should have triggered and returned SizedBox.shrink
-        // The widget tree should still contain the CoverArtBackground
         expect(find.byType(CoverArtBackground), findsOneWidget);
       });
 
       testWidgets(
-        'renders Image.file with a positive LayoutBuilder-derived cacheHeight',
+        'renders Image.file with LayoutBuilder-derived cacheWidth/cacheHeight',
         (tester) async {
           final image = buildJournalImage();
           createInvalidImageFile(image);
 
           await tester.pumpWidget(
-            ProviderScope(
-              overrides: [createEntryControllerOverride(image)],
-              child: const MaterialApp(
-                home: Scaffold(
-                  body: SizedBox(
-                    height: 240,
-                    width: 360,
-                    child: CoverArtBackground(imageId: 'image-1'),
-                  ),
-                ),
-              ),
-            ),
+            buildSubject(image, height: 240, width: 360),
           );
           await tester.pump();
 
@@ -144,11 +141,11 @@ void main() {
           expect(imageWidget.fit, BoxFit.cover);
           expect(imageWidget.errorBuilder, isNotNull);
 
-          // The cacheHeight cap is applied by ResizeImage wrapping FileImage,
-          // sized from `constraints.maxHeight * 3` inside the LayoutBuilder.
-          // 240 logical px × 3 = 720 physical px ceiling on decoded bitmap.
+          // Both axes are capped: maxWidth × DPR and maxHeight × DPR.
+          // 360 × 3 = 1080 width; 240 × 3 = 720 height.
           expect(imageWidget.image, isA<ResizeImage>());
           final resize = imageWidget.image as ResizeImage;
+          expect(resize.width, 1080);
           expect(resize.height, 720);
           expect(resize.imageProvider, isA<FileImage>());
         },
@@ -161,18 +158,7 @@ void main() {
           createInvalidImageFile(image);
 
           await tester.pumpWidget(
-            ProviderScope(
-              overrides: [createEntryControllerOverride(image)],
-              child: const MaterialApp(
-                home: Scaffold(
-                  body: SizedBox(
-                    height: 200,
-                    width: 320,
-                    child: CoverArtBackground(imageId: 'image-1'),
-                  ),
-                ),
-              ),
-            ),
+            buildSubject(image, height: 200, width: 320),
           );
           await tester.pump();
 

--- a/test/features/tasks/ui/cover_art_background_test.dart
+++ b/test/features/tasks/ui/cover_art_background_test.dart
@@ -110,7 +110,7 @@ void main() {
         );
       }
 
-      testWidgets('errorBuilder triggers when image file is invalid', (
+      testWidgets('configures errorBuilder when image file is invalid', (
         tester,
       ) async {
         final image = buildJournalImage();
@@ -123,7 +123,12 @@ void main() {
         await tester.pump(const Duration(milliseconds: 100));
         await tester.pumpAndSettle();
 
-        expect(find.byType(CoverArtBackground), findsOneWidget);
+        // The integration assertion: the rendered Image.file is wired with
+        // an errorBuilder callback so a decode failure on this invalid file
+        // can fall back without tearing down the widget. The callback's
+        // body itself is exercised in the dedicated white-box test below.
+        final imageWidget = tester.widget<Image>(find.byType(Image));
+        expect(imageWidget.errorBuilder, isNotNull);
       });
 
       testWidgets(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image caching now accounts for device pixel ratio and clamps computed cache dimensions, improving image quality and memory behavior across screens.

* **Tests**
  * Strengthened tests to assert both cached width and height and cover various layout/error scenarios.

* **Refactor**
  * Test helpers consolidated to simplify widget setup and device-pixel-ratio overrides.

* **Chores**
  * CI workflow: added step to globally activate a CLI tool during release runs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matthiasn/lotti/pull/3134)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->