### PR TITLE
fix: deterministic tiebreak for concurrent agent sync edits

### DIFF
--- a/docs/adr/0018-convergent-multi-device-execution.md
+++ b/docs/adr/0018-convergent-multi-device-execution.md
@@ -70,7 +70,15 @@ tiebreak.
    single deterministic total order with a replica-independent tiebreak:
    dominance, then a stable `hostId + id` key.
 5. Make the LWW comparator a genuine total order: **break equal `updatedAt` by
-   `hostId`** (then `id`) so identical timestamps cannot diverge across replicas.
+   a replica-independent secondary key** so identical timestamps cannot diverge
+   across replicas. *Implementation note:* for the mutable-register concurrent
+   branch the two versions share the same `id`, so `id` cannot discriminate;
+   `agent_concurrent_resolver.dart` instead breaks equal `updatedAt` by a
+   **canonical vector-clock comparison** (sorted `(hostId, counter)` entries) —
+   both replicas hold both clocks, so this is stable and needs no per-entity
+   authoring `hostId` column. This realizes the rule's intent (a deterministic,
+   replica-independent tiebreak); a literal `hostId`-then-`id` key would require
+   first persisting an authoring host on every agent row.
    This is distinct from clock skew: a fast/skewed physical clock wins a
    concurrent branch because its `updatedAt` is strictly greater (the
    equal-timestamp tiebreak never fires), so bounding *that* needs a monotonic

--- a/docs/implementation_plans/2026-05-30_daily_os_runtime_implementation_roadmap.md
+++ b/docs/implementation_plans/2026-05-30_daily_os_runtime_implementation_roadmap.md
@@ -51,12 +51,12 @@ Grouped into the six phases of §10. Each PR: **Goal · Depends on · Touches ·
 
 ### Phase 2 — State as a projection
 
-**PR 4 — State-as-projection migration (Move 1)**
-- **Goal:** flip reads to the projection; demote authoritative mutable `AgentStateEntity` rows to a regenerable cache; user-authored docs keep the `Version`/`Head` snapshot pattern.
+**PR 4 — State-as-projection migration (Move 1)** — detailed plan: [`2026-05-30_state_as_projection_plan.md`](./2026-05-30_state_as_projection_plan.md).
+- **Goal:** flip reads to the projection; demote authoritative mutable `AgentStateEntity` to a **regenerable cache that is still synced** (kept for cold-start-from-artifacts + cheap reads), with the log authoritative and the cache reconciled against the projection. User-authored docs keep the `Version`/`Head` snapshot pattern.
 - **Depends on:** PR 3 (shadow equivalence proven first).
-- **Touches:** `agent_repository` reads, state resolution in workflows; classification of `AgentStateEntity` fields (derived vs user-authored vs runtime-local).
-- **Defers:** removing the cache rows entirely (optional later).
-- **Done when:** derived state is read from the projection; concurrent multi-device edits no longer diverge on agent-derived state (sim test).
+- **Touches:** `agent_repository` reads, state resolution in workflows; grow `project()`/`AgentProjection` to the full derived state; classification of `AgentStateEntity`/`AgentSlots` fields (derived ← log/links · counters → **count-from-log** · runtime-local scheduling → don't sync · config → re-home · `processedCounterByHost` → sequence layer). Reconcile = lazy-on-read gated by a head-set/`frontierDigest` check, coalesced background refold, **strict reconcile at wake start** (aligns with the PR 7 lease).
+- **Defers:** removing the cache rows entirely (optional later); compaction's `frontierDigest`/bounded working set (PR 5). **No counter-CRDT needed** — count-from-log supersedes it.
+- **Done when:** derived state is read from the projection; the read-modify-write `wakeCounter + 1` pattern is gone; concurrent multi-device edits **self-heal** on agent-derived state and counters stay exact across partition+heal (sim test) — resolving PR 2's convergent-but-lossy counter limitation. Once the cache is a pure fold of a convergent log, LWW on it is self-healing, so PR 2's resolver drops to a transient-cache role.
 - **Realizes:** §2/§4 Move 1; ADR 0016.
 
 ### Phase 3 — Long-horizon memory

--- a/docs/implementation_plans/2026-05-30_deterministic_tiebreak_plan.md
+++ b/docs/implementation_plans/2026-05-30_deterministic_tiebreak_plan.md
@@ -182,6 +182,19 @@ clocks — per `test/README.md`):**
 
 ## Risks & deferred (explicitly out of scope)
 
+- **LWW is lossy for cumulative fields — and `AgentStateEntity` bundles
+  counters.** The resolver picks a whole-row winner and discards the loser
+  entirely, so `wakeCounter` / `processedCounterByHost` / `toolCounterByKey`
+  lose the losing side's increments when two devices update one agent's state
+  concurrently. The deterministic tiebreak does **not** fix this — a loser is
+  still a loser; it only makes *which* side loses agree across replicas. The
+  lease (PR 7) makes that row effectively single-writer per agent, so this is a
+  partition/split-brain edge case, but "rare" is not "safe." The correct fix is
+  to **derive counters from the log** (count the wake/tool events) or use a
+  **counter-CRDT** — classified in PR 4 (derived vs runtime-local vs counter)
+  and the §11 / PR 10 counter flag. Until then PR 2 converges the row
+  deterministically but is **convergent-but-lossy** for its counter fields, and
+  this must not be read as "nothing is lost."
 - **Clock skew on the LWW primary (ADR rule 6).** A later concurrent write wins
   by wall-clock `updatedAt` even when it "shouldn't"; the equal-timestamp
   tiebreak never fires for it. Bounding this needs an HLC / bounded-drift

--- a/docs/implementation_plans/2026-05-30_state_as_projection_plan.md
+++ b/docs/implementation_plans/2026-05-30_state_as_projection_plan.md
@@ -1,0 +1,150 @@
+# State-as-Projection (Move 1) — Implementation Plan (PR 4)
+
+- Status: Plan · Date: 2026-05-30
+- Part of: [`2026-05-30_daily_os_runtime_implementation_roadmap.md`](./2026-05-30_daily_os_runtime_implementation_roadmap.md) (PR 4).
+- Design baseline: [`../daily_os_ai_runtime_architecture.md`](../daily_os_ai_runtime_architecture.md) §2 / §4 (Move 1); [ADR 0016](../adr/0016-agent-state-as-log-projection.md).
+- Depends on: **PR 3** (`messagePrev` wiring + shadow projection — equivalence must be proven before reads flip). Builds on **PR 1** (the projection kernel) and resolves a limitation carried from **PR 2** (counter-loss under LWW).
+
+## Goal
+
+Flip agent-state **reads** onto the projection of the append-only log, and demote
+`AgentStateEntity` from an authoritative mutable row to a **regenerable cache**.
+After this, the log is the single source of truth and per-device state is a
+deterministic fold of it.
+
+## The model (this is the load-bearing decision)
+
+- **The append-only log (events + `AgentLink` edges) is authoritative.** It already
+  converges by set-union + the canonical fold (PR 1) — no LWW, nothing lost.
+- **`AgentStateEntity` stays synced, as a *regenerable cache* — we do NOT stop
+  syncing it.** Keeping it on the wire is a deliberate optimization:
+  - **cold-start from artifacts** — a fresh or long-offline device shows "agent is
+    on task Y, 14 wakes, last woke Z" immediately, instead of backfilling and
+    folding the whole log before it can render anything;
+  - **cheap reads** without re-folding on every access;
+  - **usable on a partial log** — a device mid-backfill still has a usable snapshot.
+- **The cache is reconciled against the projection** (below); the log wins on any
+  disagreement.
+- **Consequence — LWW becomes self-healing, not a correctness mechanism.** Once the
+  cached row is a pure function of a convergent log, it does not matter how two
+  devices merge the row on sync: the next fold recomputes the same value on both, so
+  a "wrong" LWW outcome is transiently stale, then corrected. PR 2's deterministic
+  resolver stays (it picks a sane transient value) but stops being load-bearing —
+  divergence can no longer *persist*.
+
+## Field classification (the concrete PR 4 input)
+
+`AgentStateEntity` + `AgentSlots` are overwhelmingly a denormalized cache of things
+already in the log. Each field is one of:
+
+| Field(s) | Class | Going-forward source |
+| --- | --- | --- |
+| `recentHeadMessageId` | derived | kernel `headIds` |
+| `latestSummaryMessageId` | derived | active checkpoint (PR 5) |
+| `revision` | derived | function of the log frontier (or retire) |
+| `slots.active{Task,Day,Project,Template}Id` | derived | the agent's `AgentLink` edges (`agentTask`/`agentProject`/…) — already log events |
+| `lastWakeAt`, `slots.last{OneOnOne,FeedbackScan,DailyWake,WeeklyReview}At`, "most recent unreflected activity" | derived | timestamp of the last corresponding event |
+| `wakeCounter` | **counter → count-from-log** | count wake-run events |
+| `slots.totalSessionsCompleted`, `slots.weeklyReviewCount` | **counter → count-from-log** | count ritual / review events |
+| `consecutiveFailureCount` | **counter → count-from-log** | trailing failures in the wake-run tail |
+| `toolCounterByKey` | **counter → count-from-log** | count tool-effect events per key |
+| `nextWakeAt`, `sleepUntil`, `scheduledWakeAt` | runtime-local | device-local scheduling — **do not sync** (each device schedules itself; the lease, PR 7, coordinates who executes) |
+| `slots.feedbackWindowDays`, `slots.recursionDepth` | config | re-home to `AgentConfig` / identity — not mutable state |
+| `processedCounterByHost` | sequence bookkeeping | sequence-log / sync layer, not agent state |
+| `awaitingContent` | derived gate | "has the first meaningful content/wake arrived?" |
+
+**Counters are count-from-log, which resolves PR 2's counter-loss limitation
+*without* a counter-CRDT.** Counting events is exact and convergent; LWW on a bundled
+counter row (PR 2's residual risk) drops to "a stale cached count that the next fold
+corrects." This is strictly better than a CRDT counter here.
+
+## Reconciliation strategy (when to refold the cache)
+
+"Reconcile" = re-run the projection fold from the log and replace the cached row.
+Drift happens when new events land (local wake or sync) or when a stale/clobbered
+cache row syncs in.
+
+- **Lazy-on-read, gated by a cheap frontier check.** Store the head-set digest
+  (`frontierDigest`, shared with PR 5) the cache was folded from. On read: compare to
+  the log's current heads — equal ⇒ trust the cache (O(1)); different ⇒ refold. So
+  "lazy" means "refold only when the head-set moved," not "refold every read."
+- **Strict, non-optional reconcile at wake start.** The wake is the read that must be
+  correct — acting on stale state risks wrong decisions or duplicate side effects.
+  This pairs with acquiring the PR 7 lease: make state authoritative right before the
+  device is allowed to act.
+- **Coalesced background refold on log change** (debounced per sync batch, never
+  per-event) keeps the cache usually-warm without backfill thrash.
+- **UI reads are eventual** — transient staleness is fine and self-heals.
+- **Cost is bounded:** a full fold is O(log size) today but O(`summary + recent tail`)
+  once compaction (PR 5) caps the working set — cheap enough for the wake critical
+  path.
+
+## Why this improves the actual agents (task / project / improver)
+
+Not just plumbing — the long-lived agents benefit most:
+
+- **Identical resume on any device.** A task agent reconstructs the same working state
+  from the log instead of one device clobbering another's snapshot. Project agents
+  (daily/weekly cadence) and improver agents (weekly one-on-ones) hold watermarks and
+  session counts over weeks — today the fields most at risk of LWW loss (a *missed or
+  double* weekly review under partition). Count-from-log makes
+  `totalSessionsCompleted` / `weeklyReviewCount` exact.
+- **Long-horizon memory plugs in** (PR 5): the summary pointer becomes part of the
+  fold, giving long-running agents bounded context + replay-from-summary.
+- **Safe iteration:** change how a derived field is computed (or fix a counting bug)
+  and just replay — no mutable-row migration, no corrupting persisted state.
+- **Substrate for the executive-assistant features** (planner / phases / outcomes,
+  PR 8–10): all new event/edge types folded by the same projection; this is what makes
+  them converge across devices.
+
+## Touches
+
+- `agent_projection.dart` — grow `project()`/`AgentProjection` from PR 1's minimal
+  fold (heads, latest report) to the full derived state above (pointers, watermarks,
+  log-derived counters, gate).
+- `agent_repository` reads + state resolution in `task_agent_workflow` /
+  `project_agent_workflow` / `improver_agent_workflow` — read the projection;
+  reconcile per the strategy above; stop the read-modify-write `wakeCounter + 1`
+  pattern.
+- Re-home config fields (`feedbackWindowDays`, `recursionDepth`) to `AgentConfig`;
+  drop runtime-local scheduling fields from the synced payload.
+
+## Test plan
+
+- **Shadow → live cutover:** PR 3 proves projection ≡ live mutable state across the
+  corpus; PR 4 flips reads only after that holds.
+- **Convergence sim (reused PR 1 harness):** two devices, concurrent wakes, partition +
+  heal → identical derived state *and* exact counters (no lost increments) — the case
+  PR 2's LWW could not guarantee.
+- **Reconcile correctness:** frontier-check trusts an unchanged cache (no refold) and
+  refolds when heads move; wake-start always reconciles.
+- **Field-classification regression:** each derived field equals its log-derived value
+  for a representative task / project / improver agent fixture.
+
+## Done when
+
+- Derived agent state is read from the projection; the read-modify-write counter
+  pattern is gone (counters are count-from-log).
+- Concurrent multi-device edits **self-heal** on agent-derived state (sim test), and
+  counters are exact across a partition+heal.
+- `AgentStateEntity` is demoted to a reconciled cache; PR 2's resolver is demonstrably
+  reduced to a transient-cache role.
+
+## Defers
+
+- **Removing the cache row entirely** — optional, later; the cache earns its keep for
+  cold-start.
+- **Compaction** (PR 5) — `frontierDigest` and bounded working set land there; PR 4's
+  reconcile uses a head-set digest in the interim.
+- **Counter-CRDT** — *not needed* here; count-from-log supersedes it for these fields.
+
+## Open decisions
+
+- **Who reads agent state besides the wake path?** Determines whether the coalesced
+  background refold is worth it or whether wake-time strict reconcile + lazy UI reads
+  suffice. (Quick reader survey at PR 4 kickoff.)
+- **Slots event-sourcing completeness** — confirm every slot mutation already has a
+  backing log event/link; net-new events for any that don't.
+- **`frontierDigest` definition** — settle here vs. share the exact form with PR 5.
+- **`revision`** — derive from the frontier, or retire it in favor of the vector clock
+  / head-set.

--- a/lib/features/agents/sync/agent_concurrent_resolver.dart
+++ b/lib/features/agents/sync/agent_concurrent_resolver.dart
@@ -1,0 +1,70 @@
+import 'package:lotti/features/sync/vector_clock.dart';
+
+/// Which of two concurrent versions of the same entity/link id should win.
+enum ConcurrentWinner {
+  /// Keep the version already stored locally.
+  local,
+
+  /// Apply the version received over sync.
+  incoming,
+}
+
+/// Deterministically resolves two **concurrent** versions of one id into a
+/// single winner, so every replica converges on the same version regardless of
+/// arrival order.
+///
+/// Consulted only when [VectorClock.compare] returns `VclockStatus.concurrent`
+/// (neither version dominates). Resolution order:
+///
+/// 1. **Last-writer-wins on `updatedAt`** — the strictly-newer write wins.
+/// 2. **Equal `updatedAt` → stable tiebreak** — a replica-independent canonical
+///    comparison of the two vector clocks. Both replicas hold both clocks, so
+///    both compute the same winner; on genuinely concurrent clocks this always
+///    discriminates. The degenerate equal-clock case falls back to `local` so
+///    the result is total.
+///
+/// Pure: depends only on its arguments and performs no I/O, so identical inputs
+/// yield the same winner on every device — the convergence guarantee. (Bounding
+/// a skewed physical clock that wins outright by a strictly-greater `updatedAt`
+/// is a separate concern requiring a monotonic/hybrid clock; out of scope here.)
+///
+/// **Convergent but lossy.** This picks a whole-version winner and discards the
+/// loser; it does not merge. For a register that bundles *cumulative* fields —
+/// notably `AgentStateEntity`'s `wakeCounter` / `processedCounterByHost` /
+/// `toolCounterByKey` — the losing side's increments are lost under concurrent
+/// (partition/split-brain) writes. The deterministic tiebreak only makes the
+/// loser agree across replicas; it does not make the result non-lossy. Counter
+/// fields should instead be derived from the append-only log or use a
+/// counter-CRDT (roadmap PR 4 field-classification / PR 10); until then this is
+/// a deliberate, lease-guarded (PR 7) bridge, not a "nothing is lost" merge.
+ConcurrentWinner resolveConcurrent({
+  required VectorClock localVc,
+  required VectorClock incomingVc,
+  required DateTime localUpdatedAt,
+  required DateTime incomingUpdatedAt,
+}) {
+  if (incomingUpdatedAt.isAfter(localUpdatedAt)) {
+    return ConcurrentWinner.incoming;
+  }
+  if (localUpdatedAt.isAfter(incomingUpdatedAt)) {
+    return ConcurrentWinner.local;
+  }
+  return compareClocksCanonically(incomingVc, localVc) > 0
+      ? ConcurrentWinner.incoming
+      : ConcurrentWinner.local;
+}
+
+/// A total, replica-independent ordering of two vector clocks. Compares each
+/// host's counter (0 when a host is absent) in sorted host order and returns
+/// the sign of the first difference: `1` if [a] is greater, `-1` if [b] is
+/// greater, `0` if the clocks are identical. Independent of map iteration
+/// order, so two devices comparing the same pair agree.
+int compareClocksCanonically(VectorClock a, VectorClock b) {
+  final hosts = <String>{...a.vclock.keys, ...b.vclock.keys}.toList()..sort();
+  for (final host in hosts) {
+    final counterA = a.get(host);
+    final counterB = b.get(host);
+    if (counterA != counterB) return counterA > counterB ? 1 : -1;
+  }
+  return 0;
+}

--- a/lib/features/agents/sync/agent_lww_timestamp.dart
+++ b/lib/features/agents/sync/agent_lww_timestamp.dart
@@ -1,0 +1,19 @@
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+
+/// Last-writer-wins timestamp source for [AgentDomainEntity].
+extension AgentDomainEntityLwwTimestamp on AgentDomainEntity {
+  /// The timestamp used for last-writer-wins comparison: the entity's
+  /// `updatedAt` when its variant has one, otherwise its `createdAt`.
+  ///
+  /// The union has no field common to every variant — mutable variants
+  /// (identity, state, heads, templates…) carry `updatedAt`, while append-only
+  /// variants (messages, payloads, reports, observations…) carry only
+  /// `createdAt`. Reading from the serialized form handles every current and
+  /// future variant without a per-variant `switch`; both fields serialize as
+  /// ISO-8601 strings, and every variant defines at least one of them.
+  DateTime get effectiveUpdatedAt {
+    final json = toJson();
+    final raw = (json['updatedAt'] ?? json['createdAt']) as String;
+    return DateTime.parse(raw);
+  }
+}

--- a/lib/features/agents/sync/agent_lww_timestamp.dart
+++ b/lib/features/agents/sync/agent_lww_timestamp.dart
@@ -2,18 +2,41 @@ import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 
 /// Last-writer-wins timestamp source for [AgentDomainEntity].
 extension AgentDomainEntityLwwTimestamp on AgentDomainEntity {
-  /// The timestamp used for last-writer-wins comparison: the entity's
-  /// `updatedAt` when its variant has one, otherwise its `createdAt`.
+  /// The timestamp used for last-writer-wins comparison: the variant's
+  /// `updatedAt` when it has one, otherwise its `createdAt` (append-only
+  /// variants — messages, payloads, reports, observations — carry only
+  /// `createdAt`).
   ///
-  /// The union has no field common to every variant — mutable variants
-  /// (identity, state, heads, templates…) carry `updatedAt`, while append-only
-  /// variants (messages, payloads, reports, observations…) carry only
-  /// `createdAt`. Reading from the serialized form handles every current and
-  /// future variant without a per-variant `switch`; both fields serialize as
-  /// ISO-8601 strings, and every variant defines at least one of them.
-  DateTime get effectiveUpdatedAt {
-    final json = toJson();
-    final raw = (json['updatedAt'] ?? json['createdAt']) as String;
-    return DateTime.parse(raw);
-  }
+  /// Implemented with freezed's generated, **exhaustive** `map` rather than a
+  /// serialized form: **zero allocations, no serialization, no string parsing**,
+  /// and **compile-time exhaustiveness** — adding a new `AgentDomainEntity`
+  /// variant won't compile until it is classified here, so a missing timestamp
+  /// can't slip through to a runtime failure on the sync hot path. The fields
+  /// are typed, non-nullable `DateTime`s deserialized by the model, so there is
+  /// nothing to cast or fail-to-parse.
+  DateTime get effectiveUpdatedAt => map(
+    agent: (e) => e.updatedAt,
+    agentState: (e) => e.updatedAt,
+    agentMessage: (e) => e.createdAt,
+    agentMessagePayload: (e) => e.createdAt,
+    agentReport: (e) => e.createdAt,
+    agentReportHead: (e) => e.updatedAt,
+    capture: (e) => e.createdAt,
+    parsedItem: (e) => e.createdAt,
+    dayPlan: (e) => e.updatedAt,
+    agentTemplate: (e) => e.updatedAt,
+    agentTemplateVersion: (e) => e.createdAt,
+    agentTemplateHead: (e) => e.updatedAt,
+    evolutionSession: (e) => e.updatedAt,
+    evolutionSessionRecap: (e) => e.createdAt,
+    evolutionNote: (e) => e.createdAt,
+    changeSet: (e) => e.createdAt,
+    changeDecision: (e) => e.createdAt,
+    projectRecommendation: (e) => e.updatedAt,
+    wakeTokenUsage: (e) => e.createdAt,
+    soulDocument: (e) => e.updatedAt,
+    soulDocumentVersion: (e) => e.createdAt,
+    soulDocumentHead: (e) => e.updatedAt,
+    unknown: (e) => e.createdAt,
+  );
 }

--- a/lib/features/sync/README.md
+++ b/lib/features/sync/README.md
@@ -488,13 +488,22 @@ silently dropped, the receiver's per-(host, counter) gap detection in
 will pull each child from the originating peer as an individual
 `SyncAgentEntity` / `SyncAgentLink` response.
 
-Inbound agent entities and links are guarded by vector-clock dominance before
-they overwrite the local `AgentRepository` row. If the local row's vector clock
-is equal to or newer than the incoming payload, the processor skips the upsert,
-restores the local JSON cache when the message came through `jsonPath`, and
-still records the sequence-log receipt so backfill does not keep requesting the
-same counter. Incoming-dominant or concurrent clocks continue through the
-normal apply path.
+Inbound agent entities and links are guarded by vector-clock comparison before
+they overwrite the local `AgentRepository` row:
+
+- **Local dominates or equal** (`a_gt_b` / `equal`): the processor skips the
+  upsert, restores the local JSON cache when the message came through
+  `jsonPath`, and still records the sequence-log receipt so backfill does not
+  keep requesting the same counter.
+- **Incoming dominates** (`b_gt_a`): the incoming payload is applied.
+- **Concurrent** (neither dominates): a deterministic last-writer-wins tiebreak
+  picks the winner (`features/agents/sync/agent_concurrent_resolver.dart`). The
+  strictly-newer `updatedAt` wins; on equal timestamps a replica-independent
+  canonical vector-clock comparison decides. Both devices therefore converge on
+  the same row regardless of arrival order — previously the concurrent case
+  applied whichever payload arrived last, which could diverge across replicas.
+  (Agent-derived state converges silently; unlike journal entries it does not
+  raise a user-facing `Conflict` row.)
 
 ### Dequeue-Time Outbox Bundling
 

--- a/lib/features/sync/matrix/sync_event_processor.dart
+++ b/lib/features/sync/matrix/sync_event_processor.dart
@@ -21,6 +21,8 @@ import 'package:lotti/features/agents/database/agent_repository.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/agent_link.dart';
+import 'package:lotti/features/agents/sync/agent_concurrent_resolver.dart';
+import 'package:lotti/features/agents/sync/agent_lww_timestamp.dart';
 import 'package:lotti/features/agents/wake/wake_orchestrator.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 import 'package:lotti/features/notifications/scheduler/notification_scheduler.dart';

--- a/lib/features/sync/matrix/sync_event_processor_agent_handlers.dart
+++ b/lib/features/sync/matrix/sync_event_processor_agent_handlers.dart
@@ -387,6 +387,8 @@ extension _AgentHandlers on SyncEventProcessor {
     return _localAgentPayloadDominates(
       localVc: localVc,
       incomingVc: incomingVc,
+      localUpdatedAt: () => local.effectiveUpdatedAt,
+      incomingUpdatedAt: () => incoming.effectiveUpdatedAt,
       kind: 'agentEntity',
       id: incoming.id,
       jsonPath: jsonPath,
@@ -408,6 +410,8 @@ extension _AgentHandlers on SyncEventProcessor {
     return _localAgentPayloadDominates(
       localVc: localVc,
       incomingVc: incomingVc,
+      localUpdatedAt: () => local.updatedAt,
+      incomingUpdatedAt: () => incoming.updatedAt,
       kind: 'agentLink',
       id: incoming.id,
       jsonPath: jsonPath,
@@ -418,6 +422,8 @@ extension _AgentHandlers on SyncEventProcessor {
   Future<bool> _localAgentPayloadDominates({
     required VectorClock localVc,
     required VectorClock incomingVc,
+    required DateTime Function() localUpdatedAt,
+    required DateTime Function() incomingUpdatedAt,
     required String kind,
     required String id,
     required String? jsonPath,
@@ -425,9 +431,23 @@ extension _AgentHandlers on SyncEventProcessor {
   }) async {
     try {
       final status = VectorClock.compare(localVc, incomingVc);
-      final localDominates =
-          status == VclockStatus.a_gt_b || status == VclockStatus.equal;
-      if (!localDominates) return false;
+      // Causal dominance decides first; the genuinely `concurrent` branch is
+      // resolved by a deterministic LWW + vector-clock tiebreak so two devices
+      // converge regardless of arrival order (the timestamp closures are only
+      // evaluated on that branch).
+      final keepLocal = switch (status) {
+        VclockStatus.a_gt_b || VclockStatus.equal => true,
+        VclockStatus.b_gt_a => false,
+        VclockStatus.concurrent =>
+          resolveConcurrent(
+                localVc: localVc,
+                incomingVc: incomingVc,
+                localUpdatedAt: localUpdatedAt(),
+                incomingUpdatedAt: incomingUpdatedAt(),
+              ) ==
+              ConcurrentWinner.local,
+      };
+      if (!keepLocal) return false;
 
       await _restoreDominantAgentCache(
         jsonPath: jsonPath,
@@ -436,7 +456,7 @@ extension _AgentHandlers on SyncEventProcessor {
         jsonString: restoreLocalJson(),
       );
       _trace(
-        'apply.$kind.skippedLocalDominates id=$id status=$status',
+        'apply.$kind.skippedLocalWins id=$id status=$status',
         subDomain: 'processor.apply',
       );
       return true;

--- a/test/features/agents/sync/agent_concurrent_resolver_test.dart
+++ b/test/features/agents/sync/agent_concurrent_resolver_test.dart
@@ -1,0 +1,226 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glados/glados.dart' as glados;
+import 'package:lotti/features/agents/sync/agent_concurrent_resolver.dart';
+import 'package:lotti/features/sync/vector_clock.dart';
+
+/// A pair of genuinely-concurrent versions of one id, plus their timestamps.
+///
+/// Clocks are built so they are always concurrent and never equal — `local`
+/// leads on `h0`, `incoming` leads on `h1` — which is exactly the situation in
+/// which [resolveConcurrent] is consulted. By construction `localVc` is the
+/// canonically-greater clock (it wins the `h0` comparison), so on equal
+/// timestamps the local side is the deterministic winner.
+class _Scenario {
+  const _Scenario({
+    required this.x,
+    required this.y,
+    required this.localSeconds,
+    required this.incomingSeconds,
+  });
+
+  final int x;
+  final int y;
+  final int localSeconds;
+  final int incomingSeconds;
+
+  static final _base = DateTime(2024);
+
+  VectorClock get localVc => VectorClock({'h0': x + 1, 'h1': y});
+  VectorClock get incomingVc => VectorClock({'h0': x, 'h1': y + 1});
+  DateTime get localUpdatedAt => _base.add(Duration(seconds: localSeconds));
+  DateTime get incomingUpdatedAt =>
+      _base.add(Duration(seconds: incomingSeconds));
+
+  @override
+  String toString() =>
+      '_Scenario(x:$x, y:$y, localSec:$localSeconds, incSec:$incomingSeconds)';
+}
+
+extension _AnyResolver on glados.Any {
+  glados.Generator<_Scenario> get resolverScenario =>
+      glados.CombinableAny(this).combine4(
+        glados.IntAnys(this).intInRange(0, 6),
+        glados.IntAnys(this).intInRange(0, 6),
+        glados.IntAnys(this).intInRange(0, 1000),
+        glados.IntAnys(this).intInRange(0, 1000),
+        (x, y, localSeconds, incomingSeconds) => _Scenario(
+          x: x,
+          y: y,
+          localSeconds: localSeconds,
+          incomingSeconds: incomingSeconds,
+        ),
+      );
+
+  glados.Generator<VectorClock> get smallVectorClock =>
+      glados.CombinableAny(this).combine3(
+        glados.IntAnys(this).intInRange(0, 4),
+        glados.IntAnys(this).intInRange(0, 4),
+        glados.IntAnys(this).intInRange(0, 4),
+        (a, b, c) => VectorClock({'h0': a, 'h1': b, 'h2': c}),
+      );
+}
+
+ConcurrentWinner _resolve(_Scenario s) => resolveConcurrent(
+  localVc: s.localVc,
+  incomingVc: s.incomingVc,
+  localUpdatedAt: s.localUpdatedAt,
+  incomingUpdatedAt: s.incomingUpdatedAt,
+);
+
+void main() {
+  group('resolveConcurrent — properties', () {
+    glados.Glados(
+      glados.any.resolverScenario,
+      glados.ExploreConfig(numRuns: 150),
+    ).test('newer updatedAt wins; equal falls to the greater clock', (s) {
+      // local is the canonically-greater clock, so it wins ties on updatedAt.
+      final expected = s.incomingUpdatedAt.isAfter(s.localUpdatedAt)
+          ? ConcurrentWinner.incoming
+          : ConcurrentWinner.local;
+
+      expect(_resolve(s), expected, reason: '$s');
+    }, tags: 'glados');
+
+    glados.Glados(
+      glados.any.resolverScenario,
+      glados.ExploreConfig(numRuns: 150),
+    ).test('selects the same physical version regardless of arg order', (s) {
+      // Device 1 holds the "local" version and receives "incoming".
+      final winner1 = _resolve(s) == ConcurrentWinner.local
+          ? 'localSide'
+          : 'incomingSide';
+      // Device 2 holds the "incoming" version and receives "local" (swapped).
+      final swapped = resolveConcurrent(
+        localVc: s.incomingVc,
+        incomingVc: s.localVc,
+        localUpdatedAt: s.incomingUpdatedAt,
+        incomingUpdatedAt: s.localUpdatedAt,
+      );
+      final winner2 = swapped == ConcurrentWinner.local
+          ? 'incomingSide'
+          : 'localSide';
+
+      expect(winner1, winner2, reason: 'must converge for $s');
+    }, tags: 'glados');
+  });
+
+  group('resolveConcurrent — examples', () {
+    final base = DateTime(2024);
+    const vc = VectorClock({'h0': 1, 'h1': 1});
+
+    test('strictly-newer incoming wins regardless of clocks', () {
+      expect(
+        resolveConcurrent(
+          localVc: const VectorClock({'h0': 9}),
+          incomingVc: vc,
+          localUpdatedAt: base,
+          incomingUpdatedAt: base.add(const Duration(seconds: 1)),
+        ),
+        ConcurrentWinner.incoming,
+      );
+    });
+
+    test('strictly-newer local wins regardless of clocks', () {
+      expect(
+        resolveConcurrent(
+          localVc: vc,
+          incomingVc: const VectorClock({'h0': 9}),
+          localUpdatedAt: base.add(const Duration(seconds: 1)),
+          incomingUpdatedAt: base,
+        ),
+        ConcurrentWinner.local,
+      );
+    });
+
+    test('equal updatedAt → greater incoming clock wins', () {
+      expect(
+        resolveConcurrent(
+          localVc: const VectorClock({'h0': 1, 'h1': 2}),
+          incomingVc: const VectorClock({'h0': 2, 'h1': 1}),
+          localUpdatedAt: base,
+          incomingUpdatedAt: base,
+        ),
+        ConcurrentWinner.incoming,
+      );
+    });
+
+    test('equal updatedAt → greater local clock wins', () {
+      expect(
+        resolveConcurrent(
+          localVc: const VectorClock({'h0': 2, 'h1': 1}),
+          incomingVc: const VectorClock({'h0': 1, 'h1': 2}),
+          localUpdatedAt: base,
+          incomingUpdatedAt: base,
+        ),
+        ConcurrentWinner.local,
+      );
+    });
+
+    test('equal updatedAt and identical clocks → stable local fallback', () {
+      expect(
+        resolveConcurrent(
+          localVc: vc,
+          incomingVc: vc,
+          localUpdatedAt: base,
+          incomingUpdatedAt: base,
+        ),
+        ConcurrentWinner.local,
+      );
+    });
+  });
+
+  group('compareClocksCanonically', () {
+    glados.Glados2(
+      glados.any.smallVectorClock,
+      glados.any.smallVectorClock,
+      glados.ExploreConfig(numRuns: 150),
+    ).test('is antisymmetric', (a, b) {
+      expect(
+        compareClocksCanonically(a, b),
+        -compareClocksCanonically(b, a),
+        reason: 'a=${a.vclock} b=${b.vclock}',
+      );
+    }, tags: 'glados');
+
+    test('orders by the first differing host counter', () {
+      expect(
+        compareClocksCanonically(
+          const VectorClock({'h0': 2}),
+          const VectorClock({'h0': 1}),
+        ),
+        1,
+      );
+      expect(
+        compareClocksCanonically(
+          const VectorClock({'h0': 1}),
+          const VectorClock({'h0': 2}),
+        ),
+        -1,
+      );
+    });
+
+    test('treats an absent host as counter 0', () {
+      expect(
+        compareClocksCanonically(
+          const VectorClock({'h0': 1}),
+          const VectorClock({'h1': 1}),
+        ),
+        1,
+      );
+    });
+
+    test('returns 0 for identical and for empty clocks', () {
+      expect(
+        compareClocksCanonically(
+          const VectorClock({'h0': 3, 'h1': 1}),
+          const VectorClock({'h0': 3, 'h1': 1}),
+        ),
+        0,
+      );
+      expect(
+        compareClocksCanonically(const VectorClock({}), const VectorClock({})),
+        0,
+      );
+    });
+  });
+}

--- a/test/features/agents/sync/agent_lww_timestamp_test.dart
+++ b/test/features/agents/sync/agent_lww_timestamp_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/agents/model/agent_config.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/sync/agent_lww_timestamp.dart';
+
+void main() {
+  group('AgentDomainEntity.effectiveUpdatedAt', () {
+    test('uses updatedAt for a mutable variant (state)', () {
+      final entity = AgentDomainEntity.agentState(
+        id: 'state-1',
+        agentId: 'agent-1',
+        revision: 1,
+        slots: const AgentSlots(),
+        updatedAt: DateTime(2024, 3, 16, 9, 30),
+        vectorClock: null,
+      );
+
+      expect(
+        entity.effectiveUpdatedAt.isAtSameMomentAs(
+          DateTime(2024, 3, 16, 9, 30),
+        ),
+        isTrue,
+      );
+    });
+
+    test('falls back to createdAt for an append-only variant (payload)', () {
+      final entity = AgentDomainEntity.agentMessagePayload(
+        id: 'payload-1',
+        agentId: 'agent-1',
+        createdAt: DateTime(2024, 3, 15, 8),
+        vectorClock: null,
+        content: const {'k': 'v'},
+      );
+
+      expect(
+        entity.effectiveUpdatedAt.isAtSameMomentAs(DateTime(2024, 3, 15, 8)),
+        isTrue,
+      );
+    });
+
+    test('prefers updatedAt over createdAt when a variant has both', () {
+      final entity = AgentDomainEntity.agent(
+        id: 'agent-1',
+        agentId: 'agent-1',
+        kind: 'task_agent',
+        displayName: 'Test Agent',
+        lifecycle: AgentLifecycle.active,
+        mode: AgentInteractionMode.autonomous,
+        allowedCategoryIds: const {'cat-1'},
+        currentStateId: 'state-1',
+        config: const AgentConfig(),
+        createdAt: DateTime(2024, 3, 15),
+        updatedAt: DateTime(2024, 3, 20),
+        vectorClock: null,
+      );
+
+      expect(
+        entity.effectiveUpdatedAt.isAtSameMomentAs(DateTime(2024, 3, 20)),
+        isTrue,
+      );
+    });
+  });
+}

--- a/test/features/agents/sync/agent_lww_timestamp_test.dart
+++ b/test/features/agents/sync/agent_lww_timestamp_test.dart
@@ -1,64 +1,199 @@
+// ignore_for_file: avoid_redundant_argument_values
+
 import 'package:flutter_test/flutter_test.dart';
-import 'package:lotti/features/agents/model/agent_config.dart';
+import 'package:lotti/classes/day_plan.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/sync/agent_lww_timestamp.dart';
 
+import '../test_data/change_set_factories.dart';
+import '../test_data/entity_factories.dart';
+import '../test_data/evolution_factories.dart';
+import '../test_data/soul_factories.dart';
+import '../test_data/template_factories.dart';
+import '../test_data/wake_factories.dart';
+
+/// Distinct timestamps so a variant that has *both* fields fails the test if it
+/// returns `createdAt` where it should return `updatedAt` (or vice versa).
+final _created = DateTime(2024, 1, 1);
+final _updated = DateTime(2024, 6, 1);
+
+/// One row per `AgentDomainEntity` variant: the entity and the timestamp
+/// `effectiveUpdatedAt` must return. Together these exercise every arm of the
+/// exhaustive `map` — a wrong field mapping is caught by the distinct dates,
+/// and a *missing* variant is caught by the compiler (freezed `map`).
+final _cases = <({String label, AgentDomainEntity entity, DateTime expected})>[
+  (
+    label: 'agent',
+    entity: makeTestIdentity(createdAt: _created, updatedAt: _updated),
+    expected: _updated,
+  ),
+  (
+    label: 'agentState',
+    entity: makeTestState(updatedAt: _updated),
+    expected: _updated,
+  ),
+  (
+    label: 'agentMessage',
+    entity: makeTestMessage(createdAt: _created),
+    expected: _created,
+  ),
+  (
+    label: 'agentMessagePayload',
+    entity: makeTestMessagePayload(createdAt: _created),
+    expected: _created,
+  ),
+  (
+    label: 'agentReport',
+    entity: makeTestReport(createdAt: _created),
+    expected: _created,
+  ),
+  (
+    label: 'agentReportHead',
+    entity: makeTestReportHead(updatedAt: _updated),
+    expected: _updated,
+  ),
+  (
+    label: 'capture',
+    entity: AgentDomainEntity.capture(
+      id: 'capture-1',
+      agentId: 'agent-1',
+      transcript: 't',
+      capturedAt: _created,
+      createdAt: _created,
+      vectorClock: null,
+    ),
+    expected: _created,
+  ),
+  (
+    label: 'parsedItem',
+    entity: AgentDomainEntity.parsedItem(
+      id: 'parsed-1',
+      agentId: 'agent-1',
+      captureId: 'capture-1',
+      kind: ParsedItemKind.newTask,
+      title: 'title',
+      categoryId: 'cat-1',
+      confidence: ParsedItemConfidence.high,
+      confidenceScore: 0.9,
+      createdAt: _created,
+      vectorClock: null,
+    ),
+    expected: _created,
+  ),
+  (
+    label: 'dayPlan',
+    entity: AgentDomainEntity.dayPlan(
+      id: 'plan-1',
+      agentId: 'agent-1',
+      dayId: '2024-06-01',
+      planDate: _updated,
+      data: DayPlanData(
+        planDate: _updated,
+        status: const DayPlanStatus.draft(),
+      ),
+      createdAt: _created,
+      updatedAt: _updated,
+      vectorClock: null,
+    ),
+    expected: _updated,
+  ),
+  (
+    label: 'agentTemplate',
+    entity: makeTestTemplate(createdAt: _created, updatedAt: _updated),
+    expected: _updated,
+  ),
+  (
+    label: 'agentTemplateVersion',
+    entity: makeTestTemplateVersion(createdAt: _created),
+    expected: _created,
+  ),
+  (
+    label: 'agentTemplateHead',
+    entity: makeTestTemplateHead(updatedAt: _updated),
+    expected: _updated,
+  ),
+  (
+    label: 'evolutionSession',
+    entity: makeTestEvolutionSession(createdAt: _created, updatedAt: _updated),
+    expected: _updated,
+  ),
+  (
+    label: 'evolutionSessionRecap',
+    entity: makeTestEvolutionSessionRecap(createdAt: _created),
+    expected: _created,
+  ),
+  (
+    label: 'evolutionNote',
+    entity: makeTestEvolutionNote(createdAt: _created),
+    expected: _created,
+  ),
+  (
+    label: 'changeSet',
+    entity: makeTestChangeSet(createdAt: _created),
+    expected: _created,
+  ),
+  (
+    label: 'changeDecision',
+    entity: makeTestChangeDecision(createdAt: _created),
+    expected: _created,
+  ),
+  (
+    label: 'projectRecommendation',
+    entity: makeTestProjectRecommendation(
+      createdAt: _created,
+      updatedAt: _updated,
+    ),
+    expected: _updated,
+  ),
+  (
+    label: 'wakeTokenUsage',
+    entity: makeTestWakeTokenUsage(createdAt: _created),
+    expected: _created,
+  ),
+  (
+    label: 'soulDocument',
+    entity: makeTestSoulDocument(createdAt: _created, updatedAt: _updated),
+    expected: _updated,
+  ),
+  (
+    label: 'soulDocumentVersion',
+    entity: makeTestSoulDocumentVersion(createdAt: _created),
+    expected: _created,
+  ),
+  (
+    label: 'soulDocumentHead',
+    entity: makeTestSoulDocumentHead(updatedAt: _updated),
+    expected: _updated,
+  ),
+  (
+    label: 'unknown',
+    entity: AgentDomainEntity.unknown(
+      id: 'unknown-1',
+      agentId: 'agent-1',
+      createdAt: _created,
+      vectorClock: null,
+    ),
+    expected: _created,
+  ),
+];
+
 void main() {
   group('AgentDomainEntity.effectiveUpdatedAt', () {
-    test('uses updatedAt for a mutable variant (state)', () {
-      final entity = AgentDomainEntity.agentState(
-        id: 'state-1',
-        agentId: 'agent-1',
-        revision: 1,
-        slots: const AgentSlots(),
-        updatedAt: DateTime(2024, 3, 16, 9, 30),
-        vectorClock: null,
-      );
+    for (final c in _cases) {
+      test('${c.label} resolves to its LWW timestamp', () {
+        expect(
+          c.entity.effectiveUpdatedAt.isAtSameMomentAs(c.expected),
+          isTrue,
+          reason: c.label,
+        );
+      });
+    }
 
-      expect(
-        entity.effectiveUpdatedAt.isAtSameMomentAs(
-          DateTime(2024, 3, 16, 9, 30),
-        ),
-        isTrue,
-      );
-    });
-
-    test('falls back to createdAt for an append-only variant (payload)', () {
-      final entity = AgentDomainEntity.agentMessagePayload(
-        id: 'payload-1',
-        agentId: 'agent-1',
-        createdAt: DateTime(2024, 3, 15, 8),
-        vectorClock: null,
-        content: const {'k': 'v'},
-      );
-
-      expect(
-        entity.effectiveUpdatedAt.isAtSameMomentAs(DateTime(2024, 3, 15, 8)),
-        isTrue,
-      );
-    });
-
-    test('prefers updatedAt over createdAt when a variant has both', () {
-      final entity = AgentDomainEntity.agent(
-        id: 'agent-1',
-        agentId: 'agent-1',
-        kind: 'task_agent',
-        displayName: 'Test Agent',
-        lifecycle: AgentLifecycle.active,
-        mode: AgentInteractionMode.autonomous,
-        allowedCategoryIds: const {'cat-1'},
-        currentStateId: 'state-1',
-        config: const AgentConfig(),
-        createdAt: DateTime(2024, 3, 15),
-        updatedAt: DateTime(2024, 3, 20),
-        vectorClock: null,
-      );
-
-      expect(
-        entity.effectiveUpdatedAt.isAtSameMomentAs(DateTime(2024, 3, 20)),
-        isTrue,
-      );
+    test('covers every AgentDomainEntity variant', () {
+      // Guards the data table above: if a variant is added (and classified in
+      // the exhaustive `map`), this count must be bumped with a new case.
+      expect(_cases.length, 23);
     });
   });
 }

--- a/test/features/sync/matrix/sync_event_processor_agent_handlers_test.dart
+++ b/test/features/sync/matrix/sync_event_processor_agent_handlers_test.dart
@@ -713,6 +713,40 @@ void main() {
 
         verifyNever(() => mockAgentRepo.upsertLink(any()));
       });
+
+      // Equal-timestamp link cases — exercise the canonical vector-clock
+      // tiebreak on the link path, mirroring the entity cases above.
+      test('equal updatedAt: a greater incoming link clock wins', () async {
+        when(() => mockAgentRepo.getLinkById('link-cc')).thenAnswer(
+          (_) async => linkWith(
+            vectorClock: vcLosesTie,
+            updatedAt: DateTime(2024, 3, 15),
+          ),
+        );
+        final incoming = linkWith(
+          vectorClock: vcWinsTie,
+          updatedAt: DateTime(2024, 3, 15),
+        );
+
+        await processLink(incoming);
+
+        verify(() => mockAgentRepo.upsertLink(incoming)).called(1);
+      });
+
+      test('equal updatedAt: a greater local link clock is kept', () async {
+        when(() => mockAgentRepo.getLinkById('link-cc')).thenAnswer(
+          (_) async => linkWith(
+            vectorClock: vcWinsTie,
+            updatedAt: DateTime(2024, 3, 15),
+          ),
+        );
+
+        await processLink(
+          linkWith(vectorClock: vcLosesTie, updatedAt: DateTime(2024, 3, 15)),
+        );
+
+        verifyNever(() => mockAgentRepo.upsertLink(any()));
+      });
     });
 
     test(

--- a/test/features/sync/matrix/sync_event_processor_agent_handlers_test.dart
+++ b/test/features/sync/matrix/sync_event_processor_agent_handlers_test.dart
@@ -557,6 +557,164 @@ void main() {
       ).called(1);
     });
 
+    group('concurrent-branch LWW resolution', () {
+      // Two concurrent clocks (each leads on a different host). In canonical
+      // host order `host-A` sorts first, so `vcWinsTie` (greater on host-A) is
+      // the deterministic winner whenever updatedAt ties.
+      const vcWinsTie = VectorClock({'host-A': 2, 'host-B': 1});
+      const vcLosesTie = VectorClock({'host-A': 1, 'host-B': 2});
+
+      AgentDomainEntity stateWith({
+        required VectorClock vectorClock,
+        required DateTime updatedAt,
+      }) => AgentDomainEntity.agentState(
+        id: 'state-cc',
+        agentId: 'agent-1',
+        revision: 1,
+        slots: const AgentSlots(),
+        updatedAt: updatedAt,
+        vectorClock: vectorClock,
+      );
+
+      AgentLink linkWith({
+        required VectorClock vectorClock,
+        required DateTime updatedAt,
+      }) => AgentLink.basic(
+        id: 'link-cc',
+        fromId: 'agent-1',
+        toId: 'state-1',
+        createdAt: DateTime(2024, 3),
+        updatedAt: updatedAt,
+        vectorClock: vectorClock,
+      );
+
+      Future<void> processEntity(AgentDomainEntity incoming) async {
+        when(() => event.text).thenReturn(
+          encodeMessage(
+            SyncMessage.agentEntity(
+              agentEntity: incoming,
+              status: SyncEntryStatus.update,
+            ),
+          ),
+        );
+        await processor.process(event: event, journalDb: journalDb);
+      }
+
+      Future<void> processLink(AgentLink incoming) async {
+        when(() => event.text).thenReturn(
+          encodeMessage(
+            SyncMessage.agentLink(
+              agentLink: incoming,
+              status: SyncEntryStatus.update,
+            ),
+          ),
+        );
+        await processor.process(event: event, journalDb: journalDb);
+      }
+
+      test('applies incoming entity when its updatedAt is newer', () async {
+        when(() => mockAgentRepo.getEntity('state-cc')).thenAnswer(
+          (_) async => stateWith(
+            vectorClock: vcWinsTie,
+            updatedAt: DateTime(2024, 3, 15),
+          ),
+        );
+        final incoming = stateWith(
+          vectorClock: vcLosesTie,
+          updatedAt: DateTime(2024, 3, 16),
+        );
+
+        await processEntity(incoming);
+
+        // LWW: newer updatedAt wins even though the local clock is canonically
+        // greater.
+        verify(() => mockAgentRepo.upsertEntity(incoming)).called(1);
+      });
+
+      test('keeps local entity when its updatedAt is newer', () async {
+        when(() => mockAgentRepo.getEntity('state-cc')).thenAnswer(
+          (_) async => stateWith(
+            vectorClock: vcLosesTie,
+            updatedAt: DateTime(2024, 3, 16),
+          ),
+        );
+
+        await processEntity(
+          stateWith(vectorClock: vcWinsTie, updatedAt: DateTime(2024, 3, 15)),
+        );
+
+        verifyNever(() => mockAgentRepo.upsertEntity(any()));
+      });
+
+      // The next two feed the SAME concurrent pair from both device
+      // perspectives on an equal timestamp: the canonically-greater version
+      // wins whether it is the incoming payload or the already-stored row —
+      // i.e. both devices converge on the same winner.
+      test('equal updatedAt: a greater incoming clock is applied', () async {
+        when(() => mockAgentRepo.getEntity('state-cc')).thenAnswer(
+          (_) async => stateWith(
+            vectorClock: vcLosesTie,
+            updatedAt: DateTime(2024, 3, 15),
+          ),
+        );
+        final incoming = stateWith(
+          vectorClock: vcWinsTie,
+          updatedAt: DateTime(2024, 3, 15),
+        );
+
+        await processEntity(incoming);
+
+        verify(() => mockAgentRepo.upsertEntity(incoming)).called(1);
+      });
+
+      test('equal updatedAt: a greater local clock is kept', () async {
+        when(() => mockAgentRepo.getEntity('state-cc')).thenAnswer(
+          (_) async => stateWith(
+            vectorClock: vcWinsTie,
+            updatedAt: DateTime(2024, 3, 15),
+          ),
+        );
+
+        await processEntity(
+          stateWith(vectorClock: vcLosesTie, updatedAt: DateTime(2024, 3, 15)),
+        );
+
+        verifyNever(() => mockAgentRepo.upsertEntity(any()));
+      });
+
+      test('applies incoming link when its updatedAt is newer', () async {
+        when(() => mockAgentRepo.getLinkById('link-cc')).thenAnswer(
+          (_) async => linkWith(
+            vectorClock: vcWinsTie,
+            updatedAt: DateTime(2024, 3, 15),
+          ),
+        );
+        final incoming = linkWith(
+          vectorClock: vcLosesTie,
+          updatedAt: DateTime(2024, 3, 16),
+        );
+
+        await processLink(incoming);
+
+        verify(() => mockAgentRepo.upsertLink(incoming)).called(1);
+      });
+
+      test('keeps local link when its updatedAt is newer', () async {
+        when(() => mockAgentRepo.getLinkById('link-cc')).thenAnswer(
+          (_) async => linkWith(
+            vectorClock: vcLosesTie,
+            updatedAt: DateTime(2024, 3, 16),
+          ),
+        );
+
+        await processLink(
+          linkWith(vectorClock: vcWinsTie, updatedAt: DateTime(2024, 3, 15)),
+        );
+
+        verifyNever(() => mockAgentRepo.upsertLink(any()));
+      });
+    });
+
     test(
       'no-ops a legacy SyncAgentBundle envelope so the marker advances; '
       'children recover via the per-entity / per-link backfill path',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deterministic convergence for concurrent agent updates: last-writer-wins by timestamp, with a replica-independent vector-clock tie-breaker and stable local fallback on exact ties.
  * Agent entities expose a consistent effective-updated-at (chooses updatedAt or createdAt per variant).

* **Documentation**
  * Updated sync docs and implementation plans; clarified tiebreak behavior and noted potential lossiness for cumulative counters.

* **Tests**
  * Added comprehensive tests covering timestamp/clock tie-breaking and convergence invariants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matthiasn/lotti/pull/3243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->