### PR TITLE
perf: place currentLocalTime last in prompt for prefix-cache reuse

### DIFF
--- a/lib/features/daily_os_next/agents/workflow/day_agent_workflow.dart
+++ b/lib/features/daily_os_next/agents/workflow/day_agent_workflow.dart
@@ -656,7 +656,6 @@ ${const JsonEncoder.withIndent('  ').convert(config.toJson())}''';
     final payload = <String, Object?>{
       'dayId': dayId,
       'planDate': planDate.toIso8601String(),
-      'currentLocalTime': now.toIso8601String(),
       'triggerTokens': triggerTokens.toList()..sort(),
       if (captureContext != null) 'capture': captureContext.toJson(),
       if (draftingContext != null) 'drafting': draftingContext.toJson(),
@@ -670,6 +669,9 @@ ${const JsonEncoder.withIndent('  ').convert(config.toJson())}''';
             ),
           },
       ],
+      // Keep the volatile wall-clock last so the rest of the payload stays a
+      // stable prefix across wakes, maximizing prompt prefix / KV-cache reuse.
+      'currentLocalTime': now.toIso8601String(),
     };
     return const JsonEncoder.withIndent('  ').convert(payload);
   }

--- a/test/features/daily_os_next/agents/workflow/day_agent_workflow_test.dart
+++ b/test/features/daily_os_next/agents/workflow/day_agent_workflow_test.dart
@@ -371,6 +371,9 @@ void main() {
         expect(userPayload['dayId'], dayId);
         expect(userPayload['planDate'], '2026-05-25T00:00:00.000');
         expect(userPayload['currentLocalTime'], '2026-05-25T08:00:00.000');
+        // Volatile wall-clock must be the trailing key so the rest of the
+        // payload stays a stable prefix across wakes (prefix/KV-cache reuse).
+        expect(userPayload.keys.last, 'currentLocalTime');
         expect(userPayload['triggerTokens'], ['capture-1', dayId]);
         expect(
           userPayload['recentObservations'],


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal workflow payload structure to maintain stable prefixes across operations.
  * Updated tests to reflect reorganized payload structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matthiasn/lotti/pull/3239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->