### PR TITLE
feat: healing mechanism for forked agent log

### DIFF
--- a/docs/implementation_plans/2026-05-30_daily_os_runtime_implementation_roadmap.md
+++ b/docs/implementation_plans/2026-05-30_daily_os_runtime_implementation_roadmap.md
@@ -82,11 +82,12 @@ Grouped into the six phases of §10. Each PR: **Goal · Depends on · Touches ·
 - **Done when:** long-lived agents read frozen-summary + tail; **replay-from-summary is equivalent to replay-from-genesis in the scoped sense** — identical *projection state* (heads, pointers, derived fields), preserved *provenance* (the summary records which frontier it covers via `frontierDigest`), and byte-identical replay of the *uncovered tail*. This is **not** a claim of byte-identical or semantically-lossless reproduction of the summarized prose (infeasible for LLM/text summaries); the equivalence is over projected state + coverage metadata + tail, not over the summary text itself. Two devices summarizing the same trunk converge (sim test).
 - **Realizes:** §6; ADR 0017.
 
-**PR 6 — Join-by-continuation (fork healing)**
+**PR 6 — Join-by-continuation (fork healing)** — **implemented (flag-gated
+default-off)**; detailed plan: [`2026-06-02_join_by_continuation_plan.md`](./2026-06-02_join_by_continuation_plan.md).
 - **Goal:** lazy, capped, content-addressed join node (`id = hash("join-v1" + sorted parent-head ids)`); deterministic payload, canonical envelope reconciliation.
-- **Depends on:** PR 1, PR 3 (DAG).
-- **Touches:** projection (head detection), a join-emitting behavior, sync envelope reconciliation for content-addressed events.
-- **Done when:** two devices concurrently emitting a join over the same heads write one merged node (sim test); context/prefix stay bounded under repeated forks.
+- **Depends on:** PR 1, PR 3 (DAG). ✅ both merged.
+- **Touches:** `projection/join_plan.dart` (pure decision + id), `AgentSyncService.appendJoin` (multi-parent append), `ForkHealer` + a `WakeOrchestrator.onWakeStart` pre-wake hook (one seam, all agent kinds), DI flag `LOTTI_JOIN_HEALING`.
+- **Done when:** ✅ two devices concurrently emitting a join over the same heads write one merged node (sim test in `fork_healer_test.dart`); context/prefix stay bounded under repeated forks (sim). **Scope note:** the gate is eager-at-wake-start + complete-view (no cross-wake marker, no `AgentStateEntity` field — see plan); sync-path **envelope canonicalization is deferred** (inert while `hostIdOf` is unpopulated and joins are immutable — see plan's open decision).
 - **Realizes:** §8; ADR 0018 rule 8.
 
 ### Phase 4 — Execution safety

--- a/docs/implementation_plans/2026-06-02_join_by_continuation_plan.md
+++ b/docs/implementation_plans/2026-06-02_join_by_continuation_plan.md
@@ -1,0 +1,309 @@
+# Join-by-Continuation (Fork Healing) — Implementation Plan (PR 6)
+
+- Status: **Implemented (flag-gated default-off), J1–J5 done** · Date: 2026-06-02
+- Part of: [`2026-05-30_daily_os_runtime_implementation_roadmap.md`](./2026-05-30_daily_os_runtime_implementation_roadmap.md) (PR 6).
+- Design baseline: [ADR 0018](../adr/0018-convergent-multi-device-execution.md) **rule 7–8** (forks are legal and multi-head tolerant; heal by lazy, capped, content-addressed join-by-continuation) and [ADR 0016](../adr/0016-agent-state-as-log-projection.md) (the DAG projection). Companion already-built: PR 3 (`messagePrev` DAG + head maintenance), PR 1 (projection kernel — already multi-head and multi-parent tolerant).
+- Depends on (**all merged → PR 6 is unblocked**):
+  - **PR 1** (#kernel) — `canonicalOrder` + `project()` already detect heads (`AgentProjection.headIds`) and tolerate ≥2 parents (`AgentEvent.causalParents` is a sorted-unique *set*).
+  - **PR 3** (#3249) — `messagePrev` edges are populated and `recentHeadMessageId` is maintained by `AgentSyncService._appendMessage`; the storage→event adapter (`agentEventsFromLog`) already folds multi-parent edges into `causalParents`.
+  - **PR 5** (#3257) — `ContentDigest.of(json)` (`sha256-v1:<base64url>`, canonical JSON) is available to mint the content-addressed join id.
+
+## Goal
+
+When two devices wake the same agent from a shared prefix they create a DAG
+**fork** — concurrent `messagePrev` children of one parent (ADR 0016). This is
+**legal and already converges**: `project()` returns both tips in `headIds` and
+context assembly reads across all heads in the canonical linear extension, so no
+device is wrong. But an unhealed fork means the on-device prefix never re-warms
+(each branch is a distinct prefix) and context assembly fans out across an
+ever-widening head set.
+
+PR 6 **heals the fork**: emit a **join-by-continuation** node — a single
+continuation message that links (`messagePrev`) to *all* current heads, so the
+DAG re-converges to one head and the prefix re-warms. The join is **content-addressed**
+so two devices emitting it concurrently write the *same* log entry, which
+set-union merges into one node (no join storm). Per ADR 0018 rule 8 this is **an
+optimization, never a correctness mechanism** — correctness already holds via the
+multi-head projection.
+
+## The model (the load-bearing decisions)
+
+Straight from ADR 0018 rule 8, made concrete against the current code:
+
+1. **A join is a `system` `AgentMessageEntity` with ≥2 `messagePrev` parents.**
+   It flows through the projection unchanged: `agentEventsFromLog` already
+   collects every `MessagePrevLink.toId` for a child into `causalParents`, and
+   `AgentEvent` normalizes them to a sorted-unique set. The kernel then drops all
+   joined heads out of `headIds` (they are now referenced as parents) and the
+   join becomes the single head.
+2. **The join id is content-addressed and domain-tagged**, distinct from the
+   summary coverage `frontierDigest` so the two uses can never collide:
+   `joinId = ContentDigest.of({'_tag': 'join-v1', 'parents': sortedHeadIds})`.
+   Two devices over the same head set compute a byte-identical id → the DB
+   (`insertOnConflictUpdate`, keyed by id) merges them into one row.
+   **Convergence caveat (red-team J1):** the content-address dedupes only an
+   *identical* parent set. Two devices with *different* head-set views (a
+   fully-disjoint third branch one hasn't synced) heal different supersets and
+   briefly *multiply* the fork; this self-corrects — the resulting join heads
+   form a smaller fork the next cycle heals — converging in O(branches) bounded
+   rounds, never storming (join ids are monotone children of a strictly-growing
+   parent set, so a join can never re-create an existing ancestor). The
+   completeness gate (rule 5) removes the common "node synced before its edge"
+   trigger; the disjoint-branch residue is accepted as bounded self-healing, not
+   a correctness risk (ADR 0018: the join is an optimization, never correctness).
+3. **The join payload is fully deterministic — no wall-clock, `hostId`, or vector
+   clock in the *content*.** Content = the fixed kind + the sorted parent-head id
+   set (mirrored into the message body for auditability). Everything device-specific
+   (`createdAt`, `vectorClock`, authoring `hostId`) lives in the **envelope**,
+   which the projection never folds into identity.
+4. **Per-parent `messagePrev` link ids are also content-addressed.** The current
+   single-parent scheme `msgprev-${childId}` cannot represent *n* edges from one
+   child, and two devices must mint identical edge ids to set-union them. PR 6
+   uses `msgprev-${joinId}-${parentId}` for join edges (one per parent), keeping
+   the existing `msgprev-${childId}` scheme for ordinary single-parent messages.
+5. **Emit for any fork observed at wake start over a settled view** (rule 8:
+   "≥2 heads survive past one wake cycle"). The pure `planJoin` gates on two
+   conditions only:
+   - **≥2 heads** (a single head is no fork); and
+   - **the local view is complete** — `projection.danglingParentIds.isEmpty`. A
+     `messagePrev` edge syncs as a message separate from its endpoint node, so a
+     node can arrive before the edge that marks its child as the real tip; on
+     that transient view a non-tip masquerades as a head and healing would mint
+     a join over the wrong set. Defer until the view settles (red-team J1 fix).
+
+   **No cross-wake marker / no new `AgentStateEntity` field.** An earlier draft
+   gated on a persisted "head set unchanged since last wake" digest to enforce
+   "survived a cycle." The red-team showed this both *starves* (a peer extending
+   one branch each cycle changes the set every wake → never heals) and adds a
+   synced field to the most sensitive model. It also buys nothing: forks never
+   self-resolve (two concurrent branches stay forked until a join links them),
+   and concurrent joins dedupe by content-address — so there is no transient
+   fork to "wait out" beyond the partial-sync view, which `viewComplete` already
+   covers. A fork seen at *wake start* was created by a *prior* cycle (this wake
+   has appended nothing yet), so healing it is faithful to "survived past the
+   cycle that created it." Eager-at-wake-start is therefore correct, non-starving,
+   and stateless.
+6. **The join is lazy and capped.** Lazy: emitted at wake start, not eagerly on
+   every sync. Capped: at most one join per wake; the content-addressed id makes
+   re-emission idempotent (a re-run finds the row present and stops — the existing
+   `_appendMessage` idempotency guard), so a crash-and-retry cannot storm.
+7. **Envelope reconciliation is deterministic, not LWW arrival-order.** When the
+   same join id arrives from two devices with different envelopes, the stored row
+   must converge replica-independently. Today the message sync path resolves a
+   concurrent duplicate-id by `resolveConcurrent` (canonical vector-clock
+   tiebreak) **only for `AgentStateEntity`**; plain messages fall to
+   dominance-or-apply-incoming, which is arrival-order-sensitive for the
+   *envelope*. PR 6 routes content-addressed events through the same
+   replica-independent canonicalization so the stored envelope converges (it does
+   **not** affect correctness — identity + edges already converge by id — but it
+   stops perpetual re-sync churn).
+
+**Why this is safe to land incrementally.** The join changes nothing the
+projection reads for *correctness* (heads + folds are identical with or without
+it); it only *reduces* the head count and re-warms the prefix. So the pure logic
+(J1), the append mechanism (J2), and the emission hook (J3) are each shippable
+green on their own, and emission can ship behind a default-off flag first (J3)
+exactly as PR 5's compaction did.
+
+## Where it lives (architecture)
+
+- **Pure logic — `lib/features/agents/projection/join_plan.dart` (new).**
+  `computeJoinId(List<String> headIds)` and `planJoin({required List<String>
+  headIds, String? lastHeadSetDigest})` → `JoinPlan?` (null = no join). Pure
+  functions of the head set + the prior digest; no I/O, no clocks. This is where
+  the "≥2 heads + survived a cycle" rule and the content-addressed id live, and
+  where the Glados properties bite (determinism, permutation-invariance over the
+  head set, idempotence).
+- **Append mechanism — `AgentSyncService` (`agent_sync_service.dart`).** A new
+  `appendJoin(...)` (or a generalized `_appendMessage` that accepts an explicit
+  parent *list*) writes the join message, its *n* content-addressed `messagePrev`
+  links, and advances `recentHeadMessageId` to the join — all inside one
+  `runInTransaction`, reusing the existing idempotency guard and the
+  `_upsertAgentStatePreservingHead` overlay so the head advance is not clobbered.
+- **Emission hook — `ForkHealer` + a single orchestrator pre-wake hook.**
+  `ForkHealer.maybeHealFork` reads `headIds` **and** `danglingParentIds` from a
+  **full-log projection** — `project(canonicalOrder(agentEventsFromLog(messages,
+  messagePrevLinks)))`. Messages come from `getAgentMessages(agentId)`; the
+  `messagePrev` edges (whose `fromId` is the *child message*, not the agent) come
+  from `getLinksFromMultiple(messageIds, type: messagePrev)` — batched, no N+1.
+  **Not** `reconciledAgentState` (red-team J1): that load fetches only `system`
+  markers + slot links, so its head set would be wrong. `recentHeadMessageId` is
+  likewise just *this device's* branch tip, never the head set. When `planJoin`
+  approves, `maybeHealFork` calls `appendJoin`. The four wake workflows share no
+  base class, but they all dispatch through the `WakeOrchestrator`, which gains
+  one optional `onWakeStart` hook fired just before the executor — so the join
+  emits before the wake's own messages, in **one** seam covering all agent kinds.
+  A corrupt synced log (cycle / duplicate id) is caught and skipped (non-fatal),
+  exactly like `reconciledAgentState`.
+- **Envelope canonicalization — deferred (see J4 / open decisions).** A
+  content-addressed duplicate-id message's per-device envelope (VC / `hostId` /
+  `createdAt`) is *not* reconciled in the sync apply path, because it is inert for
+  the projection today (`hostId = ''`, joins immutable, no re-sync churn). It
+  becomes load-bearing only if `hostIdOf` is ever populated, and must be added
+  with that change.
+
+The kernel (`project`/`canonicalOrder`) and the adapter (`agentEventsFromLog`)
+are **not** touched — they already handle multi-parent events. This is a deliberate
+check on the design: if the join needed kernel changes, it would not be "just an
+event."
+
+## Fork → heal lifecycle
+
+```mermaid
+stateDiagram-v2
+  [*] --> SingleHead
+  SingleHead --> Forked: two devices append off the same head (concurrent messagePrev children)
+  Forked --> Forked: local view still settling (a dangling parent) — defer
+  Forked --> Joining: a wake starts and observes ≥2 heads over a complete view
+  Joining --> SingleHead: append content-addressed join (messagePrev → all heads); head := joinId; prefix re-warms
+  Joining --> SingleHead: peer emitted the same join id concurrently → set-union merges to one node
+```
+
+## Increments (each shippable green on its own)
+
+1. **J1 — Pure join planning + id (no wiring).** New
+   `projection/join_plan.dart`: `computeJoinId(headIds)` (domain-tagged
+   `ContentDigest.of`) and `planJoin({headIds, lastHeadSetDigest})` → `JoinPlan?`
+   (`{joinId, parentIds (sorted), headSetDigest}`), returning null unless
+   `headIds.length >= 2` **and** `ContentDigest.of(sortedHeadIds) ==
+   lastHeadSetDigest` (the fork survived a cycle). Glados-tested:
+   permutation-invariance over the head set, determinism, the id is stable and
+   tag-isolated from a same-input `frontierDigest`, single-head/empty → null,
+   changed-head-set → null. Unused in production. *Done when:* analyze clean,
+   Glados green.
+2. **J2 — Multi-parent append path.** A **dedicated** `AgentSyncService.appendJoin
+   ({agentId, joinId, parentIds, at, ...})` — **not** routed through
+   `_appendMessage` (red-team J1): `_appendMessage` would add a spurious
+   single-parent `msgprev-${joinId}` edge off the pointer head *and* collide with
+   the per-parent edge-id scheme. `appendJoin` writes, in one `runInTransaction`:
+   the join `system` message via `_upsertEntityRaw`; one `messagePrev` link per
+   parent with id `msgprev-${joinId}-${parentId}`; and the head advance to
+   `joinId` through `_upsertAgentStatePreservingHead`. **Idempotency keys on the
+   join node's presence** (not on a single `prevMessageId`, which a multi-parent
+   node lacks) and re-asserts all *n* edges, so a crash between node-insert and
+   edge-inserts heals on retry (no join node left with missing parents).
+   Integration-tested over the in-memory repo
+   (`test/features/agents/sync/in_memory_agent_repository.dart`): a 2-head fork →
+   `appendJoin` → `project()` yields exactly one head (the join); re-running is a
+   no-op; a partial-commit retry completes the edge set; two "devices" appending
+   the same join id converge to one node + one edge set. Not yet called by
+   production. *Done when:* analyze clean, integration tests green, no regression
+   in existing append tests.
+3. **J3 — Emit on wake (flag-gated default-off). ✅ done.** A focused
+   `ForkHealer` (`lib/features/agents/sync/fork_healer.dart`,
+   `maybeHealFork(agentId, at, threadId, runKey)`) folds the full-log projection,
+   calls `planJoin`, and `appendJoin`s when due — catching a corrupt log as
+   non-fatal. The `WakeOrchestrator` gains one optional `onWakeStart` hook fired
+   just before the executor (covering all four agent kinds in one seam). DI
+   (`agent_providers.dart`) wires the hook to `ForkHealer` only when
+   `const bool.fromEnvironment('LOTTI_JOIN_HEALING')` is set — **default false →
+   `onWakeStart` is null → wakes run byte-identically to today**, and the flag
+   gives a real `--dart-define` enable path for the rollout (mirrors compaction).
+   **No `AgentStateEntity` field, no `build_runner`** (the eager gate is
+   stateless). Tested: `ForkHealer` over the in-memory repo (fork→heal, no-op,
+   defer-on-incomplete-view, idempotent re-fork prevention, non-fatal on a
+   corrupt log); orchestrator (hook runs before the executor with the wake
+   context; a throwing hook is non-fatal and the wake still completes).
+4. **J4 — Convergence sim; envelope canonicalization deliberately deferred. ✅
+   done.** A two-device convergence sim (in `fork_healer_test.dart`): two devices
+   fork, each heals independently with its *own* envelope, and the synced union
+   (deduped by id — the DB's `insertOnConflictUpdate`) has **one** join node and
+   **one** head, *independent of merge order*; repeated concurrent forks stay
+   bounded (every heal returns to one head; message count grows linearly — no
+   storm). **Sim trap avoided (red-team J1):** `AgentEvent` equality includes the
+   envelope, so the sim unions into an id-keyed map before folding — modelling the
+   DB — rather than concatenating raw lists (which would trip
+   `DuplicateEventIdException`).
+
+   **Envelope canonicalization is deferred, with rationale.** The original plan
+   was to canonicalize a content-addressed event's per-device envelope (min-VC /
+   lowest `hostId`) in the sync apply path. Investigation showed this is **inert
+   for correctness today** and not worth destabilizing the most sensitive path:
+   (a) the projection orders by `(hostId, id)` with `hostId = ''` in production
+   (`agentEventsFromLog` is called with no `hostIdOf`), so a divergent stored
+   envelope never changes the order or the derived state; (b) a join node is
+   **immutable**, so its vector clock is never re-resolved; and (c) a synced
+   duplicate applies via the raw repository write (not re-enqueued), so the
+   envelope is *stably divergent after one exchange — no churn*. The
+   canonicalization becomes load-bearing only if `hostIdOf` is ever populated
+   (then two devices could order the join differently); it must be added *with*
+   that change. Recorded as an open decision below. *Done when:* the sim passes;
+   the deferral is documented.
+5. **J5 — README + capping audit + roadmap refresh. ✅ done.**
+   `lib/features/agents/README.md` gained a "Fork healing: join-by-continuation"
+   section (fork→heal Mermaid lifecycle + the join id / edge-id scheme + the
+   flag); `projection/README.md`'s file table was completed (it was missing the
+   PR 5 files too) with `join_plan.dart`. The cap holds: the hook fires once per
+   wake, re-emission is idempotent, and an explicit *partial-commit retry* test
+   plus the *no-storm* assertion (message count grows linearly across repeated
+   forks) cover it. Roadmap PR 6 line + this plan's status refreshed. Three final
+   adversarial-review polish items applied: full-projection (not just heads)
+   merge-order-independence assertion; the explicit partial-commit retry test;
+   and the in-memory fake's `getAgentMessages` now filters soft-deletes to match
+   the real repo.
+
+Only **J3** changes runtime behavior, and only behind the default-off flag; J1/J2
+are pure/mechanism, J4 hardens convergence, J5 documents. The deliberate flag
+flip (turning healing on in prod) is a separate, user-driven rollout — like PR 5's
+compaction flag — with a CHANGELOG entry **then** (none now: flag off = invisible).
+
+## Test plan
+
+- **Pure logic (Glados, tagged `glados`):** `planJoin`/`computeJoinId` —
+  permutation-invariance over the head set, determinism, tag-isolation from
+  `frontierDigest`, the gate (single head / empty / dups → null; `!viewComplete`
+  → null; emit iff ≥2 heads over a complete view).
+- **Append mechanism (`appendJoin`, example tests):** fork → join → one head
+  (real projection); idempotent re-emit; per-parent edge ids; head advances to
+  the join (incl. the stale-head-with-node-present case); partial-commit retry
+  completes the edge set + head; no-state-row and <2-parent branches.
+- **Convergence sim (`fork_healer.dart` two-device):** concurrent joins over the
+  same heads → one node + one head; full projection independent of merge order;
+  repeated forks stay bounded (linear growth, no storm).
+- **Wake hook (`WakeOrchestrator`, fakeAsync):** the hook runs before the
+  executor with the wake context; a throwing hook is non-fatal; a hanging hook is
+  bounded by `wakeStartHookTimeout` — the wake proceeds in all three.
+- **Cap/crash:** a crash between join-append and commit re-emits the same id on
+  retry → still one node (no storm).
+
+Conventions: pure logic uses Glados; service/wake tests stay deterministic
+example tests with mocks + fixed clocks (`test/README.md`); no real timers;
+deterministic dates.
+
+## Defers
+
+- **Eager (non-wake) join emission** — PR 6 emits only at wake start. A background
+  coalesced join on sync (without waiting for a wake) is a later tuning knob if
+  forks linger on idle agents.
+- **Join *content* beyond parent ids** — the join carries no summary/snapshot; if
+  a future need arises to fold state into the join, that is additive and must keep
+  the content deterministic (rule 8).
+- **Generalizing `recentHeadMessageId` to a head *set*** — out of scope; the
+  single pointer remains this device's branch tip, and the full head set is always
+  computed from the projection (never from the pointer).
+
+## Open decisions
+
+- **`appendJoin` vs. generalizing `_appendMessage`.** Leaning toward a dedicated
+  `appendJoin` (clear single responsibility; `_appendMessage`'s single-head
+  fast-path stays untouched and low-risk), but a generalized `_appendMessage(...,
+  {List<String>? explicitParents})` would be DRYer. Settle in J2.
+- **Envelope canonicalization (deferred from J4 — becomes load-bearing only with
+  `hostIdOf`).** Today the projection ignores a content-addressed event's
+  per-device envelope (`hostId = ''` in prod; joins are immutable; a synced
+  duplicate doesn't re-enqueue → stably divergent, no churn), so canonicalizing it
+  in the sync apply path is inert and not worth the risk. When/if the projection
+  starts deriving `hostId` from the message (populating `hostIdOf`), a divergent
+  stored envelope *would* change the `(hostId, id)` order across devices — at that
+  point route content-addressed duplicate-id events (joins **and** PR 5 summary
+  checkpoints) through a shared replica-independent canonicalizer (min canonical
+  VC, then lowest `hostId`, then earliest `createdAt`). Add it *with* the
+  `hostIdOf` change, not before.
+- **Survival gate precision (red-team J1 confirmed real) — RESOLVED in J3 by
+  dropping the marker.** The head-set-digest "unchanged since last wake" gate
+  starved under one-branch-per-cycle churn. J3 replaced it with the stateless
+  eager-at-wake-start gate (`≥2 heads + viewComplete`), which cannot starve and
+  removes the synced field. The residual risk it leaves — a busy second device
+  re-forking right after a heal — is the *intended* steady state: the head count
+  stays bounded (≤ active devices) with a periodic collapse each cycle, which is
+  exactly the "bounds context" goal. No further tuning needed.

--- a/docs/implementation_plans/2026-06-02_join_by_continuation_plan.md
+++ b/docs/implementation_plans/2026-06-02_join_by_continuation_plan.md
@@ -109,11 +109,11 @@ exactly as PR 5's compaction did.
 
 - **Pure logic — `lib/features/agents/projection/join_plan.dart` (new).**
   `computeJoinId(List<String> headIds)` and `planJoin({required List<String>
-  headIds, String? lastHeadSetDigest})` → `JoinPlan?` (null = no join). Pure
-  functions of the head set + the prior digest; no I/O, no clocks. This is where
-  the "≥2 heads + survived a cycle" rule and the content-addressed id live, and
-  where the Glados properties bite (determinism, permutation-invariance over the
-  head set, idempotence).
+  headIds, required bool viewComplete})` → `JoinPlan?` (null = no join). Pure
+  functions of the head set + the `viewComplete` flag; no I/O, no clocks, no
+  cross-wake state. This is where the "≥2 heads over a complete view" gate and
+  the content-addressed id live, and where the Glados properties bite
+  (determinism, permutation-invariance over the head set, idempotence).
 - **Append mechanism — `AgentSyncService` (`agent_sync_service.dart`).** A new
   `appendJoin(...)` (or a generalized `_appendMessage` that accepts an explicit
   parent *list*) writes the join message, its *n* content-addressed `messagePrev`
@@ -161,16 +161,16 @@ stateDiagram-v2
 
 ## Increments (each shippable green on its own)
 
-1. **J1 — Pure join planning + id (no wiring).** New
+1. **J1 — Pure join planning + id (no wiring). ✅ done.** New
    `projection/join_plan.dart`: `computeJoinId(headIds)` (domain-tagged
-   `ContentDigest.of`) and `planJoin({headIds, lastHeadSetDigest})` → `JoinPlan?`
-   (`{joinId, parentIds (sorted), headSetDigest}`), returning null unless
-   `headIds.length >= 2` **and** `ContentDigest.of(sortedHeadIds) ==
-   lastHeadSetDigest` (the fork survived a cycle). Glados-tested:
-   permutation-invariance over the head set, determinism, the id is stable and
-   tag-isolated from a same-input `frontierDigest`, single-head/empty → null,
-   changed-head-set → null. Unused in production. *Done when:* analyze clean,
-   Glados green.
+   `ContentDigest.of`) and `planJoin({headIds, viewComplete})` → `JoinPlan?`
+   (`{joinId, parentIds (sorted)}`), returning null unless `headIds.length >= 2`
+   **and** `viewComplete` (no dangling parents — the local DAG view has settled).
+   Stateless: a pure function of the head set + that boolean, no cross-wake
+   marker. Glados-tested: permutation-invariance over the head set, determinism,
+   the id is stable and tag-isolated from a same-input `frontierDigest`,
+   single-head/empty/dups → null, `!viewComplete` → null. Unused in production.
+   *Done when:* analyze clean, Glados green.
 2. **J2 — Multi-parent append path.** A **dedicated** `AgentSyncService.appendJoin
    ({agentId, joinId, parentIds, at, ...})` — **not** routed through
    `_appendMessage` (red-team J1): `_appendMessage` would add a spurious

--- a/lib/features/agents/README.md
+++ b/lib/features/agents/README.md
@@ -438,9 +438,11 @@ it — so the DAG re-converges to one tip and the prefix re-warms.
   and each edge id is `msgprev-${joinId}-${parentId}`. Two devices healing the
   *same* fork mint byte-identical rows, so the log set-unions their concurrent
   emissions into **one** node — no join storm. The join carries no payload and no
-  wall-clock/host/clock in its *content*; the per-device envelope is reconciled
-  separately by the sync layer (and is currently inert for the projection, which
-  orders by `(hostId, id)` with `hostId = ''`).
+  wall-clock/host/clock in its *content*; the per-device envelope (`createdAt`,
+  vector clock) is **not yet canonicalized** — reconciliation is deferred because
+  it is inert for the projection today, which orders by `(hostId, id)` with
+  `hostId = ''` and never re-resolves an immutable join. It becomes load-bearing
+  only if `hostIdOf` is ever populated (see the plan's open decisions).
 - **Eager at wake start, no cross-wake state.** A fork seen at wake start was
   created by a *prior* cycle (this wake has appended nothing yet), so healing it is
   faithful to ADR 0018's "≥2 heads survive past one wake cycle." Forks never

--- a/lib/features/agents/README.md
+++ b/lib/features/agents/README.md
@@ -415,6 +415,58 @@ device-local scheduling fields are still cache-only (no backing log event yet). 
 milestone markers also show up as `System` rows in the `AgentInternalsBody`
 activity log.
 
+### Fork healing: join-by-continuation (PR 6 / ADR 0018 rule 8)
+
+When two devices wake the same agent off a shared head, each appends its own
+`messagePrev` child of that head — a **fork**: the DAG now has ≥2 heads. This is
+**legal, not corruption**. The projection (`project(canonicalOrder(...))`) is
+multi-head tolerant: it returns every tip in `headIds` and context assembly reads
+across all of them, so every device converges with or without any coordination.
+The cost of an *unhealed* fork is only that the on-device prefix never re-warms
+(each branch is a distinct prefix) and context fans out across a widening head set.
+
+**Fork healing** collapses the fork: at wake start, `ForkHealer.maybeHealFork`
+folds the agent's full log (`getAgentMessages` + the `messagePrev` edges fetched by
+`getLinksFromMultiple(messageIds, type: message_prev)`), and `planJoin` emits a
+**join-by-continuation** node when there are ≥2 heads over a *complete* view (no
+dangling parents). `AgentSyncService.appendJoin` then writes a `system` message
+that links (`messagePrev`) to **every** head and advances `recentHeadMessageId` to
+it — so the DAG re-converges to one tip and the prefix re-warms.
+
+- **Content-addressed, deterministic.** The join id is
+  `computeJoinId(headIds) = ContentDigest.of({'_tag':'join-v1','parents':sortedHeads})`
+  and each edge id is `msgprev-${joinId}-${parentId}`. Two devices healing the
+  *same* fork mint byte-identical rows, so the log set-unions their concurrent
+  emissions into **one** node — no join storm. The join carries no payload and no
+  wall-clock/host/clock in its *content*; the per-device envelope is reconciled
+  separately by the sync layer (and is currently inert for the projection, which
+  orders by `(hostId, id)` with `hostId = ''`).
+- **Eager at wake start, no cross-wake state.** A fork seen at wake start was
+  created by a *prior* cycle (this wake has appended nothing yet), so healing it is
+  faithful to ADR 0018's "≥2 heads survive past one wake cycle." Forks never
+  self-resolve, so there is nothing to wait out beyond a partially-synced view (a
+  node arrived before its parent edge) — which the *complete-view* gate covers. The
+  decision is a pure function of the current projection; no marker is persisted.
+- **Wiring.** The four wake workflows share no base class but all dispatch through
+  the `WakeOrchestrator`, which fires one optional `onWakeStart` hook just before
+  the executor (covering every agent kind in one seam). Healing is best-effort and
+  non-fatal: a corrupt synced log (cycle / duplicate id) or a slow load is caught
+  or timed out (`wakeStartHookTimeout`), and the wake proceeds regardless — healing
+  is an optimization, never a correctness mechanism.
+- **Flag-gated off.** DI wires the hook only when
+  `--dart-define=LOTTI_JOIN_HEALING=true`; by default `onWakeStart` is null and
+  wakes are byte-identical to today.
+
+```mermaid
+stateDiagram-v2
+  [*] --> SingleHead
+  SingleHead --> Forked: two devices append off the same head (concurrent messagePrev children)
+  Forked --> Forked: local view still settling (a dangling parent) — defer
+  Forked --> Joining: a wake starts and observes ≥2 heads over a complete view
+  Joining --> SingleHead: appendJoin (messagePrev → all heads); recentHeadMessageId := joinId; prefix re-warms
+  Joining --> SingleHead: peer emitted the same joinId concurrently → set-union merges to one node
+```
+
 ## Agent Kinds and Lifecycle
 
 The current persisted agent kinds are:

--- a/lib/features/agents/projection/README.md
+++ b/lib/features/agents/projection/README.md
@@ -24,6 +24,13 @@ diagnostic compare — reads do not flip to the projection until PR 4.
 | `agent_event_adapter.dart` | `agentEventsFromLog()` — maps persisted `AgentMessageEntity` + `messagePrev` links onto `AgentEvent` (PR 3 bridge). |
 | `shadow_projection.dart` | `compareShadowProjection()` + `ShadowProjectionReport`/`Status` — non-throwing compare of the projection against the live head. |
 | `derived_agent_state.dart` | `deriveAgentState()` + `DerivedAgentState` — the storage-coupled full-state fold (kernel + watermarks + active slots); `compareDerivedAgentState()` + `DerivedStateReport` — full-state shadow compare (PR 4 B5); `reconcileAgentState()` — folds the log over the cached row for the wake-start read cutover (PR 4 B6). |
+| `content_digest.dart` | `ContentDigest.of()` — versioned (`sha256-v1:`) content-addressed digest over canonical JSON; the address for captured inputs, compaction artifacts, and join ids (PR 5 / ADR 0017 §6 / ADR 0020). |
+| `input_capture.dart` | `RenderedSource`/`CapturedPayload`/`CaptureReference`/`CaptureResult`; `captureSources()` + `reconcileCapture()` — fold a wake's rendered user content into deduplicated, content-addressed per-source captures (PR 5 / ADR 0020). |
+| `input_frontier.dart` | `projectInputFrontier()` + `inputFrontierDigests()` — the active input frontier (latest-wins over `messagePayload` links and retraction markers). |
+| `compaction_plan.dart` | `planCompaction()` + `CompactionPlan`/`TailEntry` — fold the oldest tail prefix that overflows a token budget (PR 5 / ADR 0017). |
+| `compaction_summary.dart` | `selectActiveSummary()` (source-frontier maximal-complete checkpoint) + `assembleCompactedTaskLog()` — the read side: active summary + uncovered verbatim tail. |
+| `checkpoint_selection.dart` | `selectActiveCheckpoint()` — message-DAG checkpoint selection (deepest summary ancestral to every head). |
+| `join_plan.dart` | `computeJoinId()` + `planJoin()`/`JoinPlan` — fork-healing decision (PR 6 / ADR 0018 rule 8): the content-addressed join id and the ≥2-heads-over-a-complete-view gate. |
 
 ## The causal model (the load-bearing decision)
 

--- a/lib/features/agents/projection/join_plan.dart
+++ b/lib/features/agents/projection/join_plan.dart
@@ -1,0 +1,81 @@
+import 'package:equatable/equatable.dart';
+import 'package:lotti/features/agents/projection/content_digest.dart';
+
+/// Domain tag isolating the join-node digest from every other content-addressed
+/// use (notably the summary coverage `frontierDigest`, ADR 0017): the tag is
+/// part of the hashed content, so the two digests hash different shapes and can
+/// never collide or be confused (ADR 0018 rule 8).
+const String _joinTag = 'join-v1';
+
+/// Content-addressed id of the join-by-continuation node over [headIds]
+/// (ADR 0018 rule 8).
+///
+/// Computed over the **sorted, de-duplicated** head set, so two devices healing
+/// the *same* fork mint a byte-identical id — the log then set-unions their
+/// concurrent emissions into a single node (no join storm). The id carries no
+/// wall-clock, `hostId`, or vector clock: those live in the per-device envelope,
+/// which the projection reconciles separately and never folds into identity.
+String computeJoinId(Iterable<String> headIds) => ContentDigest.of({
+  '_tag': _joinTag,
+  'parents': _sortedUnique(headIds),
+});
+
+/// The decision to heal a fork: emit a join node with [joinId] linking
+/// [parentIds] (the surviving heads) via `messagePrev`. Produced by [planJoin];
+/// a null plan means "do not join this wake".
+class JoinPlan extends Equatable {
+  /// Wraps a plan. Callers obtain instances from [planJoin].
+  const JoinPlan({required this.joinId, required this.parentIds});
+
+  /// Content-addressed id of the join node ([computeJoinId] over [parentIds]).
+  final String joinId;
+
+  /// The heads to link as the join's `messagePrev` parents — **sorted,
+  /// de-duplicated**, matching the set [joinId] was computed over.
+  final List<String> parentIds;
+
+  @override
+  List<Object?> get props => [joinId, parentIds];
+}
+
+/// Decides whether to heal a fork at this wake start (ADR 0018 rule 8).
+///
+/// Pure function of the current [headIds] and whether the local DAG view is
+/// complete ([viewComplete]). Returns a [JoinPlan] when **both** hold:
+/// - there are **≥2 heads** — a single head is no fork, nothing to heal; and
+/// - the local view is **complete**, i.e. no dangling parents. A `messagePrev`
+///   edge syncs as a message separate from its endpoint node, so a node can
+///   arrive before the edge that marks its child as the real tip; on that
+///   transient view a non-tip masquerades as a head and healing would mint a
+///   join over the wrong parent set. Defer until the view settles.
+///
+/// Returns null otherwise.
+///
+/// **Why healing eagerly at wake start is correct — and faithful to "≥2 heads
+/// survive past one wake cycle".** A fork observed at *wake start* was created
+/// by a *prior* cycle (the current wake has appended nothing yet), so it has
+/// already survived the cycle that created it. Forks never self-resolve — two
+/// concurrent branches stay forked until a join links them — so deferring would
+/// only delay bounding the context, never spare an unnecessary join. The one
+/// transient worth avoiding is the partially-synced view above, which
+/// [viewComplete] gates.
+///
+/// **Convergence (ADR 0018 rule 8).** Two devices that observe the *identical*
+/// head set emit the same [JoinPlan.joinId], which set-unions into one node.
+/// Devices with *different* (partial) views heal different supersets that
+/// self-correct — the resulting join heads form a smaller fork the next cycle
+/// heals — converging in O(branches) bounded rounds, never storming (join ids
+/// are monotone children of a strictly-growing parent set, so a join can never
+/// re-create an existing ancestor).
+JoinPlan? planJoin({
+  required List<String> headIds,
+  required bool viewComplete,
+}) {
+  final heads = _sortedUnique(headIds);
+  if (heads.length < 2) return null;
+  if (!viewComplete) return null;
+  return JoinPlan(joinId: computeJoinId(heads), parentIds: heads);
+}
+
+List<String> _sortedUnique(Iterable<String> ids) =>
+    ids.toSet().toList()..sort();

--- a/lib/features/agents/state/agent_providers.dart
+++ b/lib/features/agents/state/agent_providers.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:developer' as developer;
 
+import 'package:clock/clock.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/state/config_flag_provider.dart';
 import 'package:lotti/features/agents/database/agent_database.dart';
@@ -16,6 +17,7 @@ import 'package:lotti/features/agents/state/agent_workflow_providers.dart';
 import 'package:lotti/features/agents/state/project_agent_providers.dart';
 import 'package:lotti/features/agents/state/task_agent_providers.dart';
 import 'package:lotti/features/agents/sync/agent_sync_service.dart';
+import 'package:lotti/features/agents/sync/fork_healer.dart';
 import 'package:lotti/features/agents/wake/scheduled_wake_manager.dart';
 import 'package:lotti/features/agents/wake/wake_orchestrator.dart';
 import 'package:lotti/features/agents/wake/wake_queue.dart';
@@ -152,6 +154,13 @@ WakeRunner wakeRunner(Ref ref) {
   return runner;
 }
 
+/// Fork-healing rollout flag (ADR 0018 rule 8 / PR 6). Default off: the
+/// join-by-continuation mechanism is fully built and wired, but inert until
+/// deliberately enabled with `--dart-define=LOTTI_JOIN_HEALING=true` (mirrors
+/// the compaction rollout). Turning it on appends `join` nodes to the synced
+/// agent log — a user-visible, multi-device behaviour change.
+const bool _joinHealingEnabled = bool.fromEnvironment('LOTTI_JOIN_HEALING');
+
 /// The wake orchestrator (notification listener + subscription matching).
 @Riverpod(keepAlive: true)
 WakeOrchestrator wakeOrchestrator(Ref ref) {
@@ -162,6 +171,19 @@ WakeOrchestrator wakeOrchestrator(Ref ref) {
       notifications.notifyUiOnly({agentId, agentNotification});
     };
   }
+  // Construct the fork healer once (not per wake) when the rollout flag is on.
+  WakeStartHook? onWakeStart;
+  if (_joinHealingEnabled) {
+    final forkHealer = ForkHealer(
+      syncService: ref.read(agentSyncServiceProvider),
+    );
+    onWakeStart = (agentId, runKey, threadId) => forkHealer.maybeHealFork(
+      agentId: agentId,
+      at: clock.now(),
+      threadId: threadId,
+      runKey: runKey,
+    );
+  }
   return WakeOrchestrator(
     repository: ref.watch(agentRepositoryProvider),
     queue: ref.watch(wakeQueueProvider),
@@ -170,6 +192,7 @@ WakeOrchestrator wakeOrchestrator(Ref ref) {
     onPersistedStateChanged: onPersistedStateChanged,
     syncEntityWriter: (entity) =>
         ref.read(agentSyncServiceProvider).upsertEntity(entity),
+    onWakeStart: onWakeStart,
     taskContentChecker: (taskId) async {
       final journalDb = ref.read(journalDbProvider);
 

--- a/lib/features/agents/state/agent_providers.dart
+++ b/lib/features/agents/state/agent_providers.dart
@@ -161,6 +161,25 @@ WakeRunner wakeRunner(Ref ref) {
 /// agent log — a user-visible, multi-device behaviour change.
 const bool _joinHealingEnabled = bool.fromEnvironment('LOTTI_JOIN_HEALING');
 
+/// Builds the wake-start fork-healing hook (ADR 0018 rule 8): a [WakeStartHook]
+/// that, at the start of each wake, heals the agent's fork via a [ForkHealer]
+/// over [syncService] ([now] supplies the join timestamp). The healer is built
+/// once (not per wake). Extracted from [wakeOrchestrator] so the wiring is
+/// unit-testable — the rollout flag gating it (`LOTTI_JOIN_HEALING`) is a
+/// compile-time const that tests cannot flip.
+WakeStartHook forkHealingHook(
+  AgentSyncService syncService,
+  DateTime Function() now,
+) {
+  final forkHealer = ForkHealer(syncService: syncService);
+  return (agentId, runKey, threadId) => forkHealer.maybeHealFork(
+    agentId: agentId,
+    at: now(),
+    threadId: threadId,
+    runKey: runKey,
+  );
+}
+
 /// The wake orchestrator (notification listener + subscription matching).
 @Riverpod(keepAlive: true)
 WakeOrchestrator wakeOrchestrator(Ref ref) {
@@ -171,19 +190,18 @@ WakeOrchestrator wakeOrchestrator(Ref ref) {
       notifications.notifyUiOnly({agentId, agentNotification});
     };
   }
-  // Construct the fork healer once (not per wake) when the rollout flag is on.
+  // Fork healing (ADR 0018 rule 8), gated by the default-off rollout flag. The
+  // flag is a compile-time const tests can't flip, so the gated resolution is
+  // coverage-ignored; the wiring it calls (`forkHealingHook`) is unit-tested.
   WakeStartHook? onWakeStart;
+  // coverage:ignore-start
   if (_joinHealingEnabled) {
-    final forkHealer = ForkHealer(
-      syncService: ref.read(agentSyncServiceProvider),
-    );
-    onWakeStart = (agentId, runKey, threadId) => forkHealer.maybeHealFork(
-      agentId: agentId,
-      at: clock.now(),
-      threadId: threadId,
-      runKey: runKey,
+    onWakeStart = forkHealingHook(
+      ref.watch(agentSyncServiceProvider),
+      clock.now,
     );
   }
+  // coverage:ignore-end
   return WakeOrchestrator(
     repository: ref.watch(agentRepositoryProvider),
     queue: ref.watch(wakeQueueProvider),

--- a/lib/features/agents/sync/agent_sync_service.dart
+++ b/lib/features/agents/sync/agent_sync_service.dart
@@ -451,21 +451,26 @@ class AgentSyncService {
   /// carries no payload; its parents live in the edges and its identity in the
   /// content-addressed id (the `sha256-v1:` prefix + a multi-parent `system`
   /// message is what marks a node as a join). Per-device envelope fields
-  /// (`createdAt`, vector clock) are reconciled separately (J4); they never
-  /// affect the merge, which is keyed by id.
+  /// (`createdAt`, vector clock) are *not* canonicalized (deferred — inert while
+  /// the projection orders by `(hostId, id)` with `hostId = ''` and joins are
+  /// immutable); they never affect the merge, which is keyed by id.
   ///
   /// **Its own append path — never routed through [upsertEntity]/[_appendMessage]**,
   /// which chain a *single* parent off `recentHeadMessageId` and would both add a
   /// spurious `msgprev-${joinId}` edge and collide with the per-parent edge ids.
   ///
   /// **Idempotent and atomic.** Node, all *n* edges, and the head advance commit
-  /// in one [runInTransaction]; the node is (re-)written only when absent, the
-  /// edges are idempotent by id, and the head is advanced to [joinId] **whenever
-  /// it isn't already there** — including when the join node arrived by sync —
-  /// because a head pointer left at a now-joined parent would immediately
-  /// re-fork on the next local append. Mirrors [_appendMessage]'s head
-  /// maintenance via [_upsertEntityRaw], keeping the append path the sole head
-  /// mover.
+  /// in one [runInTransaction]; the node is (re-)written only when absent, and
+  /// the edges are idempotent by id. The head is advanced to [joinId] **only
+  /// when it still points at one of the joined parents (or is unset)** —
+  /// including when the join node arrived by sync, where the head still sits on
+  /// a parent. If the head has since moved *past* the parents — e.g. the wake
+  /// timed this heal out (the future is not cancellable) and the executor
+  /// appended new messages first, or a newer message arrived — it is left alone:
+  /// collapsing back to the join would move the head **backwards** and orphan
+  /// that progress. The join node + edges are still recorded, so the residual
+  /// fork heals on the next wake. Mirrors [_appendMessage]'s head maintenance
+  /// via [_upsertEntityRaw], keeping the append path the sole head mover.
   Future<void> appendJoin({
     required String agentId,
     required String joinId,
@@ -504,8 +509,15 @@ class AgentSyncService {
           ),
         );
       }
+      // Only collapse the head onto the join while it still sits on a joined
+      // parent (or is unset). If it has moved on (a timed-out heal racing the
+      // executor, or a newer append), advancing would regress the head and
+      // orphan that progress — leave it; the residual fork heals next wake.
       final state = await _repository.getAgentState(agentId);
-      if (state != null && state.recentHeadMessageId != joinId) {
+      final head = state?.recentHeadMessageId;
+      if (state != null &&
+          head != joinId &&
+          (head == null || parents.contains(head))) {
         await _upsertEntityRaw(
           state.copyWith(recentHeadMessageId: joinId, updatedAt: at),
         );

--- a/lib/features/agents/sync/agent_sync_service.dart
+++ b/lib/features/agents/sync/agent_sync_service.dart
@@ -439,6 +439,80 @@ class AgentSyncService {
     return messages.last.id;
   }
 
+  /// Appends a **join-by-continuation** node healing a fork (ADR 0018 rule 8):
+  /// a `system` message [joinId] linked via `messagePrev` to *every* head in
+  /// [parentIds], after which the agent's head advances to the join so the DAG
+  /// re-converges to one tip and the on-device prefix re-warms.
+  ///
+  /// **Content-addressed and deterministic.** [joinId] (from `computeJoinId`)
+  /// and each edge id (`msgprev-${joinId}-${parentId}`) derive purely from the
+  /// sorted parent set, so two devices healing the same fork emit byte-identical
+  /// rows that set-union into one node + one edge set — no join storm. The join
+  /// carries no payload; its parents live in the edges and its identity in the
+  /// content-addressed id (the `sha256-v1:` prefix + a multi-parent `system`
+  /// message is what marks a node as a join). Per-device envelope fields
+  /// (`createdAt`, vector clock) are reconciled separately (J4); they never
+  /// affect the merge, which is keyed by id.
+  ///
+  /// **Its own append path — never routed through [upsertEntity]/[_appendMessage]**,
+  /// which chain a *single* parent off `recentHeadMessageId` and would both add a
+  /// spurious `msgprev-${joinId}` edge and collide with the per-parent edge ids.
+  ///
+  /// **Idempotent and atomic.** Node, all *n* edges, and the head advance commit
+  /// in one [runInTransaction]; the node is (re-)written only when absent, the
+  /// edges are idempotent by id, and the head is advanced to [joinId] **whenever
+  /// it isn't already there** — including when the join node arrived by sync —
+  /// because a head pointer left at a now-joined parent would immediately
+  /// re-fork on the next local append. Mirrors [_appendMessage]'s head
+  /// maintenance via [_upsertEntityRaw], keeping the append path the sole head
+  /// mover.
+  Future<void> appendJoin({
+    required String agentId,
+    required String joinId,
+    required List<String> parentIds,
+    required DateTime at,
+    String? threadId,
+    String? runKey,
+  }) async {
+    // Defensive: a join heals ≥2 distinct heads (planJoin already gates this).
+    final parents = parentIds.toSet().toList()..sort();
+    if (parents.length < 2) return;
+    await runInTransaction(() async {
+      final existing = await _repository.getEntity(joinId);
+      if (existing is! AgentMessageEntity) {
+        await _upsertEntityRaw(
+          AgentDomainEntity.agentMessage(
+            id: joinId,
+            agentId: agentId,
+            threadId: threadId ?? joinId,
+            kind: AgentMessageKind.system,
+            createdAt: at,
+            vectorClock: null,
+            metadata: AgentMessageMetadata(runKey: runKey),
+          ),
+        );
+      }
+      for (final parentId in parents) {
+        await upsertLink(
+          AgentLink.messagePrev(
+            id: 'msgprev-$joinId-$parentId',
+            fromId: joinId,
+            toId: parentId,
+            createdAt: at,
+            updatedAt: at,
+            vectorClock: null,
+          ),
+        );
+      }
+      final state = await _repository.getAgentState(agentId);
+      if (state != null && state.recentHeadMessageId != joinId) {
+        await _upsertEntityRaw(
+          state.copyWith(recentHeadMessageId: joinId, updatedAt: at),
+        );
+      }
+    });
+  }
+
   /// Upsert an [AgentLink] and enqueue a sync message unless [fromSync]
   /// is `true`.
   ///

--- a/lib/features/agents/sync/fork_healer.dart
+++ b/lib/features/agents/sync/fork_healer.dart
@@ -1,0 +1,92 @@
+import 'package:lotti/features/agents/database/agent_repository.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/projection/agent_event_adapter.dart';
+import 'package:lotti/features/agents/projection/agent_projection.dart';
+import 'package:lotti/features/agents/projection/canonical_order.dart';
+import 'package:lotti/features/agents/projection/join_plan.dart';
+import 'package:lotti/features/agents/sync/agent_sync_service.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/domain_logging.dart';
+
+/// Heals a forked agent log (ADR 0018 rule 8): when the agent's `messagePrev`
+/// DAG has ≥2 surviving heads at wake start, emit one content-addressed
+/// **join-by-continuation** node linking every head, collapsing the fork to a
+/// single tip so context assembly and the on-device prefix stay bounded.
+///
+/// This is an **optimization, never a correctness mechanism** — the projection
+/// is multi-head tolerant, so an unhealed fork is already consistent across
+/// devices (ADR 0018 rule 7). The join only re-converges the heads and re-warms
+/// the prefix; nothing reads it for correctness.
+///
+/// It reads the agent's full message log + `messagePrev` edges, folds them
+/// through the same projection the derive/shadow path uses, and — when
+/// [planJoin] approves — appends the join via [AgentSyncService.appendJoin]
+/// (deterministic, idempotent, content-addressed). Best-effort and non-fatal:
+/// a corrupt synced log (duplicate id / cycle) is caught and skipped rather
+/// than aborting the wake.
+class ForkHealer {
+  /// Creates a healer over an [AgentSyncService] — its repository for the reads,
+  /// its append path for the join write.
+  ForkHealer({required AgentSyncService syncService}) : _sync = syncService;
+
+  final AgentSyncService _sync;
+
+  AgentRepository get _repository => _sync.repository;
+
+  /// Heals [agentId]'s fork if one survives at wake start, returning the emitted
+  /// join id, or null when there was nothing to heal (no fork, an unsettled
+  /// view with dangling parents, or a corrupt log). [at] timestamps the join;
+  /// [threadId]/[runKey] carry the wake's provenance.
+  Future<String?> maybeHealFork({
+    required String agentId,
+    required DateTime at,
+    String? threadId,
+    String? runKey,
+  }) async {
+    final messages = await _repository.getAgentMessages(agentId);
+    // A fork needs ≥2 messages; skip the edge load entirely otherwise.
+    if (messages.length < 2) return null;
+
+    // messagePrev edges have `fromId = childMessageId`, so they are fetched by
+    // the agent's message ids (not by agentId). Batched to avoid an N+1.
+    final linksByChild = await _repository.getLinksFromMultiple(
+      [for (final message in messages) message.id],
+      type: AgentLinkTypes.messagePrev,
+    );
+    final links = [for (final group in linksByChild.values) ...group];
+
+    final JoinPlan? plan;
+    try {
+      final projection = project(
+        canonicalOrder(agentEventsFromLog(messages, links)),
+      );
+      plan = planJoin(
+        headIds: projection.headIds,
+        viewComplete: projection.danglingParentIds.isEmpty,
+      );
+    } catch (exception, stackTrace) {
+      // A peer may have synced a malformed log (duplicate id / cycle). Healing
+      // is best-effort — never abort the wake; the projection self-heals once
+      // the log is consistent again.
+      getIt<DomainLogger>().error(
+        LogDomain.sync,
+        exception,
+        message: 'fork-heal projection failed for $agentId; skipping',
+        stackTrace: stackTrace,
+        subDomain: 'agentSync.forkHeal',
+      );
+      return null;
+    }
+
+    if (plan == null) return null;
+    await _sync.appendJoin(
+      agentId: agentId,
+      joinId: plan.joinId,
+      parentIds: plan.parentIds,
+      at: at,
+      threadId: threadId,
+      runKey: runKey,
+    );
+    return plan.joinId;
+  }
+}

--- a/lib/features/agents/wake/wake_orchestrator.dart
+++ b/lib/features/agents/wake/wake_orchestrator.dart
@@ -61,6 +61,14 @@ typedef TaskContentChecker = Future<bool> Function(String taskId);
 /// state mutation that must propagate to other devices.
 typedef SyncEntityWriter = Future<void> Function(AgentDomainEntity entity);
 
+/// Optional hook run **once per wake, just before the executor**. Used by fork
+/// healing (ADR 0018 rule 8): collapse a surviving multi-head `messagePrev` fork
+/// into one continuation node before the wake acts, so context and the
+/// on-device prefix stay bounded. Best-effort — a failure is logged and the wake
+/// proceeds (healing is an optimization, never a correctness mechanism).
+typedef WakeStartHook =
+    Future<void> Function(String agentId, String runKey, String threadId);
+
 /// Signature for the callback that executes a wake cycle.
 ///
 /// [agentId] is the target agent's ID.
@@ -101,6 +109,7 @@ class WakeOrchestrator {
     this.onPersistedStateChanged,
     this.taskContentChecker,
     this.syncEntityWriter,
+    this.onWakeStart,
   }) {
     _throttle = WakeThrottleCoordinator(
       repository: repository,
@@ -132,6 +141,11 @@ class WakeOrchestrator {
   /// propagate across devices (e.g. clearing the `awaitingContent` flag).
   /// When null, falls back to the raw [repository] write.
   SyncEntityWriter? syncEntityWriter;
+
+  /// Optional pre-wake hook (fork healing, ADR 0018 rule 8) run just before the
+  /// executor for each wake. When null (the default), wakes run exactly as
+  /// before — this is the off state of the join-healing flag.
+  WakeStartHook? onWakeStart;
 
   /// Optional callback fired when persisted throttle state changes for an
   /// agent (set/clear `nextWakeAt`).
@@ -169,6 +183,13 @@ class WakeOrchestrator {
   /// result is ignored and its mutations are treated like any other DB
   /// write — i.e. they may surface as new notifications.
   static const wakeRunMaxDuration = Duration(minutes: 2);
+
+  /// Hard cap for the pre-wake [onWakeStart] hook (fork healing). The hook runs
+  /// before the executor's [wakeRunMaxDuration] race is armed, so it gets its
+  /// own bound — a pathological full-log load must not stall the wake. A timeout
+  /// is treated like any other hook failure: logged, then the wake proceeds
+  /// (healing is an optimization, never required).
+  static const wakeStartHookTimeout = Duration(seconds: 30);
 
   // Follow-up drains are handled by [WakeThrottleCoordinator]'s deferred
   // drain timer. After a subscription wake completes, a new drain is scheduled
@@ -1022,6 +1043,27 @@ class WakeOrchestrator {
           errorMessage: 'No wake executor registered',
         );
         return;
+      }
+
+      // Pre-wake fork healing (ADR 0018 rule 8): collapse a surviving multi-head
+      // fork into one continuation node before the wake acts. Best-effort and
+      // non-fatal — healing is an optimization, so a failure here must never
+      // abort the wake; log and continue.
+      final wakeStart = onWakeStart;
+      if (wakeStart != null) {
+        try {
+          await wakeStart(
+            job.agentId,
+            job.runKey,
+            threadId,
+          ).timeout(wakeStartHookTimeout);
+        } catch (e, s) {
+          _logError(
+            'pre-wake hook failed for ${DomainLogger.sanitizeId(job.agentId)}',
+            error: e,
+            stackTrace: s,
+          );
+        }
       }
 
       final startTime = clock.now();

--- a/test/features/agents/projection/join_plan_test.dart
+++ b/test/features/agents/projection/join_plan_test.dart
@@ -1,0 +1,136 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glados/glados.dart' as glados;
+import 'package:lotti/features/agents/projection/content_digest.dart';
+import 'package:lotti/features/agents/projection/join_plan.dart';
+
+import 'capture_test_fixtures.dart';
+
+extension _AnyJoin on glados.Any {
+  /// 0..6 head ids drawn from a small pool, so duplicates and reorderings of
+  /// the *same* logical head set arise naturally — exercising the sort+dedup
+  /// the join id relies on.
+  glados.Generator<List<String>> get headIds =>
+      glados.ListAnys(this).listWithLengthInRange(
+        0,
+        6,
+        glados.AnyUtils(this).choose(<String>['h1', 'h2', 'h3', 'h4', 'h5']),
+      );
+}
+
+Set<String> _unique(List<String> ids) => ids.toSet();
+
+void main() {
+  group('computeJoinId', () {
+    // ── generative properties ────────────────────────────────────────────────
+
+    glados.Glados2(
+      glados.any.headIds,
+      glados.any.shuffleSeed,
+      glados.ExploreConfig(numRuns: 300),
+    ).test('depends only on the head set, not order or duplicates', (
+      heads,
+      seed,
+    ) {
+      final reordered = shuffledBySeed(heads, seed);
+      expect(computeJoinId(heads), computeJoinId(reordered));
+      // Duplicating every head changes neither the set nor the id.
+      expect(computeJoinId(heads), computeJoinId([...heads, ...heads]));
+    }, tags: 'glados');
+
+    glados.Glados(
+      glados.any.headIds,
+      glados.ExploreConfig(numRuns: 300),
+    ).test('is domain-tagged and versioned (cannot collide with a frontier '
+        'digest over the same ids)', (heads) {
+      final sorted = _unique(heads).toList()..sort();
+      // The `join-v1` tag is inside the hashed content, so the join id differs
+      // from both an untagged digest and a differently-tagged one over the
+      // identical id set — it can never be confused with a frontierDigest.
+      expect(
+        computeJoinId(heads),
+        isNot(ContentDigest.of({'parents': sorted})),
+      );
+      expect(
+        computeJoinId(heads),
+        isNot(ContentDigest.of({'_tag': 'frontier-v1', 'parents': sorted})),
+      );
+      expect(computeJoinId(heads), startsWith('${ContentDigest.version}:'));
+    }, tags: 'glados');
+  });
+
+  group('planJoin', () {
+    // ── generative properties ────────────────────────────────────────────────
+
+    glados.Glados(
+      glados.any.headIds,
+      glados.ExploreConfig(numRuns: 400),
+    ).test('emits iff there are ≥2 heads and the view is complete', (heads) {
+      final plan = planJoin(headIds: heads, viewComplete: true);
+      if (_unique(heads).length >= 2) {
+        expect(plan, isNotNull);
+        // Heals exactly the (sorted, de-duplicated) head set, and its id is the
+        // content digest over precisely those parents.
+        expect(plan!.parentIds, _unique(heads).toList()..sort());
+        expect(plan.joinId, computeJoinId(heads));
+        expect(computeJoinId(plan.parentIds), plan.joinId);
+      } else {
+        expect(plan, isNull);
+      }
+    }, tags: 'glados');
+
+    glados.Glados(
+      glados.any.headIds,
+      glados.ExploreConfig(numRuns: 400),
+    ).test('never emits while the local view is incomplete', (heads) {
+      // Even with ≥2 heads, a dangling-parent (unsettled) view defers — healing
+      // on it could mint a join over a non-tip.
+      expect(planJoin(headIds: heads, viewComplete: false), isNull);
+    }, tags: 'glados');
+
+    glados.Glados2(
+      glados.any.headIds,
+      glados.any.shuffleSeed,
+      glados.ExploreConfig(numRuns: 300),
+    ).test('the plan depends only on the head set, not arrival order', (
+      heads,
+      seed,
+    ) {
+      expect(
+        planJoin(headIds: heads, viewComplete: true),
+        planJoin(headIds: shuffledBySeed(heads, seed), viewComplete: true),
+      );
+    }, tags: 'glados');
+
+    // ── examples ─────────────────────────────────────────────────────────────
+
+    test('heals a two-head fork observed at wake start', () {
+      final plan = planJoin(headIds: ['h2', 'h1'], viewComplete: true);
+      expect(plan, isNotNull);
+      expect(plan!.parentIds, ['h1', 'h2']); // sorted
+      expect(plan.joinId, computeJoinId(['h1', 'h2']));
+    });
+
+    test('defers while a parent edge has not synced yet (incomplete view)', () {
+      expect(planJoin(headIds: ['h1', 'h2'], viewComplete: false), isNull);
+    });
+
+    test('does not heal a single head', () {
+      expect(planJoin(headIds: ['h1'], viewComplete: true), isNull);
+    });
+
+    test('does not heal an empty head set', () {
+      expect(planJoin(headIds: const [], viewComplete: true), isNull);
+    });
+
+    test('duplicate ids collapse to one head and do not heal', () {
+      expect(planJoin(headIds: ['h1', 'h1'], viewComplete: true), isNull);
+    });
+
+    test('JoinPlan value equality follows its fields', () {
+      JoinPlan make(List<String> heads) =>
+          planJoin(headIds: heads, viewComplete: true)!;
+      expect(make(['h1', 'h2']), make(['h2', 'h1'])); // order-independent
+      expect(make(['h1', 'h2']), isNot(make(['h1', 'h3'])));
+    });
+  });
+}

--- a/test/features/agents/state/agent_providers_test.dart
+++ b/test/features/agents/state/agent_providers_test.dart
@@ -13,6 +13,7 @@ import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/agent_link.dart' as model;
+import 'package:lotti/features/agents/projection/join_plan.dart';
 import 'package:lotti/features/agents/service/agent_service.dart';
 import 'package:lotti/features/agents/service/agent_template_service.dart';
 import 'package:lotti/features/agents/service/feedback_extraction_service.dart';
@@ -54,6 +55,7 @@ import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
 import '../../../widget_test_utils.dart';
 import '../../projects/test_utils.dart';
+import '../sync/fork_test_support.dart';
 import '../test_utils.dart';
 import '../workflow/task_agent_workflow_test_helpers.dart';
 import 'agent_providers_test_helpers.dart';
@@ -4351,6 +4353,34 @@ void main() {
       );
 
       expect(result, isEmpty);
+    });
+  });
+
+  group('forkHealingHook', () {
+    test('returns a hook that heals a fork when run', () async {
+      final bench = makeForkBench();
+      await seedForkInto(bench.repo, head: 'b'); // a 2-head fork {a, b}
+
+      final hook = forkHealingHook(bench.service, () => DateTime(2024, 2));
+      await hook('agent-1', 'run-key', 'thread-1');
+
+      // The fork collapsed to a single head: the content-addressed join.
+      expect(headsOfLog(bench.repo.messages, bench.repo.links), [
+        computeJoinId(['a', 'b']),
+      ]);
+    });
+
+    test('stamps the join with the supplied wake timestamp', () async {
+      final bench = makeForkBench();
+      await seedForkInto(bench.repo, head: 'b');
+
+      final hook = forkHealingHook(bench.service, () => DateTime(2024, 7, 4));
+      await hook('agent-1', 'rk', 'thread-1');
+
+      final join = bench.repo.messages.firstWhere(
+        (m) => m.id == computeJoinId(['a', 'b']),
+      );
+      expect(join.createdAt, DateTime(2024, 7, 4));
     });
   });
 }

--- a/test/features/agents/sync/agent_sync_service_test.dart
+++ b/test/features/agents/sync/agent_sync_service_test.dart
@@ -4,6 +4,7 @@ import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/agent_link.dart';
+import 'package:lotti/features/agents/projection/join_plan.dart';
 import 'package:lotti/features/agents/sync/agent_sync_service.dart';
 import 'package:lotti/features/sync/model/sync_message.dart';
 import 'package:lotti/features/sync/sequence/sync_sequence_log_service.dart';
@@ -16,6 +17,7 @@ import 'package:mocktail/mocktail.dart';
 import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
 import '../test_data/entity_factories.dart';
+import 'fork_test_support.dart';
 
 enum _GeneratedSyncWriteKind {
   entity,
@@ -2004,6 +2006,263 @@ void main() {
             ),
           ),
         ).called(1);
+      },
+    );
+  });
+
+  group('AgentSyncService.appendJoin', () {
+    // ── write behaviour (mock repository) ────────────────────────────────────
+
+    test(
+      'writes the join node, an edge per parent, and advances the head',
+      () async {
+        when(() => mockRepository.getAgentState('agent-1')).thenAnswer(
+          (_) async => makeTestState(
+            agentId: 'agent-1',
+          ).copyWith(recentHeadMessageId: 'a'),
+        );
+        final joinId = computeJoinId(['a', 'b']);
+
+        await syncService.appendJoin(
+          agentId: 'agent-1',
+          joinId: joinId,
+          parentIds: ['b', 'a'], // unsorted on purpose
+          at: DateTime(2024, 3, 15),
+        );
+
+        final upserted = verify(
+          () => mockRepository.upsertEntity(captureAny()),
+        ).captured.cast<AgentDomainEntity>();
+        final joinMsg = upserted.whereType<AgentMessageEntity>().single;
+        expect(joinMsg.id, joinId);
+        expect(joinMsg.kind, AgentMessageKind.system);
+        expect(
+          upserted.whereType<AgentStateEntity>().single.recentHeadMessageId,
+          joinId,
+        );
+        final edges = verify(
+          () => mockRepository.upsertLink(captureAny()),
+        ).captured.cast<AgentLink>().whereType<MessagePrevLink>().toList();
+        expect(edges.map((l) => l.id).toSet(), {
+          'msgprev-$joinId-a',
+          'msgprev-$joinId-b',
+        });
+        expect(edges.every((l) => l.fromId == joinId), isTrue);
+        expect(edges.map((l) => l.toId).toSet(), {'a', 'b'});
+      },
+    );
+
+    test(
+      'does not rewrite the join node when it already exists (idempotent)',
+      () async {
+        final joinId = computeJoinId(['a', 'b']);
+        when(() => mockRepository.getEntity(joinId)).thenAnswer(
+          (_) async => makeTestMessage(
+            id: joinId,
+            agentId: 'agent-1',
+            kind: AgentMessageKind.system,
+          ),
+        );
+        when(() => mockRepository.getAgentState('agent-1')).thenAnswer(
+          (_) async => makeTestState(
+            agentId: 'agent-1',
+          ).copyWith(recentHeadMessageId: joinId),
+        );
+
+        await syncService.appendJoin(
+          agentId: 'agent-1',
+          joinId: joinId,
+          parentIds: ['a', 'b'],
+          at: DateTime(2024, 3, 15),
+        );
+
+        // Node present + head already at the join ⇒ no entity write at all, but
+        // the edges are re-asserted (idempotent by id).
+        verifyNever(() => mockRepository.upsertEntity(any()));
+        verify(() => mockRepository.upsertLink(any())).called(2);
+      },
+    );
+
+    test(
+      'advances a stale head even when the join node already exists',
+      () async {
+        // The peer's identical join synced in (node present) but this device's
+        // head pointer still sits on a now-joined parent — left there, the next
+        // local append would immediately re-fork, so the head must advance.
+        final joinId = computeJoinId(['a', 'b']);
+        when(() => mockRepository.getEntity(joinId)).thenAnswer(
+          (_) async => makeTestMessage(
+            id: joinId,
+            agentId: 'agent-1',
+            kind: AgentMessageKind.system,
+          ),
+        );
+        when(() => mockRepository.getAgentState('agent-1')).thenAnswer(
+          (_) async => makeTestState(
+            agentId: 'agent-1',
+          ).copyWith(recentHeadMessageId: 'a'),
+        );
+
+        await syncService.appendJoin(
+          agentId: 'agent-1',
+          joinId: joinId,
+          parentIds: ['a', 'b'],
+          at: DateTime(2024, 3, 15),
+        );
+
+        final upserted = verify(
+          () => mockRepository.upsertEntity(captureAny()),
+        ).captured.cast<AgentDomainEntity>();
+        expect(upserted.whereType<AgentMessageEntity>(), isEmpty); // node kept
+        expect(
+          upserted.whereType<AgentStateEntity>().single.recentHeadMessageId,
+          joinId,
+        );
+      },
+    );
+
+    test(
+      'with no state row, writes node and edges but advances no head',
+      () async {
+        final joinId = computeJoinId(['a', 'b']);
+        // Default getAgentState ⇒ null.
+        await syncService.appendJoin(
+          agentId: 'agent-1',
+          joinId: joinId,
+          parentIds: ['a', 'b'],
+          at: DateTime(2024, 3, 15),
+        );
+
+        final upserted = verify(
+          () => mockRepository.upsertEntity(captureAny()),
+        ).captured.cast<AgentDomainEntity>();
+        expect(upserted.whereType<AgentMessageEntity>().single.id, joinId);
+        expect(upserted.whereType<AgentStateEntity>(), isEmpty);
+        verify(() => mockRepository.upsertLink(any())).called(2);
+      },
+    );
+
+    test(
+      'ignores a degenerate call with fewer than two distinct parents',
+      () async {
+        await syncService.appendJoin(
+          agentId: 'agent-1',
+          joinId: 'x',
+          parentIds: ['a', 'a'], // collapses to one head
+          at: DateTime(2024, 3, 15),
+        );
+        verifyNever(() => mockRepository.upsertEntity(any()));
+        verifyNever(() => mockRepository.upsertLink(any()));
+      },
+    );
+
+    // ── DAG convergence (real projection over an in-memory log) ───────────────
+    // Bench, fork seeding, and head computation come from `fork_test_support`.
+
+    test('heals a two-head fork to a single head (real projection)', () async {
+      final b = makeForkBench();
+      await seedForkInto(b.repo, head: 'b');
+      expect(headsOfLog(b.repo.messages, b.repo.links).toSet(), {'a', 'b'});
+
+      final joinId = computeJoinId(['a', 'b']);
+      await b.service.appendJoin(
+        agentId: 'agent-1',
+        joinId: joinId,
+        parentIds: ['a', 'b'],
+        at: DateTime(2024, 2),
+      );
+
+      // The fork collapses: a, b are now the join's parents ⇒ the join is the
+      // sole head, and this device's head pointer follows.
+      expect(headsOfLog(b.repo.messages, b.repo.links), [joinId]);
+      final state = await b.repo.getAgentState('agent-1');
+      expect(state!.recentHeadMessageId, joinId);
+    });
+
+    test(
+      'two devices emitting the same join converge to one node + head',
+      () async {
+        final a = makeForkBench();
+        final c = makeForkBench();
+        await seedForkInto(a.repo, head: 'a'); // device A extended branch a
+        await seedForkInto(c.repo, head: 'b'); // device C extended branch b
+        final joinId = computeJoinId(['a', 'b']);
+        for (final dev in [a, c]) {
+          await dev.service.appendJoin(
+            agentId: 'agent-1',
+            joinId: joinId,
+            parentIds: ['a', 'b'],
+            at: DateTime(2024, 2),
+          );
+        }
+
+        // Set-union the two devices' logs, deduping by id — models the DB
+        // (insertOnConflictUpdate). AgentEvent equality includes the per-device
+        // envelope, so an *un-deduped* union would trip DuplicateEventIdException;
+        // the dedupe is exactly what makes the content-addressed join converge.
+        final messages = <String, AgentMessageEntity>{
+          for (final m in [...a.repo.messages, ...c.repo.messages]) m.id: m,
+        };
+        final links = <String, AgentLink>{
+          for (final l in [...a.repo.links, ...c.repo.links]) l.id: l,
+        };
+
+        expect(messages[joinId], isNotNull); // exactly one join node (by id)
+        expect(
+          links.values
+              .whereType<MessagePrevLink>()
+              .where((l) => l.fromId == joinId)
+              .length,
+          2, // exactly two join edges — no storm
+        );
+        expect(headsOfLog(messages.values, links.values), [joinId]);
+      },
+    );
+
+    test(
+      'completes the edge set + head on a retry after a partial commit',
+      () async {
+        // appendJoin commits node + edges + head atomically, so a true partial
+        // commit can't occur — but a re-run must still be self-completing. Seed a
+        // fork plus *only* the join node (no edges, head still on a parent), then
+        // run appendJoin: the edges and the head advance are (re-)asserted.
+        final b = makeForkBench();
+        await seedForkInto(b.repo, head: 'a');
+        final joinId = computeJoinId(['a', 'b']);
+        b.repo.seed([
+          makeTestMessage(
+            id: joinId,
+            agentId: 'agent-1',
+            kind: AgentMessageKind.system,
+          ),
+        ]);
+        // The parentless join node is itself a third head until its edges land.
+        expect(headsOfLog(b.repo.messages, b.repo.links).toSet(), {
+          'a',
+          'b',
+          joinId,
+        });
+
+        await b.service.appendJoin(
+          agentId: 'agent-1',
+          joinId: joinId,
+          parentIds: ['a', 'b'],
+          at: DateTime(2024, 2),
+        );
+
+        expect(
+          b.repo.links
+              .whereType<MessagePrevLink>()
+              .where((l) => l.fromId == joinId)
+              .map((l) => l.toId)
+              .toSet(),
+          {'a', 'b'},
+        );
+        expect(
+          (await b.repo.getAgentState('agent-1'))!.recentHeadMessageId,
+          joinId,
+        );
+        expect(headsOfLog(b.repo.messages, b.repo.links), [joinId]);
       },
     );
   });

--- a/test/features/agents/sync/agent_sync_service_test.dart
+++ b/test/features/agents/sync/agent_sync_service_test.dart
@@ -2122,6 +2122,37 @@ void main() {
     );
 
     test(
+      'does not regress the head when it has moved past the joined parents',
+      () async {
+        // Models a timed-out heal whose appendJoin completes *after* the
+        // executor already advanced the head past the fork: collapsing back to
+        // the join would orphan that progress, so the head is left alone.
+        final joinId = computeJoinId(['a', 'b']);
+        when(() => mockRepository.getAgentState('agent-1')).thenAnswer(
+          (_) async => makeTestState(
+            agentId: 'agent-1',
+          ).copyWith(recentHeadMessageId: 'w-latest'), // moved past a/b
+        );
+
+        await syncService.appendJoin(
+          agentId: 'agent-1',
+          joinId: joinId,
+          parentIds: ['a', 'b'],
+          at: DateTime(2024, 3, 15),
+        );
+
+        final upserted = verify(
+          () => mockRepository.upsertEntity(captureAny()),
+        ).captured.cast<AgentDomainEntity>();
+        // The join node + edges are still recorded (the residual fork heals on
+        // the next wake), but the head is NOT regressed onto the join.
+        expect(upserted.whereType<AgentMessageEntity>().single.id, joinId);
+        expect(upserted.whereType<AgentStateEntity>(), isEmpty);
+        verify(() => mockRepository.upsertLink(any())).called(2);
+      },
+    );
+
+    test(
       'with no state row, writes node and edges but advances no head',
       () async {
         final joinId = computeJoinId(['a', 'b']);

--- a/test/features/agents/sync/fork_healer_test.dart
+++ b/test/features/agents/sync/fork_healer_test.dart
@@ -1,0 +1,234 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/agents/model/agent_link.dart';
+import 'package:lotti/features/agents/projection/join_plan.dart';
+import 'package:lotti/features/agents/sync/fork_healer.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/domain_logging.dart';
+
+import '../../../helpers/fallbacks.dart';
+import '../../../mocks/mocks.dart';
+import '../test_data/entity_factories.dart';
+import 'fork_test_support.dart';
+import 'in_memory_agent_repository.dart';
+
+const _agentId = 'agent-1';
+
+void main() {
+  setUpAll(registerAllFallbackValues);
+
+  late InMemoryAgentRepository repo;
+  late ForkHealer healer;
+
+  setUp(() {
+    if (!getIt.isRegistered<DomainLogger>()) {
+      getIt.registerSingleton<DomainLogger>(MockDomainLogger());
+    }
+    final bench = makeForkBench();
+    repo = bench.repo;
+    healer = bench.healer;
+  });
+
+  List<String> headsOf() => headsOfLog(repo.messages, repo.links);
+
+  void seedAgent({String? head}) {
+    repo.seed([
+      makeTestState(agentId: _agentId).copyWith(recentHeadMessageId: head),
+    ]);
+  }
+
+  void seedMessage(String id, {DateTime? at}) {
+    repo.seed([
+      makeTestMessage(
+        id: id,
+        agentId: _agentId,
+        createdAt: at ?? DateTime(2024),
+      ),
+    ]);
+  }
+
+  Future<void> edge(String child, String parent) => repo.upsertLink(
+    AgentLink.messagePrev(
+      id: 'mp-$child-$parent',
+      fromId: child,
+      toId: parent,
+      createdAt: DateTime(2024, 1, 2),
+      updatedAt: DateTime(2024, 1, 2),
+      vectorClock: null,
+    ),
+  );
+
+  Future<String?> heal() => healer.maybeHealFork(
+    agentId: _agentId,
+    at: DateTime(2024, 2),
+    runKey: 'rk',
+  );
+
+  test('heals a surviving fork into a single head', () async {
+    await seedForkInto(repo, head: 'b');
+    expect(headsOf().toSet(), {'a', 'b'}); // precondition
+
+    final joinId = await heal();
+    expect(joinId, computeJoinId(['a', 'b']));
+    expect(headsOf(), [joinId]);
+    final state = await repo.getAgentState(_agentId);
+    expect(state!.recentHeadMessageId, joinId);
+  });
+
+  test('no-op on a single-head (linear) log', () async {
+    seedAgent(head: 'b');
+    seedMessage('p');
+    seedMessage('a', at: DateTime(2024, 1, 2));
+    seedMessage('b', at: DateTime(2024, 1, 3));
+    await edge('a', 'p');
+    await edge('b', 'a'); // p ← a ← b : a single head
+    expect(headsOf(), ['b']);
+
+    expect(await heal(), isNull);
+    expect(repo.messages.length, 3); // no join appended
+  });
+
+  test('no-op with fewer than two messages', () async {
+    seedAgent();
+    seedMessage('only');
+    expect(await heal(), isNull);
+    expect(repo.messages.length, 1);
+  });
+
+  test('defers when the view is incomplete (a dangling parent)', () async {
+    // a and b both point at a parent p that has not synced yet ⇒ dangling.
+    seedAgent(head: 'b');
+    seedMessage('a');
+    seedMessage('b');
+    await edge('a', 'p'); // p absent locally
+    await edge('b', 'p');
+    expect(await heal(), isNull); // viewComplete == false ⇒ defer
+    expect(repo.messages.length, 2);
+  });
+
+  test('is idempotent — a second heal neither re-forks nor re-emits', () async {
+    await seedForkInto(repo, head: 'b');
+    final joinId = await heal();
+    expect(headsOf(), [joinId]);
+
+    // The fork is gone (single head), so a re-run does nothing — and crucially
+    // never appends a second node off a now-joined parent (no re-fork).
+    expect(await heal(), isNull);
+    expect(repo.messages.where((m) => m.id == joinId).length, 1);
+    expect(headsOf(), [joinId]);
+  });
+
+  test(
+    'is non-fatal on a corrupt log (a cycle) — skips without throwing',
+    () async {
+      seedAgent(head: 'b');
+      seedMessage('a');
+      seedMessage('b');
+      await edge('a', 'b');
+      await edge('b', 'a'); // a ⇄ b cycle ⇒ canonicalOrder throws
+      expect(await heal(), isNull); // caught and skipped
+      expect(repo.messages.length, 2); // nothing appended
+    },
+  );
+
+  // ── multi-device convergence (ADR 0018 rule 8) ─────────────────────────────
+  group('multi-device convergence', () {
+    test(
+      'two devices heal the same fork to one node; the union has one head',
+      () async {
+        // Different hosts ⇒ each stamps its own envelope on the same join.
+        final a = makeForkBench(host: 'hostA');
+        final c = makeForkBench(host: 'hostC');
+        await seedForkInto(a.repo, head: 'a');
+        await seedForkInto(c.repo, head: 'b');
+
+        final jA = await a.healer.maybeHealFork(
+          agentId: _agentId,
+          at: DateTime(2024, 2),
+        );
+        final jC = await c.healer.maybeHealFork(
+          agentId: _agentId,
+          at: DateTime(2024, 2),
+        );
+        expect(jA, isNotNull);
+        expect(jA, jC); // same head set ⇒ same content-addressed join id
+
+        // Each device stamped its own envelope (hostA vs hostC), but the synced
+        // union holds exactly one join node (p, a, b, join = 4) and one head.
+        final unionMessageIds = {
+          for (final m in [...a.repo.messages, ...c.repo.messages]) m.id,
+        };
+        expect(unionMessageIds, {'p', 'a', 'b', jA});
+        expect(projectDeviceUnion([a.repo, c.repo]).headIds, [jA]);
+      },
+    );
+
+    test('the converged projection is independent of merge order', () async {
+      final a = makeForkBench(host: 'hostA');
+      final c = makeForkBench(host: 'hostC');
+      await seedForkInto(a.repo, head: 'a');
+      await seedForkInto(c.repo, head: 'b');
+      await a.healer.maybeHealFork(agentId: _agentId, at: DateTime(2024, 2));
+      await c.healer.maybeHealFork(agentId: _agentId, at: DateTime(2024, 2));
+
+      // The whole derived projection — heads, dangling parents, latest report —
+      // is identical regardless of which device's log is folded first.
+      expect(
+        projectDeviceUnion([a.repo, c.repo]),
+        projectDeviceUnion([c.repo, a.repo]),
+      );
+    });
+
+    test(
+      'repeated concurrent forks stay bounded — every heal returns to one head',
+      () async {
+        final d = makeForkBench(host: 'hostA');
+        d.repo.seed([
+          makeTestState(agentId: _agentId).copyWith(recentHeadMessageId: 'g'),
+          makeTestMessage(
+            id: 'g',
+            agentId: _agentId,
+            createdAt: DateTime(2024),
+          ),
+        ]);
+
+        var head = 'g';
+        for (var round = 1; round <= 3; round++) {
+          // Two devices append concurrently off the shared head ⇒ a 2-head fork.
+          d.repo.seed([
+            for (final tip in ['a$round', 'b$round'])
+              makeTestMessage(
+                id: tip,
+                agentId: _agentId,
+                createdAt: DateTime(2024, 1, round + 1),
+              ),
+          ]);
+          for (final tip in ['a$round', 'b$round']) {
+            await d.repo.upsertLink(
+              AgentLink.messagePrev(
+                id: 'mp-$tip-$head',
+                fromId: tip,
+                toId: head,
+                createdAt: DateTime(2024, 1, round + 1),
+                updatedAt: DateTime(2024, 1, round + 1),
+                vectorClock: null,
+              ),
+            );
+          }
+          expect(headsOfLog(d.repo.messages, d.repo.links).length, 2);
+
+          final j = await d.healer.maybeHealFork(
+            agentId: _agentId,
+            at: DateTime(2024, 2, round),
+          );
+          expect(j, isNotNull);
+          // collapses back to one head each round.
+          expect(headsOfLog(d.repo.messages, d.repo.links), [j]);
+          head = j!;
+        }
+
+        // No storm: genesis + 2 tips/round + 1 join/round over 3 rounds = 10.
+        expect(d.repo.messages.length, 1 + 3 * (2 + 1));
+      },
+    );
+  });
+}

--- a/test/features/agents/sync/fork_test_support.dart
+++ b/test/features/agents/sync/fork_test_support.dart
@@ -1,0 +1,96 @@
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_link.dart';
+import 'package:lotti/features/agents/projection/agent_event_adapter.dart';
+import 'package:lotti/features/agents/projection/agent_projection.dart';
+import 'package:lotti/features/agents/projection/canonical_order.dart';
+import 'package:lotti/features/agents/sync/agent_sync_service.dart';
+import 'package:lotti/features/agents/sync/fork_healer.dart';
+import 'package:lotti/features/sync/vector_clock.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../mocks/mocks.dart';
+import '../test_data/entity_factories.dart';
+import 'in_memory_agent_repository.dart';
+
+/// A real [AgentSyncService] + [ForkHealer] over an [InMemoryAgentRepository],
+/// with a per-host counting vector clock and a no-op outbox. The faithful
+/// bench for fork-healing tests: the services read and write exactly as they
+/// would against the database, so what they emit reads back through the
+/// projection. Two benches with different hosts model two devices stamping
+/// distinct envelopes on the same content-addressed node.
+typedef ForkBench = ({
+  AgentSyncService service,
+  ForkHealer healer,
+  InMemoryAgentRepository repo,
+});
+
+ForkBench makeForkBench({String host = 'h1'}) {
+  final repo = InMemoryAgentRepository();
+  final vc = MockVectorClockService();
+  var counter = 0;
+  when(
+    () => vc.getNextVectorClock(previous: any(named: 'previous')),
+  ).thenAnswer((_) async => VectorClock({host: ++counter}));
+  final outbox = MockOutboxService();
+  when(() => outbox.enqueueMessage(any())).thenAnswer((_) async {});
+  final service = AgentSyncService(
+    repository: repo,
+    outboxService: outbox,
+    vectorClockService: vc,
+  );
+  return (
+    service: service,
+    healer: ForkHealer(syncService: service),
+    repo: repo,
+  );
+}
+
+/// The DAG heads of an arbitrary message + link log.
+List<String> headsOfLog(
+  Iterable<AgentMessageEntity> messages,
+  Iterable<AgentLink> links,
+) => project(canonicalOrder(agentEventsFromLog(messages, links))).headIds;
+
+/// The full projection of the union of [devices]' logs, deduped by id — models
+/// the synced DB (`insertOnConflictUpdate`), so two devices' concurrent
+/// content-addressed emissions collapse to one event per id before the fold.
+AgentProjection projectDeviceUnion(Iterable<InMemoryAgentRepository> devices) {
+  final messages = <String, AgentMessageEntity>{
+    for (final d in devices)
+      for (final m in d.messages) m.id: m,
+  };
+  final links = <String, AgentLink>{
+    for (final d in devices)
+      for (final l in d.links) l.id: l,
+  };
+  return project(
+    canonicalOrder(agentEventsFromLog(messages.values, links.values)),
+  );
+}
+
+/// Seeds a two-head fork `p ← a`, `p ← b` (heads `{a, b}`) into [repo], with the
+/// agent's head pointer at [head].
+Future<void> seedForkInto(
+  InMemoryAgentRepository repo, {
+  required String head,
+  String agentId = 'agent-1',
+}) async {
+  repo.seed([
+    makeTestState(agentId: agentId).copyWith(recentHeadMessageId: head),
+    makeTestMessage(id: 'p', agentId: agentId, createdAt: DateTime(2024)),
+    makeTestMessage(id: 'a', agentId: agentId, createdAt: DateTime(2024, 1, 2)),
+    makeTestMessage(id: 'b', agentId: agentId, createdAt: DateTime(2024, 1, 2)),
+  ]);
+  for (final (child, parent) in [('a', 'p'), ('b', 'p')]) {
+    await repo.upsertLink(
+      AgentLink.messagePrev(
+        id: 'mp-$child-$parent',
+        fromId: child,
+        toId: parent,
+        createdAt: DateTime(2024, 1, 2),
+        updatedAt: DateTime(2024, 1, 2),
+        vectorClock: null,
+      ),
+    );
+  }
+}

--- a/test/features/agents/sync/in_memory_agent_repository.dart
+++ b/test/features/agents/sync/in_memory_agent_repository.dart
@@ -59,7 +59,10 @@ class InMemoryAgentRepository extends MockAgentRepository {
 
   @override
   Future<List<AgentMessageEntity>> getAgentMessages(String agentId) async =>
-      messages.where((m) => m.agentId == agentId).toList();
+      // Mirror the real query: soft-deleted messages are excluded.
+      messages
+          .where((m) => m.agentId == agentId && m.deletedAt == null)
+          .toList();
 
   @override
   Future<List<AgentMessageEntity>> getMessagesByKind(
@@ -92,4 +95,21 @@ class InMemoryAgentRepository extends MockAgentRepository {
                 (type == null || AgentDbConversions.linkType(l) == type),
           )
           .toList();
+
+  @override
+  Future<Map<String, List<AgentLink>>> getLinksFromMultiple(
+    List<String> fromIds, {
+    required String type,
+  }) async {
+    final ids = fromIds.toSet();
+    final result = <String, List<AgentLink>>{};
+    for (final link in _links.values) {
+      if (ids.contains(link.fromId) &&
+          link.deletedAt == null &&
+          AgentDbConversions.linkType(link) == type) {
+        (result[link.fromId] ??= []).add(link);
+      }
+    }
+    return result;
+  }
 }

--- a/test/features/agents/wake/wake_orchestrator_test.dart
+++ b/test/features/agents/wake/wake_orchestrator_test.dart
@@ -2412,6 +2412,98 @@ void main() {
       });
     });
 
+    group('pre-wake hook (fork healing)', () {
+      test('runs onWakeStart before the executor, with the wake context', () {
+        fakeAsync((async) {
+          final order = <String>[];
+          orchestrator = WakeOrchestrator(
+            repository: mockRepository,
+            queue: queue,
+            runner: runner,
+            onWakeStart: (agentId, runKey, threadId) async {
+              order.add('hook:$agentId:$runKey:$threadId');
+            },
+            wakeExecutor: (agentId, runKey, triggers, threadId) async {
+              order.add('executor');
+              return null;
+            },
+          );
+
+          queue.enqueue(makeJob());
+          orchestrator.processNext();
+          async.flushMicrotasks();
+
+          // The hook ran first, with agentId + runKey + threadId (= runKey).
+          expect(order, ['hook:agent-1:rk-1:rk-1', 'executor']);
+        });
+      });
+
+      test('a throwing onWakeStart is non-fatal — the wake still executes and '
+          'completes', () {
+        fakeAsync((async) {
+          var executed = false;
+          orchestrator = WakeOrchestrator(
+            repository: mockRepository,
+            queue: queue,
+            runner: runner,
+            onWakeStart: (agentId, runKey, threadId) async {
+              throw StateError('fork-heal boom');
+            },
+            wakeExecutor: (agentId, runKey, triggers, threadId) async {
+              executed = true;
+              return null;
+            },
+          );
+
+          queue.enqueue(makeJob());
+          orchestrator.processNext();
+          async.flushMicrotasks();
+
+          // Healing is an optimization — its failure must not abort the wake.
+          expect(executed, isTrue);
+          verify(
+            () => mockRepository.updateWakeRunStatus(
+              'rk-1',
+              WakeRunStatus.completed.name,
+              completedAt: any(named: 'completedAt'),
+              errorMessage: any(named: 'errorMessage'),
+            ),
+          ).called(1);
+        });
+      });
+
+      test(
+        'a hanging onWakeStart is bounded by its timeout — wake proceeds',
+        () {
+          fakeAsync((async) {
+            var executed = false;
+            orchestrator = WakeOrchestrator(
+              repository: mockRepository,
+              queue: queue,
+              runner: runner,
+              // Never completes — must be bounded by wakeStartHookTimeout.
+              onWakeStart: (agentId, runKey, threadId) =>
+                  Completer<void>().future,
+              wakeExecutor: (agentId, runKey, triggers, threadId) async {
+                executed = true;
+                return null;
+              },
+            );
+
+            queue.enqueue(makeJob());
+            orchestrator.processNext();
+            async.flushMicrotasks();
+            expect(executed, isFalse); // blocked awaiting the hook
+
+            async
+              ..elapse(WakeOrchestrator.wakeStartHookTimeout)
+              ..flushMicrotasks();
+            expect(executed, isTrue); // timeout fired, the wake ran anyway
+          });
+        },
+      );
+    });
+
     group('enqueueManualWake', () {
       test('enqueues a job and triggers processNext', () {
         fakeAsync((async) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic fork-healing at agent wake start to detect concurrent branches and emit a deterministic join to reconverge logs (runtime-gated, default-off); wake now runs an optional pre-wake hook with bounded timeout.

* **Documentation**
  * Added detailed fork-healing design, implementation plan, scope notes, and diagrams describing behavior, determinism, and deferred reconciliation.

* **Tests**
  * Extensive tests for join planning, append/idempotency, wake-hook behavior, multi-device convergence, robustness, and stress scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->