### PR TITLE
ci: run test suite in 3 shards

### DIFF
--- a/.github/workflows/flutter-test-linux-faster.yml
+++ b/.github/workflows/flutter-test-linux-faster.yml
@@ -10,10 +10,20 @@ concurrency:
 
 jobs:
   test:
-    name: Unit & Widget Tests (Linux)
+    name: Unit & Widget Tests (Linux, shard ${{ matrix.shard_label }}/3)
     permissions:
       contents: read
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard_index: 0
+            shard_label: 1
+          - shard_index: 1
+            shard_label: 2
+          - shard_index: 2
+            shard_label: 3
     steps:
       - uses: actions/checkout@v5
       - name: Cache Pub Packages
@@ -33,12 +43,18 @@ jobs:
       - name: Activate very_good_cli
         run: dart pub global activate very_good_cli
       - name: Run Flutter tests (standard)
-        run: very_good test --coverage --exclude-tags glados
+        run: |
+          very_good test --coverage --exclude-tags glados -- \
+            --total-shards=3 \
+            --shard-index=${{ matrix.shard_index }}
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: matthiasn/lotti
+          fail_ci_if_error: true
           flags: standard
+          name: standard-shard-${{ matrix.shard_label }}
+          files: coverage/lcov.info
 
   glados:
     name: Glados Property Tests (Linux)
@@ -69,4 +85,23 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: matthiasn/lotti
+          fail_ci_if_error: true
           flags: glados
+          files: coverage/lcov.info
+
+  codecov:
+    name: Publish Codecov Status
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    needs:
+      - test
+      - glados
+    steps:
+      - uses: actions/checkout@v5
+      - uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: matthiasn/lotti
+          fail_ci_if_error: true
+          run_command: send-notifications

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,10 @@
 codecov:
   notify:
-    # CI uploads two coverage reports for each commit: standard and glados.
-    # Wait for both before publishing Codecov statuses/comments.
-    after_n_builds: 2
+    # Sharded coverage uploads arrive independently, so do not let Codecov
+    # publish transient project statuses from a partial report set.
+    # The GitHub workflow sends a single notification once all coverage
+    # upload jobs have completed successfully.
+    manual_trigger: true
     wait_for_ci: true
 
 flag_management:

--- a/test/README.md
+++ b/test/README.md
@@ -27,11 +27,11 @@ The `tags` argument is a passthrough to `package:test`'s `test()`. It works the 
 
 ### Why the tag matters for CI
 
-CI runs two parallel jobs:
-- **Unit & Widget Tests** — `very_good test --exclude-tags glados` (fast feedback, all non-property tests)
+CI runs four parallel jobs:
+- **Unit & Widget Tests** — three shards of `very_good test --coverage --exclude-tags glados -- --total-shards=3 --shard-index=N` (fast feedback, all non-property tests)
 - **Glados Property Tests** — `very_good test --tags glados` (CPU-bound, runs longer in parallel)
 
-A new Glados test without `tags: 'glados'` will run in the standard suite, slowing fast feedback for everyone. The split also lets us upload separate codecov flags (`standard`, `glados`) while still merging both into the project total.
+A new Glados test without `tags: 'glados'` will run in the standard suite, slowing fast feedback for everyone. The split also lets us upload separate codecov flags (`standard`, `glados`) while still merging all three standard shards plus Glados into the project total. Codecov status publishing is manually triggered by a final CI job after every coverage upload job succeeds, so PRs do not show transient project coverage from only the Glados report or a partial standard shard set.
 
 ### Local commands
 
@@ -43,7 +43,13 @@ make coverage_glados    # test_glados   + HTML report
 make test               # full suite, no filtering — same as before
 ```
 
-All Make targets use `very_good test` to match CI behavior. Run `make activate_very_good` once on a fresh checkout.
+To reproduce one standard CI shard locally, run:
+
+```bash
+very_good test --coverage --exclude-tags glados -- --total-shards=3 --shard-index=0
+```
+
+Replace `0` with `1` or `2` for the other shards. The `--` terminator forwards the sharding arguments to the underlying `flutter test` command; the equals-form arguments keep Very Good's test optimizer enabled because no forwarded argument looks like a positional test-file target. All Make targets use `very_good test` to match CI behavior. Run `make activate_very_good` once on a fresh checkout.
 
 ### Picking `numRuns`
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now runs tests in parallel shards for faster feedback.
  * Coverage uploads and notifications are shard-aware and published explicitly after uploads.
  * Added a separate coverage notification job to report status once uploads complete.

* **Documentation**
  * Updated testing guide with local reproduction steps for specific CI shards and notes on sharded coverage behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matthiasn/lotti/pull/3172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->