### PR TITLE
feat: eliminate retraction/suggestion gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   delivery of local edits across devices.
 - Matrix sync now recovers automatically from stale empty downloads, so media
   and JSON attachments arrive more reliably without manual retries.
+- Agent task suggestions no longer flash empty when the agent revises them: a
+  wake's retractions and its new proposals now commit together, so acting on
+  one suggested checklist item no longer makes the others briefly disappear.
 
 ### Changed
 - Sticky glass footers in Tasks and Daily OS now use a token-backed scrim

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   delivery of local edits across devices.
 - Matrix sync now recovers automatically from stale empty downloads, so media
   and JSON attachments arrive more reliably without manual retries.
-- Agent task suggestions no longer flash empty when the agent revises them:
-  acting on one suggested checklist item no longer makes the others briefly
-  disappear.
+- Agent task suggestions stay stable while the agent is working: they no longer
+  flash empty or reshuffle as the agent revises them, and acting on one
+  suggested checklist item no longer makes the others disappear.
 
 ### Changed
 - Sticky glass footers in Tasks and Daily OS now use a token-backed scrim

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   delivery of local edits across devices.
 - Matrix sync now recovers automatically from stale empty downloads, so media
   and JSON attachments arrive more reliably without manual retries.
-- Agent task suggestions no longer flash empty when the agent revises them: a
-  wake's retractions and its new proposals now commit together, so acting on
-  one suggested checklist item no longer makes the others briefly disappear.
+- Agent task suggestions no longer flash empty when the agent revises them:
+  acting on one suggested checklist item no longer makes the others briefly
+  disappear.
 
 ### Changed
 - Sticky glass footers in Tasks and Daily OS now use a token-backed scrim

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -42,7 +42,7 @@
           <p>Sync diagnostics and backfill stats put less load on the database, reducing sync-related stalls and improving responsiveness on busy machines.</p>
           <p>Improved sync reliability: fewer unresolvable gaps and more dependable delivery of local edits across devices.</p>
           <p>Matrix sync now recovers automatically from stale empty downloads, so media and JSON attachments arrive more reliably without manual retries.</p>
-          <p>Fixed: agent task suggestions no longer flash empty when the agent revises them — a wake's retractions and its new proposals now commit together, so acting on one suggested checklist item no longer makes the others briefly disappear.</p>
+          <p>Fixed: agent task suggestions no longer flash empty when the agent revises them; acting on one suggested checklist item no longer makes the others briefly disappear.</p>
       </description>
     </release>
     <release version="0.9.1008" date="2026-05-22">

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -42,7 +42,7 @@
           <p>Sync diagnostics and backfill stats put less load on the database, reducing sync-related stalls and improving responsiveness on busy machines.</p>
           <p>Improved sync reliability: fewer unresolvable gaps and more dependable delivery of local edits across devices.</p>
           <p>Matrix sync now recovers automatically from stale empty downloads, so media and JSON attachments arrive more reliably without manual retries.</p>
-          <p>Fixed: agent task suggestions no longer flash empty when the agent revises them; acting on one suggested checklist item no longer makes the others briefly disappear.</p>
+          <p>Fixed: agent task suggestions stay stable while the agent is working — they no longer flash empty or reshuffle as the agent revises them, and acting on one suggested checklist item no longer makes the others disappear.</p>
       </description>
     </release>
     <release version="0.9.1008" date="2026-05-22">

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -42,6 +42,7 @@
           <p>Sync diagnostics and backfill stats put less load on the database, reducing sync-related stalls and improving responsiveness on busy machines.</p>
           <p>Improved sync reliability: fewer unresolvable gaps and more dependable delivery of local edits across devices.</p>
           <p>Matrix sync now recovers automatically from stale empty downloads, so media and JSON attachments arrive more reliably without manual retries.</p>
+          <p>Fixed: agent task suggestions no longer flash empty when the agent revises them — a wake's retractions and its new proposals now commit together, so acting on one suggested checklist item no longer makes the others briefly disappear.</p>
       </description>
     </release>
     <release version="0.9.1008" date="2026-05-22">

--- a/lib/features/agents/README.md
+++ b/lib/features/agents/README.md
@@ -638,14 +638,40 @@ confirm or reject; resolved entries (user verdicts and agent retractions)
 are kept in the LLM prompt within a bounded window so the agent learns
 from its own history.
 
-When an open proposal is no longer relevant the agent calls a dedicated
-immediate tool, `retract_suggestions`, with one or more
-`{fingerprint, reason}` entries. `SuggestionRetractionService` looks each
-one up across the task's pending change sets, transitions the item to
-`ChangeItemStatus.retracted`, and persists a matching
-`ChangeDecisionEntity{verdict: retracted, actor: agent, retractionReason}`.
-Retraction is **not user-gated** — the user simply sees the item leave the
-active list and surface in the ledger's resolved slice.
+When an open proposal is no longer relevant the agent calls
+`retract_suggestions` with one or more `{fingerprint, reason}` entries.
+Retraction is **two-phase** so it commits atomically with the wake's new
+proposals:
+
+- `SuggestionRetractionService.plan(...)` runs while the LLM is mid-turn. It
+  looks each fingerprint up across the task's pending change sets and returns
+  the per-entry outcomes (`retracted` / `notOpen` / `notFound`) for the LLM,
+  plus the matched items as `StagedRetraction`s. It **persists nothing**. The
+  strategy accumulates the staged retractions (`extractStagedRetractions`) and
+  feeds `plan` the keys staged so far so repeated calls in one wake stay
+  idempotent without any intervening write.
+- `SuggestionRetractionService.applyStaged(...)` runs at end-of-wake inside the
+  same transaction as `ChangeSetBuilder.build()` (and just before it, so the
+  builder's dedup sees the freshly-retracted statuses). For each staged item it
+  transitions it to `ChangeItemStatus.retracted` and persists a matching
+  `ChangeDecisionEntity{verdict: retracted, actor: agent, retractionReason}`.
+
+Deferring the write is what keeps the suggestion list from flashing empty: the
+old behavior persisted each retraction the instant the tool was called, so the
+`AiSummaryCard` (which watches the agent update stream) dropped the retracted
+rows seconds before the wake's replacement proposals landed. Staging collapses
+that into a single end-of-wake update — the list transitions straight from the
+old set to the new one. Applying at end-of-wake is also strictly safer: each
+retraction re-reads the parent set and skips any item a concurrent user
+confirm/reject already resolved. Retraction is **not user-gated** — the user
+simply sees the item leave the active list and surface in the ledger's resolved
+slice.
+
+The agent is also instructed (see `taskAgentScaffoldTrailing` → *Suggestion
+Hygiene*) to retract an open proposal **only when that proposal itself is
+stale** — never to withdraw the rest of a batch just because the user acted on
+one sibling, and to prefer leaving a good proposal in place over
+retract-and-re-add churn.
 
 Ledger reads are defensive against stale snapshots. An item is only exposed
 as open when both the parent `ChangeSetEntity` is still `pending` or

--- a/lib/features/agents/README.md
+++ b/lib/features/agents/README.md
@@ -652,9 +652,25 @@ proposals:
   idempotent without any intervening write.
 - `SuggestionRetractionService.applyStaged(...)` runs at end-of-wake inside the
   same transaction as `ChangeSetBuilder.build()` (and just before it, so the
-  builder's dedup sees the freshly-retracted statuses). For each staged item it
-  transitions it to `ChangeItemStatus.retracted` and persists a matching
+  builder's dedup sees the freshly-retracted statuses). It groups staged
+  retractions by parent change set and applies each set in a single re-read →
+  flip-all → write, re-validating every target by bounds, status, and
+  fingerprint (so a row a concurrent user action already resolved, or one that
+  moved under us, is skipped). For each surviving item it transitions it to
+  `ChangeItemStatus.retracted` and persists a matching
   `ChangeDecisionEntity{verdict: retracted, actor: agent, retractionReason}`.
+
+**Churn guard.** Weaker models routinely retract an open proposal AND
+re-propose an identical one in the same wake. Even committed atomically, that
+retract-then-re-add swaps a stable suggestion for a brand-new change item —
+which, when the user has just confirmed a sibling, looks like accepting one
+suggestion wipes the rest. The workflow therefore passes
+`ChangeSetBuilder.proposedFingerprints` as `applyStaged(..., skipFingerprints:
+…)`: any staged retraction whose target shares a fingerprint with something
+proposed this wake is dropped, and the matching new proposal is then dropped by
+the builder's dedup against the still-open original. The original proposal is
+left untouched. Stale retractions (not re-proposed) and supersedes (a different
+fingerprint, e.g. a new `update_running_timer` text) are unaffected.
 
 Deferring the write is what keeps the suggestion list from flashing empty: the
 old behavior persisted each retraction the instant the tool was called, so the

--- a/lib/features/agents/service/suggestion_retraction_service.dart
+++ b/lib/features/agents/service/suggestion_retraction_service.dart
@@ -79,6 +79,11 @@ class StagedRetraction {
   /// to dedupe staging across multiple `retract_suggestions` calls in one wake
   /// and to dedupe application within [SuggestionRetractionService.applyStaged].
   String get key => '${changeSet.id}:$itemIndex';
+
+  /// Structural fingerprint of the target item (`toolName + args`). Lets the
+  /// workflow detect when the agent is retracting a proposal it is
+  /// simultaneously re-proposing this wake (retract-then-re-add churn).
+  String get fingerprint => ChangeItem.fingerprint(item);
 }
 
 /// Outcome of [SuggestionRetractionService.plan]: the per-request [results] to
@@ -301,16 +306,31 @@ class SuggestionRetractionService {
   /// re-read re-validates each target by **bounds, status, and fingerprint**, so
   /// an item a concurrent user confirm/reject already resolved — or one whose
   /// row moved or changed under us — is skipped rather than mis-retracted.
-  Future<void> applyStaged(List<StagedRetraction> staged) async {
+  ///
+  /// [skipFingerprints] suppresses retractions whose target item shares a
+  /// fingerprint with something the agent is **re-proposing in the same wake**.
+  /// Retracting an open proposal and re-adding an identical one is churn: it
+  /// makes a stable suggestion vanish and reappear under the user's finger.
+  /// Skipping the retraction keeps the original open; the matching new proposal
+  /// is then dropped by the builder's dedup against that still-open original.
+  /// Stale retractions (not re-proposed) and supersedes (different fingerprint,
+  /// e.g. `update_running_timer`) carry a different fingerprint and are applied
+  /// normally.
+  Future<void> applyStaged(
+    List<StagedRetraction> staged, {
+    Set<String> skipFingerprints = const {},
+  }) async {
     if (staged.isEmpty) return;
 
-    // Dedupe by target item, preserving first-seen order, and group by parent
-    // change set so each set is read and written exactly once.
+    // Dedupe by target item, preserving first-seen order, drop churn (an item
+    // being re-proposed this wake), and group by parent change set so each set
+    // is read and written exactly once.
     final seenKeys = <String>{};
     final deduped = <StagedRetraction>[];
     final order = <String>[];
     final byChangeSetId = <String, List<StagedRetraction>>{};
     for (final retraction in staged) {
+      if (skipFingerprints.contains(retraction.fingerprint)) continue;
       if (!seenKeys.add(retraction.key)) continue;
       deduped.add(retraction);
       byChangeSetId
@@ -320,6 +340,7 @@ class SuggestionRetractionService {
           })
           .add(retraction);
     }
+    if (deduped.isEmpty) return;
 
     // 1. Persist every decision first (in staged order) so we never leave a
     //    retracted item without a matching explanation — mirrors the

--- a/lib/features/agents/service/suggestion_retraction_service.dart
+++ b/lib/features/agents/service/suggestion_retraction_service.dart
@@ -54,6 +54,45 @@ class RetractionResult {
   final String? humanSummary;
 }
 
+/// A retraction that has been validated and is queued for application at the
+/// end of the wake.
+///
+/// [SuggestionRetractionService.plan] produces these without touching the
+/// database; [SuggestionRetractionService.applyStaged] persists them. The
+/// snapshot ([changeSet], [itemIndex], [item]) lets the apply step re-read the
+/// latest persisted state and skip items a concurrent user action has already
+/// resolved.
+class StagedRetraction {
+  const StagedRetraction({
+    required this.changeSet,
+    required this.itemIndex,
+    required this.item,
+    required this.reason,
+  });
+
+  final ChangeSetEntity changeSet;
+  final int itemIndex;
+  final ChangeItem item;
+  final String reason;
+
+  /// Stable identity of the target item — `'<changeSetId>:<itemIndex>'`. Used
+  /// to dedupe staging across multiple `retract_suggestions` calls in one wake
+  /// and to dedupe application within [SuggestionRetractionService.applyStaged].
+  String get key => '${changeSet.id}:$itemIndex';
+}
+
+/// Outcome of [SuggestionRetractionService.plan]: the per-request [results] to
+/// feed back to the LLM, plus the [staged] retractions to persist later via
+/// [SuggestionRetractionService.applyStaged].
+class RetractionPlan {
+  const RetractionPlan({required this.results, required this.staged});
+
+  const RetractionPlan.empty() : results = const [], staged = const [];
+
+  final List<RetractionResult> results;
+  final List<StagedRetraction> staged;
+}
+
 typedef ChangeSetRetractionCallback =
     Future<void> Function(ChangeSetEntity changeSet);
 
@@ -66,6 +105,16 @@ typedef ChangeSetRetractionCallback =
 /// the target [ChangeItem] to [ChangeItemStatus.retracted] and persists a
 /// matching [ChangeDecisionEntity] whose `actor` is [DecisionActor.agent]
 /// and whose `retractionReason` carries the agent's justification.
+///
+/// Retraction is a two-phase operation so it can commit atomically with the
+/// wake's other writes:
+///  * [plan] validates the requested fingerprints against the current pending
+///    sets and returns the per-request outcomes (for the LLM) plus the staged
+///    retractions — it touches nothing on disk.
+///  * [applyStaged] persists those staged retractions. The workflow runs it at
+///    the end of the wake, in the same transaction as the new proposals, so the
+///    suggestion list never flashes empty between a retraction and its
+///    replacement.
 ///
 /// The service re-reads the parent [ChangeSetEntity] before mutating it so
 /// concurrent user confirmations are not overwritten — last writer wins,
@@ -84,15 +133,29 @@ class SuggestionRetractionService {
   static const _uuid = Uuid();
   static const _sub = 'SuggestionRetraction';
 
-  /// Retract every request in [requests] against the pending change sets for
-  /// `(agentId, taskId)`. Returns one [RetractionResult] per request, in the
-  /// same order.
-  Future<List<RetractionResult>> retract({
+  /// Validate [requests] against the current pending change sets for
+  /// `(agentId, taskId)` WITHOUT persisting anything.
+  ///
+  /// Returns a [RetractionPlan] whose [RetractionPlan.results] list (one entry
+  /// per request, in order) is the per-entry outcome report for the LLM, and
+  /// whose [RetractionPlan.staged] list holds the pending items that should be
+  /// retracted. The caller persists the staged retractions at the end of the
+  /// wake via [applyStaged] so they commit atomically with the wake's new
+  /// proposals — the suggestion list never flashes empty between a retraction
+  /// and its replacement.
+  ///
+  /// [alreadyStagedKeys] are item keys (`'<changeSetId>:<itemIndex>'`) staged
+  /// by earlier `retract_suggestions` calls in the same wake. Because nothing
+  /// is persisted between calls, those items still read as pending here; the
+  /// keys let a repeated request report `notOpen` and avoid staging the same
+  /// item twice.
+  Future<RetractionPlan> plan({
     required String agentId,
     required String taskId,
     required List<RetractionRequest> requests,
+    Set<String> alreadyStagedKeys = const {},
   }) async {
-    if (requests.isEmpty) return const [];
+    if (requests.isEmpty) return const RetractionPlan.empty();
 
     final pendingSets = await _syncService.repository.getPendingChangeSets(
       agentId,
@@ -100,6 +163,13 @@ class SuggestionRetractionService {
     );
 
     final results = <RetractionResult>[];
+    final staged = <StagedRetraction>[];
+    // Item keys staged so far (prior calls + this call). Prevents the same
+    // target item from being staged twice across `retract_suggestions` calls.
+    final stagedKeys = <String>{...alreadyStagedKeys};
+    // Fingerprints staged earlier in THIS call, so the same fingerprint passed
+    // twice yields `notOpen` on the second occurrence instead of re-staging.
+    final stagedThisCall = <String>{};
     Map<String, LedgerEntry>? resolvedByFingerprint;
 
     Future<LedgerEntry?> resolvedLedgerEntry(String fingerprint) async {
@@ -118,11 +188,6 @@ class SuggestionRetractionService {
       }
       return resolvedByFingerprint![fingerprint];
     }
-
-    // Fingerprints we have already retracted during this call — ensures
-    // the same fingerprint passed twice yields `notOpen` on the second
-    // occurrence rather than crashing on a stale snapshot.
-    final retractedThisCall = <String>{};
 
     for (final request in requests) {
       final matches = _locateAll(pendingSets, request.fingerprint);
@@ -148,12 +213,9 @@ class SuggestionRetractionService {
         continue;
       }
 
-      // If we already retracted this fingerprint earlier in the same
-      // call, the second pass is a no-op. The first pass swept every
-      // pending sibling; anything still matching this fingerprint is
-      // either already `retracted` or caught by the in-`_applyRetraction`
-      // bounds/status check.
-      if (retractedThisCall.contains(request.fingerprint)) {
+      // Already staged this fingerprint earlier in the same call — the second
+      // pass is a no-op (the first staged every pending sibling).
+      if (stagedThisCall.contains(request.fingerprint)) {
         final first = matches.first;
         results.add(
           RetractionResult(
@@ -167,11 +229,15 @@ class SuggestionRetractionService {
       }
 
       final pendingMatches = matches
-          .where((m) => m.item.status == ChangeItemStatus.pending)
+          .where(
+            (m) =>
+                m.item.status == ChangeItemStatus.pending &&
+                !stagedKeys.contains('${m.changeSet.id}:${m.itemIndex}'),
+          )
           .toList();
       if (pendingMatches.isEmpty) {
-        // Every match is already resolved — report the first so the
-        // LLM sees the item exists but is no longer actionable.
+        // Every match is already resolved or already staged — report the
+        // first so the LLM sees the item exists but is no longer actionable.
         final first = matches.first;
         results.add(
           RetractionResult(
@@ -184,22 +250,23 @@ class SuggestionRetractionService {
         continue;
       }
 
-      // Sibling sweep: retract every pending duplicate, not just the
-      // first. Multiple items can share a fingerprint when consecutive
-      // wakes wrote separate change sets before cross-set dedup caught
-      // them, and a single agent retraction intent should clear every
-      // open copy so the user doesn't keep seeing ghosts in the UI.
+      // Sibling sweep: stage every pending duplicate, not just the first.
+      // Multiple items can share a fingerprint when consecutive wakes wrote
+      // separate change sets before cross-set dedup caught them, and a single
+      // agent retraction intent should clear every open copy so the user
+      // doesn't keep seeing ghosts in the UI.
       for (final match in pendingMatches) {
-        await _applyRetraction(
-          changeSet: match.changeSet,
-          itemIndex: match.itemIndex,
-          item: match.item,
-          agentId: agentId,
-          taskId: taskId,
-          reason: request.reason,
+        staged.add(
+          StagedRetraction(
+            changeSet: match.changeSet,
+            itemIndex: match.itemIndex,
+            item: match.item,
+            reason: request.reason,
+          ),
         );
+        stagedKeys.add('${match.changeSet.id}:${match.itemIndex}');
       }
-      retractedThisCall.add(request.fingerprint);
+      stagedThisCall.add(request.fingerprint);
 
       // toolName / humanSummary are identical across matches (same
       // fingerprint) — use the first for the LLM response payload.
@@ -214,7 +281,35 @@ class SuggestionRetractionService {
       );
     }
 
-    return results;
+    return RetractionPlan(results: results, staged: staged);
+  }
+
+  /// Persist the [staged] retractions produced by [plan].
+  ///
+  /// Intended to run at the end of a wake — ideally inside the same transaction
+  /// that persists the wake's new proposals — so the suggestion list
+  /// transitions straight from the old set to the new one without an empty
+  /// intermediate state. Each retraction re-reads the parent [ChangeSetEntity]
+  /// and skips the item if a concurrent user confirm/reject already resolved
+  /// it, so deferring the write is strictly safer than applying it
+  /// mid-conversation.
+  Future<void> applyStaged(List<StagedRetraction> staged) async {
+    if (staged.isEmpty) return;
+
+    // Defensive dedupe: never write two retractions for the same target item,
+    // even if a caller accumulated overlapping plans.
+    final applied = <String>{};
+    for (final retraction in staged) {
+      if (!applied.add(retraction.key)) continue;
+      await _applyRetraction(
+        changeSet: retraction.changeSet,
+        itemIndex: retraction.itemIndex,
+        item: retraction.item,
+        agentId: retraction.changeSet.agentId,
+        taskId: retraction.changeSet.taskId,
+        reason: retraction.reason,
+      );
+    }
   }
 
   /// Return every `(changeSet, itemIndex, item)` tuple whose item matches

--- a/lib/features/agents/service/suggestion_retraction_service.dart
+++ b/lib/features/agents/service/suggestion_retraction_service.dart
@@ -289,27 +289,158 @@ class SuggestionRetractionService {
   /// Intended to run at the end of a wake — ideally inside the same transaction
   /// that persists the wake's new proposals — so the suggestion list
   /// transitions straight from the old set to the new one without an empty
-  /// intermediate state. Each retraction re-reads the parent [ChangeSetEntity]
-  /// and skips the item if a concurrent user confirm/reject already resolved
-  /// it, so deferring the write is strictly safer than applying it
-  /// mid-conversation.
+  /// intermediate state.
+  ///
+  /// Decisions are persisted first (one per staged item, in order), then each
+  /// parent change set is re-read **once** and all of its retractions applied in
+  /// a single write. Grouping by change set keeps DB I/O proportional to the
+  /// number of distinct sets, not the number of items, and collapses what the
+  /// `AiSummaryCard` stream sees into one update per set.
+  ///
+  /// Applying at end-of-wake is also strictly safer than mid-conversation: the
+  /// re-read re-validates each target by **bounds, status, and fingerprint**, so
+  /// an item a concurrent user confirm/reject already resolved — or one whose
+  /// row moved or changed under us — is skipped rather than mis-retracted.
   Future<void> applyStaged(List<StagedRetraction> staged) async {
     if (staged.isEmpty) return;
 
-    // Defensive dedupe: never write two retractions for the same target item,
-    // even if a caller accumulated overlapping plans.
-    final applied = <String>{};
+    // Dedupe by target item, preserving first-seen order, and group by parent
+    // change set so each set is read and written exactly once.
+    final seenKeys = <String>{};
+    final deduped = <StagedRetraction>[];
+    final order = <String>[];
+    final byChangeSetId = <String, List<StagedRetraction>>{};
     for (final retraction in staged) {
-      if (!applied.add(retraction.key)) continue;
-      await _applyRetraction(
-        changeSet: retraction.changeSet,
-        itemIndex: retraction.itemIndex,
-        item: retraction.item,
-        agentId: retraction.changeSet.agentId,
-        taskId: retraction.changeSet.taskId,
-        reason: retraction.reason,
-      );
+      if (!seenKeys.add(retraction.key)) continue;
+      deduped.add(retraction);
+      byChangeSetId
+          .putIfAbsent(retraction.changeSet.id, () {
+            order.add(retraction.changeSet.id);
+            return <StagedRetraction>[];
+          })
+          .add(retraction);
     }
+
+    // 1. Persist every decision first (in staged order) so we never leave a
+    //    retracted item without a matching explanation — mirrors the
+    //    confirmation service ordering (see
+    //    ChangeSetConfirmationService.confirmItem).
+    for (final retraction in deduped) {
+      await _persistRetractionDecision(retraction);
+    }
+
+    // 2. Apply each set's retractions in a single re-read + write + notify.
+    for (final changeSetId in order) {
+      await _applyRetractionsToChangeSet(byChangeSetId[changeSetId]!);
+    }
+  }
+
+  Future<void> _persistRetractionDecision(StagedRetraction retraction) async {
+    final item = retraction.item;
+    _domainLogger?.log(
+      LogDomains.agentWorkflow,
+      'Retracting item ${retraction.itemIndex} (${item.toolName}) in change '
+      'set ${DomainLogger.sanitizeId(retraction.changeSet.id)}',
+      subDomain: _sub,
+    );
+
+    final decision =
+        AgentDomainEntity.changeDecision(
+              id: _uuid.v4(),
+              agentId: retraction.changeSet.agentId,
+              changeSetId: retraction.changeSet.id,
+              itemIndex: retraction.itemIndex,
+              toolName: item.toolName,
+              verdict: ChangeDecisionVerdict.retracted,
+              actor: DecisionActor.agent,
+              taskId: retraction.changeSet.taskId,
+              retractionReason: retraction.reason,
+              humanSummary: item.humanSummary,
+              args: item.args,
+              createdAt: clock.now(),
+              vectorClock: const VectorClock({}),
+            )
+            as ChangeDecisionEntity;
+    await _syncService.upsertEntity(decision);
+  }
+
+  /// Applies every retraction targeting one change set in a single read/write.
+  ///
+  /// All entries share the same `changeSet.id`. The set is re-read once, every
+  /// still-valid target item is flipped to `retracted` in memory, and the set
+  /// is persisted once (only if at least one flip survived validation).
+  Future<void> _applyRetractionsToChangeSet(
+    List<StagedRetraction> retractions,
+  ) async {
+    final snapshot = retractions.first.changeSet;
+    final latest = await _syncService.repository.getEntity(snapshot.id);
+    final current = latest is ChangeSetEntity ? latest : snapshot;
+
+    var items = current.items;
+    var changed = false;
+    for (final retraction in retractions) {
+      final itemIndex = retraction.itemIndex;
+      if (itemIndex < 0 || itemIndex >= items.length) {
+        // A concurrent writer truncated items between staging and this
+        // re-read. The decision was already persisted, so surface the orphan.
+        _domainLogger?.log(
+          LogDomains.agentWorkflow,
+          'Retraction bounds mismatch after re-read: itemIndex=$itemIndex, '
+          'items=${items.length}, '
+          'changeSet=${DomainLogger.sanitizeId(current.id)}',
+          subDomain: _sub,
+        );
+        continue;
+      }
+      final existing = items[itemIndex];
+      if (existing.status != ChangeItemStatus.pending) {
+        // The user confirmed/rejected the item between staging and this
+        // re-read. Do not overwrite their decision; the agent's retraction
+        // decision record stays persisted for the audit trail.
+        _domainLogger?.log(
+          LogDomains.agentWorkflow,
+          'Retraction lost race to user action: itemIndex=$itemIndex, '
+          'observedStatus=${existing.status.name}, '
+          'changeSet=${DomainLogger.sanitizeId(current.id)}',
+          subDomain: _sub,
+        );
+        continue;
+      }
+      if (ChangeItem.fingerprint(existing) !=
+          ChangeItem.fingerprint(retraction.item)) {
+        // The row at this index is no longer the item we staged (inserted,
+        // removed, reordered, or its args changed under us). Skip rather than
+        // retract the wrong proposal; the agent can re-stage on the next wake.
+        _domainLogger?.log(
+          LogDomains.agentWorkflow,
+          'Retraction skipped — item at index changed: itemIndex=$itemIndex, '
+          'changeSet=${DomainLogger.sanitizeId(current.id)}',
+          subDomain: _sub,
+        );
+        continue;
+      }
+
+      if (!changed) {
+        items = List<ChangeItem>.from(items);
+        changed = true;
+      }
+      items[itemIndex] = existing.copyWith(status: ChangeItemStatus.retracted);
+    }
+
+    if (!changed) return;
+
+    final newSetStatus = ChangeItem.deriveSetStatus(items);
+    final updated = current.copyWith(
+      items: items,
+      status: newSetStatus,
+      resolvedAt: ChangeItem.deriveResolvedAt(
+        newStatus: newSetStatus,
+        existingResolvedAt: current.resolvedAt,
+        now: clock.now(),
+      ),
+    );
+    await _syncService.upsertEntity(updated);
+    await _notifyChangeSetRetracted(updated);
   }
 
   /// Return every `(changeSet, itemIndex, item)` tuple whose item matches
@@ -328,100 +459,6 @@ class SuggestionRetractionService {
       }
     }
     return matches;
-  }
-
-  Future<void> _applyRetraction({
-    required ChangeSetEntity changeSet,
-    required int itemIndex,
-    required ChangeItem item,
-    required String agentId,
-    required String taskId,
-    required String reason,
-  }) async {
-    final now = clock.now();
-
-    _domainLogger?.log(
-      LogDomains.agentWorkflow,
-      'Retracting item $itemIndex (${item.toolName}) in change set '
-      '${DomainLogger.sanitizeId(changeSet.id)}',
-      subDomain: _sub,
-    );
-
-    // 1. Persist the decision record first so we never leave a retracted
-    //    item without a matching explanation — mirrors the confirmation
-    //    service ordering (see ChangeSetConfirmationService.confirmItem).
-    final decision =
-        AgentDomainEntity.changeDecision(
-              id: _uuid.v4(),
-              agentId: agentId,
-              changeSetId: changeSet.id,
-              itemIndex: itemIndex,
-              toolName: item.toolName,
-              verdict: ChangeDecisionVerdict.retracted,
-              actor: DecisionActor.agent,
-              taskId: taskId,
-              retractionReason: reason,
-              humanSummary: item.humanSummary,
-              args: item.args,
-              createdAt: now,
-              vectorClock: const VectorClock({}),
-            )
-            as ChangeDecisionEntity;
-    await _syncService.upsertEntity(decision);
-
-    // 2. Re-read the parent change set and transition the item + set status.
-    final latest = await _syncService.repository.getEntity(changeSet.id);
-    final current = latest is ChangeSetEntity ? latest : changeSet;
-    if (itemIndex < 0 || itemIndex >= current.items.length) {
-      // Rare: a concurrent writer truncated items between the initial
-      // locate and the re-read. The decision entity was already persisted,
-      // so surface the orphan so it is diagnosable if it ever happens.
-      _domainLogger?.log(
-        LogDomains.agentWorkflow,
-        'Retraction bounds mismatch after re-read: itemIndex=$itemIndex, '
-        'items=${current.items.length}, '
-        'changeSet=${DomainLogger.sanitizeId(changeSet.id)}, '
-        'decision=${DomainLogger.sanitizeId(decision.id)}',
-        subDomain: _sub,
-      );
-      return;
-    }
-    if (current.items[itemIndex].status != ChangeItemStatus.pending) {
-      // The user confirmed/rejected the item between the initial pending
-      // check in retract() and this re-read. Do not overwrite their
-      // decision. The agent's retraction decision record stays persisted
-      // so the audit trail shows both the agent's intent and the user's
-      // winning action.
-      _domainLogger?.log(
-        LogDomains.agentWorkflow,
-        'Retraction lost race to user action: itemIndex=$itemIndex, '
-        'observedStatus=${current.items[itemIndex].status.name}, '
-        'changeSet=${DomainLogger.sanitizeId(changeSet.id)}, '
-        'decision=${DomainLogger.sanitizeId(decision.id)}',
-        subDomain: _sub,
-      );
-      return;
-    }
-
-    final updatedItems = List<ChangeItem>.from(current.items);
-    updatedItems[itemIndex] = updatedItems[itemIndex].copyWith(
-      status: ChangeItemStatus.retracted,
-    );
-
-    final newSetStatus = ChangeItem.deriveSetStatus(updatedItems);
-    final resolvedAt = ChangeItem.deriveResolvedAt(
-      newStatus: newSetStatus,
-      existingResolvedAt: current.resolvedAt,
-      now: now,
-    );
-
-    final updated = current.copyWith(
-      items: updatedItems,
-      status: newSetStatus,
-      resolvedAt: resolvedAt,
-    );
-    await _syncService.upsertEntity(updated);
-    await _notifyChangeSetRetracted(updated);
   }
 
   Future<void> _notifyChangeSetRetracted(ChangeSetEntity changeSet) async {

--- a/lib/features/agents/workflow/change_set_builder.dart
+++ b/lib/features/agents/workflow/change_set_builder.dart
@@ -127,6 +127,15 @@ class ChangeSetBuilder {
   /// All items accumulated so far.
   List<ChangeItem> get items => List.unmodifiable(_items);
 
+  /// Structural fingerprints (`toolName + args`) of every item proposed this
+  /// wake. The workflow passes these to
+  /// `SuggestionRetractionService.applyStaged` so a retraction of an item the
+  /// agent is simultaneously re-proposing is suppressed — otherwise the
+  /// retract-then-re-add churn makes a stable suggestion vanish and reappear
+  /// under the user.
+  Set<String> get proposedFingerprints =>
+      _items.map(ChangeItem.fingerprint).toSet();
+
   /// Whether any deferred items have been added.
   bool get hasItems => _items.isNotEmpty;
 

--- a/lib/features/agents/workflow/task_agent_strategy.dart
+++ b/lib/features/agents/workflow/task_agent_strategy.dart
@@ -147,6 +147,21 @@ class TaskAgentStrategy extends ConversationStrategy {
   /// single tool (e.g. calling `set_task_title` 4 times).
   final _usedDeferredTools = <String>{};
 
+  /// Retractions the agent requested via `retract_suggestions` this wake.
+  ///
+  /// They are validated immediately (so the LLM gets accurate per-entry
+  /// feedback) but their persistence is deferred to the end of the wake so it
+  /// commits atomically with the new proposals — otherwise the suggestion list
+  /// flashes empty for the seconds between a mid-wake retraction write and the
+  /// end-of-wake proposal write. Applied by the workflow via
+  /// [SuggestionRetractionService.applyStaged].
+  final _stagedRetractions = <StagedRetraction>[];
+
+  /// Target item keys (`'<changeSetId>:<itemIndex>'`) already staged this wake,
+  /// so repeated `retract_suggestions` calls don't stage the same item twice
+  /// (nothing is persisted between calls, so the item still reads as pending).
+  final _stagedRetractionKeys = <String>{};
+
   static const _uuid = Uuid();
 
   /// Tool name for the report publishing tool.
@@ -391,6 +406,14 @@ class TaskAgentStrategy extends ConversationStrategy {
   /// are accumulated here as [ObservationRecord] instances.
   List<ObservationRecord> extractObservations() =>
       List.unmodifiable(_observations);
+
+  /// Returns the retractions staged via `retract_suggestions` during this wake.
+  ///
+  /// The workflow applies these at the end of the wake (inside the change-set
+  /// transaction) so the retraction and the new proposals land in a single
+  /// atomic update, never leaving the suggestion list momentarily empty.
+  List<StagedRetraction> extractStagedRetractions() =>
+      List.unmodifiable(_stagedRetractions);
 
   // ── Internal handlers ──────────────────────────────────────────────────
 
@@ -645,14 +668,23 @@ class TaskAgentStrategy extends ConversationStrategy {
       return;
     }
 
-    final results = await service.retract(
+    final plan = await service.plan(
       agentId: agentId,
       taskId: taskId,
       requests: requests,
+      alreadyStagedKeys: _stagedRetractionKeys,
     );
 
+    // Stage for end-of-wake application so the retraction commits atomically
+    // with this wake's new proposals — the suggestion list never flashes empty
+    // between a retraction and its replacement.
+    for (final retraction in plan.staged) {
+      _stagedRetractions.add(retraction);
+      _stagedRetractionKeys.add(retraction.key);
+    }
+
     final response = StringBuffer('Retraction results:');
-    for (final r in results) {
+    for (final r in plan.results) {
       final label = switch (r.outcome) {
         RetractionOutcome.retracted => 'retracted',
         RetractionOutcome.notOpen => 'not_open (already resolved)',

--- a/lib/features/agents/workflow/task_agent_workflow.dart
+++ b/lib/features/agents/workflow/task_agent_workflow.dart
@@ -388,6 +388,13 @@ class TaskAgentWorkflow {
         },
       );
 
+      final retractionService = SuggestionRetractionService(
+        syncService: syncService,
+        domainLogger: domainLogger,
+        onChangeSetRetracted:
+            changeSetNotificationService?.syncAfterAgentRetraction,
+      );
+
       final strategy = TaskAgentStrategy(
         executor: executor,
         syncService: syncService,
@@ -396,12 +403,7 @@ class TaskAgentWorkflow {
         runKey: runKey,
         taskId: taskId,
         changeSetBuilder: changeSetBuilder,
-        retractionService: SuggestionRetractionService(
-          syncService: syncService,
-          domainLogger: domainLogger,
-          onChangeSetRetracted:
-              changeSetNotificationService?.syncAfterAgentRetraction,
-        ),
+        retractionService: retractionService,
         resolveTaskMetadata: () =>
             ChangeProposalFilter.resolveTaskMetadata(journalDb, taskId),
         resolveCategoryId: (entityId) async {
@@ -616,6 +618,17 @@ class TaskAgentWorkflow {
             ),
           );
         }
+
+        // 10a. Apply any retractions the agent staged during the conversation.
+        // Deferred to here — and run before the build below — so the retraction
+        // and the new proposals commit in one transaction. Persisting
+        // retractions mid-conversation (their old behavior) emptied the
+        // suggestion list for the seconds until this end-of-wake build landed
+        // the replacements; staging closes that gap. Running before build also
+        // lets the builder's dedup see the freshly-retracted statuses.
+        await retractionService.applyStaged(
+          strategy.extractStagedRetractions(),
+        );
 
         // 10b. Persist deferred change set (if any items were accumulated).
         // Pass the full pending sets so the builder can merge into an
@@ -1273,15 +1286,26 @@ to keep the user-facing suggestion list clean and trustworthy:
      have a better timer description than an existing open
      `update_running_timer` proposal, retract the old proposal first and
      then propose the newer text.
-2. **Retract stale open proposals.** If an open proposal is no longer
-   relevant — for example the current task state already matches it
-   (`priority` is already `P1`), the user made the change manually, or
-   it duplicates another open proposal you want to keep — call
+2. **Retract an open proposal only when THAT proposal is itself stale.**
+   Valid reasons: the current task state already satisfies it (`priority`
+   is already `P1`), the user already made that exact change manually, or
+   it duplicates another open proposal you are keeping. Call
    `retract_suggestions` with the item's `fp=…` fingerprint and a short
-   one-sentence reason. The user is NOT prompted; the item simply
-   disappears from the active suggestion list and is recorded as
-   retracted in the ledger. Retraction is not a failure; it is how you
-   keep the user's trust in your proposals.
+   one-sentence reason. The user is NOT prompted; the item disappears from
+   the active suggestion list and is recorded as retracted in the ledger.
+   Retraction is how you keep the user's trust — but only when the
+   proposal is genuinely dead.
+   - **Never retract a proposal just because the user acted on a
+     DIFFERENT one.** Each open proposal stands on its own. When the user
+     confirms or rejects one checklist item (or any single suggestion),
+     the OTHER open proposals are still valid and the user may still want
+     them — leave them alone. A partially-acted-on batch is normal, not a
+     signal to withdraw the rest.
+   - **Prefer leaving a good proposal in place over retract-and-re-add.**
+     Do not retract an open proposal only to re-propose a near-identical
+     one; the churn is worse than a slightly imperfect summary. (The one
+     exception is the single-open-proposal rule for `update_running_timer`
+     above.)
 3. **Do not re-propose rejected or retracted items** unless the task
    context has materially changed. When you do re-propose after a
    rejection/retraction, justify the decision in your report.

--- a/lib/features/agents/workflow/task_agent_workflow.dart
+++ b/lib/features/agents/workflow/task_agent_workflow.dart
@@ -626,8 +626,18 @@ class TaskAgentWorkflow {
         // suggestion list for the seconds until this end-of-wake build landed
         // the replacements; staging closes that gap. Running before build also
         // lets the builder's dedup see the freshly-retracted statuses.
+        //
+        // Churn guard: weaker models routinely retract an open proposal AND
+        // re-propose an identical one in the same wake. That retract-then-re-add
+        // makes a stable suggestion vanish and reappear under the user's finger
+        // (and, when the user has just confirmed a sibling, looks like accepting
+        // one wipes the rest). Suppress retractions of anything being
+        // re-proposed this wake; the matching new proposal is then dropped by
+        // the builder's dedup against the still-open original, leaving it
+        // untouched.
         await retractionService.applyStaged(
           strategy.extractStagedRetractions(),
+          skipFingerprints: changeSetBuilder.proposedFingerprints,
         );
 
         // 10b. Persist deferred change set (if any items were accumulated).

--- a/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,6 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Blaizzy/mlx-audio-swift.git",
       "state" : {
+        "branch" : "main",
         "revision" : "7734cd1fbbe86460083c1d24199737a24cadfcc8"
       }
     },

--- a/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,6 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Blaizzy/mlx-audio-swift.git",
       "state" : {
+        "branch" : "main",
         "revision" : "7734cd1fbbe86460083c1d24199737a24cadfcc8"
       }
     },

--- a/test/features/agents/service/suggestion_retraction_service_test.dart
+++ b/test/features/agents/service/suggestion_retraction_service_test.dart
@@ -224,6 +224,29 @@ extension _AnyGeneratedSuggestionRetractionScenario on glados.Any {
       );
 }
 
+/// Runs the two-phase retraction (validate, then persist) the way the workflow
+/// does at end-of-wake, returning the LLM-facing results.
+///
+/// Most tests assert on this combined behavior — it is exactly what the old
+/// single-step `retract` did. Dedicated tests below exercise
+/// [SuggestionRetractionService.plan] and
+/// [SuggestionRetractionService.applyStaged] in isolation to lock in the
+/// read-only / persist split.
+Future<List<RetractionResult>> _planThenApply(
+  SuggestionRetractionService service, {
+  required String agentId,
+  required String taskId,
+  required List<RetractionRequest> requests,
+}) async {
+  final plan = await service.plan(
+    agentId: agentId,
+    taskId: taskId,
+    requests: requests,
+  );
+  await service.applyStaged(plan.staged);
+  return plan.results;
+}
+
 void main() {
   setUpAll(registerAllFallbackValues);
 
@@ -295,7 +318,7 @@ void main() {
     ).thenAnswer((_) async => sets);
   }
 
-  group('SuggestionRetractionService.retract', () {
+  group('SuggestionRetractionService.plan + applyStaged', () {
     glados.Glados(
       glados.any.retractionScenario,
       glados.ExploreConfig(numRuns: 220),
@@ -561,14 +584,52 @@ void main() {
           ),
       ];
 
-      final results = await withClock(
+      final plan = await withClock(
         testClock,
-        () => localService.retract(
+        () => localService.plan(
           agentId: agentId,
           taskId: taskId,
           requests: requests,
         ),
       );
+
+      // plan() is read-only — validation must not persist anything.
+      expect(upserts, isEmpty, reason: 'plan() must not upsert: $scenario');
+
+      // One staged retraction per pending match, in request/match order —
+      // the exact set the apply step will later persist as decisions.
+      expect(
+        plan.staged,
+        hasLength(expected.decisions.length),
+        reason: '$scenario',
+      );
+      for (var i = 0; i < expected.decisions.length; i++) {
+        expect(
+          plan.staged[i].changeSet.id,
+          expected.decisions[i].changeSetId,
+          reason: '$scenario',
+        );
+        expect(
+          plan.staged[i].itemIndex,
+          expected.decisions[i].itemIndex,
+          reason: '$scenario',
+        );
+        expect(
+          plan.staged[i].reason,
+          expected.decisions[i].reason,
+          reason: '$scenario',
+        );
+        expect(
+          plan.staged[i].item.toolName,
+          expected.decisions[i].item.toolName,
+          reason: '$scenario',
+        );
+      }
+
+      final results = plan.results;
+
+      // Apply the staged retractions — this is where persistence happens.
+      await withClock(testClock, () => localService.applyStaged(plan.staged));
 
       expect(results, hasLength(expected.results.length), reason: '$scenario');
       for (var i = 0; i < expected.results.length; i++) {
@@ -638,7 +699,8 @@ void main() {
         final fp = ChangeItem.fingerprint(priorityItem);
         final results = await withClock(
           testClock,
-          () => service.retract(
+          () => _planThenApply(
+            service,
             agentId: 'agent-1',
             taskId: 'task-xyz',
             requests: [
@@ -696,7 +758,8 @@ void main() {
 
         final results = await withClock(
           testClock,
-          () => service.retract(
+          () => _planThenApply(
+            service,
             agentId: 'agent-1',
             taskId: 'task-xyz',
             requests: [
@@ -733,7 +796,8 @@ void main() {
 
         await withClock(
           testClock,
-          () => serviceWithCallback.retract(
+          () => _planThenApply(
+            serviceWithCallback,
             agentId: 'agent-1',
             taskId: 'task-xyz',
             requests: [
@@ -766,7 +830,8 @@ void main() {
 
         final results = await withClock(
           testClock,
-          () => serviceWithCallback.retract(
+          () => _planThenApply(
+            serviceWithCallback,
             agentId: 'agent-1',
             taskId: 'task-xyz',
             requests: [
@@ -797,7 +862,8 @@ void main() {
       ]);
       stubPendingSets([cs]);
 
-      final results = await service.retract(
+      final results = await _planThenApply(
+        service,
         agentId: 'agent-1',
         taskId: 'task-xyz',
         requests: [
@@ -821,7 +887,8 @@ void main() {
           setWith([titleItem]),
         ]);
 
-        final results = await service.retract(
+        final results = await _planThenApply(
+          service,
           agentId: 'agent-1',
           taskId: 'task-xyz',
           requests: [
@@ -873,7 +940,8 @@ void main() {
           ),
         );
 
-        final results = await service.retract(
+        final results = await _planThenApply(
+          service,
           agentId: 'agent-1',
           taskId: 'task-xyz',
           requests: [
@@ -942,7 +1010,8 @@ void main() {
           ),
         );
 
-        final results = await service.retract(
+        final results = await _planThenApply(
+          service,
           agentId: 'agent-1',
           taskId: 'task-xyz',
           requests: [
@@ -968,7 +1037,8 @@ void main() {
         final fp = ChangeItem.fingerprint(priorityItem);
         final results = await withClock(
           testClock,
-          () => service.retract(
+          () => _planThenApply(
+            service,
             agentId: 'agent-1',
             taskId: 'task-xyz',
             requests: [
@@ -996,7 +1066,8 @@ void main() {
     test(
       'returns empty list and makes no calls when given no requests',
       () async {
-        final results = await service.retract(
+        final results = await _planThenApply(
+          service,
           agentId: 'agent-1',
           taskId: 'task-xyz',
           requests: const [],
@@ -1029,7 +1100,8 @@ void main() {
 
         final results = await withClock(
           testClock,
-          () => service.retract(
+          () => _planThenApply(
+            service,
             agentId: 'agent-1',
             taskId: 'task-xyz',
             requests: [
@@ -1083,7 +1155,8 @@ void main() {
 
         final results = await withClock(
           testClock,
-          () => service.retract(
+          () => _planThenApply(
+            service,
             agentId: 'agent-1',
             taskId: 'task-xyz',
             requests: [
@@ -1124,7 +1197,8 @@ void main() {
         );
         stubPendingSets([a, b]);
 
-        final results = await service.retract(
+        final results = await _planThenApply(
+          service,
           agentId: 'agent-1',
           taskId: 'task-xyz',
           requests: [
@@ -1149,7 +1223,8 @@ void main() {
 
         await withClock(
           testClock,
-          () => service.retract(
+          () => _planThenApply(
+            service,
             agentId: 'agent-1',
             taskId: 'task-xyz',
             requests: [
@@ -1168,6 +1243,134 @@ void main() {
             subDomain: 'SuggestionRetraction',
           ),
         ).called(1);
+      },
+    );
+
+    test('plan() validates and stages without persisting anything', () async {
+      final cs = setWith([priorityItem, titleItem]);
+      stubPendingSets([cs]);
+
+      final plan = await service.plan(
+        agentId: 'agent-1',
+        taskId: 'task-xyz',
+        requests: [
+          RetractionRequest(
+            fingerprint: ChangeItem.fingerprint(priorityItem),
+            reason: 'stale',
+          ),
+        ],
+      );
+
+      expect(plan.results.single.outcome, RetractionOutcome.retracted);
+      expect(plan.results.single.toolName, 'update_task_priority');
+      expect(plan.staged, hasLength(1));
+      expect(plan.staged.single.changeSet.id, 'cs-1');
+      expect(plan.staged.single.itemIndex, 0);
+      expect(plan.staged.single.reason, 'stale');
+      expect(plan.staged.single.key, 'cs-1:0');
+      // The whole point of the split: nothing is written during planning.
+      verifyNever(() => mockSyncService.upsertEntity(any()));
+    });
+
+    test(
+      'applyStaged() persists the decision and flips only the staged item',
+      () async {
+        final cs = setWith([priorityItem, titleItem]);
+        stubPendingSets([cs]);
+
+        final plan = await service.plan(
+          agentId: 'agent-1',
+          taskId: 'task-xyz',
+          requests: [
+            RetractionRequest(
+              fingerprint: ChangeItem.fingerprint(priorityItem),
+              reason: 'stale',
+            ),
+          ],
+        );
+        await withClock(testClock, () => service.applyStaged(plan.staged));
+
+        final upserts = verify(
+          () => mockSyncService.upsertEntity(captureAny()),
+        ).captured;
+        final decision = upserts.whereType<ChangeDecisionEntity>().single;
+        expect(decision.verdict, ChangeDecisionVerdict.retracted);
+        expect(decision.actor, DecisionActor.agent);
+        expect(decision.retractionReason, 'stale');
+        expect(decision.createdAt, DateTime(2026, 4, 18, 9, 30));
+
+        final updated = upserts.whereType<ChangeSetEntity>().single;
+        expect(updated.items[0].status, ChangeItemStatus.retracted);
+        expect(
+          updated.items[1].status,
+          ChangeItemStatus.pending,
+          reason: 'sibling proposals are untouched by an unrelated retraction',
+        );
+      },
+    );
+
+    test('applyStaged([]) is a no-op', () async {
+      await service.applyStaged(const []);
+      verifyNever(() => mockSyncService.upsertEntity(any()));
+    });
+
+    test(
+      'alreadyStagedKeys keeps a repeat retraction idempotent across calls in '
+      'one wake (nothing is persisted between calls)',
+      () async {
+        final cs = setWith([priorityItem]);
+        stubPendingSets([cs]);
+        final fp = ChangeItem.fingerprint(priorityItem);
+
+        final first = await service.plan(
+          agentId: 'agent-1',
+          taskId: 'task-xyz',
+          requests: [RetractionRequest(fingerprint: fp, reason: 'first')],
+        );
+        expect(first.staged, hasLength(1));
+
+        // The item is staged but NOT yet persisted, so a second plan still
+        // sees it as pending. Without the staged key it would be staged again
+        // — leading to a duplicate retraction decision at apply time.
+        final second = await service.plan(
+          agentId: 'agent-1',
+          taskId: 'task-xyz',
+          requests: [RetractionRequest(fingerprint: fp, reason: 'second')],
+          alreadyStagedKeys: {first.staged.single.key},
+        );
+
+        expect(second.results.single.outcome, RetractionOutcome.notOpen);
+        expect(second.staged, isEmpty);
+      },
+    );
+
+    test(
+      'applyStaged dedupes overlapping staged retractions for the same item',
+      () async {
+        final cs = setWith([priorityItem]);
+        stubPendingSets([cs]);
+        final plan = await service.plan(
+          agentId: 'agent-1',
+          taskId: 'task-xyz',
+          requests: [
+            RetractionRequest(
+              fingerprint: ChangeItem.fingerprint(priorityItem),
+              reason: 'r',
+            ),
+          ],
+        );
+
+        // Apply the same staged item twice (defensive against overlapping
+        // accumulated plans) — only one decision must be written.
+        await withClock(
+          testClock,
+          () => service.applyStaged([...plan.staged, ...plan.staged]),
+        );
+
+        final decisions = verify(
+          () => mockSyncService.upsertEntity(captureAny()),
+        ).captured.whereType<ChangeDecisionEntity>().toList();
+        expect(decisions, hasLength(1));
       },
     );
   });

--- a/test/features/agents/service/suggestion_retraction_service_test.dart
+++ b/test/features/agents/service/suggestion_retraction_service_test.dart
@@ -72,6 +72,25 @@ class _GeneratedRetractionScenario {
   }
 }
 
+/// Scenario for the `applyStaged` churn guard: a list of staged item kinds
+/// (each in its own single-item change set) plus the kinds whose fingerprints
+/// are being re-proposed this wake and must therefore be skipped.
+class _GeneratedSkipScenario {
+  const _GeneratedSkipScenario({
+    required this.stagedKinds,
+    required this.skipKinds,
+  });
+
+  final List<_GeneratedRetractionItemKind> stagedKinds;
+  final List<_GeneratedRetractionItemKind> skipKinds;
+
+  @override
+  String toString() {
+    return '_GeneratedSkipScenario(stagedKinds: $stagedKinds, '
+        'skipKinds: $skipKinds)';
+  }
+}
+
 class _ExpectedRetractionResult {
   const _ExpectedRetractionResult({
     required this.fingerprint,
@@ -221,6 +240,23 @@ extension _AnyGeneratedSuggestionRetractionScenario on glados.Any {
           List<_GeneratedRetractionSetSpec> sets,
           List<_GeneratedRetractionRequestSlot> requests,
         ) => _GeneratedRetractionScenario(sets: sets, requests: requests),
+      );
+
+  glados.Generator<_GeneratedSkipScenario> get retractionSkipScenario =>
+      glados.CombinableAny(this).combine2(
+        glados.ListAnys(
+          this,
+        ).listWithLengthInRange(0, 5, retractionItemKind),
+        glados.ListAnys(
+          this,
+        ).listWithLengthInRange(0, 3, retractionItemKind),
+        (
+          List<_GeneratedRetractionItemKind> stagedKinds,
+          List<_GeneratedRetractionItemKind> skipKinds,
+        ) => _GeneratedSkipScenario(
+          stagedKinds: stagedKinds,
+          skipKinds: skipKinds,
+        ),
       );
 }
 
@@ -1496,5 +1532,174 @@ void main() {
         );
       },
     );
+
+    test(
+      'applyStaged skips a retraction whose item is being re-proposed this '
+      'wake (churn guard)',
+      () async {
+        final cs = setWith([priorityItem]);
+        stubPendingSets([cs]);
+        final plan = await service.plan(
+          agentId: 'agent-1',
+          taskId: 'task-xyz',
+          requests: [
+            RetractionRequest(
+              fingerprint: ChangeItem.fingerprint(priorityItem),
+              reason: 'r',
+            ),
+          ],
+        );
+
+        // The agent re-proposed this exact item this wake → skip it entirely.
+        await withClock(
+          testClock,
+          () => service.applyStaged(
+            plan.staged,
+            skipFingerprints: {ChangeItem.fingerprint(priorityItem)},
+          ),
+        );
+
+        // No decision, no flip — the original proposal is left untouched so it
+        // does not vanish and reappear under the user.
+        verifyNever(() => mockSyncService.upsertEntity(any()));
+      },
+    );
+
+    test(
+      'applyStaged applies only the retractions not in skipFingerprints',
+      () async {
+        final cs = setWith([priorityItem, titleItem]);
+        stubPendingSets([cs]);
+        final plan = await service.plan(
+          agentId: 'agent-1',
+          taskId: 'task-xyz',
+          requests: [
+            RetractionRequest(
+              fingerprint: ChangeItem.fingerprint(priorityItem),
+              reason: 'a',
+            ),
+            RetractionRequest(
+              fingerprint: ChangeItem.fingerprint(titleItem),
+              reason: 'b',
+            ),
+          ],
+        );
+        expect(plan.staged, hasLength(2));
+
+        // Re-proposing only the priority item → its retraction is skipped, the
+        // title retraction proceeds.
+        await withClock(
+          testClock,
+          () => service.applyStaged(
+            plan.staged,
+            skipFingerprints: {ChangeItem.fingerprint(priorityItem)},
+          ),
+        );
+
+        final upserts = verify(
+          () => mockSyncService.upsertEntity(captureAny()),
+        ).captured;
+        final decision = upserts.whereType<ChangeDecisionEntity>().single;
+        expect(decision.toolName, 'set_task_title');
+        final updated = upserts.whereType<ChangeSetEntity>().single;
+        expect(
+          updated.items[0].status,
+          ChangeItemStatus.pending,
+          reason: 're-proposed priority item is left open',
+        );
+        expect(updated.items[1].status, ChangeItemStatus.retracted);
+      },
+    );
+
+    glados.Glados(
+      glados.any.retractionSkipScenario,
+      glados.ExploreConfig(numRuns: 120),
+    ).test('applyStaged persists exactly the non-skipped staged items', (
+      scenario,
+    ) async {
+      final localSyncService = MockAgentSyncService();
+      final localRepository = MockAgentRepository();
+      final localDomainLogger = MockDomainLogger();
+      final localService = SuggestionRetractionService(
+        syncService: localSyncService,
+        domainLogger: localDomainLogger,
+      );
+
+      when(() => localSyncService.repository).thenReturn(localRepository);
+      // Re-read falls back to the staged snapshot (item still pending).
+      when(
+        () => localRepository.getEntity(any()),
+      ).thenAnswer((_) async => null);
+      final upserts = <AgentDomainEntity>[];
+      when(() => localSyncService.upsertEntity(any())).thenAnswer((inv) async {
+        upserts.add(inv.positionalArguments.single as AgentDomainEntity);
+      });
+      when(
+        () => localDomainLogger.log(
+          any(),
+          any(),
+          subDomain: any(named: 'subDomain'),
+        ),
+      ).thenReturn(null);
+
+      // Each staged item lives in its own single-item change set, so every
+      // target has a unique key (no dedupe collapsing) and one write each.
+      final staged = [
+        for (var i = 0; i < scenario.stagedKinds.length; i++)
+          StagedRetraction(
+            changeSet: makeTestChangeSet(
+              id: 'skip-cs-$i',
+              items: [scenario.stagedKinds[i].item()],
+            ),
+            itemIndex: 0,
+            item: scenario.stagedKinds[i].item(),
+            reason: 'reason-$i',
+          ),
+      ];
+      final skipFingerprints = {
+        for (final kind in scenario.skipKinds)
+          ChangeItem.fingerprint(kind.item()),
+      };
+
+      await withClock(
+        testClock,
+        () => localService.applyStaged(
+          staged,
+          skipFingerprints: skipFingerprints,
+        ),
+      );
+
+      final expectedApplied = [
+        for (final kind in scenario.stagedKinds)
+          if (!skipFingerprints.contains(ChangeItem.fingerprint(kind.item())))
+            kind,
+      ];
+      final decisions = upserts.whereType<ChangeDecisionEntity>().toList();
+      final sets = upserts.whereType<ChangeSetEntity>().toList();
+
+      // One decision + one set write per applied (non-skipped) staged item.
+      expect(decisions, hasLength(expectedApplied.length), reason: '$scenario');
+      expect(sets, hasLength(expectedApplied.length), reason: '$scenario');
+
+      // No persisted retraction may carry a skipped fingerprint.
+      for (final decision in decisions) {
+        final fingerprint = ChangeItem.fingerprintFromParts(
+          decision.toolName,
+          decision.args ?? const {},
+        );
+        expect(
+          skipFingerprints.contains(fingerprint),
+          isFalse,
+          reason: '$scenario',
+        );
+      }
+      for (final set in sets) {
+        expect(
+          set.items.single.status,
+          ChangeItemStatus.retracted,
+          reason: '$scenario',
+        );
+      }
+    }, tags: 'glados');
   });
 }

--- a/test/features/agents/service/suggestion_retraction_service_test.dart
+++ b/test/features/agents/service/suggestion_retraction_service_test.dart
@@ -422,13 +422,12 @@ void main() {
           'generated reason $index ${slot.name}';
 
       _ExpectedRetractionModel buildExpectedModel() {
-        final latestById = {for (final set in initialSets) set.id: set};
         final results = <_ExpectedRetractionResult>[];
-        final upsertKinds = <_ExpectedRetractionUpsertKind>[];
         final decisions = <_ExpectedRetractionDecision>[];
-        final updatedSets = <ChangeSetEntity>[];
         final retractedThisCall = <String>{};
 
+        // Phase 0 — replicate plan(): staging order is request-outer,
+        // match-inner; one staged decision per pending match.
         for (var i = 0; i < scenario.requests.length; i++) {
           final request = scenario.requests[i];
           final fingerprint = request.fingerprint;
@@ -474,7 +473,6 @@ void main() {
 
           final reason = reasonFor(i, request);
           for (final match in pendingMatches) {
-            upsertKinds.add(_ExpectedRetractionUpsertKind.decision);
             decisions.add(
               _ExpectedRetractionDecision(
                 changeSetId: match.changeSet.id,
@@ -483,33 +481,7 @@ void main() {
                 reason: reason,
               ),
             );
-
-            final reread = rereadEntity(match.changeSet, latestById);
-            final current = reread ?? match.changeSet;
-            if (match.itemIndex >= current.items.length) continue;
-            if (current.items[match.itemIndex].status !=
-                ChangeItemStatus.pending) {
-              continue;
-            }
-
-            final updatedItems = List<ChangeItem>.from(current.items);
-            updatedItems[match.itemIndex] = updatedItems[match.itemIndex]
-                .copyWith(status: ChangeItemStatus.retracted);
-            final newStatus = ChangeItem.deriveSetStatus(updatedItems);
-            final updatedSet = current.copyWith(
-              items: updatedItems,
-              status: newStatus,
-              resolvedAt: ChangeItem.deriveResolvedAt(
-                newStatus: newStatus,
-                existingResolvedAt: current.resolvedAt,
-                now: now,
-              ),
-            );
-            upsertKinds.add(_ExpectedRetractionUpsertKind.changeSet);
-            updatedSets.add(updatedSet);
-            latestById[updatedSet.id] = updatedSet;
           }
-
           retractedThisCall.add(fingerprint);
           final first = pendingMatches.first;
           results.add(
@@ -520,6 +492,71 @@ void main() {
               humanSummary: first.item.humanSummary,
             ),
           );
+        }
+
+        // Phase 1 — applyStaged persists every decision first, in staged order.
+        final upsertKinds = <_ExpectedRetractionUpsertKind>[
+          ...List.filled(
+            decisions.length,
+            _ExpectedRetractionUpsertKind.decision,
+          ),
+        ];
+
+        // Phase 2 — applyStaged then re-reads each change set ONCE (in
+        // first-seen order) and applies all of its still-valid flips in a
+        // single write. Each set is read before any write touches it, so the
+        // re-read always resolves against the static initial snapshot.
+        final staticInitialById = {for (final set in initialSets) set.id: set};
+        final updatedSets = <ChangeSetEntity>[];
+        final groupOrder = <String>[];
+        final groups = <String, List<_ExpectedRetractionDecision>>{};
+        for (final decision in decisions) {
+          groups
+              .putIfAbsent(decision.changeSetId, () {
+                groupOrder.add(decision.changeSetId);
+                return <_ExpectedRetractionDecision>[];
+              })
+              .add(decision);
+        }
+
+        for (final setId in groupOrder) {
+          final initial = initialSets.firstWhere((set) => set.id == setId);
+          final reread = rereadEntity(initial, staticInitialById);
+          final current = reread ?? initial;
+          var items = current.items;
+          var changed = false;
+          for (final decision in groups[setId]!) {
+            final index = decision.itemIndex;
+            if (index < 0 || index >= items.length) continue;
+            final existing = items[index];
+            if (existing.status != ChangeItemStatus.pending) continue;
+            if (ChangeItem.fingerprint(existing) !=
+                ChangeItem.fingerprint(decision.item)) {
+              continue;
+            }
+            if (!changed) {
+              items = List<ChangeItem>.from(items);
+              changed = true;
+            }
+            items[index] = existing.copyWith(
+              status: ChangeItemStatus.retracted,
+            );
+          }
+          if (!changed) continue;
+
+          final newStatus = ChangeItem.deriveSetStatus(items);
+          updatedSets.add(
+            current.copyWith(
+              items: items,
+              status: newStatus,
+              resolvedAt: ChangeItem.deriveResolvedAt(
+                newStatus: newStatus,
+                existingResolvedAt: current.resolvedAt,
+                now: now,
+              ),
+            ),
+          );
+          upsertKinds.add(_ExpectedRetractionUpsertKind.changeSet);
         }
 
         return _ExpectedRetractionModel(
@@ -1371,6 +1408,92 @@ void main() {
           () => mockSyncService.upsertEntity(captureAny()),
         ).captured.whereType<ChangeDecisionEntity>().toList();
         expect(decisions, hasLength(1));
+      },
+    );
+
+    test(
+      'applyStaged writes a change set once even with multiple retractions '
+      'targeting it',
+      () async {
+        // Two distinct pending proposals in the SAME change set.
+        final cs = setWith([priorityItem, titleItem]);
+        stubPendingSets([cs]);
+
+        final plan = await service.plan(
+          agentId: 'agent-1',
+          taskId: 'task-xyz',
+          requests: [
+            RetractionRequest(
+              fingerprint: ChangeItem.fingerprint(priorityItem),
+              reason: 'a',
+            ),
+            RetractionRequest(
+              fingerprint: ChangeItem.fingerprint(titleItem),
+              reason: 'b',
+            ),
+          ],
+        );
+        expect(plan.staged, hasLength(2));
+
+        await withClock(testClock, () => service.applyStaged(plan.staged));
+
+        final upserts = verify(
+          () => mockSyncService.upsertEntity(captureAny()),
+        ).captured;
+        // One decision per item, but the parent set is read and written once.
+        expect(upserts.whereType<ChangeDecisionEntity>(), hasLength(2));
+        final sets = upserts.whereType<ChangeSetEntity>().toList();
+        expect(
+          sets,
+          hasLength(1),
+          reason: 'batched: a change set is written exactly once per apply',
+        );
+        expect(sets.single.items[0].status, ChangeItemStatus.retracted);
+        expect(sets.single.items[1].status, ChangeItemStatus.retracted);
+        expect(sets.single.status, ChangeSetStatus.resolved);
+      },
+    );
+
+    test(
+      'applyStaged skips an item whose row changed under it but still records '
+      'the decision (fingerprint guard)',
+      () async {
+        final cs = setWith([priorityItem]);
+        stubPendingSets([cs]);
+
+        final plan = await service.plan(
+          agentId: 'agent-1',
+          taskId: 'task-xyz',
+          requests: [
+            RetractionRequest(
+              fingerprint: ChangeItem.fingerprint(priorityItem),
+              reason: 'r',
+            ),
+          ],
+        );
+        expect(plan.staged, hasLength(1));
+
+        // Between plan and apply, the row at index 0 is replaced by a different
+        // proposal (concurrent reorder/insert/args change). The re-read returns
+        // it; index alone would otherwise retract the wrong proposal.
+        when(
+          () => mockRepository.getEntity('cs-1'),
+        ).thenAnswer((_) async => cs.copyWith(items: const [titleItem]));
+
+        await withClock(testClock, () => service.applyStaged(plan.staged));
+
+        final upserts = verify(
+          () => mockSyncService.upsertEntity(captureAny()),
+        ).captured;
+        // The decision is still persisted (audit trail), but the set is NOT
+        // flipped — the guard refuses to retract a non-matching row.
+        expect(upserts.whereType<ChangeDecisionEntity>(), hasLength(1));
+        expect(
+          upserts.whereType<ChangeSetEntity>(),
+          isEmpty,
+          reason:
+              'wrong-item guard: no change-set write when fingerprint moved',
+        );
       },
     );
   });

--- a/test/features/agents/workflow/change_set_builder_test.dart
+++ b/test/features/agents/workflow/change_set_builder_test.dart
@@ -1055,6 +1055,30 @@ void main() {
       expect(builder.items[1].toolName, 'update_task_estimate');
     });
 
+    test('proposedFingerprints reflects every queued item', () async {
+      expect(builder.proposedFingerprints, isEmpty);
+
+      await builder.addItem(
+        toolName: 'set_task_title',
+        args: {'title': 'Fix bug'},
+        humanSummary: 'Set title',
+      );
+      await builder.addItem(
+        toolName: 'update_task_estimate',
+        args: {'minutes': 60},
+        humanSummary: 'Set estimate',
+      );
+
+      // These are what the workflow passes as skipFingerprints so an in-flight
+      // retraction of an item being re-proposed this wake is suppressed.
+      expect(builder.proposedFingerprints, {
+        ChangeItem.fingerprintFromParts('set_task_title', {'title': 'Fix bug'}),
+        ChangeItem.fingerprintFromParts('update_task_estimate', {
+          'minutes': 60,
+        }),
+      });
+    });
+
     test(
       'keeps only the latest running timer update per timer queued in a wake',
       () async {

--- a/test/features/agents/workflow/task_agent_strategy_test.dart
+++ b/test/features/agents/workflow/task_agent_strategy_test.dart
@@ -3225,6 +3225,141 @@ void main() {
       );
 
       test(
+        'stages retractions for end-of-wake application instead of '
+        'persisting mid-conversation',
+        () async {
+          final changeSet = makeTestChangeSet(id: 'cs-stage-1');
+          final fakeService = _FakeRetractionService(
+            responses: (requests) => [
+              RetractionResult(
+                fingerprint: requests.first.fingerprint,
+                outcome: RetractionOutcome.retracted,
+              ),
+            ],
+            staged: [
+              StagedRetraction(
+                changeSet: changeSet,
+                itemIndex: 0,
+                item: changeSet.items.first,
+                reason: 'stale',
+              ),
+            ],
+          );
+
+          final retractionStrategy = TaskAgentStrategy(
+            executor: mockExecutor,
+            syncService: mockSyncService,
+            agentId: agentId,
+            threadId: threadId,
+            runKey: runKey,
+            taskId: taskId,
+            resolveCategoryId: (_) async => 'cat-001',
+            readVectorClock: (_) async => null,
+            executeToolHandler: (_, _, _) async =>
+                const ToolExecutionResult(success: true, output: 'unused'),
+            retractionService: fakeService,
+          );
+
+          await retractionStrategy.processToolCalls(
+            toolCalls: [
+              ChatCompletionMessageToolCall(
+                id: 'call-retract-stage',
+                type: ChatCompletionMessageToolCallType.function,
+                function: ChatCompletionMessageFunctionCall(
+                  name: TaskAgentToolNames.retractSuggestions,
+                  arguments: jsonEncode({
+                    'proposals': [
+                      {'fingerprint': 'fp-stage', 'reason': 'stale'},
+                    ],
+                  }),
+                ),
+              ),
+            ],
+            manager: mockManager,
+          );
+
+          // The retraction is staged for the workflow to apply at end-of-wake.
+          final staged = retractionStrategy.extractStagedRetractions();
+          expect(staged, hasLength(1));
+          expect(staged.single.changeSet.id, 'cs-stage-1');
+          expect(staged.single.reason, 'stale');
+          // It must NOT be persisted during the conversation — otherwise the
+          // suggestion list flashes empty until the end-of-wake proposals land.
+          expect(fakeService.appliedStaged, isEmpty);
+        },
+      );
+
+      test(
+        'passes already-staged keys to plan so repeat calls stay idempotent',
+        () async {
+          final changeSet = makeTestChangeSet(id: 'cs-stage-2');
+          final fakeService = _FakeRetractionService(
+            responses: (requests) => [
+              RetractionResult(
+                fingerprint: requests.first.fingerprint,
+                outcome: RetractionOutcome.retracted,
+              ),
+            ],
+            staged: [
+              StagedRetraction(
+                changeSet: changeSet,
+                itemIndex: 0,
+                item: changeSet.items.first,
+                reason: 'stale',
+              ),
+            ],
+          );
+
+          final retractionStrategy = TaskAgentStrategy(
+            executor: mockExecutor,
+            syncService: mockSyncService,
+            agentId: agentId,
+            threadId: threadId,
+            runKey: runKey,
+            taskId: taskId,
+            resolveCategoryId: (_) async => 'cat-001',
+            readVectorClock: (_) async => null,
+            executeToolHandler: (_, _, _) async =>
+                const ToolExecutionResult(success: true, output: 'unused'),
+            retractionService: fakeService,
+          );
+
+          ChatCompletionMessageToolCall retractCall(String id) =>
+              ChatCompletionMessageToolCall(
+                id: id,
+                type: ChatCompletionMessageToolCallType.function,
+                function: ChatCompletionMessageFunctionCall(
+                  name: TaskAgentToolNames.retractSuggestions,
+                  arguments: jsonEncode({
+                    'proposals': [
+                      {'fingerprint': 'fp-stage', 'reason': 'stale'},
+                    ],
+                  }),
+                ),
+              );
+
+          await retractionStrategy.processToolCalls(
+            toolCalls: [retractCall('call-1')],
+            manager: mockManager,
+          );
+          await retractionStrategy.processToolCalls(
+            toolCalls: [retractCall('call-2')],
+            manager: mockManager,
+          );
+
+          // First call stages with no prior keys; the second call must pass the
+          // key staged by the first so the service can stay idempotent without
+          // any persistence between calls.
+          expect(fakeService.capturedCalls, hasLength(2));
+          expect(fakeService.capturedCalls.first.alreadyStagedKeys, isEmpty);
+          expect(
+            fakeService.capturedCalls[1].alreadyStagedKeys,
+            contains('cs-stage-2:0'),
+          );
+        },
+      );
+
+      test(
         'malformed proposals payload surfaces a non-empty error without '
         'invoking the retraction service',
         () async {
@@ -3536,25 +3671,43 @@ void main() {
 
 /// Captures every call and returns a scripted response list.
 class _FakeRetractionService implements SuggestionRetractionService {
-  _FakeRetractionService({required this.responses});
+  _FakeRetractionService({required this.responses, this.staged = const []});
 
   final List<RetractionResult> Function(List<RetractionRequest>) responses;
+
+  /// Staged retractions returned from [plan], so tests can assert the strategy
+  /// accumulates them for end-of-wake application instead of persisting now.
+  final List<StagedRetraction> staged;
+
   final capturedCalls = <_CapturedRetract>[];
 
+  /// Records every [applyStaged] call so tests can assert it is NOT invoked
+  /// during the conversation (persistence is deferred to the workflow).
+  final appliedStaged = <List<StagedRetraction>>[];
+
   @override
-  Future<List<RetractionResult>> retract({
+  Future<RetractionPlan> plan({
     required String agentId,
     required String taskId,
     required List<RetractionRequest> requests,
+    Set<String> alreadyStagedKeys = const {},
   }) async {
     capturedCalls.add(
       _CapturedRetract(
         agentId: agentId,
         taskId: taskId,
         requests: requests,
+        // Snapshot the set: the strategy mutates the same instance after this
+        // call returns, so a live reference would reflect later state.
+        alreadyStagedKeys: Set<String>.of(alreadyStagedKeys),
       ),
     );
-    return responses(requests);
+    return RetractionPlan(results: responses(requests), staged: staged);
+  }
+
+  @override
+  Future<void> applyStaged(List<StagedRetraction> staged) async {
+    appliedStaged.add(staged);
   }
 }
 
@@ -3563,8 +3716,10 @@ class _CapturedRetract {
     required this.agentId,
     required this.taskId,
     required this.requests,
+    this.alreadyStagedKeys = const {},
   });
   final String agentId;
   final String taskId;
   final List<RetractionRequest> requests;
+  final Set<String> alreadyStagedKeys;
 }

--- a/test/features/agents/workflow/task_agent_strategy_test.dart
+++ b/test/features/agents/workflow/task_agent_strategy_test.dart
@@ -3706,7 +3706,10 @@ class _FakeRetractionService implements SuggestionRetractionService {
   }
 
   @override
-  Future<void> applyStaged(List<StagedRetraction> staged) async {
+  Future<void> applyStaged(
+    List<StagedRetraction> staged, {
+    Set<String> skipFingerprints = const {},
+  }) async {
     appliedStaged.add(staged);
   }
 }

--- a/test/features/agents/workflow/task_agent_workflow_test.dart
+++ b/test/features/agents/workflow/task_agent_workflow_test.dart
@@ -578,6 +578,146 @@ void main() {
         },
       );
 
+      test(
+        'churn guard: retraction of an item the agent re-proposes this wake is '
+        'suppressed, leaving the original untouched',
+        () async {
+          // An open proposal the agent will both re-propose AND retract in the
+          // same wake (the weaker-model churn pattern from the field logs).
+          const openItem = ChangeItem(
+            toolName: 'add_checklist_item',
+            args: {'title': 'Draft the spec'},
+            humanSummary: 'Add: "Draft the spec"',
+          );
+          final pendingSet = makeTestChangeSet(
+            id: 'cs-churn',
+            items: const [openItem],
+          );
+          final fingerprint = ChangeItem.fingerprint(openItem);
+
+          when(
+            () => mockSyncService.repository,
+          ).thenReturn(mockAgentRepository);
+          when(
+            () => mockAgentRepository.getPendingChangeSets(
+              agentId,
+              taskId: any(named: 'taskId'),
+              limit: any(named: 'limit'),
+            ),
+          ).thenAnswer((_) async => [pendingSet]);
+          when(
+            () => mockAgentRepository.getEntity('cs-churn'),
+          ).thenAnswer((_) async => pendingSet);
+          // The build step consolidates against the still-open original.
+          when(
+            () => mockAgentRepository.getProposalLedger(
+              agentId,
+              taskId: any(named: 'taskId'),
+              changeSetFetchLimit: any(named: 'changeSetFetchLimit'),
+              resolvedLimit: any(named: 'resolvedLimit'),
+            ),
+          ).thenAnswer(
+            (_) async => ProposalLedger(
+              open: const [],
+              resolved: const [],
+              pendingSets: [pendingSet],
+            ),
+          );
+          // No real checklist titles on the task → the re-proposal is queued in
+          // the builder (so its fingerprint lands in proposedFingerprints).
+          when(
+            () => mockJournalDb.journalEntityById(any()),
+          ).thenAnswer((_) async => null);
+
+          final upserts = <AgentDomainEntity>[];
+          when(() => mockSyncService.upsertEntity(any())).thenAnswer((
+            inv,
+          ) async {
+            upserts.add(inv.positionalArguments.single as AgentDomainEntity);
+          });
+
+          mockConversationRepository.sendMessageDelegate =
+              ({
+                required conversationId,
+                required message,
+                required model,
+                required provider,
+                required inferenceRepo,
+                tools,
+                toolChoice,
+                temperature = 0.7,
+                strategy,
+              }) async {
+                if (strategy is TaskAgentStrategy) {
+                  await strategy.processToolCalls(
+                    toolCalls: [
+                      ChatCompletionMessageToolCall(
+                        id: 'repropose-call',
+                        type: ChatCompletionMessageToolCallType.function,
+                        function: ChatCompletionMessageFunctionCall(
+                          name: TaskAgentToolNames.addMultipleChecklistItems,
+                          arguments: jsonEncode({
+                            'items': [
+                              {'title': 'Draft the spec'},
+                            ],
+                          }),
+                        ),
+                      ),
+                      ChatCompletionMessageToolCall(
+                        id: 'retract-call',
+                        type: ChatCompletionMessageToolCallType.function,
+                        function: ChatCompletionMessageFunctionCall(
+                          name: TaskAgentToolNames.retractSuggestions,
+                          arguments: jsonEncode({
+                            'proposals': [
+                              {'fingerprint': fingerprint, 'reason': 'dup'},
+                            ],
+                          }),
+                        ),
+                      ),
+                      const ChatCompletionMessageToolCall(
+                        id: 'report-call',
+                        type: ChatCompletionMessageToolCallType.function,
+                        function: ChatCompletionMessageFunctionCall(
+                          name: 'update_report',
+                          arguments:
+                              '{"oneLiner":"o","tldr":"t","content":"c"}',
+                        ),
+                      ),
+                    ],
+                    manager: mockConversationManager,
+                  );
+                }
+                return null;
+              };
+
+          final result = await workflow.execute(
+            agentIdentity: testAgentIdentity,
+            runKey: runKey,
+            triggerTokens: {'entity-a'},
+            threadId: threadId,
+          );
+
+          expect(result.success, isTrue);
+
+          // The retraction targeted an item being re-proposed this wake, so it
+          // must be suppressed — no agent retraction is persisted, and the
+          // original proposal is never flipped to retracted.
+          final retractions = upserts.whereType<ChangeDecisionEntity>().where(
+            (d) =>
+                d.verdict == ChangeDecisionVerdict.retracted &&
+                d.actor == DecisionActor.agent,
+          );
+          expect(retractions, isEmpty);
+          final retractedSets = upserts.whereType<ChangeSetEntity>().where(
+            (s) => s.items.any(
+              (i) => i.status == ChangeItemStatus.retracted,
+            ),
+          );
+          expect(retractedSets, isEmpty);
+        },
+      );
+
       test('creates conversation, sends message, and persists state', () async {
         final result = await workflow.execute(
           agentIdentity: testAgentIdentity,

--- a/test/features/agents/workflow/task_agent_workflow_test.dart
+++ b/test/features/agents/workflow/task_agent_workflow_test.dart
@@ -451,6 +451,133 @@ void main() {
         );
       });
 
+      test(
+        'agent retraction is deferred and commits atomically at end-of-wake, '
+        'never mid-conversation',
+        () async {
+          // An open proposal from a previous wake that the agent will retract
+          // during this wake (e.g. after the user acted on a sibling item).
+          const openItem = ChangeItem(
+            toolName: 'add_checklist_item',
+            args: {'title': 'Draft the spec'},
+            humanSummary: 'Add: "Draft the spec"',
+          );
+          final pendingSet = makeTestChangeSet(
+            id: 'cs-retract',
+            items: const [openItem],
+          );
+          final fingerprint = ChangeItem.fingerprint(openItem);
+
+          // The retraction service reads/writes through syncService.repository.
+          when(
+            () => mockSyncService.repository,
+          ).thenReturn(mockAgentRepository);
+          when(
+            () => mockAgentRepository.getPendingChangeSets(
+              agentId,
+              taskId: any(named: 'taskId'),
+              limit: any(named: 'limit'),
+            ),
+          ).thenAnswer((_) async => [pendingSet]);
+          when(
+            () => mockAgentRepository.getEntity('cs-retract'),
+          ).thenAnswer((_) async => pendingSet);
+
+          // Capture every persisted entity, plus a snapshot taken the moment
+          // the conversation hands back — before the end-of-wake transaction.
+          final upserts = <AgentDomainEntity>[];
+          var upsertsAtConversationEnd = <AgentDomainEntity>[];
+          when(() => mockSyncService.upsertEntity(any())).thenAnswer((
+            inv,
+          ) async {
+            upserts.add(inv.positionalArguments.single as AgentDomainEntity);
+          });
+
+          mockConversationRepository.sendMessageDelegate =
+              ({
+                required conversationId,
+                required message,
+                required model,
+                required provider,
+                required inferenceRepo,
+                tools,
+                toolChoice,
+                temperature = 0.7,
+                strategy,
+              }) async {
+                if (strategy is TaskAgentStrategy) {
+                  await strategy.processToolCalls(
+                    toolCalls: [
+                      ChatCompletionMessageToolCall(
+                        id: 'retract-call',
+                        type: ChatCompletionMessageToolCallType.function,
+                        function: ChatCompletionMessageFunctionCall(
+                          name: TaskAgentToolNames.retractSuggestions,
+                          arguments: jsonEncode({
+                            'proposals': [
+                              {'fingerprint': fingerprint, 'reason': 'done'},
+                            ],
+                          }),
+                        ),
+                      ),
+                      const ChatCompletionMessageToolCall(
+                        id: 'report-call',
+                        type: ChatCompletionMessageToolCallType.function,
+                        function: ChatCompletionMessageFunctionCall(
+                          name: 'update_report',
+                          arguments:
+                              '{"oneLiner":"o","tldr":"t","content":"c"}',
+                        ),
+                      ),
+                    ],
+                    manager: mockConversationManager,
+                  );
+                }
+                // Snapshot what is persisted by the time the conversation
+                // returns — the retraction must NOT be among these yet.
+                upsertsAtConversationEnd = List.of(upserts);
+                return null;
+              };
+
+          final result = await workflow.execute(
+            agentIdentity: testAgentIdentity,
+            runKey: runKey,
+            triggerTokens: {'entity-a'},
+            threadId: threadId,
+          );
+
+          expect(result.success, isTrue);
+
+          bool isRetractionDecision(AgentDomainEntity e) =>
+              e is ChangeDecisionEntity &&
+              e.verdict == ChangeDecisionVerdict.retracted &&
+              e.actor == DecisionActor.agent;
+
+          // Mid-conversation the retraction is only validated + staged, never
+          // persisted — otherwise the suggestion list flashes empty for the
+          // seconds until the wake's end-of-wake writes land.
+          expect(
+            upsertsAtConversationEnd.any(isRetractionDecision),
+            isFalse,
+            reason: 'retraction must not persist during the conversation',
+          );
+
+          // End-of-wake the retraction decision and the flipped change set are
+          // both persisted (in the same transaction as the build step).
+          final decision = upserts
+              .whereType<ChangeDecisionEntity>()
+              .singleWhere(isRetractionDecision);
+          expect(decision.changeSetId, 'cs-retract');
+          expect(decision.retractionReason, 'done');
+
+          final retractedSet = upserts
+              .whereType<ChangeSetEntity>()
+              .where((s) => s.id == 'cs-retract')
+              .last;
+          expect(retractedSet.items.single.status, ChangeItemStatus.retracted);
+        },
+      );
+
       test('creates conversation, sends message, and persists state', () async {
         final result = await workflow.execute(
           agentIdentity: testAgentIdentity,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Agent task suggestions remain stable during revisions (no brief flashing/empty state or temporary disappearance when acting on one suggested checklist item); retractions are now applied in a way that avoids reshuffling or losing other suggestions.
* **Documentation**
  * Updated agent proposal/retraction guidance to explain the staged two‑phase retraction workflow and hygiene rules to reduce churn and prefer keeping valid proposals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matthiasn/lotti/pull/3235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->