### PR TITLE
refactor: defer agent wakes

### DIFF
--- a/lib/features/agents/model/agent_time_utils.dart
+++ b/lib/features/agents/model/agent_time_utils.dart
@@ -12,6 +12,25 @@ DateTime nextLocalDayAtTime(
   int minute = 0,
 }) => DateTime(dt.year, dt.month, dt.day + 1, hour, minute);
 
+/// Returns the next local-clock occurrence of [hour]:[minute] strictly
+/// after [dt]. If today's [hour]:[minute] hasn't passed yet, returns
+/// today; otherwise returns the same time tomorrow.
+///
+/// This differs from [nextLocalDayAtTime], which always rolls forward to
+/// the next day even if today's slot is still in the future. Used by the
+/// wake orchestrator to defer subscription-driven wakes to the next
+/// 06:00 — at 03:00 we want today's 06:00, not tomorrow's.
+DateTime nextOccurrenceOf(
+  DateTime dt, {
+  required int hour,
+  int minute = 0,
+}) {
+  final today = DateTime(dt.year, dt.month, dt.day, hour, minute);
+  return today.isAfter(dt)
+      ? today
+      : DateTime(dt.year, dt.month, dt.day + 1, hour, minute);
+}
+
 /// Accumulates success/failure/duration stats from a list of wake runs.
 ///
 /// Returns a record with the computed statistics. The [statusAccessor] and

--- a/lib/features/agents/ui/sidebar_wake_queue.dart
+++ b/lib/features/agents/ui/sidebar_wake_queue.dart
@@ -329,12 +329,30 @@ class _WakeRowState extends ConsumerState<_WakeRow> {
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final record = widget.record;
-    final subjectId =
-        record.state.slots.activeTaskId ?? record.state.slots.activeProjectId;
-    final subjectTitle = ref
-        .watch(pendingWakeTargetTitleProvider(subjectId))
-        .value
-        ?.trim();
+
+    // Try task first, then project — `??` would short-circuit on the
+    // task ID even when the task's title is blank, which is exactly the
+    // case that surfaced "Task Agent" instead of the project name on
+    // the scheduled (120 s countdown) row. The ongoing-wake row was
+    // already fixed via `_resolveOngoingRecord`; this is the matching
+    // fix for the pending-wake row.
+    final taskId = record.state.slots.activeTaskId;
+    final projectId = record.state.slots.activeProjectId;
+    String? subjectTitle;
+    if (taskId != null && taskId.isNotEmpty) {
+      subjectTitle = ref
+          .watch(pendingWakeTargetTitleProvider(taskId))
+          .value
+          ?.trim();
+    }
+    if ((subjectTitle == null || subjectTitle.isEmpty) &&
+        projectId != null &&
+        projectId.isNotEmpty) {
+      subjectTitle = ref
+          .watch(pendingWakeTargetTitleProvider(projectId))
+          .value
+          ?.trim();
+    }
     final title = subjectTitle != null && subjectTitle.isNotEmpty
         ? subjectTitle
         : record.agent.displayName;

--- a/lib/features/agents/wake/wake_orchestrator.dart
+++ b/lib/features/agents/wake/wake_orchestrator.dart
@@ -486,6 +486,10 @@ class WakeOrchestrator {
       final predicate = sub.predicate;
       if (predicate != null && !predicate(allMatched)) continue;
 
+      // The provenance bit drives both the queued job's [hasDirectMatch]
+      // flag and the throttle-gate escalation below.
+      final isDirect = trueDirect.isNotEmpty;
+
       // 4. During-execution gate: when the agent is actively executing,
       //    silently queue the notification for the drain re-check instead
       //    of going through the throttle/defer path. The drain re-check
@@ -496,7 +500,11 @@ class WakeOrchestrator {
       //    the double-run race where the safety-net dequeues a job during
       //    its async gap.
       if (runner.isRunning(sub.agentId)) {
-        final merged = queue.mergeTokens(sub.agentId, allMatched);
+        final merged = queue.mergeTokens(
+          sub.agentId,
+          allMatched,
+          isDirect: isDirect,
+        );
         if (!merged) {
           final counter = _wakeCounters[sub.agentId] ?? 0;
           _wakeCounters[sub.agentId] = counter + 1;
@@ -514,12 +522,14 @@ class WakeOrchestrator {
               triggerTokens: Set<String>.from(allMatched),
               reasonId: sub.id,
               createdAt: clock.now(),
+              hasDirectMatch: isDirect,
             ),
           );
         }
         _log(
           '${DomainLogger.sanitizeId(sub.agentId)} executing — '
-          '${merged ? 'merged tokens into queued job' : 'queued for drain re-check'}',
+          '${merged ? 'merged tokens into queued job' : 'queued for drain re-check'} '
+          '(direct=$isDirect)',
           subDomain: 'running',
         );
         continue;
@@ -530,7 +540,27 @@ class WakeOrchestrator {
       //    deferred drain timer can pick it up.
       if (_isThrottled(sub.agentId)) {
         final deadline = _throttle.deadlineFor(sub.agentId);
-        final merged = queue.mergeTokens(sub.agentId, allMatched);
+        final merged = queue.mergeTokens(
+          sub.agentId,
+          allMatched,
+          isDirect: isDirect,
+        );
+        // Escalate the deadline when a direct match arrives on top of a
+        // morning-deferred slot — leaving the user's edit waiting until
+        // 06:00 because earlier propagation already armed a long timer
+        // would defeat the entire policy.
+        if (isDirect && deadline != null) {
+          final immediate = clock.now().add(throttleWindow);
+          if (immediate.isBefore(deadline)) {
+            _log(
+              'escalating ${DomainLogger.sanitizeId(sub.agentId)} '
+              'deadline from $deadline to $immediate '
+              '(direct match arrived during propagated deferral)',
+              subDomain: 'throttle',
+            );
+            unawaited(_setThrottleDeadline(sub.agentId));
+          }
+        }
         _log(
           '${DomainLogger.sanitizeId(sub.agentId)} throttled until $deadline — '
           '${merged ? 'merged tokens' : 'enqueuing for deferred drain'}',
@@ -560,11 +590,12 @@ class WakeOrchestrator {
         triggerTokens: Set<String>.from(allMatched),
         reasonId: sub.id,
         createdAt: clock.now(),
+        hasDirectMatch: isDirect,
       );
 
       // Attempt to merge tokens into an existing queued job for this agent
       // before enqueuing a new one; this coalesces rapid-fire notifications.
-      if (!queue.mergeTokens(sub.agentId, allMatched)) {
+      if (!queue.mergeTokens(sub.agentId, allMatched, isDirect: isDirect)) {
         queue.enqueue(job);
       }
 
@@ -1045,8 +1076,27 @@ class WakeOrchestrator {
 
         // Set the throttle deadline for subscription-triggered wakes so
         // that rapid-fire mutations don't cause excessive LLM calls.
+        //
+        // If the queue holds only propagated-only jobs for this agent
+        // (e.g. fan-outs that arrived while the executor was running),
+        // honour the morning policy for the drain instead of bouncing
+        // them into a 120 s post-throttle that would force them to fire
+        // at the next minute mark. A direct-bearing queued job — or an
+        // empty queue — keeps the standard 120 s cooldown so subsequent
+        // user edits land within the throttle window.
         if (job.reason == WakeReason.subscription.name) {
-          await _setThrottleDeadline(job.agentId);
+          final hasDirectQueued = queue.hasDirectQueuedJobFor(job.agentId);
+          final hasAnyQueued = queue.hasQueuedJobFor(job.agentId);
+          final morningDeadline = hasAnyQueued && !hasDirectQueued
+              ? nextOccurrenceOf(
+                  clock.now(),
+                  hour: AgentSchedules.projectDailyDigestHour,
+                )
+              : null;
+          await _setThrottleDeadline(
+            job.agentId,
+            customDeadline: morningDeadline,
+          );
         }
       } catch (e) {
         _suppression.clearPreRegistered(job.agentId);

--- a/lib/features/agents/wake/wake_orchestrator.dart
+++ b/lib/features/agents/wake/wake_orchestrator.dart
@@ -4,8 +4,10 @@ import 'dart:developer' as developer;
 import 'package:clock/clock.dart';
 import 'package:lotti/features/agents/database/agent_database.dart';
 import 'package:lotti/features/agents/database/agent_repository.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/model/agent_time_utils.dart';
 import 'package:lotti/features/agents/wake/run_key_factory.dart';
 import 'package:lotti/features/agents/wake/wake_queue.dart';
 import 'package:lotti/features/agents/wake/wake_runner.dart';
@@ -308,8 +310,16 @@ class WakeOrchestrator {
 
   /// Set the throttle deadline for [agentId] and persist it to the agent's
   /// state entity via `nextWakeAt`.
-  Future<void> _setThrottleDeadline(String agentId) async {
-    await _throttle.setDeadline(agentId);
+  ///
+  /// [customDeadline], when provided, overrides the default
+  /// `now + throttleWindow`. Used by the propagated-match path in
+  /// [_onBatch] to defer to the next 06:00 instead of the standard
+  /// 120-second cooldown.
+  Future<void> _setThrottleDeadline(
+    String agentId, {
+    DateTime? customDeadline,
+  }) async {
+    await _throttle.setDeadline(agentId, customDeadline: customDeadline);
   }
 
   /// Set a throttle deadline from an external source (e.g. startup hydration).
@@ -429,36 +439,52 @@ class WakeOrchestrator {
     }
     for (final sub in _subscriptions) {
       // 1. Check whether any token matches the subscription's entity IDs.
+      //    A "direct" match means the agent's own entity was edited
+      //    (token in tokens AND propagated::token NOT in tokens). A
+      //    "propagated" match means the token only arrived via parent
+      //    fan-out or a link side-effect (propagated::token in tokens).
+      //    Pure-propagated matches defer the wake to the next 06:00; any
+      //    direct match keeps the existing fast-throttle behaviour.
       final matched = tokens.intersection(sub.matchEntityIds);
-      if (matched.isEmpty) continue;
+      final propagatedMatched = sub.matchEntityIds
+          .where((id) => tokens.contains(propagatedNotification(id)))
+          .toSet();
+      // The same id present in both raw and wrapped form means the raw
+      // emission was just bookkeeping for legacy listeners — treat the
+      // match as propagated for the agent's deferral decision.
+      final trueDirect = matched.difference(propagatedMatched);
+      final allMatched = matched.union(propagatedMatched);
+      if (allMatched.isEmpty) continue;
 
       _log(
-        'matched ${matched.length} token(s) for '
+        'matched ${allMatched.length} token(s) for '
         '${DomainLogger.sanitizeId(sub.agentId)} '
-        '(sub: ${DomainLogger.sanitizeId(sub.id)})',
+        '(sub: ${DomainLogger.sanitizeId(sub.id)}, '
+        'direct=${trueDirect.length}, '
+        'propagated=${propagatedMatched.length})',
         subDomain: 'onBatch',
       );
 
       // 2. Apply post-execution self-notification suppression.
-      if (_isSuppressed(sub.agentId, matched)) {
+      if (_isSuppressed(sub.agentId, allMatched)) {
         _log(
           'suppressed self-notification for '
           '${DomainLogger.sanitizeId(sub.agentId)} '
-          'matched=${matched.map(DomainLogger.sanitizeId)}',
+          'matched=${allMatched.map(DomainLogger.sanitizeId)}',
           subDomain: 'suppression',
         );
         continue;
       }
       _log(
         'not suppressed for ${DomainLogger.sanitizeId(sub.agentId)} '
-        'matched=${matched.map(DomainLogger.sanitizeId)} '
+        'matched=${allMatched.map(DomainLogger.sanitizeId)} '
         'suppression=${_suppression.debugState(sub.agentId)}',
         subDomain: 'suppression',
       );
 
       // 3. Apply optional fine-grained predicate before any queueing path.
       final predicate = sub.predicate;
-      if (predicate != null && !predicate(matched)) continue;
+      if (predicate != null && !predicate(allMatched)) continue;
 
       // 4. During-execution gate: when the agent is actively executing,
       //    silently queue the notification for the drain re-check instead
@@ -470,7 +496,7 @@ class WakeOrchestrator {
       //    the double-run race where the safety-net dequeues a job during
       //    its async gap.
       if (runner.isRunning(sub.agentId)) {
-        final merged = queue.mergeTokens(sub.agentId, matched);
+        final merged = queue.mergeTokens(sub.agentId, allMatched);
         if (!merged) {
           final counter = _wakeCounters[sub.agentId] ?? 0;
           _wakeCounters[sub.agentId] = counter + 1;
@@ -479,13 +505,13 @@ class WakeOrchestrator {
               runKey: RunKeyFactory.forSubscription(
                 agentId: sub.agentId,
                 subscriptionId: sub.id,
-                batchTokens: matched,
+                batchTokens: allMatched,
                 wakeCounter: counter,
                 timestamp: clock.now(),
               ),
               agentId: sub.agentId,
               reason: WakeReason.subscription.name,
-              triggerTokens: Set<String>.from(matched),
+              triggerTokens: Set<String>.from(allMatched),
               reasonId: sub.id,
               createdAt: clock.now(),
             ),
@@ -504,7 +530,7 @@ class WakeOrchestrator {
       //    deferred drain timer can pick it up.
       if (_isThrottled(sub.agentId)) {
         final deadline = _throttle.deadlineFor(sub.agentId);
-        final merged = queue.mergeTokens(sub.agentId, matched);
+        final merged = queue.mergeTokens(sub.agentId, allMatched);
         _log(
           '${DomainLogger.sanitizeId(sub.agentId)} throttled until $deadline — '
           '${merged ? 'merged tokens' : 'enqueuing for deferred drain'}',
@@ -522,7 +548,7 @@ class WakeOrchestrator {
       final runKey = RunKeyFactory.forSubscription(
         agentId: sub.agentId,
         subscriptionId: sub.id,
-        batchTokens: matched,
+        batchTokens: allMatched,
         wakeCounter: counter,
         timestamp: now,
       );
@@ -531,14 +557,14 @@ class WakeOrchestrator {
         runKey: runKey,
         agentId: sub.agentId,
         reason: WakeReason.subscription.name,
-        triggerTokens: Set<String>.from(matched),
+        triggerTokens: Set<String>.from(allMatched),
         reasonId: sub.id,
         createdAt: clock.now(),
       );
 
       // Attempt to merge tokens into an existing queued job for this agent
       // before enqueuing a new one; this coalesces rapid-fire notifications.
-      if (!queue.mergeTokens(sub.agentId, matched)) {
+      if (!queue.mergeTokens(sub.agentId, allMatched)) {
         queue.enqueue(job);
       }
 
@@ -559,18 +585,27 @@ class WakeOrchestrator {
       }
 
       // Defer-first: instead of dispatching immediately, set a throttle
-      // deadline and schedule a deferred drain. This allows bursty edits
-      // to coalesce into a single wake cycle.
-      // Uses _setThrottleDeadline to persist nextWakeAt so the UI shows a
-      // countdown timer.
-      unawaited(_setThrottleDeadline(sub.agentId));
+      // deadline and schedule a deferred drain. Direct matches use the
+      // standard 120 s coalescing window; pure-propagated matches (e.g.
+      // a parent task's agent waking on a child entry edit, or a project
+      // agent waking on `linkTaskToProject`) defer to the next 06:00 so
+      // the agent doesn't burn LLM tokens on every incidental fan-out.
+      final morningDeadline = trueDirect.isEmpty
+          ? nextOccurrenceOf(
+              now,
+              hour: AgentSchedules.projectDailyDigestHour,
+            )
+          : null;
+      unawaited(
+        _setThrottleDeadline(sub.agentId, customDeadline: morningDeadline),
+      );
 
       _log(
         'deferred wake for ${DomainLogger.sanitizeId(sub.agentId)}: '
-        'drain scheduled in ${throttleWindow.inSeconds}s, '
+        '${morningDeadline == null ? 'drain scheduled in ${throttleWindow.inSeconds}s' : 'drain scheduled at $morningDeadline (morning)'}, '
         'reason=subscription, '
         'sub=${DomainLogger.sanitizeId(sub.id)}, '
-        'triggers=${matched.map(DomainLogger.sanitizeId).join(',')}',
+        'triggers=${allMatched.map(DomainLogger.sanitizeId).join(',')}',
         subDomain: 'defer',
       );
     }

--- a/lib/features/agents/wake/wake_queue.dart
+++ b/lib/features/agents/wake/wake_queue.dart
@@ -7,6 +7,7 @@ class WakeJob {
     required Set<String> triggerTokens,
     required this.createdAt,
     this.reasonId,
+    this.hasDirectMatch = true,
   }) : triggerTokens = Set<String>.of(triggerTokens);
 
   /// Deterministic key derived by `RunKeyFactory`; used for deduplication.
@@ -31,6 +32,19 @@ class WakeJob {
 
   /// Wall-clock time the job was created (not persisted; in-memory only).
   final DateTime createdAt;
+
+  /// `true` when at least one trigger that contributed to this job was a
+  /// direct edit (the agent's own entity changed), `false` when every
+  /// contributing trigger was a propagated fan-out (parent IDs added by
+  /// `parentLinkedEntityIds`, link-side-effect project tokens, …).
+  ///
+  /// Manual / creation / reanalysis wakes are direct by definition and
+  /// keep the default `true`. Subscription wakes carry the orchestrator's
+  /// classification, and [WakeQueue.mergeTokens] upgrades this to `true`
+  /// when a later direct match coalesces into the same queued job — so a
+  /// pending propagated-only job that picks up a fresh direct edit no
+  /// longer fires at next 06:00 as if it were still propagated-only.
+  bool hasDirectMatch;
 }
 
 /// In-memory FIFO queue with run-key deduplication.
@@ -65,17 +79,40 @@ class WakeQueue {
   /// Merge [tokens] into the `triggerTokens` of the first queued job whose
   /// `agentId` matches [agentId].
   ///
+  /// When [isDirect] is `true`, also upgrades the job's
+  /// [WakeJob.hasDirectMatch] to `true` — a direct match coalescing onto a
+  /// previously propagated-only deferred job must not stay deferred to the
+  /// next morning. The upgrade is monotonic: a subsequent propagated-only
+  /// merge cannot downgrade a direct job back to propagated-only.
+  ///
   /// Returns `true` when a matching job was found and updated, `false`
   /// otherwise.
-  bool mergeTokens(String agentId, Set<String> tokens) {
+  bool mergeTokens(
+    String agentId,
+    Set<String> tokens, {
+    bool isDirect = false,
+  }) {
     for (final job in _queue) {
       if (job.agentId == agentId) {
         job.triggerTokens.addAll(tokens);
+        if (isDirect) job.hasDirectMatch = true;
         return true;
       }
     }
     return false;
   }
+
+  /// Whether any queued job for [agentId] carries at least one direct
+  /// match. The orchestrator uses this when picking the post-execution
+  /// throttle deadline: an empty queue or a propagated-only queue defers
+  /// the next drain to the next 06:00; a direct-bearing queue keeps the
+  /// 120 s cooldown so the user sees their edit reflected promptly.
+  bool hasDirectQueuedJobFor(String agentId) =>
+      _queue.any((job) => job.agentId == agentId && job.hasDirectMatch);
+
+  /// Whether any queued job exists for [agentId], regardless of provenance.
+  bool hasQueuedJobFor(String agentId) =>
+      _queue.any((job) => job.agentId == agentId);
 
   /// Remove all queued jobs for [agentId] and return them.
   ///

--- a/lib/features/agents/wake/wake_throttle_coordinator.dart
+++ b/lib/features/agents/wake/wake_throttle_coordinator.dart
@@ -66,8 +66,20 @@ class WakeThrottleCoordinator {
   /// If the DB write failed or hung, the timer was never scheduled and the
   /// queued job would sit until the safety net (60s) fired. Now the timer
   /// is scheduled first (synchronous), then the DB write is best-effort.
-  Future<void> setDeadline(String agentId) async {
-    final deadline = clock.now().add(throttleWindow);
+  ///
+  /// [customDeadline], when non-null, overrides the default
+  /// `now + throttleWindow`. Used by the orchestrator to defer
+  /// propagated subscription matches (parent fan-out, link-side-effects)
+  /// to the next 06:00 instead of the standard 120-second cooldown. A
+  /// custom deadline that is in the past is silently ignored — the
+  /// caller's intent was clearly "schedule for later", and a stale
+  /// timestamp would otherwise fire the drain immediately.
+  Future<void> setDeadline(String agentId, {DateTime? customDeadline}) async {
+    final now = clock.now();
+    if (customDeadline != null && !customDeadline.isAfter(now)) {
+      return;
+    }
+    final deadline = customDeadline ?? now.add(throttleWindow);
     _throttleDeadlines[agentId] = deadline;
 
     // Schedule the deferred drain FIRST (synchronous) so the timer is always

--- a/lib/features/projects/repository/project_repository.dart
+++ b/lib/features/projects/repository/project_repository.dart
@@ -315,11 +315,18 @@ class ProjectRepository {
 
         final res = await _journalDb.upsertEntryLink(link);
         if (res == 0) return false;
+        // Wrap the per-project update token with [propagatedNotification]
+        // so the wake orchestrator can tell "a task was linked under this
+        // project" apart from "the project itself was edited" — only
+        // direct project edits should burn LLM tokens immediately. Bare
+        // tokens are kept alongside so UI providers reacting to the
+        // legacy form continue to refresh.
         _updateNotifications.notify({
           projectId,
           taskId,
           projectNotification,
           projectEntityUpdateNotification(projectId),
+          propagatedNotification(projectEntityUpdateNotification(projectId)),
         });
         try {
           await _enqueueLinkSync(link, SyncEntryStatus.initial);
@@ -438,6 +445,8 @@ class ProjectRepository {
 
         if (!success) return false;
 
+        // Same propagation tagging as [linkTaskToProject]: relinking is a
+        // task-link side-effect, not a direct project edit.
         _updateNotifications.notify({
           oldLink.fromId,
           oldLink.toId,
@@ -446,6 +455,10 @@ class ProjectRepository {
           projectNotification,
           projectEntityUpdateNotification(oldLink.fromId),
           projectEntityUpdateNotification(projectId),
+          propagatedNotification(
+            projectEntityUpdateNotification(oldLink.fromId),
+          ),
+          propagatedNotification(projectEntityUpdateNotification(projectId)),
         });
         try {
           await _enqueueLinkSync(deletedLink, SyncEntryStatus.update);
@@ -472,11 +485,14 @@ class ProjectRepository {
         final deleted = await _prepareDeletedLink(link, now);
         final res = await _journalDb.upsertEntryLink(deleted);
         if (res == 0) return false;
+        // Same propagation tagging as [linkTaskToProject]: unlinking is a
+        // task-link side-effect, not a direct project edit.
         _updateNotifications.notify({
           link.fromId,
           link.toId,
           projectNotification,
           projectEntityUpdateNotification(link.fromId),
+          propagatedNotification(projectEntityUpdateNotification(link.fromId)),
         });
         try {
           await _enqueueLinkSync(deleted, SyncEntryStatus.update);

--- a/lib/logic/persistence_logic.dart
+++ b/lib/logic/persistence_logic.dart
@@ -835,6 +835,12 @@ class PersistenceLogic {
 
           // Include parent linked entry IDs so that agents subscribed to a
           // parent (e.g. a task) are notified when a child entry is edited.
+          // Parent IDs are wrapped with [propagatedNotification] so the
+          // wake orchestrator can distinguish "the parent itself was
+          // edited" (direct match → 120 s throttle) from "a child of the
+          // parent was edited" (propagated match → defer to next 06:00).
+          // UI providers continue to react to either form via the parent
+          // ID matching helpers.
           final parentIds = await _journalDb
               .parentLinkedEntityIds(journalEntity.id)
               .get();
@@ -846,6 +852,7 @@ class PersistenceLogic {
             ...journalEntity.affectedIds,
             ?linkedId,
             ...parentIds,
+            for (final id in parentIds) propagatedNotification(id),
             labelUsageNotification,
           };
           if (isAgentExecution) {

--- a/lib/services/db_notification.dart
+++ b/lib/services/db_notification.dart
@@ -141,3 +141,34 @@ const projectEntityUpdatePrefix = 'PROJECT_ENTITY_UPDATE:';
 String projectEntityUpdateNotification(String projectId) {
   return '$projectEntityUpdatePrefix$projectId';
 }
+
+/// Prefix marking a notification token that did not originate from a
+/// direct edit of the entity it references — e.g. a parent ID added by
+/// `parentLinkedEntityIds` fan-out, or a project's update token emitted
+/// as a side-effect of linking a task.
+///
+/// The agent wake orchestrator inspects this prefix when deciding how
+/// quickly to fire a subscription-driven wake: matches on a propagated
+/// token defer to the next morning (so a project agent doesn't burn
+/// tokens every time someone creates a task under it), while direct
+/// matches keep the existing fast-throttle behaviour. Consumers that
+/// only care about reactivity (UI providers, listeners) should match on
+/// either form.
+const propagatedNotificationPrefix = 'PROPAGATED::';
+
+/// Wraps [token] in the [propagatedNotificationPrefix] so consumers can
+/// distinguish a fan-out / link-side-effect emission from a direct-edit
+/// emission. See [propagatedNotificationPrefix] for the intent.
+String propagatedNotification(String token) =>
+    '$propagatedNotificationPrefix$token';
+
+/// Whether [token] was emitted as a propagated (non-direct) effect.
+bool isPropagatedNotification(String token) =>
+    token.startsWith(propagatedNotificationPrefix);
+
+/// Returns the underlying token wrapped by [propagatedNotification], or
+/// [token] itself when it was not wrapped.
+String unwrapPropagatedNotification(String token) =>
+    isPropagatedNotification(token)
+    ? token.substring(propagatedNotificationPrefix.length)
+    : token;

--- a/test/features/agents/model/agent_time_utils_test.dart
+++ b/test/features/agents/model/agent_time_utils_test.dart
@@ -184,6 +184,61 @@ void main() {
       );
     });
 
+    group('nextOccurrenceOf', () {
+      test(
+        'returns today at the requested time when it has not passed yet',
+        () {
+          // 03:15 today → next 06:00 is today, not tomorrow.
+          expect(
+            nextOccurrenceOf(DateTime(2024, 3, 15, 3, 15), hour: 6),
+            DateTime(2024, 3, 15, 6),
+          );
+        },
+      );
+
+      test("returns tomorrow when today's requested time has passed", () {
+        // 21:30 today → next 06:00 is tomorrow.
+        expect(
+          nextOccurrenceOf(DateTime(2024, 3, 15, 21, 30), hour: 6),
+          DateTime(2024, 3, 16, 6),
+        );
+      });
+
+      test('rolls forward when called exactly at the requested time', () {
+        // Edge: at 06:00 sharp, "next" is tomorrow's 06:00 — the slot
+        // we're standing on doesn't count as "after now".
+        expect(
+          nextOccurrenceOf(DateTime(2024, 3, 15, 6), hour: 6),
+          DateTime(2024, 3, 16, 6),
+        );
+      });
+
+      test('honours non-zero minute parameter', () {
+        expect(
+          nextOccurrenceOf(DateTime(2024, 3, 15, 6, 14), hour: 6, minute: 15),
+          DateTime(2024, 3, 15, 6, 15),
+        );
+        expect(
+          nextOccurrenceOf(DateTime(2024, 3, 15, 6, 16), hour: 6, minute: 15),
+          DateTime(2024, 3, 16, 6, 15),
+        );
+      });
+
+      test('crosses month and year boundaries correctly', () {
+        // 23:59 on the last day of a month → next 06:00 is the 1st of
+        // the following month.
+        expect(
+          nextOccurrenceOf(DateTime(2024, 1, 31, 23, 59), hour: 6),
+          DateTime(2024, 2, 1, 6),
+        );
+        // 23:59 on Dec 31 → next 06:00 is Jan 1 of the next year.
+        expect(
+          nextOccurrenceOf(DateTime(2024, 12, 31, 23, 59), hour: 6),
+          DateTime(2025, 1, 1, 6),
+        );
+      });
+    });
+
     glados.Glados(
       glados.any.runStatsScenario,
       glados.ExploreConfig(numRuns: 180),

--- a/test/features/agents/ui/sidebar_wake_queue_test.dart
+++ b/test/features/agents/ui/sidebar_wake_queue_test.dart
@@ -4,6 +4,7 @@ import 'package:beamer/beamer.dart';
 import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/pending_wake_record.dart';
 import 'package:lotti/features/agents/state/agent_pending_wake_providers.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
@@ -280,6 +281,112 @@ void main() {
 
       verify(() => agentService.cancelPendingWake('agent-pending')).called(1);
       verifyNever(() => agentService.clearScheduledWake(any()));
+    },
+  );
+
+  testWidgets(
+    'scheduled wake row falls through to the project title when the task '
+    'title is empty — covers the case where slots.activeTaskId points at '
+    'an entry with a blank/whitespace title and the row collapsed to the '
+    'agent.displayName (Task Agent or similar) instead of the project',
+    (tester) async {
+      final identity = makeTestIdentity(
+        agentId: 'agent-fallthrough',
+        id: 'agent-fallthrough',
+        displayName: 'Task Agent',
+      );
+      final state = makeTestState(
+        agentId: 'agent-fallthrough',
+        slots: const AgentSlots(
+          activeTaskId: 'task-empty',
+          activeProjectId: 'project-named',
+        ),
+      );
+      final record = PendingWakeRecord(
+        agent: identity,
+        state: state,
+        type: PendingWakeType.pending,
+        dueAt: fixedNow.add(const Duration(seconds: 30)),
+      );
+
+      await withClock(Clock.fixed(fixedNow), () async {
+        await tester.pumpWidget(
+          makeTestableWidgetWithScaffold(
+            const SidebarWakeQueue(),
+            theme: DesignSystemTheme.dark(),
+            overrides: [
+              pendingWakeRecordsProvider.overrideWith((ref) async => [record]),
+              ongoingWakeRecordsProvider.overrideWith(
+                (ref) async => const <OngoingWakeRecord>[],
+              ),
+              // Task title resolves to whitespace — would have collapsed
+              // straight to the displayName before the fix.
+              pendingWakeTargetTitleProvider(
+                'task-empty',
+              ).overrideWith((ref) async => null),
+              pendingWakeTargetTitleProvider(
+                'project-named',
+              ).overrideWith((ref) async => 'Platform refresh'),
+            ],
+          ),
+        );
+        // Two pumps: one for the initial build, one for the title
+        // futures to settle and the row to rebuild with the resolved
+        // project title.
+        await tester.pump();
+        await tester.pump();
+      });
+
+      expect(find.text('Platform refresh'), findsOneWidget);
+      expect(find.text('Task Agent'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'scheduled wake row reacts live to a rename of its linked task '
+    'instead of caching the snapshot title until the wake fires',
+    (tester) async {
+      final controller = StreamController<String?>();
+      addTearDown(controller.close);
+      final identity = makeTestIdentity(
+        agentId: 'agent-rename',
+        id: 'agent-rename',
+        displayName: 'Task Agent',
+      );
+      final state = makeTestState(
+        agentId: 'agent-rename',
+        slots: const AgentSlots(activeTaskId: 'task-rename'),
+      );
+      final record = PendingWakeRecord(
+        agent: identity,
+        state: state,
+        type: PendingWakeType.pending,
+        dueAt: fixedNow.add(const Duration(seconds: 30)),
+      );
+
+      await withClock(Clock.fixed(fixedNow), () async {
+        await tester.pumpWidget(
+          makeTestableWidgetWithScaffold(
+            const SidebarWakeQueue(),
+            theme: DesignSystemTheme.dark(),
+            overrides: [
+              pendingWakeRecordsProvider.overrideWith((ref) async => [record]),
+              ongoingWakeRecordsProvider.overrideWith(
+                (ref) async => const <OngoingWakeRecord>[],
+              ),
+              pendingWakeTargetTitleProvider(
+                'task-rename',
+              ).overrideWith((ref) => controller.stream.first),
+            ],
+          ),
+        );
+        await tester.pump();
+
+        controller.add('GLaDOS');
+        await tester.pump();
+        expect(find.text('GLaDOS'), findsOneWidget);
+        expect(find.text('Task Agent'), findsNothing);
+      });
     },
   );
 

--- a/test/features/agents/wake/wake_orchestrator_test.dart
+++ b/test/features/agents/wake/wake_orchestrator_test.dart
@@ -4479,5 +4479,163 @@ void main() {
         },
       );
     });
+
+    group('propagated subscription deferral (next 06:00)', () {
+      test(
+        'a propagated-only match defers nextWakeAt to the next 06:00 '
+        'instead of the standard 120 s throttle window',
+        () {
+          // Pin the wall clock so the next-06:00 calculation is
+          // deterministic regardless of when the test runs.
+          final now = DateTime(2026, 5, 10, 21, 30);
+          withClock(Clock.fixed(now), () {
+            fakeAsync((async) {
+              orchestrator
+                ..wakeExecutor = noOpExecutor
+                ..addSubscription(
+                  makeSub(matchEntityIds: {'task-parent'}),
+                );
+
+              when(
+                () => mockRepository.getAgentState('agent-1'),
+              ).thenAnswer(
+                (_) async =>
+                    AgentDomainEntity.agentState(
+                          id: 'state-1',
+                          agentId: 'agent-1',
+                          revision: 0,
+                          slots: const AgentSlots(),
+                          updatedAt: now,
+                          vectorClock: null,
+                        )
+                        as AgentStateEntity,
+              );
+
+              final controller = StreamController<Set<String>>.broadcast();
+              orchestrator.start(controller.stream);
+              addTearDown(controller.close);
+
+              // Only the propagated form is in the batch — the agent's
+              // entity wasn't directly edited; a child of it was.
+              emitTokens(async, controller, {
+                propagatedNotification('task-parent'),
+              });
+
+              // The persisted nextWakeAt should be tomorrow 06:00 (since
+              // the pinned clock is past 06:00 today), NOT now + 120 s.
+              final captured = verify(
+                () => mockRepository.upsertEntity(captureAny()),
+              ).captured;
+              final state = captured.last as AgentStateEntity;
+              expect(
+                state.nextWakeAt,
+                DateTime(2026, 5, 11, 6),
+                reason: 'propagated-only match must defer to the next 06:00',
+              );
+            });
+          });
+        },
+      );
+
+      test(
+        'a direct match keeps the existing 120 s throttle window even when '
+        'the propagated form is also present (the wrapper is just legacy '
+        'bookkeeping for UI listeners)',
+        () {
+          final now = DateTime(2026, 5, 10, 21, 30);
+          withClock(Clock.fixed(now), () {
+            fakeAsync((async) {
+              orchestrator
+                ..wakeExecutor = noOpExecutor
+                ..addSubscription(
+                  makeSub(matchEntityIds: {'task-direct'}),
+                );
+
+              when(
+                () => mockRepository.getAgentState('agent-1'),
+              ).thenAnswer(
+                (_) async =>
+                    AgentDomainEntity.agentState(
+                          id: 'state-1',
+                          agentId: 'agent-1',
+                          revision: 0,
+                          slots: const AgentSlots(),
+                          updatedAt: now,
+                          vectorClock: null,
+                        )
+                        as AgentStateEntity,
+              );
+
+              final controller = StreamController<Set<String>>.broadcast();
+              orchestrator.start(controller.stream);
+              addTearDown(controller.close);
+
+              // Only the bare token is in the batch — direct edit, not
+              // propagated. nextWakeAt should be the 120 s default.
+              emitTokens(async, controller, {'task-direct'});
+
+              final captured = verify(
+                () => mockRepository.upsertEntity(captureAny()),
+              ).captured;
+              final state = captured.last as AgentStateEntity;
+              expect(
+                state.nextWakeAt,
+                now.add(const Duration(seconds: 120)),
+              );
+            });
+          });
+        },
+      );
+
+      test(
+        'when the same id appears as both bare and propagated, the match '
+        'is treated as propagated (the legacy bare emission accompanies '
+        'the parent fan-out and must not collapse the deferral)',
+        () {
+          final now = DateTime(2026, 5, 10, 3, 15);
+          withClock(Clock.fixed(now), () {
+            fakeAsync((async) {
+              orchestrator
+                ..wakeExecutor = noOpExecutor
+                ..addSubscription(
+                  makeSub(matchEntityIds: {'task-mixed'}),
+                );
+
+              when(
+                () => mockRepository.getAgentState('agent-1'),
+              ).thenAnswer(
+                (_) async =>
+                    AgentDomainEntity.agentState(
+                          id: 'state-1',
+                          agentId: 'agent-1',
+                          revision: 0,
+                          slots: const AgentSlots(),
+                          updatedAt: now,
+                          vectorClock: null,
+                        )
+                        as AgentStateEntity,
+              );
+
+              final controller = StreamController<Set<String>>.broadcast();
+              orchestrator.start(controller.stream);
+              addTearDown(controller.close);
+
+              emitTokens(async, controller, {
+                'task-mixed',
+                propagatedNotification('task-mixed'),
+              });
+
+              // Pinned clock is before 06:00 today, so morning deferral
+              // resolves to today's 06:00 (not tomorrow's).
+              final captured = verify(
+                () => mockRepository.upsertEntity(captureAny()),
+              ).captured;
+              final state = captured.last as AgentStateEntity;
+              expect(state.nextWakeAt, DateTime(2026, 5, 10, 6));
+            });
+          });
+        },
+      );
+    });
   });
 }

--- a/test/features/agents/wake/wake_orchestrator_test.dart
+++ b/test/features/agents/wake/wake_orchestrator_test.dart
@@ -4539,8 +4539,7 @@ void main() {
 
       test(
         'a direct match keeps the existing 120 s throttle window even when '
-        'the propagated form is also present (the wrapper is just legacy '
-        'bookkeeping for UI listeners)',
+        'an unrelated propagated token sits alongside it in the same batch',
         () {
           final now = DateTime(2026, 5, 10, 21, 30);
           withClock(Clock.fixed(now), () {
@@ -4570,9 +4569,13 @@ void main() {
               orchestrator.start(controller.stream);
               addTearDown(controller.close);
 
-              // Only the bare token is in the batch — direct edit, not
-              // propagated. nextWakeAt should be the 120 s default.
-              emitTokens(async, controller, {'task-direct'});
+              // Direct token matches this subscription; the unrelated
+              // propagated token must not switch deferral to morning mode
+              // for the matched subscription.
+              emitTokens(async, controller, {
+                'task-direct',
+                propagatedNotification('task-unrelated'),
+              });
 
               final captured = verify(
                 () => mockRepository.upsertEntity(captureAny()),
@@ -4632,6 +4635,150 @@ void main() {
               ).captured;
               final state = captured.last as AgentStateEntity;
               expect(state.nextWakeAt, DateTime(2026, 5, 10, 6));
+            });
+          });
+        },
+      );
+
+      test(
+        'a direct edit arriving on top of a propagated-only morning '
+        'deferral escalates the throttle deadline back to now+120s — '
+        "the user's edit must not sit waiting until 06:00",
+        () {
+          final now = DateTime(2026, 5, 10, 21, 30);
+          withClock(Clock.fixed(now), () {
+            fakeAsync((async) {
+              orchestrator
+                ..wakeExecutor = noOpExecutor
+                ..addSubscription(
+                  makeSub(matchEntityIds: {'task-escalate'}),
+                );
+
+              when(
+                () => mockRepository.getAgentState('agent-1'),
+              ).thenAnswer(
+                (_) async =>
+                    AgentDomainEntity.agentState(
+                          id: 'state-1',
+                          agentId: 'agent-1',
+                          revision: 0,
+                          slots: const AgentSlots(),
+                          updatedAt: now,
+                          vectorClock: null,
+                        )
+                        as AgentStateEntity,
+              );
+
+              final controller = StreamController<Set<String>>.broadcast();
+              orchestrator.start(controller.stream);
+              addTearDown(controller.close);
+
+              // 1. Propagated-only batch arms a morning-deferred deadline.
+              emitTokens(async, controller, {
+                propagatedNotification('task-escalate'),
+              });
+
+              final firstCapture =
+                  verify(
+                        () => mockRepository.upsertEntity(captureAny()),
+                      ).captured.last
+                      as AgentStateEntity;
+              expect(firstCapture.nextWakeAt, DateTime(2026, 5, 11, 6));
+
+              // 2. Direct edit arrives while still deferred — must
+              //    escalate to now + 120 s.
+              emitTokens(async, controller, {'task-escalate'});
+
+              final escalated =
+                  verify(
+                        () => mockRepository.upsertEntity(captureAny()),
+                      ).captured.last
+                      as AgentStateEntity;
+              expect(
+                escalated.nextWakeAt,
+                now.add(const Duration(seconds: 120)),
+                reason:
+                    'a direct match coalescing onto a morning-deferred '
+                    'job must reset the throttle to the 120 s window',
+              );
+
+              // The queued job's provenance must also flip to direct so
+              // the post-execution throttle and any later drain pick the
+              // immediate path.
+              expect(queue.hasDirectQueuedJobFor('agent-1'), isTrue);
+            });
+          });
+        },
+      );
+
+      test(
+        'post-execution throttle defers to next 06:00 when only '
+        'propagated-only jobs are queued during the run — a fan-out that '
+        'arrives mid-execution must not coast in on a 120 s drain',
+        () {
+          final now = DateTime(2026, 5, 10, 21, 30);
+          withClock(Clock.fixed(now), () {
+            fakeAsync((async) {
+              final gate = Completer<Map<String, VectorClock>?>();
+              orchestrator
+                ..wakeExecutor =
+                    ((agentId, runKey, triggers, threadId) => gate.future)
+                ..addSubscription(
+                  makeSub(matchEntityIds: {'task-postexec'}),
+                );
+
+              when(
+                () => mockRepository.getAgentState('agent-1'),
+              ).thenAnswer(
+                (_) async =>
+                    AgentDomainEntity.agentState(
+                          id: 'state-1',
+                          agentId: 'agent-1',
+                          revision: 0,
+                          slots: const AgentSlots(),
+                          updatedAt: now,
+                          vectorClock: null,
+                        )
+                        as AgentStateEntity,
+              );
+
+              // Drive the executor mid-flight by direct-enqueuing a job
+              // (bypasses the _onBatch deferral) so the running flag is
+              // set before our propagated batch arrives.
+              queue.enqueue(
+                makeJob(
+                  triggerTokens: {'task-postexec'},
+                  // ignore: avoid_redundant_argument_values
+                  runKey: 'rk-1',
+                ),
+              );
+              unawaited(orchestrator.processNext());
+              async.flushMicrotasks();
+              expect(runner.isRunning('agent-1'), isTrue);
+
+              final controller = StreamController<Set<String>>.broadcast();
+              orchestrator.start(controller.stream);
+              addTearDown(controller.close);
+
+              // Propagated-only batch arrives during execution → queued
+              // with hasDirectMatch=false.
+              emitTokens(async, controller, {
+                propagatedNotification('task-postexec'),
+              });
+              expect(queue.hasDirectQueuedJobFor('agent-1'), isFalse);
+
+              // Finish execution. The post-execution throttle must use
+              // morning, not 120 s.
+              gate.complete(const {});
+              async.flushMicrotasks();
+
+              final captured =
+                  verify(
+                    () => mockRepository.upsertEntity(captureAny()),
+                  ).captured.whereType<AgentStateEntity>().lastWhere(
+                    (s) => s.nextWakeAt != null,
+                  );
+              expect(captured.nextWakeAt, DateTime(2026, 5, 11, 6));
             });
           });
         },

--- a/test/features/agents/wake/wake_throttle_coordinator_test.dart
+++ b/test/features/agents/wake/wake_throttle_coordinator_test.dart
@@ -368,6 +368,94 @@ void main() {
       });
     });
 
+    test(
+      'setDeadline honours customDeadline and persists that exact timestamp '
+      'instead of now+throttleWindow',
+      () {
+        final now = DateTime(2024, 3, 15, 10, 30);
+        final morning = DateTime(2024, 3, 16, 6);
+
+        fakeAsync((async) {
+          final coordinator = createCoordinator(
+            onDrainRequested: () async {},
+          );
+
+          try {
+            withClock(Clock.fixed(now), () {
+              unawaited(
+                coordinator.setDeadline('agent-1', customDeadline: morning),
+              );
+            });
+            async.flushMicrotasks();
+
+            final captured =
+                verify(
+                      () => repository.upsertEntity(captureAny()),
+                    ).captured.single
+                    as AgentStateEntity;
+
+            expect(
+              captured.nextWakeAt,
+              morning,
+              reason:
+                  'customDeadline must be persisted verbatim — propagated '
+                  'matches need a precise next-06:00 target',
+            );
+            expect(
+              withClock(
+                Clock.fixed(now),
+                () => coordinator.isThrottled('agent-1'),
+              ),
+              isTrue,
+            );
+            expect(coordinator.deadlineFor('agent-1'), morning);
+          } finally {
+            coordinator.dispose();
+          }
+        });
+      },
+    );
+
+    test(
+      'setDeadline silently ignores a customDeadline that is in the past — '
+      'a stale timestamp must not collapse a propagated wake into an '
+      'immediate fire',
+      () {
+        final now = DateTime(2024, 3, 15, 10, 30);
+        final yesterday = now.subtract(const Duration(days: 1));
+
+        fakeAsync((async) {
+          final coordinator = createCoordinator(
+            onDrainRequested: () async {},
+          );
+
+          try {
+            withClock(Clock.fixed(now), () {
+              unawaited(
+                coordinator.setDeadline(
+                  'agent-1',
+                  customDeadline: yesterday,
+                ),
+              );
+            });
+            async.flushMicrotasks();
+
+            verifyNever(() => repository.upsertEntity(any()));
+            expect(coordinator.deadlineFor('agent-1'), isNull);
+            expect(
+              withClock(
+                Clock.fixed(now),
+                () => coordinator.isThrottled('agent-1'),
+              ),
+              isFalse,
+            );
+          } finally {
+            coordinator.dispose();
+          }
+        });
+      },
+    );
+
     test('drains after throttle window even when persistence fails', () {
       final now = DateTime(2024, 3, 15, 10, 30);
       var drainRequests = 0;

--- a/test/features/projects/repository/project_repository_test.dart
+++ b/test/features/projects/repository/project_repository_test.dart
@@ -606,13 +606,19 @@ void main() {
       expect(captured.toId, 'task-001');
       expect(captured.hidden, isNull);
 
-      // Verify notifications include entity IDs and project token
+      // Verify notifications include entity IDs, the project token, and
+      // the propagated form so the wake orchestrator defers the parent
+      // project agent's wake to the next 06:00 instead of firing immediately
+      // on every task link.
       verify(
         () => mockNotifications.notify({
           'project-001',
           'task-001',
           projectNotification,
           projectEntityUpdateNotification('project-001'),
+          propagatedNotification(
+            projectEntityUpdateNotification('project-001'),
+          ),
         }),
       ).called(1);
 
@@ -787,7 +793,11 @@ void main() {
         verify(() => mockDb.upsertEntryLink(any())).called(2);
         // Sync enqueued for both delete and create after commit
         verify(() => mockOutboxService.enqueueMessage(any())).called(2);
-        // Notifications include old project, new project, task, and token
+        // Notifications include the old project, new project, task, and
+        // the bare + propagated forms of each project token so wake
+        // orchestrator subscriptions on the project IDs defer to morning
+        // (relinking is a task-link side-effect, not a direct project
+        // edit).
         verify(
           () => mockNotifications.notify({
             'project-old',
@@ -796,6 +806,12 @@ void main() {
             projectNotification,
             projectEntityUpdateNotification('project-old'),
             projectEntityUpdateNotification('project-001'),
+            propagatedNotification(
+              projectEntityUpdateNotification('project-old'),
+            ),
+            propagatedNotification(
+              projectEntityUpdateNotification('project-001'),
+            ),
           }),
         ).called(1);
       },
@@ -933,6 +949,9 @@ void main() {
           'task-001',
           projectNotification,
           projectEntityUpdateNotification('project-001'),
+          propagatedNotification(
+            projectEntityUpdateNotification('project-001'),
+          ),
         }),
       ).called(1);
       // Verify sync was enqueued

--- a/test/logic/persistence_logic_update_test.dart
+++ b/test/logic/persistence_logic_update_test.dart
@@ -66,6 +66,10 @@ class _GeneratedUpdateDbEntityScenario {
     ..._expectedAffectedIds(kind, 'entity-$seed'),
     ?linkedId,
     ...parentIds,
+    // Each parent ID is also emitted in propagated form so the wake
+    // orchestrator can defer parent-fan-out matches to the next 06:00
+    // instead of treating them as direct edits.
+    for (final id in parentIds) propagatedNotification(id),
     labelUsageNotification,
   };
 

--- a/test/services/db_notification_test.dart
+++ b/test/services/db_notification_test.dart
@@ -1109,4 +1109,47 @@ void main() {
       expect(innerCapture, isTrue);
     });
   });
+
+  group('propagated notification helpers', () {
+    test(
+      'propagatedNotification round-trips via unwrapPropagatedNotification',
+      () {
+        const inner = 'task-123';
+        final wrapped = propagatedNotification(inner);
+
+        expect(wrapped.startsWith(propagatedNotificationPrefix), isTrue);
+        expect(isPropagatedNotification(wrapped), isTrue);
+        expect(unwrapPropagatedNotification(wrapped), inner);
+      },
+    );
+
+    test('isPropagatedNotification returns false for bare tokens', () {
+      expect(isPropagatedNotification('task-123'), isFalse);
+      expect(isPropagatedNotification(''), isFalse);
+      expect(
+        isPropagatedNotification(projectEntityUpdateNotification('p-1')),
+        isFalse,
+        reason: 'project update tokens use a different prefix',
+      );
+    });
+
+    test(
+      'unwrapPropagatedNotification leaves bare tokens unchanged so callers '
+      'can defensively unwrap without checking the prefix first',
+      () {
+        expect(unwrapPropagatedNotification('task-123'), 'task-123');
+      },
+    );
+
+    test(
+      'wrapping a project-update token survives a round-trip — the wake '
+      'orchestrator relies on this to detect linkTaskToProject side-effects',
+      () {
+        final inner = projectEntityUpdateNotification('project-42');
+        final wrapped = propagatedNotification(inner);
+
+        expect(unwrapPropagatedNotification(wrapped), inner);
+      },
+    );
+  });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notifications now distinguish direct vs propagated matches and can defer propagated-only work to the next configured morning (06:00) for better batching.
  * Added scheduling helper to compute the next occurrence of a given clock time.
  * Wake queue now tracks whether queued items have a direct match to drive throttle/escalation.

* **Bug Fixes**
  * Wake-row UI now falls back to project title when a task title is empty.

* **Tests**
  * Added unit and widget tests covering propagation, throttling, scheduling, and UI fallback.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matthiasn/lotti/pull/3135)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->