### PR TITLE
feat: standing agreements

### DIFF
--- a/docs/implementation_plans/2026-05-30_daily_os_runtime_implementation_roadmap.md
+++ b/docs/implementation_plans/2026-05-30_daily_os_runtime_implementation_roadmap.md
@@ -24,10 +24,11 @@
   agent-state counters; content-addressed input capture and compaction; and
   flag-gated lazy join/fork healing.
 - **Gaps to close:** Foundation B leader leasing/fencing; attention negotiation
-  planner wiring; outcome tracking; EU fallback tier; and the content-addressed
-  response cache. Standing agreements are now modeled as durable
-  `StandingAgreementEntity` records with an indexed local projection, but the
-  planner does not consume them yet.
+  planner award/verification wiring; outcome tracking; EU fallback tier; and
+  the content-addressed response cache. Standing agreements are modeled as
+  durable `StandingAgreementEntity` records, have a first-class synced
+  authoring service, and are read by the day planner through the indexed local
+  projection rather than source-table JSON scans.
 
 ## PR sequence
 
@@ -116,7 +117,7 @@ default-off)**; detailed plan: [`2026-06-02_join_by_continuation_plan.md`](./202
 
 **PR 8 — Planner MVP (proposal-only)**
 - **Goal:** `attention_request` events (impact/priority/deadline-slack/energy-fit/cadence + **evidence references** + bounded fields), standing agreements, and indexed planner-window lookup feed an LLM-mediated planner behavior; a **deterministic non-negotiable verifier** (recurrence + preemption, checked against health actuals, with manual override/bypass) validates the result; VOI gate; output = `ChangeSet` proposal. **No auto-mutations.**
-- **Resolved foundation:** `AttentionRequestEntity`, `AttentionClaimDispositionEntity`, `AttentionAwardEntity`, `StandingAgreementEntity`, the evidence/award `AgentLink` variants, and indexed local projections for attention claims and standing agreements exist. Claims are producer-maintained: task/project/health agents must emit or withdraw them during their own scheduled or event-driven wakes, before day planning reads. The planner must not synchronously wake many producer agents during drafting. This does **not** yet wire a planner wake, brief builder, verifier, VOI gate, award persistence flow, or `ChangeSet` emission. There is no speculative deterministic planner arbitrator in production.
+- **Resolved foundation:** `AttentionRequestEntity`, `AttentionClaimDispositionEntity`, `AttentionAwardEntity`, `StandingAgreementEntity`, the evidence/award `AgentLink` variants, indexed local projections for attention claims and standing agreements, and a synced `StandingAgreementService` authoring/lifecycle path exist. Claims are producer-maintained: task/project/health agents must emit or withdraw them during their own scheduled or event-driven wakes, before day planning reads. The planner must not synchronously wake many producer agents during drafting. This does **not** yet wire a planner wake, brief builder, verifier, VOI gate, award persistence flow, or `ChangeSet` emission. There is no speculative deterministic planner arbitrator in production.
 - **Depends on:** PR 4 (projection). (Auto-commit later needs PR 7.)
 - **Touches:** new event/edge types; planner behavior; verifier; `ChangeSet` emission; `DayPlan` (awards → `PlannedBlock`).
 - **Defers:** auto-resolution of anything irreversible; auto-commit (needs lease).

--- a/lib/features/agents/README.md
+++ b/lib/features/agents/README.md
@@ -209,6 +209,9 @@ Persisted agent-side entities include:
   `SoulDocumentHeadEntity`
 - `ChangeSetEntity` and `ChangeDecisionEntity`
 - `ProjectRecommendationEntity`
+- `AttentionRequestEntity`, `AttentionClaimDispositionEntity`, and
+  `AttentionAwardEntity`
+- `StandingAgreementEntity`
 - `WakeTokenUsageEntity`
 
 Persisted links include:
@@ -249,6 +252,7 @@ flowchart LR
     Msg["Messages + payloads"]
     Report["Reports + report heads"]
     Change["Change sets + decisions"]
+    Attention["Attention claims + agreements"]
     Template["Templates + versions + heads"]
     Evo["Evolution sessions + notes"]
     Reco["Project recommendations"]
@@ -262,6 +266,7 @@ flowchart LR
   Agent --> Msg
   Agent --> Report
   Agent --> Change
+  Agent --> Attention
   Agent --> Wake
   Template --> Agent
   Template --> Evo
@@ -289,6 +294,8 @@ The persisted memory surface includes:
 - structured observations, stored as observation messages plus payloads
 - reports and report-head pointers
 - change sets, decisions, and project recommendations
+- attention requests, claim dispositions, awards, and standing agreements used
+  by day-planning reads
 - template versions, evolution sessions, persisted ritual recaps, and
   evolution notes
 - wake token usage and wake-run history

--- a/lib/features/agents/service/standing_agreement_service.dart
+++ b/lib/features/agents/service/standing_agreement_service.dart
@@ -1,0 +1,299 @@
+import 'package:clock/clock.dart';
+import 'package:lotti/features/agents/database/agent_repository.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/attention_negotiation.dart';
+import 'package:lotti/features/agents/sync/agent_sync_service.dart';
+import 'package:uuid/uuid.dart';
+
+/// Authoring and lifecycle service for durable planner agreements.
+///
+/// Standing agreements are synced agent-domain records. This service is the
+/// write boundary used by UI, agent tools, and maintenance code so callers do
+/// not hand-roll entity construction or bypass [AgentSyncService]. Input
+/// normalization and invariant validation apply to this local authoring path
+/// only; inbound sync writes go straight to [AgentRepository] and are accepted
+/// as-is to keep peers converging.
+class StandingAgreementService {
+  StandingAgreementService({
+    required this.repository,
+    required this.syncService,
+  });
+
+  final AgentRepository repository;
+  final AgentSyncService syncService;
+
+  static const _uuid = Uuid();
+
+  /// Fetch a non-deleted standing agreement by id.
+  Future<StandingAgreementEntity?> getAgreement(String agreementId) async {
+    final entity = await repository.getEntity(agreementId);
+    if (entity is StandingAgreementEntity && entity.deletedAt == null) {
+      return entity;
+    }
+    return null;
+  }
+
+  /// Create a new active standing agreement.
+  ///
+  /// If [agreementId] is supplied it must not already exist; generated ids rely
+  /// on UUID uniqueness and avoid a defensive source-table read.
+  Future<StandingAgreementEntity> createAgreement({
+    required String agentId,
+    required String title,
+    required StandingAgreementScope scope,
+    required StandingAgreementCadence cadence,
+    String? agreementId,
+    StandingAgreementStatus status = StandingAgreementStatus.active,
+    StandingAgreementEnforcement enforcement =
+        StandingAgreementEnforcement.target,
+    StandingAgreementApprovalMode approvalMode =
+        StandingAgreementApprovalMode.ask,
+    String? categoryId,
+    String? targetId,
+    String? targetKind,
+    String? customScope,
+    String? customCadence,
+    int? minCount,
+    int? maxCount,
+    int? minMinutes,
+    int? maxMinutes,
+    int? preferredSessionMinutes,
+    bool canPreempt = false,
+    int priority = 0,
+    List<String> preemptibleCategoryIds = const [],
+    List<String> protectedCategoryIds = const [],
+    List<AttentionEvidenceRef> evidenceRefs = const [],
+    DateTime? activeFrom,
+    DateTime? activeUntil,
+    String? rationale,
+  }) async {
+    final id = agreementId ?? _uuid.v4();
+    final now = clock.now();
+    final agreement =
+        AgentDomainEntity.standingAgreement(
+              id: id,
+              agentId: agentId,
+              title: _requireNonBlank('title', title),
+              scope: scope,
+              cadence: cadence,
+              status: status,
+              enforcement: enforcement,
+              approvalMode: approvalMode,
+              categoryId: _trimOptional(categoryId),
+              targetId: _trimOptional(targetId),
+              targetKind: _trimOptional(targetKind),
+              customScope: _trimOptional(customScope),
+              customCadence: _trimOptional(customCadence),
+              minCount: minCount,
+              maxCount: maxCount,
+              minMinutes: minMinutes,
+              maxMinutes: maxMinutes,
+              preferredSessionMinutes: preferredSessionMinutes,
+              canPreempt: canPreempt,
+              priority: priority,
+              preemptibleCategoryIds: _normalizeIds(preemptibleCategoryIds),
+              protectedCategoryIds: _normalizeIds(protectedCategoryIds),
+              evidenceRefs: evidenceRefs,
+              activeFrom: activeFrom,
+              activeUntil: activeUntil,
+              rationale: _trimOptional(rationale),
+              createdAt: now,
+              updatedAt: now,
+              vectorClock: null,
+            )
+            as StandingAgreementEntity;
+    _validateAgreement(agreement);
+
+    // Generated ids rely on UUID uniqueness, so the common path is a single
+    // write with no read to make atomic. Only the caller-supplied-id path
+    // guards against collisions, and only it needs the read-then-write
+    // wrapped in a transaction.
+    if (agreementId == null) {
+      await syncService.upsertEntity(agreement);
+      return agreement;
+    }
+
+    return syncService.runInTransaction(() async {
+      if (await repository.getEntity(id) != null) {
+        throw StateError('Standing agreement $id already exists');
+      }
+      await syncService.upsertEntity(agreement);
+      return agreement;
+    });
+  }
+
+  /// Persist a caller-edited agreement through the synced write path.
+  ///
+  /// The returned entity is normalized, validated, and stamped with the current
+  /// time as `updatedAt`. Callers that only need lifecycle transitions should
+  /// prefer [activateAgreement], [pauseAgreement], or [retireAgreement].
+  Future<StandingAgreementEntity> saveAgreement(
+    StandingAgreementEntity agreement,
+  ) async {
+    final updated = agreement.copyWith(
+      title: _requireNonBlank('title', agreement.title),
+      categoryId: _trimOptional(agreement.categoryId),
+      targetId: _trimOptional(agreement.targetId),
+      targetKind: _trimOptional(agreement.targetKind),
+      customScope: _trimOptional(agreement.customScope),
+      customCadence: _trimOptional(agreement.customCadence),
+      rationale: _trimOptional(agreement.rationale),
+      preemptibleCategoryIds: _normalizeIds(
+        agreement.preemptibleCategoryIds,
+      ),
+      protectedCategoryIds: _normalizeIds(agreement.protectedCategoryIds),
+      updatedAt: clock.now(),
+    );
+    _validateAgreement(updated);
+    await syncService.upsertEntity(updated);
+    return updated;
+  }
+
+  /// Make a paused or retired agreement active again.
+  Future<StandingAgreementEntity> activateAgreement({
+    required String agreementId,
+  }) {
+    return _setStatus(agreementId, StandingAgreementStatus.active);
+  }
+
+  /// Pause an agreement without deleting its audit trail.
+  Future<StandingAgreementEntity> pauseAgreement({
+    required String agreementId,
+  }) {
+    return _setStatus(agreementId, StandingAgreementStatus.paused);
+  }
+
+  /// Retire an agreement so it remains historical but stops influencing plans.
+  Future<StandingAgreementEntity> retireAgreement({
+    required String agreementId,
+  }) {
+    return _setStatus(agreementId, StandingAgreementStatus.retired);
+  }
+
+  /// Soft-delete an agreement.
+  Future<StandingAgreementEntity> deleteAgreement({
+    required String agreementId,
+  }) async {
+    final agreement = await _loadAgreement(agreementId, includeDeleted: true);
+    if (agreement.deletedAt != null) return agreement;
+
+    final now = clock.now();
+    final updated = agreement.copyWith(
+      deletedAt: now,
+      updatedAt: now,
+    );
+    await syncService.upsertEntity(updated);
+    return updated;
+  }
+
+  Future<StandingAgreementEntity> _setStatus(
+    String agreementId,
+    StandingAgreementStatus status,
+  ) async {
+    final agreement = await _loadAgreement(agreementId);
+    if (agreement.status == status) return agreement;
+
+    final updated = agreement.copyWith(
+      status: status,
+      updatedAt: clock.now(),
+    );
+    await syncService.upsertEntity(updated);
+    return updated;
+  }
+
+  Future<StandingAgreementEntity> _loadAgreement(
+    String agreementId, {
+    bool includeDeleted = false,
+  }) async {
+    final entity = await repository.getEntity(agreementId);
+    if (entity is! StandingAgreementEntity) {
+      throw StateError('Standing agreement $agreementId not found');
+    }
+    if (!includeDeleted && entity.deletedAt != null) {
+      throw StateError('Standing agreement $agreementId not found');
+    }
+    return entity;
+  }
+
+  static String _requireNonBlank(String name, String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) {
+      throw ArgumentError('$name must not be blank');
+    }
+    return trimmed;
+  }
+
+  static String? _trimOptional(String? value) {
+    final trimmed = value?.trim();
+    if (trimmed == null || trimmed.isEmpty) return null;
+    return trimmed;
+  }
+
+  static List<String> _normalizeIds(List<String> ids) {
+    final seen = <String>{};
+    final normalized = <String>[];
+    for (final id in ids) {
+      final trimmed = id.trim();
+      if (trimmed.isNotEmpty && seen.add(trimmed)) {
+        normalized.add(trimmed);
+      }
+    }
+    return normalized;
+  }
+
+  static void _validateAgreement(StandingAgreementEntity agreement) {
+    if (agreement.scope == StandingAgreementScope.custom &&
+        agreement.customScope == null) {
+      throw ArgumentError('customScope is required for custom scope');
+    }
+    if (agreement.cadence == StandingAgreementCadence.custom &&
+        agreement.customCadence == null) {
+      throw ArgumentError('customCadence is required for custom cadence');
+    }
+
+    _validateNonNegative('minCount', agreement.minCount);
+    _validateNonNegative('maxCount', agreement.maxCount);
+    _validateNonNegative('minMinutes', agreement.minMinutes);
+    _validateNonNegative('maxMinutes', agreement.maxMinutes);
+    _validatePositive(
+      'preferredSessionMinutes',
+      agreement.preferredSessionMinutes,
+    );
+    _validateMinMax('count', agreement.minCount, agreement.maxCount);
+    _validateMinMax('minutes', agreement.minMinutes, agreement.maxMinutes);
+
+    final preferredSessionMinutes = agreement.preferredSessionMinutes;
+    final maxMinutes = agreement.maxMinutes;
+    if (preferredSessionMinutes != null &&
+        maxMinutes != null &&
+        preferredSessionMinutes > maxMinutes) {
+      throw ArgumentError('preferredSessionMinutes must be <= maxMinutes');
+    }
+
+    final activeFrom = agreement.activeFrom;
+    final activeUntil = agreement.activeUntil;
+    if (activeFrom != null &&
+        activeUntil != null &&
+        activeFrom.isAfter(activeUntil)) {
+      throw ArgumentError('activeFrom must be before or equal to activeUntil');
+    }
+  }
+
+  static void _validateNonNegative(String name, int? value) {
+    if (value != null && value < 0) {
+      throw ArgumentError('$name must not be negative');
+    }
+  }
+
+  static void _validatePositive(String name, int? value) {
+    if (value != null && value <= 0) {
+      throw ArgumentError('$name must be positive');
+    }
+  }
+
+  static void _validateMinMax(String name, int? min, int? max) {
+    if (min != null && max != null && min > max) {
+      throw ArgumentError('min$name must be <= max$name');
+    }
+  }
+}

--- a/lib/features/agents/state/agent_providers.dart
+++ b/lib/features/agents/state/agent_providers.dart
@@ -13,6 +13,7 @@ import 'package:lotti/features/agents/service/feedback_extraction_service.dart';
 import 'package:lotti/features/agents/service/improver_agent_service.dart';
 import 'package:lotti/features/agents/service/project_activity_monitor.dart';
 import 'package:lotti/features/agents/service/soul_document_service.dart';
+import 'package:lotti/features/agents/service/standing_agreement_service.dart';
 import 'package:lotti/features/agents/state/agent_workflow_providers.dart';
 import 'package:lotti/features/agents/state/project_agent_providers.dart';
 import 'package:lotti/features/agents/state/task_agent_providers.dart';
@@ -279,6 +280,15 @@ AgentService agentService(Ref ref) {
 @Riverpod(keepAlive: true)
 AgentTemplateService agentTemplateService(Ref ref) {
   return AgentTemplateService(
+    repository: ref.watch(agentRepositoryProvider),
+    syncService: ref.watch(agentSyncServiceProvider),
+  );
+}
+
+/// The standing agreement authoring service.
+@Riverpod(keepAlive: true)
+StandingAgreementService standingAgreementService(Ref ref) {
+  return StandingAgreementService(
     repository: ref.watch(agentRepositoryProvider),
     syncService: ref.watch(agentSyncServiceProvider),
   );

--- a/lib/features/agents/state/agent_providers.g.dart
+++ b/lib/features/agents/state/agent_providers.g.dart
@@ -726,6 +726,59 @@ final class AgentTemplateServiceProvider
 String _$agentTemplateServiceHash() =>
     r'104340be1f31a3ca3b8a0e5b3726a0084969940b';
 
+/// The standing agreement authoring service.
+
+@ProviderFor(standingAgreementService)
+final standingAgreementServiceProvider = StandingAgreementServiceProvider._();
+
+/// The standing agreement authoring service.
+
+final class StandingAgreementServiceProvider
+    extends
+        $FunctionalProvider<
+          StandingAgreementService,
+          StandingAgreementService,
+          StandingAgreementService
+        >
+    with $Provider<StandingAgreementService> {
+  /// The standing agreement authoring service.
+  StandingAgreementServiceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'standingAgreementServiceProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$standingAgreementServiceHash();
+
+  @$internal
+  @override
+  $ProviderElement<StandingAgreementService> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  StandingAgreementService create(Ref ref) {
+    return standingAgreementService(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(StandingAgreementService value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<StandingAgreementService>(value),
+    );
+  }
+}
+
+String _$standingAgreementServiceHash() =>
+    r'2f3c97889efc7697a270dddad5ee1d763b7e8c0f';
+
 /// The soul document service.
 
 @ProviderFor(soulDocumentService)

--- a/test/features/agents/service/standing_agreement_service_test.dart
+++ b/test/features/agents/service/standing_agreement_service_test.dart
@@ -1,0 +1,522 @@
+import 'package:clock/clock.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/agents/database/agent_database.dart';
+import 'package:lotti/features/agents/database/agent_repository.dart';
+import 'package:lotti/features/agents/model/agent_config.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/model/attention_negotiation.dart';
+import 'package:lotti/features/agents/service/standing_agreement_service.dart';
+import 'package:lotti/features/sync/vector_clock.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../helpers/fallbacks.dart';
+import '../../../mocks/mocks.dart';
+
+void main() {
+  setUpAll(registerAllFallbackValues);
+
+  const agentId = 'fitness-agent-001';
+  final now = DateTime(2026, 6, 6, 9);
+
+  late MockAgentRepository repository;
+  late MockAgentSyncService syncService;
+  late StandingAgreementService service;
+
+  setUp(() {
+    repository = MockAgentRepository();
+    syncService = MockAgentSyncService();
+    service = StandingAgreementService(
+      repository: repository,
+      syncService: syncService,
+    );
+
+    when(() => syncService.upsertEntity(any())).thenAnswer((_) async {});
+  });
+
+  group('createAgreement', () {
+    test('writes a normalized active agreement through sync', () async {
+      when(
+        () => repository.getEntity('agreement-001'),
+      ).thenAnswer((_) async => null);
+
+      final agreement = await withClock(Clock.fixed(now), () {
+        return service.createAgreement(
+          agreementId: 'agreement-001',
+          agentId: agentId,
+          title: '  Strength three times per week  ',
+          scope: StandingAgreementScope.fitness,
+          cadence: StandingAgreementCadence.weekly,
+          enforcement: StandingAgreementEnforcement.nonNegotiable,
+          approvalMode: StandingAgreementApprovalMode.autoAccept,
+          categoryId: ' health ',
+          targetId: ' strength ',
+          targetKind: ' habit ',
+          minCount: 3,
+          maxCount: 4,
+          minMinutes: 135,
+          maxMinutes: 240,
+          preferredSessionMinutes: 45,
+          canPreempt: true,
+          priority: 90,
+          preemptibleCategoryIds: const [' admin ', 'admin', ''],
+          protectedCategoryIds: const [' sleep ', 'sleep'],
+          evidenceRefs: const [
+            AttentionEvidenceRef(
+              kind: AttentionEvidenceKind.health,
+              id: 'workout-history',
+              label: 'Recent workouts',
+            ),
+          ],
+          activeFrom: DateTime(2026, 6),
+          activeUntil: DateTime(2026, 7),
+          rationale: '  Current fitness baseline  ',
+        );
+      });
+
+      expect(agreement.id, 'agreement-001');
+      expect(agreement.agentId, agentId);
+      expect(agreement.title, 'Strength three times per week');
+      expect(agreement.status, StandingAgreementStatus.active);
+      expect(agreement.enforcement, StandingAgreementEnforcement.nonNegotiable);
+      expect(agreement.approvalMode, StandingAgreementApprovalMode.autoAccept);
+      expect(agreement.categoryId, 'health');
+      expect(agreement.targetId, 'strength');
+      expect(agreement.targetKind, 'habit');
+      expect(agreement.minCount, 3);
+      expect(agreement.maxCount, 4);
+      expect(agreement.minMinutes, 135);
+      expect(agreement.maxMinutes, 240);
+      expect(agreement.preferredSessionMinutes, 45);
+      expect(agreement.canPreempt, isTrue);
+      expect(agreement.priority, 90);
+      expect(agreement.preemptibleCategoryIds, ['admin']);
+      expect(agreement.protectedCategoryIds, ['sleep']);
+      expect(agreement.evidenceRefs.single.id, 'workout-history');
+      expect(agreement.rationale, 'Current fitness baseline');
+      expect(agreement.createdAt, now);
+      expect(agreement.updatedAt, now);
+      expect(agreement.vectorClock, isNull);
+
+      final captured =
+          verify(
+                () => syncService.upsertEntity(captureAny()),
+              ).captured.single
+              as StandingAgreementEntity;
+      expect(captured, same(agreement));
+    });
+
+    test('rejects duplicate explicit ids before writing', () async {
+      when(
+        () => repository.getEntity('agreement-001'),
+      ).thenAnswer((_) async => _agreement());
+
+      await expectLater(
+        () => service.createAgreement(
+          agreementId: 'agreement-001',
+          agentId: agentId,
+          title: 'Exercise',
+          scope: StandingAgreementScope.fitness,
+          cadence: StandingAgreementCadence.weekly,
+        ),
+        throwsA(isA<StateError>()),
+      );
+
+      verifyNever(() => syncService.upsertEntity(any()));
+    });
+
+    test('validates required and bounded agreement fields', () async {
+      await expectLater(
+        () => service.createAgreement(
+          agentId: agentId,
+          title: ' ',
+          scope: StandingAgreementScope.fitness,
+          cadence: StandingAgreementCadence.weekly,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      await expectLater(
+        () => service.createAgreement(
+          agentId: agentId,
+          title: 'Custom scope',
+          scope: StandingAgreementScope.custom,
+          cadence: StandingAgreementCadence.weekly,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      await expectLater(
+        () => service.createAgreement(
+          agentId: agentId,
+          title: 'Custom cadence',
+          scope: StandingAgreementScope.fitness,
+          cadence: StandingAgreementCadence.custom,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      await expectLater(
+        () => service.createAgreement(
+          agentId: agentId,
+          title: 'Negative count',
+          scope: StandingAgreementScope.fitness,
+          cadence: StandingAgreementCadence.weekly,
+          minCount: -1,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      await expectLater(
+        () => service.createAgreement(
+          agentId: agentId,
+          title: 'Bad session length',
+          scope: StandingAgreementScope.fitness,
+          cadence: StandingAgreementCadence.weekly,
+          preferredSessionMinutes: 0,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      await expectLater(
+        () => service.createAgreement(
+          agentId: agentId,
+          title: 'Inverted minutes',
+          scope: StandingAgreementScope.fitness,
+          cadence: StandingAgreementCadence.weekly,
+          minMinutes: 90,
+          maxMinutes: 30,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      await expectLater(
+        () => service.createAgreement(
+          agentId: agentId,
+          title: 'Preferred session exceeds max minutes',
+          scope: StandingAgreementScope.fitness,
+          cadence: StandingAgreementCadence.weekly,
+          preferredSessionMinutes: 45,
+          maxMinutes: 30,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      await expectLater(
+        () => service.createAgreement(
+          agentId: agentId,
+          title: 'Inverted active dates',
+          scope: StandingAgreementScope.fitness,
+          cadence: StandingAgreementCadence.weekly,
+          activeFrom: DateTime(2026, 6, 10),
+          activeUntil: DateTime(2026, 6),
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      verifyNever(() => syncService.upsertEntity(any()));
+    });
+  });
+
+  group('saveAgreement', () {
+    test('normalizes caller-edited agreements and stamps updatedAt', () async {
+      final agreement = _agreement(
+        title: '  Keep paperwork bounded  ',
+        scope: StandingAgreementScope.custom,
+        cadence: StandingAgreementCadence.custom,
+        customScope: '  admin load  ',
+        customCadence: '  every work week  ',
+        categoryId: ' admin ',
+        targetId: ' taxes ',
+        targetKind: ' task ',
+        rationale: '  Avoid late scramble  ',
+        preemptibleCategoryIds: const [' inbox ', 'inbox'],
+        protectedCategoryIds: const [' deep-work ', ''],
+      );
+
+      final saved = await withClock(Clock.fixed(now), () {
+        return service.saveAgreement(agreement);
+      });
+
+      expect(saved.title, 'Keep paperwork bounded');
+      expect(saved.customScope, 'admin load');
+      expect(saved.customCadence, 'every work week');
+      expect(saved.categoryId, 'admin');
+      expect(saved.targetId, 'taxes');
+      expect(saved.targetKind, 'task');
+      expect(saved.rationale, 'Avoid late scramble');
+      expect(saved.preemptibleCategoryIds, ['inbox']);
+      expect(saved.protectedCategoryIds, ['deep-work']);
+      expect(saved.updatedAt, now);
+
+      verify(() => syncService.upsertEntity(saved)).called(1);
+    });
+  });
+
+  group('lifecycle', () {
+    test('pauses, activates, and retires agreements by id', () async {
+      final active = _agreement();
+      final paused = active.copyWith(status: StandingAgreementStatus.paused);
+
+      when(() => repository.getEntity('agreement-001')).thenAnswer(
+        (_) async => active,
+      );
+      final pausedResult = await withClock(Clock.fixed(now), () {
+        return service.pauseAgreement(agreementId: 'agreement-001');
+      });
+      expect(pausedResult.status, StandingAgreementStatus.paused);
+      expect(pausedResult.updatedAt, now);
+
+      when(() => repository.getEntity('agreement-001')).thenAnswer(
+        (_) async => paused,
+      );
+      final activeResult = await withClock(Clock.fixed(now), () {
+        return service.activateAgreement(agreementId: 'agreement-001');
+      });
+      expect(activeResult.status, StandingAgreementStatus.active);
+      expect(activeResult.updatedAt, now);
+
+      final retiredResult = await withClock(Clock.fixed(now), () {
+        return service.retireAgreement(agreementId: 'agreement-001');
+      });
+      expect(retiredResult.status, StandingAgreementStatus.retired);
+      expect(retiredResult.updatedAt, now);
+
+      final written = verify(
+        () => syncService.upsertEntity(captureAny()),
+      ).captured.cast<StandingAgreementEntity>();
+      expect(
+        written.map((agreement) => agreement.status),
+        [
+          StandingAgreementStatus.paused,
+          StandingAgreementStatus.active,
+          StandingAgreementStatus.retired,
+        ],
+      );
+    });
+
+    test('does not rewrite an unchanged status', () async {
+      final paused = _agreement(
+        status: StandingAgreementStatus.paused,
+      );
+      when(
+        () => repository.getEntity('agreement-001'),
+      ).thenAnswer((_) async => paused);
+
+      final result = await service.pauseAgreement(agreementId: 'agreement-001');
+
+      expect(result, same(paused));
+      verifyNever(() => syncService.upsertEntity(any()));
+    });
+
+    test(
+      'soft deletes once and leaves an already deleted record unchanged',
+      () async {
+        final active = _agreement();
+        when(
+          () => repository.getEntity('agreement-001'),
+        ).thenAnswer((_) async => active);
+
+        final deleted = await withClock(Clock.fixed(now), () {
+          return service.deleteAgreement(agreementId: 'agreement-001');
+        });
+
+        expect(deleted.deletedAt, now);
+        expect(deleted.updatedAt, now);
+        verify(() => syncService.upsertEntity(deleted)).called(1);
+
+        clearInteractions(syncService);
+        when(() => repository.getEntity('agreement-001')).thenAnswer(
+          (_) async => deleted,
+        );
+
+        final unchanged = await service.deleteAgreement(
+          agreementId: 'agreement-001',
+        );
+
+        expect(unchanged, same(deleted));
+        verifyNever(() => syncService.upsertEntity(any()));
+      },
+    );
+
+    test('throws when the id does not point at a live agreement', () async {
+      when(
+        () => repository.getEntity('missing-agreement'),
+      ).thenAnswer((_) async => null);
+      await expectLater(
+        () => service.pauseAgreement(agreementId: 'missing-agreement'),
+        throwsA(isA<StateError>()),
+      );
+
+      when(() => repository.getEntity('agent-entity')).thenAnswer(
+        (_) async => AgentDomainEntity.agent(
+          id: 'agent-entity',
+          agentId: 'agent-entity',
+          kind: 'task_agent',
+          displayName: 'Task Agent',
+          lifecycle: AgentLifecycle.active,
+          mode: AgentInteractionMode.autonomous,
+          allowedCategoryIds: const {},
+          currentStateId: 'state-entity',
+          config: const AgentConfig(),
+          createdAt: now,
+          updatedAt: now,
+          vectorClock: null,
+        ),
+      );
+      await expectLater(
+        () => service.pauseAgreement(agreementId: 'agent-entity'),
+        throwsA(isA<StateError>()),
+      );
+
+      when(() => repository.getEntity('deleted-agreement')).thenAnswer(
+        (_) async => _agreement(
+          id: 'deleted-agreement',
+          deletedAt: now,
+        ),
+      );
+      await expectLater(
+        () => service.pauseAgreement(agreementId: 'deleted-agreement'),
+        throwsA(isA<StateError>()),
+      );
+    });
+  });
+
+  group('getAgreement', () {
+    test('returns only non-deleted standing agreements', () async {
+      final agreement = _agreement();
+      when(
+        () => repository.getEntity('agreement-001'),
+      ).thenAnswer((_) async => agreement);
+      expect(await service.getAgreement('agreement-001'), same(agreement));
+
+      when(() => repository.getEntity('deleted-agreement')).thenAnswer(
+        (_) async => _agreement(
+          id: 'deleted-agreement',
+          deletedAt: now,
+        ),
+      );
+      expect(await service.getAgreement('deleted-agreement'), isNull);
+
+      when(() => repository.getEntity('agent-entity')).thenAnswer(
+        (_) async => AgentDomainEntity.agent(
+          id: 'agent-entity',
+          agentId: 'agent-entity',
+          kind: 'task_agent',
+          displayName: 'Task Agent',
+          lifecycle: AgentLifecycle.active,
+          mode: AgentInteractionMode.autonomous,
+          allowedCategoryIds: const {},
+          currentStateId: 'state-entity',
+          config: const AgentConfig(),
+          createdAt: now,
+          updatedAt: now,
+          vectorClock: null,
+        ),
+      );
+      expect(await service.getAgreement('agent-entity'), isNull);
+    });
+  });
+
+  test('created agreements surface in planner-window inputs', () async {
+    final db = AgentDatabase(inMemoryDatabase: true, background: false);
+    addTearDown(db.close);
+    final realRepository = AgentRepository(db);
+    final writer = MockAgentSyncService();
+    final projectionService = StandingAgreementService(
+      repository: realRepository,
+      syncService: writer,
+    );
+
+    when(() => writer.upsertEntity(any())).thenAnswer((invocation) async {
+      final entity = invocation.positionalArguments.single as AgentDomainEntity;
+      await realRepository.upsertEntity(entity);
+    });
+
+    final agreement = await withClock(Clock.fixed(now), () {
+      return projectionService.createAgreement(
+        agentId: agentId,
+        title: 'Exercise three times per week',
+        scope: StandingAgreementScope.fitness,
+        cadence: StandingAgreementCadence.weekly,
+        minCount: 3,
+        preferredSessionMinutes: 45,
+        activeFrom: DateTime(2026, 6),
+      );
+    });
+
+    final inputs = await realRepository.getAttentionPlanningInputsForWindow(
+      start: DateTime(2026, 6, 8),
+      end: DateTime(2026, 6, 9),
+      agreementScopes: const {StandingAgreementScope.fitness},
+    );
+
+    expect(inputs.claims, isEmpty);
+    expect(inputs.standingAgreements.map((item) => item.id), [agreement.id]);
+  });
+}
+
+StandingAgreementEntity _agreement({
+  String id = 'agreement-001',
+  String agentId = 'fitness-agent-001',
+  String title = 'Exercise three times per week',
+  StandingAgreementScope scope = StandingAgreementScope.fitness,
+  StandingAgreementCadence cadence = StandingAgreementCadence.weekly,
+  StandingAgreementStatus status = StandingAgreementStatus.active,
+  StandingAgreementEnforcement enforcement =
+      StandingAgreementEnforcement.target,
+  StandingAgreementApprovalMode approvalMode =
+      StandingAgreementApprovalMode.ask,
+  String? categoryId,
+  String? targetId,
+  String? targetKind,
+  String? customScope,
+  String? customCadence,
+  int? minCount = 3,
+  int? maxCount,
+  int? minMinutes = 135,
+  int? maxMinutes,
+  int? preferredSessionMinutes = 45,
+  bool canPreempt = false,
+  int priority = 0,
+  List<String> preemptibleCategoryIds = const [],
+  List<String> protectedCategoryIds = const [],
+  String? rationale,
+  DateTime? createdAt,
+  DateTime? updatedAt,
+  DateTime? deletedAt,
+}) {
+  final effectiveCreatedAt = createdAt ?? DateTime(2026, 6);
+  final effectiveUpdatedAt = updatedAt ?? DateTime(2026, 6);
+
+  return AgentDomainEntity.standingAgreement(
+        id: id,
+        agentId: agentId,
+        title: title,
+        scope: scope,
+        cadence: cadence,
+        status: status,
+        enforcement: enforcement,
+        approvalMode: approvalMode,
+        categoryId: categoryId,
+        targetId: targetId,
+        targetKind: targetKind,
+        customScope: customScope,
+        customCadence: customCadence,
+        minCount: minCount,
+        maxCount: maxCount,
+        minMinutes: minMinutes,
+        maxMinutes: maxMinutes,
+        preferredSessionMinutes: preferredSessionMinutes,
+        canPreempt: canPreempt,
+        priority: priority,
+        preemptibleCategoryIds: preemptibleCategoryIds,
+        protectedCategoryIds: protectedCategoryIds,
+        rationale: rationale,
+        createdAt: effectiveCreatedAt,
+        updatedAt: effectiveUpdatedAt,
+        vectorClock: const VectorClock({'node-1': 1}),
+        deletedAt: deletedAt,
+      )
+      as StandingAgreementEntity;
+}

--- a/test/features/agents/state/agent_providers_test.dart
+++ b/test/features/agents/state/agent_providers_test.dart
@@ -20,6 +20,7 @@ import 'package:lotti/features/agents/service/agent_template_service.dart';
 import 'package:lotti/features/agents/service/feedback_extraction_service.dart';
 import 'package:lotti/features/agents/service/improver_agent_service.dart';
 import 'package:lotti/features/agents/service/project_activity_monitor.dart';
+import 'package:lotti/features/agents/service/standing_agreement_service.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/agents/sync/agent_sync_service.dart';
 import 'package:lotti/features/agents/wake/scheduled_wake_manager.dart';
@@ -3159,6 +3160,28 @@ void main() {
       final service = container.read(agentTemplateServiceProvider);
       expect(service, isA<AgentTemplateService>());
       expect(service.repository, same(mockRepo));
+    });
+  });
+
+  group('standingAgreementServiceProvider', () {
+    test('creates service with injected dependencies', () {
+      final mockRepo = MockAgentRepository();
+      final mockSyncService = MockAgentSyncService();
+      final mockOutbox = MockOutboxService();
+
+      final container = ProviderContainer(
+        overrides: [
+          agentRepositoryProvider.overrideWithValue(mockRepo),
+          agentSyncServiceProvider.overrideWithValue(mockSyncService),
+          outboxServiceProvider.overrideWithValue(mockOutbox),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final service = container.read(standingAgreementServiceProvider);
+      expect(service, isA<StandingAgreementService>());
+      expect(service.repository, same(mockRepo));
+      expect(service.syncService, same(mockSyncService));
     });
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added standing-agreement authoring and lifecycle (create, update, activate, pause, retire, soft-delete) with planner-aware persistence so agreements appear in day-planning inputs.

* **Documentation**
  * Clarified roadmap gaps and persistence approach; expanded architecture docs to include attention-related durable memory and planner integration.

* **Tests**
  * Added unit and integration tests covering creation, validation, lifecycle transitions, deletion, and planner visibility.

* **Chores**
  * Wired the new service into app providers for runtime lookup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->