### PR TITLE
feat: surface image generation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   centered dialog on desktop — instead of taking over the whole screen. The
   fields are unchanged (title, category, target date); Cancel/Create sit inside
   the overlay, and the new project shows up in the list as soon as you save.
+- When the image provider turns down a cover art request, the modal now says the
+  provider rejected it and shows the provider's own reason verbatim (for example
+  "PROHIBITED_CONTENT") instead of a generic "Failed to generate image" — so
+  it's clear the block is the AI provider's content policy, not Lotti, and you
+  can reword the request and try again.
 
 ## [0.9.1025]
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ test_glados:
 
 .PHONY: analyze
 analyze:
-	$(FLUTTER_CMD) analyze
+	FLUTTER="$(FLUTTER_CMD)" DART="$(DART_CMD)" ./tool/analyze.sh
 
 .PHONY: junit_test
 junit_test:

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -35,6 +35,7 @@
     <release version="0.9.1026" date="2026-06-16">
       <description>
           <p>Creating a project now opens a compact overlay — a bottom sheet on phones, a centered dialog on desktop — instead of taking over the whole screen. The fields are unchanged (title, category, target date), and the new project shows up in the list as soon as you save.</p>
+          <p>When the image provider turns down a cover art request, the modal now says the provider rejected it and shows the provider's own reason verbatim (for example "PROHIBITED_CONTENT") instead of a generic "Failed to generate image" — so it's clear the block is the AI provider's content policy, not Lotti, and you can reword the request and try again.</p>
       </description>
     </release>
     <release version="0.9.1025" date="2026-06-15">

--- a/lib/features/ai/model/image_generation_error.dart
+++ b/lib/features/ai/model/image_generation_error.dart
@@ -1,0 +1,22 @@
+/// Exception thrown when image generation fails in a way the UI should explain.
+///
+/// [message] retains the rich, log-friendly diagnostics (finish reason, token
+/// usage, raw payload). [providerReason] is the *verbatim* reason the provider
+/// itself returned — e.g. a Gemini `finishReason` like `PROHIBITED_CONTENT`, a
+/// `promptFeedback.blockReason`, or the message from an HTTP error body. It is
+/// surfaced to the user as-is (never paraphrased), so they see exactly what the
+/// provider said rather than an invented description. `null` when the failure
+/// did not originate from a provider response (e.g. a network timeout).
+class ImageGenerationException implements Exception {
+  ImageGenerationException(this.message, {this.providerReason});
+
+  /// Human-readable, log-friendly description including provider diagnostics.
+  final String message;
+
+  /// The provider's own reason string, shown verbatim in the UI. `null` when
+  /// no provider reason is available.
+  final String? providerReason;
+
+  @override
+  String toString() => 'ImageGenerationException: $message';
+}

--- a/lib/features/ai/repository/gemini_image_generation.dart
+++ b/lib/features/ai/repository/gemini_image_generation.dart
@@ -3,6 +3,7 @@ import 'dart:developer' as developer;
 
 import 'package:http/http.dart' as http;
 import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/model/image_generation_error.dart';
 import 'package:lotti/features/ai/repository/gemini_inference_payloads.dart';
 import 'package:lotti/features/ai/repository/gemini_utils.dart';
 import 'package:lotti/features/ai/util/image_processing_utils.dart';
@@ -60,9 +61,10 @@ Future<GeneratedImage> generateGeminiImage({
       .timeout(const Duration(seconds: 120));
 
   if (response.statusCode < 200 || response.statusCode >= 300) {
-    throw Exception(
+    throw ImageGenerationException(
       'Gemini image generation error ${response.statusCode} for model '
       '"$model": ${response.body}',
+      providerReason: _httpErrorReason(response.statusCode, response.body),
     );
   }
 
@@ -77,9 +79,10 @@ Future<GeneratedImage> generateGeminiImage({
 GeneratedImage extractGeminiImageFromResponse(Map<String, dynamic> response) {
   final candidates = response['candidates'];
   if (candidates is! List || candidates.isEmpty) {
-    throw Exception(
+    throw ImageGenerationException(
       'No candidates in image generation response'
       '${_responseDiagnostics(response, null)}',
+      providerReason: _providerReason(response, null),
     );
   }
 
@@ -87,17 +90,19 @@ GeneratedImage extractGeminiImageFromResponse(Map<String, dynamic> response) {
   final candidate = first is Map<String, dynamic> ? first : null;
   final content = candidate != null ? candidate['content'] : null;
   if (content is! Map<String, dynamic>) {
-    throw Exception(
+    throw ImageGenerationException(
       'No content in image generation response'
       '${_responseDiagnostics(response, candidate)}',
+      providerReason: _providerReason(response, candidate),
     );
   }
 
   final parts = content['parts'];
   if (parts is! List || parts.isEmpty) {
-    throw Exception(
+    throw ImageGenerationException(
       'No parts in image generation response'
       '${_responseDiagnostics(response, candidate)}',
+      providerReason: _providerReason(response, candidate),
     );
   }
 
@@ -123,10 +128,69 @@ GeneratedImage extractGeminiImageFromResponse(Map<String, dynamic> response) {
     }
   }
 
-  throw Exception(
+  throw ImageGenerationException(
     'No image data found in response'
     '${_responseDiagnostics(response, candidate)}',
+    providerReason: _providerReason(response, candidate),
   );
+}
+
+/// Extracts the provider's *verbatim* reason for an empty/blocked response, to
+/// be shown to the user as-is (never paraphrased).
+///
+/// Prefers a prompt-level `promptFeedback.blockReason`, then the candidate's
+/// terminal `finishReason` (e.g. `PROHIBITED_CONTENT`), and appends any
+/// human-readable `finishMessage`. Returns `null` when the response carries no
+/// reason — the UI then falls back to a generic failure message. Deliberately
+/// provider-shaped and unmapped, so new/other reasons surface truthfully
+/// without code changes.
+String? _providerReason(
+  Map<String, dynamic> response,
+  Map<String, dynamic>? candidate,
+) {
+  final promptFeedback = response['promptFeedback'];
+  final blockReason = promptFeedback is Map<String, dynamic>
+      ? promptFeedback['blockReason']
+      : null;
+  final finishReason = candidate?['finishReason'];
+  final finishMessage = candidate?['finishMessage'];
+
+  final parts = <String>[
+    if (blockReason is String && blockReason.isNotEmpty) blockReason,
+    if (finishReason is String && finishReason.isNotEmpty) finishReason,
+  ];
+  var reason = parts.isEmpty ? null : parts.join(' / ');
+
+  if (finishMessage is String && finishMessage.isNotEmpty) {
+    reason = reason == null ? finishMessage : '$reason: $finishMessage';
+  }
+  return reason;
+}
+
+/// Builds the provider's verbatim reason for a non-2xx HTTP response.
+///
+/// Gemini error bodies are shaped `{"error": {"status": ..., "message": ...}}`;
+/// when present we surface `STATUS: message`, otherwise fall back to the HTTP
+/// status code so the user still sees a concrete provider signal.
+String _httpErrorReason(int statusCode, String body) {
+  try {
+    final decoded = jsonDecode(body);
+    if (decoded is Map<String, dynamic>) {
+      final error = decoded['error'];
+      if (error is Map<String, dynamic>) {
+        final message = error['message'];
+        final status = error['status'];
+        if (message is String && message.isNotEmpty) {
+          return status is String && status.isNotEmpty
+              ? '$status: $message'
+              : message;
+        }
+      }
+    }
+  } on FormatException {
+    // Non-JSON body — fall through to the status code.
+  }
+  return 'HTTP $statusCode';
 }
 
 /// Builds a human-readable diagnostics suffix explaining *why* a Gemini image

--- a/lib/features/ai/services/skill_inference_runner.dart
+++ b/lib/features/ai/services/skill_inference_runner.dart
@@ -14,6 +14,7 @@ import 'package:lotti/features/ai/helpers/entity_state_helper.dart';
 import 'package:lotti/features/ai/helpers/prompt_builder_helper.dart';
 import 'package:lotti/features/ai/helpers/skill_prompt_builder.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/model/image_generation_error.dart';
 import 'package:lotti/features/ai/model/resolved_profile.dart';
 import 'package:lotti/features/ai/repository/ai_input_repository.dart';
 import 'package:lotti/features/ai/repository/cloud_inference_repository.dart';
@@ -21,6 +22,7 @@ import 'package:lotti/features/ai/repository/gemini_thinking_config.dart';
 import 'package:lotti/features/ai/repository/task_summary_resolver.dart';
 import 'package:lotti/features/ai/services/profile_automation_service.dart';
 import 'package:lotti/features/ai/state/consts.dart';
+import 'package:lotti/features/ai/state/image_generation_error_controller.dart';
 import 'package:lotti/features/ai/state/inference_status_controller.dart';
 import 'package:lotti/features/ai/util/image_processing_utils.dart';
 import 'package:lotti/features/journal/repository/journal_repository.dart';
@@ -96,6 +98,28 @@ class SkillInferenceRunner {
     }
   }
 
+  /// Sets the [ImageGenerationErrorController] for an entity (and optionally
+  /// its linked task) so the cover-art UI can show the provider's verbatim
+  /// failure reason. Passing `null` clears any stale error from a previous
+  /// attempt.
+  void _setImageGenerationError(
+    String? providerReason, {
+    required String entityId,
+    String? linkedTaskId,
+  }) {
+    _ref
+        .read(imageGenerationErrorControllerProvider(id: entityId).notifier)
+        .setError(providerReason);
+
+    if (linkedTaskId != null) {
+      _ref
+          .read(
+            imageGenerationErrorControllerProvider(id: linkedTaskId).notifier,
+          )
+          .setError(providerReason);
+    }
+  }
+
   /// Wraps a skill inference body with status tracking.
   ///
   /// Sets status to [InferenceStatus.running] before [body], then
@@ -107,6 +131,7 @@ class SkillInferenceRunner {
     required String subDomain,
     required Future<void> Function() body,
     String? linkedTaskId,
+    void Function(Object error)? onError,
   }) async {
     _setStatus(
       InferenceStatus.running,
@@ -135,6 +160,7 @@ class SkillInferenceRunner {
         stackTrace: stack,
         subDomain: subDomain,
       );
+      onError?.call(e);
     }
   }
 
@@ -835,11 +861,31 @@ class SkillInferenceRunner {
         automationResult.skill?.skillType.toResponseType ??
         AiResponseType.imageGeneration;
 
+    // Clear any error from a previous attempt so the UI starts this run fresh.
+    _setImageGenerationError(
+      null,
+      entityId: entryId,
+      linkedTaskId: linkedTaskId,
+    );
+
     await _withStatusTracking(
       entityId: entryId,
       responseType: responseType,
       subDomain: 'runImageGeneration',
       linkedTaskId: linkedTaskId,
+      onError: (error) {
+        // Surface the provider's verbatim reason to the UI when we have one
+        // (e.g. a Gemini `finishReason`); other failures (network, internal)
+        // carry no provider reason and fall back to a generic message.
+        final providerReason = error is ImageGenerationException
+            ? error.providerReason
+            : null;
+        _setImageGenerationError(
+          providerReason,
+          entityId: entryId,
+          linkedTaskId: linkedTaskId,
+        );
+      },
       body: () async {
         // 0. Validate automation result — inside status tracking so the UI
         // transitions to running before any early throw/return (prevents the

--- a/lib/features/ai/state/image_generation_error_controller.dart
+++ b/lib/features/ai/state/image_generation_error_controller.dart
@@ -1,0 +1,28 @@
+import 'package:lotti/utils/cache_extension.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'image_generation_error_controller.g.dart';
+
+/// Holds the provider's *verbatim* failure reason for an entity/task id (e.g. a
+/// Gemini `finishReason` like `PROHIBITED_CONTENT`) so the cover-art UI can show
+/// the actual reason the provider returned, framed by a localized "rejected"
+/// message — never an invented description.
+///
+/// Keyed by id exactly like `InferenceStatusController`, and driven by
+/// `SkillInferenceRunner.runImageGeneration`: cleared to `null` when a run
+/// starts and populated when a run fails with a provider reason. `null` means
+/// "no provider reason" (e.g. a network error), so the UI falls back to a
+/// generic failure message.
+@riverpod
+class ImageGenerationErrorController extends _$ImageGenerationErrorController {
+  @override
+  String? build({required String id}) {
+    ref.cacheFor(inferenceStateCacheDuration);
+    return null;
+  }
+
+  // ignore: use_setters_to_change_properties
+  void setError(String? providerReason) {
+    state = providerReason;
+  }
+}

--- a/lib/features/ai/state/image_generation_error_controller.g.dart
+++ b/lib/features/ai/state/image_generation_error_controller.g.dart
@@ -1,0 +1,173 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'image_generation_error_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Holds the provider's *verbatim* failure reason for an entity/task id (e.g. a
+/// Gemini `finishReason` like `PROHIBITED_CONTENT`) so the cover-art UI can show
+/// the actual reason the provider returned, framed by a localized "rejected"
+/// message — never an invented description.
+///
+/// Keyed by id exactly like `InferenceStatusController`, and driven by
+/// `SkillInferenceRunner.runImageGeneration`: cleared to `null` when a run
+/// starts and populated when a run fails with a provider reason. `null` means
+/// "no provider reason" (e.g. a network error), so the UI falls back to a
+/// generic failure message.
+
+@ProviderFor(ImageGenerationErrorController)
+final imageGenerationErrorControllerProvider =
+    ImageGenerationErrorControllerFamily._();
+
+/// Holds the provider's *verbatim* failure reason for an entity/task id (e.g. a
+/// Gemini `finishReason` like `PROHIBITED_CONTENT`) so the cover-art UI can show
+/// the actual reason the provider returned, framed by a localized "rejected"
+/// message — never an invented description.
+///
+/// Keyed by id exactly like `InferenceStatusController`, and driven by
+/// `SkillInferenceRunner.runImageGeneration`: cleared to `null` when a run
+/// starts and populated when a run fails with a provider reason. `null` means
+/// "no provider reason" (e.g. a network error), so the UI falls back to a
+/// generic failure message.
+final class ImageGenerationErrorControllerProvider
+    extends $NotifierProvider<ImageGenerationErrorController, String?> {
+  /// Holds the provider's *verbatim* failure reason for an entity/task id (e.g. a
+  /// Gemini `finishReason` like `PROHIBITED_CONTENT`) so the cover-art UI can show
+  /// the actual reason the provider returned, framed by a localized "rejected"
+  /// message — never an invented description.
+  ///
+  /// Keyed by id exactly like `InferenceStatusController`, and driven by
+  /// `SkillInferenceRunner.runImageGeneration`: cleared to `null` when a run
+  /// starts and populated when a run fails with a provider reason. `null` means
+  /// "no provider reason" (e.g. a network error), so the UI falls back to a
+  /// generic failure message.
+  ImageGenerationErrorControllerProvider._({
+    required ImageGenerationErrorControllerFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'imageGenerationErrorControllerProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$imageGenerationErrorControllerHash();
+
+  @override
+  String toString() {
+    return r'imageGenerationErrorControllerProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  ImageGenerationErrorController create() => ImageGenerationErrorController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(String? value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<String?>(value),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is ImageGenerationErrorControllerProvider &&
+        other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$imageGenerationErrorControllerHash() =>
+    r'969685c9d5f686ab157b2ee7f4be237e12d02db1';
+
+/// Holds the provider's *verbatim* failure reason for an entity/task id (e.g. a
+/// Gemini `finishReason` like `PROHIBITED_CONTENT`) so the cover-art UI can show
+/// the actual reason the provider returned, framed by a localized "rejected"
+/// message — never an invented description.
+///
+/// Keyed by id exactly like `InferenceStatusController`, and driven by
+/// `SkillInferenceRunner.runImageGeneration`: cleared to `null` when a run
+/// starts and populated when a run fails with a provider reason. `null` means
+/// "no provider reason" (e.g. a network error), so the UI falls back to a
+/// generic failure message.
+
+final class ImageGenerationErrorControllerFamily extends $Family
+    with
+        $ClassFamilyOverride<
+          ImageGenerationErrorController,
+          String?,
+          String?,
+          String?,
+          String
+        > {
+  ImageGenerationErrorControllerFamily._()
+    : super(
+        retry: null,
+        name: r'imageGenerationErrorControllerProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// Holds the provider's *verbatim* failure reason for an entity/task id (e.g. a
+  /// Gemini `finishReason` like `PROHIBITED_CONTENT`) so the cover-art UI can show
+  /// the actual reason the provider returned, framed by a localized "rejected"
+  /// message — never an invented description.
+  ///
+  /// Keyed by id exactly like `InferenceStatusController`, and driven by
+  /// `SkillInferenceRunner.runImageGeneration`: cleared to `null` when a run
+  /// starts and populated when a run fails with a provider reason. `null` means
+  /// "no provider reason" (e.g. a network error), so the UI falls back to a
+  /// generic failure message.
+
+  ImageGenerationErrorControllerProvider call({required String id}) =>
+      ImageGenerationErrorControllerProvider._(argument: id, from: this);
+
+  @override
+  String toString() => r'imageGenerationErrorControllerProvider';
+}
+
+/// Holds the provider's *verbatim* failure reason for an entity/task id (e.g. a
+/// Gemini `finishReason` like `PROHIBITED_CONTENT`) so the cover-art UI can show
+/// the actual reason the provider returned, framed by a localized "rejected"
+/// message — never an invented description.
+///
+/// Keyed by id exactly like `InferenceStatusController`, and driven by
+/// `SkillInferenceRunner.runImageGeneration`: cleared to `null` when a run
+/// starts and populated when a run fails with a provider reason. `null` means
+/// "no provider reason" (e.g. a network error), so the UI falls back to a
+/// generic failure message.
+
+abstract class _$ImageGenerationErrorController extends $Notifier<String?> {
+  late final _$args = ref.$arg as String;
+  String get id => _$args;
+
+  String? build({required String id});
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<String?, String?>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<String?, String?>,
+              String?,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, () => build(id: _$args));
+  }
+}

--- a/lib/features/ai/ui/image_generation/cover_art_skill_modal.dart
+++ b/lib/features/ai/ui/image_generation/cover_art_skill_modal.dart
@@ -4,6 +4,7 @@ import 'dart:developer' as developer;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/ai/state/consts.dart';
+import 'package:lotti/features/ai/state/image_generation_error_controller.dart';
 import 'package:lotti/features/ai/state/inference_status_controller.dart';
 import 'package:lotti/features/ai/state/skill_trigger_providers.dart';
 import 'package:lotti/features/ai/ui/animation/ai_running_animation.dart';
@@ -177,6 +178,15 @@ class _CoverArtProgressViewState extends ConsumerState<_CoverArtProgressView> {
     final isError = _hasObservedRunning && status == InferenceStatus.error;
     final isRunning = status == InferenceStatus.running || !_hasObservedRunning;
 
+    // When errored, the provider's verbatim reason (e.g. `PROHIBITED_CONTENT`)
+    // is shown as-is under a localized "rejected" title. `null` (no provider
+    // reason, e.g. a network error) falls back to a generic message.
+    final errorReason = isError
+        ? ref.watch(
+            imageGenerationErrorControllerProvider(id: widget.linkedTaskId),
+          )
+        : null;
+
     return Padding(
       padding: const EdgeInsets.all(24),
       child: Column(
@@ -204,7 +214,12 @@ class _CoverArtProgressViewState extends ConsumerState<_CoverArtProgressView> {
           const SizedBox(height: 24),
           // Status text
           Text(
-            _statusText(context, isComplete: isComplete, isError: isError),
+            _statusText(
+              context,
+              isComplete: isComplete,
+              isError: isError,
+              errorReason: errorReason,
+            ),
             textAlign: TextAlign.center,
             style: context.textTheme.titleMedium,
           ),
@@ -215,6 +230,7 @@ class _CoverArtProgressViewState extends ConsumerState<_CoverArtProgressView> {
               context,
               isComplete: isComplete,
               isError: isError,
+              errorReason: errorReason,
             ),
             textAlign: TextAlign.center,
             style: context.textTheme.bodyMedium?.copyWith(
@@ -231,8 +247,15 @@ class _CoverArtProgressViewState extends ConsumerState<_CoverArtProgressView> {
     BuildContext context, {
     required bool isComplete,
     required bool isError,
+    required String? errorReason,
   }) {
-    if (isError) return context.messages.imageGenerationError;
+    if (isError) {
+      // A provider reason means the request was rejected by the provider;
+      // surface that with a localized title. Otherwise it's a generic failure.
+      return errorReason != null
+          ? context.messages.imageGenerationProviderRejectedTitle
+          : context.messages.imageGenerationError;
+    }
     if (isComplete) return context.messages.coverArtGenerationComplete;
     return context.messages.imageGenerationGenerating;
   }
@@ -241,8 +264,14 @@ class _CoverArtProgressViewState extends ConsumerState<_CoverArtProgressView> {
     BuildContext context, {
     required bool isComplete,
     required bool isError,
+    required String? errorReason,
   }) {
-    if (isError || isComplete) {
+    if (isError) {
+      // Show the provider's verbatim reason (e.g. `PROHIBITED_CONTENT`) as-is;
+      // fall back to the dismiss hint when no provider reason is available.
+      return errorReason ?? context.messages.coverArtGenerationDismissHint;
+    }
+    if (isComplete) {
       return context.messages.coverArtGenerationDismissHint;
     }
     // Running

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -2042,6 +2042,7 @@
   "habitsPendingLaterHeader": "Později dnes",
   "imageGenerationError": "Nepodařilo se vygenerovat obrázek",
   "imageGenerationGenerating": "Generování obrázku...",
+  "imageGenerationProviderRejectedTitle": "Poskytovatel obrázků tuto žádost odmítl",
   "imageGenerationWithReferences": "{count, plural, =0{Žádné referenční obrázky} =1{Používá se 1 referenční obrázek} other{Používá se {count} referenčních obrázků}}",
   "@imageGenerationWithReferences": {
     "placeholders": {

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2233,6 +2233,7 @@
   "habitsPendingLaterHeader": "Später heute",
   "imageGenerationError": "Bildgenerierung fehlgeschlagen",
   "imageGenerationGenerating": "Bild wird generiert...",
+  "imageGenerationProviderRejectedTitle": "Der Bildanbieter hat diese Anfrage abgelehnt",
   "imageGenerationWithReferences": "{count, plural, =0{Keine Referenzbilder} =1{Mit 1 Referenzbild} other{Mit {count} Referenzbildern}}",
   "@imageGenerationWithReferences": {
     "placeholders": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2498,6 +2498,7 @@
   "habitsPendingLaterHeader": "Later today",
   "imageGenerationError": "Failed to generate image",
   "imageGenerationGenerating": "Generating image...",
+  "imageGenerationProviderRejectedTitle": "The image provider rejected this request",
   "imageGenerationWithReferences": "{count, plural, =0{No reference images} =1{Using 1 reference image} other{Using {count} reference images}}",
   "@imageGenerationWithReferences": {
     "placeholders": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2233,6 +2233,7 @@
   "habitsPendingLaterHeader": "Más tarde hoy",
   "imageGenerationError": "Error al generar imagen",
   "imageGenerationGenerating": "Generando imagen...",
+  "imageGenerationProviderRejectedTitle": "El proveedor de imágenes rechazó esta solicitud",
   "imageGenerationWithReferences": "{count, plural, =0{Sin imágenes de referencia} =1{Usando 1 imagen de referencia} other{Usando {count} imágenes de referencia}}",
   "@imageGenerationWithReferences": {
     "placeholders": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -2233,6 +2233,7 @@
   "habitsPendingLaterHeader": "Plus tard dans la journée",
   "imageGenerationError": "Échec de la génération d'image",
   "imageGenerationGenerating": "Génération de l'image...",
+  "imageGenerationProviderRejectedTitle": "Le fournisseur d'images a refusé cette demande",
   "imageGenerationWithReferences": "{count, plural, =0{Aucune image de référence} =1{Avec 1 image de référence} other{Avec {count} images de référence}}",
   "@imageGenerationWithReferences": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -8520,6 +8520,12 @@ abstract class AppLocalizations {
   /// **'Generating image...'**
   String get imageGenerationGenerating;
 
+  /// No description provided for @imageGenerationProviderRejectedTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'The image provider rejected this request'**
+  String get imageGenerationProviderRejectedTitle;
+
   /// No description provided for @imageGenerationWithReferences.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -4915,6 +4915,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get imageGenerationGenerating => 'Generování obrázku...';
 
   @override
+  String get imageGenerationProviderRejectedTitle =>
+      'Poskytovatel obrázků tuto žádost odmítl';
+
+  @override
   String imageGenerationWithReferences(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -4916,6 +4916,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get imageGenerationGenerating => 'Bild wird generiert...';
 
   @override
+  String get imageGenerationProviderRejectedTitle =>
+      'Der Bildanbieter hat diese Anfrage abgelehnt';
+
+  @override
   String imageGenerationWithReferences(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -4855,6 +4855,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get imageGenerationGenerating => 'Generating image...';
 
   @override
+  String get imageGenerationProviderRejectedTitle =>
+      'The image provider rejected this request';
+
+  @override
   String imageGenerationWithReferences(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -4944,6 +4944,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get imageGenerationGenerating => 'Generando imagen...';
 
   @override
+  String get imageGenerationProviderRejectedTitle =>
+      'El proveedor de imágenes rechazó esta solicitud';
+
+  @override
   String imageGenerationWithReferences(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -4955,6 +4955,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get imageGenerationGenerating => 'Génération de l\'image...';
 
   @override
+  String get imageGenerationProviderRejectedTitle =>
+      'Le fournisseur d\'images a refusé cette demande';
+
+  @override
   String imageGenerationWithReferences(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -4953,6 +4953,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get imageGenerationGenerating => 'Se generează imaginea...';
 
   @override
+  String get imageGenerationProviderRejectedTitle =>
+      'Furnizorul de imagini a respins această solicitare';
+
+  @override
   String imageGenerationWithReferences(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -2233,6 +2233,7 @@
   "habitsPendingLaterHeader": "Mai târziu astăzi",
   "imageGenerationError": "Generarea imaginii a eșuat",
   "imageGenerationGenerating": "Se generează imaginea...",
+  "imageGenerationProviderRejectedTitle": "Furnizorul de imagini a respins această solicitare",
   "imageGenerationWithReferences": "{count, plural, =0{Fără imagini de referință} =1{Cu 1 imagine de referință} few{Cu {count} imagini de referință} other{Cu {count} de imagini de referință}}",
   "@imageGenerationWithReferences": {
     "placeholders": {

--- a/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,6 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Blaizzy/mlx-audio-swift.git",
       "state" : {
-        "branch" : "main",
         "revision" : "7734cd1fbbe86460083c1d24199737a24cadfcc8"
       }
     },

--- a/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,6 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Blaizzy/mlx-audio-swift.git",
       "state" : {
-        "branch" : "main",
         "revision" : "7734cd1fbbe86460083c1d24199737a24cadfcc8"
       }
     },

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1026+4144
+version: 0.9.1026+4145
 
 msix_config:
   display_name: LottiApp

--- a/test/features/ai/repository/gemini_image_generation_test.dart
+++ b/test/features/ai/repository/gemini_image_generation_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/model/image_generation_error.dart';
 import 'package:lotti/features/ai/repository/gemini_image_generation.dart';
 import 'package:lotti/features/ai/repository/gemini_inference_payloads.dart';
 
@@ -323,6 +324,79 @@ void main() {
     });
   });
 
+  group('provider reason (verbatim, for the UI)', () {
+    ImageGenerationException reasonFor(Map<String, dynamic> response) {
+      try {
+        extractGeminiImageFromResponse(response);
+      } on ImageGenerationException catch (e) {
+        return e;
+      }
+      fail('expected ImageGenerationException');
+    }
+
+    test('carries the candidate finishReason verbatim', () {
+      final e = reasonFor(const {
+        'candidates': [
+          {
+            'finishReason': 'PROHIBITED_CONTENT',
+            'content': {'parts': <dynamic>[]},
+          },
+        ],
+      });
+      expect(e.providerReason, 'PROHIBITED_CONTENT');
+    });
+
+    test(
+      'carries the promptFeedback blockReason when there are no candidates',
+      () {
+        final e = reasonFor(const {
+          'candidates': <dynamic>[],
+          'promptFeedback': {'blockReason': 'BLOCKLIST'},
+        });
+        expect(e.providerReason, 'BLOCKLIST');
+      },
+    );
+
+    test('appends a human finishMessage to the reason when present', () {
+      final e = reasonFor(const {
+        'candidates': [
+          {
+            'finishReason': 'IMAGE_SAFETY',
+            'finishMessage': 'Generated image violates policy.',
+            'content': {'parts': <dynamic>[]},
+          },
+        ],
+      });
+      expect(
+        e.providerReason,
+        'IMAGE_SAFETY: Generated image violates policy.',
+      );
+    });
+
+    test('is null when the response carries no reason at all', () {
+      final e = reasonFor(const {
+        'candidates': [
+          {
+            'content': {'parts': <dynamic>[]},
+          },
+        ],
+      });
+      expect(e.providerReason, isNull);
+    });
+
+    test('is not classified or remapped — unknown reasons surface as-is', () {
+      final e = reasonFor(const {
+        'candidates': [
+          {
+            'finishReason': 'SOME_FUTURE_REASON',
+            'content': {'parts': <dynamic>[]},
+          },
+        ],
+      });
+      expect(e.providerReason, 'SOME_FUTURE_REASON');
+    });
+  });
+
   group('generateGeminiImage', () {
     test(
       'posts to the generateContent endpoint and returns the image',
@@ -371,6 +445,34 @@ void main() {
         ),
       );
     });
+
+    test(
+      'surfaces the provider error message verbatim on HTTP errors',
+      () async {
+        final client = _CapturingClient(
+          statusCode: 400,
+          body:
+              '{"error":{"status":"INVALID_ARGUMENT","message":"Unsupported '
+              'model"}}',
+        );
+
+        await expectLater(
+          generateGeminiImage(
+            httpClient: client,
+            prompt: 'a cat',
+            model: 'gemini-3-pro-image-preview',
+            provider: _provider(),
+          ),
+          throwsA(
+            isA<ImageGenerationException>().having(
+              (e) => e.providerReason,
+              'providerReason',
+              'INVALID_ARGUMENT: Unsupported model',
+            ),
+          ),
+        );
+      },
+    );
 
     test(
       'includes the system message in the request body when provided',

--- a/test/features/ai/services/skill_inference_runner_test.dart
+++ b/test/features/ai/services/skill_inference_runner_test.dart
@@ -11,6 +11,7 @@ import 'package:lotti/classes/task.dart';
 import 'package:lotti/features/agents/database/agent_database.dart';
 import 'package:lotti/features/ai/helpers/automatic_image_analysis_trigger.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/model/image_generation_error.dart';
 import 'package:lotti/features/ai/model/resolved_profile.dart';
 import 'package:lotti/features/ai/model/skill_assignment.dart';
 import 'package:lotti/features/ai/repository/ai_input_repository.dart';
@@ -19,6 +20,7 @@ import 'package:lotti/features/ai/repository/gemini_inference_repository.dart';
 import 'package:lotti/features/ai/services/profile_automation_service.dart';
 import 'package:lotti/features/ai/services/skill_inference_runner.dart';
 import 'package:lotti/features/ai/state/consts.dart';
+import 'package:lotti/features/ai/state/image_generation_error_controller.dart';
 import 'package:lotti/features/ai/state/inference_status_controller.dart';
 import 'package:lotti/features/ai/util/image_processing_utils.dart';
 import 'package:lotti/features/journal/repository/journal_repository.dart';
@@ -3333,6 +3335,85 @@ void main() {
           final prompt = captured.first as String;
           expect(prompt, contains('**Entry Notes:**'));
           expect(prompt, contains('Sunset over mountains, painterly style'));
+        },
+      );
+
+      String? imageGenError(String id) =>
+          container.read(imageGenerationErrorControllerProvider(id: id));
+
+      void stubImageGenPipeline(String entryId, String taskId) {
+        when(
+          () => mockAiInputRepo.getEntity(entryId),
+        ).thenAnswer(
+          (_) async =>
+              makeTextEntry(id: entryId, markdown: 'A scene', categoryId: 'c'),
+        );
+        when(
+          () => mockAiInputRepo.buildTaskDetailsJson(id: taskId),
+        ).thenAnswer((_) async => '{}');
+        when(
+          () => mockAiInputRepo.buildLinkedTasksJson(taskId),
+        ).thenAnswer((_) async => '{}');
+        when(
+          () => mockTaskSummaryResolver.resolve(taskId),
+        ).thenAnswer((_) async => 'brief');
+      }
+
+      test(
+        'publishes the provider reason to the error controller on rejection',
+        () async {
+          stubImageGenPipeline('img-rej', 'task-rej');
+          when(
+            () => mockCloudRepo.generateImage(
+              prompt: any(named: 'prompt'),
+              model: any(named: 'model'),
+              provider: any(named: 'provider'),
+              systemMessage: any(named: 'systemMessage'),
+              referenceImages: any(named: 'referenceImages'),
+            ),
+          ).thenThrow(
+            ImageGenerationException(
+              'blocked',
+              providerReason: 'PROHIBITED_CONTENT',
+            ),
+          );
+          stubLoggingException();
+
+          await runner.runImageGeneration(
+            entryId: 'img-rej',
+            automationResult: makeImageGenResult(),
+            linkedTaskId: 'task-rej',
+          );
+
+          // Set for both the entry and the linked task (the UI watches the
+          // task) so the cover-art modal can surface the verbatim reason.
+          expect(imageGenError('task-rej'), 'PROHIBITED_CONTENT');
+          expect(imageGenError('img-rej'), 'PROHIBITED_CONTENT');
+        },
+      );
+
+      test(
+        'leaves the error reason null when the failure has no provider reason',
+        () async {
+          stubImageGenPipeline('img-net', 'task-net');
+          when(
+            () => mockCloudRepo.generateImage(
+              prompt: any(named: 'prompt'),
+              model: any(named: 'model'),
+              provider: any(named: 'provider'),
+              systemMessage: any(named: 'systemMessage'),
+              referenceImages: any(named: 'referenceImages'),
+            ),
+          ).thenThrow(Exception('network down'));
+          stubLoggingException();
+
+          await runner.runImageGeneration(
+            entryId: 'img-net',
+            automationResult: makeImageGenResult(),
+            linkedTaskId: 'task-net',
+          );
+
+          expect(imageGenError('task-net'), isNull);
         },
       );
 

--- a/test/features/ai/state/image_generation_error_controller_test.dart
+++ b/test/features/ai/state/image_generation_error_controller_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/ai/state/image_generation_error_controller.dart';
+
+void main() {
+  late ProviderContainer container;
+
+  setUp(() {
+    container = ProviderContainer();
+  });
+  tearDown(() {
+    container.dispose();
+  });
+
+  String? read(String id) =>
+      container.read(imageGenerationErrorControllerProvider(id: id));
+
+  group('ImageGenerationErrorController', () {
+    test('initial reason is null', () {
+      expect(read('task-1'), isNull);
+    });
+
+    test('setError stores the provider reason verbatim', () {
+      container
+          .read(imageGenerationErrorControllerProvider(id: 'task-1').notifier)
+          .setError('PROHIBITED_CONTENT');
+
+      expect(read('task-1'), 'PROHIBITED_CONTENT');
+    });
+
+    test('setError(null) clears a previously set reason', () {
+      final provider = imageGenerationErrorControllerProvider(id: 'task-1');
+      container.read(provider.notifier).setError('IMAGE_SAFETY');
+      expect(read('task-1'), 'IMAGE_SAFETY');
+
+      container.read(provider.notifier).setError(null);
+      expect(read('task-1'), isNull);
+    });
+
+    test('reasons are isolated per id', () {
+      container
+          .read(imageGenerationErrorControllerProvider(id: 'task-1').notifier)
+          .setError('PROHIBITED_CONTENT');
+
+      expect(read('task-1'), 'PROHIBITED_CONTENT');
+      expect(read('task-2'), isNull);
+    });
+  });
+}

--- a/test/features/ai/ui/image_generation/cover_art_skill_modal_test.dart
+++ b/test/features/ai/ui/image_generation/cover_art_skill_modal_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/ai/state/consts.dart';
+import 'package:lotti/features/ai/state/image_generation_error_controller.dart';
 import 'package:lotti/features/ai/state/inference_status_controller.dart';
 import 'package:lotti/features/ai/state/reference_image_selection_controller.dart';
 import 'package:lotti/features/ai/state/skill_trigger_providers.dart';
@@ -507,6 +508,76 @@ void main() {
       expect(find.text('Failed to generate image'), findsOneWidget);
       expect(find.byIcon(Icons.error_outline_rounded), findsOneWidget);
     });
+
+    testWidgets(
+      'shows the provider reason verbatim under a localized rejected title',
+      (tester) async {
+        await tester.pumpWidget(
+          RiverpodWidgetTestBench(
+            overrides: [
+              referenceImageSelectionControllerProvider(
+                taskId: testLinkedTaskId,
+              ).overrideWith(
+                () => FakeReferenceImageSelectionController(
+                  const ReferenceImageSelectionState(),
+                ),
+              ),
+              triggerSkillProvider.overrideWith((ref, params) {
+                ref
+                    .read(
+                      inferenceStatusControllerProvider(
+                        id: testLinkedTaskId,
+                        aiResponseType: AiResponseType.imageGeneration,
+                      ).notifier,
+                    )
+                    .setStatus(InferenceStatus.running);
+                return Future<void>.value();
+              }),
+            ],
+            child: const _CoverArtSkillModalHost(
+              entityId: testEntityId,
+              skillId: testSkillId,
+              linkedTaskId: testLinkedTaskId,
+            ),
+          ),
+        );
+
+        await tester.pump();
+        await tester.pump();
+        await tester.pump();
+
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(_CoverArtSkillModalHost)),
+        );
+        // Provider rejection: error status + a verbatim provider reason.
+        container
+            .read(
+              imageGenerationErrorControllerProvider(
+                id: testLinkedTaskId,
+              ).notifier,
+            )
+            .setError('PROHIBITED_CONTENT');
+        container
+            .read(
+              inferenceStatusControllerProvider(
+                id: testLinkedTaskId,
+                aiResponseType: AiResponseType.imageGeneration,
+              ).notifier,
+            )
+            .setStatus(InferenceStatus.error);
+        await tester.pump();
+
+        // Localized frame attributing the block to the provider...
+        expect(
+          find.text('The image provider rejected this request'),
+          findsOneWidget,
+        );
+        // ...plus the provider's verbatim reason, not an invented description.
+        expect(find.text('PROHIBITED_CONTENT'), findsOneWidget);
+        expect(find.text('Failed to generate image'), findsNothing);
+        expect(find.byIcon(Icons.error_outline_rounded), findsOneWidget);
+      },
+    );
   });
 }
 

--- a/tool/analyze.sh
+++ b/tool/analyze.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Runs the full lint suite reliably from the command line.
+#
+# Why this exists: `flutter analyze` now drives the LSP analysis server, which
+# loads the custom_lint (riverpod_lint) plugin in-process. On a project this
+# size that overwhelms the server and the OS kills it — surfacing as
+# "analysis server exited with code -9" (SIGKILL). So we run the core + Very
+# Good Analysis lints with the plugin TEMPORARILY disabled, then run
+# custom_lint in its own process, where it is stable. custom_lint stays
+# enabled in analysis_options.yaml so the IDE keeps its live riverpod lints.
+#
+# Commands are taken from the FLUTTER / DART env vars (set by the Makefile so
+# the FVM wrapper is used on macOS); they default to the fvm-wrapped tools.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+FLUTTER="${FLUTTER:-fvm flutter}"
+DART="${DART:-fvm dart}"
+
+OPTIONS="analysis_options.yaml"
+BACKUP="$(mktemp)"
+cp "$OPTIONS" "$BACKUP"
+restore() { cp "$BACKUP" "$OPTIONS"; rm -f "$BACKUP"; }
+trap restore EXIT INT TERM
+
+# Comment out `plugins:` / `- custom_lint` for the core analyze pass only.
+sed -E -i.sedbak \
+  's/^([[:space:]]*)(plugins:|- custom_lint)/\1# \2/' "$OPTIONS"
+rm -f "$OPTIONS.sedbak"
+
+echo "==> Core + Very Good Analysis lints (custom_lint temporarily disabled)"
+# shellcheck disable=SC2086  # word-splitting on FLUTTER/DART is intentional
+$FLUTTER analyze
+
+# Restore the real config before running custom_lint in its own process.
+restore
+trap - EXIT INT TERM
+
+echo "==> custom_lint (riverpod_lint)"
+# shellcheck disable=SC2086
+$DART run custom_lint


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cover art generation now displays provider-specific rejection reasons (e.g., PROHIBITED_CONTENT) instead of generic error messages when a request is rejected, with support across multiple languages.

* **Chores**
  * Version bump to 0.9.1026+4145.
  * Build tooling updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->