### PR TITLE
feat: planning modal

### DIFF
--- a/lib/features/ai/ui/animation/ai_running_animation.dart
+++ b/lib/features/ai/ui/animation/ai_running_animation.dart
@@ -89,7 +89,7 @@ class AiRunningAnimationWrapper extends ConsumerWidget {
   }
 }
 
-class AiRunningDecoderBars extends ConsumerStatefulWidget {
+class AiRunningDecoderBars extends ConsumerWidget {
   const AiRunningDecoderBars({
     required this.entryId,
     required this.responseTypes,
@@ -103,6 +103,7 @@ class AiRunningDecoderBars extends ConsumerStatefulWidget {
   static const defaultRandomness = 1.0;
   static const defaultAmplitude = 0.7;
   static const defaultPulse = 0.6;
+  static const defaultLineCount = 5;
   static const transitionDuration = Duration(milliseconds: 340);
 
   @visibleForTesting
@@ -123,11 +124,99 @@ class AiRunningDecoderBars extends ConsumerStatefulWidget {
   final bool isInteractive;
 
   @override
-  ConsumerState<AiRunningDecoderBars> createState() =>
-      _AiRunningDecoderBarsState();
+  Widget build(BuildContext context, WidgetRef ref) {
+    // The presence envelope (fade/scale in & out, collapse to zero) lives in
+    // [AiThinkingShaderPresence]; here we only feed it the entry's
+    // inference-running signal and, when interactive, the tap-to-progress
+    // affordance.
+    final isRunning = ref.watch(
+      inferenceRunningControllerProvider(
+        id: entryId,
+        responseTypes: responseTypes,
+      ),
+    );
+
+    final bars = AiThinkingShaderPresence(
+      isRunning: isRunning,
+      height: height,
+      indicatorKey: indicatorKey,
+    );
+
+    if (!isInteractive) {
+      return bars;
+    }
+
+    return Semantics(
+      button: true,
+      label: context.messages.aiRunningActivityOpenProgress,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () => _handleAiActivityTap(
+          context: context,
+          ref: ref,
+          entryId: entryId,
+          responseTypes: responseTypes,
+        ),
+        child: bars,
+      ),
+    );
+  }
 }
 
-class _AiRunningDecoderBarsState extends ConsumerState<AiRunningDecoderBars>
+/// Reusable presence/fade envelope around [AiThinkingLineShader].
+///
+/// Renders nothing while [isRunning] is false and the exit animation has
+/// finished; on `isRunning` → true it fades and scales the shader in over
+/// [transitionDuration], and reverses on the way out before collapsing to
+/// zero reserved height. The shader amplitude, pulse, and opacity are
+/// scaled by the eased presence progress so entry/exit read as a single
+/// motion.
+///
+/// Extracted from [AiRunningDecoderBars] so surfaces that aren't tied to
+/// the per-entry inference provider — e.g. the day-planning modal action
+/// bar — can show the same "AI is thinking" shader driven by their own
+/// busy signal.
+class AiThinkingShaderPresence extends StatefulWidget {
+  const AiThinkingShaderPresence({
+    required this.isRunning,
+    this.height = AiRunningDecoderBars.defaultHeight,
+    this.speed = AiRunningDecoderBars.defaultSpeed,
+    this.amplitude = AiRunningDecoderBars.defaultAmplitude,
+    this.randomness = AiRunningDecoderBars.defaultRandomness,
+    this.pulse = AiRunningDecoderBars.defaultPulse,
+    this.lineCount = AiRunningDecoderBars.defaultLineCount,
+    this.transitionDuration = AiRunningDecoderBars.transitionDuration,
+    this.primaryColor,
+    this.secondaryColor,
+    this.indicatorKey,
+    super.key,
+  });
+
+  final bool isRunning;
+  final double height;
+  final double speed;
+  final double amplitude;
+  final double randomness;
+  final double pulse;
+  final int lineCount;
+  final Duration transitionDuration;
+
+  /// Defaults to `tokens.colors.interactive.enabled` when null.
+  final Color? primaryColor;
+
+  /// Defaults to `tokens.colors.text.highEmphasis` when null.
+  final Color? secondaryColor;
+
+  /// Optional key placed on the animated reserved-height box so hosts can
+  /// assert presence/absence in tests.
+  final Key? indicatorKey;
+
+  @override
+  State<AiThinkingShaderPresence> createState() =>
+      _AiThinkingShaderPresenceState();
+}
+
+class _AiThinkingShaderPresenceState extends State<AiThinkingShaderPresence>
     with SingleTickerProviderStateMixin {
   late final AnimationController _presenceController;
 
@@ -138,7 +227,7 @@ class _AiRunningDecoderBarsState extends ConsumerState<AiRunningDecoderBars>
     super.initState();
     _presenceController = AnimationController(
       vsync: this,
-      duration: AiRunningDecoderBars.transitionDuration,
+      duration: widget.transitionDuration,
     );
     _presenceController.addStatusListener((status) {
       if (status == AnimationStatus.dismissed && mounted) {
@@ -146,18 +235,22 @@ class _AiRunningDecoderBarsState extends ConsumerState<AiRunningDecoderBars>
       }
     });
 
-    // `ref.listen` (in build) only reacts to subsequent changes, so seed the
-    // presence here for inference that is already running when this widget
-    // first mounts — fully shown, without an entry animation.
-    final isRunning = ref.read(
-      inferenceRunningControllerProvider(
-        id: widget.entryId,
-        responseTypes: widget.responseTypes,
-      ),
-    );
-    if (isRunning) {
+    // Seed the presence for a busy signal that is already true when this
+    // widget first mounts — fully shown, without an entry animation.
+    if (widget.isRunning) {
       _buildBars = true;
       _presenceController.value = 1;
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant AiThinkingShaderPresence oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.transitionDuration != oldWidget.transitionDuration) {
+      _presenceController.duration = widget.transitionDuration;
+    }
+    if (widget.isRunning != oldWidget.isRunning) {
+      _syncPresence(widget.isRunning);
     }
   }
 
@@ -192,20 +285,13 @@ class _AiRunningDecoderBarsState extends ConsumerState<AiRunningDecoderBars>
 
   @override
   Widget build(BuildContext context) {
-    // React to running-state changes via a listener rather than mutating the
-    // controller during build (which would be a build-phase side effect).
-    ref.listen<bool>(
-      inferenceRunningControllerProvider(
-        id: widget.entryId,
-        responseTypes: widget.responseTypes,
-      ),
-      (_, isRunning) => _syncPresence(isRunning),
-    );
-
     final tokens = context.designTokens;
     final spacing = tokens.spacing;
     final bottomGap = spacing.step2;
-    final bars = AnimatedBuilder(
+    final primary = widget.primaryColor ?? tokens.colors.interactive.enabled;
+    final secondary = widget.secondaryColor ?? tokens.colors.text.highEmphasis;
+
+    return AnimatedBuilder(
       animation: _presenceController,
       builder: (context, _) {
         final progress = _presenceProgress;
@@ -215,7 +301,7 @@ class _AiRunningDecoderBarsState extends ConsumerState<AiRunningDecoderBars>
         }
 
         return SizedBox(
-          key: AiRunningDecoderBars.indicatorKey,
+          key: widget.indicatorKey,
           height: (widget.height + bottomGap) * progress,
           width: double.infinity,
           child: Align(
@@ -232,14 +318,14 @@ class _AiRunningDecoderBarsState extends ConsumerState<AiRunningDecoderBars>
                   return AiThinkingLineShader(
                     width: width,
                     height: shaderHeight,
-                    speed: AiRunningDecoderBars.defaultSpeed,
-                    amplitude: AiRunningDecoderBars.defaultAmplitude * progress,
-                    randomness: AiRunningDecoderBars.defaultRandomness,
-                    lineCount: 5,
-                    pulse: AiRunningDecoderBars.defaultPulse * progress,
+                    speed: widget.speed,
+                    amplitude: widget.amplitude * progress,
+                    randomness: widget.randomness,
+                    lineCount: widget.lineCount,
+                    pulse: widget.pulse * progress,
                     opacity: progress,
-                    primaryColor: tokens.colors.interactive.enabled,
-                    secondaryColor: tokens.colors.text.highEmphasis,
+                    primaryColor: primary,
+                    secondaryColor: secondary,
                     backgroundColor: Colors.transparent,
                   );
                 },
@@ -248,25 +334,6 @@ class _AiRunningDecoderBarsState extends ConsumerState<AiRunningDecoderBars>
           ),
         );
       },
-    );
-
-    if (!widget.isInteractive) {
-      return bars;
-    }
-
-    return Semantics(
-      button: true,
-      label: context.messages.aiRunningActivityOpenProgress,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: () => _handleAiActivityTap(
-          context: context,
-          ref: ref,
-          entryId: widget.entryId,
-          responseTypes: widget.responseTypes,
-        ),
-        child: bars,
-      ),
     );
   }
 }

--- a/lib/features/daily_os_next/README.md
+++ b/lib/features/daily_os_next/README.md
@@ -79,39 +79,52 @@ Runtime behavior:
   `capture_submitted:<captureId>` trigger token.
 - The selected local plan date lives in `dailyOsNextSelectedDateProvider`
   (`state/selected_date_provider.dart`); `DailyOsNextRoot` watches it and keeps
-  the date strip visible on Capture and Day surfaces, while the desktop
-  sidebar's month calendar (shown beneath the active Daily OS nav row)
-  drives the same provider.
-  Capture submissions use that selected date for day-agent routing, Reconcile
-  carries it into pending decisions, and Drafting returns to the root after the
-  plan persists so the date-aware shell remains in control. Background agent or
-  sync updates reload the current plan stale-while-revalidate: the root keeps
-  rendering the last Capture or Day surface while the provider re-fetches, and
-  only shows the loading shell for the initial route load. The same Riverpod
-  contract applies inside Reconcile, Drafting, Shutdown, and the Day captures
-  panel: if an `AsyncValue` still has a previous value, the UI renders that
-  value instead of replacing the section or page with a spinner.
-- Routing on a day without a plan is tracked-time aware (design handoff v2,
-  item 2): when the day already has recorded sessions, the root mounts
-  `DayPage` in **empty mode** (`hasPlan: false` with a synthetic
-  `DraftPlan.emptyForDay`) so the timeline is visible without creating a plan
-  first. Empty mode lands on the Day view, renders an honest "No plan yet"
-  stat strip (neutral `CapacityDonut` over tracked minutes, tracked legend),
-  swaps the Refine/Commit footer for a single "Speak a check-in" CTA that
-  routes into Capture, and hides the delete-plan menu entry. A completely
-  empty day still lands directly on Capture.
+  the date strip visible on the Day surface, while the desktop sidebar's month
+  calendar (shown beneath the active Daily OS nav row) drives the same provider.
+  `DailyOsNextRoot` always renders `DayPage` for the selected date — the real
+  plan when one exists, otherwise the empty Day surface. The
+  Capture → Reconcile → Drafting ritual runs inside a full-height
+  **day-planning modal** (`showDayPlanningModal`,
+  `ui/pages/day_planning_modal.dart`), a Wolt multi-page sheet pushed on the
+  root navigator (full-height bottom sheet on phones — covering the bottom nav
+  — dialog on wide). The modal is opened from the empty surface's footer CTA
+  (`DayPlanningCreate`) and from the Day surface's Refine CTA
+  (`DayPlanningAdapt`). Each step submits against the selected date for
+  day-agent routing; on create the Drafting step closes the whole modal once
+  the plan is ready and invalidates `currentDraftPlanProvider` so the root
+  re-renders the new plan. Background agent or sync updates reload the current
+  plan stale-while-revalidate: the root keeps rendering the last Day surface
+  while the provider re-fetches, and only shows the loading shell for the
+  initial route load. The same Riverpod contract applies inside the modal's
+  Reconcile and Drafting steps, Shutdown, and the Day captures panel: if an
+  `AsyncValue` still has a previous value, the UI renders that value instead of
+  replacing the section or page with a spinner.
+- The root surface is identical on every no-plan day (design handoff v2,
+  item 2): `DailyOsNextRoot` mounts `DayPage` in **empty mode**
+  (`hasPlan: false` with a synthetic `DraftPlan.emptyForDay`) so any recorded
+  sessions stay visible on the timeline without creating a plan first. Empty
+  mode renders an honest "No plan yet" stat strip (neutral `CapacityDonut` over
+  tracked minutes, tracked legend), swaps the Refine/Commit footer for a single
+  "Speak a check-in" CTA that opens the day-planning modal, and hides the
+  delete-plan menu entry. The modal's Capture step still shows the "Today so
+  far" `TimeSpentCard` for the day's tracked time, fed by
+  `dailyOsActualTimeBlocksProvider`.
 
 ```mermaid
 stateDiagram-v2
   [*] --> Loading: route enters date
   Loading --> DayPlan: plan exists
-  Loading --> DayEmpty: no plan, tracked time
-  Loading --> Capture: no plan, nothing tracked
-  DayEmpty --> Capture: "Speak a check-in" CTA
-  Capture --> Reconcile: submit capture
-  Reconcile --> Drafting: build my day
-  Drafting --> DayPlan: plan persists
-  DayPlan --> Capture: plan deleted
+  Loading --> DayEmpty: no plan (timeline still shows tracked time)
+  DayEmpty --> Modal: "Speak a check-in" CTA (create)
+  DayPlan --> Modal: Refine CTA (adapt)
+  state Modal {
+    [*] --> Capture
+    Capture --> Reconcile: continue
+    Reconcile --> Drafting: build my day
+    [*] --> Refine: adapt intent
+  }
+  Modal --> DayPlan: Drafting ready / refine diff persists
+  DayPlan --> DayEmpty: plan deleted
 ```
 
 - The "Today so far" tracked-time block is one shared widget,
@@ -295,9 +308,11 @@ stateDiagram-v2
   a diff. Final refine transcripts stop in the same editable review field as
   initial capture, and the controller submits its current reviewed text to
   `propose_plan_diff` so stale widget parameters cannot drop the user's edits.
-  From Day, refinement opens in a Wolt modal over the existing plan surface
-  (bottom sheet on narrow screens, dialog on wider screens); the full
-  `RefinePage` remains as a direct-route fallback. Failed or empty proposals
+  From Day, the Refine CTA opens the shared day-planning modal with a
+  `DayPlanningAdapt` intent (`showDayPlanningModal`), whose Refine step hosts
+  `RefineModalContent` over the existing plan surface (bottom sheet on narrow
+  screens, dialog on wider screens); the full `RefinePage` remains as a
+  direct-route fallback. Failed or empty proposals
   keep the review field open and show inline feedback instead of silently
   closing. Proposed changes render as independent suggestion cards, matching
   task-agent approval affordances: each row can be accepted or rejected, then

--- a/lib/features/daily_os_next/state/reconcile_controller.dart
+++ b/lib/features/daily_os_next/state/reconcile_controller.dart
@@ -3,6 +3,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
+import 'package:lotti/features/daily_os_next/agents/domain/day_agent_slots.dart';
 import 'package:lotti/features/daily_os_next/logic/day_agent_interface.dart';
 import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
 import 'package:lotti/features/daily_os_next/state/daily_os_preferences_controller.dart';
@@ -89,7 +90,21 @@ class ReconcileController extends AsyncNotifier<ReconcileData> {
   Future<ReconcileData> build() async {
     _agent = ref.watch(dayAgentProvider);
     final preferences = ref.watch(dailyOsPreferencesControllerProvider);
-    ref.watch(reconcileCaptureUpdateProvider(params.captureId.value));
+    // When the capture-submitted parse wake finishes (running true → false),
+    // re-read so the Heard column fills in even if the per-capture update
+    // notification doesn't carry the capture id. Uses `listen` (not `watch`)
+    // so the signal's intermediate emissions don't re-run — and abort — the
+    // initial parse build.
+    ref
+      ..watch(reconcileCaptureUpdateProvider(params.captureId.value))
+      ..listen(agentIsRunningProvider(dayAgentIdForDate(params.dayDate)), (
+        previous,
+        next,
+      ) {
+        final wasRunning = previous?.value ?? false;
+        final isRunning = next.value ?? false;
+        if (wasRunning && !isRunning) ref.invalidateSelf();
+      });
     final triageDecisions =
         state.value?.triageDecisions ?? const <String, TriageResult>{};
     final parsedFuture = _agent.parseCaptureToItems(params.captureId);

--- a/lib/features/daily_os_next/ui/pages/capture_page.dart
+++ b/lib/features/daily_os_next/ui/pages/capture_page.dart
@@ -21,6 +21,11 @@ import 'package:lotti/widgets/nav_bar/design_system_bottom_navigation_bar.dart';
 
 part 'capture_layout_metrics.dart';
 
+/// Max width for the centred capture column and the "Today so far" card so
+/// the calm single column reads comfortably on wide layouts. Defined once so
+/// the standalone page and the modal content can't drift apart.
+const double _captureContentMaxWidth = 560;
+
 /// Entry surface of the agentic Daily OS — voice-first check-in.
 ///
 /// Layout: vertically centred greeting → headline → voice button →
@@ -93,7 +98,9 @@ class CapturePage extends ConsumerWidget {
                   ),
                   child: Center(
                     child: ConstrainedBox(
-                      constraints: const BoxConstraints(maxWidth: 560),
+                      constraints: const BoxConstraints(
+                        maxWidth: _captureContentMaxWidth,
+                      ),
                       child: TimeSpentCard(
                         blocks: actualBlocks,
                         title: _timeSpentTitle(context),
@@ -117,7 +124,9 @@ class CapturePage extends ConsumerWidget {
                         ),
                         child: Center(
                           child: ConstrainedBox(
-                            constraints: const BoxConstraints(maxWidth: 560),
+                            constraints: const BoxConstraints(
+                              maxWidth: _captureContentMaxWidth,
+                            ),
                             child: Padding(
                               padding: EdgeInsets.symmetric(
                                 horizontal: tokens.spacing.step5,
@@ -209,21 +218,16 @@ class CapturePage extends ConsumerWidget {
 /// standalone capture surface, but without the page chrome (AppBar /
 /// bottom-nav padding / inline advance CTA) — the modal supplies a top bar
 /// and a sticky glass action bar instead. The voice orb stays the in-body
-/// hero recording control; advance/secondary actions live in the action
-/// bar. [trailingBuilder], when provided, appends a widget below the state
-/// row using the live [CaptureState] (used to keep the standalone page's
-/// inline CTA while it still exists).
+/// hero recording control; advance/secondary actions live in the action bar.
 class CaptureModalContent extends ConsumerWidget {
   const CaptureModalContent({
     this.forDate,
     this.actualBlocks = const [],
-    this.trailingBuilder,
     super.key,
   });
 
   final DateTime? forDate;
   final List<TimeBlock> actualBlocks;
-  final Widget Function(BuildContext, CaptureState)? trailingBuilder;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -244,7 +248,9 @@ class CaptureModalContent extends ConsumerWidget {
             ),
             child: Center(
               child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 560),
+                constraints: const BoxConstraints(
+                  maxWidth: _captureContentMaxWidth,
+                ),
                 child: TimeSpentCard(
                   blocks: actualBlocks,
                   title: _timeSpentTitle(context),
@@ -266,7 +272,9 @@ class CaptureModalContent extends ConsumerWidget {
                   constraints: BoxConstraints(minHeight: constraints.maxHeight),
                   child: Center(
                     child: ConstrainedBox(
-                      constraints: const BoxConstraints(maxWidth: 560),
+                      constraints: const BoxConstraints(
+                        maxWidth: _captureContentMaxWidth,
+                      ),
                       child: Padding(
                         padding: EdgeInsets.symmetric(
                           horizontal: tokens.spacing.step5,
@@ -299,9 +307,11 @@ class CaptureModalContent extends ConsumerWidget {
                                   layout.liveTranscriptLineCount,
                               reviewTranscriptLineCount:
                                   layout.reviewTranscriptLineCount,
+                              // The modal's sticky glass bar already offers a
+                              // "Type instead" pill, so drop the redundant
+                              // inline link from the idle hint.
+                              showInlineTypeInstead: false,
                             ),
-                            if (trailingBuilder != null)
-                              trailingBuilder!(context, state),
                           ],
                         ),
                       ),
@@ -461,12 +471,18 @@ class _StateSlot extends StatelessWidget {
     required this.height,
     required this.liveTranscriptLineCount,
     required this.reviewTranscriptLineCount,
+    this.showInlineTypeInstead = true,
   });
 
   final CaptureState state;
   final double height;
   final int liveTranscriptLineCount;
   final int reviewTranscriptLineCount;
+
+  /// Whether the idle hint includes the inline "Type instead" link. The
+  /// modal host sets this false because its sticky glass bar carries the
+  /// same action.
+  final bool showInlineTypeInstead;
 
   @override
   Widget build(BuildContext context) {
@@ -477,6 +493,7 @@ class _StateSlot extends StatelessWidget {
         height: height,
         liveTranscriptLineCount: liveTranscriptLineCount,
         reviewTranscriptLineCount: reviewTranscriptLineCount,
+        showInlineTypeInstead: showInlineTypeInstead,
       ),
     );
 
@@ -502,12 +519,14 @@ class _StateRow extends ConsumerWidget {
     required this.height,
     required this.liveTranscriptLineCount,
     required this.reviewTranscriptLineCount,
+    this.showInlineTypeInstead = true,
   });
 
   final CaptureState state;
   final double height;
   final int liveTranscriptLineCount;
   final int reviewTranscriptLineCount;
+  final bool showInlineTypeInstead;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -517,6 +536,7 @@ class _StateRow extends ConsumerWidget {
     switch (state.phase) {
       case CapturePhase.idle:
         return _IdleCaptureActions(
+          showTypeInstead: showInlineTypeInstead,
           onTypeInstead: () =>
               ref.read(captureControllerProvider.notifier).startTyping(),
         );
@@ -632,9 +652,17 @@ String? _captureErrorMessage(BuildContext context, CaptureError? error) {
 }
 
 class _IdleCaptureActions extends StatelessWidget {
-  const _IdleCaptureActions({required this.onTypeInstead});
+  const _IdleCaptureActions({
+    required this.onTypeInstead,
+    this.showTypeInstead = true,
+  });
 
   final VoidCallback onTypeInstead;
+
+  /// When false, only the "Tap to talk" hint renders — the inline
+  /// "Type instead" link is dropped (the modal host carries it on its
+  /// sticky glass bar instead).
+  final bool showTypeInstead;
 
   @override
   Widget build(BuildContext context) {
@@ -642,15 +670,19 @@ class _IdleCaptureActions extends StatelessWidget {
     final dotStyle = tokens.typography.styles.body.bodySmall.copyWith(
       color: tokens.colors.text.lowEmphasis,
     );
+    final talkHint = Text(
+      context.messages.dailyOsNextCaptureIdleTalk,
+      style: dotStyle,
+    );
+    if (!showTypeInstead) {
+      return talkHint;
+    }
     return Wrap(
       alignment: WrapAlignment.center,
       crossAxisAlignment: WrapCrossAlignment.center,
       spacing: tokens.spacing.step2,
       children: [
-        Text(
-          context.messages.dailyOsNextCaptureIdleTalk,
-          style: dotStyle,
-        ),
+        talkHint,
         Container(
           width: tokens.spacing.step1,
           height: tokens.spacing.step1,

--- a/lib/features/daily_os_next/ui/pages/capture_page.dart
+++ b/lib/features/daily_os_next/ui/pages/capture_page.dart
@@ -203,6 +203,143 @@ class CapturePage extends ConsumerWidget {
   }
 }
 
+/// Scaffold-free capture content for hosting inside the day-planning modal.
+///
+/// Renders the same calm greeting → headline → voice orb → state row as the
+/// standalone capture surface, but without the page chrome (AppBar /
+/// bottom-nav padding / inline advance CTA) — the modal supplies a top bar
+/// and a sticky glass action bar instead. The voice orb stays the in-body
+/// hero recording control; advance/secondary actions live in the action
+/// bar. [trailingBuilder], when provided, appends a widget below the state
+/// row using the live [CaptureState] (used to keep the standalone page's
+/// inline CTA while it still exists).
+class CaptureModalContent extends ConsumerWidget {
+  const CaptureModalContent({
+    this.forDate,
+    this.actualBlocks = const [],
+    this.trailingBuilder,
+    super.key,
+  });
+
+  final DateTime? forDate;
+  final List<TimeBlock> actualBlocks;
+  final Widget Function(BuildContext, CaptureState)? trailingBuilder;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final tokens = context.designTokens;
+    final state = ref.watch(captureControllerProvider);
+
+    return Column(
+      children: [
+        // "Today so far" pins to the top; greeting + orb stay centred in
+        // the remaining space below (handoff v2 item 1).
+        if (actualBlocks.isNotEmpty)
+          Padding(
+            padding: EdgeInsets.fromLTRB(
+              tokens.spacing.step5,
+              tokens.spacing.step4,
+              tokens.spacing.step5,
+              0,
+            ),
+            child: Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 560),
+                child: TimeSpentCard(
+                  blocks: actualBlocks,
+                  title: _timeSpentTitle(context),
+                ),
+              ),
+            ),
+          ),
+        Expanded(
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final layout = CaptureLayoutMetrics.resolve(
+                tokens,
+                phase: state.phase,
+                viewportHeight: constraints.maxHeight,
+              );
+
+              return SingleChildScrollView(
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                  child: Center(
+                    child: ConstrainedBox(
+                      constraints: const BoxConstraints(maxWidth: 560),
+                      child: Padding(
+                        padding: EdgeInsets.symmetric(
+                          horizontal: tokens.spacing.step5,
+                          vertical: tokens.spacing.step6,
+                        ),
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            const _GreetingBlock(),
+                            SizedBox(height: tokens.spacing.step6),
+                            _Headline(forDate: forDate),
+                            _PastTrackingPrompt(forDate: forDate),
+                            SizedBox(height: tokens.spacing.step8),
+                            VoiceButton(
+                              phase: state.phase,
+                              dbfs: state.dbfs,
+                              semanticLabel: _voiceButtonLabel(
+                                context,
+                                state.phase,
+                              ),
+                              onTap: () => ref
+                                  .read(captureControllerProvider.notifier)
+                                  .toggle(),
+                            ),
+                            SizedBox(height: tokens.spacing.step5),
+                            _StateSlot(
+                              state: state,
+                              height: layout.stateSlotHeight,
+                              liveTranscriptLineCount:
+                                  layout.liveTranscriptLineCount,
+                              reviewTranscriptLineCount:
+                                  layout.reviewTranscriptLineCount,
+                            ),
+                            if (trailingBuilder != null)
+                              trailingBuilder!(context, state),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+
+  String? _timeSpentTitle(BuildContext context) {
+    final date = forDate;
+    if (date == null) return null;
+    final now = clock.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final picked = DateTime(date.year, date.month, date.day);
+    if (picked.isAtSameMomentAs(today)) return null;
+    return context.messages.dailyOsNextTimeSpentTitlePast;
+  }
+
+  String _voiceButtonLabel(BuildContext context, CapturePhase phase) {
+    switch (phase) {
+      case CapturePhase.idle:
+      case CapturePhase.error:
+        return context.messages.dailyOsNextCaptureVoiceButtonStart;
+      case CapturePhase.listening:
+        return context.messages.dailyOsNextCaptureVoiceButtonStop;
+      case CapturePhase.transcribing:
+      case CapturePhase.captured:
+        return context.messages.dailyOsNextCaptureVoiceButtonReset;
+    }
+  }
+}
+
 class _GreetingBlock extends ConsumerWidget {
   const _GreetingBlock();
 

--- a/lib/features/daily_os_next/ui/pages/daily_os_next_root.dart
+++ b/lib/features/daily_os_next/ui/pages/daily_os_next_root.dart
@@ -1,22 +1,24 @@
+import 'dart:async';
+
 import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
-import 'package:lotti/features/daily_os_next/state/actual_time_blocks_provider.dart';
 import 'package:lotti/features/daily_os_next/state/day_agent_provider.dart';
 import 'package:lotti/features/daily_os_next/state/selected_date_provider.dart';
-import 'package:lotti/features/daily_os_next/ui/pages/capture_page.dart';
 import 'package:lotti/features/daily_os_next/ui/pages/day_page.dart';
+import 'package:lotti/features/daily_os_next/ui/pages/day_planning_modal.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 
 /// Entry point for the Daily OS Next surface.
 ///
-/// Routes between [CapturePage] (no drafted plan yet) and [DayPage]
-/// (plan exists) based on the currently selected date. Surfaces a
-/// small date picker on both paths so the user can choose the day
-/// before recording the planning capture.
+/// Shows the [DayPage] for the selected date: the real plan when one
+/// exists, otherwise the empty Day surface (its timeline still reflects
+/// any tracked time) whose footer CTA opens the day-planning modal
+/// ([showDayPlanningModal]) for the Capture → Reconcile → Drafting ritual.
+/// A small date strip lets the user pick the day first.
 class DailyOsNextRoot extends ConsumerStatefulWidget {
   const DailyOsNextRoot({super.key});
 
@@ -25,13 +27,6 @@ class DailyOsNextRoot extends ConsumerStatefulWidget {
 }
 
 class _DailyOsNextRootState extends ConsumerState<DailyOsNextRoot> {
-  /// Day for which the user tapped the empty Day surface's "Speak a
-  /// check-in" CTA — forces Capture for that day even though it has
-  /// tracked time. Comparing against the current selection (instead of
-  /// listening + resetting a flag) means no `setState` inside a
-  /// provider listener and an automatic reset on date change.
-  DateTime? _checkInDate;
-
   DateTime get _today {
     final now = clock.now();
     return DateTime(now.year, now.month, now.day);
@@ -77,35 +72,13 @@ class _DailyOsNextRootState extends ConsumerState<DailyOsNextRoot> {
     final selectedDate = ref.watch(dailyOsNextSelectedDateProvider);
     final asyncPlan = ref.watch(currentDraftPlanProvider(selectedDate));
     if (asyncPlan.hasValue) {
-      final plan = asyncPlan.requireValue;
-      if (plan != null) return _buildSurface(selectedDate, plan);
-
-      // Wait for the tracked-time projection before choosing between
-      // Capture and the empty Day surface — rendering on a coerced
-      // empty list would flash Capture and then flip once the
-      // recorded sessions arrive. Errors fall through as "no tracked
-      // time" so a failing projection never blocks the ritual.
-      final actualBlocks = ref.watch(
-        dailyOsActualTimeBlocksProvider(selectedDate),
-      );
-      if (actualBlocks.isLoading && !actualBlocks.hasValue) {
-        return const _LoadingShell();
-      }
-      return _buildSurface(
-        selectedDate,
-        null,
-        actualBlocks: actualBlocks.value ?? const [],
-      );
+      return _buildSurface(selectedDate, asyncPlan.requireValue);
     }
     if (asyncPlan.hasError) return _ErrorShell(error: '${asyncPlan.error}');
     return const _LoadingShell();
   }
 
-  Widget _buildSurface(
-    DateTime selectedDate,
-    DraftPlan? plan, {
-    List<TimeBlock> actualBlocks = const [],
-  }) {
+  Widget _buildSurface(DateTime selectedDate, DraftPlan? plan) {
     final strip = _DateStrip(
       selected: selectedDate,
       isToday: selectedDate.isAtSameMomentAs(_today),
@@ -121,27 +94,21 @@ class _DailyOsNextRootState extends ConsumerState<DailyOsNextRoot> {
         dateStrip: strip,
       );
     }
-    // No plan, but the day already has tracked time — land on the Day
-    // surface in its empty mode so the recorded sessions are visible
-    // on the timeline without creating a plan first (handoff v2 item
-    // 2). The footer CTA routes into Capture.
-    if (actualBlocks.isNotEmpty && _checkInDate != selectedDate) {
-      return DayPage(
-        key: ValueKey('empty-${selectedDate.toIso8601String()}'),
-        draft: DraftPlan.emptyForDay(selectedDate),
-        hasPlan: false,
-        onCheckIn: () => setState(() => _checkInDate = selectedDate),
-        dateStrip: strip,
-      );
-    }
-    // No plan for the selected date — drop into Capture so the
-    // user can start one for that day. Capture is keyed on
-    // [selectedDate] so the submitted capture lands on the
-    // chosen day's day-agent.
-    return CapturePage(
-      key: ValueKey('capture-${selectedDate.toIso8601String()}'),
-      forDate: selectedDate,
-      actualBlocks: actualBlocks,
+    // No plan for the selected date — show the Day surface in its empty
+    // mode so any recorded sessions are still visible on the timeline.
+    // The footer CTA opens the day-planning modal (Capture → Reconcile →
+    // Drafting), a full-height layer that covers the bottom nav.
+    return DayPage(
+      key: ValueKey('empty-${selectedDate.toIso8601String()}'),
+      draft: DraftPlan.emptyForDay(selectedDate),
+      hasPlan: false,
+      onCheckIn: () => unawaited(
+        showDayPlanningModal(
+          context: context,
+          dayDate: selectedDate,
+          intent: const DayPlanningCreate(),
+        ),
+      ),
       dateStrip: strip,
     );
   }

--- a/lib/features/daily_os_next/ui/pages/day_page.dart
+++ b/lib/features/daily_os_next/ui/pages/day_page.dart
@@ -11,7 +11,7 @@ import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
 import 'package:lotti/features/daily_os_next/state/actual_time_blocks_provider.dart';
 import 'package:lotti/features/daily_os_next/state/day_agent_provider.dart';
 import 'package:lotti/features/daily_os_next/ui/daily_os_next_routes.dart';
-import 'package:lotti/features/daily_os_next/ui/pages/refine_page.dart';
+import 'package:lotti/features/daily_os_next/ui/pages/day_planning_modal.dart';
 import 'package:lotti/features/daily_os_next/ui/widgets/agenda_view.dart';
 import 'package:lotti/features/daily_os_next/ui/widgets/captures_panel.dart';
 import 'package:lotti/features/daily_os_next/ui/widgets/day_timeline.dart';
@@ -75,11 +75,12 @@ class _DayPageState extends ConsumerState<DayPage> {
   late PlanView _view = widget.hasPlan ? PlanView.agenda : PlanView.day;
 
   Future<void> _openRefine() async {
-    final updatedPlan = await showRefineModal(
+    await showDayPlanningModal(
       context: context,
-      draft: widget.draft,
+      dayDate: widget.draft.dayDate,
+      intent: DayPlanningAdapt(widget.draft),
     );
-    if (!mounted || updatedPlan == null) return;
+    if (!mounted) return;
     ref.invalidate(currentDraftPlanProvider(widget.draft.dayDate));
   }
 

--- a/lib/features/daily_os_next/ui/pages/day_planning_modal.dart
+++ b/lib/features/daily_os_next/ui/pages/day_planning_modal.dart
@@ -2,6 +2,7 @@ import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
+import 'package:lotti/features/daily_os_next/state/actual_time_blocks_provider.dart';
 import 'package:lotti/features/daily_os_next/state/capture_controller.dart';
 import 'package:lotti/features/daily_os_next/state/day_agent_provider.dart';
 import 'package:lotti/features/daily_os_next/state/drafting_controller.dart';
@@ -128,7 +129,7 @@ SliverWoltModalSheetPage _captureStepPage(
       SliverToBoxAdapter(
         child: SizedBox(
           height: _stepViewportHeight(context),
-          child: CaptureModalContent(forDate: day),
+          child: _CaptureStepBody(day: day),
         ),
       ),
     ],
@@ -136,30 +137,72 @@ SliverWoltModalSheetPage _captureStepPage(
   );
 }
 
-class _CaptureStepBar extends ConsumerWidget {
+/// Capture step body: feeds [CaptureModalContent] the day's already-tracked
+/// time so the "Today so far" card (handoff v2 item 1) appears in the modal,
+/// matching the standalone capture surface. A loading/error projection falls
+/// through as "no tracked time" rather than blocking the ritual.
+class _CaptureStepBody extends ConsumerWidget {
+  const _CaptureStepBody({required this.day});
+
+  final DateTime day;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final actualBlocks =
+        ref.watch(dailyOsActualTimeBlocksProvider(day)).value ?? const [];
+    return CaptureModalContent(forDate: day, actualBlocks: actualBlocks);
+  }
+}
+
+class _CaptureStepBar extends ConsumerStatefulWidget {
   const _CaptureStepBar({required this.day});
 
   final DateTime day;
 
-  Future<void> _continue(BuildContext context, WidgetRef ref) async {
+  @override
+  ConsumerState<_CaptureStepBar> createState() => _CaptureStepBarState();
+}
+
+class _CaptureStepBarState extends ConsumerState<_CaptureStepBar> {
+  /// True while `submitCapture` is in flight — guards against a double tap
+  /// creating two captures and pushing two Reconcile pages, and disables the
+  /// bar's pills for the duration.
+  bool _submitting = false;
+
+  Future<void> _continue() async {
+    if (_submitting) return;
     final state = ref.read(captureControllerProvider);
     final transcript = state.transcript.trim();
     if (transcript.isEmpty) return;
+    setState(() => _submitting = true);
     final agent = ref.read(dayAgentProvider);
-    final captureId = await agent.submitCapture(
-      transcript: transcript,
-      capturedAt: _capturedAtForDay(day),
-      audioId: state.audioId,
-    );
-    if (!context.mounted) return;
-    WoltModalSheet.of(context).pushPage(
-      _reconcileStepPage(context, day, captureId),
-    );
-    ref.read(captureControllerProvider.notifier).reset();
+    try {
+      final captureId = await agent.submitCapture(
+        transcript: transcript,
+        capturedAt: _capturedAtForDay(widget.day),
+        audioId: state.audioId,
+      );
+      if (!mounted) return;
+      // Capture the sheet state here (a live context): the pushed page's
+      // back action must not close over this bar's context, which is defunct
+      // once the Reconcile page replaces it.
+      final sheet = WoltModalSheet.of(context);
+      sheet.pushPage(
+        _reconcileStepPage(
+          context,
+          widget.day,
+          captureId,
+          onBack: sheet.popPage,
+        ),
+      );
+      ref.read(captureControllerProvider.notifier).reset();
+    } finally {
+      if (mounted) setState(() => _submitting = false);
+    }
   }
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final messages = context.messages;
     final state = ref.watch(captureControllerProvider);
@@ -167,13 +210,14 @@ class _CaptureStepBar extends ConsumerWidget {
     final Widget actions;
     switch (state.phase) {
       case CapturePhase.captured:
-        final canContinue = state.transcript.trim().isNotEmpty;
+        final canContinue = state.transcript.trim().isNotEmpty && !_submitting;
         actions = Row(
           children: [
             Expanded(
               child: DsGlassPill(
                 icon: Icons.mic_rounded,
                 label: messages.dailyOsNextReconcileReRecord,
+                enabled: !_submitting,
                 onTap: () =>
                     ref.read(captureControllerProvider.notifier).reset(),
               ),
@@ -185,7 +229,8 @@ class _CaptureStepBar extends ConsumerWidget {
                 label: messages.dailyOsNextCaptureReconcileCta,
                 fillColor: tokens.colors.interactive.enabled,
                 foregroundColor: tokens.colors.text.onInteractiveAlert,
-                onTap: canContinue ? () => _continue(context, ref) : () {},
+                enabled: canContinue,
+                onTap: _continue,
               ),
             ),
           ],
@@ -218,12 +263,13 @@ class _CaptureStepBar extends ConsumerWidget {
 SliverWoltModalSheetPage _reconcileStepPage(
   BuildContext context,
   DateTime day,
-  CaptureId captureId,
-) {
+  CaptureId captureId, {
+  required VoidCallback onBack,
+}) {
   final params = ReconcileParams(captureId: captureId, dayDate: day);
   return ModalUtils.sliverModalSheetPage(
     context: context,
-    onTapBack: () => WoltModalSheet.of(context).popPage(),
+    onTapBack: onBack,
     slivers: [
       SliverToBoxAdapter(child: _ReconcileStepContent(params: params)),
       const SliverToBoxAdapter(child: SizedBox(height: _barClearance)),
@@ -276,12 +322,14 @@ class _ReconcileStepBar extends ConsumerWidget {
     final data = ref.read(reconcileControllerProvider(params)).value;
     if (data == null) return;
     final selections = reconcileDraftingSelections(data);
-    WoltModalSheet.of(context).pushPage(
+    final sheet = WoltModalSheet.of(context);
+    sheet.pushPage(
       _draftingStepPage(
         context,
         day: day,
         captureId: params.captureId,
         selections: selections,
+        onBack: sheet.popPage,
       ),
     );
   }
@@ -328,6 +376,7 @@ SliverWoltModalSheetPage _draftingStepPage(
   required DateTime day,
   required CaptureId captureId,
   required ({List<String> taskIds, List<String> captureItemIds}) selections,
+  required VoidCallback onBack,
 }) {
   final params = DraftingParams(
     captureId: captureId,
@@ -337,7 +386,7 @@ SliverWoltModalSheetPage _draftingStepPage(
   );
   return ModalUtils.sliverModalSheetPage(
     context: context,
-    onTapBack: () => WoltModalSheet.of(context).popPage(),
+    onTapBack: onBack,
     showCloseButton: false,
     slivers: [
       SliverToBoxAdapter(
@@ -379,7 +428,14 @@ class _DraftingStepContentState extends ConsumerState<_DraftingStepContent> {
           WidgetsBinding.instance.addPostFrameCallback((_) {
             if (!mounted) return;
             ref.invalidate(currentDraftPlanProvider(widget.day));
-            Navigator.of(context).pop();
+            // Only auto-close if the modal is still the current route — a
+            // competing dismissal (close button / barrier tap) within the
+            // same frame can already be popping it, and a second pop would
+            // target the surface beneath.
+            final route = ModalRoute.of(context);
+            if (route?.isCurrent ?? false) {
+              Navigator.of(context).pop();
+            }
           });
         }
       },

--- a/lib/features/daily_os_next/ui/pages/day_planning_modal.dart
+++ b/lib/features/daily_os_next/ui/pages/day_planning_modal.dart
@@ -122,16 +122,10 @@ double _stepViewportHeight(BuildContext context) =>
 
 DateTime _capturedAtForDay(DateTime day) {
   final now = clock.now();
-  return DateTime(
-    day.year,
-    day.month,
-    day.day,
-    now.hour,
-    now.minute,
-    now.second,
-    now.millisecond,
-    now.microsecond,
-  );
+  // Preserve [day]'s timezone by adding the elapsed time since midnight,
+  // rather than mixing [day]'s date with [now]'s wall-clock components.
+  // `clock.now()` is always local here, so local midnight is correct.
+  return day.add(now.difference(DateTime(now.year, now.month, now.day)));
 }
 
 // ─────────────────────────────── Capture ───────────────────────────────
@@ -329,22 +323,33 @@ class _ReconcileStepContent extends ConsumerWidget {
   }
 }
 
-class _ReconcileStepBar extends ConsumerWidget {
+class _ReconcileStepBar extends ConsumerStatefulWidget {
   const _ReconcileStepBar({required this.params, required this.day});
 
   final ReconcileParams params;
   final DateTime day;
 
-  void _buildDay(BuildContext context, WidgetRef ref) {
-    final data = ref.read(reconcileControllerProvider(params)).value;
+  @override
+  ConsumerState<_ReconcileStepBar> createState() => _ReconcileStepBarState();
+}
+
+class _ReconcileStepBarState extends ConsumerState<_ReconcileStepBar> {
+  /// True once "Build my day" has pushed the Drafting page — guards against
+  /// rapid re-taps stacking duplicate Drafting steps on the modal navigator.
+  bool _pushing = false;
+
+  void _buildDay() {
+    if (_pushing) return;
+    final data = ref.read(reconcileControllerProvider(widget.params)).value;
     if (data == null) return;
+    setState(() => _pushing = true);
     final selections = reconcileDraftingSelections(data);
     final sheet = WoltModalSheet.of(context);
     sheet.pushPage(
       _draftingStepPage(
         context,
-        day: day,
-        captureId: params.captureId,
+        day: widget.day,
+        captureId: widget.params.captureId,
         selections: selections,
         onBack: sheet.popPage,
       ),
@@ -352,10 +357,11 @@ class _ReconcileStepBar extends ConsumerWidget {
   }
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final messages = context.messages;
-    final state = ref.watch(reconcileControllerProvider(params));
+    final state = ref.watch(reconcileControllerProvider(widget.params));
+    final canBuild = state.hasValue && !_pushing;
 
     return DayPlanningGlassActionBar(
       topSlot: DayPlanningThinkingShader(
@@ -367,6 +373,7 @@ class _ReconcileStepBar extends ConsumerWidget {
             child: DsGlassPill(
               icon: Icons.mic_rounded,
               label: messages.dailyOsNextReconcileReRecord,
+              enabled: !_pushing,
               onTap: () => WoltModalSheet.of(context).popPage(),
             ),
           ),
@@ -377,7 +384,8 @@ class _ReconcileStepBar extends ConsumerWidget {
               label: messages.dailyOsNextReconcileBuildDayCta,
               fillColor: tokens.colors.interactive.enabled,
               foregroundColor: tokens.colors.text.onInteractiveAlert,
-              onTap: () => _buildDay(context, ref),
+              enabled: canBuild,
+              onTap: _buildDay,
             ),
           ),
         ],

--- a/lib/features/daily_os_next/ui/pages/day_planning_modal.dart
+++ b/lib/features/daily_os_next/ui/pages/day_planning_modal.dart
@@ -1,0 +1,466 @@
+import 'package:clock/clock.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
+import 'package:lotti/features/daily_os_next/state/capture_controller.dart';
+import 'package:lotti/features/daily_os_next/state/day_agent_provider.dart';
+import 'package:lotti/features/daily_os_next/state/drafting_controller.dart';
+import 'package:lotti/features/daily_os_next/state/reconcile_controller.dart';
+import 'package:lotti/features/daily_os_next/state/refine_controller.dart';
+import 'package:lotti/features/daily_os_next/ui/pages/capture_page.dart';
+import 'package:lotti/features/daily_os_next/ui/pages/drafting_page.dart';
+import 'package:lotti/features/daily_os_next/ui/pages/reconcile_page.dart';
+import 'package:lotti/features/daily_os_next/ui/pages/refine_page.dart';
+import 'package:lotti/features/daily_os_next/ui/widgets/day_planning_glass_action_bar.dart';
+import 'package:lotti/features/daily_os_next/ui/widgets/day_planning_thinking_shader.dart';
+import 'package:lotti/features/design_system/components/glass_action_bar.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/widgets/misc/wolt_modal_config.dart';
+import 'package:lotti/widgets/modal/modal_utils.dart';
+import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
+
+/// What the day-planning modal opens to.
+sealed class DayPlanningIntent {
+  const DayPlanningIntent();
+}
+
+/// Start a brand-new plan: Capture → Reconcile → Drafting.
+class DayPlanningCreate extends DayPlanningIntent {
+  const DayPlanningCreate();
+}
+
+/// Adapt an existing plan via the voice-driven Refine step.
+class DayPlanningAdapt extends DayPlanningIntent {
+  const DayPlanningAdapt(this.draft);
+
+  final DraftPlan draft;
+}
+
+/// Opens the day-planning interaction as a full-height modal layer that
+/// covers the app's bottom navigation.
+///
+/// The interaction is a Wolt multi-page sheet pushed on the **root**
+/// navigator with [WoltModalType.bottomSheet] `forceMaxHeight`, so it sits
+/// above the shell (mobile) or renders as a dialog (wide). Each step is a
+/// page whose `stickyActionBar` is a [DayPlanningGlassActionBar] carrying
+/// the AI thinking shader at its top edge; the step bodies are the
+/// scaffold-free `*ModalContent` widgets. Steps advance via
+/// `WoltModalSheet.of(context).pushPage(...)` and retreat via `popPage()`.
+///
+/// On create, the Drafting step closes the whole modal once the plan is
+/// ready and invalidates [currentDraftPlanProvider] so the day surface
+/// shows the new plan.
+Future<void> showDayPlanningModal({
+  required BuildContext context,
+  required DateTime dayDate,
+  required DayPlanningIntent intent,
+}) {
+  final isDark = Theme.of(context).brightness == Brightness.dark;
+  final day = DateTime(dayDate.year, dayDate.month, dayDate.day);
+
+  return WoltModalSheet.show<void>(
+    context: context,
+    useRootNavigator: true,
+    modalTypeBuilder: _dayPlanningModalType,
+    barrierDismissible: true,
+    modalBarrierColor: ModalUtils.getModalBarrierColor(
+      isDark: isDark,
+      context: context,
+    ),
+    pageListBuilder: (modalContext) => [
+      switch (intent) {
+        DayPlanningCreate() => _captureStepPage(modalContext, day),
+        DayPlanningAdapt(:final draft) => _refineStepPage(modalContext, draft),
+      },
+    ],
+  );
+}
+
+/// Full-height bottom sheet on phones (covers the nav), dialog on wide.
+WoltModalType _dayPlanningModalType(BuildContext context) {
+  final width = MediaQuery.of(context).size.width;
+  if (width < WoltModalConfig.pageBreakpoint) {
+    // Full-height bottom sheet so the layer covers the bottom nav and the
+    // centered Capture/Drafting steps have a bounded viewport to fill.
+    return const WoltBottomSheetType(forceMaxHeight: true);
+  }
+  return WoltModalType.dialog();
+}
+
+/// Bottom padding reserved under scrolling step content so the last rows
+/// clear the sticky glass action bar.
+const double _barClearance = 112;
+
+/// Height given to step bodies that center/fill or scroll internally
+/// (Capture, Drafting, Refine). Wolt lays page content in a
+/// shrink-wrapping viewport (unbounded height), so those bodies — which
+/// rely on a bounded box for `Expanded`/`SingleChildScrollView` — need an
+/// explicit height rather than `SliverFillRemaining`. Sized as a fraction
+/// of the screen so the full-height sheet reads as a calm, near-full layer
+/// with the sticky bar docked below.
+double _stepViewportHeight(BuildContext context) =>
+    MediaQuery.sizeOf(context).height * 0.72;
+
+DateTime _capturedAtForDay(DateTime day) {
+  final now = clock.now();
+  return DateTime(
+    day.year,
+    day.month,
+    day.day,
+    now.hour,
+    now.minute,
+    now.second,
+    now.millisecond,
+    now.microsecond,
+  );
+}
+
+// ─────────────────────────────── Capture ───────────────────────────────
+
+SliverWoltModalSheetPage _captureStepPage(
+  BuildContext context,
+  DateTime day,
+) {
+  return ModalUtils.sliverModalSheetPage(
+    context: context,
+    slivers: [
+      SliverToBoxAdapter(
+        child: SizedBox(
+          height: _stepViewportHeight(context),
+          child: CaptureModalContent(forDate: day),
+        ),
+      ),
+    ],
+    stickyActionBar: _CaptureStepBar(day: day),
+  );
+}
+
+class _CaptureStepBar extends ConsumerWidget {
+  const _CaptureStepBar({required this.day});
+
+  final DateTime day;
+
+  Future<void> _continue(BuildContext context, WidgetRef ref) async {
+    final state = ref.read(captureControllerProvider);
+    final transcript = state.transcript.trim();
+    if (transcript.isEmpty) return;
+    final agent = ref.read(dayAgentProvider);
+    final captureId = await agent.submitCapture(
+      transcript: transcript,
+      capturedAt: _capturedAtForDay(day),
+      audioId: state.audioId,
+    );
+    if (!context.mounted) return;
+    WoltModalSheet.of(context).pushPage(
+      _reconcileStepPage(context, day, captureId),
+    );
+    ref.read(captureControllerProvider.notifier).reset();
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final tokens = context.designTokens;
+    final messages = context.messages;
+    final state = ref.watch(captureControllerProvider);
+
+    final Widget actions;
+    switch (state.phase) {
+      case CapturePhase.captured:
+        final canContinue = state.transcript.trim().isNotEmpty;
+        actions = Row(
+          children: [
+            Expanded(
+              child: DsGlassPill(
+                icon: Icons.mic_rounded,
+                label: messages.dailyOsNextReconcileReRecord,
+                onTap: () =>
+                    ref.read(captureControllerProvider.notifier).reset(),
+              ),
+            ),
+            SizedBox(width: tokens.spacing.step2),
+            Expanded(
+              child: DsGlassPill(
+                icon: Icons.arrow_forward_rounded,
+                label: messages.dailyOsNextCaptureReconcileCta,
+                fillColor: tokens.colors.interactive.enabled,
+                foregroundColor: tokens.colors.text.onInteractiveAlert,
+                onTap: canContinue ? () => _continue(context, ref) : () {},
+              ),
+            ),
+          ],
+        );
+      case CapturePhase.idle:
+      case CapturePhase.error:
+        actions = DsGlassPill(
+          icon: Icons.keyboard_rounded,
+          label: messages.dailyOsNextCaptureTypeInstead,
+          expand: true,
+          onTap: () =>
+              ref.read(captureControllerProvider.notifier).startTyping(),
+        );
+      case CapturePhase.listening:
+      case CapturePhase.transcribing:
+        actions = const SizedBox(width: double.infinity);
+    }
+
+    return DayPlanningGlassActionBar(
+      topSlot: DayPlanningThinkingShader(
+        isThinking: state.phase == CapturePhase.transcribing,
+      ),
+      actions: actions,
+    );
+  }
+}
+
+// ────────────────────────────── Reconcile ──────────────────────────────
+
+SliverWoltModalSheetPage _reconcileStepPage(
+  BuildContext context,
+  DateTime day,
+  CaptureId captureId,
+) {
+  final params = ReconcileParams(captureId: captureId, dayDate: day);
+  return ModalUtils.sliverModalSheetPage(
+    context: context,
+    onTapBack: () => WoltModalSheet.of(context).popPage(),
+    slivers: [
+      SliverToBoxAdapter(child: _ReconcileStepContent(params: params)),
+      const SliverToBoxAdapter(child: SizedBox(height: _barClearance)),
+    ],
+    stickyActionBar: _ReconcileStepBar(params: params, day: day),
+  );
+}
+
+class _ReconcileStepContent extends ConsumerWidget {
+  const _ReconcileStepContent({required this.params});
+
+  final ReconcileParams params;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final tokens = context.designTokens;
+    final state = ref.watch(reconcileControllerProvider(params));
+    return switch (state) {
+      _ when state.hasValue => ReconcileModalContent(
+        params: params,
+        data: state.requireValue,
+      ),
+      _ when state.hasError => Padding(
+        padding: EdgeInsets.all(tokens.spacing.step8),
+        child: Center(
+          child: Text(
+            context.messages.dailyOsNextGenericError,
+            textAlign: TextAlign.center,
+            style: tokens.typography.styles.body.bodyMedium.copyWith(
+              color: tokens.colors.text.mediumEmphasis,
+            ),
+          ),
+        ),
+      ),
+      _ => Padding(
+        padding: EdgeInsets.all(tokens.spacing.step10),
+        child: const Center(child: CircularProgressIndicator()),
+      ),
+    };
+  }
+}
+
+class _ReconcileStepBar extends ConsumerWidget {
+  const _ReconcileStepBar({required this.params, required this.day});
+
+  final ReconcileParams params;
+  final DateTime day;
+
+  void _buildDay(BuildContext context, WidgetRef ref) {
+    final data = ref.read(reconcileControllerProvider(params)).value;
+    if (data == null) return;
+    final selections = reconcileDraftingSelections(data);
+    WoltModalSheet.of(context).pushPage(
+      _draftingStepPage(
+        context,
+        day: day,
+        captureId: params.captureId,
+        selections: selections,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final tokens = context.designTokens;
+    final messages = context.messages;
+    final state = ref.watch(reconcileControllerProvider(params));
+
+    return DayPlanningGlassActionBar(
+      topSlot: DayPlanningThinkingShader(
+        isThinking: state.isLoading && !state.hasValue,
+      ),
+      actions: Row(
+        children: [
+          Expanded(
+            child: DsGlassPill(
+              icon: Icons.mic_rounded,
+              label: messages.dailyOsNextReconcileReRecord,
+              onTap: () => WoltModalSheet.of(context).popPage(),
+            ),
+          ),
+          SizedBox(width: tokens.spacing.step2),
+          Expanded(
+            child: DsGlassPill(
+              icon: Icons.arrow_forward_rounded,
+              label: messages.dailyOsNextReconcileBuildDayCta,
+              fillColor: tokens.colors.interactive.enabled,
+              foregroundColor: tokens.colors.text.onInteractiveAlert,
+              onTap: () => _buildDay(context, ref),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────── Drafting ──────────────────────────────
+
+SliverWoltModalSheetPage _draftingStepPage(
+  BuildContext context, {
+  required DateTime day,
+  required CaptureId captureId,
+  required ({List<String> taskIds, List<String> captureItemIds}) selections,
+}) {
+  final params = DraftingParams(
+    captureId: captureId,
+    decidedTaskIds: selections.taskIds,
+    decidedCaptureItemIds: selections.captureItemIds,
+    dayDate: day,
+  );
+  return ModalUtils.sliverModalSheetPage(
+    context: context,
+    onTapBack: () => WoltModalSheet.of(context).popPage(),
+    showCloseButton: false,
+    slivers: [
+      SliverToBoxAdapter(
+        child: SizedBox(
+          height: _stepViewportHeight(context),
+          child: _DraftingStepContent(params: params, day: day),
+        ),
+      ),
+    ],
+    stickyActionBar: _DraftingStepBar(params: params),
+  );
+}
+
+class _DraftingStepContent extends ConsumerStatefulWidget {
+  const _DraftingStepContent({required this.params, required this.day});
+
+  final DraftingParams params;
+  final DateTime day;
+
+  @override
+  ConsumerState<_DraftingStepContent> createState() =>
+      _DraftingStepContentState();
+}
+
+class _DraftingStepContentState extends ConsumerState<_DraftingStepContent> {
+  bool _advanced = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+
+    ref.listen<AsyncValue<DraftingState>>(
+      draftingControllerProvider(widget.params),
+      (previous, next) {
+        final value = next.value;
+        if (value == null || _advanced) return;
+        if (value.phase == DraftingPhase.ready && value.draft != null) {
+          _advanced = true;
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!mounted) return;
+            ref.invalidate(currentDraftPlanProvider(widget.day));
+            Navigator.of(context).pop();
+          });
+        }
+      },
+    );
+
+    final asyncState = ref.watch(draftingControllerProvider(widget.params));
+    return switch (asyncState) {
+      _ when asyncState.hasValue => DraftingModalContent(
+        state: asyncState.requireValue,
+      ),
+      _ when asyncState.hasError => Center(
+        child: Padding(
+          padding: EdgeInsets.all(tokens.spacing.step8),
+          child: Text(
+            context.messages.dailyOsNextGenericError,
+            textAlign: TextAlign.center,
+            style: tokens.typography.styles.body.bodyMedium.copyWith(
+              color: tokens.colors.text.mediumEmphasis,
+            ),
+          ),
+        ),
+      ),
+      _ => const Center(child: CircularProgressIndicator()),
+    };
+  }
+}
+
+class _DraftingStepBar extends ConsumerWidget {
+  const _DraftingStepBar({required this.params});
+
+  final DraftingParams params;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(draftingControllerProvider(params));
+    final isThinking =
+        state.isLoading || state.value?.phase == DraftingPhase.drafting;
+    return DayPlanningGlassActionBar(
+      topSlot: DayPlanningThinkingShader(isThinking: isThinking),
+      actions: const SizedBox(width: double.infinity),
+    );
+  }
+}
+
+// ──────────────────────────────── Refine ───────────────────────────────
+
+SliverWoltModalSheetPage _refineStepPage(
+  BuildContext context,
+  DraftPlan draft,
+) {
+  return ModalUtils.sliverModalSheetPage(
+    context: context,
+    title: context.messages.dailyOsNextRefineTitle,
+    slivers: [
+      SliverToBoxAdapter(
+        child: SizedBox(
+          height: _stepViewportHeight(context),
+          child: RefineModalContent(draft: draft),
+        ),
+      ),
+      const SliverToBoxAdapter(child: SizedBox(height: _barClearance)),
+    ],
+    stickyActionBar: _RefineStepBar(draft: draft),
+  );
+}
+
+class _RefineStepBar extends ConsumerWidget {
+  const _RefineStepBar({required this.draft});
+
+  final DraftPlan draft;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final phase = ref.watch(
+      refineControllerProvider(draft).select((s) => s.phase),
+    );
+    return DayPlanningGlassActionBar(
+      topSlot: DayPlanningThinkingShader(
+        isThinking: phase == RefinePhase.thinking,
+      ),
+      actions: const SizedBox(width: double.infinity),
+    );
+  }
+}

--- a/lib/features/daily_os_next/ui/pages/day_planning_modal.dart
+++ b/lib/features/daily_os_next/ui/pages/day_planning_modal.dart
@@ -19,6 +19,7 @@ import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/widgets/misc/wolt_modal_config.dart';
 import 'package:lotti/widgets/modal/modal_utils.dart';
+import 'package:lotti/widgets/modal/sized_wolt_dialog_type.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
 /// What the day-planning modal opens to.
@@ -63,7 +64,8 @@ Future<void> showDayPlanningModal({
   return WoltModalSheet.show<void>(
     context: context,
     useRootNavigator: true,
-    modalTypeBuilder: _dayPlanningModalType,
+    modalTypeBuilder: (modalContext) =>
+        _dayPlanningModalType(modalContext, intent),
     barrierDismissible: true,
     modalBarrierColor: ModalUtils.getModalBarrierColor(
       isDark: isDark,
@@ -78,15 +80,30 @@ Future<void> showDayPlanningModal({
   );
 }
 
-/// Full-height bottom sheet on phones (covers the nav), dialog on wide.
-WoltModalType _dayPlanningModalType(BuildContext context) {
+/// Target width of the desktop/tablet dialog. Wider than Wolt's default
+/// ~524px so the two-column Reconcile and Drafting steps and the learning
+/// cards have room to breathe; [SizedWoltDialogType] shrinks it to fit on
+/// narrower screens.
+const double _dayPlanningDialogWidth = 920;
+
+/// Bottom sheet on phones (covers the nav), dialog on wide.
+///
+/// The Create ritual (Capture → Reconcile → Drafting) runs as a calm
+/// full-height bottom sheet so it reads as a near-full layer; the Adapt
+/// (Refine) flow is a compact, content-sized panel that shouldn't stretch
+/// to fill the screen for its sparse voice content.
+WoltModalType _dayPlanningModalType(
+  BuildContext context,
+  DayPlanningIntent intent,
+) {
   final width = MediaQuery.of(context).size.width;
   if (width < WoltModalConfig.pageBreakpoint) {
-    // Full-height bottom sheet so the layer covers the bottom nav and the
-    // centered Capture/Drafting steps have a bounded viewport to fill.
-    return const WoltBottomSheetType(forceMaxHeight: true);
+    return switch (intent) {
+      DayPlanningCreate() => const WoltBottomSheetType(forceMaxHeight: true),
+      DayPlanningAdapt() => const WoltBottomSheetType(),
+    };
   }
-  return WoltModalType.dialog();
+  return const SizedWoltDialogType(preferredWidth: _dayPlanningDialogWidth);
 }
 
 /// Bottom padding reserved under scrolling step content so the last rows
@@ -490,12 +507,11 @@ SliverWoltModalSheetPage _refineStepPage(
     context: context,
     title: context.messages.dailyOsNextRefineTitle,
     slivers: [
-      SliverToBoxAdapter(
-        child: SizedBox(
-          height: _stepViewportHeight(context),
-          child: RefineModalContent(draft: draft),
-        ),
-      ),
+      // Refine's modal content is a content-sized scroll view (voice panel +
+      // diff rows), so let it size to its content instead of forcing the
+      // full step viewport height — otherwise the sparse idle state leaves a
+      // large empty gap below the orb.
+      SliverToBoxAdapter(child: RefineModalContent(draft: draft)),
       const SliverToBoxAdapter(child: SizedBox(height: _barClearance)),
     ],
     stickyActionBar: _RefineStepBar(draft: draft),

--- a/lib/features/daily_os_next/ui/pages/drafting_page.dart
+++ b/lib/features/daily_os_next/ui/pages/drafting_page.dart
@@ -115,11 +115,15 @@ class DraftingModalContent extends StatelessWidget {
 
   final DraftingState state;
 
+  /// Width at/above which the skeleton and learning cards sit side by side.
+  /// Compared against the actual available width (the modal/dialog box), not
+  /// the screen, so the dialog never forces two cramped columns.
+  static const double _twoColumnBreakpoint = 760;
+
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final teal = tokens.colors.interactive.enabled;
-    final isWide = MediaQuery.sizeOf(context).width >= 900;
 
     final left = Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -148,23 +152,29 @@ class DraftingModalContent extends StatelessWidget {
         Expanded(
           child: SingleChildScrollView(
             padding: EdgeInsets.all(tokens.spacing.step6),
-            child: isWide
-                ? Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Expanded(child: left),
-                      SizedBox(width: tokens.spacing.step6),
-                      Expanded(child: right),
-                    ],
-                  )
-                : Column(
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                final isWide = constraints.maxWidth >= _twoColumnBreakpoint;
+                if (!isWide) {
+                  return Column(
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
                       left,
                       SizedBox(height: tokens.spacing.step6),
                       right,
                     ],
-                  ),
+                  );
+                }
+                return Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Expanded(child: left),
+                    SizedBox(width: tokens.spacing.step6),
+                    Expanded(child: right),
+                  ],
+                );
+              },
+            ),
           ),
         ),
       ],

--- a/lib/features/daily_os_next/ui/pages/drafting_page.dart
+++ b/lib/features/daily_os_next/ui/pages/drafting_page.dart
@@ -88,7 +88,7 @@ class _DraftingPageState extends ConsumerState<DraftingPage> {
       backgroundColor: tokens.colors.background.level01,
       body: SafeArea(
         child: switch (asyncState) {
-          _ when asyncState.hasValue => _DraftingBody(
+          _ when asyncState.hasValue => DraftingModalContent(
             state: asyncState.requireValue,
           ),
           _ when asyncState.hasError => Center(
@@ -107,8 +107,11 @@ class _DraftingPageState extends ConsumerState<DraftingPage> {
   }
 }
 
-class _DraftingBody extends StatelessWidget {
-  const _DraftingBody({required this.state});
+/// Scaffold-free drafting wait content (indeterminate progress strip +
+/// reasoning skeleton / learning cards) for hosting inside the
+/// day-planning modal as well as the standalone [DraftingPage].
+class DraftingModalContent extends StatelessWidget {
+  const DraftingModalContent({required this.state, super.key});
 
   final DraftingState state;
 

--- a/lib/features/daily_os_next/ui/pages/reconcile_page.dart
+++ b/lib/features/daily_os_next/ui/pages/reconcile_page.dart
@@ -283,41 +283,91 @@ class _DefaultBehaviorHint extends StatelessWidget {
   }
 }
 
+/// The work the user has effectively committed to taking on for the day,
+/// derived from a reconcile result — the inputs the drafting step needs.
+///
+/// Matched/update parsed items and pending triage rows carry task IDs.
+/// NEW/unlinked parsed items carry parsed capture item IDs so drafting can
+/// still create tasks from the approved capture text before placing them.
+({List<String> taskIds, List<String> captureItemIds})
+reconcileDraftingSelections(ReconcileData data) {
+  final taskIds = <String>{};
+  final captureItemIds = <String>{};
+  for (final item in data.parsed) {
+    if (item.kind == ParsedItemKind.matched ||
+        item.kind == ParsedItemKind.update) {
+      final taskId = item.matchedTaskId;
+      if (taskId != null) {
+        taskIds.add(taskId);
+      } else {
+        captureItemIds.add(item.id);
+      }
+    } else {
+      captureItemIds.add(item.id);
+    }
+  }
+  for (final entry in data.triageDecisions.entries) {
+    final action = entry.value.action;
+    if (action == TriageAction.today || action == TriageAction.doNow) {
+      taskIds.add(entry.key);
+    }
+  }
+  return (taskIds: taskIds.toList(), captureItemIds: captureItemIds.toList());
+}
+
+/// Scaffold-free reconcile content (the Heard / Decide columns) for hosting
+/// inside the day-planning modal. Unlike [_ReconcileBody] it carries no
+/// footer — the modal's sticky glass action bar supplies the Re-record /
+/// Build day actions — and it does not scroll itself (the modal page's
+/// sliver scroll viewport owns scrolling).
+class ReconcileModalContent extends StatelessWidget {
+  const ReconcileModalContent({
+    required this.params,
+    required this.data,
+    super.key,
+  });
+
+  final ReconcileParams params;
+  final ReconcileData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final isWide = MediaQuery.sizeOf(context).width >= 720;
+    final heardColumn = _HeardColumn(params: params, items: data.parsed);
+    final decideColumn = _DecideColumn(params: params, items: data.pending);
+
+    return Padding(
+      padding: EdgeInsets.symmetric(
+        horizontal: tokens.spacing.step6,
+        vertical: tokens.spacing.step5,
+      ),
+      child: isWide
+          ? Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(flex: 6, child: heardColumn),
+                SizedBox(width: tokens.spacing.step6),
+                Expanded(flex: 5, child: decideColumn),
+              ],
+            )
+          : Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                heardColumn,
+                SizedBox(height: tokens.spacing.step6),
+                decideColumn,
+              ],
+            ),
+    );
+  }
+}
+
 class _ReconcileFooter extends StatelessWidget {
   const _ReconcileFooter({required this.params, required this.data});
 
   final ReconcileParams params;
   final ReconcileData data;
-
-  /// The work the user has effectively committed to taking on today.
-  ///
-  /// Matched/update parsed items and pending triage rows carry task IDs.
-  /// NEW/unlinked parsed items carry parsed capture item IDs so drafting can
-  /// still create tasks from the approved capture text before placing them.
-  ({List<String> taskIds, List<String> captureItemIds}) _draftingSelections() {
-    final taskIds = <String>{};
-    final captureItemIds = <String>{};
-    for (final item in data.parsed) {
-      if (item.kind == ParsedItemKind.matched ||
-          item.kind == ParsedItemKind.update) {
-        final taskId = item.matchedTaskId;
-        if (taskId != null) {
-          taskIds.add(taskId);
-        } else {
-          captureItemIds.add(item.id);
-        }
-      } else {
-        captureItemIds.add(item.id);
-      }
-    }
-    for (final entry in data.triageDecisions.entries) {
-      final action = entry.value.action;
-      if (action == TriageAction.today || action == TriageAction.doNow) {
-        taskIds.add(entry.key);
-      }
-    }
-    return (taskIds: taskIds.toList(), captureItemIds: captureItemIds.toList());
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -356,7 +406,7 @@ class _ReconcileFooter extends StatelessWidget {
     );
     final draftButton = FilledButton.icon(
       onPressed: () {
-        final selections = _draftingSelections();
+        final selections = reconcileDraftingSelections(data);
         Navigator.of(context).push<void>(
           MaterialPageRoute<void>(
             builder: (_) => DraftingPage(

--- a/lib/features/daily_os_next/ui/pages/reconcile_page.dart
+++ b/lib/features/daily_os_next/ui/pages/reconcile_page.dart
@@ -13,6 +13,16 @@ import 'package:lotti/features/design_system/theme/typography_helpers.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/widgets/nav_bar/design_system_bottom_navigation_bar.dart';
 
+/// Width at/above which the reconcile surface lays the Heard / Decide
+/// columns side by side; below it they stack. Shared by the page, the modal
+/// content, and the footer so the breakpoint can't drift between them.
+const double _reconcileTwoColumnBreakpoint = 720;
+
+/// Flex weights for the side-by-side Heard / Decide columns — the Heard
+/// column (parsed items) gets slightly more room than the Decide column.
+const int _heardColumnFlex = 6;
+const int _decideColumnFlex = 5;
+
 /// Second screen of the agentic loop — turn the spoken check-in into
 /// editable structure and fold in the existing corpus.
 ///
@@ -93,7 +103,8 @@ class _ReconcileBody extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final tokens = context.designTokens;
-    final isWide = MediaQuery.sizeOf(context).width >= 720;
+    final isWide =
+        MediaQuery.sizeOf(context).width >= _reconcileTwoColumnBreakpoint;
 
     final heardColumn = _HeardColumn(params: params, items: data.parsed);
     final decideColumn = _DecideColumn(
@@ -113,9 +124,9 @@ class _ReconcileBody extends ConsumerWidget {
                 ? Row(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Expanded(flex: 6, child: heardColumn),
+                      Expanded(flex: _heardColumnFlex, child: heardColumn),
                       SizedBox(width: tokens.spacing.step6),
-                      Expanded(flex: 5, child: decideColumn),
+                      Expanded(flex: _decideColumnFlex, child: decideColumn),
                     ],
                   )
                 : Column(
@@ -333,7 +344,8 @@ class ReconcileModalContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
-    final isWide = MediaQuery.sizeOf(context).width >= 720;
+    final isWide =
+        MediaQuery.sizeOf(context).width >= _reconcileTwoColumnBreakpoint;
     final heardColumn = _HeardColumn(params: params, items: data.parsed);
     final decideColumn = _DecideColumn(params: params, items: data.pending);
 
@@ -346,9 +358,9 @@ class ReconcileModalContent extends StatelessWidget {
           ? Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Expanded(flex: 6, child: heardColumn),
+                Expanded(flex: _heardColumnFlex, child: heardColumn),
                 SizedBox(width: tokens.spacing.step6),
-                Expanded(flex: 5, child: decideColumn),
+                Expanded(flex: _decideColumnFlex, child: decideColumn),
               ],
             )
           : Column(
@@ -373,7 +385,8 @@ class _ReconcileFooter extends StatelessWidget {
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final messages = context.messages;
-    final isWide = MediaQuery.sizeOf(context).width >= 720;
+    final isWide =
+        MediaQuery.sizeOf(context).width >= _reconcileTwoColumnBreakpoint;
     final buttonShape = RoundedRectangleBorder(
       borderRadius: BorderRadius.circular(tokens.radii.badgesPills),
     );

--- a/lib/features/daily_os_next/ui/pages/reconcile_page.dart
+++ b/lib/features/daily_os_next/ui/pages/reconcile_page.dart
@@ -1,9 +1,12 @@
 import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/features/agents/state/agent_query_providers.dart';
+import 'package:lotti/features/daily_os_next/agents/domain/day_agent_slots.dart';
 import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
 import 'package:lotti/features/daily_os_next/state/reconcile_controller.dart';
 import 'package:lotti/features/daily_os_next/ui/pages/drafting_page.dart';
+import 'package:lotti/features/daily_os_next/ui/widgets/day_planning_thinking_shader.dart';
 import 'package:lotti/features/daily_os_next/ui/widgets/parsed_card.dart';
 import 'package:lotti/features/daily_os_next/ui/widgets/pending_card.dart';
 import 'package:lotti/features/design_system/components/ds_dashed_border.dart';
@@ -154,6 +157,14 @@ class _HeardColumn extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final tokens = context.designTokens;
+    // While the capture-submitted parse wake is still running, the parsed
+    // cards haven't landed yet — surface the AI thinking shader above the
+    // empty placeholder so the column reads as "working", not "done/empty".
+    final isParsing =
+        ref
+            .watch(agentIsRunningProvider(dayAgentIdForDate(params.dayDate)))
+            .value ??
+        false;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -162,7 +173,11 @@ class _HeardColumn extends ConsumerWidget {
           count: items.length,
         ),
         SizedBox(height: tokens.spacing.step4),
-        if (items.isEmpty)
+        if (items.isEmpty) ...[
+          if (isParsing) ...[
+            const DayPlanningThinkingShader(isThinking: true),
+            SizedBox(height: tokens.spacing.step3),
+          ],
           DsDashedBorder(
             color: tokens.colors.decorative.level02,
             radius: tokens.radii.m,
@@ -177,6 +192,7 @@ class _HeardColumn extends ConsumerWidget {
               ),
             ),
           ),
+        ],
         for (final item in items) ...[
           ParsedCard(
             item: item,
@@ -344,8 +360,6 @@ class ReconcileModalContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
-    final isWide =
-        MediaQuery.sizeOf(context).width >= _reconcileTwoColumnBreakpoint;
     final heardColumn = _HeardColumn(params: params, items: data.parsed);
     final decideColumn = _DecideColumn(params: params, items: data.pending);
 
@@ -354,23 +368,32 @@ class ReconcileModalContent extends StatelessWidget {
         horizontal: tokens.spacing.step6,
         vertical: tokens.spacing.step5,
       ),
-      child: isWide
-          ? Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Expanded(flex: _heardColumnFlex, child: heardColumn),
-                SizedBox(width: tokens.spacing.step6),
-                Expanded(flex: _decideColumnFlex, child: decideColumn),
-              ],
-            )
-          : Column(
+      // Decide two-column vs stacked from the actual available width (the
+      // modal/dialog box), not the screen size — the dialog can be far
+      // narrower than the screen.
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final isWide = constraints.maxWidth >= _reconcileTwoColumnBreakpoint;
+          if (!isWide) {
+            return Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
                 heardColumn,
                 SizedBox(height: tokens.spacing.step6),
                 decideColumn,
               ],
-            ),
+            );
+          }
+          return Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(flex: _heardColumnFlex, child: heardColumn),
+              SizedBox(width: tokens.spacing.step6),
+              Expanded(flex: _decideColumnFlex, child: decideColumn),
+            ],
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/features/daily_os_next/ui/widgets/day_planning_glass_action_bar.dart
+++ b/lib/features/daily_os_next/ui/widgets/day_planning_glass_action_bar.dart
@@ -3,7 +3,7 @@ import 'package:lotti/features/design_system/components/glass_strip.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 
 /// Sticky glass action bar for the day-planning modal — the planner's
-/// counterpart to the task details [TaskActionBar].
+/// counterpart to the task details `TaskActionBar`.
 ///
 /// Built on the shared [DesignSystemGlassStrip] (top hairline + backdrop
 /// blur + scrim gradient), it stacks an optional [topSlot] (the AI thinking
@@ -35,7 +35,7 @@ class DayPlanningGlassActionBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final DsTokens tokens = context.designTokens;
+    final tokens = context.designTokens;
     final spacing = tokens.spacing;
 
     // The glass surface extends edge-to-edge into the system home-indicator

--- a/lib/features/daily_os_next/ui/widgets/day_planning_glass_action_bar.dart
+++ b/lib/features/daily_os_next/ui/widgets/day_planning_glass_action_bar.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/features/design_system/components/glass_strip.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+
+/// Sticky glass action bar for the day-planning modal — the planner's
+/// counterpart to the task details [TaskActionBar].
+///
+/// Built on the shared [DesignSystemGlassStrip] (top hairline + backdrop
+/// blur + scrim gradient), it stacks an optional [topSlot] (the AI thinking
+/// shader, riding the top edge of the bar) above an [actions] row. All of a
+/// planning step's clickable interactions live in [actions]; the body above
+/// stays display-only.
+///
+/// Used as each step's `stickyActionBar` inside the Wolt multi-page modal,
+/// so a single bar treatment carries across Capture → Reconcile → Drafting
+/// → Refine while the contents change per step.
+class DayPlanningGlassActionBar extends StatelessWidget {
+  const DayPlanningGlassActionBar({
+    required this.actions,
+    this.topSlot,
+    super.key,
+  });
+
+  /// The action row (buttons/pills). Laid out full-width below [topSlot].
+  final Widget actions;
+
+  /// Optional widget pinned to the top edge of the bar — the day-planning
+  /// thinking shader. Collapses to zero height when idle, so the bar keeps
+  /// its standard padding whether or not it is present.
+  final Widget? topSlot;
+
+  /// Stable test key for the optional top (shader) slot.
+  @visibleForTesting
+  static const Key topSlotKey = ValueKey('day-planning-action-bar-top-slot');
+
+  @override
+  Widget build(BuildContext context) {
+    final DsTokens tokens = context.designTokens;
+    final spacing = tokens.spacing;
+
+    // The glass surface extends edge-to-edge into the system home-indicator
+    // inset; the touchable row sits above it via the bottom padding.
+    final safeBottomInset = MediaQuery.paddingOf(context).bottom;
+
+    return DesignSystemGlassStrip(
+      child: Padding(
+        padding: EdgeInsets.fromLTRB(
+          spacing.step5,
+          spacing.step4,
+          spacing.step5,
+          spacing.step4 + safeBottomInset,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            if (topSlot != null) KeyedSubtree(key: topSlotKey, child: topSlot!),
+            actions,
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/daily_os_next/ui/widgets/day_planning_thinking_shader.dart
+++ b/lib/features/daily_os_next/ui/widgets/day_planning_thinking_shader.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/features/ai/ui/animation/ai_running_animation.dart';
+
+/// Day-planning variant of the Task Details "AI is thinking" decoder-bars
+/// shader.
+///
+/// Reuses [AiThinkingShaderPresence] — the exact same shader visual and
+/// fade/scale presence envelope used on the Task Details action bar — but
+/// is driven by the planner's own busy signal (capture transcribing,
+/// reconcile loading, drafting, or refine "thinking") rather than the
+/// per-entry inference provider that [AiRunningDecoderBars] watches.
+///
+/// Designed to sit in the `topSlot` of the day-planning glass action bar so
+/// the shader rides the top edge of the bar, mirroring Task Details.
+class DayPlanningThinkingShader extends StatelessWidget {
+  const DayPlanningThinkingShader({required this.isThinking, super.key});
+
+  /// Whether the day agent is currently working. Drives the presence
+  /// envelope: true fades/scales the shader in, false reverses it out.
+  final bool isThinking;
+
+  /// Stable key on the animated reserved-height box, for presence asserts.
+  @visibleForTesting
+  static const Key indicatorKey = ValueKey('day-planning-thinking-shader');
+
+  @override
+  Widget build(BuildContext context) {
+    return AiThinkingShaderPresence(
+      isRunning: isThinking,
+      indicatorKey: indicatorKey,
+    );
+  }
+}

--- a/lib/features/design_system/components/glass_action_bar.dart
+++ b/lib/features/design_system/components/glass_action_bar.dart
@@ -84,28 +84,34 @@ class DsGlassRoundButton extends StatelessWidget {
       child: Material(
         color: Colors.transparent,
         shape: const CircleBorder(),
-        child: InkWell(
-          customBorder: const CircleBorder(),
-          onTap: onPressed,
-          child: Container(
-            width: diameter,
-            height: diameter,
-            decoration: BoxDecoration(
-              color: backgroundColor ?? dsGlassChipFill(tokens),
-              shape: BoxShape.circle,
-            ),
-            // foregroundDecoration so the hairline outline doesn't eat
-            // into the icon's content rect — keeps the glyph centred.
-            foregroundDecoration: isTranslucent
-                ? BoxDecoration(
-                    shape: BoxShape.circle,
-                    border: dsGlassChipBorder(tokens),
-                  )
-                : null,
-            child: Icon(
-              icon,
-              size: iconSize,
-              color: iconColor ?? tokens.colors.text.highEmphasis,
+        // Background lives on [Ink] (not the inner Container) so the InkWell
+        // splash/highlight renders above it instead of being obscured.
+        child: Ink(
+          width: diameter,
+          height: diameter,
+          decoration: BoxDecoration(
+            color: backgroundColor ?? dsGlassChipFill(tokens),
+            shape: BoxShape.circle,
+          ),
+          child: InkWell(
+            customBorder: const CircleBorder(),
+            onTap: onPressed,
+            child: Container(
+              width: diameter,
+              height: diameter,
+              // foregroundDecoration so the hairline outline doesn't eat
+              // into the icon's content rect — keeps the glyph centred.
+              foregroundDecoration: isTranslucent
+                  ? BoxDecoration(
+                      shape: BoxShape.circle,
+                      border: dsGlassChipBorder(tokens),
+                    )
+                  : null,
+              child: Icon(
+                icon,
+                size: iconSize,
+                color: iconColor ?? tokens.colors.text.highEmphasis,
+              ),
             ),
           ),
         ),
@@ -201,26 +207,32 @@ class DsGlassPill extends StatelessWidget {
       excludeSemantics: true,
       child: Material(
         color: Colors.transparent,
-        child: InkWell(
-          borderRadius: pillRadius,
-          onTap: enabled ? onTap : null,
-          child: Container(
-            height: height,
-            width: expand ? double.infinity : null,
-            padding: EdgeInsets.symmetric(horizontal: spacing.step5),
-            decoration: BoxDecoration(
-              color: effectiveFill ?? dsGlassChipFill(tokens),
-              borderRadius: pillRadius,
+        // Background lives on [Ink] (not the inner Container) so the InkWell
+        // splash/highlight renders above it instead of being obscured.
+        child: Ink(
+          height: height,
+          width: expand ? double.infinity : null,
+          decoration: BoxDecoration(
+            color: effectiveFill ?? dsGlassChipFill(tokens),
+            borderRadius: pillRadius,
+          ),
+          child: InkWell(
+            borderRadius: pillRadius,
+            onTap: enabled ? onTap : null,
+            child: Container(
+              height: height,
+              width: expand ? double.infinity : null,
+              padding: EdgeInsets.symmetric(horizontal: spacing.step5),
+              // foregroundDecoration keeps the hairline a hairline without
+              // widening the pill (which would shift action-row layout).
+              foregroundDecoration: isTranslucent
+                  ? BoxDecoration(
+                      borderRadius: pillRadius,
+                      border: dsGlassChipBorder(tokens),
+                    )
+                  : null,
+              child: Center(widthFactor: expand ? null : 1, child: content),
             ),
-            // foregroundDecoration keeps the hairline a hairline without
-            // widening the pill (which would shift action-row layout).
-            foregroundDecoration: isTranslucent
-                ? BoxDecoration(
-                    borderRadius: pillRadius,
-                    border: dsGlassChipBorder(tokens),
-                  )
-                : null,
-            child: Center(widthFactor: expand ? null : 1, child: content),
           ),
         ),
       ),

--- a/lib/features/design_system/components/glass_action_bar.dart
+++ b/lib/features/design_system/components/glass_action_bar.dart
@@ -1,0 +1,215 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+
+/// Shared "glass chip" building blocks for sticky bottom action bars that
+/// float over backdrop-blurred glass (see [DesignSystemGlassStrip]).
+///
+/// These were originally private to the task details action bar
+/// (`task_action_bar.dart`). They live here so every sticky glass bar —
+/// the task details bar and the day-planning modal bar — shares one
+/// silhouette, one alpha tuning, and one hairline outline instead of
+/// drifting per-feature.
+///
+/// No `surface.*`/`glass.*` design token covers "chip on glass over
+/// arbitrary underlying content", so the alpha bumps below are
+/// intentionally defined here once rather than fragmenting across widgets.
+
+/// Alpha applied to the chip fill on top of `surface.focusPressed`. Sits
+/// above any `surface.*` token so the chip silhouette stays opaque enough
+/// to contrast the foreground against bright content (e.g. white chat
+/// bubbles or embedded screenshots bleeding through the glass blur).
+const double kDsGlassFillAlpha = 0.55;
+
+/// Alpha for the hairline outline drawn over the chip fill. Painted via
+/// `foregroundDecoration` so it doesn't widen the chip and trip
+/// action-row layout thresholds.
+const double kDsGlassBorderAlpha = 0.45;
+
+/// Translucent fill used by glass chips when the caller supplies no solid
+/// background colour.
+Color dsGlassChipFill(DsTokens tokens) =>
+    tokens.colors.surface.focusPressed.withValues(alpha: kDsGlassFillAlpha);
+
+/// Hairline outline drawn over a translucent glass chip.
+Border dsGlassChipBorder(DsTokens tokens) => Border.all(
+  color: tokens.colors.decorative.level01.withValues(
+    alpha: kDsGlassBorderAlpha,
+  ),
+);
+
+/// Circular icon-only action button used on glass bars.
+///
+/// [backgroundColor] / [iconColor] are optional overrides; when null the
+/// shared translucent glass-chip styling ([dsGlassChipFill] +
+/// [dsGlassChipBorder]) is used so the silhouette and glyph stay visible
+/// regardless of what's behind the bar. Callers that pass a solid
+/// [backgroundColor] (e.g. an active/alert state) bring their own
+/// contrast, so no hairline outline is drawn in that case.
+class DsGlassRoundButton extends StatelessWidget {
+  const DsGlassRoundButton({
+    required this.icon,
+    required this.semanticLabel,
+    required this.onPressed,
+    this.backgroundColor,
+    this.iconColor,
+    this.diameter = defaultDiameter,
+    this.iconSize = defaultIconSize,
+    super.key,
+  });
+
+  /// Default round-button diameter. Matches `tokens.spacing.step9` (48),
+  /// the standard hit-target; the design system has no dedicated
+  /// icon-button-size token.
+  static const double defaultDiameter = 48;
+
+  /// Default icon glyph size inside the round button.
+  static const double defaultIconSize = 20;
+
+  final IconData icon;
+  final String semanticLabel;
+  final VoidCallback onPressed;
+  final Color? backgroundColor;
+  final Color? iconColor;
+  final double diameter;
+  final double iconSize;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final isTranslucent = backgroundColor == null;
+    return Semantics(
+      button: true,
+      label: semanticLabel,
+      excludeSemantics: true,
+      child: Material(
+        color: Colors.transparent,
+        shape: const CircleBorder(),
+        child: InkWell(
+          customBorder: const CircleBorder(),
+          onTap: onPressed,
+          child: Container(
+            width: diameter,
+            height: diameter,
+            decoration: BoxDecoration(
+              color: backgroundColor ?? dsGlassChipFill(tokens),
+              shape: BoxShape.circle,
+            ),
+            // foregroundDecoration so the hairline outline doesn't eat
+            // into the icon's content rect — keeps the glyph centred.
+            foregroundDecoration: isTranslucent
+                ? BoxDecoration(
+                    shape: BoxShape.circle,
+                    border: dsGlassChipBorder(tokens),
+                  )
+                : null,
+            child: Icon(
+              icon,
+              size: iconSize,
+              color: iconColor ?? tokens.colors.text.highEmphasis,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Pill-shaped glass action button: an optional leading icon plus a label,
+/// one tap target.
+///
+/// Idle/translucent (no [fillColor]): the shared glass-chip styling with a
+/// hairline outline. Solid ([fillColor] set, e.g. the teal primary
+/// action): a filled pill with no outline. [expand] stretches the pill to
+/// fill its parent's width (centred content) for full-width primary
+/// actions; otherwise the pill hugs its content.
+class DsGlassPill extends StatelessWidget {
+  const DsGlassPill({
+    required this.label,
+    required this.onTap,
+    this.icon,
+    this.fillColor,
+    this.foregroundColor,
+    this.semanticLabel,
+    this.expand = false,
+    this.height = defaultHeight,
+    this.iconSize = DsGlassRoundButton.defaultIconSize,
+    super.key,
+  });
+
+  /// Default pill height — matches [DsGlassRoundButton.defaultDiameter] so
+  /// a pill and round buttons line up on the same action row.
+  static const double defaultHeight = DsGlassRoundButton.defaultDiameter;
+
+  final String label;
+  final VoidCallback onTap;
+  final IconData? icon;
+  final Color? fillColor;
+  final Color? foregroundColor;
+  final String? semanticLabel;
+  final bool expand;
+  final double height;
+  final double iconSize;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final spacing = tokens.spacing;
+    final isTranslucent = fillColor == null;
+    final foreground = foregroundColor ?? tokens.colors.text.highEmphasis;
+    final pillRadius = BorderRadius.circular(tokens.radii.badgesPills);
+    final textStyle = tokens.typography.styles.subtitle.subtitle2.copyWith(
+      color: foreground,
+    );
+
+    final content = Row(
+      mainAxisSize: expand ? MainAxisSize.max : MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        if (icon != null) ...[
+          Icon(icon, size: iconSize, color: foreground),
+          SizedBox(width: spacing.step2),
+        ],
+        Flexible(
+          child: Text(
+            label,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            textAlign: TextAlign.center,
+            style: textStyle,
+          ),
+        ),
+      ],
+    );
+
+    return Semantics(
+      button: true,
+      label: semanticLabel ?? label,
+      excludeSemantics: true,
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: pillRadius,
+          onTap: onTap,
+          child: Container(
+            height: height,
+            width: expand ? double.infinity : null,
+            padding: EdgeInsets.symmetric(horizontal: spacing.step5),
+            decoration: BoxDecoration(
+              color: fillColor ?? dsGlassChipFill(tokens),
+              borderRadius: pillRadius,
+            ),
+            // foregroundDecoration keeps the hairline a hairline without
+            // widening the pill (which would shift action-row layout).
+            foregroundDecoration: isTranslucent
+                ? BoxDecoration(
+                    borderRadius: pillRadius,
+                    border: dsGlassChipBorder(tokens),
+                  )
+                : null,
+            child: Center(widthFactor: expand ? null : 1, child: content),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/design_system/components/glass_action_bar.dart
+++ b/lib/features/design_system/components/glass_action_bar.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 
 /// Shared "glass chip" building blocks for sticky bottom action bars that
-/// float over backdrop-blurred glass (see [DesignSystemGlassStrip]).
+/// float over backdrop-blurred glass (see `DesignSystemGlassStrip`).
 ///
 /// These were originally private to the task details action bar
 /// (`task_action_bar.dart`). They live here so every sticky glass bar —
@@ -122,6 +122,12 @@ class DsGlassRoundButton extends StatelessWidget {
 /// action): a filled pill with no outline. [expand] stretches the pill to
 /// fill its parent's width (centred content) for full-width primary
 /// actions; otherwise the pill hugs its content.
+///
+/// When [enabled] is false the pill renders as a non-actionable affordance:
+/// the solid [fillColor] is dropped for the translucent glass treatment, the
+/// foreground dims to `text.lowEmphasis`, [onTap] is not wired, and the
+/// `Semantics` node reports `enabled: false` so assistive tech doesn't
+/// announce it as a live button.
 class DsGlassPill extends StatelessWidget {
   const DsGlassPill({
     required this.label,
@@ -131,6 +137,7 @@ class DsGlassPill extends StatelessWidget {
     this.foregroundColor,
     this.semanticLabel,
     this.expand = false,
+    this.enabled = true,
     this.height = defaultHeight,
     this.iconSize = DsGlassRoundButton.defaultIconSize,
     super.key,
@@ -147,6 +154,7 @@ class DsGlassPill extends StatelessWidget {
   final Color? foregroundColor;
   final String? semanticLabel;
   final bool expand;
+  final bool enabled;
   final double height;
   final double iconSize;
 
@@ -154,8 +162,13 @@ class DsGlassPill extends StatelessWidget {
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final spacing = tokens.spacing;
-    final isTranslucent = fillColor == null;
-    final foreground = foregroundColor ?? tokens.colors.text.highEmphasis;
+    // Disabled pills drop any solid fill for the translucent glass treatment
+    // and dim the foreground, so they read as non-actionable.
+    final effectiveFill = enabled ? fillColor : null;
+    final isTranslucent = effectiveFill == null;
+    final foreground = enabled
+        ? (foregroundColor ?? tokens.colors.text.highEmphasis)
+        : tokens.colors.text.lowEmphasis;
     final pillRadius = BorderRadius.circular(tokens.radii.badgesPills);
     final textStyle = tokens.typography.styles.subtitle.subtitle2.copyWith(
       color: foreground,
@@ -183,19 +196,20 @@ class DsGlassPill extends StatelessWidget {
 
     return Semantics(
       button: true,
+      enabled: enabled,
       label: semanticLabel ?? label,
       excludeSemantics: true,
       child: Material(
         color: Colors.transparent,
         child: InkWell(
           borderRadius: pillRadius,
-          onTap: onTap,
+          onTap: enabled ? onTap : null,
           child: Container(
             height: height,
             width: expand ? double.infinity : null,
             padding: EdgeInsets.symmetric(horizontal: spacing.step5),
             decoration: BoxDecoration(
-              color: fillColor ?? dsGlassChipFill(tokens),
+              color: effectiveFill ?? dsGlassChipFill(tokens),
               borderRadius: pillRadius,
             ),
             // foregroundDecoration keeps the hairline a hairline without

--- a/lib/features/tasks/ui/widgets/task_action_bar.dart
+++ b/lib/features/tasks/ui/widgets/task_action_bar.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/ai/helpers/automatic_image_analysis_trigger.dart';
+import 'package:lotti/features/design_system/components/glass_action_bar.dart';
 import 'package:lotti/features/design_system/components/glass_strip.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/journal/state/entry_controller.dart';
@@ -114,25 +115,6 @@ class TaskActionBar extends ConsumerStatefulWidget {
   @override
   ConsumerState<TaskActionBar> createState() => _TaskActionBarState();
 }
-
-/// Shared "glass chip" styling values used by both [_TrackTimePill] (idle
-/// state) and [_RoundActionButton] (when no caller override is supplied).
-///
-/// These exist as file-level constants so the alpha bumps stay in sync
-/// across the action bar — no `surface.*` token covers "chip on glass
-/// over arbitrary underlying content", so the values are intentionally
-/// hard-coded here rather than fragmenting across widgets.
-
-/// Alpha applied to the chip fill on top of `surface.focusPressed`. Sits
-/// above any `surface.*` token so the chip silhouette stays opaque
-/// enough to contrast the foreground against bright content (e.g. white
-/// chat bubbles or embedded screenshots bleeding through the glass blur).
-const double _glassFillAlpha = 0.55;
-
-/// Alpha for the hairline outline drawn over the chip fill. Painted via
-/// `foregroundDecoration` so it doesn't widen the chip and trip the
-/// action-row layout thresholds.
-const double _glassBorderAlpha = 0.45;
 
 class _TaskActionBarState extends ConsumerState<TaskActionBar> {
   final TimeService _timeService = getIt<TimeService>();
@@ -349,7 +331,7 @@ class _TaskActionBarState extends ConsumerState<TaskActionBar> {
                       onStop: _onStopTimer,
                     ),
                     SizedBox(width: spacing.step4),
-                    _RoundActionButton(
+                    DsGlassRoundButton(
                       key: TaskActionBar.audioKey,
                       icon: Icons.mic_rounded,
                       semanticLabel: isRecordingAudio
@@ -363,7 +345,7 @@ class _TaskActionBarState extends ConsumerState<TaskActionBar> {
                     ),
                     if (showChecklist) ...[
                       SizedBox(width: spacing.step4),
-                      _RoundActionButton(
+                      DsGlassRoundButton(
                         key: TaskActionBar.checklistKey,
                         icon: Icons.checklist_rounded,
                         semanticLabel: messages.addActionAddChecklist,
@@ -372,7 +354,7 @@ class _TaskActionBarState extends ConsumerState<TaskActionBar> {
                     ],
                     if (showImage) ...[
                       SizedBox(width: spacing.step4),
-                      _RoundActionButton(
+                      DsGlassRoundButton(
                         key: TaskActionBar.imageKey,
                         icon: Icons.image_rounded,
                         semanticLabel: messages.addActionImportImage,
@@ -380,7 +362,7 @@ class _TaskActionBarState extends ConsumerState<TaskActionBar> {
                       ),
                     ],
                     SizedBox(width: spacing.step4),
-                    _RoundActionButton(
+                    DsGlassRoundButton(
                       key: TaskActionBar.moreKey,
                       icon: Icons.more_horiz_rounded,
                       semanticLabel: messages.taskActionBarMoreActions,

--- a/lib/features/tasks/ui/widgets/task_action_bar.dart
+++ b/lib/features/tasks/ui/widgets/task_action_bar.dart
@@ -35,8 +35,10 @@ part 'task_action_bar_buttons.dart';
 ///   items like Event / Text / Paste image / link to event / capture
 ///   screenshot — the latter is desktop-only inside that menu)
 ///
-/// The action row is a [Wrap], so on narrow viewports — typically
-/// phones — the trailing icons reflow onto a second run instead of
+/// The action row is a single [Row] with width-based priority drop: on
+/// narrow viewports the lower-priority trailing icons (image, then
+/// checklist) are hidden once the inner width falls below
+/// [minWidthForImageButton] / [minWidthForChecklistButton] instead of
 /// overflowing the right edge.
 class TaskActionBar extends ConsumerStatefulWidget {
   const TaskActionBar({

--- a/lib/features/tasks/ui/widgets/task_action_bar_buttons.dart
+++ b/lib/features/tasks/ui/widgets/task_action_bar_buttons.dart
@@ -1,6 +1,7 @@
-// The action bar's pill and round-button widgets — part of the
-// task_action_bar library so they share the file-level glass-chip
-// styling constants.
+// The action bar's Track time pill widgets — part of the
+// task_action_bar library. Glass-chip fill/outline styling comes from the
+// shared `glass_action_bar.dart` helpers (`dsGlassChipFill` /
+// `dsGlassChipBorder`); the round affordances use `DsGlassRoundButton`.
 part of 'task_action_bar.dart';
 
 /// Primary "Track time" pill.
@@ -44,9 +45,7 @@ class _TrackTimePill extends StatelessWidget {
     // underlying content without losing the glass aesthetic.
     final fillColor = isTracking
         ? tokens.colors.alert.error.defaultColor
-        : tokens.colors.surface.focusPressed.withValues(
-            alpha: _glassFillAlpha,
-          );
+        : dsGlassChipFill(tokens);
     // The error palette has no dedicated on-color token — its
     // defaultColor is a vivid red across both themes, so a fixed white
     // foreground stays legible on top.
@@ -96,11 +95,7 @@ class _TrackTimePill extends StatelessWidget {
                 ? null
                 : BoxDecoration(
                     borderRadius: pillRadius,
-                    border: Border.all(
-                      color: tokens.colors.decorative.level01.withValues(
-                        alpha: _glassBorderAlpha,
-                      ),
-                    ),
+                    border: dsGlassChipBorder(tokens),
                   ),
             child: ConstrainedBox(
               constraints: BoxConstraints(minWidth: idleContentWidth),
@@ -209,82 +204,6 @@ class _PillStopButton extends StatelessWidget {
               Icons.stop_rounded,
               size: TaskActionBar.pillStopIconSize,
               color: Colors.white,
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-/// Circular icon-only action button — the round affordances after the
-/// Track time pill. [backgroundColor] / [iconColor] are optional
-/// overrides; when null, the default surface-hover + high-emphasis
-/// colors are used. The audio button passes the alert-error fill while
-/// a recording session for the open task is active.
-class _RoundActionButton extends StatelessWidget {
-  const _RoundActionButton({
-    required this.icon,
-    required this.semanticLabel,
-    required this.onPressed,
-    this.backgroundColor,
-    this.iconColor,
-    super.key,
-  });
-
-  final IconData icon;
-  final String semanticLabel;
-  final VoidCallback onPressed;
-  final Color? backgroundColor;
-  final Color? iconColor;
-
-  @override
-  Widget build(BuildContext context) {
-    final tokens = context.designTokens;
-    // Round buttons sit on a translucent glass strip; when no caller
-    // override is supplied the chip uses the shared "glass chip"
-    // styling (`_glassFillAlpha`, `_glassBorderAlpha`) so the
-    // silhouette and glyph stay visible regardless of what's behind the
-    // bar. Caller overrides (e.g. recording = solid red) already carry
-    // their own contrast.
-    final isTranslucent = backgroundColor == null;
-    final defaultFill = tokens.colors.surface.focusPressed.withValues(
-      alpha: _glassFillAlpha,
-    );
-    return Semantics(
-      button: true,
-      label: semanticLabel,
-      excludeSemantics: true,
-      child: Material(
-        color: Colors.transparent,
-        shape: const CircleBorder(),
-        child: InkWell(
-          customBorder: const CircleBorder(),
-          onTap: onPressed,
-          child: Container(
-            width: TaskActionBar.buttonSize,
-            height: TaskActionBar.buttonSize,
-            decoration: BoxDecoration(
-              color: backgroundColor ?? defaultFill,
-              shape: BoxShape.circle,
-            ),
-            // foregroundDecoration so the hairline outline doesn't eat
-            // into the icon's content rect — keeps the icon centered
-            // exactly the same as before the outline was added.
-            foregroundDecoration: isTranslucent
-                ? BoxDecoration(
-                    shape: BoxShape.circle,
-                    border: Border.all(
-                      color: tokens.colors.decorative.level01.withValues(
-                        alpha: _glassBorderAlpha,
-                      ),
-                    ),
-                  )
-                : null,
-            child: Icon(
-              icon,
-              size: TaskActionBar.iconSize,
-              color: iconColor ?? tokens.colors.text.highEmphasis,
             ),
           ),
         ),

--- a/lib/widgets/modal/sized_wolt_dialog_type.dart
+++ b/lib/widgets/modal/sized_wolt_dialog_type.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
+
+/// A [WoltDialogType] whose target width is configurable.
+///
+/// Wolt's default [WoltDialogType] hard-codes the dialog width to the small
+/// breakpoint (~524px), which is too narrow for rich content such as the
+/// day-planning modal's two-column Reconcile and Drafting layouts. This
+/// subclass keeps Wolt's centering, shape, and transitions but renders the
+/// dialog at [preferredWidth] on screens large enough to host it, shrinking
+/// to fit (less the standard dialog padding) on narrower screens.
+class SizedWoltDialogType extends WoltDialogType {
+  const SizedWoltDialogType({required this.preferredWidth});
+
+  /// Target dialog width on screens with room for it.
+  final double preferredWidth;
+
+  @override
+  BoxConstraints layoutModal(Size availableSize) {
+    final available = availableSize.width - WoltDialogType.minPadding;
+    var width = available < preferredWidth ? available : preferredWidth;
+    if (width < 0) width = 0;
+    var maxHeight = availableSize.height * 0.8;
+    if (maxHeight < 360) maxHeight = 360;
+    return BoxConstraints(
+      minWidth: width,
+      maxWidth: width,
+      maxHeight: maxHeight,
+    );
+  }
+}

--- a/test/features/ai/ui/animation/ai_running_animation_test.dart
+++ b/test/features/ai/ui/animation/ai_running_animation_test.dart
@@ -1245,4 +1245,54 @@ void main() {
       );
     });
   });
+
+  group('AiThinkingShaderPresence', () {
+    const key = ValueKey('presence-box');
+
+    testWidgets('adopts a new transitionDuration on rebuild', (tester) async {
+      // Seeded fully shown at mount with a short exit duration.
+      await tester.pumpWidget(
+        makeTestableWidget(
+          const Center(
+            child: AiThinkingShaderPresence(
+              isRunning: true,
+              transitionDuration: Duration(milliseconds: 100),
+              indicatorKey: key,
+            ),
+          ),
+        ),
+      );
+      expect(find.byKey(key), findsOneWidget);
+
+      // Rebuild with isRunning false AND a much longer transitionDuration:
+      // didUpdateWidget must adopt the new duration for the exit animation.
+      await tester.pumpWidget(
+        makeTestableWidget(
+          const Center(
+            child: AiThinkingShaderPresence(
+              isRunning: false,
+              transitionDuration: Duration(seconds: 1),
+              indicatorKey: key,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // Past the OLD 100ms duration the shader would be gone; with the
+      // adopted 1s duration it is still mid-exit.
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(find.byKey(key), findsOneWidget);
+      final shader = tester.widget<AiThinkingLineShader>(
+        find.byType(AiThinkingLineShader),
+      );
+      expect(shader.opacity, greaterThan(0));
+      expect(shader.opacity, lessThan(1));
+
+      // After the full new duration it collapses away.
+      await tester.pump(const Duration(seconds: 1));
+      expect(find.byKey(key), findsNothing);
+      expect(find.byType(AiThinkingLineShader), findsNothing);
+    });
+  });
 }

--- a/test/features/daily_os_next/ui/pages/capture_page_test.dart
+++ b/test/features/daily_os_next/ui/pages/capture_page_test.dart
@@ -18,6 +18,7 @@ import 'package:lotti/features/daily_os_next/state/reconcile_controller.dart';
 import 'package:lotti/features/daily_os_next/ui/pages/capture_page.dart';
 import 'package:lotti/features/daily_os_next/ui/pages/reconcile_page.dart';
 import 'package:lotti/features/daily_os_next/ui/widgets/live_waveform.dart';
+import 'package:lotti/features/daily_os_next/ui/widgets/time_spent_card.dart';
 import 'package:lotti/features/daily_os_next/ui/widgets/voice_button.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/sync/vector_clock.dart';
@@ -1056,6 +1057,207 @@ void main() {
         );
       },
     );
+  });
+
+  group('CaptureModalContent', () {
+    TimeBlock blockOn(DateTime day) => TimeBlock(
+      id: 'actual:entry-1',
+      title: 'Client follow-up',
+      start: DateTime(day.year, day.month, day.day, 9),
+      end: DateTime(day.year, day.month, day.day, 10),
+      type: TimeBlockType.manual,
+      state: TimeBlockState.completed,
+      category: _category,
+      taskId: 'task-1',
+    );
+
+    // The modal hosts the scaffold-free content inside a bounded box over a
+    // Material surface (the Wolt sheet); mirror that here so the body's
+    // Expanded/LayoutBuilder has a finite viewport and its InkWells find a
+    // Material ancestor.
+    Widget host(Widget child) => Material(
+      type: MaterialType.transparency,
+      child: SizedBox(height: 760, child: child),
+    );
+
+    testWidgets(
+      'renders the calm capture body and omits the time-spent card when '
+      'there is no tracked time',
+      (tester) async {
+        final harness = _AudioHarness()..arm();
+        await _pumpCapture(
+          tester,
+          harness: harness,
+          page: host(const CaptureModalContent()),
+        );
+
+        final messages = tester
+            .element(find.byType(CaptureModalContent))
+            .messages;
+        expect(find.byType(VoiceButton), findsOneWidget);
+        expect(find.text(messages.dailyOsNextCaptureIdleTalk), findsOneWidget);
+        expect(find.byType(TimeSpentCard), findsNothing);
+        // The inline "Type instead" link is dropped in the modal — its
+        // sticky glass bar carries that action instead.
+        expect(
+          find.text(messages.dailyOsNextCaptureTypeInstead),
+          findsNothing,
+        );
+
+        await harness.dispose();
+      },
+    );
+
+    testWidgets(
+      'surfaces the Today so far card for tracked time on the current day',
+      (tester) async {
+        final harness = _AudioHarness()..arm();
+        await withClock(Clock.fixed(DateTime(2026, 5, 26, 9)), () async {
+          await _pumpCapture(
+            tester,
+            harness: harness,
+            page: host(
+              CaptureModalContent(
+                forDate: DateTime(2026, 5, 26),
+                actualBlocks: [blockOn(DateTime(2026, 5, 26))],
+              ),
+            ),
+          );
+
+          final messages = tester
+              .element(find.byType(CaptureModalContent))
+              .messages;
+          expect(find.byType(TimeSpentCard), findsOneWidget);
+          expect(find.text('Client follow-up'), findsOneWidget);
+          // forDate == today → the present-tense eyebrow.
+          expect(
+            find.text(messages.dailyOsNextTimeSpentTitle),
+            findsOneWidget,
+          );
+          expect(
+            find.text(messages.dailyOsNextTimeSpentTitlePast),
+            findsNothing,
+          );
+        });
+        await harness.dispose();
+      },
+    );
+
+    testWidgets('uses the date-neutral eyebrow when tracking a past day', (
+      tester,
+    ) async {
+      final harness = _AudioHarness()..arm();
+      await withClock(Clock.fixed(DateTime(2026, 5, 26, 9)), () async {
+        await _pumpCapture(
+          tester,
+          harness: harness,
+          page: host(
+            CaptureModalContent(
+              forDate: DateTime(2026, 5, 24),
+              actualBlocks: [blockOn(DateTime(2026, 5, 24))],
+            ),
+          ),
+        );
+
+        final messages = tester
+            .element(find.byType(CaptureModalContent))
+            .messages;
+        expect(
+          find.text(messages.dailyOsNextTimeSpentTitlePast),
+          findsOneWidget,
+        );
+        expect(find.text(messages.dailyOsNextTimeSpentTitle), findsNothing);
+      });
+      await harness.dispose();
+    });
+
+    testWidgets(
+      'falls back to the present-tense eyebrow when no forDate is given',
+      (tester) async {
+        final harness = _AudioHarness()..arm();
+        await _pumpCapture(
+          tester,
+          harness: harness,
+          page: host(
+            CaptureModalContent(
+              actualBlocks: [blockOn(DateTime(2026, 5, 26))],
+            ),
+          ),
+        );
+
+        final messages = tester
+            .element(find.byType(CaptureModalContent))
+            .messages;
+        // forDate == null → _timeSpentTitle returns null → default eyebrow.
+        expect(find.text(messages.dailyOsNextTimeSpentTitle), findsOneWidget);
+        expect(
+          find.text(messages.dailyOsNextTimeSpentTitlePast),
+          findsNothing,
+        );
+
+        await harness.dispose();
+      },
+    );
+
+    testWidgets('tapping the voice button arms the listening phase', (
+      tester,
+    ) async {
+      final harness = _AudioHarness()..arm();
+      await _pumpCapture(
+        tester,
+        harness: harness,
+        page: host(const CaptureModalContent()),
+      );
+
+      await tester.tap(find.byType(VoiceButton));
+      await tester.pump();
+      await tester.pump();
+
+      final messages = tester
+          .element(find.byType(CaptureModalContent))
+          .messages;
+      expect(find.text(messages.dailyOsNextCaptureListening), findsOneWidget);
+
+      await harness.dispose();
+    });
+
+    for (final (phase, labelOf)
+        in <(CapturePhase, String Function(AppLocalizations))>[
+          (CapturePhase.idle, (m) => m.dailyOsNextCaptureVoiceButtonStart),
+          (CapturePhase.error, (m) => m.dailyOsNextCaptureVoiceButtonStart),
+          (CapturePhase.listening, (m) => m.dailyOsNextCaptureVoiceButtonStop),
+          (
+            CapturePhase.transcribing,
+            (m) => m.dailyOsNextCaptureVoiceButtonReset,
+          ),
+          (CapturePhase.captured, (m) => m.dailyOsNextCaptureVoiceButtonReset),
+        ]) {
+      testWidgets('voice button semantic label for $phase', (tester) async {
+        await tester.pumpWidget(
+          _wrap(
+            host(const CaptureModalContent()),
+            overrides: [
+              captureControllerProvider.overrideWith(
+                _StubCaptureController.factory(
+                  CaptureState(
+                    phase: phase,
+                    transcript: '',
+                    amplitudes: const [],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+        await tester.pump();
+
+        final messages = tester
+            .element(find.byType(CaptureModalContent))
+            .messages;
+        final button = tester.widget<VoiceButton>(find.byType(VoiceButton));
+        expect(button.semanticLabel, labelOf(messages));
+      });
+    }
   });
 
   group('CaptureLayoutMetrics', () {

--- a/test/features/daily_os_next/ui/pages/daily_os_next_root_test.dart
+++ b/test/features/daily_os_next/ui/pages/daily_os_next_root_test.dart
@@ -163,6 +163,10 @@ void main() {
 
           expect(find.byType(CaptureModalContent), findsOneWidget);
           expect(find.byType(DayPage), findsOneWidget);
+          // The tracked-time the user saw on the Day surface now also rides
+          // the top of the modal's capture step (handoff v2 item 1): the
+          // session title appears both on the timeline and in the card.
+          expect(find.text('Client follow-up'), findsNWidgets(2));
         });
       },
     );

--- a/test/features/daily_os_next/ui/pages/daily_os_next_root_test.dart
+++ b/test/features/daily_os_next/ui/pages/daily_os_next_root_test.dart
@@ -109,7 +109,7 @@ void main() {
 
     testWidgets(
       'a no-plan day with tracked time lands on the empty Day surface; '
-      'the check-in CTA routes into Capture with the tracked card',
+      'the check-in CTA opens the day-planning modal over it',
       (tester) async {
         final actualBlock = TimeBlock(
           id: 'actual:entry-1',
@@ -155,18 +155,14 @@ void main() {
           expect(cta, findsOneWidget);
           expect(find.text(messages.dailyOsNextDayRefineCta), findsNothing);
 
-          // The CTA drops into Capture; the tracked card rides along.
+          // The CTA opens the day-planning modal (Capture step) as a
+          // full-cover layer; the Day surface stays mounted underneath.
           await tester.tap(cta);
           await tester.pump();
-          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 400));
 
-          expect(find.byType(CapturePage), findsOneWidget);
-          expect(find.byType(DayPage), findsNothing);
-          expect(
-            find.text(messages.dailyOsNextTimeSpentTitle),
-            findsOneWidget,
-          );
-          expect(find.text('Client follow-up'), findsOneWidget);
+          expect(find.byType(CaptureModalContent), findsOneWidget);
+          expect(find.byType(DayPage), findsOneWidget);
         });
       },
     );

--- a/test/features/daily_os_next/ui/pages/day_planning_modal_screenshots_test.dart
+++ b/test/features/daily_os_next/ui/pages/day_planning_modal_screenshots_test.dart
@@ -28,6 +28,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/agents/state/agent_query_providers.dart';
 import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
 import 'package:lotti/features/daily_os_next/logic/mock_day_agent.dart';
 import 'package:lotti/features/daily_os_next/state/actual_time_blocks_provider.dart';
@@ -207,6 +208,9 @@ Future<void> _openModal(
           dailyOsActualTimeBlocksProvider.overrideWith(
             (ref, date) async => const <TimeBlock>[],
           ),
+          agentIsRunningProvider.overrideWith(
+            (ref, agentId) => Stream.value(false),
+          ),
           if (agent != null) dayAgentProvider.overrideWithValue(agent),
         ],
         home: Builder(
@@ -352,6 +356,19 @@ void main() {
     await _tapPill(tester, _messages(tester).dailyOsNextCaptureReconcileCta);
     await _tapPill(tester, _messages(tester).dailyOsNextReconcileBuildDayCta);
     await _capture(tester, '06_drafting_dark');
+  });
+
+  testWidgets('drafting (wide two-column) — dark', (tester) async {
+    await _openModal(
+      tester,
+      intent: const DayPlanningCreate(),
+      capture: _captured,
+      agent: _PendingDraftAgent(),
+      size: const Size(1100, 900),
+    );
+    await _tapPill(tester, _messages(tester).dailyOsNextCaptureReconcileCta);
+    await _tapPill(tester, _messages(tester).dailyOsNextReconcileBuildDayCta);
+    await _capture(tester, '06b_drafting_wide_dark');
   });
 
   testWidgets('refine — dark', (tester) async {

--- a/test/features/daily_os_next/ui/pages/day_planning_modal_screenshots_test.dart
+++ b/test/features/daily_os_next/ui/pages/day_planning_modal_screenshots_test.dart
@@ -1,0 +1,408 @@
+/// Screenshot harness for the day-planning modal.
+///
+/// Drives the real Wolt multi-page sheet ([showDayPlanningModal]) through its
+/// Capture → Reconcile → Drafting → Refine steps (plus the standalone
+/// `CaptureModalContent` "Today so far" variant) and writes PNGs to
+/// `screenshots/daily_os_next/` (gitignored) for design review. Not a golden
+/// test — there are no stored baselines; the assertions only guard that each
+/// scenario renders without exceptions.
+///
+/// The "AI is thinking" decoder-bars use a fragment shader that does not
+/// compile under headless `flutter test`, so the shader paints nothing in
+/// these captures — review the bar layout/clearance, not the shader itself.
+///
+/// Opt-in (real-font loading leaks process-wide — see `main`). Run:
+/// `LOTTI_SCREENSHOT_DIR=/tmp/day_planning fvm flutter test \
+///   test/features/daily_os_next/ui/pages/day_planning_modal_screenshots_test.dart`
+library;
+
+import 'dart:async';
+import 'dart:io';
+import 'dart:ui' as ui;
+
+import 'package:clock/clock.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
+import 'package:lotti/features/daily_os_next/logic/mock_day_agent.dart';
+import 'package:lotti/features/daily_os_next/state/actual_time_blocks_provider.dart';
+import 'package:lotti/features/daily_os_next/state/capture_controller.dart';
+import 'package:lotti/features/daily_os_next/state/day_agent_provider.dart';
+import 'package:lotti/features/daily_os_next/ui/pages/capture_page.dart';
+import 'package:lotti/features/daily_os_next/ui/pages/day_planning_modal.dart';
+import 'package:lotti/features/daily_os_next/ui/widgets/day_planning_glass_action_bar.dart';
+import 'package:lotti/features/design_system/components/glass_action_bar.dart';
+import 'package:lotti/features/design_system/theme/design_system_theme.dart';
+import 'package:lotti/l10n/app_localizations.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:path/path.dart' as p;
+
+const ValueKey<String> _boundaryKey = ValueKey<String>('day-planning-shot');
+final DateTime _now = DateTime(2026, 6, 7, 9, 41);
+
+const _captured = CaptureState(
+  phase: CapturePhase.captured,
+  transcript:
+      'Plan tomorrow morning: two hours of deep work on the planner, '
+      'then a check-in with the design team and a short walk.',
+  amplitudes: [],
+);
+
+const _category = DayAgentCategory(
+  id: 'cat-client',
+  name: 'Client Work',
+  colorHex: '4F9DDE',
+);
+
+/// Pins a fixed [CaptureState] so the modal renders deterministically
+/// without the recorder/transcription stack.
+class _FakeCaptureController extends CaptureController {
+  _FakeCaptureController(this._initial);
+
+  final CaptureState _initial;
+
+  @override
+  CaptureState build() => _initial;
+
+  @override
+  void reset() => state = const CaptureState.idle();
+
+  @override
+  void startTyping() => state = const CaptureState(
+    phase: CapturePhase.captured,
+    transcript: '',
+    amplitudes: [],
+  );
+
+  @override
+  Future<void> toggle() async {}
+}
+
+/// Drafting agent whose draft never resolves — keeps the Drafting step on
+/// screen in its "drafting" phase for a stable capture.
+class _PendingDraftAgent extends MockDayAgent {
+  _PendingDraftAgent()
+    : super(
+        parseLatency: Duration.zero,
+        pendingLatency: Duration.zero,
+        triageLatency: Duration.zero,
+        summarizeLatency: Duration.zero,
+      );
+
+  final Completer<DraftPlan> _draft = Completer<DraftPlan>();
+
+  @override
+  Future<DraftPlan> draftDayPlan({
+    required CaptureId captureId,
+    required List<String> decidedTaskIds,
+    required DateTime dayDate,
+    List<String> decidedCaptureItemIds = const [],
+    List<TimeBlock> calendarBlocks = const [],
+    bool Function()? isCancelled,
+  }) => _draft.future;
+}
+
+MockDayAgent _fastAgent() => MockDayAgent(
+  parseLatency: Duration.zero,
+  pendingLatency: Duration.zero,
+  triageLatency: Duration.zero,
+  draftLatency: Duration.zero,
+  summarizeLatency: Duration.zero,
+  clock: () => _now,
+);
+
+Widget _app({
+  required Widget home,
+  required Brightness brightness,
+  required List<Override> overrides,
+  required Size size,
+}) {
+  return RepaintBoundary(
+    key: _boundaryKey,
+    child: ProviderScope(
+      overrides: overrides,
+      child: MediaQuery(
+        data: MediaQueryData(size: size),
+        child: MaterialApp(
+          debugShowCheckedModeBanner: false,
+          theme: brightness == Brightness.dark
+              ? DesignSystemTheme.dark()
+              : DesignSystemTheme.light(),
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: home,
+        ),
+      ),
+    ),
+  );
+}
+
+Future<void> _capture(WidgetTester tester, String name) async {
+  final boundary =
+      tester.element(find.byKey(_boundaryKey)).findRenderObject()!
+          as RenderRepaintBoundary;
+  await tester.runAsync(() async {
+    final image = await boundary.toImage(pixelRatio: 2);
+    final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
+    final dir =
+        Platform.environment['LOTTI_SCREENSHOT_DIR'] ??
+        p.join('screenshots', 'daily_os_next');
+    final file = File(p.join(dir, '$name.png'));
+    await file.parent.create(recursive: true);
+    await file.writeAsBytes(
+      byteData!.buffer.asUint8List(
+        byteData.offsetInBytes,
+        byteData.lengthInBytes,
+      ),
+      flush: true,
+    );
+    stdout.writeln('wrote screenshot: ${file.path}');
+  });
+}
+
+Future<void> _settle(WidgetTester tester) async {
+  for (var i = 0; i < 14; i++) {
+    await tester.pump(const Duration(milliseconds: 80));
+  }
+}
+
+AppLocalizations _messages(WidgetTester tester) =>
+    tester.element(find.byType(DayPlanningGlassActionBar)).messages;
+
+/// Pumps an app whose single button opens the day-planning modal, taps it,
+/// and settles the entry animation. Returns once the modal is on screen.
+Future<void> _openModal(
+  WidgetTester tester, {
+  required DayPlanningIntent intent,
+  CaptureState capture = const CaptureState.idle(),
+  MockDayAgent? agent,
+  Brightness brightness = Brightness.dark,
+  Size size = const Size(420, 900),
+}) async {
+  tester.view
+    ..physicalSize = size * 2
+    ..devicePixelRatio = 2;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await withClock(Clock.fixed(_now), () async {
+    await tester.pumpWidget(
+      _app(
+        brightness: brightness,
+        size: size,
+        overrides: [
+          captureControllerProvider.overrideWith(
+            () => _FakeCaptureController(capture),
+          ),
+          dailyOsActualTimeBlocksProvider.overrideWith(
+            (ref, date) async => const <TimeBlock>[],
+          ),
+          if (agent != null) dayAgentProvider.overrideWithValue(agent),
+        ],
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                onPressed: () => showDayPlanningModal(
+                  context: context,
+                  dayDate: DateTime(2026, 6, 8),
+                  intent: intent,
+                ),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await _settle(tester);
+  });
+}
+
+Future<void> _tapPill(WidgetTester tester, String label) async {
+  await withClock(Clock.fixed(_now), () async {
+    await tester.tap(find.widgetWithText(DsGlassPill, label));
+    await _settle(tester);
+  });
+}
+
+void main() {
+  // OPT-IN ONLY. The harness loads real fonts via FontLoader, which
+  // registers them process-wide with no way to unload — under very_good's
+  // single-isolate optimizer that changes text metrics for unrelated tests.
+  // So it only runs when explicitly requested for design review.
+  final captureEnabled =
+      Platform.environment['LOTTI_CAPTURE_SCREENSHOTS'] == 'true' ||
+      Platform.environment.containsKey('LOTTI_SCREENSHOT_DIR');
+  if (!captureEnabled) {
+    test(
+      'day-planning screenshot harness (opt-in)',
+      () {},
+      skip:
+          'Design-review screenshots are opt-in: run with '
+          'LOTTI_SCREENSHOT_DIR=<dir> (or LOTTI_CAPTURE_SCREENSHOTS=true) '
+          'because the real-font loading leaks process-wide.',
+    );
+    return;
+  }
+
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    Future<ByteData> fontBytes(String path) async {
+      final bytes = await File(path).readAsBytes();
+      return ByteData.view(bytes.buffer);
+    }
+
+    final inter = FontLoader('Inter')
+      ..addFont(
+        fontBytes('assets/fonts/Inter/Inter-VariableFont_opsz,wght.ttf'),
+      );
+    final inconsolata = FontLoader('Inconsolata')
+      ..addFont(fontBytes('assets/fonts/Inconsolata/Inconsolata-Regular.ttf'))
+      ..addFont(fontBytes('assets/fonts/Inconsolata/Inconsolata-Medium.ttf'));
+    await inter.load();
+    await inconsolata.load();
+
+    final flutterRoot =
+        Platform.environment['FLUTTER_ROOT'] ?? '.fvm/flutter_sdk';
+    final iconFont = File(
+      p.join(
+        flutterRoot,
+        'bin',
+        'cache',
+        'artifacts',
+        'material_fonts',
+        'MaterialIcons-Regular.otf',
+      ),
+    );
+    if (iconFont.existsSync()) {
+      final icons = FontLoader('MaterialIcons')
+        ..addFont(fontBytes(iconFont.path));
+      await icons.load();
+    }
+  });
+
+  testWidgets('capture idle — dark', (tester) async {
+    await _openModal(tester, intent: const DayPlanningCreate());
+    expect(find.byType(CaptureModalContent), findsOneWidget);
+    await _capture(tester, '01_capture_idle_dark');
+  });
+
+  testWidgets('capture idle — light', (tester) async {
+    await _openModal(
+      tester,
+      intent: const DayPlanningCreate(),
+      brightness: Brightness.light,
+    );
+    expect(find.byType(CaptureModalContent), findsOneWidget);
+    await _capture(tester, '02_capture_idle_light');
+  });
+
+  testWidgets('capture captured (re-record + continue) — dark', (tester) async {
+    await _openModal(
+      tester,
+      intent: const DayPlanningCreate(),
+      capture: _captured,
+    );
+    expect(find.byType(DsGlassPill), findsNWidgets(2));
+    await _capture(tester, '03_capture_captured_dark');
+  });
+
+  testWidgets('reconcile (narrow) — dark', (tester) async {
+    await _openModal(
+      tester,
+      intent: const DayPlanningCreate(),
+      capture: _captured,
+      agent: _fastAgent(),
+    );
+    await _tapPill(tester, _messages(tester).dailyOsNextCaptureReconcileCta);
+    await _capture(tester, '04_reconcile_narrow_dark');
+  });
+
+  testWidgets('reconcile (wide two-column) — dark', (tester) async {
+    await _openModal(
+      tester,
+      intent: const DayPlanningCreate(),
+      capture: _captured,
+      agent: _fastAgent(),
+      size: const Size(1100, 900),
+    );
+    await _tapPill(tester, _messages(tester).dailyOsNextCaptureReconcileCta);
+    await _capture(tester, '05_reconcile_wide_dark');
+  });
+
+  testWidgets('drafting — dark', (tester) async {
+    await _openModal(
+      tester,
+      intent: const DayPlanningCreate(),
+      capture: _captured,
+      agent: _PendingDraftAgent(),
+    );
+    await _tapPill(tester, _messages(tester).dailyOsNextCaptureReconcileCta);
+    await _tapPill(tester, _messages(tester).dailyOsNextReconcileBuildDayCta);
+    await _capture(tester, '06_drafting_dark');
+  });
+
+  testWidgets('refine — dark', (tester) async {
+    await _openModal(
+      tester,
+      intent: DayPlanningAdapt(DraftPlan.emptyForDay(DateTime(2026, 6, 8))),
+      agent: _fastAgent(),
+    );
+    await _capture(tester, '07_refine_dark');
+  });
+
+  testWidgets('capture with "Today so far" card — dark', (tester) async {
+    // The modal does NOT currently pass actualBlocks; this renders
+    // CaptureModalContent directly to evaluate the dropped card.
+    final block = TimeBlock(
+      id: 'actual:entry-1',
+      title: 'Client follow-up',
+      start: DateTime(2026, 6, 8, 8),
+      end: DateTime(2026, 6, 8, 9, 30),
+      type: TimeBlockType.manual,
+      state: TimeBlockState.completed,
+      category: _category,
+    );
+    const size = Size(420, 900);
+    tester.view
+      ..physicalSize = size * 2
+      ..devicePixelRatio = 2;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await withClock(Clock.fixed(_now), () async {
+      await tester.pumpWidget(
+        _app(
+          brightness: Brightness.dark,
+          size: size,
+          overrides: [
+            captureControllerProvider.overrideWith(
+              () => _FakeCaptureController(const CaptureState.idle()),
+            ),
+          ],
+          home: Scaffold(
+            body: CaptureModalContent(
+              forDate: DateTime(2026, 6, 8),
+              actualBlocks: [block],
+            ),
+          ),
+        ),
+      );
+      await _settle(tester);
+    });
+    expect(find.text('Client follow-up'), findsOneWidget);
+    await _capture(tester, '08_capture_today_so_far_dark');
+  });
+}

--- a/test/features/daily_os_next/ui/pages/day_planning_modal_test.dart
+++ b/test/features/daily_os_next/ui/pages/day_planning_modal_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/agents/state/agent_query_providers.dart';
 import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
 import 'package:lotti/features/daily_os_next/logic/mock_day_agent.dart';
 import 'package:lotti/features/daily_os_next/state/actual_time_blocks_provider.dart';
@@ -171,6 +172,11 @@ Future<void> _openCreate(
         // far" card is deterministic and never reaches GetIt-backed services.
         dailyOsActualTimeBlocksProvider.overrideWith(
           (ref, date) async => actualBlocks,
+        ),
+        // Idle agent-running signal so the reconcile Heard column's parsing
+        // shader stays off and the provider never reaches the wake runner.
+        agentIsRunningProvider.overrideWith(
+          (ref, agentId) => Stream.value(false),
         ),
         if (agent != null) dayAgentProvider.overrideWithValue(agent),
       ],
@@ -535,10 +541,11 @@ void main() {
 
       await _openCreate(tester, size: const Size(1280, 900));
       expect(find.byType(CaptureModalContent), findsOneWidget);
-      // The dialog branch constrains the content far below the 1280 width,
-      // unlike the full-width phone bottom sheet above.
+      // The dialog branch constrains the content to the configured width —
+      // wider than the phone content but well below the full 1280 screen.
       final width = tester.getSize(find.byType(CaptureModalContent)).width;
-      expect(width, lessThan(900));
+      expect(width, lessThan(1280));
+      expect(width, greaterThan(700));
     });
   });
 }

--- a/test/features/daily_os_next/ui/pages/day_planning_modal_test.dart
+++ b/test/features/daily_os_next/ui/pages/day_planning_modal_test.dart
@@ -1,0 +1,369 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
+import 'package:lotti/features/daily_os_next/logic/mock_day_agent.dart';
+import 'package:lotti/features/daily_os_next/state/capture_controller.dart';
+import 'package:lotti/features/daily_os_next/state/day_agent_provider.dart';
+import 'package:lotti/features/daily_os_next/ui/pages/capture_page.dart';
+import 'package:lotti/features/daily_os_next/ui/pages/day_planning_modal.dart';
+import 'package:lotti/features/daily_os_next/ui/pages/drafting_page.dart';
+import 'package:lotti/features/daily_os_next/ui/pages/reconcile_page.dart';
+import 'package:lotti/features/daily_os_next/ui/pages/refine_page.dart';
+import 'package:lotti/features/daily_os_next/ui/widgets/day_planning_glass_action_bar.dart';
+import 'package:lotti/features/daily_os_next/ui/widgets/day_planning_thinking_shader.dart';
+import 'package:lotti/features/design_system/components/glass_action_bar.dart';
+import 'package:lotti/l10n/app_localizations.dart';
+
+import '../../../../widget_test_utils.dart';
+
+/// Minimal capture controller that pins a fixed [CaptureState] so the modal
+/// renders deterministically without the recorder/transcription stack.
+class _FakeCaptureController extends CaptureController {
+  _FakeCaptureController(this._initial);
+
+  final CaptureState _initial;
+
+  @override
+  CaptureState build() => _initial;
+
+  @override
+  void reset() => state = const CaptureState.idle();
+
+  @override
+  void startTyping() => state = const CaptureState(
+    phase: CapturePhase.captured,
+    transcript: '',
+    amplitudes: [],
+  );
+
+  @override
+  Future<void> toggle() async {}
+}
+
+/// Reconcile agent whose parse step throws — drives the error branch.
+class _ThrowingReconcileAgent extends MockDayAgent {
+  _ThrowingReconcileAgent()
+    : super(parseLatency: Duration.zero, pendingLatency: Duration.zero);
+
+  @override
+  Future<List<ParsedItem>> parseCaptureToItems(CaptureId id) async {
+    throw StateError('parse failed');
+  }
+}
+
+/// Drafting agent whose draft step throws — drives the error branch.
+class _ThrowingDraftAgent extends MockDayAgent {
+  _ThrowingDraftAgent()
+    : super(
+        parseLatency: Duration.zero,
+        pendingLatency: Duration.zero,
+        summarizeLatency: Duration.zero,
+      );
+
+  @override
+  Future<DraftPlan> draftDayPlan({
+    required CaptureId captureId,
+    required List<String> decidedTaskIds,
+    required DateTime dayDate,
+    List<String> decidedCaptureItemIds = const [],
+    List<TimeBlock> calendarBlocks = const [],
+    bool Function()? isCancelled,
+  }) async {
+    throw StateError('draft failed');
+  }
+}
+
+/// Drafting agent whose draft never resolves (a never-completing
+/// [Completer], so no pending timer) — keeps the Drafting step on screen in
+/// its "drafting" phase for a stable assertion.
+class _PendingDraftAgent extends MockDayAgent {
+  _PendingDraftAgent()
+    : super(
+        parseLatency: Duration.zero,
+        pendingLatency: Duration.zero,
+        summarizeLatency: Duration.zero,
+      );
+
+  final Completer<DraftPlan> _draft = Completer<DraftPlan>();
+
+  @override
+  Future<DraftPlan> draftDayPlan({
+    required CaptureId captureId,
+    required List<String> decidedTaskIds,
+    required DateTime dayDate,
+    List<String> decidedCaptureItemIds = const [],
+    List<TimeBlock> calendarBlocks = const [],
+    bool Function()? isCancelled,
+  }) => _draft.future;
+}
+
+MockDayAgent _fastAgent() => MockDayAgent(
+  parseLatency: Duration.zero,
+  pendingLatency: Duration.zero,
+  triageLatency: Duration.zero,
+  draftLatency: Duration.zero,
+  summarizeLatency: Duration.zero,
+  clock: () => DateTime(2024, 3, 15, 9),
+);
+
+const _captured = CaptureState(
+  phase: CapturePhase.captured,
+  transcript: 'Plan tomorrow morning',
+  amplitudes: [],
+);
+
+Future<void> _settle(WidgetTester tester) async {
+  for (var i = 0; i < 12; i++) {
+    await tester.pump(const Duration(milliseconds: 80));
+  }
+}
+
+Future<void> _openCreate(
+  WidgetTester tester, {
+  CaptureState capture = const CaptureState.idle(),
+  MockDayAgent? agent,
+  Size size = const Size(420, 900),
+}) async {
+  await tester.pumpWidget(
+    makeTestableWidget(
+      Builder(
+        builder: (context) => Center(
+          child: ElevatedButton(
+            onPressed: () => showDayPlanningModal(
+              context: context,
+              dayDate: DateTime(2024, 3, 15),
+              intent: const DayPlanningCreate(),
+            ),
+            child: const Text('open'),
+          ),
+        ),
+      ),
+      mediaQueryData: MediaQueryData(size: size),
+      overrides: [
+        captureControllerProvider.overrideWith(
+          () => _FakeCaptureController(capture),
+        ),
+        if (agent != null) dayAgentProvider.overrideWithValue(agent),
+      ],
+    ),
+  );
+  await tester.tap(find.text('open'));
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 400));
+}
+
+AppLocalizations _l10n(WidgetTester tester) => AppLocalizations.of(
+  tester.element(find.byType(DayPlanningGlassActionBar)),
+)!;
+
+Future<void> _tapPill(WidgetTester tester, String label) async {
+  await tester.tap(find.widgetWithText(DsGlassPill, label));
+  await _settle(tester);
+}
+
+void main() {
+  group('showDayPlanningModal — capture step', () {
+    testWidgets('opens the Capture step with a glass action bar + shader', (
+      tester,
+    ) async {
+      await _openCreate(tester);
+      expect(find.byType(CaptureModalContent), findsOneWidget);
+      expect(find.byType(DayPlanningGlassActionBar), findsOneWidget);
+      expect(find.byType(DayPlanningThinkingShader), findsOneWidget);
+    });
+
+    testWidgets('idle bar offers only the "type instead" action', (
+      tester,
+    ) async {
+      await _openCreate(tester);
+      expect(find.byType(DsGlassPill), findsOneWidget);
+      expect(find.byIcon(Icons.keyboard_rounded), findsOneWidget);
+      expect(find.byIcon(Icons.arrow_forward_rounded), findsNothing);
+    });
+
+    testWidgets('captured bar offers re-record + continue', (tester) async {
+      await _openCreate(tester, capture: _captured);
+      expect(find.byType(DsGlassPill), findsNWidgets(2));
+      expect(find.byIcon(Icons.mic_rounded), findsOneWidget);
+      expect(find.byIcon(Icons.arrow_forward_rounded), findsOneWidget);
+    });
+
+    testWidgets('listening bar shows no action pills and no shader', (
+      tester,
+    ) async {
+      await _openCreate(
+        tester,
+        capture: const CaptureState(
+          phase: CapturePhase.listening,
+          transcript: '',
+          amplitudes: [],
+        ),
+      );
+      expect(find.byType(DsGlassPill), findsNothing);
+      expect(find.byKey(DayPlanningThinkingShader.indicatorKey), findsNothing);
+    });
+
+    testWidgets('transcribing bar lights the thinking shader', (tester) async {
+      await _openCreate(
+        tester,
+        capture: const CaptureState(
+          phase: CapturePhase.transcribing,
+          transcript: '',
+          amplitudes: [],
+        ),
+      );
+      expect(find.byType(DsGlassPill), findsNothing);
+      expect(
+        find.byKey(DayPlanningThinkingShader.indicatorKey),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('error bar offers the "type instead" fallback', (tester) async {
+      await _openCreate(
+        tester,
+        capture: const CaptureState(
+          phase: CapturePhase.error,
+          transcript: '',
+          amplitudes: [],
+          error: CaptureError.noAudioRecorded,
+        ),
+      );
+      expect(find.byIcon(Icons.keyboard_rounded), findsOneWidget);
+    });
+
+    testWidgets('"type instead" flips capture into the captured editor', (
+      tester,
+    ) async {
+      await _openCreate(tester);
+      await tester.tap(find.byIcon(Icons.keyboard_rounded));
+      await tester.pump();
+      expect(find.byType(DsGlassPill), findsNWidgets(2));
+    });
+  });
+
+  group('showDayPlanningModal — create chain', () {
+    testWidgets('continue advances Capture → Reconcile', (tester) async {
+      await _openCreate(tester, capture: _captured, agent: _fastAgent());
+      final messages = _l10n(tester);
+      await _tapPill(tester, messages.dailyOsNextCaptureReconcileCta);
+      expect(find.byType(ReconcileModalContent), findsOneWidget);
+    });
+
+    testWidgets('build day advances Reconcile → Drafting with the shader', (
+      tester,
+    ) async {
+      await _openCreate(
+        tester,
+        capture: _captured,
+        agent: _PendingDraftAgent(),
+      );
+      final messages = _l10n(tester);
+      await _tapPill(tester, messages.dailyOsNextCaptureReconcileCta);
+      await _tapPill(tester, messages.dailyOsNextReconcileBuildDayCta);
+      expect(find.byType(DraftingModalContent), findsOneWidget);
+      expect(
+        find.byKey(DayPlanningThinkingShader.indicatorKey),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('drafting ready closes the modal', (tester) async {
+      await _openCreate(tester, capture: _captured, agent: _fastAgent());
+      final messages = _l10n(tester);
+      await _tapPill(tester, messages.dailyOsNextCaptureReconcileCta);
+      await _tapPill(tester, messages.dailyOsNextReconcileBuildDayCta);
+      await _settle(tester);
+      // The whole modal layer is gone once drafting is ready.
+      expect(find.byType(DayPlanningGlassActionBar), findsNothing);
+      expect(find.byType(DraftingModalContent), findsNothing);
+      expect(find.byType(ReconcileModalContent), findsNothing);
+    });
+
+    testWidgets('reconcile re-record steps back to capture', (tester) async {
+      await _openCreate(tester, capture: _captured, agent: _fastAgent());
+      final messages = _l10n(tester);
+      await _tapPill(tester, messages.dailyOsNextCaptureReconcileCta);
+      expect(find.byType(ReconcileModalContent), findsOneWidget);
+      await _tapPill(tester, messages.dailyOsNextReconcileReRecord);
+      expect(find.byType(CaptureModalContent), findsOneWidget);
+    });
+
+    testWidgets('reconcile surfaces an error when parsing fails', (
+      tester,
+    ) async {
+      await _openCreate(
+        tester,
+        capture: _captured,
+        agent: _ThrowingReconcileAgent(),
+      );
+      final messages = _l10n(tester);
+      await _tapPill(tester, messages.dailyOsNextCaptureReconcileCta);
+      expect(find.text(messages.dailyOsNextGenericError), findsOneWidget);
+    });
+
+    testWidgets('drafting surfaces an error when the draft fails', (
+      tester,
+    ) async {
+      await _openCreate(
+        tester,
+        capture: _captured,
+        agent: _ThrowingDraftAgent(),
+      );
+      final messages = _l10n(tester);
+      await _tapPill(tester, messages.dailyOsNextCaptureReconcileCta);
+      await _tapPill(tester, messages.dailyOsNextReconcileBuildDayCta);
+      expect(find.text(messages.dailyOsNextGenericError), findsOneWidget);
+    });
+  });
+
+  group('showDayPlanningModal — adapt (refine)', () {
+    testWidgets('opens the Refine step with its title, body and glass bar', (
+      tester,
+    ) async {
+      final draft = DraftPlan.emptyForDay(DateTime(2024, 3, 15));
+      await tester.pumpWidget(
+        makeTestableWidget(
+          Builder(
+            builder: (context) => Center(
+              child: ElevatedButton(
+                onPressed: () => showDayPlanningModal(
+                  context: context,
+                  dayDate: draft.dayDate,
+                  intent: DayPlanningAdapt(draft),
+                ),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+          mediaQueryData: const MediaQueryData(size: Size(420, 900)),
+          overrides: [
+            captureControllerProvider.overrideWith(
+              () => _FakeCaptureController(const CaptureState.idle()),
+            ),
+            dayAgentProvider.overrideWithValue(_fastAgent()),
+          ],
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      final messages = _l10n(tester);
+      expect(find.byType(RefineModalContent), findsOneWidget);
+      expect(find.byType(DayPlanningGlassActionBar), findsOneWidget);
+      expect(find.text(messages.dailyOsNextRefineTitle), findsWidgets);
+    });
+  });
+
+  group('showDayPlanningModal — responsive', () {
+    testWidgets('renders as a dialog on wide viewports', (tester) async {
+      await _openCreate(tester, size: const Size(1280, 900));
+      expect(find.byType(CaptureModalContent), findsOneWidget);
+      expect(find.byType(DayPlanningGlassActionBar), findsOneWidget);
+    });
+  });
+}

--- a/test/features/daily_os_next/ui/pages/day_planning_modal_test.dart
+++ b/test/features/daily_os_next/ui/pages/day_planning_modal_test.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
 import 'package:lotti/features/daily_os_next/logic/mock_day_agent.dart';
+import 'package:lotti/features/daily_os_next/state/actual_time_blocks_provider.dart';
 import 'package:lotti/features/daily_os_next/state/capture_controller.dart';
 import 'package:lotti/features/daily_os_next/state/day_agent_provider.dart';
 import 'package:lotti/features/daily_os_next/ui/pages/capture_page.dart';
@@ -100,6 +100,26 @@ class _PendingDraftAgent extends MockDayAgent {
   }) => _draft.future;
 }
 
+/// Capture-submit agent whose [submitCapture] never completes and counts
+/// calls — exercises the in-flight double-submit guard on the Capture bar.
+class _PendingSubmitAgent extends MockDayAgent {
+  _PendingSubmitAgent()
+    : super(parseLatency: Duration.zero, pendingLatency: Duration.zero);
+
+  int submitCalls = 0;
+  final Completer<CaptureId> _capture = Completer<CaptureId>();
+
+  @override
+  Future<CaptureId> submitCapture({
+    required String transcript,
+    required DateTime capturedAt,
+    String? audioId,
+  }) {
+    submitCalls++;
+    return _capture.future;
+  }
+}
+
 MockDayAgent _fastAgent() => MockDayAgent(
   parseLatency: Duration.zero,
   pendingLatency: Duration.zero,
@@ -125,6 +145,7 @@ Future<void> _openCreate(
   WidgetTester tester, {
   CaptureState capture = const CaptureState.idle(),
   MockDayAgent? agent,
+  List<TimeBlock> actualBlocks = const [],
   Size size = const Size(420, 900),
 }) async {
   await tester.pumpWidget(
@@ -146,6 +167,11 @@ Future<void> _openCreate(
         captureControllerProvider.overrideWith(
           () => _FakeCaptureController(capture),
         ),
+        // Pin the tracked-time projection so the capture step's "Today so
+        // far" card is deterministic and never reaches GetIt-backed services.
+        dailyOsActualTimeBlocksProvider.overrideWith(
+          (ref, date) async => actualBlocks,
+        ),
         if (agent != null) dayAgentProvider.overrideWithValue(agent),
       ],
     ),
@@ -161,6 +187,21 @@ AppLocalizations _l10n(WidgetTester tester) => AppLocalizations.of(
 
 Future<void> _tapPill(WidgetTester tester, String label) async {
   await tester.tap(find.widgetWithText(DsGlassPill, label));
+  await _settle(tester);
+}
+
+/// Invokes the Wolt top-bar back affordance — the leading [IconButton]
+/// carrying [Icons.arrow_back_rounded], wired to the page's `onTapBack` →
+/// `popPage`. Its `onPressed` is invoked directly rather than via a pointer
+/// tap: the Wolt top-bar layer intercepts synthetic hit-tests at that
+/// position, but the callback is the behavior under test and the resulting
+/// navigation is asserted by the caller.
+Future<void> _tapBack(WidgetTester tester) async {
+  final backButton = find.ancestor(
+    of: find.byIcon(Icons.arrow_back_rounded),
+    matching: find.byType(IconButton),
+  );
+  tester.widget<IconButton>(backButton.first).onPressed!();
   await _settle(tester);
 }
 
@@ -243,6 +284,70 @@ void main() {
       await tester.pump();
       expect(find.byType(DsGlassPill), findsNWidgets(2));
     });
+
+    testWidgets('captured re-record resets back to the idle prompt', (
+      tester,
+    ) async {
+      await _openCreate(tester, capture: _captured);
+      expect(find.byIcon(Icons.arrow_forward_rounded), findsOneWidget);
+      await tester.tap(find.widgetWithIcon(DsGlassPill, Icons.mic_rounded));
+      await tester.pump();
+      // Reset → the idle bar offers only the type-instead pill.
+      expect(find.byIcon(Icons.keyboard_rounded), findsOneWidget);
+      expect(find.byIcon(Icons.arrow_forward_rounded), findsNothing);
+    });
+
+    testWidgets(
+      'captured with an empty transcript disables the continue pill',
+      (
+        tester,
+      ) async {
+        await _openCreate(
+          tester,
+          capture: const CaptureState(
+            phase: CapturePhase.captured,
+            transcript: '   ',
+            amplitudes: [],
+          ),
+          agent: _fastAgent(),
+        );
+        final continuePill = find.widgetWithIcon(
+          DsGlassPill,
+          Icons.arrow_forward_rounded,
+        );
+        expect(continuePill, findsOneWidget);
+        expect(tester.widget<DsGlassPill>(continuePill).enabled, isFalse);
+        // Tapping the disabled pill must not advance to Reconcile.
+        await tester.tap(continuePill, warnIfMissed: false);
+        await _settle(tester);
+        expect(find.byType(ReconcileModalContent), findsNothing);
+        expect(find.byType(CaptureModalContent), findsOneWidget);
+      },
+    );
+
+    testWidgets('shows the Today so far card when the day has tracked time', (
+      tester,
+    ) async {
+      await _openCreate(
+        tester,
+        actualBlocks: [
+          TimeBlock(
+            id: 'actual:entry-1',
+            title: 'Client follow-up',
+            start: DateTime(2024, 3, 15, 9),
+            end: DateTime(2024, 3, 15, 10),
+            type: TimeBlockType.manual,
+            state: TimeBlockState.completed,
+            category: const DayAgentCategory(
+              id: 'c',
+              name: 'Work',
+              colorHex: '5ED4B7',
+            ),
+          ),
+        ],
+      );
+      expect(find.text('Client follow-up'), findsOneWidget);
+    });
   });
 
   group('showDayPlanningModal — create chain', () {
@@ -290,6 +395,49 @@ void main() {
       expect(find.byType(ReconcileModalContent), findsOneWidget);
       await _tapPill(tester, messages.dailyOsNextReconcileReRecord);
       expect(find.byType(CaptureModalContent), findsOneWidget);
+    });
+
+    testWidgets('reconcile back button pops back to capture', (tester) async {
+      await _openCreate(tester, capture: _captured, agent: _fastAgent());
+      final messages = _l10n(tester);
+      await _tapPill(tester, messages.dailyOsNextCaptureReconcileCta);
+      expect(find.byType(ReconcileModalContent), findsOneWidget);
+      await _tapBack(tester);
+      expect(find.byType(CaptureModalContent), findsOneWidget);
+    });
+
+    testWidgets('drafting back button pops back to reconcile', (tester) async {
+      await _openCreate(
+        tester,
+        capture: _captured,
+        agent: _PendingDraftAgent(),
+      );
+      final messages = _l10n(tester);
+      await _tapPill(tester, messages.dailyOsNextCaptureReconcileCta);
+      await _tapPill(tester, messages.dailyOsNextReconcileBuildDayCta);
+      expect(find.byType(DraftingModalContent), findsOneWidget);
+      await _tapBack(tester);
+      expect(find.byType(ReconcileModalContent), findsOneWidget);
+    });
+
+    testWidgets('continue ignores a second tap while submit is in flight', (
+      tester,
+    ) async {
+      final agent = _PendingSubmitAgent();
+      await _openCreate(tester, capture: _captured, agent: agent);
+      final messages = _l10n(tester);
+      final cta = find.widgetWithText(
+        DsGlassPill,
+        messages.dailyOsNextCaptureReconcileCta,
+      );
+      await tester.tap(cta);
+      await tester.pump();
+      // While the first submit hangs, the pill is disabled, so a second tap
+      // is a no-op — exactly one capture is submitted.
+      expect(tester.widget<DsGlassPill>(cta).enabled, isFalse);
+      await tester.tap(cta, warnIfMissed: false);
+      await tester.pump();
+      expect(agent.submitCalls, 1);
     });
 
     testWidgets('reconcile surfaces an error when parsing fails', (
@@ -360,10 +508,37 @@ void main() {
   });
 
   group('showDayPlanningModal — responsive', () {
-    testWidgets('renders as a dialog on wide viewports', (tester) async {
+    testWidgets('phone viewport fills the width as a bottom sheet', (
+      tester,
+    ) async {
+      tester.view
+        ..physicalSize = const Size(420, 900)
+        ..devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await _openCreate(tester);
+      expect(find.byType(CaptureModalContent), findsOneWidget);
+      // The full-height bottom sheet spans the whole 420-wide phone.
+      final width = tester.getSize(find.byType(CaptureModalContent)).width;
+      expect(width, closeTo(420, 2));
+    });
+
+    testWidgets('wide viewport renders a width-bounded centered dialog', (
+      tester,
+    ) async {
+      tester.view
+        ..physicalSize = const Size(1280, 900)
+        ..devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
       await _openCreate(tester, size: const Size(1280, 900));
       expect(find.byType(CaptureModalContent), findsOneWidget);
-      expect(find.byType(DayPlanningGlassActionBar), findsOneWidget);
+      // The dialog branch constrains the content far below the 1280 width,
+      // unlike the full-width phone bottom sheet above.
+      final width = tester.getSize(find.byType(CaptureModalContent)).width;
+      expect(width, lessThan(900));
     });
   });
 }

--- a/test/features/daily_os_next/ui/pages/reconcile_page_test.dart
+++ b/test/features/daily_os_next/ui/pages/reconcile_page_test.dart
@@ -5,12 +5,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
+import 'package:lotti/features/agents/state/agent_query_providers.dart';
 import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
 import 'package:lotti/features/daily_os_next/logic/mock_day_agent.dart';
 import 'package:lotti/features/daily_os_next/state/day_agent_provider.dart';
 import 'package:lotti/features/daily_os_next/state/reconcile_controller.dart';
 import 'package:lotti/features/daily_os_next/ui/pages/drafting_page.dart';
 import 'package:lotti/features/daily_os_next/ui/pages/reconcile_page.dart';
+import 'package:lotti/features/daily_os_next/ui/widgets/day_planning_thinking_shader.dart';
 import 'package:lotti/features/daily_os_next/ui/widgets/parsed_card.dart';
 import 'package:lotti/features/daily_os_next/ui/widgets/pending_card.dart';
 import 'package:lotti/features/design_system/components/glass_strip.dart';
@@ -23,9 +25,18 @@ Widget _wrap(
   Widget child, {
   List<Override> overrides = const [],
   MediaQueryData mediaQueryData = const MediaQueryData(size: Size(1400, 900)),
+  bool agentRunning = false,
 }) {
   return ProviderScope(
-    overrides: overrides,
+    overrides: [
+      // Single agent-running override (Riverpod forbids overriding a family
+      // twice). Defaults to idle so the Heard column's parsing shader stays
+      // off; pass agentRunning: true for the parse-in-flight case.
+      agentIsRunningProvider.overrideWith(
+        (ref, agentId) => Stream.value(agentRunning),
+      ),
+      ...overrides,
+    ],
     child: makeTestableWidget2(
       child,
       mediaQueryData: mediaQueryData,
@@ -110,6 +121,31 @@ class _RefreshBlockingAgent extends MockDayAgent {
     }
     return Future.value(const <PendingItem>[]);
   }
+}
+
+/// Parse returns nothing until [ready] flips true (simulating the
+/// capture-submitted parse wake completing), then surfaces one item.
+class _LateParseAgent extends MockDayAgent {
+  _LateParseAgent()
+    : super(
+        parseLatency: Duration.zero,
+        pendingLatency: Duration.zero,
+        triageLatency: Duration.zero,
+        clock: () => DateTime(2026, 5, 25, 9),
+      );
+
+  bool ready = false;
+
+  @override
+  Future<List<ParsedItem>> parseCaptureToItems(CaptureId id) async {
+    if (!ready) return const [];
+    return [_parsed('p_late', kind: ParsedItemKind.newTask, title: 'Drafted')];
+  }
+
+  @override
+  Future<List<PendingItem>> surfacePendingDecisions({
+    DateTime? forDate,
+  }) async => const [];
 }
 
 /// Shared category for hand-built fixtures — the colour is irrelevant to
@@ -209,6 +245,42 @@ void main() {
       expect(find.byType(PendingCard), findsNWidgets(3));
       expect(find.byType(CircularProgressIndicator), findsNothing);
     });
+
+    testWidgets(
+      're-reads parsed items when the parse wake finishes (running '
+      'true → false)',
+      (tester) async {
+        _setWideSurface(tester);
+        final running = StreamController<bool>.broadcast();
+        addTearDown(running.close);
+        final agent = _LateParseAgent();
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              agentIsRunningProvider.overrideWith((ref, id) => running.stream),
+              dayAgentProvider.overrideWithValue(agent),
+            ],
+            child: makeTestableWidget2(
+              const ReconcilePage(captureId: CaptureId('cap_late')),
+              mediaQueryData: const MediaQueryData(size: Size(1400, 900)),
+            ),
+          ),
+        );
+        running.add(true);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 200));
+        // Wake still running, parse hasn't produced items yet.
+        expect(find.byType(ParsedCard), findsNothing);
+
+        // Wake completes and the parsed items are now available.
+        agent.ready = true;
+        running.add(false);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 200));
+        expect(find.byType(ParsedCard), findsOneWidget);
+      },
+    );
 
     testWidgets('shows both column headers with their item counts', (
       tester,
@@ -534,7 +606,12 @@ void main() {
       final agent = _fastAgent();
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [dayAgentProvider.overrideWithValue(agent)],
+          overrides: [
+            agentIsRunningProvider.overrideWith(
+              (ref, agentId) => Stream.value(false),
+            ),
+            dayAgentProvider.overrideWithValue(agent),
+          ],
           child: makeTestableWidget2(
             const ReconcilePage(captureId: CaptureId('cap_x')),
             mediaQueryData: const MediaQueryData(size: Size(600, 1400)),
@@ -812,6 +889,82 @@ void main() {
       // column and the two overlines share roughly the same vertical line.
       expect(decide.dx, greaterThan(heard.dx));
       expect((decide.dy - heard.dy).abs(), lessThan(1));
+    });
+
+    testWidgets(
+      'Heard column shows the thinking shader while the parse wake runs, '
+      'with the pending column already populated',
+      (tester) async {
+        _setWideSurface(tester);
+        final params = ReconcileParams(
+          captureId: const CaptureId('cap_parsing'),
+          dayDate: DateTime(2026, 5, 25),
+        );
+        final data = _reconcileData(
+          pending: const [
+            PendingItem(
+              taskId: 't_pending',
+              title: _kPendingTitle,
+              category: _category,
+              reason: PendingItemReason.overdue,
+              overdueByDays: 2,
+            ),
+          ],
+        );
+
+        await tester.pumpWidget(
+          _wrap(
+            ReconcileModalContent(params: params, data: data),
+            overrides: [dayAgentProvider.overrideWithValue(_fastAgent())],
+            agentRunning: true,
+          ),
+        );
+        await tester.pump(const Duration(milliseconds: 200));
+
+        // Pending decisions render immediately while parsing continues.
+        expect(find.text(_kPendingTitle), findsOneWidget);
+        // The Heard column surfaces the AI thinking shader (parse in flight).
+        expect(
+          find.byKey(DayPlanningThinkingShader.indicatorKey),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets('Heard column hides the shader once the agent is idle', (
+      tester,
+    ) async {
+      _setWideSurface(tester);
+      final params = ReconcileParams(
+        captureId: const CaptureId('cap_idle'),
+        dayDate: DateTime(2026, 5, 25),
+      );
+      final data = _reconcileData(
+        pending: const [
+          PendingItem(
+            taskId: 't_pending',
+            title: _kPendingTitle,
+            category: _category,
+            reason: PendingItemReason.overdue,
+            overdueByDays: 2,
+          ),
+        ],
+      );
+
+      // _wrap defaults agentIsRunningProvider to false.
+      await tester.pumpWidget(
+        _wrap(
+          ReconcileModalContent(params: params, data: data),
+          overrides: [dayAgentProvider.overrideWithValue(_fastAgent())],
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(find.text(_kPendingTitle), findsOneWidget);
+      expect(
+        find.byKey(DayPlanningThinkingShader.indicatorKey),
+        findsNothing,
+      );
     });
   });
 }

--- a/test/features/daily_os_next/ui/pages/reconcile_page_test.dart
+++ b/test/features/daily_os_next/ui/pages/reconcile_page_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:glados/glados.dart' as glados;
 import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
 import 'package:lotti/features/daily_os_next/logic/mock_day_agent.dart';
 import 'package:lotti/features/daily_os_next/state/day_agent_provider.dart';
@@ -109,6 +110,47 @@ class _RefreshBlockingAgent extends MockDayAgent {
     }
     return Future.value(const <PendingItem>[]);
   }
+}
+
+/// Shared category for hand-built fixtures — the colour is irrelevant to
+/// the selection logic and layout under test.
+const _category = DayAgentCategory(
+  id: 'work',
+  name: 'Work',
+  colorHex: '5ED4B7',
+);
+
+/// Builds a [ParsedItem] with just the fields the selection logic reads.
+ParsedItem _parsed(
+  String id, {
+  required ParsedItemKind kind,
+  String? matchedTaskId,
+  String title = 'Parsed item',
+}) {
+  return ParsedItem(
+    id: id,
+    kind: kind,
+    title: title,
+    category: _category,
+    confidence: ParsedItemConfidence.high,
+    matchedTaskId: matchedTaskId,
+  );
+}
+
+/// Builds a [TriageResult] for the given action.
+TriageResult _triage(String taskId, TriageAction action) =>
+    TriageResult(taskId: taskId, action: action);
+
+ReconcileData _reconcileData({
+  List<ParsedItem> parsed = const [],
+  List<PendingItem> pending = const [],
+  Map<String, TriageResult> triageDecisions = const {},
+}) {
+  return ReconcileData(
+    parsed: parsed,
+    pending: pending,
+    triageDecisions: triageDecisions,
+  );
 }
 
 void main() {
@@ -506,6 +548,322 @@ void main() {
       expect(find.byType(PendingCard), findsNWidgets(3));
     });
   });
+
+  group('reconcileDraftingSelections', () {
+    test('matched item with a task id contributes its task id', () {
+      final result = reconcileDraftingSelections(
+        _reconcileData(
+          parsed: [
+            _parsed('p1', kind: ParsedItemKind.matched, matchedTaskId: 't1'),
+          ],
+        ),
+      );
+
+      expect(result.taskIds, equals(['t1']));
+      expect(result.captureItemIds, isEmpty);
+    });
+
+    test('update item with a task id contributes its task id', () {
+      final result = reconcileDraftingSelections(
+        _reconcileData(
+          parsed: [
+            _parsed('p1', kind: ParsedItemKind.update, matchedTaskId: 't1'),
+          ],
+        ),
+      );
+
+      expect(result.taskIds, equals(['t1']));
+      expect(result.captureItemIds, isEmpty);
+    });
+
+    test(
+      'matched item with a null task id falls back to its capture item id',
+      () {
+        final result = reconcileDraftingSelections(
+          _reconcileData(
+            parsed: [_parsed('p1', kind: ParsedItemKind.matched)],
+          ),
+        );
+
+        expect(result.taskIds, isEmpty);
+        expect(result.captureItemIds, equals(['p1']));
+      },
+    );
+
+    test(
+      'update item with a null task id falls back to its capture item id',
+      () {
+        final result = reconcileDraftingSelections(
+          _reconcileData(
+            parsed: [_parsed('p1', kind: ParsedItemKind.update)],
+          ),
+        );
+
+        expect(result.taskIds, isEmpty);
+        expect(result.captureItemIds, equals(['p1']));
+      },
+    );
+
+    test('newTask item always contributes its capture item id', () {
+      final result = reconcileDraftingSelections(
+        _reconcileData(
+          parsed: [
+            // A matchedTaskId is present but irrelevant for a newTask kind,
+            // which is never task-bound.
+            _parsed('p1', kind: ParsedItemKind.newTask, matchedTaskId: 't1'),
+          ],
+        ),
+      );
+
+      expect(result.taskIds, isEmpty);
+      expect(result.captureItemIds, equals(['p1']));
+    });
+
+    test(
+      'triage decision with action today contributes its key as a task id',
+      () {
+        final result = reconcileDraftingSelections(
+          _reconcileData(
+            triageDecisions: {'t1': _triage('t1', TriageAction.today)},
+          ),
+        );
+
+        expect(result.taskIds, equals(['t1']));
+        expect(result.captureItemIds, isEmpty);
+      },
+    );
+
+    test(
+      'triage decision with action doNow contributes its key as a task id',
+      () {
+        final result = reconcileDraftingSelections(
+          _reconcileData(
+            triageDecisions: {'t1': _triage('t1', TriageAction.doNow)},
+          ),
+        );
+
+        expect(result.taskIds, equals(['t1']));
+        expect(result.captureItemIds, isEmpty);
+      },
+    );
+
+    test('triage decisions with non-selecting actions are excluded', () {
+      final result = reconcileDraftingSelections(
+        _reconcileData(
+          triageDecisions: {
+            't_defer': _triage('t_defer', TriageAction.defer),
+            't_done': _triage('t_done', TriageAction.done),
+            't_drop': _triage('t_drop', TriageAction.drop),
+          },
+        ),
+      );
+
+      expect(result.taskIds, isEmpty);
+      expect(result.captureItemIds, isEmpty);
+    });
+
+    test(
+      'a task id from both a matched item and a today triage appears once',
+      () {
+        final result = reconcileDraftingSelections(
+          _reconcileData(
+            parsed: [
+              _parsed('p1', kind: ParsedItemKind.matched, matchedTaskId: 't1'),
+            ],
+            triageDecisions: {'t1': _triage('t1', TriageAction.today)},
+          ),
+        );
+
+        expect(result.taskIds, equals(['t1']));
+        expect(result.captureItemIds, isEmpty);
+      },
+    );
+
+    test('combines parsed and triage contributions across branches', () {
+      final result = reconcileDraftingSelections(
+        _reconcileData(
+          parsed: [
+            _parsed('p1', kind: ParsedItemKind.matched, matchedTaskId: 't1'),
+            _parsed('p2', kind: ParsedItemKind.update, matchedTaskId: 't2'),
+            _parsed('p3', kind: ParsedItemKind.matched), // null → capture
+            _parsed('p4', kind: ParsedItemKind.newTask), // new → capture
+          ],
+          triageDecisions: {
+            't_today': _triage('t_today', TriageAction.today),
+            't_now': _triage('t_now', TriageAction.doNow),
+            't_defer': _triage('t_defer', TriageAction.defer),
+          },
+        ),
+      );
+
+      expect(
+        result.taskIds,
+        unorderedEquals(['t1', 't2', 't_today', 't_now']),
+      );
+      expect(result.captureItemIds, unorderedEquals(['p3', 'p4']));
+    });
+  });
+
+  group('reconcileDraftingSelections (Glados)', () {
+    // The strongest single invariant is the partition property: it pins down
+    // exactly where each parsed item lands AND that the two output lists never
+    // overlap on parsed-derived ids, which subsumes the weaker
+    // "every id is unique" and "each parsed item contributes once" properties.
+    // Triage today/doNow keys are then checked to be a subset of taskIds.
+    glados.Glados<List<_SelectionSpec>>(
+      glados.any.selectionSpecs,
+    ).test('partitions parsed items and folds in triage selections', (specs) {
+      // Real parsed-item ids are unique per capture, so assign each generated
+      // item a position-unique id. Matched-task ids and triage keys still draw
+      // from a tiny seed space so they collide across the list and exercise the
+      // Set-based de-duplication.
+      final parsed = [
+        for (var i = 0; i < specs.length; i++) specs[i].parsedItemAt(i),
+      ];
+      final triageDecisions = {
+        for (final s in specs)
+          if (s.triageTaskId != null) s.triageTaskId!: s.triageResult!,
+      };
+      final data = _reconcileData(
+        parsed: parsed,
+        triageDecisions: triageDecisions,
+      );
+
+      final result = reconcileDraftingSelections(data);
+      final taskIds = result.taskIds;
+      final captureItemIds = result.captureItemIds;
+
+      // (a) No duplicates within either list.
+      expect(taskIds.toSet().length, taskIds.length);
+      expect(captureItemIds.toSet().length, captureItemIds.length);
+
+      // (b) Every parsed item lands in exactly one bucket, on the expected
+      //     side, with the expected id.
+      for (final item in parsed) {
+        final boundTaskId =
+            (item.kind == ParsedItemKind.matched ||
+                item.kind == ParsedItemKind.update)
+            ? item.matchedTaskId
+            : null;
+        if (boundTaskId != null) {
+          expect(taskIds, contains(boundTaskId));
+          expect(captureItemIds, isNot(contains(item.id)));
+        } else {
+          expect(captureItemIds, contains(item.id));
+        }
+      }
+
+      // (c) Every today/doNow triage key ends up in taskIds; other actions
+      //     never add their key on their own.
+      for (final entry in triageDecisions.entries) {
+        final action = entry.value.action;
+        if (action == TriageAction.today || action == TriageAction.doNow) {
+          expect(taskIds, contains(entry.key));
+        }
+      }
+    }, tags: 'glados');
+  });
+
+  group('ReconcileModalContent', () {
+    testWidgets('narrow surface stacks the decide column below heard', (
+      tester,
+    ) async {
+      await _pumpModal(tester, width: 500, height: 1200);
+
+      final context = tester.element(find.byType(ReconcileModalContent));
+      final messages = context.messages;
+
+      // Column content rendered.
+      expect(find.text(_kHeardTitle), findsOneWidget);
+      expect(find.text(_kPendingTitle), findsOneWidget);
+
+      final heard = tester.getTopLeft(
+        find.text(messages.dailyOsNextReconcileHeardOverline),
+      );
+      final decide = tester.getTopLeft(
+        find.text(messages.dailyOsNextReconcileDecideOverline),
+      );
+
+      // Stacked: decide overline sits below the heard overline, roughly
+      // sharing the same left edge.
+      expect(decide.dy, greaterThan(heard.dy));
+      expect((decide.dx - heard.dx).abs(), lessThan(1));
+    });
+
+    testWidgets('wide surface lays heard and decide columns side by side', (
+      tester,
+    ) async {
+      await _pumpModal(tester, width: 1200, height: 900);
+
+      final context = tester.element(find.byType(ReconcileModalContent));
+      final messages = context.messages;
+
+      expect(find.text(_kHeardTitle), findsOneWidget);
+      expect(find.text(_kPendingTitle), findsOneWidget);
+
+      final heard = tester.getTopLeft(
+        find.text(messages.dailyOsNextReconcileHeardOverline),
+      );
+      final decide = tester.getTopLeft(
+        find.text(messages.dailyOsNextReconcileDecideOverline),
+      );
+
+      // Side by side: the decide column starts to the right of the heard
+      // column and the two overlines share roughly the same vertical line.
+      expect(decide.dx, greaterThan(heard.dx));
+      expect((decide.dy - heard.dy).abs(), lessThan(1));
+    });
+  });
+}
+
+const _kHeardTitle = 'Review the deck';
+const _kPendingTitle = 'Pay invoices';
+
+/// Pumps a [ReconcileModalContent] at the given surface size with one parsed
+/// and one pending item so both columns carry visible content. The decide
+/// column is a [ConsumerWidget] that reads the reconcile controller for triage
+/// decisions, so a [ProviderScope] with a fast in-memory agent is supplied.
+Future<void> _pumpModal(
+  WidgetTester tester, {
+  required double width,
+  required double height,
+}) async {
+  tester.view
+    ..physicalSize = Size(width, height)
+    ..devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+
+  final params = ReconcileParams(
+    captureId: const CaptureId('cap_modal'),
+    dayDate: DateTime(2026, 5, 25),
+  );
+  final data = _reconcileData(
+    parsed: [
+      _parsed(
+        'p_heard',
+        kind: ParsedItemKind.newTask,
+        title: _kHeardTitle,
+      ),
+    ],
+    pending: const [
+      PendingItem(
+        taskId: 't_pending',
+        title: _kPendingTitle,
+        category: _category,
+        reason: PendingItemReason.overdue,
+        overdueByDays: 2,
+      ),
+    ],
+  );
+
+  await tester.pumpWidget(
+    _wrap(
+      ReconcileModalContent(params: params, data: data),
+      overrides: [dayAgentProvider.overrideWithValue(_fastAgent())],
+      mediaQueryData: MediaQueryData(size: Size(width, height)),
+    ),
+  );
+  await tester.pump(const Duration(milliseconds: 200));
 }
 
 /// Agent whose parse step surfaces a matched item that has no resolved
@@ -560,4 +918,86 @@ class _BreakLinkRecordingAgent extends MockDayAgent {
       confidence: ParsedItemConfidence.high,
     );
   }
+}
+
+/// A single generated reconcile entry: one parsed item plus an optional triage
+/// decision keyed on a generated task id. The parsed item's own id is assigned
+/// from its list position ([parsedItemAt]) so parsed ids stay unique (as they
+/// are in real captures), while matched-task ids and triage keys draw from a
+/// tiny seed space so they collide across the list and exercise the de-dup path.
+class _SelectionSpec {
+  const _SelectionSpec({
+    required this.kind,
+    required this.hasMatchedTaskId,
+    required this.matchedTaskSeed,
+    required this.hasTriage,
+    required this.triageSeed,
+    required this.triageAction,
+  });
+
+  final ParsedItemKind kind;
+  final bool hasMatchedTaskId;
+  final int matchedTaskSeed;
+  final bool hasTriage;
+  final int triageSeed;
+  final TriageAction triageAction;
+
+  String? get matchedTaskId => hasMatchedTaskId ? 't_$matchedTaskSeed' : null;
+
+  ParsedItem parsedItemAt(int index) => ParsedItem(
+    id: 'p_$index',
+    kind: kind,
+    title: 'Parsed $index',
+    category: _category,
+    confidence: ParsedItemConfidence.high,
+    matchedTaskId: matchedTaskId,
+  );
+
+  String? get triageTaskId => hasTriage ? 't_$triageSeed' : null;
+
+  TriageResult? get triageResult => hasTriage
+      ? TriageResult(taskId: triageTaskId!, action: triageAction)
+      : null;
+
+  @override
+  String toString() =>
+      '_SelectionSpec(kind: $kind, '
+      'matched: $matchedTaskId, triage: $triageTaskId/$triageAction)';
+}
+
+extension _AnySelectionSpecs on glados.Any {
+  glados.Generator<ParsedItemKind> get parsedItemKind =>
+      choose(ParsedItemKind.values);
+
+  glados.Generator<TriageAction> get triageAction =>
+      choose(TriageAction.values);
+
+  glados.Generator<_SelectionSpec> get selectionSpec => combine6(
+    parsedItemKind,
+    this.bool,
+    // Small seed ranges so matched-task ids and triage task ids collide across
+    // the list, exercising the Set-based de-duplication.
+    intInRange(0, 4),
+    this.bool,
+    intInRange(0, 4),
+    triageAction,
+    (
+      ParsedItemKind kind,
+      bool hasMatchedTaskId,
+      int matchedTaskSeed,
+      bool hasTriage,
+      int triageSeed,
+      TriageAction triageAction,
+    ) => _SelectionSpec(
+      kind: kind,
+      hasMatchedTaskId: hasMatchedTaskId,
+      matchedTaskSeed: matchedTaskSeed,
+      hasTriage: hasTriage,
+      triageSeed: triageSeed,
+      triageAction: triageAction,
+    ),
+  );
+
+  glados.Generator<List<_SelectionSpec>> get selectionSpecs =>
+      list(selectionSpec);
 }

--- a/test/features/daily_os_next/ui/widgets/day_planning_glass_action_bar_test.dart
+++ b/test/features/daily_os_next/ui/widgets/day_planning_glass_action_bar_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/daily_os_next/ui/widgets/day_planning_glass_action_bar.dart';
+import 'package:lotti/features/design_system/components/glass_strip.dart';
+import 'package:lotti/features/design_system/theme/design_system_theme.dart';
+
+import '../../../../widget_test_utils.dart';
+
+void main() {
+  group('DayPlanningGlassActionBar', () {
+    testWidgets('renders the actions on a shared glass strip', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const DayPlanningGlassActionBar(
+            actions: Text('actions-row'),
+          ),
+          theme: DesignSystemTheme.light(),
+        ),
+      );
+
+      expect(find.byType(DesignSystemGlassStrip), findsOneWidget);
+      expect(find.text('actions-row'), findsOneWidget);
+      expect(find.byKey(DayPlanningGlassActionBar.topSlotKey), findsNothing);
+    });
+
+    testWidgets('places the topSlot above the actions when provided', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const DayPlanningGlassActionBar(
+            topSlot: SizedBox(height: 12, child: Text('shader')),
+            actions: Text('actions-row'),
+          ),
+          theme: DesignSystemTheme.light(),
+        ),
+      );
+
+      expect(find.byKey(DayPlanningGlassActionBar.topSlotKey), findsOneWidget);
+
+      final shaderY = tester
+          .getCenter(find.byKey(DayPlanningGlassActionBar.topSlotKey))
+          .dy;
+      final actionsY = tester.getCenter(find.text('actions-row')).dy;
+      expect(shaderY, lessThan(actionsY));
+    });
+  });
+}

--- a/test/features/daily_os_next/ui/widgets/day_planning_glass_action_bar_test.dart
+++ b/test/features/daily_os_next/ui/widgets/day_planning_glass_action_bar_test.dart
@@ -44,5 +44,36 @@ void main() {
       final actionsY = tester.getCenter(find.text('actions-row')).dy;
       expect(shaderY, lessThan(actionsY));
     });
+
+    testWidgets('extends its bottom padding by the safe-area inset', (
+      tester,
+    ) async {
+      const inset = 34.0;
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const DayPlanningGlassActionBar(actions: Text('actions-row')),
+          theme: DesignSystemTheme.light(),
+          mediaQueryData: const MediaQueryData(
+            size: Size(420, 900),
+            padding: EdgeInsets.only(bottom: inset),
+          ),
+        ),
+      );
+
+      // The bar's content padding: equal horizontal (step5), equal top
+      // (step4), and a bottom of step4 + the system home-indicator inset.
+      final padding = tester
+          .widgetList<Padding>(
+            find.descendant(
+              of: find.byType(DayPlanningGlassActionBar),
+              matching: find.byType(Padding),
+            ),
+          )
+          .map((p) => p.padding)
+          .whereType<EdgeInsets>()
+          .firstWhere((e) => e.left == e.right && e.left > 0 && e.top > 0);
+
+      expect(padding.bottom - padding.top, inset);
+    });
   });
 }

--- a/test/features/daily_os_next/ui/widgets/day_planning_thinking_shader_test.dart
+++ b/test/features/daily_os_next/ui/widgets/day_planning_thinking_shader_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/ai/ui/animation/ai_running_animation.dart';
 import 'package:lotti/features/ai/ui/animation/ai_state_shader_animation.dart';
@@ -43,6 +42,47 @@ void main() {
       );
       expect(shader.route, AiThinkingShaderRoute.decoderBars);
       expect(shader.opacity, 1);
+    });
+
+    testWidgets('fades the shader in over the transition when thinking '
+        'starts after mount', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const DayPlanningThinkingShader(isThinking: false),
+          theme: DesignSystemTheme.light(),
+        ),
+      );
+      expect(find.byKey(DayPlanningThinkingShader.indicatorKey), findsNothing);
+
+      // Flip to thinking — the presence envelope animates in rather than
+      // seeding fully shown (which only happens when mounted already true).
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const DayPlanningThinkingShader(isThinking: true),
+          theme: DesignSystemTheme.light(),
+        ),
+      );
+      await tester.pump(); // kick the controller forward
+      await tester.pump(AiRunningDecoderBars.transitionDuration ~/ 2);
+      // Part-way through entry: present but not yet at full opacity.
+      expect(
+        find.byKey(DayPlanningThinkingShader.indicatorKey),
+        findsOneWidget,
+      );
+      final midShader = tester.widget<AiThinkingLineShader>(
+        find.byType(AiThinkingLineShader),
+      );
+      expect(midShader.opacity, greaterThan(0));
+      expect(midShader.opacity, lessThan(1));
+
+      // After the full transition it settles fully shown.
+      await tester.pump(AiRunningDecoderBars.transitionDuration);
+      expect(
+        tester
+            .widget<AiThinkingLineShader>(find.byType(AiThinkingLineShader))
+            .opacity,
+        1,
+      );
     });
 
     testWidgets('reverses out and collapses when thinking stops', (

--- a/test/features/daily_os_next/ui/widgets/day_planning_thinking_shader_test.dart
+++ b/test/features/daily_os_next/ui/widgets/day_planning_thinking_shader_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/ai/ui/animation/ai_running_animation.dart';
+import 'package:lotti/features/ai/ui/animation/ai_state_shader_animation.dart';
+import 'package:lotti/features/daily_os_next/ui/widgets/day_planning_thinking_shader.dart';
+import 'package:lotti/features/design_system/theme/design_system_theme.dart';
+
+import '../../../../widget_test_utils.dart';
+
+void main() {
+  group('DayPlanningThinkingShader', () {
+    testWidgets('renders nothing while not thinking', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const DayPlanningThinkingShader(isThinking: false),
+          theme: DesignSystemTheme.light(),
+        ),
+      );
+
+      expect(
+        find.byKey(DayPlanningThinkingShader.indicatorKey),
+        findsNothing,
+      );
+      expect(find.byType(AiThinkingLineShader), findsNothing);
+    });
+
+    testWidgets('fades the shader in once thinking starts', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const DayPlanningThinkingShader(isThinking: true),
+          theme: DesignSystemTheme.light(),
+        ),
+      );
+
+      // Seeded fully shown at mount (no entry animation), so the shader is
+      // present immediately.
+      expect(
+        find.byKey(DayPlanningThinkingShader.indicatorKey),
+        findsOneWidget,
+      );
+      final shader = tester.widget<AiThinkingLineShader>(
+        find.byType(AiThinkingLineShader),
+      );
+      expect(shader.route, AiThinkingShaderRoute.decoderBars);
+      expect(shader.opacity, 1);
+    });
+
+    testWidgets('reverses out and collapses when thinking stops', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const DayPlanningThinkingShader(isThinking: true),
+          theme: DesignSystemTheme.light(),
+        ),
+      );
+      expect(
+        find.byKey(DayPlanningThinkingShader.indicatorKey),
+        findsOneWidget,
+      );
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const DayPlanningThinkingShader(isThinking: false),
+          theme: DesignSystemTheme.light(),
+        ),
+      );
+      // Let the exit transition complete.
+      await tester.pump(AiRunningDecoderBars.transitionDuration);
+      await tester.pump(AiRunningDecoderBars.transitionDuration);
+
+      expect(
+        find.byKey(DayPlanningThinkingShader.indicatorKey),
+        findsNothing,
+      );
+      expect(find.byType(AiThinkingLineShader), findsNothing);
+    });
+  });
+}

--- a/test/features/design_system/components/glass_action_bar_test.dart
+++ b/test/features/design_system/components/glass_action_bar_test.dart
@@ -19,9 +19,9 @@ Future<void> _pump(
   );
 }
 
-/// Reads the styled [Container] (the one carrying the [BoxDecoration]) inside
-/// the given root widget type. Both [DsGlassRoundButton] and [DsGlassPill]
-/// render exactly one [Container], which is the decorated one.
+/// Reads the inner [Container] (which carries the hairline
+/// [Container.foregroundDecoration]) inside the given root widget type. Both
+/// [DsGlassRoundButton] and [DsGlassPill] render exactly one [Container].
 Container _decoratedContainer(WidgetTester tester, Type rootType) {
   return tester.widget<Container>(
     find.descendant(
@@ -29,6 +29,15 @@ Container _decoratedContainer(WidgetTester tester, Type rootType) {
       matching: find.byType(Container),
     ),
   );
+}
+
+/// Reads the background [BoxDecoration] from the [Ink] widget — the fill
+/// lives on [Ink] (not the Container) so the InkWell splash renders above it.
+BoxDecoration _inkDecoration(WidgetTester tester, Type rootType) {
+  final ink = tester.widget<Ink>(
+    find.descendant(of: find.byType(rootType), matching: find.byType(Ink)),
+  );
+  return ink.decoration! as BoxDecoration;
 }
 
 DsTokens _tokens(WidgetTester tester, Type rootType) {
@@ -118,10 +127,9 @@ void main() {
           ),
         );
 
-        final container = _decoratedContainer(tester, DsGlassRoundButton);
-        final decoration = container.decoration! as BoxDecoration;
-        expect(decoration.color, bg);
+        expect(_inkDecoration(tester, DsGlassRoundButton).color, bg);
         // No hairline outline drawn when a solid background is supplied.
+        final container = _decoratedContainer(tester, DsGlassRoundButton);
         expect(container.foregroundDecoration, isNull);
       },
     );
@@ -139,10 +147,12 @@ void main() {
         );
 
         final tokens = _tokens(tester, DsGlassRoundButton);
-        final container = _decoratedContainer(tester, DsGlassRoundButton);
-        final decoration = container.decoration! as BoxDecoration;
-        expect(decoration.color, dsGlassChipFill(tokens));
+        expect(
+          _inkDecoration(tester, DsGlassRoundButton).color,
+          dsGlassChipFill(tokens),
+        );
 
+        final container = _decoratedContainer(tester, DsGlassRoundButton);
         final foreground = container.foregroundDecoration! as BoxDecoration;
         expect(foreground.border, isNotNull);
         expect(foreground.border, dsGlassChipBorder(tokens));
@@ -255,9 +265,8 @@ void main() {
           ),
         );
 
+        expect(_inkDecoration(tester, DsGlassPill).color, fill);
         final container = _decoratedContainer(tester, DsGlassPill);
-        final decoration = container.decoration! as BoxDecoration;
-        expect(decoration.color, fill);
         expect(container.foregroundDecoration, isNull);
       },
     );
@@ -274,10 +283,12 @@ void main() {
         );
 
         final tokens = _tokens(tester, DsGlassPill);
-        final container = _decoratedContainer(tester, DsGlassPill);
-        final decoration = container.decoration! as BoxDecoration;
-        expect(decoration.color, dsGlassChipFill(tokens));
+        expect(
+          _inkDecoration(tester, DsGlassPill).color,
+          dsGlassChipFill(tokens),
+        );
 
+        final container = _decoratedContainer(tester, DsGlassPill);
         final foreground = container.foregroundDecoration! as BoxDecoration;
         expect(foreground.border, isNotNull);
         expect(foreground.border, dsGlassChipBorder(tokens));
@@ -416,8 +427,7 @@ void main() {
         final tokens = _tokens(tester, DsGlassPill);
 
         // (b) Solid fill is dropped for the translucent glass fill.
-        final container = _decoratedContainer(tester, DsGlassPill);
-        final decoration = container.decoration! as BoxDecoration;
+        final decoration = _inkDecoration(tester, DsGlassPill);
         expect(decoration.color, dsGlassChipFill(tokens));
         expect(decoration.color, isNot(fill));
 

--- a/test/features/design_system/components/glass_action_bar_test.dart
+++ b/test/features/design_system/components/glass_action_bar_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/components/glass_action_bar.dart';
+import 'package:lotti/features/design_system/theme/design_system_theme.dart';
+
+import '../../../widget_test_utils.dart';
+
+void main() {
+  group('DsGlassRoundButton', () {
+    testWidgets('renders the icon and fires onPressed when tapped', (
+      tester,
+    ) async {
+      var taps = 0;
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          DsGlassRoundButton(
+            icon: Icons.mic_rounded,
+            semanticLabel: 'Record',
+            onPressed: () => taps++,
+          ),
+          theme: DesignSystemTheme.light(),
+        ),
+      );
+
+      expect(find.byIcon(Icons.mic_rounded), findsOneWidget);
+      await tester.tap(find.byType(DsGlassRoundButton));
+      expect(taps, 1);
+    });
+
+    testWidgets('uses the default diameter and honours a custom one', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          Column(
+            children: [
+              DsGlassRoundButton(
+                key: const Key('default'),
+                icon: Icons.add,
+                semanticLabel: 'Add',
+                onPressed: () {},
+              ),
+              DsGlassRoundButton(
+                key: const Key('big'),
+                icon: Icons.add,
+                semanticLabel: 'Add big',
+                diameter: 64,
+                onPressed: () {},
+              ),
+            ],
+          ),
+          theme: DesignSystemTheme.light(),
+        ),
+      );
+
+      expect(
+        tester.getSize(find.byKey(const Key('default'))),
+        const Size.square(DsGlassRoundButton.defaultDiameter),
+      );
+      expect(
+        tester.getSize(find.byKey(const Key('big'))),
+        const Size.square(64),
+      );
+    });
+
+    testWidgets('applies the iconColor override', (tester) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          DsGlassRoundButton(
+            icon: Icons.stop,
+            semanticLabel: 'Stop',
+            iconColor: const Color(0xFFAABBCC),
+            onPressed: () {},
+          ),
+          theme: DesignSystemTheme.light(),
+        ),
+      );
+
+      final icon = tester.widget<Icon>(find.byIcon(Icons.stop));
+      expect(icon.color, const Color(0xFFAABBCC));
+    });
+  });
+
+  group('DsGlassPill', () {
+    testWidgets('renders label and leading icon and fires onTap', (
+      tester,
+    ) async {
+      var taps = 0;
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          DsGlassPill(
+            label: 'Build day',
+            icon: Icons.arrow_forward_rounded,
+            onTap: () => taps++,
+          ),
+          theme: DesignSystemTheme.light(),
+        ),
+      );
+
+      expect(find.text('Build day'), findsOneWidget);
+      expect(find.byIcon(Icons.arrow_forward_rounded), findsOneWidget);
+      await tester.tap(find.byType(DsGlassPill));
+      expect(taps, 1);
+    });
+
+    testWidgets('expand stretches the pill to the available width', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          SizedBox(
+            width: 320,
+            child: DsGlassPill(
+              key: const Key('pill'),
+              label: 'Wide',
+              expand: true,
+              onTap: () {},
+            ),
+          ),
+          theme: DesignSystemTheme.light(),
+        ),
+      );
+
+      expect(tester.getSize(find.byKey(const Key('pill'))).width, 320);
+    });
+
+    testWidgets('applies the foregroundColor override to the label', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          DsGlassPill(
+            label: 'Tinted',
+            foregroundColor: const Color(0xFF112233),
+            onTap: () {},
+          ),
+          theme: DesignSystemTheme.light(),
+        ),
+      );
+
+      final text = tester.widget<Text>(find.text('Tinted'));
+      expect(text.style?.color, const Color(0xFF112233));
+    });
+  });
+}

--- a/test/features/design_system/components/glass_action_bar_test.dart
+++ b/test/features/design_system/components/glass_action_bar_test.dart
@@ -2,8 +2,38 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/design_system/components/glass_action_bar.dart';
 import 'package:lotti/features/design_system/theme/design_system_theme.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 
 import '../../../widget_test_utils.dart';
+
+Future<void> _pump(
+  WidgetTester tester,
+  Widget child, {
+  ThemeData? theme,
+}) {
+  return tester.pumpWidget(
+    makeTestableWidgetWithScaffold(
+      child,
+      theme: theme ?? DesignSystemTheme.light(),
+    ),
+  );
+}
+
+/// Reads the styled [Container] (the one carrying the [BoxDecoration]) inside
+/// the given root widget type. Both [DsGlassRoundButton] and [DsGlassPill]
+/// render exactly one [Container], which is the decorated one.
+Container _decoratedContainer(WidgetTester tester, Type rootType) {
+  return tester.widget<Container>(
+    find.descendant(
+      of: find.byType(rootType),
+      matching: find.byType(Container),
+    ),
+  );
+}
+
+DsTokens _tokens(WidgetTester tester, Type rootType) {
+  return tester.element(find.byType(rootType)).designTokens;
+}
 
 void main() {
   group('DsGlassRoundButton', () {
@@ -11,14 +41,12 @@ void main() {
       tester,
     ) async {
       var taps = 0;
-      await tester.pumpWidget(
-        makeTestableWidgetWithScaffold(
-          DsGlassRoundButton(
-            icon: Icons.mic_rounded,
-            semanticLabel: 'Record',
-            onPressed: () => taps++,
-          ),
-          theme: DesignSystemTheme.light(),
+      await _pump(
+        tester,
+        DsGlassRoundButton(
+          icon: Icons.mic_rounded,
+          semanticLabel: 'Record',
+          onPressed: () => taps++,
         ),
       );
 
@@ -30,26 +58,24 @@ void main() {
     testWidgets('uses the default diameter and honours a custom one', (
       tester,
     ) async {
-      await tester.pumpWidget(
-        makeTestableWidgetWithScaffold(
-          Column(
-            children: [
-              DsGlassRoundButton(
-                key: const Key('default'),
-                icon: Icons.add,
-                semanticLabel: 'Add',
-                onPressed: () {},
-              ),
-              DsGlassRoundButton(
-                key: const Key('big'),
-                icon: Icons.add,
-                semanticLabel: 'Add big',
-                diameter: 64,
-                onPressed: () {},
-              ),
-            ],
-          ),
-          theme: DesignSystemTheme.light(),
+      await _pump(
+        tester,
+        Column(
+          children: [
+            DsGlassRoundButton(
+              key: const Key('default'),
+              icon: Icons.add,
+              semanticLabel: 'Add',
+              onPressed: () {},
+            ),
+            DsGlassRoundButton(
+              key: const Key('big'),
+              icon: Icons.add,
+              semanticLabel: 'Add big',
+              diameter: 64,
+              onPressed: () {},
+            ),
+          ],
         ),
       );
 
@@ -64,20 +90,100 @@ void main() {
     });
 
     testWidgets('applies the iconColor override', (tester) async {
-      await tester.pumpWidget(
-        makeTestableWidgetWithScaffold(
-          DsGlassRoundButton(
-            icon: Icons.stop,
-            semanticLabel: 'Stop',
-            iconColor: const Color(0xFFAABBCC),
-            onPressed: () {},
-          ),
-          theme: DesignSystemTheme.light(),
+      await _pump(
+        tester,
+        DsGlassRoundButton(
+          icon: Icons.stop,
+          semanticLabel: 'Stop',
+          iconColor: const Color(0xFFAABBCC),
+          onPressed: () {},
         ),
       );
 
       final icon = tester.widget<Icon>(find.byIcon(Icons.stop));
       expect(icon.color, const Color(0xFFAABBCC));
+    });
+
+    testWidgets(
+      'solid branch fills with backgroundColor and draws no hairline border',
+      (tester) async {
+        const bg = Color(0xFF123456);
+        await _pump(
+          tester,
+          DsGlassRoundButton(
+            icon: Icons.bolt,
+            semanticLabel: 'Active',
+            backgroundColor: bg,
+            onPressed: () {},
+          ),
+        );
+
+        final container = _decoratedContainer(tester, DsGlassRoundButton);
+        final decoration = container.decoration! as BoxDecoration;
+        expect(decoration.color, bg);
+        // No hairline outline drawn when a solid background is supplied.
+        expect(container.foregroundDecoration, isNull);
+      },
+    );
+
+    testWidgets(
+      'translucent branch uses glass fill and a hairline border',
+      (tester) async {
+        await _pump(
+          tester,
+          DsGlassRoundButton(
+            icon: Icons.bolt,
+            semanticLabel: 'Idle',
+            onPressed: () {},
+          ),
+        );
+
+        final tokens = _tokens(tester, DsGlassRoundButton);
+        final container = _decoratedContainer(tester, DsGlassRoundButton);
+        final decoration = container.decoration! as BoxDecoration;
+        expect(decoration.color, dsGlassChipFill(tokens));
+
+        final foreground = container.foregroundDecoration! as BoxDecoration;
+        expect(foreground.border, isNotNull);
+        expect(foreground.border, dsGlassChipBorder(tokens));
+      },
+    );
+
+    testWidgets(
+      'default iconColor falls back to text.highEmphasis',
+      (tester) async {
+        await _pump(
+          tester,
+          DsGlassRoundButton(
+            icon: Icons.close,
+            semanticLabel: 'Close',
+            onPressed: () {},
+          ),
+        );
+
+        final tokens = _tokens(tester, DsGlassRoundButton);
+        final icon = tester.widget<Icon>(find.byIcon(Icons.close));
+        expect(icon.color, tokens.colors.text.highEmphasis);
+      },
+    );
+
+    testWidgets('exposes a button semantics node with its label', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        DsGlassRoundButton(
+          icon: Icons.mic_rounded,
+          semanticLabel: 'Record',
+          onPressed: () {},
+        ),
+      );
+
+      expect(find.bySemanticsLabel('Record'), findsOneWidget);
+      expect(
+        tester.getSemantics(find.bySemanticsLabel('Record')),
+        matchesSemantics(label: 'Record', isButton: true),
+      );
     });
   });
 
@@ -86,14 +192,12 @@ void main() {
       tester,
     ) async {
       var taps = 0;
-      await tester.pumpWidget(
-        makeTestableWidgetWithScaffold(
-          DsGlassPill(
-            label: 'Build day',
-            icon: Icons.arrow_forward_rounded,
-            onTap: () => taps++,
-          ),
-          theme: DesignSystemTheme.light(),
+      await _pump(
+        tester,
+        DsGlassPill(
+          label: 'Build day',
+          icon: Icons.arrow_forward_rounded,
+          onTap: () => taps++,
         ),
       );
 
@@ -106,18 +210,16 @@ void main() {
     testWidgets('expand stretches the pill to the available width', (
       tester,
     ) async {
-      await tester.pumpWidget(
-        makeTestableWidgetWithScaffold(
-          SizedBox(
-            width: 320,
-            child: DsGlassPill(
-              key: const Key('pill'),
-              label: 'Wide',
-              expand: true,
-              onTap: () {},
-            ),
+      await _pump(
+        tester,
+        SizedBox(
+          width: 320,
+          child: DsGlassPill(
+            key: const Key('pill'),
+            label: 'Wide',
+            expand: true,
+            onTap: () {},
           ),
-          theme: DesignSystemTheme.light(),
         ),
       );
 
@@ -127,19 +229,215 @@ void main() {
     testWidgets('applies the foregroundColor override to the label', (
       tester,
     ) async {
-      await tester.pumpWidget(
-        makeTestableWidgetWithScaffold(
-          DsGlassPill(
-            label: 'Tinted',
-            foregroundColor: const Color(0xFF112233),
-            onTap: () {},
-          ),
-          theme: DesignSystemTheme.light(),
+      await _pump(
+        tester,
+        DsGlassPill(
+          label: 'Tinted',
+          foregroundColor: const Color(0xFF112233),
+          onTap: () {},
         ),
       );
 
       final text = tester.widget<Text>(find.text('Tinted'));
       expect(text.style?.color, const Color(0xFF112233));
     });
+
+    testWidgets(
+      'solid branch fills with fillColor and draws no hairline border',
+      (tester) async {
+        const fill = Color(0xFF0A7E76);
+        await _pump(
+          tester,
+          DsGlassPill(
+            label: 'Primary',
+            fillColor: fill,
+            onTap: () {},
+          ),
+        );
+
+        final container = _decoratedContainer(tester, DsGlassPill);
+        final decoration = container.decoration! as BoxDecoration;
+        expect(decoration.color, fill);
+        expect(container.foregroundDecoration, isNull);
+      },
+    );
+
+    testWidgets(
+      'translucent default uses glass fill and a hairline border',
+      (tester) async {
+        await _pump(
+          tester,
+          DsGlassPill(
+            label: 'Idle',
+            onTap: () {},
+          ),
+        );
+
+        final tokens = _tokens(tester, DsGlassPill);
+        final container = _decoratedContainer(tester, DsGlassPill);
+        final decoration = container.decoration! as BoxDecoration;
+        expect(decoration.color, dsGlassChipFill(tokens));
+
+        final foreground = container.foregroundDecoration! as BoxDecoration;
+        expect(foreground.border, isNotNull);
+        expect(foreground.border, dsGlassChipBorder(tokens));
+      },
+    );
+
+    testWidgets(
+      'default foreground falls back to text.highEmphasis for label and icon',
+      (tester) async {
+        await _pump(
+          tester,
+          DsGlassPill(
+            label: 'Neutral',
+            icon: Icons.arrow_forward_rounded,
+            onTap: () {},
+          ),
+        );
+
+        final tokens = _tokens(tester, DsGlassPill);
+        final text = tester.widget<Text>(find.text('Neutral'));
+        expect(text.style?.color, tokens.colors.text.highEmphasis);
+
+        final icon = tester.widget<Icon>(
+          find.byIcon(Icons.arrow_forward_rounded),
+        );
+        expect(icon.color, tokens.colors.text.highEmphasis);
+      },
+    );
+
+    testWidgets('renders no icon when icon is null', (tester) async {
+      await _pump(
+        tester,
+        DsGlassPill(
+          label: 'No icon',
+          onTap: () {},
+        ),
+      );
+
+      expect(
+        find.descendant(
+          of: find.byType(DsGlassPill),
+          matching: find.byType(Icon),
+        ),
+        findsNothing,
+      );
+    });
+
+    testWidgets('label truncates with a single-line ellipsis', (tester) async {
+      await _pump(
+        tester,
+        DsGlassPill(
+          label: 'A very long label that should be ellipsized',
+          onTap: () {},
+        ),
+      );
+
+      final text = tester.widget<Text>(
+        find.text('A very long label that should be ellipsized'),
+      );
+      expect(text.maxLines, 1);
+      expect(text.overflow, TextOverflow.ellipsis);
+    });
+
+    testWidgets(
+      'without expand the pill hugs its content (narrower than parent)',
+      (tester) async {
+        await _pump(
+          tester,
+          SizedBox(
+            width: 320,
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: DsGlassPill(
+                key: const Key('pill'),
+                label: 'Hug',
+                onTap: () {},
+              ),
+            ),
+          ),
+        );
+
+        final pillWidth = tester.getSize(find.byKey(const Key('pill'))).width;
+        expect(pillWidth, lessThan(320));
+      },
+    );
+
+    testWidgets('uses semanticLabel when it differs from the label', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        DsGlassPill(
+          label: 'Go',
+          semanticLabel: 'Build the day plan',
+          onTap: () {},
+        ),
+      );
+
+      expect(find.bySemanticsLabel('Build the day plan'), findsOneWidget);
+      expect(find.bySemanticsLabel('Go'), findsNothing);
+    });
+
+    testWidgets('enabled true wires onTap', (tester) async {
+      var taps = 0;
+      await _pump(
+        tester,
+        DsGlassPill(
+          label: 'Tap me',
+          onTap: () => taps++,
+        ),
+      );
+
+      await tester.tap(find.byType(DsGlassPill));
+      expect(taps, 1);
+    });
+
+    testWidgets(
+      'enabled false: drops fill, dims foreground, ignores taps, disables a11y',
+      (tester) async {
+        var taps = 0;
+        const fill = Color(0xFF0A7E76);
+        await _pump(
+          tester,
+          DsGlassPill(
+            label: 'Disabled',
+            fillColor: fill,
+            enabled: false,
+            onTap: () => taps++,
+          ),
+        );
+
+        // (a) onTap does not fire.
+        await tester.tap(find.byType(DsGlassPill), warnIfMissed: false);
+        expect(taps, 0);
+
+        final tokens = _tokens(tester, DsGlassPill);
+
+        // (b) Solid fill is dropped for the translucent glass fill.
+        final container = _decoratedContainer(tester, DsGlassPill);
+        final decoration = container.decoration! as BoxDecoration;
+        expect(decoration.color, dsGlassChipFill(tokens));
+        expect(decoration.color, isNot(fill));
+
+        // (c) Foreground dims to text.lowEmphasis.
+        final text = tester.widget<Text>(find.text('Disabled'));
+        expect(text.style?.color, tokens.colors.text.lowEmphasis);
+
+        // (d) Semantics reports a disabled button.
+        expect(
+          tester.getSemantics(find.bySemanticsLabel('Disabled')),
+          matchesSemantics(
+            label: 'Disabled',
+            isButton: true,
+            hasEnabledState: true,
+            // Asserted explicitly: the node carries enabled-state and is off.
+            // ignore: avoid_redundant_argument_values
+            isEnabled: false,
+          ),
+        );
+      },
+    );
   });
 }

--- a/test/features/tasks/ui/widgets/task_action_bar_test.dart
+++ b/test/features/tasks/ui/widgets/task_action_bar_test.dart
@@ -493,19 +493,18 @@ void main() {
     ).called(1);
   });
 
-  /// Reads the round audio button's background color directly off the
-  /// inner Container so we can compare against the design tokens'
-  /// alert/error red and the default surface-hover color.
+  /// Reads the round audio button's background color off the [Ink] widget
+  /// (the fill lives there, not the inner Container, so the InkWell splash
+  /// renders above it) to compare against the design tokens' alert/error red
+  /// and the default surface-hover color.
   Color audioButtonFill(WidgetTester tester) {
-    final container = tester.widget<Container>(
+    final ink = tester.widget<Ink>(
       find.descendant(
         of: find.byKey(TaskActionBar.audioKey),
-        matching: find.byWidgetPredicate(
-          (w) => w is Container && w.decoration is BoxDecoration,
-        ),
+        matching: find.byType(Ink),
       ),
     );
-    return (container.decoration! as BoxDecoration).color!;
+    return (ink.decoration! as BoxDecoration).color!;
   }
 
   testWidgets(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Day Planning Modal: unified multi-step interface for creating new daily plans (Capture → Reconcile → Drafting) and refining existing ones.
  * Improved empty day workflow with direct "Speak a check-in" CTA that opens the planning modal.
  * Refine flow now uses the shared day planning modal instead of separate route.

* **Refactor**
  * Extracted AI thinking shader animation into reusable component for consistent use across features.
  * Created modal-specific UI variants for capture, reconcile, and drafting steps.
  * Added glass-style action bar components for consistent sticky action bar styling.

* **Documentation**
  * Updated day-planning UI routing and state management documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->