### PR TITLE
fix: unresolvable sync entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   active-row indexes that avoid SQLite temp sorts during large project-agent
   wake context builds.
 
+### Fixed
+- Sync now preserves local sequence mappings when recovering burnt vector-clock
+  counters, reducing cases where peers can get stuck on unresolvable gaps.
+
 ## [0.9.1005]
 ### Changed
 - AI popup menu now opens a model-override picker when you tap an

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -37,6 +37,7 @@
           <p>Active audio recordings now show a prominent desktop sidebar card above the running timer, with a larger speech-weighted dBFS-reactive recording orb, red signal-reactive frame, subtle red shadow, elapsed time, and one-tap stop control so runaway microphone sessions are harder to miss.</p>
           <p>Audio and image entry Actions menus on desktop can now reveal the backing file in Finder, File Explorer, or Files.</p>
           <p>Agent batch lookups for latest per-agent reports and states now use ranked active-row indexes that avoid SQLite temp sorts during large project-agent wake context builds.</p>
+          <p>Sync now preserves local sequence mappings when recovering burnt vector-clock counters, reducing cases where peers can get stuck on unresolvable gaps.</p>
       </description>
     </release>
     <release version="0.9.1005" date="2026-05-22">

--- a/lib/database/sync_db.dart
+++ b/lib/database/sync_db.dart
@@ -1039,6 +1039,77 @@ class SyncDatabase extends _$SyncDatabase {
     });
   }
 
+  /// Record that this host authoritatively burnt one of its own counters.
+  ///
+  /// The guard lives in the database layer so the authoritative-row check and
+  /// write happen in one transaction. Rows already bound to a payload
+  /// ([SyncSequenceStatus.received], [SyncSequenceStatus.backfilled], or
+  /// [SyncSequenceStatus.deleted]) are left untouched; other rows are converted
+  /// to [SyncSequenceStatus.unresolvable] with `entry_id` explicitly cleared.
+  Future<bool> recordOwnUnresolvableSequenceCounter({
+    required String hostId,
+    required int counter,
+    SyncSequencePayloadType payloadType = SyncSequencePayloadType.journalEntity,
+    DateTime? now,
+  }) async {
+    final timestamp = now ?? DateTime.now();
+    return transaction(() async {
+      Future<bool> tryUpdateExisting() async {
+        final updated =
+            await (update(syncSequenceLog)..where(
+                  (t) =>
+                      t.hostId.equals(hostId) &
+                      t.counter.equals(counter) &
+                      t.status.isNotIn([
+                        SyncSequenceStatus.received.index,
+                        SyncSequenceStatus.backfilled.index,
+                        SyncSequenceStatus.deleted.index,
+                      ]),
+                ))
+                .write(
+                  SyncSequenceLogCompanion(
+                    entryId: const Value(null),
+                    payloadType: Value(payloadType.index),
+                    status: Value(SyncSequenceStatus.unresolvable.index),
+                    updatedAt: Value(timestamp),
+                  ),
+                );
+        if (updated == 0) return false;
+        await _refreshSequenceWatermark(
+          hostId: hostId,
+          counter: counter,
+          status: SyncSequenceStatus.unresolvable.index,
+        );
+        return true;
+      }
+
+      if (await tryUpdateExisting()) return true;
+
+      final inserted = await into(syncSequenceLog).insertReturningOrNull(
+        SyncSequenceLogCompanion(
+          hostId: Value(hostId),
+          counter: Value(counter),
+          entryId: const Value(null),
+          payloadType: Value(payloadType.index),
+          status: Value(SyncSequenceStatus.unresolvable.index),
+          createdAt: Value(timestamp),
+          updatedAt: Value(timestamp),
+        ),
+        mode: InsertMode.insertOrIgnore,
+      );
+      if (inserted != null) {
+        await _refreshSequenceWatermark(
+          hostId: hostId,
+          counter: counter,
+          status: SyncSequenceStatus.unresolvable.index,
+        );
+        return true;
+      }
+
+      return tryUpdateExisting();
+    });
+  }
+
   /// Record an own-host VC reservation before the counter is handed to a
   /// caller that may write to another database. The insert is intentionally
   /// `OR IGNORE`: a catch-up reservation must never clobber an already-bound
@@ -1075,9 +1146,10 @@ class SyncDatabase extends _$SyncDatabase {
   }
 
   /// Return own-host reservations that have not yet been bound to a sync
-  /// payload or explicitly marked unresolvable. Startup reconciliation uses
-  /// this to enqueue durable unresolvable broadcasts before converting the
-  /// rows to terminal status.
+  /// payload or explicitly released. These rows are diagnostic pre-bind
+  /// markers only; startup reconciliation must use
+  /// [burnPendingSequenceCountersForHost] for counters that are safe to
+  /// convert to terminal unresolvable markers.
   Future<List<int>> reservedSequenceCountersForHost({
     required String hostId,
   }) async {
@@ -1105,22 +1177,59 @@ class SyncDatabase extends _$SyncDatabase {
   }) async {
     final timestamp = now ?? DateTime.now();
     await transaction(() async {
-      await into(syncSequenceLog).insertOnConflictUpdate(
-        SyncSequenceLogCompanion(
-          hostId: Value(hostId),
-          counter: Value(counter),
-          entryId: const Value(null),
-          payloadType: Value(SyncSequencePayloadType.journalEntity.index),
-          status: Value(SyncSequenceStatus.burnPending.index),
-          createdAt: Value(timestamp),
-          updatedAt: Value(timestamp),
-        ),
-      );
-      await _refreshSequenceWatermark(
-        hostId: hostId,
-        counter: counter,
-        status: SyncSequenceStatus.burnPending.index,
-      );
+      final existing = await getEntryByHostAndCounter(hostId, counter);
+      if (existing == null) {
+        await into(syncSequenceLog).insert(
+          SyncSequenceLogCompanion(
+            hostId: Value(hostId),
+            counter: Value(counter),
+            entryId: const Value(null),
+            payloadType: Value(SyncSequencePayloadType.journalEntity.index),
+            status: Value(SyncSequenceStatus.burnPending.index),
+            createdAt: Value(timestamp),
+            updatedAt: Value(timestamp),
+          ),
+        );
+        await _refreshSequenceWatermark(
+          hostId: hostId,
+          counter: counter,
+          status: SyncSequenceStatus.burnPending.index,
+        );
+        return;
+      }
+
+      if (existing.status != SyncSequenceStatus.reserved.index &&
+          existing.status != SyncSequenceStatus.burnPending.index) {
+        return;
+      }
+
+      final updated =
+          await (update(syncSequenceLog)..where(
+                (t) =>
+                    t.hostId.equals(hostId) &
+                    t.counter.equals(counter) &
+                    t.status.isIn([
+                      SyncSequenceStatus.reserved.index,
+                      SyncSequenceStatus.burnPending.index,
+                    ]),
+              ))
+              .write(
+                SyncSequenceLogCompanion(
+                  entryId: const Value(null),
+                  payloadType: Value(
+                    SyncSequencePayloadType.journalEntity.index,
+                  ),
+                  status: Value(SyncSequenceStatus.burnPending.index),
+                  updatedAt: Value(timestamp),
+                ),
+              );
+      if (updated != 0) {
+        await _refreshSequenceWatermark(
+          hostId: hostId,
+          counter: counter,
+          status: SyncSequenceStatus.burnPending.index,
+        );
+      }
     });
   }
 

--- a/lib/database/sync_db.dart
+++ b/lib/database/sync_db.dart
@@ -59,6 +59,17 @@ enum SyncSequenceStatus {
   /// This happens when a counter was superseded before being recorded
   /// (e.g., rapid edits where intermediate versions were never persisted).
   unresolvable,
+
+  /// Own-host counter was reserved but has not yet been bound to an outbound
+  /// payload. This is a durable crash-recovery marker: if the process exits
+  /// before a later `recordSentEntry` overwrites it, the row stays forensic
+  /// instead of disappearing into an unexplained sequence hole.
+  reserved,
+
+  /// Own-host reservation was explicitly released without a payload, but the
+  /// durable unresolvable broadcast has not completed yet. Startup
+  /// reconciliation retries these rows.
+  burnPending,
 }
 
 bool _isResolvedSequenceStatusIndex(int status) =>
@@ -1026,6 +1037,108 @@ class SyncDatabase extends _$SyncDatabase {
       await _refreshSequenceWatermarkAfterMutation(entry);
       return result;
     });
+  }
+
+  /// Record an own-host VC reservation before the counter is handed to a
+  /// caller that may write to another database. The insert is intentionally
+  /// `OR IGNORE`: a catch-up reservation must never clobber an already-bound
+  /// sequence row if local state has advanced around a previously observed
+  /// counter.
+  Future<int> recordReservedSequenceCounter({
+    required String hostId,
+    required int counter,
+    DateTime? now,
+  }) async {
+    final timestamp = now ?? DateTime.now();
+    return transaction(() async {
+      final inserted = await into(syncSequenceLog).insert(
+        SyncSequenceLogCompanion(
+          hostId: Value(hostId),
+          counter: Value(counter),
+          entryId: const Value(null),
+          payloadType: Value(SyncSequencePayloadType.journalEntity.index),
+          status: Value(SyncSequenceStatus.reserved.index),
+          createdAt: Value(timestamp),
+          updatedAt: Value(timestamp),
+        ),
+        mode: InsertMode.insertOrIgnore,
+      );
+      if (inserted != 0) {
+        await _refreshSequenceWatermark(
+          hostId: hostId,
+          counter: counter,
+          status: SyncSequenceStatus.reserved.index,
+        );
+      }
+      return inserted;
+    });
+  }
+
+  /// Return own-host reservations that have not yet been bound to a sync
+  /// payload or explicitly marked unresolvable. Startup reconciliation uses
+  /// this to enqueue durable unresolvable broadcasts before converting the
+  /// rows to terminal status.
+  Future<List<int>> reservedSequenceCountersForHost({
+    required String hostId,
+  }) async {
+    final rows =
+        await (select(syncSequenceLog)
+              ..where(
+                (t) =>
+                    t.hostId.equals(hostId) &
+                    t.status.equals(SyncSequenceStatus.reserved.index),
+              )
+              ..orderBy([(t) => OrderingTerm(expression: t.counter)]))
+            .get();
+    return [for (final row in rows) row.counter];
+  }
+
+  /// Mark a reservation as an authoritative local burn whose outbound
+  /// unresolvable marker still needs to be durably enqueued. Unlike
+  /// [SyncSequenceStatus.reserved], this status is safe for startup
+  /// reconciliation to retry as `unresolvable`: it is only written when a VC
+  /// reservation is released.
+  Future<void> markReservedSequenceCounterBurnPending({
+    required String hostId,
+    required int counter,
+    DateTime? now,
+  }) async {
+    final timestamp = now ?? DateTime.now();
+    await transaction(() async {
+      await into(syncSequenceLog).insertOnConflictUpdate(
+        SyncSequenceLogCompanion(
+          hostId: Value(hostId),
+          counter: Value(counter),
+          entryId: const Value(null),
+          payloadType: Value(SyncSequencePayloadType.journalEntity.index),
+          status: Value(SyncSequenceStatus.burnPending.index),
+          createdAt: Value(timestamp),
+          updatedAt: Value(timestamp),
+        ),
+      );
+      await _refreshSequenceWatermark(
+        hostId: hostId,
+        counter: counter,
+        status: SyncSequenceStatus.burnPending.index,
+      );
+    });
+  }
+
+  /// Return own-host reservations that were explicitly released but whose
+  /// unresolvable marker still needs a durable outbound enqueue.
+  Future<List<int>> burnPendingSequenceCountersForHost({
+    required String hostId,
+  }) async {
+    final rows =
+        await (select(syncSequenceLog)
+              ..where(
+                (t) =>
+                    t.hostId.equals(hostId) &
+                    t.status.equals(SyncSequenceStatus.burnPending.index),
+              )
+              ..orderBy([(t) => OrderingTerm(expression: t.counter)]))
+            .get();
+    return [for (final row in rows) row.counter];
   }
 
   /// Get the highest contiguous resolved counter for a given host, starting

--- a/lib/features/sync/README.md
+++ b/lib/features/sync/README.md
@@ -65,7 +65,7 @@ At runtime, the sync feature owns:
 | `matrix/` | Session management, room discovery/persistence, message sending, read markers, verification, and high-level lifecycle |
 | `matrix/pipeline/` | Attachment ingestion + index, metrics aggregation, and the `sync.limited` Phase-0 diagnostic listener |
 | `queue/` | Persistent inbound queue, per-room worker, `onSync` bridge for catch-up, and pending-decryption holding pen |
-| `sequence/` | Record `(hostId, counter)` coverage, detect gaps, and track missing/requested/backfilled/deleted/unresolvable states |
+| `sequence/` | Record `(hostId, counter)` coverage, detect gaps, and track reserved/burn-pending/missing/requested/backfilled/deleted/unresolvable states |
 | `backfill/` | Send missing-counter requests and answer peer requests with resend, deleted, unresolvable, or covering-payload hints |
 | `state/` and `ui/` | Riverpod controllers and sync-facing settings, stats, diagnostics, provisioning, and maintenance screens |
 | `actor/` | Separate isolate-based sync implementation; present in the repo, but not wired by the default bootstrap path above |
@@ -858,12 +858,21 @@ states such as:
 - `backfilled`
 - `deleted`
 - `unresolvable`
+- `reserved`
+- `burnPending`
 
 Important implementation details:
 
 - gap detection runs for hosts that have been seen online, plus the current
   originating host
 - sent entries from this device are recorded so peers can request them later
+- local vector-clock reservations insert an own-host `reserved` row before the
+  counter is handed to the write path; `recordSentEntry` overwrites that row
+  with `received`
+- only explicitly released reservations become `burnPending`; startup
+  reconciliation retries those as durable `unresolvable` broadcasts, but does
+  not blindly terminalize plain `reserved` rows because a crash may have left a
+  real local payload behind before outbox logging ran
 - later vector clocks do not automatically close gaps; explicit coverage still
   matters
 - verified covering entries are used as hints when an exact payload is no
@@ -876,6 +885,20 @@ Important implementation details:
 `BackfillRequestService` periodically sends bounded batches of missing
 counters, supports manual full historical backfill, and can re-request entries
 that were previously requested but never resolved.
+
+Own-host reservation lifecycle:
+
+```mermaid
+stateDiagram-v2
+  [*] --> Reserved: reserve VC counter
+  Reserved --> Received: recordSentEntry binds payload
+  Reserved --> BurnPending: release without payload
+  BurnPending --> Unresolvable: marker enqueued
+  Missing --> Requested: backfill batch sent
+  Requested --> Backfilled: verified payload arrives
+  Requested --> Deleted: responder confirms purge
+  Requested --> Unresolvable: originator confirms burn
+```
 
 `BackfillResponseHandler` can answer a request with one of four outcomes:
 

--- a/lib/features/sync/backfill/backfill_response_handler.dart
+++ b/lib/features/sync/backfill/backfill_response_handler.dart
@@ -131,20 +131,15 @@ class BackfillResponseHandler {
   /// recorded, burnt, or the payload VC regressed below the counter).
   ///
   /// Always called on our own host — the callers in [_processBackfillEntry]
-  /// and [_sendHintOrUnresolvable] gate on `hostId == myHost`. The self-log
-  /// upsert mirrors the broadcast so our own sequence log agrees with what
-  /// peers will write after receiving it (self-echoes are suppressed on the
-  /// Matrix pipeline, so `handleBackfillResponse` never fires for us).
+  /// and [_sendHintOrUnresolvable] gate on `hostId == myHost`. Enqueue the
+  /// outbound marker before terminalizing the local sequence row so a failed
+  /// outbox write leaves a retryable reservation/miss instead of silently
+  /// dropping the proactive repair signal.
   Future<void> _sendUnresolvableResponse({
     required String hostId,
     required int counter,
     SyncSequencePayloadType? payloadType,
   }) async {
-    await _sequenceLogService.markOwnCounterUnresolvable(
-      hostId: hostId,
-      counter: counter,
-      payloadType: payloadType ?? SyncSequencePayloadType.journalEntity,
-    );
     await _outboxService.enqueueMessage(
       SyncMessage.backfillResponse(
         hostId: hostId,
@@ -153,6 +148,11 @@ class BackfillResponseHandler {
         unresolvable: true,
         payloadType: payloadType,
       ),
+    );
+    await _sequenceLogService.markOwnCounterUnresolvable(
+      hostId: hostId,
+      counter: counter,
+      payloadType: payloadType ?? SyncSequencePayloadType.journalEntity,
     );
 
     _trace(

--- a/lib/features/sync/sequence/sync_sequence_log_service.dart
+++ b/lib/features/sync/sequence/sync_sequence_log_service.dart
@@ -1098,6 +1098,10 @@ class SyncSequenceLogService {
   /// to our own host, if any skip is ever relaxed) will then see an existing
   /// authoritative row and leave it alone.
   ///
+  /// The authoritative-row guard is implemented inside
+  /// [SyncDatabase.recordOwnUnresolvableSequenceCounter] so the check and
+  /// mutation happen in one database transaction.
+  ///
   /// Not wired through [handleBackfillResponse] because that is the handler
   /// for INCOMING responses, and own-host broadcasts never flow through it
   /// on the originator — self-echoes are suppressed in the Matrix pipeline.
@@ -1109,33 +1113,30 @@ class SyncSequenceLogService {
     required int counter,
     SyncSequencePayloadType payloadType = SyncSequencePayloadType.journalEntity,
   }) async {
-    final now = DateTime.now();
-    await _syncDatabase.recordSequenceEntry(
-      SyncSequenceLogCompanion(
-        hostId: Value(hostId),
-        counter: Value(counter),
-        // Explicitly clear any stale entry_id on an existing row (e.g. one
-        // inserted earlier via a covered-VC hint referring to a different
-        // entity). The unresolvable marker must stand alone — a lingering
-        // entry_id would let later reset/verify paths treat the counter as
-        // if it had a known payload and reopen it.
-        entryId: const Value(null),
-        payloadType: Value(payloadType.index),
-        status: Value(SyncSequenceStatus.unresolvable.index),
-        createdAt: Value(now),
-        updatedAt: Value(now),
-      ),
+    final recorded = await _syncDatabase.recordOwnUnresolvableSequenceCounter(
+      hostId: hostId,
+      counter: counter,
+      payloadType: payloadType,
     );
     _trace(
-      'markOwnCounterUnresolvable hostId=$hostId counter=$counter',
+      recorded
+          ? 'markOwnCounterUnresolvable hostId=$hostId counter=$counter'
+          : 'markOwnCounterUnresolvable skipped hostId=$hostId '
+                'counter=$counter',
       subDomain: 'sequence.ownUnresolvable',
     );
   }
 
-  /// Return own-host reservations left behind without a matching outbound
-  /// payload. A caller must enqueue the durable unresolvable broadcast before
-  /// converting each row via [markOwnCounterUnresolvable]; otherwise a failed
-  /// outbox write would drop the proactive repair signal.
+  /// Return own-host pre-bind crash markers left behind by
+  /// `reserveNextVectorClock`.
+  ///
+  /// Rows returned from [reservedCountersForHost] are diagnostic only and must
+  /// not be automatically converted via [markOwnCounterUnresolvable]. A crash
+  /// can happen after the payload commits but before [recordSentEntry]
+  /// replaces the `reserved` row, so treating plain reservations as
+  /// unresolvable could burn a real payload mapping. Only rows in
+  /// [SyncSequenceStatus.burnPending] carry the "released without payload"
+  /// guarantee and are safe for startup reconciliation.
   Future<List<int>> reservedCountersForHost({
     required String hostId,
   }) async {

--- a/lib/features/sync/sequence/sync_sequence_log_service.dart
+++ b/lib/features/sync/sequence/sync_sequence_log_service.dart
@@ -1132,6 +1132,44 @@ class SyncSequenceLogService {
     );
   }
 
+  /// Return own-host reservations left behind without a matching outbound
+  /// payload. A caller must enqueue the durable unresolvable broadcast before
+  /// converting each row via [markOwnCounterUnresolvable]; otherwise a failed
+  /// outbox write would drop the proactive repair signal.
+  Future<List<int>> reservedCountersForHost({
+    required String hostId,
+  }) async {
+    final counters = await _syncDatabase.reservedSequenceCountersForHost(
+      hostId: hostId,
+    );
+    if (counters.isNotEmpty) {
+      _trace(
+        'reservedCountersForHost hostId=$hostId '
+        'count=${counters.length} counters=$counters',
+        subDomain: 'sequence.reservedCounters',
+      );
+    }
+    return counters;
+  }
+
+  /// Return own-host reservations that were explicitly released without a
+  /// payload, but whose outbound unresolvable marker still needs to be retried.
+  Future<List<int>> burnPendingCountersForHost({
+    required String hostId,
+  }) async {
+    final counters = await _syncDatabase.burnPendingSequenceCountersForHost(
+      hostId: hostId,
+    );
+    if (counters.isNotEmpty) {
+      _trace(
+        'burnPendingCountersForHost hostId=$hostId '
+        'count=${counters.length} counters=$counters',
+        subDomain: 'sequence.burnPendingCounters',
+      );
+    }
+    return counters;
+  }
+
   Future<void> handleBackfillResponse({
     required String hostId,
     required int counter,

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -439,6 +439,23 @@ Future<void> registerSingletons() async {
     required String hostId,
     required int counter,
   }) async {
+    final existing = await syncSequenceLogService.getEntryByHostAndCounter(
+      hostId,
+      counter,
+    );
+    final existingStatus = existing?.status;
+    if (existingStatus == SyncSequenceStatus.received.index ||
+        existingStatus == SyncSequenceStatus.backfilled.index ||
+        existingStatus == SyncSequenceStatus.deleted.index) {
+      domainLogger.log(
+        LogDomains.sync,
+        'vc.burn.broadcast.skipBound host=$hostId counter=$counter '
+        'status=$existingStatus',
+        subDomain: 'vc.burn.broadcast',
+      );
+      return;
+    }
+
     await outboxService.enqueueMessage(
       SyncMessage.backfillResponse(
         hostId: hostId,
@@ -458,47 +475,40 @@ Future<void> registerSingletons() async {
   // unresolvable=true so peers close the gap on arrival instead of having to
   // issue a backfill request first. Registered here because the handler has
   // to fire into OutboxService, which is only now available. The handler is
-  // fire-and-forget by design: it must never throw and must never block the
-  // caller — see VectorClockService._onReleaseBurn.
-  vectorClockService.setBurnHandler((hostId, counter) {
-    // Fire-and-forget: schedule the local-log write + broadcast, swallow
-    // failures at the handler boundary. `unawaited` would still surface
-    // errors to the zone; we catch explicitly so a transient sequence-log
-    // or outbox issue doesn't poison the write path that triggered the
-    // burn.
-    //
+  // awaited by VectorClockService so the durable enqueue attempt finishes
+  // before `release()` returns; failures are still swallowed here because the
+  // VC counter is already persisted and cannot be rewound.
+  vectorClockService.setBurnHandler((hostId, counter) async {
     // [hostId] is the host captured at reservation time, not whatever
     // [VectorClockService.getHost] returns now — if setNewHost ran between
     // reserve and release the broadcast would otherwise be attributed to
     // the new host, producing a phantom unresolvable on the new host's
     // counter space and leaving the actual burnt counter on the old host
     // unannounced.
-    Future<void>(() async {
-      try {
-        // Enqueue first. If the outbox write fails, the row remains
-        // `reserved` and startup/backfill can retry; terminalizing first
-        // would make a transient outbox failure silently drop the proactive
-        // repair signal.
-        await enqueueOwnUnresolvableMarker(
-          hostId: hostId,
-          counter: counter,
-        );
-        domainLogger.log(
-          LogDomains.sync,
-          'vc.burn.broadcast host=$hostId counter=$counter',
-          subDomain: 'vc.burn.broadcast',
-        );
-      } catch (error, stackTrace) {
-        domainLogger.error(
-          LogDomains.sync,
-          'vc burn broadcast failed; counter $counter will fall back to '
-          'reactive backfill resolution',
-          error: error,
-          stackTrace: stackTrace,
-          subDomain: 'vc.burn.broadcast',
-        );
-      }
-    });
+    try {
+      // Enqueue first. If the outbox write fails, the row remains
+      // `burnPending` and startup/backfill can retry; terminalizing first
+      // would make a transient outbox failure silently drop the proactive
+      // repair signal.
+      await enqueueOwnUnresolvableMarker(
+        hostId: hostId,
+        counter: counter,
+      );
+      domainLogger.log(
+        LogDomains.sync,
+        'vc.burn.broadcast host=$hostId counter=$counter',
+        subDomain: 'vc.burn.broadcast',
+      );
+    } catch (error, stackTrace) {
+      domainLogger.error(
+        LogDomains.sync,
+        'vc burn broadcast failed; counter $counter will fall back to '
+        'reactive backfill resolution',
+        error: error,
+        stackTrace: stackTrace,
+        subDomain: 'vc.burn.broadcast',
+      );
+    }
   });
 
   // Crash recovery for counters explicitly released in a previous process but
@@ -515,16 +525,30 @@ Future<void> registerSingletons() async {
             .burnPendingCountersForHost(
               hostId: hostId,
             );
+        var reconciled = 0;
         for (final counter in counters) {
-          await enqueueOwnUnresolvableMarker(
-            hostId: hostId,
-            counter: counter,
-          );
+          try {
+            await enqueueOwnUnresolvableMarker(
+              hostId: hostId,
+              counter: counter,
+            );
+            reconciled++;
+          } catch (error, stackTrace) {
+            domainLogger.error(
+              LogDomains.sync,
+              'vc burn reconciliation failed for host=$hostId '
+              'counter=$counter; continuing',
+              error: error,
+              stackTrace: stackTrace,
+              subDomain: 'vc.burn.reconcile',
+            );
+          }
         }
         if (counters.isNotEmpty) {
           domainLogger.log(
             LogDomains.sync,
-            'vc.burn.reconcile host=$hostId count=${counters.length} '
+            'vc.burn.reconcile host=$hostId count=$reconciled '
+            'attempted=${counters.length} '
             'counters=$counters',
             subDomain: 'vc.burn.reconcile',
           );

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -435,6 +435,24 @@ Future<void> registerSingletons() async {
     }
   }());
 
+  Future<void> enqueueOwnUnresolvableMarker({
+    required String hostId,
+    required int counter,
+  }) async {
+    await outboxService.enqueueMessage(
+      SyncMessage.backfillResponse(
+        hostId: hostId,
+        counter: counter,
+        deleted: false,
+        unresolvable: true,
+      ),
+    );
+    await syncSequenceLogService.markOwnCounterUnresolvable(
+      hostId: hostId,
+      counter: counter,
+    );
+  }
+
   // Proactive VC burn broadcast: when a reservation releases (write rejected,
   // scope threw, commitWhen=false), enqueue a SyncBackfillResponse with
   // unresolvable=true so peers close the gap on arrival instead of having to
@@ -457,22 +475,13 @@ Future<void> registerSingletons() async {
     // unannounced.
     Future<void>(() async {
       try {
-        // Record in our OWN sequence log first so our local state matches
-        // what peers will see after receiving the broadcast below. We do
-        // NOT route through handleBackfillResponse because self-echoes are
-        // suppressed on the Matrix pipeline — that handler never fires for
-        // our own message on our own side.
-        await syncSequenceLogService.markOwnCounterUnresolvable(
+        // Enqueue first. If the outbox write fails, the row remains
+        // `reserved` and startup/backfill can retry; terminalizing first
+        // would make a transient outbox failure silently drop the proactive
+        // repair signal.
+        await enqueueOwnUnresolvableMarker(
           hostId: hostId,
           counter: counter,
-        );
-        await outboxService.enqueueMessage(
-          SyncMessage.backfillResponse(
-            hostId: hostId,
-            counter: counter,
-            deleted: false,
-            unresolvable: true,
-          ),
         );
         domainLogger.log(
           LogDomains.sync,
@@ -491,6 +500,47 @@ Future<void> registerSingletons() async {
       }
     });
   });
+
+  // Crash recovery for counters explicitly released in a previous process but
+  // not yet broadcast as unresolvable. Plain `reserved` rows are not retried
+  // here: a crash after the payload DB write but before outbox/sequence
+  // logging can leave a real payload behind, so only `burnPending` rows are
+  // authoritative burns.
+  unawaited(
+    Future<void>(() async {
+      try {
+        final hostId = await vectorClockService.getHost();
+        if (hostId == null) return;
+        final counters = await syncSequenceLogService
+            .burnPendingCountersForHost(
+              hostId: hostId,
+            );
+        for (final counter in counters) {
+          await enqueueOwnUnresolvableMarker(
+            hostId: hostId,
+            counter: counter,
+          );
+        }
+        if (counters.isNotEmpty) {
+          domainLogger.log(
+            LogDomains.sync,
+            'vc.burn.reconcile host=$hostId count=${counters.length} '
+            'counters=$counters',
+            subDomain: 'vc.burn.reconcile',
+          );
+        }
+      } catch (error, stackTrace) {
+        domainLogger.error(
+          LogDomains.sync,
+          'vc burn reconciliation failed; burn-pending counters will retry '
+          'on the next startup or reactive backfill',
+          error: error,
+          stackTrace: stackTrace,
+          subDomain: 'vc.burn.reconcile',
+        );
+      }
+    }),
+  );
   final backfillResponseHandler = BackfillResponseHandler(
     journalDb: journalDb,
     sequenceLogService: syncSequenceLogService,

--- a/lib/services/vector_clock_service.dart
+++ b/lib/services/vector_clock_service.dart
@@ -81,7 +81,7 @@ class VcReservation {
     if (_finalized) return;
     _finalized = true;
     await _service._markBurnPending(_hostId, _counter);
-    _service._onReleaseBurn(_hostId, _counter);
+    await _service._onReleaseBurn(_hostId, _counter);
   }
 }
 
@@ -89,8 +89,8 @@ class _VcScope {
   final List<VcReservation> reservations = [];
 }
 
-/// Handler invoked synchronously when a reserved counter is released without
-/// a matching write (a "burn"). Implementations typically enqueue a proactive
+/// Async handler invoked when a reserved counter is released without a matching
+/// write (a "burn"). Implementations typically enqueue a proactive
 /// `SyncBackfillResponse(unresolvable=true)` for the given `(hostId, counter)`
 /// so peers close the gap without waiting for the reactive backfill-request
 /// path.
@@ -101,10 +101,11 @@ class _VcScope {
 /// the broadcast must attribute the burnt counter to the host that actually
 /// reserved it.
 ///
-/// The handler MUST NOT throw. Errors are the handler's responsibility to log
-/// and swallow — the VC counter is already persisted and cannot be rewound,
-/// so a handler exception would be uselessly destructive.
-typedef VcBurnHandler = void Function(String hostId, int counter);
+/// The handler is awaited so durable outbox persistence can complete before
+/// [VcReservation.release] returns. Handler errors are caught and logged by
+/// [VectorClockService] — the VC counter is already persisted and cannot be
+/// rewound, so a handler exception must not escape the finalizer.
+typedef VcBurnHandler = Future<void> Function(String hostId, int counter);
 
 class VectorClockService {
   VectorClockService() {
@@ -334,7 +335,7 @@ class VectorClockService {
   /// service's current [_host] if [setNewHost] ran between reserve and
   /// release. The broadcast must attribute the burnt counter to the host
   /// that actually reserved it.
-  void _onReleaseBurn(String hostId, int counter) {
+  Future<void> _onReleaseBurn(String hostId, int counter) async {
     // DomainLogger may not be registered in some test harnesses / bootstrap
     // paths; use the `isRegistered` guard so a release on a minimally-wired
     // service (e.g. unit test seeding the SettingsDb counter) does not crash.
@@ -349,7 +350,7 @@ class VectorClockService {
     final handler = _burnHandler;
     if (handler == null) return;
     try {
-      handler(hostId, counter);
+      await handler(hostId, counter);
     } catch (error, stackTrace) {
       if (getIt.isRegistered<DomainLogger>()) {
         getIt<DomainLogger>().error(

--- a/lib/services/vector_clock_service.dart
+++ b/lib/services/vector_clock_service.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:crypto/crypto.dart';
 import 'package:lotti/database/settings_db.dart';
+import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/features/sync/utils.dart';
 import 'package:lotti/features/sync/vector_clock.dart';
 import 'package:lotti/get_it.dart';
@@ -28,6 +29,12 @@ import 'package:meta/meta.dart';
 /// counter — no entity carries it — which IS recoverable.
 ///
 /// Recovery of burnt counters:
+/// - reservation writes an own-host `reserved` sequence row before returning
+///   the counter. If the process crashes before the write path binds the row
+///   through `recordSentEntry`, the marker remains available for diagnostics
+///   and reactive backfill.
+/// - release upgrades that reservation to `burnPending` before broadcasting
+///   so startup can safely retry only counters known to have no payload.
 /// - [release] logs the burn and emits a proactive `unresolvable` broadcast
 ///   (when a handler is registered — see
 ///   [VectorClockService.setBurnHandler]) so receivers mark the counter as
@@ -70,9 +77,10 @@ class VcReservation {
   /// asks the registered burn handler (if any) to broadcast an
   /// `unresolvable` hint to peers so they can resolve the gap immediately
   /// instead of waiting for the next backfill round-trip. Idempotent.
-  void release() {
+  Future<void> release() async {
     if (_finalized) return;
     _finalized = true;
+    await _service._markBurnPending(_hostId, _counter);
     _service._onReleaseBurn(_hostId, _counter);
   }
 }
@@ -239,6 +247,7 @@ class VectorClockService {
         _host,
         this,
       );
+      await _recordReservedCounter(_host, effectiveCounter);
 
       final scope = Zone.current[_zoneKey] as _VcScope?;
       if (scope != null) {
@@ -304,13 +313,13 @@ class VectorClockService {
         }
       } else {
         for (final reservation in scope.reservations.reversed) {
-          reservation.release();
+          await reservation.release();
         }
       }
       return result;
     } catch (_) {
       for (final reservation in scope.reservations.reversed) {
-        reservation.release();
+        await reservation.release();
       }
       rethrow;
     }
@@ -332,7 +341,8 @@ class VectorClockService {
     if (getIt.isRegistered<DomainLogger>()) {
       getIt<DomainLogger>().error(
         LogDomains.sync,
-        'VC counter burnt (reservation released; counter already persisted)',
+        'VC counter burnt host=$hostId counter=$counter '
+        '(reservation released; counter already persisted)',
         subDomain: 'vc.burn',
       );
     }
@@ -349,6 +359,50 @@ class VectorClockService {
           error: error,
           stackTrace: stackTrace,
           subDomain: 'vc.burn.handler',
+        );
+      }
+    }
+  }
+
+  Future<void> _recordReservedCounter(String hostId, int counter) async {
+    if (!getIt.isRegistered<SyncDatabase>()) return;
+
+    try {
+      await getIt<SyncDatabase>().recordReservedSequenceCounter(
+        hostId: hostId,
+        counter: counter,
+      );
+    } catch (error, stackTrace) {
+      if (getIt.isRegistered<DomainLogger>()) {
+        getIt<DomainLogger>().error(
+          LogDomains.sync,
+          'VC reservation ledger write failed host=$hostId counter=$counter; '
+          'counter already persisted and will fall back to reactive backfill',
+          error: error,
+          stackTrace: stackTrace,
+          subDomain: 'vc.reserve.ledger',
+        );
+      }
+    }
+  }
+
+  Future<void> _markBurnPending(String hostId, int counter) async {
+    if (!getIt.isRegistered<SyncDatabase>()) return;
+
+    try {
+      await getIt<SyncDatabase>().markReservedSequenceCounterBurnPending(
+        hostId: hostId,
+        counter: counter,
+      );
+    } catch (error, stackTrace) {
+      if (getIt.isRegistered<DomainLogger>()) {
+        getIt<DomainLogger>().error(
+          LogDomains.sync,
+          'VC burn-pending ledger write failed host=$hostId counter=$counter; '
+          'counter already persisted and will fall back to reactive backfill',
+          error: error,
+          stackTrace: stackTrace,
+          subDomain: 'vc.burn.ledger',
         );
       }
     }

--- a/test/database/sync_db_test.dart
+++ b/test/database/sync_db_test.dart
@@ -188,11 +188,58 @@ enum _GeneratedSequenceLifecycleStatus {
   backfilled,
   deleted,
   unresolvable,
+  reserved,
+  burnPending,
 }
 
 enum _GeneratedRequestTimestamp { absent, fresh, atCutoff, old }
 
 enum _GeneratedUpdatedTimestamp { fresh, atCutoff, old }
+
+enum _GeneratedReservationOutcome { stillReserved, boundReceived, burnPending }
+
+class _ReservationLifecycleScenario {
+  const _ReservationLifecycleScenario({
+    required this.outcomes,
+  });
+
+  static const hostId = 'generated-reservation-host';
+  static final start = DateTime(2026, 5, 24, 11);
+
+  final List<_GeneratedReservationOutcome> outcomes;
+
+  List<int> get expectedReservedCounters => [
+    for (var index = 0; index < outcomes.length; index++)
+      if (outcomes[index] == _GeneratedReservationOutcome.stillReserved)
+        index + 1,
+  ];
+
+  List<int> get expectedBurnPendingCounters => [
+    for (var index = 0; index < outcomes.length; index++)
+      if (outcomes[index] == _GeneratedReservationOutcome.burnPending)
+        index + 1,
+  ];
+
+  int? get expectedWatermark {
+    if (outcomes.isEmpty) return null;
+
+    var prefix = 0;
+    for (final outcome in outcomes) {
+      if (outcome != _GeneratedReservationOutcome.boundReceived) break;
+      prefix++;
+    }
+    return prefix;
+  }
+
+  SyncSequenceStatus expectedStatus(int counter) {
+    return switch (outcomes[counter - 1]) {
+      _GeneratedReservationOutcome.stillReserved => SyncSequenceStatus.reserved,
+      _GeneratedReservationOutcome.boundReceived => SyncSequenceStatus.received,
+      _GeneratedReservationOutcome.burnPending =>
+        SyncSequenceStatus.burnPending,
+    };
+  }
+}
 
 class _SequenceLifecycleRowSpec {
   const _SequenceLifecycleRowSpec({
@@ -234,6 +281,9 @@ class _SequenceLifecycleRowSpec {
       _GeneratedSequenceLifecycleStatus.deleted => SyncSequenceStatus.deleted,
       _GeneratedSequenceLifecycleStatus.unresolvable =>
         SyncSequenceStatus.unresolvable,
+      _GeneratedSequenceLifecycleStatus.reserved => SyncSequenceStatus.reserved,
+      _GeneratedSequenceLifecycleStatus.burnPending =>
+        SyncSequenceStatus.burnPending,
       _GeneratedSequenceLifecycleStatus.absent => throw StateError(
         'Absent lifecycle rows do not have a sync status',
       ),
@@ -462,6 +512,16 @@ extension _AnyOutboxClaimScenario on Any {
 
   Generator<_GeneratedUpdatedTimestamp> get generatedUpdatedTimestamp =>
       choose(_GeneratedUpdatedTimestamp.values);
+
+  Generator<_GeneratedReservationOutcome> get generatedReservationOutcome =>
+      choose(_GeneratedReservationOutcome.values);
+
+  Generator<_ReservationLifecycleScenario> get reservationLifecycleScenario =>
+      listWithLengthInRange(
+        0,
+        14,
+        generatedReservationOutcome,
+      ).map((outcomes) => _ReservationLifecycleScenario(outcomes: outcomes));
 
   Generator<_OutboxClaimRowSpec> get outboxClaimRowSpec => combine3(
     intInRange(0, 6),
@@ -2554,6 +2614,51 @@ void main() {
     );
 
     test(
+      'reserved counters do not advance the contiguous resolved watermark',
+      () async {
+        final database = db!;
+        const hostId = 'host-reserved';
+
+        await database.recordSequenceEntry(
+          SyncSequenceLogCompanion(
+            hostId: const Value(hostId),
+            counter: const Value(1),
+            status: Value(SyncSequenceStatus.received.index),
+            createdAt: Value(DateTime(2026, 5, 24, 11)),
+            updatedAt: Value(DateTime(2026, 5, 24, 11)),
+          ),
+        );
+        await database.recordReservedSequenceCounter(
+          hostId: hostId,
+          counter: 2,
+          now: DateTime(2026, 5, 24, 11, 1),
+        );
+        await database.recordSequenceEntry(
+          SyncSequenceLogCompanion(
+            hostId: const Value(hostId),
+            counter: const Value(3),
+            status: Value(SyncSequenceStatus.received.index),
+            createdAt: Value(DateTime(2026, 5, 24, 11, 2)),
+            updatedAt: Value(DateTime(2026, 5, 24, 11, 2)),
+          ),
+        );
+
+        expect(await database.getLastCounterForHost(hostId), 1);
+        expect(await database.reservedSequenceCountersForHost(hostId: hostId), [
+          2,
+        ]);
+
+        await database.updateSequenceStatus(
+          hostId,
+          2,
+          SyncSequenceStatus.unresolvable,
+        );
+
+        expect(await database.getLastCounterForHost(hostId), 3);
+      },
+    );
+
+    test(
       'resolved status literals used by getLastCounterForHost stay aligned '
       'with SyncSequenceStatus enum indices',
       () {
@@ -2561,6 +2666,8 @@ void main() {
         expect(SyncSequenceStatus.backfilled.index, 3);
         expect(SyncSequenceStatus.deleted.index, 4);
         expect(SyncSequenceStatus.unresolvable.index, 5);
+        expect(SyncSequenceStatus.reserved.index, 6);
+        expect(SyncSequenceStatus.burnPending.index, 7);
       },
     );
 
@@ -6417,6 +6524,99 @@ void main() {
   });
 
   group('generated sequence lifecycle operations', () {
+    Glados(any.reservationLifecycleScenario, ExploreConfig(numRuns: 100)).test(
+      'preserve the reservation lifecycle invariants',
+      (scenario) async {
+        final database = SyncDatabase(inMemoryDatabase: true);
+        try {
+          for (var index = 0; index < scenario.outcomes.length; index++) {
+            final counter = index + 1;
+            await database.recordReservedSequenceCounter(
+              hostId: _ReservationLifecycleScenario.hostId,
+              counter: counter,
+              now: _ReservationLifecycleScenario.start.add(
+                Duration(minutes: counter),
+              ),
+            );
+
+            switch (scenario.outcomes[index]) {
+              case _GeneratedReservationOutcome.stillReserved:
+                break;
+              case _GeneratedReservationOutcome.boundReceived:
+                await database.recordSequenceEntry(
+                  SyncSequenceLogCompanion(
+                    hostId: const Value(_ReservationLifecycleScenario.hostId),
+                    counter: Value(counter),
+                    entryId: Value('reservation-entry-$counter'),
+                    payloadType: Value(
+                      SyncSequencePayloadType.journalEntity.index,
+                    ),
+                    status: Value(SyncSequenceStatus.received.index),
+                    createdAt: Value(
+                      _ReservationLifecycleScenario.start.add(
+                        Duration(minutes: counter),
+                      ),
+                    ),
+                    updatedAt: Value(
+                      _ReservationLifecycleScenario.start.add(
+                        Duration(minutes: counter, seconds: 1),
+                      ),
+                    ),
+                  ),
+                );
+              case _GeneratedReservationOutcome.burnPending:
+                await database.markReservedSequenceCounterBurnPending(
+                  hostId: _ReservationLifecycleScenario.hostId,
+                  counter: counter,
+                  now: _ReservationLifecycleScenario.start.add(
+                    Duration(minutes: counter, seconds: 2),
+                  ),
+                );
+            }
+          }
+
+          expect(
+            await database.reservedSequenceCountersForHost(
+              hostId: _ReservationLifecycleScenario.hostId,
+            ),
+            scenario.expectedReservedCounters,
+          );
+          expect(
+            await database.burnPendingSequenceCountersForHost(
+              hostId: _ReservationLifecycleScenario.hostId,
+            ),
+            scenario.expectedBurnPendingCounters,
+          );
+          expect(
+            await database.getLastCounterForHost(
+              _ReservationLifecycleScenario.hostId,
+            ),
+            scenario.expectedWatermark,
+          );
+
+          for (
+            var counter = 1;
+            counter <= scenario.outcomes.length;
+            counter++
+          ) {
+            final row = await database.getEntryByHostAndCounter(
+              _ReservationLifecycleScenario.hostId,
+              counter,
+            );
+            expect(row, isNotNull, reason: 'counter $counter');
+            expect(
+              row!.status,
+              scenario.expectedStatus(counter).index,
+              reason: 'counter $counter',
+            );
+          }
+        } finally {
+          await database.close();
+        }
+      },
+      tags: 'glados',
+    );
+
     Glados(any.sequenceLifecycleScenario, ExploreConfig(numRuns: 180)).test(
       'match the generated reset and retirement model',
       (scenario) async {

--- a/test/database/sync_db_test.dart
+++ b/test/database/sync_db_test.dart
@@ -6524,6 +6524,261 @@ void main() {
   });
 
   group('generated sequence lifecycle operations', () {
+    test(
+      'markReservedSequenceCounterBurnPending does not overwrite an '
+      'already-bound row',
+      () async {
+        final database = SyncDatabase(inMemoryDatabase: true);
+        try {
+          final createdAt = DateTime(2026, 5, 24, 11);
+          await database.recordSequenceEntry(
+            SyncSequenceLogCompanion(
+              hostId: const Value('burn-conflict-host'),
+              counter: const Value(1),
+              entryId: const Value('bound-entry'),
+              payloadType: Value(SyncSequencePayloadType.journalEntity.index),
+              status: Value(SyncSequenceStatus.received.index),
+              createdAt: Value(createdAt),
+              updatedAt: Value(createdAt),
+            ),
+          );
+
+          await database.markReservedSequenceCounterBurnPending(
+            hostId: 'burn-conflict-host',
+            counter: 1,
+            now: createdAt.add(const Duration(minutes: 1)),
+          );
+
+          final row = await database.getEntryByHostAndCounter(
+            'burn-conflict-host',
+            1,
+          );
+          expect(row, isNotNull);
+          expect(row!.status, SyncSequenceStatus.received.index);
+          expect(row.entryId, 'bound-entry');
+          expect(
+            await database.burnPendingSequenceCountersForHost(
+              hostId: 'burn-conflict-host',
+            ),
+            isEmpty,
+          );
+        } finally {
+          await database.close();
+        }
+      },
+    );
+
+    test(
+      'recordOwnUnresolvableSequenceCounter inserts absent counters as '
+      'unresolvable with no payload mapping',
+      () async {
+        final database = SyncDatabase(inMemoryDatabase: true);
+        try {
+          final now = DateTime(2026, 5, 24, 12);
+
+          final recorded = await database.recordOwnUnresolvableSequenceCounter(
+            hostId: 'own-burn-host',
+            counter: 1,
+            now: now,
+          );
+
+          expect(recorded, isTrue);
+          final row = await database.getEntryByHostAndCounter(
+            'own-burn-host',
+            1,
+          );
+          expect(row, isNotNull);
+          expect(row!.status, SyncSequenceStatus.unresolvable.index);
+          expect(row.entryId, isNull);
+          expect(row.payloadType, SyncSequencePayloadType.journalEntity.index);
+          expect(await database.getLastCounterForHost('own-burn-host'), 1);
+        } finally {
+          await database.close();
+        }
+      },
+    );
+
+    test(
+      'recordOwnUnresolvableSequenceCounter converts non-authoritative rows '
+      'and clears stale payload mappings',
+      () async {
+        final database = SyncDatabase(inMemoryDatabase: true);
+        try {
+          final createdAt = DateTime(2026, 5, 24, 12);
+          await database.recordSequenceEntry(
+            SyncSequenceLogCompanion(
+              hostId: const Value('own-burn-update-host'),
+              counter: const Value(1),
+              entryId: const Value('stale-entry'),
+              payloadType: Value(SyncSequencePayloadType.journalEntity.index),
+              status: Value(SyncSequenceStatus.missing.index),
+              createdAt: Value(createdAt),
+              updatedAt: Value(createdAt),
+            ),
+          );
+
+          final recorded = await database.recordOwnUnresolvableSequenceCounter(
+            hostId: 'own-burn-update-host',
+            counter: 1,
+            payloadType: SyncSequencePayloadType.entryLink,
+            now: createdAt.add(const Duration(minutes: 1)),
+          );
+
+          expect(recorded, isTrue);
+          final row = await database.getEntryByHostAndCounter(
+            'own-burn-update-host',
+            1,
+          );
+          expect(row, isNotNull);
+          expect(row!.status, SyncSequenceStatus.unresolvable.index);
+          expect(row.entryId, isNull);
+          expect(row.payloadType, SyncSequencePayloadType.entryLink.index);
+          expect(
+            row.updatedAt,
+            createdAt.add(const Duration(minutes: 1)),
+          );
+        } finally {
+          await database.close();
+        }
+      },
+    );
+
+    test(
+      'recordOwnUnresolvableSequenceCounter does not overwrite '
+      'authoritative payload mappings',
+      () async {
+        final database = SyncDatabase(inMemoryDatabase: true);
+        try {
+          final createdAt = DateTime(2026, 5, 24, 12);
+          final statuses = [
+            SyncSequenceStatus.received,
+            SyncSequenceStatus.backfilled,
+            SyncSequenceStatus.deleted,
+          ];
+
+          for (final status in statuses) {
+            final counter = status.index + 1;
+            await database.recordSequenceEntry(
+              SyncSequenceLogCompanion(
+                hostId: const Value('own-burn-authoritative-host'),
+                counter: Value(counter),
+                entryId: Value('entry-$counter'),
+                payloadType: Value(SyncSequencePayloadType.journalEntity.index),
+                status: Value(status.index),
+                createdAt: Value(createdAt),
+                updatedAt: Value(createdAt),
+              ),
+            );
+
+            final recorded = await database
+                .recordOwnUnresolvableSequenceCounter(
+                  hostId: 'own-burn-authoritative-host',
+                  counter: counter,
+                  payloadType: SyncSequencePayloadType.entryLink,
+                  now: createdAt.add(const Duration(minutes: 1)),
+                );
+
+            expect(recorded, isFalse, reason: '$status');
+            final row = await database.getEntryByHostAndCounter(
+              'own-burn-authoritative-host',
+              counter,
+            );
+            expect(row, isNotNull);
+            expect(row!.status, status.index, reason: '$status');
+            expect(row.entryId, 'entry-$counter', reason: '$status');
+            expect(
+              row.payloadType,
+              SyncSequencePayloadType.journalEntity.index,
+              reason: '$status',
+            );
+            expect(row.updatedAt, createdAt, reason: '$status');
+          }
+        } finally {
+          await database.close();
+        }
+      },
+    );
+
+    Glados(
+      any.generatedSequenceLifecycleStatus,
+      ExploreConfig(numRuns: 80),
+    ).test(
+      'only transitions absent, reserved, or burnPending rows to burnPending',
+      (status) async {
+        final database = SyncDatabase(inMemoryDatabase: true);
+        const hostId = 'generated-burn-pending-guard-host';
+        const counter = 1;
+        final createdAt = DateTime(2026, 5, 24, 12);
+        try {
+          final shouldTransition =
+              status == _GeneratedSequenceLifecycleStatus.absent ||
+              status == _GeneratedSequenceLifecycleStatus.reserved ||
+              status == _GeneratedSequenceLifecycleStatus.burnPending;
+          final seedEntryId = shouldTransition ? null : 'original-entry';
+
+          if (status != _GeneratedSequenceLifecycleStatus.absent) {
+            await database.recordSequenceEntry(
+              SyncSequenceLogCompanion(
+                hostId: const Value(hostId),
+                counter: const Value(counter),
+                entryId: seedEntryId == null
+                    ? const Value.absent()
+                    : Value(seedEntryId),
+                payloadType: Value(SyncSequencePayloadType.journalEntity.index),
+                status: Value(
+                  _SequenceLifecycleRowSpec(
+                    status: status,
+                    payloadType: SyncSequencePayloadType.journalEntity,
+                    hasEntryId: seedEntryId != null,
+                    requestCount: 0,
+                    lastRequestedAt: _GeneratedRequestTimestamp.absent,
+                    updatedAt: _GeneratedUpdatedTimestamp.fresh,
+                  ).syncStatus.index,
+                ),
+                createdAt: Value(createdAt),
+                updatedAt: Value(createdAt),
+              ),
+            );
+          }
+
+          await database.markReservedSequenceCounterBurnPending(
+            hostId: hostId,
+            counter: counter,
+            now: createdAt.add(const Duration(minutes: 1)),
+          );
+
+          final row = await database.getEntryByHostAndCounter(hostId, counter);
+          expect(row, isNotNull, reason: '$status');
+
+          if (shouldTransition) {
+            expect(
+              row!.status,
+              SyncSequenceStatus.burnPending.index,
+              reason: '$status',
+            );
+            expect(row.entryId, isNull, reason: '$status');
+          } else {
+            expect(
+              row!.status,
+              _SequenceLifecycleRowSpec(
+                status: status,
+                payloadType: SyncSequencePayloadType.journalEntity,
+                hasEntryId: seedEntryId != null,
+                requestCount: 0,
+                lastRequestedAt: _GeneratedRequestTimestamp.absent,
+                updatedAt: _GeneratedUpdatedTimestamp.fresh,
+              ).syncStatus.index,
+              reason: '$status',
+            );
+            expect(row.entryId, seedEntryId, reason: '$status');
+          }
+        } finally {
+          await database.close();
+        }
+      },
+      tags: 'glados',
+    );
+
     Glados(any.reservationLifecycleScenario, ExploreConfig(numRuns: 100)).test(
       'preserve the reservation lifecycle invariants',
       (scenario) async {

--- a/test/features/sync/backfill/backfill_response_handler_test.dart
+++ b/test/features/sync/backfill/backfill_response_handler_test.dart
@@ -298,6 +298,46 @@ void main() {
     });
 
     test(
+      'does not terminalize own missing counter when unresolvable enqueue '
+      'fails, leaving the retryable reservation/miss state intact',
+      () async {
+        const request = SyncBackfillRequest(
+          entries: [
+            BackfillRequestEntry(hostId: aliceHostId, counter: 3),
+          ],
+          requesterId: requesterId,
+        );
+
+        when(
+          () => mockSequenceService.getEntryByHostAndCounter(aliceHostId, 3),
+        ).thenAnswer((_) async => null);
+        when(() => mockOutboxService.enqueueMessage(any())).thenThrow(
+          StateError('outbox unavailable'),
+        );
+
+        await handler.handleBackfillRequest(request);
+
+        verify(
+          () => mockOutboxService.enqueueMessage(
+            const SyncMessage.backfillResponse(
+              hostId: aliceHostId,
+              counter: 3,
+              deleted: false,
+              unresolvable: true,
+            ),
+          ),
+        ).called(1);
+        verifyNever(
+          () => mockSequenceService.markOwnCounterUnresolvable(
+            hostId: any(named: 'hostId'),
+            counter: any(named: 'counter'),
+            payloadType: any(named: 'payloadType'),
+          ),
+        );
+      },
+    );
+
+    test(
       'ignores request when entry in log but has no entryId and not our host',
       () async {
         // Request for Bob's counter - entry exists but no entryId

--- a/test/features/sync/sequence/sync_sequence_log_service_test.dart
+++ b/test/features/sync/sequence/sync_sequence_log_service_test.dart
@@ -5999,14 +5999,15 @@ void main() {
 
   group('markOwnCounterUnresolvable', () {
     test(
-      'upserts a row with status=unresolvable and entryId explicitly null '
-      '— clears any stale payload mapping (e.g. from a covered-VC hint) '
-      'so later reset/verify paths do not treat the counter as if it had '
-      'a known payload',
+      'delegates own-counter burns to the database-level guarded write',
       () async {
         when(
-          () => mockDb.recordSequenceEntry(any()),
-        ).thenAnswer((_) async => 1);
+          () => mockDb.recordOwnUnresolvableSequenceCounter(
+            hostId: aliceHostId,
+            counter: 42,
+            payloadType: SyncSequencePayloadType.journalEntity,
+          ),
+        ).thenAnswer((_) async => true);
 
         await service.markOwnCounterUnresolvable(
           hostId: aliceHostId,
@@ -6014,26 +6015,102 @@ void main() {
         );
 
         verify(
-          () => mockDb.recordSequenceEntry(
-            any(
-              that: isA<SyncSequenceLogCompanion>()
-                  .having((c) => c.hostId, 'hostId', const Value(aliceHostId))
-                  .having((c) => c.counter, 'counter', const Value(42))
-                  .having(
-                    (c) => c.entryId,
-                    'entryId',
-                    const Value<String?>(null),
-                  )
-                  .having(
-                    (c) => c.status,
-                    'status',
-                    Value(SyncSequenceStatus.unresolvable.index),
-                  ),
-            ),
+          () => mockDb.recordOwnUnresolvableSequenceCounter(
+            hostId: aliceHostId,
+            counter: 42,
+            payloadType: SyncSequencePayloadType.journalEntity,
           ),
         ).called(1);
       },
     );
+
+    test(
+      'logs skipped when the database-level guard preserves an authoritative '
+      'payload mapping',
+      () async {
+        for (final status in [
+          SyncSequenceStatus.received,
+          SyncSequenceStatus.backfilled,
+          SyncSequenceStatus.deleted,
+        ]) {
+          final counter = 100 + status.index;
+          when(
+            () => mockDb.recordOwnUnresolvableSequenceCounter(
+              hostId: aliceHostId,
+              counter: counter,
+              payloadType: SyncSequencePayloadType.journalEntity,
+            ),
+          ).thenAnswer((_) async => false);
+
+          await service.markOwnCounterUnresolvable(
+            hostId: aliceHostId,
+            counter: counter,
+          );
+        }
+
+        verify(
+          () => mockLogging.captureEvent(
+            any<String>(
+              that: contains('markOwnCounterUnresolvable skipped'),
+            ),
+            domain: LogDomains.sync,
+            subDomain: 'sequence.ownUnresolvable',
+          ),
+        ).called(3);
+      },
+    );
+  });
+
+  group('own-host reservation queries', () {
+    test('returns and logs non-empty reserved counters', () async {
+      when(
+        () => mockDb.reservedSequenceCountersForHost(hostId: aliceHostId),
+      ).thenAnswer((_) async => [4, 9]);
+
+      final counters = await service.reservedCountersForHost(
+        hostId: aliceHostId,
+      );
+
+      expect(counters, [4, 9]);
+      verify(
+        () => mockLogging.captureEvent(
+          any<String>(
+            that: allOf(
+              contains('reservedCountersForHost hostId=$aliceHostId'),
+              contains('count=2'),
+              contains('counters=[4, 9]'),
+            ),
+          ),
+          domain: LogDomains.sync,
+          subDomain: 'sequence.reservedCounters',
+        ),
+      ).called(1);
+    });
+
+    test('returns and logs non-empty burn-pending counters', () async {
+      when(
+        () => mockDb.burnPendingSequenceCountersForHost(hostId: aliceHostId),
+      ).thenAnswer((_) async => [7, 12]);
+
+      final counters = await service.burnPendingCountersForHost(
+        hostId: aliceHostId,
+      );
+
+      expect(counters, [7, 12]);
+      verify(
+        () => mockLogging.captureEvent(
+          any<String>(
+            that: allOf(
+              contains('burnPendingCountersForHost hostId=$aliceHostId'),
+              contains('count=2'),
+              contains('counters=[7, 12]'),
+            ),
+          ),
+          domain: LogDomains.sync,
+          subDomain: 'sequence.burnPendingCounters',
+        ),
+      ).called(1);
+    });
   });
 
   group('_trace routing', () {

--- a/test/services/vector_clock_service_test.dart
+++ b/test/services/vector_clock_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:drift/drift.dart' show Value;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/database/settings_db.dart';
@@ -5,13 +7,20 @@ import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/features/sync/sequence/sync_sequence_payload_type.dart';
 import 'package:lotti/features/sync/vector_clock.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/domain_logging.dart';
 import 'package:lotti/services/vector_clock_service.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../helpers/fallbacks.dart';
+import '../mocks/mocks.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late SettingsDb settingsDb;
   late VectorClockService service;
+
+  setUpAll(registerAllFallbackValues);
 
   setUp(() async {
     await getIt.reset();
@@ -278,7 +287,9 @@ void main() {
       () async {
         await service.setNextAvailableCounter(20);
         final burnt = <int>[];
-        service.setBurnHandler((_, counter) => burnt.add(counter));
+        service.setBurnHandler((_, counter) async {
+          burnt.add(counter);
+        });
 
         final reservation = await service.reserveNextVectorClock();
         await reservation.release();
@@ -307,7 +318,7 @@ void main() {
 
         await service.setNextAvailableCounter(30);
         final host = await service.getHost();
-        service.setBurnHandler((_, _) {
+        service.setBurnHandler((_, _) async {
           throw StateError('broadcast failed');
         });
 
@@ -330,6 +341,125 @@ void main() {
       },
     );
 
+    test('release awaits the burn handler before completing', () async {
+      await service.setNextAvailableCounter(35);
+      final handlerStarted = Completer<void>();
+      final handlerMayFinish = Completer<void>();
+      final events = <String>[];
+      var releaseCompleted = false;
+      service.setBurnHandler((_, counter) async {
+        events.add('start:$counter');
+        handlerStarted.complete();
+        await handlerMayFinish.future;
+        events.add('finish:$counter');
+      });
+
+      final reservation = await service.reserveNextVectorClock();
+      final releaseFuture = reservation.release().whenComplete(() {
+        releaseCompleted = true;
+      });
+
+      await handlerStarted.future;
+      await Future<void>.value();
+
+      expect(releaseCompleted, isFalse);
+      expect(events, ['start:35']);
+
+      handlerMayFinish.complete();
+      await releaseFuture;
+
+      expect(releaseCompleted, isTrue);
+      expect(events, ['start:35', 'finish:35']);
+
+      service.setBurnHandler(null);
+    });
+
+    test(
+      'reservation ledger write failures are logged without losing the '
+      'persisted counter',
+      () async {
+        final syncDb = MockSyncDatabase();
+        final domainLogger = MockDomainLogger();
+        getIt
+          ..registerSingleton<SyncDatabase>(syncDb)
+          ..registerSingleton<DomainLogger>(domainLogger);
+        _stubDomainLoggerError(domainLogger);
+        when(
+          () => syncDb.recordReservedSequenceCounter(
+            hostId: any(named: 'hostId'),
+            counter: any(named: 'counter'),
+          ),
+        ).thenThrow(StateError('ledger failed'));
+
+        await service.setNextAvailableCounter(60);
+        final reservation = await service.reserveNextVectorClock();
+
+        expect(await service.getNextAvailableCounter(), 61);
+        verify(
+          () => domainLogger.error(
+            LogDomains.sync,
+            any<String>(
+              that: contains('VC reservation ledger write failed'),
+            ),
+            error: any<dynamic>(named: 'error'),
+            stackTrace: any<StackTrace>(named: 'stackTrace'),
+            subDomain: 'vc.reserve.ledger',
+          ),
+        ).called(1);
+
+        await reservation.commit();
+      },
+    );
+
+    test(
+      'burn-pending ledger write failures are logged while the burn handler '
+      'still gets the counter',
+      () async {
+        final syncDb = MockSyncDatabase();
+        final domainLogger = MockDomainLogger();
+        getIt
+          ..registerSingleton<SyncDatabase>(syncDb)
+          ..registerSingleton<DomainLogger>(domainLogger);
+        _stubDomainLoggerError(domainLogger);
+        when(
+          () => syncDb.recordReservedSequenceCounter(
+            hostId: any(named: 'hostId'),
+            counter: any(named: 'counter'),
+          ),
+        ).thenAnswer((_) async => 1);
+        when(
+          () => syncDb.markReservedSequenceCounterBurnPending(
+            hostId: any(named: 'hostId'),
+            counter: any(named: 'counter'),
+          ),
+        ).thenThrow(StateError('burn ledger failed'));
+
+        await service.setNextAvailableCounter(70);
+        final burnt = <int>[];
+        service.setBurnHandler((_, counter) async {
+          burnt.add(counter);
+        });
+
+        final reservation = await service.reserveNextVectorClock();
+        await reservation.release();
+
+        expect(burnt, [70]);
+        verify(
+          () => domainLogger.error(
+            LogDomains.sync,
+            any<String>(
+              that: contains('VC burn-pending ledger write failed'),
+            ),
+            error: any<dynamic>(named: 'error'),
+            stackTrace: any<StackTrace>(named: 'stackTrace'),
+            subDomain: 'vc.burn.ledger',
+          ),
+        ).called(1);
+
+        service.setBurnHandler(null);
+      },
+    );
+
     test('commit is idempotent and safe to call before release', () async {
       await service.setNextAvailableCounter(40);
       final reservation = await service.reserveNextVectorClock();
@@ -343,7 +473,9 @@ void main() {
       () async {
         await service.setNextAvailableCounter(50);
         final burnt = <int>[];
-        service.setBurnHandler((_, counter) => burnt.add(counter));
+        service.setBurnHandler((_, counter) async {
+          burnt.add(counter);
+        });
 
         final reservation = await service.reserveNextVectorClock();
         await reservation.commit();
@@ -407,17 +539,18 @@ void main() {
       () async {
         await service.setNextAvailableCounter(200);
         final burnt = <int>[];
-        service.setBurnHandler((_, counter) => burnt.add(counter));
+        service.setBurnHandler((_, counter) async {
+          burnt.add(counter);
+        });
 
-        expect(
-          () => service.withVcScope<void>(() async {
+        await expectLater(
+          service.withVcScope<void>(() async {
             await service.getNextVectorClock();
             await service.getNextVectorClock();
             throw StateError('write rejected');
           }),
           throwsA(isA<StateError>()),
         );
-        await Future<void>.delayed(Duration.zero);
 
         // Both counters burnt — broadcast in reverse (latest first) so
         // the handler's ordering matches the release order.
@@ -439,7 +572,9 @@ void main() {
       () async {
         await service.setNextAvailableCounter(300);
         final burnt = <int>[];
-        service.setBurnHandler((_, counter) => burnt.add(counter));
+        service.setBurnHandler((_, counter) async {
+          burnt.add(counter);
+        });
 
         final applied = await service.withVcScope<bool>(
           () async {
@@ -506,7 +641,9 @@ void main() {
       () async {
         await service.setNextAvailableCounter(600);
         final burnt = <int>[];
-        service.setBurnHandler((_, counter) => burnt.add(counter));
+        service.setBurnHandler((_, counter) async {
+          burnt.add(counter);
+        });
 
         final applied = await service.withVcScope<bool>(
           () async {
@@ -541,7 +678,7 @@ void main() {
       () async {
         await service.setNextAvailableCounter(800);
         final burnt = <({String hostId, int counter})>[];
-        service.setBurnHandler((hostId, counter) {
+        service.setBurnHandler((hostId, counter) async {
           burnt.add((hostId: hostId, counter: counter));
         });
 
@@ -567,8 +704,11 @@ void main() {
       'burn handler exception does not propagate into the scope finalizer '
       '— the counter is already burnt; a handler throw must not cascade',
       () async {
+        final domainLogger = MockDomainLogger();
+        getIt.registerSingleton<DomainLogger>(domainLogger);
+        _stubDomainLoggerError(domainLogger);
         await service.setNextAvailableCounter(700);
-        service.setBurnHandler((_, _) {
+        service.setBurnHandler((_, _) async {
           throw StateError('handler boom');
         });
 
@@ -581,9 +721,32 @@ void main() {
           commitWhen: (applied) => applied,
         );
         expect(applied, isFalse);
+        verify(
+          () => domainLogger.error(
+            LogDomains.sync,
+            any<String>(
+              that: contains('VC burn broadcast handler threw'),
+            ),
+            error: any<dynamic>(named: 'error'),
+            stackTrace: any<StackTrace>(named: 'stackTrace'),
+            subDomain: 'vc.burn.handler',
+          ),
+        ).called(1);
 
         service.setBurnHandler(null);
       },
     );
   });
+}
+
+void _stubDomainLoggerError(MockDomainLogger domainLogger) {
+  when(
+    () => domainLogger.error(
+      any<String>(),
+      any<String>(),
+      error: any<dynamic>(named: 'error'),
+      stackTrace: any<StackTrace>(named: 'stackTrace'),
+      subDomain: any<String>(named: 'subDomain'),
+    ),
+  ).thenReturn(null);
 }

--- a/test/services/vector_clock_service_test.dart
+++ b/test/services/vector_clock_service_test.dart
@@ -1,5 +1,8 @@
+import 'package:drift/drift.dart' show Value;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/database/settings_db.dart';
+import 'package:lotti/database/sync_db.dart';
+import 'package:lotti/features/sync/sequence/sync_sequence_payload_type.dart';
 import 'package:lotti/features/sync/vector_clock.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/vector_clock_service.dart';
@@ -203,6 +206,51 @@ void main() {
 
   group('VectorClockService reservations', () {
     test(
+      'reserveNextVectorClock records a durable reserved sequence row '
+      'when the sync database is available',
+      () async {
+        final syncDb = SyncDatabase(inMemoryDatabase: true);
+        getIt.registerSingleton<SyncDatabase>(syncDb);
+        addTearDown(syncDb.close);
+
+        await service.setNextAvailableCounter(900);
+        final host = await service.getHost();
+
+        final reservation = await service.reserveNextVectorClock();
+
+        final reserved = await syncDb.getEntryByHostAndCounter(host!, 900);
+        expect(reserved, isNotNull);
+        expect(reserved!.entryId, isNull);
+        expect(reserved.status, SyncSequenceStatus.reserved.index);
+        expect(await syncDb.reservedSequenceCountersForHost(hostId: host), [
+          900,
+        ]);
+
+        await syncDb.recordSequenceEntry(
+          SyncSequenceLogCompanion(
+            hostId: Value(host),
+            counter: const Value(900),
+            entryId: const Value('entry-900'),
+            payloadType: Value(SyncSequencePayloadType.journalEntity.index),
+            status: Value(SyncSequenceStatus.received.index),
+            createdAt: Value(DateTime(2026, 5, 24, 11, 4)),
+            updatedAt: Value(DateTime(2026, 5, 24, 11, 4)),
+          ),
+        );
+
+        final bound = await syncDb.getEntryByHostAndCounter(host, 900);
+        expect(bound!.entryId, 'entry-900');
+        expect(bound.status, SyncSequenceStatus.received.index);
+        expect(
+          await syncDb.reservedSequenceCountersForHost(hostId: host),
+          isEmpty,
+        );
+
+        await reservation.commit();
+      },
+    );
+
+    test(
       'reserveNextVectorClock persists the advance eagerly — a crash '
       'between reserve and any subsequent entity write can only burn the '
       'counter, never re-hand it (collision-safe across DB files)',
@@ -233,7 +281,7 @@ void main() {
         service.setBurnHandler((_, counter) => burnt.add(counter));
 
         final reservation = await service.reserveNextVectorClock();
-        reservation.release();
+        await reservation.release();
 
         expect(burnt, [20]);
 
@@ -244,6 +292,39 @@ void main() {
         final reloaded = VectorClockService();
         await reloaded.initialized;
         expect(await reloaded.getNextAvailableCounter(), 21);
+
+        service.setBurnHandler(null);
+      },
+    );
+
+    test(
+      'release marks the reserved row burnPending before invoking the '
+      'handler so a failed broadcast remains retryable',
+      () async {
+        final syncDb = SyncDatabase(inMemoryDatabase: true);
+        getIt.registerSingleton<SyncDatabase>(syncDb);
+        addTearDown(syncDb.close);
+
+        await service.setNextAvailableCounter(30);
+        final host = await service.getHost();
+        service.setBurnHandler((_, _) {
+          throw StateError('broadcast failed');
+        });
+
+        final reservation = await service.reserveNextVectorClock();
+        await reservation.release();
+
+        final row = await syncDb.getEntryByHostAndCounter(host!, 30);
+        expect(row, isNotNull);
+        expect(row!.entryId, isNull);
+        expect(row.status, SyncSequenceStatus.burnPending.index);
+        expect(
+          await syncDb.reservedSequenceCountersForHost(hostId: host),
+          isEmpty,
+        );
+        expect(await syncDb.burnPendingSequenceCountersForHost(hostId: host), [
+          30,
+        ]);
 
         service.setBurnHandler(null);
       },
@@ -266,7 +347,7 @@ void main() {
 
         final reservation = await service.reserveNextVectorClock();
         await reservation.commit();
-        reservation.release(); // no-op — already finalized by commit
+        await reservation.release(); // no-op — already finalized by commit
 
         expect(burnt, isEmpty);
         final reloaded = VectorClockService();
@@ -472,7 +553,7 @@ void main() {
         final newHost = await service.setNewHost();
         expect(newHost, isNot(originalHost));
 
-        reservation.release();
+        await reservation.release();
 
         expect(burnt, hasLength(1));
         expect(burnt.single.hostId, originalHost);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Durable own-host reservation lifecycle with reserved → burn-pending states, queryable counters, and startup reconciliation to retry pending broadcasts.

* **Bug Fixes**
  * Outbox enqueue now happens before marking counters terminal to avoid accidental overwrites; improves recovery and reduces stuck unresolvable gaps.

* **Documentation**
  * Expanded sync docs with lifecycle details and a Mermaid state diagram.

* **Tests**
  * New and extended tests covering reservation, burn-pending, async release/burn sequencing, and reconciliation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matthiasn/lotti/pull/3205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->