### PR TITLE
fix: starting new timer while timer runs persists end time

### DIFF
--- a/lib/get_it.dart
+++ b/lib/get_it.dart
@@ -98,7 +98,18 @@ Future<void> registerSingletons() async {
     ..registerSingleton<EditorDb>(EditorDb())
     ..registerSingleton<SyncDatabase>(SyncDatabase())
     ..registerSingleton<VectorClockService>(VectorClockService())
-    ..registerSingleton<TimeService>(TimeService());
+    ..registerSingleton<TimeService>(
+      // When a new timer replaces a still-running one, persist the outgoing
+      // entry's real stop time so it is not left with the stale dateTo it
+      // was created with (≈ its start time). Existing entry text is
+      // preserved — only the end time is written.
+      TimeService(
+        (entry) => getIt<PersistenceLogic>().updateJournalEntry(
+          journalEntityId: entry.meta.id,
+          dateTo: DateTime.now(),
+        ),
+      ),
+    );
 
   // Initialize config flags before constructing services that depend on them.
   await initConfigFlags(getIt<JournalDb>(), inMemoryDatabase: false);

--- a/lib/services/time_service.dart
+++ b/lib/services/time_service.dart
@@ -1,11 +1,24 @@
 import 'dart:async';
 
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/services/domain_logging.dart';
+
+/// Persists the end time of a timer that is being stopped because a new
+/// one is starting. Implemented by the persistence layer and injected so
+/// this low-level service stays free of a direct database dependency (and
+/// so unit tests can observe the call without a real DB).
+typedef PersistTimerStop = Future<void> Function(JournalEntity entry);
 
 class TimeService {
-  TimeService() {
+  TimeService([this._persistTimerStop]) {
     _controller = StreamController<JournalEntity?>.broadcast();
   }
+
+  /// Persists the outgoing entry's end time when a running session is
+  /// implicitly stopped by [start]. Null when the service is constructed
+  /// without persistence (bare unit tests) — finalization is then skipped.
+  final PersistTimerStop? _persistTimerStop;
 
   late final StreamController<JournalEntity?> _controller;
   JournalEntity? _current;
@@ -13,7 +26,15 @@ class TimeService {
   StreamSubscription<int>? _periodicSubscription;
 
   Future<void> start(JournalEntity journalEntity, JournalEntity? linked) async {
-    if (_current != null) {
+    final outgoing = _current;
+    if (outgoing != null) {
+      // A new session is replacing one that is still running. Persist the
+      // outgoing entry's real stop time before discarding it; otherwise it
+      // keeps the stale `dateTo` it was created with (≈ its start time) and
+      // the whole elapsed span is lost. Only the end time is written, so
+      // the entry's existing text is preserved. A failure here must never
+      // block the new timer from starting.
+      await _finalizeOutgoing(outgoing);
       await stop();
     }
 
@@ -36,6 +57,26 @@ class TimeService {
         );
       }
     });
+  }
+
+  /// Writes the outgoing timer's stop time via the injected persistence
+  /// callback, swallowing (but logging) any failure so the replacing timer
+  /// always starts.
+  Future<void> _finalizeOutgoing(JournalEntity entry) async {
+    final persist = _persistTimerStop;
+    if (persist == null) {
+      return;
+    }
+    try {
+      await persist(entry);
+    } catch (exception, stackTrace) {
+      getIt<DomainLogger>().error(
+        LogDomain.persistence,
+        exception,
+        stackTrace: stackTrace,
+        subDomain: 'finalizeRunningTimer',
+      );
+    }
   }
 
   JournalEntity? getCurrent() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1018+4130
+version: 0.9.1018+4131
 
 msix_config:
   display_name: LottiApp

--- a/test/services/time_service_test.dart
+++ b/test/services/time_service_test.dart
@@ -4,6 +4,7 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/services/time_service.dart';
 
 import '../test_data/test_data.dart';
+import '../widget_test_utils.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -207,6 +208,77 @@ void main() {
 
         timeService.stop();
       });
+    });
+  });
+
+  // Starting a new timer while one is already running implicitly stops the
+  // old one. The outgoing entry must be persisted with its real stop time,
+  // otherwise it keeps the stale `dateTo` it was created with (≈ its start
+  // time) and the whole elapsed span is lost.
+  group('finalizes the outgoing timer when replaced', () {
+    setUp(() async {
+      // Registers a real DomainLogger so the finalize error path can log.
+      await setUpTestGetIt();
+    });
+
+    tearDown(tearDownTestGetIt);
+
+    test('persists the outgoing entry once when a new timer replaces a '
+        'running one', () async {
+      final finalized = <JournalEntity>[];
+      final service = TimeService(
+        (entry) async => finalized.add(entry),
+      );
+      addTearDown(service.stop);
+
+      await service.start(testTextEntry, null);
+      expect(finalized, isEmpty, reason: 'nothing to finalize on first start');
+
+      await service.start(testImageEntry, null);
+
+      expect(finalized.map((e) => e.id), [testTextEntry.id]);
+      expect(service.getCurrent()?.id, testImageEntry.id);
+    });
+
+    test('does not persist when starting the very first timer', () async {
+      final finalized = <JournalEntity>[];
+      final service = TimeService(
+        (entry) async => finalized.add(entry),
+      );
+      addTearDown(service.stop);
+
+      await service.start(testTextEntry, null);
+
+      expect(finalized, isEmpty);
+    });
+
+    test(
+      'does not persist on an explicit stop (already saved by the caller)',
+      () async {
+        // The Stop button persists `dateTo = now` via EntryController.save
+        // before calling stop(); finalizing again here would double-write.
+        final finalized = <JournalEntity>[];
+        final service = TimeService(
+          (entry) async => finalized.add(entry),
+        );
+
+        await service.start(testTextEntry, null);
+        await service.stop();
+
+        expect(finalized, isEmpty);
+      },
+    );
+
+    test('a failing finalize still starts the replacing timer', () async {
+      final service = TimeService(
+        (_) async => throw Exception('db unavailable'),
+      );
+      addTearDown(service.stop);
+
+      await service.start(testTextEntry, null);
+      await service.start(testImageEntry, null);
+
+      expect(service.getCurrent()?.id, testImageEntry.id);
     });
   });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed timer persistence: when starting a new timer while one is already running, the previous timer's end time is now properly saved to your journal. The app remains stable if saving encounters an error.

## Chores
* Version bump to 0.9.1018+4131.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->