### PR TITLE
feat: add filter for flagged entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1015]
+### Added
+- The linked entries "Filter & Sort" modal now has a "Show flagged entries
+  only" toggle that narrows the list below a task to flagged entries; the
+  list updates immediately when the toggle or an entry's flag changes.
+
 ## [0.9.1014]
 ### Added
 - New "Agent memory compaction" flag in Settings → Flags (off by default):

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -32,6 +32,11 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="0.9.1015" date="2026-06-04">
+      <description>
+          <p>The linked entries "Filter and Sort" modal now has a "Show flagged entries only" toggle that narrows the list below a task to flagged entries, updating immediately when the toggle or an entry's flag changes.</p>
+      </description>
+    </release>
     <release version="0.9.1014" date="2026-06-04">
       <description>
           <p>New "Agent memory compaction" flag in Settings (off by default): task agents summarize older task-log entries into a rolling memory using their own model, keeping the wake context compact while recent entries stay verbatim.</p>

--- a/lib/features/agents/state/agent_query_providers.g.dart
+++ b/lib/features/agents/state/agent_query_providers.g.dart
@@ -618,7 +618,8 @@ final class AgentRecentMessagesFamily extends $Family
 /// Fetch recent messages grouped by thread ID for an agent.
 ///
 /// Returns a map of threadId → list of [AgentMessageEntity] sorted
-/// chronologically within each thread. Threads are sorted most-recent-first
+/// chronologically within each thread (conversation-order tiebreak for rows
+/// sharing the wake timestamp). Threads are sorted most-recent-first
 /// (by the latest message in each thread).
 
 @ProviderFor(agentMessagesByThread)
@@ -627,7 +628,8 @@ final agentMessagesByThreadProvider = AgentMessagesByThreadFamily._();
 /// Fetch recent messages grouped by thread ID for an agent.
 ///
 /// Returns a map of threadId → list of [AgentMessageEntity] sorted
-/// chronologically within each thread. Threads are sorted most-recent-first
+/// chronologically within each thread (conversation-order tiebreak for rows
+/// sharing the wake timestamp). Threads are sorted most-recent-first
 /// (by the latest message in each thread).
 
 final class AgentMessagesByThreadProvider
@@ -643,7 +645,8 @@ final class AgentMessagesByThreadProvider
   /// Fetch recent messages grouped by thread ID for an agent.
   ///
   /// Returns a map of threadId → list of [AgentMessageEntity] sorted
-  /// chronologically within each thread. Threads are sorted most-recent-first
+  /// chronologically within each thread (conversation-order tiebreak for rows
+  /// sharing the wake timestamp). Threads are sorted most-recent-first
   /// (by the latest message in each thread).
   AgentMessagesByThreadProvider._({
     required AgentMessagesByThreadFamily super.from,
@@ -690,12 +693,13 @@ final class AgentMessagesByThreadProvider
 }
 
 String _$agentMessagesByThreadHash() =>
-    r'61afa9ccae181277496e1c17a9e3af536d49a3ef';
+    r'8c6eaa8385fad36e4a1af79ddf103f067ad651d0';
 
 /// Fetch recent messages grouped by thread ID for an agent.
 ///
 /// Returns a map of threadId → list of [AgentMessageEntity] sorted
-/// chronologically within each thread. Threads are sorted most-recent-first
+/// chronologically within each thread (conversation-order tiebreak for rows
+/// sharing the wake timestamp). Threads are sorted most-recent-first
 /// (by the latest message in each thread).
 
 final class AgentMessagesByThreadFamily extends $Family
@@ -716,7 +720,8 @@ final class AgentMessagesByThreadFamily extends $Family
   /// Fetch recent messages grouped by thread ID for an agent.
   ///
   /// Returns a map of threadId → list of [AgentMessageEntity] sorted
-  /// chronologically within each thread. Threads are sorted most-recent-first
+  /// chronologically within each thread (conversation-order tiebreak for rows
+  /// sharing the wake timestamp). Threads are sorted most-recent-first
   /// (by the latest message in each thread).
 
   AgentMessagesByThreadProvider call(String agentId) =>

--- a/lib/features/journal/README.md
+++ b/lib/features/journal/README.md
@@ -291,7 +291,7 @@ That includes:
 
 - outgoing link lookup via [`LinkedEntriesController`](state/linked_entries_controller.dart)
 - reverse-link lookup via [`LinkedFromEntriesController`](state/linked_from_entries_controller.dart)
-- hidden-link and AI-entry visibility toggles
+- hidden-link, AI-entry, and flagged-only visibility toggles
 - timer-aware highlighting of active linked entries
 - scroll-to-entry focus intents and temporary highlight pulses
 
@@ -311,6 +311,7 @@ The important runtime details are:
 
 - outgoing links are fetched from `JournalRepository.getLinksFromId(...)`
 - hidden links can be included or excluded without changing the rest of the page
+- the Filter & Sort modal can narrow the outgoing list to flagged entries only (`meta.flag == EntryFlag.import`); the check runs per row in `LinkedEntriesWidget` against the watched entry, so flagging or unflagging an entry updates the filtered list reactively
 - outgoing links are ordered by the linked entity's editable `dateFrom`, not by link creation time
 - `LinkedEntriesWithTimer` only reacts to active timer entry ID changes, not every timer tick
 - `HighlightScrollMixin` retries scroll-to-entry until the target widget is actually mounted, then applies a temporary highlight pulse

--- a/lib/features/journal/state/linked_entries_controller.dart
+++ b/lib/features/journal/state/linked_entries_controller.dart
@@ -107,6 +107,24 @@ class IncludeAiEntriesController extends _$IncludeAiEntriesController {
   bool get includeAiEntries => state;
 }
 
+/// Per-entry toggle that narrows the linked entries list to flagged
+/// entries only (`meta.flag == EntryFlag.import`, the flag toggled via
+/// the entry header's flag icon). Defaults to off so all linked entries
+/// stay visible until the user opts in.
+@riverpod
+class ShowFlaggedOnlyController extends _$ShowFlaggedOnlyController {
+  @override
+  bool build({required String id}) {
+    return false;
+  }
+
+  set showFlaggedOnly(bool value) {
+    state = value;
+  }
+
+  bool get showFlaggedOnly => state;
+}
+
 /// Per-entry toggle state for the activity filter pills shown above the
 /// linked entries list (Timer / Audio / Images). Defaults to all kinds
 /// active so existing behavior is preserved when the bar mounts.

--- a/lib/features/journal/state/linked_entries_controller.g.dart
+++ b/lib/features/journal/state/linked_entries_controller.g.dart
@@ -299,6 +299,133 @@ abstract class _$IncludeAiEntriesController extends $Notifier<bool> {
   }
 }
 
+/// Per-entry toggle that narrows the linked entries list to flagged
+/// entries only (`meta.flag == EntryFlag.import`, the flag toggled via
+/// the entry header's flag icon). Defaults to off so all linked entries
+/// stay visible until the user opts in.
+
+@ProviderFor(ShowFlaggedOnlyController)
+final showFlaggedOnlyControllerProvider = ShowFlaggedOnlyControllerFamily._();
+
+/// Per-entry toggle that narrows the linked entries list to flagged
+/// entries only (`meta.flag == EntryFlag.import`, the flag toggled via
+/// the entry header's flag icon). Defaults to off so all linked entries
+/// stay visible until the user opts in.
+final class ShowFlaggedOnlyControllerProvider
+    extends $NotifierProvider<ShowFlaggedOnlyController, bool> {
+  /// Per-entry toggle that narrows the linked entries list to flagged
+  /// entries only (`meta.flag == EntryFlag.import`, the flag toggled via
+  /// the entry header's flag icon). Defaults to off so all linked entries
+  /// stay visible until the user opts in.
+  ShowFlaggedOnlyControllerProvider._({
+    required ShowFlaggedOnlyControllerFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'showFlaggedOnlyControllerProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$showFlaggedOnlyControllerHash();
+
+  @override
+  String toString() {
+    return r'showFlaggedOnlyControllerProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  ShowFlaggedOnlyController create() => ShowFlaggedOnlyController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is ShowFlaggedOnlyControllerProvider &&
+        other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$showFlaggedOnlyControllerHash() =>
+    r'e3b93d0dec4b87e1ea1b105851996351b5b4c2ce';
+
+/// Per-entry toggle that narrows the linked entries list to flagged
+/// entries only (`meta.flag == EntryFlag.import`, the flag toggled via
+/// the entry header's flag icon). Defaults to off so all linked entries
+/// stay visible until the user opts in.
+
+final class ShowFlaggedOnlyControllerFamily extends $Family
+    with
+        $ClassFamilyOverride<
+          ShowFlaggedOnlyController,
+          bool,
+          bool,
+          bool,
+          String
+        > {
+  ShowFlaggedOnlyControllerFamily._()
+    : super(
+        retry: null,
+        name: r'showFlaggedOnlyControllerProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// Per-entry toggle that narrows the linked entries list to flagged
+  /// entries only (`meta.flag == EntryFlag.import`, the flag toggled via
+  /// the entry header's flag icon). Defaults to off so all linked entries
+  /// stay visible until the user opts in.
+
+  ShowFlaggedOnlyControllerProvider call({required String id}) =>
+      ShowFlaggedOnlyControllerProvider._(argument: id, from: this);
+
+  @override
+  String toString() => r'showFlaggedOnlyControllerProvider';
+}
+
+/// Per-entry toggle that narrows the linked entries list to flagged
+/// entries only (`meta.flag == EntryFlag.import`, the flag toggled via
+/// the entry header's flag icon). Defaults to off so all linked entries
+/// stay visible until the user opts in.
+
+abstract class _$ShowFlaggedOnlyController extends $Notifier<bool> {
+  late final _$args = ref.$arg as String;
+  String get id => _$args;
+
+  bool build({required String id});
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<bool, bool>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<bool, bool>,
+              bool,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, () => build(id: _$args));
+  }
+}
+
 /// Per-entry toggle state for the activity filter pills shown above the
 /// linked entries list (Timer / Audio / Images). Defaults to all kinds
 /// active so existing behavior is preserved when the bar mounts.

--- a/lib/features/journal/ui/widgets/entry_detail_linked.dart
+++ b/lib/features/journal/ui/widgets/entry_detail_linked.dart
@@ -37,6 +37,9 @@ class LinkedEntriesWidget extends ConsumerWidget {
     final activeKinds = ref.watch(
       linkedEntriesActivityFilterControllerProvider(id: item.id),
     );
+    final showFlaggedOnly = ref.watch(
+      showFlaggedOnlyControllerProvider(id: item.id),
+    );
 
     if (orderedLinks.isEmpty) {
       return const SizedBox.shrink();
@@ -74,6 +77,7 @@ class LinkedEntriesWidget extends ConsumerWidget {
                 isHighlighted: highlightedEntryId == toId,
                 isActiveTimer: activeTimerEntryId == toId,
                 activeKinds: activeKinds,
+                showFlaggedOnly: showFlaggedOnly,
               ),
             );
           },
@@ -83,14 +87,15 @@ class LinkedEntriesWidget extends ConsumerWidget {
   }
 }
 
-/// Wraps [EntryDetailsWidget] so the activity-filter pill set can hide
-/// entries whose kind has been toggled off without forcing the parent to
+/// Wraps [EntryDetailsWidget] so the activity-filter pill set and the
+/// flagged-only toggle can hide entries without forcing the parent to
 /// pre-resolve every linked entity.
 class _FilteredEntryDetails extends ConsumerWidget {
   const _FilteredEntryDetails({
     required this.itemId,
     required this.showAiEntry,
     required this.activeKinds,
+    required this.showFlaggedOnly,
     super.key,
     this.hideTaskEntries = false,
     this.linkedFrom,
@@ -107,6 +112,7 @@ class _FilteredEntryDetails extends ConsumerWidget {
   final JournalEntity? linkedFrom;
   final EntryLink? link;
   final Set<LinkedEntryActivityFilter> activeKinds;
+  final bool showFlaggedOnly;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -114,6 +120,9 @@ class _FilteredEntryDetails extends ConsumerWidget {
     if (entry != null) {
       final kind = LinkedEntryActivityFilter.fromEntity(entry);
       if (kind != null && !activeKinds.contains(kind)) {
+        return const SizedBox.shrink();
+      }
+      if (showFlaggedOnly && entry.meta.flag != EntryFlag.import) {
         return const SizedBox.shrink();
       }
     }

--- a/lib/features/journal/ui/widgets/linked_entries_filter_modal.dart
+++ b/lib/features/journal/ui/widgets/linked_entries_filter_modal.dart
@@ -7,9 +7,10 @@ import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/widgets/modal/modal_utils.dart';
 
 /// Single-page modal that lets the user pick the sort order for linked
-/// entries and toggle visibility of hidden entries. Reuses the same
-/// exclusive-choice pill (`DesignSystemFilterChoicePill`) and palette as
-/// the task list filter modal.
+/// entries, toggle visibility of hidden entries, and narrow the list to
+/// flagged entries only. Reuses the same exclusive-choice pill
+/// (`DesignSystemFilterChoicePill`) and palette as the task list filter
+/// modal.
 Future<void> showLinkedEntriesFilterModal({
   required BuildContext context,
   required String entryId,
@@ -46,6 +47,13 @@ class _LinkedEntriesFilterModalBody extends ConsumerWidget {
     );
     final includeHiddenNotifier = ref.read(
       includeHiddenControllerProvider(id: entryId).notifier,
+    );
+
+    final showFlaggedOnly = ref.watch(
+      showFlaggedOnlyControllerProvider(id: entryId),
+    );
+    final showFlaggedOnlyNotifier = ref.read(
+      showFlaggedOnlyControllerProvider(id: entryId).notifier,
     );
 
     String sortLabel(LinkedEntriesSortOrder option) => switch (option) {
@@ -87,6 +95,14 @@ class _LinkedEntriesFilterModalBody extends ConsumerWidget {
           palette: palette,
           tokens: tokens,
           onChanged: () => includeHiddenNotifier.includeHidden = !includeHidden,
+        ),
+        _ToggleRow(
+          label: messages.journalLinkedEntriesShowFlaggedOnly,
+          value: showFlaggedOnly,
+          palette: palette,
+          tokens: tokens,
+          onChanged: () =>
+              showFlaggedOnlyNotifier.showFlaggedOnly = !showFlaggedOnly,
         ),
         SizedBox(height: spacing.step8),
       ],

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -2016,6 +2016,7 @@
   "journalLinkedEntriesActivityFilterImages": "Obrázky",
   "journalLinkedEntriesActivityFilterTimer": "Časovač",
   "journalLinkedEntriesFilterModalTitle": "Filtrovat a řadit",
+  "journalLinkedEntriesShowFlaggedOnly": "Zobrazit pouze označené záznamy",
   "journalLinkedEntriesShowHidden": "Zobrazit skryté záznamy",
   "journalLinkedEntriesSortLabel": "Řadit podle",
   "journalLinkedEntriesSortNewestFirst": "Nejnovější první",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2224,6 +2224,7 @@
   "journalLinkedEntriesActivityFilterImages": "Bilder",
   "journalLinkedEntriesActivityFilterTimer": "Timer",
   "journalLinkedEntriesFilterModalTitle": "Filtern & Sortieren",
+  "journalLinkedEntriesShowFlaggedOnly": "Nur markierte Einträge anzeigen",
   "journalLinkedEntriesShowHidden": "Versteckte Einträge anzeigen",
   "journalLinkedEntriesSortLabel": "Sortieren nach",
   "journalLinkedEntriesSortNewestFirst": "Neueste zuerst",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2461,6 +2461,7 @@
   "journalLinkedEntriesActivityFilterImages": "Images",
   "journalLinkedEntriesActivityFilterTimer": "Timer",
   "journalLinkedEntriesFilterModalTitle": "Filter & Sort",
+  "journalLinkedEntriesShowFlaggedOnly": "Show flagged entries only",
   "journalLinkedEntriesShowHidden": "Show hidden entries",
   "journalLinkedEntriesSortLabel": "Sort by",
   "journalLinkedEntriesSortNewestFirst": "Newest first",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2224,6 +2224,7 @@
   "journalLinkedEntriesActivityFilterImages": "Imágenes",
   "journalLinkedEntriesActivityFilterTimer": "Temporizador",
   "journalLinkedEntriesFilterModalTitle": "Filtrar y ordenar",
+  "journalLinkedEntriesShowFlaggedOnly": "Mostrar solo entradas marcadas",
   "journalLinkedEntriesShowHidden": "Mostrar entradas ocultas",
   "journalLinkedEntriesSortLabel": "Ordenar por",
   "journalLinkedEntriesSortNewestFirst": "Más recientes primero",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -2224,6 +2224,7 @@
   "journalLinkedEntriesActivityFilterImages": "Images",
   "journalLinkedEntriesActivityFilterTimer": "Minuteur",
   "journalLinkedEntriesFilterModalTitle": "Filtrer et trier",
+  "journalLinkedEntriesShowFlaggedOnly": "Afficher uniquement les entrées suivies",
   "journalLinkedEntriesShowHidden": "Afficher les entrées masquées",
   "journalLinkedEntriesSortLabel": "Trier par",
   "journalLinkedEntriesSortNewestFirst": "Plus récent d'abord",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -8388,6 +8388,12 @@ abstract class AppLocalizations {
   /// **'Filter & Sort'**
   String get journalLinkedEntriesFilterModalTitle;
 
+  /// No description provided for @journalLinkedEntriesShowFlaggedOnly.
+  ///
+  /// In en, this message translates to:
+  /// **'Show flagged entries only'**
+  String get journalLinkedEntriesShowFlaggedOnly;
+
   /// No description provided for @journalLinkedEntriesShowHidden.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -4841,6 +4841,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get journalLinkedEntriesFilterModalTitle => 'Filtrovat a řadit';
 
   @override
+  String get journalLinkedEntriesShowFlaggedOnly =>
+      'Zobrazit pouze označené záznamy';
+
+  @override
   String get journalLinkedEntriesShowHidden => 'Zobrazit skryté záznamy';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -4844,6 +4844,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get journalLinkedEntriesFilterModalTitle => 'Filtern & Sortieren';
 
   @override
+  String get journalLinkedEntriesShowFlaggedOnly =>
+      'Nur markierte Einträge anzeigen';
+
+  @override
   String get journalLinkedEntriesShowHidden => 'Versteckte Einträge anzeigen';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -4784,6 +4784,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get journalLinkedEntriesFilterModalTitle => 'Filter & Sort';
 
   @override
+  String get journalLinkedEntriesShowFlaggedOnly => 'Show flagged entries only';
+
+  @override
   String get journalLinkedEntriesShowHidden => 'Show hidden entries';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -4866,6 +4866,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get journalLinkedEntriesFilterModalTitle => 'Filtrar y ordenar';
 
   @override
+  String get journalLinkedEntriesShowFlaggedOnly =>
+      'Mostrar solo entradas marcadas';
+
+  @override
   String get journalLinkedEntriesShowHidden => 'Mostrar entradas ocultas';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -4867,6 +4867,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get journalLinkedEntriesFilterModalTitle => 'Filtrer et trier';
 
   @override
+  String get journalLinkedEntriesShowFlaggedOnly =>
+      'Afficher uniquement les entrées suivies';
+
+  @override
   String get journalLinkedEntriesShowHidden => 'Afficher les entrées masquées';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -4867,6 +4867,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get journalLinkedEntriesFilterModalTitle => 'Filtrare și sortare';
 
   @override
+  String get journalLinkedEntriesShowFlaggedOnly =>
+      'Afișați doar intrările marcate';
+
+  @override
   String get journalLinkedEntriesShowHidden => 'Afișați intrările ascunse';
 
   @override

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -2224,6 +2224,7 @@
   "journalLinkedEntriesActivityFilterImages": "Imagini",
   "journalLinkedEntriesActivityFilterTimer": "Cronometru",
   "journalLinkedEntriesFilterModalTitle": "Filtrare și sortare",
+  "journalLinkedEntriesShowFlaggedOnly": "Afișați doar intrările marcate",
   "journalLinkedEntriesShowHidden": "Afișați intrările ascunse",
   "journalLinkedEntriesSortLabel": "Sortați după",
   "journalLinkedEntriesSortNewestFirst": "Cele mai noi mai întâi",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1014+4113
+version: 0.9.1015+4114
 
 msix_config:
   display_name: LottiApp

--- a/test/features/journal/state/linked_entries_controller_test.dart
+++ b/test/features/journal/state/linked_entries_controller_test.dart
@@ -422,6 +422,64 @@ void main() {
     });
   });
 
+  group('ShowFlaggedOnlyController', () {
+    const testId = 'test-entry-id';
+
+    test('initializes with default value of false', () {
+      // Act
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final result = container.read(
+        showFlaggedOnlyControllerProvider(id: testId),
+      );
+
+      // Assert
+      expect(result, isFalse);
+    });
+
+    test('can update value', () {
+      // Act
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final controller = container.read(
+        showFlaggedOnlyControllerProvider(id: testId).notifier,
+      );
+
+      // Initial state should be false
+      expect(controller.showFlaggedOnly, isFalse);
+
+      // Update the value
+      controller.showFlaggedOnly = true;
+
+      // Assert
+      expect(controller.showFlaggedOnly, isTrue);
+      expect(
+        container.read(showFlaggedOnlyControllerProvider(id: testId)),
+        isTrue,
+      );
+    });
+
+    test('state is scoped per entry id', () {
+      // Act
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container
+              .read(showFlaggedOnlyControllerProvider(id: testId).notifier)
+              .showFlaggedOnly =
+          true;
+
+      // Assert: another entry id keeps its own independent default
+      expect(
+        container.read(showFlaggedOnlyControllerProvider(id: testId)),
+        isTrue,
+      );
+      expect(
+        container.read(showFlaggedOnlyControllerProvider(id: 'other-id')),
+        isFalse,
+      );
+    });
+  });
+
   group('NewestLinkedIdController', () {
     const testId = 'test-entry-id';
     final baseDate = DateTime(2024, 3, 15, 10, 30);

--- a/test/features/journal/ui/widgets/entry_detail_linked_test.dart
+++ b/test/features/journal/ui/widgets/entry_detail_linked_test.dart
@@ -2,11 +2,14 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/features/journal/state/linked_entries_controller.dart';
 import 'package:lotti/features/journal/ui/widgets/entry_detail_linked.dart';
+import 'package:lotti/features/journal/ui/widgets/entry_details_widget.dart';
 import 'package:lotti/features/journal/ui/widgets/linked_entries_activity_filter_bar.dart';
 import 'package:lotti/features/user_activity/state/user_activity_service.dart';
 import 'package:lotti/get_it.dart';
@@ -480,6 +483,81 @@ void main() {
 
       // Non-task entry exists, so section is shown with filter bar
       expect(find.byType(LinkedEntriesActivityFilterBar), findsOneWidget);
+    });
+
+    testWidgets('flagged-only toggle reactively hides non-flagged entries', (
+      tester,
+    ) async {
+      final flaggedEntry = testTextEntry.copyWith(
+        meta: testTextEntry.meta.copyWith(
+          id: 'flagged-entry-id',
+          flag: EntryFlag.import,
+        ),
+      );
+
+      final flaggedLink = EntryLink.basic(
+        id: 'link-flagged',
+        fromId: testTask.meta.id,
+        toId: flaggedEntry.meta.id,
+        createdAt: DateTime(2024, 1, 2),
+        updatedAt: DateTime(2024, 1, 2),
+        vectorClock: null,
+      );
+
+      mockLinkedEntries([testLink, flaggedLink]);
+
+      when(
+        () => mockJournalDb.journalEntityById(testTextEntry.meta.id),
+      ).thenAnswer((_) async => testTextEntry);
+      when(
+        () => mockJournalDb.journalEntityById(flaggedEntry.meta.id),
+      ).thenAnswer((_) async => flaggedEntry);
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          LinkedEntriesWidget(testTask),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      Finder entryDetails(String id) => find.byWidgetPredicate(
+        (widget) => widget is EntryDetailsWidget && widget.itemId == id,
+      );
+
+      // Both linked entries render while the filter is off.
+      expect(entryDetails(flaggedEntry.meta.id), findsOneWidget);
+      expect(entryDetails(testTextEntry.meta.id), findsOneWidget);
+
+      // Toggling flagged-only on hides the non-flagged entry.
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(LinkedEntriesWidget)),
+      );
+      container
+              .read(
+                showFlaggedOnlyControllerProvider(
+                  id: testTask.meta.id,
+                ).notifier,
+              )
+              .showFlaggedOnly =
+          true;
+      await tester.pumpAndSettle();
+
+      expect(entryDetails(flaggedEntry.meta.id), findsOneWidget);
+      expect(entryDetails(testTextEntry.meta.id), findsNothing);
+
+      // Toggling it back off restores the non-flagged entry.
+      container
+              .read(
+                showFlaggedOnlyControllerProvider(
+                  id: testTask.meta.id,
+                ).notifier,
+              )
+              .showFlaggedOnly =
+          false;
+      await tester.pumpAndSettle();
+
+      expect(entryDetails(flaggedEntry.meta.id), findsOneWidget);
+      expect(entryDetails(testTextEntry.meta.id), findsOneWidget);
     });
   });
 }

--- a/test/features/journal/ui/widgets/linked_entries_filter_modal_test.dart
+++ b/test/features/journal/ui/widgets/linked_entries_filter_modal_test.dart
@@ -40,7 +40,7 @@ void main() {
     return (tester, container, messages);
   }
 
-  testWidgets('renders sort pills and the show-hidden switch', (tester) async {
+  testWidgets('renders sort pills and the toggle switches', (tester) async {
     final (_, _, messages) = await pumpAndOpenModal(tester);
 
     expect(
@@ -57,6 +57,10 @@ void main() {
       findsOneWidget,
     );
     expect(find.text(messages.journalLinkedEntriesShowHidden), findsOneWidget);
+    expect(
+      find.text(messages.journalLinkedEntriesShowFlaggedOnly),
+      findsOneWidget,
+    );
   });
 
   testWidgets('tapping "Oldest first" updates the sort controller', (
@@ -98,4 +102,37 @@ void main() {
       isTrue,
     );
   });
+
+  testWidgets(
+    'tapping the flagged-only row flips the show-flagged-only state',
+    (tester) async {
+      final (_, container, messages) = await pumpAndOpenModal(tester);
+
+      expect(
+        container.read(showFlaggedOnlyControllerProvider(id: entryId)),
+        isFalse,
+      );
+
+      await tester.tap(
+        find.text(messages.journalLinkedEntriesShowFlaggedOnly),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(showFlaggedOnlyControllerProvider(id: entryId)),
+        isTrue,
+      );
+
+      // Toggling again restores the default.
+      await tester.tap(
+        find.text(messages.journalLinkedEntriesShowFlaggedOnly),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(showFlaggedOnlyControllerProvider(id: entryId)),
+        isFalse,
+      );
+    },
+  );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 0.9.1015

* **New Features**
  * Added "Show flagged entries only" toggle in the linked entries Filter & Sort modal; filters to flagged entries with real-time updates
  * Expanded localization support across Czech, German, Spanish, French, and Romanian

* **Documentation**
  * Updated feature documentation with linked-entry visibility controls and filtering behavior

* **Tests**
  * Added tests for the new flagged-only filtering functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->