### PR TITLE
feat: refine time analysis view

### DIFF
--- a/lib/features/insights/README.md
+++ b/lib/features/insights/README.md
@@ -182,8 +182,8 @@ stateDiagram-v2
     [*] --> Loading: first watch of window W
     Loading --> Ready: buckets(W)
     Ready --> Ready: period switch within W\n(zero DB, in-memory slice)
-    Ready --> LoadingW2: range needs another year\n(new family instance W2)
-    LoadingW2 --> Ready: buckets(W2)\nW stays cached (cacheFor 5min)
+    Ready --> StaleW2: range needs another year\n(new instance W2 loads; page keeps last data — no spinner)
+    StaleW2 --> Ready: buckets(W2)\nW stays cached (cacheFor 5min)
     Ready --> Refetching: entry/task/link/private notification
     Refetching --> Ready: equal data → no re-emit (no flash)\nchanged data → rebuild
 ```
@@ -202,6 +202,17 @@ stateDiagram-v2
   a notification batch every ~100ms, each refetch costs a full window
   query); `cacheFor(dashboardCacheDuration)` keeps recently used windows
   alive across tab switches.
+- **keepPreviousData across years.** A new-year instance starts at
+  `AsyncLoading` with no value, which `skipLoadingOnReload` cannot bridge (it
+  only retains a value *within* one instance). So `TimeAnalysisPage` (a
+  `ConsumerStatefulWidget`) retains the last fully-loaded generation — buckets
+  paired with the exact selection they cover, since year-windowed buckets and
+  their range must travel together — and keeps rendering it until `buckets(W2)`
+  resolves. A year-crossing step therefore never flashes a spinner over the
+  established dashboard. The header/stepper always tracks the *live* selection,
+  so the control responds instantly while the body shows the previous period
+  for the ~35ms cold fetch (the Riverpod analogue of `keepPreviousData: true`).
+  Within a year the family key is stable, so this path never engages.
 
 ## Visualization (Stephen Few rules)
 
@@ -214,9 +225,11 @@ stateDiagram-v2
   axes, horizontal gridlines only.
 - In-progress periods plot only their **elapsed** buckets (today is the right
   edge) instead of reserving empty future slots; the period label carries the
-  full scope. Today's bar carries a quiet marker border. Y-axis labels roll
-  hours into days on long ranges (a cumulative year tick reads "42d", not
-  "1008h").
+  full scope. Today's bar carries a quiet marker border. Y-axis labels are
+  whole hours throughout — no day rollup, since days are ambiguous for tracked
+  time (a 24h day? an 8h workday?) — so a cumulative year tick reads "1008h"
+  and the left gutter (`reservedSize`) reserves extra width for those
+  four-digit ticks. This matches the hours-only KPI summary.
 - Granularity tiers: hourly for 1-day ranges, daily up to 120 days, weekly
   beyond (a full year ≈ 52 x-points). Partial edge weeks are flagged in tooltips.
 - At most 6 series plus a slate **Other (+N)** rollup — tightened to 5 on the

--- a/lib/features/insights/README.md
+++ b/lib/features/insights/README.md
@@ -229,7 +229,8 @@ stateDiagram-v2
   whole hours throughout — no day rollup, since days are ambiguous for tracked
   time (a 24h day? an 8h workday?) — so a cumulative year tick reads "1008h"
   and the left gutter (`reservedSize`) reserves extra width for those
-  four-digit ticks. This matches the hours-only KPI summary.
+  four-digit ticks. This matches the KPI summary, which likewise rounds to
+  whole hours at long spans (100h+) and otherwise keeps compact `h m` detail.
 - Granularity tiers: hourly for 1-day ranges, daily up to 120 days, weekly
   beyond (a full year ≈ 52 x-points). Partial edge weeks are flagged in tooltips.
 - At most 6 series plus a slate **Other (+N)** rollup — tightened to 5 on the

--- a/lib/features/insights/ui/time_analysis_page.dart
+++ b/lib/features/insights/ui/time_analysis_page.dart
@@ -28,15 +28,39 @@ import 'package:lotti/l10n/app_localizations_context.dart';
 /// the pure logic functions (~1-3ms per build at 10k-50k entries, measured
 /// — well within a frame),
 /// and passes plain values to dumb child widgets.
-class TimeAnalysisPage extends ConsumerWidget {
+/// **keepPreviousData.** [insightsBucketsProvider] is an `autoDispose.family`
+/// keyed by calendar year ([insightsWindowFor]). Stepping between periods of
+/// the *same* year reuses one cached bucket set — no fetch, no loading. But
+/// stepping across a year boundary (every step at year granularity; Jan↔Dec
+/// for months; the odd week or quarter) is a *new* family instance that starts
+/// at `AsyncLoading` with no value — and `skipLoadingOnReload` cannot bridge
+/// it, since it only retains a value *within* one instance. Left alone, that
+/// flashes a spinner over the whole dashboard on every year-crossing step. So
+/// the last fully-loaded generation is retained by the state and kept on
+/// screen until the new window resolves, while the header/stepper always tracks
+/// the live selection for instant feedback — the Riverpod equivalent of
+/// `keepPreviousData: true`.
+class TimeAnalysisPage extends ConsumerStatefulWidget {
   const TimeAnalysisPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<TimeAnalysisPage> createState() => _TimeAnalysisPageState();
+}
+
+class _TimeAnalysisPageState extends ConsumerState<TimeAnalysisPage> {
+  /// The most recent generation whose buckets had fully loaded. Retained across
+  /// builds so a year-boundary window switch keeps rendering it until the new
+  /// buckets arrive, instead of blanking to a spinner. Null only before the
+  /// very first load resolves (or until a cold cache fills on return).
+  _DashboardData? _lastData;
+
+  @override
+  Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final messages = context.messages;
 
     final selection = ref.watch(insightsRangeControllerProvider);
+    final controller = ref.read(insightsRangeControllerProvider.notifier);
     final bucketsAsync = ref.watch(
       insightsBucketsProvider(insightsWindowFor(selection.range)),
     );
@@ -46,14 +70,31 @@ class TimeAnalysisPage extends ConsumerWidget {
     // the comparison week for Sunday/Saturday-first regions). `.value`
     // (valueOrNull) so a still-loading previous window never blanks or blocks
     // the established dashboard.
-    final previousRange = ref
-        .read(insightsRangeControllerProvider.notifier)
-        .previousComparisonRange;
+    final previousRange = controller.previousComparisonRange;
     final previousBuckets = previousRange == null
         ? null
         : ref
               .watch(insightsBucketsProvider(insightsWindowFor(previousRange)))
               .value;
+
+    // Capture the freshest fully-loaded generation, pairing the buckets with
+    // the exact selection they cover. `.value` is non-null both for a settled
+    // AsyncData and for a same-instance reload (Riverpod retains the prior
+    // value), so within a year this simply tracks the current data; across a
+    // year it stops updating while the new window loads, freezing [_lastData]
+    // on the previous period. Assigning a field in build() is safe here: it
+    // feeds only this build and the next, and never itself schedules a rebuild.
+    final buckets = bucketsAsync.value;
+    if (buckets != null) {
+      _lastData = _DashboardData(
+        selection: selection,
+        buckets: buckets,
+        previousRange: previousRange,
+        previousBuckets: previousBuckets,
+      );
+    }
+    final data = _lastData;
+
     final preferences = ref.watch(insightsPreferencesControllerProvider);
     final categories =
         ref.watch(categoriesStreamProvider).value ??
@@ -72,55 +113,72 @@ class TimeAnalysisPage extends ConsumerWidget {
       // inverts between light and dark, so page/card swap by brightness).
       backgroundColor: insightsPageSurface(context),
       body: SafeArea(
-        child: bucketsAsync.when(
-          // Background refreshes and window switches must never blank the
-          // established dashboard — loading shells are for first paint only.
-          skipLoadingOnReload: true,
-          skipLoadingOnRefresh: true,
-          loading: () => const Center(child: CircularProgressIndicator()),
-          error: (error, _) => Center(
-            child: Text(
-              messages.insightsLoadError,
-              style: tokens.typography.styles.body.bodySmall.copyWith(
-                color: tokens.colors.text.lowEmphasis,
+        // First paint only: no generation has loaded yet, so a loading shell
+        // (or the error message if that very first fetch failed) is all there
+        // is to show. Once any generation has rendered, a loading new window or
+        // a transient error keeps the last one on screen rather than blanking.
+        child: data == null
+            ? (bucketsAsync.hasError
+                  ? Center(
+                      child: Text(
+                        messages.insightsLoadError,
+                        style: tokens.typography.styles.body.bodySmall.copyWith(
+                          color: tokens.colors.text.lowEmphasis,
+                        ),
+                      ),
+                    )
+                  : const Center(child: CircularProgressIndicator()))
+            : _DashboardContent(
+                selection: selection,
+                data: data,
+                resolver: resolver,
+                categories: categories,
+                focusCategoryIds: preferences.focusCategoryIds,
+                onSelectUnit: controller.selectUnit,
+                onStep: controller.step,
+                onSelectToDate: controller.selectToDate,
+                onOpenCalendar: () =>
+                    showInsightsPeriodPicker(context: context),
+                onToggleCompare: controller.toggleCompare,
+                onToggleFocusCategory: ref
+                    .read(insightsPreferencesControllerProvider.notifier)
+                    .toggleFocusCategory,
               ),
-            ),
-          ),
-          data: (buckets) => _DashboardContent(
-            buckets: buckets,
-            selection: selection,
-            previousBuckets: previousBuckets,
-            previousRange: previousRange,
-            resolver: resolver,
-            categories: categories,
-            focusCategoryIds: preferences.focusCategoryIds,
-            onSelectUnit: ref
-                .read(insightsRangeControllerProvider.notifier)
-                .selectUnit,
-            onStep: ref.read(insightsRangeControllerProvider.notifier).step,
-            onSelectToDate: ref
-                .read(insightsRangeControllerProvider.notifier)
-                .selectToDate,
-            onOpenCalendar: () => showInsightsPeriodPicker(context: context),
-            onToggleCompare: ref
-                .read(insightsRangeControllerProvider.notifier)
-                .toggleCompare,
-            onToggleFocusCategory: ref
-                .read(insightsPreferencesControllerProvider.notifier)
-                .toggleFocusCategory,
-          ),
-        ),
       ),
     );
   }
 }
 
+/// A fully-resolved dashboard generation: a bucket set paired with the exact
+/// [selection] (and comparison window) it was computed for. Buckets are
+/// year-windowed, so the range they cover and the buckets must always travel
+/// together — rendering one period's buckets against another period's range
+/// would zero-fill the dashboard. Retained by [_TimeAnalysisPageState] for
+/// keepPreviousData across year-boundary loads.
+@immutable
+class _DashboardData {
+  const _DashboardData({
+    required this.selection,
+    required this.buckets,
+    required this.previousRange,
+    required this.previousBuckets,
+  });
+
+  final InsightsPeriodSelection selection;
+  final InsightsDayBuckets buckets;
+
+  /// Comparison window + its buckets when compare is on (else null). The
+  /// buckets can be null even here if the comparison window had not finished
+  /// loading when this generation was captured; the body simply omits the
+  /// comparison columns until a later generation carries them.
+  final InsightsRange? previousRange;
+  final InsightsDayBuckets? previousBuckets;
+}
+
 class _DashboardContent extends StatelessWidget {
   const _DashboardContent({
-    required this.buckets,
     required this.selection,
-    required this.previousBuckets,
-    required this.previousRange,
+    required this.data,
     required this.resolver,
     required this.categories,
     required this.focusCategoryIds,
@@ -132,12 +190,15 @@ class _DashboardContent extends StatelessWidget {
     required this.onToggleFocusCategory,
   });
 
-  final InsightsDayBuckets buckets;
+  /// The live selection — drives the header/stepper only, so a year-boundary
+  /// step gets instant feedback even while [data] is still the previous
+  /// generation. Every body figure reads [data].selection instead.
   final InsightsPeriodSelection selection;
 
-  /// Previous-period buckets + range when comparison is on (else null).
-  final InsightsDayBuckets? previousBuckets;
-  final InsightsRange? previousRange;
+  /// The generation rendered in the body — possibly the previous period while a
+  /// new window loads (keepPreviousData). Its buckets and range are a matched
+  /// pair, never mixed across generations.
+  final _DashboardData data;
 
   final InsightsCategoryResolver resolver;
   final List<CategoryDefinition> categories;
@@ -153,7 +214,12 @@ class _DashboardContent extends StatelessWidget {
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final messages = context.messages;
-    final range = selection.range;
+    // Body figures derive from the generation's own selection/buckets — never
+    // the live [selection], whose range may point at a year still loading
+    // (which would zero-fill every derivation below).
+    final bodySelection = data.selection;
+    final range = bodySelection.range;
+    final buckets = data.buckets;
 
     // Pure derivations, recomputed per build (~1-3ms at 10k-50k entries,
     // measured — well within a frame). The daily/ranked aggregation is
@@ -184,8 +250,8 @@ class _DashboardContent extends StatelessWidget {
     // comparison is surfaced numerically (KPI deltas + the table's Δ% /
     // Previous columns), never as a second chart series: a previous-period
     // reference bar fights the focal data and reads as a loading/empty bar.
-    final compareRange = previousRange;
-    final prevBuckets = previousBuckets;
+    final compareRange = data.previousRange;
+    final prevBuckets = data.previousBuckets;
     InsightsKpis? previousKpis;
     Map<String?, int>? previousByCategory;
     if (compareRange != null && prevBuckets != null) {
@@ -237,10 +303,10 @@ class _DashboardContent extends StatelessWidget {
             // Don't strand the user on a dead period: widening to the whole
             // year (where data is likeliest) is the quieter secondary path,
             // dropped once already viewing the year.
-            secondaryActionLabel: selection.unit != InsightsPeriodUnit.year
+            secondaryActionLabel: bodySelection.unit != InsightsPeriodUnit.year
                 ? messages.insightsEmptyShowYear
                 : null,
-            onSecondaryAction: selection.unit != InsightsPeriodUnit.year
+            onSecondaryAction: bodySelection.unit != InsightsPeriodUnit.year
                 ? () => onSelectUnit(InsightsPeriodUnit.year)
                 : null,
           )

--- a/lib/features/insights/ui/time_analysis_page.dart
+++ b/lib/features/insights/ui/time_analysis_page.dart
@@ -128,21 +128,36 @@ class _TimeAnalysisPageState extends ConsumerState<TimeAnalysisPage> {
                       ),
                     )
                   : const Center(child: CircularProgressIndicator()))
-            : _DashboardContent(
-                selection: selection,
-                data: data,
-                resolver: resolver,
-                categories: categories,
-                focusCategoryIds: preferences.focusCategoryIds,
-                onSelectUnit: controller.selectUnit,
-                onStep: controller.step,
-                onSelectToDate: controller.selectToDate,
-                onOpenCalendar: () =>
-                    showInsightsPeriodPicker(context: context),
-                onToggleCompare: controller.toggleCompare,
-                onToggleFocusCategory: ref
-                    .read(insightsPreferencesControllerProvider.notifier)
-                    .toggleFocusCategory,
+            : Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  // A failed window load keeps the last dashboard on screen
+                  // (never a blanking shell — that's the keepPreviousData
+                  // contract) but flags the staleness in a slim, non-blocking
+                  // strip. Without it, a deliberate step whose load fails would
+                  // silently mislabel the previous period's figures as the
+                  // newly selected one. Transient background-refetch errors show
+                  // it too and clear on the next successful refetch.
+                  if (bucketsAsync.hasError) const _StaleDataNotice(),
+                  Expanded(
+                    child: _DashboardContent(
+                      selection: selection,
+                      data: data,
+                      resolver: resolver,
+                      categories: categories,
+                      focusCategoryIds: preferences.focusCategoryIds,
+                      onSelectUnit: controller.selectUnit,
+                      onStep: controller.step,
+                      onSelectToDate: controller.selectToDate,
+                      onOpenCalendar: () =>
+                          showInsightsPeriodPicker(context: context),
+                      onToggleCompare: controller.toggleCompare,
+                      onToggleFocusCategory: ref
+                          .read(insightsPreferencesControllerProvider.notifier)
+                          .toggleFocusCategory,
+                    ),
+                  ),
+                ],
               ),
       ),
     );
@@ -173,6 +188,48 @@ class _DashboardData {
   /// comparison columns until a later generation carries them.
   final InsightsRange? previousRange;
   final InsightsDayBuckets? previousBuckets;
+}
+
+/// Slim, non-blocking strip shown above the (retained) dashboard when a window
+/// load fails. It surfaces the failure without blanking the established data —
+/// the project's "background refresh uses a subtle affordance, never a loading
+/// or error shell" rule. Aligned to the dashboard's content gutter (step6).
+class _StaleDataNotice extends StatelessWidget {
+  const _StaleDataNotice();
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+        tokens.spacing.step6,
+        tokens.spacing.step4,
+        tokens.spacing.step6,
+        0,
+      ),
+      child: Row(
+        children: [
+          Icon(
+            Icons.sync_problem_rounded,
+            size: tokens.spacing.step5,
+            color: tokens.colors.text.lowEmphasis,
+          ),
+          SizedBox(width: tokens.spacing.step2),
+          Flexible(
+            child: Text(
+              context.messages.insightsRefreshError,
+              style: tokens.typography.styles.others.caption.copyWith(
+                color: tokens.colors.text.lowEmphasis,
+              ),
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
 }
 
 class _DashboardContent extends StatelessWidget {

--- a/lib/features/insights/ui/widgets/insights_chart_card_charts.dart
+++ b/lib/features/insights/ui/widgets/insights_chart_card_charts.dart
@@ -102,7 +102,8 @@ class StackedBarChart extends StatelessWidget {
               leftTitles: AxisTitles(
                 sideTitles: SideTitles(
                   showTitles: true,
-                  reservedSize: 44,
+                  reservedSize:
+                      56, // fits four-digit hour ticks (see _axisLabel)
                   interval: interval,
                   getTitlesWidget: (value, meta) => SideTitleWidget(
                     meta: meta,
@@ -194,11 +195,14 @@ class StackedBarChart extends StatelessWidget {
                               brightness,
                               seriesKey: data.seriesKeys[s],
                             ),
-                            // Hairline cut between bands (skip the first, which
-                            // sits on the baseline).
-                            borderSide: from == 0.0
-                                ? BorderSide.none
-                                : segmentEdge,
+                            // Hairline cut between bands, in the card colour.
+                            // Applied to EVERY band, baseline included: fl_chart
+                            // strokes a stack item's whole rectangle (left/right
+                            // sides too, not just the divider edge), so bordering
+                            // only the upper bands left the baseline band a
+                            // hair wider than the rest. A uniform edge insets
+                            // every band equally, keeping the bar one width.
+                            borderSide: segmentEdge,
                           ),
                         );
                         from += value;
@@ -303,7 +307,7 @@ class StackedAreaChart extends StatelessWidget {
           leftTitles: AxisTitles(
             sideTitles: SideTitles(
               showTitles: true,
-              reservedSize: 44,
+              reservedSize: 56, // fits four-digit hour ticks (see _axisLabel)
               interval: interval,
               getTitlesWidget: (value, meta) => SideTitleWidget(
                 meta: meta,
@@ -516,15 +520,10 @@ String _axisLabel(double seconds) {
   final minutes = seconds ~/ 60;
   if (minutes < 60) return '${minutes}m';
   final h = minutes / 60;
-  // Roll into days once the hour count would reach 3-4 digits, so a cumulative
-  // year tick reads "42d" instead of "1008h" (which overflows the gutter and
-  // clips to a wrong-order "008h"); also keeps one unit voice with the KPI.
-  if (h >= 24) {
-    final d = h / 24;
-    return d == d.roundToDouble()
-        ? '${d.round()}d'
-        : '${d.toStringAsFixed(1)}d';
-  }
+  // Whole hours throughout — no day rollup. Days are ambiguous for tracked
+  // time (a 24h day? an 8h workday?), so the axis speaks the same hours voice
+  // as the KPI summary. Four-digit cumulative-year ticks ("1008h") are why the
+  // left gutter (reservedSize) reserves extra width.
   return h == h.roundToDouble() ? '${h.round()}h' : '${h.toStringAsFixed(1)}h';
 }
 

--- a/lib/features/insights/ui/widgets/insights_format.dart
+++ b/lib/features/insights/ui/widgets/insights_format.dart
@@ -25,16 +25,18 @@ String formatDurationTable(int seconds) {
   return '$h:${m.toString().padLeft(2, '0')}';
 }
 
-/// Compact with a day rollup for long spans: `40d 7h`, otherwise `2h 15m` /
-/// `45m`. Headline totals at quarter/year scale reach four-digit hour counts
-/// ("966h 59m") that are hard to grasp; rolling into days makes the magnitude
-/// legible. Kicks in at 100h (~4 days), below which `2h`-style reads fine.
-String formatDurationWithDays(int seconds) {
+/// The KPI summary figure: compact `2h 15m` / `45m` for normal spans, a single
+/// rounded whole-hour count for long ones (`967h`). At quarter/year scale the
+/// total reaches a four-digit hour count whose trailing minutes are noise
+/// ("966h 59m"); collapsing to whole hours keeps the magnitude legible. Days
+/// are deliberately avoided — "10d" is ambiguous (a 24h day? an 8h workday?)
+/// for tracked time nobody logs around the clock. Rounds rather than truncates
+/// so a ~59-minute remainder isn't silently dropped. The 100h cut-in (~4 days)
+/// is where the minute detail stops earning its place.
+String formatDurationSummary(int seconds) {
   final totalHours = seconds ~/ 3600;
   if (totalHours < 100) return formatDurationCompact(seconds);
-  final d = totalHours ~/ 24;
-  final h = totalHours % 24;
-  return h == 0 ? '${d}d' : '${d}d ${h}h';
+  return '${(seconds / 3600).round()}h';
 }
 
 /// `42%`; values under 1% render as `<1%` so small categories never show

--- a/lib/features/insights/ui/widgets/insights_kpi_row.dart
+++ b/lib/features/insights/ui/widgets/insights_kpi_row.dart
@@ -245,9 +245,9 @@ class _KpiTile extends StatelessWidget {
             ),
             SizedBox(height: tokens.spacing.step3),
             Text(
-              // Rolls into days at quarter/year scale so a ~1000h headline
-              // stays legible; below 100h this is the familiar "3h 40m".
-              formatDurationWithDays(seconds),
+              // Rounds to whole hours at quarter/year scale so a ~1000h
+              // summary stays legible; below 100h this is the familiar "3h 40m".
+              formatDurationSummary(seconds),
               style: calmDisplayStyle(tokens),
             ),
             // In compare mode the trend leads: the signed delta is the second
@@ -279,7 +279,7 @@ class _KpiTile extends StatelessWidget {
                 // The baseline + comparison basis trails the delta: same
                 // elapsed days while in progress, the whole period once done.
                 '${context.messages.insightsCompareVs} '
-                '${formatDurationWithDays(previousSeconds)}'
+                '${formatDurationSummary(previousSeconds)}'
                 ' · '
                 '${inProgress ? context.messages.insightsCompareSameDays : context.messages.insightsCompareFullPeriod}',
                 style: tokens.typography.styles.others.caption.copyWith(

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -2144,6 +2144,7 @@
   "insightsRangeMtd": "Tento měsíc",
   "insightsRangeYearToDate": "Tento rok zatím",
   "insightsRangeYtd": "Tento rok",
+  "insightsRefreshError": "Nepodařilo se obnovit — zobrazují se naposledy načtená data",
   "insightsTableAvgPerDay": "Ø/DEN",
   "insightsTableCategory": "KATEGORIE",
   "insightsTableCompareNote": "Změna oproti předchozímu období",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2352,6 +2352,7 @@
   "insightsRangeMtd": "Dieser Monat",
   "insightsRangeYearToDate": "Dieses Jahr bisher",
   "insightsRangeYtd": "Dieses Jahr",
+  "insightsRefreshError": "Aktualisierung fehlgeschlagen — zuletzt geladene Daten werden angezeigt",
   "insightsTableAvgPerDay": "Ø/TAG",
   "insightsTableCategory": "KATEGORIE",
   "insightsTableCompareNote": "Änderung ggü. dem vorigen Zeitraum",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2627,6 +2627,7 @@
   "insightsRangeMtd": "This month",
   "insightsRangeYearToDate": "This year so far",
   "insightsRangeYtd": "This year",
+  "insightsRefreshError": "Couldn't refresh — showing the last loaded data",
   "insightsTableAvgPerDay": "AVG/DAY",
   "insightsTableCategory": "CATEGORY",
   "insightsTableCompareNote": "Change is vs the previous period",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2352,6 +2352,7 @@
   "insightsRangeMtd": "Este mes",
   "insightsRangeYearToDate": "Este año hasta ahora",
   "insightsRangeYtd": "Este año",
+  "insightsRefreshError": "No se pudo actualizar — se muestran los últimos datos cargados",
   "insightsTableAvgPerDay": "MEDIA/DÍA",
   "insightsTableCategory": "CATEGORÍA",
   "insightsTableCompareNote": "Cambio frente al período anterior",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -2352,6 +2352,7 @@
   "insightsRangeMtd": "Ce mois-ci",
   "insightsRangeYearToDate": "Cette année jusqu'ici",
   "insightsRangeYtd": "Cette année",
+  "insightsRefreshError": "Échec de l'actualisation — affichage des dernières données chargées",
   "insightsTableAvgPerDay": "MOY./JOUR",
   "insightsTableCategory": "CATÉGORIE",
   "insightsTableCompareNote": "Évolution par rapport à la période précédente",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -9066,6 +9066,12 @@ abstract class AppLocalizations {
   /// **'This year'**
   String get insightsRangeYtd;
 
+  /// No description provided for @insightsRefreshError.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t refresh — showing the last loaded data'**
+  String get insightsRefreshError;
+
   /// No description provided for @insightsTableAvgPerDay.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -5219,6 +5219,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get insightsRangeYtd => 'Tento rok';
 
   @override
+  String get insightsRefreshError =>
+      'Nepodařilo se obnovit — zobrazují se naposledy načtená data';
+
+  @override
   String get insightsTableAvgPerDay => 'Ø/DEN';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -5223,6 +5223,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get insightsRangeYtd => 'Dieses Jahr';
 
   @override
+  String get insightsRefreshError =>
+      'Aktualisierung fehlgeschlagen — zuletzt geladene Daten werden angezeigt';
+
+  @override
   String get insightsTableAvgPerDay => 'Ø/TAG';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -5157,6 +5157,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get insightsRangeYtd => 'This year';
 
   @override
+  String get insightsRefreshError =>
+      'Couldn\'t refresh — showing the last loaded data';
+
+  @override
   String get insightsTableAvgPerDay => 'AVG/DAY';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -5250,6 +5250,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get insightsRangeYtd => 'Este año';
 
   @override
+  String get insightsRefreshError =>
+      'No se pudo actualizar — se muestran los últimos datos cargados';
+
+  @override
   String get insightsTableAvgPerDay => 'MEDIA/DÍA';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -5262,6 +5262,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get insightsRangeYtd => 'Cette année';
 
   @override
+  String get insightsRefreshError =>
+      'Échec de l\'actualisation — affichage des dernières données chargées';
+
+  @override
   String get insightsTableAvgPerDay => 'MOY./JOUR';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -5264,6 +5264,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get insightsRangeYtd => 'Anul acesta';
 
   @override
+  String get insightsRefreshError =>
+      'Reîmprospătarea a eșuat — se afișează ultimele date încărcate';
+
+  @override
   String get insightsTableAvgPerDay => 'MEDIE/ZI';
 
   @override

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -2352,6 +2352,7 @@
   "insightsRangeMtd": "Luna aceasta",
   "insightsRangeYearToDate": "Anul acesta până acum",
   "insightsRangeYtd": "Anul acesta",
+  "insightsRefreshError": "Reîmprospătarea a eșuat — se afișează ultimele date încărcate",
   "insightsTableAvgPerDay": "MEDIE/ZI",
   "insightsTableCategory": "CATEGORIE",
   "insightsTableCompareNote": "Modificare față de perioada anterioară",

--- a/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,6 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Blaizzy/mlx-audio-swift.git",
       "state" : {
-        "branch" : "main",
         "revision" : "7734cd1fbbe86460083c1d24199737a24cadfcc8"
       }
     },

--- a/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,6 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Blaizzy/mlx-audio-swift.git",
       "state" : {
-        "branch" : "main",
         "revision" : "7734cd1fbbe86460083c1d24199737a24cadfcc8"
       }
     },

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1022+4138
+version: 0.9.1022+4139
 
 msix_config:
   display_name: LottiApp

--- a/test/features/insights/ui/time_analysis_page_test.dart
+++ b/test/features/insights/ui/time_analysis_page_test.dart
@@ -310,4 +310,49 @@ void main() {
       expect(find.text('2h 15m'), findsNothing);
     },
   );
+
+  testWidgets(
+    'a failed year-crossing load keeps the last data and surfaces a '
+    'non-blocking refresh notice instead of a shell',
+    (tester) async {
+      // 2026 loads; the 2025 window fetch throws. After a successful first
+      // load the data is never blanked, so the failure must be surfaced inline.
+      when(
+        () => repository.fetchTimeRows(
+          start: any(named: 'start'),
+          end: any(named: 'end'),
+        ),
+      ).thenAnswer((invocation) {
+        final start = invocation.namedArguments[#start] as DateTime;
+        if (start.year <= 2025) throw StateError('boom');
+        return Future.value([
+          row(daysAgo: 1, hour: 9, minutes: 135, categoryId: 'cat-client'),
+        ]);
+      });
+      await pumpPage(tester);
+      expect(find.text('2h 15m'), findsOneWidget);
+
+      await withClock(Clock.fixed(fixedNow), () async {
+        await tester.tap(find.text('Month'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Year'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 600));
+        // Step back into 2025 — the window load throws.
+        await tester.tap(find.byIcon(Icons.chevron_left_rounded));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 600));
+      });
+
+      // The 2026 figures stay on screen — never the load-error shell or a
+      // spinner.
+      expect(find.text('2h 15m'), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.text("Couldn't load time data"), findsNothing);
+      // The failure is surfaced as a slim, non-blocking notice instead.
+      expect(find.textContaining("Couldn't refresh"), findsOneWidget);
+      // The header still reflects the period the user stepped to.
+      expect(find.text('2025'), findsOneWidget);
+    },
+  );
 }

--- a/test/features/insights/ui/time_analysis_page_test.dart
+++ b/test/features/insights/ui/time_analysis_page_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -246,4 +248,66 @@ void main() {
     // — named at both the KPI and the table (never the misleading full period).
     expect(find.textContaining('same days'), findsWidgets);
   });
+
+  testWidgets(
+    'stepping across a year keeps the previous data on screen while the new '
+    'window loads, instead of flashing a spinner',
+    (tester) async {
+      // The bucket window is keyed by year, so crossing a year boundary spins
+      // up a fresh provider instance with no value yet. The current year
+      // (2026) loads at once; the previous year (2025) is held pending so the
+      // transition frame can be observed.
+      final pending2025 = Completer<List<InsightsTimeRow>>();
+      when(
+        () => repository.fetchTimeRows(
+          start: any(named: 'start'),
+          end: any(named: 'end'),
+        ),
+      ).thenAnswer((invocation) {
+        final start = invocation.namedArguments[#start] as DateTime;
+        if (start.year <= 2025) return pending2025.future;
+        // 2026: a single 2h 15m entry — non-round so it can't collide with a
+        // round chart axis tick.
+        return Future.value([
+          row(daysAgo: 1, hour: 9, minutes: 135, categoryId: 'cat-client'),
+        ]);
+      });
+      await pumpPage(tester);
+      expect(find.text('2h 15m'), findsOneWidget); // June 2026 month-to-date
+
+      await withClock(Clock.fixed(fixedNow), () async {
+        // Widen to the year — still 2026, same in-memory window, no fetch.
+        await tester.tap(find.text('Month'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Year'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 600));
+        // Step back into 2025: a new window that stays pending.
+        await tester.tap(find.byIcon(Icons.chevron_left_rounded));
+        await tester.pump();
+      });
+
+      // keepPreviousData: 2025 is still loading, but the dashboard keeps the
+      // 2026 figures on screen rather than flashing a loading shell.
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.text('2h 15m'), findsOneWidget);
+      // The header/stepper, however, already reflects the period just selected.
+      expect(find.text('2025'), findsOneWidget);
+
+      // Once 2025 resolves, the body swaps to its figures (4h 50m).
+      await withClock(Clock.fixed(fixedNow), () async {
+        pending2025.complete([
+          InsightsTimeRow(
+            dateFrom: DateTime(2025, 6, 1, 9),
+            dateTo: DateTime(2025, 6, 1, 13, 50),
+            categoryId: 'cat-client',
+          ),
+        ]);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 600));
+      });
+      expect(find.text('4h 50m'), findsOneWidget);
+      expect(find.text('2h 15m'), findsNothing);
+    },
+  );
 }

--- a/test/features/insights/ui/widgets/insights_chart_card_test.dart
+++ b/test/features/insights/ui/widgets/insights_chart_card_test.dart
@@ -278,6 +278,33 @@ void main() {
     expect(borders.last, greaterThan(0.0));
   });
 
+  testWidgets(
+    'every stacked band carries the divider edge, so the bar is one width',
+    (tester) async {
+      // Two bands in one bucket. The baseline band used to skip the hairline
+      // edge while the band above carried it; because fl_chart strokes a stack
+      // item's whole rectangle (sides included), that left the baseline band a
+      // hair wider than the rest. Now every band carries the same edge.
+      final data = InsightsChartData(
+        granularity: InsightsGranularity.day,
+        bucketStarts: [DateTime(2026, 6)],
+        seriesKeys: const ['cat-a', 'cat-b'],
+        values: const [
+          [3600],
+          [1800],
+        ],
+      );
+      await withClock(Clock.fixed(DateTime(2026, 6, 7, 15)), () async {
+        await pumpCard(tester, data: data);
+      });
+
+      final chart = tester.widget<BarChart>(find.byType(BarChart));
+      final stack = chart.data.barGroups.single.barRods.single.rodStackItems;
+      expect(stack.length, 2);
+      expect(stack.every((item) => item.borderSide.width > 0), isTrue);
+    },
+  );
+
   group('tooltips', () {
     testWidgets(
       'bar tooltip reads out every band for the bucket, largest first',
@@ -452,6 +479,27 @@ void main() {
       // Thinned to every 5th label: May 9 shown, May 10 suppressed.
       expect(find.text('May 9'), findsOneWidget);
       expect(find.text('May 10'), findsNothing);
+    });
+
+    testWidgets('y-axis labels stay in whole hours, never days', (
+      tester,
+    ) async {
+      // 24h in one bucket lands a gridline exactly at 24h. The axis used to
+      // roll anything >= 24h into days ("1d"); it now reads plain hours so it
+      // speaks the same unit as the KPI summary.
+      final data = InsightsChartData(
+        granularity: InsightsGranularity.day,
+        bucketStarts: [DateTime(2026, 6)],
+        seriesKeys: const ['cat-a'],
+        values: const [
+          [86400],
+        ],
+      );
+      await withClock(Clock.fixed(DateTime(2026, 6, 7, 15)), () async {
+        await pumpCard(tester, data: data);
+      });
+      expect(find.text('24h'), findsOneWidget);
+      expect(find.text('1d'), findsNothing);
     });
   });
 }

--- a/test/features/insights/ui/widgets/insights_format_test.dart
+++ b/test/features/insights/ui/widgets/insights_format_test.dart
@@ -33,20 +33,22 @@ void main() {
     });
   });
 
-  group('formatDurationWithDays', () {
+  group('formatDurationSummary', () {
     test('reads like compact below 100h', () {
-      expect(formatDurationWithDays(0), '0m');
-      expect(formatDurationWithDays(2 * 3600 + 15 * 60), '2h 15m');
-      expect(formatDurationWithDays(99 * 3600), '99h');
+      expect(formatDurationSummary(0), '0m');
+      expect(formatDurationSummary(2 * 3600 + 15 * 60), '2h 15m');
+      expect(formatDurationSummary(99 * 3600), '99h');
+      expect(formatDurationSummary(99 * 3600 + 59 * 60), '99h 59m');
     });
 
-    test('rolls into days at and above 100h', () {
-      // 100h = 4 days 4 hours.
-      expect(formatDurationWithDays(100 * 3600), '4d 4h');
-      // Whole days drop the hour component.
-      expect(formatDurationWithDays(120 * 3600), '5d');
-      // ~966h (the legacy hard-to-grasp case) becomes a legible day count.
-      expect(formatDurationWithDays(966 * 3600 + 59 * 60), '40d 6h');
+    test('collapses to rounded whole hours at and above 100h', () {
+      // The minute remainder turns to noise at this magnitude, so it folds
+      // into a single hour count — never the ambiguous "4d 4h".
+      expect(formatDurationSummary(100 * 3600), '100h');
+      // Rounds to the nearest hour: 966h 59m → 967h ...
+      expect(formatDurationSummary(966 * 3600 + 59 * 60), '967h');
+      // ... and 966h 29m → 966h.
+      expect(formatDurationSummary(966 * 3600 + 29 * 60), '966h');
     });
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Time Analysis now preserves the last loaded dashboard when switching across calendar years; background loads no longer show a blocking spinner.
  * Added a non-blocking “couldn’t refresh” notice when insights refresh fails, showing the last loaded data.
* **Bug Fixes**
  * Header/stepper updates continue to reflect the current selection while charts/tables retain cached data until new buckets are ready.
* **Style**
  * Duration KPIs now display whole hours for longer ranges (e.g., `967h`).
  * Chart axis labels and stacked segment separators were refined for clearer hour-based labeling.
* **Documentation**
  * Updated dashboard window caching and y-axis labeling documentation.
* **Tests**
  * Added UI regression coverage for year-boundary and chart/label behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->