### PR TITLE
feat: audio recording indicator in sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.1006]
+## [0.9.1007]
 ### Added
+- Active audio recordings now show a prominent desktop sidebar card above the
+  running timer, with a larger speech-weighted dBFS-reactive recording orb,
+  red signal-reactive frame, subtle red shadow, elapsed time, and one-tap stop
+  control so runaway microphone sessions are harder to miss.
 - Audio and image entry Actions menus on desktop can now reveal the backing
   file in Finder, File Explorer, or Files.
 

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -32,8 +32,9 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
-    <release version="0.9.1006" date="2026-05-22">
+    <release version="0.9.1007" date="2026-05-22">
       <description>
+          <p>Active audio recordings now show a prominent desktop sidebar card above the running timer, with a larger speech-weighted dBFS-reactive recording orb, red signal-reactive frame, subtle red shadow, elapsed time, and one-tap stop control so runaway microphone sessions are harder to miss.</p>
           <p>Audio and image entry Actions menus on desktop can now reveal the backing file in Finder, File Explorer, or Files.</p>
       </description>
     </release>

--- a/lib/beamer/beamer_app.dart
+++ b/lib/beamer/beamer_app.dart
@@ -48,18 +48,12 @@ import 'package:lotti/services/time_service.dart';
 import 'package:lotti/utils/consts.dart';
 import 'package:lotti/utils/uuid.dart';
 import 'package:lotti/widgets/misc/desktop_menu.dart';
+import 'package:lotti/widgets/misc/sidebar_audio_recording_section.dart';
 import 'package:lotti/widgets/misc/sidebar_timer_section.dart';
 import 'package:lotti/widgets/misc/time_recording_indicator.dart';
 import 'package:lotti/widgets/misc/zoom_wrapper.dart';
 import 'package:lotti/widgets/nav_bar/design_system_bottom_navigation_bar.dart';
 import 'package:matrix/matrix.dart';
-
-class AppScreenConstants {
-  const AppScreenConstants._();
-
-  static const double navigationTimeIndicatorBottom = 0;
-  static const double navigationAudioIndicatorRight = 100;
-}
 
 /// Check if the app is running inside Flatpak sandbox
 bool _isRunningInFlatpak() {
@@ -71,9 +65,7 @@ bool _isRunningInFlatpak() {
 /// True when the tasks tab is active and the tasks beamer location points
 /// at a `/tasks/<uuid>` task detail. Used by both shells: the mobile shell
 /// hides the bottom nav pill so the page-owned `TaskActionBar` can dock
-/// flush against the home indicator, and the desktop shell hides the
-/// bottom-right floating recording indicator since the action bar already
-/// exposes the same affordance. Pure function of router state, no
+/// flush against the home indicator. Pure function of router state, no
 /// widget-lifecycle race.
 bool isTaskDetailRoute(BeamLocation<dynamic>? location, int activeTabIndex) {
   // Tasks is always the first destination; if any other tab is active
@@ -317,12 +309,9 @@ class _AppScreenState extends ConsumerState<AppScreen> {
           Beamer(routerDelegate: navService.settingsDelegate),
         ];
 
-        // Listen to the tasks delegate so both shells rebuild when the
+        // Listen to the tasks delegate so the mobile shell rebuilds when the
         // tasks route changes (push to / pop from task details). That's how
-        // we know whether to hide:
-        //   - the mobile bottom nav pill; and
-        //   - the desktop bottom-right floating recording indicator, which
-        //     is redundant once the TaskActionBar is on screen.
+        // we know whether to hide the mobile bottom nav pill.
         // See [_isTaskDetailRoute].
         return ListenableBuilder(
           listenable: navService.tasksDelegate,
@@ -467,16 +456,6 @@ class _AppScreenState extends ConsumerState<AppScreen> {
                       ),
                   ],
                 ),
-                // Hidden on `/tasks/<uuid>` — the desktop TaskActionBar
-                // already surfaces the recording control there, so the
-                // floating indicator would be redundant. Stays visible on
-                // the tasks list and on every other top-level destination.
-                if (!_isRunningInFlatpak() && !_isTaskDetailRoute(index))
-                  const Positioned(
-                    right: AppScreenConstants.navigationAudioIndicatorRight,
-                    bottom: AppScreenConstants.navigationTimeIndicatorBottom,
-                    child: AudioRecordingIndicator(),
-                  ),
               ],
             ),
           ),
@@ -745,10 +724,10 @@ class _MyBeamerAppState extends ConsumerState<MyBeamerApp> {
 }
 
 /// Composer for the desktop sidebar's `aboveSettings` slot. Stacks the
-/// optional inline Wake Queue (when its config flag is enabled) above
-/// the running-timer panel (when a timer is active), so the running
-/// timer sits closest to the Settings entry below. The separator
-/// between the two is rendered only when both are actually visible.
+/// optional inline Wake Queue (when its config flag is enabled), audio
+/// recording panel, and running-timer panel, so the running timer still sits
+/// closest to the Settings entry below. Separators are rendered only between
+/// sections that are actually visible.
 class _DesktopSidebarAboveSettings extends ConsumerWidget {
   const _DesktopSidebarAboveSettings({required this.showWakeQueue});
 
@@ -759,11 +738,14 @@ class _DesktopSidebarAboveSettings extends ConsumerWidget {
     final tokens = context.designTokens;
     final wakesVisible =
         showWakeQueue && sidebarWakeQueueHasVisibleContent(ref);
+    final audioVisible =
+        !_isRunningInFlatpak() && sidebarAudioRecordingHasVisibleContent(ref);
 
     return StreamBuilder<JournalEntity?>(
       stream: getIt<TimeService>().getStream(),
       builder: (context, snapshot) {
         final hasTimer = snapshot.data != null;
+        final hasBelowWake = audioVisible || hasTimer;
         return Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -778,7 +760,18 @@ class _DesktopSidebarAboveSettings extends ConsumerWidget {
               curve: Curves.easeInOut,
               alignment: Alignment.bottomCenter,
               child: SizedBox(
-                height: (wakesVisible && hasTimer) ? tokens.spacing.step3 : 0,
+                height: (wakesVisible && hasBelowWake)
+                    ? tokens.spacing.step3
+                    : 0,
+              ),
+            ),
+            if (!_isRunningInFlatpak()) const SidebarAudioRecordingSection(),
+            AnimatedSize(
+              duration: SidebarAudioRecordingSection.animationDuration,
+              curve: Curves.easeInOut,
+              alignment: Alignment.bottomCenter,
+              child: SizedBox(
+                height: (audioVisible && hasTimer) ? tokens.spacing.step3 : 0,
               ),
             ),
             const SidebarTimerSection(),

--- a/lib/features/speech/README.md
+++ b/lib/features/speech/README.md
@@ -31,7 +31,7 @@ lib/features/speech/
 
 ```mermaid
 flowchart LR
-  User["User"] --> RecordingUI["AudioRecordingModal / AudioRecordingIndicator"]
+  User["User"] --> RecordingUI["AudioRecordingModal / sidebar + mobile indicators"]
   User --> PlaybackUI["AudioPlayerWidget"]
   User --> TranscriptUI["SpeechModalContent"]
   User --> EditorUI["Editor context menu"]
@@ -77,6 +77,8 @@ Standard recording goes through `AudioRecorderRepository`, which wraps the
 
 - Riverpod state for recording UI
 - VU calculation from dBFS samples
+- live dBFS exposure for the modal VU meter, the speech-weighted desktop
+  sidebar orb, and the mobile recording pill
 - linked-entry and category context
 - coordination with app-wide playback
 - persistence through `SpeechRepository`
@@ -121,8 +123,9 @@ stateDiagram-v2
 ```
 
 One implementation detail worth calling out: the state object still has
-`showIndicator`, but the current `AudioRecordingIndicator` widget derives
-visibility from `status == recording && !modalVisible` rather than that field.
+`showIndicator`, but the current desktop `SidebarAudioRecordingSection` and
+mobile `AudioRecordingIndicator` derive visibility from
+`status == recording && !modalVisible` rather than that field.
 
 ### Standard recording flow
 
@@ -130,6 +133,7 @@ visibility from `status == recording && !modalVisible` rather than that field.
 sequenceDiagram
   participant User as "User"
   participant Modal as "AudioRecordingModal"
+  participant Sidebar as "SidebarAudioRecordingSection"
   participant Ctl as "AudioRecorderController"
   participant Repo as "AudioRecorderRepository"
   participant Speech as "SpeechRepository"
@@ -142,6 +146,8 @@ sequenceDiagram
   Ctl->>Repo: startRecording()
   Repo-->>Ctl: AudioNote + amplitude stream
   Ctl->>Ctl: update dBFS, RMS-based VU, progress
+  Ctl-->>Modal: VU meter + elapsed time
+  Ctl-->>Sidebar: dBFS-reactive orb, red frame/shadow + elapsed time
   User->>Modal: tap stop
   Modal->>Ctl: stop()
   Ctl->>Repo: stopRecording()

--- a/lib/features/speech/ui/widgets/recording/README.md
+++ b/lib/features/speech/ui/widgets/recording/README.md
@@ -1,6 +1,8 @@
 # Audio Recording UI Components
 
-This directory contains the UI components for audio recording functionality in Lotti. The recording system provides a visual VU meter, recording controls, and status indicators.
+This directory contains the UI components for audio recording functionality in
+Lotti. The recording system provides a visual VU meter, recording controls, and
+status indicators driven by the same live dBFS stream.
 
 ## Components Overview
 
@@ -46,14 +48,40 @@ AudioRecordingModal.show(
 )
 ```
 
-### 3. AudioRecordingIndicator
+### 3. AudioRecordingOrb
 
-A small floating indicator that appears when recording is active and the modal is not visible.
+The `AudioRecordingOrb` is the compact signal visualization used by persistent
+recording surfaces.
 
 **Features:**
-- Shows microphone icon and recording duration
-- Clicking reopens the recording modal
-- Positioned at bottom-right of screen
+- Maps live dBFS into a clamped 0-1 signal intensity with a speech-weighted
+  response curve so normal microphone input remains visually obvious
+- Keeps a slow pulse running so the microphone state remains visible even
+  during silence
+- Expands glow, outer wave, ring, and core radius with louder input
+- Switches to the warning token when the signal reaches the clipping threshold
+
+**Usage:**
+```dart
+AudioRecordingOrb(
+  dBFS: state.dBFS,
+  size: tokens.spacing.step6,
+)
+```
+
+### 4. Persistent Recording Indicators
+
+Persistent indicators appear when recording is active and the modal is not
+visible. They read `AudioRecorderState.dBFS` directly, so the animation follows
+the same audio stream as the VU meter.
+
+**Features:**
+- Desktop: `SidebarAudioRecordingSection` renders a full-width card in the
+  sidebar above `SidebarTimerSection`, with linked task title, live orb,
+  dBFS-reactive red frame/shadow intensity, duration, and a stop button.
+- Mobile: `AudioRecordingIndicator` renders the compact bottom-nav pill with
+  the same live orb and duration.
+- Clicking the non-stop body reopens the recording modal.
 - Auto-hides when modal is visible or recording stops
 
 ## Architecture
@@ -64,6 +92,7 @@ recording/
 ├── analog_vu_meter.dart       # Main VU meter widget
 ├── vu_meter_painter.dart      # Custom painter for VU meter visuals
 ├── vu_meter_constants.dart    # Animation durations and constants
+├── audio_recording_orb.dart   # Compact dBFS-reactive orb visualization
 ├── audio_recording_modal.dart # Recording modal interface
 ├── audio_recording_indicator.dart # Small recording indicator
 └── README.md                  # This file
@@ -177,7 +206,9 @@ The recording system uses:
 2. `AudioRecordingModal` opens showing VU meter
 3. User taps record button to start
 4. VU meter shows real-time audio levels
-5. `AudioRecordingIndicator` appears if user navigates away
+5. Persistent indicators appear if user navigates away: the desktop sidebar
+   card sits above the running timer card; the mobile pill sits in the bottom
+   navigation overlay
 6. User taps stop to end recording
 7. If auto-transcribe enabled, transcription begins
 8. Audio entry is created and saved

--- a/lib/features/speech/ui/widgets/recording/audio_recording_indicator.dart
+++ b/lib/features/speech/ui/widgets/recording/audio_recording_indicator.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/journal/state/entry_controller.dart';
 import 'package:lotti/features/journal/util/entry_tools.dart';
 import 'package:lotti/features/speech/state/recorder_controller.dart';
 import 'package:lotti/features/speech/state/recorder_state.dart';
 import 'package:lotti/features/speech/ui/widgets/recording/audio_recording_modal.dart';
+import 'package:lotti/features/speech/ui/widgets/recording/audio_recording_orb.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/themes/theme.dart';
 
 class AudioRecordingIndicatorConstants {
@@ -35,6 +38,7 @@ class AudioRecordingIndicator extends ConsumerWidget {
         return const SizedBox.shrink();
       }
 
+      final tokens = context.designTokens;
       final linkedId = state.linkedId;
 
       final linkedEntry = linkedId != null
@@ -52,41 +56,42 @@ class AudioRecordingIndicator extends ConsumerWidget {
 
       return MouseRegion(
         cursor: SystemMouseCursors.click,
-        child: GestureDetector(
-          key: const Key('audio_recording_indicator'),
-          onTap: onTap,
-          child: ClipRRect(
-            borderRadius: const BorderRadius.only(
-              topLeft: Radius.circular(
-                AudioRecordingIndicatorConstants.borderRadius,
+        child: Semantics(
+          button: true,
+          label: context.messages.taskActionBarAudioRecordingActive,
+          child: GestureDetector(
+            key: const Key('audio_recording_indicator'),
+            onTap: onTap,
+            child: ClipRRect(
+              borderRadius: BorderRadius.only(
+                topLeft: Radius.circular(tokens.radii.s),
+                topRight: Radius.circular(tokens.radii.s),
               ),
-              topRight: Radius.circular(
-                AudioRecordingIndicatorConstants.borderRadius,
-              ),
-            ),
-            child: Container(
-              height: AudioRecordingIndicatorConstants.indicatorHeight,
-              color: context.colorScheme.error,
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  const SizedBox(width: 5),
-                  Icon(
-                    Icons.mic_outlined,
-                    size: AudioRecordingIndicatorConstants.iconSize,
-                    color: context.colorScheme.onError,
-                  ),
-                  Padding(
-                    padding: AudioRecordingIndicatorConstants.textPadding,
-                    child: Text(
-                      formatDuration(state.progress),
-                      style: tabularFigureStyle(
-                        fontSize: fontSizeMedium,
-                        color: context.colorScheme.onError,
+              child: Container(
+                height: tokens.spacing.step6,
+                color: tokens.colors.alert.error.defaultColor,
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    SizedBox(width: tokens.spacing.step2),
+                    AudioRecordingOrb(
+                      dBFS: state.dBFS,
+                      size: tokens.spacing.step6,
+                    ),
+                    SizedBox(width: tokens.spacing.step2),
+                    Padding(
+                      padding: EdgeInsets.only(right: tokens.spacing.step4),
+                      child: Text(
+                        formatDuration(state.progress),
+                        style: tokens.typography.styles.subtitle.subtitle2
+                            .copyWith(
+                              color: tokens.colors.text.onInteractiveAlert,
+                              fontFeatures: numericBadgeFontFeatures,
+                            ),
                       ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
           ),

--- a/lib/features/speech/ui/widgets/recording/audio_recording_orb.dart
+++ b/lib/features/speech/ui/widgets/recording/audio_recording_orb.dart
@@ -34,7 +34,7 @@ class AudioRecordingSignalLevel {
 
     return AudioRecordingSignalLevel(
       normalized: normalized,
-      isClipping: dBFS >= _clippingDbfs,
+      isClipping: dBFS > _clippingDbfs,
     );
   }
 

--- a/lib/features/speech/ui/widgets/recording/audio_recording_orb.dart
+++ b/lib/features/speech/ui/widgets/recording/audio_recording_orb.dart
@@ -45,6 +45,17 @@ class AudioRecordingSignalLevel {
 
   final double normalized;
   final bool isClipping;
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is AudioRecordingSignalLevel &&
+            other.normalized == normalized &&
+            other.isClipping == isClipping;
+  }
+
+  @override
+  int get hashCode => Object.hash(normalized, isClipping);
 }
 
 class AudioRecordingOrb extends StatefulWidget {

--- a/lib/features/speech/ui/widgets/recording/audio_recording_orb.dart
+++ b/lib/features/speech/ui/widgets/recording/audio_recording_orb.dart
@@ -1,0 +1,218 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+
+class AudioRecordingOrbConstants {
+  const AudioRecordingOrbConstants._();
+
+  static const Duration pulseDuration = Duration(milliseconds: 1400);
+}
+
+@immutable
+class AudioRecordingSignalLevel {
+  const AudioRecordingSignalLevel({
+    required this.normalized,
+    required this.isClipping,
+  });
+
+  factory AudioRecordingSignalLevel.fromDbfs(double dBFS) {
+    if (!dBFS.isFinite) {
+      return const AudioRecordingSignalLevel(
+        normalized: 0,
+        isClipping: false,
+      );
+    }
+
+    final linear = ((dBFS - _floorDbfs) / (_ceilingDbfs - _floorDbfs)).clamp(
+      0.0,
+      1.0,
+    );
+    // Bias the display toward the normal speech range so live mic changes are
+    // visible at sidebar size instead of only reacting near clipping.
+    final normalized = math.pow(linear, _responseCurve).toDouble();
+
+    return AudioRecordingSignalLevel(
+      normalized: normalized,
+      isClipping: dBFS >= _clippingDbfs,
+    );
+  }
+
+  static const double _clippingDbfs = -3;
+  static const double _floorDbfs = -64;
+  static const double _ceilingDbfs = 0;
+  static const double _responseCurve = 0.9;
+
+  final double normalized;
+  final bool isClipping;
+}
+
+class AudioRecordingOrb extends StatefulWidget {
+  const AudioRecordingOrb({
+    required this.dBFS,
+    this.size,
+    this.active = true,
+    super.key,
+  });
+
+  final double dBFS;
+  final double? size;
+  final bool active;
+
+  @override
+  State<AudioRecordingOrb> createState() => _AudioRecordingOrbState();
+}
+
+class _AudioRecordingOrbState extends State<AudioRecordingOrb>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _pulseController;
+
+  @override
+  void initState() {
+    super.initState();
+    _pulseController = AnimationController(
+      duration: AudioRecordingOrbConstants.pulseDuration,
+      vsync: this,
+    );
+    _syncPulse();
+  }
+
+  @override
+  void didUpdateWidget(AudioRecordingOrb oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.active != widget.active) {
+      _syncPulse();
+    }
+  }
+
+  void _syncPulse() {
+    if (widget.active) {
+      _pulseController.repeat();
+    } else {
+      _pulseController
+        ..stop()
+        ..value = 0;
+    }
+  }
+
+  @override
+  void dispose() {
+    _pulseController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final orbSize = widget.size ?? tokens.spacing.step6;
+    final signalLevel = AudioRecordingSignalLevel.fromDbfs(widget.dBFS);
+
+    return RepaintBoundary(
+      child: SizedBox.square(
+        dimension: orbSize,
+        child: AnimatedBuilder(
+          animation: _pulseController,
+          builder: (context, _) {
+            return CustomPaint(
+              painter: AudioRecordingOrbPainter(
+                signalLevel: signalLevel,
+                phase: widget.active ? _pulseController.value : 0,
+                baseColor: tokens.colors.alert.error.defaultColor,
+                clippingColor: tokens.colors.alert.warning.defaultColor,
+                highlightColor: tokens.colors.text.onInteractiveAlert,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class AudioRecordingOrbPainter extends CustomPainter {
+  const AudioRecordingOrbPainter({
+    required this.signalLevel,
+    required this.phase,
+    required this.baseColor,
+    required this.clippingColor,
+    required this.highlightColor,
+  });
+
+  final AudioRecordingSignalLevel signalLevel;
+  final double phase;
+  final Color baseColor;
+  final Color clippingColor;
+  final Color highlightColor;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final shortestSide = math.min(size.width, size.height);
+    if (shortestSide <= 0) return;
+
+    final center = Offset(size.width / 2, size.height / 2);
+    final signal = signalLevel.normalized;
+    final pulse = (math.sin(phase * math.pi * 2) + 1) / 2;
+    final pulseImpact = 0.35 + signal * 0.65;
+    final color = signalLevel.isClipping ? clippingColor : baseColor;
+
+    final glowRadius =
+        shortestSide * (0.30 + signal * 0.12 + pulse * 0.07 * pulseImpact);
+    final glowAlpha = (0.32 + signal * 0.45 + pulse * 0.16 * pulseImpact).clamp(
+      0.0,
+      0.92,
+    );
+    canvas.drawCircle(
+      center,
+      glowRadius,
+      Paint()..color = color.withValues(alpha: glowAlpha),
+    );
+
+    final waveRadius = shortestSide * (0.27 + signal * 0.10 + pulse * 0.08);
+    final waveAlpha = ((1 - pulse) * (0.22 + signal * 0.45)).clamp(0.0, 0.58);
+    canvas.drawCircle(
+      center,
+      waveRadius,
+      Paint()
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = shortestSide * (0.03 + signal * 0.03)
+        ..color = color.withValues(alpha: waveAlpha),
+    );
+
+    final ringRadius =
+        shortestSide * (0.22 + signal * 0.11 + pulse * 0.05 * pulseImpact);
+    canvas.drawCircle(
+      center,
+      ringRadius,
+      Paint()
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = shortestSide * (0.08 + signal * 0.04)
+        ..color = color.withValues(alpha: 0.96),
+    );
+
+    final coreRadius =
+        shortestSide * (0.16 + signal * 0.14 + pulse * 0.04 * pulseImpact);
+    final coreRect = Rect.fromCircle(center: center, radius: coreRadius);
+    canvas.drawCircle(
+      center,
+      coreRadius,
+      Paint()
+        ..shader = RadialGradient(
+          colors: [
+            highlightColor.withValues(alpha: 0.95),
+            color.withValues(alpha: 0.95),
+            color.withValues(alpha: 0.65),
+          ],
+          stops: const [0, 0.55, 1],
+        ).createShader(coreRect),
+    );
+  }
+
+  @override
+  bool shouldRepaint(AudioRecordingOrbPainter oldDelegate) {
+    return oldDelegate.signalLevel != signalLevel ||
+        oldDelegate.phase != phase ||
+        oldDelegate.baseColor != baseColor ||
+        oldDelegate.clippingColor != clippingColor ||
+        oldDelegate.highlightColor != highlightColor;
+  }
+}

--- a/lib/widgets/README.md
+++ b/lib/widgets/README.md
@@ -195,6 +195,16 @@ Inline panel surfaced in the desktop sidebar's `aboveSettings` slot whenever a t
 - Interactions: tapping the body navigates to the running task (or the timer's journal entry, if not task-linked); tapping the stop button calls `TimeService.stop()`.
 - Idle state: collapses to `SizedBox.shrink` so the slot consumes no vertical space.
 
+### SidebarAudioRecordingSection
+Inline panel surfaced in the desktop sidebar's `aboveSettings` slot whenever an audio recording is active and the recording modal is not visible. It sits above `SidebarTimerSection` and uses the same card radius, padding rhythm, elapsed-time typography, and circular stop affordance.
+
+- Layout: linked task/title fallback over a body row with an emphasized,
+  dBFS-reactive `AudioRecordingOrb`, monospaced HH:MM:SS, and a circular stop
+  button.
+- Signal: reads `AudioRecorderState.dBFS`, which is fed by the `record` package amplitude stream for standard recording and by realtime PCM amplitude calculation for realtime recording. The same speech-weighted signal value drives the orb and the card frame's red border/shadow intensity.
+- Interactions: tapping the body reopens `AudioRecordingModal`; tapping the stop button calls `AudioRecorderController.stop()` or `stopRealtime()` based on the active recording mode.
+- Idle state: collapses to `SizedBox.shrink` so the slot consumes no vertical space.
+
 ### TimeRecordingIndicator
 Visual indicator showing whether time recording is currently active. Used on **mobile** only — it sits in the bottom-nav overlay above the navigation bar. On desktop the running timer is rendered by `SidebarTimerSection` instead.
 

--- a/lib/widgets/misc/sidebar_audio_recording_section.dart
+++ b/lib/widgets/misc/sidebar_audio_recording_section.dart
@@ -1,0 +1,306 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/database/database.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/journal/util/entry_tools.dart';
+import 'package:lotti/features/speech/state/recorder_controller.dart';
+import 'package:lotti/features/speech/state/recorder_state.dart';
+import 'package:lotti/features/speech/ui/widgets/recording/audio_recording_modal.dart';
+import 'package:lotti/features/speech/ui/widgets/recording/audio_recording_orb.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/themes/theme.dart' show numericBadgeFontFeatures;
+
+final FutureProviderFamily<JournalEntity?, String>
+sidebarAudioRecordingLinkedEntryProvider = FutureProvider.autoDispose
+    .family<JournalEntity?, String>((ref, id) {
+      return getIt<JournalDb>().journalEntityById(id);
+    });
+
+bool sidebarAudioRecordingHasVisibleContent(WidgetRef ref) {
+  final state = ref.watch(audioRecorderControllerProvider);
+  return state.status == AudioRecorderStatus.recording && !state.modalVisible;
+}
+
+/// Inline audio recording panel rendered in the desktop sidebar's
+/// `aboveSettings` slot whenever the microphone is active and the modal is
+/// not already open.
+///
+/// The card intentionally mirrors `SidebarTimerSection`: title row, live
+/// elapsed time, and a stop button. The leading orb is driven by the recorder's
+/// live dBFS stream so background sidebar recording remains visually active
+/// even when the user is working in another tab or route.
+class SidebarAudioRecordingSection extends ConsumerWidget {
+  const SidebarAudioRecordingSection({super.key});
+
+  /// Matches `SidebarTimerSection.animationDuration` so the audio and timer
+  /// cards collapse with the same rhythm.
+  static const Duration animationDuration = Duration(milliseconds: 220);
+
+  static const Key _hiddenKey = ValueKey('sidebar-audio-recording-hidden');
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(audioRecorderControllerProvider);
+    final shouldShow =
+        state.status == AudioRecorderStatus.recording && !state.modalVisible;
+
+    final child = shouldShow
+        ? _SidebarAudioRecordingCard(
+            key: const ValueKey('sidebar-audio-recording-card-visible'),
+            state: state,
+          )
+        : const SizedBox.shrink(key: _hiddenKey);
+
+    return AnimatedSize(
+      duration: animationDuration,
+      curve: Curves.easeInOut,
+      alignment: Alignment.bottomCenter,
+      child: AnimatedSwitcher(
+        duration: animationDuration,
+        switchInCurve: Curves.easeIn,
+        switchOutCurve: Curves.easeOut,
+        child: child,
+      ),
+    );
+  }
+}
+
+class _SidebarAudioRecordingCard extends ConsumerWidget {
+  const _SidebarAudioRecordingCard({
+    required this.state,
+    super.key,
+  });
+
+  final AudioRecorderState state;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final tokens = context.designTokens;
+    final messages = context.messages;
+    final linkedId = state.linkedId;
+    final linkedEntry = linkedId == null
+        ? null
+        : ref.watch(sidebarAudioRecordingLinkedEntryProvider(linkedId)).value;
+    final title = _resolveTitle(
+      linkedEntry: linkedEntry,
+      fallback: messages.taskActionBarAudioRecordingActive,
+    );
+    final durationText = formatDuration(state.progress);
+
+    return Semantics(
+      container: true,
+      liveRegion: true,
+      label: messages.taskActionBarAudioRecordingActive,
+      child: _SignalReactiveCardFrame(
+        dBFS: state.dBFS,
+        child: Material(
+          key: const Key('sidebar_audio_recording_card'),
+          color: Colors.transparent,
+          borderRadius: BorderRadius.circular(tokens.radii.s),
+          clipBehavior: Clip.antiAlias,
+          child: InkWell(
+            onTap: () => AudioRecordingModal.show(
+              context,
+              linkedId: linkedId,
+              categoryId: linkedEntry?.meta.categoryId,
+              useRootNavigator: false,
+            ),
+            child: Padding(
+              padding: EdgeInsets.fromLTRB(
+                tokens.spacing.step4,
+                tokens.spacing.step3,
+                tokens.spacing.step3,
+                tokens.spacing.step3,
+              ),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _RecordingTitleRow(title: title),
+                  SizedBox(height: tokens.spacing.step2),
+                  _RecordingBodyRow(
+                    dBFS: state.dBFS,
+                    durationText: durationText,
+                    onStop: () => unawaited(_stop(ref)),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _resolveTitle({
+    required JournalEntity? linkedEntry,
+    required String fallback,
+  }) {
+    if (linkedEntry is Task) {
+      final title = linkedEntry.data.title.trim();
+      if (title.isNotEmpty) return title;
+    }
+
+    final linkedText = linkedEntry?.entryText?.plainText.trim();
+    if (linkedText != null && linkedText.isNotEmpty) return linkedText;
+    return fallback;
+  }
+
+  Future<void> _stop(WidgetRef ref) async {
+    final controller = ref.read(audioRecorderControllerProvider.notifier);
+    if (state.isRealtimeMode) {
+      await controller.stopRealtime();
+    } else {
+      await controller.stop();
+    }
+  }
+}
+
+class _SignalReactiveCardFrame extends StatelessWidget {
+  const _SignalReactiveCardFrame({
+    required this.dBFS,
+    required this.child,
+  });
+
+  final double dBFS;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final signalLevel = AudioRecordingSignalLevel.fromDbfs(dBFS);
+    final signal = signalLevel.normalized;
+    final frameSignal = math.pow(signal, 3).toDouble();
+    final color = tokens.colors.alert.error.defaultColor;
+    final borderRadius = BorderRadius.circular(tokens.radii.s);
+    final borderWidth = tokens.spacing.step1 * (0.25 + frameSignal * 0.75);
+    final borderAlpha = (0.22 + frameSignal * 0.50).clamp(0.0, 0.78);
+    final shadowAlpha = (0.04 + frameSignal * 0.12).clamp(0.0, 0.18);
+    final backgroundAlpha = (0.08 + frameSignal * 0.05).clamp(0.0, 0.16);
+
+    return AnimatedContainer(
+      key: const Key('sidebar_audio_recording_card_frame'),
+      duration: SidebarAudioRecordingSection.animationDuration,
+      curve: Curves.easeOut,
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: backgroundAlpha),
+        borderRadius: borderRadius,
+        border: Border.all(
+          color: color.withValues(alpha: borderAlpha),
+          width: borderWidth,
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: color.withValues(alpha: shadowAlpha),
+            blurRadius:
+                tokens.spacing.step3 + frameSignal * tokens.spacing.step5,
+            spreadRadius: frameSignal * tokens.spacing.step1 * 0.5,
+          ),
+        ],
+      ),
+      child: child,
+    );
+  }
+}
+
+class _RecordingTitleRow extends StatelessWidget {
+  const _RecordingTitleRow({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    return Text(
+      title,
+      maxLines: 2,
+      overflow: TextOverflow.ellipsis,
+      style: tokens.typography.styles.others.caption.copyWith(
+        color: tokens.colors.text.mediumEmphasis,
+      ),
+    );
+  }
+}
+
+class _RecordingBodyRow extends StatelessWidget {
+  const _RecordingBodyRow({
+    required this.dBFS,
+    required this.durationText,
+    required this.onStop,
+  });
+
+  final double dBFS;
+  final String durationText;
+  final VoidCallback onStop;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final errorColor = tokens.colors.alert.error.defaultColor;
+
+    return Row(
+      children: [
+        AudioRecordingOrb(
+          dBFS: dBFS,
+          size: tokens.spacing.step7,
+        ),
+        SizedBox(width: tokens.spacing.step3),
+        Expanded(
+          child: Text(
+            durationText,
+            style: tokens.typography.styles.subtitle.subtitle2.copyWith(
+              color: errorColor,
+              fontFeatures: numericBadgeFontFeatures,
+            ),
+          ),
+        ),
+        _StopAudioRecordingButton(onStop: onStop),
+      ],
+    );
+  }
+}
+
+class _StopAudioRecordingButton extends StatelessWidget {
+  const _StopAudioRecordingButton({required this.onStop});
+
+  final VoidCallback onStop;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final errorColor = tokens.colors.alert.error.defaultColor;
+    final tooltip = context.messages.audioRecordingStop;
+
+    return Semantics(
+      button: true,
+      label: tooltip,
+      child: Tooltip(
+        message: tooltip,
+        excludeFromSemantics: true,
+        child: Material(
+          color: errorColor.withAlpha(40),
+          shape: const CircleBorder(),
+          clipBehavior: Clip.antiAlias,
+          child: InkWell(
+            customBorder: const CircleBorder(),
+            onTap: onStop,
+            child: SizedBox.square(
+              dimension: tokens.spacing.step7,
+              child: Icon(
+                Icons.stop_rounded,
+                size: tokens.spacing.step5,
+                color: errorColor,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/misc/sidebar_audio_recording_section.dart
+++ b/lib/widgets/misc/sidebar_audio_recording_section.dart
@@ -23,7 +23,12 @@ sidebarAudioRecordingLinkedEntryProvider = FutureProvider.autoDispose
     });
 
 bool sidebarAudioRecordingHasVisibleContent(WidgetRef ref) {
-  final state = ref.watch(audioRecorderControllerProvider);
+  return ref.watch(
+    audioRecorderControllerProvider.select(_recordingIsVisible),
+  );
+}
+
+bool _recordingIsVisible(AudioRecorderState state) {
   return state.status == AudioRecorderStatus.recording && !state.modalVisible;
 }
 
@@ -46,14 +51,13 @@ class SidebarAudioRecordingSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final state = ref.watch(audioRecorderControllerProvider);
-    final shouldShow =
-        state.status == AudioRecorderStatus.recording && !state.modalVisible;
+    final shouldShow = ref.watch(
+      audioRecorderControllerProvider.select(_recordingIsVisible),
+    );
 
     final child = shouldShow
-        ? _SidebarAudioRecordingCard(
-            key: const ValueKey('sidebar-audio-recording-card-visible'),
-            state: state,
+        ? const _SidebarAudioRecordingCard(
+            key: ValueKey('sidebar-audio-recording-card-visible'),
           )
         : const SizedBox.shrink(key: _hiddenKey);
 
@@ -72,18 +76,15 @@ class SidebarAudioRecordingSection extends ConsumerWidget {
 }
 
 class _SidebarAudioRecordingCard extends ConsumerWidget {
-  const _SidebarAudioRecordingCard({
-    required this.state,
-    super.key,
-  });
-
-  final AudioRecorderState state;
+  const _SidebarAudioRecordingCard({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final linkedId = ref.watch(
+      audioRecorderControllerProvider.select((state) => state.linkedId),
+    );
     final tokens = context.designTokens;
     final messages = context.messages;
-    final linkedId = state.linkedId;
     final linkedEntry = linkedId == null
         ? null
         : ref.watch(sidebarAudioRecordingLinkedEntryProvider(linkedId)).value;
@@ -91,14 +92,12 @@ class _SidebarAudioRecordingCard extends ConsumerWidget {
       linkedEntry: linkedEntry,
       fallback: messages.taskActionBarAudioRecordingActive,
     );
-    final durationText = formatDuration(state.progress);
 
     return Semantics(
       container: true,
       liveRegion: true,
       label: messages.taskActionBarAudioRecordingActive,
       child: _SignalReactiveCardFrame(
-        dBFS: state.dBFS,
         child: Material(
           key: const Key('sidebar_audio_recording_card'),
           color: Colors.transparent,
@@ -108,7 +107,7 @@ class _SidebarAudioRecordingCard extends ConsumerWidget {
             onTap: () => AudioRecordingModal.show(
               context,
               linkedId: linkedId,
-              categoryId: linkedEntry?.meta.categoryId,
+              categoryId: linkedEntry?.categoryId,
               useRootNavigator: false,
             ),
             child: Padding(
@@ -124,11 +123,7 @@ class _SidebarAudioRecordingCard extends ConsumerWidget {
                 children: [
                   _RecordingTitleRow(title: title),
                   SizedBox(height: tokens.spacing.step2),
-                  _RecordingBodyRow(
-                    dBFS: state.dBFS,
-                    durationText: durationText,
-                    onStop: () => unawaited(_stop(ref)),
-                  ),
+                  const _RecordingBodyRow(),
                 ],
               ),
             ),
@@ -151,28 +146,20 @@ class _SidebarAudioRecordingCard extends ConsumerWidget {
     if (linkedText != null && linkedText.isNotEmpty) return linkedText;
     return fallback;
   }
-
-  Future<void> _stop(WidgetRef ref) async {
-    final controller = ref.read(audioRecorderControllerProvider.notifier);
-    if (state.isRealtimeMode) {
-      await controller.stopRealtime();
-    } else {
-      await controller.stop();
-    }
-  }
 }
 
-class _SignalReactiveCardFrame extends StatelessWidget {
+class _SignalReactiveCardFrame extends ConsumerWidget {
   const _SignalReactiveCardFrame({
-    required this.dBFS,
     required this.child,
   });
 
-  final double dBFS;
   final Widget child;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final dBFS = ref.watch(
+      audioRecorderControllerProvider.select((state) => state.dBFS),
+    );
     final tokens = context.designTokens;
     final signalLevel = AudioRecordingSignalLevel.fromDbfs(dBFS);
     final signal = signalLevel.normalized;
@@ -184,10 +171,8 @@ class _SignalReactiveCardFrame extends StatelessWidget {
     final shadowAlpha = (0.04 + frameSignal * 0.12).clamp(0.0, 0.18);
     final backgroundAlpha = (0.08 + frameSignal * 0.05).clamp(0.0, 0.16);
 
-    return AnimatedContainer(
+    return DecoratedBox(
       key: const Key('sidebar_audio_recording_card_frame'),
-      duration: SidebarAudioRecordingSection.animationDuration,
-      curve: Curves.easeOut,
       decoration: BoxDecoration(
         color: color.withValues(alpha: backgroundAlpha),
         borderRadius: borderRadius,
@@ -228,26 +213,28 @@ class _RecordingTitleRow extends StatelessWidget {
   }
 }
 
-class _RecordingBodyRow extends StatelessWidget {
-  const _RecordingBodyRow({
-    required this.dBFS,
-    required this.durationText,
-    required this.onStop,
-  });
-
-  final double dBFS;
-  final String durationText;
-  final VoidCallback onStop;
+class _RecordingBodyRow extends ConsumerWidget {
+  const _RecordingBodyRow();
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(
+      audioRecorderControllerProvider.select(
+        (state) => (
+          dBFS: state.dBFS,
+          progress: state.progress,
+          isRealtimeMode: state.isRealtimeMode,
+        ),
+      ),
+    );
     final tokens = context.designTokens;
     final errorColor = tokens.colors.alert.error.defaultColor;
+    final durationText = formatDuration(state.progress);
 
     return Row(
       children: [
         AudioRecordingOrb(
-          dBFS: dBFS,
+          dBFS: state.dBFS,
           size: tokens.spacing.step7,
         ),
         SizedBox(width: tokens.spacing.step3),
@@ -260,9 +247,25 @@ class _RecordingBodyRow extends StatelessWidget {
             ),
           ),
         ),
-        _StopAudioRecordingButton(onStop: onStop),
+        _StopAudioRecordingButton(
+          onStop: () => unawaited(
+            _stop(ref, isRealtimeMode: state.isRealtimeMode),
+          ),
+        ),
       ],
     );
+  }
+
+  Future<void> _stop(
+    WidgetRef ref, {
+    required bool isRealtimeMode,
+  }) async {
+    final controller = ref.read(audioRecorderControllerProvider.notifier);
+    if (isRealtimeMode) {
+      await controller.stopRealtime();
+    } else {
+      await controller.stop();
+    }
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1006+4088
+version: 0.9.1007+4089
 
 msix_config:
   display_name: LottiApp

--- a/test/beamer/beamer_app_test.dart
+++ b/test/beamer/beamer_app_test.dart
@@ -25,6 +25,7 @@ import 'package:lotti/providers/service_providers.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/services/time_service.dart';
 import 'package:lotti/themes/theme.dart';
+import 'package:lotti/widgets/misc/sidebar_audio_recording_section.dart';
 import 'package:lotti/widgets/misc/sidebar_timer_section.dart';
 import 'package:lotti/widgets/misc/time_recording_indicator.dart';
 import 'package:lotti/widgets/nav_bar/design_system_bottom_navigation_bar.dart';
@@ -658,14 +659,20 @@ void main() {
         await _pumpAppScreen(tester, navService: mockNavService);
 
         // The legacy bottom-anchored TimeRecordingIndicator must not appear in
-        // the desktop layout; it has been replaced by SidebarTimerSection
-        // which renders inside the desktop sidebar's aboveSettings slot.
+        // the desktop layout; timer and audio recording cards render inside
+        // the desktop sidebar's aboveSettings slot.
         expect(find.byType(TimeRecordingIndicator), findsNothing);
         expect(
           find.byType(SidebarTimerSection),
           findsOneWidget,
           reason:
               'SidebarTimerSection should be wired into the desktop sidebar.',
+        );
+        expect(
+          find.byType(SidebarAudioRecordingSection),
+          findsOneWidget,
+          reason:
+              'SidebarAudioRecordingSection should be wired above the timer.',
         );
 
         await tester.pumpWidget(const SizedBox.shrink());
@@ -739,14 +746,13 @@ void main() {
 
   group('isTaskDetailRoute', () {
     // Single source of truth for the drives the predicate: this is the
-    // exact same callsite shape used by both shells in beamer_app.dart
-    // (mobile bottom-nav suppression + desktop floating recording
-    // indicator hiding), so unit-testing it covers both behaviors.
+    // exact same callsite shape used by the mobile shell in beamer_app.dart
+    // for bottom-nav suppression.
 
     test('returns false when the active tab is not the tasks tab', () {
       // Even with a task-detail location, any non-tasks tab keeps the
-      // floating indicator visible — the desktop TaskActionBar only
-      // renders inside the tasks-tab pane.
+      // bottom navigation visible — the TaskActionBar only renders inside
+      // the tasks-tab pane.
       final location = TasksLocation(
         RouteInformation(uri: Uri.parse('/tasks/${const Uuid().v4()}')),
       );

--- a/test/beamer/beamer_app_test.dart
+++ b/test/beamer/beamer_app_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io' show Platform;
 
 import 'package:beamer/beamer.dart';
 import 'package:flutter/material.dart';
@@ -37,6 +38,14 @@ import 'package:uuid/uuid.dart';
 import '../mocks/mocks.dart';
 import '../mocks/sync_config_test_mocks.dart';
 import '../widget_test_utils.dart';
+
+bool _isFlatpakTestHost() {
+  return Platform.isLinux &&
+      ((Platform.environment['FLATPAK_ID']?.isNotEmpty ?? false) ||
+          Platform.environment.containsKey('FLATPAK_SANDBOX') ||
+          (Platform.environment['XDG_RUNTIME_DIR']?.contains('flatpak') ??
+              false));
+}
 
 int calculateClampedIndex({
   required int rawIndex,
@@ -670,9 +679,8 @@ void main() {
         );
         expect(
           find.byType(SidebarAudioRecordingSection),
-          findsOneWidget,
-          reason:
-              'SidebarAudioRecordingSection should be wired above the timer.',
+          _isFlatpakTestHost() ? findsNothing : findsOneWidget,
+          reason: 'Audio section is hidden in Flatpak builds.',
         );
 
         await tester.pumpWidget(const SizedBox.shrink());

--- a/test/features/speech/ui/widgets/recording/audio_recording_indicator_test.dart
+++ b/test/features/speech/ui/widgets/recording/audio_recording_indicator_test.dart
@@ -8,6 +8,7 @@ import 'package:lotti/features/speech/repository/audio_recorder_repository.dart'
 import 'package:lotti/features/speech/state/recorder_controller.dart';
 import 'package:lotti/features/speech/state/recorder_state.dart';
 import 'package:lotti/features/speech/ui/widgets/recording/audio_recording_indicator.dart';
+import 'package:lotti/features/speech/ui/widgets/recording/audio_recording_orb.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
 import 'package:lotti/services/db_notification.dart';
@@ -126,7 +127,7 @@ void main() {
       );
 
       await tester.pumpWidget(makeTestableWidget(state));
-      await tester.pumpAndSettle();
+      await tester.pump();
 
       expect(find.byKey(const Key('audio_recording_indicator')), findsNothing);
     });
@@ -142,7 +143,7 @@ void main() {
       );
 
       await tester.pumpWidget(makeTestableWidget(state));
-      await tester.pumpAndSettle();
+      await tester.pump();
 
       expect(find.byKey(const Key('audio_recording_indicator')), findsNothing);
     });
@@ -160,13 +161,13 @@ void main() {
       );
 
       await tester.pumpWidget(makeTestableWidget(state));
-      await tester.pumpAndSettle();
+      await tester.pump();
 
       expect(
         find.byKey(const Key('audio_recording_indicator')),
         findsOneWidget,
       );
-      expect(find.byIcon(Icons.mic_outlined), findsOneWidget);
+      expect(find.byType(AudioRecordingOrb), findsOneWidget);
 
       // FittedBox might be scaling the text, so let's find it within the widget tree
       final textFinder = find.descendant(
@@ -190,7 +191,7 @@ void main() {
       );
 
       await tester.pumpWidget(makeTestableWidget(state));
-      await tester.pumpAndSettle();
+      await tester.pump();
 
       final container = tester.widget<Container>(
         find.descendant(
@@ -223,7 +224,7 @@ void main() {
       );
 
       await tester.pumpWidget(makeTestableWidget(state));
-      await tester.pumpAndSettle();
+      await tester.pump();
 
       // Verify the indicator exists
       expect(
@@ -249,7 +250,7 @@ void main() {
       expect(mouseRegion.cursor, SystemMouseCursors.click);
 
       // Verify it has the expected content
-      expect(find.byIcon(Icons.mic_outlined), findsOneWidget);
+      expect(find.byType(AudioRecordingOrb), findsOneWidget);
     });
 
     testWidgets('indicator shows correct duration format', (tester) async {
@@ -270,7 +271,7 @@ void main() {
         );
 
         await tester.pumpWidget(makeTestableWidget(state));
-        await tester.pumpAndSettle();
+        await tester.pump();
 
         // FittedBox might be scaling the text, so let's find it within the widget tree
         final textFinder = find.descendant(
@@ -298,7 +299,7 @@ void main() {
       );
 
       await tester.pumpWidget(makeTestableWidget(state));
-      await tester.pumpAndSettle();
+      await tester.pump();
 
       final indicatorSize = tester.getSize(
         find.byKey(const Key('audio_recording_indicator')),
@@ -332,7 +333,7 @@ void main() {
         );
 
         await tester.pumpWidget(makeTestableWidget(state));
-        await tester.pumpAndSettle();
+        await tester.pump();
 
         final size = tester.getSize(
           find.byKey(const Key('audio_recording_indicator')),
@@ -379,7 +380,7 @@ void main() {
       await tester.pumpWidget(
         makeTestableWidget(state, linkedEntry: mockEntry),
       );
-      await tester.pumpAndSettle();
+      await tester.pump();
 
       // Verify indicator exists
       expect(
@@ -407,7 +408,7 @@ void main() {
         );
 
         await tester.pumpWidget(makeTestableWidget(state));
-        await tester.pumpAndSettle();
+        await tester.pump();
 
         // Verify indicator exists
         expect(
@@ -440,7 +441,7 @@ void main() {
           ],
         ),
       );
-      await tester.pumpAndSettle();
+      await tester.pump();
 
       // Should show empty widget when exception occurs
       expect(find.byKey(const Key('audio_recording_indicator')), findsNothing);
@@ -458,7 +459,7 @@ void main() {
       );
 
       await tester.pumpWidget(makeTestableWidget(state));
-      await tester.pumpAndSettle();
+      await tester.pump();
 
       final clipRRect = tester.widget<ClipRRect>(
         find.descendant(

--- a/test/features/speech/ui/widgets/recording/audio_recording_indicator_timer_text_test.dart
+++ b/test/features/speech/ui/widgets/recording/audio_recording_indicator_timer_text_test.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/speech/state/recorder_controller.dart';
 import 'package:lotti/features/speech/state/recorder_state.dart';
 import 'package:lotti/features/speech/ui/widgets/recording/audio_recording_indicator.dart';
+
+import '../../../../../widget_test_utils.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -27,16 +28,12 @@ void main() {
 
     Future<double> pumpAndMeasure(Duration d) async {
       await tester.pumpWidget(
-        ProviderScope(
+        makeTestableWidgetWithScaffold(
+          const Center(child: AudioRecordingIndicator()),
           overrides: [overrideWithProgress(d)],
-          child: const MaterialApp(
-            home: Scaffold(
-              body: Center(child: AudioRecordingIndicator()),
-            ),
-          ),
         ),
       );
-      await tester.pumpAndSettle();
+      await tester.pump();
       final byKey = find.byKey(const Key('audio_recording_indicator'));
       expect(byKey, findsOneWidget);
       final textFinder = find.descendant(

--- a/test/features/speech/ui/widgets/recording/audio_recording_orb_test.dart
+++ b/test/features/speech/ui/widgets/recording/audio_recording_orb_test.dart
@@ -47,6 +47,16 @@ void main() {
       expect(level.normalized, 0);
       expect(level.isClipping, isFalse);
     });
+
+    test('uses value equality for repaint comparisons', () {
+      final first = AudioRecordingSignalLevel.fromDbfs(-30);
+      final second = AudioRecordingSignalLevel.fromDbfs(-30);
+      final third = AudioRecordingSignalLevel.fromDbfs(-12);
+
+      expect(first, second);
+      expect(first.hashCode, second.hashCode);
+      expect(first, isNot(third));
+    });
   });
 
   testWidgets('paints from live dBFS level and advances pulse phase', (

--- a/test/features/speech/ui/widgets/recording/audio_recording_orb_test.dart
+++ b/test/features/speech/ui/widgets/recording/audio_recording_orb_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/speech/ui/widgets/recording/audio_recording_orb.dart';
+
+import '../../../../../widget_test_utils.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('AudioRecordingSignalLevel', () {
+    test('maps silence, speech, and hot input into an emphasized signal', () {
+      expect(AudioRecordingSignalLevel.fromDbfs(-160).normalized, 0);
+      expect(AudioRecordingSignalLevel.fromDbfs(-64).normalized, 0);
+      expect(
+        AudioRecordingSignalLevel.fromDbfs(-60).normalized,
+        closeTo(0.08, 0.01),
+      );
+      expect(
+        AudioRecordingSignalLevel.fromDbfs(-30).normalized,
+        closeTo(0.57, 0.01),
+      );
+      expect(
+        AudioRecordingSignalLevel.fromDbfs(-12).normalized,
+        closeTo(0.82, 0.01),
+      );
+      expect(
+        AudioRecordingSignalLevel.fromDbfs(-8).normalized,
+        closeTo(0.89, 0.01),
+      );
+      expect(
+        AudioRecordingSignalLevel.fromDbfs(-3).normalized,
+        closeTo(0.96, 0.01),
+      );
+      expect(AudioRecordingSignalLevel.fromDbfs(12).normalized, 1);
+    });
+
+    test('marks only near-full-scale samples as clipping', () {
+      expect(AudioRecordingSignalLevel.fromDbfs(-4).isClipping, isFalse);
+      expect(AudioRecordingSignalLevel.fromDbfs(-3).isClipping, isTrue);
+      expect(AudioRecordingSignalLevel.fromDbfs(0).isClipping, isTrue);
+    });
+
+    test('treats non-finite input as silence', () {
+      final level = AudioRecordingSignalLevel.fromDbfs(double.nan);
+
+      expect(level.normalized, 0);
+      expect(level.isClipping, isFalse);
+    });
+  });
+
+  testWidgets('paints from live dBFS level and advances pulse phase', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      makeTestableWidgetWithScaffold(
+        const AudioRecordingOrb(dBFS: -30),
+      ),
+    );
+    await tester.pump();
+
+    final orbPaint = find.descendant(
+      of: find.byType(AudioRecordingOrb),
+      matching: find.byType(CustomPaint),
+    );
+    final firstPainter =
+        tester
+                .widget<CustomPaint>(
+                  orbPaint,
+                )
+                .painter!
+            as AudioRecordingOrbPainter;
+    expect(firstPainter.signalLevel.normalized, closeTo(0.57, 0.01));
+    expect(firstPainter.signalLevel.isClipping, isFalse);
+
+    await tester.pump(AudioRecordingOrbConstants.pulseDuration ~/ 2);
+
+    final secondPainter =
+        tester
+                .widget<CustomPaint>(
+                  orbPaint,
+                )
+                .painter!
+            as AudioRecordingOrbPainter;
+    expect(secondPainter.phase, isNot(equals(firstPainter.phase)));
+  });
+
+  testWidgets('uses warning color when dBFS reaches clipping threshold', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      makeTestableWidgetWithScaffold(
+        const AudioRecordingOrb(dBFS: -1),
+      ),
+    );
+    await tester.pump();
+
+    final tokens = tester.element(find.byType(AudioRecordingOrb)).designTokens;
+    final orbPaint = find.descendant(
+      of: find.byType(AudioRecordingOrb),
+      matching: find.byType(CustomPaint),
+    );
+    final painter =
+        tester
+                .widget<CustomPaint>(
+                  orbPaint,
+                )
+                .painter!
+            as AudioRecordingOrbPainter;
+
+    expect(painter.signalLevel.isClipping, isTrue);
+    expect(painter.clippingColor, tokens.colors.alert.warning.defaultColor);
+  });
+}

--- a/test/features/speech/ui/widgets/recording/audio_recording_orb_test.dart
+++ b/test/features/speech/ui/widgets/recording/audio_recording_orb_test.dart
@@ -35,9 +35,10 @@ void main() {
       expect(AudioRecordingSignalLevel.fromDbfs(12).normalized, 1);
     });
 
-    test('marks only near-full-scale samples as clipping', () {
+    test('marks only samples above clipping threshold as clipping', () {
       expect(AudioRecordingSignalLevel.fromDbfs(-4).isClipping, isFalse);
-      expect(AudioRecordingSignalLevel.fromDbfs(-3).isClipping, isTrue);
+      expect(AudioRecordingSignalLevel.fromDbfs(-3).isClipping, isFalse);
+      expect(AudioRecordingSignalLevel.fromDbfs(-2.9).isClipping, isTrue);
       expect(AudioRecordingSignalLevel.fromDbfs(0).isClipping, isTrue);
     });
 

--- a/test/widgets/misc/sidebar_audio_recording_section_test.dart
+++ b/test/widgets/misc/sidebar_audio_recording_section_test.dart
@@ -112,10 +112,10 @@ void main() {
 
   BoxDecoration frameDecoration(WidgetTester tester) {
     return tester
-            .widget<AnimatedContainer>(
+            .widget<DecoratedBox>(
               find.byKey(const Key('sidebar_audio_recording_card_frame')),
             )
-            .decoration!
+            .decoration
         as BoxDecoration;
   }
 

--- a/test/widgets/misc/sidebar_audio_recording_section_test.dart
+++ b/test/widgets/misc/sidebar_audio_recording_section_test.dart
@@ -1,0 +1,261 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/entry_text.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/classes/task.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/speech/state/recorder_controller.dart';
+import 'package:lotti/features/speech/state/recorder_state.dart';
+import 'package:lotti/features/speech/ui/widgets/recording/audio_recording_orb.dart';
+import 'package:lotti/themes/theme.dart' show numericBadgeFontFeatures;
+import 'package:lotti/widgets/misc/sidebar_audio_recording_section.dart';
+
+import '../../widget_test_utils.dart';
+
+class _FakeAudioRecorderController extends AudioRecorderController {
+  _FakeAudioRecorderController(this._initial);
+
+  final AudioRecorderState _initial;
+  int stopCalls = 0;
+  int stopRealtimeCalls = 0;
+
+  @override
+  AudioRecorderState build() => _initial;
+
+  @override
+  Future<String?> stop() async {
+    stopCalls += 1;
+    state = state.copyWith(status: AudioRecorderStatus.stopped);
+    return 'audio-entry';
+  }
+
+  @override
+  Future<String?> stopRealtime() async {
+    stopRealtimeCalls += 1;
+    state = state.copyWith(status: AudioRecorderStatus.stopped);
+    return 'realtime-audio-entry';
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _FakeAudioRecorderController controller;
+
+  AudioRecorderState recorderState({
+    AudioRecorderStatus status = AudioRecorderStatus.recording,
+    Duration progress = const Duration(minutes: 7, seconds: 40),
+    double dBFS = -18,
+    bool modalVisible = false,
+    String? linkedId,
+    bool isRealtimeMode = false,
+  }) {
+    return AudioRecorderState(
+      status: status,
+      progress: progress,
+      vu: -6,
+      dBFS: dBFS,
+      showIndicator: true,
+      modalVisible: modalVisible,
+      linkedId: linkedId,
+      isRealtimeMode: isRealtimeMode,
+    );
+  }
+
+  Task makeTask(String id, {String title = 'Implement recording orb'}) {
+    final now = DateTime(2026, 5, 22, 14);
+    return Task(
+      meta: Metadata(
+        id: id,
+        createdAt: now,
+        updatedAt: now,
+        dateFrom: now,
+        dateTo: now,
+        categoryId: 'category-1',
+      ),
+      data: TaskData(
+        title: title,
+        dateFrom: now,
+        dateTo: now,
+        status: TaskStatus.open(
+          id: 'status-id',
+          createdAt: now,
+          utcOffset: 0,
+        ),
+        statusHistory: const [],
+      ),
+      entryText: const EntryText(plainText: 'task fallback text'),
+    );
+  }
+
+  Future<void> pumpSection(
+    WidgetTester tester,
+    AudioRecorderState state, {
+    JournalEntity? linkedEntry,
+  }) async {
+    await tester.pumpWidget(
+      makeTestableWidgetWithScaffold(
+        const SidebarAudioRecordingSection(),
+        overrides: [
+          audioRecorderControllerProvider.overrideWith(() {
+            return controller = _FakeAudioRecorderController(state);
+          }),
+          if (state.linkedId != null && linkedEntry != null)
+            sidebarAudioRecordingLinkedEntryProvider(
+              state.linkedId!,
+            ).overrideWith((ref) => linkedEntry),
+        ],
+      ),
+    );
+    await tester.pump();
+  }
+
+  BoxDecoration frameDecoration(WidgetTester tester) {
+    return tester
+            .widget<AnimatedContainer>(
+              find.byKey(const Key('sidebar_audio_recording_card_frame')),
+            )
+            .decoration!
+        as BoxDecoration;
+  }
+
+  testWidgets('collapses when the recorder is not active', (tester) async {
+    await pumpSection(
+      tester,
+      recorderState(status: AudioRecorderStatus.stopped),
+    );
+    await tester.pump(SidebarAudioRecordingSection.animationDuration);
+
+    expect(find.byKey(const Key('sidebar_audio_recording_card')), findsNothing);
+    expect(find.byType(AudioRecordingOrb), findsNothing);
+    expect(find.byIcon(Icons.stop_rounded), findsNothing);
+  });
+
+  testWidgets('renders linked task title, duration, orb, and stop button', (
+    tester,
+  ) async {
+    await pumpSection(
+      tester,
+      recorderState(
+        linkedId: 'task-1',
+        dBFS: -12,
+        progress: const Duration(hours: 1, minutes: 2, seconds: 3),
+      ),
+      linkedEntry: makeTask('task-1', title: 'Urgent voice note'),
+    );
+    await tester.pump(SidebarAudioRecordingSection.animationDuration);
+
+    expect(find.text('Urgent voice note'), findsOneWidget);
+    expect(find.text('01:02:03'), findsOneWidget);
+    expect(find.byType(AudioRecordingOrb), findsOneWidget);
+    expect(find.byIcon(Icons.stop_rounded), findsOneWidget);
+
+    final orb = tester.widget<AudioRecordingOrb>(
+      find.byType(AudioRecordingOrb),
+    );
+    expect(orb.dBFS, -12);
+    expect(orb.size, dsTokensLight.spacing.step7);
+
+    final material = tester.widget<Material>(
+      find.byKey(const Key('sidebar_audio_recording_card')),
+    );
+    expect(material.borderRadius, BorderRadius.circular(dsTokensLight.radii.s));
+
+    final frame = frameDecoration(tester);
+    expect(frame.borderRadius, BorderRadius.circular(dsTokensLight.radii.s));
+  });
+
+  testWidgets('intensifies the card frame from live dBFS input', (
+    tester,
+  ) async {
+    await pumpSection(tester, recorderState(dBFS: -60));
+    final quietFrame = frameDecoration(tester);
+    final quietBorder = quietFrame.border! as Border;
+    final quietShadow = quietFrame.boxShadow!.single;
+
+    controller.state = controller.state.copyWith(dBFS: -12);
+    await tester.pump();
+    final loudFrame = frameDecoration(tester);
+    final loudBorder = loudFrame.border! as Border;
+    final loudShadow = loudFrame.boxShadow!.single;
+
+    expect(loudBorder.top.width, greaterThan(quietBorder.top.width));
+    expect(quietBorder.top.width, lessThan(dsTokensLight.spacing.step1 / 2));
+    expect(
+      loudBorder.top.width,
+      greaterThan(dsTokensLight.spacing.step1 * 0.6),
+    );
+    expect(
+      loudBorder.top.width,
+      lessThan(dsTokensLight.spacing.step1 * 0.75),
+    );
+    controller.state = controller.state.copyWith(dBFS: 0);
+    await tester.pump();
+    final fullScaleFrame = frameDecoration(tester);
+    final fullScaleBorder = fullScaleFrame.border! as Border;
+
+    expect(fullScaleBorder.top.width, dsTokensLight.spacing.step1);
+    expect(loudBorder.top.color.a, greaterThan(quietBorder.top.color.a));
+    expect(loudShadow.blurRadius, greaterThan(quietShadow.blurRadius));
+    expect(loudShadow.spreadRadius, greaterThan(quietShadow.spreadRadius));
+    expect(loudFrame.color!.a, greaterThan(quietFrame.color!.a));
+  });
+
+  testWidgets('keeps the card frame red when input is clipping', (
+    tester,
+  ) async {
+    await pumpSection(tester, recorderState(dBFS: -1));
+
+    final frame = frameDecoration(tester);
+    final border = frame.border! as Border;
+
+    expect(
+      border.top.color.withValues(alpha: 1),
+      dsTokensLight.colors.alert.error.defaultColor,
+    );
+  });
+
+  testWidgets('time text uses tabular figure features', (tester) async {
+    await pumpSection(tester, recorderState());
+
+    final text = tester.widget<Text>(find.text('00:07:40'));
+    final features = text.style?.fontFeatures ?? const <FontFeature>[];
+
+    expect(features, containsAll(numericBadgeFontFeatures));
+  });
+
+  testWidgets('stop button stops a standard recording without opening modal', (
+    tester,
+  ) async {
+    await pumpSection(tester, recorderState());
+
+    await tester.tap(find.byIcon(Icons.stop_rounded));
+    await tester.pump();
+
+    expect(controller.stopCalls, 1);
+    expect(controller.stopRealtimeCalls, 0);
+  });
+
+  testWidgets('stop button uses realtime stop for realtime sessions', (
+    tester,
+  ) async {
+    await pumpSection(
+      tester,
+      recorderState(isRealtimeMode: true),
+    );
+
+    await tester.tap(find.byIcon(Icons.stop_rounded));
+    await tester.pump();
+
+    expect(controller.stopCalls, 0);
+    expect(controller.stopRealtimeCalls, 1);
+  });
+
+  testWidgets('uses localized fallback title when there is no linked entry', (
+    tester,
+  ) async {
+    await pumpSection(tester, recorderState());
+
+    expect(find.text('Audio recording in progress'), findsOneWidget);
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop sidebar card for active audio recordings with a live, speech‑weighted dBFS orb, red signal framing/shadow, elapsed time, tap-to-open modal, and one‑tap stop control; persistent mobile indicators behavior clarified.

* **Documentation**
  * Changelog, release notes, and recording UI READMEs updated to document visibility rules, dBFS/reactive visuals, and recording UX flow.

* **Tests**
  * Added/updated widget and unit tests for the orb, sidebar section, indicator behavior, visuals, timing, and stop interactions.

* **Chores**
  * Version bumped to 0.9.1007.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matthiasn/lotti/pull/3202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->