### PR TITLE
fix: set title denied by policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1013]
+### Fixed
+- Task agents now fall back to a pending title-change proposal when the
+  immediate initial-title write is blocked by category policy, instead of
+  repeatedly reporting a policy-denied tool error.
+
 ## [0.9.1012]
 ### Changed
 - Task detail pages now show running AI activity as subtle shader-based

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -32,6 +32,11 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="0.9.1013" date="2026-06-02">
+      <description>
+          <p>Task agents now fall back to a pending title-change proposal when the immediate initial-title write is blocked by category policy, instead of repeatedly reporting a policy-denied tool error.</p>
+      </description>
+    </release>
     <release version="0.9.1012" date="2026-05-31">
       <description>
           <p>Task detail pages now show running AI activity as subtle shader-based decoder bars integrated into the sticky action bar, replacing the separate Siri-wave strip above it.</p>

--- a/lib/features/agents/README.md
+++ b/lib/features/agents/README.md
@@ -633,21 +633,25 @@ is null or empty-after-trim, the call routes through `AgentToolExecutor`
 like any other immediate tool — the title is applied without a user
 confirmation prompt so a freshly dictated task gets a meaningful name
 without an empty-looking suggestion sitting in the panel waiting for
-approval. Once a title is present the tool reverts to the normal
-deferred path.
+approval. If `AgentToolExecutor` rejects that autonomous write with a
+category-policy denial, the strategy converts the same tool call back
+into a normal change-set proposal instead of returning the denial to the
+model. Once a title is present the tool reverts to the normal deferred
+path.
 
-The auto-apply check (`_shouldAutoApplyInitialTitle`) deliberately
+The auto-apply check (`_shouldAutoApplyInitialField`) deliberately
 re-runs the metadata resolver on every call rather than trusting the
-cached snapshot, so a title populated by any source — a concurrent
-user edit, a prior auto-apply in the same wake, a synced edit from
-another device — is seen before dispatch. After a successful auto-apply
-the strategy also marks `set_task_title` as used in `_usedDeferredTools`
-and invalidates the cached snapshot, so a repeat call in the same wake
-cannot re-auto-apply on the pre-write snapshot. The dispatcher itself
-stays simple: it is the single write path for both auto-applied initial
-titles and user-confirmed renames, so the "don't overwrite a populated
-title" invariant is enforced at the strategy boundary and not at the
-mutation boundary (where it would otherwise block legitimate renames).
+cached snapshot, so a title populated by any source — a concurrent user
+edit, a prior auto-apply in the same wake, a synced edit from another
+device — is seen before dispatch. After a successful auto-apply or
+policy-fallback proposal, the strategy also marks `set_task_title` as
+used in `_usedDeferredTools`, so a repeat call in the same wake cannot
+re-auto-apply on the pre-write snapshot and instead hits the same
+single-use guard as other deferred tools. The dispatcher itself stays
+simple: it is the single write path for both auto-applied initial titles
+and user-confirmed renames, so the "don't overwrite a populated title"
+invariant is enforced at the strategy boundary and not at the mutation
+boundary (where it would otherwise block legitimate renames).
 
 ### Confirmation Path
 

--- a/lib/features/agents/tools/agent_tool_registry.dart
+++ b/lib/features/agents/tools/agent_tool_registry.dart
@@ -114,11 +114,12 @@ class AgentToolRegistry {
       name: TaskAgentToolNames.setTaskTitle,
       description:
           'Set the title of the task. When the task has no title yet the '
-          'title is applied immediately without user confirmation so the '
-          'task starts life with a meaningful name. When an existing '
-          'title is present the change goes through the standard user '
-          'confirmation flow; only call it then if the user has '
-          'explicitly asked to rename.',
+          'title is applied immediately without user confirmation when '
+          'category policy permits it, so the task starts life with a '
+          'meaningful name. If policy blocks that immediate write, or when '
+          'an existing title is present, the change goes through the '
+          'standard user confirmation flow; only call it then if the user '
+          'has explicitly asked to rename.',
       parameters: {
         'type': 'object',
         'properties': {

--- a/lib/features/agents/workflow/task_agent_strategy.dart
+++ b/lib/features/agents/workflow/task_agent_strategy.dart
@@ -278,12 +278,15 @@ class TaskAgentStrategy extends ConversationStrategy {
             policyFallbackBuilder != null &&
             AgentToolRegistry.deferredTools.contains(toolName)) {
           final csBuilder = policyFallbackBuilder;
+          _taskMetadataResolved = false;
+          _cachedTaskMetadata = null;
           final itemCountBefore = csBuilder.items.length;
           final response = await _addToChangeSet(csBuilder, toolName, args);
           if (csBuilder.items.length > itemCountBefore) {
             _usedDeferredTools.add(toolName);
           }
           manager.addToolResponse(toolCallId: call.id, response: response);
+          await _recordToolResultMessage(toolName: toolName);
           continue;
         }
         manager.addToolResponse(toolCallId: call.id, response: result.output);

--- a/lib/features/agents/workflow/task_agent_strategy.dart
+++ b/lib/features/agents/workflow/task_agent_strategy.dart
@@ -253,11 +253,13 @@ class TaskAgentStrategy extends ConversationStrategy {
       // `set_task_language` on a task with no language yet is applied
       // immediately, while language changes on tasks that already have
       // one continue to require user confirmation.
+      final canUseInitialAutoApply = !_usedDeferredTools.contains(toolName);
       final autoApplyInitial =
-          (toolName == TaskAgentToolNames.setTaskTitle &&
-              await _shouldAutoApplyInitialField((s) => s.title)) ||
-          (toolName == TaskAgentToolNames.setTaskLanguage &&
-              await _shouldAutoApplyInitialField((s) => s.languageCode));
+          canUseInitialAutoApply &&
+          ((toolName == TaskAgentToolNames.setTaskTitle &&
+                  await _shouldAutoApplyInitialField((s) => s.title)) ||
+              (toolName == TaskAgentToolNames.setTaskLanguage &&
+                  await _shouldAutoApplyInitialField((s) => s.languageCode)));
       if (autoApplyInitial) {
         await _recordActionMessage(toolName: toolName, args: args);
         final result = await executor.execute(
@@ -268,6 +270,22 @@ class TaskAgentStrategy extends ConversationStrategy {
           executeHandler: () => executeToolHandler(toolName, args, manager),
           readVectorClock: readVectorClock,
         );
+        // The initial-field shortcut is still an autonomous write. If the
+        // category policy blocks it, keep the user path alive by converting
+        // the same tool call into the normal confirmable proposal.
+        final policyFallbackBuilder = changeSetBuilder;
+        if (result.policyDenied &&
+            policyFallbackBuilder != null &&
+            AgentToolRegistry.deferredTools.contains(toolName)) {
+          final csBuilder = policyFallbackBuilder;
+          final itemCountBefore = csBuilder.items.length;
+          final response = await _addToChangeSet(csBuilder, toolName, args);
+          if (csBuilder.items.length > itemCountBefore) {
+            _usedDeferredTools.add(toolName);
+          }
+          manager.addToolResponse(toolCallId: call.id, response: response);
+          continue;
+        }
         manager.addToolResponse(toolCallId: call.id, response: result.output);
         if (result.success) {
           // The field is now populated. Prevent a repeat call to the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1013+4111
+version: 0.9.1013+4112
 
 msix_config:
   display_name: LottiApp

--- a/test/features/agents/workflow/task_agent_strategy_test.dart
+++ b/test/features/agents/workflow/task_agent_strategy_test.dart
@@ -2716,6 +2716,17 @@ void main() {
             manager: mockManager,
           );
 
+          verify(
+            () => mockExecutor.execute(
+              toolName: TaskAgentToolNames.setTaskTitle,
+              args: const {'title': 'PR Review for Ibad'},
+              targetEntityId: any(named: 'targetEntityId'),
+              resolveCategoryId: any(named: 'resolveCategoryId'),
+              executeHandler: any(named: 'executeHandler'),
+              readVectorClock: any(named: 'readVectorClock'),
+            ),
+          ).called(1);
+
           expect(builder.hasItems, isTrue);
           expect(builder.items, hasLength(1));
           expect(
@@ -2742,6 +2753,92 @@ void main() {
                 named: 'response',
                 that: contains('already called this session'),
               ),
+            ),
+          ).called(1);
+          final persistedMessages = verify(
+            () => mockSyncService.upsertEntity(captureAny()),
+          ).captured.whereType<AgentMessageEntity>().toList();
+          expect(
+            persistedMessages.where(
+              (message) =>
+                  message.kind == AgentMessageKind.toolResult &&
+                  message.metadata.toolName ==
+                      TaskAgentToolNames.setTaskTitle &&
+                  message.metadata.errorMessage == null &&
+                  !message.metadata.policyDenied,
+            ),
+            hasLength(1),
+          );
+        },
+      );
+
+      test(
+        'set_task_title policy fallback rechecks metadata before queuing',
+        () async {
+          var resolveCount = 0;
+          final (:strategy, :builder) = _createStrategyWithMetadata(
+            executor: mockExecutor,
+            syncService: mockSyncService,
+            resolveTaskMetadata: () async {
+              resolveCount += 1;
+              return (
+                    title: resolveCount == 1 ? null : 'PR Review for Ibad',
+                    status: 'IN PROGRESS',
+                    priority: 'P1',
+                    estimateMinutes: 120,
+                    dueDate: '2026-03-15',
+                    languageCode: 'en',
+                  )
+                  as TaskMetadataSnapshot;
+            },
+          );
+
+          when(
+            () => mockExecutor.execute(
+              toolName: any(named: 'toolName'),
+              args: any(named: 'args'),
+              targetEntityId: any(named: 'targetEntityId'),
+              resolveCategoryId: any(named: 'resolveCategoryId'),
+              executeHandler: any(named: 'executeHandler'),
+              readVectorClock: any(named: 'readVectorClock'),
+            ),
+          ).thenAnswer(
+            (_) async => const ToolExecutionResult(
+              success: false,
+              output: 'Policy denied: Category cat-999 not in allowed set',
+              policyDenied: true,
+              denialReason: 'Category cat-999 not in allowed set',
+            ),
+          );
+
+          final toolCalls = [
+            ChatCompletionMessageToolCall(
+              id: 'call-policy-denied-title',
+              type: ChatCompletionMessageToolCallType.function,
+              function: ChatCompletionMessageFunctionCall(
+                name: TaskAgentToolNames.setTaskTitle,
+                arguments: jsonEncode({'title': 'PR Review for Ibad'}),
+              ),
+            ),
+          ];
+
+          await strategy.processToolCalls(
+            toolCalls: toolCalls,
+            manager: mockManager,
+          );
+
+          expect(resolveCount, 2);
+          expect(
+            builder.hasItems,
+            isFalse,
+            reason:
+                'fresh metadata should suppress a now-redundant fallback '
+                'proposal',
+          );
+          verify(
+            () => mockManager.addToolResponse(
+              toolCallId: 'call-policy-denied-title',
+              response: 'Skipped: title is already "PR Review for Ibad".',
             ),
           ).called(1);
         },

--- a/test/features/agents/workflow/task_agent_strategy_test.dart
+++ b/test/features/agents/workflow/task_agent_strategy_test.dart
@@ -2655,6 +2655,99 @@ void main() {
       );
 
       test(
+        'set_task_title falls back to a proposal when initial auto-apply is '
+        'policy denied',
+        () async {
+          const emptyTitleSnapshot =
+              (
+                    title: null,
+                    status: 'IN PROGRESS',
+                    priority: 'P1',
+                    estimateMinutes: 120,
+                    dueDate: '2026-03-15',
+                    languageCode: 'en',
+                  )
+                  as TaskMetadataSnapshot;
+          final (:strategy, :builder) = _createStrategyWithMetadata(
+            executor: mockExecutor,
+            syncService: mockSyncService,
+            resolveTaskMetadata: () async => emptyTitleSnapshot,
+          );
+
+          when(
+            () => mockExecutor.execute(
+              toolName: any(named: 'toolName'),
+              args: any(named: 'args'),
+              targetEntityId: any(named: 'targetEntityId'),
+              resolveCategoryId: any(named: 'resolveCategoryId'),
+              executeHandler: any(named: 'executeHandler'),
+              readVectorClock: any(named: 'readVectorClock'),
+            ),
+          ).thenAnswer(
+            (_) async => const ToolExecutionResult(
+              success: false,
+              output: 'Policy denied: Category cat-999 not in allowed set',
+              policyDenied: true,
+              denialReason: 'Category cat-999 not in allowed set',
+            ),
+          );
+
+          final toolCalls = [
+            ChatCompletionMessageToolCall(
+              id: 'call-policy-denied-title',
+              type: ChatCompletionMessageToolCallType.function,
+              function: ChatCompletionMessageFunctionCall(
+                name: TaskAgentToolNames.setTaskTitle,
+                arguments: jsonEncode({'title': 'PR Review for Ibad'}),
+              ),
+            ),
+            ChatCompletionMessageToolCall(
+              id: 'call-repeat-title',
+              type: ChatCompletionMessageToolCallType.function,
+              function: ChatCompletionMessageFunctionCall(
+                name: TaskAgentToolNames.setTaskTitle,
+                arguments: jsonEncode({'title': 'PR Review for Ibad'}),
+              ),
+            ),
+          ];
+
+          await strategy.processToolCalls(
+            toolCalls: toolCalls,
+            manager: mockManager,
+          );
+
+          expect(builder.hasItems, isTrue);
+          expect(builder.items, hasLength(1));
+          expect(
+            builder.items.single.toolName,
+            TaskAgentToolNames.setTaskTitle,
+          );
+          expect(
+            builder.items.single.humanSummary,
+            'Set title to "PR Review for Ibad"',
+          );
+          verify(
+            () => mockManager.addToolResponse(
+              toolCallId: 'call-policy-denied-title',
+              response: any(
+                named: 'response',
+                that: contains('set_task_title proposal recorded'),
+              ),
+            ),
+          ).called(1);
+          verify(
+            () => mockManager.addToolResponse(
+              toolCallId: 'call-repeat-title',
+              response: any(
+                named: 'response',
+                that: contains('already called this session'),
+              ),
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
         'set_task_title stays deferred when an existing title is present',
         () async {
           final (:strategy, :builder) = _createStrategyWithMetadata(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Task agents now gracefully fall back to proposing title changes when blocked by category policy, preventing repeated policy-denied tool errors and reducing redundant error responses.

* **Documentation**
  * Updated agent documentation to clarify when titles are auto-applied, how policy fallbacks work, and the retry/guarding behavior for repeated title-change attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->