### PR TITLE
feat: enable TTS on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1025]
+### Added
+- Experimental on-device text-to-speech is now available on Linux too (in
+  addition to macOS and iOS): with the "Enable local AI summary playback" flag
+  on, the AI summary card's play button reads a task's TL;DR aloud — or the full
+  report when expanded — synthesized locally with the Supertonic model, no
+  cloud. Still off by default; the model (~400 MB) downloads once on first use.
+
 ## [0.9.1024]
 ### Changed
 - Category selection is now one consistent picker across the app. Assigning a

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -40,6 +40,36 @@ direct-build/output/
 └── cargokit/                        # Cargokit patches
 ```
 
+### ONNX Runtime (on-device TTS)
+
+`flutter_onnxruntime` (vendored fork under `third_party/flutter_onnxruntime`)
+powers on-device TTS. Its Linux CMake otherwise **downloads** the ONNX Runtime
+binary at configure time, which fails in the offline Flathub build sandbox
+(`CMake Error … extraction directory doesn't exist`).
+
+This is handled directly in the manifest template
+(`com.matthiasn.lotti.flatpak-flutter.yml`), not via the `foreign_deps.json`
+overlay — that overlay targets pub.dev packages (objectbox, sqlite3), whereas
+this is a path-dependency fork we own:
+
+- An `onnxruntime` module vendors the official prebuilt runtime as declared
+  per-arch `archive` sources (fetched in the networked download phase) and
+  installs `lib/` + `include/` into `/app`.
+- The `lotti` module exports `ONNXRUNTIME_ROOT_DIR=/app` (and
+  `CMAKE_PREFIX_PATH=/app`); the fork's CMake seeds `ONNXRUNTIME_ROOT_DIR` from
+  that env (a `LOTTI FORK PATCH`) and finds the pre-provided runtime instead of
+  downloading.
+
+**When bumping the ONNX Runtime version** (must match what the fork's CMake
+expects — currently `1.22.0`): update both the URL and the `sha256` for each
+arch in the `onnxruntime` module. Get the hashes with:
+
+```bash
+for a in x64 aarch64; do
+  curl -sL "https://github.com/microsoft/onnxruntime/releases/download/v<VER>/onnxruntime-linux-$a-<VER>.tgz" | sha256sum
+done
+```
+
 ## Release Workflow
 
 ### Automated (primary path)

--- a/flatpak/com.matthiasn.lotti.flatpak-flutter.yml
+++ b/flatpak/com.matthiasn.lotti.flatpak-flutter.yml
@@ -86,6 +86,28 @@ modules:
       - type: archive
         url: https://github.com/kupferlauncher/keybinder/releases/download/keybinder-3.0-v0.3.2/keybinder-3.0-0.3.2.tar.gz
         sha256: e6e3de4e1f3b201814a956ab8f16dfc8a262db1937ff1eee4d855365398c6020
+  # ONNX Runtime for on-device TTS (flutter_onnxruntime). The plugin's CMake
+  # otherwise downloads this binary at configure time, which fails in Flathub's
+  # offline build sandbox. Vendor the official prebuilt runtime as a declared
+  # source (fetched during the networked download phase) and install it into
+  # /app so the plugin links it via ONNXRUNTIME_ROOT_DIR / CMAKE_PREFIX_PATH.
+  - name: onnxruntime
+    buildsystem: simple
+    build-commands:
+      - install -d /app/lib /app/include
+      - cp -a lib/. /app/lib/
+      - cp -a include/. /app/include/
+    sources:
+      - type: archive
+        only-arches:
+          - x86_64
+        url: https://github.com/microsoft/onnxruntime/releases/download/v1.22.0/onnxruntime-linux-x64-1.22.0.tgz
+        sha256: 8344d55f93d5bc5021ce342db50f62079daf39aaafb5d311a451846228be49b3
+      - type: archive
+        only-arches:
+          - aarch64
+        url: https://github.com/microsoft/onnxruntime/releases/download/v1.22.0/onnxruntime-linux-aarch64-1.22.0.tgz
+        sha256: bb76395092d150b52c7092dc6b8f2fe4d80f0f3bf0416d2f269193e347e24702
   # NOTE: No separate flutter-sdk module - Flutter is included in lotti sources for flatpak-flutter
   - name: lotti
     buildsystem: simple
@@ -97,9 +119,16 @@ modules:
         CARGO_HOME: /run/build/lotti/cargo
         RUSTUP_HOME: /var/lib/rustup
         FLUTTER_SUPPRESS_ANALYTICS: "true"
+        # Resolve /app-installed deps (libmpv, onnxruntime, ...) and point
+        # flutter_onnxruntime's CMake at the vendored ONNX Runtime in /app so it
+        # links the pre-provided library instead of downloading one (the build
+        # runs offline). Set here in env, not as a standalone `export`
+        # build-command — each build-command runs in its own shell, so an export
+        # on its own line would not carry into the `flutter build` invocation.
+        CMAKE_PREFIX_PATH: /app
+        ONNXRUNTIME_ROOT_DIR: /app
     build-commands:
       - flutter pub get --offline
-      - export CMAKE_PREFIX_PATH=/app:$CMAKE_PREFIX_PATH
       - flutter build linux --release --no-pub --verbose
       - |
         arch="x64"

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -32,6 +32,11 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="0.9.1025" date="2026-06-15">
+      <description>
+          <p>Experimental on-device text-to-speech is now available on Linux too: with the "Enable local AI summary playback" flag on, the AI summary card's play button reads a task's TL;DR aloud, synthesized locally with the Supertonic model — no cloud. Still off by default; the model (~400 MB) downloads once on first use.</p>
+      </description>
+    </release>
     <release version="0.9.1024" date="2026-06-15">
       <description>
           <p>Category selection is now one consistent picker across the app: assigning a category (entries, tasks, projects, habits, dashboards, time blocks) opens the same searchable sheet and applies on tap, and the habits and dashboards category filters use that same sheet with an Apply button instead of toggling on each tap.</p>

--- a/lib/features/tts/README.md
+++ b/lib/features/tts/README.md
@@ -5,22 +5,26 @@ On-device text-to-speech that reads a task's AI **TL;DR** aloud: it runs the
 (~99M params, 44.1kHz 16-bit WAV) locally via `flutter_onnxruntime` and plays
 the result through the app's existing `media_kit` stack. No cloud, no API.
 
-The engine is wired (`ttsEngine` → `SupertonicOnnxEngine` on the Apple platforms
-— macOS + iOS — behind a `TtsEngine` interface). onnxruntime ships as a
-statically linked binary, which CocoaPods rejects under the project's dynamic
-`use_frameworks!`; rather than the global `use_frameworks! :linkage => :static`
-(which breaks `super_native_extensions`' Rust FFI), both `macos/Podfile` and
-`ios/Podfile` use a targeted `pre_install` hook that forces only the
-`flutter_onnxruntime` plugin and its `onnxruntime-*` deps to link statically
-(`static_library` on macOS; `static_framework` on iOS so the ObjC `@import` in
-`GeneratedPluginRegistrant.m` finds a module). The ten voice-style JSONs are
-bundled under `assets/tts/voice_styles/`; the ~400MB `onnx/` model files are
-**downloaded from Hugging Face on first use** (see the download repository —
-filenames verified against the repo). This feature **replaces** the previous
-MLX/Qwen3-TTS "speak summary" path and is gated behind the
+The engine is wired (`ttsEngine` → `SupertonicOnnxEngine` on macOS, iOS, and
+Linux — behind a `TtsEngine` interface). On the Apple platforms onnxruntime
+ships as a statically linked binary, which CocoaPods rejects under the project's
+dynamic `use_frameworks!`; rather than the global
+`use_frameworks! :linkage => :static` (which breaks `super_native_extensions`'
+Rust FFI), both `macos/Podfile` and `ios/Podfile` use a targeted `pre_install`
+hook that forces only the `flutter_onnxruntime` plugin and its `onnxruntime-*`
+deps to link statically (`static_library` on macOS; `static_framework` on iOS so
+the ObjC `@import` in `GeneratedPluginRegistrant.m` finds a module). On Linux
+there is no such friction: the plugin's CMake resolves onnxruntime from a system
+install via `pkg-config` when present and otherwise auto-downloads the official
+`onnxruntime-linux-x64`/`-aarch64` release at build time, and audio plays through
+`media_kit_libs_linux` (libmpv → PipeWire/PulseAudio/ALSA). The ten voice-style
+JSONs are bundled under `assets/tts/voice_styles/`; the ~400MB `onnx/` model
+files are **downloaded from Hugging Face on first use** (see the download
+repository — filenames verified against the repo). This feature **replaces** the
+previous MLX/Qwen3-TTS "speak summary" path and is gated behind the
 `enable_ai_summary_tts` config flag (default off), so the playback control
-appears once the flag is on, the engine is supported (macOS or iOS), and a
-TL;DR exists.
+appears once the flag is on, the engine is supported (macOS, iOS, or Linux), and
+a TL;DR exists.
 
 ## Architecture
 
@@ -74,6 +78,28 @@ distinct from the audio control. This **replaced** the old fire-and-forget MLX
   (flutter/flutter#162613). Without it, synthesis blocks the main thread and the
   preparing spinner stutters. See `third_party/flutter_onnxruntime/LOTTI_PATCHES.md`.
 
+## Platform threading caveat
+
+`isSupported` is true on macOS, iOS, and Linux, but the off-main-thread
+guarantee differs per platform:
+
+- **iOS** offloads `runInference` correctly via its working platform-channel
+  task queue.
+- **macOS** is offloaded by the fork patch above (`workQueue`).
+- **Linux** uses the **upstream** plugin unchanged: its GLib/GTK
+  `method_call_handler` dispatches `runInference` **synchronously on the
+  platform (main) thread**, and the Linux desktop embedder has no
+  background-task-queue API to offload to. ONNX Runtime's own intra-op thread
+  pool still parallelizes the math across cores, but the ~32 inference calls per
+  utterance block the UI thread for the duration of synthesis — the same stall
+  the macOS fork was created to avoid. Functionally TTS works on Linux (audio
+  generates and plays); the smooth-UX guarantee does **not** yet hold there.
+  Closing this needs the macOS treatment ported to the Linux plugin (offload
+  `runInference` to a `GTask`/worker thread and reply from the worker) — a
+  native fork patch analogous to the macOS one, not a Dart-side change (calling
+  the channel from a background Dart isolate would not help, since the native
+  handler still runs on the GTK main thread).
+
 ## Remaining work (handoff)
 
 - **End-to-end run:** the first playback downloads ~400MB of `onnx/` model
@@ -83,6 +109,10 @@ distinct from the audio control. This **replaced** the old fire-and-forget MLX
   `isSupported` on macOS + iOS and `ios/Podfile` links the static framework),
   but the ~400MB model download is heavy on a phone and inference is slower on
   mobile CPUs — add a Wi-Fi/size confirmation before enabling it broadly on iOS.
+- **Linux off-main-thread patch:** port the macOS `workQueue` offload to the
+  Linux plugin so `runInference` no longer blocks the GTK main thread (see
+  "Platform threading caveat"), then exercise an end-to-end run on Linux
+  (download + synth + playback) on PipeWire/PulseAudio.
 - **Dead-code cleanup:** `MlxAudioChannel.speakText`/`stopSpeaking` and the
   Qwen3-TTS catalog entry are unreachable but still co-tested with ASR
   behaviour; remove them in a focused pass that preserves the ASR tests.
@@ -133,6 +163,16 @@ The `onnx/` model files (`duration_predictor`, `text_encoder`,
 bundled. The tiny voice-style JSONs (`voice_styles/<id>.json`) are bundled
 assets. `flutter_onnxruntime` fetches its native runtime at install time and
 needs iOS deployment target ≥ 16.0 (`ios/Podfile` is on 17.0) and macOS ≥ 14.0.
+On Linux the runtime is the onnxruntime shared library. For local desktop builds
+the plugin's CMake resolves it from a system install (`pkg-config`) or, failing
+that, auto-downloads it at build time. That auto-download is unavailable in the
+**offline Flathub sandbox**, so the Flathub manifest vendors the official
+prebuilt runtime into `/app` and points the build at it via
+`ONNXRUNTIME_ROOT_DIR=/app` (see `flatpak/README.md` → "ONNX Runtime (on-device
+TTS)" and `third_party/flutter_onnxruntime/LOTTI_PATCHES.md`). Playback needs the
+libmpv stack bundled by `media_kit_libs_linux` reaching a running audio server
+(PipeWire, PulseAudio, or ALSA) — no microphone or other runtime permission is
+required for playback.
 
 ## Testing
 

--- a/lib/features/tts/engine/supertonic_onnx_engine.dart
+++ b/lib/features/tts/engine/supertonic_onnx_engine.dart
@@ -27,8 +27,8 @@ typedef TempDirProvider = Future<Directory> Function();
 ///
 /// The loaded session and per-voice styles are cached so repeated playback
 /// reuses them. Synthesis writes a 44.1kHz WAV to a temp file the player
-/// opens. Gated to the Apple platforms (macOS + iOS), where `flutter_onnxruntime`
-/// is integrated and verified to link; other platforms fall back to the
+/// opens. Gated to the platforms where `flutter_onnxruntime` is integrated and
+/// verified to link (macOS, iOS, Linux); other platforms fall back to the
 /// unavailable engine.
 ///
 /// The session loader, voice-style loader, and temp-dir provider are injected
@@ -54,7 +54,8 @@ class SupertonicOnnxEngine implements TtsEngine {
   int _counter = 0;
 
   @override
-  bool get isSupported => platform.isMacOS || platform.isIOS;
+  bool get isSupported =>
+      platform.isMacOS || platform.isIOS || platform.isLinux;
 
   @override
   Future<File> synthesizeToFile({

--- a/lib/features/tts/state/tts_engine_provider.dart
+++ b/lib/features/tts/state/tts_engine_provider.dart
@@ -33,12 +33,12 @@ class UnavailableTtsEngine implements TtsEngine {
   Future<void> dispose() async {}
 }
 
-/// Provides the on-device TTS engine — the Supertonic ONNX engine on the Apple
-/// platforms (macOS + iOS), the unavailable fallback elsewhere. Tests override
-/// this with a fake.
+/// Provides the on-device TTS engine — the Supertonic ONNX engine on the
+/// platforms where `flutter_onnxruntime` is integrated (macOS, iOS, Linux), the
+/// unavailable fallback elsewhere. Tests override this with a fake.
 @Riverpod(keepAlive: true)
 TtsEngine ttsEngine(Ref ref) {
-  if (!platform.isMacOS && !platform.isIOS) {
+  if (!platform.isMacOS && !platform.isIOS && !platform.isLinux) {
     return const UnavailableTtsEngine();
   }
   final engine = SupertonicOnnxEngine();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1024+4142
+version: 0.9.1025+4143
 
 msix_config:
   display_name: LottiApp

--- a/test/features/tts/engine/supertonic_onnx_engine_test.dart
+++ b/test/features/tts/engine/supertonic_onnx_engine_test.dart
@@ -67,26 +67,39 @@ void main() {
   );
 
   group('isSupported', () {
-    test('is true on the Apple platforms and false elsewhere', () {
-      final engine = buildEngine();
-      final originalMac = platform.isMacOS;
-      final originalIos = platform.isIOS;
-      addTearDown(() {
-        platform.isMacOS = originalMac;
-        platform.isIOS = originalIos;
-      });
+    late bool originalMac;
+    late bool originalIos;
+    late bool originalLinux;
 
+    setUp(() {
+      originalMac = platform.isMacOS;
+      originalIos = platform.isIOS;
+      originalLinux = platform.isLinux;
+      // Clean baseline so the host platform doesn't leak into assertions.
       platform.isMacOS = false;
       platform.isIOS = false;
-      expect(engine.isSupported, isFalse);
-
-      platform.isMacOS = true;
-      expect(engine.isSupported, isTrue);
-
-      platform.isMacOS = false;
-      platform.isIOS = true;
-      expect(engine.isSupported, isTrue);
+      platform.isLinux = false;
     });
+    tearDown(() {
+      platform.isMacOS = originalMac;
+      platform.isIOS = originalIos;
+      platform.isLinux = originalLinux;
+    });
+
+    test('is false when no supported platform flag is set', () {
+      expect(buildEngine().isSupported, isFalse);
+    });
+
+    for (final entry in <String, void Function()>{
+      'macOS': () => platform.isMacOS = true,
+      'iOS': () => platform.isIOS = true,
+      'Linux': () => platform.isLinux = true,
+    }.entries) {
+      test('is true on ${entry.key}', () {
+        entry.value();
+        expect(buildEngine().isSupported, isTrue);
+      });
+    }
   });
 
   group('synthesizeToFile', () {

--- a/test/features/tts/state/tts_engine_provider_test.dart
+++ b/test/features/tts/state/tts_engine_provider_test.dart
@@ -32,31 +32,42 @@ void main() {
   group('ttsEngine provider', () {
     late bool originalMac;
     late bool originalIos;
+    late bool originalLinux;
 
     setUp(() {
       originalMac = platform.isMacOS;
       originalIos = platform.isIOS;
+      originalLinux = platform.isLinux;
+      // Clean baseline so the host platform doesn't leak into assertions.
+      platform.isMacOS = false;
+      platform.isIOS = false;
+      platform.isLinux = false;
     });
     tearDown(() {
       platform.isMacOS = originalMac;
       platform.isIOS = originalIos;
+      platform.isLinux = originalLinux;
     });
 
-    test('falls back to the unavailable engine off the Apple platforms', () {
-      platform.isMacOS = false;
-      platform.isIOS = false;
+    test('falls back to the unavailable engine on unsupported platforms', () {
       final container = ProviderContainer();
       addTearDown(container.dispose);
 
       expect(container.read(ttsEngineProvider), isA<UnavailableTtsEngine>());
     });
 
-    test('provides the Supertonic engine on the Apple platforms', () {
-      platform.isMacOS = true;
-      final container = ProviderContainer();
-      addTearDown(container.dispose);
+    for (final entry in <String, void Function()>{
+      'macOS': () => platform.isMacOS = true,
+      'iOS': () => platform.isIOS = true,
+      'Linux': () => platform.isLinux = true,
+    }.entries) {
+      test('provides the Supertonic engine on ${entry.key}', () {
+        entry.value();
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
 
-      expect(container.read(ttsEngineProvider), isA<SupertonicOnnxEngine>());
-    });
+        expect(container.read(ttsEngineProvider), isA<SupertonicOnnxEngine>());
+      });
+    }
   });
 }

--- a/third_party/flutter_onnxruntime/LOTTI_PATCHES.md
+++ b/third_party/flutter_onnxruntime/LOTTI_PATCHES.md
@@ -34,12 +34,41 @@ the engine from any thread.
 
 Search the file for `LOTTI FORK PATCH` to find the exact changes. Only the
 **macOS** implementation is patched; iOS/Android/Linux/Windows are byte-for-byte
-upstream (iOS already offloads correctly via its working task queue, and TTS is
-macOS-only for now).
+upstream (iOS already offloads correctly via its working task queue).
+
+TTS now also targets **Linux**, but the Linux plugin is still upstream for
+threading and runs `runInference` synchronously on the GTK main thread (no
+background-task-queue API in the Linux desktop embedder to offload to). So Linux
+synthesis blocks the UI thread the same way macOS did before this patch —
+functional, but not yet smooth. Porting the `workQueue` offload to the Linux
+plugin (dispatch `runInference` to a `GTask`/worker thread, reply from the
+worker) is the analogous fix; see `lib/features/tts/README.md` → "Platform
+threading caveat".
+
+### Linux: offline-build runtime resolution
+
+**File:** `linux/CMakeLists.txt` (search for `LOTTI FORK PATCH`).
+
+Upstream's Linux CMake downloads the ONNX Runtime binary at configure time when
+no system copy is found. That fails in offline/sandboxed builds (Flathub), where
+the network is unavailable during the build. The patch seeds the
+`ONNXRUNTIME_ROOT_DIR` cache variable from the environment variable of the same
+name, so the build can point at a pre-provided runtime (`lib/` + `include/`
+under a prefix such as `/app`) and skip the download. Unset → empty → upstream
+system-search-then-download behaviour is preserved. The Flathub manifest sets
+`ONNXRUNTIME_ROOT_DIR=/app` and vendors the runtime there; see
+`flatpak/README.md` → "ONNX Runtime (on-device TTS)".
 
 ## Upgrading
 
 When bumping `flutter_onnxruntime`, re-vendor the new version and re-apply the
-two `LOTTI FORK PATCH` edits (the `workQueue` property + the `handle` →
-`handleLocked` split). Ideally this lands upstream once macOS gains task-queue
-support (or as an opt-in `DispatchQueue` fallback); drop the fork then.
+`LOTTI FORK PATCH` edits:
+
+- **macOS** (`FlutterOnnxruntimePlugin.swift`): the `workQueue` property + the
+  `handle` → `handleLocked` split. Ideally this lands upstream once macOS gains
+  task-queue support (or as an opt-in `DispatchQueue` fallback); drop it then.
+- **Linux** (`linux/CMakeLists.txt`): the `ONNXRUNTIME_ROOT_DIR` env seeding.
+
+If the bundled ONNX Runtime **version** changes, also update the pinned binary
+URL + per-arch `sha256` in the Flathub manifest's `onnxruntime` module
+(`flatpak/com.matthiasn.lotti.flatpak-flutter.yml`).

--- a/third_party/flutter_onnxruntime/linux/CMakeLists.txt
+++ b/third_party/flutter_onnxruntime/linux/CMakeLists.txt
@@ -27,10 +27,25 @@ if(USE_SYSTEM_ONNXRUNTIME)
 
   # If pkg-config didn't find it, try to find it manually
   if(NOT ONNXRUNTIME_FOUND)
-    # Specify custom paths where ONNX Runtime might be installed
-    set(ONNXRUNTIME_ROOT_DIR
-        ""
-        CACHE PATH "ONNX Runtime root directory")
+    # Specify custom paths where ONNX Runtime might be installed.
+    # LOTTI FORK PATCH: seed from the ONNXRUNTIME_ROOT_DIR environment variable
+    # so offline/sandboxed builds (e.g. Flathub) can point at a pre-provided
+    # runtime (lib/ + include/ under that prefix, such as /app) instead of
+    # falling through to the network download below. When the env var is set it
+    # wins via FORCE, so a stale empty cache entry from an earlier configure
+    # (CMake never overwrites a cached value without FORCE) cannot mask it on
+    # reconfigure. When unset, the cache defaults to empty without FORCE, which
+    # preserves the upstream system-search-then-download behaviour and still
+    # honours an explicit -DONNXRUNTIME_ROOT_DIR override.
+    if(NOT ONNXRUNTIME_ROOT_DIR AND NOT "$ENV{ONNXRUNTIME_ROOT_DIR}" STREQUAL "")
+      set(ONNXRUNTIME_ROOT_DIR
+          "$ENV{ONNXRUNTIME_ROOT_DIR}"
+          CACHE PATH "ONNX Runtime root directory" FORCE)
+    else()
+      set(ONNXRUNTIME_ROOT_DIR
+          "$ENV{ONNXRUNTIME_ROOT_DIR}"
+          CACHE PATH "ONNX Runtime root directory")
+    endif()
 
     # Look for the library
     find_library(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Experimental on-device text-to-speech is now available on Linux. When you enable the “Enable local AI summary playback” flag, the AI summary card can read the TL;DR aloud (or the full report when expanded) using the Supertonic model, which downloads on first use (~400 MB). Feature remains off by default.
* **Documentation**
  * Updated TTS and Linux Flatpak/offline build notes for bundled on-device ONNX Runtime, first-use model behavior, and current Linux playback threading limitations.
* **Tests**
  * Improved platform-flag coverage for supported Linux/macOS/iOS scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->