### PR TITLE
fix: restore scroll-to-entry on DailyOS Next calendar tap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   "Uncategorized" in time-by-category views (including the Daily OS time
   history): the denormalized category column is now backfilled once from
   the stored entry data.
+- Daily OS Next: tapping a recorded session on the Day timeline now reopens
+  its task scrolled to — and briefly highlighting — that exact entry again,
+  instead of dropping you at the top of the task.
 
 ## [0.9.1016]
 ### Added

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -36,6 +36,7 @@
       <description>
           <p>New desktop "Time Analysis" dashboard under Daily OS, opened from a sidebar entry beneath the month calendar onto the full screen: see where your time went per category and per day, with quick range presets (1d, 7d, 30d, MTD, YTD, last month), a custom date range, a daily/cumulative chart toggle, headline totals, optional focus categories, and a precise per-category table. Range switching is instantaneous even with years of entries, and private entries stay hidden unless the private flag is on.</p>
           <p>Time tracked on entries created before mid-2024 could show up as "Uncategorized" in time-by-category views; the category data is now backfilled once on upgrade.</p>
+          <p>Daily OS Next: tapping a recorded session on the Day timeline now reopens its task scrolled to — and briefly highlighting — that exact entry again, instead of dropping you at the top of the task.</p>
       </description>
     </release>
     <release version="0.9.1016" date="2026-06-06">

--- a/lib/features/daily_os_next/logic/day_agent_models.dart
+++ b/lib/features/daily_os_next/logic/day_agent_models.dart
@@ -222,6 +222,13 @@ enum TimeBlockState {
   dropped,
 }
 
+/// Prefix used to encode a tracked [TimeBlock]'s id from the journal
+/// entry id of the time recording it projects (`actual:<entryId>`).
+/// The prefix keeps recorded-session ids distinct from drafted/agent
+/// block ids, and lets the Day timeline recover the backing entry id
+/// so tapping a tracked block can scroll the task detail page to it.
+const actualTimeBlockIdPrefix = 'actual:';
+
 /// A scheduled placement on a day. The agent emits these from
 /// `drafted_day_plan`; every `ai` block carries a verbatim `reason`
 /// string that the UI surfaces in the WhyChip popover.
@@ -264,6 +271,14 @@ class TimeBlock {
   final String? location;
 
   Duration get duration => end.difference(start);
+
+  /// The journal entry id of the time recording this block projects, or
+  /// null when the block is not a tracked recording (drafted/agent/cal
+  /// blocks keep their own ids). Derived from the [actualTimeBlockIdPrefix]
+  /// encoding applied when projecting real entries onto the timeline.
+  String? get trackedEntryId => id.startsWith(actualTimeBlockIdPrefix)
+      ? id.substring(actualTimeBlockIdPrefix.length)
+      : null;
 
   TimeBlock copyWith({
     String? id,

--- a/lib/features/daily_os_next/state/actual_time_blocks_provider.dart
+++ b/lib/features/daily_os_next/state/actual_time_blocks_provider.dart
@@ -104,7 +104,7 @@ List<TimeBlock> actualTimeBlocksForEntries({
 
     out.add(
       TimeBlock(
-        id: 'actual:${entry.meta.id}',
+        id: '$actualTimeBlockIdPrefix${entry.meta.id}',
         title: title,
         start: entry.meta.dateFrom,
         end: entry.meta.dateTo,

--- a/lib/features/daily_os_next/ui/widgets/day_timeline.dart
+++ b/lib/features/daily_os_next/ui/widgets/day_timeline.dart
@@ -4,6 +4,7 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
 import 'package:lotti/features/daily_os_next/ui/category_color.dart';
 import 'package:lotti/features/daily_os_next/ui/widgets/day_timeline_folding.dart';
@@ -13,8 +14,10 @@ import 'package:lotti/features/design_system/components/ds_dashed_border.dart';
 import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/design_system/theme/typography_helpers.dart';
+import 'package:lotti/features/tasks/state/task_focus_controller.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/services/nav_service.dart';
+import 'package:lotti/utils/consts.dart';
 
 part 'day_timeline_block.dart';
 part 'day_timeline_fold_surface.dart';

--- a/lib/features/daily_os_next/ui/widgets/day_timeline_block.dart
+++ b/lib/features/daily_os_next/ui/widgets/day_timeline_block.dart
@@ -60,7 +60,7 @@ class _BlockPosition extends StatelessWidget {
 /// faint neutral fill, neutral left border, a small category dot, a green
 /// check when done, a mono time range, and a "· tracked" suffix. They
 /// never read as drafted: they already happened.
-class DayBlock extends StatelessWidget {
+class DayBlock extends ConsumerWidget {
   const DayBlock({
     required this.block,
     this.tracked = false,
@@ -76,7 +76,7 @@ class DayBlock extends StatelessWidget {
   final ValueChanged<String>? onRename;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final tokens = context.designTokens;
     final category = _categoryColor();
     final isBuffer = block.type == TimeBlockType.buffer;
@@ -84,7 +84,23 @@ class DayBlock extends StatelessWidget {
     final taskId = block.taskId?.trim();
     final onTap = taskId == null || taskId.isEmpty
         ? null
-        : () => beamToNamed('/tasks/$taskId');
+        : () {
+            // Tracked blocks project a real time recording. Publish the
+            // focus intent before navigating so the task detail page
+            // scrolls to (and highlights) that exact recording, matching
+            // the old calendar behaviour. Drafted/agent blocks have no
+            // backing entry, so they just open the task at the top.
+            final entryId = block.trackedEntryId;
+            if (entryId != null) {
+              publishTaskFocus(
+                taskId: taskId,
+                entryId: entryId,
+                ref: ref,
+                alignment: kDefaultScrollAlignment,
+              );
+            }
+            beamToNamed('/tasks/$taskId');
+          };
 
     final fill = isBuffer
         ? Colors.transparent

--- a/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,6 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Blaizzy/mlx-audio-swift.git",
       "state" : {
-        "branch" : "main",
         "revision" : "7734cd1fbbe86460083c1d24199737a24cadfcc8"
       }
     },

--- a/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,6 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Blaizzy/mlx-audio-swift.git",
       "state" : {
-        "branch" : "main",
         "revision" : "7734cd1fbbe86460083c1d24199737a24cadfcc8"
       }
     },

--- a/test/features/daily_os_next/logic/day_agent_models_test.dart
+++ b/test/features/daily_os_next/logic/day_agent_models_test.dart
@@ -153,6 +153,33 @@ void main() {
     expect(block.duration, const Duration(minutes: 45));
   });
 
+  group('TimeBlock.trackedEntryId', () {
+    TimeBlock blockWithId(String id) => TimeBlock(
+      id: id,
+      title: 'Focus',
+      start: DateTime(2026, 5, 25, 9),
+      end: DateTime(2026, 5, 25, 9, 45),
+      type: TimeBlockType.manual,
+      state: TimeBlockState.completed,
+      category: const DayAgentCategory(
+        id: 'c1',
+        name: 'Work',
+        colorHex: 'AABBCC',
+      ),
+    );
+
+    test('decodes the backing entry id from a tracked (actual:) block', () {
+      expect(
+        blockWithId('${actualTimeBlockIdPrefix}entry-42').trackedEntryId,
+        'entry-42',
+      );
+    });
+
+    test('returns null for drafted/agent blocks without the prefix', () {
+      expect(blockWithId('b_ai').trackedEntryId, isNull);
+    });
+  });
+
   group('TimeBlock.copyWith', () {
     final base = TimeBlock(
       id: 'b1',

--- a/test/features/daily_os_next/ui/widgets/day_timeline_test.dart
+++ b/test/features/daily_os_next/ui/widgets/day_timeline_test.dart
@@ -1,6 +1,7 @@
 import 'package:clock/clock.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
 import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
@@ -9,8 +10,10 @@ import 'package:lotti/features/daily_os_next/ui/widgets/editable_title.dart';
 import 'package:lotti/features/daily_os_next/ui/widgets/why_chip.dart';
 import 'package:lotti/features/design_system/components/ds_dashed_border.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/tasks/state/task_focus_controller.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/services/nav_service.dart';
+import 'package:lotti/utils/consts.dart';
 
 import '../../../../widget_test_utils.dart';
 
@@ -134,11 +137,19 @@ void _setView(WidgetTester tester, Size size) {
 Widget _wrap(
   Widget child, {
   Size size = const Size(1280, 1200),
+  ProviderContainer? container,
 }) {
-  return makeTestableWidget2(
+  // The timeline's blocks are ConsumerWidgets (they publish task-focus
+  // intents on tap), so every render needs a ProviderScope. When a test
+  // wants to read the published intent it passes its own [container].
+  final app = makeTestableWidget2(
     child,
     mediaQueryData: MediaQueryData(size: size),
   );
+  if (container != null) {
+    return UncontrolledProviderScope(container: container, child: app);
+  }
+  return ProviderScope(child: app);
 }
 
 void main() {
@@ -250,6 +261,103 @@ void main() {
 
       expect(openedPath, isNull);
     });
+
+    testWidgets(
+      'tracked blocks publish a scroll-to-entry focus intent before navigating',
+      (tester) async {
+        _setView(tester, const Size(1280, 1200));
+
+        String? openedPath;
+        beamToNamedOverride = (path) => openedPath = path;
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+
+        await tester.pumpWidget(
+          _wrap(
+            container: container,
+            DayTimeline(
+              draft: _draftWithBlocks(
+                blocks: const [],
+                actualBlocks: [
+                  _timeBlock(
+                    id: '${actualTimeBlockIdPrefix}entry-7',
+                    title: 'Recorded session',
+                    startHour: 8,
+                    endHour: 9,
+                    type: TimeBlockType.manual,
+                    state: TimeBlockState.completed,
+                    taskId: 'task-9',
+                  ),
+                ],
+              ),
+              clock: () => DateTime(2026, 5, 25, 9, 15),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        await tester.tap(
+          find.byKey(
+            const Key('daily_os_day_block_${actualTimeBlockIdPrefix}entry-7'),
+          ),
+        );
+        await tester.pump();
+
+        // Navigates to the backing task...
+        expect(openedPath, '/tasks/task-9');
+
+        // ...and first publishes the intent that makes the task page scroll
+        // to (and highlight) the tapped recording, using the decoded entry id.
+        final intent = container.read(
+          taskFocusControllerProvider(id: 'task-9'),
+        );
+        expect(intent, isNotNull);
+        expect(intent!.target, TaskFocusTarget.entry);
+        expect(intent.entryId, 'entry-7');
+        expect(intent.alignment, kDefaultScrollAlignment);
+      },
+    );
+
+    testWidgets(
+      'drafted task-linked blocks navigate without a focus intent',
+      (tester) async {
+        _setView(tester, const Size(1280, 1200));
+
+        beamToNamedOverride = (_) {};
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+
+        await tester.pumpWidget(
+          _wrap(
+            container: container,
+            DayTimeline(
+              draft: _draftWithBlocks(
+                blocks: [
+                  _timeBlock(
+                    id: 'plan-task',
+                    title: 'Planned block',
+                    startHour: 8,
+                    endHour: 9,
+                    taskId: 'task-1',
+                  ),
+                ],
+              ),
+              clock: () => DateTime(2026, 5, 25, 9, 15),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        await tester.tap(find.byKey(const Key('daily_os_day_block_plan-task')));
+        await tester.pump();
+
+        // No backing recording → no scroll target published.
+        expect(
+          container.read(taskFocusControllerProvider(id: 'task-1')),
+          isNull,
+        );
+      },
+    );
 
     testWidgets('AI blocks render a WhyChip; cal and buffer blocks do not', (
       tester,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Fixed Daily OS Next day timeline navigation: tapping a recorded session now reopens its associated task and scrolls directly to the exact entry with a brief highlight, instead of jumping to the task's top.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->