### PR TITLE
fix: creation of duplicate proposals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Label usage counts in the labels list no longer include deleted journal
   entries, and entries marked private only count while the "Show private
   entries" flag is enabled.
+- Task-agent suggestions now suppress verbatim duplicate proposals even when
+  their underlying tool arguments differ, so identical checklist suggestions
+  appear only once.
 
 ## [0.9.1014]
 ### Added

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -39,6 +39,7 @@
           <p>Agent memory compaction now runs by default for task, project, and day agents, and the Settings flag that controlled it has been removed.</p>
           <p>Config flag changes from Settings now sync to your other devices when a flag is flipped, without broadcasting default startup flag seeding.</p>
           <p>Label usage counts in the labels list no longer include deleted journal entries, and entries marked private only count while the "Show private entries" flag is enabled.</p>
+          <p>Task-agent suggestions now suppress verbatim duplicate proposals even when their underlying tool arguments differ, so identical checklist suggestions appear only once.</p>
       </description>
     </release>
     <release version="0.9.1014" date="2026-06-04">

--- a/lib/features/agents/model/change_set.dart
+++ b/lib/features/agents/model/change_set.dart
@@ -36,6 +36,8 @@ abstract class ChangeItem with _$ChangeItem {
       _$ChangeItemFromJson(json);
 
   static const _deepEquals = DeepCollectionEquality();
+  static final RegExp _whitespaceRegExp = RegExp(r'\s+');
+  static const _updateRunningTimerToolName = 'update_running_timer';
 
   /// Structural fingerprint from raw parts, without requiring a [ChangeItem].
   ///
@@ -52,6 +54,48 @@ abstract class ChangeItem with _$ChangeItem {
   /// same mutation are considered equal regardless of presentation.
   static String fingerprint(ChangeItem item) =>
       fingerprintFromParts(item.toolName, item.args);
+
+  /// User-visible duplicate key based on the mutation tool and the rendered
+  /// proposal text.
+  ///
+  /// Structural fingerprints catch identical tool arguments. This key catches
+  /// the companion case where different argument shapes render the exact same
+  /// suggestion to the user (for example two checklist item ids resolving to
+  /// `Check off: "Address CodeRabbit review comments"`).
+  static String? displayDuplicateKey(ChangeItem item) =>
+      displayDuplicateKeyFromParts(
+        item.toolName,
+        item.humanSummary,
+        args: item.args,
+      );
+
+  /// User-visible duplicate key from raw parts, without requiring a
+  /// [ChangeItem].
+  static String? displayDuplicateKeyFromParts(
+    String toolName,
+    String humanSummary, {
+    Map<String, dynamic>? args,
+  }) {
+    final normalizedSummary = humanSummary
+        .trim()
+        .replaceAll(_whitespaceRegExp, ' ')
+        .toLowerCase();
+    if (normalizedSummary.isEmpty) return null;
+
+    final buffer = StringBuffer('$toolName:$normalizedSummary');
+    if (toolName == _updateRunningTimerToolName) {
+      final timerId = _runningTimerIdFromArgs(args);
+      if (timerId != null) buffer.write('|timer:$timerId');
+    }
+    return buffer.toString();
+  }
+
+  static String? _runningTimerIdFromArgs(Map<String, dynamic>? args) {
+    final timerId = args?['timerId'];
+    if (timerId is! String) return null;
+    final trimmed = timerId.trim();
+    return trimmed.isEmpty ? null : trimmed;
+  }
 
   /// Derives the overall `ChangeSetStatus` from a list of item statuses.
   ///

--- a/lib/features/agents/state/unified_suggestion_providers.dart
+++ b/lib/features/agents/state/unified_suggestion_providers.dart
@@ -85,6 +85,7 @@ Future<UnifiedSuggestionList> unifiedSuggestionList(
 
   final open = <PendingSuggestion>[];
   final seenFingerprints = <String>{};
+  final seenDisplayKeys = <String>{};
   for (final cs in ledger.pendingSets) {
     for (var i = 0; i < cs.items.length; i++) {
       final item = cs.items[i];
@@ -93,6 +94,8 @@ Future<UnifiedSuggestionList> unifiedSuggestionList(
       // Race-condition dedup: two wakes may have produced sets with the
       // exact same fingerprint before persistence-time dedup kicks in.
       if (!seenFingerprints.add(fingerprint)) continue;
+      final displayKey = ChangeItem.displayDuplicateKey(item);
+      if (displayKey != null && !seenDisplayKeys.add(displayKey)) continue;
       open.add(
         PendingSuggestion(
           changeSet: cs,

--- a/lib/features/agents/workflow/change_set_builder.dart
+++ b/lib/features/agents/workflow/change_set_builder.dart
@@ -163,6 +163,21 @@ class ChangeSetBuilder {
           'Proceed to the next tool or finish your analysis.';
     }
 
+    final displayKey = ChangeItem.displayDuplicateKeyFromParts(
+      toolName,
+      humanSummary,
+      args: args,
+    );
+    if (displayKey != null &&
+        _items.any(
+          (item) => ChangeItem.displayDuplicateKey(item) == displayKey,
+        )) {
+      return 'Already queued — this exact visible $toolName proposal was '
+          'already recorded. Do NOT call this tool again with the same '
+          'user-facing summary. Proceed to the next tool or finish your '
+          'analysis.';
+    }
+
     if (toolName == TaskAgentToolNames.updateRunningTimer) {
       final timerId = _runningTimerIdFromArgs(args);
       _items.removeWhere(
@@ -261,6 +276,10 @@ class ChangeSetBuilder {
     // dedup cannot collapse, because each row stays a distinct
     // ChangeItem at the persistence layer.
     final queuedFingerprints = _items.map(ChangeItem.fingerprint).toSet();
+    final queuedDisplayKeys = {
+      for (final item in _items)
+        if (ChangeItem.displayDuplicateKey(item) case final String key) key,
+    };
 
     var added = 0;
     var skipped = 0;
@@ -328,7 +347,7 @@ class ChangeSetBuilder {
           singularToolName,
           element,
         );
-        if (!queuedFingerprints.add(fingerprint)) {
+        if (queuedFingerprints.contains(fingerprint)) {
           redundant++;
           redundantDetails.add(
             'identical $singularToolName proposal already queued in this '
@@ -345,6 +364,22 @@ class ChangeSetBuilder {
                 summaryPrefix,
                 resolvedState: resolvedState,
               );
+        final displayKey = ChangeItem.displayDuplicateKeyFromParts(
+          singularToolName,
+          summary,
+          args: element,
+        );
+        if (displayKey != null && queuedDisplayKeys.contains(displayKey)) {
+          redundant++;
+          redundantDetails.add(
+            'identical visible $singularToolName proposal already queued in '
+            'this wake — skipped.',
+          );
+          continue;
+        }
+        queuedFingerprints.add(fingerprint);
+        if (displayKey != null) queuedDisplayKeys.add(displayKey);
+
         _items.add(
           ChangeItem(
             toolName: singularToolName,
@@ -405,6 +440,8 @@ class ChangeSetBuilder {
   /// persisted [ChangeDecisionEntity] records whose verdict was `rejected`.
   /// These are merged into the dedup set so that items the user rejected
   /// in a previous (now-resolved) change set are still blocked.
+  /// [rejectedDisplayKeys] applies the same sticky rejection rule to
+  /// verbatim user-facing summaries whose tool arguments changed shape.
   ///
   /// When existing pending change sets exist, all their items are
   /// consolidated into a single set together with the new items. Any
@@ -416,6 +453,7 @@ class ChangeSetBuilder {
     AgentSyncService syncService, {
     List<ChangeSetEntity> existingPendingSets = const [],
     Set<String> rejectedFingerprints = const {},
+    Set<String> rejectedDisplayKeys = const {},
   }) async {
     if (!hasItems) return null;
 
@@ -446,6 +484,7 @@ class ChangeSetBuilder {
       _items,
       existingItems,
       rejectedFingerprints: rejectedFingerprints,
+      rejectedDisplayKeys: rejectedDisplayKeys,
     );
     if (deduped.isEmpty) return null;
 
@@ -607,19 +646,34 @@ class ChangeSetBuilder {
   ///
   /// [rejectedFingerprints] are merged into the dedup set so that items
   /// rejected in previously-resolved change sets are still blocked.
+  /// [rejectedDisplayKeys] does the same for verbatim user-facing summaries.
   static List<ChangeItem> _deduplicateItems(
     List<ChangeItem> proposed,
     List<ChangeItem> existing, {
     Set<String> rejectedFingerprints = const {},
+    Set<String> rejectedDisplayKeys = const {},
   }) {
-    if (existing.isEmpty && rejectedFingerprints.isEmpty) return proposed;
+    if (existing.isEmpty &&
+        rejectedFingerprints.isEmpty &&
+        rejectedDisplayKeys.isEmpty) {
+      return proposed;
+    }
     final existingHashes = {
       ...existing.map(ChangeItem.fingerprint),
       ...rejectedFingerprints,
     };
-    return proposed
-        .where((item) => !existingHashes.contains(ChangeItem.fingerprint(item)))
-        .toList();
+    final existingDisplayKeys = {
+      ...rejectedDisplayKeys,
+      for (final item in existing)
+        if (ChangeItem.displayDuplicateKey(item) case final String key) key,
+    };
+    return proposed.where((item) {
+      if (existingHashes.contains(ChangeItem.fingerprint(item))) {
+        return false;
+      }
+      final displayKey = ChangeItem.displayDuplicateKey(item);
+      return displayKey == null || !existingDisplayKeys.contains(displayKey);
+    }).toList();
   }
 
   static ChangeSetEntity _retireConsolidatedSet(ChangeSetEntity set) {

--- a/lib/features/agents/workflow/task_agent_workflow.dart
+++ b/lib/features/agents/workflow/task_agent_workflow.dart
@@ -11,6 +11,7 @@ import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/agent_link.dart';
+import 'package:lotti/features/agents/model/change_set.dart';
 import 'package:lotti/features/agents/model/proposal_ledger.dart';
 import 'package:lotti/features/agents/projection/content_digest.dart';
 import 'package:lotti/features/agents/projection/decision_events.dart';
@@ -847,11 +848,23 @@ class TaskAgentWorkflow {
             .where((e) => e.verdict == ChangeDecisionVerdict.rejected)
             .map((e) => e.fingerprint)
             .toSet();
+        final rejectedDisplayKeys = {
+          for (final entry in ledger.resolved)
+            if (entry.verdict == ChangeDecisionVerdict.rejected)
+              if (ChangeItem.displayDuplicateKeyFromParts(
+                    entry.toolName,
+                    entry.humanSummary,
+                    args: entry.args,
+                  )
+                  case final String key)
+                key,
+        };
 
         await changeSetBuilder.build(
           syncService,
           existingPendingSets: pendingSets,
           rejectedFingerprints: rejectedFingerprints,
+          rejectedDisplayKeys: rejectedDisplayKeys,
         );
 
         // 11. Persist state.
@@ -1752,6 +1765,11 @@ to keep the user-facing suggestion list clean and trustworthy:
         ..writeln();
     }
 
+    final openProposalGuard = _formatOpenProposalGuard(ledger);
+    if (openProposalGuard.isNotEmpty) {
+      buffer.write(openProposalGuard);
+    }
+
     buffer.writeln(
       'Analyze the current state and call tools if needed. If the report '
       'would materially change, call `update_report` with the full updated '
@@ -1825,6 +1843,37 @@ to keep the user-facing suggestion list clean and trustworthy:
       }
       buffer.writeln();
     }
+
+    return buffer.toString();
+  }
+
+  /// Renders a compact, high-salience guard immediately before the final wake
+  /// instruction so OPEN proposals are treated as current work-cycle state,
+  /// not just historical context earlier in the prompt.
+  String _formatOpenProposalGuard(ProposalLedger ledger) {
+    if (ledger.open.isEmpty) return '';
+
+    final buffer = StringBuffer()
+      ..writeln('## Open Proposal Guard')
+      ..writeln()
+      ..writeln(
+        'Before proposing any change, compare it against these OPEN '
+        'proposals. Do not propose the same user-facing action again '
+        '(for `update_running_timer`, compare per `timerId`). If an OPEN '
+        'proposal is stale, call `retract_suggestions` with its fingerprint; '
+        'otherwise leave it open.',
+      )
+      ..writeln()
+      ..writeln(
+        ledger.open
+            .map(
+              (e) =>
+                  '- [fp=${e.fingerprint}] `${e.toolName}`: '
+                  '${e.humanSummary.trim()}',
+            )
+            .join('\n'),
+      )
+      ..writeln();
 
     return buffer.toString();
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1015+4116
+version: 0.9.1015+4117
 
 msix_config:
   display_name: LottiApp

--- a/test/features/agents/model/change_set_test.dart
+++ b/test/features/agents/model/change_set_test.dart
@@ -95,6 +95,33 @@ extension _AnyChangeSetScenarios on glados.Any {
 
 void main() {
   group('ChangeItem', () {
+    test('displayDuplicateKey preserves running timer identity', () {
+      const firstTimer = ChangeItem(
+        toolName: 'update_running_timer',
+        args: {'timerId': 'timer-1'},
+        humanSummary: 'Update running timer text: "Focus block"',
+      );
+      const secondTimer = ChangeItem(
+        toolName: 'update_running_timer',
+        args: {'timerId': 'timer-2'},
+        humanSummary: '  Update   running timer text: "Focus block"  ',
+      );
+      const checklistItem = ChangeItem(
+        toolName: 'update_checklist_item',
+        args: {'id': 'checklist-1', 'isChecked': true},
+        humanSummary: '  Check off:   "Review comments"  ',
+      );
+
+      expect(
+        ChangeItem.displayDuplicateKey(firstTimer),
+        isNot(ChangeItem.displayDuplicateKey(secondTimer)),
+      );
+      expect(
+        ChangeItem.displayDuplicateKey(checklistItem),
+        'update_checklist_item:check off: "review comments"',
+      );
+    });
+
     glados.Glados(
       glados.any.changeItemStatuses,
       glados.ExploreConfig(numRuns: 160),

--- a/test/features/agents/state/unified_suggestion_providers_test.dart
+++ b/test/features/agents/state/unified_suggestion_providers_test.dart
@@ -288,12 +288,15 @@ class _GeneratedUnifiedSuggestionScenario {
 
   List<_GeneratedOpenSuggestionExpectation> get expectedOpen {
     final seen = <String>{};
+    final seenDisplayKeys = <String>{};
     final open = <_GeneratedOpenSuggestionExpectation>[];
     for (final changeSet in pendingSets) {
       for (final (itemIndex, item) in changeSet.items.indexed) {
         if (item.status != ChangeItemStatus.pending) continue;
         final fingerprint = ChangeItem.fingerprint(item);
         if (!seen.add(fingerprint)) continue;
+        final displayKey = ChangeItem.displayDuplicateKey(item);
+        if (displayKey != null && !seenDisplayKeys.add(displayKey)) continue;
         open.add(
           (
             changeSetId: changeSet.id,
@@ -721,6 +724,120 @@ void main() {
         // First occurrence wins; iteration order is by pendingSets input
         // order (newer first as supplied by the repository).
         expect(result.open.single.changeSet.id, 'cs-new');
+      },
+    );
+
+    test(
+      'deduplicates verbatim visible suggestions across change sets',
+      () async {
+        final agent = makeTestIdentity();
+        const summary = 'Check off: "Address CodeRabbit review comments"';
+        final earlier = makeTestChangeSet(
+          id: 'cs-old-visible',
+          agentId: agent.agentId,
+          taskId: 'task-abc',
+          createdAt: DateTime(2026, 4, 18, 9),
+          items: const [
+            ChangeItem(
+              toolName: 'update_checklist_item',
+              args: {'id': 'old-item-id', 'isChecked': true},
+              humanSummary: summary,
+            ),
+          ],
+        );
+        final newer = makeTestChangeSet(
+          id: 'cs-new-visible',
+          agentId: agent.agentId,
+          taskId: 'task-abc',
+          createdAt: DateTime(2026, 4, 18, 10),
+          items: const [
+            ChangeItem(
+              toolName: 'update_checklist_item',
+              args: {'id': 'new-item-id', 'isChecked': true},
+              humanSummary: summary,
+            ),
+          ],
+        );
+
+        final container = build(
+          agent: agent,
+          ledger: ProposalLedger(
+            open: const [],
+            resolved: const [],
+            pendingSets: [newer, earlier],
+          ),
+        );
+        final sub = container.listen(
+          unifiedSuggestionListProvider('task-abc'),
+          (_, _) {},
+        );
+        addTearDown(sub.close);
+
+        final result = await container.read(
+          unifiedSuggestionListProvider('task-abc').future,
+        );
+
+        expect(result.open, hasLength(1));
+        expect(result.open.single.changeSet.id, 'cs-new-visible');
+        expect(result.open.single.item.humanSummary, summary);
+      },
+    );
+
+    test(
+      'keeps same-summary running timer suggestions for different timers',
+      () async {
+        final agent = makeTestIdentity();
+        const summary = 'Update running timer text: "Focus block"';
+        final changeSet = makeTestChangeSet(
+          id: 'cs-running-visible',
+          agentId: agent.agentId,
+          taskId: 'task-abc',
+          createdAt: DateTime(2026, 4, 18, 10),
+          items: const [
+            ChangeItem(
+              toolName: TaskAgentToolNames.updateRunningTimer,
+              args: {
+                'timerId': 'timer-1',
+                'summary': 'Focus block',
+              },
+              humanSummary: summary,
+            ),
+            ChangeItem(
+              toolName: TaskAgentToolNames.updateRunningTimer,
+              args: {
+                'timerId': 'timer-2',
+                'summary': 'Focus block',
+              },
+              humanSummary: summary,
+            ),
+          ],
+        );
+
+        final container = build(
+          agent: agent,
+          ledger: ProposalLedger(
+            open: const [],
+            resolved: const [],
+            pendingSets: [changeSet],
+          ),
+        );
+        final sub = container.listen(
+          unifiedSuggestionListProvider('task-abc'),
+          (_, _) {},
+        );
+        addTearDown(sub.close);
+
+        final result = await container.read(
+          unifiedSuggestionListProvider('task-abc').future,
+        );
+
+        expect(result.open, hasLength(2));
+        expect(
+          result.open
+              .map((suggestion) => suggestion.item.args['timerId'])
+              .toSet(),
+          {'timer-1', 'timer-2'},
+        );
       },
     );
 

--- a/test/features/agents/workflow/change_set_builder_test.dart
+++ b/test/features/agents/workflow/change_set_builder_test.dart
@@ -452,6 +452,7 @@ class _GeneratedChecklistUpdateScenario {
 
   _ExpectedChecklistUpdateBatch expected() {
     final queuedFingerprints = <String>{};
+    final queuedDisplayKeys = <String>{};
     final kept = <_ExpectedChecklistUpdateItem>[];
     var skipped = 0;
     var redundant = 0;
@@ -473,15 +474,28 @@ class _GeneratedChecklistUpdateScenario {
         TaskAgentToolNames.updateChecklistItem,
         value,
       );
-      if (!queuedFingerprints.add(fingerprint)) {
+      if (queuedFingerprints.contains(fingerprint)) {
         redundant++;
         continue;
       }
 
+      final summary = _summary(value, state);
+      final displayKey = ChangeItem.displayDuplicateKeyFromParts(
+        TaskAgentToolNames.updateChecklistItem,
+        summary,
+        args: value,
+      );
+      if (displayKey != null && queuedDisplayKeys.contains(displayKey)) {
+        redundant++;
+        continue;
+      }
+      queuedFingerprints.add(fingerprint);
+      if (displayKey != null) queuedDisplayKeys.add(displayKey);
+
       kept.add(
         _ExpectedChecklistUpdateItem(
           args: value,
-          summary: _summary(value, state),
+          summary: summary,
         ),
       );
     }
@@ -1122,6 +1136,36 @@ void main() {
         );
         expect(builder.items.first.args['summary'], 'Latest timer text');
         expect(builder.items.last.args['summary'], 'Other timer text');
+      },
+    );
+
+    test(
+      'keeps same-summary running timer updates for different timers',
+      () async {
+        final firstResult = await builder.addItem(
+          toolName: TaskAgentToolNames.updateRunningTimer,
+          args: const {
+            'timerId': 'timer-1',
+            'summary': 'Focus block',
+          },
+          humanSummary: 'Update running timer text: "Focus block"',
+        );
+        final secondResult = await builder.addItem(
+          toolName: TaskAgentToolNames.updateRunningTimer,
+          args: const {
+            'timerId': 'timer-2',
+            'summary': 'Focus block',
+          },
+          humanSummary: 'Update running timer text: "Focus block"',
+        );
+
+        expect(firstResult, isNull);
+        expect(secondResult, isNull);
+        expect(builder.items, hasLength(2));
+        expect(
+          builder.items.map((item) => item.args['timerId']),
+          ['timer-1', 'timer-2'],
+        );
       },
     );
   });
@@ -2207,6 +2251,115 @@ void main() {
         hasLength(1),
       );
     });
+
+    test(
+      'drops verbatim visible duplicates even when tool args differ',
+      () async {
+        await builder.addItem(
+          toolName: 'update_checklist_item',
+          args: {'id': 'new-item-id', 'isChecked': true},
+          humanSummary: 'Check off: "Address CodeRabbit review comments"',
+        );
+
+        final existingSet = makeTestChangeSet(
+          items: const [
+            ChangeItem(
+              toolName: 'update_checklist_item',
+              args: {'id': 'old-item-id', 'isChecked': true},
+              humanSummary: 'Check off: "Address CodeRabbit review comments"',
+            ),
+          ],
+        );
+
+        final result = await builder.build(
+          mockSyncService,
+          existingPendingSets: [existingSet],
+        );
+
+        expect(
+          result,
+          isNull,
+          reason: 'verbatim duplicate suggestions must not be persisted',
+        );
+        verifyNever(() => mockSyncService.upsertEntity(any()));
+      },
+    );
+
+    test(
+      'sticky-rejects verbatim visible duplicates by rejectedDisplayKeys',
+      () async {
+        const summary = 'Check off: "Address CodeRabbit review comments"';
+        await builder.addItem(
+          toolName: 'update_checklist_item',
+          args: {'id': 'new-item-id', 'isChecked': true},
+          humanSummary: summary,
+        );
+
+        final rejectedDisplayKey = ChangeItem.displayDuplicateKeyFromParts(
+          'update_checklist_item',
+          summary,
+          args: {'id': 'rejected-item-id', 'isChecked': true},
+        );
+
+        final result = await builder.build(
+          mockSyncService,
+          existingPendingSets: [],
+          rejectedDisplayKeys: {rejectedDisplayKey!},
+        );
+
+        expect(
+          result,
+          isNull,
+          reason:
+              'verbatim duplicate rejected suggestions must stay suppressed',
+        );
+        verifyNever(() => mockSyncService.upsertEntity(any()));
+      },
+    );
+
+    test(
+      'does not dedupe same-summary running timer updates for different timers',
+      () async {
+        await builder.addItem(
+          toolName: TaskAgentToolNames.updateRunningTimer,
+          args: const {
+            'timerId': 'timer-2',
+            'summary': 'Focus block',
+          },
+          humanSummary: 'Update running timer text: "Focus block"',
+        );
+
+        final existingSet = makeTestChangeSet(
+          items: const [
+            ChangeItem(
+              toolName: TaskAgentToolNames.updateRunningTimer,
+              args: {
+                'timerId': 'timer-1',
+                'summary': 'Focus block',
+              },
+              humanSummary: 'Update running timer text: "Focus block"',
+            ),
+          ],
+        );
+
+        final result = await builder.build(
+          mockSyncService,
+          existingPendingSets: [existingSet],
+        );
+
+        expect(result, isNotNull);
+        final timerItems = result!.items
+            .where(
+              (item) => item.toolName == TaskAgentToolNames.updateRunningTimer,
+            )
+            .toList();
+        expect(timerItems, hasLength(2));
+        expect(
+          timerItems.map((item) => item.args['timerId']),
+          ['timer-1', 'timer-2'],
+        );
+      },
+    );
 
     test('returns null when all items are duplicates', () async {
       await builder.addItem(

--- a/test/features/agents/workflow/task_agent_workflow_test.dart
+++ b/test/features/agents/workflow/task_agent_workflow_test.dart
@@ -3782,6 +3782,76 @@ void main() {
         );
 
         test(
+          'renders open proposal guard immediately before final instruction',
+          () async {
+            stubLedger(
+              ProposalLedger(
+                open: [
+                  openEntry(
+                    toolName: 'update_checklist_item',
+                    args: const {'id': 'item-1', 'isChecked': true},
+                    humanSummary: 'Check off: "Address review comments"',
+                  ),
+                ],
+                resolved: const [],
+              ),
+            );
+
+            final message = await executeAndCaptureMessage();
+
+            expect(message, isNotNull);
+            expect(message, contains('## Open Proposal Guard'));
+            expect(
+              message,
+              contains(
+                'Do not propose the same user-facing action again '
+                '(for `update_running_timer`, compare per `timerId`).',
+              ),
+            );
+            expect(
+              message,
+              contains(
+                'for `update_running_timer`, compare per `timerId`',
+              ),
+            );
+            expect(
+              message,
+              contains(
+                '`update_checklist_item`: '
+                'Check off: "Address review comments"',
+              ),
+            );
+
+            const guardHeader = '## Open Proposal Guard';
+            const finalInstruction =
+                'Analyze the current state and call tools if needed.';
+            final guardIndex = message!.indexOf(guardHeader);
+            final finalInstructionIndex = message.indexOf(finalInstruction);
+            expect(guardIndex, greaterThanOrEqualTo(0));
+            expect(finalInstructionIndex, greaterThan(guardIndex));
+            final expectedFingerprint = ChangeItem.fingerprintFromParts(
+              'update_checklist_item',
+              const {'id': 'item-1', 'isChecked': true},
+            );
+            final guardEntry =
+                '- [fp=$expectedFingerprint] `update_checklist_item`: '
+                'Check off: "Address review comments"';
+            final guardEntryIndex = message.indexOf(guardEntry, guardIndex);
+            expect(guardEntryIndex, greaterThan(guardIndex));
+            expect(finalInstructionIndex, greaterThan(guardEntryIndex));
+            expect(
+              message
+                  .substring(
+                    guardEntryIndex + guardEntry.length,
+                    finalInstructionIndex,
+                  )
+                  .trim(),
+              isEmpty,
+            );
+          },
+        );
+
+        test(
           'omits the Proposal Ledger section when the ledger is empty',
           () async {
             // Default stub is an empty ledger; do not override.
@@ -3789,6 +3859,7 @@ void main() {
 
             expect(message, isNotNull);
             expect(message, isNot(contains('## Proposal Ledger')));
+            expect(message, isNot(contains('## Open Proposal Guard')));
           },
         );
 
@@ -5136,6 +5207,97 @@ void main() {
             // Verify the resolver looked up the checklist item.
             verify(
               () => mockJournalDb.journalEntityById('cl-item-1'),
+            ).called(1);
+          },
+        );
+
+        test(
+          'update_checklist_items duplicate visible proposal is filtered by '
+          'the ledger at build time',
+          () async {
+            const summary = 'Check off: "Address CodeRabbit review comments"';
+            const existingItem = ChangeItem(
+              toolName: TaskAgentToolNames.updateChecklistItem,
+              args: {'id': 'cl-existing', 'isChecked': true},
+              humanSummary: summary,
+            );
+            final pendingSet = makeTestChangeSet(
+              id: 'cs-existing-visible-duplicate',
+              items: const [existingItem],
+            );
+            final newChecklistItem = JournalEntity.checklistItem(
+              meta: Metadata(
+                id: 'cl-new',
+                createdAt: DateTime(2024, 3, 15),
+                dateFrom: DateTime(2024, 3, 15),
+                dateTo: DateTime(2024, 3, 15),
+                updatedAt: DateTime(2024, 3, 15),
+              ),
+              data: const ChecklistItemData(
+                title: 'Address CodeRabbit review comments',
+                isChecked: false,
+                linkedChecklists: [],
+              ),
+            );
+            final upserts = <AgentDomainEntity>[];
+
+            when(
+              () => mockSyncService.repository,
+            ).thenReturn(mockAgentRepository);
+            when(
+              () => mockAgentRepository.getEntity(pendingSet.id),
+            ).thenAnswer((_) async => pendingSet);
+            when(
+              () => mockAgentRepository.getProposalLedger(
+                agentId,
+                taskId: any(named: 'taskId'),
+                changeSetFetchLimit: any(named: 'changeSetFetchLimit'),
+                resolvedLimit: any(named: 'resolvedLimit'),
+              ),
+            ).thenAnswer(
+              (_) async => ProposalLedger(
+                open: [
+                  LedgerEntry(
+                    changeSetId: pendingSet.id,
+                    itemIndex: 0,
+                    toolName: existingItem.toolName,
+                    args: existingItem.args,
+                    humanSummary: existingItem.humanSummary,
+                    fingerprint: ChangeItem.fingerprint(existingItem),
+                    status: ChangeItemStatus.pending,
+                    createdAt: pendingSet.createdAt,
+                  ),
+                ],
+                resolved: const [],
+                pendingSets: [pendingSet],
+              ),
+            );
+            when(
+              () => mockJournalDb.journalEntityById('cl-new'),
+            ).thenAnswer((_) async => newChecklistItem);
+            when(() => mockSyncService.upsertEntity(any())).thenAnswer((
+              invocation,
+            ) async {
+              upserts.add(
+                invocation.positionalArguments.single as AgentDomainEntity,
+              );
+            });
+
+            final result = await executeWithToolCallOnRealTask(
+              TaskAgentToolNames.updateChecklistItems,
+              '{"items":[{"id":"cl-new","isChecked":true}]}',
+            );
+
+            expect(result.success, isTrue);
+            expect(
+              upserts.whereType<ChangeSetEntity>(),
+              isEmpty,
+              reason:
+                  'the duplicate visible proposal must not create or merge a '
+                  'change set',
+            );
+            verify(
+              () => mockJournalDb.journalEntityById('cl-new'),
             ).called(1);
           },
         );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent prompts now include an "Open Proposal Guard" that compares new proposals against open items and retracts stale suggestions.

* **Bug Fixes**
  * Task-agent suggestions now suppress verbatim duplicate proposals even when underlying tool arguments differ, so identical checklist suggestions appear only once.
  * Updates for distinct running timers remain separate and are not collapsed.

* **Tests**
  * Added tests covering visible deduplication and guard rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->