### PR TITLE
 fix: start calendar week on the device region's first weekday

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Daily OS Next: tapping a recorded session on the Day timeline now reopens
   its task scrolled to — and briefly highlighting — that exact entry again,
   instead of dropping you at the top of the task.
+- Calendars now start the week on the day your region uses (Monday in most
+  of the world, Sunday in the US and similar regions) instead of always on
+  Sunday. The week start follows your device region, so it stays correct
+  even when the app is shown in English. Affects the Daily OS sidebar month
+  calendar and the date pickers.
 
 ## [0.9.1016]
 ### Added

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -38,6 +38,7 @@
           <p>Time tracked on entries created before mid-2024 could show up as "Uncategorized" in time-by-category views; the category data is now backfilled once on upgrade.</p>
           <p>Daily OS Next: tapping a recorded session on the Day timeline now reopens its task scrolled to — and briefly highlighting — that exact entry again, instead of dropping you at the top of the task.</p>
           <p>Task and project lists stay snappier under sync: a task's project is now resolved from a denormalized, indexed column and batched across rows instead of one query per task, and the projects overview plus the saved-filter sidebar counts coalesce rapid update notifications into a single refresh.</p>
+          <p>Calendars now start the week on the day your region uses (Monday in most of the world, Sunday in the US and similar regions) instead of always on Sunday. The week start follows your device region, so it stays correct even when the app is shown in English.</p>
       </description>
     </release>
     <release version="0.9.1016" date="2026-06-06">

--- a/lib/features/daily_os/state/unified_daily_os_data_aggregation.dart
+++ b/lib/features/daily_os/state/unified_daily_os_data_aggregation.dart
@@ -574,14 +574,18 @@ int calculateDayEndHour(
   // Find max end time across all planned slots
   for (final slot in planned) {
     // If entry ends on the next day (crosses midnight), treat as hour 24
-    final endHour = !slot.endTime.isBefore(nextDay) ? 24 : slot.endTime.hour + 1;
+    final endHour = !slot.endTime.isBefore(nextDay)
+        ? 24
+        : slot.endTime.hour + 1;
     if (endHour > latest) latest = endHour;
   }
 
   // Find max end time across all actual slots
   for (final slot in actual) {
     // If entry ends on the next day (crosses midnight), treat as hour 24
-    final endHour = !slot.endTime.isBefore(nextDay) ? 24 : slot.endTime.hour + 1;
+    final endHour = !slot.endTime.isBefore(nextDay)
+        ? 24
+        : slot.endTime.hour + 1;
     if (endHour > latest) latest = endHour;
   }
 

--- a/lib/features/design_system/components/calendar_pickers/design_system_time_calendar_picker.dart
+++ b/lib/features/design_system/components/calendar_pickers/design_system_time_calendar_picker.dart
@@ -4,6 +4,7 @@ import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/utils/week_start.dart';
 
 part 'design_system_interactive_time_calendar_picker.dart';
 
@@ -217,9 +218,9 @@ class _MonthCalendarCard extends StatelessWidget {
     final palette = _TimeCalendarPalette.fromMode(mode);
     final geometry = _TimeCalendarGeometry.fromTokens(tokens);
     final localeTag = Localizations.localeOf(context).toLanguageTag();
-    final firstDayOfWeek = MaterialLocalizations.of(
-      context,
-    ).firstDayOfWeekIndex;
+    // Week start follows the device region (e.g. Monday in Europe), not the
+    // app UI language — see [deviceFirstDayOfWeekIndex].
+    final firstDayOfWeek = deviceFirstDayOfWeekIndex(context);
     final visibleLabel = DateFormat.yMMMM(localeTag).format(visibleMonth);
     final weeks = _buildMonthGrid(visibleMonth, firstDayOfWeek);
 
@@ -633,7 +634,7 @@ class _TimeCalendarPalette {
 List<List<int?>> _buildMonthGrid(DateTime month, int firstDayOfWeekIndex) {
   final firstDay = DateTime(month.year, month.month);
   final daysInMonth = _daysInMonth(month);
-  final offset = (firstDay.weekday % 7 - firstDayOfWeekIndex + 7) % 7;
+  final offset = leadingDayOffset(firstDay, firstDayOfWeekIndex);
   final cells = <int?>[
     ...List<int?>.filled(offset, null),
     ...List<int?>.generate(daysInMonth, (index) => index + 1),

--- a/lib/features/design_system/components/navigation/sidebar_month_calendar.dart
+++ b/lib/features/design_system/components/navigation/sidebar_month_calendar.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/design_system/theme/typography_helpers.dart';
+import 'package:lotti/utils/week_start.dart';
 
 /// Compact month calendar for the desktop navigation sidebar — the
 /// `CalendarWidget` from the Daily OS design handoff (sidebar spec):
@@ -58,12 +59,13 @@ class SidebarMonthCalendar extends StatelessWidget {
     };
 
     final daysInMonth = DateUtils.getDaysInMonth(month.year, month.month);
-    final firstDayOffset = DateUtils.firstDayOffset(
-      month.year,
-      month.month,
-      materialLocalizations,
-    );
-    final firstDayOfWeekIndex = materialLocalizations.firstDayOfWeekIndex;
+    // Start the week from the *device region's* convention (Monday in most
+    // of the world, Sunday in the US/etc.), not the app UI language — see
+    // [deviceFirstDayOfWeekIndex]. `DateUtils.firstDayOffset` is keyed by
+    // MaterialLocalizations, so compute the leading-cell offset by hand.
+    final firstDayOfWeekIndex = deviceFirstDayOfWeekIndex(context);
+    final firstOfMonth = DateTime(month.year, month.month);
+    final firstDayOffset = leadingDayOffset(firstOfMonth, firstDayOfWeekIndex);
     final narrowWeekdays = materialLocalizations.narrowWeekdays;
 
     return Column(

--- a/lib/utils/week_start.dart
+++ b/lib/utils/week_start.dart
@@ -1,0 +1,164 @@
+/// Locale-aware first-day-of-week resolution for calendar grids.
+///
+/// Calendars in the app render a Monday-to-Sunday (or Sunday-to-Saturday)
+/// grid. The starting weekday is a *regional* convention, not a language
+/// one: most of the world starts the week on Monday, the US/Canada and a
+/// number of other countries start on Sunday, and a few Middle-Eastern
+/// countries start on Saturday.
+///
+/// The naive source — `MaterialLocalizations.firstDayOfWeekIndex` — is keyed
+/// by the resolved *app UI language*, so an English UI always reports Sunday
+/// even when the user lives in a Monday-first region. The same is true of
+/// `intl`'s `DateSymbols.FIRSTDAYOFWEEK`: both flatten English to Sunday.
+///
+/// To match what the user actually expects we resolve the start of the week
+/// from the *device region* (the country code of the platform locale),
+/// independent of which language the app is shown in. The region → weekday
+/// mapping below is taken verbatim from CLDR **v46** `weekData/firstDay`
+/// (`001` defaults to Monday). v46 is the version bundled by `intl 0.20.2`,
+/// this app's pinned `intl`, so the two stay consistent — e.g. intl's own
+/// `pt_PT`/`mt` data also reports Sunday, and `en_AU` reports Monday. When
+/// upgrading `intl`/CLDR, re-derive these sets from the new `weekData`.
+///
+/// All indices use `MaterialLocalizations.firstDayOfWeekIndex` conventions:
+/// `0` = Sunday, `1` = Monday, … `6` = Saturday — so the result is a drop-in
+/// replacement for that property in the existing calendar grid math.
+library;
+
+import 'package:flutter/material.dart';
+
+const int _sunday = 0;
+const int _monday = 1;
+const int _saturday = 6;
+
+/// ISO 3166-1 alpha-2 regions whose week starts on **Sunday**
+/// (CLDR v46 `weekData/firstDay = sun`).
+const Set<String> sundayFirstRegions = {
+  'AG',
+  'AS',
+  'BD',
+  'BR',
+  'BS',
+  'BT',
+  'BW',
+  'BZ',
+  'CA',
+  'CO',
+  'DM',
+  'DO',
+  'ET',
+  'GU',
+  'HK',
+  'HN',
+  'ID',
+  'IL',
+  'IN',
+  'JM',
+  'JP',
+  'KE',
+  'KH',
+  'KR',
+  'LA',
+  'MH',
+  'MM',
+  'MO',
+  'MT',
+  'MX',
+  'MZ',
+  'NI',
+  'NP',
+  'PA',
+  'PE',
+  'PH',
+  'PK',
+  'PR',
+  'PT',
+  'PY',
+  'SA',
+  'SG',
+  'SV',
+  'TH',
+  'TT',
+  'TW',
+  'UM',
+  'US',
+  'VE',
+  'VI',
+  'WS',
+  'YE',
+  'ZA',
+  'ZW',
+};
+
+/// ISO 3166-1 alpha-2 regions whose week starts on **Saturday**
+/// (CLDR v46 `weekData/firstDay = sat`).
+const Set<String> saturdayFirstRegions = {
+  'AF',
+  'BH',
+  'DJ',
+  'DZ',
+  'EG',
+  'IQ',
+  'IR',
+  'JO',
+  'KW',
+  'LY',
+  'OM',
+  'QA',
+  'SD',
+  'SY',
+};
+
+/// Resolves the first day of the week for [regionCode] (an ISO 3166-1
+/// alpha-2 country code, case-insensitive).
+///
+/// Returns a `MaterialLocalizations.firstDayOfWeekIndex`-style value
+/// (`0` = Sunday … `6` = Saturday). When [regionCode] is null/empty or not a
+/// recognised Sunday/Saturday region, [fallback] is returned — for an
+/// unknown region that defaults to Monday via the caller, while a missing
+/// region falls back to the UI-locale value the caller passes in.
+int firstDayOfWeekIndexForRegion(String? regionCode, {required int fallback}) {
+  if (regionCode == null || regionCode.isEmpty) {
+    return fallback;
+  }
+  final region = regionCode.toUpperCase();
+  if (sundayFirstRegions.contains(region)) {
+    return _sunday;
+  }
+  if (saturdayFirstRegions.contains(region)) {
+    return _saturday;
+  }
+  return _monday;
+}
+
+/// Resolves the first day of the week from the *device* region rather than
+/// the app UI language, so an English UI on a Monday-first device still
+/// starts the week on Monday.
+///
+/// Reads the country code from the platform locale and maps it via
+/// [firstDayOfWeekIndexForRegion]. When the device exposes no region, falls
+/// back to the resolved UI locale's
+/// `MaterialLocalizations.firstDayOfWeekIndex`.
+///
+/// Note: the platform locale is read directly rather than through an
+/// inherited dependency, so a calendar will not rebuild on its own if the OS
+/// region changes mid-session — it picks up the new value on the next
+/// rebuild. In practice an OS region change rebuilds `MaterialApp`, so the
+/// calendars refresh anyway.
+int deviceFirstDayOfWeekIndex(BuildContext context) {
+  final deviceLocale = WidgetsBinding.instance.platformDispatcher.locale;
+  return firstDayOfWeekIndexForRegion(
+    deviceLocale.countryCode,
+    fallback: MaterialLocalizations.of(context).firstDayOfWeekIndex,
+  );
+}
+
+/// Number of leading empty cells before day 1 in a month grid that starts
+/// the week on [firstDayOfWeekIndex] (`0` = Sunday … `6` = Saturday).
+///
+/// [firstOfMonth] is the first day of the month. The result is in
+/// `[0, 6]`: it converts `DateTime.weekday` (1 = Mon … 7 = Sun) into the
+/// Sunday-indexed column, then rotates so the grid's first column lands on
+/// [firstDayOfWeekIndex].
+int leadingDayOffset(DateTime firstOfMonth, int firstDayOfWeekIndex) =>
+    (firstOfMonth.weekday % 7 - firstDayOfWeekIndex + 7) % 7;

--- a/test/database/conversions_test.dart
+++ b/test/database/conversions_test.dart
@@ -702,7 +702,11 @@ void main() {
           makeDbEntity(makeDashboardJson(items: items)),
         );
 
-        expect(dashboard.items, hasLength(expectedKnown), reason: 'kinds=$kinds');
+        expect(
+          dashboard.items,
+          hasLength(expectedKnown),
+          reason: 'kinds=$kinds',
+        );
       },
       tags: 'glados',
     );

--- a/test/features/agents/database/agent_repository_test.dart
+++ b/test/features/agents/database/agent_repository_test.dart
@@ -499,37 +499,43 @@ void main() {
       glados.Glados(
         glados.IntAnys(glados.any).intInRange(0, 2100), // requested-id count
         glados.ExploreConfig(numRuns: 120),
-      ).test('chunking dedups its input and never exceeds the host-var cap', (
-        count,
-      ) {
-        // Half the ids are duplicated to exercise the dedup step.
-        final input = <String>[
-          for (var i = 0; i < count; i++) 'id-$i',
-          for (var i = 0; i < count ~/ 2; i++) 'id-$i',
-        ];
-        final deduped = input.toSet();
+      ).test(
+        'chunking dedups its input and never exceeds the host-var cap',
+        (
+          count,
+        ) {
+          // Half the ids are duplicated to exercise the dedup step.
+          final input = <String>[
+            for (var i = 0; i < count; i++) 'id-$i',
+            for (var i = 0; i < count ~/ 2; i++) 'id-$i',
+          ];
+          final deduped = input.toSet();
 
-        final chunks = AgentRepository.debugSqliteInClauseChunks(input).toList();
-        final flattened = chunks.expand((chunk) => chunk).toList();
+          final chunks = AgentRepository.debugSqliteInClauseChunks(
+            input,
+          ).toList();
+          final flattened = chunks.expand((chunk) => chunk).toList();
 
-        // No chunk exceeds the SQLite host-variable cut-off.
-        for (final chunk in chunks) {
-          expect(
-            chunk.length,
-            lessThanOrEqualTo(AgentRepository.debugInClauseChunkSize),
-            reason: 'count=$count',
-          );
-        }
-        // Every distinct input id appears exactly once across all chunks ...
-        expect(flattened.toSet(), deduped, reason: 'count=$count');
-        expect(flattened, hasLength(deduped.length), reason: 'count=$count');
-        // ... and an empty input yields no chunks at all.
-        if (deduped.isEmpty) {
-          expect(chunks, isEmpty, reason: 'count=$count');
-        } else {
-          expect(chunks, isNotEmpty, reason: 'count=$count');
-        }
-      }, tags: 'glados');
+          // No chunk exceeds the SQLite host-variable cut-off.
+          for (final chunk in chunks) {
+            expect(
+              chunk.length,
+              lessThanOrEqualTo(AgentRepository.debugInClauseChunkSize),
+              reason: 'count=$count',
+            );
+          }
+          // Every distinct input id appears exactly once across all chunks ...
+          expect(flattened.toSet(), deduped, reason: 'count=$count');
+          expect(flattened, hasLength(deduped.length), reason: 'count=$count');
+          // ... and an empty input yields no chunks at all.
+          if (deduped.isEmpty) {
+            expect(chunks, isEmpty, reason: 'count=$count');
+          } else {
+            expect(chunks, isNotEmpty, reason: 'count=$count');
+          }
+        },
+        tags: 'glados',
+      );
     });
 
     test('upsert overwrites existing entity with same ID', () async {

--- a/test/features/ai/ui/settings/services/provider_prompt_setup_service_test.dart
+++ b/test/features/ai/ui/settings/services/provider_prompt_setup_service_test.dart
@@ -35,7 +35,10 @@ void main() {
       glados.IntAnys(glados.any).intInRange(0, 1 << 12),
       glados.IntAnys(glados.any).intInRange(0, 1 << 12),
       glados.ExploreConfig(numRuns: 120),
-    ).test('totalModels == modelsCreated + modelsVerified', (created, verified) {
+    ).test('totalModels == modelsCreated + modelsVerified', (
+      created,
+      verified,
+    ) {
       final result = GeminiFtueResult(
         modelsCreated: created,
         modelsVerified: verified,

--- a/test/features/ai_chat/ui/widgets/chat_interface/message_timestamp_test.dart
+++ b/test/features/ai_chat/ui/widgets/chat_interface/message_timestamp_test.dart
@@ -76,27 +76,47 @@ void main() {
       glados.IntAnys(glados.any).intInRange(0, 24),
       glados.IntAnys(glados.any).intInRange(0, 60),
       glados.ExploreConfig(numRuns: 120),
-    ).test('formatted clock is well-formed HH:mm for any wall-clock time', (
-      hour,
-      minute,
-    ) {
-      final ts = DateTime(2024, 3, 15, hour, minute);
-      final label = _formatTime(ts);
+    ).test(
+      'formatted clock is well-formed HH:mm for any wall-clock time',
+      (
+        hour,
+        minute,
+      ) {
+        final ts = DateTime(2024, 3, 15, hour, minute);
+        final label = _formatTime(ts);
 
-      expect(label.length, 5, reason: 'label "$label" is not 5 chars');
-      expect(label[2], ':', reason: 'separator missing in "$label"');
+        expect(label.length, 5, reason: 'label "$label" is not 5 chars');
+        expect(label[2], ':', reason: 'separator missing in "$label"');
 
-      final parts = label.split(':');
-      expect(parts.length, 2);
-      expect(parts[0].length, 2, reason: 'hour field not zero-padded: "$label"');
-      expect(parts[1].length, 2, reason: 'min field not zero-padded: "$label"');
+        final parts = label.split(':');
+        expect(parts.length, 2);
+        expect(
+          parts[0].length,
+          2,
+          reason: 'hour field not zero-padded: "$label"',
+        );
+        expect(
+          parts[1].length,
+          2,
+          reason: 'min field not zero-padded: "$label"',
+        );
 
-      final parsedHour = int.parse(parts[0]);
-      final parsedMinute = int.parse(parts[1]);
-      expect(parsedHour, hour);
-      expect(parsedMinute, minute);
-      expect(parsedHour, inInclusiveRange(0, 23), reason: 'hour out of range');
-      expect(parsedMinute, inInclusiveRange(0, 59), reason: 'min out of range');
-    }, tags: 'glados');
+        final parsedHour = int.parse(parts[0]);
+        final parsedMinute = int.parse(parts[1]);
+        expect(parsedHour, hour);
+        expect(parsedMinute, minute);
+        expect(
+          parsedHour,
+          inInclusiveRange(0, 23),
+          reason: 'hour out of range',
+        );
+        expect(
+          parsedMinute,
+          inInclusiveRange(0, 59),
+          reason: 'min out of range',
+        );
+      },
+      tags: 'glados',
+    );
   });
 }

--- a/test/features/design_system/components/calendar_pickers/design_system_time_calendar_picker_test.dart
+++ b/test/features/design_system/components/calendar_pickers/design_system_time_calendar_picker_test.dart
@@ -416,5 +416,32 @@ void main() {
         expect(tester.takeException(), isNull);
       },
     );
+
+    testWidgets(
+      'weekday columns follow the device region week-start',
+      (tester) async {
+        // English UI throughout; only the device region changes. A US device
+        // starts the week on Sunday, a UK device on Monday — so the MON
+        // column slides to the left edge for the UK region.
+        tester.platformDispatcher.localeTestValue = const Locale('en', 'US');
+        addTearDown(tester.platformDispatcher.clearLocaleTestValue);
+        await pumpPicker(
+          tester,
+          presentation: DesignSystemTimeCalendarPickerPresentation.regular,
+          mode: DesignSystemTimeCalendarPickerMode.light,
+        );
+        final mondayXSundayFirst = tester.getTopLeft(find.text('MON')).dx;
+
+        tester.platformDispatcher.localeTestValue = const Locale('en', 'GB');
+        await pumpPicker(
+          tester,
+          presentation: DesignSystemTimeCalendarPickerPresentation.regular,
+          mode: DesignSystemTimeCalendarPickerMode.light,
+        );
+        final mondayXMondayFirst = tester.getTopLeft(find.text('MON')).dx;
+
+        expect(mondayXMondayFirst, lessThan(mondayXSundayFirst));
+      },
+    );
   });
 }

--- a/test/features/design_system/components/navigation/sidebar_month_calendar_test.dart
+++ b/test/features/design_system/components/navigation/sidebar_month_calendar_test.dart
@@ -12,6 +12,29 @@ Widget _wrap(Widget child) => makeTestableWidget2(
   mediaQueryData: const MediaQueryData(size: Size(400, 800)),
 );
 
+/// The seven weekday-header letters in render order. They are the first
+/// seven [Text] widgets inside the calendar grid (day numbers follow).
+List<String> _weekdayHeaders(WidgetTester tester) => tester
+    .widgetList<Text>(
+      find.descendant(
+        of: find.byType(GridView),
+        matching: find.byType(Text),
+      ),
+    )
+    .take(7)
+    .map((text) => text.data ?? '')
+    .toList();
+
+Widget _mayCalendar() => _wrap(
+  SidebarMonthCalendar(
+    month: DateTime(2026, 5),
+    today: DateTime(2026, 5, 24),
+    onPreviousMonth: () {},
+    onNextMonth: () {},
+    onDaySelected: (_) {},
+  ),
+);
+
 void main() {
   group('SidebarMonthCalendar', () {
     testWidgets(
@@ -163,5 +186,58 @@ void main() {
           .length;
       expect(markedBoxes, unmarkedBoxes + 1);
     });
+
+    testWidgets(
+      'starts the week on Sunday for a Sunday-first device region',
+      (tester) async {
+        // English UI, but a US device — the week must still start on Sunday.
+        tester.platformDispatcher.localeTestValue = const Locale('en', 'US');
+        addTearDown(tester.platformDispatcher.clearLocaleTestValue);
+
+        await tester.pumpWidget(_mayCalendar());
+
+        final headers = _weekdayHeaders(tester);
+        // Sunday-first → S, M, T, … (Sunday then Monday).
+        expect(headers.first, 'S');
+        expect(headers[1], 'M');
+      },
+    );
+
+    testWidgets(
+      'starts the week on Monday for a Monday-first device region',
+      (tester) async {
+        // Same English UI, but a UK device — the week starts on Monday,
+        // proving week-start follows the device region, not the UI language.
+        tester.platformDispatcher.localeTestValue = const Locale('en', 'GB');
+        addTearDown(tester.platformDispatcher.clearLocaleTestValue);
+
+        await tester.pumpWidget(_mayCalendar());
+
+        final headers = _weekdayHeaders(tester);
+        // Monday-first → M, T, W, … (Monday then Tuesday).
+        expect(headers.first, 'M');
+        expect(headers[1], 'T');
+      },
+    );
+
+    testWidgets(
+      'shifts the leading-day offset with the region week-start',
+      (tester) async {
+        // 1 May 2026 is a Friday. Sunday-first leaves 5 leading blanks
+        // before the "1" cell; Monday-first leaves 4. Compare the on-screen
+        // x-position of "1" between the two regions to prove the shift.
+        tester.platformDispatcher.localeTestValue = const Locale('en', 'US');
+        addTearDown(tester.platformDispatcher.clearLocaleTestValue);
+        await tester.pumpWidget(_mayCalendar());
+        final sundayFirstX = tester.getTopLeft(find.text('1')).dx;
+
+        tester.platformDispatcher.localeTestValue = const Locale('en', 'GB');
+        await tester.pumpWidget(_mayCalendar());
+        final mondayFirstX = tester.getTopLeft(find.text('1')).dx;
+
+        // One fewer leading blank → the "1" sits one column to the left.
+        expect(mondayFirstX, lessThan(sundayFirstX));
+      },
+    );
   });
 }

--- a/test/features/design_system/components/task_filters/design_system_task_filter_sheet_test.dart
+++ b/test/features/design_system/components/task_filters/design_system_task_filter_sheet_test.dart
@@ -467,22 +467,24 @@ void main() {
         expect(state.selectAgentFilter('agent-1'), same(state));
       });
 
-      test('switches selection and counts a non-first option in appliedCount',
-          () {
-        final state = seed();
-        // The first option is the neutral default → appliedCount stays 0.
-        expect(state.appliedCount, 0);
+      test(
+        'switches selection and counts a non-first option in appliedCount',
+        () {
+          final state = seed();
+          // The first option is the neutral default → appliedCount stays 0.
+          expect(state.appliedCount, 0);
 
-        final switched = state.selectAgentFilter('agent-1');
-        expect(switched.selectedAgentFilterId, 'agent-1');
-        // Selecting a non-first agent option adds exactly one to the count.
-        expect(switched.appliedCount, 1);
+          final switched = state.selectAgentFilter('agent-1');
+          expect(switched.selectedAgentFilterId, 'agent-1');
+          // Selecting a non-first agent option adds exactly one to the count.
+          expect(switched.appliedCount, 1);
 
-        // Switching back to the first (default) option drops the count again.
-        final backToDefault = switched.selectAgentFilter('agent-all');
-        expect(backToDefault.selectedAgentFilterId, 'agent-all');
-        expect(backToDefault.appliedCount, 0);
-      });
+          // Switching back to the first (default) option drops the count again.
+          final backToDefault = switched.selectAgentFilter('agent-all');
+          expect(backToDefault.selectedAgentFilterId, 'agent-all');
+          expect(backToDefault.appliedCount, 0);
+        },
+      );
     });
 
     group('selectSearchMode', () {

--- a/test/features/journal/state/journal_page_controller_test.dart
+++ b/test/features/journal/state/journal_page_controller_test.dart
@@ -210,77 +210,89 @@ void main() {
           glados.any,
         ).intInRange(0, JournalPageController.pageSize + 1),
         glados.ExploreConfig(numRuns: 120),
-      ).test('next key is the cumulative end offset for full-page chains', (
-        numFullPages,
-        lastPageLen,
-      ) {
-        fakeAsync((async) {
-          final controller = container.read(
-            journalPageControllerProvider(false).notifier,
-          );
-          settle(async);
-          controller.debugPostFilterNextRawOffset = null;
+      ).test(
+        'next key is the cumulative end offset for full-page chains',
+        (
+          numFullPages,
+          lastPageLen,
+        ) {
+          fakeAsync((async) {
+            final controller = container.read(
+              journalPageControllerProvider(false).notifier,
+            );
+            settle(async);
+            controller.debugPostFilterNextRawOffset = null;
 
-          const pageSize = JournalPageController.pageSize;
+            const pageSize = JournalPageController.pageSize;
 
-          // Build a chain of [numFullPages] full pages followed by one page
-          // of [lastPageLen] items, with keys = cumulative start offsets.
-          final pages = <List<JournalEntity>>[
-            for (var i = 0; i < numFullPages; i++) page(pageSize),
-            page(lastPageLen),
-          ];
-          final keys = <int>[];
-          var offset = 0;
-          for (final p in pages) {
-            keys.add(offset);
-            offset += p.length;
-          }
+            // Build a chain of [numFullPages] full pages followed by one page
+            // of [lastPageLen] items, with keys = cumulative start offsets.
+            final pages = <List<JournalEntity>>[
+              for (var i = 0; i < numFullPages; i++) page(pageSize),
+              page(lastPageLen),
+            ];
+            final keys = <int>[];
+            var offset = 0;
+            for (final p in pages) {
+              keys.add(offset);
+              offset += p.length;
+            }
 
-          final state = PagingState<int, JournalEntity>(
-            keys: keys,
-            pages: pages,
-          );
-          final next = controller.debugGetNextPageKey(state);
+            final state = PagingState<int, JournalEntity>(
+              keys: keys,
+              pages: pages,
+            );
+            final next = controller.debugGetNextPageKey(state);
 
-          if (lastPageLen < pageSize) {
-            // Short last page -> data exhausted -> no further page.
-            expect(next, isNull, reason: 'len=$lastPageLen pages=$numFullPages');
-          } else {
-            // Every page full -> next key is the exclusive end offset, which
-            // equals lastKey + lastPage.length and the total item count.
-            final totalItems = pages.fold<int>(0, (sum, p) => sum + p.length);
-            expect(next, totalItems, reason: 'pages=${numFullPages + 1}');
-            expect(next, keys.last + pages.last.length);
-          }
-        });
-      }, tags: 'glados');
+            if (lastPageLen < pageSize) {
+              // Short last page -> data exhausted -> no further page.
+              expect(
+                next,
+                isNull,
+                reason: 'len=$lastPageLen pages=$numFullPages',
+              );
+            } else {
+              // Every page full -> next key is the exclusive end offset, which
+              // equals lastKey + lastPage.length and the total item count.
+              final totalItems = pages.fold<int>(0, (sum, p) => sum + p.length);
+              expect(next, totalItems, reason: 'pages=${numFullPages + 1}');
+              expect(next, keys.last + pages.last.length);
+            }
+          });
+        },
+        tags: 'glados',
+      );
 
       glados.Glados(
         glados.IntAnys(glados.any).intInRange(0, 100000),
         glados.ExploreConfig(numRuns: 120),
-      ).test('a pending post-filter offset wins and is consumed exactly once', (
-        rawOffset,
-      ) {
-        fakeAsync((async) {
-          final controller = container.read(
-            journalPageControllerProvider(false).notifier,
-          );
-          settle(async);
+      ).test(
+        'a pending post-filter offset wins and is consumed exactly once',
+        (
+          rawOffset,
+        ) {
+          fakeAsync((async) {
+            final controller = container.read(
+              journalPageControllerProvider(false).notifier,
+            );
+            settle(async);
 
-          const pageSize = JournalPageController.pageSize;
-          final fullState = PagingState<int, JournalEntity>(
-            keys: const [0],
-            pages: [page(pageSize)],
-          );
+            const pageSize = JournalPageController.pageSize;
+            final fullState = PagingState<int, JournalEntity>(
+              keys: const [0],
+              pages: [page(pageSize)],
+            );
 
-          controller.debugPostFilterNextRawOffset = rawOffset;
-          // First call returns the override and consumes it.
-          expect(controller.debugGetNextPageKey(fullState), rawOffset);
-          expect(controller.debugPostFilterNextRawOffset, isNull);
-          // Second call falls back to the computed cumulative key.
-          expect(controller.debugGetNextPageKey(fullState), pageSize);
-        });
-      }, tags: 'glados');
+            controller.debugPostFilterNextRawOffset = rawOffset;
+            // First call returns the override and consumes it.
+            expect(controller.debugGetNextPageKey(fullState), rawOffset);
+            expect(controller.debugPostFilterNextRawOffset, isNull);
+            // Second call falls back to the computed cumulative key.
+            expect(controller.debugGetNextPageKey(fullState), pageSize);
+          });
+        },
+        tags: 'glados',
+      );
     });
 
     group('Initialization', () {

--- a/test/utils/week_start_test.dart
+++ b/test/utils/week_start_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/utils/week_start.dart';
+
+void main() {
+  group('firstDayOfWeekIndexForRegion', () {
+    // Indices follow MaterialLocalizations.firstDayOfWeekIndex:
+    // 0 = Sunday, 1 = Monday, 6 = Saturday.
+    const sunday = 0;
+    const monday = 1;
+    const saturday = 6;
+
+    // A sentinel fallback that is none of the three real results, so a test
+    // failing into the fallback is unambiguous.
+    const fallback = 3;
+
+    test('maps Sunday-first regions to Sunday', () {
+      for (final region in ['US', 'CA', 'JP', 'IL', 'BR']) {
+        expect(
+          firstDayOfWeekIndexForRegion(region, fallback: fallback),
+          sunday,
+          reason: '$region should start the week on Sunday',
+        );
+      }
+    });
+
+    test('maps Saturday-first regions to Saturday', () {
+      for (final region in ['EG', 'SY', 'QA']) {
+        expect(
+          firstDayOfWeekIndexForRegion(region, fallback: fallback),
+          saturday,
+          reason: '$region should start the week on Saturday',
+        );
+      }
+    });
+
+    test('maps Monday-first / unlisted regions to Monday', () {
+      // DE/GB/FR are Monday-first; ZZ is not a real region and must still
+      // resolve to the world-default Monday rather than the fallback.
+      for (final region in ['DE', 'GB', 'FR', 'ZZ']) {
+        expect(
+          firstDayOfWeekIndexForRegion(region, fallback: fallback),
+          monday,
+          reason: '$region should start the week on Monday',
+        );
+      }
+    });
+
+    test('follows CLDR v46 for regions that older snapshots got wrong', () {
+      // These four were Sunday/Saturday in pre-v46 CLDR but are Monday in
+      // v46 (AE moved to a Sat/Sun weekend in 2022). Pinning them guards the
+      // region sets against silently regressing to a stale snapshot.
+      for (final region in ['AU', 'CN', 'GT', 'AE']) {
+        expect(
+          firstDayOfWeekIndexForRegion(region, fallback: fallback),
+          monday,
+          reason: '$region is Monday-first in CLDR v46',
+        );
+      }
+    });
+
+    test('is case-insensitive on the region code', () {
+      expect(firstDayOfWeekIndexForRegion('us', fallback: fallback), sunday);
+      expect(firstDayOfWeekIndexForRegion('eg', fallback: fallback), saturday);
+    });
+
+    test('returns the fallback only when no region is available', () {
+      expect(firstDayOfWeekIndexForRegion(null, fallback: fallback), fallback);
+      expect(firstDayOfWeekIndexForRegion('', fallback: fallback), fallback);
+    });
+
+    test('the Sunday and Saturday region sets are disjoint', () {
+      expect(
+        sundayFirstRegions.intersection(saturdayFirstRegions),
+        isEmpty,
+      );
+    });
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendars now start the week based on your device's regional setting (Monday in most regions, Sunday in the US and similar regions), rather than always using Sunday. This applies to the Daily OS sidebar calendar and date pickers.

* **Tests**
  * Added tests to verify calendar week-start behavior respects device region settings.

* **Documentation**
  * Updated changelog with calendar week-start region changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->