### PR TITLE
feat: add config option for Gemini thinking, low by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   moving it below only on truly constrained widths.
 
 ## [0.9.1010]
+### Added
+- AI popup skill runs can override the Gemini thinking effort for a single
+  invocation after choosing the model, so one saved model row can still be used
+  with different thinking budgets per use case.
+
 ### Changed
 - Daily OS Next now personalizes the greeting from Settings > Advanced > About,
   lets typed capture start from the idle screen, filters processing categories,

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -85,6 +85,7 @@
     </release>
     <release version="0.9.1010" date="2026-05-28">
       <description>
+          <p>AI popup skill runs can override the Gemini thinking effort for a single invocation after choosing the model, so one saved model row can still be used with different thinking budgets per use case.</p>
           <p>Daily OS Next now ships the full voice-first agentic surface — capture, reconcile, drafting, day-plan, refine-by-voice, commit, and shutdown screens — behind the existing feature flag, with localized copy in all supported languages.</p>
           <p>Daily OS Next now personalizes the greeting from Settings &gt; Advanced &gt; About, lets typed capture start from the idle screen, filters processing categories, wraps mobile task titles, compares planned and actual timelines with a shared scroll/zoom surface, folds idle midnight-to-midnight day gaps with a 24-hour time rail, shows recorded journal time in the Actual lane, keeps task-backed agenda titles in sync, refreshes without whole-page loading flashes, and avoids surfacing weeks-old overdue tasks in daily proposals.</p>
           <p>Daily OS Next agenda rows now use a cleaner mobile-first layout with task cover art thumbnails, tighter metadata pills, token-backed progress, and task-backed Day timeline blocks and task-report links that open the linked task inside the app.</p>

--- a/lib/features/agents/util/inference_provider_resolver.dart
+++ b/lib/features/agents/util/inference_provider_resolver.dart
@@ -120,6 +120,91 @@ Future<ResolvedInferenceProvider?> resolveInferenceProviderWithModel({
   return null;
 }
 
+/// Resolves the configured model row and provider for an [AiConfigModel.id].
+///
+/// Profile slots use model config ids for new writes so they can point at a
+/// specific saved model row even when several rows share the same
+/// provider-native `providerModelId` but differ in settings such as reasoning
+/// effort.
+Future<ResolvedInferenceProvider?> resolveInferenceProviderForModelConfigId({
+  required String modelConfigId,
+  required AiConfigRepository aiConfigRepository,
+  String logTag = 'InferenceProviderResolver',
+}) async {
+  final config = await aiConfigRepository.getConfigById(modelConfigId);
+  if (config is! AiConfigModel) {
+    developer.log(
+      'Requested model config not found or wrong type '
+      '(modelConfigIdLength=${modelConfigId.length})',
+      name: logTag,
+    );
+    return null;
+  }
+
+  return _resolveProviderForModel(
+    config,
+    aiConfigRepository: aiConfigRepository,
+    logTag: logTag,
+  );
+}
+
+/// Resolves a profile slot.
+///
+/// New profiles store [modelId] as an [AiConfigModel.id]. Legacy profiles store
+/// the provider-native `providerModelId`, so this falls back to the old lookup
+/// path when direct config-id resolution fails.
+Future<ResolvedInferenceProvider?> resolveInferenceProviderForProfileSlot({
+  required String modelId,
+  required AiConfigRepository aiConfigRepository,
+  String logTag = 'InferenceProviderResolver',
+}) async {
+  final models = await aiConfigRepository.getConfigsByType(AiConfigType.model);
+  for (final config in models.whereType<AiConfigModel>()) {
+    if (config.id == modelId) {
+      return _resolveProviderForModel(
+        config,
+        aiConfigRepository: aiConfigRepository,
+        logTag: logTag,
+      );
+    }
+  }
+
+  return resolveInferenceProviderWithModel(
+    modelId: modelId,
+    aiConfigRepository: aiConfigRepository,
+    logTag: logTag,
+  );
+}
+
+Future<ResolvedInferenceProvider?> _resolveProviderForModel(
+  AiConfigModel model, {
+  required AiConfigRepository aiConfigRepository,
+  required String logTag,
+}) async {
+  final providerId = model.inferenceProviderId;
+  final provider = await aiConfigRepository.getConfigById(providerId);
+
+  if (provider is! AiConfigInferenceProvider) {
+    developer.log(
+      'Skipping provider ${DomainLogger.sanitizeId(providerId)}: '
+      'not an inference provider',
+      name: logTag,
+    );
+    return null;
+  }
+
+  if (!provider.isUsable) {
+    developer.log(
+      'Skipping provider ${DomainLogger.sanitizeId(providerId)}: '
+      'API key is not configured',
+      name: logTag,
+    );
+    return null;
+  }
+
+  return (model: model, provider: provider);
+}
+
 Set<InferenceProviderType> _providerTypesForKnownModel(String modelId) {
   return {
     for (final entry in knownModelsByProvider.entries)

--- a/lib/features/ai/README.md
+++ b/lib/features/ai/README.md
@@ -424,8 +424,8 @@ flowchart LR
 | Operation | Dedicated branches | Fallback |
 | --- | --- | --- |
 | `generate()` | Ollama, Gemini, Mistral | OpenAI-compatible chat streaming |
-| `generateWithImages()` | Ollama | OpenAI-compatible multimodal chat |
-| `generateWithAudio()` | Whisper, Voxtral, MLX Audio native bridge, OpenAI transcription endpoint, Mistral transcription endpoint | OpenAI-compatible audio chat completions |
+| `generateWithImages()` | Ollama | OpenAI-compatible multimodal chat; Gemini receives `reasoning_effort` for its thinking mode |
+| `generateWithAudio()` | Whisper, Voxtral, MLX Audio native bridge, OpenAI transcription endpoint, Mistral transcription endpoint | OpenAI-compatible audio chat completions; Gemini receives `reasoning_effort` for its thinking mode |
 | `generateWithMessages()` | Gemini, Ollama, Mistral | OpenAI-compatible full-history chat |
 | `generateImage()` | Gemini, Alibaba DashScope | Unsupported for all other provider types |
 
@@ -435,8 +435,11 @@ This routing is implemented in code, not inferred from documentation. If a provi
 
 Gemini thinking effort is stored on the configured model row as
 `AiConfigModel.geminiThinkingMode`. The field defaults to `low`, so older model
-rows that do not have the JSON key deserialize to the faster setting. The model
-edit form only shows the selector when the row's owning provider is Gemini.
+rows that do not have the JSON key deserialize to the faster setting. This is a
+default for the saved model row, not a global policy: popup-triggered skills can
+override the Gemini effort for one invocation after the model has been selected.
+The model edit form only shows the selector when the row's owning provider is
+Gemini.
 
 Runtime routing uses the resolved `AiConfigModel`, not a provider-model-name
 lookup table:
@@ -444,15 +447,21 @@ lookup table:
 ```mermaid
 flowchart TD
   Settings["InferenceModelEditPage"] --> ModelRow["AiConfig.model<br/>geminiThinkingMode"]
-  Profile["AiConfig.inferenceProfile<br/>providerModelId slot"] --> Resolver["ProfileResolver / resolveInferenceProviderWithModel"]
+  Profile["AiConfig.inferenceProfile<br/>AiConfigModel.id slot"] --> Resolver["ProfileResolver / resolveInferenceProviderForProfileSlot"]
   Resolver --> ModelRow
+  Popup["AI popup skill run"] --> ModelPick["Model picker"]
+  ModelPick --> EffortPick{"Gemini provider?"}
+  EffortPick -->|yes| Override["Per-run thinking mode"]
+  EffortPick -->|no| NoOverride["Use model-row default"]
   ModelRow --> CallSite["Chat, skill, prompt, and agent call sites"]
+  Override --> CallSite
+  NoOverride --> CallSite
   CallSite --> Cloud["CloudInferenceRepository"]
   Cloud --> IsGemini{"provider.type == gemini?"}
   IsGemini -->|yes| Config["GeminiThinkingConfig.fromMode(mode ?? low)"]
   IsGemini -->|no| Other["Provider-specific or OpenAI-compatible path"]
   Config --> Gemini3{"modelId starts with gemini-3?"}
-  Gemini3 -->|yes| Level["thinkingConfig.thinkingLevel<br/>minimal / low / medium / high"]
+  Gemini3 -->|yes| Level["thinkingConfig.thinkingLevel<br/>Flash: minimal / low / medium / high<br/>Pro: low / high"]
   Gemini3 -->|no| Budget["thinkingConfig.thinkingBudget<br/>mapped fallback"]
 ```
 
@@ -584,9 +593,9 @@ Operational details from the seeded definitions:
 - `Local (Ollama)` ships with image-analysis automation but no transcription slot
 - `Local Power (Ollama)` currently ships with no default skill assignments
 
-`seedDefaults()` is **strictly seed-on-create**: it looks up each profile by its well-known ID and writes only when the row is missing. Once a profile exists, the seeder never touches it again — user edits to model slots, the `isDefault` flag, names, descriptions, and skill assignments survive every restart and app upgrade. Updating a bundled default in code (e.g. swapping the Ollama thinking model) therefore only affects fresh installs; existing installs keep whatever the user has.
+`seedDefaults()` is **strictly seed-on-create**: it looks up each profile by its well-known ID and writes only when the row is missing. Freshly seeded profiles write `AiConfigModel.id` slot values when the corresponding model rows exist. Once a profile exists, the seeder never overwrites user-edited names, descriptions, flags, or skill assignments.
 
-`upgradeExisting()` is a one-time backfill that adds default `skillAssignments` to existing default profiles whose `skillAssignments` are still empty (legacy installs from before the field existed). It only ever fills empties — non-empty assignment lists are preserved.
+`upgradeExisting()` backfills two migration-safe pieces after model rows exist: legacy profile slots that still contain provider-native model IDs are rewritten to `AiConfigModel.id` when the match is unambiguous, and default `skillAssignments` are added only to existing default profiles whose `skillAssignments` are still empty. Non-empty assignment lists are preserved.
 
 `ModelPrepopulationService.backfillNewModels()` seeds known model rows for
 configured providers at startup. Known model identity is the

--- a/lib/features/ai/README.md
+++ b/lib/features/ai/README.md
@@ -180,13 +180,16 @@ Resolution for `resolveForCategory`:
 2. resolve it through `ProfileResolver.resolveByProfileId`
 
 Only the thinking slot is fatal. Optional slots resolve best-effort.
-Model slots store provider-native `providerModelId` strings, not the local
-model row IDs. When multiple synced model rows share the same
-`providerModelId`, provider resolution walks every candidate and uses the
-first provider row that still exists, has the required credentials, and matches
-the provider type that owns that known model ID. This is intentional sync
-hygiene: an orphaned duplicate row from another device must not abort an agent
-wake when a valid provider/model pair is still configured locally.
+Model slots store `AiConfigModel.id` (the local model row ID) with a legacy
+`providerModelId` fallback: `resolveInferenceProviderForProfileSlot` first
+tries an exact model-row ID match and only then falls back to the old
+provider-native lookup for profiles written before the migration. On the
+legacy path, when multiple synced model rows share the same `providerModelId`,
+provider resolution walks every candidate and uses the first provider row that
+still exists, has the required credentials, and matches the provider type that
+owns that known model ID. This is intentional sync hygiene: an orphaned
+duplicate row from another device must not abort an agent wake when a valid
+provider/model pair is still configured locally.
 
 Recording-triggered transcription has a direct fallback in
 `ProfileAutomationService`: it first tries the profile automation path above,

--- a/lib/features/ai/helpers/profile_locality.dart
+++ b/lib/features/ai/helpers/profile_locality.dart
@@ -13,12 +13,9 @@ import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 /// model. This function fails closed instead: a referenced model whose model
 /// or provider config can't be looked up is treated as **not local**.
 ///
-/// Profile slots store the `providerModelId` string (see `ai_config.dart`
-/// docstring on `inferenceProfile`). The lookup chain therefore matches the
-/// same pattern as `resolveInferenceProvider`: scan all `AiConfigModel` rows
-/// for a `providerModelId` match, then `getConfigById` on the model's
-/// `inferenceProviderId`. We must not assume the stored slot value equals a
-/// row's primary key.
+/// New profile slots store `AiConfigModel.id`; legacy profiles may still store
+/// provider-native `providerModelId` strings. The lookup below supports both
+/// shapes, but always prefers the exact model-row id when present.
 ///
 /// Used by the synced-audio dispatcher to refuse running an entry against a
 /// profile that could route any slot through a cloud provider. A profile with
@@ -43,15 +40,17 @@ Future<bool> profileIsLocal(
 
   if (referencedModelIds.isEmpty) return true;
 
-  // Load every model + provider row once; profile slots reference
-  // `providerModelId`, not the row's primary key, so a single scan is the
-  // load-bearing lookup. Providers are batch-fetched too so we don't hit
-  // the repository per slot inside the loop below.
+  // Load every model + provider row once. Providers are batch-fetched too so
+  // we don't hit the repository per slot inside the loop below.
   final modelRows = await repository.getConfigsByType(AiConfigType.model);
-  final modelsByProviderModelId = <String, AiConfigModel>{
-    for (final config in modelRows.whereType<AiConfigModel>())
-      config.providerModelId: config,
-  };
+  final modelsById = <String, AiConfigModel>{};
+  final modelsByProviderModelId = <String, List<AiConfigModel>>{};
+  for (final config in modelRows.whereType<AiConfigModel>()) {
+    modelsById[config.id] = config;
+    (modelsByProviderModelId[config.providerModelId] ??= <AiConfigModel>[]).add(
+      config,
+    );
+  }
   final providerRows = await repository.getConfigsByType(
     AiConfigType.inferenceProvider,
   );
@@ -60,8 +59,12 @@ Future<bool> profileIsLocal(
       config.id: config,
   };
 
-  for (final providerModelId in referencedModelIds) {
-    final modelConfig = modelsByProviderModelId[providerModelId];
+  for (final modelId in referencedModelIds) {
+    final legacyMatches =
+        modelsByProviderModelId[modelId] ?? const <AiConfigModel>[];
+    final modelConfig =
+        modelsById[modelId] ??
+        (legacyMatches.length == 1 ? legacyMatches.single : null);
     if (modelConfig == null) {
       // Referenced-but-unresolved model id. Fail closed.
       return false;

--- a/lib/features/ai/model/ai_config.dart
+++ b/lib/features/ai/model/ai_config.dart
@@ -97,30 +97,34 @@ sealed class AiConfig with _$AiConfig {
 
   /// Inference profile — named bundle of model assignments per capability slot.
   ///
-  /// Each slot stores a `providerModelId` string (the same kind of string used
-  /// by `AgentTemplateEntity.modelId`). At runtime, each slot is resolved via
-  /// the existing `resolveInferenceProvider()` chain:
-  /// `providerModelId → AiConfigModel → AiConfigInferenceProvider`.
+  /// Each slot stores an `AiConfigModel.id` for new writes so profiles can
+  /// target a specific saved model row even when multiple rows share the same
+  /// provider-native `providerModelId` but differ in settings.
+  ///
+  /// Legacy profiles may still carry provider-native model ids. Runtime
+  /// resolution first treats a slot as `AiConfigModel.id`, then falls back to
+  /// the legacy `providerModelId → AiConfigModel → AiConfigInferenceProvider`
+  /// chain.
   const factory AiConfig.inferenceProfile({
     required String id,
     required String name,
     required DateTime createdAt,
 
-    /// providerModelId string for agentic thinking (tool calling, reasoning).
+    /// Model config id for agentic thinking (tool calling, reasoning).
     required String thinkingModelId,
 
-    /// providerModelId string for high-end thinking tasks (e.g. coding prompt
+    /// Model config id for high-end thinking tasks (e.g. coding prompt
     /// generation) where quality matters more than speed/cost.
     /// Falls back to the regular thinking model when not set.
     String? thinkingHighEndModelId,
 
-    /// providerModelId string for image recognition / vision tasks.
+    /// Model config id for image recognition / vision tasks.
     String? imageRecognitionModelId,
 
-    /// providerModelId string for audio transcription.
+    /// Model config id for audio transcription.
     String? transcriptionModelId,
 
-    /// providerModelId string for image generation.
+    /// Model config id for image generation.
     String? imageGenerationModelId,
 
     /// Whether this is a system-seeded default (non-deletable).

--- a/lib/features/ai/model/resolved_profile.dart
+++ b/lib/features/ai/model/resolved_profile.dart
@@ -29,7 +29,7 @@ class ResolvedProfile {
     this.skillAssignments = const [],
   });
 
-  /// The providerModelId string for the thinking slot.
+  /// The provider-native model id for the thinking slot.
   final String thinkingModelId;
 
   /// The resolved inference provider for thinking.
@@ -38,7 +38,7 @@ class ResolvedProfile {
   /// The configured model row used for thinking, when resolved from a profile.
   final AiConfigModel? thinkingModel;
 
-  /// The providerModelId string for high-end thinking (nullable).
+  /// The provider-native model id for high-end thinking (nullable).
   /// Falls back to [thinkingModelId] when not set.
   final String? thinkingHighEndModelId;
 
@@ -49,7 +49,7 @@ class ResolvedProfile {
   /// The configured model row used for high-end thinking, when set.
   final AiConfigModel? thinkingHighEndModel;
 
-  /// The providerModelId string for image recognition (nullable).
+  /// The provider-native model id for image recognition (nullable).
   final String? imageRecognitionModelId;
 
   /// The resolved inference provider for image recognition (nullable).
@@ -58,7 +58,7 @@ class ResolvedProfile {
   /// The configured model row used for image recognition, when set.
   final AiConfigModel? imageRecognitionModel;
 
-  /// The providerModelId string for transcription (nullable).
+  /// The provider-native model id for transcription (nullable).
   final String? transcriptionModelId;
 
   /// The resolved inference provider for transcription (nullable).
@@ -67,7 +67,7 @@ class ResolvedProfile {
   /// The configured model row used for transcription, when set.
   final AiConfigModel? transcriptionModel;
 
-  /// The providerModelId string for image generation (nullable).
+  /// The provider-native model id for image generation (nullable).
   final String? imageGenerationModelId;
 
   /// The resolved inference provider for image generation (nullable).

--- a/lib/features/ai/repository/cloud_inference_repository.dart
+++ b/lib/features/ai/repository/cloud_inference_repository.dart
@@ -59,8 +59,8 @@ class CloudInferenceRepository {
     int? maxTokens,
     List<ChatCompletionTool>? tools,
     ChatCompletionToolChoiceOption? toolChoice,
-    bool stream = true,
     ReasoningEffort? reasoningEffort,
+    bool stream = true,
   }) {
     final ChatCompletionToolChoiceOption? effectiveToolChoice;
     if (toolChoice != null) {
@@ -241,6 +241,7 @@ class CloudInferenceRepository {
     AiConfigInferenceProvider? provider,
     List<ChatCompletionTool>? tools,
     String? systemMessage,
+    GeminiThinkingMode? geminiThinkingMode,
   }) {
     final client =
         overrideClient ??
@@ -263,6 +264,12 @@ class CloudInferenceRepository {
     }
 
     // For other providers, use the standard OpenAI-compatible format
+    final reasoningEffort =
+        provider?.inferenceProviderType == InferenceProviderType.gemini &&
+            GeminiThinkingConfig.isGemini3(model)
+        ? _geminiReasoningEffort(geminiThinkingMode ?? GeminiThinkingMode.low)
+        : null;
+
     if (tools != null && tools.isNotEmpty) {
       developer.log(
         'Passing ${tools.length} tools to image API: ${tools.map((t) => t.function.name).join(', ')}',
@@ -296,6 +303,7 @@ class CloudInferenceRepository {
         temperature: temperature,
         maxTokens: maxCompletionTokens,
         tools: tools,
+        reasoningEffort: reasoningEffort,
       ),
     );
 
@@ -338,6 +346,7 @@ class CloudInferenceRepository {
         ChatCompletionMessageInputAudioFormat.mp3,
     List<String>? speechDictionaryTerms,
     String? systemMessage,
+    GeminiThinkingMode? geminiThinkingMode,
   }) {
     // For Whisper, use the dedicated repository
     if (provider.inferenceProviderType == InferenceProviderType.whisper) {
@@ -448,6 +457,11 @@ class CloudInferenceRepository {
         provider.inferenceProviderType.requiresDataUriForAudio
         ? 'data:;base64,$audioBase64'
         : audioBase64;
+    final reasoningEffort =
+        provider.inferenceProviderType == InferenceProviderType.gemini &&
+            GeminiThinkingConfig.isGemini3(model)
+        ? _geminiReasoningEffort(geminiThinkingMode ?? GeminiThinkingMode.low)
+        : null;
 
     return client
         .createChatCompletionStream(
@@ -472,20 +486,7 @@ class CloudInferenceRepository {
             model: model,
             maxCompletionTokens: maxCompletionTokens,
             tools: tools,
-            // Audio-in-chat-completions calls on Gemini are effectively
-            // transcription / short-answer tasks (record button, voice
-            // capture). Thinking tokens add latency and cost without
-            // changing the transcript, so we pin reasoning to `low` here
-            // regardless of the model's default thinking config. This is
-            // intentionally independent of the workflow-side
-            // `geminiThinkingMode` setting (PR #3216), which applies to
-            // text/chat reasoning where extra thinking is useful.
-            // Other providers ignore `reasoningEffort` — only Gemini
-            // currently honours it, so we only set it for Gemini.
-            reasoningEffort:
-                provider.inferenceProviderType == InferenceProviderType.gemini
-                ? ReasoningEffort.low
-                : null,
+            reasoningEffort: reasoningEffort,
             stream: stream,
           ),
         )
@@ -628,6 +629,15 @@ class CloudInferenceRepository {
       thinkingMode: base.thinkingMode,
       includeThoughts: base.thinkingBudget != 0,
     );
+  }
+
+  ReasoningEffort _geminiReasoningEffort(GeminiThinkingMode mode) {
+    return switch (mode) {
+      GeminiThinkingMode.minimal => ReasoningEffort.minimal,
+      GeminiThinkingMode.low => ReasoningEffort.low,
+      GeminiThinkingMode.medium => ReasoningEffort.medium,
+      GeminiThinkingMode.high => ReasoningEffort.high,
+    };
   }
 
   // Delegate Ollama-specific methods to OllamaInferenceRepository

--- a/lib/features/ai/repository/cloud_inference_repository.dart
+++ b/lib/features/ai/repository/cloud_inference_repository.dart
@@ -267,7 +267,10 @@ class CloudInferenceRepository {
     final reasoningEffort =
         provider?.inferenceProviderType == InferenceProviderType.gemini &&
             GeminiThinkingConfig.isGemini3(model)
-        ? _geminiReasoningEffort(geminiThinkingMode ?? GeminiThinkingMode.low)
+        ? _geminiReasoningEffort(
+            model,
+            geminiThinkingMode ?? GeminiThinkingMode.low,
+          )
         : null;
 
     if (tools != null && tools.isNotEmpty) {
@@ -460,7 +463,10 @@ class CloudInferenceRepository {
     final reasoningEffort =
         provider.inferenceProviderType == InferenceProviderType.gemini &&
             GeminiThinkingConfig.isGemini3(model)
-        ? _geminiReasoningEffort(geminiThinkingMode ?? GeminiThinkingMode.low)
+        ? _geminiReasoningEffort(
+            model,
+            geminiThinkingMode ?? GeminiThinkingMode.low,
+          )
         : null;
 
     return client
@@ -631,8 +637,15 @@ class CloudInferenceRepository {
     );
   }
 
-  ReasoningEffort _geminiReasoningEffort(GeminiThinkingMode mode) {
-    return switch (mode) {
+  /// Maps a [GeminiThinkingMode] to the OpenAI-compatible `reasoning_effort`
+  /// value for [model], collapsing modes that the model does not support
+  /// (non-Flash Gemini 3 only accepts low/high) via
+  /// [GeminiThinkingConfig.effectiveMode].
+  ReasoningEffort _geminiReasoningEffort(
+    String model,
+    GeminiThinkingMode mode,
+  ) {
+    return switch (GeminiThinkingConfig.effectiveMode(model, mode)) {
       GeminiThinkingMode.minimal => ReasoningEffort.minimal,
       GeminiThinkingMode.low => ReasoningEffort.low,
       GeminiThinkingMode.medium => ReasoningEffort.medium,

--- a/lib/features/ai/repository/gemini_thinking_config.dart
+++ b/lib/features/ai/repository/gemini_thinking_config.dart
@@ -75,13 +75,28 @@ class GeminiThinkingConfig {
   /// -   8192+            → `high`
   String _thinkingLevel({required String modelId}) {
     final mode = thinkingMode ?? _budgetToMode(thinkingBudget);
-    if (!isGemini3Flash(modelId)) {
+    return effectiveMode(modelId, mode).apiValue;
+  }
+
+  /// Collapses [mode] to the set of thinking levels supported by [modelId].
+  ///
+  /// Gemini 3 Flash supports all four levels. Other Gemini 3 models (Pro)
+  /// currently accept only `low` and `high`, so minimal/low collapse to
+  /// [GeminiThinkingMode.low] and medium/high to [GeminiThinkingMode.high].
+  /// Non-Gemini-3 model IDs are returned unchanged.
+  static GeminiThinkingMode effectiveMode(
+    String modelId,
+    GeminiThinkingMode mode,
+  ) {
+    if (isGemini3(modelId) && !isGemini3Flash(modelId)) {
       return switch (mode) {
-        GeminiThinkingMode.minimal || GeminiThinkingMode.low => 'low',
-        GeminiThinkingMode.medium || GeminiThinkingMode.high => 'high',
+        GeminiThinkingMode.minimal ||
+        GeminiThinkingMode.low => GeminiThinkingMode.low,
+        GeminiThinkingMode.medium ||
+        GeminiThinkingMode.high => GeminiThinkingMode.high,
       };
     }
-    return mode.apiValue;
+    return mode;
   }
 
   int _thinkingBudget() {

--- a/lib/features/ai/repository/gemini_thinking_config.dart
+++ b/lib/features/ai/repository/gemini_thinking_config.dart
@@ -51,7 +51,7 @@ class GeminiThinkingConfig {
   Map<String, dynamic> toJson({String? modelId}) {
     if (modelId != null && isGemini3(modelId)) {
       return <String, dynamic>{
-        'thinkingLevel': _thinkingLevel(),
+        'thinkingLevel': _thinkingLevel(modelId: modelId),
         'includeThoughts': includeThoughts,
       };
     }
@@ -63,14 +63,24 @@ class GeminiThinkingConfig {
 
   /// Maps the numeric [thinkingBudget] to a Gemini 3.x `thinkingLevel` value.
   ///
+  /// Gemini 3 Flash accepts `minimal`, `low`, `medium`, and `high`. Gemini 3
+  /// Pro currently accepts only `low` and `high`, so minimal/low collapse to
+  /// `low` and medium/high collapse to `high` for non-Flash Gemini 3 models.
+  ///
   /// Budget semantics:
   /// -  -1 (auto/dynamic) → `high` (Gemini 3 default, dynamic reasoning)
   /// -   0 (disabled)     → `minimal` (closest Gemini 3 equivalent)
   /// -   1–4095           → `low`
   /// -   4096–8191        → `medium`
   /// -   8192+            → `high`
-  String _thinkingLevel() {
+  String _thinkingLevel({required String modelId}) {
     final mode = thinkingMode ?? _budgetToMode(thinkingBudget);
+    if (!isGemini3Flash(modelId)) {
+      return switch (mode) {
+        GeminiThinkingMode.minimal || GeminiThinkingMode.low => 'low',
+        GeminiThinkingMode.medium || GeminiThinkingMode.high => 'high',
+      };
+    }
     return mode.apiValue;
   }
 
@@ -83,6 +93,11 @@ class GeminiThinkingConfig {
   static bool isGemini3(String modelId) {
     final id = modelId.replaceFirst('models/', '');
     return id.startsWith('gemini-3');
+  }
+
+  static bool isGemini3Flash(String modelId) {
+    final id = modelId.replaceFirst('models/', '').toLowerCase();
+    return id.startsWith('gemini-3') && id.contains('flash');
   }
 }
 

--- a/lib/features/ai/repository/unified_ai_inference_repository.dart
+++ b/lib/features/ai/repository/unified_ai_inference_repository.dart
@@ -407,32 +407,22 @@ class UnifiedAiInferenceRepository {
       final speechTerms = speechDictionaryTerms.isNotEmpty
           ? speechDictionaryTerms
           : null;
-      return provider.inferenceProviderType == InferenceProviderType.gemini
-          ? cloudRepo.generateWithAudio(
-              prompt,
-              model: model.providerModelId,
-              audioBase64: preparedAudio.base64,
-              baseUrl: provider.baseUrl,
-              apiKey: provider.apiKey,
-              provider: provider,
-              maxCompletionTokens: model.maxCompletionTokens,
-              stream: isAiStreamingEnabled,
-              audioFormat: preparedAudio.format,
-              speechDictionaryTerms: speechTerms,
-              geminiThinkingMode: model.geminiThinkingMode,
-            )
-          : cloudRepo.generateWithAudio(
-              prompt,
-              model: model.providerModelId,
-              audioBase64: preparedAudio.base64,
-              baseUrl: provider.baseUrl,
-              apiKey: provider.apiKey,
-              provider: provider,
-              maxCompletionTokens: model.maxCompletionTokens,
-              stream: isAiStreamingEnabled,
-              audioFormat: preparedAudio.format,
-              speechDictionaryTerms: speechTerms,
-            );
+      return cloudRepo.generateWithAudio(
+        prompt,
+        model: model.providerModelId,
+        audioBase64: preparedAudio.base64,
+        baseUrl: provider.baseUrl,
+        apiKey: provider.apiKey,
+        provider: provider,
+        maxCompletionTokens: model.maxCompletionTokens,
+        stream: isAiStreamingEnabled,
+        audioFormat: preparedAudio.format,
+        speechDictionaryTerms: speechTerms,
+        geminiThinkingMode:
+            provider.inferenceProviderType == InferenceProviderType.gemini
+            ? model.geminiThinkingMode
+            : null,
+      );
     } else if (images.isNotEmpty) {
       // No function calling tools for image analysis tasks
       // This prevents models from getting confused about their capabilities
@@ -441,28 +431,20 @@ class UnifiedAiInferenceRepository {
         name: 'UnifiedAiInferenceRepository',
       );
 
-      return provider.inferenceProviderType == InferenceProviderType.gemini
-          ? cloudRepo.generateWithImages(
-              prompt,
-              model: model.providerModelId,
-              temperature: temperature,
-              images: images,
-              baseUrl: provider.baseUrl,
-              apiKey: provider.apiKey,
-              provider: provider,
-              maxCompletionTokens: model.maxCompletionTokens,
-              geminiThinkingMode: model.geminiThinkingMode,
-            )
-          : cloudRepo.generateWithImages(
-              prompt,
-              model: model.providerModelId,
-              temperature: temperature,
-              images: images,
-              baseUrl: provider.baseUrl,
-              apiKey: provider.apiKey,
-              provider: provider,
-              maxCompletionTokens: model.maxCompletionTokens,
-            );
+      return cloudRepo.generateWithImages(
+        prompt,
+        model: model.providerModelId,
+        temperature: temperature,
+        images: images,
+        baseUrl: provider.baseUrl,
+        apiKey: provider.apiKey,
+        provider: provider,
+        maxCompletionTokens: model.maxCompletionTokens,
+        geminiThinkingMode:
+            provider.inferenceProviderType == InferenceProviderType.gemini
+            ? model.geminiThinkingMode
+            : null,
+      );
     } else {
       // No tools attached — checklist updates and task summaries are
       // handled by the agent system. Other response types (image analysis,

--- a/lib/features/ai/repository/unified_ai_inference_repository.dart
+++ b/lib/features/ai/repository/unified_ai_inference_repository.dart
@@ -404,20 +404,35 @@ class UnifiedAiInferenceRepository {
       final speechDictionaryTerms = await promptBuilderHelper
           .getSpeechDictionaryTerms(entity);
 
-      return cloudRepo.generateWithAudio(
-        prompt,
-        model: model.providerModelId,
-        audioBase64: preparedAudio.base64,
-        baseUrl: provider.baseUrl,
-        apiKey: provider.apiKey,
-        provider: provider,
-        maxCompletionTokens: model.maxCompletionTokens,
-        stream: isAiStreamingEnabled,
-        audioFormat: preparedAudio.format,
-        speechDictionaryTerms: speechDictionaryTerms.isNotEmpty
-            ? speechDictionaryTerms
-            : null,
-      );
+      final speechTerms = speechDictionaryTerms.isNotEmpty
+          ? speechDictionaryTerms
+          : null;
+      return provider.inferenceProviderType == InferenceProviderType.gemini
+          ? cloudRepo.generateWithAudio(
+              prompt,
+              model: model.providerModelId,
+              audioBase64: preparedAudio.base64,
+              baseUrl: provider.baseUrl,
+              apiKey: provider.apiKey,
+              provider: provider,
+              maxCompletionTokens: model.maxCompletionTokens,
+              stream: isAiStreamingEnabled,
+              audioFormat: preparedAudio.format,
+              speechDictionaryTerms: speechTerms,
+              geminiThinkingMode: model.geminiThinkingMode,
+            )
+          : cloudRepo.generateWithAudio(
+              prompt,
+              model: model.providerModelId,
+              audioBase64: preparedAudio.base64,
+              baseUrl: provider.baseUrl,
+              apiKey: provider.apiKey,
+              provider: provider,
+              maxCompletionTokens: model.maxCompletionTokens,
+              stream: isAiStreamingEnabled,
+              audioFormat: preparedAudio.format,
+              speechDictionaryTerms: speechTerms,
+            );
     } else if (images.isNotEmpty) {
       // No function calling tools for image analysis tasks
       // This prevents models from getting confused about their capabilities
@@ -426,16 +441,28 @@ class UnifiedAiInferenceRepository {
         name: 'UnifiedAiInferenceRepository',
       );
 
-      return cloudRepo.generateWithImages(
-        prompt,
-        model: model.providerModelId,
-        temperature: temperature,
-        images: images,
-        baseUrl: provider.baseUrl,
-        apiKey: provider.apiKey,
-        provider: provider,
-        maxCompletionTokens: model.maxCompletionTokens,
-      );
+      return provider.inferenceProviderType == InferenceProviderType.gemini
+          ? cloudRepo.generateWithImages(
+              prompt,
+              model: model.providerModelId,
+              temperature: temperature,
+              images: images,
+              baseUrl: provider.baseUrl,
+              apiKey: provider.apiKey,
+              provider: provider,
+              maxCompletionTokens: model.maxCompletionTokens,
+              geminiThinkingMode: model.geminiThinkingMode,
+            )
+          : cloudRepo.generateWithImages(
+              prompt,
+              model: model.providerModelId,
+              temperature: temperature,
+              images: images,
+              baseUrl: provider.baseUrl,
+              apiKey: provider.apiKey,
+              provider: provider,
+              maxCompletionTokens: model.maxCompletionTokens,
+            );
     } else {
       // No tools attached — checklist updates and task summaries are
       // handled by the agent system. Other response types (image analysis,

--- a/lib/features/ai/services/skill_image_analysis_runner.dart
+++ b/lib/features/ai/services/skill_image_analysis_runner.dart
@@ -21,6 +21,7 @@ extension SkillImageAnalysisRunner on SkillInferenceRunner {
     required AutomationResult automationResult,
     String? linkedTaskId,
     String? overrideModelId,
+    GeminiThinkingMode? geminiThinkingMode,
   }) async {
     final skill = automationResult.skill;
     final profile = automationResult.resolvedProfile;
@@ -36,6 +37,10 @@ extension SkillImageAnalysisRunner on SkillInferenceRunner {
     );
     final provider = target.provider;
     final modelId = target.modelId;
+    final effectiveThinkingMode = _geminiThinkingModeForTarget(
+      target,
+      geminiThinkingMode,
+    );
     if (provider == null || modelId == null) {
       developer.log(
         'Profile missing image recognition provider/model for $imageEntryId',
@@ -93,6 +98,7 @@ extension SkillImageAnalysisRunner on SkillInferenceRunner {
           images: images,
           provider: provider,
           systemMessage: promptResult.systemMessage,
+          geminiThinkingMode: effectiveThinkingMode,
         );
 
         // 6. Collect streaming response.

--- a/lib/features/ai/services/skill_inference_runner.dart
+++ b/lib/features/ai/services/skill_inference_runner.dart
@@ -17,6 +17,7 @@ import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/model/resolved_profile.dart';
 import 'package:lotti/features/ai/repository/ai_input_repository.dart';
 import 'package:lotti/features/ai/repository/cloud_inference_repository.dart';
+import 'package:lotti/features/ai/repository/gemini_thinking_config.dart';
 import 'package:lotti/features/ai/repository/task_summary_resolver.dart';
 import 'package:lotti/features/ai/services/profile_automation_service.dart';
 import 'package:lotti/features/ai/state/consts.dart';
@@ -151,6 +152,7 @@ class SkillInferenceRunner {
       fallback: () => (
         provider: profile.transcriptionProvider,
         modelId: profile.transcriptionModelId,
+        model: profile.transcriptionModel,
       ),
     );
   }
@@ -172,6 +174,25 @@ class SkillInferenceRunner {
       fallback: () => (
         provider: profile.imageRecognitionProvider,
         modelId: profile.imageRecognitionModelId,
+        model: profile.imageRecognitionModel,
+      ),
+    );
+  }
+
+  /// Resolves the `(provider, modelId, model)` target used by prompt
+  /// generation. The profile fallback is the high-end thinking slot, falling
+  /// back to the regular thinking slot through [ResolvedProfile].
+  Future<_InferenceTarget> _resolvePromptGenerationTarget({
+    required ResolvedProfile profile,
+    required String? overrideModelId,
+  }) {
+    return _resolveOverrideTarget(
+      overrideModelId: overrideModelId,
+      slotKind: _OverrideSlotKind.promptGeneration,
+      fallback: () => (
+        provider: profile.effectiveHighEndProvider,
+        modelId: profile.effectiveHighEndModelId,
+        model: profile.effectiveHighEndModel,
       ),
     );
   }
@@ -213,7 +234,30 @@ class SkillInferenceRunner {
     return (
       provider: providerConfig,
       modelId: modelConfig.providerModelId,
+      model: modelConfig,
     );
+  }
+
+  /// Resolves the effective Gemini thinking mode for [target].
+  ///
+  /// Returns null unless the target provider is Gemini and the model is a
+  /// Gemini 3 variant. Otherwise the per-invocation [override] wins, then
+  /// the model row's saved default, then [GeminiThinkingMode.low].
+  GeminiThinkingMode? _geminiThinkingModeForTarget(
+    _InferenceTarget target,
+    GeminiThinkingMode? override,
+  ) {
+    final provider = target.provider;
+    if (provider?.inferenceProviderType != InferenceProviderType.gemini) {
+      return null;
+    }
+    final modelId = target.model?.providerModelId ?? target.modelId;
+    if (modelId == null || !GeminiThinkingConfig.isGemini3(modelId)) {
+      return null;
+    }
+    return override ??
+        target.model?.geminiThinkingMode ??
+        GeminiThinkingMode.low;
   }
 
   /// Run skill-based transcription; see [SkillTranscriptionRunner].
@@ -222,11 +266,13 @@ class SkillInferenceRunner {
     required AutomationResult automationResult,
     String? linkedTaskId,
     String? overrideModelId,
+    GeminiThinkingMode? geminiThinkingMode,
   }) => runTranscriptionImpl(
     audioEntryId: audioEntryId,
     automationResult: automationResult,
     linkedTaskId: linkedTaskId,
     overrideModelId: overrideModelId,
+    geminiThinkingMode: geminiThinkingMode,
   );
 
   /// Run skill-based image analysis; see [SkillImageAnalysisRunner].
@@ -235,11 +281,13 @@ class SkillInferenceRunner {
     required AutomationResult automationResult,
     String? linkedTaskId,
     String? overrideModelId,
+    GeminiThinkingMode? geminiThinkingMode,
   }) => runImageAnalysisImpl(
     imageEntryId: imageEntryId,
     automationResult: automationResult,
     linkedTaskId: linkedTaskId,
     overrideModelId: overrideModelId,
+    geminiThinkingMode: geminiThinkingMode,
   );
 
   /// Run skill-based prompt generation; see [SkillPromptGenerationRunner].
@@ -247,10 +295,14 @@ class SkillInferenceRunner {
     required String entryId,
     required AutomationResult automationResult,
     String? linkedTaskId,
+    String? overrideModelId,
+    GeminiThinkingMode? geminiThinkingMode,
   }) => runPromptGenerationImpl(
     entryId: entryId,
     automationResult: automationResult,
     linkedTaskId: linkedTaskId,
+    overrideModelId: overrideModelId,
+    geminiThinkingMode: geminiThinkingMode,
   );
 
   /// Run skill-based image generation; see [SkillImageGenerationRunner].
@@ -367,24 +419,29 @@ class SkillInferenceRunner {
   }
 }
 
-/// Resolved (provider, modelId) pair returned by the per-slot resolver
-/// helpers ([SkillInferenceRunner._resolveTranscriptionTarget],
-/// [SkillInferenceRunner._resolveImageAnalysisTarget]). Either field
-/// may be null when the override is unresolvable and the profile slot
-/// is also empty — the caller short-circuits with a "missing
-/// provider/model" log in that case.
+/// Resolved (provider, modelId, model) tuple returned by the per-slot
+/// resolver helpers ([SkillInferenceRunner._resolveTranscriptionTarget],
+/// [SkillInferenceRunner._resolveImageAnalysisTarget],
+/// [SkillInferenceRunner._resolvePromptGenerationTarget]). Fields may be
+/// null when the override is unresolvable and the profile slot is also
+/// empty — the caller short-circuits with a "missing provider/model" log
+/// in that case. The `model` field carries the resolved `AiConfigModel`
+/// row so per-model settings (e.g. Gemini thinking mode) survive
+/// resolution.
 typedef _InferenceTarget = ({
   AiConfigInferenceProvider? provider,
   String? modelId,
+  AiConfigModel? model,
 });
 
 /// Identifier for which profile slot a per-invocation override is
 /// targeting. The [label] is interpolated into warning logs so a
-/// future third slot kind only needs a new enum value, not a new
+/// future slot kind only needs a new enum value, not a new
 /// magic-string literal that could typo-drift across the codebase.
 enum _OverrideSlotKind {
   transcription('transcription'),
-  imageAnalysis('image analysis');
+  imageAnalysis('image analysis'),
+  promptGeneration('prompt generation');
 
   const _OverrideSlotKind(this.label);
 

--- a/lib/features/ai/services/skill_prompt_generation_runner.dart
+++ b/lib/features/ai/services/skill_prompt_generation_runner.dart
@@ -16,6 +16,8 @@ extension SkillPromptGenerationRunner on SkillInferenceRunner {
     required String entryId,
     required AutomationResult automationResult,
     String? linkedTaskId,
+    String? overrideModelId,
+    GeminiThinkingMode? geminiThinkingMode,
   }) async {
     final skill = automationResult.skill;
     final profile = automationResult.resolvedProfile;
@@ -25,8 +27,23 @@ extension SkillPromptGenerationRunner on SkillInferenceRunner {
         'skill=${skill != null}, profile=${profile != null}',
       );
     }
-    final provider = profile.effectiveHighEndProvider;
-    final modelId = profile.effectiveHighEndModelId;
+    final target = await _resolvePromptGenerationTarget(
+      profile: profile,
+      overrideModelId: overrideModelId,
+    );
+    final provider = target.provider;
+    final modelId = target.modelId;
+    final effectiveThinkingMode = _geminiThinkingModeForTarget(
+      target,
+      geminiThinkingMode,
+    );
+    if (provider == null || modelId == null) {
+      developer.log(
+        'Profile missing prompt generation provider/model for $entryId',
+        name: _logTag,
+      );
+      return;
+    }
 
     await _withStatusTracking(
       entityId: entryId,
@@ -77,7 +94,7 @@ extension SkillPromptGenerationRunner on SkillInferenceRunner {
           apiKey: provider.apiKey,
           provider: provider,
           systemMessage: promptResult.systemMessage,
-          geminiThinkingMode: profile.effectiveHighEndModel?.geminiThinkingMode,
+          geminiThinkingMode: effectiveThinkingMode,
         );
 
         // 6. Collect streaming response.

--- a/lib/features/ai/services/skill_prompt_generation_runner.dart
+++ b/lib/features/ai/services/skill_prompt_generation_runner.dart
@@ -31,19 +31,15 @@ extension SkillPromptGenerationRunner on SkillInferenceRunner {
       profile: profile,
       overrideModelId: overrideModelId,
     );
-    final provider = target.provider;
-    final modelId = target.modelId;
+    // Unlike the optional transcription/image slots, the prompt-generation
+    // fallback is the profile's required thinking slot, so the resolved
+    // target always carries a provider and model id.
+    final provider = target.provider!;
+    final modelId = target.modelId!;
     final effectiveThinkingMode = _geminiThinkingModeForTarget(
       target,
       geminiThinkingMode,
     );
-    if (provider == null || modelId == null) {
-      developer.log(
-        'Profile missing prompt generation provider/model for $entryId',
-        name: _logTag,
-      );
-      return;
-    }
 
     await _withStatusTracking(
       entityId: entryId,

--- a/lib/features/ai/services/skill_transcription_runner.dart
+++ b/lib/features/ai/services/skill_transcription_runner.dart
@@ -21,6 +21,7 @@ extension SkillTranscriptionRunner on SkillInferenceRunner {
     required AutomationResult automationResult,
     String? linkedTaskId,
     String? overrideModelId,
+    GeminiThinkingMode? geminiThinkingMode,
   }) async {
     final skill = automationResult.skill;
     final profile = automationResult.resolvedProfile;
@@ -36,6 +37,10 @@ extension SkillTranscriptionRunner on SkillInferenceRunner {
     );
     final provider = target.provider;
     final modelId = target.modelId;
+    final effectiveThinkingMode = _geminiThinkingModeForTarget(
+      target,
+      geminiThinkingMode,
+    );
     if (provider == null || modelId == null) {
       developer.log(
         'Profile missing transcription provider/model for $audioEntryId',
@@ -97,6 +102,7 @@ extension SkillTranscriptionRunner on SkillInferenceRunner {
           apiKey: provider.apiKey,
           provider: provider,
           systemMessage: promptResult.systemMessage,
+          geminiThinkingMode: effectiveThinkingMode,
           speechDictionaryTerms: speechDictionaryTerms.isNotEmpty
               ? speechDictionaryTerms
               : null,

--- a/lib/features/ai/state/ai_config_initialization.dart
+++ b/lib/features/ai/state/ai_config_initialization.dart
@@ -18,15 +18,28 @@ Future<void> aiConfigInitialization(Ref ref) async {
     aiConfigRepository: aiConfigRepo,
   );
 
-  await profileService.seedDefaults();
-
+  // Backfill known models before seeding so that new default profiles can
+  // resolve their model slots to existing `AiConfigModel` rows right away.
   final modelService = ModelPrepopulationService(repository: aiConfigRepo);
   try {
     await modelService.backfillNewModels();
-    await profileService.upgradeExisting();
   } catch (error, stackTrace) {
     developer.log(
       'Failed to backfill known models: $error',
+      name: 'aiConfigInitialization',
+      stackTrace: stackTrace,
+    );
+  }
+
+  await profileService.seedDefaults();
+
+  // Isolated from the backfill try/catch so a flaky backfill never skips
+  // the profile upgrade pass.
+  try {
+    await profileService.upgradeExisting();
+  } catch (error, stackTrace) {
+    developer.log(
+      'Failed to upgrade inference profiles: $error',
       name: 'aiConfigInitialization',
       stackTrace: stackTrace,
     );

--- a/lib/features/ai/state/ai_config_initialization.dart
+++ b/lib/features/ai/state/ai_config_initialization.dart
@@ -14,14 +14,16 @@ part 'ai_config_initialization.g.dart';
 @Riverpod(keepAlive: true)
 Future<void> aiConfigInitialization(Ref ref) async {
   final aiConfigRepo = ref.watch(aiConfigRepositoryProvider);
-
-  await ProfileSeedingService(
+  final profileService = ProfileSeedingService(
     aiConfigRepository: aiConfigRepo,
-  ).seedDefaults();
+  );
+
+  await profileService.seedDefaults();
 
   final modelService = ModelPrepopulationService(repository: aiConfigRepo);
   try {
     await modelService.backfillNewModels();
+    await profileService.upgradeExisting();
   } catch (error, stackTrace) {
     developer.log(
       'Failed to backfill known models: $error',

--- a/lib/features/ai/state/settings/inference_provider_form_controller.dart
+++ b/lib/features/ai/state/settings/inference_provider_form_controller.dart
@@ -4,6 +4,7 @@ import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/model/inference_provider_form_state.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 import 'package:lotti/features/ai/util/model_prepopulation_service.dart';
+import 'package:lotti/features/ai/util/profile_seeding_service.dart';
 import 'package:lotti/services/dev_logger.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -241,6 +242,10 @@ class InferenceProviderFormController
               'Pre-populated $modelsCreated models for provider ${config.name}',
         );
       }
+
+      await ProfileSeedingService(
+        aiConfigRepository: repository,
+      ).upgradeExisting();
     }
   }
 

--- a/lib/features/ai/state/skill_trigger_providers.dart
+++ b/lib/features/ai/state/skill_trigger_providers.dart
@@ -107,16 +107,20 @@ final hasAvailableSkillsProvider = FutureProvider.autoDispose
 /// popup-menu pickers set it when the user chooses a non-default model
 /// for one specific entry, and the dispatch in [triggerSkillProvider]
 /// forwards it to the matching `SkillInferenceRunner` entry point
-/// (only [SkillType.transcription] and [SkillType.imageAnalysis]
-/// honour it today; other skill types ignore it). The runner routes
-/// the call to that model + its parent provider instead of the
-/// profile slot.
+/// (transcription, image analysis, and prompt generation honour it today).
+/// The runner routes the call to that model + its parent provider instead of
+/// the profile slot.
+///
+/// `geminiThinkingMode` is also per-invocation. When set for a Gemini-backed
+/// run, it overrides the selected model row's saved default effort for this
+/// call only.
 typedef TriggerSkillParams = ({
   String entityId,
   String skillId,
   String? linkedTaskId,
   List<ProcessedReferenceImage>? referenceImages,
   String? overrideModelId,
+  GeminiThinkingMode? geminiThinkingMode,
 });
 
 /// Provider to trigger a skill-based inference run.
@@ -223,6 +227,7 @@ final triggerSkillProvider = FutureProvider.autoDispose
                 automationResult: automationResult,
                 linkedTaskId: params.linkedTaskId,
                 overrideModelId: params.overrideModelId,
+                geminiThinkingMode: params.geminiThinkingMode,
               );
             case SkillType.imageAnalysis:
               await runner.runImageAnalysis(
@@ -230,6 +235,7 @@ final triggerSkillProvider = FutureProvider.autoDispose
                 automationResult: automationResult,
                 linkedTaskId: params.linkedTaskId,
                 overrideModelId: params.overrideModelId,
+                geminiThinkingMode: params.geminiThinkingMode,
               );
             case SkillType.promptGeneration:
             case SkillType.imagePromptGeneration:
@@ -237,6 +243,8 @@ final triggerSkillProvider = FutureProvider.autoDispose
                 entryId: params.entityId,
                 automationResult: automationResult,
                 linkedTaskId: params.linkedTaskId,
+                overrideModelId: params.overrideModelId,
+                geminiThinkingMode: params.geminiThinkingMode,
               );
             case SkillType.imageGeneration:
               final linkedTaskId = params.linkedTaskId;

--- a/lib/features/ai/ui/image_generation/cover_art_skill_modal.dart
+++ b/lib/features/ai/ui/image_generation/cover_art_skill_modal.dart
@@ -106,6 +106,7 @@ class _CoverArtSkillModalState extends ConsumerState<CoverArtSkillModal> {
           linkedTaskId: widget.linkedTaskId,
           referenceImages: referenceImages.isNotEmpty ? referenceImages : null,
           overrideModelId: null,
+          geminiThinkingMode: null,
         )).future,
       ),
     );

--- a/lib/features/ai/ui/inference_profile_form.dart
+++ b/lib/features/ai/ui/inference_profile_form.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/model/skill_assignment.dart';
+import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 import 'package:lotti/features/ai/skills/built_in_skills.dart';
 import 'package:lotti/features/ai/state/consts.dart';
 import 'package:lotti/features/ai/state/inference_profile_controller.dart';
@@ -289,9 +290,16 @@ class _InferenceProfileFormState extends ConsumerState<InferenceProfileForm> {
   /// persisting an inconsistent state where a skill claims to be automated
   /// but the profile has no model to execute it.
   ///
+  /// Takes the *normalized* slot values being persisted (not the raw form
+  /// state) so a slot cleared during save — e.g. an ambiguous legacy id —
+  /// also disables its dependent skill automation.
+  ///
   /// Note: only checks built-in skills — custom/future skills pass through
   /// unchanged. Extend this when custom skill editing is added.
-  List<SkillAssignment> _sanitizedSkillAssignments() {
+  List<SkillAssignment> _sanitizedSkillAssignments({
+    required String? transcriptionModelId,
+    required String? imageRecognitionModelId,
+  }) {
     // First, deduplicate legacy same-SkillType entries: keep only the last
     // assignment per SkillType so profiles migrated from older formats
     // don't persist conflicting duplicates.
@@ -313,7 +321,11 @@ class _InferenceProfileFormState extends ConsumerState<InferenceProfileForm> {
       if (!a.automate) return a;
       final skill = builtInSkills.where((s) => s.id == a.skillId).firstOrNull;
       if (skill == null) return a;
-      final hasModel = _modelIdForSkillType(skill.skillType) != null;
+      final hasModel = switch (skill.skillType) {
+        SkillType.transcription => transcriptionModelId != null,
+        SkillType.imageAnalysis => imageRecognitionModelId != null,
+        _ => false,
+      };
       if (hasModel) return a;
       return SkillAssignment(skillId: a.skillId);
     }).toList();
@@ -361,17 +373,60 @@ class _InferenceProfileFormState extends ConsumerState<InferenceProfileForm> {
     setState(() => _isSaving = true);
     try {
       final now = DateTime.now();
+      final repository = ref.read(aiConfigRepositoryProvider);
+      final modelConfigs = await repository.getConfigsByType(
+        AiConfigType.model,
+      );
+      final models = modelConfigs.whereType<AiConfigModel>().toList(
+        growable: false,
+      );
+      final thinkingModelId = _normalizeModelSlotId(
+        _thinkingModelId,
+        models,
+      );
+      final thinkingHighEndModelId = _normalizeModelSlotId(
+        _thinkingHighEndModelId,
+        models,
+      );
+      final imageRecognitionModelId = _normalizeModelSlotId(
+        _imageRecognitionModelId,
+        models,
+      );
+      final transcriptionModelId = _normalizeModelSlotId(
+        _transcriptionModelId,
+        models,
+      );
+      final imageGenerationModelId = _normalizeModelSlotId(
+        _imageGenerationModelId,
+        models,
+      );
+      // An ambiguous legacy id normalizes to null; the thinking slot is
+      // required, so force an explicit re-selection instead of persisting
+      // an arbitrary or unresolved value.
+      if (thinkingModelId == null) {
+        if (mounted) {
+          setState(() => _thinkingModelId = null);
+          context.showToast(
+            tone: DesignSystemToastTone.error,
+            title: context.messages.inferenceProfileThinkingRequired,
+          );
+        }
+        return;
+      }
       final profile =
           AiConfig.inferenceProfile(
                 id: widget.existingProfile?.id ?? const Uuid().v4(),
                 name: _nameController.text.trim(),
-                thinkingModelId: _thinkingModelId!,
-                thinkingHighEndModelId: _thinkingHighEndModelId,
-                imageRecognitionModelId: _imageRecognitionModelId,
-                transcriptionModelId: _transcriptionModelId,
-                imageGenerationModelId: _imageGenerationModelId,
+                thinkingModelId: thinkingModelId,
+                thinkingHighEndModelId: thinkingHighEndModelId,
+                imageRecognitionModelId: imageRecognitionModelId,
+                transcriptionModelId: transcriptionModelId,
+                imageGenerationModelId: imageGenerationModelId,
                 desktopOnly: _desktopOnly,
-                skillAssignments: _sanitizedSkillAssignments(),
+                skillAssignments: _sanitizedSkillAssignments(
+                  transcriptionModelId: transcriptionModelId,
+                  imageRecognitionModelId: imageRecognitionModelId,
+                ),
                 isDefault: widget.existingProfile?.isDefault ?? false,
                 // The selector mutates `_pinnedHostId`; on a brand-new
                 // profile this is null and the auto-trigger stays inert
@@ -405,6 +460,42 @@ class _InferenceProfileFormState extends ConsumerState<InferenceProfileForm> {
       }
     }
   }
+}
+
+/// Resolves a slot value to the model row it identifies: an exact
+/// [AiConfigModel.id] match first, then a unique legacy `providerModelId`
+/// fallback. Ambiguous (2+ rows sharing the legacy id) or unknown values
+/// return `null` so the UI never shows an arbitrary row as selected.
+AiConfigModel? _resolveModelSlot(
+  String? slotValue,
+  List<AiConfigModel> models,
+) {
+  if (slotValue == null) return null;
+  final exact = models.where((model) => model.id == slotValue).firstOrNull;
+  if (exact != null) return exact;
+
+  final matches = models
+      .where((model) => model.providerModelId == slotValue)
+      .toList(growable: false);
+  return matches.length == 1 ? matches.single : null;
+}
+
+/// Maps a slot value to the canonical [AiConfigModel.id] for persistence,
+/// using the same resolution rule as [_resolveModelSlot]:
+///
+/// - exact model-row id match → kept as-is
+/// - unique legacy `providerModelId` match → normalized to that row's id
+/// - ambiguous legacy id (2+ rows) → `null`, forcing re-selection so an
+///   arbitrary row is never silently persisted
+/// - no match → kept as-is (the model row may not have synced yet)
+String? _normalizeModelSlotId(String? slotValue, List<AiConfigModel> models) {
+  if (slotValue == null) return null;
+  final resolved = _resolveModelSlot(slotValue, models);
+  if (resolved != null) return resolved.id;
+
+  final isAmbiguous =
+      models.where((model) => model.providerModelId == slotValue).length > 1;
+  return isAmbiguous ? null : slotValue;
 }
 
 /// A toggle tile for a single skill assignment.

--- a/lib/features/ai/ui/inference_profile_slot_field.dart
+++ b/lib/features/ai/ui/inference_profile_slot_field.dart
@@ -39,9 +39,7 @@ class _ModelSlotField extends ConsumerWidget {
 
     final filteredModels = allModels.where(filter).toList();
 
-    final selectedModel = modelId != null
-        ? allModels.where((m) => m.providerModelId == modelId).firstOrNull
-        : null;
+    final selectedModel = _resolveModelSlot(modelId, allModels);
 
     return InkWell(
       onTap: filteredModels.isNotEmpty
@@ -159,6 +157,13 @@ class _SlotModelPickerContentState extends State<_SlotModelPickerContent> {
           providerLabel.toLowerCase().contains(queryLower);
     }).toList();
 
+    // Resolve the slot value with the shared exact-id/unique-provider-id
+    // rule so an ambiguous legacy id never marks multiple rows selected.
+    final resolvedSelectedId = _resolveModelSlot(
+      widget.selectedModelId,
+      widget.models,
+    )?.id;
+
     return Padding(
       padding: const EdgeInsets.all(20),
       child: Column(
@@ -185,8 +190,8 @@ class _SlotModelPickerContentState extends State<_SlotModelPickerContent> {
               _SlotModelPickerRow(
                 model: model,
                 providerLabel: providerNamesById[model.inferenceProviderId],
-                selected: model.providerModelId == widget.selectedModelId,
-                onTap: () => widget.onSelected(model.providerModelId),
+                selected: model.id == resolvedSelectedId,
+                onTap: () => widget.onSelected(model.id),
               ),
         ],
       ),

--- a/lib/features/ai/ui/settings/README.md
+++ b/lib/features/ai/ui/settings/README.md
@@ -122,8 +122,8 @@ AiConfigCard(
 
 The model edit form owns user-editable model-row fields: display name,
 provider-native model ID, owning provider, modalities, reasoning/function-call
-flags, max completion tokens, and Gemini thinking mode. The Gemini thinking
-selector is conditional on the selected provider resolving to
+flags, max completion tokens, and the default Gemini thinking mode. The Gemini
+thinking selector is conditional on the selected provider resolving to
 `InferenceProviderType.gemini`; non-Gemini rows keep the stored default value
 but do not render the selector.
 
@@ -309,7 +309,8 @@ logged via `LoggingService` under `AI_CONFIG / DELETE_SERVICE`.
 ### 3. Tabbed Navigation
 - **Providers Tab**: Manage AI inference providers (OpenAI, Anthropic, etc.)
 - **Models Tab**: Manage AI models with advanced filtering options. Gemini
-  model rows also expose the thinking mode used at inference time.
+  model rows also expose the default thinking mode; popup-triggered skills can
+  override that default for one invocation.
 - **Prompts Tab**: Manage AI prompts and templates
 
 ### 4. Direct Navigation

--- a/lib/features/ai/ui/settings/ai_settings_page.dart
+++ b/lib/features/ai/ui/settings/ai_settings_page.dart
@@ -662,15 +662,29 @@ class _AiSettingsPageState extends ConsumerState<AiSettingsPage>
       );
     }
     final tokens = context.designTokens;
-    final modelNamesById = <String, String>{
-      for (final m in models) m.providerModelId: m.name,
-    };
+    final modelNamesById = <String, String>{};
+    for (final model in models) {
+      modelNamesById[model.id] = model.name;
+      modelNamesById.putIfAbsent(model.providerModelId, () => model.name);
+    }
     final providerTypeByProviderId = <String, InferenceProviderType>{
       for (final p in providers) p.id: p.inferenceProviderType,
     };
-    final providerIdByModelProviderModelId = <String, String>{
-      for (final m in models) m.providerModelId: m.inferenceProviderId,
-    };
+    final providerIdByModelId = <String, String>{};
+    final modelsByProviderModelId = <String, List<AiConfigModel>>{};
+    for (final model in models) {
+      providerIdByModelId[model.id] = model.inferenceProviderId;
+      (modelsByProviderModelId[model.providerModelId] ??= <AiConfigModel>[])
+          .add(model);
+    }
+    for (final entry in modelsByProviderModelId.entries) {
+      if (entry.value.length == 1) {
+        providerIdByModelId.putIfAbsent(
+          entry.key,
+          () => entry.value.single.inferenceProviderId,
+        );
+      }
+    }
     // A profile earns the Active badge iff it's the winning candidate
     // for at least one configured provider — same rule the detail
     // page uses for its "Active profile" section.
@@ -686,7 +700,7 @@ class _AiSettingsPageState extends ConsumerState<AiSettingsPage>
         isActive: activeProfileIds.contains(profile.id),
         providerTypeFor: () => _providerTypeForProfile(
           profile,
-          providerIdByModelProviderModelId,
+          providerIdByModelId,
           providerTypeByProviderId,
         ),
         modelLookup: (id) => modelNamesById[id],
@@ -760,8 +774,8 @@ class _AiSettingsPageState extends ConsumerState<AiSettingsPage>
   }
 
   /// Best-guess provider type for a profile card. The profile schema
-  /// doesn't carry a provider id — it just references models by their
-  /// `providerModelId`. Walk the five skill slots in priority order
+  /// doesn't carry a provider id — it just references model rows. Walk
+  /// the five skill slots in priority order
   /// (thinking → thinking-high-end → image recognition → transcription
   /// → image generation) and pick the first model whose owning provider
   /// we can resolve. Returns null when none of the slots resolve — the
@@ -769,7 +783,7 @@ class _AiSettingsPageState extends ConsumerState<AiSettingsPage>
   /// Gemini.
   InferenceProviderType? _providerTypeForProfile(
     AiConfigInferenceProfile profile,
-    Map<String, String> providerIdByModelProviderModelId,
+    Map<String, String> providerIdByModelId,
     Map<String, InferenceProviderType> providerTypeByProviderId,
   ) {
     final candidates = <String?>[
@@ -781,7 +795,7 @@ class _AiSettingsPageState extends ConsumerState<AiSettingsPage>
     ];
     for (final candidate in candidates) {
       if (candidate == null) continue;
-      final providerId = providerIdByModelProviderModelId[candidate];
+      final providerId = providerIdByModelId[candidate];
       if (providerId == null) continue;
       final type = providerTypeByProviderId[providerId];
       if (type != null) return type;

--- a/lib/features/ai/ui/settings/ai_settings_page.dart
+++ b/lib/features/ai/ui/settings/ai_settings_page.dart
@@ -662,23 +662,24 @@ class _AiSettingsPageState extends ConsumerState<AiSettingsPage>
       );
     }
     final tokens = context.designTokens;
-    final modelNamesById = <String, String>{};
-    for (final model in models) {
-      modelNamesById[model.id] = model.name;
-      modelNamesById.putIfAbsent(model.providerModelId, () => model.name);
-    }
     final providerTypeByProviderId = <String, InferenceProviderType>{
       for (final p in providers) p.id: p.inferenceProviderType,
     };
+    final modelNamesById = <String, String>{};
     final providerIdByModelId = <String, String>{};
     final modelsByProviderModelId = <String, List<AiConfigModel>>{};
     for (final model in models) {
+      modelNamesById[model.id] = model.name;
       providerIdByModelId[model.id] = model.inferenceProviderId;
       (modelsByProviderModelId[model.providerModelId] ??= <AiConfigModel>[])
           .add(model);
     }
+    // Legacy slots store provider-native ids; only fall back to those when
+    // the providerModelId is unique so an ambiguous id never resolves to an
+    // arbitrary row's name or provider.
     for (final entry in modelsByProviderModelId.entries) {
       if (entry.value.length == 1) {
+        modelNamesById.putIfAbsent(entry.key, () => entry.value.single.name);
         providerIdByModelId.putIfAbsent(
           entry.key,
           () => entry.value.single.inferenceProviderId,

--- a/lib/features/ai/ui/settings/inference_model_edit_page.dart
+++ b/lib/features/ai/ui/settings/inference_model_edit_page.dart
@@ -12,11 +12,10 @@ import 'package:lotti/features/ai/ui/settings/widgets/form_components/form_compo
 import 'package:lotti/features/ai/ui/settings/widgets/form_components/form_error_extension.dart';
 import 'package:lotti/features/ai/ui/settings/widgets/modality_selection_modal.dart';
 import 'package:lotti/features/ai/ui/settings/widgets/provider_selection_modal.dart';
+import 'package:lotti/features/ai/ui/widgets/gemini_thinking_mode_picker_modal.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/widgets/nav_bar/design_system_bottom_navigation_bar.dart';
-import 'package:lotti/widgets/selection/selection_modal_base.dart';
-import 'package:lotti/widgets/selection/selection_option.dart';
 import 'package:lotti/widgets/selection/unified_toggle.dart';
 
 /// Create / edit page for an inference model row. Rewritten in v3 to
@@ -369,22 +368,17 @@ class _InferenceModelEditPageState
     };
   }
 
-  void _showGeminiThinkingModeSelectionModal(
+  Future<void> _showGeminiThinkingModeSelectionModal(
     BuildContext context,
     GeminiThinkingMode selectedMode,
     ValueChanged<GeminiThinkingMode> onChanged,
-  ) {
-    SelectionModalBase.show(
+  ) async {
+    final mode = await GeminiThinkingModePickerModal.show(
       context: context,
-      title: context.messages.modelEditGeminiThinkingModeLabel,
-      child: _GeminiThinkingModePickerContent(
-        selectedMode: selectedMode,
-        onChanged: (mode) {
-          onChanged(mode);
-          Navigator.of(context).pop();
-        },
-      ),
+      selectedMode: selectedMode,
     );
+    if (mode == null || !context.mounted) return;
+    onChanged(mode);
   }
 
   Widget _buildErrorState(BuildContext context) {
@@ -424,68 +418,6 @@ class _InferenceModelEditPageState
         ),
       ),
     );
-  }
-}
-
-class _GeminiThinkingModePickerContent extends StatelessWidget {
-  const _GeminiThinkingModePickerContent({
-    required this.selectedMode,
-    required this.onChanged,
-  });
-
-  final GeminiThinkingMode selectedMode;
-  final ValueChanged<GeminiThinkingMode> onChanged;
-
-  @override
-  Widget build(BuildContext context) {
-    const modes = GeminiThinkingMode.values;
-    return SelectionModalContent(
-      children: [
-        SelectionOptionsList(
-          itemCount: modes.length,
-          itemBuilder: (context, index) {
-            final mode = modes[index];
-            return SelectionOption(
-              title: _label(context, mode),
-              description: _description(context, mode),
-              icon: _icon(mode),
-              isSelected: mode == selectedMode,
-              onTap: () => onChanged(mode),
-            );
-          },
-        ),
-      ],
-    );
-  }
-
-  String _label(BuildContext context, GeminiThinkingMode mode) {
-    final messages = context.messages;
-    return switch (mode) {
-      GeminiThinkingMode.minimal => messages.geminiThinkingModeMinimalLabel,
-      GeminiThinkingMode.low => messages.geminiThinkingModeLowLabel,
-      GeminiThinkingMode.medium => messages.geminiThinkingModeMediumLabel,
-      GeminiThinkingMode.high => messages.geminiThinkingModeHighLabel,
-    };
-  }
-
-  String _description(BuildContext context, GeminiThinkingMode mode) {
-    final messages = context.messages;
-    return switch (mode) {
-      GeminiThinkingMode.minimal =>
-        messages.geminiThinkingModeMinimalDescription,
-      GeminiThinkingMode.low => messages.geminiThinkingModeLowDescription,
-      GeminiThinkingMode.medium => messages.geminiThinkingModeMediumDescription,
-      GeminiThinkingMode.high => messages.geminiThinkingModeHighDescription,
-    };
-  }
-
-  IconData _icon(GeminiThinkingMode mode) {
-    return switch (mode) {
-      GeminiThinkingMode.minimal => Icons.flash_on_rounded,
-      GeminiThinkingMode.low => Icons.speed_rounded,
-      GeminiThinkingMode.medium => Icons.psychology_alt_rounded,
-      GeminiThinkingMode.high => Icons.auto_awesome_rounded,
-    };
   }
 }
 

--- a/lib/features/ai/ui/settings/util/active_profile.dart
+++ b/lib/features/ai/ui/settings/util/active_profile.dart
@@ -21,16 +21,19 @@ AiConfigInferenceProfile? pickActiveProfileForProvider({
   required List<AiConfigModel> providerModels,
 }) {
   if (providerModels.isEmpty || profiles.isEmpty) return null;
-  final providerModelIds = providerModels.map((m) => m.providerModelId).toSet();
+  final profileSlotIds = <String>{
+    for (final model in providerModels) model.id,
+    for (final model in providerModels) model.providerModelId,
+  };
 
   AiConfigInferenceProfile? firstTouching;
   for (final p in profiles) {
     final touches =
-        providerModelIds.contains(p.thinkingModelId) ||
-        providerModelIds.contains(p.thinkingHighEndModelId) ||
-        providerModelIds.contains(p.imageRecognitionModelId) ||
-        providerModelIds.contains(p.transcriptionModelId) ||
-        providerModelIds.contains(p.imageGenerationModelId);
+        profileSlotIds.contains(p.thinkingModelId) ||
+        profileSlotIds.contains(p.thinkingHighEndModelId) ||
+        profileSlotIds.contains(p.imageRecognitionModelId) ||
+        profileSlotIds.contains(p.transcriptionModelId) ||
+        profileSlotIds.contains(p.imageGenerationModelId);
 
     if (touches) {
       if (p.isDefault) return p;

--- a/lib/features/ai/ui/unified_ai_skills_modal.dart
+++ b/lib/features/ai/ui/unified_ai_skills_modal.dart
@@ -7,10 +7,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/model/resolved_profile.dart';
+import 'package:lotti/features/ai/repository/gemini_thinking_config.dart';
 import 'package:lotti/features/ai/state/consts.dart';
 import 'package:lotti/features/ai/state/profile_automation_providers.dart';
 import 'package:lotti/features/ai/state/skill_trigger_providers.dart';
 import 'package:lotti/features/ai/ui/image_generation/cover_art_skill_modal.dart';
+import 'package:lotti/features/ai/ui/widgets/gemini_thinking_mode_picker_modal.dart';
 import 'package:lotti/features/ai/ui/widgets/inference_model_picker_modal.dart';
 import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
@@ -20,10 +22,16 @@ import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/providers/service_providers.dart';
 import 'package:lotti/widgets/modal/index.dart';
 
-/// (modelId, providerId) tuple pulled from a [ResolvedProfile] for one
-/// per-invocation override slot. Both fields are nullable because a
-/// freshly-installed profile may not have populated the slot yet.
-typedef _ProfileSlotValue = ({String? modelId, String? providerId});
+/// (configId, modelId, providerId) tuple pulled from a [ResolvedProfile]
+/// for one per-invocation override slot. `configId` is the resolved
+/// `AiConfigModel.id` row, `modelId` the wire-level `providerModelId`.
+/// All fields are nullable because a freshly-installed profile may not
+/// have populated the slot yet.
+typedef _ProfileSlotValue = ({
+  String? configId,
+  String? modelId,
+  String? providerId,
+});
 
 /// Per-skill configuration for the model-override popup flow. Each
 /// entry plugs in a modality filter, profile-slot accessor, and the
@@ -45,8 +53,8 @@ class _SkillModelOverrideConfig {
   /// image analysis).
   final Modality modality;
 
-  /// Pulls the `(providerModelId, providerId)` pair for the override
-  /// slot out of the resolved profile.
+  /// Pulls the `(configId, providerModelId, providerId)` tuple for the
+  /// override slot out of the resolved profile.
   final _ProfileSlotValue Function(ResolvedProfile) slotAccessor;
 
   /// Returns the picker modal title for this slot. Resolved against
@@ -59,13 +67,21 @@ class _SkillModelOverrideConfig {
 }
 
 _ProfileSlotValue _transcriptionSlot(ResolvedProfile p) => (
+  configId: p.transcriptionModel?.id,
   modelId: p.transcriptionModelId,
   providerId: p.transcriptionProvider?.id,
 );
 
 _ProfileSlotValue _imageAnalysisSlot(ResolvedProfile p) => (
+  configId: p.imageRecognitionModel?.id,
   modelId: p.imageRecognitionModelId,
   providerId: p.imageRecognitionProvider?.id,
+);
+
+_ProfileSlotValue _highEndThinkingSlot(ResolvedProfile p) => (
+  configId: p.effectiveHighEndModel?.id,
+  modelId: p.effectiveHighEndModelId,
+  providerId: p.effectiveHighEndProvider.id,
 );
 
 /// Skill types that open a model-override picker on tap, keyed by
@@ -84,6 +100,18 @@ const _modelOverrideConfigs = <SkillType, _SkillModelOverrideConfig>{
     titleSelector: _imageAnalysisTitleSelector,
     defaultBadgeSelector: _imageAnalysisBadgeSelector,
   ),
+  SkillType.promptGeneration: _SkillModelOverrideConfig(
+    modality: Modality.text,
+    slotAccessor: _highEndThinkingSlot,
+    titleSelector: _promptGenerationTitleSelector,
+    defaultBadgeSelector: _promptGenerationBadgeSelector,
+  ),
+  SkillType.imagePromptGeneration: _SkillModelOverrideConfig(
+    modality: Modality.text,
+    slotAccessor: _highEndThinkingSlot,
+    titleSelector: _promptGenerationTitleSelector,
+    defaultBadgeSelector: _promptGenerationBadgeSelector,
+  ),
 };
 
 String _transcriptionTitleSelector(AppLocalizations m) =>
@@ -94,6 +122,10 @@ String _imageAnalysisTitleSelector(AppLocalizations m) =>
     m.aiImageAnalysisPickerTitle;
 String _imageAnalysisBadgeSelector(AppLocalizations m) =>
     m.aiImageAnalysisPickerDefaultBadge;
+String _promptGenerationTitleSelector(AppLocalizations m) =>
+    m.aiPromptGenerationPickerTitle;
+String _promptGenerationBadgeSelector(AppLocalizations m) =>
+    m.designSystemDefaultLabel;
 
 class UnifiedAiModal {
   static Future<void> show<T>({
@@ -163,6 +195,7 @@ class UnifiedAiModal {
                 linkedTaskId: linkedTaskId,
                 referenceImages: null,
                 overrideModelId: null,
+                geminiThinkingMode: null,
               )).future,
             ),
           );
@@ -218,9 +251,11 @@ class UnifiedAiModal {
   /// Profile resolution mirrors [triggerSkillProvider]'s logic: linked
   /// task uses the task's profile, standalone entries fall back to
   /// the entry category's `defaultProfileId`. The resolved profile's
-  /// per-slot wire-level `providerModelId` is translated to an
-  /// `AiConfigModel.id` by matching against the loaded model list, so
-  /// the picker can highlight that row as the default.
+  /// per-slot `AiConfigModel.id` is matched exactly against the loaded
+  /// model list so the picker can highlight that row as the default;
+  /// the wire-level `(providerModelId, providerId)` pair is only a
+  /// legacy fallback, since several rows can share the same provider
+  /// model while differing in settings such as thinking mode.
   ///
   /// When the picker resolves with the same id as the default we
   /// pass `null` as the override — same semantic as "no override" so
@@ -256,17 +291,35 @@ class UnifiedAiModal {
         .whereType<AiConfigModel>()
         .where((m) => m.inputModalities.contains(config.modality))
         .toList();
+    final providerConfigs = await repo.getConfigsByType(
+      AiConfigType.inferenceProvider,
+    );
+    final providersById = <String, AiConfigInferenceProvider>{
+      for (final provider
+          in providerConfigs.whereType<AiConfigInferenceProvider>())
+        provider.id: provider,
+    };
 
-    // Translate the profile's wire-level providerModelId to the
-    // AiConfigModel.id so the picker can compare rows. A missing
-    // match (deleted model, empty slot) leaves defaultModelId null;
-    // the picker renders the list without a default row.
+    // Match the profile's resolved AiConfigModel.id exactly, then fall
+    // back to translating the wire-level providerModelId for slots that
+    // resolved without a model row. A missing match (deleted model,
+    // empty slot) leaves defaultModelId null; the picker renders the
+    // list without a default row.
     String? defaultModelId;
     if (resolvedProfile != null) {
       final slot = config.slotAccessor(resolvedProfile);
+      final configId = slot.configId;
+      if (configId != null) {
+        defaultModelId = modalityCapable
+            .where((m) => m.id == configId)
+            .firstOrNull
+            ?.id;
+      }
       final providerModelId = slot.modelId;
       final providerId = slot.providerId;
-      if (providerModelId != null && providerId != null) {
+      if (defaultModelId == null &&
+          providerModelId != null &&
+          providerId != null) {
         defaultModelId = modalityCapable
             .where(
               (m) =>
@@ -297,6 +350,27 @@ class UnifiedAiModal {
     // so we bail before firing the trigger.
     if (!context.mounted) return;
 
+    final selectedModel = modalityCapable.firstWhereOrNull(
+      (model) => model.id == picked,
+    );
+    final selectedProvider = selectedModel != null
+        ? providersById[selectedModel.inferenceProviderId]
+        : null;
+
+    GeminiThinkingMode? geminiThinkingMode;
+    if (selectedProvider?.inferenceProviderType ==
+            InferenceProviderType.gemini &&
+        selectedModel != null &&
+        GeminiThinkingConfig.isGemini3(selectedModel.providerModelId)) {
+      final pickedMode = await GeminiThinkingModePickerModal.show(
+        context: context,
+        selectedMode: selectedModel.geminiThinkingMode,
+      );
+      if (pickedMode == null) return;
+      geminiThinkingMode = pickedMode;
+      if (!context.mounted) return;
+    }
+
     // Same id as default → no override semantic — the runner reads
     // the profile slot. Different id → forward as override.
     final overrideId = picked == defaultModelId ? null : picked;
@@ -309,6 +383,7 @@ class UnifiedAiModal {
           linkedTaskId: linkedTaskId,
           referenceImages: null,
           overrideModelId: overrideId,
+          geminiThinkingMode: geminiThinkingMode,
         )).future,
       ),
     );

--- a/lib/features/ai/ui/widgets/gemini_thinking_mode_picker_modal.dart
+++ b/lib/features/ai/ui/widgets/gemini_thinking_mode_picker_modal.dart
@@ -10,9 +10,7 @@ import 'package:lotti/widgets/selection/selection_option.dart';
 /// Model settings use this as the saved default for a model row. Invocation
 /// flows use the same content as a one-run override picker, preselected to the
 /// row default.
-class GeminiThinkingModePickerModal {
-  const GeminiThinkingModePickerModal._();
-
+abstract final class GeminiThinkingModePickerModal {
   static Future<GeminiThinkingMode?> show({
     required BuildContext context,
     required GeminiThinkingMode selectedMode,

--- a/lib/features/ai/ui/widgets/gemini_thinking_mode_picker_modal.dart
+++ b/lib/features/ai/ui/widgets/gemini_thinking_mode_picker_modal.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/widgets/modal/modal_utils.dart';
+import 'package:lotti/widgets/selection/selection_modal_base.dart';
+import 'package:lotti/widgets/selection/selection_option.dart';
+
+/// Reusable Gemini thinking-mode picker.
+///
+/// Model settings use this as the saved default for a model row. Invocation
+/// flows use the same content as a one-run override picker, preselected to the
+/// row default.
+class GeminiThinkingModePickerModal {
+  const GeminiThinkingModePickerModal._();
+
+  static Future<GeminiThinkingMode?> show({
+    required BuildContext context,
+    required GeminiThinkingMode selectedMode,
+    String? title,
+  }) {
+    return ModalUtils.showSinglePageModal<GeminiThinkingMode>(
+      context: context,
+      title: title ?? context.messages.modelEditGeminiThinkingModeLabel,
+      padding: EdgeInsets.zero,
+      builder: (modalContext) => GeminiThinkingModePickerContent(
+        selectedMode: selectedMode,
+        onChanged: (mode) => Navigator.of(modalContext).pop(mode),
+      ),
+    );
+  }
+}
+
+class GeminiThinkingModePickerContent extends StatelessWidget {
+  const GeminiThinkingModePickerContent({
+    required this.selectedMode,
+    required this.onChanged,
+    super.key,
+  });
+
+  final GeminiThinkingMode selectedMode;
+  final ValueChanged<GeminiThinkingMode> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    const modes = GeminiThinkingMode.values;
+    return SelectionModalContent(
+      children: [
+        SelectionOptionsList(
+          itemCount: modes.length,
+          itemBuilder: (context, index) {
+            final mode = modes[index];
+            return SelectionOption(
+              title: label(context, mode),
+              description: description(context, mode),
+              icon: icon(mode),
+              isSelected: mode == selectedMode,
+              onTap: () => onChanged(mode),
+            );
+          },
+        ),
+      ],
+    );
+  }
+
+  static String label(BuildContext context, GeminiThinkingMode mode) {
+    final messages = context.messages;
+    return switch (mode) {
+      GeminiThinkingMode.minimal => messages.geminiThinkingModeMinimalLabel,
+      GeminiThinkingMode.low => messages.geminiThinkingModeLowLabel,
+      GeminiThinkingMode.medium => messages.geminiThinkingModeMediumLabel,
+      GeminiThinkingMode.high => messages.geminiThinkingModeHighLabel,
+    };
+  }
+
+  static String description(BuildContext context, GeminiThinkingMode mode) {
+    final messages = context.messages;
+    return switch (mode) {
+      GeminiThinkingMode.minimal =>
+        messages.geminiThinkingModeMinimalDescription,
+      GeminiThinkingMode.low => messages.geminiThinkingModeLowDescription,
+      GeminiThinkingMode.medium => messages.geminiThinkingModeMediumDescription,
+      GeminiThinkingMode.high => messages.geminiThinkingModeHighDescription,
+    };
+  }
+
+  static IconData icon(GeminiThinkingMode mode) {
+    return switch (mode) {
+      GeminiThinkingMode.minimal => Icons.flash_on_rounded,
+      GeminiThinkingMode.low => Icons.speed_rounded,
+      GeminiThinkingMode.medium => Icons.psychology_alt_rounded,
+      GeminiThinkingMode.high => Icons.auto_awesome_rounded,
+    };
+  }
+}

--- a/lib/features/ai/ui/widgets/profile_pinning_selector.dart
+++ b/lib/features/ai/ui/widgets/profile_pinning_selector.dart
@@ -213,8 +213,8 @@ class ProfilePinningSelector extends ConsumerWidget {
     final providersById = {
       for (final provider in providers) provider.id: provider,
     };
-    // Index models by both keys profile slots can carry — `providerModelId`
-    // (the standard) and `id` (legacy / forward-compat). One pass over the
+    // Index models by both keys profile slots can carry — `id`
+    // (the standard) and `providerModelId` (legacy). One pass over the
     // model list builds both maps; the loop below is then O(slots) instead
     // of O(slots × models).
     final modelsByProviderModelId = <String, AiConfigModel>{};
@@ -225,7 +225,7 @@ class ProfilePinningSelector extends ConsumerWidget {
     }
     final types = <InferenceProviderType>{};
     for (final id in referencedModelIds) {
-      final model = modelsByProviderModelId[id] ?? modelsById[id];
+      final model = modelsById[id] ?? modelsByProviderModelId[id];
       if (model == null) continue;
       final provider = providersById[model.inferenceProviderId];
       if (provider == null) continue;

--- a/lib/features/ai/util/profile_resolver.dart
+++ b/lib/features/ai/util/profile_resolver.dart
@@ -89,7 +89,7 @@ class ProfileResolver {
     AiConfigInferenceProfile config,
   ) async {
     // Resolve thinking slot (fatal if missing).
-    final thinkingSlot = await resolveInferenceProviderWithModel(
+    final thinkingSlot = await resolveInferenceProviderForProfileSlot(
       modelId: config.thinkingModelId,
       aiConfigRepository: _aiConfigRepository,
       logTag: _logTag,
@@ -105,7 +105,7 @@ class ProfileResolver {
 
     // Resolve optional slots (non-fatal).
     final thinkingHighEndSlot = config.thinkingHighEndModelId != null
-        ? await resolveInferenceProviderWithModel(
+        ? await resolveInferenceProviderForProfileSlot(
             modelId: config.thinkingHighEndModelId!,
             aiConfigRepository: _aiConfigRepository,
             logTag: _logTag,
@@ -113,7 +113,7 @@ class ProfileResolver {
         : null;
 
     final imageRecognitionSlot = config.imageRecognitionModelId != null
-        ? await resolveInferenceProviderWithModel(
+        ? await resolveInferenceProviderForProfileSlot(
             modelId: config.imageRecognitionModelId!,
             aiConfigRepository: _aiConfigRepository,
             logTag: _logTag,
@@ -121,7 +121,7 @@ class ProfileResolver {
         : null;
 
     final transcriptionSlot = config.transcriptionModelId != null
-        ? await resolveInferenceProviderWithModel(
+        ? await resolveInferenceProviderForProfileSlot(
             modelId: config.transcriptionModelId!,
             aiConfigRepository: _aiConfigRepository,
             logTag: _logTag,
@@ -129,7 +129,7 @@ class ProfileResolver {
         : null;
 
     final imageGenerationSlot = config.imageGenerationModelId != null
-        ? await resolveInferenceProviderWithModel(
+        ? await resolveInferenceProviderForProfileSlot(
             modelId: config.imageGenerationModelId!,
             aiConfigRepository: _aiConfigRepository,
             logTag: _logTag,
@@ -137,27 +137,19 @@ class ProfileResolver {
         : null;
 
     return ResolvedProfile(
-      thinkingModelId: config.thinkingModelId,
+      thinkingModelId: thinkingSlot.model.providerModelId,
       thinkingProvider: thinkingSlot.provider,
       thinkingModel: thinkingSlot.model,
-      thinkingHighEndModelId: thinkingHighEndSlot != null
-          ? config.thinkingHighEndModelId
-          : null,
+      thinkingHighEndModelId: thinkingHighEndSlot?.model.providerModelId,
       thinkingHighEndProvider: thinkingHighEndSlot?.provider,
       thinkingHighEndModel: thinkingHighEndSlot?.model,
-      imageRecognitionModelId: imageRecognitionSlot != null
-          ? config.imageRecognitionModelId
-          : null,
+      imageRecognitionModelId: imageRecognitionSlot?.model.providerModelId,
       imageRecognitionProvider: imageRecognitionSlot?.provider,
       imageRecognitionModel: imageRecognitionSlot?.model,
-      transcriptionModelId: transcriptionSlot != null
-          ? config.transcriptionModelId
-          : null,
+      transcriptionModelId: transcriptionSlot?.model.providerModelId,
       transcriptionProvider: transcriptionSlot?.provider,
       transcriptionModel: transcriptionSlot?.model,
-      imageGenerationModelId: imageGenerationSlot != null
-          ? config.imageGenerationModelId
-          : null,
+      imageGenerationModelId: imageGenerationSlot?.model.providerModelId,
       imageGenerationProvider: imageGenerationSlot?.provider,
       imageGenerationModel: imageGenerationSlot?.model,
       skillAssignments: config.skillAssignments,

--- a/lib/features/ai/util/profile_seeding_service.dart
+++ b/lib/features/ai/util/profile_seeding_service.dart
@@ -5,6 +5,7 @@ import 'package:lotti/features/ai/model/skill_assignment.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 import 'package:lotti/features/ai/skills/built_in_skills.dart';
 import 'package:lotti/features/ai/state/consts.dart';
+import 'package:meta/meta.dart';
 
 /// Well-known IDs for default inference profiles (idempotent seeding).
 const profileGeminiFlashId = 'profile-gemini-flash-001';
@@ -100,7 +101,7 @@ class ProfileSeedingService {
         final sanitized = template.skillAssignments.where((a) {
           final skill = findBuiltInSkill(a.skillId);
           if (skill == null) return true; // keep unknown skills as-is
-          return _hasSlotForSkillType(upgraded, skill.skillType);
+          return hasSlotForSkillType(upgraded, skill.skillType, models);
         }).toList();
 
         if (sanitized.isNotEmpty) {
@@ -172,18 +173,60 @@ class ProfileSeedingService {
     return slotValue;
   }
 
-  /// Returns true when the profile has the model slot required by [skillType].
-  static bool _hasSlotForSkillType(
+  /// Returns true when the profile's slot for [skillType] points at a real
+  /// configured model row — by `AiConfigModel.id` or legacy
+  /// `providerModelId`. A non-null slot value alone is not enough:
+  /// `_withResolvedModelConfigIds` leaves unknown values untouched, and
+  /// re-enabling a default skill on a slot with no backing model row would
+  /// auto-enable broken automation.
+  ///
+  /// Visible for testing: the bundled default templates only carry
+  /// transcription and image-analysis assignments, so the remaining switch
+  /// arms are exercised directly.
+  @visibleForTesting
+  static bool hasSlotForSkillType(
     AiConfigInferenceProfile profile,
     SkillType skillType,
+    List<AiConfigModel> models,
   ) {
     return switch (skillType) {
-      SkillType.transcription => profile.transcriptionModelId != null,
-      SkillType.imageAnalysis => profile.imageRecognitionModelId != null,
-      SkillType.imageGeneration => profile.imageGenerationModelId != null,
-      SkillType.promptGeneration => true, // uses thinking model
-      SkillType.imagePromptGeneration => true, // uses thinking model
+      SkillType.transcription => _slotResolvesToModelRow(
+        profile.transcriptionModelId,
+        models,
+      ),
+      SkillType.imageAnalysis => _slotResolvesToModelRow(
+        profile.imageRecognitionModelId,
+        models,
+      ),
+      SkillType.imageGeneration => _slotResolvesToModelRow(
+        profile.imageGenerationModelId,
+        models,
+      ),
+      // Prompt-generation skills run on the thinking slot (the high-end
+      // slot falls back to it at resolution time).
+      SkillType.promptGeneration => _slotResolvesToModelRow(
+        profile.thinkingModelId,
+        models,
+      ),
+      SkillType.imagePromptGeneration => _slotResolvesToModelRow(
+        profile.thinkingModelId,
+        models,
+      ),
     };
+  }
+
+  /// True when [slotValue] matches a configured model row by exact
+  /// `AiConfigModel.id` or by legacy `providerModelId`. Ambiguous legacy
+  /// values (2+ rows) still count — the runtime resolver walks every
+  /// candidate — but values with no matching row at all do not.
+  static bool _slotResolvesToModelRow(
+    String? slotValue,
+    List<AiConfigModel> models,
+  ) {
+    if (slotValue == null) return false;
+    return models.any(
+      (model) => model.id == slotValue || model.providerModelId == slotValue,
+    );
   }
 
   /// The default profile definitions.

--- a/lib/features/ai/util/profile_seeding_service.dart
+++ b/lib/features/ai/util/profile_seeding_service.dart
@@ -58,10 +58,12 @@ class ProfileSeedingService {
   /// model) across app restarts.
   Future<void> seedDefaults() async {
     var seededCount = 0;
+    final models = await _fetchModelRows();
 
-    for (final profile in defaultProfiles) {
-      final existing = await _repo.getConfigById(profile.id);
+    for (final template in defaultProfiles) {
+      final existing = await _repo.getConfigById(template.id);
       if (existing != null) continue;
+      final profile = _withResolvedModelConfigIds(template, models);
       await _repo.saveConfig(profile);
       seededCount++;
     }
@@ -71,48 +73,103 @@ class ProfileSeedingService {
     }
   }
 
-  /// Upgrades existing default profiles that have empty `skillAssignments`.
+  /// Upgrades existing profiles without overwriting user-authored choices.
   ///
-  /// This is a one-time backfill on app upgrade that enables automation for
-  /// default profiles. Only touches profiles with `isDefault: true` and
-  /// empty `skillAssignments`.
+  /// This migrates legacy provider-native profile slot values to
+  /// `AiConfigModel.id` when the match is unambiguous, then backfills default
+  /// skill assignments only for default profiles whose assignments are empty.
   Future<void> upgradeExisting() async {
     var upgradedCount = 0;
+    final models = await _fetchModelRows();
+    final templatesById = {
+      for (final template in defaultProfiles) template.id: template,
+    };
+    final configs = await _repo.getConfigsByType(AiConfigType.inferenceProfile);
 
-    for (final template in defaultProfiles) {
-      final existing = await _repo.getConfigById(template.id);
-      if (existing == null) continue;
+    for (final config in configs.whereType<AiConfigInferenceProfile>()) {
+      var upgraded = _withResolvedModelConfigIds(config, models);
+      final template = templatesById[config.id];
 
-      // Only upgrade default profiles with empty skill assignments.
-      if (existing is! AiConfigInferenceProfile) continue;
-      if (!existing.isDefault) continue;
-      if (existing.skillAssignments.isNotEmpty) continue;
+      // Only backfill default skill assignments for default profiles with
+      // empty assignments. Non-empty assignment lists and non-default profiles
+      // are user-authored and must be preserved.
+      if (template != null &&
+          config.isDefault &&
+          config.skillAssignments.isEmpty &&
+          template.skillAssignments.isNotEmpty) {
+        final sanitized = template.skillAssignments.where((a) {
+          final skill = findBuiltInSkill(a.skillId);
+          if (skill == null) return true; // keep unknown skills as-is
+          return _hasSlotForSkillType(upgraded, skill.skillType);
+        }).toList();
 
-      // Apply the template's skill assignments, but only for slots that
-      // are still configured on the existing profile.
-      if (template.skillAssignments.isEmpty) continue;
+        if (sanitized.isNotEmpty) {
+          upgraded = upgraded.copyWith(skillAssignments: sanitized);
+        }
+      }
 
-      final sanitized = template.skillAssignments.where((a) {
-        final skill = findBuiltInSkill(a.skillId);
-        if (skill == null) return true; // keep unknown skills as-is
-        return _hasSlotForSkillType(existing, skill.skillType);
-      }).toList();
-
-      if (sanitized.isEmpty) continue;
-
-      final upgraded = existing.copyWith(
-        skillAssignments: sanitized,
-      );
+      if (upgraded == config) continue;
       await _repo.saveConfig(upgraded);
       upgradedCount++;
     }
 
     if (upgradedCount > 0) {
       developer.log(
-        'Upgraded $upgradedCount default profiles with skill assignments',
+        'Upgraded $upgradedCount inference profiles',
         name: _logTag,
       );
     }
+  }
+
+  Future<List<AiConfigModel>> _fetchModelRows() async {
+    final configs = await _repo.getConfigsByType(AiConfigType.model);
+    return configs.whereType<AiConfigModel>().toList(growable: false);
+  }
+
+  static AiConfigInferenceProfile _withResolvedModelConfigIds(
+    AiConfigInferenceProfile profile,
+    List<AiConfigModel> models,
+  ) {
+    return profile.copyWith(
+      thinkingModelId: _resolveModelSlot(profile.thinkingModelId, models),
+      thinkingHighEndModelId: _resolveOptionalModelSlot(
+        profile.thinkingHighEndModelId,
+        models,
+      ),
+      imageRecognitionModelId: _resolveOptionalModelSlot(
+        profile.imageRecognitionModelId,
+        models,
+      ),
+      transcriptionModelId: _resolveOptionalModelSlot(
+        profile.transcriptionModelId,
+        models,
+      ),
+      imageGenerationModelId: _resolveOptionalModelSlot(
+        profile.imageGenerationModelId,
+        models,
+      ),
+    );
+  }
+
+  static String? _resolveOptionalModelSlot(
+    String? slotValue,
+    List<AiConfigModel> models,
+  ) {
+    if (slotValue == null) return null;
+    return _resolveModelSlot(slotValue, models);
+  }
+
+  static String _resolveModelSlot(
+    String slotValue,
+    List<AiConfigModel> models,
+  ) {
+    if (models.any((model) => model.id == slotValue)) return slotValue;
+
+    final matches = models
+        .where((model) => model.providerModelId == slotValue)
+        .toList(growable: false);
+    if (matches.length == 1) return matches.single.id;
+    return slotValue;
   }
 
   /// Returns true when the profile has the model slot required by [skillType].

--- a/lib/features/ai_chat/services/audio_transcription_service.dart
+++ b/lib/features/ai_chat/services/audio_transcription_service.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 import 'package:lotti/features/ai/repository/cloud_inference_repository.dart';
+import 'package:lotti/features/ai/repository/gemini_thinking_config.dart';
 import 'package:lotti/features/ai/repository/mistral_realtime_transcription_repository.dart';
 import 'package:lotti/features/ai/repository/mistral_transcription_repository.dart';
 import 'package:lotti/features/ai/util/known_models.dart';
@@ -112,16 +113,31 @@ class AudioTranscriptionService {
     final audioBase64 = base64Encode(bytes);
 
     final cloud = ref.read(cloudInferenceRepositoryProvider);
-    final stream = cloud.generateWithAudio(
-      _kTranscriptionPrompt,
-      model: model.providerModelId,
-      audioBase64: audioBase64,
-      baseUrl: provider.baseUrl,
-      apiKey: provider.apiKey,
-      provider: provider,
-      maxCompletionTokens: model.maxCompletionTokens,
-      speechDictionaryTerms: speechDictionaryTerms,
-    );
+    final useGeminiThinkingMode =
+        provider.inferenceProviderType == InferenceProviderType.gemini &&
+        GeminiThinkingConfig.isGemini3(model.providerModelId);
+    final stream = useGeminiThinkingMode
+        ? cloud.generateWithAudio(
+            _kTranscriptionPrompt,
+            model: model.providerModelId,
+            audioBase64: audioBase64,
+            baseUrl: provider.baseUrl,
+            apiKey: provider.apiKey,
+            provider: provider,
+            maxCompletionTokens: model.maxCompletionTokens,
+            speechDictionaryTerms: speechDictionaryTerms,
+            geminiThinkingMode: model.geminiThinkingMode,
+          )
+        : cloud.generateWithAudio(
+            _kTranscriptionPrompt,
+            model: model.providerModelId,
+            audioBase64: audioBase64,
+            baseUrl: provider.baseUrl,
+            apiKey: provider.apiKey,
+            provider: provider,
+            maxCompletionTokens: model.maxCompletionTokens,
+            speechDictionaryTerms: speechDictionaryTerms,
+          );
 
     await for (final chunk in stream) {
       final content = chunk.choices?.firstOrNull?.delta?.content ?? '';

--- a/lib/features/ai_chat/services/audio_transcription_service.dart
+++ b/lib/features/ai_chat/services/audio_transcription_service.dart
@@ -116,28 +116,19 @@ class AudioTranscriptionService {
     final useGeminiThinkingMode =
         provider.inferenceProviderType == InferenceProviderType.gemini &&
         GeminiThinkingConfig.isGemini3(model.providerModelId);
-    final stream = useGeminiThinkingMode
-        ? cloud.generateWithAudio(
-            _kTranscriptionPrompt,
-            model: model.providerModelId,
-            audioBase64: audioBase64,
-            baseUrl: provider.baseUrl,
-            apiKey: provider.apiKey,
-            provider: provider,
-            maxCompletionTokens: model.maxCompletionTokens,
-            speechDictionaryTerms: speechDictionaryTerms,
-            geminiThinkingMode: model.geminiThinkingMode,
-          )
-        : cloud.generateWithAudio(
-            _kTranscriptionPrompt,
-            model: model.providerModelId,
-            audioBase64: audioBase64,
-            baseUrl: provider.baseUrl,
-            apiKey: provider.apiKey,
-            provider: provider,
-            maxCompletionTokens: model.maxCompletionTokens,
-            speechDictionaryTerms: speechDictionaryTerms,
-          );
+    final stream = cloud.generateWithAudio(
+      _kTranscriptionPrompt,
+      model: model.providerModelId,
+      audioBase64: audioBase64,
+      baseUrl: provider.baseUrl,
+      apiKey: provider.apiKey,
+      provider: provider,
+      maxCompletionTokens: model.maxCompletionTokens,
+      speechDictionaryTerms: speechDictionaryTerms,
+      geminiThinkingMode: useGeminiThinkingMode
+          ? model.geminiThinkingMode
+          : null,
+    );
 
     await for (final chunk in stream) {
       final content = chunk.choices?.firstOrNull?.delta?.content ?? '';

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -474,6 +474,7 @@
   "aiProfileCardActiveBadge": "Aktivní",
   "aiProfileModelPickerSearchHint": "Hledat modely…",
   "aiProfileSlotModelMissing": "chybí",
+  "aiPromptGenerationPickerTitle": "Vyber model pro generování promptů",
   "aiProviderAlibabaDescription": "Rodina modelů Qwen od Alibaba Cloud přes DashScope API",
   "aiProviderAlibabaName": "Alibaba Cloud (Qwen)",
   "aiProviderAnthropicDescription": "Rodina AI asistentů Claude od Anthropic",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -634,6 +634,7 @@
   "aiProfileCardActiveBadge": "Aktiv",
   "aiProfileModelPickerSearchHint": "Modelle suchen…",
   "aiProfileSlotModelMissing": "fehlt",
+  "aiPromptGenerationPickerTitle": "Wähle ein Modell für die Prompt-Generierung",
   "aiProviderAlibabaDescription": "Alibaba Clouds Qwen-Modellfamilie über die DashScope-API",
   "aiProviderAlibabaName": "Alibaba Cloud (Qwen)",
   "aiProviderAnthropicDescription": "Anthropics Claude-Familie von AI-Assistenten",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -822,6 +822,7 @@
   "aiProfileCardActiveBadge": "Active",
   "aiProfileModelPickerSearchHint": "Search models…",
   "aiProfileSlotModelMissing": "missing",
+  "aiPromptGenerationPickerTitle": "Pick a prompt generation model",
   "aiProviderAlibabaDescription": "Alibaba Cloud's Qwen family of models via DashScope API",
   "aiProviderAlibabaName": "Alibaba Cloud (Qwen)",
   "aiProviderAnthropicDescription": "Anthropic's Claude family of AI assistants",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -634,6 +634,7 @@
   "aiProfileCardActiveBadge": "Activo",
   "aiProfileModelPickerSearchHint": "Buscar modelos…",
   "aiProfileSlotModelMissing": "no encontrado",
+  "aiPromptGenerationPickerTitle": "Elige un modelo para generar prompts",
   "aiProviderAlibabaDescription": "La familia de modelos Qwen de Alibaba Cloud a través de la API DashScope",
   "aiProviderAlibabaName": "Alibaba Cloud (Qwen)",
   "aiProviderAnthropicDescription": "La familia de asistentes AI Claude de Anthropic",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -634,6 +634,7 @@
   "aiProfileCardActiveBadge": "Actif",
   "aiProfileModelPickerSearchHint": "Rechercher des modèles…",
   "aiProfileSlotModelMissing": "manquant",
+  "aiPromptGenerationPickerTitle": "Choisis un modèle de génération de prompts",
   "aiProviderAlibabaDescription": "La famille de modèles Qwen d'Alibaba Cloud via l'API DashScope",
   "aiProviderAlibabaName": "Alibaba Cloud (Qwen)",
   "aiProviderAnthropicDescription": "La famille d'assistants AI Claude d'Anthropic",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2509,6 +2509,12 @@ abstract class AppLocalizations {
   /// **'missing'**
   String get aiProfileSlotModelMissing;
 
+  /// No description provided for @aiPromptGenerationPickerTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Pick a prompt generation model'**
+  String get aiPromptGenerationPickerTitle;
+
   /// No description provided for @aiProviderAlibabaDescription.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1393,6 +1393,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get aiProfileSlotModelMissing => 'chybí';
 
   @override
+  String get aiPromptGenerationPickerTitle =>
+      'Vyber model pro generování promptů';
+
+  @override
   String get aiProviderAlibabaDescription =>
       'Rodina modelů Qwen od Alibaba Cloud přes DashScope API';
 

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1401,6 +1401,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get aiProfileSlotModelMissing => 'fehlt';
 
   @override
+  String get aiPromptGenerationPickerTitle =>
+      'Wähle ein Modell für die Prompt-Generierung';
+
+  @override
   String get aiProviderAlibabaDescription =>
       'Alibaba Clouds Qwen-Modellfamilie über die DashScope-API';
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1380,6 +1380,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get aiProfileSlotModelMissing => 'missing';
 
   @override
+  String get aiPromptGenerationPickerTitle => 'Pick a prompt generation model';
+
+  @override
   String get aiProviderAlibabaDescription =>
       'Alibaba Cloud\'s Qwen family of models via DashScope API';
 

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1399,6 +1399,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get aiProfileSlotModelMissing => 'no encontrado';
 
   @override
+  String get aiPromptGenerationPickerTitle =>
+      'Elige un modelo para generar prompts';
+
+  @override
   String get aiProviderAlibabaDescription =>
       'La familia de modelos Qwen de Alibaba Cloud a través de la API DashScope';
 

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1408,6 +1408,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get aiProfileSlotModelMissing => 'manquant';
 
   @override
+  String get aiPromptGenerationPickerTitle =>
+      'Choisis un modèle de génération de prompts';
+
+  @override
   String get aiProviderAlibabaDescription =>
       'La famille de modèles Qwen d\'Alibaba Cloud via l\'API DashScope';
 

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1407,6 +1407,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get aiProfileSlotModelMissing => 'lipsește';
 
   @override
+  String get aiPromptGenerationPickerTitle =>
+      'Alegeți un model pentru generarea prompturilor';
+
+  @override
   String get aiProviderAlibabaDescription =>
       'Familia de modele Qwen de la Alibaba Cloud prin API-ul DashScope';
 

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -634,6 +634,7 @@
   "aiProfileCardActiveBadge": "Activ",
   "aiProfileModelPickerSearchHint": "Căutați modele…",
   "aiProfileSlotModelMissing": "lipsește",
+  "aiPromptGenerationPickerTitle": "Alegeți un model pentru generarea prompturilor",
   "aiProviderAlibabaDescription": "Familia de modele Qwen de la Alibaba Cloud prin API-ul DashScope",
   "aiProviderAlibabaName": "Alibaba Cloud (Qwen)",
   "aiProviderAnthropicDescription": "Familia de asistenți AI Claude de la Anthropic",

--- a/test/features/agents/util/inference_provider_resolver_test.dart
+++ b/test/features/agents/util/inference_provider_resolver_test.dart
@@ -480,4 +480,151 @@ void main() {
       }
     }, tags: 'glados');
   });
+
+  group('resolveInferenceProviderForModelConfigId', () {
+    test('resolves the model row and its usable provider', () async {
+      final model = testAiModel(id: 'config-row-1');
+      when(
+        () => mockAiConfig.getConfigById('config-row-1'),
+      ).thenAnswer((_) async => model);
+      when(
+        () => mockAiConfig.getConfigById('provider-1'),
+      ).thenAnswer((_) async => testInferenceProvider());
+
+      final resolved = await resolveInferenceProviderForModelConfigId(
+        modelConfigId: 'config-row-1',
+        aiConfigRepository: mockAiConfig,
+      );
+
+      expect(resolved, isNotNull);
+      expect(resolved!.model.id, 'config-row-1');
+      expect(resolved.provider.id, 'provider-1');
+    });
+
+    test('returns null when the config id does not exist', () async {
+      when(
+        () => mockAiConfig.getConfigById('missing'),
+      ).thenAnswer((_) async => null);
+
+      final resolved = await resolveInferenceProviderForModelConfigId(
+        modelConfigId: 'missing',
+        aiConfigRepository: mockAiConfig,
+      );
+
+      expect(resolved, isNull);
+    });
+
+    test('returns null when the config id is not a model', () async {
+      when(
+        () => mockAiConfig.getConfigById('provider-as-model'),
+      ).thenAnswer((_) async => testInferenceProvider(id: 'provider-as-model'));
+
+      final resolved = await resolveInferenceProviderForModelConfigId(
+        modelConfigId: 'provider-as-model',
+        aiConfigRepository: mockAiConfig,
+      );
+
+      expect(resolved, isNull);
+    });
+
+    test('returns null when the parent provider is missing', () async {
+      when(
+        () => mockAiConfig.getConfigById('config-row-1'),
+      ).thenAnswer((_) async => testAiModel(id: 'config-row-1'));
+      when(
+        () => mockAiConfig.getConfigById('provider-1'),
+      ).thenAnswer((_) async => null);
+
+      final resolved = await resolveInferenceProviderForModelConfigId(
+        modelConfigId: 'config-row-1',
+        aiConfigRepository: mockAiConfig,
+      );
+
+      expect(resolved, isNull);
+    });
+
+    test(
+      'returns null when the parent provider has no API key',
+      () async {
+        when(
+          () => mockAiConfig.getConfigById('config-row-1'),
+        ).thenAnswer((_) async => testAiModel(id: 'config-row-1'));
+        when(
+          () => mockAiConfig.getConfigById('provider-1'),
+        ).thenAnswer((_) async => testInferenceProvider(apiKey: ''));
+
+        final resolved = await resolveInferenceProviderForModelConfigId(
+          modelConfigId: 'config-row-1',
+          aiConfigRepository: mockAiConfig,
+        );
+
+        expect(resolved, isNull);
+      },
+    );
+  });
+
+  group('resolveInferenceProviderForProfileSlot', () {
+    test('prefers an exact AiConfigModel.id match', () async {
+      // Two rows share the providerModelId; the slot stores the row id of
+      // the second one, which must win over the wire-level fallback.
+      final rowA = testAiModel(id: 'row-a', inferenceProviderId: 'provider-a');
+      final rowB = testAiModel(id: 'row-b');
+      when(
+        () => mockAiConfig.getConfigsByType(AiConfigType.model),
+      ).thenAnswer((_) async => [rowA, rowB]);
+      when(
+        () => mockAiConfig.getConfigById('provider-1'),
+      ).thenAnswer((_) async => testInferenceProvider());
+
+      final resolved = await resolveInferenceProviderForProfileSlot(
+        modelId: 'row-b',
+        aiConfigRepository: mockAiConfig,
+      );
+
+      expect(resolved, isNotNull);
+      expect(resolved!.model.id, 'row-b');
+      expect(resolved.provider.id, 'provider-1');
+      // The exact-id path never falls through to the legacy candidate walk.
+      verifyNever(() => mockAiConfig.getConfigById('provider-a'));
+    });
+
+    test(
+      'falls back to the legacy providerModelId lookup for old slots',
+      () async {
+        when(
+          () => mockAiConfig.getConfigsByType(AiConfigType.model),
+        ).thenAnswer((_) async => [testAiModel()]);
+        when(
+          () => mockAiConfig.getConfigById('provider-1'),
+        ).thenAnswer((_) async => testInferenceProvider());
+
+        final resolved = await resolveInferenceProviderForProfileSlot(
+          modelId: 'models/gemini-3-flash-preview',
+          aiConfigRepository: mockAiConfig,
+        );
+
+        expect(resolved, isNotNull);
+        expect(resolved!.model.id, 'model-1');
+      },
+    );
+
+    test(
+      'returns null when an exact-id match has an unusable provider',
+      () async {
+        when(
+          () => mockAiConfig.getConfigsByType(AiConfigType.model),
+        ).thenAnswer((_) async => [testAiModel()]);
+        when(
+          () => mockAiConfig.getConfigById('provider-1'),
+        ).thenAnswer((_) async => testInferenceProvider(apiKey: ''));
+
+        final resolved = await resolveInferenceProviderForProfileSlot(
+          modelId: 'model-1',
+          aiConfigRepository: mockAiConfig,
+        );
+
+        expect(resolved, isNull);
+      },
+    );
+  });
 }

--- a/test/features/ai/repository/cloud_inference_repository_test.dart
+++ b/test/features/ai/repository/cloud_inference_repository_test.dart
@@ -1797,7 +1797,8 @@ void main() {
     );
 
     test(
-      'generateWithAudio maps Gemini 3 thinking mode to reasoning effort',
+      'generateWithAudio collapses unsupported thinking modes for '
+      'non-Flash Gemini 3 models',
       () async {
         final geminiProvider =
             AiConfig.inferenceProvider(
@@ -1810,33 +1811,105 @@ void main() {
                 )
                 as AiConfigInferenceProvider;
 
-        when(
-          () => mockClient.createChatCompletionStream(
-            request: any(named: 'request'),
-          ),
-        ).thenAnswer((_) => const Stream.empty());
+        // Gemini 3 Pro only accepts low/high; minimal must collapse to low
+        // (mirroring GeminiThinkingConfig's thinkingLevel collapse).
+        const expectedByMode = {
+          GeminiThinkingMode.minimal: ReasoningEffort.low,
+          GeminiThinkingMode.low: ReasoningEffort.low,
+          GeminiThinkingMode.medium: ReasoningEffort.high,
+          GeminiThinkingMode.high: ReasoningEffort.high,
+        };
 
-        await repository
-            .generateWithAudio(
-              prompt,
-              model: 'models/gemini-3.1-pro-preview',
-              audioBase64: 'base64-audio-data',
-              baseUrl: geminiProvider.baseUrl,
-              apiKey: geminiProvider.apiKey,
-              provider: geminiProvider,
-              overrideClient: mockClient,
-              geminiThinkingMode: GeminiThinkingMode.minimal,
-            )
-            .toList();
+        for (final entry in expectedByMode.entries) {
+          when(
+            () => mockClient.createChatCompletionStream(
+              request: any(named: 'request'),
+            ),
+          ).thenAnswer((_) => const Stream.empty());
 
-        final captured = verify(
-          () => mockClient.createChatCompletionStream(
-            request: captureAny(named: 'request'),
-          ),
-        ).captured;
+          await repository
+              .generateWithAudio(
+                prompt,
+                model: 'models/gemini-3.1-pro-preview',
+                audioBase64: 'base64-audio-data',
+                baseUrl: geminiProvider.baseUrl,
+                apiKey: geminiProvider.apiKey,
+                provider: geminiProvider,
+                overrideClient: mockClient,
+                geminiThinkingMode: entry.key,
+              )
+              .toList();
 
-        final request = captured.first as CreateChatCompletionRequest;
-        expect(request.reasoningEffort, ReasoningEffort.minimal);
+          final captured = verify(
+            () => mockClient.createChatCompletionStream(
+              request: captureAny(named: 'request'),
+            ),
+          ).captured;
+
+          final request = captured.first as CreateChatCompletionRequest;
+          expect(
+            request.reasoningEffort,
+            entry.value,
+            reason: 'mode ${entry.key} on Gemini 3 Pro',
+          );
+        }
+      },
+    );
+
+    test(
+      'generateWithAudio keeps all four reasoning efforts for Gemini 3 Flash',
+      () async {
+        final geminiProvider =
+            AiConfig.inferenceProvider(
+                  id: 'gemini-provider',
+                  name: 'Gemini',
+                  baseUrl: 'https://generativelanguage.googleapis.com',
+                  apiKey: 'test-api-key',
+                  createdAt: DateTime(2024, 3, 15),
+                  inferenceProviderType: InferenceProviderType.gemini,
+                )
+                as AiConfigInferenceProvider;
+
+        const expectedByMode = {
+          GeminiThinkingMode.minimal: ReasoningEffort.minimal,
+          GeminiThinkingMode.low: ReasoningEffort.low,
+          GeminiThinkingMode.medium: ReasoningEffort.medium,
+          GeminiThinkingMode.high: ReasoningEffort.high,
+        };
+
+        for (final entry in expectedByMode.entries) {
+          when(
+            () => mockClient.createChatCompletionStream(
+              request: any(named: 'request'),
+            ),
+          ).thenAnswer((_) => const Stream.empty());
+
+          await repository
+              .generateWithAudio(
+                prompt,
+                model: 'gemini-3-flash-preview',
+                audioBase64: 'base64-audio-data',
+                baseUrl: geminiProvider.baseUrl,
+                apiKey: geminiProvider.apiKey,
+                provider: geminiProvider,
+                overrideClient: mockClient,
+                geminiThinkingMode: entry.key,
+              )
+              .toList();
+
+          final captured = verify(
+            () => mockClient.createChatCompletionStream(
+              request: captureAny(named: 'request'),
+            ),
+          ).captured;
+
+          final request = captured.first as CreateChatCompletionRequest;
+          expect(
+            request.reasoningEffort,
+            entry.value,
+            reason: 'mode ${entry.key} on Gemini 3 Flash',
+          );
+        }
       },
     );
 

--- a/test/features/ai/repository/cloud_inference_repository_test.dart
+++ b/test/features/ai/repository/cloud_inference_repository_test.dart
@@ -1706,6 +1706,140 @@ void main() {
       },
     );
 
+    test(
+      'generateWithImages maps Gemini 3 thinking mode to reasoning effort',
+      () async {
+        final geminiProvider =
+            AiConfig.inferenceProvider(
+                  id: 'gemini-provider',
+                  name: 'Gemini',
+                  baseUrl: 'https://generativelanguage.googleapis.com',
+                  apiKey: 'test-api-key',
+                  createdAt: DateTime(2024, 3, 15),
+                  inferenceProviderType: InferenceProviderType.gemini,
+                )
+                as AiConfigInferenceProvider;
+
+        when(
+          () => mockClient.createChatCompletionStream(
+            request: any(named: 'request'),
+          ),
+        ).thenAnswer((_) => const Stream.empty());
+
+        await repository
+            .generateWithImages(
+              prompt,
+              model: 'gemini-3-flash-preview',
+              temperature: null,
+              baseUrl: geminiProvider.baseUrl,
+              apiKey: geminiProvider.apiKey,
+              images: const ['base64-image-data'],
+              provider: geminiProvider,
+              overrideClient: mockClient,
+              geminiThinkingMode: GeminiThinkingMode.high,
+            )
+            .toList();
+
+        final captured = verify(
+          () => mockClient.createChatCompletionStream(
+            request: captureAny(named: 'request'),
+          ),
+        ).captured;
+
+        final request = captured.first as CreateChatCompletionRequest;
+        expect(request.reasoningEffort, ReasoningEffort.high);
+      },
+    );
+
+    test(
+      'generateWithImages skips reasoning effort for pre-Gemini 3 models',
+      () async {
+        final geminiProvider =
+            AiConfig.inferenceProvider(
+                  id: 'gemini-provider',
+                  name: 'Gemini',
+                  baseUrl: 'https://generativelanguage.googleapis.com',
+                  apiKey: 'test-api-key',
+                  createdAt: DateTime(2024, 3, 15),
+                  inferenceProviderType: InferenceProviderType.gemini,
+                )
+                as AiConfigInferenceProvider;
+
+        when(
+          () => mockClient.createChatCompletionStream(
+            request: any(named: 'request'),
+          ),
+        ).thenAnswer((_) => const Stream.empty());
+
+        await repository
+            .generateWithImages(
+              prompt,
+              model: 'gemini-2.5-flash',
+              temperature: null,
+              baseUrl: geminiProvider.baseUrl,
+              apiKey: geminiProvider.apiKey,
+              images: const ['base64-image-data'],
+              provider: geminiProvider,
+              overrideClient: mockClient,
+              geminiThinkingMode: GeminiThinkingMode.high,
+            )
+            .toList();
+
+        final captured = verify(
+          () => mockClient.createChatCompletionStream(
+            request: captureAny(named: 'request'),
+          ),
+        ).captured;
+
+        final request = captured.first as CreateChatCompletionRequest;
+        expect(request.reasoningEffort, isNull);
+      },
+    );
+
+    test(
+      'generateWithAudio maps Gemini 3 thinking mode to reasoning effort',
+      () async {
+        final geminiProvider =
+            AiConfig.inferenceProvider(
+                  id: 'gemini-provider',
+                  name: 'Gemini',
+                  baseUrl: 'https://generativelanguage.googleapis.com',
+                  apiKey: 'test-api-key',
+                  createdAt: DateTime(2024, 3, 15),
+                  inferenceProviderType: InferenceProviderType.gemini,
+                )
+                as AiConfigInferenceProvider;
+
+        when(
+          () => mockClient.createChatCompletionStream(
+            request: any(named: 'request'),
+          ),
+        ).thenAnswer((_) => const Stream.empty());
+
+        await repository
+            .generateWithAudio(
+              prompt,
+              model: 'models/gemini-3.1-pro-preview',
+              audioBase64: 'base64-audio-data',
+              baseUrl: geminiProvider.baseUrl,
+              apiKey: geminiProvider.apiKey,
+              provider: geminiProvider,
+              overrideClient: mockClient,
+              geminiThinkingMode: GeminiThinkingMode.minimal,
+            )
+            .toList();
+
+        final captured = verify(
+          () => mockClient.createChatCompletionStream(
+            request: captureAny(named: 'request'),
+          ),
+        ).captured;
+
+        final request = captured.first as CreateChatCompletionRequest;
+        expect(request.reasoningEffort, ReasoningEffort.minimal);
+      },
+    );
+
     test('generate with empty tools list does not set toolChoice', () async {
       // Arrange
       final emptyTools = <ChatCompletionTool>[];

--- a/test/features/ai/repository/gemini_thinking_config_test.dart
+++ b/test/features/ai/repository/gemini_thinking_config_test.dart
@@ -18,6 +18,7 @@ enum _GeneratedGeminiThinkingModelKind {
   nullModel,
   gemini3WithPrefix,
   gemini3WithoutPrefix,
+  gemini3FlashWithPrefix,
   gemini3LegacyWithPrefix,
   gemini25,
   gemini20,
@@ -45,6 +46,8 @@ String? _generatedThinkingModelId(_GeneratedGeminiThinkingModelKind kind) {
       'models/gemini-3.1-pro-preview',
     _GeneratedGeminiThinkingModelKind.gemini3WithoutPrefix =>
       'gemini-3.1-pro-preview',
+    _GeneratedGeminiThinkingModelKind.gemini3FlashWithPrefix =>
+      'models/gemini-3-flash-preview',
     _GeneratedGeminiThinkingModelKind.gemini3LegacyWithPrefix =>
       'models/gemini-3-pro-preview',
     _GeneratedGeminiThinkingModelKind.gemini25 => 'models/gemini-2.5-pro',
@@ -55,12 +58,26 @@ String? _generatedThinkingModelId(_GeneratedGeminiThinkingModelKind kind) {
   };
 }
 
-String _generatedThinkingLevel(int budget) {
-  if (budget == -1) return 'high';
-  if (budget == 0) return 'minimal';
-  if (budget < 4096) return 'low';
-  if (budget < 8192) return 'medium';
-  return 'high';
+String _generatedThinkingLevel(int budget, {String? modelId}) {
+  final level = switch (budget) {
+    -1 => 'high',
+    0 => 'minimal',
+    < 4096 => 'low',
+    < 8192 => 'medium',
+    _ => 'high',
+  };
+
+  if (modelId != null &&
+      GeminiThinkingConfig.isGemini3(modelId) &&
+      !GeminiThinkingConfig.isGemini3Flash(modelId)) {
+    return switch (level) {
+      'minimal' || 'low' => 'low',
+      'medium' || 'high' => 'high',
+      _ => level,
+    };
+  }
+
+  return level;
 }
 
 class _GeneratedGeminiThinkingScenario {
@@ -84,7 +101,7 @@ class _GeneratedGeminiThinkingScenario {
   Map<String, dynamic> get expectedJson {
     if (isGemini3Model) {
       return {
-        'thinkingLevel': _generatedThinkingLevel(budget),
+        'thinkingLevel': _generatedThinkingLevel(budget, modelId: modelId),
         'includeThoughts': includeThoughts,
       };
     }
@@ -233,6 +250,16 @@ void main() {
           expect(
             config.toJson(modelId: 'gemini-3.1-pro-preview'),
             {
+              'thinkingLevel': switch (entry.key) {
+                GeminiThinkingMode.minimal || GeminiThinkingMode.low => 'low',
+                GeminiThinkingMode.medium || GeminiThinkingMode.high => 'high',
+              },
+              'includeThoughts': entry.key != GeminiThinkingMode.minimal,
+            },
+          );
+          expect(
+            config.toJson(modelId: 'gemini-3-flash-preview'),
+            {
               'thinkingLevel': entry.value.$2,
               'includeThoughts': entry.key != GeminiThinkingMode.minimal,
             },
@@ -364,11 +391,11 @@ void main() {
         expect(json['thinkingLevel'], 'high');
       });
 
-      test('maps disabled preset to minimal for Gemini 3', () {
+      test('maps disabled preset to low for Gemini 3 Pro', () {
         final json = GeminiThinkingConfig.disabled.toJson(
           modelId: 'gemini-3.1-pro-preview',
         );
-        expect(json['thinkingLevel'], 'minimal');
+        expect(json['thinkingLevel'], 'low');
       });
 
       test('maps standard preset (8192) to high for Gemini 3', () {
@@ -378,10 +405,10 @@ void main() {
         expect(json['thinkingLevel'], 'high');
       });
 
-      test('maps budget 4096 to medium for Gemini 3', () {
+      test('maps budget 4096 to high for Gemini 3 Pro', () {
         const config = GeminiThinkingConfig(thinkingBudget: 4096);
         final json = config.toJson(modelId: 'gemini-3-pro-preview');
-        expect(json['thinkingLevel'], 'medium');
+        expect(json['thinkingLevel'], 'high');
       });
 
       test('maps budget 2048 to low for Gemini 3', () {

--- a/test/features/ai/repository/unified_ai_inference_repository_test.dart
+++ b/test/features/ai/repository/unified_ai_inference_repository_test.dart
@@ -1413,6 +1413,101 @@ void main() {
         }
       });
 
+      test(
+        'forwards the model row thinking mode to generateWithImages '
+        'for Gemini providers',
+        () async {
+          final tempDir = Directory.systemTemp.createTempSync('image_gemini');
+          overrideTempDirs.add(tempDir);
+          when(() => mockDirectory.path).thenReturn(tempDir.path);
+
+          final imageEntity = JournalImage(
+            meta: _createMetadata(),
+            data: ImageData(
+              capturedAt: DateTime(2024, 3, 15, 10, 30),
+              imageId: 'test-image',
+              imageFile: 'test.jpg',
+              imageDirectory: '/images/',
+            ),
+          );
+          Directory('${tempDir.path}/images').createSync(recursive: true);
+          File(
+            '${tempDir.path}/images/test.jpg',
+          ).writeAsBytesSync(Uint8List.fromList([1, 2, 3, 4]));
+
+          final promptConfig = _createPrompt(
+            id: 'prompt-1',
+            name: 'Image Analysis',
+            requiredInputData: [InputDataType.images],
+            aiResponseType: AiResponseType.imageAnalysis,
+          );
+          final model = _createModel(
+            id: 'model-1',
+            inferenceProviderId: 'provider-1',
+            providerModelId: 'gemini-3-flash-preview',
+            geminiThinkingMode: GeminiThinkingMode.high,
+          );
+          final provider = _createProvider(
+            id: 'provider-1',
+            inferenceProviderType: InferenceProviderType.gemini,
+          );
+
+          _stubInferenceContext(
+            mockAiInputRepo: mockAiInputRepo,
+            mockAiConfigRepo: mockAiConfigRepo,
+            entity: imageEntity,
+            model: model,
+            provider: provider,
+            taskDetailsJson: '{"image": "test.jpg"}',
+          );
+          when(
+            () => mockJournalRepo.getLinkedToEntities(linkedTo: 'test-id'),
+          ).thenAnswer((_) async => []);
+          when(
+            () => mockCloudInferenceRepo.generateWithImages(
+              any(),
+              provider: any(named: 'provider'),
+              model: any(named: 'model'),
+              temperature: any(named: 'temperature'),
+              images: any(named: 'images'),
+              baseUrl: any(named: 'baseUrl'),
+              apiKey: any(named: 'apiKey'),
+              maxCompletionTokens: any(named: 'maxCompletionTokens'),
+              geminiThinkingMode: any(named: 'geminiThinkingMode'),
+            ),
+          ).thenAnswer((_) => _createMockTextStream(['A cat']));
+          _stubCreateAiResponseEntry(mockAiInputRepo);
+          when(
+            () => mockJournalRepo.updateJournalEntity(any()),
+          ).thenAnswer((_) async => true);
+
+          try {
+            await repository!.runInference(
+              entityId: 'test-id',
+              promptConfig: promptConfig,
+              onProgress: (_) {},
+              onStatusChange: (_) {},
+            );
+
+            verify(
+              () => mockCloudInferenceRepo.generateWithImages(
+                any(),
+                provider: any(named: 'provider'),
+                model: 'gemini-3-flash-preview',
+                temperature: any(named: 'temperature'),
+                images: any(named: 'images'),
+                baseUrl: any(named: 'baseUrl'),
+                apiKey: any(named: 'apiKey'),
+                maxCompletionTokens: any(named: 'maxCompletionTokens'),
+                geminiThinkingMode: GeminiThinkingMode.high,
+              ),
+            ).called(1);
+          } finally {
+            tempDir.deleteSync(recursive: true);
+          }
+        },
+      );
+
       test('rethrows when the image file is missing on disk', () async {
         // Point the documents directory at an empty temp dir WITHOUT creating
         // the image file, so _prepareImages' readAsBytes fails.
@@ -1642,6 +1737,106 @@ void main() {
           tempDir.deleteSync(recursive: true);
         }
       });
+
+      test(
+        'forwards the model row thinking mode to generateWithAudio '
+        'for Gemini providers',
+        () async {
+          final tempDir = Directory.systemTemp.createTempSync('audio_gemini');
+          overrideTempDirs.add(tempDir);
+          when(() => mockDirectory.path).thenReturn(tempDir.path);
+
+          final audioEntity = JournalAudio(
+            meta: _createMetadata(),
+            data: AudioData(
+              dateFrom: DateTime(2024, 3, 15, 10, 30),
+              dateTo: DateTime(2024, 3, 15, 10, 30),
+              audioFile: 'test.mp3',
+              audioDirectory: '/audio/',
+              duration: const Duration(seconds: 30),
+            ),
+          );
+          Directory('${tempDir.path}/audio').createSync(recursive: true);
+          File(
+            '${tempDir.path}/audio/test.mp3',
+          ).writeAsBytesSync(Uint8List.fromList([1, 2, 3]));
+
+          final promptConfig = _createPrompt(
+            id: 'prompt-1',
+            name: 'Audio Transcription',
+            requiredInputData: [InputDataType.audioFiles],
+            aiResponseType: AiResponseType.audioTranscription,
+          );
+          final model = _createModel(
+            id: 'model-1',
+            inferenceProviderId: 'provider-1',
+            providerModelId: 'gemini-3-flash-preview',
+            geminiThinkingMode: GeminiThinkingMode.medium,
+          );
+          final provider = _createProvider(
+            id: 'provider-1',
+            inferenceProviderType: InferenceProviderType.gemini,
+          );
+
+          _stubInferenceContext(
+            mockAiInputRepo: mockAiInputRepo,
+            mockAiConfigRepo: mockAiConfigRepo,
+            entity: audioEntity,
+            model: model,
+            provider: provider,
+            taskDetailsJson: '{"audio": "test.mp3"}',
+          );
+          when(
+            () => mockCloudInferenceRepo.generateWithAudio(
+              any(),
+              provider: any(named: 'provider'),
+              model: any(named: 'model'),
+              audioBase64: any(named: 'audioBase64'),
+              baseUrl: any(named: 'baseUrl'),
+              apiKey: any(named: 'apiKey'),
+              maxCompletionTokens: any(named: 'maxCompletionTokens'),
+              stream: any(named: 'stream'),
+              audioFormat: any(named: 'audioFormat'),
+              speechDictionaryTerms: any(named: 'speechDictionaryTerms'),
+              geminiThinkingMode: any(named: 'geminiThinkingMode'),
+            ),
+          ).thenAnswer((_) => _createMockTextStream(['Hello']));
+          _stubCreateAiResponseEntry(mockAiInputRepo);
+          when(
+            () => mockJournalRepo.updateJournalEntity(any()),
+          ).thenAnswer((_) async => true);
+          when(
+            () => mockJournalRepo.getLinkedToEntities(linkedTo: 'test-id'),
+          ).thenAnswer((_) async => []);
+
+          try {
+            await repository!.runInference(
+              entityId: 'test-id',
+              promptConfig: promptConfig,
+              onProgress: (_) {},
+              onStatusChange: (_) {},
+            );
+
+            verify(
+              () => mockCloudInferenceRepo.generateWithAudio(
+                any(),
+                provider: any(named: 'provider'),
+                model: 'gemini-3-flash-preview',
+                audioBase64: any(named: 'audioBase64'),
+                baseUrl: any(named: 'baseUrl'),
+                apiKey: any(named: 'apiKey'),
+                maxCompletionTokens: any(named: 'maxCompletionTokens'),
+                stream: any(named: 'stream'),
+                audioFormat: any(named: 'audioFormat'),
+                speechDictionaryTerms: any(named: 'speechDictionaryTerms'),
+                geminiThinkingMode: GeminiThinkingMode.medium,
+              ),
+            ).called(1);
+          } finally {
+            tempDir.deleteSync(recursive: true);
+          }
+        },
+      );
 
       test('handles reasoning model response with thoughts', () async {
         final taskEntity = Task(
@@ -7415,6 +7610,7 @@ AiConfigModel _createModel({
   required String id,
   required String inferenceProviderId,
   required String providerModelId,
+  GeminiThinkingMode geminiThinkingMode = GeminiThinkingMode.low,
 }) {
   return AiConfigModel(
     id: id,
@@ -7425,6 +7621,7 @@ AiConfigModel _createModel({
     inputModalities: [Modality.text],
     outputModalities: [Modality.text],
     isReasoningModel: false,
+    geminiThinkingMode: geminiThinkingMode,
   );
 }
 

--- a/test/features/ai/services/skill_inference_runner_test.dart
+++ b/test/features/ai/services/skill_inference_runner_test.dart
@@ -746,6 +746,176 @@ void main() {
         expect(updatedEntity.data.transcripts!.last.model, 'whisper-1');
       });
 
+      test(
+        'forwards the resolved Gemini thinking mode for Gemini 3 targets',
+        () async {
+          final audioEntity = makeAudioEntity();
+          final audioDir = Directory('${tempDir.path}/audio');
+          await audioDir.create(recursive: true);
+          await File(
+            '${audioDir.path}/test.aac',
+          ).writeAsBytes([0x48, 0x65]);
+
+          final geminiModelRow = testAiModel(
+            id: 'gemini-3-row',
+            providerModelId: 'gemini-3-flash-preview',
+            inferenceProviderId: 'p-audio',
+          ).copyWith(geminiThinkingMode: GeminiThinkingMode.high);
+          final result = AutomationResult(
+            handled: true,
+            resolvedProfile: ResolvedProfile(
+              thinkingModelId: 'models/gemini-3-flash-preview',
+              thinkingProvider: testInferenceProvider(),
+              transcriptionModelId: 'gemini-3-flash-preview',
+              transcriptionProvider: testInferenceProvider(id: 'p-audio'),
+              transcriptionModel: geminiModelRow,
+            ),
+            skill: testSkill,
+            skillAssignment: const SkillAssignment(
+              skillId: 'skill-transcribe',
+              automate: true,
+            ),
+          );
+
+          when(
+            () => mockAiInputRepo.getEntity('audio-1'),
+          ).thenAnswer((_) async => audioEntity);
+          when(
+            () => mockPromptBuilderHelper.getSpeechDictionaryTerms(
+              audioEntity,
+            ),
+          ).thenAnswer((_) async => []);
+          when(
+            () => mockTaskSummaryResolver.resolve(any()),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockCloudRepo.generateWithAudio(
+              any(),
+              model: any(named: 'model'),
+              audioBase64: any(named: 'audioBase64'),
+              baseUrl: any(named: 'baseUrl'),
+              apiKey: any(named: 'apiKey'),
+              provider: any(named: 'provider'),
+              systemMessage: any(named: 'systemMessage'),
+              geminiThinkingMode: any(named: 'geminiThinkingMode'),
+              speechDictionaryTerms: any(named: 'speechDictionaryTerms'),
+            ),
+          ).thenAnswer(
+            (_) => Stream.fromIterable([makeStreamChunk('Hello')]),
+          );
+          when(
+            () => mockJournalRepo.updateJournalEntity(any()),
+          ).thenAnswer((_) async => true);
+          stubLoggingEvent();
+
+          await runner.runTranscription(
+            audioEntryId: 'audio-1',
+            automationResult: result,
+          );
+
+          // The model row's saved default thinking mode reaches the cloud
+          // call because the target is a Gemini 3 model on a Gemini
+          // provider and no per-invocation override was given.
+          verify(
+            () => mockCloudRepo.generateWithAudio(
+              any(),
+              model: 'gemini-3-flash-preview',
+              audioBase64: any(named: 'audioBase64'),
+              baseUrl: any(named: 'baseUrl'),
+              apiKey: any(named: 'apiKey'),
+              provider: any(named: 'provider'),
+              systemMessage: any(named: 'systemMessage'),
+              geminiThinkingMode: GeminiThinkingMode.high,
+              speechDictionaryTerms: any(named: 'speechDictionaryTerms'),
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'a per-invocation thinking mode override beats the model default',
+        () async {
+          final audioEntity = makeAudioEntity();
+          final audioDir = Directory('${tempDir.path}/audio');
+          await audioDir.create(recursive: true);
+          await File(
+            '${audioDir.path}/test.aac',
+          ).writeAsBytes([0x48, 0x65]);
+
+          final geminiModelRow = testAiModel(
+            id: 'gemini-3-row',
+            providerModelId: 'gemini-3-flash-preview',
+            inferenceProviderId: 'p-audio',
+          ).copyWith(geminiThinkingMode: GeminiThinkingMode.high);
+          final result = AutomationResult(
+            handled: true,
+            resolvedProfile: ResolvedProfile(
+              thinkingModelId: 'models/gemini-3-flash-preview',
+              thinkingProvider: testInferenceProvider(),
+              transcriptionModelId: 'gemini-3-flash-preview',
+              transcriptionProvider: testInferenceProvider(id: 'p-audio'),
+              transcriptionModel: geminiModelRow,
+            ),
+            skill: testSkill,
+            skillAssignment: const SkillAssignment(
+              skillId: 'skill-transcribe',
+              automate: true,
+            ),
+          );
+
+          when(
+            () => mockAiInputRepo.getEntity('audio-1'),
+          ).thenAnswer((_) async => audioEntity);
+          when(
+            () => mockPromptBuilderHelper.getSpeechDictionaryTerms(
+              audioEntity,
+            ),
+          ).thenAnswer((_) async => []);
+          when(
+            () => mockTaskSummaryResolver.resolve(any()),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockCloudRepo.generateWithAudio(
+              any(),
+              model: any(named: 'model'),
+              audioBase64: any(named: 'audioBase64'),
+              baseUrl: any(named: 'baseUrl'),
+              apiKey: any(named: 'apiKey'),
+              provider: any(named: 'provider'),
+              systemMessage: any(named: 'systemMessage'),
+              geminiThinkingMode: any(named: 'geminiThinkingMode'),
+              speechDictionaryTerms: any(named: 'speechDictionaryTerms'),
+            ),
+          ).thenAnswer(
+            (_) => Stream.fromIterable([makeStreamChunk('Hello')]),
+          );
+          when(
+            () => mockJournalRepo.updateJournalEntity(any()),
+          ).thenAnswer((_) async => true);
+          stubLoggingEvent();
+
+          await runner.runTranscription(
+            audioEntryId: 'audio-1',
+            automationResult: result,
+            geminiThinkingMode: GeminiThinkingMode.minimal,
+          );
+
+          verify(
+            () => mockCloudRepo.generateWithAudio(
+              any(),
+              model: 'gemini-3-flash-preview',
+              audioBase64: any(named: 'audioBase64'),
+              baseUrl: any(named: 'baseUrl'),
+              apiKey: any(named: 'apiKey'),
+              provider: any(named: 'provider'),
+              systemMessage: any(named: 'systemMessage'),
+              geminiThinkingMode: GeminiThinkingMode.minimal,
+              speechDictionaryTerms: any(named: 'speechDictionaryTerms'),
+            ),
+          ).called(1);
+        },
+      );
+
       test('returns early on empty transcription response', () async {
         final audioEntity = makeAudioEntity();
 

--- a/test/features/ai/state/ai_config_initialization_test.dart
+++ b/test/features/ai/state/ai_config_initialization_test.dart
@@ -122,7 +122,10 @@ void main() {
     test('completes normally and still seeds profiles when model backfill '
         'throws', () async {
       when(() => repo.getConfigById(any())).thenAnswer((_) async => null);
+      when(() => repo.getConfigsByType(any())).thenAnswer((_) async => []);
       // Backfill reads inference-provider configs first; make that throw.
+      // Seeding and upgrading read model/profile configs, which stay stubbed
+      // above, so they must still run after the backfill failure.
       when(
         () => repo.getConfigsByType(AiConfigType.inferenceProvider),
       ).thenThrow(Exception('db unavailable'));
@@ -136,7 +139,38 @@ void main() {
         completes,
       );
 
-      // Profile seeding ran to completion before the backfill failure.
+      // Profile seeding ran to completion despite the backfill failure.
+      expect(
+        savedConfigs(),
+        hasLength(ProfileSeedingService.defaultProfiles.length),
+      );
+
+      // The upgrade pass also ran: it reads the existing inference profiles.
+      verify(
+        () => repo.getConfigsByType(AiConfigType.inferenceProfile),
+      ).called(1);
+    });
+
+    test('completes normally and still backfills models when profile '
+        'upgrade throws', () async {
+      when(() => repo.getConfigById(any())).thenAnswer((_) async => null);
+      when(() => repo.getConfigsByType(any())).thenAnswer((_) async => []);
+      // upgradeExisting() is the only step reading inference profiles.
+      when(
+        () => repo.getConfigsByType(AiConfigType.inferenceProfile),
+      ).thenThrow(Exception('db unavailable'));
+
+      final container = createContainer();
+
+      await expectLater(
+        container.read(aiConfigInitializationProvider.future),
+        completes,
+      );
+
+      // Backfill and seeding both completed before the upgrade failure.
+      verify(
+        () => repo.getConfigsByType(AiConfigType.inferenceProvider),
+      ).called(1);
       expect(
         savedConfigs(),
         hasLength(ProfileSeedingService.defaultProfiles.length),

--- a/test/features/ai/state/settings/inference_provider_form_controller_test.dart
+++ b/test/features/ai/state/settings/inference_provider_form_controller_test.dart
@@ -207,6 +207,7 @@ void main() {
   setUpAll(() {
     registerFallbackValue(testConfig);
     registerFallbackValue(ollamaConfig);
+    registerFallbackValue(AiConfigType.model);
   });
 
   setUp(() {
@@ -269,7 +270,7 @@ void main() {
       // Arrange
       when(() => mockRepository.saveConfig(any())).thenAnswer((_) async {});
       when(
-        () => mockRepository.getConfigsByType(AiConfigType.model),
+        () => mockRepository.getConfigsByType(any()),
       ).thenAnswer((_) async => []);
 
       // Act
@@ -1151,10 +1152,7 @@ void main() {
       // Arrange
       when(() => mockRepository.saveConfig(any())).thenAnswer((_) async {});
       when(
-        () => mockRepository.getConfigsByType(AiConfigType.model),
-      ).thenAnswer((_) async => []);
-      when(
-        () => mockRepository.getConfigsByType(AiConfigType.inferenceProvider),
+        () => mockRepository.getConfigsByType(any()),
       ).thenAnswer((_) async => []);
 
       // Act
@@ -1181,10 +1179,7 @@ void main() {
       // Arrange
       when(() => mockRepository.saveConfig(any())).thenAnswer((_) async {});
       when(
-        () => mockRepository.getConfigsByType(AiConfigType.model),
-      ).thenAnswer((_) async => []);
-      when(
-        () => mockRepository.getConfigsByType(AiConfigType.inferenceProvider),
+        () => mockRepository.getConfigsByType(any()),
       ).thenAnswer((_) async => []);
 
       // Act
@@ -1203,11 +1198,13 @@ void main() {
 
       await controller.addConfig(geminiConfig);
 
-      // Assert - should save provider and check for existing models
+      // Assert - should save provider and check for existing models.
+      // Two reads: the model prepopulation pass and the subsequent
+      // profile upgrade pass each fetch the model rows.
       verify(() => mockRepository.saveConfig(geminiConfig)).called(1);
       verify(
         () => mockRepository.getConfigsByType(AiConfigType.model),
-      ).called(1);
+      ).called(2);
     });
   });
 

--- a/test/features/ai/state/skill_trigger_providers_test.dart
+++ b/test/features/ai/state/skill_trigger_providers_test.dart
@@ -1077,6 +1077,7 @@ void main() {
           linkedTaskId: 'task-1',
           referenceImages: null,
           overrideModelId: null,
+          geminiThinkingMode: null,
         )).future,
       );
 
@@ -1137,6 +1138,7 @@ void main() {
             linkedTaskId: null,
             referenceImages: null,
             overrideModelId: null,
+            geminiThinkingMode: null,
           )).future,
         );
 
@@ -1181,6 +1183,7 @@ void main() {
           linkedTaskId: 'task-no-profile',
           referenceImages: null,
           overrideModelId: null,
+          geminiThinkingMode: null,
         )).future,
       );
 
@@ -1238,6 +1241,8 @@ void main() {
           audioEntryId: any(named: 'audioEntryId'),
           automationResult: any(named: 'automationResult'),
           linkedTaskId: any(named: 'linkedTaskId'),
+          overrideModelId: any(named: 'overrideModelId'),
+          geminiThinkingMode: any(named: 'geminiThinkingMode'),
         ),
       ).thenAnswer((_) async {});
 
@@ -1257,6 +1262,7 @@ void main() {
           linkedTaskId: 'task-1',
           referenceImages: null,
           overrideModelId: null,
+          geminiThinkingMode: null,
         )).future,
       );
 
@@ -1265,6 +1271,8 @@ void main() {
           audioEntryId: 'audio-entry-1',
           automationResult: any(named: 'automationResult'),
           linkedTaskId: 'task-1',
+          overrideModelId: any(named: 'overrideModelId'),
+          geminiThinkingMode: any(named: 'geminiThinkingMode'),
         ),
       ).called(1);
     });
@@ -1309,6 +1317,8 @@ void main() {
             audioEntryId: any(named: 'audioEntryId'),
             automationResult: any(named: 'automationResult'),
             linkedTaskId: any(named: 'linkedTaskId'),
+            overrideModelId: any(named: 'overrideModelId'),
+            geminiThinkingMode: any(named: 'geminiThinkingMode'),
           ),
         ).thenThrow(StateError('runner blew up'));
 
@@ -1330,6 +1340,7 @@ void main() {
             linkedTaskId: 'task-1',
             referenceImages: null,
             overrideModelId: null,
+            geminiThinkingMode: null,
           )).future,
         );
 
@@ -1415,6 +1426,8 @@ void main() {
             audioEntryId: any(named: 'audioEntryId'),
             automationResult: any(named: 'automationResult'),
             linkedTaskId: any(named: 'linkedTaskId'),
+            overrideModelId: any(named: 'overrideModelId'),
+            geminiThinkingMode: any(named: 'geminiThinkingMode'),
           ),
         ).thenAnswer((_) async {});
 
@@ -1435,6 +1448,7 @@ void main() {
             linkedTaskId: null,
             referenceImages: null,
             overrideModelId: null,
+            geminiThinkingMode: null,
           )).future,
         );
 
@@ -1446,6 +1460,8 @@ void main() {
           () => mockRunner.runTranscription(
             audioEntryId: 'standalone-audio-1',
             automationResult: any(named: 'automationResult'),
+            overrideModelId: any(named: 'overrideModelId'),
+            geminiThinkingMode: any(named: 'geminiThinkingMode'),
           ),
         ).called(1);
       },
@@ -1484,6 +1500,7 @@ void main() {
             linkedTaskId: null,
             referenceImages: null,
             overrideModelId: null,
+            geminiThinkingMode: null,
           )).future,
         );
 
@@ -1543,6 +1560,8 @@ void main() {
           imageEntryId: any(named: 'imageEntryId'),
           automationResult: any(named: 'automationResult'),
           linkedTaskId: any(named: 'linkedTaskId'),
+          overrideModelId: any(named: 'overrideModelId'),
+          geminiThinkingMode: any(named: 'geminiThinkingMode'),
         ),
       ).thenAnswer((_) async {});
 
@@ -1562,6 +1581,7 @@ void main() {
           linkedTaskId: 'task-img',
           referenceImages: null,
           overrideModelId: null,
+          geminiThinkingMode: null,
         )).future,
       );
 
@@ -1570,6 +1590,8 @@ void main() {
           imageEntryId: 'image-entry-1',
           automationResult: any(named: 'automationResult'),
           linkedTaskId: 'task-img',
+          overrideModelId: any(named: 'overrideModelId'),
+          geminiThinkingMode: any(named: 'geminiThinkingMode'),
         ),
       ).called(1);
     });
@@ -1632,6 +1654,7 @@ void main() {
             automationResult: any(named: 'automationResult'),
             linkedTaskId: any(named: 'linkedTaskId'),
             overrideModelId: any(named: 'overrideModelId'),
+            geminiThinkingMode: any(named: 'geminiThinkingMode'),
           ),
         ).thenAnswer((_) async {});
 
@@ -1651,6 +1674,7 @@ void main() {
             linkedTaskId: 'task-img',
             referenceImages: null,
             overrideModelId: 'override-vision-model-id',
+            geminiThinkingMode: null,
           )).future,
         );
 
@@ -1660,6 +1684,7 @@ void main() {
             automationResult: any(named: 'automationResult'),
             linkedTaskId: 'task-img',
             overrideModelId: 'override-vision-model-id',
+            geminiThinkingMode: any(named: 'geminiThinkingMode'),
           ),
         ).called(1);
       },
@@ -1703,6 +1728,8 @@ void main() {
           entryId: any(named: 'entryId'),
           automationResult: any(named: 'automationResult'),
           linkedTaskId: any(named: 'linkedTaskId'),
+          overrideModelId: any(named: 'overrideModelId'),
+          geminiThinkingMode: any(named: 'geminiThinkingMode'),
         ),
       ).thenAnswer((_) async {});
 
@@ -1722,6 +1749,7 @@ void main() {
           linkedTaskId: 'task-prompt',
           referenceImages: null,
           overrideModelId: null,
+          geminiThinkingMode: null,
         )).future,
       );
 
@@ -1730,6 +1758,8 @@ void main() {
           entryId: 'audio-entry-2',
           automationResult: any(named: 'automationResult'),
           linkedTaskId: 'task-prompt',
+          overrideModelId: any(named: 'overrideModelId'),
+          geminiThinkingMode: any(named: 'geminiThinkingMode'),
         ),
       ).called(1);
     });
@@ -1795,6 +1825,7 @@ void main() {
           linkedTaskId: 'task-imggen',
           referenceImages: null,
           overrideModelId: null,
+          geminiThinkingMode: null,
         )).future,
       );
 
@@ -1878,6 +1909,7 @@ void main() {
           linkedTaskId: 'task-imggen2',
           referenceImages: refImages,
           overrideModelId: null,
+          geminiThinkingMode: null,
         )).future,
       );
 
@@ -1932,6 +1964,8 @@ void main() {
             entryId: any(named: 'entryId'),
             automationResult: any(named: 'automationResult'),
             linkedTaskId: any(named: 'linkedTaskId'),
+            overrideModelId: any(named: 'overrideModelId'),
+            geminiThinkingMode: any(named: 'geminiThinkingMode'),
           ),
         ).thenAnswer((_) async {});
 
@@ -1951,6 +1985,7 @@ void main() {
             linkedTaskId: 'task-img-prompt',
             referenceImages: null,
             overrideModelId: null,
+            geminiThinkingMode: null,
           )).future,
         );
 
@@ -1959,6 +1994,8 @@ void main() {
             entryId: 'entry-img-prompt',
             automationResult: any(named: 'automationResult'),
             linkedTaskId: 'task-img-prompt',
+            overrideModelId: any(named: 'overrideModelId'),
+            geminiThinkingMode: any(named: 'geminiThinkingMode'),
           ),
         ).called(1);
         verifyNever(
@@ -2047,6 +2084,7 @@ void main() {
             linkedTaskId: null,
             referenceImages: null,
             overrideModelId: null,
+            geminiThinkingMode: null,
           )).future,
         );
 

--- a/test/features/ai/ui/inference_profile_form_test.dart
+++ b/test/features/ai/ui/inference_profile_form_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/model/skill_assignment.dart';
+import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 import 'package:lotti/features/ai/skills/built_in_skills.dart';
 import 'package:lotti/features/ai/state/consts.dart';
 import 'package:lotti/features/ai/state/inference_profile_controller.dart';
@@ -13,18 +14,22 @@ import 'package:lotti/features/ai/ui/widgets/profile_pinning_selector.dart';
 import 'package:lotti/features/design_system/components/search/design_system_search.dart';
 import 'package:lotti/features/sync/model/sync_node_profile.dart';
 import 'package:lotti/features/sync/state/synced_audio_inference_providers.dart';
+import 'package:mocktail/mocktail.dart';
 
+import '../../../mocks/mocks.dart';
 import '../../../widget_test_utils.dart';
 import '../../agents/test_utils.dart';
 
 void main() {
   late StreamController<List<AiConfig>> profileStreamController;
   late _FakeInferenceProfileController fakeProfileController;
+  late MockAiConfigRepository mockAiConfigRepository;
 
   setUp(() {
     profileStreamController = StreamController<List<AiConfig>>();
     fakeProfileController = _FakeInferenceProfileController()
       ..streamController = profileStreamController;
+    mockAiConfigRepository = MockAiConfigRepository();
   });
 
   tearDown(() {
@@ -37,9 +42,14 @@ void main() {
     List<AiConfig> providers = const [],
     List<SyncNodeProfile> knownNodes = const [],
   }) {
+    when(
+      () => mockAiConfigRepository.getConfigsByType(AiConfigType.model),
+    ).thenAnswer((_) async => models);
+
     return makeTestableWidgetNoScroll(
       InferenceProfileForm(existingProfile: existingProfile),
       overrides: [
+        aiConfigRepositoryProvider.overrideWithValue(mockAiConfigRepository),
         inferenceProfileControllerProvider.overrideWith(() {
           return fakeProfileController;
         }),
@@ -344,7 +354,7 @@ void main() {
       expect(fakeProfileController.savedProfiles.first.name, 'My New Profile');
       expect(
         fakeProfileController.savedProfiles.first.thinkingModelId,
-        'models/flash',
+        'tm-1',
       );
     });
 
@@ -1419,7 +1429,7 @@ void main() {
 
       expect(fakeProfileController.savedProfiles, hasLength(1));
       final saved = fakeProfileController.savedProfiles.first;
-      expect(saved.thinkingHighEndModelId, 'models/gemini-pro');
+      expect(saved.thinkingHighEndModelId, 'tm-2');
     });
 
     testWidgets('preserves existing profile ID when editing', (tester) async {

--- a/test/features/ai/ui/inference_profile_form_test.dart
+++ b/test/features/ai/ui/inference_profile_form_test.dart
@@ -1565,9 +1565,11 @@ void main() {
         await tester.pump(const Duration(milliseconds: 300));
 
         expect(fakeProfileController.savedProfiles, hasLength(1));
+        // Slots persist the canonical AiConfigModel.id, not the wire-level
+        // providerModelId.
         expect(
           fakeProfileController.savedProfiles.first.imageRecognitionModelId,
-          'models/vision',
+          'ir-1',
         );
       },
     );
@@ -1627,9 +1629,11 @@ void main() {
         await tester.pump(const Duration(milliseconds: 300));
 
         expect(fakeProfileController.savedProfiles, hasLength(1));
+        // Slots persist the canonical AiConfigModel.id, not the wire-level
+        // providerModelId.
         expect(
           fakeProfileController.savedProfiles.first.transcriptionModelId,
-          'models/whisper',
+          'tr-1',
         );
       },
     );
@@ -1689,10 +1693,113 @@ void main() {
         await tester.pump(const Duration(milliseconds: 300));
 
         expect(fakeProfileController.savedProfiles, hasLength(1));
+        // Slots persist the canonical AiConfigModel.id, not the wire-level
+        // providerModelId.
         expect(
           fakeProfileController.savedProfiles.first.imageGenerationModelId,
-          'models/imagen',
+          'ig-1',
         );
+      },
+    );
+  });
+
+  group('save-time slot normalization', () {
+    final visionModel =
+        AiConfig.model(
+              id: 'vision-row',
+              name: 'Vision Model',
+              providerModelId: 'models/vision',
+              inferenceProviderId: 'prov-1',
+              createdAt: DateTime(2024),
+              inputModalities: const [Modality.text, Modality.image],
+              outputModalities: const [Modality.text],
+              isReasoningModel: false,
+              supportsFunctionCalling: true,
+            )
+            as AiConfigModel;
+
+    AiConfigModel duplicateThinkingModel(String id) =>
+        AiConfig.model(
+              id: id,
+              name: 'Dup $id',
+              providerModelId: 'models/dup-thinking',
+              inferenceProviderId: 'prov-1',
+              createdAt: DateTime(2024),
+              inputModalities: const [Modality.text],
+              outputModalities: const [Modality.text],
+              isReasoningModel: false,
+              supportsFunctionCalling: true,
+            )
+            as AiConfigModel;
+
+    testWidgets(
+      'keeps image-analysis automation enabled when the slot resolves',
+      (tester) async {
+        final imageSkill = builtInSkills.firstWhere(
+          (s) => s.skillType == SkillType.imageAnalysis,
+        );
+        final profile = testInferenceProfile(
+          id: 'p-img-skill',
+          name: 'Image Skill Profile',
+          thinkingModelId: 'vision-row',
+          imageRecognitionModelId: 'vision-row',
+          skillAssignments: [
+            SkillAssignment(skillId: imageSkill.id, automate: true),
+          ],
+        );
+
+        await tester.pumpWidget(
+          buildSubject(existingProfile: profile, models: [visionModel]),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        await tester.tap(find.text('Save'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(fakeProfileController.savedProfiles, hasLength(1));
+        final saved = fakeProfileController.savedProfiles.first;
+        // The slot resolves to a real model row, so the automated
+        // image-analysis assignment survives the save-time sanitizer.
+        final assignment = saved.skillAssignments.singleWhere(
+          (a) => a.skillId == imageSkill.id,
+        );
+        expect(assignment.automate, isTrue);
+      },
+    );
+
+    testWidgets(
+      'aborts the save with a toast when the thinking slot value is an '
+      'ambiguous legacy id',
+      (tester) async {
+        // Two model rows share the legacy providerModelId the profile's
+        // thinking slot still stores — persisting either would pick an
+        // arbitrary row, so the save must force a re-selection instead.
+        final profile = testInferenceProfile(
+          id: 'p-ambiguous',
+          name: 'Ambiguous Profile',
+          thinkingModelId: 'models/dup-thinking',
+        );
+
+        await tester.pumpWidget(
+          buildSubject(
+            existingProfile: profile,
+            models: [
+              duplicateThinkingModel('dup-a'),
+              duplicateThinkingModel('dup-b'),
+            ],
+          ),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        await tester.tap(find.text('Save'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(fakeProfileController.savedProfiles, isEmpty);
+        expect(find.text('A thinking model is required'), findsOneWidget);
       },
     );
   });

--- a/test/features/ai/ui/settings/inference_provider_edit_page_test.dart
+++ b/test/features/ai/ui/settings/inference_provider_edit_page_test.dart
@@ -114,6 +114,11 @@ void main() {
     when(
       () => mockRepository.getConfigsByType(AiConfigType.prompt),
     ).thenAnswer((_) async => []);
+    // Saving a new provider runs a profile-upgrade pass after model
+    // prepopulation, which reads the existing inference profiles.
+    when(
+      () => mockRepository.getConfigsByType(AiConfigType.inferenceProfile),
+    ).thenAnswer((_) async => []);
 
     // Default category mock responses
     when(

--- a/test/features/ai/ui/unified_ai_skills_modal_test.dart
+++ b/test/features/ai/ui/unified_ai_skills_modal_test.dart
@@ -763,6 +763,21 @@ void main() {
 
     testWidgets('closes modal after skill selection', (tester) async {
       // Arrange
+      final now = DateTime(2024, 3, 15, 10);
+      final promptModel = _buildModel(
+        id: 'prompt-model',
+        name: 'Prompt Model',
+        providerModelId: 'gpt-4o',
+        providerId: 'provider-openai',
+        modality: Modality.text,
+        t: now,
+      );
+      final promptProvider = _buildProvider(
+        id: 'provider-openai',
+        name: 'OpenAI',
+        t: now,
+      );
+      TriggerSkillParams? capturedParams;
       await tester.pumpWidget(
         buildTestWidget(
           UnifiedAiPopUpMenu(
@@ -770,14 +785,16 @@ void main() {
             linkedFromId: null,
           ),
           overrides: [
-            hasAvailableSkillsProvider((
-              entityId: testTaskEntity.id,
-              linkedFromId: null,
-            )).overrideWith((ref) => Future.value(true)),
-            availableSkillsForEntityProvider((
-              entityId: testTaskEntity.id,
-              linkedFromId: null,
-            )).overrideWith((ref) => Future.value([testSkills.last])),
+            ..._baseOverrides(
+              entity: testTaskEntity,
+              skill: testSkills.last,
+              models: [promptModel],
+              resolver: _NullProfileResolver(),
+              configs: [promptModel, promptProvider],
+            ),
+            triggerSkillProvider.overrideWith((ref, params) async {
+              capturedParams = params;
+            }),
           ],
         ),
       );
@@ -788,20 +805,85 @@ void main() {
 
       // Act - Open the modal
       await tester.tap(find.byIcon(Icons.assistant_rounded));
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pumpAndSettle();
 
       // Verify modal is open
       expect(find.byType(UnifiedAiSkillsList), findsOneWidget);
 
       // Select a skill
       await tester.tap(find.text('Prompt Generation Skill'));
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pumpAndSettle();
 
       // Assert - Modal should be closed
       expect(find.byType(UnifiedAiSkillsList), findsNothing);
+      expect(capturedParams?.overrideModelId, promptModel.id);
     });
+
+    testWidgets(
+      'Gemini 3 prompt generation asks for thinking mode and forwards it',
+      (tester) async {
+        final now = DateTime(2024, 3, 15, 10);
+        final geminiProvider =
+            AiConfig.inferenceProvider(
+                  id: 'provider-gemini',
+                  baseUrl: 'https://generativelanguage.googleapis.com',
+                  name: 'Gemini',
+                  inferenceProviderType: InferenceProviderType.gemini,
+                  apiKey: '',
+                  createdAt: now,
+                )
+                as AiConfigInferenceProvider;
+        final geminiModel =
+            AiConfig.model(
+                  id: 'gemini-text-model',
+                  name: 'Gemini 3 Flash',
+                  providerModelId: 'gemini-3-flash-preview',
+                  inferenceProviderId: geminiProvider.id,
+                  createdAt: now,
+                  inputModalities: const [Modality.text],
+                  outputModalities: const [Modality.text],
+                  isReasoningModel: true,
+                )
+                as AiConfigModel;
+        TriggerSkillParams? capturedParams;
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            UnifiedAiPopUpMenu(
+              journalEntity: testTaskEntity,
+              linkedFromId: null,
+            ),
+            overrides: [
+              ..._baseOverrides(
+                entity: testTaskEntity,
+                skill: testSkills.last,
+                models: [geminiModel],
+                resolver: _NullProfileResolver(),
+                configs: [geminiModel, geminiProvider],
+              ),
+              triggerSkillProvider.overrideWith((ref, params) async {
+                capturedParams = params;
+              }),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byIcon(Icons.assistant_rounded));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Prompt Generation Skill'));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(UnifiedAiSkillsList), findsNothing);
+        expect(find.text('Gemini thinking mode'), findsOneWidget);
+
+        await tester.tap(find.text('High'));
+        await tester.pumpAndSettle();
+
+        expect(capturedParams?.overrideModelId, geminiModel.id);
+        expect(capturedParams?.geminiThinkingMode, GeminiThinkingMode.high);
+      },
+    );
   });
 
   group('Image Generation Skill Handling', () {

--- a/test/features/ai/ui/unified_ai_skills_modal_test.dart
+++ b/test/features/ai/ui/unified_ai_skills_modal_test.dart
@@ -884,6 +884,82 @@ void main() {
         expect(capturedParams?.geminiThinkingMode, GeminiThinkingMode.high);
       },
     );
+
+    testWidgets(
+      'prompt generation marks the profile high-end thinking row as the '
+      'picker default via its AiConfigModel.id and collapses picking it '
+      'to a null override',
+      (tester) async {
+        final now = DateTime(2024, 3, 15, 10);
+        final provider = _buildProvider(id: 'p-a', name: 'Provider A', t: now);
+        final defaultModel = _buildModel(
+          id: 'm-default',
+          name: 'Default Thinker',
+          providerModelId: 'wire-a',
+          providerId: 'p-a',
+          modality: Modality.text,
+          t: now,
+        );
+        final otherModel = _buildModel(
+          id: 'm-other',
+          name: 'Other Thinker',
+          providerModelId: 'wire-b',
+          providerId: 'p-a',
+          modality: Modality.text,
+          t: now,
+        );
+        // The profile's high-end slot resolved to the actual model row, so
+        // the popup must match it by AiConfigModel.id — not by walking the
+        // wire-level providerModelId.
+        final profile = ResolvedProfile(
+          thinkingModelId: 'wire-a',
+          thinkingProvider: provider,
+          thinkingModel: defaultModel,
+        );
+        TriggerSkillParams? capturedParams;
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            UnifiedAiPopUpMenu(
+              journalEntity: testTaskEntity,
+              linkedFromId: null,
+            ),
+            overrides: [
+              ..._baseOverrides(
+                entity: testTaskEntity,
+                skill: testSkills.last,
+                models: [defaultModel, otherModel],
+                resolver: _FixedProfileResolver(profile),
+                configs: [defaultModel, otherModel, provider],
+              ),
+              triggerSkillProvider.overrideWith((ref, params) async {
+                capturedParams = params;
+              }),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byIcon(Icons.assistant_rounded));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Prompt Generation Skill'));
+        await tester.pumpAndSettle();
+
+        // Picker shows both text-capable rows.
+        expect(find.byType(InferenceModelPickerModal), findsOneWidget);
+        expect(find.text('Default Thinker'), findsOneWidget);
+        expect(find.text('Other Thinker'), findsOneWidget);
+
+        // Picking the default row collapses the override to null so the
+        // runner reads the profile slot.
+        await tester.tap(find.text('Default Thinker'));
+        await tester.pumpAndSettle();
+
+        expect(capturedParams, isNotNull);
+        expect(capturedParams!.overrideModelId, isNull);
+        expect(capturedParams!.geminiThinkingMode, isNull);
+      },
+    );
   });
 
   group('Image Generation Skill Handling', () {

--- a/test/features/ai/ui/widgets/gemini_thinking_mode_picker_modal_test.dart
+++ b/test/features/ai/ui/widgets/gemini_thinking_mode_picker_modal_test.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/ui/widgets/gemini_thinking_mode_picker_modal.dart';
+import 'package:lotti/widgets/selection/selection_option.dart';
+
+import '../../../../widget_test_utils.dart';
+
+void main() {
+  group('GeminiThinkingModePickerContent', () {
+    testWidgets(
+      'renders one option per thinking mode with localized label and '
+      'description, marking only the preselected mode as selected',
+      (tester) async {
+        await tester.pumpWidget(
+          makeTestableWidget(
+            GeminiThinkingModePickerContent(
+              selectedMode: GeminiThinkingMode.medium,
+              onChanged: (_) {},
+            ),
+          ),
+        );
+        await tester.pump();
+
+        // All four modes render with their English labels + descriptions.
+        expect(find.text('Minimal'), findsOneWidget);
+        expect(find.text('Low'), findsOneWidget);
+        expect(find.text('Medium'), findsOneWidget);
+        expect(find.text('High'), findsOneWidget);
+        expect(
+          find.text('Balanced reasoning for more careful answers.'),
+          findsOneWidget,
+        );
+
+        // Exactly one option is selected, and it's the medium one.
+        final options = tester
+            .widgetList<SelectionOption>(find.byType(SelectionOption))
+            .toList();
+        expect(options, hasLength(GeminiThinkingMode.values.length));
+        final selected = options.where((o) => o.isSelected).toList();
+        expect(selected, hasLength(1));
+        expect(selected.single.title, 'Medium');
+      },
+    );
+
+    testWidgets('tapping an option invokes onChanged with that mode', (
+      tester,
+    ) async {
+      GeminiThinkingMode? changed;
+      await tester.pumpWidget(
+        makeTestableWidget(
+          GeminiThinkingModePickerContent(
+            selectedMode: GeminiThinkingMode.low,
+            onChanged: (mode) => changed = mode,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.tap(find.text('High'));
+      await tester.pump();
+
+      expect(changed, GeminiThinkingMode.high);
+    });
+
+    test('label, description, and icon are distinct per mode', () {
+      // The icon mapping is pure; label/description require a context and
+      // are covered by the widget test above. Distinctness here guards
+      // against copy-paste errors when a new mode is added.
+      final icons = GeminiThinkingMode.values
+          .map(GeminiThinkingModePickerContent.icon)
+          .toSet();
+      expect(icons, hasLength(GeminiThinkingMode.values.length));
+    });
+  });
+
+  group('GeminiThinkingModePickerModal.show', () {
+    Widget buildLauncher({
+      required ValueChanged<GeminiThinkingMode?> onResult,
+      String? title,
+    }) {
+      return makeTestableWidget(
+        Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () async {
+              final result = await GeminiThinkingModePickerModal.show(
+                context: context,
+                selectedMode: GeminiThinkingMode.low,
+                title: title,
+              );
+              onResult(result);
+            },
+            child: const Text('Open'),
+          ),
+        ),
+      );
+    }
+
+    testWidgets(
+      'opens with the default localized title and returns the tapped mode',
+      (tester) async {
+        GeminiThinkingMode? result;
+        var resultSet = false;
+        await tester.pumpWidget(
+          buildLauncher(
+            onResult: (mode) {
+              result = mode;
+              resultSet = true;
+            },
+          ),
+        );
+
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Gemini thinking mode'), findsOneWidget);
+        expect(find.byType(GeminiThinkingModePickerContent), findsOneWidget);
+
+        await tester.tap(find.text('Minimal'));
+        await tester.pumpAndSettle();
+
+        expect(resultSet, isTrue);
+        expect(result, GeminiThinkingMode.minimal);
+        expect(find.byType(GeminiThinkingModePickerContent), findsNothing);
+      },
+    );
+
+    testWidgets('uses the custom title when provided', (tester) async {
+      await tester.pumpWidget(
+        buildLauncher(onResult: (_) {}, title: 'Pick effort'),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Pick effort'), findsOneWidget);
+      expect(find.text('Gemini thinking mode'), findsNothing);
+    });
+
+    testWidgets('dismissing the modal resolves with null', (tester) async {
+      GeminiThinkingMode? result = GeminiThinkingMode.high;
+      var resultSet = false;
+      await tester.pumpWidget(
+        buildLauncher(
+          onResult: (mode) {
+            result = mode;
+            resultSet = true;
+          },
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+      expect(find.byType(GeminiThinkingModePickerContent), findsOneWidget);
+
+      // Tap outside the sheet to dismiss without selecting.
+      await tester.tapAt(const Offset(10, 10));
+      await tester.pumpAndSettle();
+
+      expect(resultSet, isTrue);
+      expect(result, isNull);
+    });
+  });
+}

--- a/test/features/ai/util/profile_seeding_service_test.dart
+++ b/test/features/ai/util/profile_seeding_service_test.dart
@@ -5,7 +5,7 @@ import 'package:lotti/features/ai/skills/built_in_skills.dart';
 import 'package:lotti/features/ai/util/profile_seeding_service.dart';
 import 'package:mocktail/mocktail.dart';
 
-import '../../../mocks/mocks.dart';
+import '../test_utils.dart';
 
 void main() {
   late MockAiConfigRepository mockRepo;
@@ -362,7 +362,19 @@ void main() {
   group('ProfileSeedingService.upgradeExisting', () {
     test('upgrades default profiles with empty skillAssignments', () async {
       // Existing profile has empty skill assignments but has the model
-      // slots required by the template's skill assignments.
+      // slots required by the template's skill assignments, and a model
+      // row exists for those slots (skills are only re-enabled when the
+      // slot resolves to a real configured model).
+      when(
+        () => mockRepo.getConfigsByType(AiConfigType.model),
+      ).thenAnswer(
+        (_) async => [
+          AiTestDataFactory.createTestModel(
+            id: 'model-gemini-flash',
+            providerModelId: 'models/gemini-3-flash-preview',
+          ),
+        ],
+      );
       when(
         () => mockRepo.getConfigsByType(AiConfigType.inferenceProfile),
       ).thenAnswer(
@@ -446,6 +458,16 @@ void main() {
       // Template has both transcription and image analysis skills.
       // Only transcription skill should survive filtering.
       when(
+        () => mockRepo.getConfigsByType(AiConfigType.model),
+      ).thenAnswer(
+        (_) async => [
+          AiTestDataFactory.createTestModel(
+            id: 'model-gemini-flash',
+            providerModelId: 'models/gemini-3-flash-preview',
+          ),
+        ],
+      );
+      when(
         () => mockRepo.getConfigsByType(AiConfigType.inferenceProfile),
       ).thenAnswer(
         (_) async => [
@@ -478,10 +500,227 @@ void main() {
       expect(skillIds, isNot(contains(skillImageAnalysisContextId)));
     });
 
+    test(
+      'does not re-enable skills when slots have no backing model row',
+      () async {
+        // Slots are non-null but point at models that are not configured
+        // (empty model table). Backfilling skills would auto-enable broken
+        // automation, so the profile must be left untouched.
+        when(
+          () => mockRepo.getConfigsByType(AiConfigType.inferenceProfile),
+        ).thenAnswer(
+          (_) async => [
+            AiConfig.inferenceProfile(
+              id: profileGeminiFlashId,
+              name: 'Gemini Flash',
+              thinkingModelId: 'models/gemini-3-flash-preview',
+              imageRecognitionModelId: 'models/gemini-3-flash-preview',
+              transcriptionModelId: 'models/gemini-3-flash-preview',
+              isDefault: true,
+              createdAt: DateTime(2026),
+            ),
+          ],
+        );
+
+        await service.upgradeExisting();
+
+        verifyNever(() => mockRepo.saveConfig(any()));
+      },
+    );
+
+    test(
+      'rewrites legacy provider-native slots to model row ids on upgrade',
+      () async {
+        when(
+          () => mockRepo.getConfigsByType(AiConfigType.model),
+        ).thenAnswer(
+          (_) async => [
+            AiTestDataFactory.createTestModel(
+              id: 'model-gemini-flash',
+              providerModelId: 'models/gemini-3-flash-preview',
+            ),
+          ],
+        );
+        when(
+          () => mockRepo.getConfigsByType(AiConfigType.inferenceProfile),
+        ).thenAnswer(
+          (_) async => [
+            AiConfig.inferenceProfile(
+              id: profileGeminiFlashId,
+              name: 'Gemini Flash',
+              thinkingModelId: 'models/gemini-3-flash-preview',
+              transcriptionModelId: 'models/gemini-3-flash-preview',
+              isDefault: true,
+              createdAt: DateTime(2026),
+            ),
+          ],
+        );
+
+        await service.upgradeExisting();
+
+        final captured = verify(
+          () => mockRepo.saveConfig(captureAny(that: isA<AiConfig>())),
+        ).captured;
+        final upgraded = captured.single as AiConfigInferenceProfile;
+        expect(upgraded.thinkingModelId, 'model-gemini-flash');
+        expect(upgraded.transcriptionModelId, 'model-gemini-flash');
+      },
+    );
+
+    test(
+      'keeps ambiguous legacy slot values unchanged on upgrade',
+      () async {
+        // Two model rows share the same providerModelId — rewriting would
+        // pick an arbitrary row, so the legacy value must be preserved.
+        when(
+          () => mockRepo.getConfigsByType(AiConfigType.model),
+        ).thenAnswer(
+          (_) async => [
+            AiTestDataFactory.createTestModel(
+              id: 'model-gemini-flash-a',
+              providerModelId: 'models/gemini-3-flash-preview',
+            ),
+            AiTestDataFactory.createTestModel(
+              id: 'model-gemini-flash-b',
+              providerModelId: 'models/gemini-3-flash-preview',
+            ),
+          ],
+        );
+        when(
+          () => mockRepo.getConfigsByType(AiConfigType.inferenceProfile),
+        ).thenAnswer(
+          (_) async => [
+            AiConfig.inferenceProfile(
+              id: profileGeminiFlashId,
+              name: 'Gemini Flash',
+              thinkingModelId: 'models/gemini-3-flash-preview',
+              transcriptionModelId: 'models/gemini-3-flash-preview',
+              isDefault: true,
+              createdAt: DateTime(2026),
+            ),
+          ],
+        );
+
+        await service.upgradeExisting();
+
+        // Slots stay legacy (ambiguous), but skill backfill still runs:
+        // the runtime resolver can walk the candidate rows.
+        final captured = verify(
+          () => mockRepo.saveConfig(captureAny(that: isA<AiConfig>())),
+        ).captured;
+        final upgraded = captured.single as AiConfigInferenceProfile;
+        expect(
+          upgraded.thinkingModelId,
+          'models/gemini-3-flash-preview',
+        );
+        expect(
+          upgraded.transcriptionModelId,
+          'models/gemini-3-flash-preview',
+        );
+        expect(
+          upgraded.skillAssignments.map((a) => a.skillId),
+          contains(skillTranscribeContextId),
+        );
+      },
+    );
+
     test('does nothing when profiles do not exist', () async {
       await service.upgradeExisting();
 
       verifyNever(() => mockRepo.saveConfig(any()));
     });
+  });
+
+  group('ProfileSeedingService.hasSlotForSkillType', () {
+    // The bundled default templates only carry transcription and
+    // image-analysis assignments, so the remaining skill types are pinned
+    // down directly: each one must require its slot to resolve to a real
+    // configured model row.
+    final models = [
+      AiTestDataFactory.createTestModel(
+        id: 'row-1',
+        providerModelId: 'wire-1',
+      ),
+    ];
+
+    AiConfigInferenceProfile profileWith({
+      String thinkingModelId = 'missing',
+      String? imageGenerationModelId,
+    }) {
+      return AiConfig.inferenceProfile(
+            id: 'p',
+            name: 'P',
+            thinkingModelId: thinkingModelId,
+            imageGenerationModelId: imageGenerationModelId,
+            createdAt: DateTime(2026),
+          )
+          as AiConfigInferenceProfile;
+    }
+
+    test('imageGeneration requires a resolvable image-generation slot', () {
+      expect(
+        ProfileSeedingService.hasSlotForSkillType(
+          profileWith(imageGenerationModelId: 'row-1'),
+          SkillType.imageGeneration,
+          models,
+        ),
+        isTrue,
+      );
+      expect(
+        ProfileSeedingService.hasSlotForSkillType(
+          profileWith(imageGenerationModelId: 'unknown'),
+          SkillType.imageGeneration,
+          models,
+        ),
+        isFalse,
+      );
+      expect(
+        ProfileSeedingService.hasSlotForSkillType(
+          profileWith(),
+          SkillType.imageGeneration,
+          models,
+        ),
+        isFalse,
+      );
+    });
+
+    test(
+      'prompt-generation skill types require a resolvable thinking slot, '
+      'accepting both row ids and legacy providerModelIds',
+      () {
+        for (final skillType in [
+          SkillType.promptGeneration,
+          SkillType.imagePromptGeneration,
+        ]) {
+          expect(
+            ProfileSeedingService.hasSlotForSkillType(
+              profileWith(thinkingModelId: 'row-1'),
+              skillType,
+              models,
+            ),
+            isTrue,
+            reason: '$skillType with exact row id',
+          );
+          expect(
+            ProfileSeedingService.hasSlotForSkillType(
+              profileWith(thinkingModelId: 'wire-1'),
+              skillType,
+              models,
+            ),
+            isTrue,
+            reason: '$skillType with legacy providerModelId',
+          );
+          expect(
+            ProfileSeedingService.hasSlotForSkillType(
+              profileWith(),
+              skillType,
+              models,
+            ),
+            isFalse,
+            reason: '$skillType with unresolvable slot',
+          );
+        }
+      },
+    );
   });
 }

--- a/test/features/ai/util/profile_seeding_service_test.dart
+++ b/test/features/ai/util/profile_seeding_service_test.dart
@@ -28,6 +28,12 @@ void main() {
 
     // Default: all profiles missing (return null for any ID lookup).
     when(() => mockRepo.getConfigById(any())).thenAnswer((_) async => null);
+    when(
+      () => mockRepo.getConfigsByType(AiConfigType.model),
+    ).thenAnswer((_) async => const <AiConfig>[]);
+    when(
+      () => mockRepo.getConfigsByType(AiConfigType.inferenceProfile),
+    ).thenAnswer((_) async => const <AiConfig>[]);
     when(() => mockRepo.saveConfig(any())).thenAnswer((_) async {});
   });
 
@@ -357,19 +363,20 @@ void main() {
     test('upgrades default profiles with empty skillAssignments', () async {
       // Existing profile has empty skill assignments but has the model
       // slots required by the template's skill assignments.
-      when(() => mockRepo.getConfigById(any())).thenAnswer((_) async => null);
       when(
-        () => mockRepo.getConfigById(profileGeminiFlashId),
+        () => mockRepo.getConfigsByType(AiConfigType.inferenceProfile),
       ).thenAnswer(
-        (_) async => AiConfig.inferenceProfile(
-          id: profileGeminiFlashId,
-          name: 'Gemini Flash',
-          thinkingModelId: 'models/gemini-3-flash-preview',
-          imageRecognitionModelId: 'models/gemini-3-flash-preview',
-          transcriptionModelId: 'models/gemini-3-flash-preview',
-          isDefault: true,
-          createdAt: DateTime(2026),
-        ),
+        (_) async => [
+          AiConfig.inferenceProfile(
+            id: profileGeminiFlashId,
+            name: 'Gemini Flash',
+            thinkingModelId: 'models/gemini-3-flash-preview',
+            imageRecognitionModelId: 'models/gemini-3-flash-preview',
+            transcriptionModelId: 'models/gemini-3-flash-preview',
+            isDefault: true,
+            createdAt: DateTime(2026),
+          ),
+        ],
       );
 
       await service.upgradeExisting();
@@ -391,20 +398,21 @@ void main() {
     });
 
     test('skips profiles that already have skillAssignments', () async {
-      when(() => mockRepo.getConfigById(any())).thenAnswer((_) async => null);
       when(
-        () => mockRepo.getConfigById(profileGeminiFlashId),
+        () => mockRepo.getConfigsByType(AiConfigType.inferenceProfile),
       ).thenAnswer(
-        (_) async => AiConfig.inferenceProfile(
-          id: profileGeminiFlashId,
-          name: 'Gemini Flash',
-          thinkingModelId: 'models/gemini-3-flash-preview',
-          isDefault: true,
-          skillAssignments: [
-            const SkillAssignment(skillId: 'existing-skill', automate: true),
-          ],
-          createdAt: DateTime(2026),
-        ),
+        (_) async => [
+          AiConfig.inferenceProfile(
+            id: profileGeminiFlashId,
+            name: 'Gemini Flash',
+            thinkingModelId: 'models/gemini-3-flash-preview',
+            isDefault: true,
+            skillAssignments: [
+              const SkillAssignment(skillId: 'existing-skill', automate: true),
+            ],
+            createdAt: DateTime(2026),
+          ),
+        ],
       );
 
       await service.upgradeExisting();
@@ -414,17 +422,18 @@ void main() {
     });
 
     test('skips non-default profiles', () async {
-      when(() => mockRepo.getConfigById(any())).thenAnswer((_) async => null);
       when(
-        () => mockRepo.getConfigById(profileGeminiFlashId),
+        () => mockRepo.getConfigsByType(AiConfigType.inferenceProfile),
       ).thenAnswer(
-        (_) async => AiConfig.inferenceProfile(
-          id: profileGeminiFlashId,
-          name: 'Gemini Flash',
-          thinkingModelId: 'models/gemini-3-flash-preview',
-          createdAt: DateTime(2026),
-          // isDefault defaults to false.
-        ),
+        (_) async => [
+          AiConfig.inferenceProfile(
+            id: profileGeminiFlashId,
+            name: 'Gemini Flash',
+            thinkingModelId: 'models/gemini-3-flash-preview',
+            createdAt: DateTime(2026),
+            // isDefault defaults to false.
+          ),
+        ],
       );
 
       await service.upgradeExisting();
@@ -436,20 +445,21 @@ void main() {
       // Profile has transcription but no image recognition model.
       // Template has both transcription and image analysis skills.
       // Only transcription skill should survive filtering.
-      when(() => mockRepo.getConfigById(any())).thenAnswer((_) async => null);
       when(
-        () => mockRepo.getConfigById(profileGeminiFlashId),
+        () => mockRepo.getConfigsByType(AiConfigType.inferenceProfile),
       ).thenAnswer(
-        (_) async => AiConfig.inferenceProfile(
-          id: profileGeminiFlashId,
-          name: 'Gemini Flash',
-          thinkingModelId: 'models/gemini-3-flash-preview',
-          transcriptionModelId: 'models/gemini-3-flash-preview',
-          // No imageRecognitionModelId — image analysis skill should
-          // be filtered out.
-          isDefault: true,
-          createdAt: DateTime(2026),
-        ),
+        (_) async => [
+          AiConfig.inferenceProfile(
+            id: profileGeminiFlashId,
+            name: 'Gemini Flash',
+            thinkingModelId: 'models/gemini-3-flash-preview',
+            transcriptionModelId: 'models/gemini-3-flash-preview',
+            // No imageRecognitionModelId — image analysis skill should
+            // be filtered out.
+            isDefault: true,
+            createdAt: DateTime(2026),
+          ),
+        ],
       );
 
       await service.upgradeExisting();
@@ -469,8 +479,6 @@ void main() {
     });
 
     test('does nothing when profiles do not exist', () async {
-      when(() => mockRepo.getConfigById(any())).thenAnswer((_) async => null);
-
       await service.upgradeExisting();
 
       verifyNever(() => mockRepo.saveConfig(any()));

--- a/test/features/ai_chat/services/audio_transcription_service_test.dart
+++ b/test/features/ai_chat/services/audio_transcription_service_test.dart
@@ -156,6 +156,106 @@ void main() {
     await dir.delete(recursive: true);
   });
 
+  test(
+    'forwards the model row thinking mode for Gemini 3 audio models',
+    () async {
+      // Isolated DB: the shared instance already carries a
+      // 'gemini-2.5-flash' row from earlier tests, which would win the
+      // batch-model selection over the Gemini 3 row under test.
+      final isolatedDb = AiConfigDb(inMemoryDatabase: true);
+      addTearDown(isolatedDb.close);
+      final aiRepo = AiConfigRepository(isolatedDb);
+      await aiRepo.saveConfig(
+        AiConfig.inferenceProvider(
+          id: 'p-g3',
+          baseUrl: 'http://localhost:1234',
+          apiKey: 'k',
+          name: 'Gemini',
+          createdAt: DateTime(2024, 3, 15, 10, 30),
+          inferenceProviderType: InferenceProviderType.gemini,
+        ),
+        fromSync: true,
+      );
+      await aiRepo.saveConfig(
+        AiConfig.model(
+          id: 'm-g3',
+          name: 'gemini-3-flash',
+          providerModelId: 'gemini-3-flash-preview',
+          inferenceProviderId: 'p-g3',
+          createdAt: DateTime(2024, 3, 15, 10, 30),
+          inputModalities: const [Modality.audio],
+          outputModalities: const [Modality.text],
+          isReasoningModel: true,
+          geminiThinkingMode: GeminiThinkingMode.medium,
+        ),
+        fromSync: true,
+      );
+
+      final dir = await Directory.systemTemp.createTemp('svc_test_');
+      final file = File('${dir.path}/a.m4a');
+      await file.writeAsBytes([1, 2, 3, 4]);
+
+      final mockCloud = MockCloudInferenceRepository();
+      when(
+        () => mockCloud.generateWithAudio(
+          any(),
+          model: any(named: 'model'),
+          audioBase64: any(named: 'audioBase64'),
+          baseUrl: any(named: 'baseUrl'),
+          apiKey: any(named: 'apiKey'),
+          provider: any(named: 'provider'),
+          maxCompletionTokens: any(named: 'maxCompletionTokens'),
+          overrideClient: any(named: 'overrideClient'),
+          tools: any(named: 'tools'),
+          speechDictionaryTerms: any(named: 'speechDictionaryTerms'),
+          geminiThinkingMode: any(named: 'geminiThinkingMode'),
+        ),
+      ).thenAnswer(
+        (_) => Stream<CreateChatCompletionStreamResponse>.fromIterable([
+          const CreateChatCompletionStreamResponse(
+            id: '1',
+            object: 'chat.completion.chunk',
+            created: 0,
+            choices: [
+              ChatCompletionStreamResponseChoice(
+                index: 0,
+                delta: ChatCompletionStreamResponseDelta(content: 'hi'),
+              ),
+            ],
+          ),
+        ]),
+      );
+
+      final container = ProviderContainer(
+        overrides: [
+          aiConfigRepositoryProvider.overrideWith((_) => aiRepo),
+          cloudInferenceRepositoryProvider.overrideWith((_) => mockCloud),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final svc = container.read(audioTranscriptionServiceProvider);
+      final result = await svc.transcribe(file.path);
+
+      expect(result, 'hi');
+      // The Gemini 3 row's saved thinking mode reaches the cloud call.
+      verify(
+        () => mockCloud.generateWithAudio(
+          any(),
+          model: 'gemini-3-flash-preview',
+          audioBase64: any(named: 'audioBase64'),
+          baseUrl: any(named: 'baseUrl'),
+          apiKey: any(named: 'apiKey'),
+          provider: any(named: 'provider'),
+          maxCompletionTokens: any(named: 'maxCompletionTokens'),
+          speechDictionaryTerms: any(named: 'speechDictionaryTerms'),
+          geminiThinkingMode: GeminiThinkingMode.medium,
+        ),
+      ).called(1);
+      await dir.delete(recursive: true);
+    },
+  );
+
   test('fallbacks to first audio-capable model when flash not found', () async {
     final aiRepo = AiConfigRepository(sharedDb);
     await aiRepo.saveConfig(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI popup skill runs can override Gemini thinking effort for single invocations; prompt-generation flows support per-invocation model overrides and thinking-mode selection.

* **Documentation**
  * Clarified AI provider routing, Gemini thinking-mode semantics, profile migration, and seeded-profile behavior.

* **Localization**
  * Added localized label for the prompt-generation model picker (multiple languages).

* **Tests**
  * Expanded tests covering Gemini thinking-mode mappings, profile/model migration, and new picker/modal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->