### PR TITLE
feat: improve agent context for better cacheability

### DIFF
--- a/lib/features/agents/README.md
+++ b/lib/features/agents/README.md
@@ -33,11 +33,17 @@ Startup does this:
 - Task agent wake prompts include:
   - current task JSON context
   - current report + recent observations
-  - parent project context with the latest project-agent `tldr` and full
-    report body when the task belongs to a project
+  - parent project context with the latest project-agent `oneLiner` and `tldr`
+    (the full report body is omitted to keep wake prefill small) when the task
+    belongs to a project
   - related tasks in the same parent project, capped to a lightweight
     sibling-task directory with stored task-agent `tldr` values only
   - linked task context
+  - these blocks are ordered stable-first — label/correction context,
+    parent-project and linked-task summaries, then current task context —
+    followed by the volatile tail (current report, agent journal, proposal
+    ledger, trigger tokens), so the stable header stays byte-identical across
+    wakes and a prompt prefix cache can restore it instead of re-prefilling
 - Task agents also expose a read-only `get_related_task_details` tool for
   on-demand drill-down into a sibling task that was included in the current
   related-task directory. The tool is scoped to the current wake's allowlist;
@@ -48,9 +54,10 @@ Startup does this:
   The shared model default remains unchanged.
 - Linked task context for agents is built directly in
   `TaskAgentWorkflow._buildLinkedTasksContextJson` (forked from
-  `AiInputRepository.buildLinkedTasksJson` for the wake path), and injects
-  `latestTaskAgentReport` from each linked task's associated task agent (via
-  `agent_task` links + `agentReportHead`).
+  `AiInputRepository.buildLinkedTasksJson` for the wake path), and injects a
+  compact summary (`latestTaskAgentReportOneLiner` / `latestTaskAgentReportTldr`)
+  of each linked task's associated task-agent report (via `agent_task` links +
+  `agentReportHead`) — not the full report body, to keep wake prefill small.
 - Linked-task `latestSummary` payloads are stripped before prompt submission
   and are not used for Task Agent execution.
 - Related-task directory rows are built in `AiInputRepository` from the

--- a/lib/features/agents/workflow/project_agent_workflow.dart
+++ b/lib/features/agents/workflow/project_agent_workflow.dart
@@ -674,6 +674,12 @@ from the project context, linked task reports, and the latest changes.
 Use `record_observations` for private notes that should persist across wakes
 but are not shown in the user-facing report.
 
+## Tool Usage
+
+When several independent updates are warranted in one wake, issue them as
+parallel tool calls in a single turn rather than one per turn.
+`update_project_report` stays the separate, final step.
+
 ## Deferred Tools
 
 The `recommend_next_steps`, `update_project_status`, and `create_task` tools

--- a/lib/features/agents/workflow/project_agent_workflow.dart
+++ b/lib/features/agents/workflow/project_agent_workflow.dart
@@ -788,20 +788,23 @@ immediately.''';
 
     _writeProjectContext(buf, projectEntity);
 
-    if (lastReport != null) {
-      buf
-        ..writeln()
-        ..writeln('## Previous Report')
-        ..writeln()
-        ..writeln(lastReport.content);
-    }
-
+    // Stable header first (project identity + linked-task summaries) so the
+    // cross-wake prefix cache can restore it; the volatile tail (previous
+    // report, observations, trigger tokens) follows.
     if (linkedTasksContext != '{}') {
       buf
         ..writeln()
         ..writeln('## Linked Tasks')
         ..writeln()
         ..writeln(linkedTasksContext);
+    }
+
+    if (lastReport != null) {
+      buf
+        ..writeln()
+        ..writeln('## Previous Report')
+        ..writeln()
+        ..writeln(lastReport.content);
     }
 
     if (observations.isNotEmpty) {
@@ -964,10 +967,12 @@ immediately.''';
           for (final link in taskLinks.orderedPrimaryFirst()) {
             final report = reportsByAgentId[link.fromId];
             if (report == null) continue;
-            final content = report.content.trim();
-            if (content.isEmpty) continue;
+            // Gate on a non-empty body so only "real" reports surface, but
+            // embed just the compact summary to keep wake prefill small.
+            if (report.content.trim().isEmpty) continue;
             row['taskAgentId'] = link.fromId;
-            row['latestTaskAgentReport'] = content;
+            row['latestTaskAgentReportOneLiner'] = report.oneLiner;
+            row['latestTaskAgentReportTldr'] = report.tldr;
             row['latestTaskAgentReportCreatedAt'] = report.createdAt
                 .toIso8601String();
             break;

--- a/lib/features/agents/workflow/task_agent_workflow.dart
+++ b/lib/features/agents/workflow/task_agent_workflow.dart
@@ -1303,18 +1303,90 @@ to keep the user-facing suggestion list clean and trustworthy:
   }) async {
     final buffer = StringBuffer();
 
-    if (lastReport != null && lastReport.content.isNotEmpty) {
+    // Ordering is by volatility, least-volatile first: a stable header (label /
+    // correction context, parent-project + linked-task summaries, current task
+    // context) leads so oMLX's cross-wake prefix cache can restore it, and the
+    // volatile tail (report, journal, ledger, trigger tokens) follows.
+
+    // Inject label context and correction examples.
+    try {
+      final taskEntity = await journalDb.journalEntityById(taskId);
+      if (taskEntity is Task) {
+        // Label context for the assign_task_labels tool.
+        final labelContext = await TaskLabelHandler.buildLabelContext(
+          task: taskEntity,
+          journalDb: journalDb,
+        );
+        if (labelContext.isNotEmpty) {
+          buffer.write(labelContext);
+        }
+
+        // Correction examples for checklist item title accuracy.
+        final correctionContext = await CorrectionExamplesBuilder.buildContext(
+          task: taskEntity,
+          journalDb: journalDb,
+        );
+        if (correctionContext.isNotEmpty) {
+          buffer.write(correctionContext);
+        }
+      }
+    } catch (e, s) {
+      _logError(
+        'failed to build label/correction context',
+        error: e,
+        stackTrace: s,
+      );
+      // Non-fatal: continue without context.
+    }
+
+    if (projectContextJson.isNotEmpty && projectContextJson != '{}') {
       buffer
-        ..writeln('## Current Report')
-        ..writeln(lastReport.content)
+        ..writeln('## Parent Project Context')
+        ..writeln('```json')
+        ..writeln(projectContextJson)
+        ..writeln('```')
         ..writeln();
-    } else {
+    }
+
+    if (linkedTasksJson.isNotEmpty && linkedTasksJson != '{}') {
       buffer
-        ..writeln(
-          '## First Wake — No prior report exists. '
-          'Produce an initial report.',
-        )
+        ..writeln('## Linked Tasks')
+        ..writeln('```json')
+        ..writeln(linkedTasksJson)
+        ..writeln('```')
         ..writeln();
+    }
+
+    buffer
+      ..writeln('## Current Task Context')
+      ..writeln('```json')
+      ..writeln(taskDetailsJson)
+      ..writeln('```')
+      ..writeln();
+
+    // --- Volatile tail: changes most across wakes, so it follows the stable
+    // header above to keep that header byte-identical and prefix-cacheable. ---
+
+    final activeTimerSection = _buildActiveTimerSection(timeService, taskId);
+    if (activeTimerSection.isNotEmpty) {
+      buffer.write(activeTimerSection);
+    }
+
+    final editableTimeEntriesSection = await _buildEditableTimeEntriesSection(
+      timeService,
+      taskId,
+    );
+    if (editableTimeEntriesSection.isNotEmpty) {
+      buffer.write(editableTimeEntriesSection);
+    }
+
+    // Proposal ledger — a single status-sorted view of every suggestion the
+    // agent has ever produced for this task. Supersedes the older split
+    // between "recent user decisions" and "pending proposals": both are now
+    // different status slices of the same ledger, so the agent can reason
+    // about its own history without duplicated or conflicting sections.
+    if (!ledger.isEmpty) {
+      buffer.writeln(_formatProposalLedger(ledger));
     }
 
     if (journalObservations.isNotEmpty) {
@@ -1354,82 +1426,18 @@ to keep the user-facing suggestion list clean and trustworthy:
       buffer.writeln();
     }
 
-    buffer
-      ..writeln('## Current Task Context')
-      ..writeln('```json')
-      ..writeln(taskDetailsJson)
-      ..writeln('```')
-      ..writeln();
-
-    final activeTimerSection = _buildActiveTimerSection(timeService, taskId);
-    if (activeTimerSection.isNotEmpty) {
-      buffer.write(activeTimerSection);
-    }
-
-    final editableTimeEntriesSection = await _buildEditableTimeEntriesSection(
-      timeService,
-      taskId,
-    );
-    if (editableTimeEntriesSection.isNotEmpty) {
-      buffer.write(editableTimeEntriesSection);
-    }
-
-    if (projectContextJson.isNotEmpty && projectContextJson != '{}') {
+    if (lastReport != null && lastReport.content.isNotEmpty) {
       buffer
-        ..writeln('## Parent Project Context')
-        ..writeln('```json')
-        ..writeln(projectContextJson)
-        ..writeln('```')
+        ..writeln('## Current Report')
+        ..writeln(lastReport.content)
         ..writeln();
-    }
-
-    if (linkedTasksJson.isNotEmpty && linkedTasksJson != '{}') {
+    } else {
       buffer
-        ..writeln('## Linked Tasks')
-        ..writeln('```json')
-        ..writeln(linkedTasksJson)
-        ..writeln('```')
+        ..writeln(
+          '## First Wake — No prior report exists. '
+          'Produce an initial report.',
+        )
         ..writeln();
-    }
-
-    // Inject label context and correction examples.
-    try {
-      final taskEntity = await journalDb.journalEntityById(taskId);
-      if (taskEntity is Task) {
-        // Label context for the assign_task_labels tool.
-        final labelContext = await TaskLabelHandler.buildLabelContext(
-          task: taskEntity,
-          journalDb: journalDb,
-        );
-        if (labelContext.isNotEmpty) {
-          buffer.write(labelContext);
-        }
-
-        // Correction examples for checklist item title accuracy.
-        final correctionContext = await CorrectionExamplesBuilder.buildContext(
-          task: taskEntity,
-          journalDb: journalDb,
-        );
-        if (correctionContext.isNotEmpty) {
-          buffer.write(correctionContext);
-        }
-      }
-    } catch (e, s) {
-      _logError(
-        'failed to build label/correction context',
-        error: e,
-        stackTrace: s,
-      );
-      // Non-fatal: continue without context.
-    }
-
-    // Proposal ledger — a single status-sorted view of every suggestion the
-    // agent has ever produced for this task. Supersedes the older split
-    // between "recent user decisions" and "pending proposals": both are now
-    // different status slices of the same ledger, so the agent can reason
-    // about its own history without duplicated or conflicting sections.
-    if (!ledger.isEmpty) {
-      buffer.writeln(_formatProposalLedger(ledger));
     }
 
     if (triggerTokens.isNotEmpty) {
@@ -1527,7 +1535,9 @@ to keep the user-facing suggestion list clean and trustworthy:
   /// wake path:
   /// 1. Builds linked task context directly from linked task entities.
   /// 2. Removes legacy `latestSummary` fields.
-  /// 3. Injects the latest task-agent report for each linked task when present.
+  /// 3. Injects a compact summary (oneLiner/tldr) of the latest task-agent
+  ///    report for each linked task when present — not the full body, to keep
+  ///    wake prefill small.
   ///
   /// This keeps prompt context aligned with the Agent Capabilities architecture
   /// where task summaries are being phased out in favor of task-agent reports.
@@ -1614,11 +1624,13 @@ to keep the user-facing suggestion list clean and trustworthy:
           for (final link in links.orderedPrimaryFirst()) {
             final report = reportsByAgentId[link.fromId];
             if (report == null) continue;
-            final content = report.content.trim();
-            if (content.isEmpty) continue;
+            // Gate on a non-empty body so only "real" reports surface, but
+            // embed just the compact summary to keep wake prefill small.
+            if (report.content.trim().isEmpty) continue;
             reportByTaskId[taskId] = _LinkedTaskAgentReport(
               agentId: link.fromId,
-              content: content,
+              oneLiner: report.oneLiner,
+              tldr: report.tldr,
               createdAt: report.createdAt,
             );
             break;
@@ -1638,7 +1650,8 @@ to keep the user-facing suggestion list clean and trustworthy:
         }
 
         row['taskAgentId'] = linkedReport.agentId;
-        row['latestTaskAgentReport'] = linkedReport.content;
+        row['latestTaskAgentReportOneLiner'] = linkedReport.oneLiner;
+        row['latestTaskAgentReportTldr'] = linkedReport.tldr;
         row['latestTaskAgentReportCreatedAt'] = linkedReport.createdAt
             .toIso8601String();
       }
@@ -1932,12 +1945,14 @@ to keep the user-facing suggestion list clean and trustworthy:
 class _LinkedTaskAgentReport {
   const _LinkedTaskAgentReport({
     required this.agentId,
-    required this.content,
+    required this.oneLiner,
+    required this.tldr,
     required this.createdAt,
   });
 
   final String agentId;
-  final String content;
+  final String? oneLiner;
+  final String? tldr;
   final DateTime createdAt;
 }
 

--- a/lib/features/agents/workflow/task_agent_workflow.dart
+++ b/lib/features/agents/workflow/task_agent_workflow.dart
@@ -1159,6 +1159,11 @@ Use this as high-level planning context:
   unnecessary tool call wastes a turn and clutters the audit log.
 - Only call tools when you have sufficient confidence in the change.
 - Do not call tools speculatively or redundantly.
+- **Batch independent calls**: when a wake warrants several updates that do not
+  depend on each other (e.g., labels, priority, due date, estimate, checklist
+  items), emit them as parallel tool calls in a single turn rather than one
+  tool per turn — fewer turns is faster. `update_report` stays the separate,
+  final step.
 - When a tool call fails, note the failure in observations and move on.
 - Each tool call is audited and must stay within the task's category scope.
 - **Learn from past decisions**: Review the `## Proposal Ledger` section in

--- a/lib/features/ai/repository/ai_input_repository.dart
+++ b/lib/features/ai/repository/ai_input_repository.dart
@@ -229,8 +229,10 @@ class AiInputRepository {
 
   /// Build parent project context for a task-agent wake.
   ///
-  /// Returns `{}` when the task is not linked to a project or when no usable
-  /// current project-agent report exists.
+  /// Embeds the parent project agent's report as a compact `oneLiner`/`tldr`
+  /// summary rather than its full markdown body, to keep each wake's prompt
+  /// (and prefill cost) small. Returns `{}` when the task is not linked to a
+  /// project or when no usable current project-agent report exists.
   Future<String> buildProjectContextJsonForTask(String taskId) async {
     try {
       final project = await _projectRepository.getProjectForTask(taskId);
@@ -252,8 +254,12 @@ class AiInputRepository {
         'latestProjectAgentReport': <String, dynamic>{
           'agentId': report.agentId,
           'createdAt': report.createdAt.toIso8601String(),
+          'oneLiner': report.oneLiner,
           'tldr': report.tldr,
-          'content': report.content,
+          // Full `content` intentionally omitted: embedding another agent's
+          // full report body inflated every wake's prefill. The compact
+          // `oneLiner`/`tldr` carry current state; detail can be fetched on
+          // demand via a `read_full_report` tool if added later.
         },
       };
 

--- a/test/features/agents/workflow/project_agent_workflow_test.dart
+++ b/test/features/agents/workflow/project_agent_workflow_test.dart
@@ -989,7 +989,9 @@ void main() {
         final taskReport = makeTestReport(
           agentId: 'task-agent-1',
           createdAt: DateTime(2024, 6, 21, 9, 30),
-          content: 'Task is 80% complete with 3 tests passing.',
+          oneLiner: 'Tests nearly done.',
+          tldr: 'Task is 80% complete with 3 tests passing.',
+          content: '## Full Body\nDetailed task report goes here.',
         );
 
         when(
@@ -1025,12 +1027,16 @@ void main() {
           threadId: threadId,
         );
 
+        // Compact summary (tldr/oneLiner) is embedded…
         expect(capturedMessage, contains('80% complete'));
+        expect(capturedMessage, contains('Tests nearly done.'));
         expect(capturedMessage, contains('task-agent-1'));
         expect(
           capturedMessage,
           contains(DateTime(2024, 6, 21, 9, 30).toIso8601String()),
         );
+        // …but the full report body is trimmed out to save prefill.
+        expect(capturedMessage, isNot(contains('Detailed task report')));
       });
 
       test('resolves observation payloads into user message', () async {
@@ -2386,6 +2392,7 @@ void main() {
 
         final newerReport = makeTestReport(
           agentId: 'new-agent',
+          tldr: 'Newer agent report.',
           content: 'Newer agent report.',
         );
 
@@ -2471,6 +2478,7 @@ void main() {
 
           final olderReport = makeTestReport(
             agentId: 'older-agent',
+            tldr: 'Older agent still has the useful report.',
             content: 'Older agent still has the useful report.',
           );
           when(

--- a/test/features/agents/workflow/task_agent_workflow_test.dart
+++ b/test/features/agents/workflow/task_agent_workflow_test.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/checklist_item_data.dart';
+import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
@@ -32,6 +33,7 @@ import 'package:openai_dart/openai_dart.dart';
 import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
 import '../../../widget_test_utils.dart';
+import '../../categories/test_utils.dart';
 import '../test_utils.dart';
 import 'task_agent_workflow_test_helpers.dart';
 
@@ -2395,6 +2397,70 @@ void main() {
 
         return capturedMessage;
       }
+
+      test(
+        'injects label and correction-example context when available',
+        () async {
+          when(() => mockJournalDb.journalEntityById(taskId)).thenAnswer(
+            (_) async => Task(
+              data: TaskData(
+                status: TaskStatus.open(
+                  id: 'status_id',
+                  createdAt: DateTime(2024, 3, 15),
+                  utcOffset: 60,
+                ),
+                title: 'Labelled task',
+                statusHistory: const [],
+                dateTo: DateTime(2024, 3, 15),
+                dateFrom: DateTime(2024, 3, 15),
+              ),
+              meta: Metadata(
+                id: taskId,
+                createdAt: DateTime(2024, 3, 15),
+                dateFrom: DateTime(2024, 3, 15),
+                dateTo: DateTime(2024, 3, 15),
+                updatedAt: DateTime(2024, 3, 15),
+                categoryId: 'cat-001',
+              ),
+            ),
+          );
+          when(() => mockJournalDb.getAllLabelDefinitions()).thenAnswer(
+            (_) async => [
+              LabelDefinition(
+                id: 'lbl-bug',
+                createdAt: DateTime(2024),
+                updatedAt: DateTime(2024),
+                name: 'Bug',
+                color: '#FF0000',
+                vectorClock: null,
+                applicableCategoryIds: const ['cat-001'],
+              ),
+            ],
+          );
+          when(() => mockJournalDb.getCategoryById('cat-001')).thenAnswer(
+            (_) async => CategoryTestUtils.createTestCategory(
+              id: 'cat-001',
+              correctionExamples: [
+                ChecklistCorrectionExample(
+                  before: 'mac OS',
+                  after: 'macOS',
+                  capturedAt: DateTime(2024, 5, 2),
+                ),
+              ],
+            ),
+          );
+
+          final message = await executeAndCaptureMessage();
+
+          expect(message, isNotNull);
+          // Label-context branch: available labels injected.
+          expect(message, contains('## Available Labels'));
+          expect(message, contains('Bug'));
+          // Correction-example branch: category examples injected.
+          expect(message, contains('## Correction Examples'));
+          expect(message, contains('macOS'));
+        },
+      );
 
       test('includes existing report in user message', () async {
         final report =

--- a/test/features/agents/workflow/task_agent_workflow_test.dart
+++ b/test/features/agents/workflow/task_agent_workflow_test.dart
@@ -2554,6 +2554,8 @@ void main() {
                     scope: 'current',
                     createdAt: DateTime(2024, 6, 14, 8),
                     vectorClock: null,
+                    oneLiner: 'Linked task is on track.',
+                    tldr: 'Linked task TLDR: integration nearly done.',
                     content: '## Linked Agent Report\nFrom task agent.',
                   )
                   as AgentReportEntity;
@@ -2584,8 +2586,15 @@ void main() {
           expect(message, isNotNull);
           expect(message, contains('## Linked Tasks'));
           expect(message, contains('Related'));
-          expect(message, contains('latestTaskAgentReport'));
-          expect(message, contains('From task agent.'));
+          expect(message, contains('latestTaskAgentReportTldr'));
+          // Compact summary is embedded…
+          expect(
+            message,
+            contains('Linked task TLDR: integration nearly done.'),
+          );
+          expect(message, contains('Linked task is on track.'));
+          // …but the full report body is trimmed out to save prefill.
+          expect(message, isNot(contains('From task agent.')));
           expect(message, isNot(contains('latestSummary')));
         },
       );
@@ -2626,6 +2635,7 @@ void main() {
                     scope: 'current',
                     createdAt: now,
                     vectorClock: null,
+                    tldr: 'Report B summary',
                     content: 'report-b',
                   )
                   as AgentReportEntity;
@@ -2636,6 +2646,7 @@ void main() {
                     scope: 'current',
                     createdAt: now,
                     vectorClock: null,
+                    tldr: 'Report A summary',
                     content: 'report-a',
                   )
                   as AgentReportEntity;
@@ -2662,12 +2673,13 @@ void main() {
           // `getLatestReportsByAgentIds` fetch followed by an
           // in-memory walk of the sorted links. Correctness contract
           // is the same — the first link in `orderedPrimaryFirst`
-          // order whose report has non-empty content wins — and is
-          // asserted here through the rendered message:
-          // `report-b` must show up, `report-a` must NOT.
+          // order whose report has non-empty content wins. Reports are
+          // now embedded as their compact tldr (not the full body), so
+          // the tie-break is asserted via the rendered summary:
+          // report B's tldr must show up, report A's must NOT.
           expect(message, isNotNull);
-          expect(message, contains('report-b'));
-          expect(message, isNot(contains('report-a')));
+          expect(message, contains('Report B summary'));
+          expect(message, isNot(contains('Report A summary')));
         },
       );
 

--- a/test/features/ai/repository/ai_input_repository_test.dart
+++ b/test/features/ai/repository/ai_input_repository_test.dart
@@ -270,7 +270,8 @@ void main() {
               as ProjectEntry;
 
       test(
-        'returns project metadata plus latest full project report',
+        'returns project metadata plus compact report summary '
+        '(oneLiner/tldr, not full body)',
         () async {
           final report =
               AgentDomainEntity.agentReport(
@@ -279,6 +280,7 @@ void main() {
                     scope: 'current',
                     createdAt: projectDate,
                     vectorClock: null,
+                    oneLiner: 'Improving wake-cycle context quality.',
                     tldr: 'Project is focused on wake-cycle context quality.',
                     content:
                         '## Project Report\nFull project context goes here.',
@@ -305,20 +307,22 @@ void main() {
           );
           expect(decoded['project'], containsPair('status', 'ACTIVE'));
           expect(decoded['project'], containsPair('categoryId', 'cat-123'));
+
+          final reportJson =
+              decoded['latestProjectAgentReport'] as Map<String, dynamic>;
           expect(
-            decoded['latestProjectAgentReport'],
+            reportJson,
+            containsPair('oneLiner', 'Improving wake-cycle context quality.'),
+          );
+          expect(
+            reportJson,
             containsPair(
               'tldr',
               'Project is focused on wake-cycle context quality.',
             ),
           );
-          expect(
-            decoded['latestProjectAgentReport'],
-            containsPair(
-              'content',
-              '## Project Report\nFull project context goes here.',
-            ),
-          );
+          // Full body is intentionally omitted to keep wake prefill small.
+          expect(reportJson.containsKey('content'), isFalse);
         },
       );
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Prompt composition now emits a stable header before a volatile tail to improve wake prefill caching.
  * Linked-task and project reports are embedded as compact summaries (one-liner/tldr) to reduce prompt size.

* **New Features**
  * Added a “Tool Usage” guideline to batch independent metadata tool calls in one turn while keeping update as final step.
  * Linked-tasks context now precedes previous-report context; label/correction context is included in the stable header.

* **Documentation**
  * Updated agent workflow docs and README to describe stable/volatile prefill and compact-report behavior.

* **Tests**
  * Updated tests and fixtures to validate compact summary embedding and omission of full report bodies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matthiasn/lotti/pull/3233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->