### PR TITLE
feat: burned sequence accounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Backfill sync now distinguishes intentionally burned vector-clock counters
   (benign voided numbers in the monotonic sequence) from genuinely unresolvable
-  entries, and the Backfill settings screen shows a separate "Burned" count, so
-  the diagnostics no longer flag voided counters as data loss.
+  entries, with a separate "Burned" count in the Backfill settings screen, so
+  newly burned counters are no longer reported as data loss. Entries already
+  marked unresolvable keep that label until they settle into the correct bucket
+  as peers are re-asked.
 - Daily OS Next refine-by-voice now opens as a responsive Wolt modal over the
   current plan surface, and keeps the reviewed transcript visible with inline
   feedback when a proposal fails or produces no usable changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.1011]
 ### Changed
+- Backfill sync now distinguishes intentionally burned vector-clock counters
+  (benign voided numbers in the monotonic sequence) from genuinely unresolvable
+  entries, and the Backfill settings screen shows a separate "Burned" count, so
+  the diagnostics no longer flag voided counters as data loss.
 - Daily OS Next refine-by-voice now opens as a responsive Wolt modal over the
   current plan surface, and keeps the reviewed transcript visible with inline
   feedback when a proposal fails or produces no usable changes.

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -34,7 +34,7 @@
   <releases>
     <release version="0.9.1011" date="2026-05-30">
       <description>
-          <p>Backfill sync now distinguishes intentionally burned vector-clock counters (benign voided numbers in the monotonic sequence) from genuinely unresolvable entries, and the Backfill settings screen shows a separate "Burned" count, so the diagnostics no longer flag voided counters as data loss.</p>
+          <p>Backfill sync now distinguishes intentionally burned vector-clock counters (benign voided numbers in the monotonic sequence) from genuinely unresolvable entries, with a separate "Burned" count in the Backfill settings screen, so newly burned counters are no longer reported as data loss. Entries already marked unresolvable keep that label until they settle into the correct bucket as peers are re-asked.</p>
           <p>Daily OS Next refine-by-voice now opens as a responsive Wolt modal over the current plan surface, and keeps the reviewed transcript visible with inline feedback when a proposal fails or produces no usable changes.</p>
           <p>Daily OS Next measures the date controls, Agenda/Day switcher, and header actions before placing them, keeping the switcher inline whenever it fits and moving it below only on truly constrained widths.</p>
       </description>

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -34,6 +34,7 @@
   <releases>
     <release version="0.9.1011" date="2026-05-30">
       <description>
+          <p>Backfill sync now distinguishes intentionally burned vector-clock counters (benign voided numbers in the monotonic sequence) from genuinely unresolvable entries, and the Backfill settings screen shows a separate "Burned" count, so the diagnostics no longer flag voided counters as data loss.</p>
           <p>Daily OS Next refine-by-voice now opens as a responsive Wolt modal over the current plan surface, and keeps the reviewed transcript visible with inline feedback when a proposal fails or produces no usable changes.</p>
           <p>Daily OS Next measures the date controls, Agenda/Day switcher, and header actions before placing them, keeping the switcher inline whenever it fits and moving it below only on truly constrained widths.</p>
       </description>

--- a/lib/database/sync_db.dart
+++ b/lib/database/sync_db.dart
@@ -55,9 +55,15 @@ enum SyncSequenceStatus {
   /// Responder confirmed the entry was purged/deleted
   deleted,
 
-  /// Originating host confirmed it cannot resolve its own counter.
-  /// This happens when a counter was superseded before being recorded
-  /// (e.g., rapid edits where intermediate versions were never persisted).
+  /// Receiver give-up: a `missing`/`requested` row that never resolved after
+  /// exhausting backfill retries (`retireExhaustedRequestedEntries`) or aging
+  /// past the amnesty window (`retireAgedOutRequestedEntries`). The payload's
+  /// fate is genuinely unknown — it may still be recoverable from a peer, so
+  /// the row stays reopenable: a later backfill hint flips it back to
+  /// [requested], and the "Ask peers again for unresolvable" action re-asks.
+  /// Counts as resolved for the watermark so a permanently lost counter does
+  /// not block the contiguous prefix forever. Distinct from the authoritative
+  /// [burned] non-event.
   unresolvable,
 
   /// Own-host counter was reserved but has not yet been bound to an outbound
@@ -67,16 +73,46 @@ enum SyncSequenceStatus {
   reserved,
 
   /// Own-host reservation was explicitly released without a payload, but the
-  /// durable unresolvable broadcast has not completed yet. Startup
-  /// reconciliation retries these rows.
+  /// durable broadcast has not completed yet. Startup reconciliation retries
+  /// these rows, upgrading each to a [burned] marker once the outbound
+  /// `unresolvable=true` broadcast is enqueued.
   burnPending,
+
+  /// Authoritative non-event: the originating host confirmed this counter
+  /// carries no payload — a vector-clock reservation released without a
+  /// write, or a value superseded before being recorded. Terminal and
+  /// benign, like a voided number in a monotonic invoice sequence: there is
+  /// nothing to fetch. Reached on the originator via
+  /// `recordOwnUnresolvableSequenceCounter` and on a peer when a backfill
+  /// response carries `unresolvable=true` (the originator is authoritative
+  /// for its own counters). Counts as resolved for the watermark so it never
+  /// blocks the contiguous prefix. Distinct from [unresolvable].
+  burned,
+}
+
+/// Terminal sequence states that satisfy the contiguous-prefix watermark.
+///
+/// Single source of truth for the "resolved" set. The watermark CTEs in
+/// [SyncDatabase] and the partial index
+/// `idx_sync_sequence_log_resolved_host_counter` inline the matching status
+/// indices as SQL literals (`IN (0, 3, 4, 5, 8)`); keep those aligned with
+/// this getter — a property test pins them together.
+extension SyncSequenceStatusX on SyncSequenceStatus {
+  /// Whether this status counts as resolved for the contiguous-prefix
+  /// watermark — i.e. it will never carry a future payload and so must not
+  /// block the prefix from advancing past its counter.
+  bool get isResolved =>
+      this == SyncSequenceStatus.received ||
+      this == SyncSequenceStatus.backfilled ||
+      this == SyncSequenceStatus.deleted ||
+      this == SyncSequenceStatus.unresolvable ||
+      this == SyncSequenceStatus.burned;
 }
 
 bool _isResolvedSequenceStatusIndex(int status) =>
-    status == SyncSequenceStatus.received.index ||
-    status == SyncSequenceStatus.backfilled.index ||
-    status == SyncSequenceStatus.deleted.index ||
-    status == SyncSequenceStatus.unresolvable.index;
+    status >= 0 &&
+    status < SyncSequenceStatus.values.length &&
+    SyncSequenceStatus.values[status].isResolved;
 
 @DataClassName('OutboxItem')
 @TableIndex.sql(
@@ -219,15 +255,17 @@ class Outbox extends Table {
   'ON sync_sequence_log (host_id, status)',
 )
 // Covers `getLastCounterForHost`. The watermark CTE only needs rows whose
-// status is terminal/resolved (`received`, `backfilled`, `deleted`, or
-// `unresolvable`) ordered by counter for a single host. A literal-status
-// partial index lets SQLite walk exactly that subset in `(host_id, counter)`
-// order instead of scanning every row for the host and filtering
-// `missing/requested` rows out inside the window function.
+// status is terminal/resolved (`received`, `backfilled`, `deleted`,
+// `unresolvable`, or `burned`) ordered by counter for a single host. A
+// literal-status partial index lets SQLite walk exactly that subset in
+// `(host_id, counter)` order instead of scanning every row for the host and
+// filtering `missing/requested` rows out inside the window function. The
+// status literals mirror [SyncSequenceStatusX.isResolved]; the v24 migration
+// rebuilds this index when `burned` (8) is appended to the resolved set.
 @TableIndex.sql(
   'CREATE INDEX idx_sync_sequence_log_resolved_host_counter '
   'ON sync_sequence_log (host_id, counter) '
-  'WHERE status IN (0, 3, 4, 5)',
+  'WHERE status IN (0, 3, 4, 5, 8)',
 )
 @TableIndex.sql(
   'CREATE INDEX idx_sync_sequence_log_payload_resolution '
@@ -1044,8 +1082,11 @@ class SyncDatabase extends _$SyncDatabase {
   /// The guard lives in the database layer so the authoritative-row check and
   /// write happen in one transaction. Rows already bound to a payload
   /// ([SyncSequenceStatus.received], [SyncSequenceStatus.backfilled], or
-  /// [SyncSequenceStatus.deleted]) are left untouched; other rows are converted
-  /// to [SyncSequenceStatus.unresolvable] with `entry_id` explicitly cleared.
+  /// [SyncSequenceStatus.deleted]) — and rows already
+  /// [SyncSequenceStatus.burned] — are left untouched (the latter makes a
+  /// repeat burn idempotent); other rows are converted to
+  /// [SyncSequenceStatus.burned] (the authoritative non-event) with `entry_id`
+  /// explicitly cleared. Returns whether a row was written.
   Future<bool> recordOwnUnresolvableSequenceCounter({
     required String hostId,
     required int counter,
@@ -1064,13 +1105,14 @@ class SyncDatabase extends _$SyncDatabase {
                         SyncSequenceStatus.received.index,
                         SyncSequenceStatus.backfilled.index,
                         SyncSequenceStatus.deleted.index,
+                        SyncSequenceStatus.burned.index,
                       ]),
                 ))
                 .write(
                   SyncSequenceLogCompanion(
                     entryId: const Value(null),
                     payloadType: Value(payloadType.index),
-                    status: Value(SyncSequenceStatus.unresolvable.index),
+                    status: Value(SyncSequenceStatus.burned.index),
                     updatedAt: Value(timestamp),
                   ),
                 );
@@ -1078,7 +1120,7 @@ class SyncDatabase extends _$SyncDatabase {
         await _refreshSequenceWatermark(
           hostId: hostId,
           counter: counter,
-          status: SyncSequenceStatus.unresolvable.index,
+          status: SyncSequenceStatus.burned.index,
         );
         return true;
       }
@@ -1091,7 +1133,7 @@ class SyncDatabase extends _$SyncDatabase {
           counter: Value(counter),
           entryId: const Value(null),
           payloadType: Value(payloadType.index),
-          status: Value(SyncSequenceStatus.unresolvable.index),
+          status: Value(SyncSequenceStatus.burned.index),
           createdAt: Value(timestamp),
           updatedAt: Value(timestamp),
         ),
@@ -1101,7 +1143,7 @@ class SyncDatabase extends _$SyncDatabase {
         await _refreshSequenceWatermark(
           hostId: hostId,
           counter: counter,
-          status: SyncSequenceStatus.unresolvable.index,
+          status: SyncSequenceStatus.burned.index,
         );
         return true;
       }
@@ -1312,7 +1354,7 @@ class SyncDatabase extends _$SyncDatabase {
           ROW_NUMBER() OVER (ORDER BY counter) AS rn
         FROM sync_sequence_log
         WHERE host_id = ?
-          AND status IN (0, 3, 4, 5)
+          AND status IN (0, 3, 4, 5, 8)
       )
       SELECT CASE
         WHEN NOT EXISTS (
@@ -1398,7 +1440,7 @@ class SyncDatabase extends _$SyncDatabase {
         FROM sync_sequence_log
         WHERE host_id = ?
           AND counter > ?
-          AND status IN (0, 3, 4, 5)
+          AND status IN (0, 3, 4, 5, 8)
       )
       SELECT COALESCE(
         (
@@ -1738,6 +1780,7 @@ class SyncDatabase extends _$SyncDatabase {
     final backfilled = SyncSequenceStatus.backfilled.index;
     final deleted = SyncSequenceStatus.deleted.index;
     final unresolvable = SyncSequenceStatus.unresolvable.index;
+    final burned = SyncSequenceStatus.burned.index;
 
     final hostIds = perHost.keys.toList()..sort();
     final hostStats = [
@@ -1749,6 +1792,7 @@ class SyncDatabase extends _$SyncDatabase {
           backfilledCount: perHost[host]![backfilled] ?? 0,
           deletedCount: perHost[host]![deleted] ?? 0,
           unresolvableCount: perHost[host]![unresolvable] ?? 0,
+          burnedCount: perHost[host]![burned] ?? 0,
         ),
     ];
 
@@ -2299,7 +2343,7 @@ class SyncDatabase extends _$SyncDatabase {
   }
 
   @override
-  int get schemaVersion => 23;
+  int get schemaVersion => 24;
 
   @override
   MigrationStrategy get migration {
@@ -2729,6 +2773,24 @@ class SyncDatabase extends _$SyncDatabase {
           if (inboundQueueExists != null) {
             await customStatement(_idxInboundEventQueueActiveStatusRoom);
           }
+          await customStatement('ANALYZE');
+        }
+        if (from < 24) {
+          // burned(8) is a new terminal/resolved status (split out of
+          // unresolvable). Rebuild the resolved partial index so the watermark
+          // CTE can use it for burned rows, which become the largest resolved
+          // bucket. Drop + recreate because the partial WHERE changed
+          // (IN (0, 3, 4, 5) -> IN (0, 3, 4, 5, 8)); keep it aligned with
+          // [SyncSequenceStatusX.isResolved].
+          await customStatement(
+            'DROP INDEX IF EXISTS idx_sync_sequence_log_resolved_host_counter',
+          );
+          await customStatement(
+            'CREATE INDEX IF NOT EXISTS '
+            'idx_sync_sequence_log_resolved_host_counter '
+            'ON sync_sequence_log (host_id, counter) '
+            'WHERE status IN (0, 3, 4, 5, 8)',
+          );
           await customStatement('ANALYZE');
         }
       },

--- a/lib/database/sync_db.g.dart
+++ b/lib/database/sync_db.g.dart
@@ -2975,7 +2975,7 @@ abstract class _$SyncDatabase extends GeneratedDatabase {
   );
   late final Index idxSyncSequenceLogResolvedHostCounter = Index(
     'idx_sync_sequence_log_resolved_host_counter',
-    'CREATE INDEX idx_sync_sequence_log_resolved_host_counter ON sync_sequence_log (host_id, counter) WHERE status IN (0, 3, 4, 5)',
+    'CREATE INDEX idx_sync_sequence_log_resolved_host_counter ON sync_sequence_log (host_id, counter) WHERE status IN (0, 3, 4, 5, 8)',
   );
   late final Index idxSyncSequenceLogPayloadResolution = Index(
     'idx_sync_sequence_log_payload_resolution',

--- a/lib/features/design_system/state/pane_width_controller.g.dart
+++ b/lib/features/design_system/state/pane_width_controller.g.dart
@@ -42,7 +42,7 @@ final class PaneWidthControllerProvider
 }
 
 String _$paneWidthControllerHash() =>
-    r'fe96e65d017bc707ef92a2d2fc8f5e8f9990f332';
+    r'cab1608c86ffb5c3dfb40fd96bf5ab4fd1713e8c';
 
 abstract class _$PaneWidthController extends $Notifier<PaneWidths> {
   PaneWidths build();

--- a/lib/features/sync/README.md
+++ b/lib/features/sync/README.md
@@ -65,7 +65,7 @@ At runtime, the sync feature owns:
 | `matrix/` | Session management, room discovery/persistence, message sending, read markers, verification, and high-level lifecycle |
 | `matrix/pipeline/` | Attachment ingestion + index, metrics aggregation, and the `sync.limited` Phase-0 diagnostic listener |
 | `queue/` | Persistent inbound queue, per-room worker, `onSync` bridge for catch-up, and pending-decryption holding pen |
-| `sequence/` | Record `(hostId, counter)` coverage, detect gaps, and track reserved/burn-pending/missing/requested/backfilled/deleted/unresolvable states |
+| `sequence/` | Record `(hostId, counter)` coverage, detect gaps, and track reserved/burn-pending/burned/missing/requested/backfilled/deleted/unresolvable states |
 | `backfill/` | Send missing-counter requests and answer peer requests with resend, deleted, unresolvable, or covering-payload hints |
 | `state/` and `ui/` | Riverpod controllers and sync-facing settings, stats, diagnostics, provisioning, and maintenance screens |
 | `actor/` | Separate isolate-based sync implementation; present in the repo, but not wired by the default bootstrap path above |
@@ -860,6 +860,7 @@ states such as:
 - `unresolvable`
 - `reserved`
 - `burnPending`
+- `burned`
 
 Important implementation details:
 
@@ -870,9 +871,25 @@ Important implementation details:
   counter is handed to the write path; `recordSentEntry` overwrites that row
   with `received`
 - only explicitly released reservations become `burnPending`; startup
-  reconciliation retries those as durable `unresolvable` broadcasts, but does
-  not blindly terminalize plain `reserved` rows because a crash may have left a
-  real local payload behind before outbox logging ran
+  reconciliation retries those by enqueueing the durable `unresolvable=true`
+  broadcast and terminalizing the local row to `burned`, but does not blindly
+  terminalize plain `reserved` rows because a crash may have left a real local
+  payload behind before outbox logging ran
+- `burned` and `unresolvable` are the two terminal "we will never get a payload
+  here" outcomes, and the split is deliberate. `burned` is the **authoritative
+  non-event**: the originating host — or a peer applying that host's
+  `unresolvable=true` broadcast, since the originator is authoritative for its
+  own counters — confirming a counter carries no payload, like a voided number
+  in a monotonic invoice sequence. It is terminal and never reopened.
+  `unresolvable` is the **receiver give-up** for a `missing`/`requested` row
+  that exhausted backfill retries (`retireExhaustedRequestedEntries`) or aged
+  past the 7-day amnesty (`retireAgedOutRequestedEntries`); its payload may
+  still be recoverable from a peer, so it stays reopenable by a later hint or
+  the "ask peers again" action. Both count as resolved for the
+  contiguous-prefix watermark (`SyncSequenceStatusX.isResolved`, the single
+  source of truth mirrored by the watermark CTEs and the
+  `idx_sync_sequence_log_resolved_host_counter` partial index), so neither
+  blocks it
 - later vector clocks do not automatically close gaps; explicit coverage still
   matters
 - verified covering entries are used as hints when an exact payload is no
@@ -893,18 +910,33 @@ stateDiagram-v2
   [*] --> Reserved: reserve VC counter
   Reserved --> Received: recordSentEntry binds payload
   Reserved --> BurnPending: release without payload
-  BurnPending --> Unresolvable: marker enqueued
+  BurnPending --> Burned: own-counter burn marker enqueued
+
   Missing --> Requested: backfill batch sent
   Requested --> Backfilled: verified payload arrives
   Requested --> Deleted: responder confirms purge
-  Requested --> Unresolvable: originator confirms burn
+  Requested --> Burned: peer applies originator's unresolvable=true
+  Requested --> Unresolvable: backfill retries exhausted
+  Missing --> Unresolvable: amnesty aged out
+  Unresolvable --> Requested: later hint reopens
+  Unresolvable --> Missing: ask peers again
+
+  Burned --> [*]: terminal non-event
+  Deleted --> [*]
+  Backfilled --> [*]
 ```
+
+`burned` has no outgoing edges — it is terminal. `unresolvable` keeps edges
+back to `requested`/`missing` because a give-up may still be recovered from a
+peer.
 
 `BackfillResponseHandler` can answer a request with one of four outcomes:
 
 - exact payload resend
 - `deleted`
-- `unresolvable`
+- `unresolvable` — only ever sent by the originating host for its own counter;
+  the receiving peer classifies an incoming `unresolvable=true` as the terminal
+  `burned` state (the wire flag is unchanged, so old and new peers interoperate)
 - a verified covering payload hint
 
 Responses are rate-limited and cooled down per `(hostId, counter)` so repair

--- a/lib/features/sync/current_architecture.md
+++ b/lib/features/sync/current_architecture.md
@@ -391,6 +391,18 @@ partial index). The wire format is unchanged — a backfill response still carri
 peers interoperate. See `README.md` (Sequence Log And Backfill) for the full
 own-host lifecycle diagram.
 
+The v24 migration is index-only: it does **not** reclassify the existing backlog
+of `unresolvable`(5) rows, because their provenance (authoritative burn vs.
+receiver give-up) was never stored, so an old burn cannot be told apart from a
+genuine loss after the fact. Those rows keep status 5 — and the stats keep
+bucketing them as unresolvable — until the existing "Ask peers again for
+unresolvable" action (`resetAllUnresolvable`) flips them back to `missing` and
+re-asks: an authoritative `unresolvable=true` answer then self-classifies as
+`burned`, while a genuine loss retires back to `unresolvable`. So the burn/loss
+split is exact for new traffic and settles the historical backlog only as the
+user resets and the system re-converges. `burned`(8) is therefore the
+"going-forward" bucket.
+
 ```mermaid
 stateDiagram-v2
   BurnPending --> Burned: own-counter burn marker enqueued

--- a/lib/features/sync/current_architecture.md
+++ b/lib/features/sync/current_architecture.md
@@ -366,6 +366,41 @@ That order is deliberate. It is also why a bad "current vector clock" can
 create a large false gap even if some older counters were correctly marked as
 covered.
 
+### Terminal outcomes: `burned` vs `unresolvable` (Drift v24)
+
+Every "we will never get a payload here" outcome used to collapse into a single
+`unresolvable` status, which made the Backfill settings screen report mostly
+clean vector-clock burns as if they were data loss. As of schema v24 the
+terminal set is split:
+
+- **`burned`** — the authoritative non-event. The originating host confirms one
+  of its own counters carries no payload (a VC reservation released without a
+  write, or a value superseded before being recorded), and a peer maps an
+  incoming `unresolvable=true` backfill response to the same state because the
+  originator is authoritative for its own counters. Terminal; never reopened.
+- **`unresolvable`** — the receiver give-up. A `missing`/`requested` row that
+  exhausted backfill retries or aged past the 7-day amnesty. Its payload may
+  still exist on a peer, so it stays reopenable (`unresolvable -> requested` on
+  a later hint, `unresolvable -> missing` via "ask peers again").
+
+Both count as resolved for the contiguous-prefix watermark
+(`SyncSequenceStatusX.isResolved`, mirrored as the SQL literals `IN (0, 3, 4, 5,
+8)` in the watermark CTEs and the `idx_sync_sequence_log_resolved_host_counter`
+partial index). The wire format is unchanged — a backfill response still carries
+`unresolvable=true`; only the receiver's classification changed, so old and new
+peers interoperate. See `README.md` (Sequence Log And Backfill) for the full
+own-host lifecycle diagram.
+
+```mermaid
+stateDiagram-v2
+  BurnPending --> Burned: own-counter burn marker enqueued
+  Requested --> Burned: peer applies originator's unresolvable=true
+  Requested --> Unresolvable: backfill retries exhausted
+  Missing --> Unresolvable: amnesty aged out
+  Unresolvable --> Requested: later hint reopens
+  Burned --> [*]: terminal non-event
+```
+
 ## Code-Backed Failure Surfaces
 
 The sections below are not guesses without evidence. Each one is backed by

--- a/lib/features/sync/sequence/sync_sequence_log_service.dart
+++ b/lib/features/sync/sequence/sync_sequence_log_service.dart
@@ -103,11 +103,12 @@ class _GapEntriesView extends ListBase<({String hostId, int counter})> {
   }
 }
 
+// Delegates to [SyncSequenceStatusX.isResolved] (the single source of truth in
+// sync_db.dart) so the watermark "resolved" set is defined in exactly one place.
 bool _isResolvedSequenceStatusIndex(int status) =>
-    status == SyncSequenceStatus.received.index ||
-    status == SyncSequenceStatus.backfilled.index ||
-    status == SyncSequenceStatus.deleted.index ||
-    status == SyncSequenceStatus.unresolvable.index;
+    status >= 0 &&
+    status < SyncSequenceStatus.values.length &&
+    SyncSequenceStatus.values[status].isResolved;
 
 /// Service for managing the sync sequence log, which tracks received entries
 /// by (hostId, counter) pairs to detect gaps and enable backfill requests.
@@ -1211,19 +1212,25 @@ class SyncSequenceLogService {
     }
 
     if (unresolvable) {
-      // Mark as unresolvable. Upsert (not update-only) because a proactive
-      // burn broadcast from the originator frequently arrives on a peer
-      // that has not yet materialized `(hostId, counter)` — gap detection
-      // hasn't run for this host yet, no covered-VC hint has referenced
-      // the counter, and so on. An `updateSequenceStatus` call would
-      // silently no-op in that common case and drop the authoritative
-      // marker, sending the peer back into reactive backfill later when
-      // the gap eventually surfaces.
+      // Classify the incoming `unresolvable=true` as [burned]: a backfill
+      // response carrying that flag is only ever sent by the originating host
+      // for its own counter (foreign-host requests get covering hints, never
+      // `unresolvable`), and the originator is authoritative for its own
+      // counters, so this is a clean non-event rather than a receiver give-up.
+      // Upsert (not update-only) because a proactive burn broadcast from the
+      // originator frequently arrives on a peer that has not yet materialized
+      // `(hostId, counter)` — gap detection hasn't run for this host yet, no
+      // covered-VC hint has referenced the counter, and so on. An
+      // `updateSequenceStatus` call would silently no-op in that common case
+      // and drop the authoritative marker, sending the peer back into reactive
+      // backfill later when the gap eventually surfaces.
       //
       // Do NOT downgrade rows that already have an authoritative success
       // state (received / backfilled / deleted) — if the peer obtained
       // the payload through another route, that's strictly better than
-      // the originator's unresolvable hint and should win.
+      // the originator's burn hint and should win. An already-[burned] row
+      // is likewise left alone: it is terminal, and re-writing it would only
+      // churn `updated_at` and re-emit a trace for an unchanged status.
       final existing = await _syncDatabase.getEntryByHostAndCounter(
         hostId,
         counter,
@@ -1231,7 +1238,8 @@ class SyncSequenceLogService {
       if (existing != null &&
           (existing.status == SyncSequenceStatus.received.index ||
               existing.status == SyncSequenceStatus.backfilled.index ||
-              existing.status == SyncSequenceStatus.deleted.index)) {
+              existing.status == SyncSequenceStatus.deleted.index ||
+              existing.status == SyncSequenceStatus.burned.index)) {
         _trace(
           'handleBackfillResponse: unresolvable ignored for '
           'hostId=$hostId counter=$counter — existing status='
@@ -1247,19 +1255,19 @@ class SyncSequenceLogService {
           hostId: Value(hostId),
           counter: Value(counter),
           // Clear any stale payload mapping for the same reason as in
-          // [markOwnCounterUnresolvable]: the unresolvable marker asserts
-          // no entity is bound to this counter, and a lingering entry_id
-          // would let later reset/verify paths reopen it.
+          // [markOwnCounterUnresolvable]: the burn marker asserts no entity is
+          // bound to this counter, so a lingering entry_id must not survive.
           entryId: const Value(null),
           payloadType: Value(payloadType.index),
-          status: Value(SyncSequenceStatus.unresolvable.index),
+          status: Value(SyncSequenceStatus.burned.index),
           createdAt: Value(existing?.createdAt ?? now),
           updatedAt: Value(now),
         ),
       );
 
       _trace(
-        'handleBackfillResponse hostId=$hostId counter=$counter unresolvable=true',
+        'handleBackfillResponse hostId=$hostId counter=$counter '
+        'unresolvable=true → burned',
         subDomain: 'sequence.backfillResponse',
       );
       return;
@@ -1296,10 +1304,14 @@ class SyncSequenceLogService {
       return;
     }
 
-    // Don't overwrite already received/backfilled/deleted entries
+    // Don't overwrite already received/backfilled/deleted entries, and never
+    // reopen a [burned] row: burned is the authoritative terminal non-event,
+    // and a later hint covering a *different* entity on our own counter must
+    // not resurrect it (see backfill_response_handler's covering-hint guard).
     if (existing.status == SyncSequenceStatus.received.index ||
         existing.status == SyncSequenceStatus.backfilled.index ||
-        existing.status == SyncSequenceStatus.deleted.index) {
+        existing.status == SyncSequenceStatus.deleted.index ||
+        existing.status == SyncSequenceStatus.burned.index) {
       _trace(
         'handleBackfillResponse: entry already has status=${SyncSequenceStatus.values[existing.status]} hostId=$hostId counter=$counter',
         subDomain: 'sequence.backfillResponse',

--- a/lib/features/sync/sequence/sync_sequence_log_service.dart
+++ b/lib/features/sync/sequence/sync_sequence_log_service.dart
@@ -692,6 +692,23 @@ class SyncSequenceLogService {
           counter,
         );
 
+        if (existing != null &&
+            existing.status == SyncSequenceStatus.burned.index) {
+          // burned is the authoritative terminal non-event: never reopen it,
+          // and never overwrite its empty payload mapping with the received
+          // entity's id. The originator re-sending its own burnt counter is a
+          // contradiction we ignore. Mirrors the handleBackfillResponse hint
+          // guard so burned has no outgoing edges on any receive path. The row
+          // is already resolved, so the forward-only watermark-cache advance we
+          // skip here is a no-op.
+          _trace(
+            'recordReceivedEntry: burned preserved (originator) '
+            'hostId=$hostId counter=$counter',
+            subDomain: 'sequence.burnPreserved',
+          );
+          continue;
+        }
+
         // Determine the new status:
         // - If already received/backfilled → keep existing status (don't downgrade)
         // - If we explicitly requested this entry → backfilled (request fulfilled)
@@ -747,6 +764,22 @@ class SyncSequenceLogService {
           hostId,
           counter,
         );
+
+        if (existing != null &&
+            existing.status == SyncSequenceStatus.burned.index) {
+          // burned is the authoritative terminal non-event. A different host's
+          // entry that merely covers this counter in its vector clock must not
+          // reopen the burn or stamp its own entry id onto it (covering an
+          // own-host burn from a different entity is unsound). The row is
+          // already resolved, so skipping the forward-only watermark-cache
+          // advance below is a no-op.
+          _trace(
+            'recordReceivedEntry: burned preserved (covered) '
+            'hostId=$hostId counter=$counter',
+            subDomain: 'sequence.burnPreserved',
+          );
+          continue;
+        }
 
         // Determine the new status (same logic as for originator)
         final SyncSequenceStatus status;

--- a/lib/features/sync/tuning.dart
+++ b/lib/features/sync/tuning.dart
@@ -7,6 +7,7 @@ class BackfillHostStats {
     required this.backfilledCount,
     required this.deletedCount,
     required this.unresolvableCount,
+    required this.burnedCount,
   });
 
   final int receivedCount;
@@ -15,6 +16,11 @@ class BackfillHostStats {
   final int backfilledCount;
   final int deletedCount;
   final int unresolvableCount;
+
+  /// Authoritative non-events (`SyncSequenceStatus.burned`): counters the
+  /// originating host confirmed carry no payload. Benign — split out of
+  /// [unresolvableCount] so diagnostics don't read voided counters as loss.
+  final int burnedCount;
 }
 
 /// Aggregate stats across all hosts.
@@ -27,6 +33,7 @@ class BackfillStats {
     required this.totalBackfilled,
     required this.totalDeleted,
     required this.totalUnresolvable,
+    required this.totalBurned,
   });
 
   factory BackfillStats.fromHostStats(List<BackfillHostStats> stats) {
@@ -38,6 +45,7 @@ class BackfillStats {
       totalBackfilled: stats.fold(0, (sum, s) => sum + s.backfilledCount),
       totalDeleted: stats.fold(0, (sum, s) => sum + s.deletedCount),
       totalUnresolvable: stats.fold(0, (sum, s) => sum + s.unresolvableCount),
+      totalBurned: stats.fold(0, (sum, s) => sum + s.burnedCount),
     );
   }
 
@@ -48,6 +56,7 @@ class BackfillStats {
   final int totalBackfilled;
   final int totalDeleted;
   final int totalUnresolvable;
+  final int totalBurned;
 
   int get totalEntries =>
       totalReceived +
@@ -55,7 +64,8 @@ class BackfillStats {
       totalRequested +
       totalBackfilled +
       totalDeleted +
-      totalUnresolvable;
+      totalUnresolvable +
+      totalBurned;
 }
 
 /// Sync and Outbox tuning constants, centralized for easy documentation and

--- a/lib/features/sync/ui/backfill_settings_page.dart
+++ b/lib/features/sync/ui/backfill_settings_page.dart
@@ -48,7 +48,7 @@ class BackfillSettingsPage extends StatelessWidget {
 ///   1. **Status row** — three welded cells (Inbound queue · Missing
 ///      · Skipped) on a single rounded surface. Operator-critical
 ///      counters live here so they sit at eye level.
-///   2. **Sync statistics** — leader-dot ledger of seven counts.
+///   2. **Sync statistics** — leader-dot ledger of eight counts.
 ///   3. **Automatic backfill** — toggle card.
 ///   4. **Advanced recovery** — collapsed group containing every
 ///      manual recovery action.
@@ -339,7 +339,7 @@ class _StatusCell extends StatelessWidget {
 }
 
 /// Sync statistics ledger card. Header (chart icon · title · device
-/// count meta · refresh) above seven leader-dot rows.
+/// count meta · refresh) above eight leader-dot rows.
 class _SyncStatsCard extends StatelessWidget {
   const _SyncStatsCard({
     required this.stats,
@@ -473,6 +473,14 @@ class _Ledger extends StatelessWidget {
           label: messages.backfillStatsUnresolvable,
           value: stats.totalUnresolvable,
           color: unresolvableTone,
+        ),
+        // Authoritative non-events: always low-emphasis. Unlike unresolvable,
+        // a non-zero burned count is benign (voided vector-clock counters with
+        // nothing to fetch), so it never escalates to the error tone.
+        _LedgerRow(
+          label: messages.backfillStatsBurned,
+          value: stats.totalBurned,
+          color: lowEmphasis,
         ),
       ],
     );

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -950,6 +950,7 @@
   "backfillSettingsSubtitle": "Správa obnovy mezer v synchronizaci",
   "backfillSettingsTitle": "Synchronizace doplnění",
   "backfillStatsBackfilled": "Doplněno",
+  "backfillStatsBurned": "Anulováno",
   "backfillStatsDeleted": "Smazáno",
   "backfillStatsMissing": "Chybí",
   "backfillStatsNoData": "Žádná dostupná data synchronizace",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1110,6 +1110,7 @@
   "backfillSettingsSubtitle": "Synchronisierungslücken verwalten",
   "backfillSettingsTitle": "Sync-Nachfüllung",
   "backfillStatsBackfilled": "Nachgefüllt",
+  "backfillStatsBurned": "Entwertet",
   "backfillStatsDeleted": "Gelöscht",
   "backfillStatsMissing": "Fehlend",
   "backfillStatsNoData": "Keine Synchronisierungsdaten verfügbar",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1306,6 +1306,7 @@
   "backfillSettingsSubtitle": "Manage sync gap recovery",
   "backfillSettingsTitle": "Backfill sync",
   "backfillStatsBackfilled": "Backfilled",
+  "backfillStatsBurned": "Burned",
   "backfillStatsDeleted": "Deleted",
   "backfillStatsMissing": "Missing",
   "backfillStatsNoData": "No sync data available",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1110,6 +1110,7 @@
   "backfillSettingsSubtitle": "Gestionar recuperación de brechas de sincronización",
   "backfillSettingsTitle": "Relleno de sincronización",
   "backfillStatsBackfilled": "Rellenado",
+  "backfillStatsBurned": "Anulado",
   "backfillStatsDeleted": "Eliminado",
   "backfillStatsMissing": "Faltante",
   "backfillStatsNoData": "No hay datos de sincronización disponibles",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1110,6 +1110,7 @@
   "backfillSettingsSubtitle": "Gérer la récupération des écarts de synchronisation",
   "backfillSettingsTitle": "Rattrapage de synchronisation",
   "backfillStatsBackfilled": "Rattrapé",
+  "backfillStatsBurned": "Annulé",
   "backfillStatsDeleted": "Supprimé",
   "backfillStatsMissing": "Manquant",
   "backfillStatsNoData": "Aucune donnée de synchronisation disponible",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3859,6 +3859,12 @@ abstract class AppLocalizations {
   /// **'Backfilled'**
   String get backfillStatsBackfilled;
 
+  /// No description provided for @backfillStatsBurned.
+  ///
+  /// In en, this message translates to:
+  /// **'Burned'**
+  String get backfillStatsBurned;
+
   /// No description provided for @backfillStatsDeleted.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -2287,6 +2287,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get backfillStatsBackfilled => 'Doplněno';
 
   @override
+  String get backfillStatsBurned => 'Anulováno';
+
+  @override
   String get backfillStatsDeleted => 'Smazáno';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2279,6 +2279,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get backfillStatsBackfilled => 'Nachgefüllt';
 
   @override
+  String get backfillStatsBurned => 'Entwertet';
+
+  @override
   String get backfillStatsDeleted => 'Gelöscht';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2249,6 +2249,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get backfillStatsBackfilled => 'Backfilled';
 
   @override
+  String get backfillStatsBurned => 'Burned';
+
+  @override
   String get backfillStatsDeleted => 'Deleted';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2280,6 +2280,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get backfillStatsBackfilled => 'Rellenado';
 
   @override
+  String get backfillStatsBurned => 'Anulado';
+
+  @override
   String get backfillStatsDeleted => 'Eliminado';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2289,6 +2289,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get backfillStatsBackfilled => 'Rattrapé';
 
   @override
+  String get backfillStatsBurned => 'Annulé';
+
+  @override
   String get backfillStatsDeleted => 'Supprimé';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -2296,6 +2296,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get backfillStatsBackfilled => 'Completat';
 
   @override
+  String get backfillStatsBurned => 'Anulat';
+
+  @override
   String get backfillStatsDeleted => 'Șters';
 
   @override

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -1110,6 +1110,7 @@
   "backfillSettingsSubtitle": "Gestionează recuperarea lacunelor de sincronizare",
   "backfillSettingsTitle": "Completare sincronizare",
   "backfillStatsBackfilled": "Completat",
+  "backfillStatsBurned": "Anulat",
   "backfillStatsDeleted": "Șters",
   "backfillStatsMissing": "Lipsă",
   "backfillStatsNoData": "Nu există date de sincronizare disponibile",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1011+4106
+version: 0.9.1011+4107
 
 msix_config:
   display_name: LottiApp

--- a/test/database/sync_db_migration_test.dart
+++ b/test/database/sync_db_migration_test.dart
@@ -96,7 +96,7 @@ void main() {
             .customSelect('PRAGMA user_version')
             .get();
         expect(versionResult.first.read<int>('user_version'), db.schemaVersion);
-        expect(db.schemaVersion, 23);
+        expect(db.schemaVersion, 24);
 
         // Verify sync_sequence_log table exists and has correct schema
         final seqLogResult = await db
@@ -154,7 +154,7 @@ void main() {
 
       // Verify schema version
       final versionResult = await db.customSelect('PRAGMA user_version').get();
-      expect(versionResult.first.read<int>('user_version'), 23);
+      expect(versionResult.first.read<int>('user_version'), 24);
 
       // Verify all tables exist
       final tablesResult = await db
@@ -330,7 +330,7 @@ void main() {
 
       // Verify schema version updated
       final versionResult = await db.customSelect('PRAGMA user_version').get();
-      expect(versionResult.first.read<int>('user_version'), 23);
+      expect(versionResult.first.read<int>('user_version'), 24);
 
       // Verify existing row survived with null payload_size
       final items = await db.oldestOutboxItems(10);
@@ -409,7 +409,7 @@ void main() {
 
       // Verify schema version updated
       final versionResult = await db.customSelect('PRAGMA user_version').get();
-      expect(versionResult.first.read<int>('user_version'), 23);
+      expect(versionResult.first.read<int>('user_version'), 24);
 
       // Verify existing row survived with default priority=2 (low)
       final items = await db.oldestOutboxItems(10);
@@ -490,7 +490,7 @@ void main() {
       final db = SyncDatabase(overriddenFilename: 'test_sync_v8.db');
 
       final versionResult = await db.customSelect('PRAGMA user_version').get();
-      expect(versionResult.first.read<int>('user_version'), 23);
+      expect(versionResult.first.read<int>('user_version'), 24);
 
       final indexResults = await db
           .customSelect(
@@ -582,7 +582,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 23);
+        expect(versionResult.first.read<int>('user_version'), 24);
 
         // v11 replaces the v10 index with the covering variant; when the
         // migration steps v9 → v11 in one run, the v10 index must no longer
@@ -694,7 +694,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 23);
+        expect(versionResult.first.read<int>('user_version'), 24);
 
         final oldIndex = await db
             .customSelect(
@@ -810,7 +810,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 23);
+        expect(versionResult.first.read<int>('user_version'), 24);
 
         final ready = await db
             .customSelect(
@@ -900,7 +900,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 23);
+        expect(versionResult.first.read<int>('user_version'), 24);
 
         final pendingIndex = await db
             .customSelect(
@@ -942,7 +942,7 @@ void main() {
         );
         expect(
           sequenceResolvedSql,
-          contains('status IN (0, 3, 4, 5)'),
+          contains('status IN (0, 3, 4, 5, 8)'),
         );
 
         await db.close();
@@ -1022,7 +1022,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 23);
+        expect(versionResult.first.read<int>('user_version'), 24);
 
         final newIndices = await db
             .customSelect(
@@ -1118,7 +1118,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 23);
+        expect(versionResult.first.read<int>('user_version'), 24);
 
         final sendingIndex = await db
             .customSelect(
@@ -1174,7 +1174,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 23);
+        expect(versionResult.first.read<int>('user_version'), 24);
 
         final index = await db
             .customSelect(
@@ -1185,7 +1185,92 @@ void main() {
         expect(index, hasLength(1));
         final indexSql = index.first.readNullable<String>('sql');
         expect(indexSql, contains('host_id, counter'));
-        expect(indexSql, contains('WHERE status IN (0, 3, 4, 5)'));
+        // Migrations always run to the latest schema, so opening a v22 DB
+        // lands on the v24 resolved-index shape (burned (8) included).
+        expect(indexSql, contains('WHERE status IN (0, 3, 4, 5, 8)'));
+
+        await db.close();
+      },
+    );
+
+    test(
+      'v24 migration rebuilds the resolved index to include burned (8) and '
+      'the watermark advances across a burned counter',
+      () async {
+        final dbFile = File(
+          path.join(testDirectory!.path, 'test_sync_v24_burned.db'),
+        );
+        final sqlite = sqlite3.open(dbFile.path);
+
+        sqlite
+          ..execute('''
+            CREATE TABLE sync_sequence_log (
+              host_id TEXT NOT NULL,
+              counter INTEGER NOT NULL,
+              entry_id TEXT,
+              payload_type INTEGER NOT NULL DEFAULT 0,
+              originating_host_id TEXT,
+              status INTEGER NOT NULL DEFAULT 0,
+              created_at INTEGER NOT NULL,
+              updated_at INTEGER NOT NULL,
+              request_count INTEGER NOT NULL DEFAULT 0,
+              last_requested_at INTEGER,
+              json_path TEXT,
+              PRIMARY KEY (host_id, counter)
+            )
+          ''')
+          // The pre-v24 resolved index: burned (8) is absent from the WHERE.
+          ..execute(
+            'CREATE INDEX idx_sync_sequence_log_resolved_host_counter '
+            'ON sync_sequence_log (host_id, counter) '
+            'WHERE status IN (0, 3, 4, 5)',
+          )
+          ..execute('''
+            CREATE TABLE sync_sequence_watermarks (
+              host_id TEXT PRIMARY KEY NOT NULL,
+              last_counter INTEGER NOT NULL DEFAULT 0,
+              updated_at INTEGER NOT NULL
+            )
+          ''')
+          ..execute('PRAGMA user_version = 23')
+          ..dispose();
+
+        final db = SyncDatabase(overriddenFilename: 'test_sync_v24_burned.db');
+
+        final versionResult = await db
+            .customSelect('PRAGMA user_version')
+            .get();
+        expect(versionResult.first.read<int>('user_version'), 24);
+
+        // v24 drops and recreates the partial index so burned (8) joins the
+        // resolved set.
+        final index = await db
+            .customSelect(
+              "SELECT sql FROM sqlite_master WHERE type='index' "
+              "AND name = 'idx_sync_sequence_log_resolved_host_counter'",
+            )
+            .get();
+        expect(index, hasLength(1));
+        expect(
+          index.first.readNullable<String>('sql'),
+          contains('WHERE status IN (0, 3, 4, 5, 8)'),
+        );
+
+        // Raw-insert a contiguous run with a burned counter in the middle so
+        // getLastCounterForHost rebuilds the watermark via the CTE. If burned
+        // did not count as resolved, the contiguous prefix would stop at 1.
+        const hostId = 'host-v24';
+        Future<void> insert(int counter, int status) => db.customStatement(
+          'INSERT INTO sync_sequence_log '
+          '(host_id, counter, status, created_at, updated_at) '
+          'VALUES (?, ?, ?, 0, 0)',
+          [hostId, counter, status],
+        );
+        await insert(1, SyncSequenceStatus.received.index);
+        await insert(2, SyncSequenceStatus.burned.index);
+        await insert(3, SyncSequenceStatus.received.index);
+
+        expect(await db.getLastCounterForHost(hostId), 3);
 
         await db.close();
       },

--- a/test/database/sync_db_test.dart
+++ b/test/database/sync_db_test.dart
@@ -468,7 +468,8 @@ extension _SyncSequenceStatusModelX on SyncSequenceStatus {
       this == SyncSequenceStatus.received ||
       this == SyncSequenceStatus.backfilled ||
       this == SyncSequenceStatus.deleted ||
-      this == SyncSequenceStatus.unresolvable;
+      this == SyncSequenceStatus.unresolvable ||
+      this == SyncSequenceStatus.burned;
 }
 
 class _OutboxClaimModelRow {
@@ -2572,7 +2573,7 @@ void main() {
                   ROW_NUMBER() OVER (ORDER BY counter) AS rn
                 FROM sync_sequence_log
                 WHERE host_id = ?
-                  AND status IN (0, 3, 4, 5)
+                  AND status IN (0, 3, 4, 5, 8)
               )
               SELECT CASE
                 WHEN NOT EXISTS (
@@ -2960,6 +2961,46 @@ void main() {
     });
   });
 
+  group('SyncSequenceStatusX.isResolved', () {
+    // The resolved set is the single source of truth behind the watermark CTEs
+    // and the `idx_sync_sequence_log_resolved_host_counter` partial index,
+    // whose WHERE clauses inline these status indices as SQL literals.
+    const resolvedStatuses = {
+      SyncSequenceStatus.received,
+      SyncSequenceStatus.backfilled,
+      SyncSequenceStatus.deleted,
+      SyncSequenceStatus.unresolvable,
+      SyncSequenceStatus.burned,
+    };
+
+    Glados(any.choose(SyncSequenceStatus.values)).test(
+      'is true exactly for the documented resolved set',
+      (status) {
+        expect(
+          status.isResolved,
+          resolvedStatuses.contains(status),
+          reason: '$status',
+        );
+      },
+      tags: 'glados',
+    );
+
+    test('resolved indices match the SQL literals IN (0, 3, 4, 5, 8)', () {
+      final resolvedIndices = {
+        for (final status in SyncSequenceStatus.values)
+          if (status.isResolved) status.index,
+      };
+      expect(resolvedIndices, {0, 3, 4, 5, 8});
+    });
+
+    test('burned and burnPending sit on opposite sides of the split', () {
+      // burnPending is a transient own-host marker awaiting its broadcast;
+      // burned is its terminal, resolved successor.
+      expect(SyncSequenceStatus.burnPending.isResolved, isFalse);
+      expect(SyncSequenceStatus.burned.isResolved, isTrue);
+    });
+  });
+
   group('getBackfillStats Tests', () {
     setUp(() async {
       db = SyncDatabase(inMemoryDatabase: true);
@@ -3121,6 +3162,38 @@ void main() {
       expect(stats.hostStats.first.deletedCount, 1);
       expect(stats.totalUnresolvable, 2);
       expect(stats.totalDeleted, 1);
+    });
+
+    test('counts burned entries separately from unresolvable', () async {
+      final database = db!;
+      const hostId = 'host-1';
+
+      Future<void> add(int counter, SyncSequenceStatus status) {
+        return database.recordSequenceEntry(
+          SyncSequenceLogCompanion(
+            hostId: const Value(hostId),
+            counter: Value(counter),
+            status: Value(status.index),
+            createdAt: Value(DateTime(2024, 3, counter)),
+            updatedAt: Value(DateTime(2024, 3, counter)),
+          ),
+        );
+      }
+
+      await add(1, SyncSequenceStatus.unresolvable);
+      await add(2, SyncSequenceStatus.burned);
+      await add(3, SyncSequenceStatus.burned);
+      await add(4, SyncSequenceStatus.burned);
+
+      final stats = await database.getBackfillStats();
+
+      expect(stats.hostStats, hasLength(1));
+      expect(stats.hostStats.first.unresolvableCount, 1);
+      expect(stats.hostStats.first.burnedCount, 3);
+      // Burned is its own bucket — it must NOT inflate unresolvable.
+      expect(stats.totalUnresolvable, 1);
+      expect(stats.totalBurned, 3);
+      expect(stats.totalEntries, 4);
     });
   });
 
@@ -5452,8 +5525,8 @@ void main() {
       expect(updated.first.payloadSize, 9999);
     });
 
-    test('schema version is 23', () {
-      expect(db.schemaVersion, 23);
+    test('schema version is 24', () {
+      expect(db.schemaVersion, 24);
     });
 
     test(
@@ -6570,7 +6643,7 @@ void main() {
 
     test(
       'recordOwnUnresolvableSequenceCounter inserts absent counters as '
-      'unresolvable with no payload mapping',
+      'burned with no payload mapping',
       () async {
         final database = SyncDatabase(inMemoryDatabase: true);
         try {
@@ -6588,7 +6661,7 @@ void main() {
             1,
           );
           expect(row, isNotNull);
-          expect(row!.status, SyncSequenceStatus.unresolvable.index);
+          expect(row!.status, SyncSequenceStatus.burned.index);
           expect(row.entryId, isNull);
           expect(row.payloadType, SyncSequencePayloadType.journalEntity.index);
           expect(await database.getLastCounterForHost('own-burn-host'), 1);
@@ -6630,7 +6703,7 @@ void main() {
             1,
           );
           expect(row, isNotNull);
-          expect(row!.status, SyncSequenceStatus.unresolvable.index);
+          expect(row!.status, SyncSequenceStatus.burned.index);
           expect(row.entryId, isNull);
           expect(row.payloadType, SyncSequencePayloadType.entryLink.index);
           expect(
@@ -6693,6 +6766,41 @@ void main() {
             );
             expect(row.updatedAt, createdAt, reason: '$status');
           }
+        } finally {
+          await database.close();
+        }
+      },
+    );
+
+    test(
+      'recordOwnUnresolvableSequenceCounter is idempotent on an already-burned '
+      'row — a repeat burn does not rewrite the row or churn updated_at',
+      () async {
+        final database = SyncDatabase(inMemoryDatabase: true);
+        try {
+          final now = DateTime(2026, 5, 24, 12);
+          final first = await database.recordOwnUnresolvableSequenceCounter(
+            hostId: 'own-burn-idempotent-host',
+            counter: 1,
+            now: now,
+          );
+          expect(first, isTrue);
+
+          final second = await database.recordOwnUnresolvableSequenceCounter(
+            hostId: 'own-burn-idempotent-host',
+            counter: 1,
+            now: now.add(const Duration(minutes: 5)),
+          );
+          // burned is in the isNotIn guard, so the repeat finds nothing to
+          // update and nothing to insert.
+          expect(second, isFalse);
+
+          final row = await database.getEntryByHostAndCounter(
+            'own-burn-idempotent-host',
+            1,
+          );
+          expect(row!.status, SyncSequenceStatus.burned.index);
+          expect(row.updatedAt, now);
         } finally {
           await database.close();
         }

--- a/test/features/sync/sequence/sync_sequence_log_service_test.dart
+++ b/test/features/sync/sequence/sync_sequence_log_service_test.dart
@@ -945,6 +945,79 @@ void main() {
   });
 
   group('recordReceivedEntry', () {
+    test(
+      "does not reopen a burned row for the originating host's own counter — "
+      'burned is terminal even against a contradictory re-send',
+      () async {
+        final bench = _RealSequenceLogTestBench.create(myHostId: myHostId);
+        try {
+          await bench.database.recordSequenceEntry(
+            SyncSequenceLogCompanion(
+              hostId: const Value(aliceHostId),
+              counter: const Value(3),
+              entryId: const Value(null),
+              status: Value(SyncSequenceStatus.burned.index),
+              createdAt: Value(DateTime(2026, 5, 24, 10)),
+              updatedAt: Value(DateTime(2026, 5, 24, 10)),
+            ),
+          );
+
+          await bench.service.recordReceivedEntry(
+            entryId: 'late-alice-3',
+            vectorClock: const VectorClock({aliceHostId: 3}),
+            originatingHostId: aliceHostId,
+          );
+
+          final row = await bench.database.getEntryByHostAndCounter(
+            aliceHostId,
+            3,
+          );
+          expect(row?.status, SyncSequenceStatus.burned.index);
+          // The burn's empty payload mapping must survive.
+          expect(row?.entryId, isNull);
+        } finally {
+          await bench.close();
+        }
+      },
+    );
+
+    test(
+      'does not reopen a burned row that a different host entry merely covers '
+      'in its vector clock — no phantom cross-entity mapping',
+      () async {
+        final bench = _RealSequenceLogTestBench.create(myHostId: myHostId);
+        try {
+          await bench.database.recordSequenceEntry(
+            SyncSequenceLogCompanion(
+              hostId: const Value(bobHostId),
+              counter: const Value(5),
+              entryId: const Value(null),
+              status: Value(SyncSequenceStatus.burned.index),
+              createdAt: Value(DateTime(2026, 5, 24, 10)),
+              updatedAt: Value(DateTime(2026, 5, 24, 10)),
+            ),
+          );
+
+          // Alice's entry carries bob:5 in its vector clock — a covering
+          // reference from a different entity, not bob's payload at counter 5.
+          await bench.service.recordReceivedEntry(
+            entryId: 'alice-entry-covering-bob-5',
+            vectorClock: const VectorClock({aliceHostId: 2, bobHostId: 5}),
+            originatingHostId: aliceHostId,
+          );
+
+          final bobRow = await bench.database.getEntryByHostAndCounter(
+            bobHostId,
+            5,
+          );
+          expect(bobRow?.status, SyncSequenceStatus.burned.index);
+          expect(bobRow?.entryId, isNull);
+        } finally {
+          await bench.close();
+        }
+      },
+    );
+
     test('records entry without gaps when sequential', () async {
       // Alice counter 1, first entry we've seen from Alice
       const vectorClock = VectorClock({aliceHostId: 1});

--- a/test/features/sync/sequence/sync_sequence_log_service_test.dart
+++ b/test/features/sync/sequence/sync_sequence_log_service_test.dart
@@ -353,11 +353,15 @@ class _BackfillResponseStateScenario {
         _ => SyncSequenceStatus.deleted,
       },
       _BackfillResponseKind.unresolvable => switch (existingState) {
-        _GeneratedCounterState.absent => SyncSequenceStatus.unresolvable,
+        // Incoming `unresolvable=true` is authoritative for the originator's
+        // own counter, so the receiver records it as the terminal [burned]
+        // non-event — unless a strictly better local success state already
+        // won (received / backfilled / deleted), which is preserved.
+        _GeneratedCounterState.absent => SyncSequenceStatus.burned,
         _GeneratedCounterState.received => SyncSequenceStatus.received,
         _GeneratedCounterState.backfilled => SyncSequenceStatus.backfilled,
         _GeneratedCounterState.deleted => SyncSequenceStatus.deleted,
-        _ => SyncSequenceStatus.unresolvable,
+        _ => SyncSequenceStatus.burned,
       },
       _BackfillResponseKind.hint => switch (existingState) {
         _GeneratedCounterState.absent => SyncSequenceStatus.requested,
@@ -596,7 +600,8 @@ extension _SyncSequenceStatusX on SyncSequenceStatus {
       this == SyncSequenceStatus.received ||
       this == SyncSequenceStatus.backfilled ||
       this == SyncSequenceStatus.deleted ||
-      this == SyncSequenceStatus.unresolvable;
+      this == SyncSequenceStatus.unresolvable ||
+      this == SyncSequenceStatus.burned;
 }
 
 extension _AnySequenceGapScenario on glados.Any {
@@ -2718,9 +2723,9 @@ void main() {
     });
 
     test(
-      'upserts an unresolvable row when unresolvable=true and no row '
-      'exists yet — proactive burn broadcasts must land on peers that '
-      'never materialized (hostId, counter)',
+      'records a burned row when unresolvable=true and no row exists yet — '
+      'proactive burn broadcasts must land on peers that never materialized '
+      '(hostId, counter)',
       () async {
         when(
           () => mockDb.getEntryByHostAndCounter(aliceHostId, 3),
@@ -2751,7 +2756,7 @@ void main() {
                   .having(
                     (c) => c.status,
                     'status',
-                    Value(SyncSequenceStatus.unresolvable.index),
+                    Value(SyncSequenceStatus.burned.index),
                   ),
             ),
           ),
@@ -2821,7 +2826,7 @@ void main() {
                   .having(
                     (c) => c.status,
                     'status',
-                    Value(SyncSequenceStatus.unresolvable.index),
+                    Value(SyncSequenceStatus.burned.index),
                   ),
             ),
           ),
@@ -2976,6 +2981,53 @@ void main() {
       expect(captured.status.value, SyncSequenceStatus.requested.index);
       expect(captured.entryId.value, 'valid-hint-entry');
     });
+
+    test(
+      'unresolvable=true leaves an already-burned row untouched — burned is '
+      'terminal, so re-applying it would only churn updated_at',
+      () async {
+        when(() => mockDb.getEntryByHostAndCounter(aliceHostId, 3)).thenAnswer(
+          (_) async => _createLogItem(
+            aliceHostId,
+            3,
+            status: SyncSequenceStatus.burned,
+          ),
+        );
+
+        await service.handleBackfillResponse(
+          hostId: aliceHostId,
+          counter: 3,
+          deleted: false,
+          unresolvable: true,
+        );
+
+        verifyNever(() => mockDb.recordSequenceEntry(any()));
+        verifyNever(() => mockDb.updateSequenceStatus(any(), any(), any()));
+      },
+    );
+
+    test(
+      'a later hint never reopens a burned row — unlike an unresolvable '
+      'give-up, burned is the authoritative terminal non-event',
+      () async {
+        when(() => mockDb.getEntryByHostAndCounter(aliceHostId, 3)).thenAnswer(
+          (_) async => _createLogItem(
+            aliceHostId,
+            3,
+            status: SyncSequenceStatus.burned,
+          ),
+        );
+
+        await service.handleBackfillResponse(
+          hostId: aliceHostId,
+          counter: 3,
+          deleted: false,
+          entryId: 'late-hint-entry',
+        );
+
+        verifyNever(() => mockDb.recordSequenceEntry(any()));
+      },
+    );
 
     glados.Glados(
       _AnySequenceGapScenario(glados.any).backfillResponseStateScenario,
@@ -3256,6 +3308,7 @@ void main() {
           backfilledCount: 3,
           deletedCount: 0,
           unresolvableCount: 0,
+          burnedCount: 4,
         ),
       ]);
 

--- a/test/features/sync/state/backfill_stats_controller_test.dart
+++ b/test/features/sync/state/backfill_stats_controller_test.dart
@@ -24,6 +24,7 @@ void main() {
       backfilledCount: 10,
       deletedCount: 1,
       unresolvableCount: 0,
+      burnedCount: 0,
     ),
   ]);
 

--- a/test/features/sync/tuning_test.dart
+++ b/test/features/sync/tuning_test.dart
@@ -1,55 +1,127 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:glados/glados.dart'
+    show
+        Any,
+        CombinableAny,
+        ExploreConfig,
+        Generator,
+        Glados,
+        IntAnys,
+        ListAnys,
+        any;
 import 'package:lotti/features/sync/tuning.dart';
 
+/// A generated [BackfillHostStats] scenario. Wrapping the raw counts in a named
+/// class (instead of generating [BackfillHostStats] directly) keeps Glados
+/// failure output legible — it prints this `toString()` rather than
+/// `Instance of 'BackfillHostStats'`.
+class _GeneratedHostStats {
+  const _GeneratedHostStats({
+    required this.received,
+    required this.missing,
+    required this.requested,
+    required this.backfilled,
+    required this.deleted,
+    required this.unresolvable,
+    required this.burned,
+  });
+
+  final int received;
+  final int missing;
+  final int requested;
+  final int backfilled;
+  final int deleted;
+  final int unresolvable;
+  final int burned;
+
+  BackfillHostStats toHostStats() => BackfillHostStats(
+    receivedCount: received,
+    missingCount: missing,
+    requestedCount: requested,
+    backfilledCount: backfilled,
+    deletedCount: deleted,
+    unresolvableCount: unresolvable,
+    burnedCount: burned,
+  );
+
+  @override
+  String toString() =>
+      '_GeneratedHostStats(received: $received, missing: $missing, '
+      'requested: $requested, backfilled: $backfilled, deleted: $deleted, '
+      'unresolvable: $unresolvable, burned: $burned)';
+}
+
+extension _AnyBackfillHostStats on Any {
+  Generator<_GeneratedHostStats> get backfillHostStats => combine7(
+    intInRange(0, 1000),
+    intInRange(0, 1000),
+    intInRange(0, 1000),
+    intInRange(0, 1000),
+    intInRange(0, 1000),
+    intInRange(0, 1000),
+    intInRange(0, 1000),
+    (
+      int received,
+      int missing,
+      int requested,
+      int backfilled,
+      int deleted,
+      int unresolvable,
+      int burned,
+    ) => _GeneratedHostStats(
+      received: received,
+      missing: missing,
+      requested: requested,
+      backfilled: backfilled,
+      deleted: deleted,
+      unresolvable: unresolvable,
+      burned: burned,
+    ),
+  );
+
+  Generator<List<_GeneratedHostStats>> get backfillHostStatsList =>
+      listWithLengthInRange(0, 8, backfillHostStats);
+}
+
 void main() {
-  group('BackfillStats', () {
-    test('fromHostStats creates stats from list', () {
-      const hostStats = [
-        BackfillHostStats(
-          receivedCount: 10,
-          missingCount: 2,
-          requestedCount: 1,
-          backfilledCount: 3,
-          deletedCount: 0,
-          unresolvableCount: 1,
-        ),
-        BackfillHostStats(
-          receivedCount: 5,
-          missingCount: 1,
-          requestedCount: 0,
-          backfilledCount: 2,
-          deletedCount: 1,
-          unresolvableCount: 0,
-        ),
-      ];
+  group('BackfillStats.fromHostStats', () {
+    Glados(any.backfillHostStatsList, ExploreConfig(numRuns: 150)).test(
+      'every total is the per-field fold and totalEntries sums all eight '
+      'buckets',
+      (generated) {
+        final hostStats = [for (final g in generated) g.toHostStats()];
+        final stats = BackfillStats.fromHostStats(hostStats);
 
-      final stats = BackfillStats.fromHostStats(hostStats);
+        int foldOf(int Function(BackfillHostStats) field) =>
+            hostStats.fold(0, (sum, h) => sum + field(h));
 
-      expect(stats.totalReceived, 15);
-      expect(stats.totalMissing, 3);
-      expect(stats.totalRequested, 1);
-      expect(stats.totalBackfilled, 5);
-      expect(stats.totalDeleted, 1);
-      expect(stats.totalUnresolvable, 1);
-      expect(stats.hostStats, hostStats);
-    });
+        expect(stats.totalReceived, foldOf((h) => h.receivedCount));
+        expect(stats.totalMissing, foldOf((h) => h.missingCount));
+        expect(stats.totalRequested, foldOf((h) => h.requestedCount));
+        expect(stats.totalBackfilled, foldOf((h) => h.backfilledCount));
+        expect(stats.totalDeleted, foldOf((h) => h.deletedCount));
+        expect(stats.totalUnresolvable, foldOf((h) => h.unresolvableCount));
+        expect(stats.totalBurned, foldOf((h) => h.burnedCount));
+        expect(stats.hostStats, hostStats);
 
-    test('totalEntries returns sum of all counts', () {
-      final stats = BackfillStats.fromHostStats(const [
-        BackfillHostStats(
-          receivedCount: 10,
-          missingCount: 5,
-          requestedCount: 3,
-          backfilledCount: 7,
-          deletedCount: 2,
-          unresolvableCount: 1,
-        ),
-      ]);
+        // totalEntries is exactly the sum of every per-status total, so a
+        // burned counter is counted once and never folded into unresolvable.
+        expect(
+          stats.totalEntries,
+          stats.totalReceived +
+              stats.totalMissing +
+              stats.totalRequested +
+              stats.totalBackfilled +
+              stats.totalDeleted +
+              stats.totalUnresolvable +
+              stats.totalBurned,
+          reason: '$generated',
+        );
+      },
+      tags: 'glados',
+    );
 
-      expect(stats.totalEntries, 28);
-    });
-
-    test('fromHostStats works with empty list', () {
+    test('is the additive identity for an empty host list', () {
       final stats = BackfillStats.fromHostStats(const []);
 
       expect(stats.totalReceived, 0);
@@ -58,8 +130,9 @@ void main() {
       expect(stats.totalBackfilled, 0);
       expect(stats.totalDeleted, 0);
       expect(stats.totalUnresolvable, 0);
-      expect(stats.hostStats, isEmpty);
+      expect(stats.totalBurned, 0);
       expect(stats.totalEntries, 0);
+      expect(stats.hostStats, isEmpty);
     });
   });
 

--- a/test/features/sync/ui/backfill_settings_page_test.dart
+++ b/test/features/sync/ui/backfill_settings_page_test.dart
@@ -39,6 +39,7 @@ void main() {
       backfilledCount: 11,
       deletedCount: 7,
       unresolvableCount: 3,
+      burnedCount: 9,
     ),
   ]);
 
@@ -140,7 +141,7 @@ void main() {
   });
 
   group('BackfillSettingsBody · sync statistics ledger', () {
-    testWidgets('renders all seven labelled rows', (tester) async {
+    testWidgets('renders all eight labelled rows', (tester) async {
       await pumpBody(tester);
       final messages = messagesOf(tester);
 
@@ -155,18 +156,48 @@ void main() {
       expect(find.text(messages.backfillStatsRequested), findsOneWidget);
       expect(find.text(messages.backfillStatsDeleted), findsOneWidget);
       expect(find.text(messages.backfillStatsUnresolvable), findsOneWidget);
+      expect(find.text(messages.backfillStatsBurned), findsOneWidget);
     });
 
     testWidgets('shows correct values for each stat', (tester) async {
       await pumpBody(tester);
 
-      // Total entries = 100 + 5 + 2 + 11 + 7 + 3 = 128
-      expect(find.text('128'), findsOneWidget);
+      // Total entries = 100 + 5 + 2 + 11 + 7 + 3 + 9 = 137
+      expect(find.text('137'), findsOneWidget);
       expect(find.text('100'), findsOneWidget); // received
       expect(find.text('11'), findsOneWidget); // backfilled
       expect(find.text('2'), findsOneWidget); // requested
       expect(find.text('7'), findsOneWidget); // deleted
       expect(find.text('3'), findsOneWidget); // unresolvable
+      expect(find.text('9'), findsOneWidget); // burned
+    });
+
+    testWidgets('Burned row uses the benign tone, not the error tone', (
+      tester,
+    ) async {
+      await pumpBody(tester);
+
+      Color? valueColorOf(String text) =>
+          tester.widget<Text>(find.text(text)).style?.color;
+
+      // populatedStats: burned = 9 and deleted = 7 are both benign
+      // (low-emphasis); unresolvable = 3 is > 0 so it escalates to the error
+      // tone. Burned must track the benign tone even though it is non-zero.
+      final burnedColor = valueColorOf('9');
+      final deletedColor = valueColorOf('7');
+      final unresolvableColor = valueColorOf('3');
+
+      expect(burnedColor, isNotNull);
+      expect(
+        burnedColor,
+        deletedColor,
+        reason: 'burned shares the benign low-emphasis tone with deleted',
+      );
+      expect(
+        burnedColor,
+        isNot(unresolvableColor),
+        reason: 'a non-zero burned count must not turn red like unresolvable',
+      );
     });
 
     testWidgets('formats values >= 1000 with thousands separators', (
@@ -181,6 +212,7 @@ void main() {
             backfilledCount: 34811,
             deletedCount: 201,
             unresolvableCount: 152601,
+            burnedCount: 0,
           ),
         ]),
       );
@@ -341,6 +373,7 @@ void main() {
               backfilledCount: 0,
               deletedCount: 0,
               unresolvableCount: 0,
+              burnedCount: 0,
             ),
           ]),
         );
@@ -372,6 +405,7 @@ void main() {
               backfilledCount: 0,
               deletedCount: 0,
               unresolvableCount: 0,
+              burnedCount: 0,
             ),
           ]),
         );
@@ -403,6 +437,7 @@ void main() {
               backfilledCount: 0,
               deletedCount: 0,
               unresolvableCount: 0,
+              burnedCount: 0,
             ),
           ]),
         );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backfill settings show a new "Burned" count; burned counters are treated as benign (not data loss) and rendered with low emphasis.

* **Database**
  * Migration updates resolved-watermark behavior to progress past burned counters; schema version bumped.

* **Localization**
  * "Burned" label added for English, Czech, German, Spanish, French, and Romanian.

* **Documentation**
  * Sync/sequence docs explain burned vs unresolvable semantics.

* **Tests**
  * Tests updated to cover burned counting, watermark, and idempotency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matthiasn/lotti/pull/3241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->