### PR TITLE
docs: planning agent architecture

### DIFF
--- a/docs/adr/0022-long-lived-daily-os-planner.md
+++ b/docs/adr/0022-long-lived-daily-os-planner.md
@@ -122,10 +122,16 @@ assumption becomes more expensive.
     planner's life — relocating amnesia rather than curing it. Confirmed user
     knowledge (e.g. "never schedule deep work before 10:00") is therefore a
     keyed, supersedable, user-confirmable record, excluded from the compaction
-    fold and injected into the prompt as a stable standing block (cf. ADR 0014
-    critical-observation injection). Agent-inferred observations stay in the
-    compactable episodic stream until the slow loop or an explicit user
-    confirmation promotes them. The store is specified in the implementation
+    fold. To keep durable memory from growing the prompt without bound as the
+    planner ages, it is surfaced **two-tier**, borrowing Claude Code's
+    memory-index pattern: a compact **index of one-line hooks** is always
+    present, and the full statement of an item is pulled in **on demand, scoped**
+    to the active workspace (`global` always; `category:` / `project:` when the
+    wake touches that scope), reusing the same scoped-retrieval machinery as
+    attention claims. Always-on critical items may still be injected verbatim
+    (cf. ADR 0014 critical-observation injection). Agent-inferred observations
+    stay in the compactable episodic stream until the slow loop or an explicit
+    user confirmation promotes them. The store is specified in the implementation
     plan's "Durable Planner Knowledge" section.
 
 11. **Domain agents are peers, not part of the planner.** Specialist agents

--- a/docs/adr/0022-long-lived-daily-os-planner.md
+++ b/docs/adr/0022-long-lived-daily-os-planner.md
@@ -1,0 +1,167 @@
+# ADR 0022: Long-Lived Daily OS Planner
+
+- Status: Accepted
+- Date: 2026-06-07
+
+## Context
+
+Daily OS Next currently models the planning agent as one active
+`AgentIdentityEntity` per local calendar day. `DayAgentService.createDayAgent`
+derives the agent identity from the day-plan id, stores that id in
+`AgentSlots.activeDayId`, and routes capture, draft, refine, commit, memory, and
+observations through that per-day `agentId`.
+
+That shape is useful for task agents because each task should have a bounded
+private context. It is the wrong boundary for day planning. The planner is meant
+to learn across days and categories: what capacity the user actually commits
+to, what gets carried over, when capture text refers to existing work, which
+categories are usually under-estimated, and which interventions the user
+accepts or rejects.
+
+The current code makes those learning paths structurally weak:
+
+- `DayAgentService.createDayAgent` permits one day-agent identity per local day.
+- `DayAgentPlanService.summarizeRecentPatterns` reads recent plans by
+  `agentId`, so a new day cannot see yesterday's plans under the current model.
+- `DayAgentWorkflow` loads observations, captures, and compaction memory by
+  `agentId`, so the memory substrate is reset at each day boundary.
+- `DayAgentWorkflow.execute` derives the target day from
+  `state.slots.activeDayId`, which is safe only while one agent owns one day.
+
+At the same time, the day-plan storage model already has the right day boundary:
+`DayPlanEntity` has a deterministic day-plan id, `dayId`, and `planDate`. The
+day does not need to be represented as an agent identity.
+
+Daily OS Next is still early enough that migration compatibility is not the
+primary constraint. We should fix the model directly before the per-day identity
+assumption becomes more expensive.
+
+## Decision
+
+1. **Daily OS uses one long-lived planner/shepherd identity.** There is one
+   active planner `AgentIdentityEntity` for the Daily OS planning behavior. The
+   persisted kind may remain `day_agent` until a broader naming cleanup is
+   worth doing, but service and workflow semantics are planner-shaped, not
+   date-agent-shaped.
+
+2. **A day is an explicit workspace, not an agent identity.** The day workspace
+   key remains:
+
+   ```text
+   dayId = dayPlanId(localDay(date)) // dayplan-YYYY-MM-DD
+   ```
+
+   Day-scoped records must carry or derive this workspace explicitly. The
+   planner may own many day workspaces.
+
+3. **`AgentSlots.activeDayId` is not authoritative planner context.** A
+   long-lived planner cannot read its target day from mutable agent state.
+   Day-scoped wakes must carry a target `dayId` through wake context, trigger
+   tokens, or a captured workspace record. The workflow must fail fast when a
+   day-scoped wake cannot resolve a day.
+
+4. **Planner wakes are workspace-scoped.** Every day-scoped wake carries an
+   explicit token such as:
+
+   ```text
+   planning_day:<dayId>
+   drafting:<dayId>
+   refine:<dayId>
+   capture_submitted:<captureId>
+   decided_task:<taskId>
+   decided_capture_item:<parsedItemId>
+   ```
+
+   Tool calls that include `dayId` must be rejected if the requested day does
+   not match the wake workspace.
+
+5. **Captures need explicit day scope.** Captured time and planning target are
+   not the same concept. `CaptureEntity` must carry the planning `dayId`
+   directly or through an equivalent deterministic link. Parsed items can
+   continue to derive day scope through their capture.
+
+6. **Memory separates global planner knowledge from day workspace context.**
+   The planner's long-running memory is intentional and cross-day. Raw
+   day-scoped inputs, such as capture transcripts, parsed items, draft blocks,
+   and refine transcripts, must be filtered to the active workspace unless they
+   are deliberately summarized into global learning.
+
+7. **Per-day threads/runs remain useful, but not as identities.** A day wake may
+   run in a day-scoped thread/run for bounded prompt context, inspectability,
+   retries, and debugging. Durable memory and learning belong to the
+   long-lived planner identity.
+
+8. **Provider-specific inference remains behind provider-neutral contracts.**
+   Forced tool-choice behavior is required for reliable day planning, but the
+   workflow contract must stay generic across Gemini, Mistral, OpenAI-compatible
+   providers, and future providers.
+
+9. **Deep analysis is delegated to disposable scoped analyst runs.** The
+   long-lived planner may spawn or schedule one-off analyst conversations for
+   bounded investigations such as "why did planned work spill over this week?"
+   or "which project keeps displacing workouts?". These analyst runs may use
+   tools, inspect a larger local corpus, and reason in their own temporary
+   context. They are not durable planning identities. Their output is a compact
+   analysis artifact with evidence references, findings, confidence, and
+   recommendations. The planner consumes that artifact, not the analyst's raw
+   transcript.
+
+## Target Runtime Shape
+
+```mermaid
+flowchart TD
+  Planner["Long-lived Daily OS planner<br/>AgentIdentityEntity"]
+  GlobalMemory["Global planner memory<br/>observations, compaction, reports"]
+  DayWorkspace["Day workspace<br/>dayId = dayplan-YYYY-MM-DD"]
+  Capture["CaptureEntity<br/>agentId + dayId"]
+  Plan["DayPlanEntity<br/>agentId + dayId + planDate"]
+  Wake["Wake context<br/>plannerAgentId + dayId + trigger tokens"]
+  Thread["Day-scoped thread/run<br/>bounded prompt and wake log"]
+  Analyst["Disposable analyst run<br/>temporary tool-using conversation"]
+  Brief["Analysis artifact<br/>findings + evidence refs"]
+
+  Planner --> GlobalMemory
+  Planner --> Wake
+  Planner --> Analyst
+  Wake --> DayWorkspace
+  Wake --> Thread
+  Analyst --> Brief
+  Brief --> Planner
+  DayWorkspace --> Capture
+  DayWorkspace --> Plan
+  Capture --> Plan
+```
+
+## Consequences
+
+- Cross-day learning becomes structurally possible because plans,
+  observations, memory compaction, reports, and token usage belong to one
+  durable planner identity.
+- Day isolation moves into explicit workspace context, validation, and filtered
+  queries. This is safer than implicit isolation through agent identity because
+  the boundary is visible in every wake and tool call.
+- `getDayAgentForDate` cannot simply return the same agent for every date. That
+  naive change would leak captures and context across days. The service API
+  must be reshaped around `getOrCreatePlannerAgent` and day workspace helpers.
+- Wake queue and scheduled wake semantics must become workspace-aware. Current
+  agent-wide dedupe/superseding would let one day's wake cancel another day's
+  work once all days share one planner.
+- Scheduled wakes need either global-only semantics or persisted trigger tokens
+  / workspace context. A single `AgentState.scheduledWakeAt` is not enough for
+  multiple day-scoped planner wakes.
+- Deep analysis can happen without polluting the planner's main context. The
+  planner may delegate a bounded question to a disposable analyst run, then
+  retain only a compact artifact and evidence references.
+- Some existing docs and tests that describe "one day-agent per calendar date"
+  are superseded by this decision and must be updated during implementation.
+
+## Related
+
+- [ADR 0016: Agent State as Log Projection](./0016-agent-state-as-log-projection.md)
+- [ADR 0017: Deterministic Log Compaction](./0017-deterministic-log-compaction.md)
+- [ADR 0019: Attention Negotiation Protocol](./0019-attention-negotiation-protocol.md)
+- [ADR 0020: Agent Input Capture](./0020-agent-input-capture.md)
+- [ADR 0021: LLM-Mediated Attention Claim Weighing](./0021-llm-mediated-attention-claim-weighing.md)
+- [Long-Lived Daily OS Planner implementation plan](../implementation_plans/2026-06-07_long_lived_daily_os_planner.md)
+- Supersedes the identity-granularity decision in
+  [Day Agent Layer - Implementation Plan](../implementation_plans/2026-05-25_day_agent_layer.md)

--- a/docs/adr/0022-long-lived-daily-os-planner.md
+++ b/docs/adr/0022-long-lived-daily-os-planner.md
@@ -54,11 +54,19 @@ assumption becomes more expensive.
    Day-scoped records must carry or derive this workspace explicitly. The
    planner may own many day workspaces.
 
-3. **`AgentSlots.activeDayId` is not authoritative planner context.** A
-   long-lived planner cannot read its target day from mutable agent state.
-   Day-scoped wakes must carry a target `dayId` through wake context, trigger
-   tokens, or a captured workspace record. The workflow must fail fast when a
-   day-scoped wake cannot resolve a day.
+3. **The planner workflow MUST NOT read `AgentSlots.activeDayId`, and must stop
+   deriving it.** A long-lived planner cannot read its target day from mutable
+   agent state. This is stronger than "not authoritative": today `activeDayId`
+   is *derived* from the per-day `AgentDayLink` by the state projection
+   (`derived_agent_state.dart`) and *written back* by `reconcileAgentState` on
+   every wake, so under one planner with many day links it would reconcile to a
+   single most-recent day and persist it, corrupting the slot and emitting a
+   permanent `activeDayId` derived-field mismatch. The refactor must therefore
+   stop creating one `AgentDayLink` per day for the planner (or exclude
+   `activeDayId` from derivation, reconcile write-back, and diagnostics), not
+   merely stop reading the slot at execution time. Day-scoped wakes carry a
+   target `dayId` through wake context and trigger tokens; the workflow fails
+   fast when a day-scoped wake cannot resolve a day.
 
 4. **Planner wakes are workspace-scoped.** Every day-scoped wake carries an
    explicit token such as:
@@ -96,37 +104,85 @@ assumption becomes more expensive.
    workflow contract must stay generic across Gemini, Mistral, OpenAI-compatible
    providers, and future providers.
 
-9. **Deep analysis is delegated to disposable scoped analyst runs.** The
-   long-lived planner may spawn or schedule one-off analyst conversations for
-   bounded investigations such as "why did planned work spill over this week?"
-   or "which project keeps displacing workouts?". These analyst runs may use
-   tools, inspect a larger local corpus, and reason in their own temporary
-   context. They are not durable planning identities. Their output is a compact
-   analysis artifact with evidence references, findings, confidence, and
-   recommendations. The planner consumes that artifact, not the analyst's raw
-   transcript.
+9. **Planner learning has two loops.** The fast loop is daily and unsupervised:
+   raw day-scoped inputs and planner observations accrue on the long-lived
+   identity's log as episodic memory, compacted per ADR 0017. The slow loop is
+   the weekly one-on-one ritual (`TemplateEvolutionWorkflow`), now bound to the
+   single planner identity, which consolidates recurring daily observations into
+   durable, user-approved knowledge. Nothing becomes a durable preference except
+   through the weekly gate or an explicit user confirmation. Daily episodic
+   memory may be aged aggressively *precisely because* anything worth keeping is
+   promoted through the slow loop. This is the architectural answer to "learn
+   day to day" while keeping "the weekly one-on-one".
+
+10. **User-stated knowledge is durable and compaction-exempt.** "Memorize what I
+    tell you" requires a store that LLM log compaction cannot dissolve. Routing
+    user instructions through agent-inferred `record_observations` into the
+    shared compaction fold (ADR 0017) silently degrades them over a long-lived
+    planner's life — relocating amnesia rather than curing it. Confirmed user
+    knowledge (e.g. "never schedule deep work before 10:00") is therefore a
+    keyed, supersedable, user-confirmable record, excluded from the compaction
+    fold and injected into the prompt as a stable standing block (cf. ADR 0014
+    critical-observation injection). Agent-inferred observations stay in the
+    compactable episodic stream until the slow loop or an explicit user
+    confirmation promotes them. The store is specified in the implementation
+    plan's "Durable Planner Knowledge" section.
+
+11. **Domain agents are peers, not part of the planner.** Specialist agents
+    (e.g. fitness, sleep) are separate durable identities. They negotiate for
+    calendar time through the existing attention-claim and standing-agreement
+    protocol (ADR 0019, ADR 0021); the long-lived planner is the stable
+    counterparty and sole arbitrator they negotiate with. The planner weighs
+    their claims and proposes plan changes through the ChangeSet gate (ADR
+    0006), but does not absorb domain reasoning. This is the *inverse* of a
+    planner-spawned analyst run (planner-owns-throwaway-investigator vs.
+    durable-peer-petitions-planner) and is specified separately in ADR 0023.
+
+12. **Day-scoped scheduling needs explicit workspace context, not a single
+    timestamp.** A single `AgentState.scheduledWakeAt` cannot represent several
+    outstanding day-scoped wakes under one planner; a second day's
+    `set_next_wake` clobbers the first. Scheduled day wakes must be either
+    global-only planner wakes or persisted scheduled-wake records carrying a
+    workspace key and trigger tokens (ADR 0010). The self-scheduled morning
+    pre-warm is day-scoped and therefore requires the latter; it must not be
+    restored as a context-less wake, and "global-only scheduled wakes" must not
+    silently remove it.
+
+13. **Deep disposable analysis is deferred.** One-off, planner-spawned
+    investigation runs that write a compact artifact and close are deliberately
+    out of scope here. Deferring them avoids pre-committing analysis *ownership*
+    before the domain-agent boundary (ADR 0023) is settled — several of the
+    motivating questions ("why does this project keep displacing workouts?") are
+    exactly what a durable domain agent exists to answer. They may be
+    reintroduced in a later ADR, reusing the existing `AgentReportEntity` scope
+    (which already carries `scope`, `confidence`, and `provenance`) rather than a
+    new artifact entity.
 
 ## Target Runtime Shape
 
 ```mermaid
 flowchart TD
   Planner["Long-lived Daily OS planner<br/>AgentIdentityEntity"]
-  GlobalMemory["Global planner memory<br/>observations, compaction, reports"]
+  Episodic["Episodic day memory<br/>observations + compacted log (fast loop)"]
+  Weekly["Weekly one-on-one ritual<br/>TemplateEvolutionWorkflow (slow loop)"]
+  Knowledge["Durable planner knowledge<br/>user-confirmed, compaction-exempt"]
   DayWorkspace["Day workspace<br/>dayId = dayplan-YYYY-MM-DD"]
   Capture["CaptureEntity<br/>agentId + dayId"]
   Plan["DayPlanEntity<br/>agentId + dayId + planDate"]
   Wake["Wake context<br/>plannerAgentId + dayId + trigger tokens"]
   Thread["Day-scoped thread/run<br/>bounded prompt and wake log"]
-  Analyst["Disposable analyst run<br/>temporary tool-using conversation"]
-  Brief["Analysis artifact<br/>findings + evidence refs"]
+  Domain["Domain agents: fitness, sleep<br/>separate durable identities (ADR 0023)"]
+  Claim["AttentionRequest claims<br/>requestedMinutes + window + cadence"]
 
-  Planner --> GlobalMemory
+  Planner --> Episodic
+  Episodic --> Weekly
+  Weekly --> Knowledge
+  Knowledge --> Planner
   Planner --> Wake
-  Planner --> Analyst
   Wake --> DayWorkspace
   Wake --> Thread
-  Analyst --> Brief
-  Brief --> Planner
+  Domain --> Claim
+  Claim --> Planner
   DayWorkspace --> Capture
   DayWorkspace --> Plan
   Capture --> Plan
@@ -143,25 +199,51 @@ flowchart TD
 - `getDayAgentForDate` cannot simply return the same agent for every date. That
   naive change would leak captures and context across days. The service API
   must be reshaped around `getOrCreatePlannerAgent` and day workspace helpers.
-- Wake queue and scheduled wake semantics must become workspace-aware. Current
-  agent-wide dedupe/superseding would let one day's wake cancel another day's
-  work once all days share one planner.
+- Wake queue and scheduled wake semantics must become workspace-aware — across
+  superseding, dedupe, **and token merge/extraction**. Current agent-wide
+  `removeByAgent` superseding and `mergeTokens` merging (both keyed only by
+  `agentId`), plus "first matching token wins" extraction helpers, would let one
+  day's manual wake drop or contaminate another day's queued work once all days
+  share one planner. This must land **with or before** the identity collapse,
+  not in a later PR, or there is a live cross-day wake-cancellation and
+  wrong-day-drafting window.
+- All planner wakes across all days now share **one execution lease and one
+  state chain** (ADR 0018). Single-flight by `agentId` therefore becomes a
+  *global* planner serialization point, not the per-day sharding the old model
+  accidentally provided; a slow draft for one day blocks unrelated days. This is
+  acceptable for planner judgment initially, but is a property of *this* decision
+  and should be revisited only with evidence.
 - Scheduled wakes need either global-only semantics or persisted trigger tokens
   / workspace context. A single `AgentState.scheduledWakeAt` is not enough for
-  multiple day-scoped planner wakes.
-- Deep analysis can happen without polluting the planner's main context. The
-  planner may delegate a bounded question to a disposable analyst run, then
-  retain only a compact artifact and evidence references.
+  multiple day-scoped planner wakes, and a context-less scheduled wake cannot
+  drive the day-scoped morning pre-warm.
+- Durable cross-day memory needs a contradiction/decay policy. Confirmed
+  knowledge is revisable (recency-wins supersession) at the weekly gate or by
+  explicit user retraction; daily episodic memory is recency-weighted. Without
+  this, durable memory becomes stale truth — the same risk previously flagged
+  only for analysis artifacts now applies to the planner's own long-lived memory.
+- State reconstruction cost grows with the planner's lifetime. The projection
+  loads and folds the agent's full observation/message set per wake (ADR 0016);
+  collapsing N tiny per-day logs into one long-lived log removes the bound the
+  old model accidentally had. Compaction (ADR 0017) bounds the rendered tail but
+  not the query/fold input, so a multi-year planner needs a projection snapshot
+  or incremental fold story.
 - Some existing docs and tests that describe "one day-agent per calendar date"
   are superseded by this decision and must be updated during implementation.
 
 ## Related
 
+- [ADR 0006: Change Set — Deferred Tool Confirmation Workflow](./0006-change-set-deferred-tool-confirmation.md)
+- [ADR 0010: Scheduled Wake Infrastructure](./0010-scheduled-wake-infrastructure.md)
+- [ADR 0014: Cross-Wake Critical Observation Injection](./0014-cross-wake-critical-observation-injection.md)
 - [ADR 0016: Agent State as Log Projection](./0016-agent-state-as-log-projection.md)
 - [ADR 0017: Deterministic Log Compaction](./0017-deterministic-log-compaction.md)
+- [ADR 0018: Convergent Multi-Device Execution](./0018-convergent-multi-device-execution.md)
 - [ADR 0019: Attention Negotiation Protocol](./0019-attention-negotiation-protocol.md)
 - [ADR 0020: Agent Input Capture](./0020-agent-input-capture.md)
 - [ADR 0021: LLM-Mediated Attention Claim Weighing](./0021-llm-mediated-attention-claim-weighing.md)
+- [ADR 0023: Durable Domain Agents and Time Negotiation](./0023-durable-domain-agents-and-time-negotiation.md)
+  — the peer fitness/sleep agents that negotiate with this planner for time.
 - [Long-Lived Daily OS Planner implementation plan](../implementation_plans/2026-06-07_long_lived_daily_os_planner.md)
 - Supersedes the identity-granularity decision in
   [Day Agent Layer - Implementation Plan](../implementation_plans/2026-05-25_day_agent_layer.md)

--- a/docs/adr/0023-durable-domain-agents-and-time-negotiation.md
+++ b/docs/adr/0023-durable-domain-agents-and-time-negotiation.md
@@ -1,0 +1,218 @@
+# ADR 0023: Durable Domain Agents and Time Negotiation
+
+- Status: Proposed
+- Date: 2026-06-07
+
+## Context
+
+The long-lived Daily OS planner (ADR 0022) is the durable identity that owns the
+day plan and arbitrates what gets scheduled. But the planner is not the only mind
+the product wants. The goal is a small set of **durable, domain-specific agents**
+— a fitness agent, a sleep coach, later nutrition, finances, maintenance — each
+with its own memory, its own goals, and its own view of how the user is doing in
+that domain. These agents should **negotiate with the planner for calendar time**:
+a fitness agent should be able to ask for three workout blocks this week; a sleep
+coach should be able to protect a wind-down window.
+
+This is the inverse of the "disposable analyst run" idea that ADR 0022
+deliberately deferred (Decision 13). An analyst run is ephemeral, planner-spawned,
+read-only, and informational. A domain agent is durable, self-owned,
+self-scheduled, and *allocative* — its output is a claim on scarce time, not a
+report.
+
+Most of the negotiation substrate already exists in `lib/features/agents/`, built
+by ADR 0019 (attention negotiation protocol) and ADR 0021 (LLM-mediated claim
+weighing). What is missing is the **producer side**: there is no durable domain
+agent that can author claims for a non-task domain.
+
+### What already exists (verified in code)
+
+- `AttentionRequestEntity` (`agent_domain_entity.dart`) — an event-sourced,
+  immutable, evidence-backed claim that already carries `requestedMinutes`,
+  `scopeKind` (`day` | `dateRange` | `deadline` | `recurrence`), `earliestStart`
+  / `latestEnd` / `deadline`, `energyFit`, `impact`, `urgency`, `cadence`,
+  `targetId` / `targetKind`, `rationale`, and `evidenceRefs`. It already models
+  "claim 45 minutes Tuesday evening", not merely "interrupt the user".
+- `AttentionClaimDispositionEntity` — projects claim lifecycle
+  (`open` → `proposed` → `satisfied` / `declined` / `deferred` / `superseded`
+  / `expired` / `withdrawn`) without mutating the original claim.
+- `AttentionAwardEntity` — a planner proposal for a **concrete plan block**
+  (`dayId`, `planId`, `blockId`, `startTime`, `endTime`, `rank`, `utilityScore`).
+  It is a proposal: schedule mutation still flows through the ChangeSet gate
+  (ADR 0006).
+- `StandingAgreementEntity` with `StandingAgreementScope` already enumerating
+  `fitness` and `sleep`, plus `cadence`, `enforcement`
+  (`preference` | `target` | `nonNegotiable`), `approvalMode`
+  (`autoAccept` | `ask` | `reject`), `canPreempt`, and quota fields
+  (`minCount` / `maxCount` / `minMinutes` / `preferredSessionMinutes`).
+- `AttentionEvidenceRef` with `AttentionEvidenceKind` already including `.health`
+  and `.outcome`.
+- The day planner **already reads claims and standing agreements** for the
+  planning window: `day_agent_context_builder.dart` calls
+  `getAttentionPlanningInputsForWindow(start, end)` and renders both into the
+  planner prompt.
+
+### What is missing (the gap)
+
+- `AgentKinds` has only `task_agent`, `project_agent`, `day_agent`,
+  `template_improver` — **no domain agent kind**.
+- `request_attention` is wired only to task agents: `AttentionRequestHandler`
+  hardcodes `_taskTargetKind = 'task'` and reads `task.categoryId`, so a claim
+  cannot be authored for a non-task domain.
+- There is no **self-scheduled producer wake** for a domain agent (e.g. a nightly
+  "did the user hit 2 of 3 workouts?" check that emits or refreshes claims).
+- The planner's **arbitration path** — weigh claims → emit `AttentionAwardEntity`
+  → propose an `add_block` ChangeSet — is designed in ADR 0021 but not yet wired
+  for the day planner.
+- Claims are inherently **horizon-scoped** ("3 workouts this week"), but the
+  planner's wake contract (ADR 0022) is rigidly `planning_day:<dayId>`.
+
+## Decision
+
+1. **Domain agents are durable, first-class identities.** Introduce a
+   `domain_agent` `AgentKind`, one durable identity per life domain (initially
+   `fitness` and `sleep`, mapped to `StandingAgreementScope`). They have their
+   own memory substrate and learning loops, mirroring the planner's two-loop
+   model (ADR 0022 Decisions 9–10), not a per-day or per-task identity. Memory
+   coherence, not claim volume, sets the granularity: one durable agent per
+   scope, not one per workout.
+
+2. **Domain agents produce claims; they never write the calendar.** A domain
+   agent's only path to time is to author an `AttentionRequestEntity` (and,
+   for recurring commitments, a `StandingAgreementEntity`). It does **not** add,
+   move, or drop `PlannedBlock`s, and it does not call the planner synchronously.
+   Claims are events on the synced log, discovered by the planner through the
+   existing window-overlap projection — convergence-safe across devices
+   (ADR 0018), exactly as ADR 0019 Decision 2 ("bids are events, not RPCs").
+
+3. **`request_attention` is generalized off the task-only path.** The handler
+   must accept a category/target-agnostic claim so a fitness claim is not forced
+   through a `Task`. `targetKind` becomes domain-shaped (e.g. `fitness`,
+   `sleep`), `categoryId` is supplied by the domain agent's configuration rather
+   than read from a task, and the task path becomes one caller among several.
+
+4. **The planner is the sole arbitrator.** The planner — and only the planner —
+   weighs competing claims against the current plan, standing agreements, recent
+   outcomes, and durable knowledge (ADR 0021 Decision 3), then emits an
+   `AttentionAwardEntity` and a corresponding `add_block` ChangeSet. The award
+   records provenance (which `requestId` it satisfies; one block may satisfy
+   several claims). This claim → weigh → award → ChangeSet path is the core new
+   build of this ADR. Domain agents are **producers**; the planner is the single
+   **consumer/arbitrator**. This asymmetry is intentional: multi-agent contention
+   needs one accountable arbitrator, not N peers writing shared plan state.
+
+5. **The user stays in control through standing agreements.** Whether an award
+   is applied silently or shown for approval is governed by the matching
+   `StandingAgreementApprovalMode`: `autoAccept` for low-risk recurring habit
+   blocks, `ask` (default) routes through the ChangeSet / ChangeDecision gate
+   (ADR 0006), `reject` blocks. `enforcement = nonNegotiable` + `canPreempt`
+   let a durable commitment ("gym 3×/week") outrank a soft work block. A domain
+   agent cannot silently colonize the user's evenings: every block it wins is
+   either user-approved or governed by an agreement the user previously set.
+
+6. **Domain agents are self-scheduled producers.** A domain agent wakes on its
+   own cadence (e.g. nightly) to evaluate its domain model against actuals and
+   emit, refresh, or withdraw claims. This is what makes it a coach with goals
+   rather than a passive helper. It reuses the existing scheduled-wake
+   infrastructure (ADR 0010); the new work is wiring a non-task, non-day producer
+   into it.
+
+7. **Negotiation is horizon-scoped, not day-scoped.** Because cadence claims span
+   ranges ("3 workouts this week", "90 minutes before Sunday"), the planner
+   gains a `planning_window:<range>` wake alongside ADR 0022's
+   `planning_day:<dayId>`, so a weekly-cadence claim is weighable while drafting
+   a single day. This is additive to ADR 0022's wake contract, not a
+   contradiction of it.
+
+8. **Claims carry inspectable justification.** A domain agent cites
+   `evidenceRefs` of kind `health` / `outcome` (e.g. workout actuals, sleep
+   actuals) plus a `rationale`. The planner reads evidence summaries in its
+   brief and weighs them; it does not import the domain agent's raw memory.
+
+## Target Runtime Shape
+
+```mermaid
+flowchart TD
+  Fitness["Fitness agent<br/>kind=domain_agent scope=fitness<br/>durable identity + memory"]
+  Sleep["Sleep agent<br/>kind=domain_agent scope=sleep"]
+  Task["Task agents (existing)"]
+
+  Agreement["StandingAgreementEntity<br/>fitness 3x/week, sleep wind-down"]
+  Claim["AttentionRequestEntity<br/>requestedMinutes, window, cadence, evidence"]
+  Index["Attention planning inputs<br/>window-overlap projection"]
+
+  Planner["Long-lived Daily OS planner (ADR 0022)<br/>sole arbitrator"]
+  Award["AttentionAwardEntity<br/>concrete block + provenance"]
+  CS["ChangeSet add_block"]
+  Gate["StandingAgreementApprovalMode<br/>autoAccept / ask / reject -> user gate (ADR 0006)"]
+  Plan["DayPlanEntity.plannedBlocks"]
+
+  Fitness --> Agreement
+  Fitness --> Claim
+  Sleep --> Claim
+  Task --> Claim
+  Agreement --> Index
+  Claim --> Index
+  Index --> Planner
+  Planner --> Award
+  Award --> CS --> Gate --> Plan
+  Award -. provenance .-> Claim
+```
+
+## Consequences
+
+- The product gains genuine specialist coaches that compete for time on the
+  user's behalf, with the planner as a single, learning, accountable arbitrator.
+- No new negotiation protocol is invented: the existing attention-claim /
+  standing-agreement model is reused, and "attention" is understood as
+  scheduled calendar time, not push-notification interruption.
+- The decoupling discipline holds: domain agents depend only on the claim /
+  agreement log and never on planner internals, and the planner reads
+  materialized claim projections rather than fanning out to wake producers
+  synchronously during drafting.
+- ADR 0022 does **not** need reopening. Domain agents live in a separate feature
+  and negotiate through an already-decoupled projection read; the durable planner
+  ADR 0022 creates is in fact a *prerequisite* for good arbitration (weighing
+  fitness vs. work needs cross-day memory of "this project keeps displacing
+  workouts").
+- A cadence/recurrence verifier (ADR 0019 Decision 4's "gym 3×/week may pre-empt"
+  enforcement against health actuals) is still required to turn a one-off claim
+  into a durable habit guarantee; it remains the largest unbuilt enforcement
+  piece.
+
+## Non-Goals
+
+- Letting domain agents mutate the calendar directly. They claim; the planner
+  arbitrates; the ChangeSet gate applies.
+- Making the planner just one peer among equals. The planner is a *privileged*
+  peer — the sole arbitrator of shared day-plan state.
+- Shipping every domain at once. Fitness and sleep first; nutrition, finances,
+  and maintenance reuse the same machinery via `StandingAgreementScope`.
+- Reintroducing disposable analyst runs (ADR 0022 Decision 13). A domain agent
+  is the durable answer to most questions an analyst run would have investigated.
+
+## Open Questions
+
+1. Identity granularity: one durable `domain_agent` per `StandingAgreementScope`,
+   or per scope + category (e.g. running vs. strength vs. recovery)?
+2. How autonomous should the planner be allowed to be? The mechanism exists
+   (`StandingAgreementApprovalMode`); the *policy defaults* per scope are a
+   product decision (silent recurring sleep block vs. always-ask).
+3. Should the cadence verifier live with the domain agent (produces/withdraws
+   claims based on actuals) or the planner (refuses to retire a claim until the
+   quota is met)?
+4. Does `planning_window:<range>` need first-class scheduled-wake support, or can
+   the planner derive the relevant horizon from the active claims it reads?
+5. Do domain agents reuse the planner's durable-knowledge store (ADR 0022
+   Decision 10) for their own "what the user told me" facts, or hold a per-agent
+   variant?
+
+## Related
+
+- [ADR 0006: Change Set — Deferred Tool Confirmation Workflow](./0006-change-set-deferred-tool-confirmation.md)
+- [ADR 0010: Scheduled Wake Infrastructure](./0010-scheduled-wake-infrastructure.md)
+- [ADR 0018: Convergent Multi-Device Execution](./0018-convergent-multi-device-execution.md)
+- [ADR 0019: Attention Negotiation Protocol](./0019-attention-negotiation-protocol.md)
+- [ADR 0021: LLM-Mediated Attention Claim Weighing](./0021-llm-mediated-attention-claim-weighing.md)
+- [ADR 0022: Long-Lived Daily OS Planner](./0022-long-lived-daily-os-planner.md)
+  — the planner these domain agents negotiate with.

--- a/docs/adr/0024-correction-lexicon-and-transcript-correction.md
+++ b/docs/adr/0024-correction-lexicon-and-transcript-correction.md
@@ -1,0 +1,174 @@
+# ADR 0024: Correction Lexicon and Deterministic Transcript Correction
+
+- Status: Proposed
+- Date: 2026-06-07
+
+## Context
+
+Speech-to-text and LLM generation consistently mis-spell a small set of terms
+that matter to the user: the app's own name (`Lotti`, which cloud models tend to
+write as the more common `Lottie`), personal place names (a town STT reliably
+mis-hears), and domain jargon. These are not soft preferences — they are
+"never again" corrections the user wants to be applied everywhere,
+deterministically.
+
+Lotti already has the seed of a fix, but only partially:
+
+- `CategoryDefinition.speechDictionary` (a `List<String>`) is a per-category
+  vocabulary list, addable from the editor context menu
+  (`speech_dictionary_service.dart`). It is consumed during transcription two
+  ways: as a biasing block written into the transcription prompt
+  (`prompt_builder_helper.dart` → `skill_prompt_builder.dart`), and as
+  vocabulary hints to local STT (`mlx_audio_channel.dart` `dictionaryTerms`).
+- `CategoryDefinition.correctionExamples` is a sibling mechanism for checklist
+  correction.
+
+Four gaps make this insufficient for the "never again" cases:
+
+1. **Category-scoped only — no global terms.** The app name and personal place
+   names apply everywhere; today they would have to be added to every category.
+2. **Biasing only, and biasing is engine-dependent.** Vocabulary/dictionary
+   hints work only on engines that accept them. Local Whisper does not take a
+   usable vocabulary, and prompt-style biasing there is unreliable — so there is
+   no guarantee exactly where it is most needed.
+3. **Transcription only.** Nothing corrects general LLM *generation* output, so a
+   model writing `Lottie` in a summary or plan is unaffected.
+4. **Unergonomic.** Maintaining lists in category settings is clunky, and adding
+   a bare *correct* term never captures the *wrong → right* mapping that a
+   deterministic correction needs.
+
+This relates to the durable-memory work in ADR 0022: a correction term is durable
+user knowledge. But it is a *different class* from planner preferences — it is
+app-owned, always-on, and applied deterministically, not planner-scoped, lazily
+recalled, and LLM-weighed.
+
+## Decision
+
+1. **A correction lexicon is durable, user-confirmed memory — app-owned, not
+   planner-owned.** Model correction terms on the durable `Version` / `Head`,
+   propose → user-confirm pattern (as in ADR 0022 Decision 10), but as an
+   app-level store that the planner, every other agent, the transcription
+   pipeline, and the editor all *read*. It extends, rather than replaces, the
+   existing `category.speechDictionary`.
+
+2. **Two scopes.** Keep per-category, and add **global** (always-on, applies
+   everywhere regardless of category). The app name and personal place names are
+   global.
+
+3. **Two modes per term.**
+   - `bias` — the existing behavior: term added to engine vocabulary / prompt
+     hint. Opportunistic; "prefer this spelling."
+   - `hardReplace` — a deterministic `knownWrong[] → canonical` map. Opt-in
+     per term, word-boundary aware. "This must never survive."
+
+4. **Deterministic post-STT correction is the guarantee, and it is
+   engine-independent.** A correction pass runs over the transcript *text* in the
+   pipeline, after whichever engine produced it — so it works identically for
+   local Whisper, voxtral, mlx, and cloud engines. Engine biasing is an
+   opportunistic first layer; the post-pass is what makes "never again" actually
+   hold. This pass lives at the pipeline level (`skill_transcription_runner` /
+   `unified_ai_inference_repository`), not inside per-engine adapters.
+
+5. **Apply to generation, not just transcription.** Inject the global lexicon as
+   a compact glossary into user-facing LLM generation prompts, and run
+   `hardReplace` on generated output — so `Lotti` is enforced when a model
+   *writes*, not only when it *transcribes*.
+
+6. **Optional local-LLM cleanup layer for fuzzy errors.** For garbled phrases the
+   deterministic map cannot catch, a small **local** model may clean up
+   transcript segments, given the lexicon as context. It must be conservative
+   (correct transcription errors only, never paraphrase or drop content), keep
+   the **raw transcript as source of truth**, and store the corrected text as a
+   derived artifact with provenance. It triggers on utterance/segment boundaries
+   (correcting committed segments once), **finalize-time first** — not live
+   "every other sentence", which would make the on-screen transcript flicker and
+   is O(n²) on context. It is **degradable**: if no local model is available, the
+   deterministic pass alone still works; capture never depends on it.
+
+7. **Learned in-place.** Correcting a term where you see it (select the wrong
+   word in a transcript, type the canonical form) stores a **global**
+   `wrong → canonical` pair. This becomes the primary path, replacing the
+   unergonomic category-settings flow, and captures the mapping the post-pass
+   needs.
+
+8. **Always-on, not lazily recalled.** The lexicon is the explicit exception to
+   the planner's two-tier lazy recall (ADR 0022 Decision 10): the terms are
+   small, high-value, and unpredictable in where they apply, so they are always
+   present in the relevant prompt — and applied at the first capture of a day
+   with no dependency on planner context or a wake.
+
+9. **Raw is source of truth; corrected is derived.** Keep the raw transcript;
+   store corrections as a derived artifact with provenance (which terms / model /
+   lexicon version applied), inspectable and reversible, so corrections do not
+   become unattributable mutations across synced devices.
+
+## Layering
+
+```mermaid
+flowchart TD
+  Audio["Audio capture (incl. day-planning stream)"]
+  STT["STT engine (local Whisper / voxtral / mlx / cloud)"]
+  Bias["Layer 1 — bias (opportunistic)<br/>vocab hints where engine supports it"]
+  LLM["Layer 2a — optional local-LLM cleanup<br/>conservative, lexicon as context, segment-boundary"]
+  Replace["Layer 2b — deterministic hardReplace (the guarantee)<br/>knownWrong -> canonical, engine-independent"]
+  Lexicon["Correction lexicon (durable, user-confirmed)<br/>global + category, bias + hardReplace"]
+  Out["Corrected transcript (derived) + raw transcript (source of truth)"]
+  Gen["Any user-facing LLM generation<br/>(planner, summaries, ...)"]
+
+  Audio --> STT
+  Lexicon -. terms .-> Bias
+  Bias --> STT
+  STT --> LLM --> Replace --> Out
+  Lexicon -. wrong->canonical .-> Replace
+  Lexicon -. glossary + hardReplace .-> Gen
+  Out -. correct-in-place teaches .-> Lexicon
+```
+
+## Consequences
+
+- The "never again" guarantee no longer depends on the STT engine cooperating;
+  it is enforced deterministically on output text, including for local Whisper.
+- Global terms (app name, personal place names) are maintained once and applied
+  everywhere — transcription and generation — rather than per category.
+- The lexicon is a second, distinct durable-knowledge class alongside planner
+  preferences (ADR 0022). Keeping them separate avoids leaking app-wide spelling
+  rules into the planner's scoped, weighed memory.
+- Corrections are auditable and reversible because the raw transcript is retained
+  and the correction provenance is recorded.
+- The optional local-LLM layer adds a quality bump for fuzzy errors without
+  becoming a hard dependency or a privacy/network concern.
+
+## Non-Goals
+
+- Live "every other sentence" streaming correction in the first version. Start
+  finalize-time, per committed segment; add live incremental only if long
+  dictations need it.
+- Aggressive LLM rewriting/paraphrasing of captures. The local-LLM layer fixes
+  transcription errors only; planning captures must not have their meaning
+  silently changed.
+- Replacing `category.speechDictionary`. This extends it (adds global scope and
+  the `hardReplace` mode) and keeps category-scoped jargon working.
+- Putting correction terms in the planner's knowledge store. They are app-owned
+  and always-on, not planner-scoped.
+
+## Open Questions
+
+1. Storage shape: a dedicated app-level `CorrectionLexiconEntity` (durable
+   Version/Head), or a global counterpart to `category.speechDictionary` on a
+   settings/profile entity?
+2. False-positive containment for `hardReplace`: word-boundary + case rules are
+   the baseline — is per-term case sensitivity worth exposing?
+3. Should the optional fuzzy/phonetic match against canonical terms (to catch
+   *new* garbled variants) be suggest-only, or auto-apply above a confidence
+   threshold?
+4. Which local model backs the cleanup layer, and is it shared with existing
+   local inference (ollama / mlx) or a dedicated small model?
+
+## Related
+
+- [ADR 0020: Agent Input Capture](./0020-agent-input-capture.md)
+- [ADR 0022: Long-Lived Daily OS Planner](./0022-long-lived-daily-os-planner.md)
+  — the durable-knowledge / two-tier recall model; this lexicon is its
+  always-on exception.
+- `lib/features/speech/` and `lib/features/ai/` — the existing
+  `category.speechDictionary` mechanism this decision extends.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -51,3 +51,4 @@ Each ADR should contain:
 - [`0021-llm-mediated-attention-claim-weighing.md`](./0021-llm-mediated-attention-claim-weighing.md)
 - [`0022-long-lived-daily-os-planner.md`](./0022-long-lived-daily-os-planner.md)
 - [`0023-durable-domain-agents-and-time-negotiation.md`](./0023-durable-domain-agents-and-time-negotiation.md)
+- [`0024-correction-lexicon-and-transcript-correction.md`](./0024-correction-lexicon-and-transcript-correction.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -49,3 +49,4 @@ Each ADR should contain:
 - [`0019-attention-negotiation-protocol.md`](./0019-attention-negotiation-protocol.md)
 - [`0020-agent-input-capture.md`](./0020-agent-input-capture.md)
 - [`0021-llm-mediated-attention-claim-weighing.md`](./0021-llm-mediated-attention-claim-weighing.md)
+- [`0022-long-lived-daily-os-planner.md`](./0022-long-lived-daily-os-planner.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -50,3 +50,4 @@ Each ADR should contain:
 - [`0020-agent-input-capture.md`](./0020-agent-input-capture.md)
 - [`0021-llm-mediated-attention-claim-weighing.md`](./0021-llm-mediated-attention-claim-weighing.md)
 - [`0022-long-lived-daily-os-planner.md`](./0022-long-lived-daily-os-planner.md)
+- [`0023-durable-domain-agents-and-time-negotiation.md`](./0023-durable-domain-agents-and-time-negotiation.md)

--- a/docs/implementation_plans/2026-05-25_day_agent_layer.md
+++ b/docs/implementation_plans/2026-05-25_day_agent_layer.md
@@ -1,8 +1,10 @@
 # Day Agent Layer — Implementation Plan
 
 **Date:** 2026-05-25
-**Status:** Plan committed; awaiting selection of phase-1 starting slice
-**Scope:** Agentic layer that powers the Daily OS surface (9 screens in `Claude_Design/design_handoff_daily_os/`). Mirrors the existing task-agent layer in `lib/features/agents/`, scoped to one agent instance per calendar date.
+**Status:** Superseded by [ADR 0022](../adr/0022-long-lived-daily-os-planner.md)
+and the [long-lived Daily OS planner implementation plan](./2026-06-07_long_lived_daily_os_planner.md).
+**Scope:** Historical plan for the day-agent layer. Its one-agent-per-calendar-date
+identity decision is no longer the target architecture.
 
 ---
 

--- a/docs/implementation_plans/2026-06-07_long_lived_daily_os_planner.md
+++ b/docs/implementation_plans/2026-06-07_long_lived_daily_os_planner.md
@@ -95,13 +95,14 @@ PlannerKnowledgeEntity        // new AgentDomainEntity variant; durable, compact
   id
   agentId = plannerAgentId
   key                         // stable slug, e.g. "deep-work-earliest-start"
+  hook                        // one-line index entry (like memory `description`)
   value                       // structured or text, e.g. "10:00 local"
   statementText               // verbatim "never schedule deep work before 10am"
   source = userStated | agentInferred
   status = proposed | confirmed | retracted
   supersedesId?               // the prior entry this replaces (recency-wins)
   scope = global | category:<id> | project:<id>
-  createdAt, confirmedAt?, retractedAt?
+  createdAt, confirmedAt?, retractedAt?, reviewAfter?
   vectorClock
 ```
 
@@ -205,17 +206,41 @@ Fields are listed in Target Data Model above. Key properties:
    surfaced in the "What I've learned" panel. A `source = userStated` instruction
    may skip straight to `confirmed`. This is the path user instructions take
    instead of `record_observations`.
-3. **Compaction-exempt.** `PlannerKnowledgeEntity` is its own kind, **excluded
-   from `projectInputEvents`' fold substrate** and from the compaction tail. The
-   active `Head` set of confirmed knowledge is injected into the prompt as a
-   dedicated, byte-stable "Standing knowledge" block (cf. ADR 0014), so it is
-   never re-summarized and stays prefix-cache friendly. The summarizer's soft
-   "preserve preferences" instruction becomes a backstop, not the only defense.
-4. **Reconciled with the weekly ritual.** The weekly `TemplateEvolutionWorkflow`
+3. **Compaction-exempt, surfaced two-tier (Claude Code memory-index pattern).**
+   `PlannerKnowledgeEntity` is its own kind, **excluded from
+   `projectInputEvents`' fold substrate** and from the compaction tail, so it is
+   never re-summarized. But injecting the *entire* confirmed `Head` set every
+   wake re-creates unbounded prompt growth as the planner ages. Instead, mirror
+   Claude Code's `MEMORY.md`: each entry carries a one-line `hook` (like the
+   memory `description` field), and the prompt always carries only the **compact
+   index of hooks**. The full `statementText` of an item is retrieved **on
+   demand, scoped** to the active workspace — `scope = global` always present,
+   `category:` / `project:` pulled when the wake touches that scope — using the
+   same scoped-retrieval machinery as attention claims. A small set of always-on
+   critical items may still be injected verbatim (cf. ADR 0014). The summarizer's
+   soft "preserve preferences" instruction becomes a backstop, not the only
+   defense.
+4. **User-editable, with staleness re-confirm.** Borrowing Claude Code's
+   editable-and-dated memory: the "What I've learned" panel lets the user **edit**
+   a durable fact directly (not just confirm/retract), and each entry stamps
+   `confirmedAt` / `reviewAfter`. A durable preference that has gone stale or
+   unexercised re-surfaces for re-confirmation ("you told me 'no deep work before
+   10' a while ago — still true?") rather than being treated as permanent truth.
+   This closes the ADR 0022 stale-durable-memory risk.
+5. **Reconciled with the weekly ritual.** The weekly `TemplateEvolutionWorkflow`
    folds confirmed knowledge into the next user-approved template version. Daily
    = fast capture into the durable store; weekly = consolidation into directives.
    The knowledge store is the single source of truth both read, eliminating
    drift between "the template says X" and "an observation says not-X".
+
+### What we deliberately do NOT copy from Claude Code memory
+
+- **Agent-writes-freely.** Claude Code lets the agent write memories directly;
+  Lotti keeps the stricter `propose_knowledge` → user-`confirm_knowledge` gate,
+  appropriate for the planner's longer-horizon autonomy.
+- **The file/frontmatter format.** Lotti takes the *schema shape* (key, hook,
+  type, supersedes, scope) into a synced freezed entity with vector clocks and
+  conflict resolution (ADR 0016/0018), not single-machine Markdown files.
 
 Deep disposable analysis runs are deferred (ADR 0022 Decision 13); most
 questions they would answer ("why does this project keep displacing workouts?")
@@ -546,10 +571,13 @@ Add or update focused tests before broad suite runs:
 
 - durable-knowledge tests (PR5):
   - `propose_knowledge` then `confirm_knowledge` persists a confirmed entry;
-  - confirmed knowledge survives a compaction fold and appears in the next
-    wake's "Standing knowledge" prompt block;
+  - confirmed knowledge survives a compaction fold (not folded into the summary);
+  - the prompt always carries the hook index; a `category:`-scoped item's full
+    `statementText` is pulled in only on a wake touching that category;
   - contradicting knowledge supersedes by recency (`supersedesId`), not both;
-  - `retract_knowledge` removes an entry from the injected `Head` set;
+  - `retract_knowledge` removes an entry from the active `Head` set;
+  - a past-`reviewAfter` entry surfaces for re-confirmation rather than applying
+    silently;
   - `summarizeRecentPatterns` still sees multiple days under one planner.
 
 ## Verification Strategy

--- a/docs/implementation_plans/2026-06-07_long_lived_daily_os_planner.md
+++ b/docs/implementation_plans/2026-06-07_long_lived_daily_os_planner.md
@@ -318,6 +318,10 @@ Work:
    taught the workspace/reason taxonomy or they will collide cross-day under one
    planner. Define the reason-class taxonomy (capture / draft / refine /
    creation) so same-day-different-reason work is not wrongly dropped.
+   Non-workspace agents (task / project) pass a `null` workspace key, and the
+   queue helpers must treat `null` safely — `null` partitions only with `null`,
+   never matching a Daily OS `day:<dayId>` key — so this change cannot introduce
+   cross-agent collisions for agents that do not use workspaces.
 3. Preserve the existing single-flight runner by `agentId`. Document that one
    planner therefore serializes day work across days (acceptable for planner
    judgment; revisit only with evidence).
@@ -434,8 +438,11 @@ Work:
 2. Add `propose_knowledge` / `confirm_knowledge` / `retract_knowledge` handlers;
    surface them in the "What I've learned" panel. `source = userStated` may go
    straight to `confirmed`.
-3. Exempt knowledge from compaction; inject the confirmed `Head` set as a stable
-   "Standing knowledge" prompt block (cf. ADR 0014).
+3. Exempt knowledge from compaction; inject a compact **hook index** derived from
+   the confirmed `Head` set as the stable "Standing knowledge" prompt block (cf.
+   ADR 0014). Full `statementText` is retrieved on demand, scoped, per the
+   two-tier pattern (property #3 above) — not the full entries, to avoid
+   unbounded prompt growth.
 4. Split memory: feed compacted episodic memory as cross-day context; feed raw
    captures, parsed items, baseline plan, refine transcript, and decided items
    only for the active `dayId`; keep `summarize_recent_patterns` cross-day.
@@ -630,10 +637,10 @@ Before merging the full refactor:
 
 ## Open Decisions
 
-1. **(Resolved — must be decided in PR2, not left open.)** Day-scoped scheduled
-   wakes cannot ride a single `scheduledWakeAt`. PR2 must pick: global-only
-   planner wakes, or persisted scheduled-wake records with workspace key +
-   trigger tokens. Either way the day-scoped morning pre-warm must survive.
+1. **(To be resolved in PR2.)** Day-scoped scheduled wakes cannot ride a single
+   `scheduledWakeAt`. PR2 must pick: global-only planner wakes, or persisted
+   scheduled-wake records with workspace key + trigger tokens. Either way the
+   day-scoped morning pre-warm must survive.
 2. Should observation scope be represented directly in `ObservationRecord`, or
    should scoped observations be modeled as message/link metadata?
 3. Should wake queue workspace keys be generic across all agent kinds now, or
@@ -641,9 +648,11 @@ Before merging the full refactor:
 4. When the implementation is complete, should the persisted kind be renamed
    from `day_agent` to `daily_os_planner`, or is that churn not worth the
    migration?
-5. Should `PlannerKnowledgeEntity` be its own `AgentDomainEntity` variant
-   (preferred, mirroring `Version`/`Head`), or can confirmed knowledge ride an
-   `AgentReportEntity` scope?
+5. The Target Data Model and PR5 assume `PlannerKnowledgeEntity` is a new
+   `AgentDomainEntity` variant (the preferred approach, mirroring
+   `Version`/`Head`). The only point left to confirm before PR5 is the fallback:
+   if the variant's generated-code churn proves unjustified, ride an
+   `AgentReportEntity` scope instead. Treat the new variant as the default.
 6. What is the promotion threshold from agent-inferred observation to `proposed`
    knowledge — N recurrences across distinct days, the weekly gate only, or both?
 7. Do domain agents (ADR 0023) reuse `PlannerKnowledgeEntity` for their own

--- a/docs/implementation_plans/2026-06-07_long_lived_daily_os_planner.md
+++ b/docs/implementation_plans/2026-06-07_long_lived_daily_os_planner.md
@@ -42,17 +42,24 @@ every day.
 2. A day is represented by `dayId`, not by `agentId`.
 3. Day-scoped wakes always carry `planning_day:<dayId>` or resolve `dayId`
    through a workspace-bound capture.
-4. The workflow never uses `AgentSlots.activeDayId` as authoritative day
-   context.
+4. The workflow never reads `AgentSlots.activeDayId`, and the projection stops
+   deriving/persisting it for the planner (no per-day `AgentDayLink`).
 5. Day-scoped tool calls are rejected when their `dayId` differs from the wake
    workspace.
 6. Raw captures and parsed items are day-scoped. Cross-day learning enters the
    prompt only through deliberate summaries, observations, reports, recent-plan
    cards, or planner memory.
 7. Wake queue and scheduling semantics distinguish day workspaces under the
-   shared planner identity.
+   shared planner identity — across supersede, dedupe, token merge, and token
+   extraction.
 8. Provider-specific inference details stay behind provider-neutral tool-choice
    contracts.
+9. User-stated knowledge persists in a durable, compaction-exempt store and is
+   revisable by recency; agent-inferred observations reach durable knowledge only
+   through the weekly gate or explicit user confirmation.
+10. Nothing in the planner depends on a domain agent existing, but the planner
+    remains the durable counterparty domain agents (ADR 0023) will negotiate
+    with via attention claims.
 
 ## Target Data Model
 
@@ -84,28 +91,34 @@ ChangeSetEntity
   agentId = plannerAgentId
   taskId or target id = day_agent_plan:<dayId>
 
-AnalysisBriefEntity (or equivalent report artifact)
+PlannerKnowledgeEntity        // new AgentDomainEntity variant; durable, compaction-exempt
   id
-  plannerAgentId
-  workspaceKey = day:<dayId> | week:<isoWeek> | project:<id> | category:<id>
-  horizonStart / horizonEnd
-  sourceRefs[]
-  findings[]
-  recommendations[]
-  confidence
-  validUntil
+  agentId = plannerAgentId
+  key                         // stable slug, e.g. "deep-work-earliest-start"
+  value                       // structured or text, e.g. "10:00 local"
+  statementText               // verbatim "never schedule deep work before 10am"
+  source = userStated | agentInferred
+  status = proposed | confirmed | retracted
+  supersedesId?               // the prior entry this replaces (recency-wins)
+  scope = global | category:<id> | project:<id>
+  createdAt, confirmedAt?, retractedAt?
+  vectorClock
 ```
 
-If adding `dayId` directly to `CaptureEntity` creates too much generated-code
-churn in one PR, an equivalent deterministic `captureDay` link is acceptable
-only as a short step inside the same rollout. The final model should make day
-scope cheap and explicit to query.
+`CaptureEntity.dayId` must be **sync-safe**: it has to be a defaulted or
+derived-on-read field, not a `required` freezed field. A peer on an older build
+emits captures with no `dayId`, and a required, non-defaulted field throws on
+`fromJson`. Follow the existing forward-compatible pattern (e.g. the defaulted
+`milestone` field). If adding `dayId` directly to `CaptureEntity` still creates
+too much generated-code churn in one PR, an equivalent deterministic
+`captureDay` link is acceptable only as a short step inside the same rollout.
+The final model should make day scope cheap and explicit to query.
 
-Analysis briefs do not have to be a new entity in the first planner refactor if
-an existing report/message shape can carry the artifact cleanly. The important
-contract is that disposable analyst runs write a compact, evidence-linked
-artifact and then close; the planner never imports their raw transcript as main
-context.
+`PlannerKnowledgeEntity` is the durable, compaction-exempt store for
+"memorize what I tell you" (ADR 0022 Decisions 9–10). It is detailed in the
+"Durable Planner Knowledge" section below. Deep disposable analysis runs are
+**out of scope** for this refactor (ADR 0022 Decision 13); if reintroduced
+later they reuse the existing `AgentReportEntity` scope, not a new entity.
 
 ## Wake Contract
 
@@ -150,36 +163,80 @@ Token rules:
 - Plan and capture tools validate `args.dayId == context.dayId` when a tool
   accepts `dayId`.
 
-## Disposable Analyst Runs
+## Durable Planner Knowledge (memorize what the user tells you)
 
-The long-lived planner may need deeper investigations than a normal day wake
-should carry in context. Examples:
+A long-lived planner is only useful if it durably remembers what the user tells
+it. The current substrate cannot guarantee this: user instructions enter through
+agent-inferred `record_observations`, land in the shared compaction fold
+(ADR 0017), and are re-summarized lossily on every fold for the life of the
+planner — so "never schedule deep work before 10am" slowly dissolves. The old
+plan's `propose_preference` / `confirm_preference` / `retract_preference` tools
+were specified but never built. This section closes that gap.
 
-- Analyze why planned work spilled over during the last seven days.
-- Compare planned capacity with actual tracked time by category.
-- Inspect a project and explain why it repeatedly displaces health blocks.
-- Summarize unresolved capture phrases across a week.
+### Two memory loops
 
-These should be modeled as one-off analyst conversations:
+- **Fast loop (daily, unsupervised):** raw day-scoped inputs and agent-inferred
+  observations accrue as episodic memory on the planner's log, compacted per
+  ADR 0017. High volume, low trust, automatically aged.
+- **Slow loop (weekly, supervised — the one-on-one):** the existing
+  `TemplateEvolutionWorkflow` ritual, now bound to the single planner identity,
+  consolidates recurring observations into durable knowledge and template
+  directives, gated by the user. Wiring `day_agent` as a participating kind
+  completes the old plan's unfinished step.
 
-1. The planner or UI starts an analyst run with a bounded question, workspace
-   key, horizon, and source set.
-2. The analyst run may call read tools and inspect a larger local corpus than a
-   normal planner wake.
-3. The analyst run writes one compact artifact: findings, evidence refs,
-   confidence, recommendations, and optional proposed follow-up questions.
-4. The analyst run is closed. It is not a durable agent identity.
-5. The planner reads the artifact and decides whether it becomes an
-   observation, attention claim, plan diff, or just background context.
+Promotion is the relationship between them: a day-scoped observation becomes
+durable knowledge only when (a) the user confirms it directly, or (b) it recurs
+across distinct days and passes the weekly gate. Episodic memory can be aged
+aggressively *because* anything worth keeping is promoted.
 
-This keeps the planner long-running without turning every planning wake into a
-large analysis context.
+### `PlannerKnowledgeEntity`
+
+A new `AgentDomainEntity` variant persisted on the existing `agent_entities`
+table (no new Drift table), modeled on the durable `Version` / `Head` snapshot
+pattern already used by `AgentTemplateVersionEntity` and the soul document.
+Fields are listed in Target Data Model above. Key properties:
+
+1. **Keyed and supersedable.** A `Head` selects the active entry per `key` among
+   non-retracted entries by recency. Monday's "X" is cleanly superseded by
+   Friday's "not-X" via `supersedesId`; retraction is explicit, not LLM-guessed.
+2. **Direct user-to-durable path.** Reintroduce the tool trio as real handlers:
+   `propose_knowledge {key, value, statement, scope, source}` (writes
+   `status = proposed`), and user-gated `confirm_knowledge` / `retract_knowledge`
+   surfaced in the "What I've learned" panel. A `source = userStated` instruction
+   may skip straight to `confirmed`. This is the path user instructions take
+   instead of `record_observations`.
+3. **Compaction-exempt.** `PlannerKnowledgeEntity` is its own kind, **excluded
+   from `projectInputEvents`' fold substrate** and from the compaction tail. The
+   active `Head` set of confirmed knowledge is injected into the prompt as a
+   dedicated, byte-stable "Standing knowledge" block (cf. ADR 0014), so it is
+   never re-summarized and stays prefix-cache friendly. The summarizer's soft
+   "preserve preferences" instruction becomes a backstop, not the only defense.
+4. **Reconciled with the weekly ritual.** The weekly `TemplateEvolutionWorkflow`
+   folds confirmed knowledge into the next user-approved template version. Daily
+   = fast capture into the durable store; weekly = consolidation into directives.
+   The knowledge store is the single source of truth both read, eliminating
+   drift between "the template says X" and "an observation says not-X".
+
+Deep disposable analysis runs are deferred (ADR 0022 Decision 13); most
+questions they would answer ("why does this project keep displacing workouts?")
+belong to a durable domain agent (ADR 0023) instead.
 
 ## PR Sequence
 
-### PR 1 - Planner identity and day workspace contract
+**Ordering principle — make the system workspace-safe before flipping identity.**
+The earlier draft of this plan collapsed identity in PR1 but only fixed capture
+day-scope (PR2) and the wake queue (PR3) afterward, leaving a window where every
+day's Capture panel and drafting prompt leaked other days' captures and one day's
+manual wake could cancel another day's queued work. The corrected sequence lands
+all the workspace plumbing **additively under the existing per-day identity**
+(PR1–PR3), then flips to one planner once the flip is provably safe (PR4). The
+identity cutover (PR4) **must not ship to users without PR2 and PR3**.
 
-Goal: introduce the new contract without changing every persistence path.
+### PR 1 - Day workspace contract (additive, identity unchanged)
+
+Goal: introduce the workspace vocabulary and wake context without changing
+identity creation. Per-day identities still exist, so existing behavior is
+preserved and nothing leaks yet.
 
 Touches:
 
@@ -191,27 +248,73 @@ Touches:
 
 Work:
 
-1. Add `planning_day:<dayId>` token helpers.
+1. Add `planning_day:<dayId>` token helpers alongside the existing `drafting:` /
+   `refine:` tokens.
 2. Add `DailyOsPlannerWakeContext` and pure parsing/validation helpers.
-3. Add `getOrCreatePlannerAgent()` to `DayAgentService`.
-4. Keep `AgentIdentityEntity.kind == day_agent` for now.
-5. Stop creating one agent per date in new day-agent service paths.
-6. Make enqueue methods target the planner and include `planning_day:<dayId>`.
-7. Update workflow prompt wording from "one agent for exactly one local
-   calendar day" to "one planner operating on the current day workspace".
-8. Keep old methods only as thin compatibility wrappers if still needed by UI
-   call sites, and delete them once callers are moved.
+3. **Make the token extraction helpers workspace-filtered.** Today
+   `draftingDayIdFromTriggerTokens` / `refineDayIdFromTriggerTokens` return the
+   *first* matching token from a `Set` (non-deterministic). They must instead
+   return the token whose `dayId` matches the resolved workspace, so they are
+   correct once one identity owns many days and a merged token set holds
+   `drafting:dayA` + `drafting:dayB`.
+4. Add `getOrCreatePlannerAgent()` to `DayAgentService` (no cutover path uses it
+   yet).
+5. Have the workflow resolve target day from wake context + trigger tokens, while
+   still tolerating the current per-day slot as a fallback so behavior is
+   unchanged this PR.
 
 Done when:
 
-- Creating/using two dates yields one planner identity.
-- Draft/refine enqueue tokens include the correct `planning_day:<dayId>`.
-- Workflow can resolve day context without `AgentSlots.activeDayId`.
-- Workflow rejects a mismatched model `dayId` in plan tools.
+- Wake context resolves day from tokens; extraction helpers are deterministic
+  under a merged day-A + day-B token set (unit-tested).
+- Existing per-day behavior is unchanged.
 
-### PR 2 - Day-scoped captures and providers
+### PR 2 - Workspace-aware wake queue and scheduled wakes (additive)
 
-Goal: prevent cross-day capture leaks under one planner.
+Goal: make the queue safe for one planner with multiple outstanding day jobs,
+before any identity flip. Still per-day identity, so this is a safe refactor of
+the existing queue with its existing tests as a regression guard.
+
+Touches:
+
+- `wake_queue.dart`
+- `wake_orchestrator.dart`
+- `scheduled_wake_manager.dart`
+- day-agent service enqueue paths
+- wake queue/orchestrator/scheduled-wake tests
+
+Work:
+
+1. Add an optional workspace key to wake jobs. For Daily OS day-scoped wakes,
+   use `day:<dayId>`.
+2. Make superseding (`removeByAgent`), dedupe (`hasQueuedJobFor`), **and token
+   merge (`mergeTokens`)** partition by `(agentId, workspaceKey, reason class)`.
+   `mergeTokens` and `removeByAgent` are agentId-only today, so they must be
+   taught the workspace/reason taxonomy or they will collide cross-day under one
+   planner. Define the reason-class taxonomy (capture / draft / refine /
+   creation) so same-day-different-reason work is not wrongly dropped.
+3. Preserve the existing single-flight runner by `agentId`. Document that one
+   planner therefore serializes day work across days (acceptable for planner
+   judgment; revisit only with evidence).
+4. Resolve `set_next_wake` semantics: either global-only planner wakes, or
+   persisted scheduled-wake records carrying trigger tokens and a workspace key.
+5. **Preserve the day-scoped morning pre-warm.** A single `scheduledWakeAt`
+   cannot hold several day wakes, and a context-less scheduled wake cannot drive
+   a day-scoped pre-warm. If `set_next_wake` stays global-only, the pre-warm must
+   carry its day through a persisted record, not an empty-token wake.
+
+Done when:
+
+- A day-B capture wake cannot drop or merge into a day-A draft/refine wake
+  (tested with two day workspaces under one agentId).
+- Restored scheduled wakes either carry workspace context or are explicitly
+  global; the morning pre-warm still resolves a concrete day.
+
+### PR 3 - Day-scoped captures and providers (additive, sync-safe)
+
+Goal: make day scope explicit on captures and queries before the identity flip
+removes implicit per-day isolation. Still per-day identity, so `dayId` equals the
+agent's only day and the new filters are correct no-ops until PR4.
 
 Touches:
 
@@ -224,83 +327,106 @@ Touches:
 
 Work:
 
-1. Add required `dayId` to `CaptureEntity`.
+1. Add `dayId` to `CaptureEntity` as a **defaulted / derived-on-read** field, not
+   `required` — a required freezed field throws on `fromJson` for captures synced
+   from older peers. Thread it through `submitCapture`, `RealDayAgent`, and the
+   `refine_capture:` build path.
 2. Stamp `dayId` when submitting typed, voice, and refine captures.
-3. Resolve parse wakes from `capture.dayId` when needed.
-4. Filter capture lists, parse context, and day capture events by `dayId`.
-5. Update `capturesForDateProvider` to query planner captures for one
-   workspace, not all captures by date-agent id.
+3. Resolve parse wakes from `capture.dayId` when the token set lacks
+   `planning_day:<dayId>` (e.g. only `capture_submitted:<captureId>` is present).
+4. Filter capture lists, parse context, day capture events, and the workflow
+   memory load by `dayId`.
+5. Update `capturesForDateProvider` to query the day workspace, not all captures
+   by agent id.
 
 Done when:
 
-- Captures created for two dates under one planner do not appear in each
-  other's Capture panel.
-- Capture parse wake with only `capture_submitted:<captureId>` resolves the
-  correct day workspace.
-- Compacted day log excludes raw captures from unrelated days.
+- Captures synced from an older peer (no `dayId`) still deserialize and resolve a
+  day on read.
+- Capture lists and drafting context are day-filtered even when one agentId owns
+  multiple days (tested under a shared agentId).
+- The compacted day log excludes raw captures from unrelated days.
 
-### PR 3 - Workspace-aware wake queue and scheduled wakes
+### PR 4 - Planner identity cutover (the flip)
 
-Goal: make one planner safe with multiple outstanding day jobs.
+Goal: collapse per-day identities into one long-lived planner. Safe **only
+because** PR2 (workspace-aware queue) and PR3 (day-scoped captures) have landed.
+
+Precondition: PR2 and PR3 merged. This PR must not ship to users without them.
 
 Touches:
 
-- `wake_queue.dart`
-- `wake_orchestrator.dart`
-- `scheduled_wake_manager.dart`
-- day-agent service enqueue paths
-- wake queue/orchestrator tests
+- `day_agent_service.dart`
+- `derived_agent_state.dart` / `agent_sync_service.dart` (`activeDayId`
+  projection)
+- `day_agent_workflow.dart`
+- day-agent service/workflow/state tests
 
 Work:
 
-1. Add an optional workspace key to wake jobs. For Daily OS day-scoped wakes,
-   use `day:<dayId>`.
-2. Change manual wake superseding so it removes/merges only matching
-   `(agentId, workspaceKey, reason class)` work where appropriate.
-3. Preserve the existing single-flight runner by `agentId` unless there is a
-   demonstrated need for concurrent planner runs. Serialization is acceptable
-   for planner judgment.
-4. Decide `set_next_wake` semantics:
-   - global-only planner wake, or
-   - persisted scheduled wake records with trigger tokens and workspace key.
-5. Do not restore day-specific scheduled wakes with empty trigger tokens.
+1. Route creation/use through `getOrCreatePlannerAgent`; stop creating one
+   identity per date. Enqueue paths target the planner and include
+   `planning_day:<dayId>`.
+2. **Fix the `activeDayId` projection, not just the read.** Stop creating one
+   `AgentDayLink` per day for the planner (or exclude `activeDayId` from
+   derivation, reconcile write-back, and the derived-field-mismatch
+   diagnostics), so reconcile does not reconcile the slot to a single
+   most-recent day and persist it on every wake.
+3. Make the workflow derive day strictly from wake context; remove the per-day
+   slot fallback added in PR1. The workflow MUST NOT read `AgentSlots.activeDayId`.
+4. Reject day-scoped tool calls whose `args.dayId` differs from the wake
+   workspace.
+5. Keep `AgentIdentityEntity.kind == day_agent` (persisted-name churn deferred to
+   PR7).
 
 Done when:
 
-- A draft wake for one day cannot drop a parse/refine wake for another day.
-- Restored scheduled wakes either have workspace context or are explicitly
-  global planner wakes.
+- Two dates yield one planner identity (`getOrCreatePlannerAgent` idempotent).
+- Reconcile no longer writes or derives a stale `activeDayId`; no permanent
+  `activeDayId` derived-field mismatch.
+- Interleaved day-A / day-B wakes neither cancel nor cross-contaminate
+  (end-to-end test).
 
-### PR 4 - Planner memory split
+### PR 5 - Two-loop memory and durable knowledge
 
-Goal: use the long-lived planner memory intentionally without polluting day
-workspace prompts.
+Goal: deliver durable cross-day learning and "memorize what I tell you" (see the
+"Durable Planner Knowledge" section).
 
 Touches:
 
 - `day_agent_workflow.dart`
-- `day_capture_events.dart`
-- `AgentWakeMemory` call sites
+- `agent_domain_entity.dart` (new `PlannerKnowledgeEntity` variant, generated)
+- `day_agent_tool_names.dart` + knowledge handlers
+- compaction / projection (exempt knowledge from the fold; inject standing block)
+- `template_evolution_workflow.dart` (register `day_agent` as a participating kind)
 - observation persistence/extraction if scope fields are added
-- workflow/memory tests
+- workflow / memory / knowledge tests
 
 Work:
 
-1. Treat planner observations as global unless explicitly day-scoped.
-2. Add observation scope if needed: `global`, `day`, plus optional `dayId`.
-3. Feed compacted planner memory as global context.
-4. Feed raw captures, parsed items, baseline plan, refine transcript, and
-   decided items only for the active `dayId`.
-5. Keep `summarize_recent_patterns` cross-day, because that is intentional
-   learning.
+1. Add `PlannerKnowledgeEntity` + `Head` selection by `key` (recency,
+   non-retracted).
+2. Add `propose_knowledge` / `confirm_knowledge` / `retract_knowledge` handlers;
+   surface them in the "What I've learned" panel. `source = userStated` may go
+   straight to `confirmed`.
+3. Exempt knowledge from compaction; inject the confirmed `Head` set as a stable
+   "Standing knowledge" prompt block (cf. ADR 0014).
+4. Split memory: feed compacted episodic memory as cross-day context; feed raw
+   captures, parsed items, baseline plan, refine transcript, and decided items
+   only for the active `dayId`; keep `summarize_recent_patterns` cross-day.
+5. Wire `day_agent` into `TemplateEvolutionWorkflow` as the weekly promotion
+   gate; confirmed knowledge feeds the next template version.
+6. Add observation scope (`global` | `day` + optional `dayId`) if needed.
 
 Done when:
 
-- Recent-pattern cards can see multiple days owned by one planner.
-- Raw captures from unrelated days are absent from the prompt.
-- Global observations remain available across days.
+- A user instruction persists as confirmed knowledge, survives a compaction fold,
+  and appears in the next wake's prompt.
+- Contradicting knowledge supersedes by recency rather than both persisting.
+- Recent-pattern cards see multiple days under one planner; raw captures from
+  unrelated days are absent from the prompt.
 
-### PR 5 - Plan, refine, commit, and UI adapter cleanup
+### PR 6 - Plan, refine, commit, and UI adapter cleanup
 
 Goal: remove remaining "agent for date" assumptions from user-facing flows.
 
@@ -331,7 +457,7 @@ Done when:
 - The same flow works interleaved across two selected days under one planner.
 - UI updates for one day do not show another day's captures or pending diffs.
 
-### PR 6 - Documentation and old-model removal
+### PR 7 - Documentation and old-model removal
 
 Goal: make the codebase describe the implemented model.
 
@@ -339,7 +465,7 @@ Touches:
 
 - `lib/features/daily_os_next/README.md`
 - stale implementation plans that mention one agent per day
-- code comments and names where practical
+- code comments and names
 - tests that still assert old identity behavior
 
 Work:
@@ -347,51 +473,29 @@ Work:
 1. Update feature README architecture diagrams.
 2. Mark the old per-day identity plan as superseded by ADR 0022.
 3. Remove compatibility wrappers and unused day-agent lookup methods.
-4. Rename helpers where useful:
-   - `dayAgentIdForDate` should not imply agent identity.
-   - prefer `dayIdForDate` or `dayWorkspaceIdForDate`.
-5. Keep persisted kind/name churn for a separate cleanup only if it does not
-   obscure the core refactor.
+4. **Rename the non-persisted Dart symbols and file names off `day_agent_*`
+   within this refactor** (zero sync cost): `dayAgentIdForDate` ->
+   `dayIdForDate` / `dayWorkspaceIdForDate`, and the `day_agent_*` file tree
+   toward planner-shaped names. Half-renaming entrenches the confusion this
+   refactor exists to remove — and it becomes actively wrong once domain agents
+   (ADR 0023) exist.
+5. Keep the **persisted** `kind` string (`day_agent`) and
+   `DayPlanEntity.id = day_agent_plan:<dayId>` deferred — those carry real
+   multi-device migration cost (Open Decision 4).
 
 Done when:
 
 - No production path needs one `AgentIdentityEntity` per day.
-- Docs and comments no longer teach the obsolete model.
+- Docs, comments, and non-persisted symbol names no longer teach the obsolete
+  model.
 
-### PR 7 - Disposable analyst runs and analysis artifacts
+### Out of scope: domain agents and disposable analysis
 
-Goal: let the planner delegate bounded investigations without polluting its main
-context.
-
-Touches:
-
-- planner workflow / service boundary
-- analysis artifact model or report-message convention
-- read-only analyst tools
-- prompt reconstruction / inspectability surfaces
-- analyst-run tests
-
-Work:
-
-1. Define the analysis artifact shape. Prefer a first-class
-   `AnalysisBriefEntity` only if existing report/message entities cannot carry
-   workspace, horizon, evidence refs, and validity cleanly.
-2. Add a `startAnalysisRun` service path that accepts a bounded question,
-   workspace key, horizon, and allowed source refs.
-3. Restrict analyst tools to read-only corpus/context tools at first.
-4. Persist exactly one compact brief per completed analysis run.
-5. Ensure the planner consumes briefs as summarized inputs, not raw analyst
-   transcripts.
-6. Add retention/expiry semantics via `validUntil` or equivalent metadata so
-   stale analysis does not become permanent truth.
-
-Done when:
-
-- A week-analysis run can inspect several day plans and actuals, write a brief,
-  and close.
-- The planner prompt includes the brief summary and evidence refs without the
-  analyst transcript.
-- Failed or abandoned analyst runs do not affect planner memory.
+Durable domain agents (fitness, sleep) that negotiate with this planner for
+calendar time are specified in **ADR 0023** and implemented in a separate plan.
+They are not part of this refactor; this refactor only makes the planner the
+durable, learning counterparty they will negotiate with. Deep disposable analyst
+runs are deferred (ADR 0022 Decision 13).
 
 ## Required Tests
 
@@ -403,11 +507,18 @@ Add or update focused tests before broad suite runs:
   - Draft/refine/capture wake tokens include `planning_day:<dayId>`.
 
 - `day_agent_workflow_test.dart`
-  - workflow ignores stale `AgentSlots.activeDayId`;
+  - workflow never reads `AgentSlots.activeDayId`;
+  - reconcile does not persist a stale `activeDayId` for a multi-day planner;
   - workflow derives day from wake context;
   - workflow rejects mismatched tool `dayId`;
   - forced `parse_capture_to_items` and `draft_day_plan` retries remain
     provider-neutral.
+
+- wake queue / scheduled-wake tests
+  - a day-B manual wake does not `removeByAgent`-drop a queued day-A draft/refine;
+  - `mergeTokens` does not merge day-B tokens into a day-A job;
+  - token extraction is deterministic under a merged day-A + day-B token set;
+  - the day-scoped morning pre-warm resolves a concrete day after restore.
 
 - `day_agent_capture_service_test.dart`
   - submitted captures persist `dayId`;
@@ -433,11 +544,13 @@ Add or update focused tests before broad suite runs:
   - verify day A context and day B context do not leak;
   - refine and commit day A.
 
-- Analyst-run tests:
-  - analysis run writes one compact artifact and then closes;
-  - planner context includes the artifact, not the raw transcript;
-  - analyst tool access is read-only in the first implementation;
-  - stale `validUntil` briefs are excluded or marked stale.
+- durable-knowledge tests (PR5):
+  - `propose_knowledge` then `confirm_knowledge` persists a confirmed entry;
+  - confirmed knowledge survives a compaction fold and appears in the next
+    wake's "Standing knowledge" prompt block;
+  - contradicting knowledge supersedes by recency (`supersedesId`), not both;
+  - `retract_knowledge` removes an entry from the injected `Head` set;
+  - `summarizeRecentPatterns` still sees multiple days under one planner.
 
 ## Verification Strategy
 
@@ -461,14 +574,17 @@ Before merging the full refactor:
 
 | Risk | Mitigation |
 |---|---|
+| Broken intermediate state from flipping identity too early | Land workspace plumbing additively (PR1–PR3) under per-day identity; flip in PR4 only after PR2+PR3 |
 | Day context leak under one planner | Add `dayId` to captures, validate tool `dayId`, filter raw context by workspace |
-| One wake drops another day's wake | Add workspace key to wake queue dedupe/superseding |
-| Scheduled wake restores without day context | Make scheduled wakes global-only or persist trigger tokens/workspace key |
+| `activeDayId` corrupted by projection | Stop creating the per-day `AgentDayLink` for the planner (or exclude `activeDayId` from derivation/reconcile/diagnostics), not just "ignore the read" |
+| One wake drops/merges another day's wake | Make `removeByAgent`, dedupe, **and `mergeTokens`** partition by `(agentId, workspaceKey, reason class)`; make token extractors workspace-filtered |
+| Required `CaptureEntity.dayId` breaks sync deserialization | Make `dayId` defaulted/derived, never `required`; follow the existing forward-compatible default pattern |
+| Scheduled wake restores without day context | Make scheduled wakes global-only or persist trigger tokens/workspace key; preserve the day-scoped morning pre-warm explicitly |
 | Slow draft blocks parse/refine for another day | Keep single-flight initially for planner consistency; revisit only with evidence |
+| Per-wake projection cost grows with planner lifetime | Track as a follow-up: projection snapshot / incremental fold once one identity replaces N tiny per-day logs |
+| Durable memory becomes stale truth | Recency-wins supersession for confirmed knowledge; weekly gate for promotion; recency-weighted episodic memory |
 | Provider-specific forced tool behavior regresses | Keep generic `ChatCompletionToolChoiceOption` tests for Gemini, Mistral, and cloud routing |
 | Old docs/tests reintroduce per-day identity | Mark old plan superseded and remove compatibility wrappers after call sites move |
-| Analyst runs bloat planner context | Persist compact artifacts with evidence refs; exclude raw analyst transcripts from planner prompt |
-| Analyst findings become stale truth | Add horizon and `validUntil`; planner treats briefs as dated evidence |
 
 ## Non-Goals
 
@@ -479,14 +595,17 @@ Before merging the full refactor:
 - Rewriting task agents. Task agents should stay one agent per task.
 - Building a deterministic planner fallback. This refactor is about identity,
   workspace scope, and memory correctness.
-- Making analyst runs durable agents by default. They are one-off scoped
-  conversations unless a future domain proves it needs its own durable identity.
+- Building domain agents (fitness, sleep). They are specified separately in
+  ADR 0023; this refactor only makes the planner the durable counterparty they
+  negotiate with.
+- Disposable analyst runs. Deferred per ADR 0022 Decision 13.
 
 ## Open Decisions
 
-1. Should day-specific scheduled wakes become first-class synced entities, or
-   should `set_next_wake` remain global-only until a concrete per-day need is
-   proven?
+1. **(Resolved — must be decided in PR2, not left open.)** Day-scoped scheduled
+   wakes cannot ride a single `scheduledWakeAt`. PR2 must pick: global-only
+   planner wakes, or persisted scheduled-wake records with workspace key +
+   trigger tokens. Either way the day-scoped morning pre-warm must survive.
 2. Should observation scope be represented directly in `ObservationRecord`, or
    should scoped observations be modeled as message/link metadata?
 3. Should wake queue workspace keys be generic across all agent kinds now, or
@@ -494,11 +613,13 @@ Before merging the full refactor:
 4. When the implementation is complete, should the persisted kind be renamed
    from `day_agent` to `daily_os_planner`, or is that churn not worth the
    migration?
-5. Should analysis briefs be a new `AgentDomainEntity` variant, an
-   `AgentReportEntity` scope, or a structured message payload linked from the
-   planner log?
-6. Which read tools should analyst runs get first: day plans and actuals only,
-   or also task/project/capture corpus search?
+5. Should `PlannerKnowledgeEntity` be its own `AgentDomainEntity` variant
+   (preferred, mirroring `Version`/`Head`), or can confirmed knowledge ride an
+   `AgentReportEntity` scope?
+6. What is the promotion threshold from agent-inferred observation to `proposed`
+   knowledge — N recurrences across distinct days, the weekly gate only, or both?
+7. Do domain agents (ADR 0023) reuse `PlannerKnowledgeEntity` for their own
+   user-stated facts, or hold a per-agent variant? (Cross-ref ADR 0023.)
 
 ## Success Criteria
 
@@ -510,5 +631,8 @@ Before merging the full refactor:
   planner wake is operating on.
 - Gemini, Mistral, and OpenAI-compatible providers can all honor required
   planning tool calls through the generic tool-choice contract.
-- Scoped analyst runs can answer bounded week/day/project questions, persist a
-  compact brief, and close without expanding the planner's raw context.
+- A user instruction ("never schedule deep work before 10am") persists as
+  confirmed knowledge, survives compaction, and shapes later wakes — i.e. the
+  planner memorizes what the user tells it.
+- The weekly one-on-one ritual consolidates recurring daily observations into
+  durable, user-approved knowledge, completing the two-loop learning model.

--- a/docs/implementation_plans/2026-06-07_long_lived_daily_os_planner.md
+++ b/docs/implementation_plans/2026-06-07_long_lived_daily_os_planner.md
@@ -1,0 +1,514 @@
+# Long-Lived Daily OS Planner - Implementation Plan
+
+- Status: Plan accepted; implementation pending
+- Date: 2026-06-07
+- Decision baseline: [ADR 0022](../adr/0022-long-lived-daily-os-planner.md)
+- Scope: refactor Daily OS Next from one day-agent identity per date to one
+  long-lived planner identity with explicit day workspaces.
+
+## Goal
+
+Make Daily OS planning useful by giving it durable cross-day memory while
+preserving day-local safety. The planner should remember recent plans,
+captures, observations, outcomes, category patterns, and user decisions across
+days, but every day-specific wake and tool call must be scoped to a concrete
+`dayId`.
+
+This is a direct correction, not a compatibility bridge. Daily OS Next has low
+current usage, so the implementation should target the correct steady-state
+model and remove stale per-day identity assumptions as it goes.
+
+## Current Problem
+
+The current implementation uses the day as the agent identity:
+
+- `dayAgentIdForDate(date)` returns the day-plan id.
+- `DayAgentService.createDayAgent` creates one active `AgentIdentityEntity` per
+  local calendar day and stores the day in `AgentSlots.activeDayId`.
+- `DayAgentWorkflow.execute` reads the target day from the reconciled agent
+  state slot.
+- `DayAgentPlanService.summarizeRecentPatterns` reads recent plans by
+  `agentId`.
+- `DayAgentWorkflow` reads observations, captures, and compaction memory by
+  `agentId`.
+
+This makes each day a separate mind. It also hides day context in identity, so a
+naive long-lived refactor would leak all captures and prompt context across
+every day.
+
+## Target Invariants
+
+1. There is one active Daily OS planner identity.
+2. A day is represented by `dayId`, not by `agentId`.
+3. Day-scoped wakes always carry `planning_day:<dayId>` or resolve `dayId`
+   through a workspace-bound capture.
+4. The workflow never uses `AgentSlots.activeDayId` as authoritative day
+   context.
+5. Day-scoped tool calls are rejected when their `dayId` differs from the wake
+   workspace.
+6. Raw captures and parsed items are day-scoped. Cross-day learning enters the
+   prompt only through deliberate summaries, observations, reports, recent-plan
+   cards, or planner memory.
+7. Wake queue and scheduling semantics distinguish day workspaces under the
+   shared planner identity.
+8. Provider-specific inference details stay behind provider-neutral tool-choice
+   contracts.
+
+## Target Data Model
+
+```text
+plannerAgentId
+  AgentIdentityEntity.kind = day_agent (name may be cleaned up later)
+  AgentStateEntity slots.activeDayId = ignored for planner execution
+
+dayId
+  dayplan-YYYY-MM-DD
+
+DayPlanEntity
+  id = day_agent_plan:<dayId>
+  agentId = plannerAgentId
+  dayId = dayId
+  planDate = local date
+
+CaptureEntity
+  agentId = plannerAgentId
+  dayId = dayId              // new required day workspace
+  transcript, capturedAt, audioRef...
+
+ParsedItemEntity
+  agentId = plannerAgentId
+  captureId = CaptureEntity.id
+  day scope = capture.dayId
+
+ChangeSetEntity
+  agentId = plannerAgentId
+  taskId or target id = day_agent_plan:<dayId>
+
+AnalysisBriefEntity (or equivalent report artifact)
+  id
+  plannerAgentId
+  workspaceKey = day:<dayId> | week:<isoWeek> | project:<id> | category:<id>
+  horizonStart / horizonEnd
+  sourceRefs[]
+  findings[]
+  recommendations[]
+  confidence
+  validUntil
+```
+
+If adding `dayId` directly to `CaptureEntity` creates too much generated-code
+churn in one PR, an equivalent deterministic `captureDay` link is acceptable
+only as a short step inside the same rollout. The final model should make day
+scope cheap and explicit to query.
+
+Analysis briefs do not have to be a new entity in the first planner refactor if
+an existing report/message shape can carry the artifact cleanly. The important
+contract is that disposable analyst runs write a compact, evidence-linked
+artifact and then close; the planner never imports their raw transcript as main
+context.
+
+## Wake Contract
+
+Introduce a small explicit context object near the day-agent workflow/domain
+boundary:
+
+```dart
+class DailyOsPlannerWakeContext {
+  DailyOsPlannerWakeContext({
+    required this.plannerAgentId,
+    required this.dayId,
+    required this.reason,
+    required this.runKey,
+    required this.threadId,
+    required this.triggerTokens,
+    this.captureId,
+    this.decidedTaskIds = const [],
+    this.decidedCaptureItemIds = const [],
+  });
+
+  final String plannerAgentId;
+  final String dayId;
+  final String reason;
+  final String runKey;
+  final String threadId;
+  final Set<String> triggerTokens;
+  final String? captureId;
+  final List<String> decidedTaskIds;
+  final List<String> decidedCaptureItemIds;
+}
+```
+
+Token rules:
+
+- Every day-scoped wake includes `planning_day:<dayId>`.
+- Drafting wakes include `drafting:<dayId>`.
+- Refine wakes include `refine:<dayId>`.
+- Capture parse wakes may resolve `dayId` from `capture_submitted:<captureId>`
+  if the token set lacks `planning_day:<dayId>`, but enqueue sites should prefer
+  including both.
+- Workflow fails fast when a day-scoped wake has no resolvable `dayId`.
+- Plan and capture tools validate `args.dayId == context.dayId` when a tool
+  accepts `dayId`.
+
+## Disposable Analyst Runs
+
+The long-lived planner may need deeper investigations than a normal day wake
+should carry in context. Examples:
+
+- Analyze why planned work spilled over during the last seven days.
+- Compare planned capacity with actual tracked time by category.
+- Inspect a project and explain why it repeatedly displaces health blocks.
+- Summarize unresolved capture phrases across a week.
+
+These should be modeled as one-off analyst conversations:
+
+1. The planner or UI starts an analyst run with a bounded question, workspace
+   key, horizon, and source set.
+2. The analyst run may call read tools and inspect a larger local corpus than a
+   normal planner wake.
+3. The analyst run writes one compact artifact: findings, evidence refs,
+   confidence, recommendations, and optional proposed follow-up questions.
+4. The analyst run is closed. It is not a durable agent identity.
+5. The planner reads the artifact and decides whether it becomes an
+   observation, attention claim, plan diff, or just background context.
+
+This keeps the planner long-running without turning every planning wake into a
+large analysis context.
+
+## PR Sequence
+
+### PR 1 - Planner identity and day workspace contract
+
+Goal: introduce the new contract without changing every persistence path.
+
+Touches:
+
+- `day_agent_slots.dart`
+- `day_agent_reconcile_models.dart`
+- `day_agent_service.dart`
+- `day_agent_workflow.dart`
+- day-agent service/workflow tests
+
+Work:
+
+1. Add `planning_day:<dayId>` token helpers.
+2. Add `DailyOsPlannerWakeContext` and pure parsing/validation helpers.
+3. Add `getOrCreatePlannerAgent()` to `DayAgentService`.
+4. Keep `AgentIdentityEntity.kind == day_agent` for now.
+5. Stop creating one agent per date in new day-agent service paths.
+6. Make enqueue methods target the planner and include `planning_day:<dayId>`.
+7. Update workflow prompt wording from "one agent for exactly one local
+   calendar day" to "one planner operating on the current day workspace".
+8. Keep old methods only as thin compatibility wrappers if still needed by UI
+   call sites, and delete them once callers are moved.
+
+Done when:
+
+- Creating/using two dates yields one planner identity.
+- Draft/refine enqueue tokens include the correct `planning_day:<dayId>`.
+- Workflow can resolve day context without `AgentSlots.activeDayId`.
+- Workflow rejects a mismatched model `dayId` in plan tools.
+
+### PR 2 - Day-scoped captures and providers
+
+Goal: prevent cross-day capture leaks under one planner.
+
+Touches:
+
+- `agent_domain_entity.dart` and generated files via build runner
+- `day_agent_capture_service.dart`
+- `day_capture_events.dart`
+- `day_agent_context_builder.dart`
+- `day_agent_provider.dart`
+- capture/reconcile/provider tests
+
+Work:
+
+1. Add required `dayId` to `CaptureEntity`.
+2. Stamp `dayId` when submitting typed, voice, and refine captures.
+3. Resolve parse wakes from `capture.dayId` when needed.
+4. Filter capture lists, parse context, and day capture events by `dayId`.
+5. Update `capturesForDateProvider` to query planner captures for one
+   workspace, not all captures by date-agent id.
+
+Done when:
+
+- Captures created for two dates under one planner do not appear in each
+  other's Capture panel.
+- Capture parse wake with only `capture_submitted:<captureId>` resolves the
+  correct day workspace.
+- Compacted day log excludes raw captures from unrelated days.
+
+### PR 3 - Workspace-aware wake queue and scheduled wakes
+
+Goal: make one planner safe with multiple outstanding day jobs.
+
+Touches:
+
+- `wake_queue.dart`
+- `wake_orchestrator.dart`
+- `scheduled_wake_manager.dart`
+- day-agent service enqueue paths
+- wake queue/orchestrator tests
+
+Work:
+
+1. Add an optional workspace key to wake jobs. For Daily OS day-scoped wakes,
+   use `day:<dayId>`.
+2. Change manual wake superseding so it removes/merges only matching
+   `(agentId, workspaceKey, reason class)` work where appropriate.
+3. Preserve the existing single-flight runner by `agentId` unless there is a
+   demonstrated need for concurrent planner runs. Serialization is acceptable
+   for planner judgment.
+4. Decide `set_next_wake` semantics:
+   - global-only planner wake, or
+   - persisted scheduled wake records with trigger tokens and workspace key.
+5. Do not restore day-specific scheduled wakes with empty trigger tokens.
+
+Done when:
+
+- A draft wake for one day cannot drop a parse/refine wake for another day.
+- Restored scheduled wakes either have workspace context or are explicitly
+  global planner wakes.
+
+### PR 4 - Planner memory split
+
+Goal: use the long-lived planner memory intentionally without polluting day
+workspace prompts.
+
+Touches:
+
+- `day_agent_workflow.dart`
+- `day_capture_events.dart`
+- `AgentWakeMemory` call sites
+- observation persistence/extraction if scope fields are added
+- workflow/memory tests
+
+Work:
+
+1. Treat planner observations as global unless explicitly day-scoped.
+2. Add observation scope if needed: `global`, `day`, plus optional `dayId`.
+3. Feed compacted planner memory as global context.
+4. Feed raw captures, parsed items, baseline plan, refine transcript, and
+   decided items only for the active `dayId`.
+5. Keep `summarize_recent_patterns` cross-day, because that is intentional
+   learning.
+
+Done when:
+
+- Recent-pattern cards can see multiple days owned by one planner.
+- Raw captures from unrelated days are absent from the prompt.
+- Global observations remain available across days.
+
+### PR 5 - Plan, refine, commit, and UI adapter cleanup
+
+Goal: remove remaining "agent for date" assumptions from user-facing flows.
+
+Touches:
+
+- `real_day_agent.dart`
+- `day_agent_plan_service.dart`
+- `day_agent_provider.dart`
+- `drafting_controller.dart`
+- `refine_controller.dart`
+- `shutdown_controller.dart`
+- Daily OS Next UI tests
+
+Work:
+
+1. Replace date-agent lookups with planner + day workspace calls.
+2. Ensure `currentPlanForDate`, `draftDayPlan`, `proposePlanDiff`, `commitDay`,
+   `uncommitDay`, and rename/mutation paths all pass explicit day context.
+3. Keep `DayPlanEntity.id = day_agent_plan:<dayId>`.
+4. Ensure `pendingPlanDiffsForDay` and plan diff application are scoped by
+   planner plus day-plan target.
+5. Update provider invalidation to watch planner id, day id, plan id, capture
+   ids, and the broad agent notification where needed.
+
+Done when:
+
+- Capture -> parse -> reconcile -> draft -> refine -> commit works for one day.
+- The same flow works interleaved across two selected days under one planner.
+- UI updates for one day do not show another day's captures or pending diffs.
+
+### PR 6 - Documentation and old-model removal
+
+Goal: make the codebase describe the implemented model.
+
+Touches:
+
+- `lib/features/daily_os_next/README.md`
+- stale implementation plans that mention one agent per day
+- code comments and names where practical
+- tests that still assert old identity behavior
+
+Work:
+
+1. Update feature README architecture diagrams.
+2. Mark the old per-day identity plan as superseded by ADR 0022.
+3. Remove compatibility wrappers and unused day-agent lookup methods.
+4. Rename helpers where useful:
+   - `dayAgentIdForDate` should not imply agent identity.
+   - prefer `dayIdForDate` or `dayWorkspaceIdForDate`.
+5. Keep persisted kind/name churn for a separate cleanup only if it does not
+   obscure the core refactor.
+
+Done when:
+
+- No production path needs one `AgentIdentityEntity` per day.
+- Docs and comments no longer teach the obsolete model.
+
+### PR 7 - Disposable analyst runs and analysis artifacts
+
+Goal: let the planner delegate bounded investigations without polluting its main
+context.
+
+Touches:
+
+- planner workflow / service boundary
+- analysis artifact model or report-message convention
+- read-only analyst tools
+- prompt reconstruction / inspectability surfaces
+- analyst-run tests
+
+Work:
+
+1. Define the analysis artifact shape. Prefer a first-class
+   `AnalysisBriefEntity` only if existing report/message entities cannot carry
+   workspace, horizon, evidence refs, and validity cleanly.
+2. Add a `startAnalysisRun` service path that accepts a bounded question,
+   workspace key, horizon, and allowed source refs.
+3. Restrict analyst tools to read-only corpus/context tools at first.
+4. Persist exactly one compact brief per completed analysis run.
+5. Ensure the planner consumes briefs as summarized inputs, not raw analyst
+   transcripts.
+6. Add retention/expiry semantics via `validUntil` or equivalent metadata so
+   stale analysis does not become permanent truth.
+
+Done when:
+
+- A week-analysis run can inspect several day plans and actuals, write a brief,
+  and close.
+- The planner prompt includes the brief summary and evidence refs without the
+  analyst transcript.
+- Failed or abandoned analyst runs do not affect planner memory.
+
+## Required Tests
+
+Add or update focused tests before broad suite runs:
+
+- `day_agent_service_test.dart`
+  - `getOrCreatePlannerAgent` is idempotent.
+  - Two dates use the same planner identity.
+  - Draft/refine/capture wake tokens include `planning_day:<dayId>`.
+
+- `day_agent_workflow_test.dart`
+  - workflow ignores stale `AgentSlots.activeDayId`;
+  - workflow derives day from wake context;
+  - workflow rejects mismatched tool `dayId`;
+  - forced `parse_capture_to_items` and `draft_day_plan` retries remain
+    provider-neutral.
+
+- `day_agent_capture_service_test.dart`
+  - submitted captures persist `dayId`;
+  - parse wake resolves day from capture;
+  - parsed items inherit scope through capture.
+
+- `day_agent_provider_test.dart`
+  - `capturesForDateProvider` returns only captures for the selected date under
+    one planner.
+
+- `day_agent_plan_service_test.dart`
+  - `summarizeRecentPatterns` sees multiple days owned by the same planner.
+  - `draftPlanForDay`, diff, commit, and uncommit stay scoped by `dayId`.
+
+- `real_day_agent_test.dart`
+  - no "no day agent exists for date" behavior on normal paths;
+  - adapter resolves planner once and passes day workspace explicitly.
+
+- Focused end-to-end test:
+  - submit capture for day A;
+  - parse/reconcile/draft;
+  - submit capture for day B;
+  - verify day A context and day B context do not leak;
+  - refine and commit day A.
+
+- Analyst-run tests:
+  - analysis run writes one compact artifact and then closes;
+  - planner context includes the artifact, not the raw transcript;
+  - analyst tool access is read-only in the first implementation;
+  - stale `validUntil` briefs are excluded or marked stale.
+
+## Verification Strategy
+
+Per PR:
+
+1. Run `fvm dart format` on touched Dart files.
+2. Run targeted tests for touched source files.
+3. Run `dart-mcp.analyze_files` for touched Dart files when the analysis server
+   is stable; otherwise document the analyzer failure and run the closest
+   `fvm flutter analyze` fallback.
+4. Run `git diff --check`.
+
+Before merging the full refactor:
+
+1. Run all Daily OS Next agent/service/state tests.
+2. Run the focused end-to-end Daily OS Next flow.
+3. Run `make analyze`.
+4. Run broader tests only when the targeted suites are clean.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Day context leak under one planner | Add `dayId` to captures, validate tool `dayId`, filter raw context by workspace |
+| One wake drops another day's wake | Add workspace key to wake queue dedupe/superseding |
+| Scheduled wake restores without day context | Make scheduled wakes global-only or persist trigger tokens/workspace key |
+| Slow draft blocks parse/refine for another day | Keep single-flight initially for planner consistency; revisit only with evidence |
+| Provider-specific forced tool behavior regresses | Keep generic `ChatCompletionToolChoiceOption` tests for Gemini, Mistral, and cloud routing |
+| Old docs/tests reintroduce per-day identity | Mark old plan superseded and remove compatibility wrappers after call sites move |
+| Analyst runs bloat planner context | Persist compact artifacts with evidence refs; exclude raw analyst transcripts from planner prompt |
+| Analyst findings become stale truth | Add horizon and `validUntil`; planner treats briefs as dated evidence |
+
+## Non-Goals
+
+- Renaming the persisted `day_agent` kind everywhere in the same PR. The runtime
+  semantics matter more than naming churn.
+- Introducing autonomous plan mutation. Planner proposals still flow through
+  existing validation and user/standing-agreement gates.
+- Rewriting task agents. Task agents should stay one agent per task.
+- Building a deterministic planner fallback. This refactor is about identity,
+  workspace scope, and memory correctness.
+- Making analyst runs durable agents by default. They are one-off scoped
+  conversations unless a future domain proves it needs its own durable identity.
+
+## Open Decisions
+
+1. Should day-specific scheduled wakes become first-class synced entities, or
+   should `set_next_wake` remain global-only until a concrete per-day need is
+   proven?
+2. Should observation scope be represented directly in `ObservationRecord`, or
+   should scoped observations be modeled as message/link metadata?
+3. Should wake queue workspace keys be generic across all agent kinds now, or
+   introduced as optional metadata used only by Daily OS first?
+4. When the implementation is complete, should the persisted kind be renamed
+   from `day_agent` to `daily_os_planner`, or is that churn not worth the
+   migration?
+5. Should analysis briefs be a new `AgentDomainEntity` variant, an
+   `AgentReportEntity` scope, or a structured message payload linked from the
+   planner log?
+6. Which read tools should analyst runs get first: day plans and actuals only,
+   or also task/project/capture corpus search?
+
+## Success Criteria
+
+- A user can plan multiple dates with one planner identity.
+- Recent-pattern cards and planner memory reflect previous days.
+- Capture, reconcile, draft, refine, and commit remain isolated by selected day.
+- Interleaved wakes for different days do not cancel or corrupt each other.
+- The code no longer relies on `AgentSlots.activeDayId` to decide what day a
+  planner wake is operating on.
+- Gemini, Mistral, and OpenAI-compatible providers can all honor required
+  planning tool calls through the generic tool-choice contract.
+- Scoped analyst runs can answer bounded week/day/project questions, persist a
+  compact brief, and close without expanding the planner's raw context.

--- a/docs/implementation_plans/2026-06-07_planning_agent_architecture.md
+++ b/docs/implementation_plans/2026-06-07_planning_agent_architecture.md
@@ -1,0 +1,81 @@
+# Planning Agent Architecture — Overview
+
+- Status: Direction accepted; implementation pending
+- Date: 2026-06-07
+- Branch: `doc/planning_agent_architecture`
+
+This is the orientation doc that ties together the Daily OS planning-agent
+direction. It connects three pillars and points at the canonical decision
+documents. Read this first, then the linked ADRs and the detailed implementation
+plan.
+
+## The three pillars
+
+### 1. Long-lived planner identity
+
+[ADR 0022](../adr/0022-long-lived-daily-os-planner.md) replaces one `day_agent`
+identity per calendar date with **one durable planner** that owns explicit
+`dayId` workspaces. The per-day model was amnesia: each day was a separate mind
+with no memory of the last. The planner now learns across days while every
+day-specific wake and tool call stays scoped to a concrete `dayId`.
+
+### 2. Durable knowledge + two-loop learning
+
+The detailed plan
+([2026-06-07_long_lived_daily_os_planner.md](./2026-06-07_long_lived_daily_os_planner.md),
+"Durable Planner Knowledge" section) adds a compaction-exempt
+`PlannerKnowledgeEntity` — keyed, supersedable, user-confirmed — so the planner
+**memorizes what the user tells it** instead of dissolving it in LLM log
+compaction. Learning runs on two loops:
+
+- **Fast loop (daily, unsupervised):** raw day inputs and observations accrue as
+  episodic memory, aggressively compacted.
+- **Slow loop (weekly, the one-on-one):** `TemplateEvolutionWorkflow` — not yet
+  wired for `day_agent` — consolidates recurring observations into durable,
+  user-approved knowledge.
+
+The user wants both daily learning and the weekly one-on-one; promotion (daily →
+durable) is the relationship between the loops, gated by the user.
+
+### 3. Domain agents negotiating for time
+
+[ADR 0023](../adr/0023-durable-domain-agents-and-time-negotiation.md) introduces
+durable fitness/sleep agents that ask the planner for **calendar time** — a core
+part of the vision. The negotiation substrate already exists in
+`lib/features/agents/` (ADR 0019/0021):
+
+- `AttentionRequestEntity` — a claim carrying `requestedMinutes`, a schedulable
+  window, `cadence`, and evidence.
+- `AttentionAwardEntity` — a concrete block proposal that still flows through the
+  ChangeSet gate (ADR 0006).
+- `StandingAgreementEntity` — already enumerates `fitness` and `sleep` scopes,
+  with enforcement, approval mode, and pre-emption.
+
+The gap is the **producer side**: there is no `domain_agent` kind,
+`request_attention` is task-only (`_taskTargetKind`), there are no self-scheduled
+producer wakes, and the planner's claim → weigh → award → ChangeSet arbitration
+path is unbuilt. This is the *inverse* of a "disposable analyst run" (planner
+spawns a throwaway investigator) — and disposable analyst runs were deliberately
+struck from ADR 0022.
+
+## Correctness landmines (found by adversarial review)
+
+These are now reflected in the implementation plan:
+
+- `activeDayId` is *derived* from `AgentDayLink` and written back every wake — it
+  must stop being derived/persisted for the planner, not merely "ignored".
+- Single-flight, `removeByAgent`, and `mergeTokens` are keyed by `agentId` only —
+  cross-day unsafe once one planner owns many days. The wake queue must become
+  workspace-aware across supersede, dedupe, merge, and token extraction.
+- `CaptureEntity.dayId` must be defaulted/derived, not `required`, or captures
+  synced from older peers throw on deserialization.
+- PR order must land the workspace plumbing **additively** under the existing
+  per-day identity, then flip to one planner only once the flip is provably safe.
+
+## Canonical documents
+
+- [ADR 0022 — Long-Lived Daily OS Planner](../adr/0022-long-lived-daily-os-planner.md)
+- [ADR 0023 — Durable Domain Agents and Time Negotiation](../adr/0023-durable-domain-agents-and-time-negotiation.md)
+- [Long-Lived Daily OS Planner — implementation plan](./2026-06-07_long_lived_daily_os_planner.md)
+- Supersedes the per-day identity decision in
+  [Day Agent Layer — implementation plan](./2026-05-25_day_agent_layer.md)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added ADRs introducing a long-lived Daily OS planner, durable domain agents for time negotiation, and a Correction Lexicon for deterministic transcript/LLM corrections.
  * Updated ADR index to include the new entries.
  * Added implementation plans and an architecture orientation for the long-lived planner, multi-loop learning, and workspace/day isolation.
  * Marked the prior day-agent-layer plan as historical/superseded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->