### PR TITLE
fix: color picker overflows the Create Category modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   if the timer stops before you accept them.
 - Agent workflow diagnostics no longer write suggestion argument values or raw
   exception text into runtime log files.
+- The Create Category modal's colour picker no longer overflows on desktop:
+  the hue slider used to be clipped off the right edge of the modal, leaving
+  the colour ungrabbable. The picker now fits inside the modal width on every
+  platform, with the saturation square clamped to the design-system size.
 
 ## [0.9.1005]
 ### Changed

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -42,6 +42,7 @@
           <p>Sync now preserves local sequence mappings when recovering burnt vector-clock counters, reducing cases where peers can get stuck on unresolvable gaps.</p>
           <p>Fixed: task-agent suggestions no longer disappear wholesale while an agent wake is running, and stale running-timer update proposals are automatically retracted if the timer stops before you accept them.</p>
           <p>Fixed: agent workflow diagnostics no longer write suggestion argument values or raw exception text into runtime log files.</p>
+          <p>Fixed: the Create Category modal's colour picker no longer overflows on desktop — the hue slider used to be clipped off the right edge of the modal, leaving the colour ungrabbable.</p>
       </description>
     </release>
     <release version="0.9.1005" date="2026-05-22">

--- a/lib/classes/supported_language.dart
+++ b/lib/classes/supported_language.dart
@@ -43,7 +43,8 @@ enum SupportedLanguage {
   uk('uk', 'Ukrainian'),
   vi('vi', 'Vietnamese'),
   pcm('pcm', 'Nigerian Pidgin'),
-  yo('yo', 'Yoruba');
+  yo('yo', 'Yoruba')
+  ;
 
   const SupportedLanguage(this.code, this.name);
   final String code;

--- a/lib/features/ai/services/skill_inference_runner.dart
+++ b/lib/features/ai/services/skill_inference_runner.dart
@@ -898,7 +898,8 @@ typedef _InferenceTarget = ({
 /// magic-string literal that could typo-drift across the codebase.
 enum _OverrideSlotKind {
   transcription('transcription'),
-  imageAnalysis('image analysis');
+  imageAnalysis('image analysis')
+  ;
 
   const _OverrideSlotKind(this.label);
 

--- a/lib/features/ai/ui/settings/ai_settings_filter_state.dart
+++ b/lib/features/ai/ui/settings/ai_settings_filter_state.dart
@@ -36,7 +36,8 @@ abstract class AiSettingsFilterState with _$AiSettingsFilterState {
 enum AiSettingsTab {
   providers,
   models,
-  profiles;
+  profiles
+  ;
 
   /// Human-readable display name for the tab
   String get displayName {

--- a/lib/features/categories/domain/category_icon.dart
+++ b/lib/features/categories/domain/category_icon.dart
@@ -74,6 +74,15 @@ class CategoryIconConstants {
   /// Small border radius for color picker
   static const double colorPickerBorderRadius = 10;
 
+  /// Upper clamp on the `flutter_colorpicker` saturation/value square
+  /// — matches the package's own default (`colorPickerWidth = 300`) so
+  /// wide modals don't get a disproportionately huge picker. There is
+  /// no lower clamp on purpose: with `portraitOnly: true` the whole
+  /// picker is exactly this wide, so enforcing a minimum bigger than
+  /// the available width would just re-introduce horizontal overflow
+  /// on extremely narrow surfaces (split-views, narrow test rigs).
+  static const double colorPickerMaxSquareWidth = 300;
+
   /// Standard section spacing
   static const double sectionSpacing = 16;
 

--- a/lib/features/categories/ui/widgets/category_create_modal.dart
+++ b/lib/features/categories/ui/widgets/category_create_modal.dart
@@ -12,6 +12,25 @@ import 'package:lotti/services/dev_logger.dart';
 import 'package:lotti/utils/color.dart';
 import 'package:lotti/widgets/buttons/lotti_tertiary_button.dart';
 
+/// Returns the width to pass to `flutter_colorpicker.ColorPicker` given
+/// the [available] horizontal space inside the modal.
+///
+/// In `portraitOnly: true` mode the package sizes the whole picker
+/// (saturation square + hue slider below it) from `colorPickerWidth`,
+/// so this single value drives the entire layout. The result is
+/// clamped to the design-system maximum so wide modals don't render a
+/// disproportionately huge picker; the lower bound is `0.0` so an
+/// extremely narrow surface (split-view, tight column) shrinks the
+/// picker rather than overflowing it (red-team review by
+/// gemini-code-assist on PR #3215).
+@visibleForTesting
+double pickerSquareWidthFor(double available) {
+  return available.clamp(
+    0.0,
+    CategoryIconConstants.colorPickerMaxSquareWidth,
+  );
+}
+
 class CategoryCreateModal extends ConsumerStatefulWidget {
   const CategoryCreateModal({
     required this.onCategoryCreated,
@@ -80,18 +99,51 @@ class _CategoryCreateModalState extends ConsumerState<CategoryCreateModal> {
                     style: Theme.of(context).textTheme.titleLarge,
                   ),
                   const SizedBox(height: CategoryIconConstants.sectionSpacing),
-                  ColorPicker(
-                    pickerColor: _pickerColor,
-                    enableAlpha: false,
-                    labelTypes: const [],
-                    onColorChanged: (color) {
-                      setState(() {
-                        _pickerColor = color;
-                      });
+                  // `flutter_colorpicker` ships two layouts keyed off
+                  // `MediaQuery.of(context).orientation`:
+                  //   * portrait — saturation square on top, hue slider
+                  //     below; both derive their width from
+                  //     `colorPickerWidth`, so the whole picker is
+                  //     exactly `colorPickerWidth` wide.
+                  //   * landscape — saturation square on the left, a
+                  //     `sliderByPaletteType` Row on the right whose
+                  //     slider column is hard-coded to 260 px wide
+                  //     regardless of `colorPickerWidth`.
+                  // Desktop hosts (macOS, Linux, web) report landscape
+                  // orientation, so the package picks the landscape
+                  // branch inside our WoltModalSheet page and the
+                  // 260-px slider blew past the modal's right edge.
+                  //
+                  // `portraitOnly: true` forces the portrait branch
+                  // regardless of host orientation; the LayoutBuilder
+                  // then sizes the entire picker to fit available
+                  // width. The lower clamp is 0 (not a "preferred
+                  // minimum"): on extremely narrow surfaces — tight
+                  // split-views, custom test rigs — enforcing a fixed
+                  // minimum like 200 px would re-introduce a small
+                  // overflow. Scaling gracefully down to whatever
+                  // space we get is the safer default.
+                  LayoutBuilder(
+                    builder: (context, constraints) {
+                      final squareWidth = pickerSquareWidthFor(
+                        constraints.maxWidth,
+                      );
+                      return ColorPicker(
+                        pickerColor: _pickerColor,
+                        enableAlpha: false,
+                        labelTypes: const [],
+                        colorPickerWidth: squareWidth,
+                        portraitOnly: true,
+                        onColorChanged: (color) {
+                          setState(() {
+                            _pickerColor = color;
+                          });
+                        },
+                        pickerAreaBorderRadius: BorderRadius.circular(
+                          CategoryIconConstants.colorPickerBorderRadius,
+                        ),
+                      );
                     },
-                    pickerAreaBorderRadius: BorderRadius.circular(
-                      CategoryIconConstants.colorPickerBorderRadius,
-                    ),
                   ),
                   const SizedBox(height: CategoryIconConstants.sectionSpacing),
                   _buildIconPicker(),

--- a/lib/features/journal/state/linked_entries_activity_filter.dart
+++ b/lib/features/journal/state/linked_entries_activity_filter.dart
@@ -12,7 +12,8 @@ import 'package:lotti/classes/journal_entities.dart';
 enum LinkedEntryActivityFilter {
   timer,
   audio,
-  images;
+  images
+  ;
 
   /// Returns the pill kind a [entity] belongs to, or `null` when the entity
   /// is not part of the activity-filter taxonomy and should always render.

--- a/lib/features/sync/model/sync_node_profile.dart
+++ b/lib/features/sync/model/sync_node_profile.dart
@@ -15,7 +15,8 @@ enum NodeCapability {
   mlxAudio,
   ollamaLlm,
   voxtral,
-  whisper;
+  whisper
+  ;
 
   /// The inference-provider type this capability advertises support for.
   /// Used when filtering known nodes for a profile's pinning UI: a profile

--- a/lib/services/linux_location_portal.dart
+++ b/lib/services/linux_location_portal.dart
@@ -20,7 +20,8 @@ enum PortalAccuracy {
   city(2),
   neighborhood(3),
   street(4),
-  exact(5);
+  exact(5)
+  ;
 
   const PortalAccuracy(this.value);
   final int value;

--- a/test/features/categories/ui/widgets/category_create_modal_test.dart
+++ b/test/features/categories/ui/widgets/category_create_modal_test.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_colorpicker/flutter_colorpicker.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
+import 'package:lotti/features/categories/domain/category_icon.dart';
 import 'package:lotti/features/categories/repository/categories_repository.dart';
 import 'package:lotti/features/categories/ui/widgets/category_create_modal.dart';
+import 'package:lotti/utils/color.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../../mocks/mocks.dart';
@@ -184,6 +187,176 @@ void main() {
       );
       expect(createdCategories, isEmpty);
       expect(find.textContaining('Category name is required'), findsOneWidget);
+    },
+  );
+
+  // Regression: at the narrow widths WoltModalSheet uses on desktop,
+  // `flutter_colorpicker.ColorPicker` picked its landscape Row branch
+  // (square + 260-px hard-coded slider) and overflowed the modal.
+  // `portraitOnly: true` + a LayoutBuilder in CategoryCreateModal
+  // forces the portrait branch and sizes `colorPickerWidth` to fit.
+  //
+  // Built on the shared `WidgetTestBench` (with the new
+  // `surfaceConstraints` knob) instead of a bespoke MaterialApp +
+  // ProviderScope wrapper — per AGENTS.md, tests should not duplicate
+  // the standard testable wrapper.
+  Widget createModalAtWidth(double width) {
+    return WidgetTestBench(
+      overrides: [
+        categoryRepositoryProvider.overrideWithValue(mockRepository),
+      ],
+      surfaceConstraints: BoxConstraints.tightFor(width: width),
+      child: CategoryCreateModal(
+        initialName: 'Narrow',
+        onCategoryCreated: (_) {},
+      ),
+    );
+  }
+
+  testWidgets(
+    'color picker does not overflow when the modal width is 360 px '
+    '(regression for the create-category modal)',
+    (tester) async {
+      await tester.pumpWidget(createModalAtWidth(360));
+      await tester.pump();
+
+      expect(
+        tester.takeException(),
+        isNull,
+        reason:
+            'flutter_colorpicker.ColorPicker overflowed its parent at 360 '
+            'px. CategoryCreateModal must keep `portraitOnly: true` AND '
+            'wrap the picker in a LayoutBuilder that clamps '
+            '`colorPickerWidth`. Reverting either re-introduces the bug.',
+      );
+
+      // The saturation square (ColorPickerArea) is the load-bearing
+      // dimension: in the portrait branch the slider derives its
+      // width from it. Asserting on the area's actual width — rather
+      // than on the outer ColorPicker, which always inherits parent
+      // constraints — is what proves the LayoutBuilder did its job.
+      final areaSize = tester.getSize(find.byType(ColorPickerArea));
+      expect(
+        areaSize.width,
+        lessThanOrEqualTo(CategoryIconConstants.colorPickerMaxSquareWidth),
+      );
+      // And it must fit inside the modal interior (modal padding eats
+      // 16 px each side).
+      expect(areaSize.width, lessThanOrEqualTo(360 - 32));
+    },
+  );
+
+  testWidgets(
+    'color picker clamps to the design-system max on a wide modal',
+    (tester) async {
+      await tester.pumpWidget(createModalAtWidth(720));
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+
+      // On a wide modal the clamp ceiling should kick in: the
+      // saturation square stays at `colorPickerMaxSquareWidth` rather
+      // than growing to fill the available width and looking
+      // disproportionately large.
+      final areaSize = tester.getSize(find.byType(ColorPickerArea));
+      expect(
+        areaSize.width,
+        equals(CategoryIconConstants.colorPickerMaxSquareWidth),
+      );
+    },
+  );
+
+  // The clamp math behind colorPickerWidth lives in
+  // `pickerSquareWidthFor` and is unit-tested below — exercising the
+  // ultra-narrow case (the gap gemini-code-assist flagged on PR
+  // #3215) through the full modal isn't reliable because at modal
+  // widths < ~230 px the Cancel/Save Row overflows for unrelated
+  // reasons and masks the picker behaviour we actually care about.
+  group('pickerSquareWidthFor', () {
+    test('clamps to the design-system max on wide surfaces', () {
+      expect(
+        pickerSquareWidthFor(720),
+        equals(CategoryIconConstants.colorPickerMaxSquareWidth),
+      );
+      // Exactly at the ceiling stays at the ceiling.
+      expect(
+        pickerSquareWidthFor(
+          CategoryIconConstants.colorPickerMaxSquareWidth,
+        ),
+        equals(CategoryIconConstants.colorPickerMaxSquareWidth),
+      );
+    });
+
+    test('passes the available width through on tight surfaces', () {
+      // A value below the ceiling is returned unchanged — no preferred
+      // minimum is enforced. This is the property that prevents the
+      // picker from overflowing on extremely narrow surfaces (the
+      // case the PR-review bot flagged).
+      expect(pickerSquareWidthFor(180), equals(180));
+      expect(pickerSquareWidthFor(50), equals(50));
+      expect(pickerSquareWidthFor(0), equals(0));
+    });
+  });
+
+  testWidgets(
+    'dragging the saturation square flows the new color into the save call',
+    (tester) async {
+      // Capture whatever colour the modal hands to the repository when
+      // Save is tapped. The default _pickerColor is Colors.red; a drag
+      // on the saturation square fires `onColorChanged` (the closure
+      // patched into the ColorPicker by CategoryCreateModal), which
+      // calls setState with the new colour. If the closure never
+      // executes — e.g. someone removes the LayoutBuilder + ColorPicker
+      // setup or drops `setState` — the saved colour would still be
+      // red and this test would fail.
+      String? capturedColor;
+      when(
+        () => mockRepository.createCategory(
+          name: any(named: 'name'),
+          color: any(named: 'color'),
+          icon: any(named: 'icon'),
+        ),
+      ).thenAnswer((invocation) async {
+        final color =
+            invocation.namedArguments[const Symbol('color')] as String;
+        capturedColor = color;
+        final testDate = DateTime(2024, 3, 15, 10, 30);
+        return CategoryDefinition(
+          id: 'test-id',
+          name: invocation.namedArguments[const Symbol('name')] as String,
+          color: color,
+          createdAt: testDate,
+          updatedAt: testDate,
+          vectorClock: null,
+          private: false,
+          active: true,
+        );
+      });
+
+      await tester.pumpWidget(createTestWidget(onCategoryCreated: (_) {}));
+      await tester.pumpAndSettle();
+
+      // Drag inside the saturation square. The package wires this up
+      // through a RawGestureDetector with a pan recognizer, so a
+      // synthesized drag fires `onPanDown` → `onPanUpdate` → the
+      // package's `onColorChanging` → our `onColorChanged`.
+      final area = find.byType(ColorPickerArea);
+      final rect = tester.getRect(area);
+      await tester.dragFrom(
+        rect.center,
+        Offset(rect.width / 4, -rect.height / 4),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      // The saved colour must differ from the default red because the
+      // drag perturbed both saturation and value. Comparing against
+      // `colorToCssHex(Colors.red)` rather than a hard-coded string
+      // keeps the test in sync with whichever format the util emits.
+      expect(capturedColor, isNotNull);
+      expect(capturedColor, isNot(equals(colorToCssHex(Colors.red))));
     },
   );
 

--- a/test/test_helper.dart
+++ b/test/test_helper.dart
@@ -12,6 +12,7 @@ class WidgetTestBench extends StatelessWidget {
     this.overrides = const [],
     this.theme,
     this.mediaQueryData,
+    this.surfaceConstraints,
     super.key,
   });
 
@@ -20,9 +21,20 @@ class WidgetTestBench extends StatelessWidget {
   final ThemeData? theme;
   final MediaQueryData? mediaQueryData;
 
+  /// Override the inner ConstrainedBox that wraps [child]. Defaults to
+  /// `BoxConstraints(minHeight: 800, minWidth: 800)` so most widget tests
+  /// render at a comfortable desktop size. Pass a tight width (e.g.
+  /// `BoxConstraints.tightFor(width: 360)`) when testing responsive
+  /// behaviour at narrow widths — typical use-case is reproducing a
+  /// modal overflow at the actual width WoltModalSheet uses on desktop.
+  final BoxConstraints? surfaceConstraints;
+
   @override
   Widget build(BuildContext context) {
     final mediaQuery = mediaQueryData ?? phoneMediaQueryData;
+    final constraints =
+        surfaceConstraints ??
+        const BoxConstraints(minHeight: 800, minWidth: 800);
 
     return ProviderScope(
       overrides: overrides,
@@ -39,10 +51,7 @@ class WidgetTestBench extends StatelessWidget {
           supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
             body: ConstrainedBox(
-              constraints: const BoxConstraints(
-                minHeight: 800,
-                minWidth: 800,
-              ),
+              constraints: constraints,
               child: child,
             ),
           ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Create Category modal color picker overflow on desktop so the hue slider and saturation area are fully accessible and the picker fits within the modal on all platforms.
  * Ensured color selection interaction (dragging) behaves correctly after the fix.

* **Tests**
  * Added tests to verify color picker sizing and interaction across narrow and wide modal widths to prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matthiasn/lotti/pull/3215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->