### PR TITLE
fix: drop bottom hairline on docked mobile nav bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   report when expanded — synthesized locally with the Supertonic model, no
   cloud. Still off by default; the model (~400 MB) downloads once on first use.
 
+### Fixed
+- Mobile: removed the faint hairline that showed along the very bottom edge of
+  the bottom navigation bar. The bar docks flush against the screen, so its
+  bottom border is now dropped while the top and sides keep theirs.
+
 ## [0.9.1024]
 ### Changed
 - Category selection is now one consistent picker across the app. Assigning a

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -35,6 +35,7 @@
     <release version="0.9.1025" date="2026-06-15">
       <description>
           <p>Experimental on-device text-to-speech is now available on Linux too: with the "Enable local AI summary playback" flag on, the AI summary card's play button reads a task's TL;DR aloud, synthesized locally with the Supertonic model — no cloud. Still off by default; the model (~400 MB) downloads once on first use.</p>
+          <p>Fixed: removed the faint hairline that showed along the very bottom edge of the mobile bottom navigation bar, which docks flush against the screen.</p>
       </description>
     </release>
     <release version="0.9.1024" date="2026-06-15">

--- a/lib/features/design_system/components/navigation/design_system_five_slot_nav_bar.dart
+++ b/lib/features/design_system/components/navigation/design_system_five_slot_nav_bar.dart
@@ -97,15 +97,18 @@ class DesignSystemFiveSlotNavBar extends StatelessWidget {
 
   /// Total rendered height of the bar: content plus the frosted surface's
   /// vertical padding, its hairline border (which `Container` stacks onto
-  /// the padding on each side), and the absorbed bottom safe-area inset
-  /// (see [_bottomPadding]). Shared with the bottom-nav container's
-  /// occupied-height math so the numbers cannot drift apart.
+  /// the padding on each bordered side), and the absorbed bottom safe-area
+  /// inset (see [_bottomPadding]). The docked bar omits the bottom border
+  /// (`includeBottomBorder: false`), so only the top hairline contributes
+  /// here — a single [DesignSystemNavigationFrostedSurface.borderWidth], not
+  /// two. Shared with the bottom-nav container's occupied-height math so the
+  /// numbers cannot drift apart.
   static double barHeight(BuildContext context) {
     final tokens = context.designTokens;
     return contentHeight(context) +
         tokens.spacing.step2 +
         _bottomPadding(context) +
-        DesignSystemNavigationFrostedSurface.borderWidth * 2;
+        DesignSystemNavigationFrostedSurface.borderWidth;
   }
 
   /// Bottom padding of the frosted surface: [bottomInsetFraction] of the
@@ -184,6 +187,10 @@ class DesignSystemFiveSlotNavBar extends StatelessWidget {
       borderRadius: BorderRadius.vertical(
         top: Radius.circular(tokens.radii.sectionCards),
       ),
+      // Flush against the screen edge, so the bottom hairline would render
+      // as a stray light line below the bar — drop it. [barHeight] accounts
+      // for the single remaining (top) hairline.
+      includeBottomBorder: false,
       // The safe-area insets live inside the surface so the frosted fill
       // reaches the physical edges while the slot row stays clear of the
       // home indicator, notches, and landscape navigation buttons. The

--- a/lib/features/design_system/components/navigation/design_system_navigation_tab_bar.dart
+++ b/lib/features/design_system/components/navigation/design_system_navigation_tab_bar.dart
@@ -70,20 +70,38 @@ class DesignSystemNavigationFrostedSurface extends StatelessWidget {
     required this.child,
     required this.borderRadius,
     this.padding = EdgeInsets.zero,
+    this.includeBottomBorder = true,
     super.key,
   });
 
   /// Width of the hairline border drawn around the surface.
-  /// `Container` stacks it onto [padding] on every side,
+  /// `Container` stacks it onto [padding] on each bordered side,
   /// so height math that depends on this surface (e.g. the bottom nav's
   /// occupied height) must account for it through this constant rather
-  /// than a magic number. [build] passes it to `Border.all` explicitly,
+  /// than a magic number. [build] passes it to the border explicitly,
   /// so the rendered width and the height math cannot drift apart.
   static const double borderWidth = 1;
 
   final Widget child;
   final BorderRadius borderRadius;
   final EdgeInsets padding;
+
+  /// Whether the hairline border is drawn along the bottom edge. The docked
+  /// bottom navigation bar sits flush against the screen edge, so a bottom
+  /// hairline renders as a stray light line below the bar — it sets this to
+  /// `false` to drop the bottom side (the rounded top and the two sides keep
+  /// theirs). Callers that omit it shed one [borderWidth] from their height
+  /// math accordingly.
+  final bool includeBottomBorder;
+
+  static BorderSide _hairline(DsTokens tokens) => BorderSide(
+    color: tokens.colors.decorative.level01.withValues(alpha: 0.4),
+    // Deliberately explicit even though it matches the default: [borderWidth]
+    // feeds the bottom nav's occupied-height math, and relying on the
+    // framework default would let the two silently drift apart.
+    // ignore: avoid_redundant_argument_values
+    width: borderWidth,
+  );
 
   @override
   Widget build(BuildContext context) {
@@ -104,15 +122,23 @@ class DesignSystemNavigationFrostedSurface extends StatelessWidget {
           padding: padding,
           decoration: BoxDecoration(
             color: frostedFill,
-            borderRadius: borderRadius,
-            border: Border.all(
-              color: tokens.colors.decorative.level01.withValues(alpha: 0.4),
-              // Deliberately explicit even though it matches the default:
-              // [borderWidth] feeds the bottom nav's occupied-height math,
-              // and relying on the framework default would let the two
-              // silently drift apart.
-              // ignore: avoid_redundant_argument_values
-              width: borderWidth,
+            // BoxDecoration asserts a borderRadius is only valid with a
+            // uniform border; the docked bar's bottom-less border is
+            // non-uniform, so the radius is dropped here and the rounded
+            // corners come from the enclosing ClipRRect (which clips the
+            // fill and the hairline together) instead.
+            borderRadius: includeBottomBorder ? borderRadius : null,
+            // Deliberately explicit even though [borderWidth] matches the
+            // framework default: it feeds the bottom nav's occupied-height
+            // math, and relying on the default would let the two silently
+            // drift apart. The docked bottom bar drops the bottom side
+            // (includeBottomBorder == false) so no stray hairline shows
+            // below it.
+            border: Border(
+              top: _hairline(tokens),
+              left: _hairline(tokens),
+              right: _hairline(tokens),
+              bottom: includeBottomBorder ? _hairline(tokens) : BorderSide.none,
             ),
             boxShadow: [
               BoxShadow(

--- a/test/features/design_system/components/navigation/design_system_five_slot_nav_bar_test.dart
+++ b/test/features/design_system/components/navigation/design_system_five_slot_nav_bar_test.dart
@@ -273,16 +273,53 @@ void main() {
         ),
       );
       // ...and the surface extends exactly the absorbed inset
-      // (bottomInsetFraction of the OS-reported one) plus the hairline
-      // border below the slot row: the
-      // trimmed inset replaces the internal bottom padding instead of
-      // stacking onto it, so home-indicator devices get no dead space.
+      // (bottomInsetFraction of the OS-reported one) below the slot row:
+      // the trimmed inset replaces the internal bottom padding instead of
+      // stacking onto it, so home-indicator devices get no dead space. The
+      // docked bar omits the bottom hairline (includeBottomBorder: false),
+      // so no border width is added below the slot row.
       expect(
         barRect.bottom - slotRect.bottom,
         moreOrLessEquals(
-          inset * DesignSystemFiveSlotNavBar.bottomInsetFraction +
-              DesignSystemNavigationFrostedSurface.borderWidth,
+          inset * DesignSystemFiveSlotNavBar.bottomInsetFraction,
         ),
+      );
+    });
+
+    testWidgets('docked surface draws no bottom hairline, keeps the others', (
+      tester,
+    ) async {
+      await pumpBar(tester, items: barItems());
+
+      // The frosted surface's bordered Container: the only descendant whose
+      // BoxDecoration carries a Border.
+      final decoration = tester
+          .widgetList<Container>(
+            find.descendant(
+              of: find.byType(DesignSystemNavigationFrostedSurface),
+              matching: find.byType(Container),
+            ),
+          )
+          .map((c) => c.decoration)
+          .whereType<BoxDecoration>()
+          .firstWhere((d) => d.border != null);
+      final border = decoration.border! as Border;
+
+      // The docked bar sits flush against the screen edge: no bottom
+      // hairline (that was the stray light line below the bar), while the
+      // top and both sides keep their hairline.
+      expect(border.bottom, BorderSide.none);
+      expect(
+        border.top.width,
+        DesignSystemNavigationFrostedSurface.borderWidth,
+      );
+      expect(
+        border.left.width,
+        DesignSystemNavigationFrostedSurface.borderWidth,
+      );
+      expect(
+        border.right.width,
+        DesignSystemNavigationFrostedSurface.borderWidth,
       );
     });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the unwanted faint hairline along the very bottom edge of the mobile navigation bar for a cleaner look.
  * Updated the navigation bar’s border rendering so the docked content spacing no longer includes the extra bottom border thickness, resulting in more consistent alignment and proportions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->