### PR TITLE
fix: task title update in agent queue widget

### DIFF
--- a/lib/features/agents/state/agent_pending_wake_providers.dart
+++ b/lib/features/agents/state/agent_pending_wake_providers.dart
@@ -59,16 +59,21 @@ final pendingWakeRecordsProvider = FutureProvider<List<PendingWakeRecord>>((
   return records;
 });
 
-final StreamProviderFamily<void, String> _entryUpdateProvider = StreamProvider
-    .autoDispose
-    .family<void, String>((
+// Returns the raw `Set<String>` from `UpdateNotifications` rather than
+// `void`: Riverpod deduplicates `AsyncData` values using `==`, and
+// `AsyncData<void>(null) == AsyncData<void>(null)` is true — so a
+// `Stream<void>` would only notify watchers on the very first
+// emission and silently drop every subsequent one. Each emitted set
+// is identity-distinct, so `pendingWakeTargetTitleProvider` actually
+// re-runs when the linked task is renamed after a previously-blank
+// title. Same fix shape as `agentUpdateStreamProvider`.
+final StreamProviderFamily<Set<String>, String> _entryUpdateProvider =
+    StreamProvider.autoDispose.family<Set<String>, String>((
       ref,
       entryId,
     ) {
       final notifications = ref.watch(updateNotificationsProvider);
-      return notifications.updateStream
-          .where((ids) => ids.contains(entryId))
-          .map<void>((_) {});
+      return notifications.updateStream.where((ids) => ids.contains(entryId));
     });
 
 final FutureProviderFamily<String?, String?> pendingWakeTargetTitleProvider =

--- a/lib/features/agents/state/agent_pending_wake_providers.dart
+++ b/lib/features/agents/state/agent_pending_wake_providers.dart
@@ -76,8 +76,25 @@ final StreamProviderFamily<Set<String>, String> _entryUpdateProvider =
       return notifications.updateStream.where((ids) => ids.contains(entryId));
     });
 
+// `autoDispose` so each entryId's cached title and its underlying
+// `_entryUpdateProvider` stream subscription release as soon as the
+// last watcher leaves the tree. Without it both providers would pin
+// for every task/project ID the app ever queried — each adding a
+// permanent `where`-filtered listener on the global update stream.
+//
+// Two call patterns rely on this provider, both compatible with
+// autoDispose:
+//   1. Widgets (`_OngoingWakeRow`, `_WakeRow`) `ref.watch` it while
+//      the row is mounted — subscription keeps it alive; teardown
+//      releases it.
+//   2. `_resolveOngoingRecord` does a one-shot `ref.read(...).future`
+//      to seed the snapshot title, with no lingering subscription.
+//      The provider disposes after the read; the renderer's later
+//      `ref.watch` instantiates a fresh entry and triggers one extra
+//      `journalEntityById` lookup on first render — acceptable, since
+//      the snapshot path only runs when the running-agent set changes.
 final FutureProviderFamily<String?, String?> pendingWakeTargetTitleProvider =
-    FutureProvider.family<String?, String?>((
+    FutureProvider.autoDispose.family<String?, String?>((
       ref,
       String? entryId,
     ) async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1000+4066
+version: 0.9.1000+4067
 
 msix_config:
   display_name: LottiApp

--- a/test/features/agents/state/agent_pending_wake_providers_test.dart
+++ b/test/features/agents/state/agent_pending_wake_providers_test.dart
@@ -1,4 +1,5 @@
 import 'package:clock/clock.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
@@ -1426,6 +1427,69 @@ void main() {
         'Refine sidebar',
       );
     });
+
+    test(
+      're-emits the live title on every entry-update notification, even when '
+      'successive notifications carry the same payload. Regression for the '
+      'bug where `_entryUpdateProvider` mapped emissions to `void`, so '
+      '`AsyncData<void>(null) == AsyncData<void>(null)` and Riverpod silently '
+      'dropped every notification after the first — leaving a blank task '
+      'newly renamed by an agent stuck on the "Task Agent" fallback in the '
+      'sidebar wake row.',
+      () {
+        fakeAsync((async) {
+          final notifications = UpdateNotifications();
+          final container = ProviderContainer(
+            overrides: [
+              journalDbProvider.overrideWithValue(mockJournalDb),
+              updateNotificationsProvider.overrideWithValue(notifications),
+            ],
+          );
+          addTearDown(() {
+            notifications.dispose();
+            container.dispose();
+          });
+
+          var currentTitle = '';
+          when(() => mockJournalDb.journalEntityById('task-1')).thenAnswer(
+            (_) async => makeTestTask(id: 'task-1', title: currentTitle),
+          );
+
+          final observed = <AsyncValue<String?>>[];
+          final sub = container.listen<AsyncValue<String?>>(
+            pendingWakeTargetTitleProvider('task-1'),
+            (_, next) => observed.add(next),
+            fireImmediately: true,
+          );
+          addTearDown(sub.close);
+
+          // Initial read: empty title trims to null.
+          async.flushMicrotasks();
+          expect(observed.last, const AsyncData<String?>(null));
+
+          // First rename — provider re-evaluates and picks up the new title.
+          currentTitle = 'First rename';
+          notifications.notify({'task-1'});
+          async
+            ..elapse(const Duration(milliseconds: 150))
+            ..flushMicrotasks();
+          expect(observed.last, const AsyncData<String?>('First rename'));
+
+          // Second rename on the same entry ID. With the old `void` payload
+          // this emission compared equal to the previous one and was deduped
+          // away; the provider would not re-run and `observed.last` would
+          // still read 'First rename'. With the `Set<String>` payload each
+          // emission is identity-distinct, so the provider re-evaluates and
+          // we see 'Second rename'.
+          currentTitle = 'Second rename';
+          notifications.notify({'task-1'});
+          async
+            ..elapse(const Duration(milliseconds: 150))
+            ..flushMicrotasks();
+          expect(observed.last, const AsyncData<String?>('Second rename'));
+        });
+      },
+    );
   });
 
   group('hourlyWakeActivityProvider', () {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pending wake target task titles now refresh on every notification, even when successive notifications contain identical payloads for the same entry.

* **Tests**
  * Added a regression test verifying task title updates emit correctly after each notification event, including duplicate-payload cases.

* **Chores**
  * App version bumped to 0.9.1000+4067.

* **Documentation**
  * Clarified provider lifecycle and update-emission behavior to ensure reliable title refreshes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matthiasn/lotti/pull/3165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->