### PR TITLE
feat: cap mobile bottom nav at five slots with More overflow sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reads those notes back later — so after an overworked stretch it plans a
   gentler day instead of piling on. Sustainability over throughput.
 
+### Changed
+- Mobile: the bottom navigation bar no longer crams every destination into
+  one row with shrinking labels. It now shows Tasks, DailyOS (when
+  enabled), and Logbook plus a "More" slot; Settings and the remaining
+  flag-gated destinations (Projects, Habits, Insights) open from a More
+  bottom sheet instead — that's also where newly toggled pages appear.
+  While one of them is on screen, the More slot takes its name and the
+  active highlight so you can always see where you are. Daily OS also
+  moved directly after Tasks across mobile and the desktop sidebar. The
+  bar docks flush against the bottom screen edge — full width, no floating
+  gap — with the home-indicator inset absorbed into the bar surface, and
+  its top corners now use the gentler card radius (matched by the settings
+  header's bottom corners).
+
 ## [0.9.1017]
 ### Added
 - New desktop "Time Analysis" dashboard under Daily OS, opened from a

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -35,6 +35,7 @@
     <release version="0.9.1018" date="2026-06-10">
       <description>
           <p>The Daily OS planner now sees the last week in context when drafting a day: planned-vs-recorded time per category, missed sessions by name, and upcoming plans plus deadlines for the next five days. It also keeps a short note on how each day actually went, written as the day closes, and reads those notes back later — so after an overworked stretch it plans a gentler day instead of piling on. Sustainability over throughput.</p>
+          <p>Mobile: the bottom navigation bar no longer crams every destination into one row with shrinking labels. It now shows Tasks, DailyOS (when enabled), and Logbook plus a "More" slot; Settings and the remaining flag-gated destinations (Projects, Habits, Insights) open from a More bottom sheet instead — that's also where newly toggled pages appear — and the More slot takes the active destination's name and highlight while one of them is on screen. Daily OS moved directly after Tasks across mobile and the desktop sidebar. The bar docks flush against the bottom screen edge with the home-indicator inset absorbed into the bar surface, and its top corners use the gentler card radius.</p>
       </description>
     </release>
     <release version="0.9.1017" date="2026-06-07">

--- a/lib/beamer/beamer_app.dart
+++ b/lib/beamer/beamer_app.dart
@@ -1,4 +1,5 @@
 import 'dart:io' show Platform;
+import 'dart:math' as math;
 
 import 'package:beamer/beamer.dart';
 import 'package:flutter/material.dart';
@@ -15,7 +16,7 @@ import 'package:lotti/features/ai/ui/settings/ai_settings_navigation_service.dar
 import 'package:lotti/features/ai/ui/settings/services/ai_setup_prompt_service.dart';
 import 'package:lotti/features/ai/ui/settings/widgets/ai_provider_selection_modal.dart';
 import 'package:lotti/features/daily_os_next/ui/widgets/sidebar_calendar.dart';
-import 'package:lotti/features/design_system/components/navigation/design_system_navigation_tab_bar.dart';
+import 'package:lotti/features/design_system/components/navigation/design_system_five_slot_nav_bar.dart';
 import 'package:lotti/features/design_system/components/navigation/desktop_navigation_sidebar.dart';
 import 'package:lotti/features/design_system/components/navigation/resizable_divider.dart';
 import 'package:lotti/features/design_system/components/toasts/design_system_toast.dart';
@@ -27,6 +28,8 @@ import 'package:lotti/features/insights/ui/widgets/insights_sidebar_entry.dart';
 import 'package:lotti/features/settings/state/zoom_controller.dart';
 import 'package:lotti/features/settings/ui/pages/outbox/outbox_badge.dart';
 import 'package:lotti/features/settings/ui/pages/outbox/outbox_trailing_badge.dart';
+import 'package:lotti/features/speech/state/recorder_controller.dart';
+import 'package:lotti/features/speech/state/recorder_state.dart';
 import 'package:lotti/features/speech/ui/widgets/recording/audio_recording_indicator.dart';
 import 'package:lotti/features/sync/state/matrix_login_controller.dart';
 import 'package:lotti/features/sync/state/synced_audio_inference_providers.dart';
@@ -53,6 +56,7 @@ import 'package:lotti/widgets/misc/sidebar_timer_section.dart';
 import 'package:lotti/widgets/misc/time_recording_indicator.dart';
 import 'package:lotti/widgets/misc/zoom_wrapper.dart';
 import 'package:lotti/widgets/nav_bar/design_system_bottom_navigation_bar.dart';
+import 'package:lotti/widgets/nav_bar/mobile_nav_more_sheet.dart';
 import 'package:matrix/matrix.dart';
 
 /// Check if the app is running inside Flatpak sandbox
@@ -93,8 +97,8 @@ int clampNavigationIndex({required int rawIndex, required int itemCount}) {
 
 enum _AppNavigationDestinationKind {
   tasks,
-  projects,
   dailyOs,
+  projects,
   habits,
   dashboards,
   journal,
@@ -113,6 +117,22 @@ class _AppNavigationDestination {
 
   final _AppNavigationDestinationKind kind;
   final String label;
+
+  /// Whether this destination claims one of the mobile bar's destination
+  /// slots. Tasks and Daily OS are the most important pages — Daily OS
+  /// never overflows — and Journal keeps its slot alongside them.
+  /// Settings is always relegated to the More sheet, joined by the
+  /// flag-gated destinations, so the sheet is also where newly toggled
+  /// pages appear.
+  bool get isMobilePrimary => switch (kind) {
+    _AppNavigationDestinationKind.tasks ||
+    _AppNavigationDestinationKind.dailyOs ||
+    _AppNavigationDestinationKind.journal => true,
+    _AppNavigationDestinationKind.projects ||
+    _AppNavigationDestinationKind.habits ||
+    _AppNavigationDestinationKind.dashboards ||
+    _AppNavigationDestinationKind.settings => false,
+  };
 
   /// Base icon for this destination. The desktop sidebar uses this directly;
   /// compact navigation may decorate it through [mobileIconWrapper].
@@ -135,11 +155,11 @@ class _AppNavigationDestination {
     return mobileIconWrapper?.call(icon) ?? icon;
   }
 
-  DesignSystemNavigationTabBarItem toDesignSystemItem({
+  DesignSystemFiveSlotNavBarItem toFiveSlotItem({
     required bool active,
     required VoidCallback onTap,
   }) {
-    return DesignSystemNavigationTabBarItem(
+    return DesignSystemFiveSlotNavBarItem(
       label: label,
       icon: _mobileIcon(active: false),
       activeIcon: _mobileIcon(active: true),
@@ -313,10 +333,10 @@ class _AppScreenState extends ConsumerState<AppScreen> {
 
         final beamerChildren = [
           Beamer(routerDelegate: navService.tasksDelegate),
-          if (isProjectsPageEnabled)
-            Beamer(routerDelegate: navService.projectsDelegate),
           if (isDailyOsPageEnabled)
             Beamer(routerDelegate: navService.calendarDelegate),
+          if (isProjectsPageEnabled)
+            Beamer(routerDelegate: navService.projectsDelegate),
           if (isHabitsPageEnabled)
             Beamer(routerDelegate: navService.habitsDelegate),
           if (isDashboardsPageEnabled)
@@ -495,12 +515,72 @@ class _AppScreenState extends ConsumerState<AppScreen> {
     // every route change.
     final showBottomNav = !_isTaskDetailRoute(index);
 
+    // Fixed bar line-up: Tasks, Daily OS (when enabled), Logbook, More.
+    // Everything else — Settings always, plus the flag-gated destinations
+    // — lives behind the More slot, which is where newly toggled pages
+    // surface. Entries carry their full destination index so taps route
+    // through the same NavService indices the IndexedStack uses.
+    final primaryEntries = <(int, _AppNavigationDestination)>[];
+    final overflowEntries = <(int, _AppNavigationDestination)>[];
+    for (var i = 0; i < destinations.length; i++) {
+      (destinations[i].isMobilePrimary ? primaryEntries : overflowEntries).add(
+        (i, destinations[i]),
+      );
+    }
+
+    _AppNavigationDestination? activeOverflowDestination;
+    for (final (i, destination) in overflowEntries) {
+      if (i == index) {
+        activeOverflowDestination = destination;
+        break;
+      }
+    }
+
     final designSystemBottomNavigationBar = DesignSystemBottomNavigationBar(
       items: [
-        for (var i = 0; i < destinations.length; i++)
-          destinations[i].toDesignSystemItem(
+        for (final (i, destination) in primaryEntries)
+          destination.toFiveSlotItem(
             active: i == index,
             onTap: () => navService.tapIndex(i),
+          ),
+        if (overflowEntries.isNotEmpty)
+          DesignSystemFiveSlotNavBarItem(
+            // While an overflow destination is on screen the More slot
+            // takes its name and the active tint — visually and for screen
+            // readers — so the bar reflects location even though the
+            // destination has no own slot. Otherwise it announces how many
+            // destinations hide behind it.
+            label:
+                activeOverflowDestination?.label ??
+                context.messages.navTabTitleMore,
+            icon: const Icon(Icons.more_horiz_rounded),
+            active: activeOverflowDestination != null,
+            semanticsLabel:
+                activeOverflowDestination?.label ??
+                context.messages.navTabMoreSemanticsLabel(
+                  overflowEntries.length,
+                ),
+            onTap: () => showMobileNavMoreSheet(
+              context: context,
+              items: [
+                for (final (i, destination) in overflowEntries)
+                  MobileNavMoreSheetItem(
+                    label: destination.label,
+                    icon: destination._mobileIcon(active: i == index),
+                    active: i == index,
+                    // The index is resolved at tap time, not captured: a
+                    // flag change (e.g. synced from another device) while
+                    // the sheet is open re-numbers the destinations, and a
+                    // stale index would route the tap to the wrong tab.
+                    onSelected: () {
+                      final tapIndex = _currentDestinationIndex(
+                        destination.kind,
+                      );
+                      if (tapIndex != null) navService.tapIndex(tapIndex);
+                    },
+                  ),
+              ],
+            ),
           ),
       ],
       overlay: Row(
@@ -523,15 +603,21 @@ class _AppScreenState extends ConsumerState<AppScreen> {
       body: Stack(
         children: [
           const IncomingVerificationWrapper(),
-          IndexedStack(
-            index: index,
-            children: [
-              for (var i = 0; i < beamerChildren.length; i++)
-                TickerMode(
-                  enabled: i == index,
-                  child: beamerChildren[i],
-                ),
-            ],
+          // The scope keeps `occupiedHeight` (and every page padding by it)
+          // in sync with the indicator row riding above the bar, so the
+          // indicators never cover scroll content or floating actions.
+          _MobileNavOverlayHeightScope(
+            navBarVisible: showBottomNav,
+            child: IndexedStack(
+              index: index,
+              children: [
+                for (var i = 0; i < beamerChildren.length; i++)
+                  TickerMode(
+                    enabled: i == index,
+                    child: beamerChildren[i],
+                  ),
+              ],
+            ),
           ),
           if (showBottomNav)
             Positioned(
@@ -561,12 +647,6 @@ class _AppScreenState extends ConsumerState<AppScreen> {
         expandedChildBuilder: () => const TasksSavedFiltersTree(),
       ),
       _AppNavigationDestination(
-        kind: _AppNavigationDestinationKind.projects,
-        label: context.messages.navTabTitleProjects,
-        iconBuilder: ({required active}) =>
-            Icon(active ? Icons.folder_rounded : Icons.folder_outlined),
-      ),
-      _AppNavigationDestination(
         kind: _AppNavigationDestinationKind.dailyOs,
         label: context.messages.navTabTitleCalendar,
         iconBuilder: ({required active}) =>
@@ -583,6 +663,12 @@ class _AppScreenState extends ConsumerState<AppScreen> {
             InsightsSidebarEntry(),
           ],
         ),
+      ),
+      _AppNavigationDestination(
+        kind: _AppNavigationDestinationKind.projects,
+        label: context.messages.navTabTitleProjects,
+        iconBuilder: ({required active}) =>
+            Icon(active ? Icons.folder_rounded : Icons.folder_outlined),
       ),
       _AppNavigationDestination(
         kind: _AppNavigationDestinationKind.habits,
@@ -614,20 +700,116 @@ class _AppScreenState extends ConsumerState<AppScreen> {
       ),
     ];
 
+    final enabledKinds = _enabledDestinationKinds(
+      isProjectsPageEnabled: isProjectsPageEnabled,
+      isDailyOsPageEnabled: isDailyOsPageEnabled,
+      isHabitsPageEnabled: isHabitsPageEnabled,
+      isDashboardsPageEnabled: isDashboardsPageEnabled,
+    );
     return allDestinations
-        .where((destination) {
-          return switch (destination.kind) {
-            _AppNavigationDestinationKind.tasks => true,
-            _AppNavigationDestinationKind.projects => isProjectsPageEnabled,
-            _AppNavigationDestinationKind.dailyOs => isDailyOsPageEnabled,
-            _AppNavigationDestinationKind.habits => isHabitsPageEnabled,
-            _AppNavigationDestinationKind.dashboards => isDashboardsPageEnabled,
-            _AppNavigationDestinationKind.journal => true,
-            _AppNavigationDestinationKind.settings => true,
-          };
-        })
+        .where((destination) => enabledKinds.contains(destination.kind))
         .toList(growable: false);
   }
+
+  /// Destination index of [kind] as enabled *right now*, read directly
+  /// from the NavService flag getters — the same ordering
+  /// [_buildNavigationDestinations] uses via [_enabledDestinationKinds].
+  /// Resolved at tap time by the More sheet so a flag change while the
+  /// sheet is open cannot route a tap through a stale index. Null when
+  /// [kind] got disabled in the meantime.
+  int? _currentDestinationIndex(_AppNavigationDestinationKind kind) {
+    final index = _enabledDestinationKinds(
+      isProjectsPageEnabled: navService.isProjectsPageEnabled,
+      isDailyOsPageEnabled: navService.isDailyOsPageEnabled,
+      isHabitsPageEnabled: navService.isHabitsPageEnabled,
+      isDashboardsPageEnabled: navService.isDashboardsPageEnabled,
+    ).indexOf(kind);
+    return index == -1 ? null : index;
+  }
+}
+
+/// Feeds [DesignSystemBottomNavigationOverlayHeight] with the rendered
+/// height of the indicator row riding above the mobile nav bar, mirroring
+/// the indicators' own visibility rules: the time indicator shows while
+/// [TimeService] streams a running entry, the audio indicator while a
+/// recording runs outside its modal (and outside the Flatpak sandbox,
+/// which omits the indicator entirely). While the shell hides the bar —
+/// task-detail routes — the overlay is hidden with it, so no height
+/// applies. [child] is a prebuilt subtree; only widgets depending on the
+/// inherited height rebuild when an indicator appears or disappears.
+class _MobileNavOverlayHeightScope extends ConsumerWidget {
+  const _MobileNavOverlayHeightScope({
+    required this.navBarVisible,
+    required this.child,
+  });
+
+  final bool navBarVisible;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Same guard as AudioRecordingIndicator: if the recorder controller
+    // fails to build (MediaKit/audio issues), the indicator renders
+    // nothing, so no height applies either.
+    bool audioIndicatorVisible;
+    try {
+      audioIndicatorVisible =
+          !_isRunningInFlatpak() &&
+          ref.watch(
+            audioRecorderControllerProvider.select(
+              (state) =>
+                  state.status == AudioRecorderStatus.recording &&
+                  !state.modalVisible,
+            ),
+          );
+    } catch (_) {
+      audioIndicatorVisible = false;
+    }
+
+    return StreamBuilder<JournalEntity?>(
+      stream: getIt<TimeService>().getStream(),
+      builder: (context, snapshot) {
+        final timeIndicatorVisible = snapshot.data != null;
+        var height = 0.0;
+        if (navBarVisible) {
+          // Mirror the rendered indicator heights: the time indicator is
+          // AudioRecordingIndicatorConstants.indicatorHeight tall, the
+          // audio indicator spacing.step6 — the row is as tall as the
+          // tallest visible one.
+          height = math.max(
+            timeIndicatorVisible
+                ? AudioRecordingIndicatorConstants.indicatorHeight
+                : 0,
+            audioIndicatorVisible ? context.designTokens.spacing.step6 : 0,
+          );
+        }
+        return DesignSystemBottomNavigationOverlayHeight(
+          height: height,
+          child: child,
+        );
+      },
+    );
+  }
+}
+
+/// The enabled destination kinds in navigation order — the single source
+/// of truth for how flags map to tab indices, shared by the destination
+/// builder and the More sheet's tap-time index resolution.
+List<_AppNavigationDestinationKind> _enabledDestinationKinds({
+  required bool isProjectsPageEnabled,
+  required bool isDailyOsPageEnabled,
+  required bool isHabitsPageEnabled,
+  required bool isDashboardsPageEnabled,
+}) {
+  return [
+    _AppNavigationDestinationKind.tasks,
+    if (isDailyOsPageEnabled) _AppNavigationDestinationKind.dailyOs,
+    if (isProjectsPageEnabled) _AppNavigationDestinationKind.projects,
+    if (isHabitsPageEnabled) _AppNavigationDestinationKind.habits,
+    if (isDashboardsPageEnabled) _AppNavigationDestinationKind.dashboards,
+    _AppNavigationDestinationKind.journal,
+    _AppNavigationDestinationKind.settings,
+  ];
 }
 
 class MyBeamerApp extends ConsumerStatefulWidget {

--- a/lib/features/design_system/README.md
+++ b/lib/features/design_system/README.md
@@ -180,7 +180,11 @@ Representative composite or feature-shaped components:
 
 - task filters
 - task list items
-- navigation tab bar (`components/navigation/`)
+- navigation tab bar and the mobile five-slot bottom nav bar
+  (`components/navigation/`) — the five-slot bar fixes the slot count
+  (primary destinations + More) with equal flex per slot so labels never
+  shrink, docks flush against the bottom edge, and absorbs the bottom
+  safe-area inset into its own surface
 - desktop navigation sidebar with a collapsible icon-only state and a
   resizable divider that disables drag input while the sidebar is
   collapsed, preserving the previous expanded width so re-expanding
@@ -241,9 +245,10 @@ Representative components such as `DesignSystemButton`, `DesignSystemCheckbox`, 
 
 ### Shell-Aware Overlay Spacing
 
-The floating bottom navigation shell is an app-level overlay, not a normal
-`Scaffold.bottomNavigationBar`. That means any screen-level floating action
-button or status overlay that hugs the bottom edge needs explicit clearance.
+The bottom navigation shell is an app-level overlay docked flush against
+the screen's bottom edge, not a normal `Scaffold.bottomNavigationBar`. That
+means any screen-level floating action button or status overlay that hugs
+the bottom edge needs explicit clearance.
 
 The shell itself (`DesignSystemBottomNavigationBar`) and its FAB clearance
 wrapper (`DesignSystemBottomNavigationFabPadding`) live outside this feature, in
@@ -251,7 +256,10 @@ wrapper (`DesignSystemBottomNavigationFabPadding`) live outside this feature, in
 exercised through the DS widgetbook. The current contract is:
 
 - `DesignSystemBottomNavigationBar.occupiedHeight(context)` defines how much
-  vertical space the shell consumes, including safe-area inset
+  vertical space the shell consumes: the bar (including safe-area inset)
+  plus the height of the indicator overlay row currently riding above it,
+  published by the app shell through
+  `DesignSystemBottomNavigationOverlayHeight`
 - `DesignSystemBottomNavigationFabPadding` is the default wrapper for
   screen-level FABs that need to stay visually above that shell
 - feature pages should use that wrapper rather than inventing local bottom

--- a/lib/features/design_system/components/navigation/design_system_five_slot_nav_bar.dart
+++ b/lib/features/design_system/components/navigation/design_system_five_slot_nav_bar.dart
@@ -1,0 +1,229 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:lotti/features/design_system/components/navigation/design_system_navigation_tab_bar.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+
+/// One destination slot of [DesignSystemFiveSlotNavBar].
+class DesignSystemFiveSlotNavBarItem {
+  const DesignSystemFiveSlotNavBarItem({
+    required this.label,
+    required this.icon,
+    this.activeIcon,
+    this.active = false,
+    this.onTap,
+    this.semanticsLabel,
+  });
+
+  final String label;
+  final Widget icon;
+  final Widget? activeIcon;
+  final bool active;
+  final VoidCallback? onTap;
+
+  /// Overrides [label] for screen readers — used by the More slot to
+  /// announce how many destinations hide behind it.
+  final String? semanticsLabel;
+}
+
+/// Mobile bottom navigation bar capped at five slots, docked flush against
+/// the screen's bottom edge (`Tasks · DailyOS · Logbook · More`).
+///
+/// Unlike [DesignSystemNavigationTabBar] — which hugs its content and gets
+/// scaled down by a `FittedBox` when too many tabs are visible, shrinking
+/// labels into illegibility — this bar fixes the slot count and gives every
+/// slot an equal flex share, so labels always render at the caption size.
+/// Destinations beyond the cap belong in a More overflow sheet owned by the
+/// caller.
+///
+/// The bar spans the full width with only the top corners rounded, and pads
+/// the bottom safe-area inset *inside* its surface ([bottomInsetFraction]
+/// of it, replacing the internal bottom padding), so the frosted fill
+/// reaches the physical bottom edge with zero gap while the slot row stays
+/// clear of the home indicator.
+///
+/// Selection tint cross-fades over [tintDuration]; when the platform asks
+/// for reduced motion the tint snaps instead.
+class DesignSystemFiveSlotNavBar extends StatelessWidget {
+  const DesignSystemFiveSlotNavBar({
+    required this.items,
+    super.key,
+  }) : assert(
+         items.length <= maxSlots,
+         'At most five slots fit the bar; move further destinations into '
+         'the More sheet.',
+       );
+
+  /// Hard cap on the number of slots — callers budgeting destinations
+  /// against the bar (e.g. the mobile shell's More-sheet overflow) share
+  /// this constant so the numbers cannot drift apart.
+  static const int maxSlots = 5;
+
+  static const double iconSize = 22;
+
+  /// Minimum tappable extent of every slot (accessibility floor).
+  static const double minTapTarget = 44;
+
+  static const Duration tintDuration = Duration(milliseconds: 240);
+
+  /// Fraction of the bottom safe-area inset the bar absorbs into its
+  /// surface. The OS-reported home-indicator inset (34px on iPhones) is
+  /// generous for a docked bar; rendering half of it keeps the slot row
+  /// clear of the indicator without dead space below the labels.
+  static const double bottomInsetFraction = 0.5;
+
+  /// `cubic-bezier(0.25, 1, 0.5, 1)` — easeOutQuart.
+  static const Curve tintCurve = Cubic(0.25, 1, 0.5, 1);
+
+  final List<DesignSystemFiveSlotNavBarItem> items;
+
+  /// Intrinsic content height of the slot row (excluding the frosted
+  /// surface's padding and the safe-area inset). Scales with the system
+  /// text size: the label line grows under [MediaQuery.textScalerOf], so
+  /// the fixed-height row must grow with it or large-font users get
+  /// clipped captions.
+  static double contentHeight(BuildContext context) {
+    final tokens = context.designTokens;
+    final scaledCaptionHeight = MediaQuery.textScalerOf(
+      context,
+    ).scale(tokens.typography.lineHeight.caption);
+    return math.max(
+      minTapTarget,
+      iconSize + tokens.spacing.step1 + scaledCaptionHeight,
+    );
+  }
+
+  /// Total rendered height of the bar: content plus the frosted surface's
+  /// vertical padding, its hairline border (which `Container` stacks onto
+  /// the padding on each side), and the absorbed bottom safe-area inset
+  /// (see [_bottomPadding]). Shared with the bottom-nav container's
+  /// occupied-height math so the numbers cannot drift apart.
+  static double barHeight(BuildContext context) {
+    final tokens = context.designTokens;
+    return contentHeight(context) +
+        tokens.spacing.step2 +
+        _bottomPadding(context) +
+        DesignSystemNavigationFrostedSurface.borderWidth * 2;
+  }
+
+  /// Bottom padding of the frosted surface: [bottomInsetFraction] of the
+  /// safe-area inset, replacing — rather than stacking onto — the internal
+  /// `step2` padding, so home-indicator devices get no double spacing
+  /// below the slot row.
+  static double _bottomPadding(BuildContext context) {
+    final tokens = context.designTokens;
+    return math.max(
+      tokens.spacing.step2,
+      MediaQuery.paddingOf(context).bottom * bottomInsetFraction,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final insets = MediaQuery.paddingOf(context);
+
+    return DesignSystemNavigationFrostedSurface(
+      // Docked: only the top corners are rounded, the bottom edge sits
+      // flush against the screen edge — deliberately with zero gap below,
+      // including on devices that report no home-indicator inset.
+      borderRadius: BorderRadius.vertical(
+        top: Radius.circular(tokens.radii.sectionCards),
+      ),
+      // The safe-area insets live inside the surface so the frosted fill
+      // reaches the physical edges while the slot row stays clear of the
+      // home indicator, notches, and landscape navigation buttons. The
+      // bottom inset is trimmed and absorbed by _bottomPadding instead of
+      // stacking onto the internal padding.
+      padding: EdgeInsets.fromLTRB(
+        tokens.spacing.step2 + insets.left,
+        tokens.spacing.step2,
+        tokens.spacing.step2 + insets.right,
+        _bottomPadding(context),
+      ),
+      child: SizedBox(
+        height: contentHeight(context),
+        child: Row(
+          children: [
+            for (final item in items)
+              Expanded(child: _FiveSlotNavBarSlot(item: item)),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _FiveSlotNavBarSlot extends StatelessWidget {
+  const _FiveSlotNavBarSlot({required this.item});
+
+  final DesignSystemFiveSlotNavBarItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final tint = item.active
+        ? tokens.colors.interactive.enabled
+        : tokens.colors.text.mediumEmphasis;
+    final icon = item.active ? item.activeIcon ?? item.icon : item.icon;
+    final reduceMotion = MediaQuery.disableAnimationsOf(context);
+
+    // The label text is excluded below (this node already carries it), but
+    // the icon subtree keeps its semantics so badge decorations — e.g. the
+    // Settings outbox count — stay announced. The InkWell contributes the
+    // tap action.
+    return Semantics(
+      button: true,
+      selected: item.active,
+      label: item.semanticsLabel ?? item.label,
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(tokens.radii.l),
+          onTap: item.onTap,
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(
+              minHeight: DesignSystemFiveSlotNavBar.minTapTarget,
+              minWidth: DesignSystemFiveSlotNavBar.minTapTarget,
+            ),
+            child: TweenAnimationBuilder<Color?>(
+              tween: ColorTween(end: tint),
+              duration: reduceMotion
+                  ? Duration.zero
+                  : DesignSystemFiveSlotNavBar.tintDuration,
+              curve: DesignSystemFiveSlotNavBar.tintCurve,
+              builder: (context, color, _) {
+                final resolved = color ?? tint;
+                return Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    IconTheme.merge(
+                      data: IconThemeData(
+                        size: DesignSystemFiveSlotNavBar.iconSize,
+                        color: resolved,
+                      ),
+                      child: icon,
+                    ),
+                    SizedBox(height: tokens.spacing.step1),
+                    ExcludeSemantics(
+                      child: Text(
+                        item.label,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        textAlign: TextAlign.center,
+                        style: tokens.typography.styles.others.caption.copyWith(
+                          color: resolved,
+                          fontWeight: tokens.typography.weight.semiBold,
+                        ),
+                      ),
+                    ),
+                  ],
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/design_system/components/navigation/design_system_navigation_tab_bar.dart
+++ b/lib/features/design_system/components/navigation/design_system_navigation_tab_bar.dart
@@ -19,6 +19,13 @@ class DesignSystemNavigationTabBarItem {
   final VoidCallback? onTap;
 }
 
+/// Content-hugging pill tab bar from the design handoff.
+///
+/// No longer the app's mobile bottom navigation — the shell uses
+/// `DesignSystemFiveSlotNavBar` (fixed slot count, equal flex, docked)
+/// instead, because this pill shrinks via `FittedBox` when too many tabs
+/// are visible. It survives for the design-handoff showcase mockups and
+/// the widgetbook artboards that depict the original handoff spec.
 class DesignSystemNavigationTabBar extends StatelessWidget {
   const DesignSystemNavigationTabBar({
     required this.items,
@@ -65,6 +72,14 @@ class DesignSystemNavigationFrostedSurface extends StatelessWidget {
     this.padding = EdgeInsets.zero,
     super.key,
   });
+
+  /// Width of the hairline border drawn around the surface (`Border.all`'s
+  /// default below). `Container` stacks it onto [padding] on every side,
+  /// so height math that depends on this surface (e.g. the bottom nav's
+  /// occupied height) must account for it through this constant rather
+  /// than a magic number. Keep in sync with the `Border.all` call in
+  /// [build] if an explicit width is ever introduced there.
+  static const double borderWidth = 1;
 
   final Widget child;
   final BorderRadius borderRadius;

--- a/lib/features/design_system/widgetbook/design_system_navigation_tab_bar_widgetbook.dart
+++ b/lib/features/design_system/widgetbook/design_system_navigation_tab_bar_widgetbook.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_floating_action_button.dart';
+import 'package:lotti/features/design_system/components/navigation/design_system_five_slot_nav_bar.dart';
 import 'package:lotti/features/design_system/components/navigation/design_system_navigation_tab_bar.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/design_system/widgetbook/widgetbook_helpers.dart';
@@ -113,43 +114,30 @@ class _BottomNavigationShellShowcase extends StatelessWidget {
     );
   }
 
-  List<DesignSystemNavigationTabBarItem> _shellItems(BuildContext context) {
+  /// The mobile shell caps the bar at the always-visible destinations
+  /// (Tasks, Journal, Settings) plus a More slot for the flag-gated
+  /// destinations.
+  List<DesignSystemFiveSlotNavBarItem> _shellItems(BuildContext context) {
     return [
-      DesignSystemNavigationTabBarItem(
+      DesignSystemFiveSlotNavBarItem(
         label: context.messages.navTabTitleTasks,
         icon: const Icon(Icons.check_circle_outline_rounded),
         activeIcon: const Icon(Icons.check_circle_rounded),
         active: true,
       ),
-      DesignSystemNavigationTabBarItem(
-        label: context.messages.navTabTitleProjects,
-        icon: const Icon(Icons.folder_outlined),
-        activeIcon: const Icon(Icons.folder_rounded),
-      ),
-      DesignSystemNavigationTabBarItem(
-        label: context.messages.navTabTitleCalendar,
-        icon: const Icon(Icons.calendar_today_outlined),
-        activeIcon: const Icon(Icons.calendar_today_rounded),
-      ),
-      DesignSystemNavigationTabBarItem(
-        label: context.messages.navTabTitleHabits,
-        icon: const Icon(Icons.checklist_rtl_outlined),
-        activeIcon: const Icon(Icons.checklist_rtl_rounded),
-      ),
-      DesignSystemNavigationTabBarItem(
-        label: context.messages.navTabTitleInsights,
-        icon: const Icon(Icons.bar_chart_outlined),
-        activeIcon: const Icon(Icons.bar_chart_rounded),
-      ),
-      DesignSystemNavigationTabBarItem(
+      DesignSystemFiveSlotNavBarItem(
         label: context.messages.navTabTitleJournal,
         icon: const Icon(Icons.book_outlined),
         activeIcon: const Icon(Icons.book_rounded),
       ),
-      DesignSystemNavigationTabBarItem(
+      DesignSystemFiveSlotNavBarItem(
         label: context.messages.navTabTitleSettings,
         icon: const Icon(Icons.settings_outlined),
         activeIcon: const Icon(Icons.settings_rounded),
+      ),
+      DesignSystemFiveSlotNavBarItem(
+        label: context.messages.navTabTitleMore,
+        icon: const Icon(Icons.more_horiz_rounded),
       ),
     ];
   }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -2252,10 +2252,12 @@
     }
   },
   "multiSelectNoItemsFound": "Žádné položky nenalezeny",
+  "navTabMoreSemanticsLabel": "{count, plural, =1{Více, 1 další sekce} few{Více, {count} další sekce} other{Více, {count} dalších sekcí}}",
   "navTabTitleCalendar": "DailyOS",
   "navTabTitleHabits": "Zvyky",
   "navTabTitleInsights": "Přehledy",
   "navTabTitleJournal": "Zápisník",
+  "navTabTitleMore": "Více",
   "navTabTitleProjects": "Projekty",
   "navTabTitleSettings": "Nastavení",
   "navTabTitleTasks": "Úkoly",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2460,10 +2460,12 @@
     }
   },
   "multiSelectNoItemsFound": "Keine Einträge gefunden",
+  "navTabMoreSemanticsLabel": "{count, plural, =1{Mehr, 1 weiterer Bereich} other{Mehr, {count} weitere Bereiche}}",
   "navTabTitleCalendar": "DailyOS",
   "navTabTitleHabits": "Gewohnheiten",
   "navTabTitleInsights": "Einblicke",
   "navTabTitleJournal": "Logbuch",
+  "navTabTitleMore": "Mehr",
   "navTabTitleProjects": "Projekte",
   "navTabTitleSettings": "Einstellungen",
   "navTabTitleTasks": "Aufgaben",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2734,10 +2734,19 @@
     }
   },
   "multiSelectNoItemsFound": "No items found",
+  "navTabMoreSemanticsLabel": "{count, plural, =1{More, 1 additional destination} other{More, {count} additional destinations}}",
+  "@navTabMoreSemanticsLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "navTabTitleCalendar": "DailyOS",
   "navTabTitleHabits": "Habits",
   "navTabTitleInsights": "Insights",
   "navTabTitleJournal": "Logbook",
+  "navTabTitleMore": "More",
   "navTabTitleProjects": "Projects",
   "navTabTitleSettings": "Settings",
   "navTabTitleTasks": "Tasks",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2460,10 +2460,12 @@
     }
   },
   "multiSelectNoItemsFound": "No se encontraron elementos",
+  "navTabMoreSemanticsLabel": "{count, plural, =1{Más, 1 destino adicional} other{Más, {count} destinos adicionales}}",
   "navTabTitleCalendar": "DailyOS",
   "navTabTitleHabits": "Hábitos",
   "navTabTitleInsights": "Paneles",
   "navTabTitleJournal": "Diario",
+  "navTabTitleMore": "Más",
   "navTabTitleProjects": "Proyectos",
   "navTabTitleSettings": "Ajustes",
   "navTabTitleTasks": "Tareas",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -2460,10 +2460,12 @@
     }
   },
   "multiSelectNoItemsFound": "Aucun élément trouvé",
+  "navTabMoreSemanticsLabel": "{count, plural, =1{Plus, 1 section supplémentaire} other{Plus, {count} sections supplémentaires}}",
   "navTabTitleCalendar": "DailyOS",
   "navTabTitleHabits": "Habitudes",
   "navTabTitleInsights": "Tableaux de bord",
   "navTabTitleJournal": "Journal",
+  "navTabTitleMore": "Plus",
   "navTabTitleProjects": "Projets",
   "navTabTitleSettings": "Paramètres",
   "navTabTitleTasks": "Tâches",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -9562,6 +9562,12 @@ abstract class AppLocalizations {
   /// **'No items found'**
   String get multiSelectNoItemsFound;
 
+  /// No description provided for @navTabMoreSemanticsLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{More, 1 additional destination} other{More, {count} additional destinations}}'**
+  String navTabMoreSemanticsLabel(int count);
+
   /// No description provided for @navTabTitleCalendar.
   ///
   /// In en, this message translates to:
@@ -9585,6 +9591,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Logbook'**
   String get navTabTitleJournal;
+
+  /// No description provided for @navTabTitleMore.
+  ///
+  /// In en, this message translates to:
+  /// **'More'**
+  String get navTabTitleMore;
 
   /// No description provided for @navTabTitleProjects.
   ///

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -5519,6 +5519,18 @@ class AppLocalizationsCs extends AppLocalizations {
   String get multiSelectNoItemsFound => 'Žádné položky nenalezeny';
 
   @override
+  String navTabMoreSemanticsLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Více, $count dalších sekcí',
+      few: 'Více, $count další sekce',
+      one: 'Více, 1 další sekce',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get navTabTitleCalendar => 'DailyOS';
 
   @override
@@ -5529,6 +5541,9 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get navTabTitleJournal => 'Zápisník';
+
+  @override
+  String get navTabTitleMore => 'Více';
 
   @override
   String get navTabTitleProjects => 'Projekty';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -5504,6 +5504,17 @@ class AppLocalizationsDe extends AppLocalizations {
   String get multiSelectNoItemsFound => 'Keine Einträge gefunden';
 
   @override
+  String navTabMoreSemanticsLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Mehr, $count weitere Bereiche',
+      one: 'Mehr, 1 weiterer Bereich',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get navTabTitleCalendar => 'DailyOS';
 
   @override
@@ -5514,6 +5525,9 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get navTabTitleJournal => 'Logbuch';
+
+  @override
+  String get navTabTitleMore => 'Mehr';
 
   @override
   String get navTabTitleProjects => 'Projekte';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -5433,6 +5433,17 @@ class AppLocalizationsEn extends AppLocalizations {
   String get multiSelectNoItemsFound => 'No items found';
 
   @override
+  String navTabMoreSemanticsLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'More, $count additional destinations',
+      one: 'More, 1 additional destination',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get navTabTitleCalendar => 'DailyOS';
 
   @override
@@ -5443,6 +5454,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get navTabTitleJournal => 'Logbook';
+
+  @override
+  String get navTabTitleMore => 'More';
 
   @override
   String get navTabTitleProjects => 'Projects';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -5555,6 +5555,17 @@ class AppLocalizationsEs extends AppLocalizations {
   String get multiSelectNoItemsFound => 'No se encontraron elementos';
 
   @override
+  String navTabMoreSemanticsLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Más, $count destinos adicionales',
+      one: 'Más, 1 destino adicional',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get navTabTitleCalendar => 'DailyOS';
 
   @override
@@ -5565,6 +5576,9 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get navTabTitleJournal => 'Diario';
+
+  @override
+  String get navTabTitleMore => 'Más';
 
   @override
   String get navTabTitleProjects => 'Proyectos';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -5565,6 +5565,17 @@ class AppLocalizationsFr extends AppLocalizations {
   String get multiSelectNoItemsFound => 'Aucun élément trouvé';
 
   @override
+  String navTabMoreSemanticsLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Plus, $count sections supplémentaires',
+      one: 'Plus, 1 section supplémentaire',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get navTabTitleCalendar => 'DailyOS';
 
   @override
@@ -5575,6 +5586,9 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get navTabTitleJournal => 'Journal';
+
+  @override
+  String get navTabTitleMore => 'Plus';
 
   @override
   String get navTabTitleProjects => 'Projets';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -5554,6 +5554,18 @@ class AppLocalizationsRo extends AppLocalizations {
   String get multiSelectNoItemsFound => 'Nu s-au găsit elemente';
 
   @override
+  String navTabMoreSemanticsLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Mai multe, $count de secțiuni suplimentare',
+      few: 'Mai multe, $count secțiuni suplimentare',
+      one: 'Mai multe, 1 secțiune suplimentară',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get navTabTitleCalendar => 'DailyOS';
 
   @override
@@ -5564,6 +5576,9 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get navTabTitleJournal => 'Jurnal';
+
+  @override
+  String get navTabTitleMore => 'Mai multe';
 
   @override
   String get navTabTitleProjects => 'Proiecte';

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -2460,10 +2460,12 @@
     }
   },
   "multiSelectNoItemsFound": "Nu s-au găsit elemente",
+  "navTabMoreSemanticsLabel": "{count, plural, =1{Mai multe, 1 secțiune suplimentară} few{Mai multe, {count} secțiuni suplimentare} other{Mai multe, {count} de secțiuni suplimentare}}",
   "navTabTitleCalendar": "DailyOS",
   "navTabTitleHabits": "Obiceiuri",
   "navTabTitleInsights": "Informaţii",
   "navTabTitleJournal": "Jurnal",
+  "navTabTitleMore": "Mai multe",
   "navTabTitleProjects": "Proiecte",
   "navTabTitleSettings": "Setări",
   "navTabTitleTasks": "Sarcini",

--- a/lib/services/nav_service.dart
+++ b/lib/services/nav_service.dart
@@ -103,11 +103,6 @@ class NavService {
   final indexStreamController = StreamController<int>.broadcast();
 
   final tasksIndex = 0;
-  // final calendarIndex = 1;
-  // final habitsIndex = 2;
-  // final dashboardsIndex = 3;
-  // final journalIndex = 4;
-  // final settingsIndex = 5;
 
   int index = 0;
 
@@ -128,16 +123,20 @@ class NavService {
 
   Iterable<({bool enabled, String rootPath, BeamerDelegate delegate})>
   get _tabSpecs sync* {
+    // Tab order is shared with the app shell's destination list (see
+    // `_buildNavigationDestinations` in `beamer_app.dart`): Tasks and
+    // Daily OS lead as the most important pages, then Projects, then the
+    // rest, with Settings last.
     yield (enabled: true, rootPath: '/tasks', delegate: tasksDelegate);
-    yield (
-      enabled: _isProjectsPageEnabled,
-      rootPath: '/projects',
-      delegate: projectsDelegate,
-    );
     yield (
       enabled: _isDailyOsPageEnabled,
       rootPath: '/calendar',
       delegate: calendarDelegate,
+    );
+    yield (
+      enabled: _isProjectsPageEnabled,
+      rootPath: '/projects',
+      delegate: projectsDelegate,
     );
     yield (
       enabled: _isHabitsPageEnabled,

--- a/lib/widgets/README.md
+++ b/lib/widgets/README.md
@@ -244,12 +244,24 @@ Custom `WoltDialogType` that renders at a configurable target width (`preferredW
 Located in `/lib/widgets/nav_bar/`
 
 ### DesignSystemBottomNavigationBar
-Floating bottom-navigation shell that hosts the design-system tab bar and
-reserves the correct safe-area spacing for the main app scaffold.
+Mobile bottom-navigation shell that hosts the design-system five-slot bar
+(`DesignSystemFiveSlotNavBar`), docked flush against the screen's bottom
+edge with zero gap. The bar shows Tasks, DailyOS (when its flag is
+enabled — it never overflows), and Logbook plus a More slot; the bottom
+safe-area inset is absorbed into the bar surface itself. An optional
+`overlay` slot renders the time/audio recording indicators directly above
+the bar.
+
+### showMobileNavMoreSheet / MobileNavMoreSheetItem
+`WoltModalSheet`-based overflow sheet listing the destinations without a
+bar slot: Settings always, plus the flag-gated Projects, Habits, and
+Insights — newly toggled pages surface here. Selecting a row dismisses the
+sheet and navigates; the bar's More slot then renders that destination's
+name with the active tint.
 
 ### DesignSystemBottomNavigationFabPadding
 Padding helper that lifts floating action buttons clear of the shared bottom
-navigation shell.
+navigation shell (`DesignSystemBottomNavigationBar.occupiedHeight`).
 
 ## Search Widgets
 

--- a/lib/widgets/app_bar/settings_page_header.dart
+++ b/lib/widgets/app_bar/settings_page_header.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/themes/theme.dart';
 import 'package:lotti/widgets/app_bar/settings_header_dimensions.dart';
 import 'package:lotti/widgets/app_bar/title_app_bar.dart';
@@ -180,8 +181,13 @@ class SettingsPageHeader extends StatelessWidget {
                   colorScheme.surface.withValues(alpha: 0.93),
                 ],
               ),
-              borderRadius: const BorderRadius.vertical(
-                bottom: Radius.circular(24),
+              // Same radius as the bottom nav bar's top corners
+              // (DesignSystemFiveSlotNavBar), so docked chrome at both
+              // screen edges rounds identically.
+              borderRadius: BorderRadius.vertical(
+                bottom: Radius.circular(
+                  context.designTokens.radii.sectionCards,
+                ),
               ),
               boxShadow: [
                 BoxShadow(

--- a/lib/widgets/nav_bar/design_system_bottom_navigation_bar.dart
+++ b/lib/widgets/nav_bar/design_system_bottom_navigation_bar.dart
@@ -1,10 +1,11 @@
-import 'dart:math' as math;
-
 import 'package:flutter/material.dart';
-import 'package:lotti/features/design_system/components/navigation/design_system_navigation_tab_bar.dart';
+import 'package:lotti/features/design_system/components/navigation/design_system_five_slot_nav_bar.dart';
 import 'package:lotti/features/design_system/theme/breakpoints.dart';
-import 'package:lotti/features/design_system/theme/design_tokens.dart';
 
+/// Mobile bottom-navigation container: hosts the five-slot bar
+/// ([DesignSystemFiveSlotNavBar]) docked flush against the screen's bottom
+/// edge, plus an optional overlay row (time/audio recording indicators)
+/// riding above it.
 class DesignSystemBottomNavigationBar extends StatelessWidget {
   const DesignSystemBottomNavigationBar({
     required this.items,
@@ -12,84 +13,72 @@ class DesignSystemBottomNavigationBar extends StatelessWidget {
     super.key,
   });
 
-  final List<DesignSystemNavigationTabBarItem> items;
+  /// The bar's slots (at most five — overflow destinations live in the
+  /// More sheet, represented here by their More slot item).
+  final List<DesignSystemFiveSlotNavBarItem> items;
 
-  /// Optional widget rendered immediately above the pill, sized to the same
-  /// width as the pill. The overlay scales with the pill via the same
-  /// `FittedBox`, so its position stays tied to the rendered nav bar
-  /// regardless of how many tabs are visible.
+  /// Optional widget rendered immediately above the bar, stretched to the
+  /// same width so indicator rows stay tied to the rendered nav bar.
   final Widget? overlay;
 
-  static EdgeInsets padding(BuildContext context) {
-    final tokens = context.designTokens;
-    // Asymmetric vertical insets are intentional: top sits under the page
-    // content so step3 is enough, while the bottom must give the last
-    // button row a visible gap above the screen edge on platforms without
-    // a home-indicator inset (e.g. Android with 3-button nav). The
-    // SafeArea wrapping this padding stacks the home-indicator inset on
-    // top of step6 where one exists.
-    return EdgeInsets.fromLTRB(
-      tokens.spacing.step5,
-      tokens.spacing.step3,
-      tokens.spacing.step5,
-      tokens.spacing.step6,
-    );
-  }
-
-  /// Intrinsic height of a single nav-bar item row (icon + caption with the
-  /// design-system minimum), shared by the height calculations below so the
-  /// numbers can't drift apart.
-  static double _itemHeight(BuildContext context) {
-    final tokens = context.designTokens;
-    return math.max(
-      DesignSystemNavigationTabBar.defaultItemMinHeight,
-      tokens.spacing.step3 * 2 +
-          DesignSystemNavigationTabBar.defaultIconSize +
-          tokens.spacing.step1 +
-          tokens.typography.lineHeight.caption,
-    );
-  }
-
+  /// Vertical screen estate the docked bottom stack occupies: the bar
+  /// (including the bottom safe-area inset it absorbs into its surface)
+  /// plus the rendered height of the [overlay] row, published by the app
+  /// shell via [DesignSystemBottomNavigationOverlayHeight]. Content
+  /// scrolling behind the bar pads by this amount (see
+  /// [DesignSystemBottomNavigationFabPadding]).
   static double occupiedHeight(BuildContext context) {
     // In desktop layout the bottom navigation bar is not shown;
     // the sidebar replaces it, so no bottom inset is needed.
     if (isDesktopLayout(context)) return 0;
 
-    final tokens = context.designTokens;
-    final bottomSafeInset = MediaQuery.paddingOf(context).bottom;
-
-    return bottomSafeInset +
-        padding(context).vertical +
-        tokens.spacing.step2 * 2 +
-        _itemHeight(context);
+    return DesignSystemFiveSlotNavBar.barHeight(context) +
+        DesignSystemBottomNavigationOverlayHeight.of(context);
   }
 
   @override
   Widget build(BuildContext context) {
-    return SafeArea(
-      top: false,
-      child: Padding(
-        padding: padding(context),
-        child: Align(
-          child: FittedBox(
-            fit: BoxFit.scaleDown,
-            // IntrinsicWidth bounds the inner Column so the overlay row can
-            // stretch to the pill's natural width.
-            child: IntrinsicWidth(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  ?overlay,
-                  DesignSystemNavigationTabBar(items: items),
-                ],
-              ),
-            ),
-          ),
-        ),
-      ),
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        ?overlay,
+        DesignSystemFiveSlotNavBar(items: items),
+      ],
     );
   }
+}
+
+/// Publishes the rendered height of the nav bar's
+/// [DesignSystemBottomNavigationBar.overlay] row (the time/audio recording
+/// indicators) to the page stack. The app shell wraps the pages with this
+/// scope and updates [height] as indicators appear and disappear, so
+/// [DesignSystemBottomNavigationBar.occupiedHeight] — and everything padding
+/// by it — matches the full rendered bottom stack, not just the bar.
+class DesignSystemBottomNavigationOverlayHeight extends InheritedWidget {
+  const DesignSystemBottomNavigationOverlayHeight({
+    required this.height,
+    required super.child,
+    super.key,
+  });
+
+  /// Rendered height of the overlay row; 0 while no indicator is visible.
+  final double height;
+
+  /// Overlay height published by the nearest enclosing scope, or 0 when
+  /// none exists (previews and tests that render pages without the shell).
+  static double of(BuildContext context) {
+    final scope = context
+        .dependOnInheritedWidgetOfExactType<
+          DesignSystemBottomNavigationOverlayHeight
+        >();
+    return scope?.height ?? 0;
+  }
+
+  @override
+  bool updateShouldNotify(
+    DesignSystemBottomNavigationOverlayHeight oldWidget,
+  ) => height != oldWidget.height;
 }
 
 class DesignSystemBottomNavigationFabPadding extends StatelessWidget {

--- a/lib/widgets/nav_bar/mobile_nav_more_sheet.dart
+++ b/lib/widgets/nav_bar/mobile_nav_more_sheet.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/features/design_system/components/navigation/design_system_five_slot_nav_bar.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/widgets/modal/modal_utils.dart';
+
+/// One overflow destination row in the More sheet.
+class MobileNavMoreSheetItem {
+  const MobileNavMoreSheetItem({
+    required this.label,
+    required this.icon,
+    required this.onSelected,
+    this.active = false,
+  });
+
+  final String label;
+  final Widget icon;
+  final bool active;
+
+  /// Invoked after the sheet is dismissed; navigates to the destination.
+  final VoidCallback onSelected;
+}
+
+/// Opens the More overflow sheet: every enabled destination that did not fit
+/// the five-slot bar, one row each. Selecting a row dismisses the sheet and
+/// navigates; the bar's More slot then renders that destination as active.
+Future<void> showMobileNavMoreSheet({
+  required BuildContext context,
+  required List<MobileNavMoreSheetItem> items,
+}) {
+  return ModalUtils.showSinglePageModal<void>(
+    context: context,
+    title: context.messages.navTabTitleMore,
+    builder: (sheetContext) => Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (final item in items)
+          _MoreSheetRow(
+            item: item,
+            onTap: () {
+              Navigator.of(sheetContext).pop();
+              item.onSelected();
+            },
+          ),
+      ],
+    ),
+  );
+}
+
+class _MoreSheetRow extends StatelessWidget {
+  const _MoreSheetRow({required this.item, required this.onTap});
+
+  final MobileNavMoreSheetItem item;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final tint = item.active
+        ? tokens.colors.interactive.enabled
+        : tokens.colors.text.highEmphasis;
+
+    return Semantics(
+      button: true,
+      selected: item.active,
+      label: item.label,
+      onTap: onTap,
+      excludeSemantics: true,
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(tokens.radii.m),
+          onTap: onTap,
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(
+              minHeight: DesignSystemFiveSlotNavBar.minTapTarget,
+            ),
+            child: Padding(
+              padding: EdgeInsets.symmetric(
+                horizontal: tokens.spacing.step3,
+                vertical: tokens.spacing.step3,
+              ),
+              child: Row(
+                children: [
+                  IconTheme.merge(
+                    data: IconThemeData(
+                      size: DesignSystemFiveSlotNavBar.iconSize,
+                      color: item.active
+                          ? tokens.colors.interactive.enabled
+                          : tokens.colors.text.mediumEmphasis,
+                    ),
+                    child: item.icon,
+                  ),
+                  SizedBox(width: tokens.spacing.step4),
+                  Expanded(
+                    child: Text(
+                      item.label,
+                      style: tokens.typography.styles.body.bodyMedium.copyWith(
+                        color: tint,
+                      ),
+                    ),
+                  ),
+                  Icon(
+                    Icons.chevron_right_rounded,
+                    size: DesignSystemFiveSlotNavBar.iconSize,
+                    color: tokens.colors.text.lowEmphasis,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/beamer/beamer_app_test.dart
+++ b/test/beamer/beamer_app_test.dart
@@ -21,7 +21,7 @@ import 'package:lotti/features/ai/repository/ai_config_repository.dart'
 import 'package:lotti/features/ai/ui/settings/services/ai_setup_prompt_service.dart';
 import 'package:lotti/features/ai/ui/settings/widgets/ai_provider_selection_modal.dart';
 import 'package:lotti/features/daily_os_next/ui/widgets/sidebar_calendar.dart';
-import 'package:lotti/features/design_system/components/navigation/design_system_navigation_tab_bar.dart';
+import 'package:lotti/features/design_system/components/navigation/design_system_five_slot_nav_bar.dart';
 import 'package:lotti/features/design_system/components/navigation/desktop_navigation_sidebar.dart';
 import 'package:lotti/features/design_system/components/navigation/resizable_divider.dart';
 import 'package:lotti/features/design_system/state/pane_width_controller.dart';
@@ -533,41 +533,51 @@ void main() {
       await tester.pump();
     });
 
-    testWidgets('shows Projects after a flag-driven nav update', (
-      tester,
-    ) async {
-      final mockNavService = MockNavService();
-      final indexController = StreamController<int>.broadcast();
-      addTearDown(indexController.close);
+    testWidgets(
+      'routes Projects into the More sheet after a flag-driven nav update',
+      (tester) async {
+        final mockNavService = MockNavService();
+        final indexController = StreamController<int>.broadcast();
+        addTearDown(indexController.close);
 
-      var isProjectsEnabled = false;
-      await _stubNavService(
-        mockNavService,
-        indexStream: indexController.stream,
-        isProjectsEnabled: () => isProjectsEnabled,
-        isDailyOsEnabled: () => true,
-        isHabitsEnabled: () => true,
-        isDashboardsEnabled: () => true,
-      );
-      await _registerAppScreenGetIt(mockNavService);
-      addTearDown(tearDownTestGetIt);
+        var isProjectsEnabled = false;
+        await _stubNavService(
+          mockNavService,
+          indexStream: indexController.stream,
+          isProjectsEnabled: () => isProjectsEnabled,
+          isDailyOsEnabled: () => true,
+          isHabitsEnabled: () => true,
+          isDashboardsEnabled: () => true,
+        );
+        await _registerAppScreenGetIt(mockNavService);
+        addTearDown(tearDownTestGetIt);
 
-      await _pumpAppScreen(
-        tester,
-        navService: mockNavService,
-      );
-      expect(find.text('Projects'), findsNothing);
+        await _pumpAppScreen(
+          tester,
+          navService: mockNavService,
+        );
+        expect(find.text('Projects'), findsNothing);
 
-      isProjectsEnabled = true;
-      indexController.add(0);
-      await tester.pump();
-      await tester.pump();
+        isProjectsEnabled = true;
+        indexController.add(0);
+        await tester.pump();
+        await tester.pump();
 
-      expect(find.text('Projects'), findsOneWidget);
+        // Projects never claims a bar slot — it appears in the More sheet.
+        expect(find.text('Projects'), findsNothing);
+        final navBar = tester.widget<DesignSystemBottomNavigationBar>(
+          find.byType(DesignSystemBottomNavigationBar),
+        );
+        expect(navBar.items.last.label, 'More');
+        navBar.items.last.onTap?.call();
+        await tester.pumpAndSettle();
 
-      await tester.pumpWidget(const SizedBox.shrink());
-      await tester.pump();
-    });
+        expect(find.text('Projects'), findsOneWidget);
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump();
+      },
+    );
   });
 
   group('Flatpak audio indicator gating', () {
@@ -640,14 +650,19 @@ void main() {
       TestWidgetsFlutterBinding.instance.platformDispatcher.views.first.reset();
     });
 
-    for (final (index, name) in <(int, String)>[
-      (0, 'tasks'),
-      (1, 'projects'),
-      (2, 'dailyOS'),
-      (3, 'habits'),
-      (4, 'dashboards'),
-      (5, 'journal'),
-      (6, 'settings'),
+    // With every flag enabled the full index space is 0 Tasks, 1 DailyOS,
+    // 2 Projects, 3 Habits, 4 Dashboards, 5 Journal, 6 Settings. Tasks,
+    // DailyOS, and Journal hold the bar slots; Projects, Habits,
+    // Dashboards, and Settings live behind the More slot, which takes
+    // their name and the active tint while one of them is on screen.
+    for (final (index, name, moreLabel) in <(int, String, String)>[
+      (0, 'tasks', 'More'),
+      (1, 'dailyOS', 'More'),
+      (2, 'projects', 'Projects'),
+      (3, 'habits', 'Habits'),
+      (4, 'dashboards', 'Insights'),
+      (5, 'journal', 'More'),
+      (6, 'settings', 'Settings'),
     ]) {
       testWidgets('uses design-system nav on the $name tab', (tester) async {
         final mockNavService = MockNavService();
@@ -669,7 +684,40 @@ void main() {
         );
 
         expect(find.byType(DesignSystemBottomNavigationBar), findsOneWidget);
-        expect(find.byType(DesignSystemNavigationTabBar), findsOneWidget);
+        expect(find.byType(DesignSystemFiveSlotNavBar), findsOneWidget);
+
+        // The bar is capped at the three primary destinations plus More
+        // on the right — regardless of how many flag-gated destinations
+        // are enabled.
+        final navBar = tester.widget<DesignSystemBottomNavigationBar>(
+          find.byType(DesignSystemBottomNavigationBar),
+        );
+        expect(navBar.items, hasLength(4));
+        expect(
+          navBar.items.map((item) => item.label),
+          ['Tasks', 'DailyOS', 'Logbook', moreLabel],
+        );
+        // The More slot lights up exactly while an overflow destination is
+        // the active route, and its accessible name follows the visual
+        // label swap (a screen reader hears the active destination, not
+        // the overflow count).
+        final isOverflowActive = (index >= 2 && index <= 4) || index == 6;
+        expect(navBar.items.last.active, isOverflowActive);
+        expect(
+          navBar.items.last.semanticsLabel,
+          isOverflowActive ? moreLabel : 'More, 4 additional destinations',
+        );
+
+        // Docked with zero gap: the bar's surface is flush with the
+        // screen's bottom edge and spans the full width.
+        final barRect = tester.getRect(
+          find.byType(DesignSystemFiveSlotNavBar),
+        );
+        final screenSize =
+            tester.view.physicalSize / tester.view.devicePixelRatio;
+        expect(barRect.bottom, screenSize.height);
+        expect(barRect.left, 0);
+        expect(barRect.right, screenSize.width);
       });
     }
 
@@ -724,6 +772,67 @@ void main() {
       );
       expect(overlayRow.mainAxisAlignment, MainAxisAlignment.center);
     });
+
+    testWidgets(
+      'occupiedHeight inside the page stack grows by the indicator height '
+      'while a timer runs',
+      (tester) async {
+        final mockNavService = MockNavService();
+
+        await _stubNavService(
+          mockNavService,
+          indexStream: Stream.value(0),
+          isProjectsEnabled: () => true,
+          isDailyOsEnabled: () => true,
+          isHabitsEnabled: () => true,
+          isDashboardsEnabled: () => true,
+        );
+        await _registerAppScreenGetIt(
+          mockNavService,
+          runningTimer: _runningTimerEntry,
+        );
+        addTearDown(tearDownTestGetIt);
+
+        await _pumpAppScreen(tester, navService: mockNavService);
+
+        // Pages padding by occupiedHeight reserve room for the time
+        // recording indicator riding above the bar, so it never covers
+        // scroll content or floating actions.
+        final pageContext = tester.element(find.byType(IndexedStack));
+        expect(
+          DesignSystemBottomNavigationBar.occupiedHeight(pageContext),
+          DesignSystemFiveSlotNavBar.barHeight(pageContext) +
+              AudioRecordingIndicatorConstants.indicatorHeight,
+        );
+      },
+    );
+
+    testWidgets(
+      'occupiedHeight inside the page stack matches the bar while no '
+      'indicator is visible',
+      (tester) async {
+        final mockNavService = MockNavService();
+
+        await _stubNavService(
+          mockNavService,
+          indexStream: Stream.value(0),
+          isProjectsEnabled: () => true,
+          isDailyOsEnabled: () => true,
+          isHabitsEnabled: () => true,
+          isDashboardsEnabled: () => true,
+        );
+        await _registerAppScreenGetIt(mockNavService);
+        addTearDown(tearDownTestGetIt);
+
+        await _pumpAppScreen(tester, navService: mockNavService);
+
+        final pageContext = tester.element(find.byType(IndexedStack));
+        expect(
+          DesignSystemBottomNavigationBar.occupiedHeight(pageContext),
+          DesignSystemFiveSlotNavBar.barHeight(pageContext),
+        );
+      },
+    );
 
     testWidgets('Tasks bottom-nav item uses plain list icons', (tester) async {
       final mockNavService = MockNavService();
@@ -850,9 +959,9 @@ void main() {
         await tester.pump();
         await tearDownTestGetIt();
 
-        // Daily OS active (index 2 with projects enabled): the calendar
+        // Daily OS active (index 1, right after Tasks): the calendar
         // renders as the destination's expanded subtree.
-        await pumpWithActiveIndex(2);
+        await pumpWithActiveIndex(1);
         expect(find.byType(DailyOsSidebarCalendar), findsOneWidget);
         // It sits under the Daily OS row, above Habits.
         final calendarY = tester
@@ -966,8 +1075,9 @@ void main() {
       await tester.tap(find.text('Projects'));
       await tester.pump();
 
-      // Projects is at index 1 in the full destinations list
-      verify(() => mockNavService.tapIndex(1)).called(1);
+      // Projects is at index 2 in the full destinations list, after
+      // Tasks and DailyOS.
+      verify(() => mockNavService.tapIndex(2)).called(1);
 
       await tester.pumpWidget(const SizedBox.shrink());
       await tester.pump();
@@ -1160,8 +1270,9 @@ void main() {
   });
 
   group('AppScreen mobile nav item taps', () {
-    // Each bottom-nav item wires onTap to `navService.tapIndex(i)`.
-    // Verify tapping items 0–2 (Tasks, Projects, Journal) invokes the right index.
+    // Each bottom-nav slot wires onTap to `navService.tapIndex(i)` with the
+    // destination's full index, even though the bar shows only the primary
+    // slots (Tasks · DailyOS · Logbook · More).
     setUp(() {
       TestWidgetsFlutterBinding.instance.platformDispatcher.views.first
         ..physicalSize = const Size(800, 1200)
@@ -1171,35 +1282,43 @@ void main() {
       TestWidgetsFlutterBinding.instance.platformDispatcher.views.first.reset();
     });
 
-    for (final (tabIndex, tabName) in <(int, String)>[
-      (0, 'Tasks'),
-      (1, 'Projects'),
-      (5, 'Journal'), // index 5 with all optional tabs enabled
+    Future<DesignSystemBottomNavigationBar> pumpNavBar(
+      WidgetTester tester,
+      MockNavService mockNavService,
+    ) async {
+      await _stubNavService(
+        mockNavService,
+        indexStream: Stream.value(0),
+        isProjectsEnabled: () => true,
+        isDailyOsEnabled: () => true,
+        isHabitsEnabled: () => true,
+        isDashboardsEnabled: () => true,
+      );
+      await _registerAppScreenGetIt(mockNavService);
+      addTearDown(tearDownTestGetIt);
+
+      await _pumpAppScreen(tester, navService: mockNavService);
+
+      return tester.widget<DesignSystemBottomNavigationBar>(
+        find.byType(DesignSystemBottomNavigationBar),
+      );
+    }
+
+    // Bar slot → expected full destination index with all flags enabled.
+    for (final (slot, tabIndex, tabName) in <(int, int, String)>[
+      (0, 0, 'Tasks'),
+      (1, 1, 'DailyOS'),
+      (2, 5, 'Journal'),
     ]) {
       testWidgets(
-        'tapping $tabName bottom-nav item calls tapIndex($tabIndex)',
+        'tapping the $tabName slot calls tapIndex($tabIndex)',
         (tester) async {
           final mockNavService = MockNavService();
-          await _stubNavService(
-            mockNavService,
-            indexStream: Stream.value(0),
-            isProjectsEnabled: () => true,
-            isDailyOsEnabled: () => true,
-            isHabitsEnabled: () => true,
-            isDashboardsEnabled: () => true,
-          );
-          await _registerAppScreenGetIt(mockNavService);
-          addTearDown(tearDownTestGetIt);
+          final navBar = await pumpNavBar(tester, mockNavService);
 
-          await _pumpAppScreen(tester, navService: mockNavService);
-
-          // Find the DesignSystemNavigationTabBar and retrieve its items.
-          final navBar = tester.widget<DesignSystemBottomNavigationBar>(
-            find.byType(DesignSystemBottomNavigationBar),
-          );
           // Invoke the onTap callback directly — tapping in the widget tree
           // is unreliable for overlapping bottom-sheet-style nav bars.
-          navBar.items[tabIndex].onTap?.call();
+          navBar.items[slot].onTap?.call();
           await tester.pump();
 
           verify(() => mockNavService.tapIndex(tabIndex)).called(1);
@@ -1209,6 +1328,70 @@ void main() {
         },
       );
     }
+
+    testWidgets(
+      'selecting Projects in the More sheet dismisses it and calls '
+      'tapIndex(2)',
+      (tester) async {
+        final mockNavService = MockNavService();
+        final navBar = await pumpNavBar(tester, mockNavService);
+
+        // The More slot opens the overflow sheet instead of navigating.
+        navBar.items.last.onTap?.call();
+        await tester.pumpAndSettle();
+        verifyNever(() => mockNavService.tapIndex(any()));
+
+        await tester.tap(find.text('Projects'));
+        await tester.pumpAndSettle();
+
+        verify(() => mockNavService.tapIndex(2)).called(1);
+        expect(find.text('Projects'), findsNothing);
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump();
+      },
+    );
+
+    testWidgets(
+      'More-sheet taps resolve indices against the flags at tap time, not '
+      'at sheet-open time',
+      (tester) async {
+        final mockNavService = MockNavService();
+        var projectsEnabled = true;
+        await _stubNavService(
+          mockNavService,
+          indexStream: Stream.value(0),
+          isProjectsEnabled: () => projectsEnabled,
+          isDailyOsEnabled: () => true,
+          isHabitsEnabled: () => true,
+          isDashboardsEnabled: () => true,
+        );
+        await _registerAppScreenGetIt(mockNavService);
+        addTearDown(tearDownTestGetIt);
+
+        await _pumpAppScreen(tester, navService: mockNavService);
+        final navBar = tester.widget<DesignSystemBottomNavigationBar>(
+          find.byType(DesignSystemBottomNavigationBar),
+        );
+
+        navBar.items.last.onTap?.call();
+        await tester.pumpAndSettle();
+
+        // Projects gets disabled (e.g. a synced settings change) while the
+        // sheet is open: every destination after it shifts down one index.
+        projectsEnabled = false;
+
+        await tester.tap(find.text('Habits'));
+        await tester.pumpAndSettle();
+
+        // Habits resolved to its new index 2 (after Tasks and DailyOS),
+        // not the index 3 it had when the sheet captured its rows.
+        verify(() => mockNavService.tapIndex(2)).called(1);
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump();
+      },
+    );
   });
 
   group('AppScreen desktop sidebar toggle-collapsed', () {

--- a/test/features/design_system/components/navigation/design_system_five_slot_nav_bar_test.dart
+++ b/test/features/design_system/components/navigation/design_system_five_slot_nav_bar_test.dart
@@ -1,0 +1,319 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/components/navigation/design_system_five_slot_nav_bar.dart';
+import 'package:lotti/features/design_system/components/navigation/design_system_navigation_tab_bar.dart';
+import 'package:lotti/features/design_system/theme/design_system_theme.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+
+import '../../../../widget_test_utils.dart';
+
+void main() {
+  Future<void> pumpBar(
+    WidgetTester tester, {
+    required List<DesignSystemFiveSlotNavBarItem> items,
+    double width = 390,
+    MediaQueryData? mediaQueryData,
+  }) {
+    return tester.pumpWidget(
+      makeTestableWidgetWithScaffold(
+        SizedBox(
+          width: width,
+          child: DesignSystemFiveSlotNavBar(items: items),
+        ),
+        theme: DesignSystemTheme.light(),
+        mediaQueryData: mediaQueryData,
+      ),
+    );
+  }
+
+  DesignSystemFiveSlotNavBarItem item(
+    String label, {
+    bool active = false,
+    VoidCallback? onTap,
+    String? semanticsLabel,
+  }) {
+    return DesignSystemFiveSlotNavBarItem(
+      label: label,
+      icon: const Icon(Icons.circle_outlined),
+      activeIcon: const Icon(Icons.circle),
+      active: active,
+      onTap: onTap,
+      semanticsLabel: semanticsLabel,
+    );
+  }
+
+  List<DesignSystemFiveSlotNavBarItem> barItems() => [
+    item('Tasks', active: true),
+    item('Journal'),
+    item('Settings'),
+    item('More'),
+  ];
+
+  const slotLabels = ['Tasks', 'Journal', 'Settings', 'More'];
+
+  group('DesignSystemFiveSlotNavBar', () {
+    testWidgets('gives all slots an equal share of the width', (
+      tester,
+    ) async {
+      await pumpBar(tester, items: barItems());
+
+      final widths = <double>[
+        for (final label in slotLabels)
+          tester
+              .getSize(
+                find.ancestor(
+                  of: find.text(label),
+                  matching: find.byType(InkWell),
+                ),
+              )
+              .width,
+      ];
+
+      // Equal flex: every slot gets the same width, in left-to-right order.
+      expect(widths.toSet(), hasLength(1));
+      final centers = <double>[
+        for (final label in slotLabels) tester.getCenter(find.text(label)).dx,
+      ];
+      expect(centers, List.of(centers)..sort());
+    });
+
+    testWidgets('labels stay full-size on a 360px-wide device', (tester) async {
+      await pumpBar(tester, width: 360, items: barItems());
+
+      // No FittedBox scaling: the rendered label height matches the caption
+      // line height exactly, so the text is not shrunk.
+      final labelRect = tester.getRect(find.text('Tasks'));
+      expect(
+        labelRect.height,
+        dsTokensLight.typography.lineHeight.caption,
+      );
+    });
+
+    testWidgets('grows with the system text scale instead of clipping', (
+      tester,
+    ) async {
+      await pumpBar(
+        tester,
+        items: barItems(),
+        mediaQueryData: const MediaQueryData(
+          size: Size(390, 844),
+          textScaler: TextScaler.linear(1.5),
+        ),
+      );
+
+      // No RenderFlex overflow at 1.5× font scale (an overflow would fail
+      // the test via the exception handler), and the rendered bar still
+      // matches the shared height contract, which now exceeds the
+      // unscaled minimum row height.
+      final context = tester.element(find.byType(DesignSystemFiveSlotNavBar));
+      final barRect = tester.getRect(find.byType(DesignSystemFiveSlotNavBar));
+      expect(barRect.height, DesignSystemFiveSlotNavBar.barHeight(context));
+      expect(
+        DesignSystemFiveSlotNavBar.contentHeight(context),
+        greaterThan(DesignSystemFiveSlotNavBar.minTapTarget),
+      );
+    });
+
+    testWidgets('keeps slots clear of horizontal safe-area insets', (
+      tester,
+    ) async {
+      const leftInset = 30.0;
+      const rightInset = 48.0;
+      await pumpBar(
+        tester,
+        items: barItems(),
+        mediaQueryData: const MediaQueryData(
+          size: Size(844, 390),
+          padding: EdgeInsets.only(left: leftInset, right: rightInset),
+        ),
+      );
+
+      final barRect = tester.getRect(find.byType(DesignSystemFiveSlotNavBar));
+      final firstSlot = tester.getRect(
+        find.ancestor(of: find.text('Tasks'), matching: find.byType(InkWell)),
+      );
+      final lastSlot = tester.getRect(
+        find.ancestor(of: find.text('More'), matching: find.byType(InkWell)),
+      );
+
+      // The surface spans the full width, but the tappable slots stay
+      // clear of notches / landscape navigation buttons on either side.
+      expect(firstSlot.left - barRect.left, greaterThanOrEqualTo(leftInset));
+      expect(barRect.right - lastSlot.right, greaterThanOrEqualTo(rightInset));
+    });
+
+    testWidgets('docks flush: surface absorbs the bottom safe-area inset', (
+      tester,
+    ) async {
+      const inset = 34.0;
+      await pumpBar(
+        tester,
+        items: barItems(),
+        mediaQueryData: const MediaQueryData(
+          size: Size(390, 844),
+          padding: EdgeInsets.only(bottom: inset),
+        ),
+      );
+
+      final barRect = tester.getRect(find.byType(DesignSystemFiveSlotNavBar));
+      final slotRect = tester.getRect(
+        find.ancestor(of: find.text('Tasks'), matching: find.byType(InkWell)),
+      );
+
+      // The rendered bar height matches the shared height contract...
+      expect(
+        barRect.height,
+        DesignSystemFiveSlotNavBar.barHeight(
+          tester.element(find.byType(DesignSystemFiveSlotNavBar)),
+        ),
+      );
+      // ...and the surface extends exactly the absorbed inset
+      // (bottomInsetFraction of the OS-reported one) plus the hairline
+      // border below the slot row: the
+      // trimmed inset replaces the internal bottom padding instead of
+      // stacking onto it, so home-indicator devices get no dead space.
+      expect(
+        barRect.bottom - slotRect.bottom,
+        moreOrLessEquals(
+          inset * DesignSystemFiveSlotNavBar.bottomInsetFraction +
+              DesignSystemNavigationFrostedSurface.borderWidth,
+        ),
+      );
+    });
+
+    testWidgets('active slot uses the interactive tint and active icon', (
+      tester,
+    ) async {
+      await pumpBar(
+        tester,
+        items: [
+          item('Tasks', active: true),
+          item('Journal'),
+          item('Settings'),
+        ],
+      );
+      // Let the tint animation settle.
+      await tester.pump(DesignSystemFiveSlotNavBar.tintDuration);
+
+      // Active slot swaps to the filled icon; inactive slots keep the
+      // outlined one.
+      expect(find.byIcon(Icons.circle), findsOneWidget);
+      expect(find.byIcon(Icons.circle_outlined), findsNWidgets(2));
+
+      final activeLabel = tester.widget<Text>(find.text('Tasks'));
+      final inactiveLabel = tester.widget<Text>(find.text('Journal'));
+      expect(
+        activeLabel.style!.color,
+        dsTokensLight.colors.interactive.enabled,
+      );
+      expect(
+        inactiveLabel.style!.color,
+        dsTokensLight.colors.text.mediumEmphasis,
+      );
+    });
+
+    testWidgets('tapping a slot invokes only its own callback', (tester) async {
+      final taps = <String>[];
+      await pumpBar(
+        tester,
+        items: [
+          item('Tasks', active: true, onTap: () => taps.add('tasks')),
+          item('Journal', onTap: () => taps.add('journal')),
+          item('Settings', onTap: () => taps.add('settings')),
+        ],
+      );
+
+      await tester.tap(find.text('Journal'));
+      expect(taps, ['journal']);
+    });
+
+    testWidgets('every slot meets the 44px minimum tap target', (tester) async {
+      await pumpBar(tester, items: barItems());
+
+      for (final label in slotLabels) {
+        final slot = tester.getSize(
+          find.ancestor(
+            of: find.text(label),
+            matching: find.byType(InkWell),
+          ),
+        );
+        expect(
+          slot.height,
+          greaterThanOrEqualTo(DesignSystemFiveSlotNavBar.minTapTarget),
+          reason: '$label slot height',
+        );
+        expect(
+          slot.width,
+          greaterThanOrEqualTo(DesignSystemFiveSlotNavBar.minTapTarget),
+          reason: '$label slot width',
+        );
+      }
+    });
+
+    testWidgets('announces semantics label, selection, and overrides', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      await pumpBar(
+        tester,
+        items: [
+          item('Tasks', active: true, onTap: () {}),
+          item(
+            'More',
+            semanticsLabel: 'More, 4 additional destinations',
+            onTap: () {},
+          ),
+        ],
+      );
+
+      expect(
+        tester.getSemantics(find.bySemanticsLabel('Tasks')),
+        matchesSemantics(
+          label: 'Tasks',
+          isButton: true,
+          isSelected: true,
+          hasTapAction: true,
+          // The InkWell's own semantics merge into the slot node now that
+          // the subtree is no longer excluded (keeps badges announced).
+          hasFocusAction: true,
+          isFocusable: true,
+          hasSelectedState: true,
+        ),
+      );
+      // The More slot announces the hidden-destination count instead of
+      // its short visual label.
+      expect(
+        find.bySemanticsLabel('More, 4 additional destinations'),
+        findsOneWidget,
+      );
+      handle.dispose();
+    });
+
+    testWidgets('keeps badge decorations on the icon in the semantics tree', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      await pumpBar(
+        tester,
+        items: [
+          item('Tasks', active: true, onTap: () {}),
+          DesignSystemFiveSlotNavBarItem(
+            label: 'Settings',
+            icon: const Badge(
+              label: Text('3'),
+              child: Icon(Icons.settings_outlined),
+            ),
+            onTap: () {},
+          ),
+        ],
+      );
+
+      // The slot replaces only the label text's semantics; the icon
+      // subtree keeps its own, so the pending-count badge stays announced
+      // alongside the slot label.
+      expect(find.bySemanticsLabel(RegExp('Settings')), findsOneWidget);
+      expect(find.bySemanticsLabel(RegExp('3')), findsOneWidget);
+      handle.dispose();
+    });
+  });
+}

--- a/test/features/sync/ui/widgets/sync_list_scaffold_test.dart
+++ b/test/features/sync/ui/widgets/sync_list_scaffold_test.dart
@@ -77,6 +77,9 @@ Future<StreamController<List<_TestItem>>> _pumpScaffold(
 
   await tester.pumpWidget(
     MaterialApp(
+      // The scaffold's SettingsPageHeader reads context.designTokens, so the
+      // theme must carry the DsTokens extension.
+      theme: resolveTestTheme(),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: useViewSize
@@ -405,6 +408,7 @@ void main() {
         // Initial pump with both filters, select error
         await tester.pumpWidget(
           MaterialApp(
+            theme: resolveTestTheme(),
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: MediaQuery(
@@ -456,6 +460,7 @@ void main() {
 
         await tester.pumpWidget(
           MaterialApp(
+            theme: resolveTestTheme(),
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: MediaQuery(

--- a/test/services/nav_service_test.dart
+++ b/test/services/nav_service_test.dart
@@ -81,10 +81,12 @@ class _GeneratedNavScenario {
   final bool dashboards;
   final List<_GeneratedNavPath> paths;
 
+  // Mirrors `NavService._tabSpecs`: Daily OS right after Tasks, then
+  // Projects and the remaining flag-gated tabs.
   List<String> get enabledRoots => [
     '/tasks',
-    if (projects) '/projects',
     if (dailyOs) '/calendar',
+    if (projects) '/projects',
     if (habits) '/habits',
     if (dashboards) '/dashboards',
     '/journal',
@@ -331,15 +333,15 @@ void main() {
       expect(navService.currentPath, '/habits');
     });
 
-    test('orders Projects directly after Tasks when enabled', () {
+    test('orders Daily OS directly after Tasks when enabled', () {
       final navService = getIt<NavService>();
 
       expect(
         navService.beamerDelegates,
         [
           navService.tasksDelegate,
-          navService.projectsDelegate,
           navService.calendarDelegate,
+          navService.projectsDelegate,
           navService.habitsDelegate,
           navService.dashboardsDelegate,
           navService.journalDelegate,
@@ -371,8 +373,8 @@ void main() {
 
         final expectedDelegates = [
           navService.tasksDelegate,
-          if (scenario.projects) navService.projectsDelegate,
           if (scenario.dailyOs) navService.calendarDelegate,
+          if (scenario.projects) navService.projectsDelegate,
           if (scenario.habits) navService.habitsDelegate,
           if (scenario.dashboards) navService.dashboardsDelegate,
           navService.journalDelegate,
@@ -452,15 +454,15 @@ void main() {
         navService.beamerDelegates,
         [
           navService.tasksDelegate,
-          navService.projectsDelegate,
           navService.calendarDelegate,
+          navService.projectsDelegate,
           navService.habitsDelegate,
           navService.dashboardsDelegate,
           navService.journalDelegate,
           navService.settingsDelegate,
         ],
       );
-      expect(navService.projectsIndex, 1);
+      expect(navService.projectsIndex, 2);
     });
 
     test(

--- a/test/widgets/app_bar/settings_page_header_test.dart
+++ b/test/widgets/app_bar/settings_page_header_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/widgets/app_bar/settings_page_header.dart';
 
 /// Pumps a [SettingsPageHeader] inside the standard scroll-view scaffolding,
@@ -18,9 +19,21 @@ Future<void> _pumpHeader(
   double contentHeight = 400,
   ThemeData? theme,
 }) async {
+  // The header reads context.designTokens (for the bottom corner radius),
+  // so whatever theme the test supplies must carry the DsTokens extension.
+  final baseTheme = theme ?? ThemeData.light();
+  final themedWithTokens = baseTheme.copyWith(
+    extensions: [
+      ...baseTheme.extensions.values,
+      if (baseTheme.brightness == Brightness.dark)
+        dsTokensDark
+      else
+        dsTokensLight,
+    ],
+  );
   await tester.pumpWidget(
     MaterialApp(
-      theme: theme,
+      theme: themedWithTokens,
       home: MediaQuery(
         data: MediaQueryData(
           size: Size(width, height),

--- a/test/widgets/nav_bar/design_system_bottom_navigation_bar_test.dart
+++ b/test/widgets/nav_bar/design_system_bottom_navigation_bar_test.dart
@@ -1,88 +1,82 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:lotti/features/design_system/components/navigation/design_system_navigation_tab_bar.dart';
+import 'package:lotti/features/design_system/components/navigation/design_system_five_slot_nav_bar.dart';
 import 'package:lotti/features/design_system/theme/design_system_theme.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/widgets/nav_bar/design_system_bottom_navigation_bar.dart';
 
 import '../../widget_test_utils.dart';
 
 void main() {
+  const items = [
+    DesignSystemFiveSlotNavBarItem(
+      label: 'Tasks',
+      icon: Icon(Icons.check_circle_outline),
+      active: true,
+    ),
+    DesignSystemFiveSlotNavBarItem(
+      label: 'Journal',
+      icon: Icon(Icons.book_outlined),
+    ),
+    DesignSystemFiveSlotNavBarItem(
+      label: 'Settings',
+      icon: Icon(Icons.settings_outlined),
+    ),
+    DesignSystemFiveSlotNavBarItem(
+      label: 'More',
+      icon: Icon(Icons.more_horiz_rounded),
+    ),
+  ];
+
   group('DesignSystemBottomNavigationBar', () {
-    testWidgets('centers the tab bar within the bottom nav row', (
+    testWidgets('adds no gap or inset of its own around the bar', (
       tester,
     ) async {
       await tester.pumpWidget(
         makeTestableWidgetWithScaffold(
           const SizedBox(
-            width: 402,
-            child: DesignSystemBottomNavigationBar(
-              items: [
-                DesignSystemNavigationTabBarItem(
-                  label: 'Tasks',
-                  icon: Icon(Icons.check_circle_outline),
-                  active: true,
-                ),
-                DesignSystemNavigationTabBarItem(
-                  label: 'Projects',
-                  icon: Icon(Icons.folder_outlined),
-                ),
-              ],
-            ),
+            width: 390,
+            child: DesignSystemBottomNavigationBar(items: items),
           ),
           theme: DesignSystemTheme.light(),
         ),
       );
 
-      final align = tester.widget<Align>(
-        find.descendant(
-          of: find.byType(DesignSystemBottomNavigationBar),
-          matching: find.byType(Align),
+      final containerRect = tester.getRect(
+        find.byType(DesignSystemBottomNavigationBar),
+      );
+      final barRect = tester.getRect(find.byType(DesignSystemFiveSlotNavBar));
+
+      // The container contributes zero padding: when the shell pins it to
+      // the screen's bottom edge the bar surface is flush with that edge
+      // and spans the full width.
+      expect(barRect.bottom, containerRect.bottom);
+      expect(barRect.left, containerRect.left);
+      expect(barRect.right, containerRect.right);
+    });
+
+    testWidgets('occupiedHeight matches the rendered bar extent', (
+      tester,
+    ) async {
+      const noInset = MediaQueryData(size: Size(390, 844));
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const DesignSystemBottomNavigationBar(items: items),
+          theme: DesignSystemTheme.light(),
+          mediaQueryData: noInset,
         ),
       );
 
-      expect(align.alignment, Alignment.center);
-      expect(find.byType(DesignSystemNavigationTabBar), findsOneWidget);
+      final renderedHeight = tester
+          .getSize(find.byType(DesignSystemBottomNavigationBar))
+          .height;
+      final occupiedHeight = DesignSystemBottomNavigationBar.occupiedHeight(
+        tester.element(find.byType(DesignSystemBottomNavigationBar)),
+      );
+
+      expect(occupiedHeight, renderedHeight);
     });
-
-    testWidgets(
-      'reserves enough bottom breathing room to clear the screen edge on '
-      'devices without a home-indicator inset',
-      (tester) async {
-        // Pump with an explicitly zero bottom inset (Android with gesture
-        // nav off, simulators without a configured home indicator). The
-        // SafeArea around the pill contributes nothing here, so whatever
-        // gap exists below the last button row must come from padding().
-        const noInset = MediaQueryData(size: Size(390, 844));
-
-        await tester.pumpWidget(
-          makeTestableWidgetWithScaffold(
-            const DesignSystemBottomNavigationBar(
-              items: [
-                DesignSystemNavigationTabBarItem(
-                  label: 'Settings',
-                  icon: Icon(Icons.settings_outlined),
-                  active: true,
-                ),
-              ],
-            ),
-            theme: DesignSystemTheme.light(),
-            mediaQueryData: noInset,
-          ),
-        );
-
-        final pillBottom = tester
-            .getRect(find.byType(DesignSystemNavigationTabBar))
-            .bottom;
-        final navBarBottom = tester
-            .getRect(find.byType(DesignSystemBottomNavigationBar))
-            .bottom;
-
-        // 20 logical px ≈ the smallest tap-edge clearance that still reads
-        // as deliberate breathing room rather than a flush bar; the actual
-        // value is driven by a design-system spacing token.
-        expect(navBarBottom - pillBottom, greaterThanOrEqualTo(20));
-      },
-    );
 
     testWidgets('includes the bottom safe-area inset in occupied height', (
       tester,
@@ -119,7 +113,17 @@ void main() {
         tester.element(find.byType(Scaffold)),
       );
 
-      expect(withInsetHeight - withoutInsetHeight, withInset.padding.bottom);
+      // The bar absorbs bottomInsetFraction of the inset, which replaces
+      // (not stacks onto) its internal step2 bottom padding — so occupied
+      // height grows by the trimmed inset minus the padding it displaced.
+      expect(
+        withInsetHeight - withoutInsetHeight,
+        moreOrLessEquals(
+          withInset.padding.bottom *
+                  DesignSystemFiveSlotNavBar.bottomInsetFraction -
+              dsTokensLight.spacing.step2,
+        ),
+      );
     });
 
     testWidgets(
@@ -175,7 +179,7 @@ void main() {
     });
 
     testWidgets(
-      'renders the overlay above the pill in the same Column when provided',
+      'renders the overlay above the bar in the same Column when provided',
       (tester) async {
         const overlayKey = ValueKey('overlay');
 
@@ -184,17 +188,7 @@ void main() {
             const SizedBox(
               width: 402,
               child: DesignSystemBottomNavigationBar(
-                items: [
-                  DesignSystemNavigationTabBarItem(
-                    label: 'Tasks',
-                    icon: Icon(Icons.check_circle_outline),
-                    active: true,
-                  ),
-                  DesignSystemNavigationTabBarItem(
-                    label: 'Projects',
-                    icon: Icon(Icons.folder_outlined),
-                  ),
-                ],
+                items: items,
                 overlay: SizedBox(key: overlayKey, height: 24),
               ),
             ),
@@ -202,11 +196,9 @@ void main() {
           ),
         );
 
-        // Overlay is mounted.
+        // Overlay is mounted and shares the bar's Column, so it stays tied
+        // to the rendered nav bar.
         expect(find.byKey(overlayKey), findsOneWidget);
-
-        // It shares the same Column as the pill (so it scales/centers
-        // with the pill via the FittedBox + IntrinsicWidth above it).
         final column = tester.widget<Column>(
           find
               .ancestor(
@@ -218,19 +210,88 @@ void main() {
         expect(column.crossAxisAlignment, CrossAxisAlignment.stretch);
         expect(column.mainAxisSize, MainAxisSize.min);
         expect(
-          column.children.whereType<DesignSystemNavigationTabBar>(),
+          column.children.whereType<DesignSystemFiveSlotNavBar>(),
           hasLength(1),
         );
 
-        // Overlay is the first child, pill is the second — overlay is
-        // visually above the pill.
+        // Overlay is the first child — visually above the bar.
         final overlayCenter = tester.getCenter(find.byKey(overlayKey));
-        final pillCenter = tester.getCenter(
-          find.byType(DesignSystemNavigationTabBar),
+        final barCenter = tester.getCenter(
+          find.byType(DesignSystemFiveSlotNavBar),
         );
-        expect(overlayCenter.dy, lessThan(pillCenter.dy));
+        expect(overlayCenter.dy, lessThan(barCenter.dy));
       },
     );
+
+    testWidgets('occupiedHeight adds the published overlay height', (
+      tester,
+    ) async {
+      const noInset = MediaQueryData(size: Size(390, 844));
+      const scopedChildKey = ValueKey('scoped-child');
+
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          const DesignSystemBottomNavigationOverlayHeight(
+            height: 24,
+            child: SizedBox.shrink(key: scopedChildKey),
+          ),
+          theme: DesignSystemTheme.light(),
+          mediaQueryData: noInset,
+        ),
+      );
+
+      // The Scaffold sits above the scope, the keyed child below it — the
+      // difference is exactly the published overlay height.
+      final outsideScope = DesignSystemBottomNavigationBar.occupiedHeight(
+        tester.element(find.byType(Scaffold)),
+      );
+      final insideScope = DesignSystemBottomNavigationBar.occupiedHeight(
+        tester.element(find.byKey(scopedChildKey)),
+      );
+
+      expect(insideScope - outsideScope, 24);
+    });
+
+    testWidgets('FabPadding tracks published overlay height changes', (
+      tester,
+    ) async {
+      Future<void> pump(double height) {
+        return tester.pumpWidget(
+          makeTestableWidgetWithScaffold(
+            DesignSystemBottomNavigationOverlayHeight(
+              height: height,
+              child: const DesignSystemBottomNavigationFabPadding(
+                child: SizedBox.square(dimension: 56),
+              ),
+            ),
+            theme: DesignSystemTheme.light(),
+            mediaQueryData: const MediaQueryData(size: Size(390, 844)),
+          ),
+        );
+      }
+
+      double bottomPadding() {
+        final padding = tester.widget<Padding>(
+          find.descendant(
+            of: find.byType(DesignSystemBottomNavigationFabPadding),
+            matching: find.byType(Padding),
+          ),
+        );
+        return (padding.padding as EdgeInsets).bottom;
+      }
+
+      await pump(0);
+      final barOnly = bottomPadding();
+
+      // An indicator appears above the bar: the padding grows by exactly
+      // its height so the indicator row never covers the lifted child.
+      await pump(24);
+      expect(bottomPadding() - barOnly, 24);
+
+      // Indicator gone again: padding shrinks back to the bar alone.
+      await pump(0);
+      expect(bottomPadding(), barOnly);
+    });
 
     testWidgets('omits the overlay slot when none is provided', (
       tester,
@@ -239,22 +300,14 @@ void main() {
         makeTestableWidgetWithScaffold(
           const SizedBox(
             width: 402,
-            child: DesignSystemBottomNavigationBar(
-              items: [
-                DesignSystemNavigationTabBarItem(
-                  label: 'Tasks',
-                  icon: Icon(Icons.check_circle_outline),
-                  active: true,
-                ),
-              ],
-            ),
+            child: DesignSystemBottomNavigationBar(items: items),
           ),
           theme: DesignSystemTheme.light(),
         ),
       );
 
       // The outermost Column inside the nav bar is the one that hosts the
-      // pill (and would host the overlay if provided). Inner Columns belong
+      // bar (and would host the overlay if provided). Inner Columns belong
       // to each tab item.
       final column = tester
           .widgetList<Column>(
@@ -264,9 +317,9 @@ void main() {
             ),
           )
           .first;
-      // Only the pill — no overlay child contributes to the Column.
+      // Only the bar — no overlay child contributes to the Column.
       expect(column.children, hasLength(1));
-      expect(column.children.first, isA<DesignSystemNavigationTabBar>());
+      expect(column.children.first, isA<DesignSystemFiveSlotNavBar>());
     });
   });
 }

--- a/test/widgets/nav_bar/mobile_nav_more_sheet_test.dart
+++ b/test/widgets/nav_bar/mobile_nav_more_sheet_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/theme/design_system_theme.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/widgets/nav_bar/mobile_nav_more_sheet.dart';
+import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
+
+import '../../widget_test_utils.dart';
+
+void main() {
+  Future<void> pumpAndOpenSheet(
+    WidgetTester tester, {
+    required List<MobileNavMoreSheetItem> items,
+  }) async {
+    await tester.pumpWidget(
+      makeTestableWidgetWithScaffold(
+        Builder(
+          builder: (context) => TextButton(
+            onPressed: () => showMobileNavMoreSheet(
+              context: context,
+              items: items,
+            ),
+            child: const Text('open'),
+          ),
+        ),
+        theme: DesignSystemTheme.light(),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  group('showMobileNavMoreSheet', () {
+    testWidgets('lists every overflow destination with icon and label', (
+      tester,
+    ) async {
+      await pumpAndOpenSheet(
+        tester,
+        items: [
+          MobileNavMoreSheetItem(
+            label: 'Projects',
+            icon: const Icon(Icons.folder_outlined),
+            onSelected: () {},
+          ),
+          MobileNavMoreSheetItem(
+            label: 'Habits',
+            icon: const Icon(Icons.checklist_outlined),
+            onSelected: () {},
+          ),
+        ],
+      );
+
+      expect(find.text('Projects'), findsOneWidget);
+      expect(find.byIcon(Icons.folder_outlined), findsOneWidget);
+      expect(find.text('Habits'), findsOneWidget);
+      expect(find.byIcon(Icons.checklist_outlined), findsOneWidget);
+    });
+
+    testWidgets('selecting a row dismisses the sheet, then navigates', (
+      tester,
+    ) async {
+      final selections = <String>[];
+      await pumpAndOpenSheet(
+        tester,
+        items: [
+          MobileNavMoreSheetItem(
+            label: 'Projects',
+            icon: const Icon(Icons.folder_outlined),
+            onSelected: () => selections.add('projects'),
+          ),
+          MobileNavMoreSheetItem(
+            label: 'Habits',
+            icon: const Icon(Icons.checklist_outlined),
+            onSelected: () => selections.add('habits'),
+          ),
+        ],
+      );
+
+      await tester.tap(find.text('Habits'));
+      await tester.pumpAndSettle();
+
+      expect(selections, ['habits']);
+      expect(find.byType(WoltModalSheet), findsNothing);
+    });
+
+    testWidgets('highlights the active destination with the accent tint', (
+      tester,
+    ) async {
+      await pumpAndOpenSheet(
+        tester,
+        items: [
+          MobileNavMoreSheetItem(
+            label: 'Projects',
+            icon: const Icon(Icons.folder_outlined),
+            active: true,
+            onSelected: () {},
+          ),
+          MobileNavMoreSheetItem(
+            label: 'Habits',
+            icon: const Icon(Icons.checklist_outlined),
+            onSelected: () {},
+          ),
+        ],
+      );
+
+      final activeLabel = tester.widget<Text>(find.text('Projects'));
+      final inactiveLabel = tester.widget<Text>(find.text('Habits'));
+      expect(
+        activeLabel.style!.color,
+        dsTokensLight.colors.interactive.enabled,
+      );
+      expect(
+        inactiveLabel.style!.color,
+        dsTokensLight.colors.text.highEmphasis,
+      );
+
+      final activeIcon = IconTheme.of(
+        tester.element(find.byIcon(Icons.folder_outlined)),
+      );
+      expect(activeIcon.color, dsTokensLight.colors.interactive.enabled);
+    });
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile bottom nav redesigned: shows Tasks, Logbook, Settings plus a “More” slot that opens an overflow sheet; the More slot mirrors the active overflow destination and resolves targets dynamically. Bar docks flush to bottom and absorbs the home‑indicator safe‑area inset.

* **Localization**
  * Added localized title and pluralized semantics for the “More” tab in multiple languages.

* **Documentation**
  * Updated design-system and widget docs to describe five‑slot behavior, safe‑area/overlay considerations, and FAB padding.

* **Tests**
  * Added/updated widget and navigation tests for five‑slot nav and More sheet behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->