### PR TITLE
refactor: single source of truth for TTS platform support

### DIFF
--- a/lib/features/tts/engine/supertonic_onnx_engine.dart
+++ b/lib/features/tts/engine/supertonic_onnx_engine.dart
@@ -53,12 +53,17 @@ class SupertonicOnnxEngine implements TtsEngine {
   final Map<String, VoiceStyle> _voiceCache = <String, VoiceStyle>{};
   int _counter = 0;
 
-  @override
-  bool get isSupported =>
+  /// Platforms where `flutter_onnxruntime` is integrated and the Supertonic
+  /// engine can run. Single source of truth for TTS platform support — the
+  /// `ttsEngine` provider gates on this too, so the list lives in one place.
+  static bool get isPlatformSupported =>
       platform.isMacOS ||
       platform.isIOS ||
       platform.isLinux ||
       platform.isAndroid;
+
+  @override
+  bool get isSupported => isPlatformSupported;
 
   @override
   Future<File> synthesizeToFile({

--- a/lib/features/tts/state/tts_engine_provider.dart
+++ b/lib/features/tts/state/tts_engine_provider.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 
 import 'package:lotti/features/tts/engine/supertonic_onnx_engine.dart';
 import 'package:lotti/features/tts/engine/tts_engine.dart';
-import 'package:lotti/utils/platform.dart' as platform;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'tts_engine_provider.g.dart';
@@ -34,14 +33,12 @@ class UnavailableTtsEngine implements TtsEngine {
 }
 
 /// Provides the on-device TTS engine — the Supertonic ONNX engine on the
-/// platforms where `flutter_onnxruntime` is integrated (macOS, iOS, Linux), the
+/// platforms where `flutter_onnxruntime` is integrated
+/// ([SupertonicOnnxEngine.isPlatformSupported]: macOS, iOS, Linux, Android), the
 /// unavailable fallback elsewhere. Tests override this with a fake.
 @Riverpod(keepAlive: true)
 TtsEngine ttsEngine(Ref ref) {
-  if (!platform.isMacOS &&
-      !platform.isIOS &&
-      !platform.isLinux &&
-      !platform.isAndroid) {
+  if (!SupertonicOnnxEngine.isPlatformSupported) {
     return const UnavailableTtsEngine();
   }
   final engine = SupertonicOnnxEngine();

--- a/test/features/tts/engine/supertonic_onnx_engine_test.dart
+++ b/test/features/tts/engine/supertonic_onnx_engine_test.dart
@@ -91,6 +91,7 @@ void main() {
     });
 
     test('is false when no supported platform flag is set', () {
+      expect(SupertonicOnnxEngine.isPlatformSupported, isFalse);
       expect(buildEngine().isSupported, isFalse);
     });
 
@@ -102,6 +103,7 @@ void main() {
     }.entries) {
       test('is true on ${entry.key}', () {
         entry.value();
+        expect(SupertonicOnnxEngine.isPlatformSupported, isTrue);
         expect(buildEngine().isSupported, isTrue);
       });
     }


### PR DESCRIPTION
Addresses the two `gemini-code-assist[bot]` review comments on #3329 (merged), which flagged the duplicated platform-support list.

## What
- Add `static bool get SupertonicOnnxEngine.isPlatformSupported` as the single source of truth for TTS platform support (macOS, iOS, Linux, Android).
- `SupertonicOnnxEngine.isSupported` now delegates to it.
- The `ttsEngine` provider gates on it, dropping the now-unused `platform` import.
- Fix a stale provider doc comment that still listed only macOS/iOS/Linux.
- Engine tests assert the new static getter directly (single source of truth), not only via the instance getter.

## Verification
- `flutter analyze`: no issues found
- TTS gate tests (engine `isSupported` + `ttsEngine` provider) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated platform support logic in the text-to-speech engine to eliminate code duplication and improve consistency across the system.

* **Tests**
  * Expanded test coverage to validate platform support detection for all supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->