### PR TITLE
refactor: remove DateTime.now() occurrences & mock cleanup

### DIFF
--- a/lib/features/ai_chat/services/system_message_service.dart
+++ b/lib/features/ai_chat/services/system_message_service.dart
@@ -13,14 +13,18 @@ final systemMessageServiceProvider = Provider<SystemMessageService>((ref) {
 /// Builds the system message (system prompt) injected into AI requests.
 ///
 /// Notes:
-/// - Currently uses `DateTime.now()` to include today’s date for time-based
-///   reasoning in the prompt. If determinism is required for tests, consider
-///   injecting a clock similar to the `Now` typedef in the message processor.
+/// - Uses an injectable clock to include today’s date for time-based
+///   reasoning in the prompt. Tests pass a fixed [DateTime] to make the
+///   resulting prompt deterministic.
 /// - The content is a template and can be externalized or localized in the
 ///   future without changing call sites.
 class SystemMessageService {
+  SystemMessageService({DateTime Function()? now}) : _now = now ?? DateTime.now;
+
+  final DateTime Function() _now;
+
   String getSystemMessage() {
-    final now = DateTime.now();
+    final now = _now();
     final today = now.ymd;
     final tzName = now.timeZoneName;
 

--- a/lib/services/ip_geolocation_service.dart
+++ b/lib/services/ip_geolocation_service.dart
@@ -25,7 +25,7 @@ class IpGeolocationService {
     DateTime Function()? clock,
   }) async {
     final client = httpClient ?? http.Client();
-    final nowFn = clock ?? DateTime.now;
+    final now = (clock ?? DateTime.now)();
     try {
       final response = await client
           .get(
@@ -41,8 +41,6 @@ class IpGeolocationService {
         final longitude = (data['longitude'] as num?)?.toDouble();
 
         if (latitude != null && longitude != null) {
-          final now = nowFn();
-
           return Geolocation(
             createdAt: now,
             latitude: latitude,
@@ -53,7 +51,7 @@ class IpGeolocationService {
             ),
             timezone: data['timezone'] as String? ?? now.timeZoneName,
             utcOffset: data['utc_offset'] != null
-                ? _parseUtcOffset(data['utc_offset'] as String, nowFn)
+                ? _parseUtcOffset(data['utc_offset'] as String, now)
                 : now.timeZoneOffset.inMinutes,
             accuracy: _ipLocationAccuracy,
           );
@@ -67,10 +65,10 @@ class IpGeolocationService {
       );
     }
 
-    return _getLocationFromIpApiFallback(httpClient: client, clock: nowFn);
+    return _getLocationFromIpApiFallback(httpClient: client, now: now);
   }
 
-  static int _parseUtcOffset(String offset, DateTime Function() nowFn) {
+  static int _parseUtcOffset(String offset, DateTime now) {
     // Parse offset format like "+0200" or "-0430"
     try {
       if (offset.isEmpty) return 0;
@@ -91,13 +89,13 @@ class IpGeolocationService {
       );
     }
 
-    return nowFn().timeZoneOffset.inMinutes;
+    return now.timeZoneOffset.inMinutes;
   }
 
   // Alternative fallback using ip-api.com
   static Future<Geolocation?> _getLocationFromIpApiFallback({
     required http.Client httpClient,
-    required DateTime Function() clock,
+    required DateTime now,
   }) async {
     try {
       final response = await httpClient
@@ -115,8 +113,6 @@ class IpGeolocationService {
           final longitude = (data['lon'] as num?)?.toDouble();
 
           if (latitude != null && longitude != null) {
-            final now = clock();
-
             return Geolocation(
               createdAt: now,
               latitude: latitude,

--- a/lib/services/ip_geolocation_service.dart
+++ b/lib/services/ip_geolocation_service.dart
@@ -22,8 +22,10 @@ class IpGeolocationService {
 
   static Future<Geolocation?> getLocationFromIp({
     http.Client? httpClient,
+    DateTime Function()? clock,
   }) async {
     final client = httpClient ?? http.Client();
+    final nowFn = clock ?? DateTime.now;
     try {
       final response = await client
           .get(
@@ -39,7 +41,7 @@ class IpGeolocationService {
         final longitude = (data['longitude'] as num?)?.toDouble();
 
         if (latitude != null && longitude != null) {
-          final now = DateTime.now();
+          final now = nowFn();
 
           return Geolocation(
             createdAt: now,
@@ -51,7 +53,7 @@ class IpGeolocationService {
             ),
             timezone: data['timezone'] as String? ?? now.timeZoneName,
             utcOffset: data['utc_offset'] != null
-                ? _parseUtcOffset(data['utc_offset'] as String)
+                ? _parseUtcOffset(data['utc_offset'] as String, nowFn)
                 : now.timeZoneOffset.inMinutes,
             accuracy: _ipLocationAccuracy,
           );
@@ -65,10 +67,10 @@ class IpGeolocationService {
       );
     }
 
-    return _getLocationFromIpApiFallback(httpClient: client);
+    return _getLocationFromIpApiFallback(httpClient: client, clock: nowFn);
   }
 
-  static int _parseUtcOffset(String offset) {
+  static int _parseUtcOffset(String offset, DateTime Function() nowFn) {
     // Parse offset format like "+0200" or "-0430"
     try {
       if (offset.isEmpty) return 0;
@@ -89,12 +91,13 @@ class IpGeolocationService {
       );
     }
 
-    return DateTime.now().timeZoneOffset.inMinutes;
+    return nowFn().timeZoneOffset.inMinutes;
   }
 
   // Alternative fallback using ip-api.com
   static Future<Geolocation?> _getLocationFromIpApiFallback({
     required http.Client httpClient,
+    required DateTime Function() clock,
   }) async {
     try {
       final response = await httpClient
@@ -112,7 +115,7 @@ class IpGeolocationService {
           final longitude = (data['lon'] as num?)?.toDouble();
 
           if (latitude != null && longitude != null) {
-            final now = DateTime.now();
+            final now = clock();
 
             return Geolocation(
               createdAt: now,

--- a/lib/utils/timezone.dart
+++ b/lib/utils/timezone.dart
@@ -6,12 +6,14 @@ import 'package:lotti/utils/platform.dart';
 ///
 /// [overrideIsTestEnv] is intended for tests only — it bypasses the
 /// `isTestEnv` early-return so the platform-specific branches can be
-/// exercised.
+/// exercised. [clock] is also test-only and lets callers inject a fixed
+/// [DateTime] so the result is deterministic.
 Future<String> getLocalTimezone({
   String? linuxTimezoneFilePath,
   bool? overrideIsTestEnv,
+  DateTime Function()? clock,
 }) async {
-  final now = DateTime.now();
+  final now = (clock ?? DateTime.now)();
   final effectiveIsTestEnv = overrideIsTestEnv ?? isTestEnv;
 
   if (effectiveIsTestEnv) {

--- a/test/database/open_db_connection_test.dart
+++ b/test/database/open_db_connection_test.dart
@@ -150,10 +150,20 @@ void main() {
       await db.customSelect('SELECT 1 AS one').getSingle();
       await SlowQueryInterceptor.flushFileSinkForTest();
 
-      final date = DateTime.now().toIso8601String().substring(0, 10);
-      final logFile = File('${base.path}/logs/slow_queries-$date.log');
+      final logDir = Directory('${base.path}/logs');
+      final logFiles = logDir.existsSync()
+          ? logDir
+                .listSync()
+                .whereType<File>()
+                .where(
+                  (f) =>
+                      f.uri.pathSegments.last.startsWith('slow_queries-') &&
+                      f.uri.pathSegments.last.endsWith('.log'),
+                )
+                .toList()
+          : <File>[];
 
-      expect(logFile.existsSync(), isFalse);
+      expect(logFiles, isEmpty);
 
       await db.close();
     },
@@ -181,11 +191,18 @@ void main() {
       await db.customSelect('SELECT 1 AS one').getSingle();
       await SlowQueryInterceptor.flushFileSinkForTest();
 
-      final date = DateTime.now().toIso8601String().substring(0, 10);
-      final logFile = File('${base.path}/logs/slow_queries-$date.log');
+      final logFiles = Directory('${base.path}/logs')
+          .listSync()
+          .whereType<File>()
+          .where(
+            (f) =>
+                f.uri.pathSegments.last.startsWith('slow_queries-') &&
+                f.uri.pathSegments.last.endsWith('.log'),
+          )
+          .toList();
 
-      expect(logFile.existsSync(), isTrue);
-      final contents = await logFile.readAsString();
+      expect(logFiles, hasLength(1));
+      final contents = await logFiles.single.readAsString();
       expect(contents, contains('[test_slow.sqlite] select'));
       expect(contents, contains('SELECT 1 AS one'));
 

--- a/test/features/agents/state/soul_query_providers_test.dart
+++ b/test/features/agents/state/soul_query_providers_test.dart
@@ -2,17 +2,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
-import 'package:lotti/features/agents/service/agent_template_service.dart';
-import 'package:lotti/features/agents/service/soul_document_service.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/agents/state/soul_query_providers.dart';
 import 'package:mocktail/mocktail.dart';
 
+import '../../../mocks/mocks.dart';
 import '../test_utils.dart';
-
-class MockAgentTemplateService extends Mock implements AgentTemplateService {}
-
-class MockSoulDocumentService extends Mock implements SoulDocumentService {}
 
 void main() {
   late MockSoulDocumentService mockService;

--- a/test/features/agents/ui/agent_soul_detail_page_test.dart
+++ b/test/features/agents/ui/agent_soul_detail_page_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/misc.dart' show Override;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
-import 'package:lotti/features/agents/service/soul_document_service.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/agents/state/soul_query_providers.dart';
 import 'package:lotti/features/agents/ui/agent_soul_detail_page.dart';
@@ -12,10 +11,9 @@ import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:mocktail/mocktail.dart';
 
+import '../../../mocks/mocks.dart';
 import '../../../widget_test_utils.dart';
 import '../test_utils.dart';
-
-class MockSoulDocumentService extends Mock implements SoulDocumentService {}
 
 void main() {
   late MockSoulDocumentService mockSoulService;

--- a/test/features/ai/conversation/conversation_repository_test.dart
+++ b/test/features/ai/conversation/conversation_repository_test.dart
@@ -10,6 +10,8 @@ import 'package:lotti/features/ai/repository/ollama_inference_repository.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openai_dart/openai_dart.dart';
 
+import '../../../mocks/mocks.dart';
+
 class MockOllamaInferenceRepository extends Mock
     implements OllamaInferenceRepository {}
 
@@ -19,9 +21,6 @@ class MockConversationStrategy extends Mock implements ConversationStrategy {}
 
 class FakeChatCompletionMessageToolCall extends Fake
     implements ChatCompletionMessageToolCall {}
-
-class FakeAiConfigInferenceProvider extends Fake
-    implements AiConfigInferenceProvider {}
 
 class FakeConversationManager extends Fake implements ConversationManager {}
 

--- a/test/features/ai/functions/lotti_batch_checklist_handler_test.dart
+++ b/test/features/ai/functions/lotti_batch_checklist_handler_test.dart
@@ -6,16 +6,12 @@ import 'package:lotti/classes/task.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/features/ai/functions/function_handler.dart';
 import 'package:lotti/features/ai/functions/lotti_batch_checklist_handler.dart';
-import 'package:lotti/features/ai/services/auto_checklist_service.dart';
 import 'package:lotti/get_it.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openai_dart/openai_dart.dart';
 import 'package:uuid/uuid.dart';
 
 import '../../../mocks/mocks.dart';
-
-// Mocks
-class MockAutoChecklistService extends Mock implements AutoChecklistService {}
 
 const _uuid = Uuid();
 

--- a/test/features/ai/functions/lotti_checklist_handler_guard_test.dart
+++ b/test/features/ai/functions/lotti_checklist_handler_guard_test.dart
@@ -3,16 +3,12 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/features/ai/functions/lotti_checklist_handler.dart';
-import 'package:lotti/features/ai/services/auto_checklist_service.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/dev_logger.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:openai_dart/openai_dart.dart';
 import 'package:uuid/uuid.dart';
 
 import '../../../mocks/mocks.dart';
-
-class MockAutoChecklistService extends Mock implements AutoChecklistService {}
 
 const _uuid = Uuid();
 

--- a/test/features/ai/functions/lotti_checklist_handler_test.dart
+++ b/test/features/ai/functions/lotti_checklist_handler_test.dart
@@ -5,14 +5,11 @@ import 'package:lotti/classes/task.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/features/ai/functions/function_handler.dart';
 import 'package:lotti/features/ai/functions/lotti_checklist_handler.dart';
-import 'package:lotti/features/ai/services/auto_checklist_service.dart';
 import 'package:lotti/get_it.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openai_dart/openai_dart.dart';
 
 import '../../../mocks/mocks.dart';
-
-class MockAutoChecklistService extends Mock implements AutoChecklistService {}
 
 void main() {
   group('LottiChecklistItemHandler', () {

--- a/test/features/ai/functions/task_due_date_handler_test.dart
+++ b/test/features/ai/functions/task_due_date_handler_test.dart
@@ -4,14 +4,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
-import 'package:lotti/features/ai/conversation/conversation_manager.dart';
 import 'package:lotti/features/ai/functions/task_due_date_handler.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openai_dart/openai_dart.dart';
 
 import '../../../mocks/mocks.dart';
-
-class MockConversationManager extends Mock implements ConversationManager {}
 
 enum _GeneratedCurrentDueDateKind { none, same, different }
 

--- a/test/features/ai/functions/task_estimate_handler_test.dart
+++ b/test/features/ai/functions/task_estimate_handler_test.dart
@@ -4,14 +4,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
-import 'package:lotti/features/ai/conversation/conversation_manager.dart';
 import 'package:lotti/features/ai/functions/task_estimate_handler.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openai_dart/openai_dart.dart';
 
 import '../../../mocks/mocks.dart';
-
-class MockConversationManager extends Mock implements ConversationManager {}
 
 enum _GeneratedCurrentEstimateKind { none, zero, same, different }
 

--- a/test/features/ai/functions/task_priority_handler_test.dart
+++ b/test/features/ai/functions/task_priority_handler_test.dart
@@ -4,14 +4,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
-import 'package:lotti/features/ai/conversation/conversation_manager.dart';
 import 'package:lotti/features/ai/functions/task_priority_handler.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openai_dart/openai_dart.dart';
 
 import '../../../mocks/mocks.dart';
-
-class MockConversationManager extends Mock implements ConversationManager {}
 
 enum _GeneratedPriorityRequestShape {
   exact,

--- a/test/features/ai/repository/ai_config_repository_cascade_delete_test.dart
+++ b/test/features/ai/repository/ai_config_repository_cascade_delete_test.dart
@@ -9,10 +9,9 @@ import 'package:lotti/get_it.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../helpers/fallbacks.dart';
+import '../../../mocks/mocks.dart';
 
 class MockAiConfigDb extends Mock implements AiConfigDb {}
-
-class MockOutboxService extends Mock implements OutboxService {}
 
 void main() {
   late MockAiConfigDb mockDb;

--- a/test/features/ai/repository/ai_config_repository_integration_test.dart
+++ b/test/features/ai/repository/ai_config_repository_integration_test.dart
@@ -8,7 +8,7 @@ import 'package:lotti/features/sync/model/sync_message.dart';
 import 'package:lotti/features/sync/outbox/outbox_service.dart';
 import 'package:mocktail/mocktail.dart';
 
-class MockOutboxService extends Mock implements OutboxService {}
+import '../../../mocks/mocks.dart';
 
 void main() {
   late GetIt getIt;

--- a/test/features/ai/repository/ai_config_repository_test.dart
+++ b/test/features/ai/repository/ai_config_repository_test.dart
@@ -10,9 +10,9 @@ import 'package:lotti/features/sync/model/sync_message.dart';
 import 'package:lotti/features/sync/outbox/outbox_service.dart';
 import 'package:mocktail/mocktail.dart';
 
-class MockAiConfigDb extends Mock implements AiConfigDb {}
+import '../../../mocks/mocks.dart';
 
-class MockOutboxService extends Mock implements OutboxService {}
+class MockAiConfigDb extends Mock implements AiConfigDb {}
 
 void main() {
   late GetIt getIt;

--- a/test/features/ai/repository/ai_input_repository_language_test.dart
+++ b/test/features/ai/repository/ai_input_repository_language_test.dart
@@ -15,12 +15,8 @@ import 'package:mocktail/mocktail.dart';
 import '../../../mocks/mocks.dart';
 import '../test_utils.dart';
 
-class MockJournalDb extends Mock implements JournalDb {}
-
 class MockTaskProgressRepository extends Mock
     implements TaskProgressRepository {}
-
-class MockPersistenceLogic extends Mock implements PersistenceLogic {}
 
 void main() {
   late AiInputRepository repository;

--- a/test/features/ai/repository/ai_input_repository_suppressed_ids_test.dart
+++ b/test/features/ai/repository/ai_input_repository_suppressed_ids_test.dart
@@ -14,8 +14,6 @@ import 'package:mocktail/mocktail.dart';
 import '../../../mocks/mocks.dart';
 import '../test_utils.dart';
 
-class MockJournalDb extends Mock implements JournalDb {}
-
 class TestAiInputRepo extends AiInputRepository {
   TestAiInputRepo(super.ref, {required super.projectRepository})
     : super(taskSummaryResolver: TaskSummaryResolver(null));

--- a/test/features/ai/repository/ai_input_repository_test.dart
+++ b/test/features/ai/repository/ai_input_repository_test.dart
@@ -41,9 +41,6 @@ class MockTaskProgressRepository extends Mock
   }
 }
 
-// Mock for PersistenceLogic
-class MockPersistenceLogic extends Mock implements PersistenceLogic {}
-
 // Mock classes for parameters
 class FakeId extends Mock {}
 

--- a/test/features/ai/repository/ai_linked_task_context_test.dart
+++ b/test/features/ai/repository/ai_linked_task_context_test.dart
@@ -21,8 +21,6 @@ import 'package:mocktail/mocktail.dart';
 
 import '../../../mocks/mocks.dart';
 
-class MockJournalDb extends Mock implements JournalDb {}
-
 class MockTaskProgressRepository extends Mock
     implements TaskProgressRepository {
   @override
@@ -37,10 +35,6 @@ class MockTaskProgressRepository extends Mock
     );
   }
 }
-
-class MockPersistenceLogic extends Mock implements PersistenceLogic {}
-
-class MockEntitiesCacheService extends Mock implements EntitiesCacheService {}
 
 void main() {
   group('AiLinkedTaskContext', () {

--- a/test/features/ai/repository/cloud_inference_repository_test.dart
+++ b/test/features/ai/repository/cloud_inference_repository_test.dart
@@ -38,9 +38,6 @@ class FakeRequest extends Fake implements http.Request {}
 
 class FakeGeminiThinkingConfig extends Fake implements GeminiThinkingConfig {}
 
-class FakeAiConfigInferenceProvider extends Fake
-    implements AiConfigInferenceProvider {}
-
 void main() {
   setUpAll(() {
     // Register fallback values for mocktail

--- a/test/features/ai/repository/cloud_inference_wrapper_test.dart
+++ b/test/features/ai/repository/cloud_inference_wrapper_test.dart
@@ -3,16 +3,11 @@ import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/model/gemini_tool_call.dart';
-import 'package:lotti/features/ai/repository/cloud_inference_repository.dart';
 import 'package:lotti/features/ai/repository/cloud_inference_wrapper.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openai_dart/openai_dart.dart';
 
-class MockCloudInferenceRepository extends Mock
-    implements CloudInferenceRepository {}
-
-class FakeAiConfigInferenceProvider extends Fake
-    implements AiConfigInferenceProvider {}
+import '../../../mocks/mocks.dart';
 
 class FakeChatCompletionTool extends Fake implements ChatCompletionTool {}
 

--- a/test/features/ai/repository/mistral_inference_repository_test.dart
+++ b/test/features/ai/repository/mistral_inference_repository_test.dart
@@ -15,8 +15,6 @@ import '../../../mocks/mocks.dart';
 
 class FakeRequest extends Fake implements http.Request {}
 
-class FakeBaseRequest extends Fake implements http.BaseRequest {}
-
 /// Creates a mock SSE stream response for testing
 http.StreamedResponse createSseStreamedResponse({
   required List<Map<String, dynamic>> events,

--- a/test/features/ai/repository/ollama_inference_repository_test.dart
+++ b/test/features/ai/repository/ollama_inference_repository_test.dart
@@ -9,7 +9,7 @@ import 'package:lotti/features/ai/repository/ollama_inference_repository.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openai_dart/openai_dart.dart';
 
-class MockHttpClient extends Mock implements http.Client {}
+import '../../../mocks/mocks.dart';
 
 class MockStreamedResponse extends Mock implements http.StreamedResponse {}
 

--- a/test/features/ai/repository/ollama_model_management_test.dart
+++ b/test/features/ai/repository/ollama_model_management_test.dart
@@ -13,13 +13,9 @@ import 'package:lotti/features/ai/repository/gemini_inference_repository.dart';
 import 'package:lotti/features/ai/repository/ollama_inference_repository.dart';
 import 'package:mocktail/mocktail.dart';
 
+import '../../../mocks/mocks.dart';
 import '../../../test_utils/retry_fake_time.dart';
 import '../test_utils.dart';
-
-class MockHttpClient extends Mock implements http.Client {}
-
-// Add this fake for mocktail
-class FakeBaseRequest extends Fake implements http.BaseRequest {}
 
 void main() {
   setUpAll(() {

--- a/test/features/ai/repository/unified_ai_inference_repository_test.dart
+++ b/test/features/ai/repository/unified_ai_inference_repository_test.dart
@@ -23,7 +23,6 @@ import 'package:lotti/features/ai/repository/ai_input_repository.dart'
     show aiInputRepositoryProvider;
 import 'package:lotti/features/ai/repository/cloud_inference_repository.dart';
 import 'package:lotti/features/ai/repository/unified_ai_inference_repository.dart';
-import 'package:lotti/features/ai/services/auto_checklist_service.dart';
 import 'package:lotti/features/ai/services/checklist_completion_service.dart';
 import 'package:lotti/features/ai/state/inference_status_controller.dart';
 import 'package:lotti/features/categories/repository/categories_repository.dart'
@@ -44,11 +43,6 @@ import 'package:openai_dart/openai_dart.dart';
 import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
 import '../test_utils.dart';
-
-class MockCloudInferenceRepository extends Mock
-    implements CloudInferenceRepository {}
-
-class MockAutoChecklistService extends Mock implements AutoChecklistService {}
 
 class MockPromptCapabilityFilter extends Mock
     implements PromptCapabilityFilter {}

--- a/test/features/ai/repository/voxtral_inference_repository_test.dart
+++ b/test/features/ai/repository/voxtral_inference_repository_test.dart
@@ -18,8 +18,6 @@ import '../../../test_utils/retry_fake_time.dart';
 
 class FakeRequest extends Fake implements http.Request {}
 
-class FakeBaseRequest extends Fake implements http.BaseRequest {}
-
 /// Creates a mock SSE stream response for testing
 http.StreamedResponse createSseStreamedResponse({
   required List<Map<String, dynamic>> events,

--- a/test/features/ai/repository/whisper_inference_repository_test.dart
+++ b/test/features/ai/repository/whisper_inference_repository_test.dart
@@ -11,9 +11,8 @@ import 'package:lotti/features/ai/repository/whisper_inference_repository.dart';
 import 'package:lotti/features/ai/state/consts.dart';
 import 'package:mocktail/mocktail.dart';
 
+import '../../../mocks/mocks.dart';
 import '../../../test_utils/retry_fake_time.dart';
-
-class MockHttpClient extends Mock implements http.Client {}
 
 class FakeUri extends Fake implements Uri {}
 

--- a/test/features/ai/ui/ai_response_summary_modal_test.dart
+++ b/test/features/ai/ui/ai_response_summary_modal_test.dart
@@ -6,16 +6,10 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/ai/state/consts.dart';
 import 'package:lotti/features/ai/ui/ai_response_summary_modal.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
+import '../../../mocks/mocks.dart';
 import '../../../test_helper.dart';
-
-class MockUrlLauncher extends Mock
-    with MockPlatformInterfaceMixin
-    implements UrlLauncherPlatform {}
-
-class FakeLaunchOptions extends Fake implements LaunchOptions {}
 
 // Note: We don't need to implement the mocks for clipboard functionality since
 // we're only testing for the presence of UI elements

--- a/test/features/ai/ui/ai_response_summary_test.dart
+++ b/test/features/ai/ui/ai_response_summary_test.dart
@@ -7,16 +7,10 @@ import 'package:lotti/features/ai/state/consts.dart';
 import 'package:lotti/features/ai/ui/ai_response_summary.dart';
 import 'package:lotti/features/ai/ui/generated_prompt_card.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
+import '../../../mocks/mocks.dart';
 import '../../../test_helper.dart';
-
-class MockUrlLauncher extends Mock
-    with MockPlatformInterfaceMixin
-    implements UrlLauncherPlatform {}
-
-class FakeLaunchOptions extends Fake implements LaunchOptions {}
 
 void main() {
   group('AiResponseSummary', () {

--- a/test/features/ai/ui/ollama_model_installation_test.dart
+++ b/test/features/ai/ui/ollama_model_installation_test.dart
@@ -9,8 +9,7 @@ import 'package:lotti/features/ai/ui/unified_ai_progress_view.dart';
 import 'package:lotti/l10n/app_localizations.dart';
 import 'package:mocktail/mocktail.dart';
 
-class MockCloudInferenceRepository extends Mock
-    implements CloudInferenceRepository {}
+import '../../../mocks/mocks.dart';
 
 class MockAiConfigByTypeController extends AiConfigByTypeController {
   MockAiConfigByTypeController(this._configs);

--- a/test/features/ai/ui/unified_ai_progress_view_controller_test.dart
+++ b/test/features/ai/ui/unified_ai_progress_view_controller_test.dart
@@ -19,9 +19,6 @@ import '../../../mocks/mocks.dart';
 class MockUnifiedAiInferenceRepository extends Mock
     implements UnifiedAiInferenceRepository {}
 
-class MockCloudInferenceRepository extends Mock
-    implements CloudInferenceRepository {}
-
 void main() {
   late AiConfigPrompt testPromptConfig;
   late MockUnifiedAiInferenceRepository mockRepository;

--- a/test/features/ai/ui/unified_ai_progress_view_test.dart
+++ b/test/features/ai/ui/unified_ai_progress_view_test.dart
@@ -29,9 +29,6 @@ import '../test_utils.dart';
 class MockUnifiedAiInferenceRepository extends Mock
     implements UnifiedAiInferenceRepository {}
 
-class MockCloudInferenceRepository extends Mock
-    implements CloudInferenceRepository {}
-
 /// Helper to create override for UnifiedAiController with a specific state.
 Override unifiedAiControllerOverride(UnifiedAiState initialState) {
   return unifiedAiControllerProvider.overrideWithBuild(

--- a/test/features/ai_chat/repository/chat_message_processor_accumulate_tool_calls_test.dart
+++ b/test/features/ai_chat/repository/chat_message_processor_accumulate_tool_calls_test.dart
@@ -1,13 +1,9 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:lotti/features/ai/repository/cloud_inference_repository.dart';
 import 'package:lotti/features/ai_chat/repository/chat_message_processor.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openai_dart/openai_dart.dart';
 
 import '../../../mocks/mocks.dart';
-
-class MockCloudInferenceRepository extends Mock
-    implements CloudInferenceRepository {}
 
 void main() {
   group('accumulateToolCalls', () {

--- a/test/features/ai_chat/repository/chat_message_processor_test.dart
+++ b/test/features/ai_chat/repository/chat_message_processor_test.dart
@@ -4,7 +4,6 @@ import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
-import 'package:lotti/features/ai/repository/cloud_inference_repository.dart';
 import 'package:lotti/features/ai_chat/models/chat_message.dart';
 import 'package:lotti/features/ai_chat/models/task_summary_tool.dart';
 import 'package:lotti/features/ai_chat/repository/chat_message_processor.dart';
@@ -12,9 +11,6 @@ import 'package:mocktail/mocktail.dart';
 import 'package:openai_dart/openai_dart.dart';
 
 import '../../../mocks/mocks.dart';
-
-class MockCloudInferenceRepository extends Mock
-    implements CloudInferenceRepository {}
 
 void main() {
   setUpAll(() {

--- a/test/features/ai_chat/repository/chat_repository_test.dart
+++ b/test/features/ai_chat/repository/chat_repository_test.dart
@@ -5,7 +5,6 @@ import 'dart:async';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
-import 'package:lotti/features/ai/repository/cloud_inference_repository.dart';
 import 'package:lotti/features/ai_chat/models/chat_exceptions.dart';
 import 'package:lotti/features/ai_chat/models/chat_message.dart';
 import 'package:lotti/features/ai_chat/models/task_summary_tool.dart';
@@ -15,9 +14,6 @@ import 'package:mocktail/mocktail.dart';
 import 'package:openai_dart/openai_dart.dart';
 
 import '../../../mocks/mocks.dart';
-
-class MockCloudInferenceRepository extends Mock
-    implements CloudInferenceRepository {}
 
 void main() {
   setUpAll(() {

--- a/test/features/ai_chat/repository/chat_repository_test.dart
+++ b/test/features/ai_chat/repository/chat_repository_test.dart
@@ -62,7 +62,9 @@ void main() {
         cloudInferenceRepository: mockCloudInferenceRepository,
         taskSummaryRepository: mockTaskSummaryRepository,
         aiConfigRepository: mockAiConfigRepository,
-        systemMessageService: SystemMessageService(),
+        systemMessageService: SystemMessageService(
+          now: () => DateTime(2024, 3, 15),
+        ),
         loggingService: mockLoggingService,
       );
     });
@@ -1210,8 +1212,7 @@ void main() {
 
         expect(capturedSystemMessage, isNotNull);
         final sys = capturedSystemMessage!;
-        final today = DateTime.now().toIso8601String().split('T').first;
-        expect(sys, contains(today));
+        expect(sys, contains('2024-03-15'));
         expect(sys, contains('You are an AI assistant'));
         expect(sys, contains('start_date'));
         expect(sys, contains('end_date'));

--- a/test/features/ai_chat/repository/task_summary_repository_test.dart
+++ b/test/features/ai_chat/repository/task_summary_repository_test.dart
@@ -18,9 +18,10 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/utils/date_utils_extension.dart';
 import 'package:mocktail/mocktail.dart';
 
-// Mock implementations
-class MockJournalDb extends Mock implements JournalDb {}
+import '../../../mocks/mocks.dart';
 
+// Local generic selectable mock — the central [MockSelectable] requires a
+// list of values up front, but these tests stub `get()` per-test instead.
 class MockSelectable<T> extends Mock implements Selectable<T> {}
 
 class _NoAgentResolver extends TaskSummaryResolver {

--- a/test/features/ai_chat/ui/models/chat_ui_models_test.dart
+++ b/test/features/ai_chat/ui/models/chat_ui_models_test.dart
@@ -222,7 +222,7 @@ void main() {
           id: 'streaming',
           content: 'Typing...',
           role: ChatMessageRole.assistant,
-          timestamp: DateTime.now(),
+          timestamp: DateTime(2024, 3, 15, 10, 30),
           isStreaming: true,
         );
 

--- a/test/features/categories/repository/categories_repository_test.dart
+++ b/test/features/categories/repository/categories_repository_test.dart
@@ -12,17 +12,8 @@ import 'package:lotti/services/entities_cache_service.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:uuid/uuid.dart';
 
+import '../../../mocks/mocks.dart';
 import '../test_utils.dart';
-
-class MockPersistenceLogic extends Mock implements PersistenceLogic {}
-
-class MockJournalDb extends Mock implements JournalDb {}
-
-class MockEntitiesCacheService extends Mock implements EntitiesCacheService {}
-
-class MockUpdateNotifications extends Mock implements UpdateNotifications {}
-
-class FakeCategoryDefinition extends Fake implements CategoryDefinition {}
 
 void main() {
   setUpAll(() {

--- a/test/features/categories/ui/widgets/categories_type_card_test.dart
+++ b/test/features/categories/ui/widgets/categories_type_card_test.dart
@@ -8,7 +8,7 @@ import 'package:lotti/services/entities_cache_service.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:mocktail/mocktail.dart';
 
-class MockEntitiesCacheService extends Mock implements EntitiesCacheService {}
+import '../../../../mocks/mocks.dart';
 
 void main() {
   late MockEntitiesCacheService mockEntitiesCacheService;

--- a/test/features/categories/ui/widgets/category_field_test.dart
+++ b/test/features/categories/ui/widgets/category_field_test.dart
@@ -9,9 +9,8 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:mocktail/mocktail.dart';
 
+import '../../../../mocks/mocks.dart';
 import '../../../../test_helper.dart';
-
-class MockEntitiesCacheService extends Mock implements EntitiesCacheService {}
 
 void main() {
   late MockEntitiesCacheService mockCacheService;

--- a/test/features/categories/ui/widgets/category_selection_modal_content_test.dart
+++ b/test/features/categories/ui/widgets/category_selection_modal_content_test.dart
@@ -7,9 +7,8 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:mocktail/mocktail.dart';
 
+import '../../../../mocks/mocks.dart';
 import '../../../../test_helper.dart';
-
-class MockEntitiesCacheService extends Mock implements EntitiesCacheService {}
 
 void main() {
   late MockEntitiesCacheService mockEntitiesCacheService;

--- a/test/features/dashboards/state/measurables_controller_test.dart
+++ b/test/features/dashboards/state/measurables_controller_test.dart
@@ -8,11 +8,7 @@ import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/entities_cache_service.dart';
 import 'package:mocktail/mocktail.dart';
 
-class MockJournalDb extends Mock implements JournalDb {}
-
-class MockEntitiesCacheService extends Mock implements EntitiesCacheService {}
-
-class MockUpdateNotifications extends Mock implements UpdateNotifications {}
+import '../../../mocks/mocks.dart';
 
 void main() {
   late MockJournalDb mockJournalDb;

--- a/test/features/journal/state/image_paste_controller_test.dart
+++ b/test/features/journal/state/image_paste_controller_test.dart
@@ -34,9 +34,6 @@ class MockClipboardDataReader extends Mock implements ClipboardDataReader {}
 
 class MockDataReaderFile extends Mock implements DataReaderFile {}
 
-class MockAutomaticImageAnalysisTrigger extends Mock
-    implements AutomaticImageAnalysisTrigger {}
-
 class FakeJournalImage extends Fake implements JournalImage {}
 
 void main() {

--- a/test/features/labels/repository/labels_repository_edge_cases_test.dart
+++ b/test/features/labels/repository/labels_repository_edge_cases_test.dart
@@ -3,13 +3,10 @@ import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/labels/repository/labels_repository.dart';
 import 'package:lotti/features/sync/vector_clock.dart';
-import 'package:lotti/services/db_notification.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../mocks/mocks.dart';
 import '../../../test_data/test_data.dart';
-
-class MockUpdateNotifications extends Mock implements UpdateNotifications {}
 
 void main() {
   late MockPersistenceLogic persistenceLogic;

--- a/test/features/labels/repository/labels_repository_setlabels_test.dart
+++ b/test/features/labels/repository/labels_repository_setlabels_test.dart
@@ -2,21 +2,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
-import 'package:lotti/database/database.dart';
 import 'package:lotti/features/labels/repository/labels_repository.dart';
-import 'package:lotti/logic/persistence_logic.dart';
-import 'package:lotti/services/db_notification.dart';
-import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/services/logging_service.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../helpers/fallbacks.dart';
-
-class MockJournalDb extends Mock implements JournalDb {}
-
-class MockPersistenceLogic extends Mock implements PersistenceLogic {}
-
-class MockEntitiesCacheService extends Mock implements EntitiesCacheService {}
+import '../../../mocks/mocks.dart' hide MockLoggingService;
 
 class MockLoggingService extends Mock implements LoggingService {
   MockLoggingService() {
@@ -32,8 +23,6 @@ class MockLoggingService extends Mock implements LoggingService {
     ).thenAnswer((_) async {});
   }
 }
-
-class MockUpdateNotifications extends Mock implements UpdateNotifications {}
 
 void main() {
   group('LabelsRepository.setLabels suppression updates', () {

--- a/test/features/labels/repository/labels_repository_suppression_test.dart
+++ b/test/features/labels/repository/labels_repository_suppression_test.dart
@@ -1,21 +1,12 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
-import 'package:lotti/database/database.dart';
 import 'package:lotti/features/labels/repository/labels_repository.dart';
-import 'package:lotti/logic/persistence_logic.dart';
-import 'package:lotti/services/db_notification.dart';
-import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/services/logging_service.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../helpers/fallbacks.dart';
-
-class MockJournalDb extends Mock implements JournalDb {}
-
-class MockPersistenceLogic extends Mock implements PersistenceLogic {}
-
-class MockEntitiesCacheService extends Mock implements EntitiesCacheService {}
+import '../../../mocks/mocks.dart' hide MockLoggingService;
 
 class MockLoggingService extends Mock implements LoggingService {
   MockLoggingService() {
@@ -31,8 +22,6 @@ class MockLoggingService extends Mock implements LoggingService {
     ).thenAnswer((_) async {});
   }
 }
-
-class MockUpdateNotifications extends Mock implements UpdateNotifications {}
 
 void main() {
   setUpAll(() {

--- a/test/features/labels/repository/labels_repository_test.dart
+++ b/test/features/labels/repository/labels_repository_test.dart
@@ -8,23 +8,19 @@ import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
-import 'package:lotti/database/database.dart';
 import 'package:lotti/features/labels/repository/labels_repository.dart';
 import 'package:lotti/features/sync/vector_clock.dart';
-import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/db_notification.dart';
-import 'package:lotti/services/entities_cache_service.dart';
 import 'package:lotti/services/logging_service.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../helpers/fallbacks.dart';
+import '../../../mocks/mocks.dart' hide MockLoggingService;
 
-class MockPersistenceLogic extends Mock implements PersistenceLogic {}
-
-class MockJournalDb extends Mock implements JournalDb {}
-
-class MockEntitiesCacheService extends Mock implements EntitiesCacheService {}
-
+// Local [MockLoggingService] that auto-stubs `captureException` with all
+// six named arguments so test bodies don't need to repeat that wiring.
+// The central mock leaves `captureException` unstubbed and expects callers
+// to use the `stubLoggingService` helper.
 class MockLoggingService extends Mock implements LoggingService {
   MockLoggingService() {
     when(
@@ -39,8 +35,6 @@ class MockLoggingService extends Mock implements LoggingService {
     ).thenAnswer((_) async {});
   }
 }
-
-class MockUpdateNotifications extends Mock implements UpdateNotifications {}
 
 void main() {
   final baseTime = DateTime.utc(1970);

--- a/test/features/labels/services/label_assignment_processor_category_test.dart
+++ b/test/features/labels/services/label_assignment_processor_category_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
-import 'package:lotti/database/database.dart';
 import 'package:lotti/database/logging_types.dart';
 import 'package:lotti/features/labels/repository/labels_repository.dart';
 import 'package:lotti/features/labels/services/label_assignment_processor.dart';
@@ -12,7 +11,7 @@ import 'package:lotti/features/labels/services/label_validator.dart';
 import 'package:lotti/services/logging_service.dart';
 import 'package:mocktail/mocktail.dart';
 
-class MockJournalDb extends Mock implements JournalDb {}
+import '../../../mocks/mocks.dart';
 
 class FakeLabelsRepository extends Fake implements LabelsRepository {
   List<String> lastAdded = const [];

--- a/test/features/labels/services/label_validator_category_test.dart
+++ b/test/features/labels/services/label_validator_category_test.dart
@@ -1,10 +1,9 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
-import 'package:lotti/database/database.dart';
 import 'package:lotti/features/labels/services/label_validator.dart';
 import 'package:mocktail/mocktail.dart';
 
-class MockJournalDb extends Mock implements JournalDb {}
+import '../../../mocks/mocks.dart';
 
 void main() {
   group('LabelValidator.validateForCategory', () {

--- a/test/features/labels/services/label_validator_suppression_test.dart
+++ b/test/features/labels/services/label_validator_suppression_test.dart
@@ -1,10 +1,9 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
-import 'package:lotti/database/database.dart';
 import 'package:lotti/features/labels/services/label_validator.dart';
 import 'package:mocktail/mocktail.dart';
 
-class MockJournalDb extends Mock implements JournalDb {}
+import '../../../mocks/mocks.dart';
 
 void main() {
   final testDate = DateTime(2024, 3, 15);

--- a/test/features/labels/services/label_validator_test.dart
+++ b/test/features/labels/services/label_validator_test.dart
@@ -1,11 +1,10 @@
 // ignore_for_file: avoid_redundant_argument_values
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
-import 'package:lotti/database/database.dart';
 import 'package:lotti/features/labels/services/label_validator.dart';
 import 'package:mocktail/mocktail.dart';
 
-class MockJournalDb extends Mock implements JournalDb {}
+import '../../../mocks/mocks.dart';
 
 void main() {
   late MockJournalDb mockDb;

--- a/test/features/settings/ui/pages/advanced_settings_page_test.dart
+++ b/test/features/settings/ui/pages/advanced_settings_page_test.dart
@@ -15,8 +15,6 @@ import 'package:mocktail/mocktail.dart';
 import '../../../../mocks/mocks.dart';
 import '../../../../widget_test_utils.dart';
 
-class MockSyncDatabase extends Mock implements SyncDatabase {}
-
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   const n = 111;

--- a/test/features/settings/ui/pages/flags_page_test.dart
+++ b/test/features/settings/ui/pages/flags_page_test.dart
@@ -17,8 +17,6 @@ import 'package:mocktail/mocktail.dart';
 import '../../../../mocks/mocks.dart';
 import '../../../../widget_test_utils.dart';
 
-class MockUserActivityService extends Mock implements UserActivityService {}
-
 class FakeConfigFlag extends Fake implements ConfigFlag {}
 
 void main() {

--- a/test/features/settings/ui/pages/manual/theming_page_test.dart
+++ b/test/features/settings/ui/pages/manual/theming_page_test.dart
@@ -15,8 +15,6 @@ import 'package:mocktail/mocktail.dart';
 import '../../../../../mocks/mocks.dart';
 import '../../../../../widget_test_utils.dart';
 
-class MockUserActivityService extends Mock implements UserActivityService {}
-
 void main() {
   late MockSettingsDb mockSettingsDb;
   late MockJournalDb mockJournalDb;

--- a/test/features/speech/state/recorder_controller_test.dart
+++ b/test/features/speech/state/recorder_controller_test.dart
@@ -47,8 +47,6 @@ class MockRealtimeTranscriptionService extends Mock
 
 class MockRecAudioRecorder extends Mock implements rec.AudioRecorder {}
 
-class MockPersistenceLogic extends Mock implements PersistenceLogic {}
-
 class MockAutomaticPromptTrigger extends Mock
     implements AutomaticPromptTrigger {}
 

--- a/test/features/speech/ui/widgets/speech_modal/speech_modal_test.dart
+++ b/test/features/speech/ui/widgets/speech_modal/speech_modal_test.dart
@@ -6,13 +6,12 @@ import 'package:mocktail/mocktail.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
+import '../../../../../mocks/mocks.dart';
 import '../../../../../test_data/test_data.dart';
 
 class MockPathProviderPlatform extends Mock
     with MockPlatformInterfaceMixin
     implements PathProviderPlatform {}
-
-class FakeJournalAudio extends Fake implements JournalAudio {}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/features/sync/actor/outbound_queue_test.dart
+++ b/test/features/sync/actor/outbound_queue_test.dart
@@ -12,11 +12,11 @@ import 'package:lotti/features/sync/state/outbox_state_controller.dart';
 import 'package:matrix/matrix.dart';
 import 'package:mocktail/mocktail.dart';
 
+import '../../../mocks/mocks.dart';
+
 class MockMatrixSdkGateway extends Mock implements MatrixSdkGateway {}
 
 class MockClient extends Mock implements Client {}
-
-class MockRoom extends Mock implements Room {}
 
 class MockStateEvent extends Mock implements StrippedStateEvent {}
 

--- a/test/features/sync/actor/sync_actor_test.dart
+++ b/test/features/sync/actor/sync_actor_test.dart
@@ -16,6 +16,8 @@ import 'package:matrix/encryption/key_verification_manager.dart';
 import 'package:matrix/matrix.dart';
 import 'package:mocktail/mocktail.dart';
 
+import '../../../mocks/mocks.dart';
+
 abstract interface class CachedStreamController<T> {
   T? get value;
   Stream<T> get stream;
@@ -32,10 +34,6 @@ class MockDeviceKeys extends Mock implements DeviceKeys {}
 class MockKeyVerification extends Mock implements KeyVerification {}
 
 class MockSyncUpdate extends Mock implements SyncUpdate {}
-
-class MockEvent extends Mock implements Event {}
-
-class MockRoom extends Mock implements Room {}
 
 class MockEncryption extends Mock implements Encryption {}
 

--- a/test/features/sync/backfill/backfill_request_service_test.dart
+++ b/test/features/sync/backfill/backfill_request_service_test.dart
@@ -10,7 +10,6 @@ import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/features/sync/backfill/backfill_request_service.dart';
 import 'package:lotti/features/sync/model/sync_message.dart';
 import 'package:lotti/features/sync/queue/queue_pipeline_coordinator.dart';
-import 'package:lotti/features/sync/sequence/sync_sequence_log_service.dart';
 import 'package:lotti/features/sync/sequence/sync_sequence_payload_type.dart';
 import 'package:lotti/features/sync/tuning.dart';
 import 'package:mocktail/mocktail.dart';
@@ -18,11 +17,6 @@ import 'package:path/path.dart' as p;
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../../mocks/mocks.dart';
-
-class MockSyncSequenceLogService extends Mock
-    implements SyncSequenceLogService {}
-
-class MockSyncDatabase extends Mock implements SyncDatabase {}
 
 class _MockQueuePipelineCoordinator extends Mock
     implements QueuePipelineCoordinator {}

--- a/test/features/sync/backfill/backfill_response_handler_test.dart
+++ b/test/features/sync/backfill/backfill_response_handler_test.dart
@@ -5,7 +5,6 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/features/sync/backfill/backfill_response_handler.dart';
 import 'package:lotti/features/sync/model/sync_message.dart';
-import 'package:lotti/features/sync/sequence/sync_sequence_log_service.dart';
 import 'package:lotti/features/sync/sequence/sync_sequence_payload_type.dart';
 import 'package:lotti/features/sync/tuning.dart';
 import 'package:lotti/features/sync/vector_clock.dart';
@@ -15,9 +14,6 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../../../features/agents/test_utils.dart';
 import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
-
-class MockSyncSequenceLogService extends Mock
-    implements SyncSequenceLogService {}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/features/sync/gateway/matrix_sdk_gateway_test.dart
+++ b/test/features/sync/gateway/matrix_sdk_gateway_test.dart
@@ -9,9 +9,9 @@ import 'package:matrix/encryption/utils/key_verification.dart';
 import 'package:matrix/matrix.dart';
 import 'package:mocktail/mocktail.dart';
 
-class MockClient extends Mock implements Client {}
+import '../../../mocks/mocks.dart';
 
-class MockRoom extends Mock implements Room {}
+class MockClient extends Mock implements Client {}
 
 class MockLoginResponse extends Mock implements LoginResponse {}
 

--- a/test/features/sync/matrix/matrix_message_sender_test.dart
+++ b/test/features/sync/matrix/matrix_message_sender_test.dart
@@ -27,8 +27,6 @@ import 'package:mocktail/mocktail.dart';
 
 import '../../../mocks/mocks.dart';
 
-class MockRoom extends Mock implements Room {}
-
 class MockDeviceKeys extends Mock implements DeviceKeys {}
 
 enum _GeneratedSendMessageKind {

--- a/test/features/sync/matrix/pipeline/agent_vc_dominance_check_test.dart
+++ b/test/features/sync/matrix/pipeline/agent_vc_dominance_check_test.dart
@@ -173,19 +173,20 @@ void main() {
 
   tearDown(() async => db.close());
 
+  final fixedNow = DateTime(2024, 3, 15).toIso8601String();
+
   Future<void> insertEntityWithVc({
     required String id,
     required Map<String, dynamic> vc,
     String type = 'agent',
   }) async {
-    final now = DateTime.now().toIso8601String();
     final serialized =
         '{"id":"$id","vectorClock":${_jsonVc(vc)},"deletedAt":null}';
     await db.customStatement(
       'INSERT INTO agent_entities '
       '(id, agent_id, type, created_at, updated_at, serialized, schema_version) '
       'VALUES (?, ?, ?, ?, ?, ?, 1)',
-      [id, id, type, now, now, serialized],
+      [id, id, type, fixedNow, fixedNow, serialized],
     );
   }
 
@@ -193,12 +194,11 @@ void main() {
     required String id,
     required String serialized,
   }) async {
-    final now = DateTime.now().toIso8601String();
     await db.customStatement(
       'INSERT INTO agent_entities '
       '(id, agent_id, type, created_at, updated_at, serialized, schema_version) '
       'VALUES (?, ?, ?, ?, ?, ?, 1)',
-      [id, id, 'agent', now, now, serialized],
+      [id, id, 'agent', fixedNow, fixedNow, serialized],
     );
   }
 
@@ -209,14 +209,13 @@ void main() {
     String toId = 't',
     String type = 'agent_state',
   }) async {
-    final now = DateTime.now().toIso8601String();
     final serialized =
         '{"id":"$id","vectorClock":${_jsonVc(vc)},"deletedAt":null}';
     await db.customStatement(
       'INSERT INTO agent_links '
       '(id, from_id, to_id, type, created_at, updated_at, serialized, schema_version) '
       'VALUES (?, ?, ?, ?, ?, ?, ?, 1)',
-      [id, fromId, toId, type, now, now, serialized],
+      [id, fromId, toId, type, fixedNow, fixedNow, serialized],
     );
   }
 

--- a/test/features/sync/matrix/pipeline/attachment_index_test.dart
+++ b/test/features/sync/matrix/pipeline/attachment_index_test.dart
@@ -6,8 +6,6 @@ import 'package:mocktail/mocktail.dart';
 
 import '../../../../mocks/mocks.dart';
 
-class MockEvent extends Mock implements Event {}
-
 enum _GeneratedAttachmentOperationKind { record, find }
 
 enum _GeneratedAttachmentEventIdMode { valid, empty, throws }

--- a/test/features/sync/matrix/pipeline/catch_up_strategy_test.dart
+++ b/test/features/sync/matrix/pipeline/catch_up_strategy_test.dart
@@ -2418,8 +2418,6 @@ void main() {
   });
 }
 
-class MockEvent extends Mock implements Event {}
-
 class _CollectingBootstrapSink implements BootstrapSink {
   _CollectingBootstrapSink(
     this._onPage, {

--- a/test/features/sync/matrix/pipeline/read_marker_manager_test.dart
+++ b/test/features/sync/matrix/pipeline/read_marker_manager_test.dart
@@ -3,12 +3,9 @@ import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
 import 'package:lotti/features/sync/matrix/pipeline/read_marker_manager.dart';
-import 'package:matrix/matrix.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../../mocks/mocks.dart';
-
-class MockRoom extends Mock implements Room {}
 
 enum _GeneratedMarkerOperationKind {
   schedule,

--- a/test/features/sync/matrix/read_marker_service_test.dart
+++ b/test/features/sync/matrix/read_marker_service_test.dart
@@ -10,13 +10,7 @@ import '../../../mocks/mocks.dart';
 
 class MockClient extends Mock implements Client {}
 
-class MockRoom extends Mock implements Room {}
-
-class MockTimeline extends Mock implements Timeline {}
-
 typedef MockLogging = MockLoggingService;
-
-class MockEvent extends Mock implements Event {}
 
 class MockMatrixException extends Mock implements MatrixException {}
 

--- a/test/features/sync/matrix/room_test.dart
+++ b/test/features/sync/matrix/room_test.dart
@@ -12,8 +12,6 @@ import '../../../mocks/mocks.dart';
 
 class MockMatrixSyncGateway extends Mock implements MatrixSyncGateway {}
 
-class MockRoom extends Mock implements Room {}
-
 class MockMatrixClient extends Mock implements Client {}
 
 void main() {

--- a/test/features/sync/matrix/sync_engine_test.dart
+++ b/test/features/sync/matrix/sync_engine_test.dart
@@ -18,8 +18,6 @@ class MockSyncLifecycleCoordinator extends Mock
 
 class MockClient extends Mock implements Client {}
 
-class MockRoom extends Mock implements Room {}
-
 class MockRoomSummary extends Mock implements RoomSummary {}
 
 void main() {

--- a/test/features/sync/matrix/sync_event_processor_test.dart
+++ b/test/features/sync/matrix/sync_event_processor_test.dart
@@ -36,15 +36,10 @@ import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
 import '../../../test_data/test_data.dart';
 
-class MockEvent extends Mock implements Event {}
-
 class MockJournalEntityLoader extends Mock implements SyncJournalEntityLoader {}
 
 class MockBackfillResponseHandler extends Mock
     implements BackfillResponseHandler {}
-
-class MockSyncSequenceLogService extends Mock
-    implements SyncSequenceLogService {}
 
 void main() {
   setUpAll(() {

--- a/test/features/sync/matrix/sync_room_discovery_test.dart
+++ b/test/features/sync/matrix/sync_room_discovery_test.dart
@@ -11,12 +11,6 @@ import '../../../mocks/mocks.dart';
 
 class MockClient extends Mock implements Client {}
 
-class MockRoom extends Mock implements Room {}
-
-class MockTimeline extends Mock implements Timeline {}
-
-class MockEvent extends Mock implements Event {}
-
 class MockRoomSummary extends Mock implements RoomSummary {}
 
 class MockStrippedStateEvent extends Mock implements StrippedStateEvent {}

--- a/test/features/sync/matrix/sync_room_manager_test.dart
+++ b/test/features/sync/matrix/sync_room_manager_test.dart
@@ -16,8 +16,6 @@ import '../../../mocks/mocks.dart';
 
 class MockMatrixGateway extends Mock implements MatrixSyncGateway {}
 
-class MockRoom extends Mock implements Room {}
-
 class MockRoomInviteEvent extends Mock implements RoomInviteEvent {}
 
 class MockClient extends Mock implements Client {}

--- a/test/features/sync/outbox/outbox_repository_test.dart
+++ b/test/features/sync/outbox/outbox_repository_test.dart
@@ -7,7 +7,7 @@ import 'package:lotti/features/sync/state/outbox_state_controller.dart';
 import 'package:lotti/features/sync/tuning.dart';
 import 'package:mocktail/mocktail.dart';
 
-class MockSyncDatabase extends Mock implements SyncDatabase {}
+import '../../../mocks/mocks.dart';
 
 enum _GeneratedRepositoryBatchOperation {
   markSent,

--- a/test/features/sync/outbox/outbox_service_test.dart
+++ b/test/features/sync/outbox/outbox_service_test.dart
@@ -24,13 +24,11 @@ import 'package:lotti/features/sync/model/sync_message.dart';
 import 'package:lotti/features/sync/outbox/outbox_processor.dart';
 import 'package:lotti/features/sync/outbox/outbox_repository.dart';
 import 'package:lotti/features/sync/outbox/outbox_service.dart';
-import 'package:lotti/features/sync/sequence/sync_sequence_log_service.dart';
 import 'package:lotti/features/sync/sequence/sync_sequence_payload_type.dart';
 import 'package:lotti/features/sync/state/outbox_state_controller.dart';
 import 'package:lotti/features/sync/tuning.dart';
 import 'package:lotti/features/sync/vector_clock.dart';
 import 'package:lotti/features/user_activity/state/user_activity_gate.dart';
-import 'package:lotti/features/user_activity/state/user_activity_service.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/utils/consts.dart';
 import 'package:lotti/utils/file_utils.dart';
@@ -41,11 +39,7 @@ import 'package:mocktail/mocktail.dart';
 
 import '../../../mocks/mocks.dart';
 
-class MockSyncDatabase extends Mock implements SyncDatabase {}
-
 class MockUserActivityGate extends Mock implements UserActivityGate {}
-
-class MockUserActivityService extends Mock implements UserActivityService {}
 
 class MockOutboxRepository extends Mock implements OutboxRepository {}
 
@@ -57,9 +51,6 @@ class MockMatrixClient extends Mock implements Client {}
 
 class MockCachedLoginController extends Mock
     implements matrix_utils.CachedStreamController<LoginState> {}
-
-class MockSyncSequenceLogService extends Mock
-    implements SyncSequenceLogService {}
 
 class TestableOutboxService extends OutboxService {
   TestableOutboxService({

--- a/test/features/sync/sequence/sync_sequence_log_service_test.dart
+++ b/test/features/sync/sequence/sync_sequence_log_service_test.dart
@@ -15,8 +15,6 @@ import 'package:mocktail/mocktail.dart';
 
 import '../../../mocks/mocks.dart';
 
-class MockSyncDatabase extends Mock implements SyncDatabase {}
-
 enum _GeneratedCounterState {
   absent,
   received,

--- a/test/features/sync/state/sequence_log_populate_controller_test.dart
+++ b/test/features/sync/state/sequence_log_populate_controller_test.dart
@@ -12,9 +12,6 @@ import 'package:mocktail/mocktail.dart';
 
 import '../../../mocks/mocks.dart';
 
-class MockSyncSequenceLogService extends Mock
-    implements SyncSequenceLogService {}
-
 // Fake types for mocktail fallback
 class FakeEntryStream extends Fake
     implements Stream<List<({String id, Map<String, int>? vectorClock})>> {}

--- a/test/features/sync/ui/sequence_log_populate_modal_test.dart
+++ b/test/features/sync/ui/sequence_log_populate_modal_test.dart
@@ -12,9 +12,6 @@ import 'package:mocktail/mocktail.dart';
 
 import '../../../mocks/mocks.dart';
 
-class MockSyncSequenceLogService extends Mock
-    implements SyncSequenceLogService {}
-
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 

--- a/test/features/sync/ui/sync_settings_page_test.dart
+++ b/test/features/sync/ui/sync_settings_page_test.dart
@@ -17,8 +17,6 @@ import 'package:mocktail/mocktail.dart';
 import '../../../mocks/mocks.dart';
 import '../../../widget_test_utils.dart';
 
-class MockSyncDatabase extends Mock implements SyncDatabase {}
-
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 

--- a/test/features/tasks/ui/checklists/drag_utils_test.dart
+++ b/test/features/tasks/ui/checklists/drag_utils_test.dart
@@ -1,14 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
-import 'package:lotti/features/tasks/state/checklist_controller.dart';
 import 'package:lotti/features/tasks/ui/checklists/drag_utils.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:super_drag_and_drop/super_drag_and_drop.dart';
 
+import '../../../../mocks/mocks.dart';
 import '../../../../widget_test_utils.dart';
-
-class MockChecklistController extends Mock implements ChecklistController {}
 
 class MockPerformDropEvent extends Mock implements PerformDropEvent {}
 

--- a/test/features/tasks/ui/header/estimated_time_widget_test.dart
+++ b/test/features/tasks/ui/header/estimated_time_widget_test.dart
@@ -7,10 +7,9 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/services/time_service.dart';
 import 'package:mocktail/mocktail.dart';
 
+import '../../../../mocks/mocks.dart';
 import '../../../../test_helper.dart';
 import '../../../../widget_test_utils.dart';
-
-class MockTimeService extends Mock implements TimeService {}
 
 void main() {
   late MockTimeService mockTimeService;

--- a/test/features/whats_new/state/whats_new_controller_test.dart
+++ b/test/features/whats_new/state/whats_new_controller_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:lotti/database/database.dart';
 import 'package:lotti/features/whats_new/model/whats_new_content.dart';
 import 'package:lotti/features/whats_new/model/whats_new_release.dart';
 import 'package:lotti/features/whats_new/repository/whats_new_service.dart';
@@ -11,9 +10,9 @@ import 'package:lotti/utils/consts.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-class MockWhatsNewService extends Mock implements WhatsNewService {}
+import '../../../mocks/mocks.dart';
 
-class MockJournalDb extends Mock implements JournalDb {}
+class MockWhatsNewService extends Mock implements WhatsNewService {}
 
 class FakeWhatsNewRelease extends Fake implements WhatsNewRelease {}
 

--- a/test/logic/audio_import_test.dart
+++ b/test/logic/audio_import_test.dart
@@ -15,10 +15,6 @@ import 'package:path/path.dart' as path;
 
 import '../mocks/mocks.dart';
 
-class FakeJournalAudio extends Fake implements JournalAudio {}
-
-class FakeMetadata extends Fake implements Metadata {}
-
 class FakeDropItem extends Fake implements DropItem {
   FakeDropItem(this._xFile);
 

--- a/test/logic/image_import_test.dart
+++ b/test/logic/image_import_test.dart
@@ -6,7 +6,6 @@ import 'package:desktop_drop/desktop_drop.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
-import 'package:lotti/features/ai/helpers/automatic_image_analysis_trigger.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/image_import.dart';
 import 'package:lotti/logic/persistence_logic.dart';
@@ -16,12 +15,7 @@ import 'package:path/path.dart' as path;
 
 import '../mocks/mocks.dart';
 
-class MockAutomaticImageAnalysisTrigger extends Mock
-    implements AutomaticImageAnalysisTrigger {}
-
 class FakeJournalImage extends Fake implements JournalImage {}
-
-class FakeMetadata extends Fake implements Metadata {}
 
 class FakeDropItem extends Fake implements DropItem {
   FakeDropItem(this._xFile);

--- a/test/logic/media_import_test.dart
+++ b/test/logic/media_import_test.dart
@@ -20,10 +20,6 @@ import '../mocks/mocks.dart';
 
 class FakeJournalImage extends Fake implements JournalImage {}
 
-class FakeJournalAudio extends Fake implements JournalAudio {}
-
-class FakeMetadata extends Fake implements Metadata {}
-
 class FakeDropItem extends Fake implements DropItem {
   FakeDropItem(this._xFile);
 

--- a/test/services/ip_geolocation_service_test.dart
+++ b/test/services/ip_geolocation_service_test.dart
@@ -12,8 +12,6 @@ import 'package:mocktail/mocktail.dart';
 import '../mocks/mocks.dart';
 import '../test_utils/retry_fake_time.dart';
 
-class MockHttpClient extends Mock implements http.Client {}
-
 class FakeUri extends Fake implements Uri {}
 
 class FakeException extends Fake implements Exception {}

--- a/test/services/ip_geolocation_service_test.dart
+++ b/test/services/ip_geolocation_service_test.dart
@@ -22,7 +22,13 @@ void main() {
   late MockLoggingService mockLoggingService;
   late MockHttpClient mockHttpClient;
 
-  int localUtcOffsetMinutes() => DateTime.now().timeZoneOffset.inMinutes;
+  // Fixed reference moment used both as the injected clock for the service
+  // and as the source of the expected UTC-offset fallback value. Using a
+  // single fixed [DateTime] keeps offset assertions deterministic across
+  // DST transitions and machines.
+  final fixedNow = DateTime(2024, 1, 15, 12);
+  DateTime clock() => fixedNow;
+  final localUtcOffsetMinutes = fixedNow.timeZoneOffset.inMinutes;
 
   setUpAll(() {
     registerFallbackValue(FakeUri());
@@ -297,12 +303,13 @@ void main() {
 
           final result = await IpGeolocationService.getLocationFromIp(
             httpClient: mockHttpClient,
+            clock: clock,
           );
 
           expect(result, isNotNull);
           expect(
             result!.utcOffset,
-            localUtcOffsetMinutes(),
+            localUtcOffsetMinutes,
             reason: 'Failed for invalid offset: $offset',
           );
         }
@@ -454,10 +461,11 @@ void main() {
 
         final result = await IpGeolocationService.getLocationFromIp(
           httpClient: mockHttpClient,
+          clock: clock,
         );
         expect(
           result?.utcOffset,
-          localUtcOffsetMinutes(),
+          localUtcOffsetMinutes,
         );
 
         verify(

--- a/test/utils/location_fallback_test.dart
+++ b/test/utils/location_fallback_test.dart
@@ -14,6 +14,7 @@ import 'package:lotti/utils/location.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../helpers/fallbacks.dart';
+import '../mocks/mocks.dart' hide MockLoggingService;
 
 class _FakeLinuxBackend implements LinuxLocationBackend {
   _FakeLinuxBackend({this.result, this.error, this.closeError});
@@ -45,8 +46,6 @@ Future<Geolocation?> nullIpGeolocationProvider({
 }
 
 class MockLocation extends Mock implements Location {}
-
-class MockJournalDb extends Mock implements JournalDb {}
 
 class MockLoggingService extends Mock implements LoggingService {
   MockLoggingService() {

--- a/test/utils/timezone_test.dart
+++ b/test/utils/timezone_test.dart
@@ -4,19 +4,26 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/utils/timezone.dart';
 
 void main() {
+  // Fixed reference moment used to assert the function returns the same
+  // timezone name the underlying [DateTime] would expose for the injected
+  // clock — without depending on real wall-clock time.
+  final fixedNow = DateTime(2024, 3, 15, 12);
+  DateTime clock() => fixedNow;
+
   group('getLocalTimezone', () {
     test('returns system timezone name in test environment', () async {
-      final tz = await getLocalTimezone();
-      final expected = DateTime.now().timeZoneName;
-      expect(tz, expected);
+      final tz = await getLocalTimezone(clock: clock);
+      expect(tz, fixedNow.timeZoneName);
     });
 
     test(
       'returns system timezone name when isTestEnv is true explicitly',
       () async {
-        final tz = await getLocalTimezone(overrideIsTestEnv: true);
-        final expected = DateTime.now().timeZoneName;
-        expect(tz, expected);
+        final tz = await getLocalTimezone(
+          overrideIsTestEnv: true,
+          clock: clock,
+        );
+        expect(tz, fixedNow.timeZoneName);
       },
     );
 
@@ -25,9 +32,11 @@ void main() {
       () async {
         if (Platform.isLinux) return;
 
-        final tz = await getLocalTimezone(overrideIsTestEnv: false);
-        final expected = DateTime.now().timeZoneName;
-        expect(tz, expected);
+        final tz = await getLocalTimezone(
+          overrideIsTestEnv: false,
+          clock: clock,
+        );
+        expect(tz, fixedNow.timeZoneName);
       },
     );
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Time-dependent services now accept injectable clocks to produce deterministic, time-based behavior.

* **Tests**
  * Widespread test hardening: fixed timestamps/clock injection, centralized/shared test mocks, stable timezone/UTC-offset expectations, and more reliable log-file discovery for reproducible test runs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matthiasn/lotti/pull/3140)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->