### PR TITLE
fix: empty "here's what I heard" section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Task-agent suggestions now suppress verbatim duplicate proposals even when
   their underlying tool arguments differ, so identical checklist suggestions
   appear only once.
+- Daily OS Next capture wakes now retry with a forced parse step when the first
+  model response skips parsing, so Reconcile no longer stays stuck with an
+  empty "Here's what I heard" column.
 
 ### Fixed
 - Saving an event now clears the unsaved-changes state, so the save button

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -45,6 +45,7 @@
           <p>Config flag changes from Settings now sync to your other devices when a flag is flipped, without broadcasting default startup flag seeding.</p>
           <p>Label usage counts in the labels list no longer include deleted journal entries, and entries marked private only count while the "Show private entries" flag is enabled.</p>
           <p>Task-agent suggestions now suppress verbatim duplicate proposals even when their underlying tool arguments differ, so identical checklist suggestions appear only once.</p>
+          <p>Daily OS Next capture wakes now retry with a forced parse step when the first model response skips parsing, so Reconcile no longer stays stuck with an empty "Here's what I heard" column.</p>
           <p>The "Agent memory compaction" flag now also covers project and day agents: all three read their context from an append-only memory log and summarize its oldest entries into a rolling memory using their own model.</p>
           <p>Saving an event now clears the unsaved-changes state, so the save button no longer stays visible after a successful save.</p>
           <p>Buttons that customize the primary button style now apply their custom disabled color instead of silently falling back to the default.</p>

--- a/lib/features/daily_os_next/agents/workflow/day_agent_strategy.dart
+++ b/lib/features/daily_os_next/agents/workflow/day_agent_strategy.dart
@@ -66,6 +66,7 @@ class DayAgentStrategy extends ConversationStrategy {
   final DomainLogger domainLogger;
 
   final _observations = <ObservationRecord>[];
+  var _didPersistCaptureParse = false;
   var _didPersistDraftDayPlan = false;
   String? _finalResponse;
 
@@ -77,6 +78,9 @@ class DayAgentStrategy extends ConversationStrategy {
 
   /// Whether this wake successfully persisted a plan via `draft_day_plan`.
   bool get didPersistDraftDayPlan => _didPersistDraftDayPlan;
+
+  /// Whether this wake successfully persisted parsed capture items.
+  bool get didPersistCaptureParse => _didPersistCaptureParse;
 
   /// Called by the workflow after the conversation loop finishes.
   void recordFinalResponse(String? content) {
@@ -121,6 +125,10 @@ class DayAgentStrategy extends ConversationStrategy {
 
       if (DayAgentToolNames.isWorkflowHandlerTool(toolName)) {
         final result = await executeToolHandler(toolName, args, manager);
+        if (toolName == DayAgentToolNames.parseCaptureToItems &&
+            _didPersistParsedItems(result)) {
+          _didPersistCaptureParse = true;
+        }
         if (toolName == DayAgentToolNames.draftDayPlan && result.success) {
           _didPersistDraftDayPlan = true;
         }
@@ -141,6 +149,18 @@ class DayAgentStrategy extends ConversationStrategy {
     }
 
     return ConversationAction.continueConversation;
+  }
+
+  bool _didPersistParsedItems(DayAgentToolResult result) {
+    if (!result.success) return false;
+    try {
+      final decoded = jsonDecode(result.output);
+      return decoded is Map &&
+          decoded['items'] is List &&
+          (decoded['items'] as List).isNotEmpty;
+    } catch (_) {
+      return false;
+    }
   }
 
   @override

--- a/lib/features/daily_os_next/agents/workflow/day_agent_strategy.dart
+++ b/lib/features/daily_os_next/agents/workflow/day_agent_strategy.dart
@@ -155,9 +155,11 @@ class DayAgentStrategy extends ConversationStrategy {
     if (!result.success) return false;
     try {
       final decoded = jsonDecode(result.output);
-      return decoded is Map &&
-          decoded['items'] is List &&
-          (decoded['items'] as List).isNotEmpty;
+      if (decoded is Map) {
+        final items = decoded['items'];
+        return items is List && items.isNotEmpty;
+      }
+      return false;
     } catch (_) {
       return false;
     }

--- a/lib/features/daily_os_next/agents/workflow/day_agent_workflow.dart
+++ b/lib/features/daily_os_next/agents/workflow/day_agent_workflow.dart
@@ -302,6 +302,27 @@ class DayAgentWorkflow {
         strategy: strategy,
       );
 
+      if (_requiresCaptureParse(triggerTokens: triggerTokens)) {
+        if (!strategy.didPersistCaptureParse) {
+          final captureId = captureIdFromTriggerTokens(triggerTokens)!;
+          final retryUsage = await _forceCaptureParseIfMissing(
+            conversationId: conversationId,
+            modelId: modelId,
+            provider: provider,
+            inferenceRepo: inferenceRepo,
+            tools: tools,
+            strategy: strategy,
+            captureId: captureId,
+          );
+          if (retryUsage != null) {
+            usage = usage == null ? retryUsage : usage.merge(retryUsage);
+          }
+        }
+        if (!strategy.didPersistCaptureParse) {
+          throw const _MissingCaptureParseException();
+        }
+      }
+
       if (_requiresDraftDayPlan(
         dayId: dayId,
         triggerTokens: triggerTokens,
@@ -1123,6 +1144,61 @@ ${const JsonEncoder.withIndent('  ').convert(config.toJson())}''';
         draftingDayIdFromTriggerTokens(triggerTokens) == dayId;
   }
 
+  bool _requiresCaptureParse({
+    required Set<String> triggerTokens,
+  }) {
+    return captureService != null &&
+        captureIdFromTriggerTokens(triggerTokens) != null &&
+        draftingDayIdFromTriggerTokens(triggerTokens) == null &&
+        refineDayIdFromTriggerTokens(triggerTokens) == null;
+  }
+
+  Future<InferenceUsage?> _forceCaptureParseIfMissing({
+    required String conversationId,
+    required String modelId,
+    required AiConfigInferenceProvider provider,
+    required CloudInferenceWrapper inferenceRepo,
+    required List<ChatCompletionTool> tools,
+    required DayAgentStrategy strategy,
+    required String captureId,
+  }) {
+    _log(
+      'capture wake missed parse_capture_to_items — retrying with forced '
+      'tool choice',
+      subDomain: 'execute',
+    );
+    const forcedToolChoice = ChatCompletionToolChoiceOption.tool(
+      ChatCompletionNamedToolChoice(
+        type: ChatCompletionNamedToolChoiceType.function,
+        function: ChatCompletionFunctionCallOption(
+          name: DayAgentToolNames.parseCaptureToItems,
+        ),
+      ),
+    );
+    final parseOnlyTools = tools
+        .where(
+          (tool) => tool.function.name == DayAgentToolNames.parseCaptureToItems,
+        )
+        .toList(growable: false);
+
+    return conversationRepository.sendMessage(
+      conversationId: conversationId,
+      message:
+          'You did not call `parse_capture_to_items` before stopping. Call it '
+          'now for capture `$captureId` using the capture transcript and task '
+          'corpus already provided in this wake. This is the mandatory output '
+          'of a capture-submitted wake. Do not respond with plain text or call '
+          'any other tool.',
+      model: modelId,
+      provider: provider,
+      inferenceRepo: inferenceRepo,
+      tools: parseOnlyTools,
+      toolChoice: forcedToolChoice,
+      temperature: 0.3,
+      strategy: strategy,
+    );
+  }
+
   Future<InferenceUsage?> _forceDraftDayPlanIfMissing({
     required String conversationId,
     required String modelId,
@@ -1259,6 +1335,16 @@ class _MissingDraftDayPlanException implements Exception {
   @override
   String toString() {
     return 'Drafting wake did not persist draft_day_plan after forced retry.';
+  }
+}
+
+class _MissingCaptureParseException implements Exception {
+  const _MissingCaptureParseException();
+
+  @override
+  String toString() {
+    return 'Capture wake did not persist parse_capture_to_items after forced '
+        'retry.';
   }
 }
 

--- a/lib/features/daily_os_next/agents/workflow/day_agent_workflow.dart
+++ b/lib/features/daily_os_next/agents/workflow/day_agent_workflow.dart
@@ -302,7 +302,10 @@ class DayAgentWorkflow {
         strategy: strategy,
       );
 
-      if (_requiresCaptureParse(triggerTokens: triggerTokens)) {
+      if (_requiresCaptureParse(
+        triggerTokens: triggerTokens,
+        captureContext: captureContext,
+      )) {
         if (!strategy.didPersistCaptureParse) {
           final captureId = captureIdFromTriggerTokens(triggerTokens)!;
           final retryUsage = await _forceCaptureParseIfMissing(
@@ -1146,8 +1149,10 @@ ${const JsonEncoder.withIndent('  ').convert(config.toJson())}''';
 
   bool _requiresCaptureParse({
     required Set<String> triggerTokens,
+    required _CaptureContext? captureContext,
   }) {
     return captureService != null &&
+        captureContext != null &&
         captureIdFromTriggerTokens(triggerTokens) != null &&
         draftingDayIdFromTriggerTokens(triggerTokens) == null &&
         refineDayIdFromTriggerTokens(triggerTokens) == null;

--- a/test/features/daily_os_next/agents/workflow/day_agent_workflow_test.dart
+++ b/test/features/daily_os_next/agents/workflow/day_agent_workflow_test.dart
@@ -234,6 +234,27 @@ void main() {
     ];
   }
 
+  void stubCaptureContext(
+    MockDayAgentCaptureService captureService, {
+    String captureId = 'capture-1',
+  }) {
+    when(() => captureService.getCapture(captureId)).thenAnswer(
+      (_) async => makeTestCapture(
+        id: captureId,
+        agentId: agentId,
+        transcript: 'Prep demo and buy milk',
+        capturedAt: DateTime(2026, 5, 25, 7, 45),
+        createdAt: DateTime(2026, 5, 25, 7, 45),
+      ),
+    );
+    when(
+      () => captureService.buildTaskCorpusSnapshot(
+        allowedCategoryIds: any(named: 'allowedCategoryIds'),
+        day: any(named: 'day'),
+      ),
+    ).thenAnswer((_) async => const []);
+  }
+
   setUp(() {
     repository = MockAgentRepository();
     aiConfigRepository = MockAiConfigRepository();
@@ -867,6 +888,40 @@ void main() {
           },
         ],
       );
+      when(
+        () => captureService.executeTool(
+          agentId: agentId,
+          threadId: threadId,
+          runKey: runKey,
+          toolName: DayAgentToolNames.parseCaptureToItems,
+          args: any(named: 'args'),
+        ),
+      ).thenAnswer(
+        (_) async => DayAgentDirectToolResult.success(
+          const {
+            'captureId': 'capture-1',
+            'items': [
+              {'id': 'parsed-1'},
+            ],
+          },
+        ),
+      );
+      conversationRepository.toolCalls = [
+        _toolCall(
+          name: DayAgentToolNames.parseCaptureToItems,
+          args: const {
+            'captureId': 'capture-1',
+            'items': [
+              {
+                'kind': 'newTask',
+                'title': 'Prep demo',
+                'categoryId': 'work',
+                'confidenceScore': 0.4,
+              },
+            ],
+          },
+        ),
+      ];
 
       final result = await execute(
         workflow(captureService: captureService),
@@ -892,6 +947,209 @@ void main() {
           'priority': 'P2',
         },
       ]);
+    });
+
+    group('capture wake parse enforcement', () {
+      test(
+        'forces parse_capture_to_items when a capture wake stops without '
+        'parsing',
+        () async {
+          final captureService = MockDayAgentCaptureService();
+          stubCaptureContext(captureService);
+          when(
+            () => captureService.executeTool(
+              agentId: agentId,
+              threadId: threadId,
+              runKey: runKey,
+              toolName: DayAgentToolNames.parseCaptureToItems,
+              args: any(named: 'args'),
+            ),
+          ).thenAnswer(
+            (_) async => DayAgentDirectToolResult.success(
+              const {
+                'captureId': 'capture-1',
+                'items': [
+                  {'id': 'parsed-1'},
+                ],
+              },
+            ),
+          );
+          conversationRepository
+            ..toolCallsByInvocation = [
+              const <ChatCompletionMessageToolCall>[],
+              [
+                _toolCall(
+                  id: 'parse-call',
+                  name: DayAgentToolNames.parseCaptureToItems,
+                  args: const {
+                    'captureId': 'capture-1',
+                    'items': [
+                      {
+                        'kind': 'newTask',
+                        'title': 'Prep demo',
+                        'categoryId': 'work',
+                        'confidenceScore': 0.4,
+                      },
+                    ],
+                  },
+                ),
+              ],
+            ]
+            ..usageByInvocation = const [
+              InferenceUsage(inputTokens: 10, outputTokens: 5),
+              InferenceUsage(inputTokens: 3, outputTokens: 2),
+            ];
+
+          final result = await execute(
+            workflow(captureService: captureService),
+            triggerTokens: {dayAgentCaptureSubmittedToken('capture-1'), dayId},
+          );
+
+          expect(result.success, isTrue);
+          expect(conversationRepository.sendMessageCalls, hasLength(2));
+          expect(
+            conversationRepository.sendMessageCalls.first.toolChoice,
+            isNull,
+          );
+
+          final retryCall = conversationRepository.sendMessageCalls[1];
+          expect(
+            retryCall.message,
+            contains('You did not call `parse_capture_to_items`'),
+          );
+          expect(retryCall.message, contains('capture `capture-1`'));
+          expect(
+            retryCall.tools.map((tool) => tool.function.name),
+            [DayAgentToolNames.parseCaptureToItems],
+          );
+          retryCall.toolChoice!.map(
+            mode: (_) => fail('Expected named tool choice, got mode.'),
+            tool: (named) {
+              expect(
+                named.value.function.name,
+                DayAgentToolNames.parseCaptureToItems,
+              );
+            },
+          );
+
+          final args =
+              verify(
+                    () => captureService.executeTool(
+                      agentId: agentId,
+                      threadId: threadId,
+                      runKey: runKey,
+                      toolName: DayAgentToolNames.parseCaptureToItems,
+                      args: captureAny(named: 'args'),
+                    ),
+                  ).captured.single
+                  as Map<String, dynamic>;
+          expect(args['captureId'], 'capture-1');
+          expect(args['items'], isA<List<Object?>>());
+
+          final usage = upsertedEntities
+              .whereType<WakeTokenUsageEntity>()
+              .single;
+          expect(usage.inputTokens, 13);
+          expect(usage.outputTokens, 7);
+        },
+      );
+
+      test(
+        'fails the wake when the forced retry still omits parsing',
+        () async {
+          final captureService = MockDayAgentCaptureService();
+          stubCaptureContext(captureService);
+          conversationRepository.toolCallsByInvocation = [
+            const <ChatCompletionMessageToolCall>[],
+            const <ChatCompletionMessageToolCall>[],
+          ];
+
+          final result = await execute(
+            workflow(captureService: captureService),
+            triggerTokens: {dayAgentCaptureSubmittedToken('capture-1'), dayId},
+          );
+
+          expect(result.success, isFalse);
+          expect(result.error, contains('parse_capture_to_items'));
+          expect(conversationRepository.sendMessageCalls, hasLength(2));
+          expect(
+            conversationRepository.sendMessageCalls[1].toolChoice,
+            isNotNull,
+          );
+          final failureState = upsertedEntities
+              .whereType<AgentStateEntity>()
+              .last;
+          expect(failureState.consecutiveFailureCount, 1);
+          verifyNever(
+            () => captureService.executeTool(
+              agentId: any(named: 'agentId'),
+              threadId: any(named: 'threadId'),
+              runKey: any(named: 'runKey'),
+              toolName: DayAgentToolNames.parseCaptureToItems,
+              args: any(named: 'args'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'fails the wake when parsing persists zero items',
+        () async {
+          final captureService = MockDayAgentCaptureService();
+          stubCaptureContext(captureService);
+          when(
+            () => captureService.executeTool(
+              agentId: agentId,
+              threadId: threadId,
+              runKey: runKey,
+              toolName: DayAgentToolNames.parseCaptureToItems,
+              args: any(named: 'args'),
+            ),
+          ).thenAnswer(
+            (_) async => DayAgentDirectToolResult.success(
+              const {'captureId': 'capture-1', 'items': <Object?>[]},
+            ),
+          );
+          conversationRepository.toolCallsByInvocation = [
+            const <ChatCompletionMessageToolCall>[],
+            [
+              _toolCall(
+                id: 'parse-call',
+                name: DayAgentToolNames.parseCaptureToItems,
+                args: const {
+                  'captureId': 'capture-1',
+                  'items': [
+                    {
+                      'kind': 'newTask',
+                      'title': 'Home-only item',
+                      'categoryId': 'home',
+                      'confidenceScore': 0.4,
+                    },
+                  ],
+                },
+              ),
+            ],
+          ];
+
+          final result = await execute(
+            workflow(captureService: captureService),
+            triggerTokens: {dayAgentCaptureSubmittedToken('capture-1'), dayId},
+          );
+
+          expect(result.success, isFalse);
+          expect(result.error, contains('parse_capture_to_items'));
+          expect(conversationRepository.sendMessageCalls, hasLength(2));
+          verify(
+            () => captureService.executeTool(
+              agentId: agentId,
+              threadId: threadId,
+              runKey: runKey,
+              toolName: DayAgentToolNames.parseCaptureToItems,
+              args: any(named: 'args'),
+            ),
+          ).called(1);
+        },
+      );
     });
 
     test(

--- a/test/features/daily_os_next/agents/workflow/day_agent_workflow_test.dart
+++ b/test/features/daily_os_next/agents/workflow/day_agent_workflow_test.dart
@@ -1093,6 +1093,40 @@ void main() {
       );
 
       test(
+        'does not force parsing when the submitted capture is unavailable',
+        () async {
+          final captureService = MockDayAgentCaptureService();
+          when(() => captureService.getCapture('capture-1')).thenAnswer(
+            (_) async => null,
+          );
+
+          final result = await execute(
+            workflow(captureService: captureService),
+            triggerTokens: {dayAgentCaptureSubmittedToken('capture-1'), dayId},
+          );
+
+          expect(result.success, isTrue);
+          expect(conversationRepository.sendMessageCalls, hasLength(1));
+          final userPayload =
+              jsonDecode(conversationRepository.lastUserMessage!)
+                  as Map<String, dynamic>;
+          expect(userPayload.containsKey('capture'), isFalse);
+          verify(
+            () => captureService.getCapture('capture-1'),
+          ).called(1);
+          verifyNever(
+            () => captureService.executeTool(
+              agentId: any(named: 'agentId'),
+              threadId: any(named: 'threadId'),
+              runKey: any(named: 'runKey'),
+              toolName: DayAgentToolNames.parseCaptureToItems,
+              args: any(named: 'args'),
+            ),
+          );
+        },
+      );
+
+      test(
         'fails the wake when parsing persists zero items',
         () async {
           final captureService = MockDayAgentCaptureService();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Capture wakes in Daily OS Next now retry with a forced parse when the initial model response skips parsing; wakes fail cleanly if parsing still doesn't yield items, preventing Reconcile from showing an empty "Here's what I heard" column.

* **Tests**
  * Added tests for parse enforcement, forced-retry messaging, retry failure cases, unavailable-capture handling, and zero-item parse behavior.

* **Documentation**
  * Updated release notes/What's New to document the capture parse fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->