### PR TITLE
feat: inter-agent attention requests

### DIFF
--- a/lib/features/agents/README.md
+++ b/lib/features/agents/README.md
@@ -734,6 +734,9 @@ The task wake prompt is assembled from:
 - prior observation messages
 - linked-task context
 - pending change sets for the same task
+- active `AttentionRequestEntity` claims for this task, loaded through
+  `AgentRepository.getAttentionClaimsForTarget(targetKind: 'task', ...)` so
+  the prompt never scans the append-only `agent_entities` source table
 - the active running timer, when one is running. If the timer's source task
   matches the wake's task, the agent gets full details (id, started, tracked
   range, elapsed minutes, current entry text) and is steered toward
@@ -761,10 +764,12 @@ external source URLs; internal task links belong inline in the report body.
 
 ### Tool Policy
 
-Task agents have two immediate local tools:
+Task agents have three immediate local tools:
 
 - `update_report`
 - `record_observations`
+- `request_attention` *(writes an evidence-backed `AttentionRequestEntity`
+  into the synced agent log; it does not mutate the task or calendar directly)*
 
 The current deferred task tools are:
 
@@ -788,10 +793,12 @@ The current deferred task tools are:
   timer when one is running for this task; user-gated; replaces entry text
   outright)*
 
-There are no other immediate task-mutating tools today. Non-local task writes
-go through `AgentToolExecutor`, which enforces the agent's allowed category set,
-captures post-write vector clocks, and persists audit messages for tool actions
-and tool results.
+There are no other immediate task-mutating tools today. `request_attention`
+is intentionally immediate because it writes an auditable claim for the day
+planner, not a user-visible task/calendar mutation. Non-local task writes go
+through `AgentToolExecutor`, which enforces the agent's allowed category set,
+captures post-write vector clocks when a journal entity changes, and persists
+audit messages for tool actions and tool results.
 
 `ChangeSetBuilder` is responsible for the deferred path. It:
 

--- a/lib/features/agents/database/agent_database.dart
+++ b/lib/features/agents/database/agent_database.dart
@@ -30,7 +30,7 @@ class AgentDatabase extends _$AgentDatabase {
   final bool inMemoryDatabase;
 
   @override
-  int get schemaVersion => 13;
+  int get schemaVersion => 14;
 
   @override
   MigrationStrategy get migration {
@@ -342,6 +342,18 @@ class AgentDatabase extends _$AgentDatabase {
             'ON standing_agreement_index(status, scope, active_from, '
             'active_until, priority DESC, updated_at DESC, agreement_id) '
             'WHERE deleted_at IS NULL',
+          );
+          await customStatement('ANALYZE');
+        }
+        if (from < 14) {
+          await customStatement(
+            'CREATE INDEX IF NOT EXISTS '
+            'idx_attention_claims_active_target '
+            'ON attention_claim_index(target_kind, target_id, status, '
+            'updated_at DESC, request_id) '
+            'WHERE deleted_at IS NULL '
+            'AND target_kind IS NOT NULL '
+            'AND target_id IS NOT NULL',
           );
           await customStatement('ANALYZE');
         }

--- a/lib/features/agents/database/agent_database.drift
+++ b/lib/features/agents/database/agent_database.drift
@@ -92,6 +92,9 @@ CREATE INDEX idx_attention_claims_active_window
 CREATE INDEX idx_attention_claims_active_deadline
   ON attention_claim_index(status, deadline, request_id)
   WHERE deleted_at IS NULL AND deadline IS NOT NULL;
+CREATE INDEX idx_attention_claims_active_target
+  ON attention_claim_index(target_kind, target_id, status, updated_at DESC, request_id)
+  WHERE deleted_at IS NULL AND target_kind IS NOT NULL AND target_id IS NOT NULL;
 
 CREATE TABLE standing_agreement_index (
   agreement_id TEXT NOT NULL PRIMARY KEY,

--- a/lib/features/agents/database/agent_database.g.dart
+++ b/lib/features/agents/database/agent_database.g.dart
@@ -4464,6 +4464,10 @@ abstract class _$AgentDatabase extends GeneratedDatabase {
     'idx_attention_claims_active_deadline',
     'CREATE INDEX idx_attention_claims_active_deadline ON attention_claim_index (status, deadline, request_id) WHERE deleted_at IS NULL AND deadline IS NOT NULL',
   );
+  late final Index idxAttentionClaimsActiveTarget = Index(
+    'idx_attention_claims_active_target',
+    'CREATE INDEX idx_attention_claims_active_target ON attention_claim_index (target_kind, target_id, status, updated_at DESC, request_id) WHERE deleted_at IS NULL AND target_kind IS NOT NULL AND target_id IS NOT NULL',
+  );
   late final StandingAgreementIndex standingAgreementIndex =
       StandingAgreementIndex(this);
   late final Index idxStandingAgreementsActiveWindow = Index(
@@ -5120,6 +5124,7 @@ abstract class _$AgentDatabase extends GeneratedDatabase {
     attentionClaimIndex,
     idxAttentionClaimsActiveWindow,
     idxAttentionClaimsActiveDeadline,
+    idxAttentionClaimsActiveTarget,
     standingAgreementIndex,
     idxStandingAgreementsActiveWindow,
     idxStandingAgreementsActiveScopeWindow,

--- a/lib/features/agents/database/agent_repository.dart
+++ b/lib/features/agents/database/agent_repository.dart
@@ -12,6 +12,23 @@ import 'package:lotti/features/agents/model/proposal_ledger.dart';
 import 'package:lotti/services/domain_logging.dart';
 import 'package:sqlite3/sqlite3.dart' show SqliteException;
 
+/// Indexed attention-planning inputs for one planner window.
+class AttentionPlanningInputs {
+  const AttentionPlanningInputs({
+    required this.claims,
+    required this.standingAgreements,
+  });
+
+  const AttentionPlanningInputs.empty()
+    : claims = const [],
+      standingAgreements = const [];
+
+  final List<AttentionRequestEntity> claims;
+  final List<StandingAgreementEntity> standingAgreements;
+
+  bool get isEmpty => claims.isEmpty && standingAgreements.isEmpty;
+}
+
 /// Typed CRUD repository wrapping [AgentDatabase] and [AgentDbConversions].
 ///
 /// All entity reads go through [AgentDbConversions.fromEntityRow] and all
@@ -268,6 +285,114 @@ class AgentRepository {
         if (entitiesById[requestId] case final AttentionRequestEntity request)
           request,
     ];
+  }
+
+  /// Fetch active attention claims for a source target, e.g. a task agent
+  /// checking whether it already requested focus time for its task.
+  ///
+  /// Uses `attention_claim_index(target_kind, target_id, status, ...)`; it does
+  /// not scan `agent_entities` or deserialize source rows to discover matches.
+  Future<List<AttentionRequestEntity>> getAttentionClaimsForTarget({
+    required String targetKind,
+    required String targetId,
+    Set<AttentionClaimStatus> statuses = const {
+      AttentionClaimStatus.open,
+      AttentionClaimStatus.proposed,
+      AttentionClaimStatus.partiallySatisfied,
+      AttentionClaimStatus.deferred,
+    },
+    int limit = 50,
+  }) async {
+    if (targetKind.trim().isEmpty ||
+        targetId.trim().isEmpty ||
+        statuses.isEmpty ||
+        limit <= 0) {
+      return const [];
+    }
+
+    final orderedStatuses = statuses.toList(growable: false)
+      ..sort((a, b) => a.name.compareTo(b.name));
+    final statusPlaceholders = List.filled(
+      orderedStatuses.length,
+      '?',
+    ).join(', ');
+    final rows = await _db
+        .customSelect(
+          '''
+            SELECT request_id
+            FROM attention_claim_index
+            WHERE target_kind = ?
+              AND target_id = ?
+              AND status IN ($statusPlaceholders)
+              AND deleted_at IS NULL
+            ORDER BY next_review_at IS NULL,
+              next_review_at ASC,
+              deadline IS NULL,
+              deadline ASC,
+              updated_at DESC,
+              request_id ASC
+            LIMIT ?
+          ''',
+          variables: [
+            Variable.withString(targetKind),
+            Variable.withString(targetId),
+            ...orderedStatuses.map(
+              (status) => Variable.withString(status.name),
+            ),
+            Variable.withInt(limit),
+          ],
+          readsFrom: {_db.attentionClaimIndex},
+        )
+        .get();
+
+    final requestIds = [
+      for (final row in rows) row.read<String>('request_id'),
+    ];
+    final entitiesById = await getEntitiesByIds(requestIds);
+    return [
+      for (final requestId in requestIds)
+        if (entitiesById[requestId] case final AttentionRequestEntity request)
+          request,
+    ];
+  }
+
+  /// Fetch the claim and standing-agreement inputs a day planner needs for a
+  /// window. Both reads use projection indexes rather than source-table scans.
+  Future<AttentionPlanningInputs> getAttentionPlanningInputsForWindow({
+    required DateTime start,
+    required DateTime end,
+    Set<AttentionClaimStatus> claimStatuses = const {
+      AttentionClaimStatus.open,
+      AttentionClaimStatus.proposed,
+      AttentionClaimStatus.partiallySatisfied,
+      AttentionClaimStatus.deferred,
+    },
+    Set<StandingAgreementStatus> agreementStatuses = const {
+      StandingAgreementStatus.active,
+    },
+    Set<StandingAgreementScope>? agreementScopes,
+    int claimLimit = 200,
+    int agreementLimit = 200,
+  }) async {
+    final (claims, standingAgreements) = await (
+      getAttentionClaimsForWindow(
+        start: start,
+        end: end,
+        statuses: claimStatuses,
+        limit: claimLimit,
+      ),
+      getStandingAgreementsForWindow(
+        start: start,
+        end: end,
+        statuses: agreementStatuses,
+        scopes: agreementScopes,
+        limit: agreementLimit,
+      ),
+    ).wait;
+    return AttentionPlanningInputs(
+      claims: claims,
+      standingAgreements: standingAgreements,
+    );
   }
 
   /// Fetch standing agreements visible to a planning window via the local

--- a/lib/features/agents/state/change_set_providers.dart
+++ b/lib/features/agents/state/change_set_providers.dart
@@ -163,6 +163,8 @@ ChangeSetConfirmationService changeSetConfirmationService(Ref ref) {
       domainLogger: logger,
       taskAgentService: ref.watch(taskAgentServiceProvider),
       projectRepository: ref.watch(projectRepositoryProvider),
+      agentRepository: ref.watch(agentRepositoryProvider),
+      syncService: ref.watch(agentSyncServiceProvider),
     ).dispatch,
     labelsRepository: labelsRepository,
     domainLogger: logger,

--- a/lib/features/agents/state/change_set_providers.g.dart
+++ b/lib/features/agents/state/change_set_providers.g.dart
@@ -60,4 +60,4 @@ final class ChangeSetConfirmationServiceProvider
 }
 
 String _$changeSetConfirmationServiceHash() =>
-    r'18488f1f8bde1f183ad98d584b413d9c2bc2f457';
+    r'b5912e7f07eb4f98fe4aeb6aeae99b621a707289';

--- a/lib/features/agents/tools/agent_tool_registry.dart
+++ b/lib/features/agents/tools/agent_tool_registry.dart
@@ -43,6 +43,7 @@ abstract final class TaskAgentToolNames {
   static const setTaskLanguage = 'set_task_language';
   static const setTaskStatus = 'set_task_status';
   static const getRelatedTaskDetails = 'get_related_task_details';
+  static const requestAttention = 'request_attention';
 
   // Task splitting tools.
   static const createFollowUpTask = 'create_follow_up_task';
@@ -519,6 +520,91 @@ class AgentToolRegistry {
           },
         },
         'required': ['taskId'],
+        'additionalProperties': false,
+      },
+    ),
+    AgentToolDefinition(
+      name: TaskAgentToolNames.requestAttention,
+      description:
+          'Ask the day planner to reserve attention/time for this task. '
+          'Use this when the task needs scheduled work soon, has a deadline, '
+          'or should compete for planner attention. Do not use it for vague '
+          'interest; make a concrete evidence-backed claim. Check the '
+          'Attention Requests section in the task context first and do not '
+          'repeat an equivalent active request.',
+      parameters: {
+        'type': 'object',
+        'properties': {
+          'title': {
+            'type': 'string',
+            'description':
+                'Short planner-facing label. Omit to use the task title.',
+          },
+          'requestedMinutes': {
+            'type': 'integer',
+            'minimum': 1,
+            'maximum': 1440,
+            'description': 'Minutes of planner time requested for the task.',
+          },
+          'impact': {
+            'type': 'integer',
+            'minimum': 1,
+            'maximum': 5,
+            'description':
+                'How valuable it is to schedule this task now, 1 low to 5 high.',
+          },
+          'urgency': {
+            'type': 'integer',
+            'minimum': 1,
+            'maximum': 5,
+            'description':
+                'How time-sensitive the request is, 1 low to 5 high.',
+          },
+          'energyFit': {
+            'type': 'string',
+            'enum': ['low', 'neutral', 'high'],
+            'description':
+                'Energy level needed for a good slot: low, neutral, or high.',
+          },
+          'earliestStart': {
+            'type': 'string',
+            'description':
+                'Optional earliest acceptable ISO-8601 start time/date.',
+          },
+          'latestEnd': {
+            'type': 'string',
+            'description': 'Optional latest acceptable ISO-8601 end time/date.',
+          },
+          'deadline': {
+            'type': 'string',
+            'description':
+                'Optional hard or meaningful ISO-8601 deadline for the work.',
+          },
+          'nextReviewAt': {
+            'type': 'string',
+            'description':
+                'Optional ISO-8601 time when the planner should reconsider.',
+          },
+          'scopeKind': {
+            'type': 'string',
+            'enum': ['day', 'dateRange', 'deadline', 'recurrence'],
+            'description':
+                'Optional explicit planning scope. Usually omit and let the '
+                'tool infer it from latestEnd/deadline.',
+          },
+          'rationale': {
+            'type': 'string',
+            'description':
+                'Brief evidence-backed reason the planner should consider it.',
+          },
+        },
+        'required': [
+          'requestedMinutes',
+          'impact',
+          'urgency',
+          'energyFit',
+          'rationale',
+        ],
         'additionalProperties': false,
       },
     ),

--- a/lib/features/agents/tools/attention_request_handler.dart
+++ b/lib/features/agents/tools/attention_request_handler.dart
@@ -1,0 +1,363 @@
+import 'package:clock/clock.dart';
+import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/agents/database/agent_repository.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/attention_negotiation.dart';
+import 'package:lotti/features/agents/sync/agent_sync_service.dart';
+import 'package:lotti/features/agents/tools/agent_tool_executor.dart';
+import 'package:uuid/uuid.dart';
+
+/// Handles task-agent requests for planner attention/time.
+class AttentionRequestHandler {
+  AttentionRequestHandler({
+    required this.agentRepository,
+    required this.syncService,
+    required this.requestingAgentId,
+  });
+
+  final AgentRepository agentRepository;
+  final AgentSyncService syncService;
+  final String requestingAgentId;
+
+  static const _uuid = Uuid();
+  static const _taskTargetKind = 'task';
+
+  Future<ToolExecutionResult> handle(
+    Task task,
+    Map<String, dynamic> args,
+  ) async {
+    if (requestingAgentId.trim().isEmpty) {
+      return const ToolExecutionResult(
+        success: false,
+        output: 'Error: request_attention is missing the requesting agent id.',
+        errorMessage: 'Missing requesting agent id',
+      );
+    }
+
+    final categoryId = task.categoryId;
+    if (categoryId == null || categoryId.trim().isEmpty) {
+      return const ToolExecutionResult(
+        success: false,
+        output: 'Error: task has no category for an attention request.',
+        errorMessage: 'Task has no category',
+      );
+    }
+
+    final requestedMinutes = _requiredInt(
+      args,
+      'requestedMinutes',
+      min: 1,
+      max: 1440,
+    );
+    final impact = _requiredInt(args, 'impact', min: 1, max: 5);
+    final urgency = _requiredInt(args, 'urgency', min: 1, max: 5);
+    final energyFit = _requiredEnum(
+      args,
+      'energyFit',
+      AttentionEnergyFit.values,
+    );
+    final rationale = _requiredString(args, 'rationale');
+
+    final validationErrors = [
+      requestedMinutes.error,
+      impact.error,
+      urgency.error,
+      energyFit.error,
+      rationale.error,
+    ].whereType<String>();
+    if (validationErrors.isNotEmpty) {
+      return ToolExecutionResult(
+        success: false,
+        output: 'Error: ${validationErrors.first}',
+        errorMessage: validationErrors.first,
+      );
+    }
+
+    final title = _optionalString(args, 'title') ?? _defaultTitle(task);
+    final earliestStart = _optionalDateTime(args, 'earliestStart');
+    final latestEnd = _optionalDateTime(args, 'latestEnd');
+    final deadline = _optionalDateTime(args, 'deadline');
+    final nextReviewAt = _optionalDateTime(args, 'nextReviewAt');
+    final optionalDateErrors = [
+      earliestStart.error,
+      latestEnd.error,
+      deadline.error,
+      nextReviewAt.error,
+    ].whereType<String>();
+    if (optionalDateErrors.isNotEmpty) {
+      return ToolExecutionResult(
+        success: false,
+        output: 'Error: ${optionalDateErrors.first}',
+        errorMessage: optionalDateErrors.first,
+      );
+    }
+
+    final start = earliestStart.value;
+    final latest = latestEnd.value;
+    final due = deadline.value;
+    if (start != null && latest != null && !latest.isAfter(start)) {
+      return const ToolExecutionResult(
+        success: false,
+        output: 'Error: latestEnd must be after earliestStart.',
+        errorMessage: 'Invalid attention request window',
+      );
+    }
+    if (start != null && due != null && !due.isAfter(start)) {
+      return const ToolExecutionResult(
+        success: false,
+        output: 'Error: deadline must be after earliestStart.',
+        errorMessage: 'Invalid attention request deadline',
+      );
+    }
+
+    final explicitScopeKind = _optionalEnum(
+      args,
+      'scopeKind',
+      AttentionClaimScopeKind.values,
+    );
+    if (explicitScopeKind.error != null) {
+      return ToolExecutionResult(
+        success: false,
+        output: 'Error: ${explicitScopeKind.error}',
+        errorMessage: explicitScopeKind.error,
+      );
+    }
+    final scopeKind =
+        explicitScopeKind.value ??
+        _inferScopeKind(latestEnd: latest, deadline: due);
+    final now = clock.now();
+    final existing = await agentRepository.getAttentionClaimsForTarget(
+      targetKind: _taskTargetKind,
+      targetId: task.id,
+    );
+    final matching = existing
+        .where(
+          (claim) => _matchesRequest(
+            claim,
+            title: title,
+            categoryId: categoryId,
+            requestedMinutes: requestedMinutes.value!,
+            impact: impact.value!,
+            urgency: urgency.value!,
+            energyFit: energyFit.value!,
+            scopeKind: scopeKind,
+            earliestStart: start,
+            latestEnd: latest,
+            deadline: due,
+            nextReviewAt: nextReviewAt.value,
+            rationale: rationale.value!,
+          ),
+        )
+        .toList(growable: false);
+    final stale = [
+      for (final claim in existing)
+        if (!matching.any((candidate) => candidate.id == claim.id)) claim,
+    ];
+
+    if (matching.isNotEmpty) {
+      if (stale.isNotEmpty) {
+        await syncService.runInTransaction(() async {
+          for (final claim in stale) {
+            await _supersede(claim.id, now);
+          }
+        });
+      }
+      return ToolExecutionResult(
+        success: true,
+        output:
+            'Attention request already active for this task: '
+            '${matching.first.id}',
+      );
+    }
+
+    final requestId = _uuid.v4();
+    final request = AgentDomainEntity.attentionRequest(
+      id: requestId,
+      agentId: requestingAgentId,
+      kind: AttentionRequestKind.task,
+      title: title,
+      categoryId: categoryId,
+      requestedMinutes: requestedMinutes.value!,
+      impact: impact.value!,
+      urgency: urgency.value!,
+      energyFit: energyFit.value!,
+      evidenceRefs: [
+        AttentionEvidenceRef(
+          kind: AttentionEvidenceKind.task,
+          id: task.id,
+          label: task.data.title.trim().isEmpty ? task.id : task.data.title,
+        ),
+      ],
+      scopeKind: scopeKind,
+      earliestStart: start,
+      latestEnd: latest,
+      deadline: due,
+      nextReviewAt: nextReviewAt.value,
+      targetId: task.id,
+      targetKind: _taskTargetKind,
+      rationale: rationale.value,
+      createdAt: now,
+      vectorClock: null,
+    );
+
+    await syncService.runInTransaction(() async {
+      for (final claim in stale) {
+        await _supersede(claim.id, now);
+      }
+      await syncService.upsertEntity(request);
+    });
+
+    return ToolExecutionResult(
+      success: true,
+      output: 'Attention request created: $requestId',
+    );
+  }
+
+  Future<void> _supersede(String requestId, DateTime now) {
+    return syncService.upsertEntity(
+      AgentDomainEntity.attentionClaimDisposition(
+        id: _uuid.v4(),
+        agentId: requestingAgentId,
+        requestId: requestId,
+        status: AttentionClaimStatus.superseded,
+        reason: 'Superseded by a newer task attention request.',
+        createdAt: now,
+        vectorClock: null,
+      ),
+    );
+  }
+
+  static AttentionClaimScopeKind _inferScopeKind({
+    required DateTime? latestEnd,
+    required DateTime? deadline,
+  }) {
+    if (latestEnd != null) return AttentionClaimScopeKind.dateRange;
+    if (deadline != null) return AttentionClaimScopeKind.deadline;
+    return AttentionClaimScopeKind.day;
+  }
+
+  static String _defaultTitle(Task task) {
+    final title = task.data.title.trim();
+    if (title.isEmpty) return 'Schedule task work';
+    return 'Schedule: $title';
+  }
+
+  static bool _matchesRequest(
+    AttentionRequestEntity claim, {
+    required String title,
+    required String categoryId,
+    required int requestedMinutes,
+    required int impact,
+    required int urgency,
+    required AttentionEnergyFit energyFit,
+    required AttentionClaimScopeKind scopeKind,
+    required DateTime? earliestStart,
+    required DateTime? latestEnd,
+    required DateTime? deadline,
+    required DateTime? nextReviewAt,
+    required String rationale,
+  }) {
+    return claim.title == title &&
+        claim.categoryId == categoryId &&
+        claim.requestedMinutes == requestedMinutes &&
+        claim.impact == impact &&
+        claim.urgency == urgency &&
+        claim.energyFit == energyFit &&
+        claim.scopeKind == scopeKind &&
+        claim.earliestStart == earliestStart &&
+        claim.latestEnd == latestEnd &&
+        claim.deadline == deadline &&
+        claim.nextReviewAt == nextReviewAt &&
+        claim.rationale == rationale;
+  }
+
+  static _Parsed<int> _requiredInt(
+    Map<String, dynamic> args,
+    String key, {
+    required int min,
+    required int max,
+  }) {
+    final value = args[key];
+    if (value is! int) {
+      return _Parsed(error: '"$key" must be an integer.');
+    }
+    if (value < min || value > max) {
+      return _Parsed(error: '"$key" must be between $min and $max.');
+    }
+    return _Parsed(value: value);
+  }
+
+  static _Parsed<T> _requiredEnum<T extends Enum>(
+    Map<String, dynamic> args,
+    String key,
+    List<T> values,
+  ) {
+    final parsed = _optionalEnum(args, key, values);
+    if (parsed.error != null) return parsed;
+    if (parsed.value == null) {
+      return _Parsed(error: '"$key" is required.');
+    }
+    return parsed;
+  }
+
+  static _Parsed<T> _optionalEnum<T extends Enum>(
+    Map<String, dynamic> args,
+    String key,
+    List<T> values,
+  ) {
+    final value = args[key];
+    if (value == null) return const _Parsed();
+    if (value is! String || value.trim().isEmpty) {
+      return _Parsed(error: '"$key" must be a non-empty string.');
+    }
+    for (final candidate in values) {
+      if (candidate.name == value.trim()) {
+        return _Parsed(value: candidate);
+      }
+    }
+    return _Parsed(
+      error:
+          '"$key" must be one of: '
+          '${values.map((value) => value.name).join(", ")}.',
+    );
+  }
+
+  static _Parsed<String> _requiredString(
+    Map<String, dynamic> args,
+    String key,
+  ) {
+    final value = _optionalString(args, key);
+    if (value == null) return _Parsed(error: '"$key" is required.');
+    return _Parsed(value: value);
+  }
+
+  static String? _optionalString(Map<String, dynamic> args, String key) {
+    final value = args[key];
+    if (value == null) return null;
+    if (value is! String || value.trim().isEmpty) return null;
+    return value.trim();
+  }
+
+  static _Parsed<DateTime?> _optionalDateTime(
+    Map<String, dynamic> args,
+    String key,
+  ) {
+    final value = args[key];
+    if (value == null) return const _Parsed();
+    if (value is! String || value.trim().isEmpty) {
+      return _Parsed(error: '"$key" must be an ISO-8601 string.');
+    }
+    final parsed = DateTime.tryParse(value.trim());
+    if (parsed == null) {
+      return _Parsed(error: '"$key" must be a valid ISO-8601 date/time.');
+    }
+    return _Parsed(value: parsed);
+  }
+}
+
+class _Parsed<T> {
+  const _Parsed({this.value, this.error});
+
+  final T? value;
+  final String? error;
+}

--- a/lib/features/agents/tools/attention_request_handler.dart
+++ b/lib/features/agents/tools/attention_request_handler.dart
@@ -109,6 +109,13 @@ class AttentionRequestHandler {
         errorMessage: 'Invalid attention request deadline',
       );
     }
+    if (latest != null && due != null && latest.isAfter(due)) {
+      return const ToolExecutionResult(
+        success: false,
+        output: 'Error: latestEnd cannot be after the deadline.',
+        errorMessage: 'Invalid attention request window and deadline',
+      );
+    }
 
     final explicitScopeKind = _optionalEnum(
       args,
@@ -149,15 +156,20 @@ class AttentionRequestHandler {
           ),
         )
         .toList(growable: false);
-    final stale = [
+    // Keep at most one canonical active claim per task. When the incoming
+    // request matches an existing claim, retain the first match and supersede
+    // every other claim — both stale variants and any pre-existing duplicate
+    // equivalent claims, so duplicates can't accumulate.
+    final canonical = matching.isEmpty ? null : matching.first;
+    final claimsToSupersede = [
       for (final claim in existing)
-        if (!matching.any((candidate) => candidate.id == claim.id)) claim,
+        if (canonical == null || claim.id != canonical.id) claim,
     ];
 
-    if (matching.isNotEmpty) {
-      if (stale.isNotEmpty) {
+    if (canonical != null) {
+      if (claimsToSupersede.isNotEmpty) {
         await syncService.runInTransaction(() async {
-          for (final claim in stale) {
+          for (final claim in claimsToSupersede) {
             await _supersede(claim.id, now);
           }
         });
@@ -165,8 +177,7 @@ class AttentionRequestHandler {
       return ToolExecutionResult(
         success: true,
         output:
-            'Attention request already active for this task: '
-            '${matching.first.id}',
+            'Attention request already active for this task: ${canonical.id}',
       );
     }
 
@@ -201,7 +212,7 @@ class AttentionRequestHandler {
     );
 
     await syncService.runInTransaction(() async {
-      for (final claim in stale) {
+      for (final claim in claimsToSupersede) {
         await _supersede(claim.id, now);
       }
       await syncService.upsertEntity(request);
@@ -264,11 +275,23 @@ class AttentionRequestHandler {
         claim.urgency == urgency &&
         claim.energyFit == energyFit &&
         claim.scopeKind == scopeKind &&
-        claim.earliestStart == earliestStart &&
-        claim.latestEnd == latestEnd &&
-        claim.deadline == deadline &&
-        claim.nextReviewAt == nextReviewAt &&
+        _isSameMoment(claim.earliestStart, earliestStart) &&
+        _isSameMoment(claim.latestEnd, latestEnd) &&
+        _isSameMoment(claim.deadline, deadline) &&
+        _isSameMoment(claim.nextReviewAt, nextReviewAt) &&
         claim.rationale == rationale;
+  }
+
+  /// Compares two optional [DateTime] values by the instant they represent.
+  ///
+  /// Uses [DateTime.isAtSameMomentAs] rather than `==` because the stored
+  /// claim is typically read back as UTC while a freshly parsed request value
+  /// may be local; `==` also compares the `isUtc` flag and would report a
+  /// false mismatch for the same moment, causing duplicate requests.
+  static bool _isSameMoment(DateTime? a, DateTime? b) {
+    if (a == null && b == null) return true;
+    if (a == null || b == null) return false;
+    return a.isAtSameMomentAs(b);
   }
 
   static _Parsed<int> _requiredInt(

--- a/lib/features/agents/workflow/task_agent_workflow.dart
+++ b/lib/features/agents/workflow/task_agent_workflow.dart
@@ -1836,7 +1836,8 @@ to keep the user-facing suggestion list clean and trustworthy:
             'These active requests are already visible to the day planner. '
             'Do not call `request_attention` again for an equivalent ask; '
             'call it only when the task now needs a materially different '
-            'amount, window, urgency, or rationale.',
+            'ask (for example amount, impact, urgency, energy fit, scope, '
+            'timing window, review time, or rationale).',
           )
           ..writeln()
           ..writeln('```json')

--- a/lib/features/agents/workflow/task_agent_workflow.dart
+++ b/lib/features/agents/workflow/task_agent_workflow.dart
@@ -409,6 +409,7 @@ class TaskAgentWorkflow {
       _log('task not found in journal — aborting wake', subDomain: 'execute');
       return const WakeResult(success: false, error: 'Task not found');
     }
+    final taskAttentionClaims = await _attentionClaimsForTask(taskId);
 
     // 5. Assemble conversation context (the ledger was fetched before
     // compaction, which consumes its resolved entries as decision events).
@@ -425,6 +426,7 @@ class TaskAgentWorkflow {
       triggerTokens: triggerTokens,
       taskId: taskId,
       ledger: ledger,
+      attentionClaims: taskAttentionClaims,
       timeService: getIt<TimeService>(),
       // Only attach the compacted log when we're actually using it (the inline
       // log was dropped); otherwise the full inline log already carries it.
@@ -542,6 +544,9 @@ class TaskAgentWorkflow {
         timeService: getIt<TimeService>(),
         taskAgentService: taskAgentService,
         projectRepository: projectRepository,
+        agentRepository: agentRepository,
+        syncService: syncService,
+        requestingAgentId: agentId,
       );
 
       final changeSetBuilder = ChangeSetBuilder(
@@ -1574,6 +1579,7 @@ to keep the user-facing suggestion list clean and trustworthy:
     required Set<String> triggerTokens,
     required String taskId,
     ProposalLedger ledger = const ProposalLedger.empty(),
+    List<AttentionRequestEntity> attentionClaims = const [],
     TimeService? timeService,
     String? compactedTaskLog,
   }) async {
@@ -1699,6 +1705,11 @@ to keep the user-facing suggestion list clean and trustworthy:
       );
     }
 
+    final attentionSection = _formatTaskAttentionRequests(attentionClaims);
+    if (attentionSection.isNotEmpty) {
+      buffer.write(attentionSection);
+    }
+
     if (journalObservations.isNotEmpty) {
       // Cap to most recent 20 to prevent unbounded context growth.
       // journalObservations is ordered newest-first from the DB query.
@@ -1778,6 +1789,61 @@ to keep the user-facing suggestion list clean and trustworthy:
     );
 
     return (text: buffer.toString(), logStart: logStart, logEnd: logEnd);
+  }
+
+  Future<List<AttentionRequestEntity>> _attentionClaimsForTask(
+    String taskId,
+  ) async {
+    try {
+      return await agentRepository.getAttentionClaimsForTarget(
+        targetKind: 'task',
+        targetId: taskId,
+        limit: 20,
+      );
+    } catch (e, s) {
+      _logError(
+        'failed to load task attention requests',
+        error: e,
+        stackTrace: s,
+      );
+      return const [];
+    }
+  }
+
+  String _formatTaskAttentionRequests(List<AttentionRequestEntity> claims) {
+    if (claims.isEmpty) return '';
+    final rows = [
+      for (final claim in claims)
+        {
+          'id': claim.id,
+          'title': claim.title,
+          'requestedMinutes': claim.requestedMinutes,
+          'impact': claim.impact,
+          'urgency': claim.urgency,
+          'energyFit': claim.energyFit.name,
+          'scopeKind': claim.scopeKind.name,
+          'earliestStart': claim.earliestStart?.toIso8601String(),
+          'latestEnd': claim.latestEnd?.toIso8601String(),
+          'deadline': claim.deadline?.toIso8601String(),
+          'nextReviewAt': claim.nextReviewAt?.toIso8601String(),
+          'rationale': claim.rationale,
+        },
+    ];
+    return (StringBuffer()
+          ..writeln('## Attention Requests For This Task')
+          ..writeln()
+          ..writeln(
+            'These active requests are already visible to the day planner. '
+            'Do not call `request_attention` again for an equivalent ask; '
+            'call it only when the task now needs a materially different '
+            'amount, window, urgency, or rationale.',
+          )
+          ..writeln()
+          ..writeln('```json')
+          ..writeln(const JsonEncoder.withIndent('  ').convert(rows))
+          ..writeln('```')
+          ..writeln())
+        .toString();
   }
 
   /// Formats the [ProposalLedger] into a single markdown section the agent

--- a/lib/features/agents/workflow/task_tool_dispatcher.dart
+++ b/lib/features/agents/workflow/task_tool_dispatcher.dart
@@ -3,9 +3,12 @@ import 'dart:developer' as developer;
 
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/features/agents/database/agent_repository.dart';
 import 'package:lotti/features/agents/service/task_agent_service.dart';
+import 'package:lotti/features/agents/sync/agent_sync_service.dart';
 import 'package:lotti/features/agents/tools/agent_tool_executor.dart';
 import 'package:lotti/features/agents/tools/agent_tool_registry.dart';
+import 'package:lotti/features/agents/tools/attention_request_handler.dart';
 import 'package:lotti/features/agents/tools/checklist_migration_handler.dart';
 import 'package:lotti/features/agents/tools/follow_up_task_handler.dart';
 import 'package:lotti/features/agents/tools/running_timer_update_handler.dart';
@@ -50,6 +53,9 @@ class TaskToolDispatcher {
     this.domainLogger,
     this.taskAgentService,
     this.projectRepository,
+    this.agentRepository,
+    this.syncService,
+    this.requestingAgentId,
   });
 
   final JournalDb journalDb;
@@ -61,6 +67,9 @@ class TaskToolDispatcher {
   final DomainLogger? domainLogger;
   final TaskAgentService? taskAgentService;
   final ProjectRepository? projectRepository;
+  final AgentRepository? agentRepository;
+  final AgentSyncService? syncService;
+  final String? requestingAgentId;
 
   static const _uuid = Uuid();
 
@@ -165,6 +174,9 @@ class TaskToolDispatcher {
 
       case TaskAgentToolNames.updateRunningTimer:
         return _handleUpdateRunningTimer(args, taskId);
+
+      case TaskAgentToolNames.requestAttention:
+        return _handleRequestAttention(taskEntity, args);
 
       default:
         return ToolExecutionResult(
@@ -596,5 +608,28 @@ class TaskToolDispatcher {
       domainLogger: domainLogger,
     );
     return handler.handle(taskId, args);
+  }
+
+  Future<ToolExecutionResult> _handleRequestAttention(
+    Task task,
+    Map<String, dynamic> args,
+  ) async {
+    final repository = agentRepository;
+    final sync = syncService;
+    final agentId = requestingAgentId;
+    if (repository == null || sync == null || agentId == null) {
+      return const ToolExecutionResult(
+        success: false,
+        output: 'Error: request_attention is not configured.',
+        errorMessage: 'request_attention is not configured',
+      );
+    }
+
+    final handler = AttentionRequestHandler(
+      agentRepository: repository,
+      syncService: sync,
+      requestingAgentId: agentId,
+    );
+    return handler.handle(task, args);
   }
 }

--- a/lib/features/daily_os_next/README.md
+++ b/lib/features/daily_os_next/README.md
@@ -236,17 +236,18 @@ Runtime behavior:
   untouched. Both write `ChangeDecisionEntity` records per resolved item
   with `actor: user` and `verdict: confirmed | rejected`. Added blocks inherit
   `committed` state when the amended plan was already agreed/committed.
-- Attention negotiation has a persisted proposal substrate, but not the full
-  planner workflow yet. Agents can write `AttentionRequestEntity` records as
-  evidence-backed claims for attention, and the planner can write
-  `AttentionAwardEntity` records linked back to requests and concrete day plans
-  when a block is proposed. `StandingAgreementEntity` records model durable
-  user policies/goals and are discoverable through `standing_agreement_index`,
-  not source-table JSON scans. Per ADR 0021, the target planner behavior is
-  LLM-mediated claim weighing: specialist agents make window-scoped claims, the
-  day-planner LLM weighs them against the plan and standing agreements, and
-  deterministic code validates/routes the result through the `ChangeSet` gate.
-  There is no standalone deterministic arbitrator fallback in production.
+- Attention negotiation now has an indexed read/write path into planning.
+  Task agents can call `request_attention`, which writes an evidence-backed
+  `AttentionRequestEntity` into the synced agent log after checking existing
+  active claims for the same task through `attention_claim_index`. The day
+  agent loads `AgentRepository.getAttentionPlanningInputsForWindow(...)` for
+  the planning day, which returns window-visible claims plus active
+  `StandingAgreementEntity` records through projection indexes rather than
+  source-table JSON scans. Planner awards still flow through the existing
+  human-gated `ChangeSet` path: a planner may write `AttentionAwardEntity`
+  records linked back to requests and concrete day plans when proposing blocks.
+  Per ADR 0021, the planner behavior is LLM-mediated claim weighing; there is
+  no standalone deterministic arbitrator fallback in production.
 - Wakes consume any `scheduledWakeAt` timestamp that is no longer in the future
   so app restart does not replay an already-fired scheduled wake.
 - Future Daily OS Next commit, agenda, and shutdown tools should be added

--- a/lib/features/daily_os_next/agents/workflow/day_agent_workflow.dart
+++ b/lib/features/daily_os_next/agents/workflow/day_agent_workflow.dart
@@ -761,7 +761,9 @@ ${const JsonEncoder.withIndent('  ').convert(config.toJson())}''';
       final start = DateTime(planDate.year, planDate.month, planDate.day);
       return await agentRepository.getAttentionPlanningInputsForWindow(
         start: start,
-        end: start.add(const Duration(days: 1)),
+        // Use day + 1 (not Duration(days: 1)) so the window stays at local
+        // midnight across DST transitions, where a day may be 23 or 25 hours.
+        end: DateTime(start.year, start.month, start.day + 1),
       );
     } catch (e, s) {
       _logError(

--- a/lib/features/daily_os_next/agents/workflow/day_agent_workflow.dart
+++ b/lib/features/daily_os_next/agents/workflow/day_agent_workflow.dart
@@ -228,6 +228,7 @@ class DayAgentWorkflow {
       dayId: dayId,
       triggerTokens: triggerTokens,
     );
+    final attentionPlanning = await _attentionPlanningContext(dayDate);
     final systemPrompt = _buildSystemPrompt(templateCtx);
     final userMessage = _buildUserMessage(
       dayId: dayId,
@@ -239,6 +240,7 @@ class DayAgentWorkflow {
       captureContext: captureContext,
       draftingContext: draftingContext,
       refineContext: refineContext,
+      attentionPlanning: attentionPlanning,
       compactedLog: memoryView.useCompactedLog ? memoryView.compactedLog : null,
     );
 
@@ -717,6 +719,7 @@ ${const JsonEncoder.withIndent('  ').convert(config.toJson())}''';
     required _CaptureContext? captureContext,
     required _DraftingContext? draftingContext,
     required _RefineContext? refineContext,
+    required AttentionPlanningInputs attentionPlanning,
     String? compactedLog,
   }) {
     final payload = <String, Object?>{
@@ -732,6 +735,8 @@ ${const JsonEncoder.withIndent('  ').convert(config.toJson())}''';
       if (captureContext != null) 'capture': captureContext.toJson(),
       if (draftingContext != null) 'drafting': draftingContext.toJson(),
       if (refineContext != null) 'refine': refineContext.toJson(),
+      if (!attentionPlanning.isEmpty)
+        'attentionPlanning': _attentionPlanningToJson(attentionPlanning),
       if (compactedLog == null)
         'recentObservations': [
           for (final observation in observations)
@@ -747,6 +752,88 @@ ${const JsonEncoder.withIndent('  ').convert(config.toJson())}''';
       'currentLocalTime': now.toIso8601String(),
     };
     return const JsonEncoder.withIndent('  ').convert(payload);
+  }
+
+  Future<AttentionPlanningInputs> _attentionPlanningContext(
+    DateTime planDate,
+  ) async {
+    try {
+      final start = DateTime(planDate.year, planDate.month, planDate.day);
+      return await agentRepository.getAttentionPlanningInputsForWindow(
+        start: start,
+        end: start.add(const Duration(days: 1)),
+      );
+    } catch (e, s) {
+      _logError(
+        'failed to load attention planning context',
+        error: e,
+        stackTrace: s,
+      );
+      return const AttentionPlanningInputs.empty();
+    }
+  }
+
+  Map<String, Object?> _attentionPlanningToJson(
+    AttentionPlanningInputs inputs,
+  ) {
+    return {
+      'claims': [
+        for (final claim in inputs.claims)
+          {
+            'id': claim.id,
+            'agentId': claim.agentId,
+            'kind': claim.kind.name,
+            'title': claim.title,
+            'categoryId': claim.categoryId,
+            'requestedMinutes': claim.requestedMinutes,
+            'impact': claim.impact,
+            'urgency': claim.urgency,
+            'energyFit': claim.energyFit.name,
+            'scopeKind': claim.scopeKind.name,
+            'earliestStart': claim.earliestStart?.toIso8601String(),
+            'latestEnd': claim.latestEnd?.toIso8601String(),
+            'deadline': claim.deadline?.toIso8601String(),
+            'nextReviewAt': claim.nextReviewAt?.toIso8601String(),
+            'targetId': claim.targetId,
+            'targetKind': claim.targetKind,
+            'rationale': claim.rationale,
+            'evidenceRefs': [
+              for (final ref in claim.evidenceRefs)
+                {
+                  'kind': ref.kind.name,
+                  'id': ref.id,
+                  'label': ref.label,
+                },
+            ],
+          },
+      ],
+      'standingAgreements': [
+        for (final agreement in inputs.standingAgreements)
+          {
+            'id': agreement.id,
+            'agentId': agreement.agentId,
+            'title': agreement.title,
+            'scope': agreement.scope.name,
+            'cadence': agreement.cadence.name,
+            'status': agreement.status.name,
+            'enforcement': agreement.enforcement.name,
+            'approvalMode': agreement.approvalMode.name,
+            'categoryId': agreement.categoryId,
+            'targetId': agreement.targetId,
+            'targetKind': agreement.targetKind,
+            'minCount': agreement.minCount,
+            'maxCount': agreement.maxCount,
+            'minMinutes': agreement.minMinutes,
+            'maxMinutes': agreement.maxMinutes,
+            'preferredSessionMinutes': agreement.preferredSessionMinutes,
+            'priority': agreement.priority,
+            'canPreempt': agreement.canPreempt,
+            'activeFrom': agreement.activeFrom?.toIso8601String(),
+            'activeUntil': agreement.activeUntil?.toIso8601String(),
+            'rationale': agreement.rationale,
+          },
+      ],
+    };
   }
 
   Future<_CaptureContext?> _captureContext({

--- a/test/features/agents/database/agent_database_test.dart
+++ b/test/features/agents/database/agent_database_test.dart
@@ -1347,6 +1347,181 @@ void main() {
         await db.close();
       },
     );
+
+    test(
+      'v13 to v14 adds active attention target lookup index',
+      () async {
+        final dbFile = path.join(testDirectory.path, agentDbFileName);
+        final rawDb = sqlite3.open(dbFile);
+
+        rawDb
+          ..execute('''
+            CREATE TABLE agent_entities (
+              id TEXT NOT NULL PRIMARY KEY,
+              agent_id TEXT NOT NULL,
+              type TEXT NOT NULL,
+              subtype TEXT,
+              thread_id TEXT,
+              created_at DATETIME NOT NULL,
+              updated_at DATETIME NOT NULL,
+              deleted_at DATETIME,
+              serialized TEXT NOT NULL,
+              schema_version INTEGER NOT NULL DEFAULT 1
+            )
+          ''')
+          ..execute('''
+            CREATE TABLE agent_links (
+              id TEXT NOT NULL PRIMARY KEY,
+              from_id TEXT NOT NULL,
+              to_id TEXT NOT NULL,
+              type TEXT NOT NULL,
+              created_at DATETIME NOT NULL,
+              updated_at DATETIME NOT NULL,
+              deleted_at DATETIME,
+              serialized TEXT NOT NULL,
+              schema_version INTEGER NOT NULL DEFAULT 1
+            )
+          ''')
+          ..execute('''
+            CREATE TABLE attention_claim_index (
+              request_id TEXT NOT NULL PRIMARY KEY,
+              agent_id TEXT NOT NULL,
+              status TEXT NOT NULL,
+              scope_kind TEXT NOT NULL,
+              visibility_start DATETIME NOT NULL,
+              visibility_end DATETIME NOT NULL,
+              deadline DATETIME,
+              next_review_at DATETIME,
+              target_id TEXT,
+              target_kind TEXT,
+              updated_at DATETIME NOT NULL,
+              deleted_at DATETIME
+            )
+          ''')
+          ..execute('''
+            CREATE TABLE standing_agreement_index (
+              agreement_id TEXT NOT NULL PRIMARY KEY,
+              agent_id TEXT NOT NULL,
+              status TEXT NOT NULL,
+              scope TEXT NOT NULL,
+              cadence TEXT NOT NULL,
+              approval_mode TEXT NOT NULL,
+              enforcement TEXT NOT NULL,
+              active_from DATETIME NOT NULL,
+              active_until DATETIME NOT NULL,
+              priority INTEGER NOT NULL,
+              target_id TEXT,
+              target_kind TEXT,
+              updated_at DATETIME NOT NULL,
+              deleted_at DATETIME
+            )
+          ''')
+          ..execute('''
+            CREATE TABLE wake_run_log (
+              run_key TEXT NOT NULL PRIMARY KEY,
+              agent_id TEXT NOT NULL,
+              reason TEXT NOT NULL,
+              reason_id TEXT,
+              thread_id TEXT NOT NULL,
+              status TEXT NOT NULL,
+              logical_change_key TEXT,
+              created_at DATETIME NOT NULL,
+              started_at DATETIME,
+              completed_at DATETIME,
+              error_message TEXT,
+              template_id TEXT,
+              template_version_id TEXT,
+              resolved_model_id TEXT,
+              soul_id TEXT,
+              soul_version_id TEXT,
+              user_rating REAL,
+              rated_at DATETIME
+            )
+          ''')
+          ..execute('''
+            CREATE TABLE saga_log (
+              operation_id TEXT NOT NULL PRIMARY KEY,
+              agent_id TEXT NOT NULL,
+              run_key TEXT NOT NULL,
+              phase TEXT NOT NULL,
+              status TEXT NOT NULL,
+              tool_name TEXT NOT NULL,
+              last_error TEXT,
+              created_at DATETIME NOT NULL,
+              updated_at DATETIME NOT NULL
+            )
+          ''')
+          ..execute('PRAGMA user_version = 13');
+        rawDb.dispose();
+
+        final db = AgentDatabase(
+          background: false,
+          documentsDirectoryProvider: () async => testDirectory,
+          tempDirectoryProvider: () async => testDirectory,
+        );
+        addTearDown(db.close);
+
+        final versionResult = await db
+            .customSelect('PRAGMA user_version')
+            .get();
+        expect(
+          versionResult.first.read<int>('user_version'),
+          db.schemaVersion,
+        );
+
+        final indexes = await db.customSelect('''
+          SELECT name FROM sqlite_master
+          WHERE type = 'index'
+            AND tbl_name = 'attention_claim_index'
+          ORDER BY name
+        ''').get();
+        expect(
+          indexes.map((row) => row.read<String>('name')),
+          contains('idx_attention_claims_active_target'),
+        );
+
+        await db.customStatement('''
+          INSERT INTO attention_claim_index (
+            request_id,
+            agent_id,
+            status,
+            scope_kind,
+            visibility_start,
+            visibility_end,
+            target_id,
+            target_kind,
+            updated_at
+          )
+          VALUES (
+            'request-1',
+            'task-agent-1',
+            'open',
+            'dateRange',
+            '2026-05-27',
+            '2026-05-28',
+            'task-1',
+            'task',
+            '2026-05-27'
+          )
+        ''');
+
+        final plan = await db.customSelect('''
+          EXPLAIN QUERY PLAN
+          SELECT request_id
+          FROM attention_claim_index
+          WHERE target_kind = 'task'
+            AND target_id = 'task-1'
+            AND status = 'open'
+            AND deleted_at IS NULL
+        ''').get();
+        expect(
+          plan.map((row) => row.read<String>('detail')).join('\n'),
+          contains('idx_attention_claims_active_target'),
+        );
+
+        await db.close();
+      },
+    );
   });
 
   group('AgentDatabase fresh install', () {

--- a/test/features/agents/database/agent_repository_test.dart
+++ b/test/features/agents/database/agent_repository_test.dart
@@ -2061,6 +2061,8 @@ void main() {
     DateTime? latestEnd,
     DateTime? deadline,
     DateTime? nextReviewAt,
+    String? targetId = 'task-1',
+    String? targetKind = 'task',
     DateTime? createdAt,
     DateTime? deletedAt,
   }) {
@@ -2089,8 +2091,8 @@ void main() {
           latestEnd: latestEnd,
           deadline: deadline,
           nextReviewAt: nextReviewAt,
-          targetId: 'task-1',
-          targetKind: 'task',
+          targetId: targetId,
+          targetKind: targetKind,
           createdAt: createdAt ?? testDate,
           vectorClock: const VectorClock({'node-1': 10}),
           deletedAt: deletedAt,
@@ -3904,6 +3906,87 @@ void main() {
     );
 
     test(
+      'returns active claims for a concrete target without scanning sources',
+      () async {
+        final matchingClaim = makeAttentionClaim(
+          id: 'attention-claim-target',
+          targetId: 'task-target',
+          nextReviewAt: DateTime(2026, 5, 27, 8),
+        );
+        final otherTaskClaim = makeAttentionClaim(
+          id: 'attention-claim-other-task',
+          targetId: 'task-other',
+        );
+        final untargetedClaim = makeAttentionClaim(
+          id: 'attention-claim-untargeted',
+          targetId: null,
+          targetKind: null,
+        );
+        final declinedClaim = makeAttentionClaim(
+          id: 'attention-claim-target-declined',
+          targetId: 'task-target',
+          createdAt: testDate.add(const Duration(minutes: 1)),
+        );
+
+        await repo.upsertEntity(otherTaskClaim);
+        await repo.upsertEntity(untargetedClaim);
+        await repo.upsertEntity(matchingClaim);
+        await repo.upsertEntity(declinedClaim);
+        await repo.upsertEntity(
+          makeAttentionDisposition(
+            id: 'attention-disposition-target-declined',
+            requestId: declinedClaim.id,
+            status: AttentionClaimStatus.declined,
+            createdAt: testDate.add(const Duration(minutes: 2)),
+          ),
+        );
+
+        final activeClaims = await repo.getAttentionClaimsForTarget(
+          targetKind: 'task',
+          targetId: 'task-target',
+        );
+        expect(activeClaims.map((item) => item.id), [matchingClaim.id]);
+
+        final declinedClaims = await repo.getAttentionClaimsForTarget(
+          targetKind: 'task',
+          targetId: 'task-target',
+          statuses: const {AttentionClaimStatus.declined},
+        );
+        expect(declinedClaims.map((item) => item.id), [declinedClaim.id]);
+
+        final plan = await db
+            .customSelect(
+              '''
+              EXPLAIN QUERY PLAN
+              SELECT request_id
+              FROM attention_claim_index
+              WHERE target_kind = ?
+                AND target_id = ?
+                AND status IN (?)
+                AND deleted_at IS NULL
+              ORDER BY next_review_at IS NULL,
+                next_review_at ASC,
+                deadline IS NULL,
+                deadline ASC,
+                updated_at DESC,
+                request_id ASC
+              LIMIT ?
+            ''',
+              variables: [
+                Variable.withString('task'),
+                Variable.withString('task-target'),
+                Variable.withString(AttentionClaimStatus.open.name),
+                Variable.withInt(50),
+              ],
+              readsFrom: {db.attentionClaimIndex},
+            )
+            .get();
+        final detail = plan.map((row) => row.read<String>('detail')).join('\n');
+        expect(detail, contains('idx_attention_claims_active_target'));
+      },
+    );
+
+    test(
       'rebuilds the local projection from source entities for repair',
       () async {
         final claim = makeAttentionClaim(
@@ -3935,6 +4018,39 @@ void main() {
           end: DateTime(2026, 5, 28),
         );
         expect(rebuiltClaims.map((item) => item.id), [claim.id]);
+      },
+    );
+  });
+
+  group('getAttentionPlanningInputsForWindow', () {
+    test(
+      'returns visible claims and standing agreements for planner context',
+      () async {
+        final claim = makeAttentionClaim(
+          id: 'attention-claim-planner-context',
+          targetId: 'task-planner',
+          rangeStart: DateTime(2026, 5, 27),
+          rangeEnd: DateTime(2026, 5, 28),
+        );
+        final agreement = makeStandingAgreement(
+          id: 'standing-agreement-planner-context',
+          activeFrom: DateTime(2026, 5),
+          activeUntil: DateTime(2026, 6),
+        );
+
+        await repo.upsertEntity(claim);
+        await repo.upsertEntity(agreement);
+
+        final inputs = await repo.getAttentionPlanningInputsForWindow(
+          start: DateTime(2026, 5, 27),
+          end: DateTime(2026, 5, 28),
+        );
+
+        expect(inputs.isEmpty, isFalse);
+        expect(inputs.claims.map((item) => item.id), [claim.id]);
+        expect(inputs.standingAgreements.map((item) => item.id), [
+          agreement.id,
+        ]);
       },
     );
   });

--- a/test/features/agents/state/change_set_providers_test.dart
+++ b/test/features/agents/state/change_set_providers_test.dart
@@ -338,6 +338,7 @@ void main() {
           labelsRepositoryProvider.overrideWithValue(mockLabelsRepository),
           domainLoggerProvider.overrideWithValue(MockDomainLogger()),
           taskAgentServiceProvider.overrideWithValue(MockTaskAgentService()),
+          agentRepositoryProvider.overrideWithValue(mockRepository),
           projectRepositoryProvider.overrideWithValue(
             MockProjectRepository(),
           ),
@@ -398,6 +399,7 @@ void main() {
             labelsRepositoryProvider.overrideWithValue(mockLabelsRepository),
             domainLoggerProvider.overrideWithValue(MockDomainLogger()),
             taskAgentServiceProvider.overrideWithValue(MockTaskAgentService()),
+            agentRepositoryProvider.overrideWithValue(mockRepository),
             projectRepositoryProvider.overrideWithValue(
               MockProjectRepository(),
             ),

--- a/test/features/agents/tools/agent_tool_registry_test.dart
+++ b/test/features/agents/tools/agent_tool_registry_test.dart
@@ -28,8 +28,8 @@ void main() {
   });
 
   group('AgentToolRegistry.taskAgentTools', () {
-    test('contains exactly 18 tool definitions', () {
-      expect(AgentToolRegistry.taskAgentTools, hasLength(18));
+    test('contains exactly 19 tool definitions', () {
+      expect(AgentToolRegistry.taskAgentTools, hasLength(19));
     });
 
     test('all tools have non-empty name and description', () {
@@ -538,6 +538,67 @@ void main() {
         expect(required, isNot(contains('reason')));
       });
     });
+
+    group('request_attention', () {
+      late AgentToolDefinition tool;
+
+      setUp(() {
+        tool = AgentToolRegistry.taskAgentTools.firstWhere(
+          (t) => t.name == TaskAgentToolNames.requestAttention,
+        );
+      });
+
+      test('has correct name and planner-facing description', () {
+        expect(tool.name, equals(TaskAgentToolNames.requestAttention));
+        expect(tool.description, contains('day planner'));
+        expect(tool.description, contains('Attention Requests'));
+      });
+
+      test('requires bounded claim fields', () {
+        final required = tool.parameters['required'] as List;
+        expect(
+          required,
+          containsAll([
+            'requestedMinutes',
+            'impact',
+            'urgency',
+            'energyFit',
+            'rationale',
+          ]),
+        );
+
+        final properties = tool.parameters['properties'] as Map;
+        final minutes = properties['requestedMinutes'] as Map;
+        expect(minutes['type'], equals('integer'));
+        expect(minutes['minimum'], equals(1));
+        expect(minutes['maximum'], equals(1440));
+        final impact = properties['impact'] as Map;
+        expect(impact['minimum'], equals(1));
+        expect(impact['maximum'], equals(5));
+        final urgency = properties['urgency'] as Map;
+        expect(urgency['minimum'], equals(1));
+        expect(urgency['maximum'], equals(5));
+      });
+
+      test('declares energy and scope enums', () {
+        final properties = tool.parameters['properties'] as Map;
+        expect(
+          (properties['energyFit'] as Map)['enum'],
+          equals(['low', 'neutral', 'high']),
+        );
+        expect(
+          (properties['scopeKind'] as Map)['enum'],
+          equals(['day', 'dateRange', 'deadline', 'recurrence']),
+        );
+      });
+
+      test('is immediate, not a user-confirmed deferred tool', () {
+        expect(
+          AgentToolRegistry.deferredTools,
+          isNot(contains(TaskAgentToolNames.requestAttention)),
+        );
+      });
+    });
   });
 
   group('AgentToolDefinition.enabled field', () {
@@ -603,6 +664,10 @@ void main() {
       expect(
         AgentToolRegistry.deferredTools,
         isNot(contains(TaskAgentToolNames.getRelatedTaskDetails)),
+      );
+      expect(
+        AgentToolRegistry.deferredTools,
+        isNot(contains(TaskAgentToolNames.requestAttention)),
       );
     });
   });

--- a/test/features/agents/workflow/task_agent_workflow_test.dart
+++ b/test/features/agents/workflow/task_agent_workflow_test.dart
@@ -253,6 +253,13 @@ void main() {
       ),
     ).thenAnswer((_) async => const ProposalLedger.empty());
     when(
+      () => mockAgentRepository.getAttentionClaimsForTarget(
+        targetKind: any(named: 'targetKind'),
+        targetId: any(named: 'targetId'),
+        limit: any(named: 'limit'),
+      ),
+    ).thenAnswer((_) async => const <AttentionRequestEntity>[]);
+    when(
       () => mockAiInputRepository.buildLinkedFromContext(any()),
     ).thenAnswer((_) async => <AiLinkedTaskContext>[]);
     when(

--- a/test/features/agents/workflow/task_agent_workflow_test.dart
+++ b/test/features/agents/workflow/task_agent_workflow_test.dart
@@ -11,6 +11,7 @@ import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/agent_link.dart';
+import 'package:lotti/features/agents/model/attention_negotiation.dart';
 import 'package:lotti/features/agents/model/change_set.dart';
 import 'package:lotti/features/agents/model/proposal_ledger.dart';
 import 'package:lotti/features/agents/projection/content_digest.dart';
@@ -2780,6 +2781,8 @@ void main() {
         String linkedTasksJson = '{}',
         Set<String> triggerTokens = const {},
         bool throwOnLinkedContextBuild = false,
+        List<AttentionRequestEntity> attentionClaims = const [],
+        bool throwOnAttentionLoad = false,
       }) async {
         List<AiLinkedTaskContext> parseLinkedTasks(dynamic rawRows) {
           if (rawRows is! List) return const <AiLinkedTaskContext>[];
@@ -2841,6 +2844,23 @@ void main() {
         when(
           () => mockAiInputRepository.buildLinkedToContext(taskId),
         ).thenAnswer((_) async => linkedTo);
+        if (throwOnAttentionLoad) {
+          when(
+            () => mockAgentRepository.getAttentionClaimsForTarget(
+              targetKind: any(named: 'targetKind'),
+              targetId: any(named: 'targetId'),
+              limit: any(named: 'limit'),
+            ),
+          ).thenThrow(Exception('attention load failed'));
+        } else {
+          when(
+            () => mockAgentRepository.getAttentionClaimsForTarget(
+              targetKind: any(named: 'targetKind'),
+              targetId: any(named: 'targetId'),
+              limit: any(named: 'limit'),
+            ),
+          ).thenAnswer((_) async => attentionClaims);
+        }
         when(
           () => mockAiConfigRepository.getConfigsByType(AiConfigType.model),
         ).thenAnswer((_) async => [geminiModel]);
@@ -3695,6 +3715,69 @@ void main() {
           expect(message, contains('(no content)'));
         },
       );
+
+      test('renders active attention requests into the user message', () async {
+        final claim =
+            AgentDomainEntity.attentionRequest(
+                  id: 'attn-1',
+                  agentId: agentId,
+                  kind: AttentionRequestKind.task,
+                  title: 'Finish tax packet',
+                  categoryId: 'work',
+                  requestedMinutes: 90,
+                  impact: 5,
+                  urgency: 4,
+                  energyFit: AttentionEnergyFit.high,
+                  evidenceRefs: const [
+                    AttentionEvidenceRef(
+                      kind: AttentionEvidenceKind.task,
+                      id: 'task-9',
+                      label: 'Tax packet',
+                    ),
+                  ],
+                  scopeKind: AttentionClaimScopeKind.dateRange,
+                  earliestStart: DateTime.utc(2026, 5, 25, 9),
+                  latestEnd: DateTime.utc(2026, 5, 25, 17),
+                  deadline: DateTime.utc(2026, 5, 26, 12),
+                  targetId: taskId,
+                  targetKind: 'task',
+                  rationale: 'Due soon and still needs a focused block.',
+                  createdAt: DateTime.utc(2026, 5, 24, 8),
+                  vectorClock: null,
+                )
+                as AttentionRequestEntity;
+
+        final message = await executeAndCaptureMessage(
+          attentionClaims: [claim],
+        );
+
+        expect(message, isNotNull);
+        expect(message, contains('## Attention Requests For This Task'));
+        // Guidance lists every field the dedup handler matches on.
+        expect(
+          message,
+          contains('amount, impact, urgency, energy fit, scope'),
+        );
+        expect(message, contains('"id": "attn-1"'));
+        expect(message, contains('"requestedMinutes": 90'));
+        expect(message, contains('"energyFit": "high"'));
+        expect(message, contains('"scopeKind": "dateRange"'));
+        expect(message, contains('"deadline": "2026-05-26T12:00:00.000Z"'));
+      });
+
+      test('absorbs a failure loading attention requests', () async {
+        final message = await executeAndCaptureMessage(
+          throwOnAttentionLoad: true,
+        );
+
+        // The wake still produces a prompt, just without the attention
+        // section — the load failure is swallowed.
+        expect(message, isNotNull);
+        expect(
+          message,
+          isNot(contains('## Attention Requests For This Task')),
+        );
+      });
 
       group('proposal ledger', () {
         LedgerEntry openEntry({

--- a/test/features/agents/workflow/task_tool_dispatcher_test.dart
+++ b/test/features/agents/workflow/task_tool_dispatcher_test.dart
@@ -880,6 +880,182 @@ void main() {
             expect(captured.last, isA<AttentionRequestEntity>());
           },
         );
+
+        test('rejects invalid required fields without writing', () async {
+          final cases = <Map<String, dynamic>, String>{
+            {...args, 'impact': 'high'}: '"impact" must be an integer.',
+            {...args, 'impact': 9}: '"impact" must be between 1 and 5.',
+            {...args, 'requestedMinutes': 0}:
+                '"requestedMinutes" must be between 1 and 1440.',
+            ({...args}..remove('energyFit')): '"energyFit" is required.',
+            {...args, 'energyFit': ''}:
+                '"energyFit" must be a non-empty string.',
+            {...args, 'energyFit': 'turbo'}: '"energyFit" must be one of',
+            ({...args}..remove('rationale')): '"rationale" is required.',
+          };
+
+          for (final entry in cases.entries) {
+            final result = await withClock(Clock.fixed(now), () {
+              return localDispatcher.dispatch(
+                TaskAgentToolNames.requestAttention,
+                entry.key,
+                taskId,
+              );
+            });
+            expect(result.success, isFalse, reason: entry.value);
+            expect(result.output, contains(entry.value), reason: entry.value);
+            expect(result.errorMessage, isNotNull, reason: entry.value);
+          }
+          verifyNever(() => localSyncService.upsertEntity(any()));
+        });
+
+        test('rejects malformed optional date/time arguments', () async {
+          final cases = <Map<String, dynamic>, String>{
+            {...args, 'earliestStart': 5}:
+                '"earliestStart" must be an ISO-8601 string.',
+            {...args, 'deadline': 'not-a-date'}:
+                '"deadline" must be a valid ISO-8601 date/time.',
+          };
+
+          for (final entry in cases.entries) {
+            final result = await withClock(Clock.fixed(now), () {
+              return localDispatcher.dispatch(
+                TaskAgentToolNames.requestAttention,
+                entry.key,
+                taskId,
+              );
+            });
+            expect(result.success, isFalse, reason: entry.value);
+            expect(result.output, contains(entry.value), reason: entry.value);
+          }
+          verifyNever(() => localSyncService.upsertEntity(any()));
+        });
+
+        test('rejects latestEnd after the deadline', () async {
+          final result = await withClock(Clock.fixed(now), () {
+            return localDispatcher.dispatch(
+              TaskAgentToolNames.requestAttention,
+              {
+                ...args,
+                'latestEnd': '2026-05-30T17:00:00.000',
+                'deadline': '2026-05-29T12:00:00.000',
+              },
+              taskId,
+            );
+          });
+
+          expect(result.success, isFalse);
+          expect(
+            result.output,
+            contains('latestEnd cannot be after the deadline.'),
+          );
+          verifyNever(() => localSyncService.upsertEntity(any()));
+        });
+
+        test('rejects an unknown scopeKind', () async {
+          final result = await withClock(Clock.fixed(now), () {
+            return localDispatcher.dispatch(
+              TaskAgentToolNames.requestAttention,
+              {...args, 'scopeKind': 'galaxy'},
+              taskId,
+            );
+          });
+
+          expect(result.success, isFalse);
+          expect(result.output, contains('"scopeKind" must be one of'));
+          verifyNever(() => localSyncService.upsertEntity(any()));
+        });
+
+        test('derives the title from the task when none is supplied', () async {
+          final result = await withClock(Clock.fixed(now), () {
+            return localDispatcher.dispatch(
+              TaskAgentToolNames.requestAttention,
+              ({...args}..remove('title')),
+              taskId,
+            );
+          });
+
+          expect(result.success, isTrue);
+          final request =
+              verify(
+                    () => localSyncService.upsertEntity(captureAny()),
+                  ).captured.single
+                  as AttentionRequestEntity;
+          expect(request.title, 'Schedule: Test Task');
+        });
+
+        test('falls back to a generic title for a blank task title', () async {
+          when(
+            () => localJournalDb.journalEntityById(taskId),
+          ).thenAnswer(
+            (_) async => _makeTestTask(taskId, title: '', categoryId: 'work'),
+          );
+
+          final result = await withClock(Clock.fixed(now), () {
+            return localDispatcher.dispatch(
+              TaskAgentToolNames.requestAttention,
+              ({...args}..remove('title')),
+              taskId,
+            );
+          });
+
+          expect(result.success, isTrue);
+          final request =
+              verify(
+                    () => localSyncService.upsertEntity(captureAny()),
+                  ).captured.single
+                  as AttentionRequestEntity;
+          expect(request.title, 'Schedule task work');
+        });
+
+        test(
+          'collapses pre-existing duplicate equivalent claims to one',
+          () async {
+            when(
+              () => localAgentRepository.getAttentionClaimsForTarget(
+                targetKind: 'task',
+                targetId: taskId,
+              ),
+            ).thenAnswer(
+              (_) async => [
+                _makeAttentionRequest(
+                  id: 'attention-canonical',
+                  agentId: requesterAgentId,
+                  taskId: taskId,
+                  categoryId: 'work',
+                ),
+                _makeAttentionRequest(
+                  id: 'attention-duplicate',
+                  agentId: requesterAgentId,
+                  taskId: taskId,
+                  categoryId: 'work',
+                ),
+              ],
+            );
+
+            final result = await withClock(Clock.fixed(now), () {
+              return localDispatcher.dispatch(
+                TaskAgentToolNames.requestAttention,
+                args,
+                taskId,
+              );
+            });
+
+            // The first match is kept; the duplicate is superseded, and no
+            // fresh request is written.
+            expect(result.success, isTrue);
+            expect(result.output, contains('attention-canonical'));
+
+            final captured = verify(
+              () => localSyncService.upsertEntity(captureAny()),
+            ).captured.cast<AgentDomainEntity>().toList();
+            expect(captured, hasLength(1));
+            final disposition =
+                captured.single as AttentionClaimDispositionEntity;
+            expect(disposition.requestId, 'attention-duplicate');
+            expect(disposition.status, AttentionClaimStatus.superseded);
+          },
+        );
       });
     });
 

--- a/test/features/agents/workflow/task_tool_dispatcher_test.dart
+++ b/test/features/agents/workflow/task_tool_dispatcher_test.dart
@@ -1,3 +1,4 @@
+import 'package:clock/clock.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
 import 'package:lotti/classes/change_source.dart';
@@ -5,6 +6,8 @@ import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/task.dart';
 import 'package:lotti/database/database.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/attention_negotiation.dart';
 import 'package:lotti/features/agents/tools/agent_tool_registry.dart';
 import 'package:lotti/features/agents/workflow/task_tool_dispatcher.dart';
 import 'package:lotti/get_it.dart';
@@ -710,6 +713,174 @@ void main() {
         },
         tags: 'glados',
       );
+
+      group('request_attention', () {
+        const requesterAgentId = 'task-agent-001';
+        final now = DateTime(2026, 5, 26, 8);
+        final args = {
+          'title': 'Finish tax packet',
+          'requestedMinutes': 90,
+          'impact': 5,
+          'urgency': 4,
+          'energyFit': 'high',
+          'earliestStart': '2026-05-27T09:00:00.000',
+          'latestEnd': '2026-05-28T17:00:00.000',
+          'deadline': '2026-05-29T12:00:00.000',
+          'rationale': 'Due soon and still needs a focused block.',
+        };
+
+        late MockJournalDb localJournalDb;
+        late MockAgentRepository localAgentRepository;
+        late MockAgentSyncService localSyncService;
+        late TaskToolDispatcher localDispatcher;
+
+        setUp(() {
+          localJournalDb = MockJournalDb();
+          localAgentRepository = MockAgentRepository();
+          localSyncService = MockAgentSyncService();
+          localDispatcher = TaskToolDispatcher(
+            journalDb: localJournalDb,
+            journalRepository: MockJournalRepository(),
+            checklistRepository: MockChecklistRepository(),
+            labelsRepository: MockLabelsRepository(),
+            persistenceLogic: MockPersistenceLogic(),
+            timeService: MockTimeService(),
+            agentRepository: localAgentRepository,
+            syncService: localSyncService,
+            requestingAgentId: requesterAgentId,
+          );
+
+          when(
+            () => localJournalDb.journalEntityById(taskId),
+          ).thenAnswer(
+            (_) async => _makeTestTask(taskId, categoryId: 'work'),
+          );
+          when(
+            () => localAgentRepository.getAttentionClaimsForTarget(
+              targetKind: 'task',
+              targetId: taskId,
+            ),
+          ).thenAnswer((_) async => const []);
+          when(
+            () => localSyncService.upsertEntity(any()),
+          ).thenAnswer((_) async {});
+        });
+
+        test('creates a synced task attention request', () async {
+          final result = await withClock(Clock.fixed(now), () {
+            return localDispatcher.dispatch(
+              TaskAgentToolNames.requestAttention,
+              args,
+              taskId,
+            );
+          });
+
+          expect(result.success, isTrue);
+          expect(result.output, contains('Attention request created'));
+          expect(result.mutatedEntityId, isNull);
+
+          final captured =
+              verify(
+                    () => localSyncService.upsertEntity(captureAny()),
+                  ).captured.single
+                  as AgentDomainEntity;
+          expect(captured, isA<AttentionRequestEntity>());
+          final request = captured as AttentionRequestEntity;
+          expect(request.agentId, requesterAgentId);
+          expect(request.kind, AttentionRequestKind.task);
+          expect(request.title, 'Finish tax packet');
+          expect(request.categoryId, 'work');
+          expect(request.requestedMinutes, 90);
+          expect(request.impact, 5);
+          expect(request.urgency, 4);
+          expect(request.energyFit, AttentionEnergyFit.high);
+          expect(request.scopeKind, AttentionClaimScopeKind.dateRange);
+          expect(request.earliestStart, DateTime(2026, 5, 27, 9));
+          expect(request.latestEnd, DateTime(2026, 5, 28, 17));
+          expect(request.deadline, DateTime(2026, 5, 29, 12));
+          expect(request.targetId, taskId);
+          expect(request.targetKind, 'task');
+          expect(
+            request.rationale,
+            'Due soon and still needs a focused block.',
+          );
+          expect(request.createdAt, now);
+          expect(request.evidenceRefs.single.id, taskId);
+        });
+
+        test('does not duplicate an equivalent active request', () async {
+          when(
+            () => localAgentRepository.getAttentionClaimsForTarget(
+              targetKind: 'task',
+              targetId: taskId,
+            ),
+          ).thenAnswer(
+            (_) async => [
+              _makeAttentionRequest(
+                id: 'attention-existing',
+                agentId: requesterAgentId,
+                taskId: taskId,
+                categoryId: 'work',
+              ),
+            ],
+          );
+
+          final result = await withClock(Clock.fixed(now), () {
+            return localDispatcher.dispatch(
+              TaskAgentToolNames.requestAttention,
+              args,
+              taskId,
+            );
+          });
+
+          expect(result.success, isTrue);
+          expect(result.output, contains('already active'));
+          verifyNever(() => localSyncService.upsertEntity(any()));
+        });
+
+        test(
+          'supersedes stale active requests before writing the new one',
+          () async {
+            when(
+              () => localAgentRepository.getAttentionClaimsForTarget(
+                targetKind: 'task',
+                targetId: taskId,
+              ),
+            ).thenAnswer(
+              (_) async => [
+                _makeAttentionRequest(
+                  id: 'attention-stale',
+                  agentId: requesterAgentId,
+                  taskId: taskId,
+                  categoryId: 'work',
+                  requestedMinutes: 30,
+                ),
+              ],
+            );
+
+            final result = await withClock(Clock.fixed(now), () {
+              return localDispatcher.dispatch(
+                TaskAgentToolNames.requestAttention,
+                args,
+                taskId,
+              );
+            });
+
+            expect(result.success, isTrue);
+
+            final captured = verify(
+              () => localSyncService.upsertEntity(captureAny()),
+            ).captured.cast<AgentDomainEntity>().toList();
+            expect(captured, hasLength(2));
+            final disposition =
+                captured.first as AttentionClaimDispositionEntity;
+            expect(disposition.requestId, 'attention-stale');
+            expect(disposition.status, AttentionClaimStatus.superseded);
+            expect(disposition.createdAt, now);
+            expect(captured.last, isA<AttentionRequestEntity>());
+          },
+        );
+      });
     });
 
     group('dispatch — handlers requiring getIt', () {
@@ -1155,7 +1326,11 @@ LabelDefinition _makeLabelDef(String id) {
 }
 
 /// Creates a minimal [Task] entity for testing dispatch.
-Task _makeTestTask(String id, {String title = 'Test Task'}) {
+Task _makeTestTask(
+  String id, {
+  String title = 'Test Task',
+  String? categoryId,
+}) {
   return Task(
     meta: Metadata(
       id: id,
@@ -1163,6 +1338,7 @@ Task _makeTestTask(String id, {String title = 'Test Task'}) {
       dateTo: DateTime(2024, 3, 15),
       createdAt: DateTime(2024, 3, 15),
       updatedAt: DateTime(2024, 3, 15),
+      categoryId: categoryId,
     ),
     data: TaskData(
       status: TaskStatus.open(
@@ -1176,4 +1352,41 @@ Task _makeTestTask(String id, {String title = 'Test Task'}) {
       title: title,
     ),
   );
+}
+
+AttentionRequestEntity _makeAttentionRequest({
+  required String id,
+  required String agentId,
+  required String taskId,
+  required String categoryId,
+  int requestedMinutes = 90,
+}) {
+  return AgentDomainEntity.attentionRequest(
+        id: id,
+        agentId: agentId,
+        kind: AttentionRequestKind.task,
+        title: 'Finish tax packet',
+        categoryId: categoryId,
+        requestedMinutes: requestedMinutes,
+        impact: 5,
+        urgency: 4,
+        energyFit: AttentionEnergyFit.high,
+        evidenceRefs: [
+          AttentionEvidenceRef(
+            kind: AttentionEvidenceKind.task,
+            id: taskId,
+            label: 'Test Task',
+          ),
+        ],
+        scopeKind: AttentionClaimScopeKind.dateRange,
+        earliestStart: DateTime(2026, 5, 27, 9),
+        latestEnd: DateTime(2026, 5, 28, 17),
+        deadline: DateTime(2026, 5, 29, 12),
+        targetId: taskId,
+        targetKind: 'task',
+        rationale: 'Due soon and still needs a focused block.',
+        createdAt: DateTime(2026, 5, 26, 8),
+        vectorClock: null,
+      )
+      as AttentionRequestEntity;
 }

--- a/test/features/daily_os_next/agents/workflow/day_agent_workflow_test.dart
+++ b/test/features/daily_os_next/agents/workflow/day_agent_workflow_test.dart
@@ -8,6 +8,7 @@ import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/model/attention_negotiation.dart';
 import 'package:lotti/features/agents/workflow/wake_result.dart';
 import 'package:lotti/features/ai/conversation/conversation_manager.dart';
 import 'package:lotti/features/ai/conversation/conversation_repository.dart';
@@ -431,6 +432,140 @@ void main() {
           .map((p) => p.content)
           .where((c) => c['promptFormat'] == 'v2');
       expect(v2Records, isEmpty);
+    });
+
+    test('renders attention-planning claims and standing agreements into the '
+        'sent prompt', () async {
+      when(() => syncService.repository).thenReturn(repository);
+      when(
+        () => repository.getMessagesByKind(agentId, AgentMessageKind.system),
+      ).thenAnswer((_) async => []);
+      when(
+        () => repository.getMessagesByKind(agentId, AgentMessageKind.summary),
+      ).thenAnswer((_) async => []);
+      when(() => repository.getLinksFrom(agentId)).thenAnswer((_) async => []);
+
+      final claim =
+          AgentDomainEntity.attentionRequest(
+                id: 'attn-claim-1',
+                agentId: 'task-agent-7',
+                kind: AttentionRequestKind.task,
+                title: 'Finish tax packet',
+                categoryId: 'work',
+                requestedMinutes: 90,
+                impact: 5,
+                urgency: 4,
+                energyFit: AttentionEnergyFit.high,
+                evidenceRefs: const [
+                  AttentionEvidenceRef(
+                    kind: AttentionEvidenceKind.task,
+                    id: 'task-9',
+                    label: 'Tax packet',
+                  ),
+                ],
+                scopeKind: AttentionClaimScopeKind.dateRange,
+                earliestStart: DateTime.utc(2026, 5, 25, 9),
+                latestEnd: DateTime.utc(2026, 5, 25, 17),
+                deadline: DateTime.utc(2026, 5, 26, 12),
+                targetId: 'task-9',
+                targetKind: 'task',
+                rationale: 'Due soon and still needs a focused block.',
+                createdAt: DateTime.utc(2026, 5, 24, 8),
+                vectorClock: null,
+              )
+              as AttentionRequestEntity;
+      final agreement =
+          AgentDomainEntity.standingAgreement(
+                id: 'agreement-1',
+                agentId: 'soul-agent-2',
+                title: 'Exercise three times a week',
+                scope: StandingAgreementScope.fitness,
+                cadence: StandingAgreementCadence.weekly,
+                categoryId: 'health',
+                minCount: 3,
+                priority: 2,
+                rationale: 'Keep weekly movement consistent.',
+                createdAt: DateTime.utc(2026, 5, 1, 8),
+                updatedAt: DateTime.utc(2026, 5, 1, 8),
+                vectorClock: null,
+              )
+              as StandingAgreementEntity;
+      when(
+        () => repository.getAttentionPlanningInputsForWindow(
+          start: any(named: 'start'),
+          end: any(named: 'end'),
+        ),
+      ).thenAnswer(
+        (_) async => AttentionPlanningInputs(
+          claims: [claim],
+          standingAgreements: [agreement],
+        ),
+      );
+
+      final result = await execute(workflow(), triggerTokens: {dayId});
+      expect(result.success, isTrue);
+
+      final attentionPlanning =
+          (jsonDecode(conversationRepository.lastUserMessage!)
+                  as Map<String, dynamic>)['attentionPlanning']
+              as Map;
+      final claims = attentionPlanning['claims'] as List;
+      expect(claims, hasLength(1));
+      final renderedClaim = claims.single as Map;
+      expect(renderedClaim['id'], 'attn-claim-1');
+      expect(renderedClaim['kind'], 'task');
+      expect(renderedClaim['requestedMinutes'], 90);
+      expect(renderedClaim['energyFit'], 'high');
+      expect(renderedClaim['scopeKind'], 'dateRange');
+      expect(renderedClaim['earliestStart'], '2026-05-25T09:00:00.000Z');
+      expect(renderedClaim['deadline'], '2026-05-26T12:00:00.000Z');
+      expect(
+        (renderedClaim['evidenceRefs'] as List).single,
+        {'kind': 'task', 'id': 'task-9', 'label': 'Tax packet'},
+      );
+
+      final agreements = attentionPlanning['standingAgreements'] as List;
+      expect(agreements, hasLength(1));
+      final renderedAgreement = agreements.single as Map;
+      expect(renderedAgreement['id'], 'agreement-1');
+      expect(renderedAgreement['scope'], 'fitness');
+      expect(renderedAgreement['cadence'], 'weekly');
+      expect(renderedAgreement['enforcement'], 'target');
+      expect(renderedAgreement['approvalMode'], 'ask');
+      expect(renderedAgreement['minCount'], 3);
+      expect(renderedAgreement['priority'], 2);
+      expect(
+        renderedAgreement['rationale'],
+        'Keep weekly movement consistent.',
+      );
+    });
+
+    test('absorbs a failure loading attention-planning inputs', () async {
+      when(() => syncService.repository).thenReturn(repository);
+      when(
+        () => repository.getMessagesByKind(agentId, AgentMessageKind.system),
+      ).thenAnswer((_) async => []);
+      when(
+        () => repository.getMessagesByKind(agentId, AgentMessageKind.summary),
+      ).thenAnswer((_) async => []);
+      when(() => repository.getLinksFrom(agentId)).thenAnswer((_) async => []);
+      when(
+        () => repository.getAttentionPlanningInputsForWindow(
+          start: any(named: 'start'),
+          end: any(named: 'end'),
+        ),
+      ).thenThrow(StateError('attention window unavailable'));
+
+      final result = await execute(workflow(), triggerTokens: {dayId});
+
+      // The load failure degrades to empty inputs, so the section is omitted
+      // entirely (it is only rendered when non-empty) and the wake still
+      // succeeds rather than propagating the error.
+      expect(result.success, isTrue);
+      final userPayload =
+          jsonDecode(conversationRepository.lastUserMessage!)
+              as Map<String, dynamic>;
+      expect(userPayload.containsKey('attentionPlanning'), isFalse);
     });
 
     test(

--- a/test/features/daily_os_next/agents/workflow/day_agent_workflow_test.dart
+++ b/test/features/daily_os_next/agents/workflow/day_agent_workflow_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:clock/clock.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/day_plan.dart';
+import 'package:lotti/features/agents/database/agent_repository.dart';
 import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
@@ -255,6 +256,12 @@ void main() {
     when(
       () => repository.getEntitiesByAgentId(agentId, type: any(named: 'type')),
     ).thenAnswer((_) async => const <AgentDomainEntity>[]);
+    when(
+      () => repository.getAttentionPlanningInputsForWindow(
+        start: any(named: 'start'),
+        end: any(named: 'end'),
+      ),
+    ).thenAnswer((_) async => const AttentionPlanningInputs.empty());
     when(
       () => repository.updateWakeRunTemplate(
         any(),

--- a/test/features/daily_os_next/agents/workflow/day_agent_workflow_test.dart
+++ b/test/features/daily_os_next/agents/workflow/day_agent_workflow_test.dart
@@ -558,6 +558,16 @@ void main() {
 
       final result = await execute(workflow(), triggerTokens: {dayId});
 
+      // The throwing load path is actually exercised: if the workflow stopped
+      // calling getAttentionPlanningInputsForWindow, this test would no longer
+      // be proving the failure is absorbed.
+      verify(
+        () => repository.getAttentionPlanningInputsForWindow(
+          start: any(named: 'start'),
+          end: any(named: 'end'),
+        ),
+      ).called(1);
+
       // The load failure degrades to empty inputs, so the section is omitted
       // entirely (it is only rendered when non-empty) and the wake still
       // succeeds rather than propagating the error.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task agents can now submit evidence-backed attention requests via a new request tool; task wakes surface active attention requests to avoid duplicates and support supersession/deduplication.

* **Database**
  * Schema version bumped and a targeted index added to speed attention-claim lookups.

* **Tests**
  * Added migration, repository, workflow, dispatcher, and tool tests covering attention flows, validation, deduplication, and failure cases.

* **Documentation**
  * Docs updated to explain attention-request behavior and planning inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->