### PR TITLE
feat: add a 90-day span to the habit completion-rate chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it is from your goal — above a smooth 7-day-average trend line that climbs
   through a shaded "on track" band, with the raw daily rates as light dots
   behind it and a quiet, encouraging pointer below to the one habit most worth a
-  focus ("kept 5 of 30"). Logging a habit is now a small, staged celebration:
+  focus ("kept 5 of 30"). You can switch the chart between 7-, 14-, 30-, and
+  90-day windows to see anything from this week to a full quarter of progress.
+  Logging a habit is now a small, staged celebration:
   the check pops in, a soft accent glow blooms on the row, a burst of sparks
   flies from the check, its streak flame pulses and ticks up, the done count
   counts up and the progress bar eases forward, and finishing the last habit of

--- a/lib/features/habits/README.md
+++ b/lib/features/habits/README.md
@@ -307,7 +307,7 @@ That is easy to miss if you only read the state shape. The controller stores `se
 
 The completion-rate chart lives inside `HabitsChartCard` at the bottom of the page — a titled, bordered `dsCardSurface` card. The card supplies the title (`habitsCompletionRateTitle`), the time-span switch, and the zero-baseline toggle; the chart (`HabitCompletionRateChart`) supplies a headline, a single trend line, and — when a day is tapped — that day's breakdown.
 
-- **Time span** is a `TimeSpanSegmentedControl` over `[7, 14, 30]` days, always visible in the card header (no longer hidden behind a calendar toggle). Selecting a span calls `setTimeSpan`, which refetches the range and recomputes. `HabitsChartCard.timeSpans` is the single source for the offered windows. The chart also drives the day window for each dashboard row's history strip via the page's shared `rangeStart` / `rangeEnd`.
+- **Time span** is a `TimeSpanSegmentedControl` over `[7, 14, 30, 90]` days, always visible in the card header (no longer hidden behind a calendar toggle). Selecting a span calls `setTimeSpan`, which refetches the range and recomputes. `HabitsChartCard.timeSpans` is the single source for the offered windows. The chart also drives the day window for each dashboard row's history strip via the page's shared `rangeStart` / `rangeEnd`.
 - **Zero-baseline toggle** only appears when `state.minY > 20` (i.e. the lowest day clears the 20% floor, where cropping the axis is actually meaningful). It flips `zeroBased`, switching between a zero-based Y axis and the cropped minimum.
 
 ### Headline, trend line, and stats
@@ -515,7 +515,7 @@ Delete is a soft delete via `deletedAt`, not a hard remove.
 - Streaks **are now displayed**: `shortStreakCount` / `longStreakCount` surface in `HabitsSummaryCard`'s streak badge. (Previously these were computed but never rendered.)
 - The tab's per-day history is the combined **consistency heatmap**; the per-row history strip now exists only on the **dashboard** habit chart. Both are **read-only** — backfilling a past day is done through the dialog's date field, not by tapping a cell.
 - The heatmap shades by **success only** and uses the same `activeBy` ∪ recorded denominator as the chart. Weekly/monthly per-period targets (`requiredCompletions`) are still not surfaced — the heatmap measures daily success, not cadence.
-- The chart **time span** lives in the chart card's header (`TimeSpanSegmentedControl`, `[7, 14, 30]`), not behind a calendar/visibility toggle. `state.showTimeSpan` is still in the state but no longer gates the switch.
+- The chart **time span** lives in the chart card's header (`TimeSpanSegmentedControl`, `[7, 14, 30, 90]`), not behind a calendar/visibility toggle. `state.showTimeSpan` is still in the state but no longer gates the switch.
 - Text search is local page filtering (only when `showSearch` is on), not repository querying.
 - The "due now" split is based only on daily `showFrom` and current clock time.
 

--- a/lib/features/habits/ui/widgets/habits_chart_card.dart
+++ b/lib/features/habits/ui/widgets/habits_chart_card.dart
@@ -21,9 +21,9 @@ class HabitsChartCard extends ConsumerWidget {
   const HabitsChartCard({super.key});
 
   /// Time spans offered for the habits chart and the per-row history strips —
-  /// short, habit-scale windows, unlike the months/quarters the Insights
-  /// surface uses.
-  static const List<int> timeSpans = [7, 14, 30];
+  /// short-to-quarter, habit-scale windows, unlike the months/quarters the
+  /// Insights surface uses.
+  static const List<int> timeSpans = [7, 14, 30, 90];
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/widgets/charts/habits/habit_completion_rate_chart.dart
+++ b/lib/widgets/charts/habits/habit_completion_rate_chart.dart
@@ -187,9 +187,11 @@ class HabitCompletionRateChart extends ConsumerWidget
                 ),
                 extraLinesData: ExtraLinesData(
                   horizontalLines: [
-                    // The goal line, drawn where it lives and labelled "Goal"
-                    // at the right so the dashed target reads as the goal, not
-                    // just another gridline.
+                    // The goal line, drawn where it lives and labelled "Goal".
+                    // The label sits at the *left* end: an improving line climbs
+                    // toward the right, so a right-aligned label collides with
+                    // it once the rate clears target (visible on the 90-day
+                    // span); the left end stays clear.
                     HorizontalLine(
                       y: stats.target,
                       color: successColor.withValues(alpha: 0.5),
@@ -197,8 +199,9 @@ class HabitCompletionRateChart extends ConsumerWidget
                       dashArray: const [5, 3],
                       label: HorizontalLineLabel(
                         show: true,
-                        alignment: Alignment.topRight,
-                        padding: const EdgeInsets.only(right: 2, bottom: 2),
+                        // alignment defaults to topLeft — the clear end for a
+                        // line that climbs toward the right.
+                        padding: const EdgeInsets.only(left: 2, bottom: 2),
                         labelResolver: (_) => messages.habitsGoalLineLabel,
                         style: tokens.typography.styles.body.bodySmall.copyWith(
                           color: successColor.withValues(alpha: 0.9),

--- a/test/features/habits/ui/widgets/habits_chart_card_test.dart
+++ b/test/features/habits/ui/widgets/habits_chart_card_test.dart
@@ -48,7 +48,7 @@ void main() {
   });
 
   testWidgets(
-    'renders the time-span control with 7d / 14d / 30d segments',
+    'renders the time-span control with 7d / 14d / 30d / 90d segments',
     (tester) async {
       await pump(tester, HabitsState.initial());
 
@@ -58,6 +58,7 @@ void main() {
       expect(find.text('7d'), findsNWidgets(2));
       expect(find.text('14d'), findsNWidgets(2));
       expect(find.text('30d'), findsNWidgets(2));
+      expect(find.text('90d'), findsNWidgets(2));
     },
   );
 


### PR DESCRIPTION
- HabitsChartCard.timeSpans gains 90, so the header switch now offers 7d / 14d / 30d / 90d (the segmented control already formats it as "90d"). The chart, rolling average, axis ticks (3–4 inset dates) and the fetch all scale to the quarter window with no other changes.
- Move the dashed goal line's "Goal" label to the (default) top-left. An improving line climbs toward the right and, once it clears target, collided with a right-aligned label — obvious on the 90-day span; the left end stays clear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a 90-day viewing period to the habits completion-rate chart, expanding available time-span options from 7, 14, and 30 days.

* **Style**
  * Repositioned the "Goal" line label in the habits completion-rate chart for improved visibility and clarity.

* **Documentation**
  * Updated CHANGELOG and README documentation to reflect the expanded chart time-span configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->