### PR TITLE
feat: wire day-agent drafting wake trigger

### DIFF
--- a/lib/classes/day_plan.freezed.dart
+++ b/lib/classes/day_plan.freezed.dart
@@ -408,6 +408,9 @@ mixin _$PlannedBlock {
  DateTime get endTime;/// Optional note on the block
  String? get note;/// Optional task this block schedules.
  String? get taskId;/// Human-readable title used when no backing task row is available.
+/// Nullable at the model layer for backwards compatibility with legacy
+/// Daily OS blocks; the day-agent tool handler rejects null/blank titles
+/// when parsing model-emitted blocks.
  String? get title;/// What created this block.
  PlannedBlockType get type;/// Current block lifecycle state.
  PlannedBlockState get state;/// Why this block belongs at this time. Required for AI blocks at the
@@ -631,6 +634,9 @@ class _PlannedBlock implements PlannedBlock {
 /// Optional task this block schedules.
 @override final  String? taskId;
 /// Human-readable title used when no backing task row is available.
+/// Nullable at the model layer for backwards compatibility with legacy
+/// Daily OS blocks; the day-agent tool handler rejects null/blank titles
+/// when parsing model-emitted blocks.
 @override final  String? title;
 /// What created this block.
 @override@JsonKey() final  PlannedBlockType type;

--- a/lib/features/daily_os_next/agents/domain/day_agent_reconcile_models.dart
+++ b/lib/features/daily_os_next/agents/domain/day_agent_reconcile_models.dart
@@ -164,11 +164,16 @@ String dayAgentCaptureSubmittedToken(String captureId) {
 }
 
 /// Extracts the first submitted capture ID from a trigger-token set.
+///
+/// The returned ID is trimmed of surrounding whitespace so equality checks
+/// downstream (e.g. against `CaptureEntity.id`) match canonical form.
 String? captureIdFromTriggerTokens(Set<String> triggerTokens) {
   for (final token in triggerTokens) {
     if (token.startsWith(dayAgentCaptureSubmittedPrefix)) {
-      final captureId = token.substring(dayAgentCaptureSubmittedPrefix.length);
-      if (captureId.trim().isNotEmpty) return captureId;
+      final captureId = token
+          .substring(dayAgentCaptureSubmittedPrefix.length)
+          .trim();
+      if (captureId.isNotEmpty) return captureId;
     }
   }
   return null;
@@ -180,11 +185,14 @@ String dayAgentDraftingToken(String dayId) {
 }
 
 /// Extracts the first drafting-target day ID from a trigger-token set.
+///
+/// The returned ID is trimmed of surrounding whitespace so equality checks
+/// downstream (e.g. against `AgentSlots.activeDayId`) match canonical form.
 String? draftingDayIdFromTriggerTokens(Set<String> triggerTokens) {
   for (final token in triggerTokens) {
     if (token.startsWith(dayAgentDraftingPrefix)) {
-      final dayId = token.substring(dayAgentDraftingPrefix.length);
-      if (dayId.trim().isNotEmpty) return dayId;
+      final dayId = token.substring(dayAgentDraftingPrefix.length).trim();
+      if (dayId.isNotEmpty) return dayId;
     }
   }
   return null;

--- a/lib/features/daily_os_next/agents/domain/day_agent_reconcile_models.dart
+++ b/lib/features/daily_os_next/agents/domain/day_agent_reconcile_models.dart
@@ -8,6 +8,14 @@ const dayAgentCaptureSubmittedPrefix = 'capture_submitted:';
 /// Wake scheduling reason used when a capture was submitted.
 const dayAgentCaptureSubmittedReason = 'capture_submitted';
 
+/// Wake trigger token prefix used to request a day-plan drafting wake.
+// TODO(day-agent): hoist drafting + capture token helpers into a shared
+// `day_agent_trigger_tokens.dart` once Refine/Commit add more trigger families.
+const dayAgentDraftingPrefix = 'drafting:';
+
+/// Wake scheduling reason used when a draft is requested.
+const dayAgentDraftingReason = 'drafting';
+
 /// Minimum score that becomes an auto-linked match.
 const dayAgentHighConfidenceThreshold = 0.75;
 
@@ -161,6 +169,22 @@ String? captureIdFromTriggerTokens(Set<String> triggerTokens) {
     if (token.startsWith(dayAgentCaptureSubmittedPrefix)) {
       final captureId = token.substring(dayAgentCaptureSubmittedPrefix.length);
       if (captureId.trim().isNotEmpty) return captureId;
+    }
+  }
+  return null;
+}
+
+/// Creates the drafting wake trigger token for [dayId].
+String dayAgentDraftingToken(String dayId) {
+  return '$dayAgentDraftingPrefix$dayId';
+}
+
+/// Extracts the first drafting-target day ID from a trigger-token set.
+String? draftingDayIdFromTriggerTokens(Set<String> triggerTokens) {
+  for (final token in triggerTokens) {
+    if (token.startsWith(dayAgentDraftingPrefix)) {
+      final dayId = token.substring(dayAgentDraftingPrefix.length);
+      if (dayId.trim().isNotEmpty) return dayId;
     }
   }
   return null;

--- a/lib/features/daily_os_next/agents/service/day_agent_service.dart
+++ b/lib/features/daily_os_next/agents/service/day_agent_service.dart
@@ -10,6 +10,7 @@ import 'package:lotti/features/agents/service/agent_service.dart';
 import 'package:lotti/features/agents/service/agent_template_service.dart';
 import 'package:lotti/features/agents/sync/agent_sync_service.dart';
 import 'package:lotti/features/agents/wake/wake_orchestrator.dart';
+import 'package:lotti/features/daily_os_next/agents/domain/day_agent_reconcile_models.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/day_agent_slots.dart';
 import 'package:lotti/services/domain_logging.dart';
 import 'package:uuid/uuid.dart';
@@ -151,6 +152,51 @@ class DayAgentService {
   /// Find the active day agent for [date], if one exists.
   Future<AgentIdentityEntity?> getDayAgentForDate(DateTime date) {
     return _findDayAgentForDayId(dayAgentIdForDate(date));
+  }
+
+  /// Enqueue a drafting wake for the day agent that owns [dayDate].
+  ///
+  /// When [captureId] is provided, the source capture is included as a
+  /// `capture_submitted:<captureId>` trigger token so the workflow loads its
+  /// transcript and parsed items into the drafting prompt.
+  ///
+  /// Returns `false` when no active day agent exists for [dayDate]. Callers
+  /// are expected to either call [createDayAgent] first or surface the
+  /// missing-agent state in the UI.
+  Future<bool> enqueueDraftingWake({
+    required DateTime dayDate,
+    String? captureId,
+  }) async {
+    final agent = await getDayAgentForDate(dayDate);
+    if (agent == null) {
+      domainLogger.log(
+        LogDomains.agentRuntime,
+        'no day agent for '
+        '${DomainLogger.sanitizeId(dayAgentIdForDate(dayDate))}; '
+        'drafting wake not enqueued',
+        subDomain: 'drafting',
+      );
+      return false;
+    }
+    final dayId = dayAgentIdForDate(dayDate);
+    final triggerTokens = <String>{
+      dayAgentDraftingToken(dayId),
+      if (captureId != null && captureId.trim().isNotEmpty)
+        dayAgentCaptureSubmittedToken(captureId.trim()),
+    };
+    domainLogger.log(
+      LogDomains.agentRuntime,
+      'drafting wake enqueued for '
+      '${DomainLogger.sanitizeId(agent.agentId)} / '
+      '${DomainLogger.sanitizeId(dayId)}',
+      subDomain: 'drafting',
+    );
+    orchestrator.enqueueManualWake(
+      agentId: agent.agentId,
+      reason: dayAgentDraftingReason,
+      triggerTokens: triggerTokens,
+    );
+    return true;
   }
 
   /// Trigger a manual wake for [agentId].

--- a/lib/features/daily_os_next/agents/state/day_agent_providers.dart
+++ b/lib/features/daily_os_next/agents/state/day_agent_providers.dart
@@ -101,3 +101,27 @@ Future<List<DayAgentPendingItem>> pendingDecisionsForDate(
     dayId: dayId,
   );
 }
+
+/// Currently drafted day plan for [date], if any.
+///
+/// Returns the base [AgentDomainEntity] for codegen compatibility — the
+/// riverpod_generator in this codebase rejects freezed subtypes as return
+/// types. Consumers should unwrap via `mapOrNull(dayPlan: (e) => e)` to
+/// get the typed [DayPlanEntity] view.
+@riverpod
+Future<AgentDomainEntity?> draftedPlanForDate(
+  Ref ref,
+  DateTime date,
+) async {
+  final dayId = dayAgentIdForDate(date);
+  final dayAgentService = ref.watch(dayAgentServiceProvider);
+  final planService = ref.watch(dayAgentPlanServiceProvider);
+  ref.watch(agentUpdateStreamProvider(dayId));
+
+  final agent = await dayAgentService.getDayAgentForDate(date);
+  if (agent == null) return null;
+  return planService.draftPlanForDay(
+    agentId: agent.agentId,
+    dayId: dayId,
+  );
+}

--- a/lib/features/daily_os_next/agents/state/day_agent_providers.g.dart
+++ b/lib/features/daily_os_next/agents/state/day_agent_providers.g.dart
@@ -398,7 +398,7 @@ final class PendingDecisionsForDateProvider
 }
 
 String _$pendingDecisionsForDateHash() =>
-    r'c6a78d2a4d386c6765f012ce0ed515e534fc88fb';
+    r'b9f2db1bcf9a7bc5c3f36da00e977cf3e914e963';
 
 /// Pending reconcile decisions for [date].
 
@@ -424,4 +424,116 @@ final class PendingDecisionsForDateFamily extends $Family
 
   @override
   String toString() => r'pendingDecisionsForDateProvider';
+}
+
+/// Currently drafted day plan for [date], if any.
+///
+/// Returns the base [AgentDomainEntity] for codegen compatibility — the
+/// riverpod_generator in this codebase rejects freezed subtypes as return
+/// types. Consumers should unwrap via `mapOrNull(dayPlan: (e) => e)` to
+/// get the typed [DayPlanEntity] view.
+
+@ProviderFor(draftedPlanForDate)
+final draftedPlanForDateProvider = DraftedPlanForDateFamily._();
+
+/// Currently drafted day plan for [date], if any.
+///
+/// Returns the base [AgentDomainEntity] for codegen compatibility — the
+/// riverpod_generator in this codebase rejects freezed subtypes as return
+/// types. Consumers should unwrap via `mapOrNull(dayPlan: (e) => e)` to
+/// get the typed [DayPlanEntity] view.
+
+final class DraftedPlanForDateProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<AgentDomainEntity?>,
+          AgentDomainEntity?,
+          FutureOr<AgentDomainEntity?>
+        >
+    with
+        $FutureModifier<AgentDomainEntity?>,
+        $FutureProvider<AgentDomainEntity?> {
+  /// Currently drafted day plan for [date], if any.
+  ///
+  /// Returns the base [AgentDomainEntity] for codegen compatibility — the
+  /// riverpod_generator in this codebase rejects freezed subtypes as return
+  /// types. Consumers should unwrap via `mapOrNull(dayPlan: (e) => e)` to
+  /// get the typed [DayPlanEntity] view.
+  DraftedPlanForDateProvider._({
+    required DraftedPlanForDateFamily super.from,
+    required DateTime super.argument,
+  }) : super(
+         retry: null,
+         name: r'draftedPlanForDateProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$draftedPlanForDateHash();
+
+  @override
+  String toString() {
+    return r'draftedPlanForDateProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<AgentDomainEntity?> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<AgentDomainEntity?> create(Ref ref) {
+    final argument = this.argument as DateTime;
+    return draftedPlanForDate(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is DraftedPlanForDateProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$draftedPlanForDateHash() =>
+    r'e5f86020da34f26ee2ff6141cab934292c20226f';
+
+/// Currently drafted day plan for [date], if any.
+///
+/// Returns the base [AgentDomainEntity] for codegen compatibility — the
+/// riverpod_generator in this codebase rejects freezed subtypes as return
+/// types. Consumers should unwrap via `mapOrNull(dayPlan: (e) => e)` to
+/// get the typed [DayPlanEntity] view.
+
+final class DraftedPlanForDateFamily extends $Family
+    with $FunctionalFamilyOverride<FutureOr<AgentDomainEntity?>, DateTime> {
+  DraftedPlanForDateFamily._()
+    : super(
+        retry: null,
+        name: r'draftedPlanForDateProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// Currently drafted day plan for [date], if any.
+  ///
+  /// Returns the base [AgentDomainEntity] for codegen compatibility — the
+  /// riverpod_generator in this codebase rejects freezed subtypes as return
+  /// types. Consumers should unwrap via `mapOrNull(dayPlan: (e) => e)` to
+  /// get the typed [DayPlanEntity] view.
+
+  DraftedPlanForDateProvider call(DateTime date) =>
+      DraftedPlanForDateProvider._(argument: date, from: this);
+
+  @override
+  String toString() => r'draftedPlanForDateProvider';
 }

--- a/lib/features/daily_os_next/agents/workflow/day_agent_workflow.dart
+++ b/lib/features/daily_os_next/agents/workflow/day_agent_workflow.dart
@@ -162,6 +162,11 @@ class DayAgentWorkflow {
       planDate: dayDate,
       triggerTokens: triggerTokens,
     );
+    final draftingContext = await _draftingContext(
+      agentIdentity: agentIdentity,
+      dayId: dayId,
+      triggerTokens: triggerTokens,
+    );
     final systemPrompt = _buildSystemPrompt(templateCtx);
     final userMessage = _buildUserMessage(
       dayId: dayId,
@@ -170,6 +175,7 @@ class DayAgentWorkflow {
       observations: recentObservations,
       observationPayloads: observationPayloads,
       captureContext: captureContext,
+      draftingContext: draftingContext,
     );
 
     final conversationId = conversationRepository.createConversation(
@@ -489,6 +495,10 @@ Drafting rules:
 - Keep blocks inside the local plan day and within the user's capacity.
 - Calendar, buffer, and manual blocks may omit reasons when their purpose is
   self-evident.
+- When this wake's user message carries a `drafting` block (i.e. the trigger
+  tokens include `drafting:<dayId>`), your priority is to call
+  `draft_day_plan` once with the full updated block list — replacing or
+  extending `drafting.baselinePlan` rather than emitting partial diffs.
 - Refine, commit, shutdown, and agenda mutation tools are not available yet.
   Do not claim that you refined, committed, or shut down a day.
 
@@ -576,12 +586,14 @@ ${const JsonEncoder.withIndent('  ').convert(config.toJson())}''';
     required List<AgentMessageEntity> observations,
     required Map<String, AgentMessagePayloadEntity> observationPayloads,
     required _CaptureContext? captureContext,
+    required _DraftingContext? draftingContext,
   }) {
     final payload = <String, Object?>{
       'dayId': dayId,
       'planDate': planDate.toIso8601String(),
       'triggerTokens': triggerTokens.toList()..sort(),
       if (captureContext != null) 'capture': captureContext.toJson(),
+      if (draftingContext != null) 'drafting': draftingContext.toJson(),
       'recentObservations': [
         for (final observation in observations)
           {
@@ -616,6 +628,22 @@ ${const JsonEncoder.withIndent('  ').convert(config.toJson())}''';
       day: planDate,
     );
     return _CaptureContext(capture: capture, taskCorpus: corpus);
+  }
+
+  Future<_DraftingContext?> _draftingContext({
+    required AgentIdentityEntity agentIdentity,
+    required String dayId,
+    required Set<String> triggerTokens,
+  }) async {
+    final service = planService;
+    if (service == null) return null;
+    if (draftingDayIdFromTriggerTokens(triggerTokens) != dayId) return null;
+
+    final baselinePlan = await service.draftPlanForDay(
+      agentId: agentIdentity.agentId,
+      dayId: dayId,
+    );
+    return _DraftingContext(baselinePlan: baselinePlan);
   }
 
   Future<void> _persistUserMessage({
@@ -902,4 +930,44 @@ class _CaptureContext {
     'audioRef': capture.audioRef,
     'taskCorpus': taskCorpus,
   };
+}
+
+class _DraftingContext {
+  const _DraftingContext({this.baselinePlan});
+
+  final DayPlanEntity? baselinePlan;
+
+  Map<String, Object?> toJson() {
+    final plan = baselinePlan;
+    return <String, Object?>{
+      'requested': true,
+      'baselinePlan': plan == null
+          ? null
+          : <String, Object?>{
+              'planId': plan.id,
+              'dayId': plan.dayId,
+              'planDate': plan.planDate.toIso8601String(),
+              'capacityMinutes': plan.capacityMinutes,
+              'scheduledMinutes': plan.scheduledMinutes,
+              'blocks': [
+                for (final block in plan.data.plannedBlocks)
+                  <String, Object?>{
+                    'id': block.id,
+                    'title': block.title,
+                    'taskId': block.taskId,
+                    'categoryId': block.categoryId,
+                    'start': block.startTime.toIso8601String(),
+                    'end': block.endTime.toIso8601String(),
+                    'type': block.type.name,
+                    'state': block.state.name,
+                    'reason': block.reason,
+                    'note': block.note,
+                  },
+              ],
+              'energyBands': [
+                for (final band in plan.energyBands) band.toJson(),
+              ],
+            },
+    };
+  }
 }

--- a/test/features/daily_os_next/agents/domain/day_agent_reconcile_models_test.dart
+++ b/test/features/daily_os_next/agents/domain/day_agent_reconcile_models_test.dart
@@ -251,6 +251,15 @@ void _expectTokenRoundTrip() {
         isNull,
       );
     });
+
+    test('trims surrounding whitespace from the returned capture id', () {
+      expect(
+        captureIdFromTriggerTokens({
+          '$dayAgentCaptureSubmittedPrefix  capture-1  ',
+        }),
+        'capture-1',
+      );
+    });
   });
 
   group('dayAgentDraftingToken', () {
@@ -296,6 +305,15 @@ void _expectTokenRoundTrip() {
       expect(
         draftingDayIdFromTriggerTokens({'$dayAgentDraftingPrefix   '}),
         isNull,
+      );
+    });
+
+    test('trims surrounding whitespace from the returned day id', () {
+      expect(
+        draftingDayIdFromTriggerTokens({
+          '$dayAgentDraftingPrefix  dayplan-2026-05-25  ',
+        }),
+        'dayplan-2026-05-25',
       );
     });
   });

--- a/test/features/daily_os_next/agents/domain/day_agent_reconcile_models_test.dart
+++ b/test/features/daily_os_next/agents/domain/day_agent_reconcile_models_test.dart
@@ -252,6 +252,53 @@ void _expectTokenRoundTrip() {
       );
     });
   });
+
+  group('dayAgentDraftingToken', () {
+    test('prefixes the day id', () {
+      expect(
+        dayAgentDraftingToken('dayplan-2026-05-25'),
+        '${dayAgentDraftingPrefix}dayplan-2026-05-25',
+      );
+    });
+  });
+
+  group('draftingDayIdFromTriggerTokens', () {
+    test('returns the day id when a token has the prefix', () {
+      final result = draftingDayIdFromTriggerTokens({
+        dayAgentCaptureSubmittedToken('capture-1'),
+        dayAgentDraftingToken('dayplan-2026-05-25'),
+      });
+      expect(result, 'dayplan-2026-05-25');
+    });
+
+    test('returns null when no token uses the drafting prefix', () {
+      expect(
+        draftingDayIdFromTriggerTokens({
+          dayAgentCaptureSubmittedToken('capture-1'),
+          'other',
+        }),
+        isNull,
+      );
+    });
+
+    test('returns null on an empty trigger-token set', () {
+      expect(draftingDayIdFromTriggerTokens(<String>{}), isNull);
+    });
+
+    test('skips a prefix-only token without a day id', () {
+      expect(
+        draftingDayIdFromTriggerTokens({dayAgentDraftingPrefix}),
+        isNull,
+      );
+    });
+
+    test('skips a whitespace-only day id and returns null', () {
+      expect(
+        draftingDayIdFromTriggerTokens({'$dayAgentDraftingPrefix   '}),
+        isNull,
+      );
+    });
+  });
 }
 
 void _expectProjections() {

--- a/test/features/daily_os_next/agents/service/day_agent_service_test.dart
+++ b/test/features/daily_os_next/agents/service/day_agent_service_test.dart
@@ -6,6 +6,7 @@ import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/agent_link.dart';
 import 'package:lotti/features/agents/service/agent_template_service.dart';
+import 'package:lotti/features/daily_os_next/agents/domain/day_agent_reconcile_models.dart';
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_service.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -381,6 +382,109 @@ void main() {
         verifyNever(() => repository.getAgentState('task-agent'));
       },
     );
+
+    group('enqueueDraftingWake', () {
+      test(
+        'enqueues a drafting wake with the day-id token when an agent exists',
+        () async {
+          when(
+            () => repository.getActiveAgentByKindAndActiveDayId(
+              kind: AgentKinds.dayAgent,
+              activeDayId: dayId,
+            ),
+          ).thenAnswer((_) async => identity());
+
+          final result = await service.enqueueDraftingWake(dayDate: testDate);
+
+          expect(result, isTrue);
+          verify(
+            () => orchestrator.enqueueManualWake(
+              agentId: agentId,
+              reason: dayAgentDraftingReason,
+              triggerTokens: {dayAgentDraftingToken(dayId)},
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'adds the capture-submitted token when captureId is provided',
+        () async {
+          when(
+            () => repository.getActiveAgentByKindAndActiveDayId(
+              kind: AgentKinds.dayAgent,
+              activeDayId: dayId,
+            ),
+          ).thenAnswer((_) async => identity());
+
+          final result = await service.enqueueDraftingWake(
+            dayDate: testDate,
+            captureId: '  capture-42  ',
+          );
+
+          expect(result, isTrue);
+          verify(
+            () => orchestrator.enqueueManualWake(
+              agentId: agentId,
+              reason: dayAgentDraftingReason,
+              triggerTokens: {
+                dayAgentDraftingToken(dayId),
+                dayAgentCaptureSubmittedToken('capture-42'),
+              },
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'ignores a blank captureId and emits only the drafting token',
+        () async {
+          when(
+            () => repository.getActiveAgentByKindAndActiveDayId(
+              kind: AgentKinds.dayAgent,
+              activeDayId: dayId,
+            ),
+          ).thenAnswer((_) async => identity());
+
+          final result = await service.enqueueDraftingWake(
+            dayDate: testDate,
+            captureId: '   ',
+          );
+
+          expect(result, isTrue);
+          verify(
+            () => orchestrator.enqueueManualWake(
+              agentId: agentId,
+              reason: dayAgentDraftingReason,
+              triggerTokens: {dayAgentDraftingToken(dayId)},
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'returns false and skips enqueue when no day agent exists',
+        () async {
+          when(
+            () => repository.getActiveAgentByKindAndActiveDayId(
+              kind: AgentKinds.dayAgent,
+              activeDayId: dayId,
+            ),
+          ).thenAnswer((_) async => null);
+
+          final result = await service.enqueueDraftingWake(dayDate: testDate);
+
+          expect(result, isFalse);
+          verifyNever(
+            () => orchestrator.enqueueManualWake(
+              agentId: any(named: 'agentId'),
+              reason: any(named: 'reason'),
+              triggerTokens: any(named: 'triggerTokens'),
+            ),
+          );
+        },
+      );
+    });
 
     test('triggerReanalysis enqueues a manual reanalysis wake', () {
       service.triggerReanalysis(agentId);

--- a/test/features/daily_os_next/agents/state/day_agent_providers_test.dart
+++ b/test/features/daily_os_next/agents/state/day_agent_providers_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/day_plan.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
@@ -255,6 +256,94 @@ void main() {
       expect(result, const [pending]);
       verify(
         () => captureService.surfacePendingDecisions(
+          agentId: 'day-agent-001',
+          dayId: 'dayplan-2026-05-25',
+        ),
+      ).called(1);
+    });
+  });
+
+  group('draftedPlanForDateProvider', () {
+    test('returns null when no day agent exists', () async {
+      final service = MockDayAgentService();
+      final planService = MockDayAgentPlanService();
+      final notifications = UpdateNotifications();
+      final date = DateTime(2026, 5, 25, 9);
+      when(
+        () => service.getDayAgentForDate(date),
+      ).thenAnswer((_) async => null);
+      final container = ProviderContainer(
+        overrides: [
+          dayAgentServiceProvider.overrideWithValue(service),
+          dayAgentPlanServiceProvider.overrideWithValue(planService),
+          updateNotificationsProvider.overrideWithValue(notifications),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final result = await container.read(
+        draftedPlanForDateProvider(date).future,
+      );
+
+      expect(result, isNull);
+      verifyNever(
+        () => planService.draftPlanForDay(
+          agentId: any(named: 'agentId'),
+          dayId: any(named: 'dayId'),
+        ),
+      );
+    });
+
+    test('loads the drafted plan for the active day agent', () async {
+      final service = MockDayAgentService();
+      final planService = MockDayAgentPlanService();
+      final notifications = UpdateNotifications();
+      final date = DateTime(2026, 5, 25, 9);
+      final agent = makeTestIdentity(
+        id: 'day-agent-001',
+        agentId: 'day-agent-001',
+        kind: AgentKinds.dayAgent,
+      );
+      final plan =
+          AgentDomainEntity.dayPlan(
+                id: 'day_agent_plan:dayplan-2026-05-25',
+                agentId: 'day-agent-001',
+                dayId: 'dayplan-2026-05-25',
+                planDate: DateTime(2026, 5, 25),
+                data: DayPlanData(
+                  planDate: DateTime(2026, 5, 25),
+                  status: const DayPlanStatus.draft(),
+                ),
+                createdAt: DateTime(2026, 5, 25, 8),
+                updatedAt: DateTime(2026, 5, 25, 8),
+                vectorClock: null,
+              )
+              as DayPlanEntity;
+      when(
+        () => service.getDayAgentForDate(date),
+      ).thenAnswer((_) async => agent);
+      when(
+        () => planService.draftPlanForDay(
+          agentId: 'day-agent-001',
+          dayId: 'dayplan-2026-05-25',
+        ),
+      ).thenAnswer((_) async => plan);
+      final container = ProviderContainer(
+        overrides: [
+          dayAgentServiceProvider.overrideWithValue(service),
+          dayAgentPlanServiceProvider.overrideWithValue(planService),
+          updateNotificationsProvider.overrideWithValue(notifications),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final result = await container.read(
+        draftedPlanForDateProvider(date).future,
+      );
+
+      expect(result, plan);
+      verify(
+        () => planService.draftPlanForDay(
           agentId: 'day-agent-001',
           dayId: 'dayplan-2026-05-25',
         ),

--- a/test/features/daily_os_next/agents/workflow/day_agent_workflow_test.dart
+++ b/test/features/daily_os_next/agents/workflow/day_agent_workflow_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:clock/clock.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/day_plan.dart';
 import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
@@ -12,6 +13,7 @@ import 'package:lotti/features/ai/conversation/conversation_repository.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/model/inference_usage.dart';
 import 'package:lotti/features/ai/repository/inference_repository_interface.dart';
+import 'package:lotti/features/daily_os_next/agents/domain/day_agent_plan_models.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/day_agent_reconcile_models.dart';
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_capture_service.dart';
 import 'package:lotti/features/daily_os_next/agents/tools/day_agent_tool_names.dart';
@@ -424,6 +426,134 @@ void main() {
         },
       ]);
     });
+
+    test(
+      'includes a null-baseline drafting context for drafting-token wakes',
+      () async {
+        final planService = MockDayAgentPlanService();
+        when(
+          () => planService.draftPlanForDay(
+            agentId: agentId,
+            dayId: dayId,
+          ),
+        ).thenAnswer((_) async => null);
+
+        final result = await execute(
+          workflow(planService: planService),
+          triggerTokens: {dayAgentDraftingToken(dayId), dayId},
+        );
+
+        expect(result.success, isTrue);
+        final userPayload =
+            jsonDecode(conversationRepository.lastUserMessage!)
+                as Map<String, dynamic>;
+        final draftingPayload = userPayload['drafting'] as Map<String, dynamic>;
+        expect(draftingPayload['requested'], isTrue);
+        expect(draftingPayload['baselinePlan'], isNull);
+        verify(
+          () => planService.draftPlanForDay(
+            agentId: agentId,
+            dayId: dayId,
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'surfaces the existing draft as the baseline for drafting wakes',
+      () async {
+        final planService = MockDayAgentPlanService();
+        final baselinePlan =
+            AgentDomainEntity.dayPlan(
+                  id: 'day_agent_plan:$dayId',
+                  agentId: agentId,
+                  dayId: dayId,
+                  planDate: DateTime(2026, 5, 25),
+                  data: DayPlanData(
+                    planDate: DateTime(2026, 5, 25),
+                    status: const DayPlanStatus.draft(),
+                    plannedBlocks: [
+                      PlannedBlock(
+                        id: 'block-1',
+                        categoryId: 'work',
+                        startTime: DateTime(2026, 5, 25, 9),
+                        endTime: DateTime(2026, 5, 25, 10),
+                        title: 'Prep demo',
+                        reason: 'High-energy window.',
+                      ),
+                    ],
+                  ),
+                  energyBands: [
+                    DayAgentEnergyBand(
+                      start: DateTime(2026, 5, 25, 9),
+                      end: DateTime(2026, 5, 25, 12),
+                      level: DayAgentEnergyLevel.high,
+                      label: 'HIGH ENERGY',
+                    ),
+                  ],
+                  capacityMinutes: 360,
+                  scheduledMinutes: 60,
+                  createdAt: DateTime(2026, 5, 25, 8),
+                  updatedAt: DateTime(2026, 5, 25, 8),
+                  vectorClock: null,
+                )
+                as DayPlanEntity;
+        when(
+          () => planService.draftPlanForDay(
+            agentId: agentId,
+            dayId: dayId,
+          ),
+        ).thenAnswer((_) async => baselinePlan);
+
+        final result = await execute(
+          workflow(planService: planService),
+          triggerTokens: {dayAgentDraftingToken(dayId), dayId},
+        );
+
+        expect(result.success, isTrue);
+        final userPayload =
+            jsonDecode(conversationRepository.lastUserMessage!)
+                as Map<String, dynamic>;
+        final draftingPayload = userPayload['drafting'] as Map<String, dynamic>;
+        final plan = draftingPayload['baselinePlan'] as Map<String, dynamic>;
+        expect(plan['planId'], 'day_agent_plan:$dayId');
+        expect(plan['capacityMinutes'], 360);
+        expect(plan['scheduledMinutes'], 60);
+        final blocks = plan['blocks'] as List<dynamic>;
+        expect(blocks, hasLength(1));
+        expect(
+          (blocks.single as Map<String, dynamic>)['title'],
+          'Prep demo',
+        );
+        final bands = plan['energyBands'] as List<dynamic>;
+        expect(bands, hasLength(1));
+        expect((bands.single as Map<String, dynamic>)['level'], 'high');
+      },
+    );
+
+    test(
+      'omits the drafting context when no drafting token is present',
+      () async {
+        final planService = MockDayAgentPlanService();
+
+        final result = await execute(
+          workflow(planService: planService),
+          triggerTokens: {dayId},
+        );
+
+        expect(result.success, isTrue);
+        final userPayload =
+            jsonDecode(conversationRepository.lastUserMessage!)
+                as Map<String, dynamic>;
+        expect(userPayload.containsKey('drafting'), isFalse);
+        verifyNever(
+          () => planService.draftPlanForDay(
+            agentId: any(named: 'agentId'),
+            dayId: any(named: 'dayId'),
+          ),
+        );
+      },
+    );
 
     test('delegates capture tools to the configured capture service', () async {
       final captureService = MockDayAgentCaptureService();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drafting support for day planning: enqueue drafting operations for specific dates, include drafting context in agent workflow messages, and surface drafted plans for a given date.

* **Documentation**
  * Clarified that planned block titles may be null for legacy/day-imported blocks; parsing rejects null/blank titles.

* **Tests**
  * Added tests for drafting tokens, enqueue behavior, drafted-plan provider, and workflow payload/serialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matthiasn/lotti/pull/3211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->