### PR TITLE
feat: wire day-agent refine flow (propose/accept/revert)

### DIFF
--- a/lib/features/agents/model/seeded_directives.dart
+++ b/lib/features/agents/model/seeded_directives.dart
@@ -102,6 +102,16 @@ const seedDirectiveChangelog = <SeedDirectiveChange>[
         '"Nothing to do today" empty state. Buffer and calendar blocks '
         'continue to omit `taskId`.',
   ),
+  SeedDirectiveChange(
+    date: '2026-05-26',
+    kind: AgentTemplateKind.dayAgent,
+    description:
+        'Refine tools (`propose_plan_diff`, `accept_diff`, `revert_diff`) '
+        'are now available. On `refine:<dayId>` wakes, emit a structured '
+        'diff via `propose_plan_diff` referencing existing blockIds from '
+        '`refine.baselinePlan.blocks`. Never call `accept_diff` or '
+        '`revert_diff` autonomously — those are user verdicts.',
+  ),
 ];
 
 // ── Task Agent: General Directive ──────────────────────────────────────────
@@ -346,8 +356,15 @@ You are Shepherd, a day-level planning agent for Daily OS.
   that do not map to a decided task omit `taskId`. Never invent task ids.
 - Use `summarize_recent_patterns` for transient learning cards that help the
   Drafting surface explain recent timing and capacity patterns.
-- Refine, commit, shutdown, and agenda mutation tools are not available yet.
-  Do not invent unavailable day-plan tools.''';
+- On `refine:<dayId>` wakes, call `propose_plan_diff` once with the structured
+  changes the user described in the accompanying refine-capture transcript.
+  Reference existing `blockId`s from `refine.baselinePlan.blocks` for `moved`
+  and `dropped` changes; `added` changes carry a fresh `to` block payload.
+  Every change must include a non-empty `reason`.
+- Never call `accept_diff` or `revert_diff` autonomously — those are the user's
+  verdicts on a pending `ChangeSetEntity`, surfaced through the UI.
+- Commit, shutdown, and agenda mutation tools are not available yet. Do not
+  invent unavailable day-plan tools.''';
 
 // ── Day Agent: Report Directive ────────────────────────────────────────────
 

--- a/lib/features/daily_os_next/README.md
+++ b/lib/features/daily_os_next/README.md
@@ -14,8 +14,9 @@ not depend on the existing Daily OS UI controllers.
 
 The day-agent layer under `agents/` reuses the shared agent infrastructure from
 `features/agents` and adds only the Daily OS Next runtime surface area. The
-current backend supports the foundation wake, Capture/Reconcile, and draft
-day-plan tool paths; the Flutter UI integration is intentionally separate.
+current backend supports the foundation wake, Capture/Reconcile, draft
+day-plan, and refine tool paths; the Flutter UI integration is intentionally
+separate.
 
 ```mermaid
 flowchart TD
@@ -30,10 +31,11 @@ flowchart TD
   CaptureService --> Entities["agent_entities: capture + parsedItem"]
   CaptureService --> Links["agent_links: capture_to_parsed_item + parsed_item_to_task"]
   CaptureService --> Tasks["JournalDb tasks"]
-  Strategy --> PlanTools["drafting tools"]
+  Strategy --> PlanTools["draft + refine tools"]
   PlanTools --> PlanService["DayAgentPlanService"]
   PlanService --> DayPlan["agent_entities: day_plan"]
   PlanService --> PlanLinks["agent_links: capture_to_plan"]
+  PlanService --> RefineSets["agent_entities: changeSet + changeDecision"]
   DayPlan --> SharedModel["DayPlanData + PlannedBlock"]
   Schedule --> State
 ```
@@ -59,8 +61,8 @@ Runtime behavior:
   observations, and, for `capture_submitted:<captureId>` wakes, the submitted
   capture plus a bounded task corpus snapshot.
 - `DayAgentStrategy` handles private observations itself and delegates
-  `set_next_wake`, Capture/Reconcile tools, and draft plan tools through the
-  workflow handler.
+  `set_next_wake`, Capture/Reconcile tools, draft plan tools, and refine
+  tools through the workflow handler.
 - `DayAgentCaptureService` owns direct Capture/Reconcile mutations:
   `submit_capture`, `parse_capture_to_items`, `match_to_corpus`,
   `link_capture_phrase_to_task`, `break_capture_link`,
@@ -88,10 +90,39 @@ Runtime behavior:
 - `PlannedBlock` now carries the agent-facing metadata required by the draft
   flow: optional task/title, block origin (`ai`, `cal`, `buffer`, `manual`),
   lifecycle state, and the model's placement reason.
+- `DayAgentService.enqueueDraftingWake({dayDate, captureId?, decidedTaskIds})`
+  is the UI's entry point for asking the agent to draft. The wake fires with
+  `drafting:<dayId>` plus optional `capture_submitted:<id>` and
+  `decided_task:<taskId>` tokens; the workflow surfaces the baseline plan and
+  hydrated decided tasks under the `drafting` block in the user message JSON.
+- Refine is the post-draft edit surface. `DayAgentService.enqueueRefineWake(
+  {dayDate, transcript})` pre-checks that a draft plan exists, persists the
+  refine transcript as a `CaptureEntity` (id prefixed `refine_capture:`,
+  skipped when the transcript is blank), and fires a manual wake with
+  `refine:<dayId>` (and `capture_submitted:<captureId>` when a capture was
+  written). The workflow attaches a `refine` block carrying the current
+  `baselinePlan` to the user message so the model can reference existing
+  blockIds.
+- `DayAgentPlanService.proposePlanDiff` persists each model-emitted change as
+  a `ChangeItem` (tool name `move_block` / `add_block` / `drop_block`) on a
+  new pending `ChangeSetEntity` keyed by the plan id. Optional
+  `baselinePlanId` guards against stale diffs; optional `captureId` is
+  stashed in the first item's args so the change set is discoverable from a
+  refine-transcript capture.
+- `acceptPlanDiff` / `revertPlanDiff` resolve some or all items atomically
+  (default = all pending). Accept mutates the plan in place: it overlays
+  block moves, adds new blocks, drops by id, then re-sorts blocks by start
+  time, recomputes `scheduledMinutes`, and rebuilds `pinnedTasks`. Energy
+  bands, capacity, and plan status are left intact. Revert leaves the plan
+  untouched. Both write `ChangeDecisionEntity` records per resolved item
+  with `actor: user` and `verdict: confirmed | rejected`.
+- Refine is gated to plans in `draft` status. Refine on `agreed` /
+  `committed` plans is rejected with a clear error; Commit ships an
+  uncommit path later.
 - Wakes consume any `scheduledWakeAt` timestamp that is no longer in the future
   so app restart does not replay an already-fired scheduled wake.
-- Future Daily OS Next refine, commit, agenda, and shutdown tools should be
-  added under this feature without importing `features/daily_os`.
+- Future Daily OS Next commit, agenda, and shutdown tools should be added
+  under this feature without importing `features/daily_os`.
 
 ```mermaid
 stateDiagram-v2
@@ -105,6 +136,10 @@ stateDiagram-v2
   Parsed --> TaskMutated: apply_triage
   Parsed --> DraftedPlan: draft_day_plan
   DraftedPlan --> PatternCards: summarize_recent_patterns
+  DraftedPlan --> RefineCaptured: enqueueRefineWake
+  RefineCaptured --> PendingDiff: propose_plan_diff
+  PendingDiff --> DraftedPlan: accept_diff
+  PendingDiff --> DraftedPlan: revert_diff
 ```
 
 ## Testing Strategy
@@ -118,9 +153,9 @@ invariant is easier to state than to cover with examples:
 - `DayPlanData` derived durations, category grouping, and JSON round-trips
 - draft-plan JSON value objects, required AI block reasons, and positive block
   durations
+- plan-diff change validation (moved/added/dropped action-specific required
+  fields, in-day timestamp guards, unknown-blockId rejection)
 - future tool validators such as non-overlap rules and commit-state gating
-- future diff application/reversion once refine tools produce `ChangeSetEntity`
-  proposals
 
 Service and workflow tests should stay deterministic example tests with mocks,
 fixed clocks, and no real timers. They should verify transaction boundaries,

--- a/lib/features/daily_os_next/agents/domain/day_agent_slots.dart
+++ b/lib/features/daily_os_next/agents/domain/day_agent_slots.dart
@@ -12,3 +12,10 @@ DateTime localDay(DateTime date) => DateTime(date.year, date.month, date.day);
 
 /// Stable day-agent subject ID for a local calendar [date].
 String dayAgentIdForDate(DateTime date) => dayPlanId(localDay(date));
+
+/// Deterministic agent-entity ID for the drafted day plan keyed by [dayId].
+///
+/// Same prefix used by `DayAgentPlanService` so cross-service lookups
+/// (e.g. `DayAgentService.enqueueRefineWake` pre-checking that a plan
+/// exists) stay in sync without leaking the constant.
+String dayAgentPlanEntityId(String dayId) => 'day_agent_plan:$dayId';

--- a/lib/features/daily_os_next/agents/service/day_agent_plan_service.dart
+++ b/lib/features/daily_os_next/agents/service/day_agent_plan_service.dart
@@ -316,7 +316,7 @@ class DayAgentPlanService {
     required List<int>? itemIndices,
     required bool apply,
   }) async {
-    await _requireIdentity(agentId);
+    final identity = await _requireIdentity(agentId);
     final loaded = await agentRepository.getEntity(changeSetId);
     if (loaded is! ChangeSetEntity ||
         loaded.deletedAt != null ||
@@ -353,13 +353,17 @@ class DayAgentPlanService {
 
     if (apply) {
       // Pre-validate every pending selected change against the current
-      // plan before mutating anything (atomic all-or-nothing).
-      final blocksById = <String, PlannedBlock>{
-        for (final block in plan.data.plannedBlocks) block.id: block,
-      };
-      for (final entry in pendingByIndex.entries) {
-        _validateApplicable(entry.value, blocksById);
-      }
+      // plan before mutating anything (atomic all-or-nothing). The sweep
+      // is order-aware (drops/moves earlier in the batch affect later
+      // items) and re-runs the propose-time invariants against the
+      // *resolving* agent's allowed categories so a synced ChangeItem
+      // cannot smuggle an unauthorized category or out-of-day timestamp
+      // past the apply path.
+      _validateApplicableBatch(
+        pendingByIndex.entries,
+        plan,
+        identity.allowedCategoryIds,
+      );
     }
 
     final now = clock.now();
@@ -1277,25 +1281,141 @@ class DayAgentPlanService {
     }
   }
 
-  static void _validateApplicable(
-    ChangeItem item,
-    Map<String, PlannedBlock> blocksById,
+  /// Order-aware validation across a batch of pending items.
+  ///
+  /// Walks the items in resolution order against a simulated block set so
+  /// that one item's effect (e.g. dropping a block) is visible to later
+  /// items in the same batch. Also re-runs the propose-time invariants
+  /// against the resolving agent's [allowedCategoryIds]:
+  ///   * `add_block` carries a full new block — validate shape, parseable
+  ///     timestamps, `end > start`, in-day bounds, allowed category.
+  ///   * `move_block` may carry partial overrides — validate any provided
+  ///     timestamps (parseable + in-day), the effective end > effective
+  ///     start (using the live block as fallback), and any category
+  ///     override against [allowedCategoryIds].
+  ///   * `drop_block` only needs the blockId still to exist in the
+  ///     simulated set.
+  static void _validateApplicableBatch(
+    Iterable<MapEntry<int, ChangeItem>> entries,
+    DayPlanEntity plan,
+    Set<String> allowedCategoryIds,
   ) {
-    switch (item.toolName) {
-      case 'move_block':
-      case 'drop_block':
-        final blockId = item.args['blockId'] as String?;
-        if (blockId == null || !blocksById.containsKey(blockId)) {
-          throw DayAgentCaptureException(
-            'cannot apply ${item.toolName}: blockId $blockId no longer exists',
-          );
-        }
-      case 'add_block':
-        break;
-      default:
+    final simulatedIds = <String>{
+      for (final block in plan.data.plannedBlocks) block.id,
+    };
+    final blocksById = <String, PlannedBlock>{
+      for (final block in plan.data.plannedBlocks) block.id: block,
+    };
+    final dayStart = localDay(plan.planDate);
+    final dayEnd = dayStart.add(const Duration(days: 1));
+
+    void assertInDay(DateTime t, int idx, String label) {
+      if (t.isBefore(dayStart) || t.isAfter(dayEnd)) {
         throw DayAgentCaptureException(
-          'cannot apply unknown change tool "${item.toolName}"',
+          'cannot apply change at index $idx: $label is outside the plan day',
         );
+      }
+    }
+
+    void assertAllowedCategory(String categoryId, int idx) {
+      if (allowedCategoryIds.isEmpty) return;
+      if (!allowedCategoryIds.contains(categoryId)) {
+        throw DayAgentCaptureException(
+          'cannot apply change at index $idx: categoryId $categoryId is '
+          'not allowed for this agent',
+        );
+      }
+    }
+
+    DateTime? parseDate(Object? raw, int idx, String label) {
+      if (raw == null) return null;
+      if (raw is! String) {
+        throw DayAgentCaptureException(
+          'cannot apply change at index $idx: $label must be a string',
+        );
+      }
+      final parsed = DateTime.tryParse(raw);
+      if (parsed == null) {
+        throw DayAgentCaptureException(
+          'cannot apply change at index $idx: $label is not a valid '
+          'ISO-8601 date-time',
+        );
+      }
+      return parsed;
+    }
+
+    for (final entry in entries) {
+      final idx = entry.key;
+      final item = entry.value;
+      switch (item.toolName) {
+        case 'move_block':
+          final blockId = item.args['blockId'] as String?;
+          if (blockId == null || !simulatedIds.contains(blockId)) {
+            throw DayAgentCaptureException(
+              'cannot apply move_block at index $idx: blockId $blockId not '
+              'in plan (possibly dropped earlier in this batch)',
+            );
+          }
+          final live = blocksById[blockId]!;
+          final newStart = parseDate(item.args['toStart'], idx, 'toStart');
+          final newEnd = parseDate(item.args['toEnd'], idx, 'toEnd');
+          final effStart = newStart ?? live.startTime;
+          final effEnd = newEnd ?? live.endTime;
+          if (!effEnd.isAfter(effStart)) {
+            throw DayAgentCaptureException(
+              'cannot apply move_block at index $idx: effective end must '
+              'be after effective start',
+            );
+          }
+          assertInDay(effStart, idx, 'effective start');
+          assertInDay(effEnd, idx, 'effective end');
+          final newCategoryId = item.args['categoryId'];
+          if (newCategoryId is String && newCategoryId.isNotEmpty) {
+            assertAllowedCategory(newCategoryId, idx);
+          }
+        case 'drop_block':
+          final blockId = item.args['blockId'] as String?;
+          if (blockId == null || !simulatedIds.contains(blockId)) {
+            throw DayAgentCaptureException(
+              'cannot apply drop_block at index $idx: blockId $blockId not '
+              'in plan (possibly dropped earlier in this batch)',
+            );
+          }
+          simulatedIds.remove(blockId);
+        case 'add_block':
+          final categoryId = item.args['categoryId'];
+          if (categoryId is! String || categoryId.isEmpty) {
+            throw DayAgentCaptureException(
+              'cannot apply add_block at index $idx: categoryId must be a '
+              'non-empty string',
+            );
+          }
+          assertAllowedCategory(categoryId, idx);
+          final start = parseDate(item.args['toStart'], idx, 'toStart');
+          final end = parseDate(item.args['toEnd'], idx, 'toEnd');
+          if (start == null) {
+            throw DayAgentCaptureException(
+              'cannot apply add_block at index $idx: toStart is required',
+            );
+          }
+          if (end == null) {
+            throw DayAgentCaptureException(
+              'cannot apply add_block at index $idx: toEnd is required',
+            );
+          }
+          if (!end.isAfter(start)) {
+            throw DayAgentCaptureException(
+              'cannot apply add_block at index $idx: toEnd must be after '
+              'toStart',
+            );
+          }
+          assertInDay(start, idx, 'toStart');
+          assertInDay(end, idx, 'toEnd');
+        default:
+          throw DayAgentCaptureException(
+            'cannot apply unknown change tool "${item.toolName}"',
+          );
+      }
     }
   }
 
@@ -1303,13 +1423,28 @@ class DayAgentPlanService {
     ChangeItem item,
     List<PlannedBlock> blocks,
   ) {
+    // Defensive: `_validateApplicableBatch` runs immediately before this
+    // and rejects every malformed item, so the assertions below should be
+    // unreachable in normal flow. They exist so an accidental future
+    // bypass surfaces a clean `DayAgentCaptureException` instead of a
+    // bare `RangeError` / `TypeError`.
     final out = List<PlannedBlock>.of(blocks);
     final args = item.args;
     switch (item.toolName) {
       case 'move_block':
         final blockId = args['blockId'] as String;
         final index = out.indexWhere((b) => b.id == blockId);
+        if (index == -1) {
+          throw DayAgentCaptureException(
+            'cannot apply move_block: blockId $blockId not found in plan',
+          );
+        }
         final block = out[index];
+        // NB: `args['reason']` is the change-level rationale (why the user
+        // wants this edit); the per-block reason override travels under
+        // `args['blockReason']` per `_DiffChange.toArgs()`. Mixing them
+        // would overwrite the block's placement reason with the diff
+        // motivation.
         out[index] = block.copyWith(
           startTime: _argDate(args, 'toStart') ?? block.startTime,
           endTime: _argDate(args, 'toEnd') ?? block.endTime,
@@ -1319,8 +1454,8 @@ class DayAgentPlanService {
               ? args['taskId'] as String?
               : block.taskId,
           type: _argType(args) ?? block.type,
-          reason: args.containsKey('reason')
-              ? args['reason'] as String?
+          reason: args.containsKey('blockReason')
+              ? args['blockReason'] as String?
               : block.reason,
         );
       case 'add_block':
@@ -1333,12 +1468,18 @@ class DayAgentPlanService {
             title: args['title'] as String?,
             taskId: args['taskId'] as String?,
             type: _argType(args) ?? PlannedBlockType.ai,
-            reason: args['reason'] as String?,
+            reason: args['blockReason'] as String?,
           ),
         );
       case 'drop_block':
         final blockId = args['blockId'] as String;
+        final before = out.length;
         out.removeWhere((b) => b.id == blockId);
+        if (out.length == before) {
+          throw DayAgentCaptureException(
+            'cannot apply drop_block: blockId $blockId not found in plan',
+          );
+        }
     }
     return out;
   }

--- a/lib/features/daily_os_next/agents/service/day_agent_plan_service.dart
+++ b/lib/features/daily_os_next/agents/service/day_agent_plan_service.dart
@@ -7,6 +7,7 @@ import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/agent_link.dart';
+import 'package:lotti/features/agents/model/change_set.dart';
 import 'package:lotti/features/agents/sync/agent_sync_service.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/day_agent_plan_models.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/day_agent_reconcile_models.dart';
@@ -60,6 +61,20 @@ class DayAgentPlanService {
         ),
         DayAgentToolNames.summarizeRecentPatterns =>
           await _summarizeRecentPatternsTool(agentId, args),
+        DayAgentToolNames.proposePlanDiff => await _proposePlanDiffTool(
+          agentId: agentId,
+          threadId: threadId,
+          runKey: runKey,
+          args: args,
+        ),
+        DayAgentToolNames.acceptDiff => await _acceptPlanDiffTool(
+          agentId: agentId,
+          args: args,
+        ),
+        DayAgentToolNames.revertDiff => await _revertPlanDiffTool(
+          agentId: agentId,
+          args: args,
+        ),
         _ => throw DayAgentCaptureException('unknown tool "$toolName"'),
       };
       return DayAgentDirectToolResult.success(data);
@@ -81,7 +96,7 @@ class DayAgentPlanService {
     required String agentId,
     required String dayId,
   }) async {
-    final entity = await agentRepository.getEntity(_planEntityId(dayId));
+    final entity = await agentRepository.getEntity(dayAgentPlanEntityId(dayId));
     if (entity is DayPlanEntity && entity.agentId == agentId) {
       return entity;
     }
@@ -149,6 +164,292 @@ class DayAgentPlanService {
       );
     }
     return out;
+  }
+
+  /// Persist a structured plan diff against the current draft for [dayId].
+  ///
+  /// Each entry in [rawChanges] becomes a `ChangeItem` on a new
+  /// [ChangeSetEntity] (tool name `move_block` / `add_block` / `drop_block`).
+  /// Items are individually confirmable via [acceptPlanDiff] /
+  /// [revertPlanDiff]. The optional [baselinePlanId] guards against stale
+  /// diffs: when supplied and the live plan id has shifted, the proposal is
+  /// rejected. The optional [captureId] is stashed in the first item's args
+  /// so the change set is discoverable from a refine-transcript capture.
+  ///
+  /// Throws [DayAgentCaptureException] when:
+  ///   * the agent does not exist,
+  ///   * no plan exists for [dayId] (call `draft_day_plan` first),
+  ///   * the plan is `committed` (refine is gated until Commit ships an
+  ///     uncommit path),
+  ///   * [baselinePlanId] is supplied and does not match the live plan id,
+  ///   * [rawChanges] is empty, or
+  ///   * any change is malformed (missing fields for the action,
+  ///     out-of-day timestamps, unknown `blockId`, blank `reason`, etc.).
+  Future<ChangeSetEntity> proposePlanDiff({
+    required String agentId,
+    required String threadId,
+    required String runKey,
+    required String dayId,
+    required List<Object?> rawChanges,
+    String? baselinePlanId,
+    String? captureId,
+  }) async {
+    await _requireIdentity(agentId);
+    final plan = await draftPlanForDay(agentId: agentId, dayId: dayId);
+    if (plan == null) {
+      throw DayAgentCaptureException(
+        'no draft plan for $dayId; call draft_day_plan first',
+      );
+    }
+    if (plan.data.status is! DayPlanStatusDraft) {
+      throw const DayAgentCaptureException(
+        'plan is not in draft state; refine is gated until Commit ships an '
+        'uncommit path',
+      );
+    }
+    if (baselinePlanId != null && baselinePlanId != plan.id) {
+      throw DayAgentCaptureException(
+        'baselinePlanId $baselinePlanId does not match live plan ${plan.id}; '
+        'refresh the baseline and re-propose',
+      );
+    }
+    if (captureId != null) {
+      final capture = await _captureOrNull(captureId);
+      if (capture == null || capture.agentId != agentId) {
+        throw DayAgentCaptureException('capture $captureId not found');
+      }
+    }
+    if (rawChanges.isEmpty) {
+      throw const DayAgentCaptureException(
+        'propose_plan_diff requires at least one change',
+      );
+    }
+
+    final blockById = <String, PlannedBlock>{
+      for (final block in plan.data.plannedBlocks) block.id: block,
+    };
+    final parsed = <_DiffChange>[];
+    for (final raw in rawChanges) {
+      parsed.add(_parseDiffChange(raw: raw, plan: plan, blockById: blockById));
+    }
+
+    final now = clock.now();
+    final items = <ChangeItem>[];
+    for (var i = 0; i < parsed.length; i++) {
+      final change = parsed[i];
+      final args = <String, dynamic>{
+        ...change.toArgs(),
+        if (i == 0 && captureId != null) 'captureId': captureId,
+      };
+      items.add(
+        ChangeItem(
+          toolName: change.toolName,
+          args: args,
+          humanSummary: _formatChangeSummary(change, blockById),
+        ),
+      );
+    }
+
+    final changeSet =
+        AgentDomainEntity.changeSet(
+              id: 'plan_diff:${_uuid.v4()}',
+              agentId: agentId,
+              taskId: plan.id,
+              threadId: threadId,
+              runKey: runKey,
+              status: ChangeSetStatus.pending,
+              items: items,
+              createdAt: now,
+              vectorClock: null,
+            )
+            as ChangeSetEntity;
+    await syncService.upsertEntity(changeSet);
+
+    onPersistedStateChanged
+      ?..call(agentId)
+      ..call(changeSet.id);
+    return changeSet;
+  }
+
+  /// Apply some or all changes of [changeSetId] to the live plan.
+  ///
+  /// When [itemIndices] is null, every pending item is accepted; otherwise
+  /// only the listed indices are processed. Accept is atomic: if any
+  /// selected change cannot be applied (e.g., the target `blockId` is no
+  /// longer present), nothing is written. Items already resolved are
+  /// skipped silently — re-issuing accept against a partially-resolved set
+  /// is safe.
+  Future<ChangeSetEntity> acceptPlanDiff({
+    required String agentId,
+    required String changeSetId,
+    List<int>? itemIndices,
+  }) async {
+    return _resolvePlanDiff(
+      agentId: agentId,
+      changeSetId: changeSetId,
+      itemIndices: itemIndices,
+      apply: true,
+    );
+  }
+
+  /// Retract some or all changes of [changeSetId] without mutating the plan.
+  ///
+  /// Mirrors [acceptPlanDiff] but flips selected items' status to
+  /// `rejected` (with `actor = user`, `verdict = rejected`) and leaves the
+  /// plan entity untouched.
+  Future<ChangeSetEntity> revertPlanDiff({
+    required String agentId,
+    required String changeSetId,
+    List<int>? itemIndices,
+  }) async {
+    return _resolvePlanDiff(
+      agentId: agentId,
+      changeSetId: changeSetId,
+      itemIndices: itemIndices,
+      apply: false,
+    );
+  }
+
+  Future<ChangeSetEntity> _resolvePlanDiff({
+    required String agentId,
+    required String changeSetId,
+    required List<int>? itemIndices,
+    required bool apply,
+  }) async {
+    await _requireIdentity(agentId);
+    final loaded = await agentRepository.getEntity(changeSetId);
+    if (loaded is! ChangeSetEntity ||
+        loaded.deletedAt != null ||
+        loaded.agentId != agentId) {
+      throw DayAgentCaptureException('change set $changeSetId not found');
+    }
+    final changeSet = loaded;
+    final plan = await draftPlanForDay(
+      agentId: agentId,
+      dayId: _dayIdFromPlanEntityId(changeSet.taskId),
+    );
+    if (plan == null) {
+      throw DayAgentCaptureException(
+        'plan ${changeSet.taskId} no longer exists',
+      );
+    }
+    if (plan.data.status is! DayPlanStatusDraft) {
+      throw const DayAgentCaptureException(
+        'plan is not in draft state; refine resolution is blocked',
+      );
+    }
+
+    final selected = _selectIndices(
+      itemIndices: itemIndices,
+      itemCount: changeSet.items.length,
+    );
+    final pendingByIndex = <int, ChangeItem>{};
+    for (final index in selected) {
+      final item = changeSet.items[index];
+      if (item.status == ChangeItemStatus.pending) {
+        pendingByIndex[index] = item;
+      }
+    }
+
+    if (apply) {
+      // Pre-validate every pending selected change against the current
+      // plan before mutating anything (atomic all-or-nothing).
+      final blocksById = <String, PlannedBlock>{
+        for (final block in plan.data.plannedBlocks) block.id: block,
+      };
+      for (final entry in pendingByIndex.entries) {
+        _validateApplicable(entry.value, blocksById);
+      }
+    }
+
+    final now = clock.now();
+    final updatedItems = List<ChangeItem>.of(changeSet.items);
+    final decisions = <ChangeDecisionEntity>[];
+    var mutatedBlocks = List<PlannedBlock>.of(plan.data.plannedBlocks);
+    final newVerdict = apply
+        ? ChangeDecisionVerdict.confirmed
+        : ChangeDecisionVerdict.rejected;
+    final newItemStatus = apply
+        ? ChangeItemStatus.confirmed
+        : ChangeItemStatus.rejected;
+
+    for (final entry in pendingByIndex.entries) {
+      final index = entry.key;
+      final item = entry.value;
+      if (apply) {
+        mutatedBlocks = _applyItem(item, mutatedBlocks);
+      }
+      updatedItems[index] = item.copyWith(status: newItemStatus);
+      decisions.add(
+        AgentDomainEntity.changeDecision(
+              id: '${changeSet.id}:decision:$index',
+              agentId: agentId,
+              changeSetId: changeSet.id,
+              itemIndex: index,
+              toolName: item.toolName,
+              verdict: newVerdict,
+              createdAt: now,
+              vectorClock: null,
+              taskId: plan.id,
+              humanSummary: item.humanSummary,
+              args: item.args,
+            )
+            as ChangeDecisionEntity,
+      );
+    }
+
+    final newSetStatus = ChangeItem.deriveSetStatus(updatedItems);
+    final updatedChangeSet = changeSet.copyWith(
+      items: updatedItems,
+      status: newSetStatus,
+      resolvedAt: ChangeItem.deriveResolvedAt(
+        newStatus: newSetStatus,
+        existingResolvedAt: changeSet.resolvedAt,
+        now: now,
+      ),
+    );
+
+    DayPlanEntity? updatedPlan;
+    if (apply && pendingByIndex.isNotEmpty) {
+      mutatedBlocks.sort((a, b) {
+        final byStart = a.startTime.compareTo(b.startTime);
+        if (byStart != 0) return byStart;
+        return a.id.compareTo(b.id);
+      });
+      final scheduledMinutes = mutatedBlocks.fold<int>(
+        0,
+        (sum, block) => sum + block.duration.inMinutes,
+      );
+      final pinnedTasks = _pinnedTasksFor(mutatedBlocks);
+      updatedPlan = plan.copyWith(
+        data: plan.data.copyWith(
+          plannedBlocks: mutatedBlocks,
+          pinnedTasks: pinnedTasks,
+        ),
+        scheduledMinutes: scheduledMinutes,
+        updatedAt: now,
+      );
+    }
+
+    await syncService.runInTransaction(() async {
+      await syncService.upsertEntity(updatedChangeSet);
+      for (final decision in decisions) {
+        await syncService.upsertEntity(decision);
+      }
+      if (updatedPlan != null) {
+        await syncService.upsertEntity(updatedPlan);
+      }
+    });
+
+    onPersistedStateChanged
+      ?..call(agentId)
+      ..call(changeSet.id);
+    if (updatedPlan != null) {
+      onPersistedStateChanged
+        ?..call(updatedPlan.dayId)
+        ..call(updatedPlan.id);
+    }
+    return updatedChangeSet;
   }
 
   /// Persist a model-emitted draft plan.
@@ -227,7 +528,7 @@ class DayAgentPlanService {
     final existing = await draftPlanForDay(agentId: agentId, dayId: dayId);
     final plan =
         AgentDomainEntity.dayPlan(
-              id: _planEntityId(dayId),
+              id: dayAgentPlanEntityId(dayId),
               agentId: agentId,
               dayId: dayId,
               captureId: captureId,
@@ -433,6 +734,86 @@ class DayAgentPlanService {
     );
     return {
       'cards': [for (final card in cards) card.toJson()],
+    };
+  }
+
+  Future<Map<String, Object?>> _proposePlanDiffTool({
+    required String agentId,
+    required String threadId,
+    required String runKey,
+    required Map<String, dynamic> args,
+  }) async {
+    final dayId = _requiredString(args, 'dayId');
+    final changeSet = await proposePlanDiff(
+      agentId: agentId,
+      threadId: threadId,
+      runKey: runKey,
+      dayId: dayId,
+      rawChanges: _objectList(args['changes'], 'changes'),
+      baselinePlanId: _optionalString(args['baselinePlanId']),
+      captureId: _optionalString(args['captureId']),
+    );
+    return {
+      'changeSetId': changeSet.id,
+      'items': [
+        for (var i = 0; i < changeSet.items.length; i++)
+          <String, Object?>{
+            'index': i,
+            'toolName': changeSet.items[i].toolName,
+            'summary': changeSet.items[i].humanSummary,
+            'reason': changeSet.items[i].args['reason'],
+          },
+      ],
+    };
+  }
+
+  Future<Map<String, Object?>> _acceptPlanDiffTool({
+    required String agentId,
+    required Map<String, dynamic> args,
+  }) async {
+    final changeSet = await acceptPlanDiff(
+      agentId: agentId,
+      changeSetId: _requiredString(args, 'changeSetId'),
+      itemIndices: _optionalIntList(args['itemIndices']),
+    );
+    return _resolutionSummary(changeSet);
+  }
+
+  Future<Map<String, Object?>> _revertPlanDiffTool({
+    required String agentId,
+    required Map<String, dynamic> args,
+  }) async {
+    final changeSet = await revertPlanDiff(
+      agentId: agentId,
+      changeSetId: _requiredString(args, 'changeSetId'),
+      itemIndices: _optionalIntList(args['itemIndices']),
+    );
+    return _resolutionSummary(changeSet);
+  }
+
+  static Map<String, Object?> _resolutionSummary(ChangeSetEntity changeSet) {
+    var confirmed = 0;
+    var rejected = 0;
+    var pending = 0;
+    for (final item in changeSet.items) {
+      switch (item.status) {
+        case ChangeItemStatus.confirmed:
+          confirmed++;
+        case ChangeItemStatus.rejected:
+          rejected++;
+        case ChangeItemStatus.pending:
+          pending++;
+        case ChangeItemStatus.deferred:
+        case ChangeItemStatus.retracted:
+          break;
+      }
+    }
+    return {
+      'changeSetId': changeSet.id,
+      'status': changeSet.status.name,
+      'confirmedCount': confirmed,
+      'rejectedCount': rejected,
+      'pendingCount': pending,
     };
   }
 
@@ -678,5 +1059,377 @@ class DayAgentPlanService {
     return DateTime.tryParse(dayId.substring(prefix.length));
   }
 
-  static String _planEntityId(String dayId) => 'day_agent_plan:$dayId';
+  static String _dayIdFromPlanEntityId(String planEntityId) {
+    const prefix = 'day_agent_plan:';
+    if (planEntityId.startsWith(prefix)) {
+      return planEntityId.substring(prefix.length);
+    }
+    return planEntityId;
+  }
+
+  static List<int>? _optionalIntList(Object? raw) {
+    if (raw == null) return null;
+    if (raw is! List) {
+      throw const DayAgentCaptureException('itemIndices must be an array');
+    }
+    final out = <int>[];
+    for (final value in raw) {
+      if (value is int) {
+        out.add(value);
+        continue;
+      }
+      if (value is num && value % 1 == 0) {
+        out.add(value.toInt());
+        continue;
+      }
+      throw const DayAgentCaptureException(
+        'itemIndices entries must be integers',
+      );
+    }
+    return out;
+  }
+
+  static List<int> _selectIndices({
+    required List<int>? itemIndices,
+    required int itemCount,
+  }) {
+    if (itemIndices == null) {
+      return [for (var i = 0; i < itemCount; i++) i];
+    }
+    final out = <int>{};
+    for (final index in itemIndices) {
+      if (index < 0 || index >= itemCount) {
+        throw DayAgentCaptureException(
+          'itemIndex $index is out of range for a set with $itemCount items',
+        );
+      }
+      out.add(index);
+    }
+    return out.toList()..sort();
+  }
+
+  static _DiffChange _parseDiffChange({
+    required Object? raw,
+    required DayPlanEntity plan,
+    required Map<String, PlannedBlock> blockById,
+  }) {
+    if (raw is! Map) {
+      throw const DayAgentCaptureException('change must be an object');
+    }
+    final data = raw.cast<String, dynamic>();
+    final actionName = _requiredString(data, 'action');
+    final action = parseEnumByName(_DiffAction.values, actionName);
+    if (action == null) {
+      throw DayAgentCaptureException(
+        'change action must be moved, added, or dropped (got "$actionName")',
+      );
+    }
+    final reason = _requiredString(data, 'reason');
+    final blockId = _optionalString(data['blockId']);
+    final from = _optionalBlockSnapshot(data['from'], 'from', plan);
+    final to = _optionalBlockSnapshot(data['to'], 'to', plan);
+    switch (action) {
+      case _DiffAction.moved:
+        if (blockId == null) {
+          throw const DayAgentCaptureException(
+            'moved change requires blockId',
+          );
+        }
+        if (!blockById.containsKey(blockId)) {
+          throw DayAgentCaptureException(
+            'moved change references unknown blockId $blockId',
+          );
+        }
+        if (to == null) {
+          throw const DayAgentCaptureException('moved change requires `to`');
+        }
+        if (from == null) {
+          throw const DayAgentCaptureException(
+            'moved change requires `from`',
+          );
+        }
+      case _DiffAction.added:
+        if (to == null) {
+          throw const DayAgentCaptureException('added change requires `to`');
+        }
+        if (to.start == null || to.end == null) {
+          throw const DayAgentCaptureException(
+            'added change requires `to.start` and `to.end`',
+          );
+        }
+        if (to.title == null || to.title!.isEmpty) {
+          throw const DayAgentCaptureException(
+            'added change requires `to.title`',
+          );
+        }
+        if (to.categoryId == null) {
+          throw const DayAgentCaptureException(
+            'added change requires `to.categoryId`',
+          );
+        }
+      case _DiffAction.dropped:
+        if (blockId == null) {
+          throw const DayAgentCaptureException(
+            'dropped change requires blockId',
+          );
+        }
+        if (!blockById.containsKey(blockId)) {
+          throw DayAgentCaptureException(
+            'dropped change references unknown blockId $blockId',
+          );
+        }
+        if (from == null) {
+          throw const DayAgentCaptureException(
+            'dropped change requires `from`',
+          );
+        }
+    }
+    return _DiffChange(
+      action: action,
+      reason: reason,
+      blockId: blockId,
+      from: from,
+      to: to,
+    );
+  }
+
+  static _BlockSnapshot? _optionalBlockSnapshot(
+    Object? raw,
+    String label,
+    DayPlanEntity plan,
+  ) {
+    if (raw == null) return null;
+    if (raw is! Map) {
+      throw DayAgentCaptureException('`$label` must be an object');
+    }
+    final data = raw.cast<String, dynamic>();
+    final start = _optionalDateTime(data['start']);
+    final end = _optionalDateTime(data['end']);
+    if (start != null && end != null && !end.isAfter(start)) {
+      throw DayAgentCaptureException(
+        '`$label.end` must be after `$label.start`',
+      );
+    }
+    if (start != null) {
+      _assertWithinDay(start, plan.planDate, '$label.start');
+    }
+    if (end != null) {
+      _assertWithinDay(end, plan.planDate, '$label.end');
+    }
+    final typeRaw = _optionalString(data['type']);
+    final type = typeRaw == null
+        ? null
+        : parseEnumByName(PlannedBlockType.values, typeRaw);
+    if (typeRaw != null && type == null) {
+      throw DayAgentCaptureException(
+        '`$label.type` must be ai, cal, buffer, or manual (got "$typeRaw")',
+      );
+    }
+    return _BlockSnapshot(
+      start: start,
+      end: end,
+      title: _optionalString(data['title']),
+      categoryId: _optionalString(data['categoryId']),
+      taskId: _optionalString(data['taskId']),
+      type: type,
+      reason: _optionalString(data['reason']),
+    );
+  }
+
+  static void _assertWithinDay(
+    DateTime time,
+    DateTime planDate,
+    String label,
+  ) {
+    final dayStart = localDay(planDate);
+    final dayEnd = dayStart.add(const Duration(days: 1));
+    if (time.isBefore(dayStart) || time.isAfter(dayEnd)) {
+      throw DayAgentCaptureException(
+        '`$label` must fall inside the plan day',
+      );
+    }
+  }
+
+  static String _formatChangeSummary(
+    _DiffChange change,
+    Map<String, PlannedBlock> blockById,
+  ) {
+    String fmt(DateTime? time) =>
+        time == null ? '?' : time.toIso8601String().substring(11, 16);
+    final liveBlock = change.blockId == null ? null : blockById[change.blockId];
+    final title =
+        change.to?.title ?? change.from?.title ?? liveBlock?.title ?? 'block';
+    switch (change.action) {
+      case _DiffAction.moved:
+        final fromStart = fmt(change.from?.start ?? liveBlock?.startTime);
+        final fromEnd = fmt(change.from?.end ?? liveBlock?.endTime);
+        final toStart = fmt(change.to?.start);
+        final toEnd = fmt(change.to?.end);
+        return 'Move "$title" from $fromStart–$fromEnd to $toStart–$toEnd';
+      case _DiffAction.added:
+        final start = fmt(change.to?.start);
+        final end = fmt(change.to?.end);
+        return 'Add "$title" at $start–$end';
+      case _DiffAction.dropped:
+        final start = fmt(change.from?.start ?? liveBlock?.startTime);
+        final end = fmt(change.from?.end ?? liveBlock?.endTime);
+        return 'Drop "$title" at $start–$end';
+    }
+  }
+
+  static void _validateApplicable(
+    ChangeItem item,
+    Map<String, PlannedBlock> blocksById,
+  ) {
+    switch (item.toolName) {
+      case 'move_block':
+      case 'drop_block':
+        final blockId = item.args['blockId'] as String?;
+        if (blockId == null || !blocksById.containsKey(blockId)) {
+          throw DayAgentCaptureException(
+            'cannot apply ${item.toolName}: blockId $blockId no longer exists',
+          );
+        }
+      case 'add_block':
+        break;
+      default:
+        throw DayAgentCaptureException(
+          'cannot apply unknown change tool "${item.toolName}"',
+        );
+    }
+  }
+
+  static List<PlannedBlock> _applyItem(
+    ChangeItem item,
+    List<PlannedBlock> blocks,
+  ) {
+    final out = List<PlannedBlock>.of(blocks);
+    final args = item.args;
+    switch (item.toolName) {
+      case 'move_block':
+        final blockId = args['blockId'] as String;
+        final index = out.indexWhere((b) => b.id == blockId);
+        final block = out[index];
+        out[index] = block.copyWith(
+          startTime: _argDate(args, 'toStart') ?? block.startTime,
+          endTime: _argDate(args, 'toEnd') ?? block.endTime,
+          title: (args['title'] as String?) ?? block.title,
+          categoryId: (args['categoryId'] as String?) ?? block.categoryId,
+          taskId: args.containsKey('taskId')
+              ? args['taskId'] as String?
+              : block.taskId,
+          type: _argType(args) ?? block.type,
+          reason: args.containsKey('reason')
+              ? args['reason'] as String?
+              : block.reason,
+        );
+      case 'add_block':
+        out.add(
+          PlannedBlock(
+            id: 'block_${_uuid.v4()}',
+            categoryId: args['categoryId'] as String,
+            startTime: _argDate(args, 'toStart')!,
+            endTime: _argDate(args, 'toEnd')!,
+            title: args['title'] as String?,
+            taskId: args['taskId'] as String?,
+            type: _argType(args) ?? PlannedBlockType.ai,
+            reason: args['reason'] as String?,
+          ),
+        );
+      case 'drop_block':
+        final blockId = args['blockId'] as String;
+        out.removeWhere((b) => b.id == blockId);
+    }
+    return out;
+  }
+
+  static DateTime? _argDate(Map<String, dynamic> args, String key) {
+    final raw = args[key];
+    if (raw is! String) return null;
+    return DateTime.tryParse(raw);
+  }
+
+  static PlannedBlockType? _argType(Map<String, dynamic> args) {
+    final raw = args['type'];
+    if (raw is! String) return null;
+    return parseEnumByName(PlannedBlockType.values, raw);
+  }
+}
+
+enum _DiffAction { moved, added, dropped }
+
+class _DiffChange {
+  const _DiffChange({
+    required this.action,
+    required this.reason,
+    this.blockId,
+    this.from,
+    this.to,
+  });
+
+  final _DiffAction action;
+  final String reason;
+  final String? blockId;
+  final _BlockSnapshot? from;
+  final _BlockSnapshot? to;
+
+  String get toolName => switch (action) {
+    _DiffAction.moved => 'move_block',
+    _DiffAction.added => 'add_block',
+    _DiffAction.dropped => 'drop_block',
+  };
+
+  Map<String, dynamic> toArgs() {
+    final args = <String, dynamic>{
+      'action': action.name,
+      'reason': reason,
+    };
+    if (blockId != null) args['blockId'] = blockId;
+    final fromSnap = from;
+    if (fromSnap != null) {
+      if (fromSnap.start != null) {
+        args['fromStart'] = fromSnap.start!.toIso8601String();
+      }
+      if (fromSnap.end != null) {
+        args['fromEnd'] = fromSnap.end!.toIso8601String();
+      }
+      if (fromSnap.title != null) args['fromTitle'] = fromSnap.title;
+      if (fromSnap.categoryId != null) {
+        args['fromCategoryId'] = fromSnap.categoryId;
+      }
+    }
+    final toSnap = to;
+    if (toSnap != null) {
+      if (toSnap.start != null) {
+        args['toStart'] = toSnap.start!.toIso8601String();
+      }
+      if (toSnap.end != null) args['toEnd'] = toSnap.end!.toIso8601String();
+      if (toSnap.title != null) args['title'] = toSnap.title;
+      if (toSnap.categoryId != null) args['categoryId'] = toSnap.categoryId;
+      if (toSnap.taskId != null) args['taskId'] = toSnap.taskId;
+      if (toSnap.type != null) args['type'] = toSnap.type!.name;
+      if (toSnap.reason != null) args['blockReason'] = toSnap.reason;
+    }
+    return args;
+  }
+}
+
+class _BlockSnapshot {
+  const _BlockSnapshot({
+    this.start,
+    this.end,
+    this.title,
+    this.categoryId,
+    this.taskId,
+    this.type,
+    this.reason,
+  });
+
+  final DateTime? start;
+  final DateTime? end;
+  final String? title;
+  final String? categoryId;
+  final String? taskId;
+  final PlannedBlockType? type;
+  final String? reason;
 }

--- a/lib/features/daily_os_next/agents/service/day_agent_service.dart
+++ b/lib/features/daily_os_next/agents/service/day_agent_service.dart
@@ -1,4 +1,5 @@
 import 'package:clock/clock.dart';
+import 'package:lotti/classes/day_plan.dart';
 import 'package:lotti/features/agents/database/agent_repository.dart';
 import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
@@ -239,10 +240,10 @@ class DayAgentService {
     }
     final dayId = dayAgentIdForDate(dayDate);
     final plan = await repository.getEntity(dayAgentPlanEntityId(dayId));
-    if (plan is! AgentDomainEntity ||
-        plan is! DayPlanEntity ||
+    if (plan is! DayPlanEntity ||
         plan.deletedAt != null ||
-        plan.agentId != agent.agentId) {
+        plan.agentId != agent.agentId ||
+        plan.data.status is! DayPlanStatusDraft) {
       domainLogger.log(
         LogDomains.agentRuntime,
         'no draft plan for '

--- a/lib/features/daily_os_next/agents/service/day_agent_service.dart
+++ b/lib/features/daily_os_next/agents/service/day_agent_service.dart
@@ -209,6 +209,86 @@ class DayAgentService {
     return true;
   }
 
+  /// Enqueue a refine wake for the day agent that owns [dayDate].
+  ///
+  /// When [transcript] is non-blank, the text is persisted as a new
+  /// `CaptureEntity` (id prefixed `refine_capture:`) and advertised to the
+  /// workflow via a `capture_submitted:<captureId>` trigger token alongside
+  /// `refine:<dayId>`. Blank/whitespace transcripts skip the capture write
+  /// — the wake still fires with only the refine token, and the model
+  /// operates on the baseline plan + recent observations alone.
+  ///
+  /// Pre-checks that a draft plan exists for the day; returns `false` (and
+  /// no wake) when none is found, mirroring the missing-agent guard. The
+  /// agent identity, captures, and any prior change sets are left
+  /// untouched.
+  Future<bool> enqueueRefineWake({
+    required DateTime dayDate,
+    required String transcript,
+  }) async {
+    final agent = await getDayAgentForDate(dayDate);
+    if (agent == null) {
+      domainLogger.log(
+        LogDomains.agentRuntime,
+        'no day agent for '
+        '${DomainLogger.sanitizeId(dayAgentIdForDate(dayDate))}; '
+        'refine wake not enqueued',
+        subDomain: 'refine',
+      );
+      return false;
+    }
+    final dayId = dayAgentIdForDate(dayDate);
+    final plan = await repository.getEntity(dayAgentPlanEntityId(dayId));
+    if (plan is! AgentDomainEntity ||
+        plan is! DayPlanEntity ||
+        plan.deletedAt != null ||
+        plan.agentId != agent.agentId) {
+      domainLogger.log(
+        LogDomains.agentRuntime,
+        'no draft plan for '
+        '${DomainLogger.sanitizeId(dayId)}; refine wake not enqueued',
+        subDomain: 'refine',
+      );
+      return false;
+    }
+
+    final trimmedTranscript = transcript.trim();
+    final triggerTokens = <String>{dayAgentRefineToken(dayId)};
+    final now = clock.now();
+    String? captureId;
+    if (trimmedTranscript.isNotEmpty) {
+      captureId = 'refine_capture:${_uuid.v4()}';
+      final capture =
+          AgentDomainEntity.capture(
+                id: captureId,
+                agentId: agent.agentId,
+                transcript: trimmedTranscript,
+                capturedAt: now,
+                createdAt: now,
+                vectorClock: null,
+              )
+              as CaptureEntity;
+      await syncService.upsertEntity(capture);
+      triggerTokens.add(dayAgentCaptureSubmittedToken(captureId));
+      onPersistedStateChanged?.call(captureId);
+    }
+
+    domainLogger.log(
+      LogDomains.agentRuntime,
+      'refine wake enqueued for '
+      '${DomainLogger.sanitizeId(agent.agentId)} / '
+      '${DomainLogger.sanitizeId(dayId)}'
+      '${captureId == null ? ' (no transcript)' : ''}',
+      subDomain: 'refine',
+    );
+    orchestrator.enqueueManualWake(
+      agentId: agent.agentId,
+      reason: dayAgentRefineReason,
+      triggerTokens: triggerTokens,
+    );
+    return true;
+  }
+
   /// Trigger a manual wake for [agentId].
   void triggerReanalysis(String agentId) {
     domainLogger.log(

--- a/lib/features/daily_os_next/agents/tools/day_agent_tools.dart
+++ b/lib/features/daily_os_next/agents/tools/day_agent_tools.dart
@@ -349,10 +349,155 @@ const dayAgentTools = <AgentToolDefinition>[
       'additionalProperties': false,
     },
   ),
-  // Refine tools (`propose_plan_diff`, `accept_diff`, `revert_diff`) are
-  // intentionally NOT registered here yet. Their `DayAgentToolNames`
-  // constants and `planTools` membership exist so Phase 4 can wire
-  // service handlers + schemas atomically. Advertising the schemas
-  // without handlers in `DayAgentPlanService.executeTool` would let the
-  // model call them and receive an "unknown tool" error.
+  AgentToolDefinition(
+    name: DayAgentToolNames.proposePlanDiff,
+    description:
+        'Propose a structured diff against an existing day plan. Emits a '
+        'ChangeSet of moved/added/dropped block changes for the user to '
+        'accept or revert. Every change must include a non-empty reason.',
+    parameters: {
+      'type': 'object',
+      'properties': {
+        'dayId': {'type': 'string'},
+        'baselinePlanId': {
+          'type': 'string',
+          'description':
+              'ID of the DayPlanEntity this diff was computed against. '
+              'Optional — when supplied, the handler rejects the diff if '
+              'the live plan id has shifted (stale-baseline guard).',
+        },
+        'captureId': {
+          'type': 'string',
+          'description':
+              'ID of the refinement-transcript CaptureEntity, if persisted.',
+        },
+        'changes': {
+          'type': 'array',
+          'minItems': 1,
+          'items': {
+            'type': 'object',
+            'properties': {
+              'action': {
+                'type': 'string',
+                'enum': ['moved', 'added', 'dropped'],
+              },
+              'blockId': {
+                'type': 'string',
+                'description':
+                    'Required for moved/dropped; absent for added '
+                    '(server assigns the new id).',
+              },
+              'from': {
+                'type': 'object',
+                'description':
+                    'Original block snapshot. Required for moved/dropped.',
+                'properties': {
+                  'start': {'type': 'string'},
+                  'end': {'type': 'string'},
+                  'title': {'type': 'string'},
+                  'categoryId': {'type': 'string'},
+                },
+                'additionalProperties': false,
+              },
+              'to': {
+                'type': 'object',
+                'description': 'Desired block shape. Required for moved/added.',
+                'properties': {
+                  'start': {'type': 'string'},
+                  'end': {'type': 'string'},
+                  'title': {'type': 'string'},
+                  'categoryId': {'type': 'string'},
+                  'taskId': {'type': 'string'},
+                  'type': {
+                    'type': 'string',
+                    'enum': ['ai', 'cal', 'buffer', 'manual'],
+                  },
+                  'reason': {'type': 'string', 'minLength': 1},
+                },
+                'additionalProperties': false,
+              },
+              'reason': {
+                'type': 'string',
+                'minLength': 1,
+                'description': 'Why this change. Required for every change.',
+              },
+            },
+            'required': ['action', 'reason'],
+            'additionalProperties': false,
+            'allOf': [
+              {
+                'if': {
+                  'properties': {
+                    'action': {
+                      'enum': ['moved', 'dropped'],
+                    },
+                  },
+                },
+                'then': {
+                  'required': ['blockId', 'from'],
+                },
+              },
+              {
+                'if': {
+                  'properties': {
+                    'action': {
+                      'enum': ['moved', 'added'],
+                    },
+                  },
+                },
+                'then': {
+                  'required': ['to'],
+                },
+              },
+            ],
+          },
+        },
+      },
+      'required': ['dayId', 'changes'],
+      'additionalProperties': false,
+    },
+  ),
+  AgentToolDefinition(
+    name: DayAgentToolNames.acceptDiff,
+    description:
+        'Apply a previously proposed plan diff. Omit itemIndices to accept '
+        'every change in the ChangeSet.',
+    parameters: {
+      'type': 'object',
+      'properties': {
+        'changeSetId': {'type': 'string'},
+        'itemIndices': {
+          'type': 'array',
+          'items': {'type': 'integer', 'minimum': 0},
+          'description':
+              'Zero-based indices of the changes to accept. Omit to accept '
+              'all pending changes.',
+        },
+      },
+      'required': ['changeSetId'],
+      'additionalProperties': false,
+    },
+  ),
+  AgentToolDefinition(
+    name: DayAgentToolNames.revertDiff,
+    description:
+        'Retract a previously proposed plan diff without mutating the live '
+        'plan entity. Omit itemIndices to retract every change in the '
+        'ChangeSet.',
+    parameters: {
+      'type': 'object',
+      'properties': {
+        'changeSetId': {'type': 'string'},
+        'itemIndices': {
+          'type': 'array',
+          'items': {'type': 'integer', 'minimum': 0},
+          'description':
+              'Zero-based indices of the changes to retract. Omit to '
+              'retract all pending changes.',
+        },
+      },
+      'required': ['changeSetId'],
+      'additionalProperties': false,
+    },
+  ),
 ];

--- a/lib/features/daily_os_next/agents/workflow/day_agent_workflow.dart
+++ b/lib/features/daily_os_next/agents/workflow/day_agent_workflow.dart
@@ -168,6 +168,11 @@ class DayAgentWorkflow {
       triggerTokens: triggerTokens,
       captureContext: captureContext,
     );
+    final refineContext = await _refineContext(
+      agentIdentity: agentIdentity,
+      dayId: dayId,
+      triggerTokens: triggerTokens,
+    );
     final systemPrompt = _buildSystemPrompt(templateCtx);
     final userMessage = _buildUserMessage(
       dayId: dayId,
@@ -177,6 +182,7 @@ class DayAgentWorkflow {
       observationPayloads: observationPayloads,
       captureContext: captureContext,
       draftingContext: draftingContext,
+      refineContext: refineContext,
     );
 
     final conversationId = conversationRepository.createConversation(
@@ -500,8 +506,19 @@ Drafting rules:
   tokens include `drafting:<dayId>`), your priority is to call
   `draft_day_plan` once with the full updated block list — replacing or
   extending `drafting.baselinePlan` rather than emitting partial diffs.
-- Refine, commit, shutdown, and agenda mutation tools are not available yet.
-  Do not claim that you refined, committed, or shut down a day.
+
+Refine rules:
+- When this wake's user message carries a `refine` block (i.e. the trigger
+  tokens include `refine:<dayId>`), your priority is to call
+  `propose_plan_diff` once with the structured changes the user described
+  in the accompanying capture transcript. Reference existing `blockId`s
+  from `refine.baselinePlan.blocks` for `moved` and `dropped` changes;
+  `added` changes carry a fresh `to` block payload. Every change must
+  include a non-empty `reason`.
+- Do not call `accept_diff` or `revert_diff` autonomously — those are the
+  user's verdicts, surfaced through the UI.
+- Commit, shutdown, and agenda mutation tools are not available yet. Do
+  not claim that you committed or shut down a day.
 
 Record private observations and schedule one useful future wake when warranted.
 
@@ -588,6 +605,7 @@ ${const JsonEncoder.withIndent('  ').convert(config.toJson())}''';
     required Map<String, AgentMessagePayloadEntity> observationPayloads,
     required _CaptureContext? captureContext,
     required _DraftingContext? draftingContext,
+    required _RefineContext? refineContext,
   }) {
     final payload = <String, Object?>{
       'dayId': dayId,
@@ -595,6 +613,7 @@ ${const JsonEncoder.withIndent('  ').convert(config.toJson())}''';
       'triggerTokens': triggerTokens.toList()..sort(),
       if (captureContext != null) 'capture': captureContext.toJson(),
       if (draftingContext != null) 'drafting': draftingContext.toJson(),
+      if (refineContext != null) 'refine': refineContext.toJson(),
       'recentObservations': [
         for (final observation in observations)
           {
@@ -666,6 +685,22 @@ ${const JsonEncoder.withIndent('  ').convert(config.toJson())}''';
     if (capture == null || service == null) return const [];
     final entities = await service.parsedItemsForCapture(capture.id);
     return entities.whereType<ParsedItemEntity>().toList();
+  }
+
+  Future<_RefineContext?> _refineContext({
+    required AgentIdentityEntity agentIdentity,
+    required String dayId,
+    required Set<String> triggerTokens,
+  }) async {
+    final service = planService;
+    if (service == null) return null;
+    if (refineDayIdFromTriggerTokens(triggerTokens) != dayId) return null;
+
+    final baselinePlan = await service.draftPlanForDay(
+      agentId: agentIdentity.agentId,
+      dayId: dayId,
+    );
+    return _RefineContext(baselinePlan: baselinePlan);
   }
 
   Future<void> _persistUserMessage({
@@ -995,6 +1030,46 @@ class _DraftingContext {
               ],
             },
       'decidedTasks': [for (final task in decidedTasks) task.toJson()],
+    };
+  }
+}
+
+class _RefineContext {
+  const _RefineContext({this.baselinePlan});
+
+  final DayPlanEntity? baselinePlan;
+
+  Map<String, Object?> toJson() {
+    final plan = baselinePlan;
+    return <String, Object?>{
+      'requested': true,
+      'baselinePlan': plan == null
+          ? null
+          : <String, Object?>{
+              'planId': plan.id,
+              'dayId': plan.dayId,
+              'planDate': plan.planDate.toIso8601String(),
+              'capacityMinutes': plan.capacityMinutes,
+              'scheduledMinutes': plan.scheduledMinutes,
+              'blocks': [
+                for (final block in plan.data.plannedBlocks)
+                  <String, Object?>{
+                    'id': block.id,
+                    'title': block.title,
+                    'taskId': block.taskId,
+                    'categoryId': block.categoryId,
+                    'start': block.startTime.toIso8601String(),
+                    'end': block.endTime.toIso8601String(),
+                    'type': block.type.name,
+                    'state': block.state.name,
+                    'reason': block.reason,
+                    'note': block.note,
+                  },
+              ],
+              'energyBands': [
+                for (final band in plan.energyBands) band.toJson(),
+              ],
+            },
     };
   }
 }

--- a/test/features/daily_os_next/agents/service/day_agent_plan_service_test.dart
+++ b/test/features/daily_os_next/agents/service/day_agent_plan_service_test.dart
@@ -1185,6 +1185,177 @@ void main() {
           ),
         );
       });
+
+      test('rejects an unknown action name', () async {
+        seedPlan();
+        await expectLater(
+          createService().proposePlanDiff(
+            agentId: _agentId,
+            threadId: _threadId,
+            runKey: _runKey,
+            dayId: _dayId,
+            rawChanges: [
+              {
+                ...movedChange(),
+                'action': 'reshuffled',
+              },
+            ],
+          ),
+          throwsA(
+            isA<DayAgentCaptureException>().having(
+              (e) => e.message,
+              'message',
+              contains('moved, added, or dropped'),
+            ),
+          ),
+        );
+      });
+
+      test('rejects dropped with an unknown blockId', () async {
+        seedPlan();
+        await expectLater(
+          createService().proposePlanDiff(
+            agentId: _agentId,
+            threadId: _threadId,
+            runKey: _runKey,
+            dayId: _dayId,
+            rawChanges: [droppedChange(blockId: 'ghost-block')],
+          ),
+          throwsA(
+            isA<DayAgentCaptureException>().having(
+              (e) => e.message,
+              'message',
+              contains('dropped change references unknown blockId'),
+            ),
+          ),
+        );
+      });
+
+      test('rejects a snapshot whose end is not after its start', () async {
+        seedPlan();
+        await expectLater(
+          createService().proposePlanDiff(
+            agentId: _agentId,
+            threadId: _threadId,
+            runKey: _runKey,
+            dayId: _dayId,
+            rawChanges: [
+              movedChange(
+                toStart: DateTime(2026, 5, 25, 12),
+                toEnd: DateTime(2026, 5, 25, 11),
+              ),
+            ],
+          ),
+          throwsA(
+            isA<DayAgentCaptureException>().having(
+              (e) => e.message,
+              'message',
+              contains('must be after'),
+            ),
+          ),
+        );
+      });
+
+      test('rejects a snapshot with an invalid block type', () async {
+        seedPlan();
+        await expectLater(
+          createService().proposePlanDiff(
+            agentId: _agentId,
+            threadId: _threadId,
+            runKey: _runKey,
+            dayId: _dayId,
+            rawChanges: [
+              {
+                ...movedChange(),
+                'to': {
+                  'start': DateTime(2026, 5, 25, 11).toIso8601String(),
+                  'end': DateTime(2026, 5, 25, 12).toIso8601String(),
+                  'type': 'lunch',
+                },
+              },
+            ],
+          ),
+          throwsA(
+            isA<DayAgentCaptureException>().having(
+              (e) => e.message,
+              'message',
+              contains('must be ai, cal, buffer, or manual'),
+            ),
+          ),
+        );
+      });
+
+      test('rejects a non-object snapshot', () async {
+        seedPlan();
+        await expectLater(
+          createService().proposePlanDiff(
+            agentId: _agentId,
+            threadId: _threadId,
+            runKey: _runKey,
+            dayId: _dayId,
+            rawChanges: [
+              {
+                ...movedChange(),
+                'to': 'not-an-object',
+              },
+            ],
+          ),
+          throwsA(
+            isA<DayAgentCaptureException>().having(
+              (e) => e.message,
+              'message',
+              contains('`to` must be an object'),
+            ),
+          ),
+        );
+      });
+
+      test('formats a drop summary using the live block fallback', () async {
+        seedPlan();
+        final changeSet = await withClock(Clock.fixed(_now), () {
+          return createService().proposePlanDiff(
+            agentId: _agentId,
+            threadId: _threadId,
+            runKey: _runKey,
+            dayId: _dayId,
+            rawChanges: [droppedChange()],
+          );
+        });
+        expect(
+          changeSet.items.single.humanSummary,
+          startsWith('Drop "Prep demo"'),
+        );
+      });
+
+      test(
+        'encodes from-snapshot categoryId into ChangeItem args when supplied',
+        () async {
+          seedPlan();
+          final changeSet = await createService().proposePlanDiff(
+            agentId: _agentId,
+            threadId: _threadId,
+            runKey: _runKey,
+            dayId: _dayId,
+            rawChanges: [
+              {
+                'action': 'dropped',
+                'blockId': 'block-1',
+                'reason': 'capture category snapshot',
+                'from': {
+                  'start': DateTime(2026, 5, 25, 9).toIso8601String(),
+                  'end': DateTime(2026, 5, 25, 10).toIso8601String(),
+                  'title': 'Prep demo',
+                  'categoryId': 'work',
+                },
+              },
+            ],
+          );
+          expect(
+            changeSet.items.single.args['fromCategoryId'],
+            'work',
+          );
+        },
+      );
     });
 
     group('acceptPlanDiff / revertPlanDiff', () {
@@ -1568,6 +1739,833 @@ void main() {
         expect(updatedPlan.data.plannedBlocks, isEmpty);
         expect(updatedPlan.scheduledMinutes, 0);
       });
+
+      test(
+        'acceptPlanDiff rejects a move that targets a block dropped earlier '
+        'in the same batch',
+        () async {
+          seedPlan([
+            PlannedBlock(
+              id: 'block-1',
+              categoryId: 'work',
+              startTime: DateTime(2026, 5, 25, 9),
+              endTime: DateTime(2026, 5, 25, 10),
+              title: 'Prep demo',
+              reason: 'Morning focus.',
+            ),
+          ]);
+          final changeSet = seedChangeSet(
+            items: [dropBlockItem(), moveBlockItem()],
+          );
+
+          await expectLater(
+            createService().acceptPlanDiff(
+              agentId: _agentId,
+              changeSetId: changeSet.id,
+            ),
+            throwsA(
+              isA<DayAgentCaptureException>().having(
+                (e) => e.message,
+                'message',
+                contains('possibly dropped earlier'),
+              ),
+            ),
+          );
+          expect(upsertedEntities.whereType<DayPlanEntity>(), isEmpty);
+          expect(upsertedEntities.whereType<ChangeSetEntity>(), isEmpty);
+        },
+      );
+
+      test(
+        'acceptPlanDiff rejects add_block items with malformed args',
+        () async {
+          seedPlan([
+            PlannedBlock(
+              id: 'block-1',
+              categoryId: 'work',
+              startTime: DateTime(2026, 5, 25, 9),
+              endTime: DateTime(2026, 5, 25, 10),
+              title: 'Prep demo',
+              reason: 'Morning focus.',
+            ),
+          ]);
+          final changeSet = seedChangeSet(
+            items: [
+              const ChangeItem(
+                toolName: 'add_block',
+                humanSummary: 'Add malformed',
+                args: <String, dynamic>{
+                  'action': 'added',
+                  'reason': 'Bad data.',
+                  // categoryId missing entirely
+                  'toStart': '2026-05-25T13:00:00.000',
+                  'toEnd': '2026-05-25T13:30:00.000',
+                },
+              ),
+            ],
+          );
+
+          await expectLater(
+            createService().acceptPlanDiff(
+              agentId: _agentId,
+              changeSetId: changeSet.id,
+            ),
+            throwsA(
+              isA<DayAgentCaptureException>().having(
+                (e) => e.message,
+                'message',
+                contains('categoryId must be a non-empty string'),
+              ),
+            ),
+          );
+          expect(upsertedEntities.whereType<DayPlanEntity>(), isEmpty);
+        },
+      );
+
+      test(
+        'acceptPlanDiff rejects add_block whose categoryId is not allowed',
+        () async {
+          seedPlan([
+            PlannedBlock(
+              id: 'block-1',
+              categoryId: 'work',
+              startTime: DateTime(2026, 5, 25, 9),
+              endTime: DateTime(2026, 5, 25, 10),
+              title: 'Prep demo',
+              reason: 'Morning focus.',
+            ),
+          ]);
+          final changeSet = seedChangeSet(
+            items: [
+              ChangeItem(
+                toolName: 'add_block',
+                humanSummary: 'Add foreign-category block',
+                args: <String, dynamic>{
+                  'action': 'added',
+                  'reason': 'Test.',
+                  'categoryId': 'forbidden',
+                  'toStart': DateTime(
+                    2026,
+                    5,
+                    25,
+                    13,
+                  ).toIso8601String(),
+                  'toEnd': DateTime(2026, 5, 25, 14).toIso8601String(),
+                  'title': 'Test',
+                },
+              ),
+            ],
+          );
+
+          await expectLater(
+            createService().acceptPlanDiff(
+              agentId: _agentId,
+              changeSetId: changeSet.id,
+            ),
+            throwsA(
+              isA<DayAgentCaptureException>().having(
+                (e) => e.message,
+                'message',
+                contains('not allowed for this agent'),
+              ),
+            ),
+          );
+        },
+      );
+
+      test(
+        'acceptPlanDiff rejects move_block whose effective times invert',
+        () async {
+          seedPlan([
+            PlannedBlock(
+              id: 'block-1',
+              categoryId: 'work',
+              startTime: DateTime(2026, 5, 25, 9),
+              endTime: DateTime(2026, 5, 25, 10),
+              title: 'Prep demo',
+              reason: 'Morning focus.',
+            ),
+          ]);
+          final changeSet = seedChangeSet(
+            items: [
+              ChangeItem(
+                toolName: 'move_block',
+                humanSummary: 'Move "Prep demo"',
+                args: <String, dynamic>{
+                  'action': 'moved',
+                  'reason': 'Bad times.',
+                  'blockId': 'block-1',
+                  // Only toStart provided; live block's end is 10:00. New
+                  // start at 11:00 would put end before start.
+                  'toStart': DateTime(2026, 5, 25, 11).toIso8601String(),
+                },
+              ),
+            ],
+          );
+
+          await expectLater(
+            createService().acceptPlanDiff(
+              agentId: _agentId,
+              changeSetId: changeSet.id,
+            ),
+            throwsA(
+              isA<DayAgentCaptureException>().having(
+                (e) => e.message,
+                'message',
+                contains('effective end must be after effective start'),
+              ),
+            ),
+          );
+        },
+      );
+
+      test(
+        'acceptPlanDiff rejects move_block whose toStart is outside the day',
+        () async {
+          seedPlan([
+            PlannedBlock(
+              id: 'block-1',
+              categoryId: 'work',
+              startTime: DateTime(2026, 5, 25, 9),
+              endTime: DateTime(2026, 5, 25, 10),
+              title: 'Prep demo',
+              reason: 'Morning focus.',
+            ),
+          ]);
+          final changeSet = seedChangeSet(
+            items: [
+              ChangeItem(
+                toolName: 'move_block',
+                humanSummary: 'Move "Prep demo"',
+                args: <String, dynamic>{
+                  'action': 'moved',
+                  'reason': 'Out-of-day.',
+                  'blockId': 'block-1',
+                  'toStart': DateTime(2026, 5, 26, 9).toIso8601String(),
+                  'toEnd': DateTime(2026, 5, 26, 10).toIso8601String(),
+                },
+              ),
+            ],
+          );
+
+          await expectLater(
+            createService().acceptPlanDiff(
+              agentId: _agentId,
+              changeSetId: changeSet.id,
+            ),
+            throwsA(
+              isA<DayAgentCaptureException>().having(
+                (e) => e.message,
+                'message',
+                contains('outside the plan day'),
+              ),
+            ),
+          );
+        },
+      );
+
+      test(
+        'acceptPlanDiff rejects move_block whose categoryId override is foreign',
+        () async {
+          seedPlan([
+            PlannedBlock(
+              id: 'block-1',
+              categoryId: 'work',
+              startTime: DateTime(2026, 5, 25, 9),
+              endTime: DateTime(2026, 5, 25, 10),
+              title: 'Prep demo',
+              reason: 'Morning focus.',
+            ),
+          ]);
+          final changeSet = seedChangeSet(
+            items: [
+              ChangeItem(
+                toolName: 'move_block',
+                humanSummary: 'Move with foreign category',
+                args: <String, dynamic>{
+                  'action': 'moved',
+                  'reason': 'Cross-device sync attack.',
+                  'blockId': 'block-1',
+                  'categoryId': 'forbidden',
+                  'toStart': DateTime(
+                    2026,
+                    5,
+                    25,
+                    11,
+                  ).toIso8601String(),
+                  'toEnd': DateTime(2026, 5, 25, 12).toIso8601String(),
+                },
+              ),
+            ],
+          );
+
+          await expectLater(
+            createService().acceptPlanDiff(
+              agentId: _agentId,
+              changeSetId: changeSet.id,
+            ),
+            throwsA(
+              isA<DayAgentCaptureException>().having(
+                (e) => e.message,
+                'message',
+                contains('not allowed for this agent'),
+              ),
+            ),
+          );
+        },
+      );
+
+      test(
+        'acceptPlanDiff rejects unknown tool names on persisted items',
+        () async {
+          seedPlan([
+            PlannedBlock(
+              id: 'block-1',
+              categoryId: 'work',
+              startTime: DateTime(2026, 5, 25, 9),
+              endTime: DateTime(2026, 5, 25, 10),
+              title: 'Prep demo',
+              reason: 'Morning focus.',
+            ),
+          ]);
+          final changeSet = seedChangeSet(
+            items: [
+              const ChangeItem(
+                toolName: 'mystery_block_op',
+                humanSummary: 'Unknown',
+                args: <String, dynamic>{'action': 'whatever'},
+              ),
+            ],
+          );
+
+          await expectLater(
+            createService().acceptPlanDiff(
+              agentId: _agentId,
+              changeSetId: changeSet.id,
+            ),
+            throwsA(
+              isA<DayAgentCaptureException>().having(
+                (e) => e.message,
+                'message',
+                contains('unknown change tool'),
+              ),
+            ),
+          );
+        },
+      );
+
+      test(
+        'acceptPlanDiff rejects when the plan vanished between propose and '
+        'accept',
+        () async {
+          final changeSet =
+              AgentDomainEntity.changeSet(
+                    id: 'plan_diff:vanished',
+                    agentId: _agentId,
+                    taskId: planEntityId,
+                    threadId: _threadId,
+                    runKey: _runKey,
+                    status: ChangeSetStatus.pending,
+                    items: [
+                      const ChangeItem(
+                        toolName: 'add_block',
+                        humanSummary: 'orphaned',
+                        args: <String, dynamic>{
+                          'action': 'added',
+                          'reason': "doesn't matter",
+                          'categoryId': 'work',
+                          'title': 'Test',
+                          'toStart': '2026-05-25T13:00:00.000',
+                          'toEnd': '2026-05-25T14:00:00.000',
+                        },
+                      ),
+                    ],
+                    createdAt: _now,
+                    vectorClock: null,
+                  )
+                  as ChangeSetEntity;
+          agentEntities[changeSet.id] = changeSet;
+          // Note: no plan seeded for the day.
+
+          await expectLater(
+            createService().acceptPlanDiff(
+              agentId: _agentId,
+              changeSetId: changeSet.id,
+            ),
+            throwsA(
+              isA<DayAgentCaptureException>().having(
+                (e) => e.message,
+                'message',
+                contains('no longer exists'),
+              ),
+            ),
+          );
+        },
+      );
+
+      test(
+        'acceptPlanDiff rejects out-of-range itemIndices',
+        () async {
+          seedPlan([
+            PlannedBlock(
+              id: 'block-1',
+              categoryId: 'work',
+              startTime: DateTime(2026, 5, 25, 9),
+              endTime: DateTime(2026, 5, 25, 10),
+              title: 'Prep demo',
+              reason: 'Morning focus.',
+            ),
+          ]);
+          final changeSet = seedChangeSet(items: [moveBlockItem()]);
+
+          await expectLater(
+            createService().acceptPlanDiff(
+              agentId: _agentId,
+              changeSetId: changeSet.id,
+              itemIndices: const [5],
+            ),
+            throwsA(
+              isA<DayAgentCaptureException>().having(
+                (e) => e.message,
+                'message',
+                contains('out of range'),
+              ),
+            ),
+          );
+        },
+      );
+
+      test(
+        'acceptPlanDiff rejects move_block with a non-string toStart',
+        () async {
+          seedPlan([
+            PlannedBlock(
+              id: 'block-1',
+              categoryId: 'work',
+              startTime: DateTime(2026, 5, 25, 9),
+              endTime: DateTime(2026, 5, 25, 10),
+              title: 'Prep demo',
+              reason: 'Morning focus.',
+            ),
+          ]);
+          final changeSet = seedChangeSet(
+            items: [
+              const ChangeItem(
+                toolName: 'move_block',
+                humanSummary: 'bad type',
+                args: <String, dynamic>{
+                  'action': 'moved',
+                  'reason': 'r',
+                  'blockId': 'block-1',
+                  'toStart': 123,
+                },
+              ),
+            ],
+          );
+
+          await expectLater(
+            createService().acceptPlanDiff(
+              agentId: _agentId,
+              changeSetId: changeSet.id,
+            ),
+            throwsA(
+              isA<DayAgentCaptureException>().having(
+                (e) => e.message,
+                'message',
+                contains('toStart must be a string'),
+              ),
+            ),
+          );
+        },
+      );
+
+      test(
+        'acceptPlanDiff rejects move_block with an unparseable toStart',
+        () async {
+          seedPlan([
+            PlannedBlock(
+              id: 'block-1',
+              categoryId: 'work',
+              startTime: DateTime(2026, 5, 25, 9),
+              endTime: DateTime(2026, 5, 25, 10),
+              title: 'Prep demo',
+              reason: 'Morning focus.',
+            ),
+          ]);
+          final changeSet = seedChangeSet(
+            items: [
+              const ChangeItem(
+                toolName: 'move_block',
+                humanSummary: 'unparseable',
+                args: <String, dynamic>{
+                  'action': 'moved',
+                  'reason': 'r',
+                  'blockId': 'block-1',
+                  'toStart': 'not-a-date',
+                },
+              ),
+            ],
+          );
+
+          await expectLater(
+            createService().acceptPlanDiff(
+              agentId: _agentId,
+              changeSetId: changeSet.id,
+            ),
+            throwsA(
+              isA<DayAgentCaptureException>().having(
+                (e) => e.message,
+                'message',
+                contains('toStart is not a valid ISO-8601'),
+              ),
+            ),
+          );
+        },
+      );
+
+      test(
+        'acceptPlanDiff applies move_block that only changes the end time',
+        () async {
+          seedPlan([
+            PlannedBlock(
+              id: 'block-1',
+              categoryId: 'work',
+              startTime: DateTime(2026, 5, 25, 9),
+              endTime: DateTime(2026, 5, 25, 10),
+              title: 'Prep demo',
+              taskId: 'task-1',
+              reason: 'Morning focus.',
+            ),
+          ]);
+          final changeSet = seedChangeSet(
+            items: [
+              ChangeItem(
+                toolName: 'move_block',
+                humanSummary: 'extend',
+                args: <String, dynamic>{
+                  'action': 'moved',
+                  'reason': 'Extend.',
+                  'blockId': 'block-1',
+                  'toEnd': DateTime(
+                    2026,
+                    5,
+                    25,
+                    11,
+                  ).toIso8601String(),
+                },
+              ),
+            ],
+          );
+
+          await createService().acceptPlanDiff(
+            agentId: _agentId,
+            changeSetId: changeSet.id,
+          );
+
+          final updatedPlan = upsertedEntities
+              .whereType<DayPlanEntity>()
+              .single;
+          expect(
+            updatedPlan.data.plannedBlocks.single.endTime,
+            DateTime(2026, 5, 25, 11),
+          );
+        },
+      );
+
+      test(
+        'acceptPlanDiff rejects move targeting a block not in the plan',
+        () async {
+          seedPlan([
+            PlannedBlock(
+              id: 'block-1',
+              categoryId: 'work',
+              startTime: DateTime(2026, 5, 25, 9),
+              endTime: DateTime(2026, 5, 25, 10),
+              title: 'Prep demo',
+              reason: 'Morning focus.',
+            ),
+          ]);
+          final changeSet = seedChangeSet(
+            items: [moveBlockItem(blockId: 'block-ghost')],
+          );
+
+          await expectLater(
+            createService().acceptPlanDiff(
+              agentId: _agentId,
+              changeSetId: changeSet.id,
+            ),
+            throwsA(
+              isA<DayAgentCaptureException>().having(
+                (e) => e.message,
+                'message',
+                contains('not in plan'),
+              ),
+            ),
+          );
+        },
+      );
+
+      test(
+        'acceptPlanDiff rejects add_block missing toStart / toEnd / inverted',
+        () async {
+          seedPlan([
+            PlannedBlock(
+              id: 'block-1',
+              categoryId: 'work',
+              startTime: DateTime(2026, 5, 25, 9),
+              endTime: DateTime(2026, 5, 25, 10),
+              title: 'Prep demo',
+              reason: 'Morning focus.',
+            ),
+          ]);
+
+          Future<void> expectFailure({
+            required Map<String, dynamic> args,
+            required String messageFragment,
+          }) async {
+            final changeSet = seedChangeSet(
+              items: [
+                ChangeItem(
+                  toolName: 'add_block',
+                  humanSummary: 'malformed',
+                  args: args,
+                ),
+              ],
+            );
+            await expectLater(
+              createService().acceptPlanDiff(
+                agentId: _agentId,
+                changeSetId: changeSet.id,
+              ),
+              throwsA(
+                isA<DayAgentCaptureException>().having(
+                  (e) => e.message,
+                  'message',
+                  contains(messageFragment),
+                ),
+              ),
+            );
+            // Re-seed for the next iteration so each sub-case sees a fresh
+            // pending change set.
+            upsertedEntities.clear();
+          }
+
+          await expectFailure(
+            args: const <String, dynamic>{
+              'action': 'added',
+              'reason': 'r',
+              'categoryId': 'life',
+              'title': 'A',
+              'toEnd': '2026-05-25T14:00:00.000',
+            },
+            messageFragment: 'toStart is required',
+          );
+          await expectFailure(
+            args: const <String, dynamic>{
+              'action': 'added',
+              'reason': 'r',
+              'categoryId': 'life',
+              'title': 'A',
+              'toStart': '2026-05-25T14:00:00.000',
+            },
+            messageFragment: 'toEnd is required',
+          );
+          await expectFailure(
+            args: const <String, dynamic>{
+              'action': 'added',
+              'reason': 'r',
+              'categoryId': 'life',
+              'title': 'A',
+              'toStart': '2026-05-25T15:00:00.000',
+              'toEnd': '2026-05-25T14:00:00.000',
+            },
+            messageFragment: 'toEnd must be after toStart',
+          );
+        },
+      );
+
+      test(
+        'acceptPlanDiff applies move_block clearing taskId and overriding '
+        'the per-block reason via blockReason (separate from change reason)',
+        () async {
+          seedPlan([
+            PlannedBlock(
+              id: 'block-1',
+              categoryId: 'work',
+              startTime: DateTime(2026, 5, 25, 9),
+              endTime: DateTime(2026, 5, 25, 10),
+              title: 'Prep demo',
+              taskId: 'task-1',
+              reason: 'Morning focus.',
+            ),
+          ]);
+          final changeSet = seedChangeSet(
+            items: [
+              const ChangeItem(
+                toolName: 'move_block',
+                humanSummary: 'clear meta',
+                args: <String, dynamic>{
+                  'action': 'moved',
+                  // change-level rationale; must NOT clobber block.reason
+                  'reason': 'No longer tied.',
+                  'blockId': 'block-1',
+                  'taskId': null,
+                  // explicit per-block reason override (separate key)
+                  'blockReason': 'Shift to demo prep.',
+                  // categoryId not supplied — should retain 'work'
+                },
+              ),
+            ],
+          );
+
+          await createService().acceptPlanDiff(
+            agentId: _agentId,
+            changeSetId: changeSet.id,
+          );
+
+          final updated = upsertedEntities
+              .whereType<DayPlanEntity>()
+              .single
+              .data
+              .plannedBlocks
+              .single;
+          expect(updated.taskId, isNull);
+          expect(updated.reason, 'Shift to demo prep.');
+          // categoryId retained from live block
+          expect(updated.categoryId, 'work');
+        },
+      );
+
+      test(
+        'acceptPlanDiff rejects a drop targeting a block already dropped '
+        'earlier in the same batch',
+        () async {
+          seedPlan([
+            PlannedBlock(
+              id: 'block-1',
+              categoryId: 'work',
+              startTime: DateTime(2026, 5, 25, 9),
+              endTime: DateTime(2026, 5, 25, 10),
+              title: 'Prep demo',
+              reason: 'Morning focus.',
+            ),
+          ]);
+          final changeSet = seedChangeSet(
+            items: [dropBlockItem(), dropBlockItem()],
+          );
+
+          await expectLater(
+            createService().acceptPlanDiff(
+              agentId: _agentId,
+              changeSetId: changeSet.id,
+            ),
+            throwsA(
+              isA<DayAgentCaptureException>().having(
+                (e) => e.message,
+                'message',
+                contains('drop_block at index 1'),
+              ),
+            ),
+          );
+        },
+      );
+
+      test(
+        'acceptPlanDiff sorts blocks deterministically when an added block '
+        'shares a start time with an existing one',
+        () async {
+          seedPlan([
+            PlannedBlock(
+              id: 'block-1',
+              categoryId: 'work',
+              startTime: DateTime(2026, 5, 25, 9),
+              endTime: DateTime(2026, 5, 25, 10),
+              title: 'Prep demo',
+              reason: 'Morning focus.',
+            ),
+          ]);
+          // Use a deterministic id prefix; add_block always generates
+          // `block_<uuid>`, so the new block sorts AFTER 'block-1' by id
+          // when start times tie.
+          final changeSet = seedChangeSet(
+            items: [
+              ChangeItem(
+                toolName: 'add_block',
+                humanSummary: 'Add overlap',
+                args: <String, dynamic>{
+                  'action': 'added',
+                  'reason': 'Test tiebreaker.',
+                  'categoryId': 'work',
+                  'title': 'Other',
+                  'toStart': DateTime(
+                    2026,
+                    5,
+                    25,
+                    9,
+                  ).toIso8601String(),
+                  'toEnd': DateTime(
+                    2026,
+                    5,
+                    25,
+                    9,
+                    30,
+                  ).toIso8601String(),
+                },
+              ),
+            ],
+          );
+
+          await createService().acceptPlanDiff(
+            agentId: _agentId,
+            changeSetId: changeSet.id,
+          );
+
+          final blocks = upsertedEntities
+              .whereType<DayPlanEntity>()
+              .single
+              .data
+              .plannedBlocks;
+          expect(blocks, hasLength(2));
+          expect(blocks.first.startTime, DateTime(2026, 5, 25, 9));
+          expect(blocks.last.startTime, DateTime(2026, 5, 25, 9));
+          // block-1 sorts first when ids are compared lexicographically
+          // against `block_<uuid>`, so the live block stays at index 0.
+          expect(blocks.first.id, 'block-1');
+        },
+      );
+
+      test(
+        'revertPlanDiff with mixed pending and resolved items emits a '
+        'pendingCount that excludes already-resolved entries',
+        () async {
+          seedPlan([
+            PlannedBlock(
+              id: 'block-1',
+              categoryId: 'work',
+              startTime: DateTime(2026, 5, 25, 9),
+              endTime: DateTime(2026, 5, 25, 10),
+              title: 'Prep demo',
+              reason: 'Morning focus.',
+            ),
+          ]);
+          final changeSet = seedChangeSet(
+            items: [
+              moveBlockItem().copyWith(status: ChangeItemStatus.deferred),
+              addBlockItem(),
+            ],
+          );
+
+          final updated = await createService().revertPlanDiff(
+            agentId: _agentId,
+            changeSetId: changeSet.id,
+            itemIndices: const [1],
+          );
+
+          // The deferred item stays deferred; the add_block flips to rejected.
+          expect(updated.items[0].status, ChangeItemStatus.deferred);
+          expect(updated.items[1].status, ChangeItemStatus.rejected);
+        },
+      );
     });
 
     group('executeTool dispatch for refine', () {
@@ -1741,6 +2739,230 @@ void main() {
               jsonDecode(revertResult.output) as Map<String, dynamic>;
           expect(revertData['status'], 'resolved');
           expect(revertData['rejectedCount'], 1);
+        },
+      );
+
+      test(
+        'executeTool parses itemIndices including integral doubles',
+        () async {
+          final plan = seedPlan();
+          final changeSet =
+              AgentDomainEntity.changeSet(
+                    id: 'plan_diff:indices-1',
+                    agentId: _agentId,
+                    taskId: plan.id,
+                    threadId: _threadId,
+                    runKey: _runKey,
+                    status: ChangeSetStatus.pending,
+                    items: [
+                      const ChangeItem(
+                        toolName: 'add_block',
+                        humanSummary: 'a',
+                        args: <String, dynamic>{
+                          'action': 'added',
+                          'reason': 'r',
+                          'categoryId': 'life',
+                          'title': 'A',
+                          'toStart': '2026-05-25T14:00:00.000',
+                          'toEnd': '2026-05-25T14:30:00.000',
+                        },
+                      ),
+                      const ChangeItem(
+                        toolName: 'add_block',
+                        humanSummary: 'b',
+                        args: <String, dynamic>{
+                          'action': 'added',
+                          'reason': 'r',
+                          'categoryId': 'life',
+                          'title': 'B',
+                          'toStart': '2026-05-25T15:00:00.000',
+                          'toEnd': '2026-05-25T15:30:00.000',
+                        },
+                      ),
+                    ],
+                    createdAt: _now,
+                    vectorClock: null,
+                  )
+                  as ChangeSetEntity;
+          agentEntities[changeSet.id] = changeSet;
+
+          final result = await createService().executeTool(
+            agentId: _agentId,
+            threadId: _threadId,
+            runKey: _runKey,
+            toolName: DayAgentToolNames.acceptDiff,
+            args: {
+              'changeSetId': changeSet.id,
+              // Integral double mixed with int — both should parse as ints.
+              'itemIndices': const [0, 1.0],
+            },
+          );
+          expect(result.success, isTrue);
+          final data = jsonDecode(result.output) as Map<String, dynamic>;
+          expect(data['confirmedCount'], 2);
+        },
+      );
+
+      test('executeTool rejects non-list itemIndices', () async {
+        final plan = seedPlan();
+        final changeSet =
+            AgentDomainEntity.changeSet(
+                  id: 'plan_diff:indices-2',
+                  agentId: _agentId,
+                  taskId: plan.id,
+                  threadId: _threadId,
+                  runKey: _runKey,
+                  status: ChangeSetStatus.pending,
+                  items: const [
+                    ChangeItem(
+                      toolName: 'add_block',
+                      humanSummary: 'a',
+                      args: <String, dynamic>{
+                        'action': 'added',
+                        'reason': 'r',
+                        'categoryId': 'life',
+                        'title': 'A',
+                        'toStart': '2026-05-25T14:00:00.000',
+                        'toEnd': '2026-05-25T14:30:00.000',
+                      },
+                    ),
+                  ],
+                  createdAt: _now,
+                  vectorClock: null,
+                )
+                as ChangeSetEntity;
+        agentEntities[changeSet.id] = changeSet;
+
+        final result = await createService().executeTool(
+          agentId: _agentId,
+          threadId: _threadId,
+          runKey: _runKey,
+          toolName: DayAgentToolNames.acceptDiff,
+          args: {
+            'changeSetId': changeSet.id,
+            'itemIndices': 'not-a-list',
+          },
+        );
+        expect(result.success, isFalse);
+        expect(result.output, contains('itemIndices must be an array'));
+      });
+
+      test(
+        'executeTool resolution summary counts deferred + retained pending',
+        () async {
+          final plan = seedPlan();
+          // Seed a change set that includes a pending item, a deferred
+          // item, and a retracted item. Accepting only index 0 leaves
+          // the rest in their original (non-pending) states; the
+          // _resolutionSummary walks all statuses.
+          final changeSet =
+              AgentDomainEntity.changeSet(
+                    id: 'plan_diff:summary-1',
+                    agentId: _agentId,
+                    taskId: plan.id,
+                    threadId: _threadId,
+                    runKey: _runKey,
+                    status: ChangeSetStatus.partiallyResolved,
+                    items: const [
+                      ChangeItem(
+                        toolName: 'add_block',
+                        humanSummary: 'pending one',
+                        args: <String, dynamic>{
+                          'action': 'added',
+                          'reason': 'r',
+                          'categoryId': 'work',
+                          'title': 'P',
+                          'toStart': '2026-05-25T14:00:00.000',
+                          'toEnd': '2026-05-25T14:30:00.000',
+                        },
+                      ),
+                      ChangeItem(
+                        toolName: 'add_block',
+                        humanSummary: 'deferred',
+                        args: <String, dynamic>{'reason': 'r'},
+                        status: ChangeItemStatus.deferred,
+                      ),
+                      ChangeItem(
+                        toolName: 'add_block',
+                        humanSummary: 'retracted',
+                        args: <String, dynamic>{'reason': 'r'},
+                        status: ChangeItemStatus.retracted,
+                      ),
+                    ],
+                    createdAt: _now,
+                    vectorClock: null,
+                  )
+                  as ChangeSetEntity;
+          agentEntities[changeSet.id] = changeSet;
+
+          // Accept nothing (itemIndices: []) so the pending one stays
+          // pending; deferred/retracted are untouched by design.
+          final result = await createService().executeTool(
+            agentId: _agentId,
+            threadId: _threadId,
+            runKey: _runKey,
+            toolName: DayAgentToolNames.acceptDiff,
+            args: {
+              'changeSetId': changeSet.id,
+              'itemIndices': const <int>[],
+            },
+          );
+          expect(result.success, isTrue);
+          final data = jsonDecode(result.output) as Map<String, dynamic>;
+          expect(data['pendingCount'], 1);
+          expect(data['confirmedCount'], 0);
+          expect(data['rejectedCount'], 0);
+          expect(data['status'], 'partiallyResolved');
+        },
+      );
+
+      test(
+        'executeTool rejects fractional itemIndices entries',
+        () async {
+          final plan = seedPlan();
+          final changeSet =
+              AgentDomainEntity.changeSet(
+                    id: 'plan_diff:indices-3',
+                    agentId: _agentId,
+                    taskId: plan.id,
+                    threadId: _threadId,
+                    runKey: _runKey,
+                    status: ChangeSetStatus.pending,
+                    items: const [
+                      ChangeItem(
+                        toolName: 'add_block',
+                        humanSummary: 'a',
+                        args: <String, dynamic>{
+                          'action': 'added',
+                          'reason': 'r',
+                          'categoryId': 'life',
+                          'title': 'A',
+                          'toStart': '2026-05-25T14:00:00.000',
+                          'toEnd': '2026-05-25T14:30:00.000',
+                        },
+                      ),
+                    ],
+                    createdAt: _now,
+                    vectorClock: null,
+                  )
+                  as ChangeSetEntity;
+          agentEntities[changeSet.id] = changeSet;
+
+          final result = await createService().executeTool(
+            agentId: _agentId,
+            threadId: _threadId,
+            runKey: _runKey,
+            toolName: DayAgentToolNames.acceptDiff,
+            args: {
+              'changeSetId': changeSet.id,
+              'itemIndices': const [0.5],
+            },
+          );
+          expect(result.success, isFalse);
+          expect(
+            result.output,
+            contains('itemIndices entries must be integers'),
+          );
         },
       );
     });

--- a/test/features/daily_os_next/agents/service/day_agent_plan_service_test.dart
+++ b/test/features/daily_os_next/agents/service/day_agent_plan_service_test.dart
@@ -9,6 +9,7 @@ import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/agent_link.dart';
+import 'package:lotti/features/agents/model/change_set.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/day_agent_plan_models.dart';
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_capture_service.dart';
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_plan_service.dart';
@@ -839,6 +840,909 @@ void main() {
                 as List<String>;
         expect(captured, ['task-1']);
       });
+    });
+
+    group('proposePlanDiff', () {
+      DayPlanEntity seedPlan({
+        List<PlannedBlock>? blocks,
+        DayPlanStatus? status,
+      }) {
+        final plan =
+            AgentDomainEntity.dayPlan(
+                  id: 'day_agent_plan:$_dayId',
+                  agentId: _agentId,
+                  dayId: _dayId,
+                  planDate: DateTime(2026, 5, 25),
+                  data: DayPlanData(
+                    planDate: DateTime(2026, 5, 25),
+                    status: status ?? const DayPlanStatus.draft(),
+                    plannedBlocks:
+                        blocks ??
+                        [
+                          PlannedBlock(
+                            id: 'block-1',
+                            categoryId: 'work',
+                            startTime: DateTime(2026, 5, 25, 9),
+                            endTime: DateTime(2026, 5, 25, 10),
+                            title: 'Prep demo',
+                            reason: 'Morning focus.',
+                          ),
+                        ],
+                  ),
+                  capacityMinutes: 360,
+                  scheduledMinutes: 60,
+                  createdAt: _now,
+                  updatedAt: _now,
+                  vectorClock: null,
+                )
+                as DayPlanEntity;
+        agentEntities[plan.id] = plan;
+        return plan;
+      }
+
+      Map<String, Object?> movedChange({
+        String blockId = 'block-1',
+        DateTime? fromStart,
+        DateTime? fromEnd,
+        DateTime? toStart,
+        DateTime? toEnd,
+        String reason = 'Push to high-energy window.',
+      }) {
+        return {
+          'action': 'moved',
+          'blockId': blockId,
+          'reason': reason,
+          'from': {
+            'start': (fromStart ?? DateTime(2026, 5, 25, 9)).toIso8601String(),
+            'end': (fromEnd ?? DateTime(2026, 5, 25, 10)).toIso8601String(),
+            'title': 'Prep demo',
+          },
+          'to': {
+            'start': (toStart ?? DateTime(2026, 5, 25, 11)).toIso8601String(),
+            'end': (toEnd ?? DateTime(2026, 5, 25, 12)).toIso8601String(),
+          },
+        };
+      }
+
+      Map<String, Object?> addedChange({
+        DateTime? start,
+        DateTime? end,
+        String title = 'Walk',
+        String categoryId = 'life',
+      }) {
+        return {
+          'action': 'added',
+          'reason': 'Recovery between sprints.',
+          'to': {
+            'start': (start ?? DateTime(2026, 5, 25, 14)).toIso8601String(),
+            'end': (end ?? DateTime(2026, 5, 25, 14, 30)).toIso8601String(),
+            'title': title,
+            'categoryId': categoryId,
+            'type': 'manual',
+          },
+        };
+      }
+
+      Map<String, Object?> droppedChange({String blockId = 'block-1'}) {
+        return {
+          'action': 'dropped',
+          'blockId': blockId,
+          'reason': 'No longer needed.',
+          'from': {
+            'start': DateTime(2026, 5, 25, 9).toIso8601String(),
+            'end': DateTime(2026, 5, 25, 10).toIso8601String(),
+            'title': 'Prep demo',
+          },
+        };
+      }
+
+      test('persists a ChangeSetEntity and returns item summaries', () async {
+        seedPlan();
+
+        final changeSet = await withClock(Clock.fixed(_now), () {
+          return createService().proposePlanDiff(
+            agentId: _agentId,
+            threadId: _threadId,
+            runKey: _runKey,
+            dayId: _dayId,
+            rawChanges: [movedChange(), addedChange()],
+            captureId: 'capture-001',
+          );
+        });
+
+        expect(changeSet.id, startsWith('plan_diff:'));
+        expect(changeSet.agentId, _agentId);
+        expect(changeSet.taskId, 'day_agent_plan:$_dayId');
+        expect(changeSet.threadId, _threadId);
+        expect(changeSet.runKey, _runKey);
+        expect(changeSet.status, ChangeSetStatus.pending);
+        expect(changeSet.items, hasLength(2));
+        expect(changeSet.items.first.toolName, 'move_block');
+        expect(
+          changeSet.items.first.humanSummary,
+          contains('Move "Prep demo"'),
+        );
+        expect(changeSet.items.last.toolName, 'add_block');
+        expect(changeSet.items.last.humanSummary, contains('Add "Walk"'));
+        expect(changeSet.items.first.args['captureId'], 'capture-001');
+        expect(changeSet.items.last.args.containsKey('captureId'), isFalse);
+        expect(
+          upsertedEntities.whereType<ChangeSetEntity>().single,
+          changeSet,
+        );
+        expect(notifications, containsAll([_agentId, changeSet.id]));
+      });
+
+      test('rejects when no plan exists for the day', () async {
+        await expectLater(
+          createService().proposePlanDiff(
+            agentId: _agentId,
+            threadId: _threadId,
+            runKey: _runKey,
+            dayId: _dayId,
+            rawChanges: [movedChange()],
+          ),
+          throwsA(
+            isA<DayAgentCaptureException>().having(
+              (e) => e.message,
+              'message',
+              contains('no draft plan'),
+            ),
+          ),
+        );
+      });
+
+      test('rejects when the plan is not in draft state', () async {
+        // `committed` status is Phase 5 work; use the legacy `agreed`
+        // variant as a non-draft proxy until Commit lands.
+        seedPlan(
+          status: DayPlanStatus.agreed(agreedAt: DateTime(2026, 5, 25)),
+        );
+        await expectLater(
+          createService().proposePlanDiff(
+            agentId: _agentId,
+            threadId: _threadId,
+            runKey: _runKey,
+            dayId: _dayId,
+            rawChanges: [movedChange()],
+          ),
+          throwsA(
+            isA<DayAgentCaptureException>().having(
+              (e) => e.message,
+              'message',
+              contains('not in draft state'),
+            ),
+          ),
+        );
+      });
+
+      test('rejects when baselinePlanId is stale', () async {
+        final plan = seedPlan();
+        await expectLater(
+          createService().proposePlanDiff(
+            agentId: _agentId,
+            threadId: _threadId,
+            runKey: _runKey,
+            dayId: _dayId,
+            rawChanges: [movedChange()],
+            baselinePlanId: '${plan.id}-stale',
+          ),
+          throwsA(
+            isA<DayAgentCaptureException>().having(
+              (e) => e.message,
+              'message',
+              contains('does not match live plan'),
+            ),
+          ),
+        );
+      });
+
+      test('rejects when captureId is unknown', () async {
+        seedPlan();
+        await expectLater(
+          createService().proposePlanDiff(
+            agentId: _agentId,
+            threadId: _threadId,
+            runKey: _runKey,
+            dayId: _dayId,
+            rawChanges: [movedChange()],
+            captureId: 'capture-missing',
+          ),
+          throwsA(isA<DayAgentCaptureException>()),
+        );
+      });
+
+      test('rejects an empty changes list', () async {
+        seedPlan();
+        await expectLater(
+          createService().proposePlanDiff(
+            agentId: _agentId,
+            threadId: _threadId,
+            runKey: _runKey,
+            dayId: _dayId,
+            rawChanges: const [],
+          ),
+          throwsA(
+            isA<DayAgentCaptureException>().having(
+              (e) => e.message,
+              'message',
+              contains('at least one change'),
+            ),
+          ),
+        );
+      });
+
+      test('rejects moved without blockId / unknown blockId', () async {
+        seedPlan();
+        final service = createService();
+        await expectLater(
+          service.proposePlanDiff(
+            agentId: _agentId,
+            threadId: _threadId,
+            runKey: _runKey,
+            dayId: _dayId,
+            rawChanges: [
+              {
+                ...movedChange(),
+              }..remove('blockId'),
+            ],
+          ),
+          throwsA(isA<DayAgentCaptureException>()),
+        );
+        await expectLater(
+          service.proposePlanDiff(
+            agentId: _agentId,
+            threadId: _threadId,
+            runKey: _runKey,
+            dayId: _dayId,
+            rawChanges: [movedChange(blockId: 'block-ghost')],
+          ),
+          throwsA(
+            isA<DayAgentCaptureException>().having(
+              (e) => e.message,
+              'message',
+              contains('unknown blockId'),
+            ),
+          ),
+        );
+      });
+
+      test('rejects added missing required to fields', () async {
+        seedPlan();
+        await expectLater(
+          createService().proposePlanDiff(
+            agentId: _agentId,
+            threadId: _threadId,
+            runKey: _runKey,
+            dayId: _dayId,
+            rawChanges: [
+              {
+                'action': 'added',
+                'reason': 'No title.',
+                'to': {
+                  'start': DateTime(2026, 5, 25, 14).toIso8601String(),
+                  'end': DateTime(2026, 5, 25, 15).toIso8601String(),
+                  'categoryId': 'work',
+                },
+              },
+            ],
+          ),
+          throwsA(
+            isA<DayAgentCaptureException>().having(
+              (e) => e.message,
+              'message',
+              contains('to.title'),
+            ),
+          ),
+        );
+      });
+
+      test('rejects timestamps outside the plan day', () async {
+        seedPlan();
+        await expectLater(
+          createService().proposePlanDiff(
+            agentId: _agentId,
+            threadId: _threadId,
+            runKey: _runKey,
+            dayId: _dayId,
+            rawChanges: [
+              movedChange(
+                toStart: DateTime(2026, 5, 26, 9),
+                toEnd: DateTime(2026, 5, 26, 10),
+              ),
+            ],
+          ),
+          throwsA(
+            isA<DayAgentCaptureException>().having(
+              (e) => e.message,
+              'message',
+              contains('inside the plan day'),
+            ),
+          ),
+        );
+      });
+
+      test('rejects dropped without from snapshot', () async {
+        seedPlan();
+        await expectLater(
+          createService().proposePlanDiff(
+            agentId: _agentId,
+            threadId: _threadId,
+            runKey: _runKey,
+            dayId: _dayId,
+            rawChanges: [
+              {
+                ...droppedChange(),
+              }..remove('from'),
+            ],
+          ),
+          throwsA(
+            isA<DayAgentCaptureException>().having(
+              (e) => e.message,
+              'message',
+              contains('dropped change requires `from`'),
+            ),
+          ),
+        );
+      });
+    });
+
+    group('acceptPlanDiff / revertPlanDiff', () {
+      const planEntityId = 'day_agent_plan:$_dayId';
+
+      DayPlanEntity seedPlan(List<PlannedBlock> blocks) {
+        final scheduled = blocks.fold<int>(
+          0,
+          (sum, b) => sum + b.duration.inMinutes,
+        );
+        final plan =
+            AgentDomainEntity.dayPlan(
+                  id: planEntityId,
+                  agentId: _agentId,
+                  dayId: _dayId,
+                  planDate: DateTime(2026, 5, 25),
+                  data: DayPlanData(
+                    planDate: DateTime(2026, 5, 25),
+                    status: const DayPlanStatus.draft(),
+                    plannedBlocks: blocks,
+                  ),
+                  capacityMinutes: 360,
+                  scheduledMinutes: scheduled,
+                  createdAt: _now,
+                  updatedAt: _now,
+                  vectorClock: null,
+                )
+                as DayPlanEntity;
+        agentEntities[plan.id] = plan;
+        return plan;
+      }
+
+      ChangeSetEntity seedChangeSet({
+        required List<ChangeItem> items,
+      }) {
+        final changeSet =
+            AgentDomainEntity.changeSet(
+                  id: 'plan_diff:test-1',
+                  agentId: _agentId,
+                  taskId: planEntityId,
+                  threadId: _threadId,
+                  runKey: _runKey,
+                  status: ChangeSetStatus.pending,
+                  items: items,
+                  createdAt: _now,
+                  vectorClock: null,
+                )
+                as ChangeSetEntity;
+        agentEntities[changeSet.id] = changeSet;
+        return changeSet;
+      }
+
+      ChangeItem moveBlockItem({
+        String blockId = 'block-1',
+        DateTime? toStart,
+        DateTime? toEnd,
+        String? title,
+      }) {
+        return ChangeItem(
+          toolName: 'move_block',
+          humanSummary: 'Move "Prep demo"',
+          args: <String, dynamic>{
+            'action': 'moved',
+            'reason': 'New time.',
+            'blockId': blockId,
+            'toStart': (toStart ?? DateTime(2026, 5, 25, 11)).toIso8601String(),
+            'toEnd': (toEnd ?? DateTime(2026, 5, 25, 12)).toIso8601String(),
+            'title': ?title,
+          },
+        );
+      }
+
+      ChangeItem addBlockItem() {
+        return ChangeItem(
+          toolName: 'add_block',
+          humanSummary: 'Add "Walk"',
+          args: <String, dynamic>{
+            'action': 'added',
+            'reason': 'Recovery break.',
+            'toStart': DateTime(2026, 5, 25, 13).toIso8601String(),
+            'toEnd': DateTime(2026, 5, 25, 13, 30).toIso8601String(),
+            'title': 'Walk',
+            'categoryId': 'life',
+            'type': 'manual',
+          },
+        );
+      }
+
+      ChangeItem dropBlockItem({String blockId = 'block-1'}) {
+        return ChangeItem(
+          toolName: 'drop_block',
+          humanSummary: 'Drop "Prep demo"',
+          args: <String, dynamic>{
+            'action': 'dropped',
+            'reason': 'Not today.',
+            'blockId': blockId,
+          },
+        );
+      }
+
+      test(
+        'acceptPlanDiff applies all changes, rebuilds plan, writes decisions',
+        () async {
+          seedPlan([
+            PlannedBlock(
+              id: 'block-1',
+              categoryId: 'work',
+              startTime: DateTime(2026, 5, 25, 9),
+              endTime: DateTime(2026, 5, 25, 10),
+              title: 'Prep demo',
+              taskId: 'task-1',
+              reason: 'Morning focus.',
+            ),
+          ]);
+          final changeSet = seedChangeSet(
+            items: [moveBlockItem(), addBlockItem()],
+          );
+
+          final later = _now.add(const Duration(hours: 2));
+          final updated = await withClock(Clock.fixed(later), () {
+            return createService().acceptPlanDiff(
+              agentId: _agentId,
+              changeSetId: changeSet.id,
+            );
+          });
+
+          expect(updated.status, ChangeSetStatus.resolved);
+          expect(updated.resolvedAt, later);
+          expect(
+            updated.items.map((i) => i.status),
+            everyElement(ChangeItemStatus.confirmed),
+          );
+
+          final updatedPlan = upsertedEntities
+              .whereType<DayPlanEntity>()
+              .single;
+          expect(updatedPlan.data.plannedBlocks, hasLength(2));
+          expect(
+            updatedPlan.data.plannedBlocks.first.startTime,
+            DateTime(2026, 5, 25, 11),
+          );
+          expect(
+            updatedPlan.data.plannedBlocks.last.title,
+            'Walk',
+          );
+          expect(updatedPlan.scheduledMinutes, 90);
+          expect(updatedPlan.updatedAt, later);
+
+          final decisions = upsertedEntities
+              .whereType<ChangeDecisionEntity>()
+              .toList();
+          expect(decisions, hasLength(2));
+          expect(
+            decisions.map((d) => d.verdict),
+            everyElement(ChangeDecisionVerdict.confirmed),
+          );
+          expect(
+            decisions.map((d) => d.actor),
+            everyElement(DecisionActor.user),
+          );
+          expect(decisions.map((d) => d.itemIndex).toSet(), {0, 1});
+          expect(
+            notifications,
+            containsAll([_agentId, changeSet.id, _dayId, planEntityId]),
+          );
+        },
+      );
+
+      test('acceptPlanDiff with itemIndices only resolves selected', () async {
+        seedPlan([
+          PlannedBlock(
+            id: 'block-1',
+            categoryId: 'work',
+            startTime: DateTime(2026, 5, 25, 9),
+            endTime: DateTime(2026, 5, 25, 10),
+            title: 'Prep demo',
+            reason: 'Morning focus.',
+          ),
+        ]);
+        final changeSet = seedChangeSet(
+          items: [moveBlockItem(), addBlockItem()],
+        );
+
+        final updated = await withClock(Clock.fixed(_now), () {
+          return createService().acceptPlanDiff(
+            agentId: _agentId,
+            changeSetId: changeSet.id,
+            itemIndices: const [1],
+          );
+        });
+
+        expect(updated.status, ChangeSetStatus.partiallyResolved);
+        expect(updated.items[0].status, ChangeItemStatus.pending);
+        expect(updated.items[1].status, ChangeItemStatus.confirmed);
+        final updatedPlan = upsertedEntities.whereType<DayPlanEntity>().single;
+        expect(updatedPlan.data.plannedBlocks, hasLength(2));
+        expect(
+          updatedPlan.data.plannedBlocks.first.startTime,
+          DateTime(2026, 5, 25, 9),
+        );
+      });
+
+      test('acceptPlanDiff rejects when changeSet is missing', () async {
+        await expectLater(
+          createService().acceptPlanDiff(
+            agentId: _agentId,
+            changeSetId: 'plan_diff:ghost',
+          ),
+          throwsA(
+            isA<DayAgentCaptureException>().having(
+              (e) => e.message,
+              'message',
+              contains('change set'),
+            ),
+          ),
+        );
+      });
+
+      test(
+        'acceptPlanDiff rolls back when a selected item references a missing block',
+        () async {
+          seedPlan([
+            PlannedBlock(
+              id: 'block-1',
+              categoryId: 'work',
+              startTime: DateTime(2026, 5, 25, 9),
+              endTime: DateTime(2026, 5, 25, 10),
+              title: 'Prep demo',
+              reason: 'Morning focus.',
+            ),
+          ]);
+          final changeSet = seedChangeSet(
+            items: [
+              addBlockItem(),
+              moveBlockItem(blockId: 'block-ghost'),
+            ],
+          );
+
+          await expectLater(
+            createService().acceptPlanDiff(
+              agentId: _agentId,
+              changeSetId: changeSet.id,
+            ),
+            throwsA(isA<DayAgentCaptureException>()),
+          );
+          expect(
+            upsertedEntities.whereType<DayPlanEntity>(),
+            isEmpty,
+          );
+          expect(
+            upsertedEntities.whereType<ChangeSetEntity>(),
+            isEmpty,
+          );
+        },
+      );
+
+      test(
+        'acceptPlanDiff skips items already resolved on a re-issued accept',
+        () async {
+          seedPlan([
+            PlannedBlock(
+              id: 'block-1',
+              categoryId: 'work',
+              startTime: DateTime(2026, 5, 25, 9),
+              endTime: DateTime(2026, 5, 25, 10),
+              title: 'Prep demo',
+              reason: 'Morning focus.',
+            ),
+          ]);
+          final preResolvedItem = moveBlockItem().copyWith(
+            status: ChangeItemStatus.confirmed,
+          );
+          final changeSet = seedChangeSet(
+            items: [preResolvedItem, addBlockItem()],
+          );
+
+          final updated = await createService().acceptPlanDiff(
+            agentId: _agentId,
+            changeSetId: changeSet.id,
+          );
+
+          expect(updated.status, ChangeSetStatus.resolved);
+          expect(updated.items[0].status, ChangeItemStatus.confirmed);
+          expect(updated.items[1].status, ChangeItemStatus.confirmed);
+          // Only the still-pending item produced a decision row.
+          expect(
+            upsertedEntities.whereType<ChangeDecisionEntity>().single.itemIndex,
+            1,
+          );
+        },
+      );
+
+      test(
+        'revertPlanDiff flips pending items to rejected without mutating the plan',
+        () async {
+          seedPlan([
+            PlannedBlock(
+              id: 'block-1',
+              categoryId: 'work',
+              startTime: DateTime(2026, 5, 25, 9),
+              endTime: DateTime(2026, 5, 25, 10),
+              title: 'Prep demo',
+              reason: 'Morning focus.',
+            ),
+          ]);
+          final changeSet = seedChangeSet(
+            items: [moveBlockItem(), addBlockItem()],
+          );
+
+          final updated = await createService().revertPlanDiff(
+            agentId: _agentId,
+            changeSetId: changeSet.id,
+          );
+
+          expect(updated.status, ChangeSetStatus.resolved);
+          expect(
+            updated.items.map((i) => i.status),
+            everyElement(ChangeItemStatus.rejected),
+          );
+          expect(upsertedEntities.whereType<DayPlanEntity>(), isEmpty);
+          final decisions = upsertedEntities
+              .whereType<ChangeDecisionEntity>()
+              .toList();
+          expect(decisions, hasLength(2));
+          expect(
+            decisions.map((d) => d.verdict),
+            everyElement(ChangeDecisionVerdict.rejected),
+          );
+          expect(
+            decisions.map((d) => d.actor),
+            everyElement(DecisionActor.user),
+          );
+        },
+      );
+
+      test('revertPlanDiff with itemIndices only retracts selected', () async {
+        seedPlan([
+          PlannedBlock(
+            id: 'block-1',
+            categoryId: 'work',
+            startTime: DateTime(2026, 5, 25, 9),
+            endTime: DateTime(2026, 5, 25, 10),
+            title: 'Prep demo',
+            reason: 'Morning focus.',
+          ),
+        ]);
+        final changeSet = seedChangeSet(
+          items: [moveBlockItem(), addBlockItem()],
+        );
+
+        final updated = await createService().revertPlanDiff(
+          agentId: _agentId,
+          changeSetId: changeSet.id,
+          itemIndices: const [0],
+        );
+
+        expect(updated.status, ChangeSetStatus.partiallyResolved);
+        expect(updated.items[0].status, ChangeItemStatus.rejected);
+        expect(updated.items[1].status, ChangeItemStatus.pending);
+      });
+
+      test('acceptPlanDiff also drops blocks', () async {
+        seedPlan([
+          PlannedBlock(
+            id: 'block-1',
+            categoryId: 'work',
+            startTime: DateTime(2026, 5, 25, 9),
+            endTime: DateTime(2026, 5, 25, 10),
+            title: 'Prep demo',
+            reason: 'Morning focus.',
+          ),
+        ]);
+        final changeSet = seedChangeSet(items: [dropBlockItem()]);
+
+        await createService().acceptPlanDiff(
+          agentId: _agentId,
+          changeSetId: changeSet.id,
+        );
+
+        final updatedPlan = upsertedEntities.whereType<DayPlanEntity>().single;
+        expect(updatedPlan.data.plannedBlocks, isEmpty);
+        expect(updatedPlan.scheduledMinutes, 0);
+      });
+    });
+
+    group('executeTool dispatch for refine', () {
+      DayPlanEntity seedPlan() {
+        final plan =
+            AgentDomainEntity.dayPlan(
+                  id: 'day_agent_plan:$_dayId',
+                  agentId: _agentId,
+                  dayId: _dayId,
+                  planDate: DateTime(2026, 5, 25),
+                  data: DayPlanData(
+                    planDate: DateTime(2026, 5, 25),
+                    status: const DayPlanStatus.draft(),
+                    plannedBlocks: [
+                      PlannedBlock(
+                        id: 'block-1',
+                        categoryId: 'work',
+                        startTime: DateTime(2026, 5, 25, 9),
+                        endTime: DateTime(2026, 5, 25, 10),
+                        title: 'Prep demo',
+                        reason: 'Morning focus.',
+                      ),
+                    ],
+                  ),
+                  capacityMinutes: 360,
+                  scheduledMinutes: 60,
+                  createdAt: _now,
+                  updatedAt: _now,
+                  vectorClock: null,
+                )
+                as DayPlanEntity;
+        agentEntities[plan.id] = plan;
+        return plan;
+      }
+
+      test('executeTool returns JSON for propose_plan_diff', () async {
+        seedPlan();
+
+        final result = await withClock(Clock.fixed(_now), () {
+          return createService().executeTool(
+            agentId: _agentId,
+            threadId: _threadId,
+            runKey: _runKey,
+            toolName: DayAgentToolNames.proposePlanDiff,
+            args: {
+              'dayId': _dayId,
+              'changes': [
+                {
+                  'action': 'added',
+                  'reason': 'Slot lunch.',
+                  'to': {
+                    'start': DateTime(2026, 5, 25, 12).toIso8601String(),
+                    'end': DateTime(2026, 5, 25, 13).toIso8601String(),
+                    'title': 'Lunch',
+                    'categoryId': 'life',
+                    'type': 'manual',
+                  },
+                },
+              ],
+            },
+          );
+        });
+
+        expect(result.success, isTrue);
+        final data = jsonDecode(result.output) as Map<String, dynamic>;
+        expect(data['changeSetId'], isA<String>());
+        final items = data['items'] as List<dynamic>;
+        expect(items.single, containsPair('toolName', 'add_block'));
+      });
+
+      test(
+        'executeTool returns JSON for accept_diff and revert_diff',
+        () async {
+          final plan = seedPlan();
+          final changeSet =
+              AgentDomainEntity.changeSet(
+                    id: 'plan_diff:dispatch-1',
+                    agentId: _agentId,
+                    taskId: plan.id,
+                    threadId: _threadId,
+                    runKey: _runKey,
+                    status: ChangeSetStatus.pending,
+                    items: [
+                      ChangeItem(
+                        toolName: 'add_block',
+                        humanSummary: 'Add "Walk"',
+                        args: <String, dynamic>{
+                          'toStart': DateTime(
+                            2026,
+                            5,
+                            25,
+                            14,
+                          ).toIso8601String(),
+                          'toEnd': DateTime(
+                            2026,
+                            5,
+                            25,
+                            14,
+                            30,
+                          ).toIso8601String(),
+                          'title': 'Walk',
+                          'categoryId': 'life',
+                        },
+                      ),
+                    ],
+                    createdAt: _now,
+                    vectorClock: null,
+                  )
+                  as ChangeSetEntity;
+          agentEntities[changeSet.id] = changeSet;
+
+          final acceptResult = await createService().executeTool(
+            agentId: _agentId,
+            threadId: _threadId,
+            runKey: _runKey,
+            toolName: DayAgentToolNames.acceptDiff,
+            args: {'changeSetId': changeSet.id},
+          );
+          expect(acceptResult.success, isTrue);
+          final acceptData =
+              jsonDecode(acceptResult.output) as Map<String, dynamic>;
+          expect(acceptData['status'], 'resolved');
+          expect(acceptData['confirmedCount'], 1);
+
+          // Seed a fresh pending change set to exercise revert.
+          final revertSet =
+              AgentDomainEntity.changeSet(
+                    id: 'plan_diff:dispatch-2',
+                    agentId: _agentId,
+                    taskId: plan.id,
+                    threadId: _threadId,
+                    runKey: _runKey,
+                    status: ChangeSetStatus.pending,
+                    items: [
+                      ChangeItem(
+                        toolName: 'add_block',
+                        humanSummary: 'Add "Stretch"',
+                        args: <String, dynamic>{
+                          'toStart': DateTime(
+                            2026,
+                            5,
+                            25,
+                            15,
+                          ).toIso8601String(),
+                          'toEnd': DateTime(
+                            2026,
+                            5,
+                            25,
+                            15,
+                            15,
+                          ).toIso8601String(),
+                          'title': 'Stretch',
+                          'categoryId': 'life',
+                        },
+                      ),
+                    ],
+                    createdAt: _now,
+                    vectorClock: null,
+                  )
+                  as ChangeSetEntity;
+          agentEntities[revertSet.id] = revertSet;
+          final revertResult = await createService().executeTool(
+            agentId: _agentId,
+            threadId: _threadId,
+            runKey: _runKey,
+            toolName: DayAgentToolNames.revertDiff,
+            args: {'changeSetId': revertSet.id},
+          );
+          expect(revertResult.success, isTrue);
+          final revertData =
+              jsonDecode(revertResult.output) as Map<String, dynamic>;
+          expect(revertData['status'], 'resolved');
+          expect(revertData['rejectedCount'], 1);
+        },
+      );
     });
   });
 }

--- a/test/features/daily_os_next/agents/service/day_agent_service_test.dart
+++ b/test/features/daily_os_next/agents/service/day_agent_service_test.dart
@@ -606,6 +606,7 @@ void main() {
       DayPlanEntity seedPlan({
         String planAgentId = agentId,
         DateTime? deletedAt,
+        DayPlanStatus status = const DayPlanStatus.draft(),
       }) {
         return AgentDomainEntity.dayPlan(
               id: dayAgentPlanEntityId(dayId),
@@ -614,7 +615,7 @@ void main() {
               planDate: DateTime(2026, 5, 25),
               data: DayPlanData(
                 planDate: DateTime(2026, 5, 25),
-                status: const DayPlanStatus.draft(),
+                status: status,
               ),
               createdAt: now,
               updatedAt: now,
@@ -795,6 +796,35 @@ void main() {
 
         expect(result, isFalse);
         verifyNever(() => syncService.upsertEntity(any()));
+      });
+
+      test('returns false when the plan is not in draft state', () async {
+        when(
+          () => repository.getActiveAgentByKindAndActiveDayId(
+            kind: AgentKinds.dayAgent,
+            activeDayId: dayId,
+          ),
+        ).thenAnswer((_) async => identity());
+        stubPlanLookup(
+          seedPlan(
+            status: DayPlanStatus.agreed(agreedAt: DateTime(2026, 5, 25)),
+          ),
+        );
+
+        final result = await service.enqueueRefineWake(
+          dayDate: testDate,
+          transcript: 'something',
+        );
+
+        expect(result, isFalse);
+        verifyNever(() => syncService.upsertEntity(any()));
+        verifyNever(
+          () => orchestrator.enqueueManualWake(
+            agentId: any(named: 'agentId'),
+            reason: any(named: 'reason'),
+            triggerTokens: any(named: 'triggerTokens'),
+          ),
+        );
       });
     });
 

--- a/test/features/daily_os_next/agents/service/day_agent_service_test.dart
+++ b/test/features/daily_os_next/agents/service/day_agent_service_test.dart
@@ -1,5 +1,6 @@
 import 'package:clock/clock.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/day_plan.dart';
 import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
@@ -7,6 +8,7 @@ import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/agent_link.dart';
 import 'package:lotti/features/agents/service/agent_template_service.dart';
 import 'package:lotti/features/daily_os_next/agents/domain/day_agent_reconcile_models.dart';
+import 'package:lotti/features/daily_os_next/agents/domain/day_agent_slots.dart';
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_service.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -598,6 +600,202 @@ void main() {
           ).called(1);
         },
       );
+    });
+
+    group('enqueueRefineWake', () {
+      DayPlanEntity seedPlan({
+        String planAgentId = agentId,
+        DateTime? deletedAt,
+      }) {
+        return AgentDomainEntity.dayPlan(
+              id: dayAgentPlanEntityId(dayId),
+              agentId: planAgentId,
+              dayId: dayId,
+              planDate: DateTime(2026, 5, 25),
+              data: DayPlanData(
+                planDate: DateTime(2026, 5, 25),
+                status: const DayPlanStatus.draft(),
+              ),
+              createdAt: now,
+              updatedAt: now,
+              vectorClock: null,
+              deletedAt: deletedAt,
+            )
+            as DayPlanEntity;
+      }
+
+      void stubPlanLookup(DayPlanEntity? plan) {
+        when(
+          () => repository.getEntity(dayAgentPlanEntityId(dayId)),
+        ).thenAnswer((_) async => plan);
+      }
+
+      test(
+        'persists a refine capture and fires the wake with both tokens',
+        () async {
+          when(
+            () => repository.getActiveAgentByKindAndActiveDayId(
+              kind: AgentKinds.dayAgent,
+              activeDayId: dayId,
+            ),
+          ).thenAnswer((_) async => identity());
+          stubPlanLookup(seedPlan());
+
+          final result = await withClock(
+            Clock.fixed(now),
+            () => service.enqueueRefineWake(
+              dayDate: testDate,
+              transcript: 'move lunch to 1pm',
+            ),
+          );
+
+          expect(result, isTrue);
+          final captured = verify(
+            () => syncService.upsertEntity(captureAny()),
+          ).captured;
+          final capture = captured.single as CaptureEntity;
+          expect(capture.id, startsWith('refine_capture:'));
+          expect(capture.transcript, 'move lunch to 1pm');
+          expect(capture.capturedAt, now);
+          expect(changedTokens, [capture.id]);
+
+          final tokens =
+              verify(
+                    () => orchestrator.enqueueManualWake(
+                      agentId: agentId,
+                      reason: dayAgentRefineReason,
+                      triggerTokens: captureAny(named: 'triggerTokens'),
+                    ),
+                  ).captured.single
+                  as Set<String>;
+          expect(tokens, {
+            dayAgentRefineToken(dayId),
+            dayAgentCaptureSubmittedToken(capture.id),
+          });
+        },
+      );
+
+      test(
+        'blank transcript skips capture and fires wake with only refine token',
+        () async {
+          when(
+            () => repository.getActiveAgentByKindAndActiveDayId(
+              kind: AgentKinds.dayAgent,
+              activeDayId: dayId,
+            ),
+          ).thenAnswer((_) async => identity());
+          stubPlanLookup(seedPlan());
+
+          final result = await service.enqueueRefineWake(
+            dayDate: testDate,
+            transcript: '   ',
+          );
+
+          expect(result, isTrue);
+          verifyNever(() => syncService.upsertEntity(any()));
+          verify(
+            () => orchestrator.enqueueManualWake(
+              agentId: agentId,
+              reason: dayAgentRefineReason,
+              triggerTokens: {dayAgentRefineToken(dayId)},
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'returns false and skips enqueue when no day agent exists',
+        () async {
+          when(
+            () => repository.getActiveAgentByKindAndActiveDayId(
+              kind: AgentKinds.dayAgent,
+              activeDayId: dayId,
+            ),
+          ).thenAnswer((_) async => null);
+
+          final result = await service.enqueueRefineWake(
+            dayDate: testDate,
+            transcript: 'something',
+          );
+
+          expect(result, isFalse);
+          verifyNever(() => syncService.upsertEntity(any()));
+          verifyNever(
+            () => orchestrator.enqueueManualWake(
+              agentId: any(named: 'agentId'),
+              reason: any(named: 'reason'),
+              triggerTokens: any(named: 'triggerTokens'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'returns false and skips enqueue when no draft plan exists',
+        () async {
+          when(
+            () => repository.getActiveAgentByKindAndActiveDayId(
+              kind: AgentKinds.dayAgent,
+              activeDayId: dayId,
+            ),
+          ).thenAnswer((_) async => identity());
+          stubPlanLookup(null);
+
+          final result = await service.enqueueRefineWake(
+            dayDate: testDate,
+            transcript: 'something',
+          );
+
+          expect(result, isFalse);
+          verifyNever(() => syncService.upsertEntity(any()));
+          verifyNever(
+            () => orchestrator.enqueueManualWake(
+              agentId: any(named: 'agentId'),
+              reason: any(named: 'reason'),
+              triggerTokens: any(named: 'triggerTokens'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'returns false when the plan belongs to a different agent',
+        () async {
+          when(
+            () => repository.getActiveAgentByKindAndActiveDayId(
+              kind: AgentKinds.dayAgent,
+              activeDayId: dayId,
+            ),
+          ).thenAnswer((_) async => identity());
+          stubPlanLookup(seedPlan(planAgentId: 'other-agent'));
+
+          final result = await service.enqueueRefineWake(
+            dayDate: testDate,
+            transcript: 'something',
+          );
+
+          expect(result, isFalse);
+          verifyNever(() => syncService.upsertEntity(any()));
+        },
+      );
+
+      test('returns false when the plan is soft-deleted', () async {
+        when(
+          () => repository.getActiveAgentByKindAndActiveDayId(
+            kind: AgentKinds.dayAgent,
+            activeDayId: dayId,
+          ),
+        ).thenAnswer((_) async => identity());
+        stubPlanLookup(seedPlan(deletedAt: DateTime(2026, 5, 25)));
+
+        final result = await service.enqueueRefineWake(
+          dayDate: testDate,
+          transcript: 'something',
+        );
+
+        expect(result, isFalse);
+        verifyNever(() => syncService.upsertEntity(any()));
+      });
     });
 
     test('triggerReanalysis enqueues a manual reanalysis wake', () {

--- a/test/features/daily_os_next/agents/tools/day_agent_tools_test.dart
+++ b/test/features/daily_os_next/agents/tools/day_agent_tools_test.dart
@@ -31,6 +31,9 @@ void main() {
           DayAgentToolNames.createTaskFromPhrase,
           DayAgentToolNames.draftDayPlan,
           DayAgentToolNames.summarizeRecentPatterns,
+          DayAgentToolNames.proposePlanDiff,
+          DayAgentToolNames.acceptDiff,
+          DayAgentToolNames.revertDiff,
         ]),
       );
     });
@@ -152,14 +155,97 @@ void main() {
       );
     });
 
-    test('refine tool schemas are not registered yet', () {
-      // Their `DayAgentToolNames` constants and `planTools` membership
-      // exist so Phase 4 can wire schemas + service handlers atomically.
-      // Until then, the registry stays clean of unhandled tools.
-      final names = dayAgentTools.map((tool) => tool.name).toSet();
-      expect(names, isNot(contains(DayAgentToolNames.proposePlanDiff)));
-      expect(names, isNot(contains(DayAgentToolNames.acceptDiff)));
-      expect(names, isNot(contains(DayAgentToolNames.revertDiff)));
+    test('propose_plan_diff documents change-shape schema', () {
+      final properties =
+          parametersFor(DayAgentToolNames.proposePlanDiff)['properties']
+              as Map<String, dynamic>;
+      final changeSchema =
+          (properties['changes'] as Map<String, dynamic>)['items']
+              as Map<String, dynamic>;
+      final changeProperties =
+          changeSchema['properties'] as Map<String, dynamic>;
+
+      expect(
+        requiredFor(DayAgentToolNames.proposePlanDiff),
+        ['dayId', 'changes'],
+      );
+      expect(
+        (properties['changes'] as Map<String, dynamic>)['minItems'],
+        1,
+      );
+      expect(changeSchema['required'], ['action', 'reason']);
+      expect(changeSchema['additionalProperties'], isFalse);
+      expect(
+        (changeProperties['action'] as Map<String, dynamic>)['enum'],
+        ['moved', 'added', 'dropped'],
+      );
+      expect(
+        (changeProperties['reason'] as Map<String, dynamic>)['minLength'],
+        1,
+      );
+      final toProps =
+          (changeProperties['to'] as Map<String, dynamic>)['properties']
+              as Map<String, dynamic>;
+      expect(toProps.keys, containsAll(['start', 'end', 'reason']));
+    });
+
+    test('propose_plan_diff enforces action-specific required fields', () {
+      final changeSchema =
+          ((parametersFor(DayAgentToolNames.proposePlanDiff)['properties']
+                      as Map<String, dynamic>)['changes']
+                  as Map<String, dynamic>)['items']
+              as Map<String, dynamic>;
+      final allOf = changeSchema['allOf'] as List<dynamic>;
+      expect(allOf, hasLength(2));
+
+      final movedDroppedClause = allOf[0] as Map<String, dynamic>;
+      expect(
+        (((movedDroppedClause['if'] as Map<String, dynamic>)['properties']
+                as Map<String, dynamic>)['action']
+            as Map<String, dynamic>)['enum'],
+        ['moved', 'dropped'],
+      );
+      expect(
+        (movedDroppedClause['then'] as Map<String, dynamic>)['required'],
+        ['blockId', 'from'],
+      );
+
+      final movedAddedClause = allOf[1] as Map<String, dynamic>;
+      expect(
+        (((movedAddedClause['if'] as Map<String, dynamic>)['properties']
+                as Map<String, dynamic>)['action']
+            as Map<String, dynamic>)['enum'],
+        ['moved', 'added'],
+      );
+      expect(
+        (movedAddedClause['then'] as Map<String, dynamic>)['required'],
+        ['to'],
+      );
+    });
+
+    test('accept_diff and revert_diff share the resolution schema', () {
+      for (final name in const [
+        DayAgentToolNames.acceptDiff,
+        DayAgentToolNames.revertDiff,
+      ]) {
+        final params = parametersFor(name);
+        expect(params['required'], ['changeSetId'], reason: name);
+        expect(params['additionalProperties'], isFalse, reason: name);
+        final indices =
+            (params['properties'] as Map<String, dynamic>)['itemIndices']
+                as Map<String, dynamic>;
+        expect(indices['type'], 'array', reason: name);
+        expect(
+          (indices['items'] as Map<String, dynamic>)['type'],
+          'integer',
+          reason: name,
+        );
+        expect(
+          (indices['items'] as Map<String, dynamic>)['minimum'],
+          0,
+          reason: name,
+        );
+      }
     });
   });
 }

--- a/test/features/daily_os_next/agents/workflow/day_agent_workflow_test.dart
+++ b/test/features/daily_os_next/agents/workflow/day_agent_workflow_test.dart
@@ -684,6 +684,117 @@ void main() {
       },
     );
 
+    test(
+      'surfaces the baseline plan for refine-token wakes',
+      () async {
+        final planService = MockDayAgentPlanService();
+        final baselinePlan =
+            AgentDomainEntity.dayPlan(
+                  id: 'day_agent_plan:$dayId',
+                  agentId: agentId,
+                  dayId: dayId,
+                  planDate: DateTime(2026, 5, 25),
+                  data: DayPlanData(
+                    planDate: DateTime(2026, 5, 25),
+                    status: const DayPlanStatus.draft(),
+                    plannedBlocks: [
+                      PlannedBlock(
+                        id: 'block-1',
+                        categoryId: 'work',
+                        startTime: DateTime(2026, 5, 25, 9),
+                        endTime: DateTime(2026, 5, 25, 10),
+                        title: 'Prep demo',
+                        reason: 'Morning focus.',
+                      ),
+                    ],
+                  ),
+                  capacityMinutes: 360,
+                  scheduledMinutes: 60,
+                  createdAt: DateTime(2026, 5, 25, 8),
+                  updatedAt: DateTime(2026, 5, 25, 8),
+                  vectorClock: null,
+                )
+                as DayPlanEntity;
+        when(
+          () => planService.draftPlanForDay(
+            agentId: agentId,
+            dayId: dayId,
+          ),
+        ).thenAnswer((_) async => baselinePlan);
+
+        final result = await execute(
+          workflow(planService: planService),
+          triggerTokens: {dayAgentRefineToken(dayId), dayId},
+        );
+
+        expect(result.success, isTrue);
+        final userPayload =
+            jsonDecode(conversationRepository.lastUserMessage!)
+                as Map<String, dynamic>;
+        final refinePayload = userPayload['refine'] as Map<String, dynamic>;
+        expect(refinePayload['requested'], isTrue);
+        final plan = refinePayload['baselinePlan'] as Map<String, dynamic>;
+        expect(plan['planId'], 'day_agent_plan:$dayId');
+        final blocks = plan['blocks'] as List<dynamic>;
+        expect(
+          (blocks.single as Map<String, dynamic>)['id'],
+          'block-1',
+        );
+        // hydrateDecidedTasks must NOT be called on a refine wake.
+        verifyNever(
+          () => planService.hydrateDecidedTasks(
+            allowedCategoryIds: any(named: 'allowedCategoryIds'),
+            explicitTaskIds: any(named: 'explicitTaskIds'),
+            parsedItems: any(named: 'parsedItems'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'refine context carries a null baselinePlan when no draft exists',
+      () async {
+        final planService = MockDayAgentPlanService();
+        when(
+          () => planService.draftPlanForDay(
+            agentId: agentId,
+            dayId: dayId,
+          ),
+        ).thenAnswer((_) async => null);
+
+        final result = await execute(
+          workflow(planService: planService),
+          triggerTokens: {dayAgentRefineToken(dayId), dayId},
+        );
+
+        expect(result.success, isTrue);
+        final userPayload =
+            jsonDecode(conversationRepository.lastUserMessage!)
+                as Map<String, dynamic>;
+        final refinePayload = userPayload['refine'] as Map<String, dynamic>;
+        expect(refinePayload['requested'], isTrue);
+        expect(refinePayload['baselinePlan'], isNull);
+      },
+    );
+
+    test(
+      'omits the refine context when no refine token is present',
+      () async {
+        final planService = MockDayAgentPlanService();
+
+        final result = await execute(
+          workflow(planService: planService),
+          triggerTokens: {dayId},
+        );
+
+        expect(result.success, isTrue);
+        final userPayload =
+            jsonDecode(conversationRepository.lastUserMessage!)
+                as Map<String, dynamic>;
+        expect(userPayload.containsKey('refine'), isFalse);
+      },
+    );
+
     test('delegates capture tools to the configured capture service', () async {
       final captureService = MockDayAgentCaptureService();
       when(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plan refinement workflow: propose structured plan diffs (move/add/drop), include a non-empty reason per change, reference existing block IDs for moved/dropped items, and accept or revert pending diffs (partial resolution supported). Agents will not autonomously apply or reject diffs.

* **Usability**
  * Manual refine action for drafted day plans with optional short transcript submission.

* **Documentation**
  * Updated architecture and workflow docs describing refine flow, state transitions, and decision records.

* **Tests**
  * Extensive coverage added for plan-diff and refine workflows, validations, and partial apply/revert behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matthiasn/lotti/pull/3213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->