### PR TITLE
fix: missing slow query logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   normal wakes, resolving stale requests when tasks are done or no longer need
   scheduled time.
 
+### Fixed
+- Slow-query logging now starts from persisted logging settings during startup,
+  so enabled `slow_queries` and `super_slow_queries` files capture boot-time
+  database work instead of waiting for the next settings toggle.
+
 ## [0.9.1015]
 ### Added
 - The linked entries "Filter & Sort" modal now has a "Show flagged entries

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -35,6 +35,7 @@
     <release version="0.9.1016" date="2026-06-06">
       <description>
           <p>Task agents now maintain their own day-planning attention requests during normal wakes, resolving stale requests when tasks are done or no longer need scheduled time.</p>
+          <p>Slow-query logging now starts from persisted logging settings during startup, so enabled slow_queries and super_slow_queries files capture boot-time database work instead of waiting for the next settings toggle.</p>
       </description>
     </release>
     <release version="0.9.1015" date="2026-06-04">

--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -191,6 +191,7 @@ Future<void> registerSingletons() async {
 
   // Initialize config flags before constructing services that depend on them.
   await initConfigFlags(getIt<JournalDb>(), inMemoryDatabase: false);
+  await getIt<LoggingService>().listenToConfigFlag();
 
   _registerLazyServiceSafely<NotificationService>(
     NotificationService.new,
@@ -666,7 +667,6 @@ Future<void> registerSingletons() async {
   );
 
   unawaited(getIt<MatrixService>().init());
-  getIt<LoggingService>().listenToConfigFlag();
 
   // Label validator used by the assignment processor
   _registerLazyServiceSafely<LabelValidator>(

--- a/lib/services/logging_service.dart
+++ b/lib/services/logging_service.dart
@@ -61,19 +61,75 @@ class LoggingService {
         _enableLogging && _enableSlowQueryLogging;
   }
 
-  void listenToConfigFlag() {
+  /// Starts config-flag listeners and completes after both initial values have
+  /// seeded the slow-query gate.
+  ///
+  /// Cancels any existing subscriptions first so a repeated call (e.g. hot
+  /// restart or test re-init) does not leak the previous listeners.
+  Future<void> listenToConfigFlag() async {
+    await _loggingFlagSubscription?.cancel();
+    await _slowQueryFlagSubscription?.cancel();
+
+    final loggingReady = Completer<void>();
+    final slowQueryReady = Completer<void>();
+    var hasLoggingValue = false;
+    var hasSlowQueryValue = false;
+
+    void completeReady(Completer<void> completer) {
+      if (!completer.isCompleted) {
+        completer.complete();
+      }
+    }
+
+    void completeReadyError(
+      Completer<void> completer,
+      Object error,
+      StackTrace stackTrace,
+    ) {
+      if (!completer.isCompleted) {
+        completer.completeError(error, stackTrace);
+      }
+    }
+
+    void syncGateWhenReady() {
+      if (hasLoggingValue && hasSlowQueryValue) {
+        _syncSlowQueryLoggingGate();
+      }
+    }
+
     _loggingFlagSubscription = getIt<JournalDb>()
         .watchConfigFlag(enableLoggingFlag)
-        .listen((value) {
-          _enableLogging = value;
-          _syncSlowQueryLoggingGate();
-        });
+        .listen(
+          (value) {
+            _enableLogging = value;
+            hasLoggingValue = true;
+            syncGateWhenReady();
+            completeReady(loggingReady);
+          },
+          onError: (Object error, StackTrace stackTrace) {
+            completeReadyError(loggingReady, error, stackTrace);
+          },
+          onDone: () => completeReady(loggingReady),
+        );
     _slowQueryFlagSubscription = getIt<JournalDb>()
         .watchConfigFlag(logSlowQueriesFlag)
-        .listen((value) {
-          _enableSlowQueryLogging = value;
-          _syncSlowQueryLoggingGate();
-        });
+        .listen(
+          (value) {
+            _enableSlowQueryLogging = value;
+            hasSlowQueryValue = true;
+            syncGateWhenReady();
+            completeReady(slowQueryReady);
+          },
+          onError: (Object error, StackTrace stackTrace) {
+            completeReadyError(slowQueryReady, error, stackTrace);
+          },
+          onDone: () => completeReady(slowQueryReady),
+        );
+
+    await Future.wait(<Future<void>>[
+      loggingReady.future,
+      slowQueryReady.future,
+    ]);
   }
 
   Future<void> dispose() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1016+4119
+version: 0.9.1016+4120
 
 msix_config:
   display_name: LottiApp

--- a/test/database/open_db_connection_test.dart
+++ b/test/database/open_db_connection_test.dart
@@ -209,4 +209,44 @@ void main() {
       await db.close();
     },
   );
+
+  test(
+    'openDbConnection appends slow queries for background executors',
+    () async {
+      final base = Directory.systemTemp.createTempSync('slow_query_log_test_');
+      addTearDown(
+        () => base.existsSync() ? base.deleteSync(recursive: true) : null,
+      );
+
+      SlowQueryLoggingGate.isEnabled = true;
+
+      final lazy = openDbConnection(
+        'test_slow_background.sqlite',
+        slowQueryThreshold: Duration.zero,
+        documentsDirectoryProvider: () async => base,
+        tempDirectoryProvider: () async => base,
+      );
+
+      final db = SyncDatabase.connect(DatabaseConnection(lazy));
+      await db.customSelect('SELECT 1 AS one').getSingle();
+      await SlowQueryInterceptor.flushFileSinkForTest();
+
+      final logFiles = Directory('${base.path}/logs')
+          .listSync()
+          .whereType<File>()
+          .where(
+            (f) =>
+                f.uri.pathSegments.last.startsWith('slow_queries-') &&
+                f.uri.pathSegments.last.endsWith('.log'),
+          )
+          .toList();
+
+      expect(logFiles, hasLength(1));
+      final contents = await logFiles.single.readAsString();
+      expect(contents, contains('[test_slow_background.sqlite] select'));
+      expect(contents, contains('SELECT 1 AS one'));
+
+      await db.close();
+    },
+  );
 }

--- a/test/services/logging_service_test.dart
+++ b/test/services/logging_service_test.dart
@@ -68,12 +68,38 @@ void main() {
     SlowQueryLoggingGate.resetForTest();
 
     logging = getIt<LoggingService>();
-    logging.listenToConfigFlag();
-    // Allow the stream microtask to flip the internal flag
-    await Future<void>.delayed(Duration.zero);
+    await logging.listenToConfigFlag();
   });
 
   tearDown(SlowQueryLoggingGate.resetForTest);
+
+  /// Builds a [LoggingService] wired to two controllable config-flag streams so
+  /// tests can drive values, errors and `done` deterministically. Registers
+  /// teardown for the controllers and the service.
+  ({
+    LoggingService service,
+    StreamController<bool> logging,
+    StreamController<bool> slowQuery,
+  })
+  makeControlledService() {
+    final loggingController = StreamController<bool>();
+    final slowQueryController = StreamController<bool>();
+    addTearDown(loggingController.close);
+    addTearDown(slowQueryController.close);
+    when(
+      () => journalDb.watchConfigFlag(enableLoggingFlag),
+    ).thenAnswer((_) => loggingController.stream);
+    when(
+      () => journalDb.watchConfigFlag(logSlowQueriesFlag),
+    ).thenAnswer((_) => slowQueryController.stream);
+    final service = LoggingService();
+    addTearDown(service.dispose);
+    return (
+      service: service,
+      logging: loggingController,
+      slowQuery: slowQueryController,
+    );
+  }
 
   test('captureEvent writes to file when enabled', () {
     fakeAsync((async) {
@@ -240,7 +266,8 @@ void main() {
       getIt.registerSingleton<Directory>(invalidDir);
 
       // Create fresh service pointing to the invalid directory
-      final brokenLogging = LoggingService()..listenToConfigFlag();
+      final brokenLogging = LoggingService();
+      unawaited(brokenLogging.listenToConfigFlag());
 
       // Wait for stream microtask to enable logging
       async.flushMicrotasks();
@@ -268,7 +295,8 @@ void main() {
       getIt.registerSingleton<Directory>(invalidDir);
 
       // Create fresh service pointing to the invalid directory
-      final brokenLogging = LoggingService()..listenToConfigFlag();
+      final brokenLogging = LoggingService();
+      unawaited(brokenLogging.listenToConfigFlag());
 
       // Wait for stream microtask to enable logging
       async.flushMicrotasks();
@@ -346,7 +374,8 @@ void main() {
       () => journalDb.watchConfigFlag(logSlowQueriesFlag),
     ).thenAnswer((_) => slowQueryController.stream);
 
-    final svc = LoggingService()..listenToConfigFlag();
+    final svc = LoggingService();
+    unawaited(svc.listenToConfigFlag());
 
     // Initially disabled (isTestEnv = true means _enableLogging = false)
     svc.captureEvent('should be skipped', domain: 'TOGGLE');
@@ -395,7 +424,8 @@ void main() {
         () => journalDb.watchConfigFlag(logSlowQueriesFlag),
       ).thenAnswer((_) => slowQueryController.stream);
 
-      final svc = LoggingService()..listenToConfigFlag();
+      final svc = LoggingService();
+      unawaited(svc.listenToConfigFlag());
       expect(svc, isNotNull);
 
       loggingController.add(false);
@@ -414,6 +444,27 @@ void main() {
   );
 
   test(
+    'listenToConfigFlag completes after seeding initial slow query gate state',
+    () async {
+      when(
+        () => journalDb.watchConfigFlag(enableLoggingFlag),
+      ).thenAnswer((_) => Stream<bool>.value(true));
+      when(
+        () => journalDb.watchConfigFlag(logSlowQueriesFlag),
+      ).thenAnswer((_) => Stream<bool>.value(true));
+
+      SlowQueryLoggingGate.resetForTest();
+      final svc = LoggingService();
+      addTearDown(svc.dispose);
+
+      await svc.listenToConfigFlag();
+
+      expect(SlowQueryLoggingGate.isEnabled, isTrue);
+      expect(SlowQueryLoggingGate.captureFirstCallStack, isTrue);
+    },
+  );
+
+  test(
     'dispose cancels config-flag subscriptions so later events are ignored',
     () async {
       final loggingController = StreamController<bool>();
@@ -428,7 +479,8 @@ void main() {
         () => journalDb.watchConfigFlag(logSlowQueriesFlag),
       ).thenAnswer((_) => slowQueryController.stream);
 
-      final svc = LoggingService()..listenToConfigFlag();
+      final svc = LoggingService();
+      unawaited(svc.listenToConfigFlag());
 
       // Enable both flags so the slow-query gate is on, proving the
       // subscriptions are live before dispose.
@@ -462,6 +514,127 @@ void main() {
     // Both subscriptions are null; dispose must complete without throwing.
     await expectLater(svc.dispose(), completes);
   });
+
+  test(
+    'listenToConfigFlag cancels prior subscriptions when called again',
+    () async {
+      final logging1 = StreamController<bool>();
+      final slowQuery1 = StreamController<bool>();
+      final logging2 = StreamController<bool>();
+      final slowQuery2 = StreamController<bool>();
+      addTearDown(logging1.close);
+      addTearDown(slowQuery1.close);
+      addTearDown(logging2.close);
+      addTearDown(slowQuery2.close);
+
+      when(
+        () => journalDb.watchConfigFlag(enableLoggingFlag),
+      ).thenAnswer((_) => logging1.stream);
+      when(
+        () => journalDb.watchConfigFlag(logSlowQueriesFlag),
+      ).thenAnswer((_) => slowQuery1.stream);
+
+      final svc = LoggingService();
+      addTearDown(svc.dispose);
+
+      unawaited(svc.listenToConfigFlag());
+      logging1.add(true);
+      slowQuery1.add(true);
+      await Future<void>.delayed(Duration.zero);
+      expect(logging1.hasListener, isTrue);
+      expect(slowQuery1.hasListener, isTrue);
+
+      // Point the next call at fresh controllers, then re-invoke. The repeated
+      // call must cancel the prior subscriptions before creating new ones.
+      when(
+        () => journalDb.watchConfigFlag(enableLoggingFlag),
+      ).thenAnswer((_) => logging2.stream);
+      when(
+        () => journalDb.watchConfigFlag(logSlowQueriesFlag),
+      ).thenAnswer((_) => slowQuery2.stream);
+
+      unawaited(svc.listenToConfigFlag());
+      logging2.add(true);
+      slowQuery2.add(true);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        logging1.hasListener,
+        isFalse,
+        reason: 'prior logging subscription must be cancelled',
+      );
+      expect(
+        slowQuery1.hasListener,
+        isFalse,
+        reason: 'prior slow-query subscription must be cancelled',
+      );
+      expect(
+        logging2.hasListener,
+        isTrue,
+        reason: 'new logging subscription must be live',
+      );
+      expect(
+        slowQuery2.hasListener,
+        isTrue,
+        reason: 'new slow-query subscription must be live',
+      );
+    },
+  );
+
+  test(
+    'listenToConfigFlag surfaces a logging-flag stream error',
+    () async {
+      final controlled = makeControlledService();
+      final ready = controlled.service.listenToConfigFlag();
+
+      final error = StateError('logging flag stream failed');
+      controlled.logging.addError(error);
+      // The slow-query side must still complete so Future.wait resolves and
+      // the logging error is the one propagated.
+      controlled.slowQuery.add(true);
+
+      await expectLater(ready, throwsA(same(error)));
+    },
+  );
+
+  test(
+    'listenToConfigFlag surfaces a slow-query-flag stream error',
+    () async {
+      final controlled = makeControlledService();
+      final ready = controlled.service.listenToConfigFlag();
+
+      controlled.logging.add(true);
+      final error = StateError('slow-query flag stream failed');
+      controlled.slowQuery.addError(error);
+
+      await expectLater(ready, throwsA(same(error)));
+    },
+  );
+
+  test(
+    'listenToConfigFlag ignores a stream error after the gate is seeded',
+    () async {
+      final controlled = makeControlledService();
+      final ready = controlled.service.listenToConfigFlag();
+
+      // Seed both flags so the gate turns on and both completers complete.
+      controlled.logging.add(true);
+      controlled.slowQuery.add(true);
+      await ready;
+      expect(SlowQueryLoggingGate.isEnabled, isTrue);
+
+      // A late error must be swallowed by the already-completed guard: it must
+      // neither throw an unhandled error nor disturb the seeded gate state.
+      controlled.slowQuery.addError(StateError('late stream error'));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        SlowQueryLoggingGate.isEnabled,
+        isTrue,
+        reason: 'late error must not disturb the already-seeded gate',
+      );
+    },
+  );
 
   test('captureException with null stackTrace handles gracefully', () {
     fakeAsync((async) {
@@ -555,8 +728,8 @@ void main() {
         () => bufferedJournalDb.watchConfigFlag(logSlowQueriesFlag),
       ).thenAnswer((_) => Stream<bool>.value(false));
 
-      bufferedLogging = getIt<LoggingService>()..listenToConfigFlag();
-      await Future<void>.delayed(Duration.zero);
+      bufferedLogging = getIt<LoggingService>();
+      await bufferedLogging.listenToConfigFlag();
     });
 
     File? findGeneralLog() => _findLogFile(bufferedTempDocs);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Slow-query logging now initializes from persisted settings at startup, so enabled slow_queries and super_slow_queries capture boot-time database activity immediately.

* **Tests**
  * Added tests confirming slow-query logging during DB initialization.
  * Updated tests to make logging initialization deterministic and to verify listener cancellation and error handling.

* **Chores**
  * App version and release notes updated for this fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->