### PR TITLE
fix(daily-os): stabilize provider-neutral draft wakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Slow-query logging now starts from persisted logging settings during startup,
   so enabled `slow_queries` and `super_slow_queries` files capture boot-time
   database work instead of waiting for the next settings toggle.
+- Daily OS Next day planning now forces required draft tool calls through
+  Gemini and Mistral providers and keeps fast completed drafts from being
+  dropped while learning cards load.
 
 ## [0.9.1015]
 ### Added

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -41,6 +41,7 @@
           <p>Daily OS Next: a bounded "Today so far" card shows the day's recorded sessions on the Capture screen and on the empty Agenda tab, collapsing older sessions behind an expander.</p>
           <p>Daily OS Next: agenda items and day blocks now show whether they are backed by a task (blue link badge that opens the task) or are standalone time blocks, and standalone titles can be renamed inline.</p>
           <p>Daily OS Next visuals now follow the latest design handoff: a capacity donut replaces the linear meter, recorded sessions render in a neutral tracked treatment, drafted blocks carry a dashed outline, the commit sign-off composition was reworked, and typography across the feature is calmer.</p>
+          <p>Daily OS Next day planning now forces required draft tool calls through Gemini and Mistral providers and keeps fast completed drafts from being dropped while learning cards load.</p>
       </description>
     </release>
     <release version="0.9.1015" date="2026-06-04">

--- a/lib/features/ai/conversation/conversation_repository.dart
+++ b/lib/features/ai/conversation/conversation_repository.dart
@@ -203,8 +203,9 @@ class ConversationRepository extends _$ConversationRepository {
   /// for every inference call this `sendMessage` makes. This is the hook the
   /// Task Agent uses to force a terminal `update_report` call when a weaker
   /// model stopped early without publishing its report. Currently honored
-  /// only on the OpenAI-compatible inference path — Gemini/Ollama/Mistral
-  /// sub-repositories silently ignore it.
+  /// on provider adapters that support forced tools. Adapters that do not
+  /// support it should make that limitation explicit instead of silently
+  /// dropping the constraint.
   ///
   /// Returns the accumulated [InferenceUsage] across all turns, or `null`
   /// if no usage data was reported by the inference provider.

--- a/lib/features/ai/repository/cloud_inference_repository.dart
+++ b/lib/features/ai/repository/cloud_inference_repository.dart
@@ -176,6 +176,7 @@ class CloudInferenceRepository {
         maxCompletionTokens: maxCompletionTokens,
         provider: provider,
         tools: tools,
+        toolChoice: toolChoice,
         thinkingConfig: finalThinking,
       );
     }
@@ -192,6 +193,7 @@ class CloudInferenceRepository {
         temperature: temperature,
         maxCompletionTokens: maxCompletionTokens,
         tools: tools,
+        toolChoice: toolChoice,
       );
     }
 
@@ -514,8 +516,8 @@ class CloudInferenceRepository {
   /// - [toolChoice]: Optional override of the tool-selection policy. When
   ///   provided, it replaces the default `auto` behavior — useful for forcing
   ///   a terminal tool call (e.g. `update_report`) when a weaker model failed
-  ///   to emit it on its own. Currently honored only on the OpenAI-compatible
-  ///   branch; the Gemini/Ollama/Mistral sub-repositories ignore it.
+  ///   to emit it on its own. Honored by Gemini and the OpenAI-compatible
+  ///   branch; Ollama ignores it.
   /// - [thoughtSignatures]: Optional signatures from previous turns (Gemini only)
   /// - [signatureCollector]: Optional collector for new signatures (Gemini only)
   /// - [turnIndex]: Current turn number for unique tool call ID generation
@@ -563,6 +565,7 @@ class CloudInferenceRepository {
         systemMessage: systemMessage,
         maxCompletionTokens: maxCompletionTokens,
         tools: tools,
+        toolChoice: toolChoice,
         signatureCollector: signatureCollector,
         turnIndex: turnIndex,
       );
@@ -590,6 +593,7 @@ class CloudInferenceRepository {
         temperature: temperature,
         maxCompletionTokens: maxCompletionTokens,
         tools: tools,
+        toolChoice: toolChoice,
       );
     }
 

--- a/lib/features/ai/repository/gemini_inference_repository.dart
+++ b/lib/features/ai/repository/gemini_inference_repository.dart
@@ -91,6 +91,8 @@ class GeminiInferenceRepository {
   /// - `systemMessage`: optional system instruction.
   /// - `maxCompletionTokens`: model-specific token cap.
   /// - `tools`: OpenAI-style function tools mapped to Gemini function declarations.
+  /// - `toolChoice`: Optional OpenAI-style tool-selection override mapped to
+  ///   Gemini's native function-calling config.
   /// - `signatureCollector`: optional collector for capturing thought signatures
   ///   from Gemini 3 function calls (for multi-turn conversations).
   ///
@@ -111,6 +113,7 @@ class GeminiInferenceRepository {
     String? systemMessage,
     int? maxCompletionTokens,
     List<ChatCompletionTool>? tools,
+    ChatCompletionToolChoiceOption? toolChoice,
     ThoughtSignatureCollector? signatureCollector,
   }) async* {
     final uri = GeminiUtils.buildStreamGenerateContentUri(
@@ -127,6 +130,7 @@ class GeminiInferenceRepository {
       modelId: model,
       maxTokens: maxCompletionTokens,
       tools: tools,
+      toolChoice: toolChoice,
     );
 
     developer.log(
@@ -572,6 +576,7 @@ class GeminiInferenceRepository {
     String? systemMessage,
     int? maxCompletionTokens,
     List<ChatCompletionTool>? tools,
+    ChatCompletionToolChoiceOption? toolChoice,
     ThoughtSignatureCollector? signatureCollector,
     int? turnIndex,
   }) => generateTextWithMessagesImpl(
@@ -584,6 +589,7 @@ class GeminiInferenceRepository {
     systemMessage: systemMessage,
     maxCompletionTokens: maxCompletionTokens,
     tools: tools,
+    toolChoice: toolChoice,
     signatureCollector: signatureCollector,
     turnIndex: turnIndex,
   );

--- a/lib/features/ai/repository/gemini_multiturn_inference.dart
+++ b/lib/features/ai/repository/gemini_multiturn_inference.dart
@@ -23,6 +23,7 @@ extension GeminiMultiTurnInference on GeminiInferenceRepository {
   /// - [systemMessage]: Optional system instruction
   /// - [maxCompletionTokens]: Optional output token limit
   /// - [tools]: Optional function declarations
+  /// - [toolChoice]: Optional tool-selection override
   /// - [signatureCollector]: Optional collector for capturing new signatures
   /// Multi-turn variant that accepts full conversation history.
   ///
@@ -39,6 +40,7 @@ extension GeminiMultiTurnInference on GeminiInferenceRepository {
     String? systemMessage,
     int? maxCompletionTokens,
     List<ChatCompletionTool>? tools,
+    ChatCompletionToolChoiceOption? toolChoice,
     ThoughtSignatureCollector? signatureCollector,
     int? turnIndex,
   }) async* {
@@ -57,6 +59,7 @@ extension GeminiMultiTurnInference on GeminiInferenceRepository {
       modelId: model,
       maxTokens: maxCompletionTokens,
       tools: tools,
+      toolChoice: toolChoice,
     );
 
     developer.log(

--- a/lib/features/ai/repository/gemini_utils.dart
+++ b/lib/features/ai/repository/gemini_utils.dart
@@ -75,6 +75,8 @@ class GeminiUtils {
   /// - Adds `systemInstruction` when provided.
   /// - Serializes [GeminiThinkingConfig] into `generationConfig.thinkingConfig`.
   /// - Maps OpenAI-style [ChatCompletionTool] to Gemini `functionDeclarations`.
+  /// - Maps OpenAI-style forced [ChatCompletionToolChoiceOption] values to
+  ///   Gemini's native `toolConfig.functionCallingConfig`.
   static Map<String, dynamic> buildRequestBody({
     required String prompt,
     required double temperature,
@@ -83,6 +85,7 @@ class GeminiUtils {
     String? modelId,
     int? maxTokens,
     List<ChatCompletionTool>? tools,
+    ChatCompletionToolChoiceOption? toolChoice,
   }) {
     final contents = <Map<String, dynamic>>[
       {
@@ -108,6 +111,7 @@ class GeminiUtils {
             'functionDeclarations': _buildFunctionDeclarations(tools),
           },
         ],
+      'toolConfig': ?_buildToolConfig(toolChoice),
     };
 
     if (systemMessage != null && systemMessage.trim().isNotEmpty) {
@@ -139,6 +143,7 @@ class GeminiUtils {
   /// - [systemMessage]: Optional system instruction
   /// - [maxTokens]: Optional output token limit
   /// - [tools]: Optional function declarations
+  /// - [toolChoice]: Optional forced/disabled/automatic function-calling mode
   static Map<String, dynamic> buildMultiTurnRequestBody({
     required List<ChatCompletionMessage> messages,
     required double temperature,
@@ -148,6 +153,7 @@ class GeminiUtils {
     String? modelId,
     int? maxTokens,
     List<ChatCompletionTool>? tools,
+    ChatCompletionToolChoiceOption? toolChoice,
   }) {
     // Build mapping of toolCallId -> functionName from assistant messages
     // This is needed because tool responses only have the ID, not the name
@@ -185,6 +191,7 @@ class GeminiUtils {
             'functionDeclarations': _buildFunctionDeclarations(tools),
           },
         ],
+      'toolConfig': ?_buildToolConfig(toolChoice),
     };
 
     if (systemMessage != null && systemMessage.trim().isNotEmpty) {
@@ -415,6 +422,33 @@ class GeminiUtils {
           },
         )
         .toList();
+  }
+
+  static Map<String, dynamic>? _buildToolConfig(
+    ChatCompletionToolChoiceOption? toolChoice,
+  ) {
+    if (toolChoice == null) return null;
+
+    return toolChoice.map(
+      mode: (choice) {
+        final mode = switch (choice.value) {
+          ChatCompletionToolChoiceMode.none => 'NONE',
+          ChatCompletionToolChoiceMode.auto => 'AUTO',
+          ChatCompletionToolChoiceMode.required => 'ANY',
+        };
+        return {
+          'functionCallingConfig': {'mode': mode},
+        };
+      },
+      tool: (choice) {
+        return {
+          'functionCallingConfig': {
+            'mode': 'ANY',
+            'allowedFunctionNames': [choice.value.function.name],
+          },
+        };
+      },
+    );
   }
 
   /// Recursively strips `additionalProperties` from a JSON Schema map.

--- a/lib/features/ai/repository/mistral_inference_repository.dart
+++ b/lib/features/ai/repository/mistral_inference_repository.dart
@@ -51,6 +51,8 @@ class MistralInferenceRepository {
   ///   temperature: Sampling temperature
   ///   maxCompletionTokens: Maximum tokens for completion
   ///   tools: Optional list of tools for function calling
+  ///   toolChoice: Optional tool-selection override (`auto`, required, none,
+  ///     or a specific function).
   ///
   /// Returns:
   ///   Stream of chat completion responses
@@ -63,6 +65,7 @@ class MistralInferenceRepository {
     double? temperature,
     int? maxCompletionTokens,
     List<ChatCompletionTool>? tools,
+    ChatCompletionToolChoiceOption? toolChoice,
   }) async* {
     yield* _generate(
       messages: [
@@ -75,12 +78,14 @@ class MistralInferenceRepository {
       temperature: temperature,
       maxCompletionTokens: maxCompletionTokens,
       tools: tools,
+      toolChoice: toolChoice,
     );
   }
 
   /// Generate text with full conversation history.
   ///
-  /// This method supports multi-turn conversations with Mistral's API.
+  /// This method supports multi-turn conversations with Mistral's API and
+  /// the same tool-selection override as [generateText].
   Stream<CreateChatCompletionStreamResponse> generateTextWithMessages({
     required List<ChatCompletionMessage> messages,
     required String model,
@@ -89,6 +94,7 @@ class MistralInferenceRepository {
     double? temperature,
     int? maxCompletionTokens,
     List<ChatCompletionTool>? tools,
+    ChatCompletionToolChoiceOption? toolChoice,
   }) async* {
     yield* _generate(
       messages: convertMessages(messages),
@@ -98,6 +104,7 @@ class MistralInferenceRepository {
       temperature: temperature,
       maxCompletionTokens: maxCompletionTokens,
       tools: tools,
+      toolChoice: toolChoice,
     );
   }
 
@@ -212,6 +219,7 @@ class MistralInferenceRepository {
     double? temperature,
     int? maxCompletionTokens,
     List<ChatCompletionTool>? tools,
+    ChatCompletionToolChoiceOption? toolChoice,
   }) async* {
     final requestBody = <String, dynamic>{
       'model': model,
@@ -234,7 +242,7 @@ class MistralInferenceRepository {
           },
         };
       }).toList();
-      requestBody['tool_choice'] = 'auto';
+      requestBody['tool_choice'] = _serializeToolChoice(toolChoice) ?? 'auto';
     }
 
     developer.log(
@@ -351,6 +359,24 @@ class MistralInferenceRepository {
         originalError: e,
       );
     }
+  }
+
+  Object? _serializeToolChoice(ChatCompletionToolChoiceOption? toolChoice) {
+    if (toolChoice == null) return null;
+
+    return toolChoice.map(
+      mode: (choice) => switch (choice.value) {
+        ChatCompletionToolChoiceMode.none => 'none',
+        ChatCompletionToolChoiceMode.auto => 'auto',
+        // Mistral forces a tool call with `any`; `required` (the OpenAI
+        // spelling) is rejected with a 400 Bad Request.
+        ChatCompletionToolChoiceMode.required => 'any',
+      },
+      tool: (choice) => {
+        'type': 'function',
+        'function': {'name': choice.value.function.name},
+      },
+    );
   }
 
   /// Parse a streaming response chunk from Mistral's API.

--- a/lib/features/daily_os_next/state/drafting_controller.dart
+++ b/lib/features/daily_os_next/state/drafting_controller.dart
@@ -115,6 +115,29 @@ class DraftingController extends AsyncNotifier<DraftingState> {
       isCancelled: () => disposed,
     );
 
+    DraftPlan? completedDraft;
+    Object? completedDraftError;
+    StackTrace? completedDraftStack;
+    unawaited(
+      draftFuture
+          .then((value) {
+            completedDraft = value;
+            if (!ref.mounted) return;
+            final current = state.value;
+            if (current == null) return;
+            state = AsyncData(
+              current.copyWith(draft: value, phase: DraftingPhase.ready),
+            );
+          })
+          .catchError((Object error, StackTrace stack) {
+            completedDraftError = error;
+            completedDraftStack = stack;
+            if (!ref.mounted) return;
+            if (state.value == null) return;
+            state = AsyncError<DraftingState>(error, stack);
+          }),
+    );
+
     // Learning-card failures shouldn't block the draft — render an
     // empty card list and keep going. The real adapter already returns
     // `[]` for the "no day agent" case; this guard covers transient
@@ -126,28 +149,16 @@ class DraftingController extends AsyncNotifier<DraftingState> {
       learnings = const [];
     }
 
-    // The draft resolves lazily — fire-and-forget the listener that
-    // flips the phase to ready once it lands.
-    unawaited(
-      draftFuture
-          .then((value) {
-            if (!ref.mounted) return;
-            final current = state.value;
-            if (current == null) return;
-            state = AsyncData(
-              current.copyWith(draft: value, phase: DraftingPhase.ready),
-            );
-          })
-          .catchError((Object error, StackTrace stack) {
-            if (!ref.mounted) return;
-            state = AsyncError<DraftingState>(error, stack);
-          }),
-    );
+    final draftError = completedDraftError;
+    if (draftError != null) {
+      Error.throwWithStackTrace(draftError, completedDraftStack!);
+    }
 
+    final draft = completedDraft;
     return DraftingState(
-      phase: DraftingPhase.drafting,
+      phase: draft == null ? DraftingPhase.drafting : DraftingPhase.ready,
       learningCards: learnings,
-      draft: null,
+      draft: draft,
     );
   }
 }

--- a/test/features/ai/repository/cloud_inference_repository_test.dart
+++ b/test/features/ai/repository/cloud_inference_repository_test.dart
@@ -2334,6 +2334,65 @@ void main() {
       },
     );
 
+    test(
+      'generateWithMessages forwards forced tool choice to Gemini',
+      () async {
+        final provider = createGeminiProvider();
+        const model = 'gemini-2.5-pro';
+        const toolChoice = ChatCompletionToolChoiceOption.tool(
+          ChatCompletionNamedToolChoice(
+            type: ChatCompletionNamedToolChoiceType.function,
+            function: ChatCompletionFunctionCallOption(name: 'draft_day_plan'),
+          ),
+        );
+        ChatCompletionToolChoiceOption? capturedToolChoice;
+
+        when(
+          () => mockGeminiRepo.generateTextWithMessages(
+            messages: any(named: 'messages'),
+            model: any(named: 'model'),
+            temperature: any(named: 'temperature'),
+            thinkingConfig: any(named: 'thinkingConfig'),
+            provider: any(named: 'provider'),
+            thoughtSignatures: any(named: 'thoughtSignatures'),
+            systemMessage: any(named: 'systemMessage'),
+            maxCompletionTokens: any(named: 'maxCompletionTokens'),
+            tools: any(named: 'tools'),
+            toolChoice: any(named: 'toolChoice'),
+            signatureCollector: any(named: 'signatureCollector'),
+            turnIndex: any(named: 'turnIndex'),
+          ),
+        ).thenAnswer((invocation) {
+          capturedToolChoice =
+              invocation.namedArguments[#toolChoice]
+                  as ChatCompletionToolChoiceOption?;
+          return const Stream.empty();
+        });
+
+        await repository
+            .generateWithMessages(
+              messages: const [
+                ChatCompletionMessage.user(
+                  content: ChatCompletionUserMessageContent.string('Plan'),
+                ),
+              ],
+              model: model,
+              temperature: 0.5,
+              provider: provider,
+              tools: const [
+                ChatCompletionTool(
+                  type: ChatCompletionToolType.function,
+                  function: FunctionObject(name: 'draft_day_plan'),
+                ),
+              ],
+              toolChoice: toolChoice,
+            )
+            .toList();
+
+        expect(capturedToolChoice, toolChoice);
+      },
+    );
+
     test('generateWithMessages passes thought signatures to Gemini', () async {
       final provider = createGeminiProvider();
       const model = 'gemini-3-pro';
@@ -3951,6 +4010,51 @@ void main() {
           'https://api.mistral.ai/v1/chat/completions',
         );
         expect(request.headers['Authorization'], 'Bearer mistral-key');
+      },
+    );
+
+    test(
+      'generateWithMessages forwards forced tool choice to Mistral',
+      () async {
+        stubSseSend('Planned');
+
+        const tools = [
+          ChatCompletionTool(
+            type: ChatCompletionToolType.function,
+            function: FunctionObject(name: 'draft_day_plan'),
+          ),
+        ];
+        const toolChoice = ChatCompletionToolChoiceOption.tool(
+          ChatCompletionNamedToolChoice(
+            type: ChatCompletionNamedToolChoiceType.function,
+            function: ChatCompletionFunctionCallOption(name: 'draft_day_plan'),
+          ),
+        );
+
+        await repository
+            .generateWithMessages(
+              messages: const [
+                ChatCompletionMessage.user(
+                  content: ChatCompletionUserMessageContent.string('Plan'),
+                ),
+              ],
+              model: 'mistral-large',
+              temperature: 0.5,
+              provider: mistralProvider(),
+              tools: tools,
+              toolChoice: toolChoice,
+            )
+            .toList();
+
+        final captured = verify(
+          () => mockHttpClient.send(captureAny()),
+        ).captured;
+        final request = captured.first as http.Request;
+        final requestBody = jsonDecode(request.body) as Map<String, dynamic>;
+        expect(requestBody['tool_choice'], {
+          'type': 'function',
+          'function': {'name': 'draft_day_plan'},
+        });
       },
     );
 

--- a/test/features/ai/repository/gemini_utils_test.dart
+++ b/test/features/ai/repository/gemini_utils_test.dart
@@ -210,6 +210,38 @@ void main() {
       // parameters omitted when null
       expect(fn0.containsKey('parameters'), isFalse);
     });
+
+    test('serializes forced named tool choice', () {
+      const tools = [
+        ChatCompletionTool(
+          type: ChatCompletionToolType.function,
+          function: FunctionObject(name: 'draft_day_plan'),
+        ),
+      ];
+      const toolChoice = ChatCompletionToolChoiceOption.tool(
+        ChatCompletionNamedToolChoice(
+          type: ChatCompletionNamedToolChoiceType.function,
+          function: ChatCompletionFunctionCallOption(name: 'draft_day_plan'),
+        ),
+      );
+
+      final body = GeminiUtils.buildRequestBody(
+        prompt: 'Draft the day',
+        temperature: 0.2,
+        thinkingConfig: const GeminiThinkingConfig(thinkingBudget: 64),
+        tools: tools,
+        toolChoice: toolChoice,
+      );
+
+      final toolConfig = body['toolConfig'] as Map<String, dynamic>;
+      final functionCallingConfig =
+          toolConfig['functionCallingConfig'] as Map<String, dynamic>;
+      expect(functionCallingConfig['mode'], 'ANY');
+      expect(
+        functionCallingConfig['allowedFunctionNames'],
+        ['draft_day_plan'],
+      );
+    });
   });
 
   group('GeminiUtils.buildMultiTurnRequestBody', () {
@@ -249,6 +281,41 @@ void main() {
       expect(functionCall['name'], 'test_function');
       // Should have empty object as fallback for malformed JSON
       expect(functionCall['args'], <String, dynamic>{});
+    });
+
+    test('serializes forced named tool choice', () {
+      const toolChoice = ChatCompletionToolChoiceOption.tool(
+        ChatCompletionNamedToolChoice(
+          type: ChatCompletionNamedToolChoiceType.function,
+          function: ChatCompletionFunctionCallOption(name: 'draft_day_plan'),
+        ),
+      );
+
+      final body = GeminiUtils.buildMultiTurnRequestBody(
+        messages: const [
+          ChatCompletionMessage.user(
+            content: ChatCompletionUserMessageContent.string('Draft the day'),
+          ),
+        ],
+        temperature: 0.2,
+        thinkingConfig: const GeminiThinkingConfig(thinkingBudget: 64),
+        tools: const [
+          ChatCompletionTool(
+            type: ChatCompletionToolType.function,
+            function: FunctionObject(name: 'draft_day_plan'),
+          ),
+        ],
+        toolChoice: toolChoice,
+      );
+
+      final toolConfig = body['toolConfig'] as Map<String, dynamic>;
+      final functionCallingConfig =
+          toolConfig['functionCallingConfig'] as Map<String, dynamic>;
+      expect(functionCallingConfig['mode'], 'ANY');
+      expect(
+        functionCallingConfig['allowedFunctionNames'],
+        ['draft_day_plan'],
+      );
     });
 
     test('includes thought signatures in function calls', () {

--- a/test/features/ai/repository/gemini_utils_test.dart
+++ b/test/features/ai/repository/gemini_utils_test.dart
@@ -242,6 +242,44 @@ void main() {
         ['draft_day_plan'],
       );
     });
+
+    test('maps each tool-choice mode to a Gemini functionCallingConfig', () {
+      const expected = {
+        ChatCompletionToolChoiceMode.none: 'NONE',
+        ChatCompletionToolChoiceMode.auto: 'AUTO',
+        ChatCompletionToolChoiceMode.required: 'ANY',
+      };
+
+      for (final entry in expected.entries) {
+        final body = GeminiUtils.buildRequestBody(
+          prompt: 'Draft the day',
+          temperature: 0.2,
+          thinkingConfig: const GeminiThinkingConfig(thinkingBudget: 64),
+          toolChoice: ChatCompletionToolChoiceOption.mode(entry.key),
+        );
+
+        final functionCallingConfig =
+            (body['toolConfig']
+                    as Map<String, dynamic>)['functionCallingConfig']
+                as Map<String, dynamic>;
+        expect(functionCallingConfig['mode'], entry.value);
+        // Mode-only choices never pin specific function names.
+        expect(
+          functionCallingConfig.containsKey('allowedFunctionNames'),
+          isFalse,
+        );
+      }
+    });
+
+    test('omits toolConfig entirely when no tool choice is given', () {
+      final body = GeminiUtils.buildRequestBody(
+        prompt: 'Draft the day',
+        temperature: 0.2,
+        thinkingConfig: const GeminiThinkingConfig(thinkingBudget: 64),
+      );
+
+      expect(body.containsKey('toolConfig'), isFalse);
+    });
   });
 
   group('GeminiUtils.buildMultiTurnRequestBody', () {

--- a/test/features/ai/repository/mistral_inference_repository_test.dart
+++ b/test/features/ai/repository/mistral_inference_repository_test.dart
@@ -273,6 +273,50 @@ void main() {
         expect(requestBody['tool_choice'], equals('auto'));
       });
 
+      test('should serialize forced named tool choice when provided', () async {
+        final events = [
+          createSseChunkEvent(content: 'Planned'),
+          createSseFinalEvent(),
+        ];
+        when(() => mockHttpClient.send(any())).thenAnswer(
+          (_) async => createSseStreamedResponse(events: events),
+        );
+
+        const tools = [
+          ChatCompletionTool(
+            type: ChatCompletionToolType.function,
+            function: FunctionObject(name: 'draft_day_plan'),
+          ),
+        ];
+        const toolChoice = ChatCompletionToolChoiceOption.tool(
+          ChatCompletionNamedToolChoice(
+            type: ChatCompletionNamedToolChoiceType.function,
+            function: ChatCompletionFunctionCallOption(name: 'draft_day_plan'),
+          ),
+        );
+
+        final stream = repository.generateText(
+          prompt: prompt,
+          model: model,
+          baseUrl: baseUrl,
+          apiKey: apiKey,
+          tools: tools,
+          toolChoice: toolChoice,
+        );
+
+        await stream.toList();
+
+        final captured = verify(
+          () => mockHttpClient.send(captureAny()),
+        ).captured;
+        final request = captured.first as http.Request;
+        final requestBody = jsonDecode(request.body) as Map<String, dynamic>;
+        expect(requestBody['tool_choice'], {
+          'type': 'function',
+          'function': {'name': 'draft_day_plan'},
+        });
+      });
+
       test('should handle HTTP error responses', () async {
         // Arrange
         final stream = Stream.fromIterable([

--- a/test/features/ai/repository/mistral_inference_repository_test.dart
+++ b/test/features/ai/repository/mistral_inference_repository_test.dart
@@ -317,6 +317,52 @@ void main() {
         });
       });
 
+      test('serializes each tool-choice mode to its Mistral spelling', () async {
+        const expected = {
+          ChatCompletionToolChoiceMode.none: 'none',
+          ChatCompletionToolChoiceMode.auto: 'auto',
+          // Mistral forces a tool call with `any`, not OpenAI's `required`.
+          ChatCompletionToolChoiceMode.required: 'any',
+        };
+
+        for (final mode in expected.keys) {
+          when(() => mockHttpClient.send(any())).thenAnswer(
+            (_) async => createSseStreamedResponse(
+              events: [
+                createSseChunkEvent(content: 'ok'),
+                createSseFinalEvent(),
+              ],
+            ),
+          );
+
+          await repository
+              .generateText(
+                prompt: prompt,
+                model: model,
+                baseUrl: baseUrl,
+                apiKey: apiKey,
+                tools: const [
+                  ChatCompletionTool(
+                    type: ChatCompletionToolType.function,
+                    function: FunctionObject(name: 'draft_day_plan'),
+                  ),
+                ],
+                toolChoice: ChatCompletionToolChoiceOption.mode(mode),
+              )
+              .toList();
+        }
+
+        final sent = verify(() => mockHttpClient.send(captureAny()))
+            .captured
+            .cast<http.Request>()
+            .map(
+              (r) =>
+                  (jsonDecode(r.body) as Map<String, dynamic>)['tool_choice'],
+            )
+            .toList();
+        expect(sent, expected.values.toList());
+      });
+
       test('should handle HTTP error responses', () async {
         // Arrange
         final stream = Stream.fromIterable([

--- a/test/features/daily_os_next/state/drafting_controller_test.dart
+++ b/test/features/daily_os_next/state/drafting_controller_test.dart
@@ -49,6 +49,45 @@ class _CancelProbeAgent extends MockDayAgent {
   }
 }
 
+/// Agent whose draft fails while learnings stay parked. This drives the
+/// controller's synchronous rethrow path: the fire-and-forget listener records
+/// the draft error before `await learningsFuture` returns, so build() must
+/// surface that error instead of emitting a drafting state.
+class _DraftErrorAgent extends MockDayAgent {
+  _DraftErrorAgent({required this.learningsGate})
+    : super(
+        summarizeLatency: Duration.zero,
+        clock: () => DateTime(2026, 5, 25, 7),
+      );
+
+  /// Held until the test has let the draft error land.
+  final Completer<void> learningsGate;
+
+  @override
+  Future<List<LearningCard>> summarizeRecentPatterns({
+    required DateTime asOf,
+    int lookbackDays = 7,
+  }) async {
+    await learningsGate.future;
+    return super.summarizeRecentPatterns(
+      asOf: asOf,
+      lookbackDays: lookbackDays,
+    );
+  }
+
+  @override
+  Future<DraftPlan> draftDayPlan({
+    required CaptureId captureId,
+    required List<String> decidedTaskIds,
+    required DateTime dayDate,
+    List<String> decidedCaptureItemIds = const [],
+    List<TimeBlock> calendarBlocks = const [],
+    bool Function()? isCancelled,
+  }) async {
+    throw StateError('draft boom');
+  }
+}
+
 void main() {
   group('DraftingController', () {
     late MockDayAgent agent;
@@ -136,6 +175,27 @@ void main() {
         // already disposed so the resolution is a no-op.
         probe.gate.complete();
         await pumpEventQueue();
+      },
+    );
+
+    test(
+      'surfaces a draft error that lands before learnings resolve',
+      () async {
+        final agent = _DraftErrorAgent(learningsGate: Completer<void>());
+        final container = makeContainer(agent);
+
+        final future = container.read(
+          draftingControllerProvider(params()).future,
+        );
+
+        // Let the fire-and-forget draft listener record the failure while
+        // build() is still parked on the gated learnings future. With state
+        // still loading, the listener's `state.value == null` guard returns
+        // without emitting an AsyncError.
+        await pumpEventQueue();
+        agent.learningsGate.complete();
+
+        await expectLater(future, throwsA(isA<StateError>()));
       },
     );
   });

--- a/test/features/daily_os_next/ui/pages/drafting_page_test.dart
+++ b/test/features/daily_os_next/ui/pages/drafting_page_test.dart
@@ -465,6 +465,26 @@ void main() {
     );
 
     testWidgets(
+      'draft that resolves before learnings still advances to DayPage',
+      (tester) async {
+        _setSurface(tester);
+        final draft = Completer<DraftPlan>()..complete(_readyPlan());
+        final agent = _FakeAgent(draft: draft);
+        await tester.pumpWidget(_wrap(_page(), agent: agent));
+        await tester.pump();
+
+        agent.learnings.complete([_card()]);
+        await tester.pump();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+        await tester.pump(const Duration(milliseconds: 400));
+
+        expect(find.byType(DayPage), findsOneWidget);
+        expect(find.byType(DraftingPage), findsNothing);
+      },
+    );
+
+    testWidgets(
       'draft failure after the first body keeps stale drafting content mounted',
       (tester) async {
         _setSurface(tester);

--- a/test/features/design_system/components/buttons/design_system_button_test.dart
+++ b/test/features/design_system/components/buttons/design_system_button_test.dart
@@ -220,8 +220,7 @@ void main() {
               of: find.byKey(buttonKey),
               matching: find.byWidgetPredicate(
                 (widget) =>
-                    widget is DefaultTextStyle &&
-                    widget.style.color == spec.fg,
+                    widget is DefaultTextStyle && widget.style.color == spec.fg,
               ),
             ),
             findsWidgets,

--- a/test/features/journal/ui/widgets/nested_ai_responses_widget_test.dart
+++ b/test/features/journal/ui/widgets/nested_ai_responses_widget_test.dart
@@ -299,7 +299,7 @@ void main() {
       // Tap the header to collapse using the key
       await tester.tap(find.byKey(NestedAiResponsesWidget.headerKey));
       await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
 
       // Verify collapsed (SizeTransition should have value 0.0)
       final collapsedSizeTransition = tester.widget<SizeTransition>(
@@ -317,7 +317,7 @@ void main() {
       // Collapse first
       await tester.tap(headerFinder);
       await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
 
       // Verify collapsed
       var sizeTransition = tester.widget<SizeTransition>(
@@ -328,7 +328,7 @@ void main() {
       // Expand again
       await tester.tap(headerFinder);
       await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
 
       // Verify expanded
       sizeTransition = tester.widget<SizeTransition>(
@@ -358,7 +358,7 @@ void main() {
       // Collapse
       await tester.tap(headerFinder);
       await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
 
       // Verify rotation changed — when collapsed, the icon rotates
       // -0.25 turns so the chevron points right.
@@ -377,7 +377,7 @@ void main() {
       // Swipe to trigger confirmation dialog
       await tester.drag(find.byType(Dismissible), const Offset(-300, 0));
       await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
 
       // Verify AlertDialog is shown with title and content
       expect(find.byType(AlertDialog), findsOneWidget);
@@ -394,12 +394,12 @@ void main() {
       // Swipe to trigger confirmation dialog
       await tester.drag(find.byType(Dismissible), const Offset(-300, 0));
       await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
 
       // Tap Cancel button
       await tester.tap(find.text('Cancel'));
       await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
 
       // Dialog should be dismissed
       expect(find.byType(AlertDialog), findsNothing);
@@ -424,12 +424,12 @@ void main() {
       // Swipe to trigger confirmation dialog
       await tester.drag(find.byType(Dismissible), const Offset(-300, 0));
       await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
 
       // Tap Delete button
       await tester.tap(find.text('Delete'));
       await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
 
       // Verify delete was called with correct ID
       verify(
@@ -456,12 +456,12 @@ void main() {
       // Swipe to trigger confirmation dialog
       await tester.drag(dismissibleFinder, const Offset(-300, 0));
       await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
 
       // Tap Delete button
       await tester.tap(find.text('Delete'));
       await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
 
       // Verify delete was called
       verify(
@@ -493,12 +493,12 @@ void main() {
       // Swipe to trigger confirmation dialog
       await tester.drag(dismissibleFinder, const Offset(-300, 0));
       await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
 
       // Tap Delete button
       await tester.tap(find.text('Delete'));
       await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
 
       // Error snackbar should be shown
       expect(find.byType(SnackBar), findsOneWidget);
@@ -516,7 +516,7 @@ void main() {
       // Swipe to trigger confirmation dialog
       await tester.drag(find.byType(Dismissible), const Offset(-300, 0));
       await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
 
       // Verify dialog is shown
       expect(find.byType(AlertDialog), findsOneWidget);
@@ -524,7 +524,7 @@ void main() {
       // Tap outside the dialog (on the barrier)
       await tester.tapAt(const Offset(10, 10));
       await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
 
       // Dialog should be dismissed
       expect(find.byType(AlertDialog), findsNothing);

--- a/test/features/settings/ui/pages/advanced_settings_page_test.dart
+++ b/test/features/settings/ui/pages/advanced_settings_page_test.dart
@@ -19,6 +19,11 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   const n = 111;
 
+  // These tests override the mutable platform flag; capture the boot value so
+  // tearDown can restore it. Without this `isMobile = true` leaks into other
+  // tests under `very_good` (single isolate). See test/README.md.
+  final originalIsMobile = platform.isMobile;
+
   final mockSyncDatabase = MockSyncDatabase();
   final mockJournalDb = MockJournalDb();
 
@@ -36,7 +41,10 @@ void main() {
     ensureThemingServicesRegistered();
   });
 
-  tearDown(getIt.reset);
+  tearDown(() {
+    platform.isMobile = originalIsMobile;
+    getIt.reset();
+  });
 
   group('AdvancedSettingsPage', () {
     testWidgets('renders DesignSystemListItem for each setting', (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Daily OS Next now forces draft generation through Gemini and Mistral providers.
  * Fast-completed drafts are no longer dropped while learning cards finish loading.
  * Requested tool selections for AI-generated drafts are now honored consistently across supported providers.

* **Documentation**
  * Release notes updated to reflect these fixes.

* **Tests**
  * New and expanded tests added to verify tool-choice forwarding, serialization, and drafting UI/controller behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->