### PR TITLE
fix: prevent agent wake after tapping notification

### DIFF
--- a/lib/features/notifications/README.md
+++ b/lib/features/notifications/README.md
@@ -74,7 +74,9 @@ Tapping a `taskSuggestion` inbox row publishes a `TaskFocusTarget.suggestions`
 intent before opening the linked task. If the task detail is already mounted,
 it consumes that intent and scrolls directly to the proposals section; if the
 task detail is created by the navigation, it consumes the same intent after the
-proposal widget appears.
+proposal widget appears. The tap marks only the inbox row as seen; it does not
+mark suggestions acted-on and notification lifecycle writes are emitted through
+the UI-only notification stream, so opening the task cannot wake its task agent.
 
 ```mermaid
 flowchart LR

--- a/lib/features/notifications/repository/notification_repository.dart
+++ b/lib/features/notifications/repository/notification_repository.dart
@@ -269,7 +269,7 @@ class NotificationRepository {
         );
       }
       await _scheduler.schedule(updated);
-      _notify(updated, fromSync: false);
+      _notifyStateChange(updated);
       return updated;
     }, commitWhen: (result) => result != null);
   }
@@ -351,5 +351,13 @@ class NotificationRepository {
       },
       fromSync: fromSync,
     );
+  }
+
+  void _notifyStateChange(NotificationEntity entity) {
+    _updateNotifications.notifyUiOnly({
+      entity.id,
+      if (entity.linkedEntityId != null) entity.linkedEntityId!,
+      inboxNotification,
+    });
   }
 }

--- a/lib/features/notifications/ui/widgets/notification_bell.dart
+++ b/lib/features/notifications/ui/widgets/notification_bell.dart
@@ -393,26 +393,20 @@ class _InboxRow extends StatelessWidget {
       linkedId,
       focusSuggestions: entity is TaskSuggestionNotification,
     );
-    // Fire markActedOn after navigation so the badge clears as the task
-    // opens. Task-suggestion rows are task-scoped at the inbox level, so a
-    // tap clears every open suggestion alert for that task, including stale
-    // rows left by older app versions.
-    unawaited(
-      _markActedOn(linkedId).catchError((Object error, StackTrace stackTrace) {
-        FlutterError.reportError(
-          FlutterErrorDetails(exception: error, stack: stackTrace),
-        );
-        return null;
-      }),
-    );
+    // Fire markSeen after navigation so the badge clears as the task opens.
+    // Opening the task is not the same as acting on an agent suggestion; the
+    // confirmation/rejection flow owns retraction.
+    unawaited(_markSeen());
   }
 
-  Future<Object?> _markActedOn(String linkedId) {
-    final repository = getIt<NotificationRepository>();
-    if (entity is TaskSuggestionNotification) {
-      return repository.markTaskSuggestionsActedOn(linkedId);
+  Future<void> _markSeen() async {
+    try {
+      await getIt<NotificationRepository>().markSeen(entity.id);
+    } catch (error, stackTrace) {
+      FlutterError.reportError(
+        FlutterErrorDetails(exception: error, stack: stackTrace),
+      );
     }
-    return repository.markActedOn(entity.id);
   }
 
   Future<void> _handleRetract() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1003+4083
+version: 0.9.1003+4084
 
 msix_config:
   display_name: LottiApp

--- a/test/features/notifications/repository/notification_repository_test.dart
+++ b/test/features/notifications/repository/notification_repository_test.dart
@@ -519,38 +519,46 @@ void main() {
       return base;
     }
 
-    test('markSeen merges state, enqueues update and notifies', () async {
-      await seed();
-      when(
-        () => vectorClockService.getNextVectorClock(
-          previous: any(named: 'previous'),
-        ),
-      ).thenAnswer((_) async => const VectorClock({'host-a': 2}));
+    test(
+      'markSeen merges state, enqueues update and notifies UI only',
+      () async {
+        await seed();
+        when(
+          () => vectorClockService.getNextVectorClock(
+            previous: any(named: 'previous'),
+          ),
+        ).thenAnswer((_) async => const VectorClock({'host-a': 2}));
 
-      final updated = await repository.markSeen('state-test');
+        final updated = await repository.markSeen('state-test');
 
-      expect(updated, isNotNull);
-      expect(updated!.meta.seenAt, fixedNow);
-      expect(updated.meta.vectorClock, const VectorClock({'host-a': 2}));
+        expect(updated, isNotNull);
+        expect(updated!.meta.seenAt, fixedNow);
+        expect(updated.meta.vectorClock, const VectorClock({'host-a': 2}));
 
-      verify(
-        () => outboxService.enqueueNotificationStateUpdate(
-          id: 'state-test',
-          seenAt: fixedNow,
-          actedOnAt: null,
-          deletedAt: null,
-          vectorClock: const VectorClock({'host-a': 2}),
-          originatingHostId: 'host-a',
-        ),
-      ).called(1);
-      verify(() => scheduler.schedule(updated)).called(1);
-      verify(
-        () => updateNotifications.notify(
-          {'state-test', 'task-state', inboxNotification},
-          fromSync: false,
-        ),
-      ).called(1);
-    });
+        verify(
+          () => outboxService.enqueueNotificationStateUpdate(
+            id: 'state-test',
+            seenAt: fixedNow,
+            actedOnAt: null,
+            deletedAt: null,
+            vectorClock: const VectorClock({'host-a': 2}),
+            originatingHostId: 'host-a',
+          ),
+        ).called(1);
+        verify(() => scheduler.schedule(updated)).called(1);
+        verify(
+          () => updateNotifications.notifyUiOnly(
+            {'state-test', 'task-state', inboxNotification},
+          ),
+        ).called(1);
+        verifyNever(
+          () => updateNotifications.notify(
+            any<Set<String>>(),
+            fromSync: any(named: 'fromSync'),
+          ),
+        );
+      },
+    );
 
     test('markActedOn forwards actedOnAt only', () async {
       await seed();
@@ -630,15 +638,20 @@ void main() {
           fixedNow,
         );
         verify(
-          () => updateNotifications.notify(
+          () => updateNotifications.notifyUiOnly(
             any(
               that: containsAll(
                 {'task-shared', inboxNotification},
               ),
             ),
-            fromSync: false,
           ),
         ).called(2);
+        verifyNever(
+          () => updateNotifications.notify(
+            any<Set<String>>(),
+            fromSync: any(named: 'fromSync'),
+          ),
+        );
       },
     );
 
@@ -744,11 +757,16 @@ void main() {
         );
         verify(() => scheduler.schedule(updated)).called(1);
         verify(
-          () => updateNotifications.notify(
+          () => updateNotifications.notifyUiOnly(
             {'state-test', 'task-state', inboxNotification},
-            fromSync: false,
           ),
         ).called(1);
+        verifyNever(
+          () => updateNotifications.notify(
+            any<Set<String>>(),
+            fromSync: any(named: 'fromSync'),
+          ),
+        );
       },
     );
 

--- a/test/features/notifications/ui/widgets/notification_bell_test.dart
+++ b/test/features/notifications/ui/widgets/notification_bell_test.dart
@@ -30,6 +30,7 @@ void main() {
       getIt.unregister<NotificationRepository>();
     }
     getIt.registerSingleton<NotificationRepository>(repository);
+    when(() => repository.markSeen(any())).thenAnswer((_) async => null);
     when(() => repository.markActedOn(any())).thenAnswer((_) async => null);
     when(
       () => repository.markTaskSuggestionsActedOn(any()),
@@ -305,7 +306,7 @@ void main() {
   );
 
   testWidgets(
-    'tapping a row marks it acted-on and dismisses the popover',
+    'tapping a suggestion row marks it seen and opens suggestions',
     (tester) async {
       // Force desktop layout so `openLinkedTaskDetail` goes through
       // NavService (a registered mock) instead of pushing a MaterialPageRoute
@@ -350,9 +351,9 @@ void main() {
       await tester.tap(find.text('Review'));
       await tester.pump();
 
-      verify(
-        () => repository.markTaskSuggestionsActedOn('task-act-on-me'),
-      ).called(1);
+      verify(() => repository.markSeen('act-on-me')).called(1);
+      verifyNever(() => repository.markActedOn(any()));
+      verifyNever(() => repository.markTaskSuggestionsActedOn(any()));
       verify(
         () => navService.pushDesktopTaskDetail('task-act-on-me'),
       ).called(1);
@@ -365,7 +366,7 @@ void main() {
   );
 
   testWidgets(
-    'tapping a non-suggestion row marks only that row acted-on',
+    'tapping a non-suggestion row marks only that row seen',
     (tester) async {
       final navService = MockNavService();
       if (getIt.isRegistered<NavService>()) getIt.unregister<NavService>();
@@ -407,7 +408,8 @@ void main() {
       await tester.tap(find.text('Overdue task'));
       await tester.pump();
 
-      verify(() => repository.markActedOn('overdue-act-on-me')).called(1);
+      verify(() => repository.markSeen('overdue-act-on-me')).called(1);
+      verifyNever(() => repository.markActedOn(any()));
       verifyNever(() => repository.markTaskSuggestionsActedOn(any()));
       verify(
         () => navService.pushDesktopTaskDetail('task-overdue-act-on-me'),
@@ -422,7 +424,7 @@ void main() {
   );
 
   testWidgets(
-    'markActedOn failure is reported and navigation still proceeds',
+    'markSeen failure is reported and navigation still proceeds',
     (tester) async {
       final navService = MockNavService();
       if (getIt.isRegistered<NavService>()) getIt.unregister<NavService>();
@@ -437,19 +439,14 @@ void main() {
       ).thenAnswer((_) {});
 
       when(
-        () => repository.markTaskSuggestionsActedOn(any()),
-      ).thenThrow(StateError('mark-acted-boom'));
+        () => repository.markSeen(any()),
+      ).thenAnswer((_) async => throw StateError('mark-seen-boom'));
 
       final entity = _makeNotification(
         id: 'mark-failure',
         title: 'Will fail',
         body: '',
       );
-
-      final errors = <FlutterErrorDetails>[];
-      final previous = FlutterError.onError;
-      FlutterError.onError = errors.add;
-      addTearDown(() => FlutterError.onError = previous);
 
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(
@@ -470,17 +467,16 @@ void main() {
       await tester.pump();
 
       verify(
-        () => repository.markTaskSuggestionsActedOn('task-mark-failure'),
+        () => repository.markSeen('mark-failure'),
       ).called(1);
-      // Navigation runs even when markActedOn throws.
+      verifyNever(() => repository.markActedOn(any()));
+      verifyNever(() => repository.markTaskSuggestionsActedOn(any()));
+      // Navigation runs even when markSeen throws.
       verify(
         () => navService.pushDesktopTaskDetail('task-mark-failure'),
       ).called(1);
       // FlutterError.reportError should have been called with the exception.
-      expect(
-        errors.where((e) => e.exception.toString().contains('mark-acted-boom')),
-        isNotEmpty,
-      );
+      expect(tester.takeException().toString(), contains('mark-seen-boom'));
     },
   );
 
@@ -496,11 +492,6 @@ void main() {
         title: 'Cannot dismiss',
         body: '',
       );
-
-      final errors = <FlutterErrorDetails>[];
-      final previous = FlutterError.onError;
-      FlutterError.onError = errors.add;
-      addTearDown(() => FlutterError.onError = previous);
 
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(
@@ -522,10 +513,7 @@ void main() {
       verify(
         () => repository.retractTaskSuggestionsForTask('task-retract-failure'),
       ).called(1);
-      expect(
-        errors.where((e) => e.exception.toString().contains('retract-boom')),
-        isNotEmpty,
-      );
+      expect(tester.takeException().toString(), contains('retract-boom'));
       // Popover must still be present — the row text remains findable.
       expect(find.text('Cannot dismiss'), findsOneWidget);
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notification inbox behavior updated: tapping a notification row now marks it as seen instead of marking it as acted on, preventing unintended task agent activation from task suggestion notifications.

* **Documentation**
  * Updated notification documentation to clarify inbox interaction behavior and task suggestion handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matthiasn/lotti/pull/3192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->