### PR TITLE
feat: wire day-agent commit + uncommit_day

### DIFF
--- a/lib/classes/day_plan.dart
+++ b/lib/classes/day_plan.dart
@@ -59,9 +59,11 @@ enum PlannedBlockState {
 /// State machine for day plan status.
 ///
 /// Transitions:
-/// - Draft -> Agreed (user agrees to plan)
-/// - Agreed -> NeedsReview (trigger event occurs)
-/// - NeedsReview -> Agreed (user re-agrees)
+/// - Draft -> Agreed (legacy: user agrees to plan)
+/// - Agreed -> NeedsReview (legacy: trigger event occurs)
+/// - NeedsReview -> Agreed (legacy: user re-agrees)
+/// - Draft -> Committed (day-agent: user commits to plan; agent shifts to
+///   shepherding mode, one-way)
 @freezed
 sealed class DayPlanStatus with _$DayPlanStatus {
   /// Initial state - plan exists but not yet committed to.
@@ -80,6 +82,13 @@ sealed class DayPlanStatus with _$DayPlanStatus {
     /// When the plan was last agreed (before this review trigger)
     DateTime? previouslyAgreedAt,
   }) = DayPlanStatusNeedsReview;
+
+  /// Day-agent terminal state: user committed to the plan and the agent
+  /// has shifted from drafting to shepherding mode. One-way from
+  /// [DayPlanStatus.draft]; further changes require an explicit refine.
+  const factory DayPlanStatus.committed({
+    required DateTime committedAt,
+  }) = DayPlanStatusCommitted;
 
   factory DayPlanStatus.fromJson(Map<String, dynamic> json) =>
       _$DayPlanStatusFromJson(json);

--- a/lib/classes/day_plan.freezed.dart
+++ b/lib/classes/day_plan.freezed.dart
@@ -27,6 +27,10 @@ DayPlanStatus _$DayPlanStatusFromJson(
           return DayPlanStatusNeedsReview.fromJson(
             json
           );
+                case 'committed':
+          return DayPlanStatusCommitted.fromJson(
+            json
+          );
         
           default:
             throw CheckedFromJsonException(
@@ -85,13 +89,14 @@ extension DayPlanStatusPatterns on DayPlanStatus {
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( DayPlanStatusDraft value)?  draft,TResult Function( DayPlanStatusAgreed value)?  agreed,TResult Function( DayPlanStatusNeedsReview value)?  needsReview,required TResult orElse(),}){
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( DayPlanStatusDraft value)?  draft,TResult Function( DayPlanStatusAgreed value)?  agreed,TResult Function( DayPlanStatusNeedsReview value)?  needsReview,TResult Function( DayPlanStatusCommitted value)?  committed,required TResult orElse(),}){
 final _that = this;
 switch (_that) {
 case DayPlanStatusDraft() when draft != null:
 return draft(_that);case DayPlanStatusAgreed() when agreed != null:
 return agreed(_that);case DayPlanStatusNeedsReview() when needsReview != null:
-return needsReview(_that);case _:
+return needsReview(_that);case DayPlanStatusCommitted() when committed != null:
+return committed(_that);case _:
   return orElse();
 
 }
@@ -109,13 +114,14 @@ return needsReview(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( DayPlanStatusDraft value)  draft,required TResult Function( DayPlanStatusAgreed value)  agreed,required TResult Function( DayPlanStatusNeedsReview value)  needsReview,}){
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( DayPlanStatusDraft value)  draft,required TResult Function( DayPlanStatusAgreed value)  agreed,required TResult Function( DayPlanStatusNeedsReview value)  needsReview,required TResult Function( DayPlanStatusCommitted value)  committed,}){
 final _that = this;
 switch (_that) {
 case DayPlanStatusDraft():
 return draft(_that);case DayPlanStatusAgreed():
 return agreed(_that);case DayPlanStatusNeedsReview():
-return needsReview(_that);}
+return needsReview(_that);case DayPlanStatusCommitted():
+return committed(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -129,13 +135,14 @@ return needsReview(_that);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( DayPlanStatusDraft value)?  draft,TResult? Function( DayPlanStatusAgreed value)?  agreed,TResult? Function( DayPlanStatusNeedsReview value)?  needsReview,}){
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( DayPlanStatusDraft value)?  draft,TResult? Function( DayPlanStatusAgreed value)?  agreed,TResult? Function( DayPlanStatusNeedsReview value)?  needsReview,TResult? Function( DayPlanStatusCommitted value)?  committed,}){
 final _that = this;
 switch (_that) {
 case DayPlanStatusDraft() when draft != null:
 return draft(_that);case DayPlanStatusAgreed() when agreed != null:
 return agreed(_that);case DayPlanStatusNeedsReview() when needsReview != null:
-return needsReview(_that);case _:
+return needsReview(_that);case DayPlanStatusCommitted() when committed != null:
+return committed(_that);case _:
   return null;
 
 }
@@ -152,12 +159,13 @@ return needsReview(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function()?  draft,TResult Function( DateTime agreedAt)?  agreed,TResult Function( DateTime triggeredAt,  DayPlanReviewReason reason,  DateTime? previouslyAgreedAt)?  needsReview,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function()?  draft,TResult Function( DateTime agreedAt)?  agreed,TResult Function( DateTime triggeredAt,  DayPlanReviewReason reason,  DateTime? previouslyAgreedAt)?  needsReview,TResult Function( DateTime committedAt)?  committed,required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case DayPlanStatusDraft() when draft != null:
 return draft();case DayPlanStatusAgreed() when agreed != null:
 return agreed(_that.agreedAt);case DayPlanStatusNeedsReview() when needsReview != null:
-return needsReview(_that.triggeredAt,_that.reason,_that.previouslyAgreedAt);case _:
+return needsReview(_that.triggeredAt,_that.reason,_that.previouslyAgreedAt);case DayPlanStatusCommitted() when committed != null:
+return committed(_that.committedAt);case _:
   return orElse();
 
 }
@@ -175,12 +183,13 @@ return needsReview(_that.triggeredAt,_that.reason,_that.previouslyAgreedAt);case
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function()  draft,required TResult Function( DateTime agreedAt)  agreed,required TResult Function( DateTime triggeredAt,  DayPlanReviewReason reason,  DateTime? previouslyAgreedAt)  needsReview,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function()  draft,required TResult Function( DateTime agreedAt)  agreed,required TResult Function( DateTime triggeredAt,  DayPlanReviewReason reason,  DateTime? previouslyAgreedAt)  needsReview,required TResult Function( DateTime committedAt)  committed,}) {final _that = this;
 switch (_that) {
 case DayPlanStatusDraft():
 return draft();case DayPlanStatusAgreed():
 return agreed(_that.agreedAt);case DayPlanStatusNeedsReview():
-return needsReview(_that.triggeredAt,_that.reason,_that.previouslyAgreedAt);}
+return needsReview(_that.triggeredAt,_that.reason,_that.previouslyAgreedAt);case DayPlanStatusCommitted():
+return committed(_that.committedAt);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///
@@ -194,12 +203,13 @@ return needsReview(_that.triggeredAt,_that.reason,_that.previouslyAgreedAt);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function()?  draft,TResult? Function( DateTime agreedAt)?  agreed,TResult? Function( DateTime triggeredAt,  DayPlanReviewReason reason,  DateTime? previouslyAgreedAt)?  needsReview,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function()?  draft,TResult? Function( DateTime agreedAt)?  agreed,TResult? Function( DateTime triggeredAt,  DayPlanReviewReason reason,  DateTime? previouslyAgreedAt)?  needsReview,TResult? Function( DateTime committedAt)?  committed,}) {final _that = this;
 switch (_that) {
 case DayPlanStatusDraft() when draft != null:
 return draft();case DayPlanStatusAgreed() when agreed != null:
 return agreed(_that.agreedAt);case DayPlanStatusNeedsReview() when needsReview != null:
-return needsReview(_that.triggeredAt,_that.reason,_that.previouslyAgreedAt);case _:
+return needsReview(_that.triggeredAt,_that.reason,_that.previouslyAgreedAt);case DayPlanStatusCommitted() when committed != null:
+return committed(_that.committedAt);case _:
   return null;
 
 }
@@ -391,6 +401,79 @@ triggeredAt: null == triggeredAt ? _self.triggeredAt : triggeredAt // ignore: ca
 as DateTime,reason: null == reason ? _self.reason : reason // ignore: cast_nullable_to_non_nullable
 as DayPlanReviewReason,previouslyAgreedAt: freezed == previouslyAgreedAt ? _self.previouslyAgreedAt : previouslyAgreedAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class DayPlanStatusCommitted implements DayPlanStatus {
+  const DayPlanStatusCommitted({required this.committedAt, final  String? $type}): $type = $type ?? 'committed';
+  factory DayPlanStatusCommitted.fromJson(Map<String, dynamic> json) => _$DayPlanStatusCommittedFromJson(json);
+
+ final  DateTime committedAt;
+
+@JsonKey(name: 'runtimeType')
+final String $type;
+
+
+/// Create a copy of DayPlanStatus
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$DayPlanStatusCommittedCopyWith<DayPlanStatusCommitted> get copyWith => _$DayPlanStatusCommittedCopyWithImpl<DayPlanStatusCommitted>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$DayPlanStatusCommittedToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is DayPlanStatusCommitted&&(identical(other.committedAt, committedAt) || other.committedAt == committedAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,committedAt);
+
+@override
+String toString() {
+  return 'DayPlanStatus.committed(committedAt: $committedAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $DayPlanStatusCommittedCopyWith<$Res> implements $DayPlanStatusCopyWith<$Res> {
+  factory $DayPlanStatusCommittedCopyWith(DayPlanStatusCommitted value, $Res Function(DayPlanStatusCommitted) _then) = _$DayPlanStatusCommittedCopyWithImpl;
+@useResult
+$Res call({
+ DateTime committedAt
+});
+
+
+
+
+}
+/// @nodoc
+class _$DayPlanStatusCommittedCopyWithImpl<$Res>
+    implements $DayPlanStatusCommittedCopyWith<$Res> {
+  _$DayPlanStatusCommittedCopyWithImpl(this._self, this._then);
+
+  final DayPlanStatusCommitted _self;
+  final $Res Function(DayPlanStatusCommitted) _then;
+
+/// Create a copy of DayPlanStatus
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? committedAt = null,}) {
+  return _then(DayPlanStatusCommitted(
+committedAt: null == committedAt ? _self.committedAt : committedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,
   ));
 }
 

--- a/lib/classes/day_plan.g.dart
+++ b/lib/classes/day_plan.g.dart
@@ -52,6 +52,20 @@ const _$DayPlanReviewReasonEnumMap = {
   DayPlanReviewReason.manualReset: 'manualReset',
 };
 
+DayPlanStatusCommitted _$DayPlanStatusCommittedFromJson(
+  Map<String, dynamic> json,
+) => DayPlanStatusCommitted(
+  committedAt: DateTime.parse(json['committedAt'] as String),
+  $type: json['runtimeType'] as String?,
+);
+
+Map<String, dynamic> _$DayPlanStatusCommittedToJson(
+  DayPlanStatusCommitted instance,
+) => <String, dynamic>{
+  'committedAt': instance.committedAt.toIso8601String(),
+  'runtimeType': instance.$type,
+};
+
 _PlannedBlock _$PlannedBlockFromJson(Map<String, dynamic> json) =>
     _PlannedBlock(
       id: json['id'] as String,

--- a/lib/features/agents/model/seeded_directives.dart
+++ b/lib/features/agents/model/seeded_directives.dart
@@ -112,6 +112,28 @@ const seedDirectiveChangelog = <SeedDirectiveChange>[
         '`refine.baselinePlan.blocks`. Never call `accept_diff` or '
         '`revert_diff` autonomously — those are user verdicts.',
   ),
+  SeedDirectiveChange(
+    date: '2026-05-26',
+    kind: AgentTemplateKind.dayAgent,
+    description:
+        'Commit tool (`commit_day`) is now available. Never call '
+        "`commit_day` autonomously — committing is the user's decision. "
+        'Once a plan is committed (`DayPlanStatus.committed`), do not '
+        'call `draft_day_plan` or `propose_plan_diff` against it: the '
+        'service rejects both. Further edits require a refine wake the '
+        'user initiates.',
+  ),
+  SeedDirectiveChange(
+    date: '2026-05-26',
+    kind: AgentTemplateKind.dayAgent,
+    description:
+        'Uncommit tool (`uncommit_day`) is now available as the escape '
+        'hatch from a committed plan. Never call `uncommit_day` '
+        'autonomously — it is the user-initiated "edit committed plan" '
+        'action and flips the plan back to draft so drafting/refine tools '
+        'become callable again. inProgress/completed/dropped blocks are '
+        'preserved as history.',
+  ),
 ];
 
 // ── Task Agent: General Directive ──────────────────────────────────────────
@@ -363,8 +385,19 @@ You are Shepherd, a day-level planning agent for Daily OS.
   Every change must include a non-empty `reason`.
 - Never call `accept_diff` or `revert_diff` autonomously — those are the user's
   verdicts on a pending `ChangeSetEntity`, surfaced through the UI.
-- Commit, shutdown, and agenda mutation tools are not available yet. Do not
-  invent unavailable day-plan tools.''';
+- Never call `commit_day` autonomously — committing a day is the user's
+  decision, surfaced through the UI's "Lock in" CTA. Once a plan is
+  committed, you shift from drafting to shepherding: do not call
+  `draft_day_plan` or `propose_plan_diff` against a committed plan. The
+  service rejects both, so attempting either wastes a tool roundtrip.
+  Further edits require either a refine wake which the user initiates,
+  or `uncommit_day` which only the user invokes.
+- Never call `uncommit_day` autonomously either — uncommitting is the
+  user's "edit committed plan" escape hatch. It flips the plan back to
+  draft so drafting and refine tools become callable again. Wait for the
+  user to invoke it through the UI.
+- Shutdown and agenda mutation tools are not available yet. Do not invent
+  unavailable day-plan tools.''';
 
 // ── Day Agent: Report Directive ────────────────────────────────────────────
 

--- a/lib/features/daily_os_next/agents/service/day_agent_plan_service.dart
+++ b/lib/features/daily_os_next/agents/service/day_agent_plan_service.dart
@@ -75,6 +75,14 @@ class DayAgentPlanService {
           agentId: agentId,
           args: args,
         ),
+        DayAgentToolNames.commitDay => await _commitDayTool(
+          agentId: agentId,
+          args: args,
+        ),
+        DayAgentToolNames.uncommitDay => await _uncommitDayTool(
+          agentId: agentId,
+          args: args,
+        ),
         _ => throw DayAgentCaptureException('unknown tool "$toolName"'),
       };
       return DayAgentDirectToolResult.success(data);
@@ -308,6 +316,120 @@ class DayAgentPlanService {
       itemIndices: itemIndices,
       apply: false,
     );
+  }
+
+  /// Commit the day's draft plan: flip `DayPlanStatus.draft` →
+  /// `DayPlanStatus.committed` and walk every `drafted` block to
+  /// `committed`. Blocks already in `inProgress` / `completed` / `dropped`
+  /// keep their state.
+  ///
+  /// Idempotent: when the plan is already `committed`, the live entity is
+  /// returned unchanged (no write, no notification). Throws
+  /// [DayAgentCaptureException] when no plan exists, the agent does not
+  /// own it, or the plan is in some other non-draft / non-committed state
+  /// (e.g. legacy `agreed` / `needsReview`).
+  Future<DayPlanEntity> commitDay({
+    required String agentId,
+    required String dayId,
+  }) async {
+    await _requireIdentity(agentId);
+    final plan = await draftPlanForDay(agentId: agentId, dayId: dayId);
+    if (plan == null) {
+      throw DayAgentCaptureException(
+        'no draft plan for $dayId; call draft_day_plan first',
+      );
+    }
+    if (plan.data.status is DayPlanStatusCommitted) {
+      // Idempotent no-op: re-commit returns the live plan without a write.
+      return plan;
+    }
+    if (plan.data.status is! DayPlanStatusDraft) {
+      throw const DayAgentCaptureException(
+        'plan is not in draft state; commit is gated to drafts',
+      );
+    }
+
+    final now = clock.now();
+    final flippedBlocks = [
+      for (final block in plan.data.plannedBlocks)
+        if (block.state == PlannedBlockState.drafted)
+          block.copyWith(state: PlannedBlockState.committed)
+        else
+          block,
+    ];
+    final committedPlan = plan.copyWith(
+      data: plan.data.copyWith(
+        status: DayPlanStatus.committed(committedAt: now),
+        plannedBlocks: flippedBlocks,
+      ),
+      updatedAt: now,
+    );
+
+    await syncService.upsertEntity(committedPlan);
+    onPersistedStateChanged
+      ?..call(agentId)
+      ..call(dayId)
+      ..call(committedPlan.id);
+    return committedPlan;
+  }
+
+  /// Revert a committed day plan back to draft so the user can edit it again.
+  ///
+  /// Mirrors [commitDay] in reverse: flips `DayPlanStatus.committed` →
+  /// `DayPlanStatus.draft` and walks each `committed` block back to
+  /// `drafted`. Blocks already in `inProgress` / `completed` / `dropped`
+  /// keep their state — those reflect what actually happened during the
+  /// day and are preserved as history.
+  ///
+  /// Idempotent: when the plan is already `draft`, the live entity is
+  /// returned unchanged (no write, no notification). Throws
+  /// [DayAgentCaptureException] when no plan exists, the agent does not
+  /// own it, or the plan is in some other non-draft / non-committed state
+  /// (e.g. legacy `agreed` / `needsReview`).
+  Future<DayPlanEntity> uncommitDay({
+    required String agentId,
+    required String dayId,
+  }) async {
+    await _requireIdentity(agentId);
+    final plan = await draftPlanForDay(agentId: agentId, dayId: dayId);
+    if (plan == null) {
+      throw DayAgentCaptureException(
+        'no plan for $dayId to uncommit',
+      );
+    }
+    if (plan.data.status is DayPlanStatusDraft) {
+      // Idempotent no-op: already a draft, no work to do.
+      return plan;
+    }
+    if (plan.data.status is! DayPlanStatusCommitted) {
+      throw const DayAgentCaptureException(
+        'plan is not in committed state; uncommit is gated to committed '
+        'plans',
+      );
+    }
+
+    final now = clock.now();
+    final flippedBlocks = [
+      for (final block in plan.data.plannedBlocks)
+        if (block.state == PlannedBlockState.committed)
+          block.copyWith(state: PlannedBlockState.drafted)
+        else
+          block,
+    ];
+    final uncommittedPlan = plan.copyWith(
+      data: plan.data.copyWith(
+        status: const DayPlanStatus.draft(),
+        plannedBlocks: flippedBlocks,
+      ),
+      updatedAt: now,
+    );
+
+    await syncService.upsertEntity(uncommittedPlan);
+    onPersistedStateChanged
+      ?..call(agentId)
+      ..call(dayId)
+      ..call(uncommittedPlan.id);
+    return uncommittedPlan;
   }
 
   Future<ChangeSetEntity> _resolvePlanDiff({
@@ -793,6 +915,43 @@ class DayAgentPlanService {
       itemIndices: _optionalIntList(args['itemIndices']),
     );
     return _resolutionSummary(changeSet);
+  }
+
+  Future<Map<String, Object?>> _commitDayTool({
+    required String agentId,
+    required Map<String, dynamic> args,
+  }) async {
+    final committedPlan = await commitDay(
+      agentId: agentId,
+      dayId: _requiredString(args, 'dayId'),
+    );
+    final status = committedPlan.data.status;
+    final committedAt = status is DayPlanStatusCommitted
+        ? status.committedAt
+        : null;
+    return <String, Object?>{
+      'planId': committedPlan.id,
+      'dayId': committedPlan.dayId,
+      'status': 'committed',
+      'committedAt': committedAt?.toIso8601String(),
+      'blockCount': committedPlan.data.plannedBlocks.length,
+    };
+  }
+
+  Future<Map<String, Object?>> _uncommitDayTool({
+    required String agentId,
+    required Map<String, dynamic> args,
+  }) async {
+    final plan = await uncommitDay(
+      agentId: agentId,
+      dayId: _requiredString(args, 'dayId'),
+    );
+    return <String, Object?>{
+      'planId': plan.id,
+      'dayId': plan.dayId,
+      'status': 'draft',
+      'blockCount': plan.data.plannedBlocks.length,
+    };
   }
 
   static Map<String, Object?> _resolutionSummary(ChangeSetEntity changeSet) {

--- a/lib/features/daily_os_next/agents/tools/day_agent_tool_names.dart
+++ b/lib/features/daily_os_next/agents/tools/day_agent_tool_names.dart
@@ -45,6 +45,12 @@ abstract final class DayAgentToolNames {
   /// Retracts a proposed plan diff without mutating the plan entity.
   static const revertDiff = 'revert_diff';
 
+  /// Commits the day's draft plan; agent shifts from drafting to shepherding.
+  static const commitDay = 'commit_day';
+
+  /// Reverts a committed day plan back to draft so it can be edited again.
+  static const uncommitDay = 'uncommit_day';
+
   /// Foundation tools implemented by the day-agent workflow itself.
   static const foundationHandlerTools = <String>{
     setNextWake,
@@ -62,13 +68,16 @@ abstract final class DayAgentToolNames {
     createTaskFromPhrase,
   };
 
-  /// Plan-mutation tools delegated to the plan service (draft + refine).
+  /// Plan-mutation tools delegated to the plan service (draft + refine +
+  /// commit/uncommit).
   static const planTools = <String>{
     draftDayPlan,
     summarizeRecentPatterns,
     proposePlanDiff,
     acceptDiff,
     revertDiff,
+    commitDay,
+    uncommitDay,
   };
 
   /// Tools that require workflow-level handling instead of local strategy state.

--- a/lib/features/daily_os_next/agents/tools/day_agent_tools.dart
+++ b/lib/features/daily_os_next/agents/tools/day_agent_tools.dart
@@ -500,4 +500,39 @@ const dayAgentTools = <AgentToolDefinition>[
       'additionalProperties': false,
     },
   ),
+  AgentToolDefinition(
+    name: DayAgentToolNames.commitDay,
+    description:
+        "Commit the day's draft plan. Flips DayPlanStatus.draft → "
+        'DayPlanStatus.committed and walks every drafted block to '
+        'PlannedBlockState.committed. The agent shifts to shepherding mode; '
+        'further edits require an explicit refine. Idempotent: re-commit '
+        'on an already-committed plan returns the current state.',
+    parameters: {
+      'type': 'object',
+      'properties': {
+        'dayId': {'type': 'string'},
+      },
+      'required': ['dayId'],
+      'additionalProperties': false,
+    },
+  ),
+  AgentToolDefinition(
+    name: DayAgentToolNames.uncommitDay,
+    description:
+        'Revert a committed day plan back to draft so the user can edit it '
+        'again. Flips DayPlanStatus.committed → DayPlanStatus.draft and '
+        'walks each committed block back to PlannedBlockState.drafted. '
+        'Blocks already in inProgress / completed / dropped keep their '
+        'state (history preservation). Idempotent: calling on a draft plan '
+        'returns the live plan unchanged.',
+    parameters: {
+      'type': 'object',
+      'properties': {
+        'dayId': {'type': 'string'},
+      },
+      'required': ['dayId'],
+      'additionalProperties': false,
+    },
+  ),
 ];

--- a/test/classes/day_plan_test.dart
+++ b/test/classes/day_plan_test.dart
@@ -112,6 +112,24 @@ void main() {
           isNull,
         );
       });
+
+      test('committed can be serialized and deserialized', () {
+        final status = DayPlanStatus.committed(
+          committedAt: DateTime(2026, 5, 25, 9, 30),
+        );
+
+        final json = jsonEncode(status.toJson());
+        final fromJson = DayPlanStatus.fromJson(
+          jsonDecode(json) as Map<String, dynamic>,
+        );
+
+        expect(fromJson, equals(status));
+        expect(fromJson, isA<DayPlanStatusCommitted>());
+        expect(
+          (fromJson as DayPlanStatusCommitted).committedAt,
+          equals(DateTime(2026, 5, 25, 9, 30)),
+        );
+      });
     });
 
     group('PlannedBlock', () {

--- a/test/features/daily_os_next/agents/service/day_agent_plan_service_test.dart
+++ b/test/features/daily_os_next/agents/service/day_agent_plan_service_test.dart
@@ -2568,6 +2568,486 @@ void main() {
       );
     });
 
+    group('commitDay', () {
+      const planEntityId = 'day_agent_plan:$_dayId';
+
+      DayPlanEntity seedPlan({
+        DayPlanStatus status = const DayPlanStatus.draft(),
+        List<PlannedBlock>? blocks,
+      }) {
+        final plan =
+            AgentDomainEntity.dayPlan(
+                  id: planEntityId,
+                  agentId: _agentId,
+                  dayId: _dayId,
+                  planDate: DateTime(2026, 5, 25),
+                  data: DayPlanData(
+                    planDate: DateTime(2026, 5, 25),
+                    status: status,
+                    plannedBlocks:
+                        blocks ??
+                        [
+                          PlannedBlock(
+                            id: 'block-1',
+                            categoryId: 'work',
+                            startTime: DateTime(2026, 5, 25, 9),
+                            endTime: DateTime(2026, 5, 25, 10),
+                            title: 'Prep demo',
+                            reason: 'Morning focus.',
+                          ),
+                          PlannedBlock(
+                            id: 'block-2',
+                            categoryId: 'life',
+                            startTime: DateTime(2026, 5, 25, 12),
+                            endTime: DateTime(2026, 5, 25, 13),
+                            title: 'Lunch',
+                          ),
+                        ],
+                  ),
+                  capacityMinutes: 360,
+                  scheduledMinutes: 120,
+                  createdAt: _now,
+                  updatedAt: _now,
+                  vectorClock: null,
+                )
+                as DayPlanEntity;
+        agentEntities[plan.id] = plan;
+        return plan;
+      }
+
+      test(
+        'commitDay flips status + every drafted block, persists, notifies',
+        () async {
+          seedPlan();
+
+          final later = _now.add(const Duration(hours: 2));
+          final committed = await withClock(Clock.fixed(later), () {
+            return createService().commitDay(
+              agentId: _agentId,
+              dayId: _dayId,
+            );
+          });
+
+          expect(committed.data.status, isA<DayPlanStatusCommitted>());
+          expect(
+            (committed.data.status as DayPlanStatusCommitted).committedAt,
+            later,
+          );
+          expect(
+            committed.data.plannedBlocks.map((b) => b.state),
+            everyElement(PlannedBlockState.committed),
+          );
+          expect(committed.updatedAt, later);
+          expect(upsertedEntities.single, committed);
+          expect(
+            notifications,
+            containsAll([_agentId, _dayId, committed.id]),
+          );
+        },
+      );
+
+      test(
+        'commitDay leaves non-drafted block states alone',
+        () async {
+          seedPlan(
+            blocks: [
+              PlannedBlock(
+                id: 'block-1',
+                categoryId: 'work',
+                startTime: DateTime(2026, 5, 25, 9),
+                endTime: DateTime(2026, 5, 25, 10),
+                title: 'In progress',
+                reason: 'Morning focus.',
+                state: PlannedBlockState.inProgress,
+              ),
+              PlannedBlock(
+                id: 'block-2',
+                categoryId: 'work',
+                startTime: DateTime(2026, 5, 25, 11),
+                endTime: DateTime(2026, 5, 25, 12),
+                title: 'Drafted',
+                reason: 'Focus.',
+              ),
+              PlannedBlock(
+                id: 'block-3',
+                categoryId: 'life',
+                startTime: DateTime(2026, 5, 25, 13),
+                endTime: DateTime(2026, 5, 25, 14),
+                title: 'Completed',
+                state: PlannedBlockState.completed,
+              ),
+              PlannedBlock(
+                id: 'block-4',
+                categoryId: 'life',
+                startTime: DateTime(2026, 5, 25, 15),
+                endTime: DateTime(2026, 5, 25, 16),
+                title: 'Dropped',
+                state: PlannedBlockState.dropped,
+              ),
+            ],
+          );
+
+          final committed = await createService().commitDay(
+            agentId: _agentId,
+            dayId: _dayId,
+          );
+
+          final byId = {
+            for (final b in committed.data.plannedBlocks) b.id: b,
+          };
+          expect(byId['block-1']!.state, PlannedBlockState.inProgress);
+          expect(byId['block-2']!.state, PlannedBlockState.committed);
+          expect(byId['block-3']!.state, PlannedBlockState.completed);
+          expect(byId['block-4']!.state, PlannedBlockState.dropped);
+        },
+      );
+
+      test(
+        'commitDay is idempotent — re-commit returns the live plan without a write',
+        () async {
+          seedPlan(
+            status: DayPlanStatus.committed(
+              committedAt: DateTime(2026, 5, 25, 11),
+            ),
+            blocks: [
+              PlannedBlock(
+                id: 'block-1',
+                categoryId: 'work',
+                startTime: DateTime(2026, 5, 25, 9),
+                endTime: DateTime(2026, 5, 25, 10),
+                title: 'Prep demo',
+                reason: 'Morning focus.',
+                state: PlannedBlockState.committed,
+              ),
+            ],
+          );
+
+          final returned = await createService().commitDay(
+            agentId: _agentId,
+            dayId: _dayId,
+          );
+
+          expect(returned.data.status, isA<DayPlanStatusCommitted>());
+          expect(upsertedEntities, isEmpty);
+          expect(notifications, isEmpty);
+        },
+      );
+
+      test('commitDay rejects when no plan exists', () async {
+        await expectLater(
+          createService().commitDay(agentId: _agentId, dayId: _dayId),
+          throwsA(
+            isA<DayAgentCaptureException>().having(
+              (e) => e.message,
+              'message',
+              contains('no draft plan'),
+            ),
+          ),
+        );
+      });
+
+      test(
+        'commitDay rejects plans in legacy non-draft / non-committed states',
+        () async {
+          seedPlan(
+            status: DayPlanStatus.agreed(agreedAt: DateTime(2026, 5, 25)),
+          );
+
+          await expectLater(
+            createService().commitDay(agentId: _agentId, dayId: _dayId),
+            throwsA(
+              isA<DayAgentCaptureException>().having(
+                (e) => e.message,
+                'message',
+                contains('not in draft state'),
+              ),
+            ),
+          );
+          expect(upsertedEntities, isEmpty);
+        },
+      );
+
+      test(
+        'commitDay rejects when the plan belongs to a different agent',
+        () async {
+          final plan =
+              AgentDomainEntity.dayPlan(
+                    id: planEntityId,
+                    agentId: 'other-agent',
+                    dayId: _dayId,
+                    planDate: DateTime(2026, 5, 25),
+                    data: DayPlanData(
+                      planDate: DateTime(2026, 5, 25),
+                      status: const DayPlanStatus.draft(),
+                    ),
+                    createdAt: _now,
+                    updatedAt: _now,
+                    vectorClock: null,
+                  )
+                  as DayPlanEntity;
+          agentEntities[plan.id] = plan;
+
+          await expectLater(
+            createService().commitDay(agentId: _agentId, dayId: _dayId),
+            throwsA(
+              isA<DayAgentCaptureException>().having(
+                (e) => e.message,
+                'message',
+                contains('no draft plan'),
+              ),
+            ),
+          );
+        },
+      );
+
+      test('executeTool returns JSON for commit_day', () async {
+        seedPlan();
+        final later = _now.add(const Duration(hours: 1));
+        final result = await withClock(Clock.fixed(later), () {
+          return createService().executeTool(
+            agentId: _agentId,
+            threadId: _threadId,
+            runKey: _runKey,
+            toolName: DayAgentToolNames.commitDay,
+            args: {'dayId': _dayId},
+          );
+        });
+
+        expect(result.success, isTrue);
+        final data = jsonDecode(result.output) as Map<String, dynamic>;
+        expect(data['planId'], 'day_agent_plan:$_dayId');
+        expect(data['dayId'], _dayId);
+        expect(data['status'], 'committed');
+        expect(data['blockCount'], 2);
+        expect(data['committedAt'], later.toIso8601String());
+      });
+
+      test('executeTool surfaces commit failures as tool errors', () async {
+        // No plan seeded; commit_day should fail.
+        final result = await createService().executeTool(
+          agentId: _agentId,
+          threadId: _threadId,
+          runKey: _runKey,
+          toolName: DayAgentToolNames.commitDay,
+          args: {'dayId': _dayId},
+        );
+
+        expect(result.success, isFalse);
+        expect(result.output, contains('no draft plan'));
+      });
+    });
+
+    group('uncommitDay', () {
+      const planEntityId = 'day_agent_plan:$_dayId';
+
+      DayPlanEntity seedPlan({
+        DayPlanStatus status = const DayPlanStatus.draft(),
+        List<PlannedBlock>? blocks,
+      }) {
+        final plan =
+            AgentDomainEntity.dayPlan(
+                  id: planEntityId,
+                  agentId: _agentId,
+                  dayId: _dayId,
+                  planDate: DateTime(2026, 5, 25),
+                  data: DayPlanData(
+                    planDate: DateTime(2026, 5, 25),
+                    status: status,
+                    plannedBlocks:
+                        blocks ??
+                        [
+                          PlannedBlock(
+                            id: 'block-1',
+                            categoryId: 'work',
+                            startTime: DateTime(2026, 5, 25, 9),
+                            endTime: DateTime(2026, 5, 25, 10),
+                            title: 'Prep demo',
+                            reason: 'Morning focus.',
+                            state: PlannedBlockState.committed,
+                          ),
+                        ],
+                  ),
+                  createdAt: _now,
+                  updatedAt: _now,
+                  vectorClock: null,
+                )
+                as DayPlanEntity;
+        agentEntities[plan.id] = plan;
+        return plan;
+      }
+
+      test(
+        'uncommitDay flips status back to draft and walks committed blocks '
+        'back to drafted',
+        () async {
+          seedPlan(
+            status: DayPlanStatus.committed(
+              committedAt: DateTime(2026, 5, 25, 11),
+            ),
+          );
+
+          final later = _now.add(const Duration(hours: 2));
+          final plan = await withClock(Clock.fixed(later), () {
+            return createService().uncommitDay(
+              agentId: _agentId,
+              dayId: _dayId,
+            );
+          });
+
+          expect(plan.data.status, isA<DayPlanStatusDraft>());
+          expect(
+            plan.data.plannedBlocks.map((b) => b.state),
+            everyElement(PlannedBlockState.drafted),
+          );
+          expect(plan.updatedAt, later);
+          expect(upsertedEntities.single, plan);
+          expect(notifications, containsAll([_agentId, _dayId, plan.id]));
+        },
+      );
+
+      test(
+        'uncommitDay preserves inProgress / completed / dropped blocks',
+        () async {
+          seedPlan(
+            status: DayPlanStatus.committed(
+              committedAt: DateTime(2026, 5, 25, 11),
+            ),
+            blocks: [
+              PlannedBlock(
+                id: 'block-1',
+                categoryId: 'work',
+                startTime: DateTime(2026, 5, 25, 9),
+                endTime: DateTime(2026, 5, 25, 10),
+                title: 'Still committed',
+                reason: 'r',
+                state: PlannedBlockState.committed,
+              ),
+              PlannedBlock(
+                id: 'block-2',
+                categoryId: 'work',
+                startTime: DateTime(2026, 5, 25, 11),
+                endTime: DateTime(2026, 5, 25, 12),
+                title: 'In progress',
+                state: PlannedBlockState.inProgress,
+              ),
+              PlannedBlock(
+                id: 'block-3',
+                categoryId: 'life',
+                startTime: DateTime(2026, 5, 25, 13),
+                endTime: DateTime(2026, 5, 25, 14),
+                title: 'Completed',
+                state: PlannedBlockState.completed,
+              ),
+              PlannedBlock(
+                id: 'block-4',
+                categoryId: 'life',
+                startTime: DateTime(2026, 5, 25, 15),
+                endTime: DateTime(2026, 5, 25, 16),
+                title: 'Dropped',
+                state: PlannedBlockState.dropped,
+              ),
+            ],
+          );
+
+          final plan = await createService().uncommitDay(
+            agentId: _agentId,
+            dayId: _dayId,
+          );
+
+          final byId = {
+            for (final b in plan.data.plannedBlocks) b.id: b,
+          };
+          expect(byId['block-1']!.state, PlannedBlockState.drafted);
+          expect(byId['block-2']!.state, PlannedBlockState.inProgress);
+          expect(byId['block-3']!.state, PlannedBlockState.completed);
+          expect(byId['block-4']!.state, PlannedBlockState.dropped);
+        },
+      );
+
+      test(
+        'uncommitDay is idempotent on draft plans (no write, no notification)',
+        () async {
+          seedPlan(
+            blocks: [
+              PlannedBlock(
+                id: 'block-1',
+                categoryId: 'work',
+                startTime: DateTime(2026, 5, 25, 9),
+                endTime: DateTime(2026, 5, 25, 10),
+                title: 'Already draft',
+                reason: 'r',
+              ),
+            ],
+          );
+
+          final returned = await createService().uncommitDay(
+            agentId: _agentId,
+            dayId: _dayId,
+          );
+
+          expect(returned.data.status, isA<DayPlanStatusDraft>());
+          expect(upsertedEntities, isEmpty);
+          expect(notifications, isEmpty);
+        },
+      );
+
+      test('uncommitDay rejects when no plan exists', () async {
+        await expectLater(
+          createService().uncommitDay(agentId: _agentId, dayId: _dayId),
+          throwsA(
+            isA<DayAgentCaptureException>().having(
+              (e) => e.message,
+              'message',
+              contains('no plan'),
+            ),
+          ),
+        );
+      });
+
+      test(
+        'uncommitDay rejects legacy non-draft / non-committed states',
+        () async {
+          seedPlan(
+            status: DayPlanStatus.agreed(agreedAt: DateTime(2026, 5, 25)),
+          );
+
+          await expectLater(
+            createService().uncommitDay(agentId: _agentId, dayId: _dayId),
+            throwsA(
+              isA<DayAgentCaptureException>().having(
+                (e) => e.message,
+                'message',
+                contains('not in committed state'),
+              ),
+            ),
+          );
+          expect(upsertedEntities, isEmpty);
+        },
+      );
+
+      test('executeTool returns JSON for uncommit_day', () async {
+        seedPlan(
+          status: DayPlanStatus.committed(
+            committedAt: DateTime(2026, 5, 25, 11),
+          ),
+        );
+
+        final result = await createService().executeTool(
+          agentId: _agentId,
+          threadId: _threadId,
+          runKey: _runKey,
+          toolName: DayAgentToolNames.uncommitDay,
+          args: {'dayId': _dayId},
+        );
+
+        expect(result.success, isTrue);
+        final data = jsonDecode(result.output) as Map<String, dynamic>;
+        expect(data['planId'], 'day_agent_plan:$_dayId');
+        expect(data['status'], 'draft');
+        expect(data['blockCount'], 1);
+      });
+    });
+
     group('executeTool dispatch for refine', () {
       DayPlanEntity seedPlan() {
         final plan =

--- a/test/features/daily_os_next/agents/tools/day_agent_tool_names_test.dart
+++ b/test/features/daily_os_next/agents/tools/day_agent_tool_names_test.dart
@@ -19,6 +19,8 @@ void main() {
       DayAgentToolNames.proposePlanDiff,
       DayAgentToolNames.acceptDiff,
       DayAgentToolNames.revertDiff,
+      DayAgentToolNames.commitDay,
+      DayAgentToolNames.uncommitDay,
     ];
 
     test('uses the wire names expected by the day-agent prompt', () {
@@ -38,6 +40,8 @@ void main() {
         'propose_plan_diff',
         'accept_diff',
         'revert_diff',
+        'commit_day',
+        'uncommit_day',
       ]);
     });
 
@@ -71,6 +75,8 @@ void main() {
           DayAgentToolNames.proposePlanDiff,
           DayAgentToolNames.acceptDiff,
           DayAgentToolNames.revertDiff,
+          DayAgentToolNames.commitDay,
+          DayAgentToolNames.uncommitDay,
         },
       );
       expect(
@@ -126,6 +132,14 @@ void main() {
       );
       expect(
         DayAgentToolNames.isPlanTool(DayAgentToolNames.revertDiff),
+        isTrue,
+      );
+      expect(
+        DayAgentToolNames.isPlanTool(DayAgentToolNames.commitDay),
+        isTrue,
+      );
+      expect(
+        DayAgentToolNames.isPlanTool(DayAgentToolNames.uncommitDay),
         isTrue,
       );
       expect(

--- a/test/features/daily_os_next/agents/tools/day_agent_tools_test.dart
+++ b/test/features/daily_os_next/agents/tools/day_agent_tools_test.dart
@@ -34,6 +34,8 @@ void main() {
           DayAgentToolNames.proposePlanDiff,
           DayAgentToolNames.acceptDiff,
           DayAgentToolNames.revertDiff,
+          DayAgentToolNames.commitDay,
+          DayAgentToolNames.uncommitDay,
         ]),
       );
     });
@@ -221,6 +223,25 @@ void main() {
         (movedAddedClause['then'] as Map<String, dynamic>)['required'],
         ['to'],
       );
+    });
+
+    test('commit_day and uncommit_day require dayId only', () {
+      for (final name in const [
+        DayAgentToolNames.commitDay,
+        DayAgentToolNames.uncommitDay,
+      ]) {
+        final params = parametersFor(name);
+        expect(params['type'], 'object', reason: name);
+        expect(params['required'], ['dayId'], reason: name);
+        expect(params['additionalProperties'], isFalse, reason: name);
+        final properties = params['properties'] as Map<String, dynamic>;
+        expect(properties.keys, ['dayId'], reason: name);
+        expect(
+          (properties['dayId'] as Map<String, dynamic>)['type'],
+          'string',
+          reason: name,
+        );
+      }
     });
 
     test('accept_diff and revert_diff share the resolution schema', () {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Day plans now support a committed state for finalized plans with timestamp tracking
  * Added commit operation to transition drafted plans to committed status
  * Added uncommit operation to revert committed plans back to draft status
  * Blocks automatically update their status during commit/uncommit transitions

* **Tests**
  * Added comprehensive test coverage for commit and uncommit operations
  * Added tests for status state serialization and deserialization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matthiasn/lotti/pull/3214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->