### PR TITLE
feat: per-invocation image-analysis model picker in AI popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.1005]
 ### Changed
+- AI popup menu now opens a model-override picker when you tap an
+  Analyze Image skill, mirroring the existing Transcribe flow — the
+  bottom sheet lists every image-capable model you've configured so
+  you can route one specific photo to a different model without
+  editing the inference profile. Single-model setups short-circuit to
+  preserve the one-tap flow; a stale override falls back to the
+  profile slot.
 - Upgraded Flutter to 3.44.0 and aligned the Flatpak Flathub manifest
   template with the repository FVM toolchain pin, so source builds submitted
   to Flathub use the same Flutter SDK as local and CI builds.

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -34,6 +34,7 @@
   <releases>
     <release version="0.9.1005" date="2026-05-22">
       <description>
+          <p>AI popup menu now opens a model-override picker when you tap an Analyze Image skill, mirroring the existing Transcribe flow — the bottom sheet lists every image-capable model you've configured so you can route one specific photo to a different model without editing the inference profile. Single-model setups short-circuit to preserve the one-tap flow; a stale override falls back to the profile slot.</p>
           <p>Upgraded Flutter to 3.44.0 and aligned the Flatpak Flathub manifest template with the repository FVM toolchain pin, so source builds submitted to Flathub use the same Flutter SDK as local and CI builds.</p>
       </description>
     </release>

--- a/lib/features/ai/README.md
+++ b/lib/features/ai/README.md
@@ -265,40 +265,43 @@ flowchart TD
 
 The seeded task-context skills (`Transcribe (Task Context)`, `Analyze Image (Task Context)`, `Generate Cover Art`, the coding/design/research prompt generators) are therefore hidden for standalone entries; only their plain counterparts (`Transcribe Audio`, `Analyze Image`) show up. `triggerSkillProvider` also has a defensive guard: a `fullTask` skill triggered without a `linkedTaskId` is captured as an event and aborted — the popup should never offer one in that state, so reaching it is a caller bug.
 
-### Transcription Model Override
+### Per-Invocation Model Overrides
 
-When the user taps a transcription skill in the popup menu (`UnifiedAiPopUpMenu._handleTranscriptionSkill`), the flow inserts a `TranscriptionModelPickerModal` step before firing `triggerSkillProvider`. The picker lists every `AiConfigModel` whose `inputModalities` includes `Modality.audio`, with the profile's transcription slot row surfaced first and badged. The user's choice threads through as the optional `overrideTranscriptionModelId` field on `TriggerSkillParams`, which `SkillInferenceRunner.runTranscription` resolves into a `(provider, modelId)` target pair via `_resolveTranscriptionTarget` — preferring the override when it resolves to a real `AiConfigModel` + parent `AiConfigInferenceProvider`, falling back to the profile slot otherwise.
+Skill types with a per-invocation override slot (today: transcription and image-analysis) open the same `InferenceModelPickerModal` before firing `triggerSkillProvider`, so the user can route a single voice note or photo to any modality-capable model without editing the inference profile. The flow is one parameterised path — the variant table `_modelOverrideConfigs` in `unified_ai_popup_menu.dart` plugs in the per-slot modality filter, profile-slot accessor, and l10n strings. Adding a third per-invocation override slot is a one-line entry in that map plus a corresponding `_resolveOverrideTarget` call on the runner.
 
-Three short-circuits keep the common case one-tap:
+The user's choice threads through as the optional `overrideModelId` field on `TriggerSkillParams`. `SkillInferenceRunner` dispatches on `skill.skillType` and forwards `overrideModelId` to `runTranscription` or `runImageAnalysis`; each one calls its per-slot resolver (`_resolveTranscriptionTarget` / `_resolveImageAnalysisTarget`), which delegates to the shared `_resolveOverrideTarget` helper. Both resolvers return an `_InferenceTarget` record of `(AiConfigInferenceProvider?, String?)` — preferring the override when it resolves to a real `AiConfigModel` + parent `AiConfigInferenceProvider`, falling back to the profile slot (with a warning log keyed by `_OverrideSlotKind`) otherwise.
 
-- `speechCapableModels.isEmpty` — picker is not shown; the trigger is not fired (defensive path, the popup audio gate should prevent reaching here).
-- `speechCapableModels.length == 1` — picker is not shown; the trigger fires immediately with the lone model id.
+Three short-circuits keep the common case one-tap, applied identically across slot kinds:
+
+- `models.isEmpty` — picker is not shown; the trigger is not fired (defensive path, the popup modality gate should prevent reaching here).
+- `models.length == 1` — picker is not shown; the trigger fires immediately with the lone model id.
 - `picked == defaultModelId` — the override is collapsed to `null` at the popup callsite, so the runner reads the profile slot and a model deleted between picker and run still falls back gracefully (instead of trying to route to a stale id).
 
 ```mermaid
 stateDiagram-v2
-  [*] --> SkillTap: tap transcription skill in popup
+  [*] --> SkillTap: tap transcription / image-analysis skill in popup
   SkillTap --> ResolveProfile: resolve profile (task or category)
   ResolveProfile --> LoadModels: read AiConfigModel list via repository
-  LoadModels --> ComputeDefault: map profile.transcriptionModelId + provider id\nto an AiConfigModel.id
-  ComputeDefault --> Empty: speech-capable list empty
-  ComputeDefault --> Single: exactly one speech-capable model
-  ComputeDefault --> Many: 2+ speech-capable models
+  LoadModels --> ComputeDefault: variant.slotAccessor(profile)\n→ AiConfigModel.id
+  ComputeDefault --> Empty: slot-capable list empty
+  ComputeDefault --> Single: exactly one slot-capable model
+  ComputeDefault --> Many: 2+ slot-capable models
   Empty --> [*]: no-op
-  Single --> FireTrigger: overrideTranscriptionModelId = lone id
-  Many --> Picker: TranscriptionModelPickerModal.show
+  Single --> FireTrigger: overrideModelId = lone id
+  Many --> Picker: InferenceModelPickerModal.show
   Picker --> Dismissed: user cancels / dismisses
   Picker --> PickedDefault: tap default-badged row
   Picker --> PickedOther: tap any other row
   Dismissed --> [*]
-  PickedDefault --> FireTrigger: overrideTranscriptionModelId = null
-  PickedOther --> FireTrigger: overrideTranscriptionModelId = picked id
-  FireTrigger --> Runner: SkillInferenceRunner.runTranscription
-  Runner --> ResolveTarget: _resolveTranscriptionTarget(override)
+  PickedDefault --> FireTrigger: overrideModelId = null
+  PickedOther --> FireTrigger: overrideModelId = picked id
+  FireTrigger --> Dispatch: triggerSkillProvider routes by skill.skillType
+  Dispatch --> Runner: runTranscription / runImageAnalysis(overrideModelId)
+  Runner --> ResolveTarget: _resolveOverrideTarget(override)
   ResolveTarget --> OverrideOk: override resolves to AiConfigModel + provider
   ResolveTarget --> FallBack: override null / stale model / missing parent provider
-  OverrideOk --> Inference: generateWithAudio(override model + provider)
-  FallBack --> Inference: generateWithAudio(profile slot)
+  OverrideOk --> Inference: generateWithAudio / generateWithImages\n(override model + provider)
+  FallBack --> Inference: generateWithAudio / generateWithImages\n(profile slot)
   Inference --> [*]
 ```
 

--- a/lib/features/ai/services/skill_inference_runner.dart
+++ b/lib/features/ai/services/skill_inference_runner.dart
@@ -136,43 +136,74 @@ class SkillInferenceRunner {
   /// back to the profile's transcription slot when the override is
   /// null OR unresolvable. The fallback path logs a warning so a
   /// stale override surfaced in logs, not user-visible stranding.
-  Future<_TranscriptionTarget> _resolveTranscriptionTarget({
+  Future<_InferenceTarget> _resolveTranscriptionTarget({
     required ResolvedProfile profile,
     required String? overrideModelId,
-  }) async {
-    if (overrideModelId == null) {
-      return (
+  }) {
+    return _resolveOverrideTarget(
+      overrideModelId: overrideModelId,
+      slotKind: _OverrideSlotKind.transcription,
+      fallback: () => (
         provider: profile.transcriptionProvider,
         modelId: profile.transcriptionModelId,
-      );
+      ),
+    );
+  }
+
+  /// Resolves the `(provider, modelId)` pair that an image-analysis
+  /// run should target. Same shape as [_resolveTranscriptionTarget]
+  /// but reads the profile's image-recognition slot for the fallback
+  /// path. Override resolution is identical: override must point at a
+  /// real `AiConfigModel` with a resolvable parent
+  /// `AiConfigInferenceProvider`, otherwise we fall back to the
+  /// profile slot with a warning log.
+  Future<_InferenceTarget> _resolveImageAnalysisTarget({
+    required ResolvedProfile profile,
+    required String? overrideModelId,
+  }) {
+    return _resolveOverrideTarget(
+      overrideModelId: overrideModelId,
+      slotKind: _OverrideSlotKind.imageAnalysis,
+      fallback: () => (
+        provider: profile.imageRecognitionProvider,
+        modelId: profile.imageRecognitionModelId,
+      ),
+    );
+  }
+
+  /// Shared override-or-fallback resolver used by both
+  /// [_resolveTranscriptionTarget] and [_resolveImageAnalysisTarget].
+  /// Keeps the override → fallback flow in one place so the warning
+  /// log shape and resolution rules stay aligned across slot kinds.
+  Future<_InferenceTarget> _resolveOverrideTarget({
+    required String? overrideModelId,
+    required _OverrideSlotKind slotKind,
+    required _InferenceTarget Function() fallback,
+  }) async {
+    if (overrideModelId == null) {
+      return fallback();
     }
     final repo = _ref.read(aiConfigRepositoryProvider);
     final modelConfig = await repo.getConfigById(overrideModelId);
     if (modelConfig is! AiConfigModel) {
       developer.log(
-        'Override transcription modelId $overrideModelId did not resolve '
-        'to an AiConfigModel; falling back to profile slot',
+        'Override ${slotKind.label} modelId $overrideModelId did not '
+        'resolve to an AiConfigModel; falling back to profile slot',
         name: _logTag,
       );
-      return (
-        provider: profile.transcriptionProvider,
-        modelId: profile.transcriptionModelId,
-      );
+      return fallback();
     }
     final providerConfig = await repo.getConfigById(
       modelConfig.inferenceProviderId,
     );
     if (providerConfig is! AiConfigInferenceProvider) {
       developer.log(
-        'Override transcription model ${modelConfig.id} has no resolvable '
-        'parent provider ${modelConfig.inferenceProviderId}; falling back '
-        'to profile slot',
+        'Override ${slotKind.label} model ${modelConfig.id} has no '
+        'resolvable parent provider ${modelConfig.inferenceProviderId}; '
+        'falling back to profile slot',
         name: _logTag,
       );
-      return (
-        provider: profile.transcriptionProvider,
-        modelId: profile.transcriptionModelId,
-      );
+      return fallback();
     }
     return (
       provider: providerConfig,
@@ -182,9 +213,9 @@ class SkillInferenceRunner {
 
   /// Run skill-based transcription on an audio entry.
   ///
-  /// When [overrideTranscriptionModelId] is non-null and resolves to a
-  /// valid `AiConfigModel`, the run uses that model and its parent
-  /// provider instead of the profile's transcription slot. This is the
+  /// When [overrideModelId] is non-null and resolves to a valid
+  /// `AiConfigModel`, the run uses that model and its parent provider
+  /// instead of the profile's transcription slot. This is the
   /// per-invocation override path used by the popup-menu picker, so the
   /// user can route a single voice note to a different model without
   /// changing the entire profile. A stale or unresolvable override
@@ -194,7 +225,7 @@ class SkillInferenceRunner {
     required String audioEntryId,
     required AutomationResult automationResult,
     String? linkedTaskId,
-    String? overrideTranscriptionModelId,
+    String? overrideModelId,
   }) async {
     final skill = automationResult.skill;
     final profile = automationResult.resolvedProfile;
@@ -206,7 +237,7 @@ class SkillInferenceRunner {
     }
     final target = await _resolveTranscriptionTarget(
       profile: profile,
-      overrideModelId: overrideTranscriptionModelId,
+      overrideModelId: overrideModelId,
     );
     final provider = target.provider;
     final modelId = target.modelId;
@@ -332,10 +363,20 @@ class SkillInferenceRunner {
   }
 
   /// Run skill-based image analysis on an image entry.
+  ///
+  /// When [overrideModelId] is non-null and resolves to a valid
+  /// `AiConfigModel`, the run uses that model and its parent provider
+  /// instead of the profile's image-recognition slot. This is the
+  /// per-invocation override path used by the popup-menu picker, so
+  /// the user can route a single photo to a different model without
+  /// changing the entire profile. A stale or unresolvable override
+  /// falls back to the profile slot (with a warning log) — stranding
+  /// the user is worse than ignoring a stale id.
   Future<void> runImageAnalysis({
     required String imageEntryId,
     required AutomationResult automationResult,
     String? linkedTaskId,
+    String? overrideModelId,
   }) async {
     final skill = automationResult.skill;
     final profile = automationResult.resolvedProfile;
@@ -345,8 +386,12 @@ class SkillInferenceRunner {
         'skill=${skill != null}, profile=${profile != null}',
       );
     }
-    final provider = profile.imageRecognitionProvider;
-    final modelId = profile.imageRecognitionModelId;
+    final target = await _resolveImageAnalysisTarget(
+      profile: profile,
+      overrideModelId: overrideModelId,
+    );
+    final provider = target.provider;
+    final modelId = target.modelId;
     if (provider == null || modelId == null) {
       developer.log(
         'Profile missing image recognition provider/model for $imageEntryId',
@@ -836,15 +881,31 @@ class SkillInferenceRunner {
   }
 }
 
-/// Resolved (provider, modelId) pair returned by
-/// [SkillInferenceRunner._resolveTranscriptionTarget]. Either field may
-/// be null when the override is unresolvable and the profile slot is
-/// also empty — the caller short-circuits with a "missing
+/// Resolved (provider, modelId) pair returned by the per-slot resolver
+/// helpers ([SkillInferenceRunner._resolveTranscriptionTarget],
+/// [SkillInferenceRunner._resolveImageAnalysisTarget]). Either field
+/// may be null when the override is unresolvable and the profile slot
+/// is also empty — the caller short-circuits with a "missing
 /// provider/model" log in that case.
-typedef _TranscriptionTarget = ({
+typedef _InferenceTarget = ({
   AiConfigInferenceProvider? provider,
   String? modelId,
 });
+
+/// Identifier for which profile slot a per-invocation override is
+/// targeting. The [label] is interpolated into warning logs so a
+/// future third slot kind only needs a new enum value, not a new
+/// magic-string literal that could typo-drift across the codebase.
+enum _OverrideSlotKind {
+  transcription('transcription'),
+  imageAnalysis('image analysis')
+  ;
+
+  const _OverrideSlotKind(this.label);
+
+  /// Human-readable form used in developer-log messages.
+  final String label;
+}
 
 @Riverpod(keepAlive: true)
 SkillInferenceRunner skillInferenceRunner(Ref ref) {

--- a/lib/features/ai/state/unified_ai_controller.dart
+++ b/lib/features/ai/state/unified_ai_controller.dart
@@ -438,18 +438,20 @@ final hasAvailableSkillsProvider = FutureProvider.autoDispose
 
 /// Record type for trigger skill parameters.
 ///
-/// `overrideTranscriptionModelId` is consumed only by
-/// [SkillType.transcription]. Non-transcription skills ignore it. The
-/// popup-menu picker sets it when the user chooses a non-default model
-/// for one specific voice note; the trigger forwards it to
-/// [SkillInferenceRunner.runTranscription], which routes the call to
-/// that model + its parent provider instead of the profile slot.
+/// `overrideModelId` is semantically scoped by the skill's `skillType`: the
+/// popup-menu pickers set it when the user chooses a non-default model
+/// for one specific entry, and the dispatch in [triggerSkillProvider]
+/// forwards it to the matching `SkillInferenceRunner` entry point
+/// (only [SkillType.transcription] and [SkillType.imageAnalysis]
+/// honour it today; other skill types ignore it). The runner routes
+/// the call to that model + its parent provider instead of the
+/// profile slot.
 typedef TriggerSkillParams = ({
   String entityId,
   String skillId,
   String? linkedTaskId,
   List<ProcessedReferenceImage>? referenceImages,
-  String? overrideTranscriptionModelId,
+  String? overrideModelId,
 });
 
 /// Provider to trigger a skill-based inference run.
@@ -555,14 +557,14 @@ final triggerSkillProvider = FutureProvider.autoDispose
                 audioEntryId: params.entityId,
                 automationResult: automationResult,
                 linkedTaskId: params.linkedTaskId,
-                overrideTranscriptionModelId:
-                    params.overrideTranscriptionModelId,
+                overrideModelId: params.overrideModelId,
               );
             case SkillType.imageAnalysis:
               await runner.runImageAnalysis(
                 imageEntryId: params.entityId,
                 automationResult: automationResult,
                 linkedTaskId: params.linkedTaskId,
+                overrideModelId: params.overrideModelId,
               );
             case SkillType.promptGeneration:
             case SkillType.imagePromptGeneration:

--- a/lib/features/ai/ui/image_generation/cover_art_skill_modal.dart
+++ b/lib/features/ai/ui/image_generation/cover_art_skill_modal.dart
@@ -105,7 +105,7 @@ class _CoverArtSkillModalState extends ConsumerState<CoverArtSkillModal> {
           skillId: widget.skillId,
           linkedTaskId: widget.linkedTaskId,
           referenceImages: referenceImages.isNotEmpty ? referenceImages : null,
-          overrideTranscriptionModelId: null,
+          overrideModelId: null,
         )).future,
       ),
     );

--- a/lib/features/ai/ui/unified_ai_popup_menu.dart
+++ b/lib/features/ai/ui/unified_ai_popup_menu.dart
@@ -6,20 +6,96 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/model/resolved_profile.dart';
 import 'package:lotti/features/ai/state/consts.dart';
 import 'package:lotti/features/ai/state/profile_automation_providers.dart';
 import 'package:lotti/features/ai/state/unified_ai_controller.dart';
 import 'package:lotti/features/ai/ui/image_generation/cover_art_skill_modal.dart';
-import 'package:lotti/features/ai/ui/widgets/transcription_model_picker_modal.dart';
+import 'package:lotti/features/ai/ui/widgets/inference_model_picker_modal.dart';
 import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/journal/repository/journal_repository.dart';
+import 'package:lotti/l10n/app_localizations.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/providers/service_providers.dart';
 import 'package:lotti/themes/theme.dart';
-
 import 'package:lotti/widgets/app_bar/glass_action_button.dart';
 import 'package:lotti/widgets/modal/index.dart';
+
+/// (modelId, providerId) tuple pulled from a [ResolvedProfile] for one
+/// per-invocation override slot. Both fields are nullable because a
+/// freshly-installed profile may not have populated the slot yet.
+typedef _ProfileSlotValue = ({String? modelId, String? providerId});
+
+/// Per-skill configuration for the model-override popup flow. Each
+/// entry plugs in a modality filter, profile-slot accessor, and the
+/// localised title + default-badge strings used by the picker. Adding
+/// a new override slot is a one-line entry in
+/// [_modelOverrideConfigs] plus a corresponding dispatch branch in
+/// the skill inference runner.
+class _SkillModelOverrideConfig {
+  const _SkillModelOverrideConfig({
+    required this.modality,
+    required this.slotAccessor,
+    required this.titleSelector,
+    required this.defaultBadgeSelector,
+  });
+
+  /// Modality the model must accept to appear in the picker. Filters
+  /// the raw `AiConfigModel` list down to the relevant capability set
+  /// (e.g. `Modality.audio` for transcription, `Modality.image` for
+  /// image analysis).
+  final Modality modality;
+
+  /// Pulls the `(providerModelId, providerId)` pair for the override
+  /// slot out of the resolved profile.
+  final _ProfileSlotValue Function(ResolvedProfile) slotAccessor;
+
+  /// Returns the picker modal title for this slot. Resolved against
+  /// the live [AppLocalizations] at handler time.
+  final String Function(AppLocalizations) titleSelector;
+
+  /// Returns the "(default)" badge label for this slot. Same
+  /// resolution timing as [titleSelector].
+  final String Function(AppLocalizations) defaultBadgeSelector;
+}
+
+_ProfileSlotValue _transcriptionSlot(ResolvedProfile p) => (
+  modelId: p.transcriptionModelId,
+  providerId: p.transcriptionProvider?.id,
+);
+
+_ProfileSlotValue _imageAnalysisSlot(ResolvedProfile p) => (
+  modelId: p.imageRecognitionModelId,
+  providerId: p.imageRecognitionProvider?.id,
+);
+
+/// Skill types that open a model-override picker on tap, keyed by
+/// [SkillType]. Skill types not in this map fall through to the
+/// straight `triggerSkillProvider` call in [UnifiedAiModal.show].
+const _modelOverrideConfigs = <SkillType, _SkillModelOverrideConfig>{
+  SkillType.transcription: _SkillModelOverrideConfig(
+    modality: Modality.audio,
+    slotAccessor: _transcriptionSlot,
+    titleSelector: _transcriptionTitleSelector,
+    defaultBadgeSelector: _transcriptionBadgeSelector,
+  ),
+  SkillType.imageAnalysis: _SkillModelOverrideConfig(
+    modality: Modality.image,
+    slotAccessor: _imageAnalysisSlot,
+    titleSelector: _imageAnalysisTitleSelector,
+    defaultBadgeSelector: _imageAnalysisBadgeSelector,
+  ),
+};
+
+String _transcriptionTitleSelector(AppLocalizations m) =>
+    m.aiTranscriptionPickerTitle;
+String _transcriptionBadgeSelector(AppLocalizations m) =>
+    m.aiTranscriptionPickerDefaultBadge;
+String _imageAnalysisTitleSelector(AppLocalizations m) =>
+    m.aiImageAnalysisPickerTitle;
+String _imageAnalysisBadgeSelector(AppLocalizations m) =>
+    m.aiImageAnalysisPickerDefaultBadge;
 
 /// Unified AI popup menu that shows available skills for the current entity
 class UnifiedAiPopUpMenu extends ConsumerWidget {
@@ -120,18 +196,21 @@ class UnifiedAiModal {
             return;
           }
 
-          // Transcription opens the model-override picker so the user
-          // can route this single voice note to any speech-capable
-          // model (default surfaced first). The picker short-circuits
-          // when only one such model is configured, preserving the
-          // one-tap flow for the common case.
-          if (skill.skillType == SkillType.transcription) {
-            await _handleTranscriptionSkill(
+          // Skill types with a per-invocation model override (today:
+          // transcription + image analysis) open the model-override
+          // picker before firing the trigger. Each skill type plugs
+          // in its own modality filter, profile slot accessor, and
+          // l10n strings via _modelOverrideConfigs — adding a new
+          // override slot is a one-line entry in that map.
+          final overrideConfig = _modelOverrideConfigs[skill.skillType];
+          if (overrideConfig != null) {
+            await _handleSkillWithModelOverride(
               context: context,
               journalEntity: journalEntity,
               linkedTaskId: linkedTaskId,
               skill: skill,
               ref: ref,
+              config: overrideConfig,
             );
             return;
           }
@@ -144,7 +223,7 @@ class UnifiedAiModal {
                 skillId: skill.id,
                 linkedTaskId: linkedTaskId,
                 referenceImages: null,
-                overrideTranscriptionModelId: null,
+                overrideModelId: null,
               )).future,
             ),
           );
@@ -192,27 +271,29 @@ class UnifiedAiModal {
     );
   }
 
-  /// Opens the transcription-model picker, then fires the trigger
-  /// with the user's selection threaded as `overrideTranscriptionModelId`.
+  /// Opens the model-override picker for any skill type that has a
+  /// per-invocation override slot (configured in
+  /// [_modelOverrideConfigs]), then fires the trigger with the user's
+  /// selection threaded as `overrideModelId`.
   ///
   /// Profile resolution mirrors [triggerSkillProvider]'s logic: linked
-  /// task uses the task's profile, standalone audio falls back to the
-  /// entry category's `defaultProfileId`. The resolved profile's
-  /// transcription slot (a wire-level `providerModelId` string) is
-  /// translated to an `AiConfigModel.id` by matching against the
-  /// loaded model list, so the picker can highlight that row as the
-  /// default.
+  /// task uses the task's profile, standalone entries fall back to
+  /// the entry category's `defaultProfileId`. The resolved profile's
+  /// per-slot wire-level `providerModelId` is translated to an
+  /// `AiConfigModel.id` by matching against the loaded model list, so
+  /// the picker can highlight that row as the default.
   ///
   /// When the picker resolves with the same id as the default we
   /// pass `null` as the override — same semantic as "no override" so
   /// the runner reads from the profile slot, and a deleted model
   /// between picker and runner falls back gracefully.
-  static Future<void> _handleTranscriptionSkill({
+  static Future<void> _handleSkillWithModelOverride({
     required BuildContext context,
     required JournalEntity journalEntity,
     required String? linkedTaskId,
     required AiConfigSkill skill,
     required WidgetRef ref,
+    required _SkillModelOverrideConfig config,
   }) async {
     final resolver = ref.read(profileAutomationResolverProvider);
     final resolvedProfile = linkedTaskId != null
@@ -232,9 +313,9 @@ class UnifiedAiModal {
     // on-tap UI gesture.
     final repo = ref.read(aiConfigRepositoryProvider);
     final allConfigs = await repo.getConfigsByType(AiConfigType.model);
-    final speechCapable = allConfigs
+    final modalityCapable = allConfigs
         .whereType<AiConfigModel>()
-        .where((m) => m.inputModalities.contains(Modality.audio))
+        .where((m) => m.inputModalities.contains(config.modality))
         .toList();
 
     // Translate the profile's wire-level providerModelId to the
@@ -243,10 +324,11 @@ class UnifiedAiModal {
     // the picker renders the list without a default row.
     String? defaultModelId;
     if (resolvedProfile != null) {
-      final providerModelId = resolvedProfile.transcriptionModelId;
-      final providerId = resolvedProfile.transcriptionProvider?.id;
+      final slot = config.slotAccessor(resolvedProfile);
+      final providerModelId = slot.modelId;
+      final providerId = slot.providerId;
       if (providerModelId != null && providerId != null) {
-        defaultModelId = speechCapable
+        defaultModelId = modalityCapable
             .where(
               (m) =>
                   m.providerModelId == providerModelId &&
@@ -258,15 +340,22 @@ class UnifiedAiModal {
     }
 
     if (!context.mounted) return;
-    final picked = await TranscriptionModelPickerModal.show(
+    // Cache l10n on the still-mounted context before awaiting the
+    // picker — the surrounding widget may be disposed while the
+    // picker is open, after which `context.messages` would throw.
+    final messages = context.messages;
+    final picked = await InferenceModelPickerModal.show(
       context: context,
       defaultModelId: defaultModelId,
-      speechCapableModels: speechCapable,
+      models: modalityCapable,
+      title: config.titleSelector(messages),
+      defaultBadgeLabel: config.defaultBadgeSelector(messages),
     );
     if (picked == null) return;
-    // The widget could have been disposed while the picker was open
-    // (user navigated away, entry deleted). Reading ref on a
-    // deactivated element throws — bail before the trigger fires.
+    // Second mounted check: the picker `await` can resolve after the
+    // surrounding widget has been deactivated (user navigated away,
+    // entry deleted). Reading `ref` on a deactivated element throws,
+    // so we bail before firing the trigger.
     if (!context.mounted) return;
 
     // Same id as default → no override semantic — the runner reads
@@ -280,7 +369,7 @@ class UnifiedAiModal {
           skillId: skill.id,
           linkedTaskId: linkedTaskId,
           referenceImages: null,
-          overrideTranscriptionModelId: overrideId,
+          overrideModelId: overrideId,
         )).future,
       ),
     );

--- a/lib/features/ai/ui/widgets/inference_model_picker_modal.dart
+++ b/lib/features/ai/ui/widgets/inference_model_picker_modal.dart
@@ -2,38 +2,46 @@ import 'package:flutter/material.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/design_system/components/badges/design_system_badge.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
-import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/widgets/modal/modal_utils.dart';
 
-/// Bottom-sheet picker for choosing which model handles one
-/// transcription run, overriding the inference profile's slot for
-/// that single invocation. Default model is rendered first with a
-/// "(default)" badge and a check; alternatives below are tappable
-/// just the same — one tap on any row resolves the modal with that
-/// model's id.
+/// Generic bottom-sheet picker for choosing which model handles one
+/// per-invocation inference run, overriding the inference profile's
+/// slot for that single call. Used today by the transcription and
+/// image-analysis popup paths; future per-slot overrides plug in the
+/// same way by passing the relevant pre-filtered model list and the
+/// localised title + default-badge strings.
 ///
-/// When the user has zero or one speech-capable model configured the
-/// picker is degenerate (no choice to make), so [show] short-circuits
-/// and returns either the lone model id or null without rendering the
-/// modal. This keeps the "1 click for default" promise in the common
-/// single-model setup.
-class TranscriptionModelPickerModal extends StatelessWidget {
-  const TranscriptionModelPickerModal({
+/// Default model is rendered first with the supplied badge and a
+/// check; alternatives below are tappable just the same — one tap on
+/// any row resolves the modal with that model's id.
+///
+/// When the caller passes zero or one model the picker is degenerate
+/// (no choice to make), so [show] short-circuits and returns either
+/// the lone model id or null without rendering the modal. This keeps
+/// the "1 click for default" promise in the common single-model
+/// setup.
+class InferenceModelPickerModal extends StatelessWidget {
+  const InferenceModelPickerModal({
     required this.defaultModelId,
-    required this.speechCapableModels,
+    required this.models,
+    required this.defaultBadgeLabel,
     super.key,
   });
 
   /// The model id the active profile points to for this entry — used
   /// to mark which row is the default. May be `null` if the profile's
-  /// transcription slot is empty or points to a deleted model; in
-  /// that case no row gets the badge.
+  /// slot is empty or points to a deleted model; in that case no row
+  /// gets the badge.
   final String? defaultModelId;
 
-  /// Every model the user has configured whose `inputModalities`
-  /// includes [Modality.audio]. The caller filters; the modal trusts
-  /// the list.
-  final List<AiConfigModel> speechCapableModels;
+  /// Every model the caller wants the user to be able to pick. The
+  /// caller filters by modality + slot; the modal trusts the list.
+  final List<AiConfigModel> models;
+
+  /// Localised label for the "(default)" badge. Passed in rather than
+  /// read from l10n keys so the same picker serves any slot kind that
+  /// has its own badge string.
+  final String defaultBadgeLabel;
 
   /// Opens the picker and resolves with the chosen model's id. Three
   /// shapes for the return value:
@@ -42,43 +50,42 @@ class TranscriptionModelPickerModal extends StatelessWidget {
   ///     tapping the default).
   ///   - `null`             — the user dismissed the sheet (close X,
   ///     swipe, barrier tap, back nav).
-  ///   - short-circuit      — when [speechCapableModels] has 0 or 1
-  ///     entries the modal is not shown; the function returns
-  ///     immediately with the lone model id (or null if empty). This
-  ///     guarantees the popup-menu transcribe flow stays one-tap on
-  ///     setups with a single speech-capable model.
+  ///   - short-circuit      — when [models] has 0 or 1 entries the
+  ///     modal is not shown; the function returns immediately with
+  ///     the lone model id (or null if empty). This guarantees the
+  ///     popup-menu flow stays one-tap on setups with a single
+  ///     slot-capable model.
   static Future<String?> show({
     required BuildContext context,
     required String? defaultModelId,
-    required List<AiConfigModel> speechCapableModels,
+    required List<AiConfigModel> models,
+    required String title,
+    required String defaultBadgeLabel,
   }) async {
-    if (speechCapableModels.isEmpty) return null;
-    if (speechCapableModels.length == 1) {
-      return speechCapableModels.first.id;
-    }
+    if (models.isEmpty) return null;
+    if (models.length == 1) return models.first.id;
     return ModalUtils.showSinglePageModal<String>(
       context: context,
-      title: context.messages.aiTranscriptionPickerTitle,
-      builder: (_) => TranscriptionModelPickerModal(
+      title: title,
+      builder: (_) => InferenceModelPickerModal(
         defaultModelId: defaultModelId,
-        speechCapableModels: speechCapableModels,
+        models: models,
+        defaultBadgeLabel: defaultBadgeLabel,
       ),
     );
   }
 
   /// Splits the list so the default appears first when it exists in
-  /// [speechCapableModels]. When the default is missing (stale id /
-  /// no profile slot) the list renders as-is, with no row marked.
+  /// [models]. When the default is missing (stale id / no profile
+  /// slot) the list renders as-is, with no row marked.
   List<AiConfigModel> _orderedModels() {
     final defaultId = defaultModelId;
-    if (defaultId == null) return speechCapableModels;
-    final defaultModel = speechCapableModels
-        .where((m) => m.id == defaultId)
-        .firstOrNull;
-    if (defaultModel == null) return speechCapableModels;
+    if (defaultId == null) return models;
+    final defaultModel = models.where((m) => m.id == defaultId).firstOrNull;
+    if (defaultModel == null) return models;
     return [
       defaultModel,
-      ...speechCapableModels.where((m) => m.id != defaultId),
+      ...models.where((m) => m.id != defaultId),
     ];
   }
 
@@ -97,6 +104,7 @@ class TranscriptionModelPickerModal extends StatelessWidget {
             _ModelRow(
               model: ordered[i],
               isDefault: ordered[i].id == defaultModelId,
+              defaultBadgeLabel: defaultBadgeLabel,
               onTap: () => Navigator.of(context).pop(ordered[i].id),
             ),
           ],
@@ -110,17 +118,18 @@ class _ModelRow extends StatelessWidget {
   const _ModelRow({
     required this.model,
     required this.isDefault,
+    required this.defaultBadgeLabel,
     required this.onTap,
   });
 
   final AiConfigModel model;
   final bool isDefault;
+  final String defaultBadgeLabel;
   final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
-    final messages = context.messages;
     final radius = BorderRadius.circular(tokens.radii.l);
     final borderColor = isDefault
         ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.5)
@@ -162,9 +171,7 @@ class _ModelRow extends StatelessWidget {
                                 ),
                           ),
                           if (isDefault)
-                            DesignSystemBadge.filled(
-                              label: messages.aiTranscriptionPickerDefaultBadge,
-                            ),
+                            DesignSystemBadge.filled(label: defaultBadgeLabel),
                         ],
                       ),
                       if (model.providerModelId.isNotEmpty) ...[

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -401,6 +401,8 @@
   "aiFormCancel": "Zrušit",
   "aiFormFixErrors": "Prosím, opravte chyby před uložením",
   "aiFormNoChanges": "Žádné neuložené změny",
+  "aiImageAnalysisPickerDefaultBadge": "Výchozí",
+  "aiImageAnalysisPickerTitle": "Vyber model pro analýzu obrázků",
   "aiInferenceErrorAuthenticationTitle": "Autentizace selhala",
   "aiInferenceErrorConnectionFailedTitle": "Připojení selhalo",
   "aiInferenceErrorInvalidRequestTitle": "Neplatný požadavek",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -561,6 +561,8 @@
   "aiFormCancel": "Abbrechen",
   "aiFormFixErrors": "Bitte behebe die Fehler vor dem Speichern",
   "aiFormNoChanges": "Keine ungespeicherten Änderungen",
+  "aiImageAnalysisPickerDefaultBadge": "Standard",
+  "aiImageAnalysisPickerTitle": "Wähle ein Bildanalysemodell",
   "aiInferenceErrorAuthenticationTitle": "Authentifizierung fehlgeschlagen",
   "aiInferenceErrorConnectionFailedTitle": "Verbindung fehlgeschlagen",
   "aiInferenceErrorInvalidRequestTitle": "Ungültige Anfrage",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -746,6 +746,8 @@
   "aiFormCancel": "Cancel",
   "aiFormFixErrors": "Please fix errors before saving",
   "aiFormNoChanges": "No unsaved changes",
+  "aiImageAnalysisPickerDefaultBadge": "Default",
+  "aiImageAnalysisPickerTitle": "Pick an image analysis model",
   "aiInferenceErrorAuthenticationTitle": "Authentication Failed",
   "aiInferenceErrorConnectionFailedTitle": "Connection Failed",
   "aiInferenceErrorInvalidRequestTitle": "Invalid Request",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -561,6 +561,8 @@
   "aiFormCancel": "Cancelar",
   "aiFormFixErrors": "Por favor, corrige los errores antes de guardar",
   "aiFormNoChanges": "No hay cambios sin guardar",
+  "aiImageAnalysisPickerDefaultBadge": "Predeterminado",
+  "aiImageAnalysisPickerTitle": "Elige un modelo de análisis de imágenes",
   "aiInferenceErrorAuthenticationTitle": "Autenticación fallida",
   "aiInferenceErrorConnectionFailedTitle": "Conexión fallida",
   "aiInferenceErrorInvalidRequestTitle": "Solicitud no válida",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -561,6 +561,8 @@
   "aiFormCancel": "Annuler",
   "aiFormFixErrors": "Corrige les erreurs avant d'enregistrer",
   "aiFormNoChanges": "Aucune modification non enregistrée",
+  "aiImageAnalysisPickerDefaultBadge": "Par défaut",
+  "aiImageAnalysisPickerTitle": "Choisis un modèle d'analyse d'image",
   "aiInferenceErrorAuthenticationTitle": "Échec de l'authentification",
   "aiInferenceErrorConnectionFailedTitle": "Échec de la connexion",
   "aiInferenceErrorInvalidRequestTitle": "Requête invalide",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2239,6 +2239,18 @@ abstract class AppLocalizations {
   /// **'No unsaved changes'**
   String get aiFormNoChanges;
 
+  /// No description provided for @aiImageAnalysisPickerDefaultBadge.
+  ///
+  /// In en, this message translates to:
+  /// **'Default'**
+  String get aiImageAnalysisPickerDefaultBadge;
+
+  /// No description provided for @aiImageAnalysisPickerTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Pick an image analysis model'**
+  String get aiImageAnalysisPickerTitle;
+
   /// No description provided for @aiInferenceErrorAuthenticationTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1247,6 +1247,12 @@ class AppLocalizationsCs extends AppLocalizations {
   String get aiFormNoChanges => 'Žádné neuložené změny';
 
   @override
+  String get aiImageAnalysisPickerDefaultBadge => 'Výchozí';
+
+  @override
+  String get aiImageAnalysisPickerTitle => 'Vyber model pro analýzu obrázků';
+
+  @override
   String get aiInferenceErrorAuthenticationTitle => 'Autentizace selhala';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1252,6 +1252,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get aiFormNoChanges => 'Keine ungespeicherten Änderungen';
 
   @override
+  String get aiImageAnalysisPickerDefaultBadge => 'Standard';
+
+  @override
+  String get aiImageAnalysisPickerTitle => 'Wähle ein Bildanalysemodell';
+
+  @override
   String get aiInferenceErrorAuthenticationTitle =>
       'Authentifizierung fehlgeschlagen';
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1234,6 +1234,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get aiFormNoChanges => 'No unsaved changes';
 
   @override
+  String get aiImageAnalysisPickerDefaultBadge => 'Default';
+
+  @override
+  String get aiImageAnalysisPickerTitle => 'Pick an image analysis model';
+
+  @override
   String get aiInferenceErrorAuthenticationTitle => 'Authentication Failed';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1251,6 +1251,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get aiFormNoChanges => 'No hay cambios sin guardar';
 
   @override
+  String get aiImageAnalysisPickerDefaultBadge => 'Predeterminado';
+
+  @override
+  String get aiImageAnalysisPickerTitle =>
+      'Elige un modelo de análisis de imágenes';
+
+  @override
   String get aiInferenceErrorAuthenticationTitle => 'Autenticación fallida';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1258,6 +1258,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get aiFormNoChanges => 'Aucune modification non enregistrée';
 
   @override
+  String get aiImageAnalysisPickerDefaultBadge => 'Par défaut';
+
+  @override
+  String get aiImageAnalysisPickerTitle =>
+      'Choisis un modèle d\'analyse d\'image';
+
+  @override
   String get aiInferenceErrorAuthenticationTitle =>
       'Échec de l\'authentification';
 

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1259,6 +1259,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get aiFormNoChanges => 'Nu există modificări nesalvate';
 
   @override
+  String get aiImageAnalysisPickerDefaultBadge => 'Implicit';
+
+  @override
+  String get aiImageAnalysisPickerTitle =>
+      'Alegeți un model pentru analiza imaginilor';
+
+  @override
   String get aiInferenceErrorAuthenticationTitle => 'Autentificare eșuată';
 
   @override

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -561,6 +561,8 @@
   "aiFormCancel": "Anulează",
   "aiFormFixErrors": "Vă rugăm să corectați erorile înainte de salvare",
   "aiFormNoChanges": "Nu există modificări nesalvate",
+  "aiImageAnalysisPickerDefaultBadge": "Implicit",
+  "aiImageAnalysisPickerTitle": "Alegeți un model pentru analiza imaginilor",
   "aiInferenceErrorAuthenticationTitle": "Autentificare eșuată",
   "aiInferenceErrorConnectionFailedTitle": "Conexiune eșuată",
   "aiInferenceErrorInvalidRequestTitle": "Cerere invalidă",

--- a/test/features/ai/services/skill_inference_runner_test.dart
+++ b/test/features/ai/services/skill_inference_runner_test.dart
@@ -816,10 +816,10 @@ void main() {
       });
 
       test(
-        'overrideTranscriptionModelId routes the run to the override '
-        'model + its parent provider instead of the profile slot — the '
-        'popup-menu picker uses this seam to send one voice note to a '
-        'non-default model without mutating the profile',
+        'overrideModelId routes the run to the override model + its '
+        'parent provider instead of the profile slot — the popup-menu '
+        'picker uses this seam to send one voice note to a non-default '
+        'model without mutating the profile',
         () async {
           final audioEntity = makeAudioEntity();
           final audioDir = Directory('${tempDir.path}/audio');
@@ -885,7 +885,7 @@ void main() {
           await runner.runTranscription(
             audioEntryId: 'audio-1',
             automationResult: makeTranscriptionResult(),
-            overrideTranscriptionModelId: 'override-model-id',
+            overrideModelId: 'override-model-id',
           );
 
           // Inference targeted the override model + provider, NOT the
@@ -964,7 +964,7 @@ void main() {
           await runner.runTranscription(
             audioEntryId: 'audio-1',
             automationResult: makeTranscriptionResult(),
-            overrideTranscriptionModelId: 'stale-id',
+            overrideModelId: 'stale-id',
           );
 
           // Inference used the profile slot model (`whisper-1`) — the
@@ -1413,6 +1413,241 @@ void main() {
           ),
         ).called(1);
       });
+
+      test(
+        'overrideModelId routes the run to the override model + its '
+        'parent provider instead of the profile slot — the popup-menu '
+        'picker uses this seam to send one photo to a non-default '
+        'model without mutating the profile',
+        () async {
+          final imageEntity = makeImageEntity();
+          final imageDir = Directory('${tempDir.path}/images');
+          await imageDir.create(recursive: true);
+          await File('${imageDir.path}/test.jpg').writeAsBytes([0x01]);
+
+          final overrideProvider =
+              AiConfig.inferenceProvider(
+                    id: 'p-override',
+                    baseUrl: 'https://override.example.com',
+                    name: 'Override Provider',
+                    inferenceProviderType: InferenceProviderType.openAi,
+                    apiKey: 'override-key',
+                    createdAt: DateTime(2024),
+                  )
+                  as AiConfigInferenceProvider;
+          final overrideModel = AiConfig.model(
+            id: 'override-model-id',
+            name: 'Claude Sonnet Vision',
+            providerModelId: 'claude-sonnet',
+            inferenceProviderId: 'p-override',
+            createdAt: DateTime(2024),
+            inputModalities: const [Modality.image, Modality.text],
+            outputModalities: const [Modality.text],
+            isReasoningModel: false,
+          );
+
+          when(
+            () => mockAiConfigRepo.getConfigById('override-model-id'),
+          ).thenAnswer((_) async => overrideModel);
+          when(
+            () => mockAiConfigRepo.getConfigById('p-override'),
+          ).thenAnswer((_) async => overrideProvider);
+          when(
+            () => mockAiInputRepo.getEntity('img-1'),
+          ).thenAnswer((_) async => imageEntity);
+          when(
+            () => mockTaskSummaryResolver.resolve(any()),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockCloudRepo.generateWithImages(
+              any(),
+              baseUrl: any(named: 'baseUrl'),
+              apiKey: any(named: 'apiKey'),
+              model: any(named: 'model'),
+              temperature: any(named: 'temperature'),
+              images: any(named: 'images'),
+              provider: any(named: 'provider'),
+              systemMessage: any(named: 'systemMessage'),
+            ),
+          ).thenAnswer(
+            (_) => Stream.fromIterable([
+              makeStreamChunk('Override analysis'),
+            ]),
+          );
+          when(
+            () => mockJournalRepo.updateJournalEntity(any()),
+          ).thenAnswer((_) async => true);
+          stubLoggingEvent();
+
+          await runner.runImageAnalysis(
+            imageEntryId: 'img-1',
+            automationResult: makeImageAnalysisResult(),
+            overrideModelId: 'override-model-id',
+          );
+
+          // Inference targeted the override model + provider, NOT the
+          // profile slot's `vision-model` / `p-vision`.
+          verify(
+            () => mockCloudRepo.generateWithImages(
+              any(),
+              baseUrl: 'https://override.example.com',
+              apiKey: any(named: 'apiKey'),
+              model: 'claude-sonnet',
+              temperature: null,
+              images: any(named: 'images'),
+              provider: overrideProvider,
+              systemMessage: any(named: 'systemMessage'),
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'a stale override modelId (not resolvable to an AiConfigModel) '
+        'falls back to the profile slot — stranding the user with an '
+        '"image analysis does nothing" outcome is worse than ignoring '
+        'a deleted-between-picker-and-runner override',
+        () async {
+          final imageEntity = makeImageEntity();
+          final imageDir = Directory('${tempDir.path}/images');
+          await imageDir.create(recursive: true);
+          await File('${imageDir.path}/test.jpg').writeAsBytes([0x01]);
+
+          when(
+            () => mockAiConfigRepo.getConfigById('stale-id'),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockAiInputRepo.getEntity('img-1'),
+          ).thenAnswer((_) async => imageEntity);
+          when(
+            () => mockTaskSummaryResolver.resolve(any()),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockCloudRepo.generateWithImages(
+              any(),
+              baseUrl: any(named: 'baseUrl'),
+              apiKey: any(named: 'apiKey'),
+              model: any(named: 'model'),
+              temperature: any(named: 'temperature'),
+              images: any(named: 'images'),
+              provider: any(named: 'provider'),
+              systemMessage: any(named: 'systemMessage'),
+            ),
+          ).thenAnswer(
+            (_) => Stream.fromIterable([
+              makeStreamChunk('Fell back to profile'),
+            ]),
+          );
+          when(
+            () => mockJournalRepo.updateJournalEntity(any()),
+          ).thenAnswer((_) async => true);
+          stubLoggingEvent();
+
+          await runner.runImageAnalysis(
+            imageEntryId: 'img-1',
+            automationResult: makeImageAnalysisResult(),
+            overrideModelId: 'stale-id',
+          );
+
+          // Inference used the profile slot model (`vision-model`)
+          // routed via the profile slot's provider `p-vision` — the
+          // stale override was ignored. Pinning the provider too
+          // catches a hypothetical regression where the runner
+          // chooses the right model but the wrong provider.
+          verify(
+            () => mockCloudRepo.generateWithImages(
+              any(),
+              baseUrl: any(named: 'baseUrl'),
+              apiKey: any(named: 'apiKey'),
+              model: 'vision-model',
+              temperature: null,
+              images: any(named: 'images'),
+              provider: testInferenceProvider(id: 'p-vision'),
+              systemMessage: any(named: 'systemMessage'),
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'an override modelId whose parent provider does not resolve to '
+        'an AiConfigInferenceProvider falls back to the profile slot — '
+        'a model row pointing at a stale/deleted provider should not '
+        'strand the run, same defensive principle as the missing-model '
+        'fallback',
+        () async {
+          final imageEntity = makeImageEntity();
+          final imageDir = Directory('${tempDir.path}/images');
+          await imageDir.create(recursive: true);
+          await File('${imageDir.path}/test.jpg').writeAsBytes([0x01]);
+
+          final orphanModel = AiConfig.model(
+            id: 'override-model-id',
+            name: 'Orphaned Vision',
+            providerModelId: 'orphan-model',
+            inferenceProviderId: 'p-missing',
+            createdAt: DateTime(2024),
+            inputModalities: const [Modality.image, Modality.text],
+            outputModalities: const [Modality.text],
+            isReasoningModel: false,
+          );
+
+          when(
+            () => mockAiConfigRepo.getConfigById('override-model-id'),
+          ).thenAnswer((_) async => orphanModel);
+          when(
+            () => mockAiConfigRepo.getConfigById('p-missing'),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockAiInputRepo.getEntity('img-1'),
+          ).thenAnswer((_) async => imageEntity);
+          when(
+            () => mockTaskSummaryResolver.resolve(any()),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockCloudRepo.generateWithImages(
+              any(),
+              baseUrl: any(named: 'baseUrl'),
+              apiKey: any(named: 'apiKey'),
+              model: any(named: 'model'),
+              temperature: any(named: 'temperature'),
+              images: any(named: 'images'),
+              provider: any(named: 'provider'),
+              systemMessage: any(named: 'systemMessage'),
+            ),
+          ).thenAnswer(
+            (_) => Stream.fromIterable([
+              makeStreamChunk('Fell back to profile'),
+            ]),
+          );
+          when(
+            () => mockJournalRepo.updateJournalEntity(any()),
+          ).thenAnswer((_) async => true);
+          stubLoggingEvent();
+
+          await runner.runImageAnalysis(
+            imageEntryId: 'img-1',
+            automationResult: makeImageAnalysisResult(),
+            overrideModelId: 'override-model-id',
+          );
+
+          // Same provider-pinning as the stale-override case above:
+          // verifying provider `p-vision` (the profile slot) catches
+          // wrong-provider routing that a model-only check would miss.
+          verify(
+            () => mockCloudRepo.generateWithImages(
+              any(),
+              baseUrl: any(named: 'baseUrl'),
+              apiKey: any(named: 'apiKey'),
+              model: 'vision-model',
+              temperature: null,
+              images: any(named: 'images'),
+              provider: testInferenceProvider(id: 'p-vision'),
+              systemMessage: any(named: 'systemMessage'),
+            ),
+          ).called(1);
+        },
+      );
     });
 
     group('runPromptGeneration', () {

--- a/test/features/ai/state/unified_ai_controller_test.dart
+++ b/test/features/ai/state/unified_ai_controller_test.dart
@@ -1403,7 +1403,7 @@ void main() {
           skillId: 'nonexistent-skill',
           linkedTaskId: 'task-1',
           referenceImages: null,
-          overrideTranscriptionModelId: null,
+          overrideModelId: null,
         )).future,
       );
 
@@ -1463,7 +1463,7 @@ void main() {
             skillId: 'skill-1',
             linkedTaskId: null,
             referenceImages: null,
-            overrideTranscriptionModelId: null,
+            overrideModelId: null,
           )).future,
         );
 
@@ -1507,7 +1507,7 @@ void main() {
           skillId: 'skill-2',
           linkedTaskId: 'task-no-profile',
           referenceImages: null,
-          overrideTranscriptionModelId: null,
+          overrideModelId: null,
         )).future,
       );
 
@@ -1583,7 +1583,7 @@ void main() {
           skillId: 'skill-transcribe',
           linkedTaskId: 'task-1',
           referenceImages: null,
-          overrideTranscriptionModelId: null,
+          overrideModelId: null,
         )).future,
       );
 
@@ -1686,7 +1686,7 @@ void main() {
             skillId: 'skill-transcribe',
             linkedTaskId: null,
             referenceImages: null,
-            overrideTranscriptionModelId: null,
+            overrideModelId: null,
           )).future,
         );
 
@@ -1735,7 +1735,7 @@ void main() {
             skillId: 'skill-cover-art',
             linkedTaskId: null,
             referenceImages: null,
-            overrideTranscriptionModelId: null,
+            overrideModelId: null,
           )).future,
         );
 
@@ -1813,7 +1813,7 @@ void main() {
           skillId: 'skill-image',
           linkedTaskId: 'task-img',
           referenceImages: null,
-          overrideTranscriptionModelId: null,
+          overrideModelId: null,
         )).future,
       );
 
@@ -1825,6 +1825,97 @@ void main() {
         ),
       ).called(1);
     });
+
+    test(
+      'threads overrideModelId from TriggerSkillParams to '
+      'SkillInferenceRunner.runImageAnalysis when the skill type is '
+      'imageAnalysis — the popup picker sets this field when the user '
+      'routes one photo to a non-default model, and the trigger must '
+      'forward it to the runner so the per-invocation override '
+      'actually takes effect',
+      () async {
+        final skill =
+            AiConfig.skill(
+                  id: 'skill-image',
+                  name: 'Image Analysis',
+                  createdAt: DateTime(2024, 3, 15),
+                  skillType: SkillType.imageAnalysis,
+                  requiredInputModalities: [Modality.image],
+                  systemInstructions: 'System',
+                  userInstructions: 'User',
+                )
+                as AiConfigSkill;
+
+        final thinkingProvider =
+            AiConfig.inferenceProvider(
+                  id: 'anthropic-prov',
+                  name: 'Anthropic',
+                  inferenceProviderType: InferenceProviderType.anthropic,
+                  apiKey: 'key',
+                  baseUrl: 'https://api.anthropic.com',
+                  createdAt: DateTime(2024, 3, 15),
+                )
+                as AiConfigInferenceProvider;
+        final imageRecognitionProvider =
+            AiConfig.inferenceProvider(
+                  id: 'openai-prov',
+                  name: 'OpenAI',
+                  inferenceProviderType: InferenceProviderType.openAi,
+                  apiKey: 'key',
+                  baseUrl: 'https://api.openai.com',
+                  createdAt: DateTime(2024, 3, 15),
+                )
+                as AiConfigInferenceProvider;
+
+        final resolvedProfile = ResolvedProfile(
+          thinkingModelId: 'thinking-model',
+          thinkingProvider: thinkingProvider,
+          imageRecognitionModelId: 'image-model',
+          imageRecognitionProvider: imageRecognitionProvider,
+        );
+
+        when(
+          () => mockResolver.resolveForTask('task-img'),
+        ).thenAnswer((_) async => resolvedProfile);
+
+        when(
+          () => mockRunner.runImageAnalysis(
+            imageEntryId: any(named: 'imageEntryId'),
+            automationResult: any(named: 'automationResult'),
+            linkedTaskId: any(named: 'linkedTaskId'),
+            overrideModelId: any(named: 'overrideModelId'),
+          ),
+        ).thenAnswer((_) async {});
+
+        final testContainer = ProviderContainer(
+          overrides: [
+            skillRegistryProvider.overrideWithValue([skill]),
+            profileAutomationResolverProvider.overrideWithValue(mockResolver),
+            skillInferenceRunnerProvider.overrideWithValue(mockRunner),
+          ],
+        );
+        containersToDispose.add(testContainer);
+
+        await testContainer.read(
+          triggerSkillProvider((
+            entityId: 'image-entry-1',
+            skillId: 'skill-image',
+            linkedTaskId: 'task-img',
+            referenceImages: null,
+            overrideModelId: 'override-vision-model-id',
+          )).future,
+        );
+
+        verify(
+          () => mockRunner.runImageAnalysis(
+            imageEntryId: 'image-entry-1',
+            automationResult: any(named: 'automationResult'),
+            linkedTaskId: 'task-img',
+            overrideModelId: 'override-vision-model-id',
+          ),
+        ).called(1);
+      },
+    );
 
     test('successfully routes prompt generation skill to runner', () async {
       final skill =
@@ -1882,7 +1973,7 @@ void main() {
           skillId: 'skill-prompt',
           linkedTaskId: 'task-prompt',
           referenceImages: null,
-          overrideTranscriptionModelId: null,
+          overrideModelId: null,
         )).future,
       );
 
@@ -1955,7 +2046,7 @@ void main() {
           skillId: 'skill-imggen',
           linkedTaskId: 'task-imggen',
           referenceImages: null,
-          overrideTranscriptionModelId: null,
+          overrideModelId: null,
         )).future,
       );
 
@@ -2038,7 +2129,7 @@ void main() {
           skillId: 'skill-imggen2',
           linkedTaskId: 'task-imggen2',
           referenceImages: refImages,
-          overrideTranscriptionModelId: null,
+          overrideModelId: null,
         )).future,
       );
 
@@ -2111,7 +2202,7 @@ void main() {
             skillId: 'skill-img-prompt',
             linkedTaskId: 'task-img-prompt',
             referenceImages: null,
-            overrideTranscriptionModelId: null,
+            overrideModelId: null,
           )).future,
         );
 

--- a/test/features/ai/ui/unified_ai_popup_menu_test.dart
+++ b/test/features/ai/ui/unified_ai_popup_menu_test.dart
@@ -19,7 +19,7 @@ import 'package:lotti/features/ai/state/profile_automation_providers.dart';
 import 'package:lotti/features/ai/state/settings/ai_config_by_type_controller.dart';
 import 'package:lotti/features/ai/state/unified_ai_controller.dart';
 import 'package:lotti/features/ai/ui/unified_ai_popup_menu.dart';
-import 'package:lotti/features/ai/ui/widgets/transcription_model_picker_modal.dart';
+import 'package:lotti/features/ai/ui/widgets/inference_model_picker_modal.dart';
 import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations.dart';
@@ -1032,513 +1032,206 @@ void main() {
     );
   });
 
-  group('Transcription Skill Handling — model-override picker', () {
-    testWidgets(
-      'tapping a transcription skill with two speech-capable models '
-      'opens the TranscriptionModelPickerModal — proves the popup '
-      'inserts the picker step before firing the trigger, and proves '
-      'the picker is fed the full speech-capable list (the model '
-      'whose inputModalities do NOT include audio is filtered out '
-      'before the picker sees it)',
-      (tester) async {
-        final now = DateTime(2024, 3, 15, 10);
-        final transcribeSkill =
-            AiConfig.skill(
-                  id: 'skill-transcribe',
-                  name: 'Transcribe Audio',
-                  createdAt: now,
-                  skillType: SkillType.transcription,
-                  requiredInputModalities: [Modality.audio],
-                  systemInstructions: 'Transcribe the audio.',
-                  userInstructions: 'Please transcribe.',
-                  description: 'Skill-based transcription',
-                )
-                as AiConfigSkill;
-
-        // Two speech-capable models + one decoy (text only). The
-        // decoy must NOT appear in the picker.
-        final voxtral = AiConfig.model(
-          id: 'm-voxtral',
-          name: 'Voxtral Local',
-          providerModelId: 'voxtral-mini',
-          inferenceProviderId: 'p-voxtral',
-          createdAt: now,
-          inputModalities: const [Modality.audio, Modality.text],
-          outputModalities: const [Modality.text],
-          isReasoningModel: false,
-        );
-        final mistral = AiConfig.model(
-          id: 'm-mistral',
-          name: 'Mistral Cloud',
-          providerModelId: 'mistral/voxtral',
-          inferenceProviderId: 'p-mistral',
-          createdAt: now,
-          inputModalities: const [Modality.audio, Modality.text],
-          outputModalities: const [Modality.text],
-          isReasoningModel: false,
-        );
-        final textOnlyDecoy = AiConfig.model(
-          id: 'm-text-only',
-          name: 'Gemini Flash (text only)',
-          providerModelId: 'gemini-flash',
-          inferenceProviderId: 'p-gemini',
-          createdAt: now,
-          inputModalities: const [Modality.text],
-          outputModalities: const [Modality.text],
-          isReasoningModel: false,
-        );
-
-        await tester.pumpWidget(
-          buildTestWidget(
-            UnifiedAiPopUpMenu(
-              journalEntity: testAudioEntity,
-              linkedFromId: null,
-            ),
-            overrides: [
-              hasAvailableSkillsProvider((
-                entityId: testAudioEntity.id,
-                linkedFromId: null,
-              )).overrideWith((ref) => Future.value(true)),
-              availableSkillsForEntityProvider((
-                entityId: testAudioEntity.id,
-                linkedFromId: null,
-              )).overrideWith(
-                (ref) => Future.value([transcribeSkill]),
+  // Same dispatch shape covers transcription + image-analysis; the
+  // [_overrideVariants] table varies only the skill type, modality,
+  // entity factory, and profile slot. Adding a third per-invocation
+  // override slot is a new entry in the table — no test bodies copy.
+  group('Per-invocation model override — picker flow', () {
+    for (final variant in _overrideVariants) {
+      group(variant.label, () {
+        testWidgets(
+          'tapping the skill with two slot-capable models opens the '
+          'InferenceModelPickerModal — proves the popup inserts the '
+          'picker step before firing the trigger, and proves the '
+          'picker is fed the slot-capable list (the decoy model whose '
+          'inputModalities do NOT match the slot modality is filtered '
+          'out before the picker sees it)',
+          (tester) async {
+            final fx = _OverrideFixture.twoModelsPlusDecoy(variant);
+            await tester.pumpWidget(
+              buildTestWidget(
+                UnifiedAiPopUpMenu(
+                  journalEntity: fx.entity,
+                  linkedFromId: null,
+                ),
+                overrides: _baseOverrides(
+                  entity: fx.entity,
+                  skill: fx.skill,
+                  models: fx.allModels,
+                  resolver: _NullProfileResolver(),
+                  configs: fx.allModels,
+                ),
               ),
-              // Skip the real profile resolver — it depends on
-              // agent providers + AgentDatabase that aren't set up
-              // in this test surface. A `null` resolved profile
-              // means the picker's default-row badge is absent,
-              // which is fine for this assertion since we only
-              // care about which model rows render.
-              profileAutomationResolverProvider.overrideWithValue(
-                _NullProfileResolver(),
-              ),
-              aiConfigByTypeControllerProvider(
-                configType: AiConfigType.model,
-              ).overrideWith(
-                () => MockAiConfigByTypeController([
-                  voxtral,
-                  mistral,
-                  textOnlyDecoy,
-                ]),
-              ),
-              aiConfigRepositoryProvider.overrideWithValue(
-                _StubAiConfigRepository([voxtral, mistral, textOnlyDecoy]),
-              ),
-            ],
-          ),
+            );
+            await tester.pumpAndSettle();
+
+            await tester.tap(find.byIcon(Icons.assistant_rounded));
+            await tester.pumpAndSettle();
+            await tester.tap(find.text(variant.skillName));
+            await tester.pumpAndSettle();
+
+            // Picker is mounted and lists both slot-capable models;
+            // the wrong-modality decoy is absent because the popup
+            // filters by `inputModalities.contains(variant.modality)`
+            // before calling the picker.
+            expect(find.byType(InferenceModelPickerModal), findsOneWidget);
+            expect(find.text(fx.modelA.name), findsOneWidget);
+            expect(find.text(fx.modelB.name), findsOneWidget);
+            expect(find.text(fx.decoy.name), findsNothing);
+          },
         );
 
-        await tester.pumpAndSettle();
-
-        // Open the popup
-        await tester.tap(find.byIcon(Icons.assistant_rounded));
-        await tester.pumpAndSettle();
-
-        // Tap the transcription skill — should open the picker
-        // instead of firing the trigger directly.
-        await tester.tap(find.text('Transcribe Audio'));
-        await tester.pumpAndSettle();
-
-        // Picker is mounted and lists both speech-capable models;
-        // the text-only decoy is absent because the popup filters
-        // by `inputModalities.contains(Modality.audio)` before
-        // calling the picker.
-        expect(find.byType(TranscriptionModelPickerModal), findsOneWidget);
-        expect(find.text('Voxtral Local'), findsOneWidget);
-        expect(find.text('Mistral Cloud'), findsOneWidget);
-        expect(find.text('Gemini Flash (text only)'), findsNothing);
-      },
-    );
-
-    testWidgets(
-      'when only one speech-capable model is configured the picker '
-      'short-circuits and the popup fires the trigger immediately — '
-      'preserving the one-tap transcribe flow for users with a single '
-      'audio-capable model. Asserted indirectly by the absence of the '
-      'picker after the skill tap (the modal never mounts because '
-      'TranscriptionModelPickerModal.show short-circuits internally)',
-      (tester) async {
-        final now = DateTime(2024, 3, 15, 10);
-        final transcribeSkill =
-            AiConfig.skill(
-                  id: 'skill-transcribe',
-                  name: 'Transcribe Audio',
-                  createdAt: now,
-                  skillType: SkillType.transcription,
-                  requiredInputModalities: [Modality.audio],
-                  systemInstructions: 'Transcribe the audio.',
-                  userInstructions: 'Please transcribe.',
-                  description: 'Skill-based transcription',
-                )
-                as AiConfigSkill;
-
-        final voxtral = AiConfig.model(
-          id: 'm-voxtral',
-          name: 'Voxtral Local',
-          providerModelId: 'voxtral-mini',
-          inferenceProviderId: 'p-voxtral',
-          createdAt: now,
-          inputModalities: const [Modality.audio, Modality.text],
-          outputModalities: const [Modality.text],
-          isReasoningModel: false,
-        );
-
-        await tester.pumpWidget(
-          buildTestWidget(
-            UnifiedAiPopUpMenu(
-              journalEntity: testAudioEntity,
-              linkedFromId: null,
-            ),
-            overrides: [
-              hasAvailableSkillsProvider((
-                entityId: testAudioEntity.id,
-                linkedFromId: null,
-              )).overrideWith((ref) => Future.value(true)),
-              availableSkillsForEntityProvider((
-                entityId: testAudioEntity.id,
-                linkedFromId: null,
-              )).overrideWith(
-                (ref) => Future.value([transcribeSkill]),
+        testWidgets(
+          'when only one slot-capable model is configured the picker '
+          'short-circuits and the popup fires the trigger immediately '
+          '— preserving the one-tap flow. Asserts both that the modal '
+          'never mounts AND that triggerSkillProvider runs once with '
+          'the lone model id as overrideModelId; the latter catches a '
+          'regression where the short-circuit path silently skips '
+          'dispatch (which the picker-absence check alone would miss)',
+          (tester) async {
+            final fx = _OverrideFixture.singleModel(variant);
+            TriggerSkillParams? capturedParams;
+            await tester.pumpWidget(
+              buildTestWidget(
+                UnifiedAiPopUpMenu(
+                  journalEntity: fx.entity,
+                  linkedFromId: null,
+                ),
+                overrides: [
+                  ..._baseOverrides(
+                    entity: fx.entity,
+                    skill: fx.skill,
+                    models: fx.allModels,
+                    resolver: _NullProfileResolver(),
+                    configs: fx.allModels,
+                  ),
+                  triggerSkillProvider.overrideWith((ref, params) async {
+                    capturedParams = params;
+                  }),
+                ],
               ),
-              // Skip the real profile resolver — it depends on
-              // agent providers + AgentDatabase that aren't set up
-              // in this test surface. A `null` resolved profile
-              // means the picker's default-row badge is absent,
-              // which is fine for this assertion since we only
-              // care about which model rows render.
-              profileAutomationResolverProvider.overrideWithValue(
-                _NullProfileResolver(),
+            );
+            await tester.pumpAndSettle();
+
+            await tester.tap(find.byIcon(Icons.assistant_rounded));
+            await tester.pumpAndSettle();
+            await tester.tap(find.text(variant.skillName));
+            await tester.pumpAndSettle();
+
+            // No picker — short-circuit took the single-model path.
+            // Skills list closed as part of the tap handler.
+            expect(find.byType(InferenceModelPickerModal), findsNothing);
+            expect(find.byType(UnifiedAiSkillsList), findsNothing);
+            // Trigger fired with the lone model id forwarded as the
+            // override — the short-circuit isn't a silent no-op.
+            expect(capturedParams, isNotNull);
+            expect(capturedParams!.entityId, fx.entity.id);
+            expect(capturedParams!.skillId, fx.skill.id);
+            expect(capturedParams!.overrideModelId, fx.modelA.id);
+          },
+        );
+
+        testWidgets(
+          'tapping the default-badged row forwards overrideModelId: '
+          'null to triggerSkillProvider — the override is collapsed '
+          'to null when the user picks the same model the profile '
+          'already points at, so the runner reads the profile slot '
+          'and a model deleted between picker and run still falls '
+          'back gracefully',
+          (tester) async {
+            final fx = _OverrideFixture.twoModelsWithDefault(variant);
+            TriggerSkillParams? capturedParams;
+            await tester.pumpWidget(
+              buildTestWidget(
+                UnifiedAiPopUpMenu(
+                  journalEntity: fx.entity,
+                  linkedFromId: null,
+                ),
+                overrides: [
+                  entryControllerProvider(id: fx.entity.id).overrideWith(
+                    () => FakeEntryController(fx.entity),
+                  ),
+                  ..._baseOverrides(
+                    entity: fx.entity,
+                    skill: fx.skill,
+                    models: fx.allModels,
+                    resolver: _FixedProfileResolver(fx.profile!),
+                    configs: [...fx.allModels, ...fx.providers],
+                  ),
+                  triggerSkillProvider.overrideWith((ref, params) async {
+                    capturedParams = params;
+                  }),
+                ],
               ),
-              aiConfigByTypeControllerProvider(
-                configType: AiConfigType.model,
-              ).overrideWith(
-                () => MockAiConfigByTypeController([voxtral]),
+            );
+            await tester.pumpAndSettle();
+
+            await tester.tap(find.byIcon(Icons.assistant_rounded));
+            await tester.pumpAndSettle();
+            await tester.tap(find.text(variant.skillName));
+            await tester.pumpAndSettle();
+
+            // Tap the default-badged row (modelA) — the popup should
+            // fire the trigger with overrideModelId: null because the
+            // picked id matches the computed defaultModelId.
+            expect(find.byType(InferenceModelPickerModal), findsOneWidget);
+            await tester.tap(find.text(fx.modelA.name));
+            await tester.pumpAndSettle();
+
+            expect(capturedParams, isNotNull);
+            expect(capturedParams!.entityId, fx.entity.id);
+            expect(capturedParams!.skillId, fx.skill.id);
+            expect(capturedParams!.overrideModelId, isNull);
+          },
+        );
+
+        testWidgets(
+          "tapping a non-default row forwards that row's "
+          'AiConfigModel.id to triggerSkillProvider as overrideModelId '
+          '— proves the override seam threads through the popup to '
+          'the trigger when the user picks a non-profile model',
+          (tester) async {
+            final fx = _OverrideFixture.twoModelsWithDefault(variant);
+            TriggerSkillParams? capturedParams;
+            await tester.pumpWidget(
+              buildTestWidget(
+                UnifiedAiPopUpMenu(
+                  journalEntity: fx.entity,
+                  linkedFromId: null,
+                ),
+                overrides: [
+                  entryControllerProvider(id: fx.entity.id).overrideWith(
+                    () => FakeEntryController(fx.entity),
+                  ),
+                  ..._baseOverrides(
+                    entity: fx.entity,
+                    skill: fx.skill,
+                    models: fx.allModels,
+                    resolver: _FixedProfileResolver(fx.profile!),
+                    configs: [...fx.allModels, ...fx.providers],
+                  ),
+                  triggerSkillProvider.overrideWith((ref, params) async {
+                    capturedParams = params;
+                  }),
+                ],
               ),
-              aiConfigRepositoryProvider.overrideWithValue(
-                _StubAiConfigRepository([voxtral]),
-              ),
-            ],
-          ),
+            );
+            await tester.pumpAndSettle();
+
+            await tester.tap(find.byIcon(Icons.assistant_rounded));
+            await tester.pumpAndSettle();
+            await tester.tap(find.text(variant.skillName));
+            await tester.pumpAndSettle();
+            await tester.tap(find.text(fx.modelB.name));
+            await tester.pumpAndSettle();
+
+            expect(capturedParams, isNotNull);
+            expect(capturedParams!.overrideModelId, fx.modelB.id);
+          },
         );
-
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.byIcon(Icons.assistant_rounded));
-        await tester.pumpAndSettle();
-        await tester.tap(find.text('Transcribe Audio'));
-        await tester.pumpAndSettle();
-
-        // No picker was rendered — the short-circuit took the
-        // single-model path and called the trigger directly.
-        expect(find.byType(TranscriptionModelPickerModal), findsNothing);
-        // The skills list modal closed as part of the tap handler.
-        expect(find.byType(UnifiedAiSkillsList), findsNothing);
-      },
-    );
-
-    testWidgets(
-      'tapping the default-badged row forwards '
-      'overrideTranscriptionModelId: null to triggerSkillProvider — '
-      'the override is collapsed to null when the user picks the same '
-      'model the profile already points at, so the runner reads the '
-      'profile slot and a model deleted between picker and run still '
-      'falls back gracefully',
-      (tester) async {
-        final now = DateTime(2024, 3, 15, 10);
-        final transcribeSkill =
-            AiConfig.skill(
-                  id: 'skill-transcribe',
-                  name: 'Transcribe Audio',
-                  createdAt: now,
-                  skillType: SkillType.transcription,
-                  requiredInputModalities: [Modality.audio],
-                  systemInstructions: 'Transcribe the audio.',
-                  userInstructions: 'Please transcribe.',
-                  description: 'Skill-based transcription',
-                )
-                as AiConfigSkill;
-
-        final voxtralProvider =
-            AiConfig.inferenceProvider(
-                  id: 'p-voxtral',
-                  baseUrl: 'https://voxtral.local',
-                  name: 'Voxtral Local',
-                  inferenceProviderType: InferenceProviderType.openAi,
-                  apiKey: '',
-                  createdAt: now,
-                )
-                as AiConfigInferenceProvider;
-        final mistralProvider =
-            AiConfig.inferenceProvider(
-                  id: 'p-mistral',
-                  baseUrl: 'https://mistral.example.com',
-                  name: 'Mistral Cloud',
-                  inferenceProviderType: InferenceProviderType.openAi,
-                  apiKey: '',
-                  createdAt: now,
-                )
-                as AiConfigInferenceProvider;
-        final voxtral = AiConfig.model(
-          id: 'm-voxtral',
-          name: 'Voxtral Local',
-          providerModelId: 'voxtral-mini',
-          inferenceProviderId: 'p-voxtral',
-          createdAt: now,
-          inputModalities: const [Modality.audio, Modality.text],
-          outputModalities: const [Modality.text],
-          isReasoningModel: false,
-        );
-        final mistral = AiConfig.model(
-          id: 'm-mistral',
-          name: 'Mistral Cloud',
-          providerModelId: 'mistral/voxtral',
-          inferenceProviderId: 'p-mistral',
-          createdAt: now,
-          inputModalities: const [Modality.audio, Modality.text],
-          outputModalities: const [Modality.text],
-          isReasoningModel: false,
-        );
-
-        // Resolved profile points at Voxtral — the popup must
-        // recognise the Voxtral row as the default.
-        final resolvedProfile = ResolvedProfile(
-          thinkingModelId: 'thinking',
-          thinkingProvider: voxtralProvider,
-          transcriptionProvider: voxtralProvider,
-          transcriptionModelId: 'voxtral-mini',
-        );
-
-        // The popup resolves the profile via the entry's categoryId
-        // when there is no linked task. The shared `testAudioEntity`
-        // has no category, which would short-circuit defaultModelId
-        // resolution to null — so use a freshly categorised entity
-        // here.
-        final audioWithCategory = JournalAudio(
-          meta: Metadata(
-            id: 'audio-cat-1',
-            createdAt: now,
-            updatedAt: now,
-            dateFrom: now,
-            dateTo: now,
-            categoryId: 'cat-1',
-          ),
-          data: AudioData(
-            dateFrom: now,
-            dateTo: now,
-            audioFile: 'test.mp3',
-            audioDirectory: '/test',
-            duration: const Duration(minutes: 1),
-          ),
-        );
-
-        TriggerSkillParams? capturedParams;
-
-        await tester.pumpWidget(
-          buildTestWidget(
-            UnifiedAiPopUpMenu(
-              journalEntity: audioWithCategory,
-              linkedFromId: null,
-            ),
-            overrides: [
-              hasAvailableSkillsProvider((
-                entityId: audioWithCategory.id,
-                linkedFromId: null,
-              )).overrideWith((ref) => Future.value(true)),
-              availableSkillsForEntityProvider((
-                entityId: audioWithCategory.id,
-                linkedFromId: null,
-              )).overrideWith(
-                (ref) => Future.value([transcribeSkill]),
-              ),
-              profileAutomationResolverProvider.overrideWithValue(
-                _FixedProfileResolver(resolvedProfile),
-              ),
-              aiConfigByTypeControllerProvider(
-                configType: AiConfigType.model,
-              ).overrideWith(
-                () => MockAiConfigByTypeController([voxtral, mistral]),
-              ),
-              aiConfigRepositoryProvider.overrideWithValue(
-                _StubAiConfigRepository([
-                  voxtral,
-                  mistral,
-                  voxtralProvider,
-                  mistralProvider,
-                ]),
-              ),
-              triggerSkillProvider.overrideWith((ref, params) async {
-                capturedParams = params;
-              }),
-            ],
-          ),
-        );
-
-        await tester.pumpAndSettle();
-        await tester.tap(find.byIcon(Icons.assistant_rounded));
-        await tester.pumpAndSettle();
-        await tester.tap(find.text('Transcribe Audio'));
-        await tester.pumpAndSettle();
-
-        // Picker is open; both rows render. Tap the default-badged
-        // row (Voxtral) — the popup should fire the trigger with
-        // overrideTranscriptionModelId: null because the picked id
-        // matches the computed defaultModelId.
-        expect(find.byType(TranscriptionModelPickerModal), findsOneWidget);
-        await tester.tap(find.text('Voxtral Local'));
-        await tester.pumpAndSettle();
-
-        expect(capturedParams, isNotNull);
-        expect(capturedParams!.entityId, audioWithCategory.id);
-        expect(capturedParams!.skillId, 'skill-transcribe');
-        expect(capturedParams!.overrideTranscriptionModelId, isNull);
-      },
-    );
-
-    testWidgets(
-      "tapping a non-default row forwards that row's AiConfigModel.id "
-      'to triggerSkillProvider as overrideTranscriptionModelId — proves '
-      'the override seam threads through the popup to the trigger when '
-      'the user picks a non-profile model',
-      (tester) async {
-        final now = DateTime(2024, 3, 15, 10);
-        final transcribeSkill =
-            AiConfig.skill(
-                  id: 'skill-transcribe',
-                  name: 'Transcribe Audio',
-                  createdAt: now,
-                  skillType: SkillType.transcription,
-                  requiredInputModalities: [Modality.audio],
-                  systemInstructions: 'Transcribe the audio.',
-                  userInstructions: 'Please transcribe.',
-                  description: 'Skill-based transcription',
-                )
-                as AiConfigSkill;
-
-        final voxtralProvider =
-            AiConfig.inferenceProvider(
-                  id: 'p-voxtral',
-                  baseUrl: 'https://voxtral.local',
-                  name: 'Voxtral Local',
-                  inferenceProviderType: InferenceProviderType.openAi,
-                  apiKey: '',
-                  createdAt: now,
-                )
-                as AiConfigInferenceProvider;
-        final mistralProvider =
-            AiConfig.inferenceProvider(
-                  id: 'p-mistral',
-                  baseUrl: 'https://mistral.example.com',
-                  name: 'Mistral Cloud',
-                  inferenceProviderType: InferenceProviderType.openAi,
-                  apiKey: '',
-                  createdAt: now,
-                )
-                as AiConfigInferenceProvider;
-        final voxtral = AiConfig.model(
-          id: 'm-voxtral',
-          name: 'Voxtral Local',
-          providerModelId: 'voxtral-mini',
-          inferenceProviderId: 'p-voxtral',
-          createdAt: now,
-          inputModalities: const [Modality.audio, Modality.text],
-          outputModalities: const [Modality.text],
-          isReasoningModel: false,
-        );
-        final mistral = AiConfig.model(
-          id: 'm-mistral',
-          name: 'Mistral Cloud',
-          providerModelId: 'mistral/voxtral',
-          inferenceProviderId: 'p-mistral',
-          createdAt: now,
-          inputModalities: const [Modality.audio, Modality.text],
-          outputModalities: const [Modality.text],
-          isReasoningModel: false,
-        );
-
-        final resolvedProfile = ResolvedProfile(
-          thinkingModelId: 'thinking',
-          thinkingProvider: voxtralProvider,
-          transcriptionProvider: voxtralProvider,
-          transcriptionModelId: 'voxtral-mini',
-        );
-
-        final audioWithCategory = JournalAudio(
-          meta: Metadata(
-            id: 'audio-cat-2',
-            createdAt: now,
-            updatedAt: now,
-            dateFrom: now,
-            dateTo: now,
-            categoryId: 'cat-1',
-          ),
-          data: AudioData(
-            dateFrom: now,
-            dateTo: now,
-            audioFile: 'test.mp3',
-            audioDirectory: '/test',
-            duration: const Duration(minutes: 1),
-          ),
-        );
-
-        TriggerSkillParams? capturedParams;
-
-        await tester.pumpWidget(
-          buildTestWidget(
-            UnifiedAiPopUpMenu(
-              journalEntity: audioWithCategory,
-              linkedFromId: null,
-            ),
-            overrides: [
-              hasAvailableSkillsProvider((
-                entityId: audioWithCategory.id,
-                linkedFromId: null,
-              )).overrideWith((ref) => Future.value(true)),
-              availableSkillsForEntityProvider((
-                entityId: audioWithCategory.id,
-                linkedFromId: null,
-              )).overrideWith(
-                (ref) => Future.value([transcribeSkill]),
-              ),
-              profileAutomationResolverProvider.overrideWithValue(
-                _FixedProfileResolver(resolvedProfile),
-              ),
-              aiConfigByTypeControllerProvider(
-                configType: AiConfigType.model,
-              ).overrideWith(
-                () => MockAiConfigByTypeController([voxtral, mistral]),
-              ),
-              aiConfigRepositoryProvider.overrideWithValue(
-                _StubAiConfigRepository([
-                  voxtral,
-                  mistral,
-                  voxtralProvider,
-                  mistralProvider,
-                ]),
-              ),
-              triggerSkillProvider.overrideWith((ref, params) async {
-                capturedParams = params;
-              }),
-            ],
-          ),
-        );
-
-        await tester.pumpAndSettle();
-        await tester.tap(find.byIcon(Icons.assistant_rounded));
-        await tester.pumpAndSettle();
-        await tester.tap(find.text('Transcribe Audio'));
-        await tester.pumpAndSettle();
-        await tester.tap(find.text('Mistral Cloud'));
-        await tester.pumpAndSettle();
-
-        expect(capturedParams, isNotNull);
-        expect(
-          capturedParams!.overrideTranscriptionModelId,
-          'm-mistral',
-        );
-      },
-    );
+      });
+    }
   });
 
   group('resolveLinkedTask', () {
@@ -1714,6 +1407,382 @@ void main() {
   });
 }
 
+// =============================================================
+// Override-picker test harness
+// =============================================================
+
+/// The override-picker flow requires `tester.pumpAndSettle()` rather
+/// than a bounded `pump(duration)` (see test/README.md / AGENTS.md
+/// async rules) because two awaited gates run between taps: the
+/// modal sheet animation AND the async resolution of
+/// `availableSkillsForEntityProvider` / `aiConfigRepositoryProvider`.
+/// A bounded pump doesn't reliably drain the latter; the animations
+/// are deterministic and bounded so the 10s timeout warning does not
+/// apply here.
+
+/// Per-skill data driving the parameterised override-picker tests.
+/// Each variant plugs in everything that differs between the
+/// transcription and image-analysis flows: skill type + name, the
+/// modality the slot consumes, the decoy modality (a model that is
+/// configured but should be filtered OUT of the picker), entity
+/// factory, and the function that writes the variant's slot fields
+/// onto a [ResolvedProfile].
+class _OverrideVariant {
+  const _OverrideVariant({
+    required this.label,
+    required this.skillType,
+    required this.skillName,
+    required this.skillRequiredModality,
+    required this.modelModality,
+    required this.decoyModality,
+    required this.decoyName,
+    required this.modelAName,
+    required this.modelBName,
+    required this.entityFactory,
+    required this.fillSlot,
+  });
+
+  final String label;
+  final SkillType skillType;
+  final String skillName;
+  final Modality skillRequiredModality;
+  final Modality modelModality;
+  final Modality decoyModality;
+  final String decoyName;
+  final String modelAName;
+  final String modelBName;
+  final JournalEntity Function({required String id, String? categoryId})
+  entityFactory;
+  final ResolvedProfile Function({
+    required AiConfigInferenceProvider thinkingProvider,
+    required AiConfigInferenceProvider slotProvider,
+    required String slotProviderModelId,
+  })
+  fillSlot;
+}
+
+JournalEntity _audioEntityFactory({required String id, String? categoryId}) {
+  final t = DateTime(2024, 3, 15, 10);
+  return JournalAudio(
+    meta: Metadata(
+      id: id,
+      createdAt: t,
+      updatedAt: t,
+      dateFrom: t,
+      dateTo: t,
+      categoryId: categoryId,
+    ),
+    data: AudioData(
+      dateFrom: t,
+      dateTo: t,
+      audioFile: 'test.mp3',
+      audioDirectory: '/test',
+      duration: const Duration(minutes: 1),
+    ),
+  );
+}
+
+JournalEntity _imageEntityFactory({required String id, String? categoryId}) {
+  final t = DateTime(2024, 3, 15, 10);
+  return JournalImage(
+    meta: Metadata(
+      id: id,
+      createdAt: t,
+      updatedAt: t,
+      dateFrom: t,
+      dateTo: t,
+      categoryId: categoryId,
+    ),
+    data: ImageData(
+      capturedAt: t,
+      imageId: 'img-$id',
+      imageFile: 'test.jpg',
+      imageDirectory: '/test',
+    ),
+  );
+}
+
+ResolvedProfile _fillTranscriptionSlot({
+  required AiConfigInferenceProvider thinkingProvider,
+  required AiConfigInferenceProvider slotProvider,
+  required String slotProviderModelId,
+}) => ResolvedProfile(
+  thinkingModelId: 'thinking',
+  thinkingProvider: thinkingProvider,
+  transcriptionProvider: slotProvider,
+  transcriptionModelId: slotProviderModelId,
+);
+
+ResolvedProfile _fillImageRecognitionSlot({
+  required AiConfigInferenceProvider thinkingProvider,
+  required AiConfigInferenceProvider slotProvider,
+  required String slotProviderModelId,
+}) => ResolvedProfile(
+  thinkingModelId: 'thinking',
+  thinkingProvider: thinkingProvider,
+  imageRecognitionProvider: slotProvider,
+  imageRecognitionModelId: slotProviderModelId,
+);
+
+const _transcriptionOverrideVariant = _OverrideVariant(
+  label: 'transcription',
+  skillType: SkillType.transcription,
+  skillName: 'Transcribe Audio',
+  skillRequiredModality: Modality.audio,
+  modelModality: Modality.audio,
+  decoyModality: Modality.text,
+  decoyName: 'Gemini Flash (text only)',
+  modelAName: 'Voxtral Local',
+  modelBName: 'Mistral Cloud',
+  entityFactory: _audioEntityFactory,
+  fillSlot: _fillTranscriptionSlot,
+);
+
+const _imageAnalysisOverrideVariant = _OverrideVariant(
+  label: 'image analysis',
+  skillType: SkillType.imageAnalysis,
+  skillName: 'Analyze Image',
+  skillRequiredModality: Modality.image,
+  modelModality: Modality.image,
+  decoyModality: Modality.audio,
+  decoyName: 'Voxtral (audio only)',
+  modelAName: 'GPT-4o Vision',
+  modelBName: 'Claude Sonnet Vision',
+  entityFactory: _imageEntityFactory,
+  fillSlot: _fillImageRecognitionSlot,
+);
+
+const _overrideVariants = <_OverrideVariant>[
+  _transcriptionOverrideVariant,
+  _imageAnalysisOverrideVariant,
+];
+
+/// Fixture bundling the entity, skill, models, providers, and
+/// (optional) resolved profile for one variant of an override-picker
+/// test. The named constructors line up with the three shapes the
+/// parameterised tests need (filter test, single-model short-circuit,
+/// default-row + non-default-row).
+class _OverrideFixture {
+  _OverrideFixture._({
+    required this.entity,
+    required this.skill,
+    required this.modelA,
+    required this.modelB,
+    required this.decoy,
+    required this.providers,
+    required this.profile,
+  });
+
+  factory _OverrideFixture.twoModelsPlusDecoy(_OverrideVariant variant) {
+    final t = DateTime(2024, 3, 15, 10);
+    return _OverrideFixture._(
+      entity: variant.entityFactory(id: 'entity-${variant.label}-filter'),
+      skill: _buildSkill(variant, t),
+      modelA: _buildModel(
+        id: 'm-a',
+        name: variant.modelAName,
+        providerModelId: 'wire-a',
+        providerId: 'p-a',
+        modality: variant.modelModality,
+        t: t,
+      ),
+      modelB: _buildModel(
+        id: 'm-b',
+        name: variant.modelBName,
+        providerModelId: 'wire-b',
+        providerId: 'p-b',
+        modality: variant.modelModality,
+        t: t,
+      ),
+      decoy: _buildModel(
+        id: 'm-decoy',
+        name: variant.decoyName,
+        providerModelId: 'decoy/wire',
+        providerId: 'p-decoy',
+        modality: variant.decoyModality,
+        t: t,
+      ),
+      providers: const <AiConfigInferenceProvider>[],
+      profile: null,
+    );
+  }
+
+  /// Single-model shape: only [modelA] has the slot modality; the
+  /// other two slots on the fixture are unrelated wrong-modality
+  /// decoys that the popup's `inputModalities.contains(...)` filter
+  /// strips out before the picker even sees them. The fixture's
+  /// generic `modelB` / `decoy` field names are reused (rather than
+  /// reshaping the class) so the three shapes share one record
+  /// layout — the field names don't carry semantic meaning in this
+  /// shape, only the modalities do.
+  factory _OverrideFixture.singleModel(_OverrideVariant variant) {
+    final t = DateTime(2024, 3, 15, 10);
+    AiConfigModel wrongModalityDecoy(String idSuffix) => _buildModel(
+      id: 'm-decoy-$idSuffix',
+      name: '__wrong-modality-decoy-${idSuffix}__',
+      providerModelId: 'decoy-$idSuffix/wire',
+      providerId: 'p-decoy-$idSuffix',
+      modality: variant.decoyModality,
+      t: t,
+    );
+    return _OverrideFixture._(
+      entity: variant.entityFactory(id: 'entity-${variant.label}-single'),
+      skill: _buildSkill(variant, t),
+      modelA: _buildModel(
+        id: 'm-only',
+        name: variant.modelAName,
+        providerModelId: 'wire-only',
+        providerId: 'p-only',
+        modality: variant.modelModality,
+        t: t,
+      ),
+      modelB: wrongModalityDecoy('b'),
+      decoy: wrongModalityDecoy('c'),
+      providers: const <AiConfigInferenceProvider>[],
+      profile: null,
+    );
+  }
+
+  factory _OverrideFixture.twoModelsWithDefault(_OverrideVariant variant) {
+    final t = DateTime(2024, 3, 15, 10);
+    final providerA = _buildProvider(id: 'p-a', name: 'Provider A', t: t);
+    final providerB = _buildProvider(id: 'p-b', name: 'Provider B', t: t);
+    final modelA = _buildModel(
+      id: 'm-a',
+      name: variant.modelAName,
+      providerModelId: 'wire-a',
+      providerId: 'p-a',
+      modality: variant.modelModality,
+      t: t,
+    );
+    final modelB = _buildModel(
+      id: 'm-b',
+      name: variant.modelBName,
+      providerModelId: 'wire-b',
+      providerId: 'p-b',
+      modality: variant.modelModality,
+      t: t,
+    );
+    return _OverrideFixture._(
+      entity: variant.entityFactory(
+        id: 'entity-${variant.label}-cat',
+        categoryId: 'cat-1',
+      ),
+      skill: _buildSkill(variant, t),
+      modelA: modelA,
+      modelB: modelB,
+      decoy: _buildModel(
+        id: 'm-decoy',
+        name: '__unused__',
+        providerModelId: 'decoy/wire',
+        providerId: 'p-decoy',
+        modality: variant.decoyModality,
+        t: t,
+      ),
+      providers: [providerA, providerB],
+      // Profile points at modelA via providerA — the popup must
+      // recognise the modelA row as the default.
+      profile: variant.fillSlot(
+        thinkingProvider: providerA,
+        slotProvider: providerA,
+        slotProviderModelId: 'wire-a',
+      ),
+    );
+  }
+
+  final JournalEntity entity;
+  final AiConfigSkill skill;
+  final AiConfigModel modelA;
+  final AiConfigModel modelB;
+  final AiConfigModel decoy;
+  final List<AiConfigInferenceProvider> providers;
+  final ResolvedProfile? profile;
+
+  List<AiConfigModel> get allModels => [modelA, modelB, decoy];
+}
+
+AiConfigSkill _buildSkill(_OverrideVariant variant, DateTime t) =>
+    AiConfig.skill(
+          id: 'skill-${variant.label}',
+          name: variant.skillName,
+          createdAt: t,
+          skillType: variant.skillType,
+          requiredInputModalities: [variant.skillRequiredModality],
+          systemInstructions: 'System',
+          userInstructions: 'User',
+          description: 'Variant test skill',
+        )
+        as AiConfigSkill;
+
+AiConfigModel _buildModel({
+  required String id,
+  required String name,
+  required String providerModelId,
+  required String providerId,
+  required Modality modality,
+  required DateTime t,
+}) {
+  return AiConfig.model(
+        id: id,
+        name: name,
+        providerModelId: providerModelId,
+        inferenceProviderId: providerId,
+        createdAt: t,
+        inputModalities: [modality, Modality.text],
+        outputModalities: const [Modality.text],
+        isReasoningModel: false,
+      )
+      as AiConfigModel;
+}
+
+AiConfigInferenceProvider _buildProvider({
+  required String id,
+  required String name,
+  required DateTime t,
+}) =>
+    AiConfig.inferenceProvider(
+          id: id,
+          baseUrl: 'https://$id.example.com',
+          name: name,
+          inferenceProviderType: InferenceProviderType.openAi,
+          apiKey: '',
+          createdAt: t,
+        )
+        as AiConfigInferenceProvider;
+
+/// Builds the Riverpod override list every parameterised override
+/// test needs: the popup must see a single skill for [entity],
+/// resolve to [resolver]'s profile, and read [models] from the
+/// repository. The default-row tests extend this with an
+/// `entryControllerProvider` override + `triggerSkillProvider`
+/// capture override; those two cannot be folded in here cleanly
+/// because the entry-controller key is per-fixture.
+List<Override> _baseOverrides({
+  required JournalEntity entity,
+  required AiConfigSkill skill,
+  required List<AiConfigModel> models,
+  required ProfileAutomationResolver resolver,
+  required List<AiConfig> configs,
+}) {
+  return [
+    hasAvailableSkillsProvider((
+      entityId: entity.id,
+      linkedFromId: null,
+    )).overrideWith((ref) => Future.value(true)),
+    availableSkillsForEntityProvider((
+      entityId: entity.id,
+      linkedFromId: null,
+    )).overrideWith((ref) => Future.value([skill])),
+    profileAutomationResolverProvider.overrideWithValue(resolver),
+    aiConfigByTypeControllerProvider(
+      configType: AiConfigType.model,
+    ).overrideWith(() => MockAiConfigByTypeController(models)),
+    aiConfigRepositoryProvider.overrideWithValue(
+      _StubAiConfigRepository(configs),
+    ),
+  ];
+}
+
 /// Minimal stub repository so the popup's `getConfigsByType` read
 /// resolves with a known model list. The full Drift-backed
 /// repository would require seeding a temp database, which is
@@ -1743,9 +1812,9 @@ class _StubAiConfigRepository implements AiConfigRepository {
 
 /// Stub resolver returning `null` for every entry. Avoids pulling
 /// agent-database wiring into widget tests that only need to assert
-/// the transcription branch reaches the picker — the model-list
-/// rendering and rest of the chain are exercised by
-/// `transcription_model_picker_modal_test.dart` in isolation.
+/// the override branch reaches the picker — the model-list rendering
+/// and rest of the chain are exercised by
+/// `inference_model_picker_modal_test.dart` in isolation.
 class _NullProfileResolver implements ProfileAutomationResolver {
   @override
   Future<ResolvedProfile?> resolveForTask(String taskId) async => null;
@@ -1760,8 +1829,7 @@ class _NullProfileResolver implements ProfileAutomationResolver {
 /// Stub resolver returning a fixed profile for every lookup. Used by
 /// tests that need the popup to compute a non-null `defaultModelId`
 /// (so the default-badge row is rendered and we can assert that
-/// tapping it produces `overrideTranscriptionModelId: null` at the
-/// trigger seam).
+/// tapping it produces `overrideModelId: null` at the trigger seam).
 class _FixedProfileResolver implements ProfileAutomationResolver {
   _FixedProfileResolver(this._profile);
 

--- a/test/features/ai/ui/widgets/inference_model_picker_modal_test.dart
+++ b/test/features/ai/ui/widgets/inference_model_picker_modal_test.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
-import 'package:lotti/features/ai/ui/widgets/transcription_model_picker_modal.dart';
-import 'package:lotti/l10n/app_localizations.dart';
+import 'package:lotti/features/ai/ui/widgets/inference_model_picker_modal.dart';
 
 import '../../../../widget_test_utils.dart';
 
@@ -25,43 +24,41 @@ AiConfigModel _model({
   );
 }
 
-AppLocalizations _l10n(WidgetTester tester) => AppLocalizations.of(
-  tester.element(find.byType(TranscriptionModelPickerModal)),
-)!;
-
 void main() {
-  group('TranscriptionModelPickerModal — widget body', () {
+  // Synthetic badge label — the picker accepts any string, so the
+  // test stays decoupled from the project's l10n surface. The
+  // popup-menu integration tests cover the real l10n wiring.
+  const badgeLabel = 'Default';
+
+  group('InferenceModelPickerModal — widget body', () {
     testWidgets(
       'renders every model passed in, with the default row first and '
-      'marked with both the localised (default) badge and the check '
-      'icon — the alternatives render below in the supplied order, '
-      'unbadged and uncheck-iconed',
+      'marked with both the supplied badge label and the check icon — '
+      'the alternatives render below in the supplied order, unbadged '
+      'and uncheck-iconed',
       (tester) async {
         await tester.pumpWidget(
           makeTestableWidget(
-            TranscriptionModelPickerModal(
+            InferenceModelPickerModal(
               defaultModelId: 'm-default',
-              speechCapableModels: [
+              models: [
                 _model(id: 'm-other', name: 'Whisper Local'),
                 _model(id: 'm-default', name: 'Voxtral'),
                 _model(id: 'm-cloud', name: 'Mistral Cloud'),
               ],
+              defaultBadgeLabel: badgeLabel,
             ),
           ),
         );
         await tester.pump();
 
-        final messages = _l10n(tester);
         // All three names render.
         expect(find.text('Voxtral'), findsOneWidget);
         expect(find.text('Whisper Local'), findsOneWidget);
         expect(find.text('Mistral Cloud'), findsOneWidget);
 
         // Default badge appears exactly once — on the default row.
-        expect(
-          find.text(messages.aiTranscriptionPickerDefaultBadge),
-          findsOneWidget,
-        );
+        expect(find.text(badgeLabel), findsOneWidget);
 
         // Check icon appears exactly once.
         expect(find.byIcon(Icons.check_rounded), findsOneWidget);
@@ -70,18 +67,19 @@ void main() {
 
     testWidgets(
       'a missing default (no defaultModelId, or an id that does not '
-      'appear in speechCapableModels) renders the list as-is with no '
-      'check icon and no (default) badge — proves a stale profile '
-      'pointer does not crash the picker',
+      'appear in [models]) renders the list as-is with no check icon '
+      'and no default badge — proves a stale profile pointer does not '
+      'crash the picker',
       (tester) async {
         await tester.pumpWidget(
           makeTestableWidget(
-            TranscriptionModelPickerModal(
+            InferenceModelPickerModal(
               defaultModelId: 'nonexistent',
-              speechCapableModels: [
+              models: [
                 _model(id: 'm-1', name: 'Voxtral'),
                 _model(id: 'm-2', name: 'Mistral Cloud'),
               ],
+              defaultBadgeLabel: badgeLabel,
             ),
           ),
         );
@@ -90,21 +88,24 @@ void main() {
         expect(find.text('Voxtral'), findsOneWidget);
         expect(find.text('Mistral Cloud'), findsOneWidget);
         expect(find.byIcon(Icons.check_rounded), findsNothing);
-        final messages = _l10n(tester);
-        expect(
-          find.text(messages.aiTranscriptionPickerDefaultBadge),
-          findsNothing,
-        );
+        expect(find.text(badgeLabel), findsNothing);
       },
     );
 
     testWidgets(
       "tapping a row pops the picker with that row's AiConfigModel.id "
       '— covers both the default row (the seam where the override '
-      'should be cleared to null at the caller) and an alternative row',
+      'should be cleared to null at the caller) and an alternative '
+      'row',
       (tester) async {
-        const models = <String>['m-default', 'm-alt-1', 'm-alt-2'];
-        for (final tapTarget in models) {
+        const targets = <String>['m-default', 'm-alt-1', 'm-alt-2'];
+        const labels = <String, String>{
+          'm-default': 'Voxtral',
+          'm-alt-1': 'Mistral Cloud',
+          'm-alt-2': 'Whisper Local',
+        };
+
+        for (final tapTarget in targets) {
           String? captured;
           await tester.pumpWidget(
             makeTestableWidget(
@@ -114,13 +115,14 @@ void main() {
                     onPressed: () async {
                       captured = await Navigator.of(ctx).push(
                         MaterialPageRoute<String>(
-                          builder: (_) => TranscriptionModelPickerModal(
+                          builder: (_) => InferenceModelPickerModal(
                             defaultModelId: 'm-default',
-                            speechCapableModels: [
+                            models: [
                               _model(id: 'm-default', name: 'Voxtral'),
                               _model(id: 'm-alt-1', name: 'Mistral Cloud'),
                               _model(id: 'm-alt-2', name: 'Whisper Local'),
                             ],
+                            defaultBadgeLabel: badgeLabel,
                           ),
                         ),
                       );
@@ -134,13 +136,7 @@ void main() {
           await tester.tap(find.text('open'));
           await tester.pumpAndSettle();
 
-          final label = switch (tapTarget) {
-            'm-default' => 'Voxtral',
-            'm-alt-1' => 'Mistral Cloud',
-            'm-alt-2' => 'Whisper Local',
-            _ => throw StateError('unmapped target'),
-          };
-          await tester.tap(find.text(label));
+          await tester.tap(find.text(labels[tapTarget]!));
           await tester.pumpAndSettle();
           expect(captured, tapTarget);
         }
@@ -148,12 +144,11 @@ void main() {
     );
   });
 
-  group('TranscriptionModelPickerModal.show — short-circuits', () {
+  group('InferenceModelPickerModal.show — short-circuits', () {
     testWidgets(
-      'speechCapableModels.length == 1 short-circuits — the lone model '
-      'id is returned without rendering a modal, preserving the '
-      'one-tap transcribe flow for users with a single speech-capable '
-      'model configured',
+      'models.length == 1 short-circuits — the lone model id is '
+      'returned without rendering a modal, preserving the one-tap '
+      'flow for users with a single slot-capable model configured',
       (tester) async {
         String? returned;
         await tester.pumpWidget(
@@ -162,12 +157,12 @@ void main() {
               builder: (ctx) => Center(
                 child: TextButton(
                   onPressed: () async {
-                    returned = await TranscriptionModelPickerModal.show(
+                    returned = await InferenceModelPickerModal.show(
                       context: ctx,
                       defaultModelId: 'only-model',
-                      speechCapableModels: [
-                        _model(id: 'only-model', name: 'Voxtral'),
-                      ],
+                      models: [_model(id: 'only-model', name: 'Voxtral')],
+                      title: 'Pick a model',
+                      defaultBadgeLabel: badgeLabel,
                     );
                   },
                   child: const Text('open'),
@@ -181,16 +176,16 @@ void main() {
         await tester.pumpAndSettle();
 
         // No modal was shown — the widget tree contains no instance.
-        expect(find.byType(TranscriptionModelPickerModal), findsNothing);
+        expect(find.byType(InferenceModelPickerModal), findsNothing);
         expect(returned, 'only-model');
       },
     );
 
     testWidgets(
-      'speechCapableModels.isEmpty resolves to null without rendering '
-      'a modal — defensive path for the can-not-happen case where the '
-      'popup audio gate let the user through with no audio-capable '
-      'model configured',
+      'models.isEmpty resolves to null without rendering a modal — '
+      'defensive path for the can-not-happen case where the popup '
+      'modality gate let the user through with no slot-capable model '
+      'configured',
       (tester) async {
         String? returned = 'sentinel-pre';
         await tester.pumpWidget(
@@ -199,10 +194,12 @@ void main() {
               builder: (ctx) => Center(
                 child: TextButton(
                   onPressed: () async {
-                    returned = await TranscriptionModelPickerModal.show(
+                    returned = await InferenceModelPickerModal.show(
                       context: ctx,
                       defaultModelId: null,
-                      speechCapableModels: const <AiConfigModel>[],
+                      models: const <AiConfigModel>[],
+                      title: 'Pick a model',
+                      defaultBadgeLabel: badgeLabel,
                     );
                   },
                   child: const Text('open'),
@@ -215,7 +212,7 @@ void main() {
         await tester.tap(find.text('open'));
         await tester.pumpAndSettle();
 
-        expect(find.byType(TranscriptionModelPickerModal), findsNothing);
+        expect(find.byType(InferenceModelPickerModal), findsNothing);
         expect(returned, isNull);
       },
     );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-invocation model overrides expanded: tapping "Analyze Image" now opens a model picker listing available image-capable models so a single photo can be routed to a different model without editing profiles. The same picker flow generalizes the transcription override experience; single-model setups bypass the picker and stale overrides fall back to your profile default.

* **Localization**
  * Added translations for the image analysis model picker across multiple languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matthiasn/lotti/pull/3199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->