### PR TITLE
feat: simplify running timer indicator visibility logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   entries stay hidden unless the private flag is on.
 
 ### Changed
+- The desktop sidebar's running-timer card now stays visible the whole time
+  a timer is running. Previously it hid itself while you were viewing the
+  running task and could also disappear after you navigated away from the
+  Tasks tab, so the elapsed-time readout and the quick jump-back button were
+  easy to lose. The card now persists in the sidebar everywhere — including
+  while the same task is open in the main view, where it sits alongside the
+  task's own running indicator.
 - Task and project lists stay snappier under sync: a task's project is now
   resolved from a denormalized, indexed column (and batched across rows
   instead of one query per task), and the projects overview plus the

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -39,6 +39,7 @@
           <p>Daily OS Next: tapping a recorded session on the Day timeline now reopens its task scrolled to — and briefly highlighting — that exact entry again, instead of dropping you at the top of the task.</p>
           <p>Daily OS Next: the sidebar month calendar now starts the week on your device region's first weekday — Monday across most of Europe, Sunday in the US — read from the OS region rather than the app language, instead of always starting on Sunday.</p>
           <p>Task and project lists stay snappier under sync: a task's project is now resolved from a denormalized, indexed column and batched across rows instead of one query per task, and the projects overview plus the saved-filter sidebar counts coalesce rapid update notifications into a single refresh.</p>
+          <p>The desktop sidebar's running-timer card now stays visible the whole time a timer is running, instead of hiding while you view the running task or after navigating away from the Tasks tab. The elapsed time and the quick jump-back button now persist in the sidebar everywhere — including alongside the task's own running indicator when that task is open.</p>
       </description>
     </release>
     <release version="0.9.1016" date="2026-06-06">

--- a/lib/features/tasks/README.md
+++ b/lib/features/tasks/README.md
@@ -218,8 +218,9 @@ Checklist content is modeled separately through checklist entities and linked ch
   no per-page lifecycle plumbing), so the action bar can dock flush
   against the home indicator. This predicate is mobile-only — the desktop
   shell has no floating recording indicator; the desktop running-timer
-  surface is the sidebar `SidebarTimerSection` card, which hides itself via
-  its own logic (see "Sidebar timer coordination" below).
+  surface is the sidebar `SidebarTimerSection` card, which stays visible for
+  the whole lifetime of a running timer (see "Sidebar timer coordination"
+  below).
   TaskActionBar consumes the safe-area inset internally.
 
 ```mermaid
@@ -245,37 +246,34 @@ This page is not just "show task fields." It is the task workspace where task me
 
 ### Sidebar timer coordination
 
-`SidebarTimerSection` (desktop, `aboveSettings` slot — see `lib/widgets/README.md` for the visual contract) and `TaskActionBar`'s running pill both render the same live `TimeService` session. To avoid duplicating the task title on screen, the sidebar card hides itself when the action bar is already showing the indicator — but only when the action bar is actually visible.
+`SidebarTimerSection` (desktop, `aboveSettings` slot — see `lib/widgets/README.md` for the visual contract) and `TaskActionBar`'s running pill both render the same live `TimeService` session. They are allowed to be on screen at the same time: the sidebar card is **not** suppressed while the running task is open in the details pane. A single, always-present place to read the elapsed time and jump back to the running task is worth more than avoiding the duplicate title — so the duplication is intentional.
 
-The hide condition is the conjunction of:
+Visibility is a pure function of `TimeService.getStream()`:
 
-- the running timer's `linkedFrom` is a `Task`,
-- `linkedFrom.meta.id == NavService.desktopSelectedTaskId`, and
-- `NavService.currentPath` starts with `/tasks/` (i.e. user is on a task-detail route).
+- a running entity → the card is shown,
+- `null` (timer stopped) → the card collapses to `SizedBox.shrink`.
 
-The route check matters because `desktopSelectedTaskId` is sticky across tab switches: it's only mutated by `NavService.resetDesktopTaskDetail` (called from `tasks_location.dart` on URL changes), `NavService.pushDesktopTaskDetail` (linked-task taps via `task_navigation.dart`), and `NavService.popDesktopTaskDetail` (desktop back arrow in `task_detail_back_leading.dart`). Without the path guard, switching from a task to e.g. Habits would leave the sidebar card hidden even though the action bar is no longer on screen.
+Neither `NavService.desktopSelectedTaskId`, the active route, nor the selected top-level tab affects visibility. The card therefore survives every navigation: opening the running task, switching to Habits/Settings, or leaving the Tasks tab entirely all leave it in place. The stream is seeded with `TimeService.getCurrent()` as `initialData` so an already-running session renders on the first frame instead of flashing through a hidden state.
 
-Reactivity sources composed inside the card:
-
-- `TimeService.getStream()` — running entity + duration. Seeded with `TimeService.getCurrent()` as `initialData` so an already-running session renders on first frame instead of flashing through a hidden state.
-- `NavService.desktopSelectedTaskId` (`ValueListenableBuilder`) — selection changes inside the tasks pane.
-- `NavService.getIndexStream()` (`StreamBuilder`) — top-level tab/route changes; `currentPath` is read synchronously when the stream emits.
-
-The show/hide flip runs through an `AnimatedSwitcher` + `AnimatedSize` (`SidebarTimerSection.animationDuration` ≈ 220 ms, `Curves.easeInOut`) so the card fades and the surrounding sidebar collapses smoothly instead of popping.
+The appear/disappear transition runs through an `AnimatedSwitcher` + `AnimatedSize` (`SidebarTimerSection.animationDuration` ≈ 220 ms, `Curves.easeInOut`) so the card fades and the surrounding sidebar collapses smoothly instead of popping.
 
 ```mermaid
 stateDiagram-v2
     [*] --> Hidden
-    Hidden --> Visible: TimeService emits a running entity\nand hide-condition is false
+    Hidden --> Visible: TimeService emits a running entity
     Visible --> Hidden: TimeService emits null (timer stopped)
-    Visible --> Hidden: linkedFrom.task.id == openTaskId\nAND currentPath startsWith /tasks/
-    Hidden --> Visible: openTaskId changes (different task selected)
-    Hidden --> Visible: currentPath leaves /tasks/<uuid>\n(tab switch / nav away)
+    note right of Visible
+      Navigation, the open task, and the
+      selected tab do NOT affect visibility —
+      the card persists everywhere while a
+      timer is running (duplicated with the
+      action bar on the task detail page).
+    end note
     note right of Hidden
-      AnimatedSwitcher fades the
-      outgoing card; AnimatedSize
-      collapses the surrounding column
-      (~220 ms, Curves.easeInOut).
+      AnimatedSwitcher fades the outgoing
+      card; AnimatedSize collapses the
+      surrounding column (~220 ms,
+      Curves.easeInOut).
     end note
 ```
 

--- a/lib/widgets/README.md
+++ b/lib/widgets/README.md
@@ -191,6 +191,7 @@ Inline panel surfaced in the desktop sidebar's `aboveSettings` slot whenever a t
 - Layout: a text-only title row (task title) over a body row with a timer icon, the tabular HH:MM:SS duration, and a circular stop button.
 - Typography: Inter with `numericBadgeFontFeatures` (tabular figures, slashed zero, `cv02`/`cv03`/`cv04` open digits) so 4/6/9 stay legible at small sizes and digits do not breathe.
 - Interactions: tapping the body navigates to the running task (or the timer's journal entry, if not task-linked); tapping the stop button calls `TimeService.stop()`.
+- Visibility: shown for the entire lifetime of a running timer, driven solely by `TimeService.getStream()`. It is intentionally not hidden when the running task is open in the details pane (the action bar's running pill and this card may both show at once) and persists across tab navigation. See "Sidebar timer coordination" in `lib/features/tasks/README.md`.
 - Idle state: collapses to `SizedBox.shrink` so the slot consumes no vertical space.
 
 ### SidebarAudioRecordingSection

--- a/lib/widgets/misc/sidebar_timer_section.dart
+++ b/lib/widgets/misc/sidebar_timer_section.dart
@@ -7,7 +7,6 @@ import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/journal/util/entry_tools.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
-import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/services/time_service.dart';
 import 'package:lotti/themes/theme.dart' show numericBadgeFontFeatures;
 import 'package:lotti/widgets/misc/timer_navigation.dart';
@@ -19,28 +18,22 @@ import 'package:lotti/widgets/misc/timer_navigation.dart';
 /// timer's journal entry, if not linked to a task). Tapping the stop
 /// button stops the timer.
 ///
-/// The card is hidden in two situations, each producing a smooth
-/// fade-and-collapse transition rather than a hard pop:
-///
-/// * No timer is running. There is nothing to show.
-/// * The running timer is linked to the same task that is currently
-///   open in the desktop task-details pane (tracked via
-///   [NavService.desktopSelectedTaskId]) AND the user is actually
-///   viewing a task-detail route. The detail page already shows a
-///   running indicator in its sticky action bar, so duplicating the
-///   title in the sidebar is just noise. The route check matters
-///   because [NavService.desktopSelectedTaskId] is sticky across tab
-///   switches — without it, switching from a task to e.g. Habits would
-///   leave the sidebar timer hidden even though the user can no longer
-///   see the action-bar indicator.
+/// Visibility is a pure function of whether a timer is running: the card
+/// stays mounted for the entire lifetime of a session and collapses only
+/// when no timer is running. It is deliberately *not* suppressed when the
+/// running task is open in the task-details pane, nor when the user
+/// navigates to another tab. The running indicator in the task detail
+/// action bar and this sidebar card may both be on screen at once — that
+/// duplication is intentional. A single, always-present sidebar surface
+/// guarantees the user never loses the elapsed-time readout or the
+/// one-tap path back to the running task, no matter where they are in the
+/// app.
 ///
 /// Reactivity:
 ///
-/// * [TimeService.getStream] drives running/duration updates.
-/// * [NavService.desktopSelectedTaskId] drives selection changes inside
-///   the tasks pane.
-/// * [NavService.getIndexStream] drives top-level tab/route changes;
-///   we read [NavService.currentPath] synchronously when it fires.
+/// * [TimeService.getStream] drives running/duration updates and is the
+///   sole input to visibility — appearance and disappearance follow the
+///   timer starting and stopping, nothing else.
 class SidebarTimerSection extends ConsumerWidget {
   const SidebarTimerSection({super.key});
 
@@ -50,57 +43,33 @@ class SidebarTimerSection extends ConsumerWidget {
   @visibleForTesting
   static const Duration animationDuration = Duration(milliseconds: 220);
 
-  /// Stable key used by the hidden state. Sharing one key across all
-  /// hidden variants keeps [AnimatedSwitcher] from running an extra
-  /// transition when we toggle between "no timer" and
-  /// "timer hidden because the task is open".
+  /// Stable key for the collapsed (no running timer) state so the
+  /// [AnimatedSwitcher] animates a single hidden ↔ visible transition.
   static const Key _hiddenKey = ValueKey('sidebar-timer-hidden');
-
-  /// True when [path] points at an individual task-detail route
-  /// (e.g. `/tasks/<uuid>`), as opposed to the tasks list root or any
-  /// other top-level tab.
-  static bool _isTaskDetailRoute(String path) => path.startsWith('/tasks/');
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final timeService = getIt<TimeService>();
-    final navService = getIt<NavService>();
 
     return StreamBuilder<JournalEntity?>(
       stream: timeService.getStream(),
       initialData: timeService.getCurrent(),
       builder: (context, snapshot) {
-        final current = snapshot.data;
-        return ValueListenableBuilder<String?>(
-          valueListenable: navService.desktopSelectedTaskId,
-          builder: (context, openTaskId, _) {
-            return StreamBuilder<int>(
-              // Tab/route switches don't otherwise rebuild this widget;
-              // subscribe to the nav index stream so we re-evaluate the
-              // active path when the user moves between top-level tabs.
-              stream: navService.getIndexStream(),
-              builder: (context, _) {
-                final child = _resolveChild(
-                  ref: ref,
-                  timeService: timeService,
-                  navService: navService,
-                  current: current,
-                  openTaskId: openTaskId,
-                );
-                return AnimatedSize(
-                  duration: animationDuration,
-                  curve: Curves.easeInOut,
-                  alignment: Alignment.bottomCenter,
-                  child: AnimatedSwitcher(
-                    duration: animationDuration,
-                    switchInCurve: Curves.easeIn,
-                    switchOutCurve: Curves.easeOut,
-                    child: child,
-                  ),
-                );
-              },
-            );
-          },
+        final child = _resolveChild(
+          ref: ref,
+          timeService: timeService,
+          current: snapshot.data,
+        );
+        return AnimatedSize(
+          duration: animationDuration,
+          curve: Curves.easeInOut,
+          alignment: Alignment.bottomCenter,
+          child: AnimatedSwitcher(
+            duration: animationDuration,
+            switchInCurve: Curves.easeIn,
+            switchOutCurve: Curves.easeOut,
+            child: child,
+          ),
         );
       },
     );
@@ -109,20 +78,12 @@ class SidebarTimerSection extends ConsumerWidget {
   Widget _resolveChild({
     required WidgetRef ref,
     required TimeService timeService,
-    required NavService navService,
     required JournalEntity? current,
-    required String? openTaskId,
   }) {
     if (current == null) {
       return const SizedBox.shrink(key: _hiddenKey);
     }
     final linkedFrom = timeService.linkedFrom;
-    if (linkedFrom is Task &&
-        openTaskId != null &&
-        linkedFrom.meta.id == openTaskId &&
-        _isTaskDetailRoute(navService.currentPath)) {
-      return const SizedBox.shrink(key: _hiddenKey);
-    }
     return _SidebarTimerCard(
       key: ValueKey('sidebar-timer-${current.meta.id}'),
       current: current,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1018+4129
+version: 0.9.1018+4130
 
 msix_config:
   display_name: LottiApp

--- a/test/beamer/beamer_app_test.dart
+++ b/test/beamer/beamer_app_test.dart
@@ -196,9 +196,10 @@ Future<void> _stubNavService(
   );
   when(() => navService.tapIndex(any())).thenReturn(null);
   when(() => navService.isDesktopMode).thenReturn(false);
-  // SidebarTimerSection reads these to decide whether to hide when the
-  // running task matches the open task. Empty selection + a non-task
-  // root path in these tests so the sidebar timer surfaces normally.
+  // The desktop tasks pane (`tasks_tab_page.dart`) reads
+  // `desktopSelectedTaskId` for its detail selection; stub it with an
+  // empty selection so the pane builds. (The sidebar running-timer card
+  // no longer reads it — it stays visible whenever a timer runs.)
   when(
     () => navService.desktopSelectedTaskId,
   ).thenReturn(ValueNotifier<String?>(null));
@@ -627,9 +628,9 @@ void main() {
     // Pin a mobile-width surface so AppScreen takes the mobile-shell branch
     // regardless of any view-size leakage from earlier tests in a bundled
     // `very_good test` run. Without this, a contaminated view ≥960 px wide
-    // routes AppScreen into the desktop sidebar, which mounts
-    // DesktopNavigationSidebar / SidebarTimerSection and trips on the
-    // unstubbed `MockNavService.desktopSelectedTaskId` getter.
+    // routes AppScreen into the desktop layout, which mounts the desktop
+    // tasks pane (`tasks_tab_page.dart`) and trips on the unstubbed
+    // `MockNavService.desktopSelectedTaskId` getter.
     setUp(() {
       TestWidgetsFlutterBinding.instance.platformDispatcher.views.first
         ..physicalSize = const Size(800, 1200)

--- a/test/widgets/misc/sidebar_timer_section_test.dart
+++ b/test/widgets/misc/sidebar_timer_section_test.dart
@@ -283,8 +283,11 @@ void main() {
   });
 
   testWidgets(
-    'hides the card when the running task is open in the details pane',
+    'stays visible when the running task is open in the details pane',
     (tester) async {
+      // The task detail action bar shows its own running pill; the
+      // sidebar card is intentionally rendered alongside it (the
+      // duplication is allowed) so the timer is never lost from view.
       final task = makeTask('task-open', title: 'Refine sidebar visibility');
       final timer = makeTimerEntry(
         'timer-open',
@@ -299,19 +302,19 @@ void main() {
       await tester.pump();
       expect(find.text('Refine sidebar visibility'), findsOneWidget);
 
+      // Selecting the running task in the details pane must NOT hide it.
       desktopSelectedTaskId.value = 'task-open';
-      // Pump past the fade+collapse animation.
       await tester.pump();
       await tester.pump(SidebarTimerSection.animationDuration);
 
-      expect(find.text('Refine sidebar visibility'), findsNothing);
-      expect(find.byIcon(Icons.timer_outlined), findsNothing);
-      expect(find.byIcon(Icons.stop_rounded), findsNothing);
+      expect(find.text('Refine sidebar visibility'), findsOneWidget);
+      expect(find.byIcon(Icons.timer_outlined), findsOneWidget);
+      expect(find.byIcon(Icons.stop_rounded), findsOneWidget);
     },
   );
 
   testWidgets(
-    'reappears when navigating away from the running task',
+    'stays visible regardless of which task is selected',
     (tester) async {
       final task = makeTask('task-here', title: 'Tracked');
       final timer = makeTimerEntry('timer-here');
@@ -324,8 +327,9 @@ void main() {
       desktopSelectedTaskId.value = 'task-here';
       await tester.pump();
       await tester.pump(SidebarTimerSection.animationDuration);
-      expect(find.text('Tracked'), findsNothing);
+      expect(find.text('Tracked'), findsOneWidget);
 
+      // Switching the selected task in the pane leaves the card untouched.
       desktopSelectedTaskId.value = 'some-other-task';
       await tester.pump();
       await tester.pump(SidebarTimerSection.animationDuration);
@@ -336,13 +340,12 @@ void main() {
   );
 
   testWidgets(
-    'stays visible when on a non-task route, even if selected task matches',
+    'stays visible when navigating away from the Tasks tab',
     (tester) async {
-      // Sticky state: user opened a task, started a timer, then
-      // switched tabs. desktopSelectedTaskId is still pointing at the
-      // task, but the user is now on /habits, so the sticky action bar
-      // is no longer visible — the sidebar must keep showing the
-      // running indicator.
+      // Sticky state: user opened a task, started a timer, then switched
+      // tabs. desktopSelectedTaskId still points at the task and the
+      // route is no longer a task-detail route — neither must hide the
+      // sidebar card.
       final task = makeTask('task-sticky', title: 'Sticky');
       final timer = makeTimerEntry('timer-sticky');
 
@@ -354,11 +357,10 @@ void main() {
       desktopSelectedTaskId.value = 'task-sticky';
       await tester.pump();
       await tester.pump(SidebarTimerSection.animationDuration);
-      // Sanity: while on the task route, the card is hidden.
-      expect(find.text('Sticky'), findsNothing);
+      expect(find.text('Sticky'), findsOneWidget);
 
       // User switches to the Habits tab — currentPath is no longer a
-      // task-detail route. The card must come back.
+      // task-detail route. The card must remain.
       setCurrentPath('/habits');
       await tester.pump();
       await tester.pump(SidebarTimerSection.animationDuration);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sidebar timer card now remains visible whenever a timer is running, persisting across navigation and when viewing the tracked task’s details.

* **Documentation**
  * Updated release notes and feature docs to describe the sidebar timer’s persistent behavior.

* **Tests**
  * Updated tests to assert the sidebar timer stays visible and functional across navigation/task selection.

* **Chores**
  * Version bump.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->