### PR TITLE
fix: start Daily OS sidebar calendar week on Monday

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Daily OS Next: tapping a recorded session on the Day timeline now reopens
   its task scrolled to — and briefly highlighting — that exact entry again,
   instead of dropping you at the top of the task.
+- Daily OS Next: the sidebar month calendar now starts the week on your
+  device region's first weekday — Monday across most of Europe, Sunday in
+  the US — read from the OS region (natively on macOS) rather than the app
+  language, instead of always starting on Sunday.
 
 ## [0.9.1016]
 ### Added

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -37,6 +37,7 @@
           <p>New desktop "Time Analysis" dashboard under Daily OS, opened from a sidebar entry beneath the month calendar onto the full screen: see where your time went per category and per day, with quick range presets (1d, 7d, 30d, MTD, YTD, last month), a custom date range, a daily/cumulative chart toggle, headline totals, optional focus categories, and a precise per-category table. Range switching is instantaneous even with years of entries, and private entries stay hidden unless the private flag is on.</p>
           <p>Time tracked on entries created before mid-2024 could show up as "Uncategorized" in time-by-category views; the category data is now backfilled once on upgrade.</p>
           <p>Daily OS Next: tapping a recorded session on the Day timeline now reopens its task scrolled to — and briefly highlighting — that exact entry again, instead of dropping you at the top of the task.</p>
+          <p>Daily OS Next: the sidebar month calendar now starts the week on your device region's first weekday — Monday across most of Europe, Sunday in the US — read from the OS region rather than the app language, instead of always starting on Sunday.</p>
           <p>Task and project lists stay snappier under sync: a task's project is now resolved from a denormalized, indexed column and batched across rows instead of one query per task, and the projects overview plus the saved-filter sidebar counts coalesce rapid update notifications into a single refresh.</p>
       </description>
     </release>

--- a/lib/features/daily_os/ui/widgets/time_history_header/date_label_row.dart
+++ b/lib/features/daily_os/ui/widgets/time_history_header/date_label_row.dart
@@ -10,6 +10,8 @@ import 'package:lotti/features/daily_os/ui/widgets/time_history_header/status_in
 import 'package:lotti/features/daily_os/ui/widgets/time_history_header/today_button.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/utils/date_utils_extension.dart';
+import 'package:lotti/utils/device_region.dart';
+import 'package:lotti/utils/first_day_of_week_picker.dart';
 
 /// Date label row at the bottom of the header.
 class DateLabelRow extends ConsumerWidget {
@@ -110,11 +112,16 @@ class DateLabelRow extends ConsumerWidget {
     WidgetRef ref,
     DateTime currentDate,
   ) async {
+    final firstDayOfWeekIndex = await ref.read(
+      firstDayOfWeekIndexProvider.future,
+    );
+    if (!context.mounted) return;
     final picked = await showDatePicker(
       context: context,
       initialDate: currentDate,
       firstDate: DateTime(2020),
       lastDate: DateTime(2100),
+      builder: firstDayOfWeekPickerBuilder(firstDayOfWeekIndex),
     );
 
     if (picked != null) {

--- a/lib/features/daily_os_next/ui/pages/daily_os_next_root.dart
+++ b/lib/features/daily_os_next/ui/pages/daily_os_next_root.dart
@@ -11,6 +11,8 @@ import 'package:lotti/features/daily_os_next/ui/pages/day_page.dart';
 import 'package:lotti/features/daily_os_next/ui/pages/day_planning_modal.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/utils/device_region.dart';
+import 'package:lotti/utils/first_day_of_week_picker.dart';
 
 /// Entry point for the Daily OS Next surface.
 ///
@@ -42,6 +44,10 @@ class _DailyOsNextRootState extends ConsumerState<DailyOsNextRoot> {
     // `lastDate` and trip a `showDatePicker` assertion. Day arithmetic
     // via the `DateTime` constructor stays DST-safe.
     final selected = ref.read(dailyOsNextSelectedDateProvider);
+    final firstDayOfWeekIndex = await ref.read(
+      firstDayOfWeekIndexProvider.future,
+    );
+    if (!mounted) return;
     final picked = await showDatePicker(
       context: context,
       initialDate: selected,
@@ -55,6 +61,7 @@ class _DailyOsNextRootState extends ConsumerState<DailyOsNextRoot> {
         selected.month,
         selected.day,
       ),
+      builder: firstDayOfWeekPickerBuilder(firstDayOfWeekIndex),
     );
     if (picked != null) {
       ref.read(dailyOsNextSelectedDateProvider.notifier).select(picked);

--- a/lib/features/daily_os_next/ui/widgets/sidebar_calendar.dart
+++ b/lib/features/daily_os_next/ui/widgets/sidebar_calendar.dart
@@ -5,6 +5,7 @@ import 'package:lotti/features/daily_os_next/state/day_agent_provider.dart';
 import 'package:lotti/features/daily_os_next/state/selected_date_provider.dart';
 import 'package:lotti/features/design_system/components/navigation/sidebar_month_calendar.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/utils/device_region.dart';
 
 /// Desktop-sidebar month calendar wired to the Daily OS Next state:
 /// plan-day dots come from [dailyOsPlanDaysProvider]; tapping a day
@@ -52,6 +53,11 @@ class _DailyOsSidebarCalendarState
     }
     final markedDays =
         ref.watch(dailyOsPlanDaysProvider(_month)).value ?? const <DateTime>{};
+    // Week-start follows the device region (US → Sunday, Europe → Monday),
+    // resolved natively because macOS hides the region from Flutter's locale
+    // APIs. Defaults to Monday while the async lookup resolves.
+    final firstDayOfWeekIndex =
+        ref.watch(firstDayOfWeekIndexProvider).value ?? (DateTime.monday % 7);
 
     // Indent to the nav rows' inner content padding so the month title
     // lines up with the destination icons instead of hugging the
@@ -70,6 +76,7 @@ class _DailyOsSidebarCalendarState
         today: clock.now(),
         selectedDay: selectedDay,
         markedDays: markedDays,
+        firstDayOfWeekIndex: firstDayOfWeekIndex,
         onPreviousMonth: () => _shiftMonth(-1),
         onNextMonth: () => _shiftMonth(1),
         onDaySelected: ref

--- a/lib/features/design_system/components/navigation/sidebar_month_calendar.dart
+++ b/lib/features/design_system/components/navigation/sidebar_month_calendar.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/design_system/theme/typography_helpers.dart';
+import 'package:lotti/utils/first_day_of_week.dart';
 
 /// Compact month calendar for the desktop navigation sidebar — the
 /// `CalendarWidget` from the Daily OS design handoff (sidebar spec):
@@ -20,6 +21,7 @@ class SidebarMonthCalendar extends StatelessWidget {
     this.selectedDay,
     this.markedDays = const <DateTime>{},
     this.today,
+    this.firstDayOfWeekIndex,
     super.key,
   });
 
@@ -43,6 +45,15 @@ class SidebarMonthCalendar extends StatelessWidget {
   /// `clock.now()`.
   final DateTime? today;
 
+  /// Explicit first column of the grid (Flutter convention:
+  /// `0 = Sunday` … `6 = Saturday`). When null, falls back to the app
+  /// locale's `MaterialLocalizations.firstDayOfWeekIndex`.
+  ///
+  /// The Daily OS host derives this from the device region (US starts on
+  /// Sunday, most of Europe on Monday), resolved natively since macOS hides
+  /// the region from Flutter's locale APIs.
+  final int? firstDayOfWeekIndex;
+
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
@@ -57,13 +68,14 @@ class SidebarMonthCalendar extends StatelessWidget {
       for (final day in markedDays) DateTime(day.year, day.month, day.day),
     };
 
+    final firstDayOfWeekIndex =
+        this.firstDayOfWeekIndex ?? materialLocalizations.firstDayOfWeekIndex;
     final daysInMonth = DateUtils.getDaysInMonth(month.year, month.month);
-    final firstDayOffset = DateUtils.firstDayOffset(
-      month.year,
-      month.month,
-      materialLocalizations,
+    final firstDayOffset = leadingBlankDayCount(
+      year: month.year,
+      month: month.month,
+      firstDayOfWeekIndex: firstDayOfWeekIndex,
     );
-    final firstDayOfWeekIndex = materialLocalizations.firstDayOfWeekIndex;
     final narrowWeekdays = materialLocalizations.narrowWeekdays;
 
     return Column(

--- a/lib/features/insights/ui/widgets/insights_range_selector.dart
+++ b/lib/features/insights/ui/widgets/insights_range_selector.dart
@@ -1,11 +1,14 @@
 import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/insights/logic/time_bucketing.dart';
 import 'package:lotti/features/insights/model/insights_models.dart';
 import 'package:lotti/features/insights/ui/widgets/insights_pill_button.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/utils/device_region.dart';
+import 'package:lotti/utils/first_day_of_week_picker.dart';
 
 /// Quick-access range presets plus a custom range picker, mirroring the
 /// Cursor usage dashboard: `[May 30 – Jun 05 ▾] 1d 7d 30d MTD YTD Last
@@ -48,6 +51,13 @@ class InsightsRangeSelector extends StatelessWidget {
 
   Future<void> _pickCustomRange(BuildContext context) async {
     final now = clock.now();
+    // Read once for the picker (event handler, not a widget dependency), so
+    // the calendar starts the week on the device region's first weekday.
+    final firstDayOfWeekIndex = await ProviderScope.containerOf(
+      context,
+      listen: false,
+    ).read(firstDayOfWeekIndexProvider.future);
+    if (!context.mounted) return;
     final picked = await showDateRangePicker(
       context: context,
       firstDate: DateTime(now.year - 10),
@@ -56,6 +66,7 @@ class InsightsRangeSelector extends StatelessWidget {
         start: dayStart(range.startDay),
         end: dayStart(range.endDayExclusive - 1),
       ),
+      builder: firstDayOfWeekPickerBuilder(firstDayOfWeekIndex),
     );
     if (picked != null) {
       onCustomRangeSelected(picked.start, picked.end);

--- a/lib/utils/device_region.dart
+++ b/lib/utils/device_region.dart
@@ -1,0 +1,57 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/utils/first_day_of_week.dart';
+
+@visibleForTesting
+const deviceRegionChannelName = 'com.matthiasn.lotti/device_region';
+
+const _deviceRegionChannel = MethodChannel(deviceRegionChannelName);
+
+/// Resolves the device's ISO-3166 region (e.g. `DE`, `US`).
+///
+/// macOS hides the System-Settings *Region* from Flutter's locale APIs —
+/// both `PlatformDispatcher.locales` and `Platform.localeName` report the UI
+/// *language* (often `en_US`), never the region — so on macOS the region is
+/// fetched natively over [deviceRegionChannelName]. Every other platform
+/// carries the region in [Platform.localeName].
+class DeviceRegion {
+  const DeviceRegion({this.methodChannel = _deviceRegionChannel});
+
+  final MethodChannel methodChannel;
+
+  /// The device region, or null when it cannot be determined.
+  ///
+  /// [isMacOS] and [localeName] are injectable seams for tests; in
+  /// production they default to the running platform.
+  Future<String?> regionCode({bool? isMacOS, String? localeName}) async {
+    final macOS = isMacOS ?? Platform.isMacOS;
+    if (macOS) {
+      try {
+        final code = await methodChannel.invokeMethod<String>('getRegionCode');
+        if (code != null && code.trim().isNotEmpty) return code.trim();
+      } on Object {
+        // Channel missing or failed — fall through to locale-name parsing.
+      }
+    }
+    return regionFromLocaleName(localeName ?? Platform.localeName);
+  }
+}
+
+/// The platform region resolver. Overridden in tests.
+final deviceRegionProvider = Provider<DeviceRegion>(
+  (ref) => const DeviceRegion(),
+  name: 'deviceRegionProvider',
+);
+
+/// First weekday (`0 = Sunday` … `6 = Saturday`) for the device region.
+///
+/// Resolves the region via [deviceRegionProvider] and maps it through the
+/// CLDR table, so US devices start the week on Sunday while European devices
+/// start on Monday. Defaults to Monday for unknown regions.
+final firstDayOfWeekIndexProvider = FutureProvider<int>((ref) async {
+  final region = await ref.watch(deviceRegionProvider).regionCode();
+  return firstDayOfWeekIndexForCountry(region);
+}, name: 'firstDayOfWeekIndexProvider');

--- a/lib/utils/first_day_of_week.dart
+++ b/lib/utils/first_day_of_week.dart
@@ -1,0 +1,149 @@
+/// Resolves which weekday a calendar week starts on, by region, plus the
+/// month-grid layout offset that follows from it.
+///
+/// The week-start convention is a *regional* property, not a language one:
+/// a German user running the app in English still expects weeks to begin on
+/// Monday. So the calendar derives its first day from the device region
+/// (see `DeviceRegion`), using the CLDR `weekData/firstDay` table.
+///
+/// First-day indices use Flutter's weekday convention, matching
+/// `MaterialLocalizations.firstDayOfWeekIndex`:
+/// `0 = Sunday`, `1 = Monday`, … `6 = Saturday`.
+library;
+
+/// Territories whose week starts on **Sunday** (CLDR `firstDay = sun`).
+const _sundayFirstCountries = <String>{
+  'AG',
+  'AS',
+  'AU',
+  'BD',
+  'BR',
+  'BS',
+  'BT',
+  'BW',
+  'BZ',
+  'CA',
+  'CN',
+  'CO',
+  'DM',
+  'DO',
+  'ET',
+  'GT',
+  'GU',
+  'HK',
+  'HN',
+  'ID',
+  'IL',
+  'IN',
+  'JM',
+  'JP',
+  'KE',
+  'KH',
+  'KR',
+  'LA',
+  'MH',
+  'MM',
+  'MO',
+  'MT',
+  'MX',
+  'MZ',
+  'NI',
+  'NP',
+  'PA',
+  'PE',
+  'PH',
+  'PK',
+  'PR',
+  'PY',
+  'SA',
+  'SG',
+  'SV',
+  'TH',
+  'TT',
+  'TW',
+  'UM',
+  'US',
+  'VE',
+  'VI',
+  'WS',
+  'YE',
+  'ZA',
+  'ZW',
+};
+
+/// Territories whose week starts on **Saturday** (CLDR `firstDay = sat`).
+const _saturdayFirstCountries = <String>{
+  'AE',
+  'AF',
+  'BH',
+  'DJ',
+  'DZ',
+  'EG',
+  'IQ',
+  'IR',
+  'JO',
+  'KW',
+  'LY',
+  'OM',
+  'QA',
+  'SD',
+  'SY',
+};
+
+/// First weekday for [countryCode] (an ISO-3166 region like `DE`, `US`).
+///
+/// Defaults to **Monday** — the CLDR global default — for unknown or missing
+/// regions. Case-insensitive.
+int firstDayOfWeekIndexForCountry(String? countryCode) {
+  if (countryCode == null || countryCode.isEmpty) return DateTime.monday % 7;
+  final code = countryCode.toUpperCase();
+  if (_sundayFirstCountries.contains(code)) return DateTime.sunday % 7;
+  if (_saturdayFirstCountries.contains(code)) return DateTime.saturday % 7;
+  return DateTime.monday % 7;
+}
+
+/// Extracts the ISO-3166 region from an OS locale identifier such as
+/// `en_DE`, `en_DE.UTF-8`, `de-DE`, or `zh_Hant_HK`. Returns null when the
+/// identifier carries no region.
+///
+/// Used as the region source on platforms that expose it through the locale
+/// name (Linux/Windows/mobile); macOS needs a native lookup instead.
+String? regionFromLocaleName(String localeName) {
+  // Drop any charset/modifier suffix ("en_DE.UTF-8" -> "en_DE").
+  final base = localeName.split('.').first.split('@').first;
+  // The first subtag is the language; the region is a later two-letter
+  // subtag. Matching by position (rather than by case) accepts a lowercase
+  // region ("en_us") without mistaking a two-letter language ("en") for one.
+  for (final part in base.split(RegExp('[_-]')).skip(1)) {
+    if (RegExp(r'^[A-Za-z]{2}$').hasMatch(part)) return part.toUpperCase();
+  }
+  return null;
+}
+
+/// Number of blank leading cells before day 1 of [month]/[year] in a month
+/// grid whose columns start on [firstDayOfWeekIndex].
+///
+/// Mirrors `DateUtils.firstDayOffset`, but takes an explicit first-day index
+/// so the grid can start on a chosen weekday rather than the app locale's.
+int leadingBlankDayCount({
+  required int year,
+  required int month,
+  required int firstDayOfWeekIndex,
+}) {
+  // Catches passing `DateTime.sunday` (7) instead of its index (0): 7 would
+  // silently offset the grid as if the week started on Saturday.
+  assert(
+    firstDayOfWeekIndex >= 0 && firstDayOfWeekIndex <= 6,
+    'firstDayOfWeekIndex must be 0 (Sunday) … 6 (Saturday), got '
+    '$firstDayOfWeekIndex',
+  );
+  // UTC so a local DST/timezone anomaly can never shift the 1st's weekday.
+  // Relies on Dart's Euclidean %: for a positive divisor the result is
+  // always non-negative (e.g. -1 % 7 == 6, -2 % 7 == 5), unlike C/JS — so
+  // a Sunday index (0) and negative dividends below resolve correctly.
+  // `weekday` is 1 (Mon) … 7 (Sun); shift to 0 (Mon) … 6 (Sun).
+  final weekdayFromMonday = DateTime.utc(year, month).weekday - 1;
+  // Convert the Sunday-based first-day index to the same Monday-based frame.
+  final firstDayFromMonday = (firstDayOfWeekIndex - 1) % 7;
+  return (weekdayFromMonday - firstDayFromMonday) % 7;
+}

--- a/lib/utils/first_day_of_week_picker.dart
+++ b/lib/utils/first_day_of_week_picker.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+/// A `builder` for [showDatePicker] / [showDateRangePicker] that makes the
+/// picker's calendar start the week on [firstDayOfWeekIndex] (the device
+/// region's first weekday, `0 = Sunday` … `6 = Saturday`).
+///
+/// Material pickers read the first day only from [MaterialLocalizations] and
+/// expose no override. Among the app's supported UI languages only English
+/// defaults to Sunday — de/fr/es/ro/cs already start on Monday — so the only
+/// mismatch correctable without changing the displayed language is English →
+/// its Monday variant (`en_GB`, whose picker labels are identical to `en_US`).
+/// Any locale that already matches the desired first day is left untouched.
+TransitionBuilder firstDayOfWeekPickerBuilder(int firstDayOfWeekIndex) {
+  return (context, child) {
+    final picker = child ?? const SizedBox.shrink();
+    if (MaterialLocalizations.of(context).firstDayOfWeekIndex ==
+        firstDayOfWeekIndex) {
+      return picker;
+    }
+    final isEnglish = Localizations.localeOf(context).languageCode == 'en';
+    if (isEnglish && firstDayOfWeekIndex == DateTime.monday % 7) {
+      return Localizations.override(
+        context: context,
+        locale: const Locale('en', 'GB'),
+        child: picker,
+      );
+    }
+    return picker;
+  };
+}

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC10F02044A3C60003C045 /* AppDelegate.swift */; };
 		33CC10F30000AC000003C045 /* AudioConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC10F20000AC000003C045 /* AudioConverter.swift */; };
 		5A4D00032D00000200000001 /* FileActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4D00022D00000200000001 /* FileActions.swift */; };
+		5A4D00052D00000200000001 /* DeviceRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4D00042D00000200000001 /* DeviceRegion.swift */; };
 		5A4D00012D00000100000001 /* MlxAudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4D00002D00000100000001 /* MlxAudio.swift */; };
 		5A4D01012D00000200000001 /* MLXAudioCore in Frameworks */ = {isa = PBXBuildFile; productRef = 5A4D01112D00000200000001 /* MLXAudioCore */; };
 		5A4D01022D00000200000001 /* MLXAudioSTT in Frameworks */ = {isa = PBXBuildFile; productRef = 5A4D01122D00000200000001 /* MLXAudioSTT */; };
@@ -73,6 +74,7 @@
 		33CC10F72044A3C60003C045 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = Runner/Info.plist; sourceTree = "<group>"; };
 		33CC10F20000AC000003C045 /* AudioConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioConverter.swift; sourceTree = "<group>"; };
 		5A4D00022D00000200000001 /* FileActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileActions.swift; sourceTree = "<group>"; };
+		5A4D00042D00000200000001 /* DeviceRegion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceRegion.swift; sourceTree = "<group>"; };
 		5A4D00002D00000100000001 /* MlxAudio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MlxAudio.swift; sourceTree = "<group>"; };
 		33CC11122044BFA00003C045 /* MainFlutterWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainFlutterWindow.swift; sourceTree = "<group>"; };
 		33CEB47222A05771004F2AC0 /* Flutter-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Flutter-Debug.xcconfig"; sourceTree = "<group>"; };
@@ -171,6 +173,7 @@
 				33CC10F02044A3C60003C045 /* AppDelegate.swift */,
 				33CC10F20000AC000003C045 /* AudioConverter.swift */,
 				5A4D00022D00000200000001 /* FileActions.swift */,
+				5A4D00042D00000200000001 /* DeviceRegion.swift */,
 				5A4D00002D00000100000001 /* MlxAudio.swift */,
 				33CC11122044BFA00003C045 /* MainFlutterWindow.swift */,
 				33E51913231747F40026EE4D /* DebugProfile.entitlements */,
@@ -382,6 +385,7 @@
 				33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */,
 				33CC10F30000AC000003C045 /* AudioConverter.swift in Sources */,
 				5A4D00032D00000200000001 /* FileActions.swift in Sources */,
+				5A4D00052D00000200000001 /* DeviceRegion.swift in Sources */,
 				5A4D00012D00000100000001 /* MlxAudio.swift in Sources */,
 				33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */,
 				335BBD1B22A9A15E00E9071D /* GeneratedPluginRegistrant.swift in Sources */,

--- a/macos/Runner/DeviceRegion.swift
+++ b/macos/Runner/DeviceRegion.swift
@@ -1,0 +1,29 @@
+import Cocoa
+import FlutterMacOS
+
+/// Exposes the macOS System-Settings *Region* to Flutter.
+///
+/// Flutter's locale APIs report the preferred *language* (often `en_US` for
+/// GUI apps, regardless of the configured region), so the calendar reads the
+/// region directly from `Locale.current` to decide the first day of the week.
+class DeviceRegion {
+    static func register(with registrar: FlutterPluginRegistrar) {
+        let channel = FlutterMethodChannel(
+            name: "com.matthiasn.lotti/device_region",
+            binaryMessenger: registrar.messenger
+        )
+
+        channel.setMethodCallHandler { call, result in
+            switch call.method {
+            case "getRegionCode":
+                if #available(macOS 13.0, *) {
+                    result(Locale.current.region?.identifier)
+                } else {
+                    result(Locale.current.regionCode)
+                }
+            default:
+                result(FlutterMethodNotImplemented)
+            }
+        }
+    }
+}

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -15,6 +15,8 @@ class MainFlutterWindow: NSWindow {
         FileActions.register(with: fileActionsRegistrar)
         let mlxAudioRegistrar = flutterViewController.registrar(forPlugin: "MlxAudio")
         MlxAudio.register(with: mlxAudioRegistrar)
+        let deviceRegionRegistrar = flutterViewController.registrar(forPlugin: "DeviceRegion")
+        DeviceRegion.register(with: deviceRegionRegistrar)
         RegisterGeneratedPlugins(registry: flutterViewController)
 
         super.awakeFromNib()

--- a/test/features/daily_os/ui/widgets/time_history_header/date_label_row_test.dart
+++ b/test/features/daily_os/ui/widgets/time_history_header/date_label_row_test.dart
@@ -7,6 +7,7 @@ import 'package:lotti/features/daily_os/state/time_budget_progress_controller.da
 import 'package:lotti/features/daily_os/state/unified_daily_os_data_controller.dart';
 import 'package:lotti/features/daily_os/ui/widgets/time_history_header/date_label_row.dart';
 import 'package:lotti/features/daily_os/ui/widgets/time_history_header/day_label_chip.dart';
+import 'package:lotti/utils/device_region.dart';
 
 import '../../../../../test_helper.dart';
 import 'test_helpers.dart';
@@ -43,6 +44,7 @@ void main() {
         dayBudgetStatsProvider(date: date).overrideWith(
           (ref) async => effectiveStats,
         ),
+        firstDayOfWeekIndexProvider.overrideWith((ref) async => 1),
       ],
       child: DateLabelRow(
         selectedDate: date,

--- a/test/features/daily_os_next/ui/pages/daily_os_next_root_test.dart
+++ b/test/features/daily_os_next/ui/pages/daily_os_next_root_test.dart
@@ -13,6 +13,7 @@ import 'package:lotti/features/daily_os_next/ui/pages/capture_page.dart';
 import 'package:lotti/features/daily_os_next/ui/pages/daily_os_next_root.dart';
 import 'package:lotti/features/daily_os_next/ui/pages/day_page.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/utils/device_region.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../../mocks/mocks.dart';
@@ -32,6 +33,7 @@ Widget _wrap(
       dailyOsActualTimeBlocksProvider.overrideWith(
         (ref, _) async => actualBlocks,
       ),
+      firstDayOfWeekIndexProvider.overrideWith((ref) async => 1),
       ...overrides,
     ],
     child: makeTestableWidget2(

--- a/test/features/daily_os_next/ui/widgets/sidebar_calendar_test.dart
+++ b/test/features/daily_os_next/ui/widgets/sidebar_calendar_test.dart
@@ -6,6 +6,7 @@ import 'package:lotti/features/daily_os_next/state/day_agent_provider.dart';
 import 'package:lotti/features/daily_os_next/state/selected_date_provider.dart';
 import 'package:lotti/features/daily_os_next/ui/widgets/sidebar_calendar.dart';
 import 'package:lotti/features/design_system/components/navigation/sidebar_month_calendar.dart';
+import 'package:lotti/utils/device_region.dart';
 
 import '../../../../widget_test_utils.dart';
 
@@ -14,6 +15,7 @@ void main() {
     Widget wrap({
       Set<DateTime> planDays = const {},
       List<DateTime>? requestedMonths,
+      int firstDayOfWeekIndex = 1,
     }) {
       return ProviderScope(
         overrides: [
@@ -21,6 +23,9 @@ void main() {
             requestedMonths?.add(month);
             return planDays;
           }),
+          firstDayOfWeekIndexProvider.overrideWith(
+            (ref) async => firstDayOfWeekIndex,
+          ),
         ],
         child: makeTestableWidget2(
           const Material(
@@ -56,6 +61,22 @@ void main() {
             find.byType(SidebarMonthCalendar),
           );
           expect(calendar.markedDays, {DateTime(2026, 5, 13)});
+        });
+      },
+    );
+
+    testWidgets(
+      'feeds the region-derived first weekday into the month calendar',
+      (tester) async {
+        await withClock(Clock.fixed(DateTime(2026, 5, 24, 9)), () async {
+          // A US device resolves to a Sunday-first week (index 0).
+          await tester.pumpWidget(wrap(firstDayOfWeekIndex: 0));
+          await tester.pump();
+
+          final calendar = tester.widget<SidebarMonthCalendar>(
+            find.byType(SidebarMonthCalendar),
+          );
+          expect(calendar.firstDayOfWeekIndex, 0);
         });
       },
     );

--- a/test/features/design_system/components/navigation/sidebar_month_calendar_test.dart
+++ b/test/features/design_system/components/navigation/sidebar_month_calendar_test.dart
@@ -44,6 +44,33 @@ void main() {
       },
     );
 
+    testWidgets(
+      'injected firstDayOfWeekIndex shifts the grid (Monday vs Sunday start)',
+      (tester) async {
+        Future<double> dayOneDx(int firstDayOfWeekIndex) async {
+          await tester.pumpWidget(
+            _wrap(
+              SidebarMonthCalendar(
+                month: DateTime(2026, 5),
+                today: DateTime(2026, 5, 24),
+                firstDayOfWeekIndex: firstDayOfWeekIndex,
+                onPreviousMonth: () {},
+                onNextMonth: () {},
+                onDaySelected: (_) {},
+              ),
+            ),
+          );
+          return tester.getCenter(find.text('1')).dx;
+        }
+
+        // 1 May 2026 is a Friday. With a Monday-start week it sits in the 5th
+        // column; switching to a Sunday-start week shifts it one column right.
+        final mondayStartDx = await dayOneDx(DateTime.monday % 7); // 1
+        final sundayStartDx = await dayOneDx(DateTime.sunday % 7); // 0
+        expect(sundayStartDx, greaterThan(mondayStartDx));
+      },
+    );
+
     testWidgets('today is highlighted with the teal circle', (tester) async {
       await tester.pumpWidget(
         _wrap(

--- a/test/features/insights/ui/widgets/insights_range_selector_test.dart
+++ b/test/features/insights/ui/widgets/insights_range_selector_test.dart
@@ -6,6 +6,7 @@ import 'package:lotti/features/insights/logic/range_presets.dart';
 import 'package:lotti/features/insights/logic/time_bucketing.dart';
 import 'package:lotti/features/insights/model/insights_models.dart';
 import 'package:lotti/features/insights/ui/widgets/insights_range_selector.dart';
+import 'package:lotti/utils/device_region.dart';
 
 import '../../../../widget_test_utils.dart';
 
@@ -22,6 +23,9 @@ void main() {
     return tester.pumpWidget(
       makeTestableWidget(
         mediaQueryData: desktopMq,
+        overrides: [
+          firstDayOfWeekIndexProvider.overrideWith((ref) async => 1),
+        ],
         InsightsRangeSelector(
           range: range,
           onPresetSelected: onPreset ?? (_) {},

--- a/test/utils/device_region_test.dart
+++ b/test/utils/device_region_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/utils/device_region.dart';
+
+class _FakeDeviceRegion extends DeviceRegion {
+  const _FakeDeviceRegion(this.region);
+
+  final String? region;
+
+  @override
+  Future<String?> regionCode({bool? isMacOS, String? localeName}) async =>
+      region;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel(deviceRegionChannelName);
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  void stubChannel(Object? Function(MethodCall call) handler) {
+    messenger.setMockMethodCallHandler(channel, (call) async => handler(call));
+  }
+
+  tearDown(() => messenger.setMockMethodCallHandler(channel, null));
+
+  group('DeviceRegion.regionCode', () {
+    test('macOS: the native region wins over the UI-language locale', () async {
+      stubChannel((call) {
+        expect(call.method, 'getRegionCode');
+        return 'DE';
+      });
+
+      final region = await const DeviceRegion().regionCode(
+        isMacOS: true,
+        localeName: 'en_US',
+      );
+
+      expect(region, 'DE');
+    });
+
+    test(
+      'macOS: empty native result falls back to the locale region',
+      () async {
+        stubChannel((_) => null);
+
+        final region = await const DeviceRegion().regionCode(
+          isMacOS: true,
+          localeName: 'en_DE',
+        );
+
+        expect(region, 'DE');
+      },
+    );
+
+    test('macOS: a channel failure falls back to the locale region', () async {
+      stubChannel((_) => throw PlatformException(code: 'unavailable'));
+
+      final region = await const DeviceRegion().regionCode(
+        isMacOS: true,
+        localeName: 'en_GB',
+      );
+
+      expect(region, 'GB');
+    });
+
+    test(
+      'non-macOS: uses the locale region without touching the channel',
+      () async {
+        var channelCalled = false;
+        stubChannel((_) {
+          channelCalled = true;
+          return 'XX';
+        });
+
+        final region = await const DeviceRegion().regionCode(
+          isMacOS: false,
+          localeName: 'de_DE.UTF-8',
+        );
+
+        expect(region, 'DE');
+        expect(channelCalled, isFalse);
+      },
+    );
+
+    test('non-macOS: a region-less locale yields null', () async {
+      final region = await const DeviceRegion().regionCode(
+        isMacOS: false,
+        localeName: 'en',
+      );
+
+      expect(region, isNull);
+    });
+  });
+
+  group('firstDayOfWeekIndexProvider', () {
+    Future<int> resolve(String? region) async {
+      final container = ProviderContainer(
+        overrides: [
+          deviceRegionProvider.overrideWithValue(_FakeDeviceRegion(region)),
+        ],
+      );
+      addTearDown(container.dispose);
+      return container.read(firstDayOfWeekIndexProvider.future);
+    }
+
+    test('US region starts the week on Sunday', () async {
+      expect(await resolve('US'), 0);
+    });
+
+    test('European region starts the week on Monday', () async {
+      expect(await resolve('DE'), 1);
+    });
+
+    test('unknown/null region defaults to Monday', () async {
+      expect(await resolve(null), 1);
+    });
+  });
+}

--- a/test/utils/first_day_of_week_picker_test.dart
+++ b/test/utils/first_day_of_week_picker_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/utils/first_day_of_week_picker.dart';
+
+void main() {
+  // Renders the picker builder for [locale] asking for [desiredIndex], and
+  // reports the `firstDayOfWeekIndex` the wrapped subtree actually sees.
+  Future<int> firstDayInPicker(
+    WidgetTester tester, {
+    required Locale locale,
+    required int desiredIndex,
+  }) async {
+    late int observed;
+    final builder = firstDayOfWeekPickerBuilder(desiredIndex);
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: locale,
+        localizationsDelegates: const [
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: const [
+          Locale('en', 'US'),
+          Locale('en', 'GB'),
+          Locale('de'),
+        ],
+        home: Builder(
+          builder: (context) => builder(
+            context,
+            Builder(
+              builder: (inner) {
+                observed = MaterialLocalizations.of(inner).firstDayOfWeekIndex;
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return observed;
+  }
+
+  group('firstDayOfWeekPickerBuilder', () {
+    testWidgets('forces Monday for English when the region wants Monday', (
+      tester,
+    ) async {
+      // en_US defaults to Sunday (0); region wants Monday (1) -> en_GB.
+      expect(
+        await firstDayInPicker(
+          tester,
+          locale: const Locale('en', 'US'),
+          desiredIndex: DateTime.monday % 7,
+        ),
+        1,
+      );
+    });
+
+    testWidgets('leaves the picker untouched when it already matches', (
+      tester,
+    ) async {
+      // en_US is already Sunday and Sunday is wanted -> no override.
+      expect(
+        await firstDayInPicker(
+          tester,
+          locale: const Locale('en', 'US'),
+          desiredIndex: DateTime.sunday % 7,
+        ),
+        0,
+      );
+    });
+
+    testWidgets('keeps a non-English locale (already Monday) unchanged', (
+      tester,
+    ) async {
+      // German starts on Monday; we never switch its language to force a
+      // different first day, so it stays Monday even if Sunday is requested.
+      expect(
+        await firstDayInPicker(
+          tester,
+          locale: const Locale('de'),
+          desiredIndex: DateTime.sunday % 7,
+        ),
+        1,
+      );
+    });
+  });
+}

--- a/test/utils/first_day_of_week_test.dart
+++ b/test/utils/first_day_of_week_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/utils/first_day_of_week.dart';
+
+void main() {
+  group('firstDayOfWeekIndexForCountry', () {
+    test('European/Monday-default regions start on Monday', () {
+      // DE/FR/GB are not in the Sunday or Saturday sets, so they fall to the
+      // CLDR global default of Monday (index 1).
+      for (final code in ['DE', 'FR', 'GB', 'RO', 'ES', 'CZ']) {
+        expect(firstDayOfWeekIndexForCountry(code), 1, reason: code);
+      }
+    });
+
+    test('Sunday-first regions return Sunday (0)', () {
+      for (final code in ['US', 'CA', 'JP', 'BR', 'IN', 'SA']) {
+        expect(firstDayOfWeekIndexForCountry(code), 0, reason: code);
+      }
+    });
+
+    test('Saturday-first regions return Saturday (6)', () {
+      for (final code in ['EG', 'AE', 'IR', 'QA']) {
+        expect(firstDayOfWeekIndexForCountry(code), 6, reason: code);
+      }
+    });
+
+    test('is case-insensitive', () {
+      expect(firstDayOfWeekIndexForCountry('us'), 0);
+      expect(firstDayOfWeekIndexForCountry('de'), 1);
+    });
+
+    test('null, empty, or unknown regions default to Monday', () {
+      expect(firstDayOfWeekIndexForCountry(null), 1);
+      expect(firstDayOfWeekIndexForCountry(''), 1);
+      expect(firstDayOfWeekIndexForCountry('ZZ'), 1);
+    });
+  });
+
+  group('regionFromLocaleName', () {
+    test('extracts the region from common identifier shapes', () {
+      expect(regionFromLocaleName('en_DE'), 'DE');
+      expect(regionFromLocaleName('en_DE.UTF-8'), 'DE');
+      expect(regionFromLocaleName('de-DE'), 'DE');
+      expect(regionFromLocaleName('zh_Hant_HK'), 'HK');
+      expect(regionFromLocaleName('en_US@calendar=gregorian'), 'US');
+    });
+
+    test('normalizes a lowercase region without matching the language', () {
+      // Lowercase region is accepted and upper-cased...
+      expect(regionFromLocaleName('en_us.UTF-8'), 'US');
+      // ...but the two-letter language subtag is never taken for a region.
+      expect(regionFromLocaleName('fr'), isNull);
+    });
+
+    test('returns null when no region is present', () {
+      expect(regionFromLocaleName('en'), isNull);
+      expect(regionFromLocaleName('de'), isNull);
+      expect(regionFromLocaleName(''), isNull);
+    });
+  });
+
+  group('leadingBlankDayCount', () {
+    // 1 May 2026 is a Friday; 1 June 2026 is a Monday.
+    test('Friday-starting month: 4 blanks for Monday-start, 5 for Sunday', () {
+      expect(
+        leadingBlankDayCount(year: 2026, month: 5, firstDayOfWeekIndex: 1),
+        4,
+      );
+      expect(
+        leadingBlankDayCount(year: 2026, month: 5, firstDayOfWeekIndex: 0),
+        5,
+      );
+    });
+
+    test('Monday-starting month: 0 blanks for Monday-start, 1 for Sunday', () {
+      expect(
+        leadingBlankDayCount(year: 2026, month: 6, firstDayOfWeekIndex: 1),
+        0,
+      );
+      expect(
+        leadingBlankDayCount(year: 2026, month: 6, firstDayOfWeekIndex: 0),
+        1,
+      );
+    });
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar month calendar now uses your device region’s first weekday (e.g., Monday in much of Europe, Sunday in the US).

* **Bug Fixes**
  * Calendar week start no longer always defaults to Sunday; macOS region resolution has been improved so the sidebar matches your system settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->