### PR TITLE
feat: habits completion polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it is from your goal — above a smooth 7-day-average trend line that climbs
   through a shaded "on track" band, with the raw daily rates as light dots
   behind it and a quiet, encouraging pointer below to the one habit most worth a
-  focus ("kept 5 of 30"). You can switch the chart between 7-, 14-, 30-, and
-  90-day windows to see anything from this week to a full quarter of progress.
+  focus ("kept 5 of 30"). You can switch the chart between 14-, 30-, and 90-day
+  windows to see anything from a fortnight to a full quarter of progress.
   Logging a habit is now a small, staged celebration:
   the check pops in, a soft accent glow blooms on the row, a burst of sparks
   flies from the check, its streak flame pulses and ticks up, the done count

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it is from your goal — above a smooth 7-day-average trend line that climbs
   through a shaded "on track" band, with the raw daily rates as light dots
   behind it and a quiet, encouraging pointer below to the one habit most worth a
-  focus ("kept 5 of 30"). Logging a habit is now a small, staged celebration:
+  focus ("kept 5 of 30"). You can switch the chart between 7-, 14-, 30-, and
+  90-day windows to see anything from this week to a full quarter of progress.
+  Logging a habit is now a small, staged celebration:
   the check pops in, a soft accent glow blooms on the row, a burst of sparks
   flies from the check, its streak flame pulses and ticks up, the done count
   counts up and the progress bar eases forward, and finishing the last habit of

--- a/lib/features/habits/README.md
+++ b/lib/features/habits/README.md
@@ -307,7 +307,7 @@ That is easy to miss if you only read the state shape. The controller stores `se
 
 The completion-rate chart lives inside `HabitsChartCard` at the bottom of the page — a titled, bordered `dsCardSurface` card. The card supplies the title (`habitsCompletionRateTitle`), the time-span switch, and the zero-baseline toggle; the chart (`HabitCompletionRateChart`) supplies a headline, a single trend line, and — when a day is tapped — that day's breakdown.
 
-- **Time span** is a `TimeSpanSegmentedControl` over `[7, 14, 30]` days, always visible in the card header (no longer hidden behind a calendar toggle). Selecting a span calls `setTimeSpan`, which refetches the range and recomputes. `HabitsChartCard.timeSpans` is the single source for the offered windows. The chart also drives the day window for each dashboard row's history strip via the page's shared `rangeStart` / `rangeEnd`.
+- **Time span** is a `TimeSpanSegmentedControl` over `[7, 14, 30, 90]` days, always visible in the card header (no longer hidden behind a calendar toggle). Selecting a span calls `setTimeSpan`, which refetches the range and recomputes. `HabitsChartCard.timeSpans` is the single source for the offered windows. The chart also drives the day window for each dashboard row's history strip via the page's shared `rangeStart` / `rangeEnd`.
 - **Zero-baseline toggle** only appears when `state.minY > 20` (i.e. the lowest day clears the 20% floor, where cropping the axis is actually meaningful). It flips `zeroBased`, switching between a zero-based Y axis and the cropped minimum.
 
 ### Headline, trend line, and stats
@@ -515,7 +515,7 @@ Delete is a soft delete via `deletedAt`, not a hard remove.
 - Streaks **are now displayed**: `shortStreakCount` / `longStreakCount` surface in `HabitsSummaryCard`'s streak badge. (Previously these were computed but never rendered.)
 - The tab's per-day history is the combined **consistency heatmap**; the per-row history strip now exists only on the **dashboard** habit chart. Both are **read-only** — backfilling a past day is done through the dialog's date field, not by tapping a cell.
 - The heatmap shades by **success only** and uses the same `activeBy` ∪ recorded denominator as the chart. Weekly/monthly per-period targets (`requiredCompletions`) are still not surfaced — the heatmap measures daily success, not cadence.
-- The chart **time span** lives in the chart card's header (`TimeSpanSegmentedControl`, `[7, 14, 30]`), not behind a calendar/visibility toggle. `state.showTimeSpan` is still in the state but no longer gates the switch.
+- The chart **time span** lives in the chart card's header (`TimeSpanSegmentedControl`, `[7, 14, 30, 90]`), not behind a calendar/visibility toggle. `state.showTimeSpan` is still in the state but no longer gates the switch.
 - Text search is local page filtering (only when `showSearch` is on), not repository querying.
 - The "due now" split is based only on daily `showFrom` and current clock time.
 

--- a/lib/features/habits/README.md
+++ b/lib/features/habits/README.md
@@ -425,6 +425,8 @@ Completions can be captured three ways from a `HabitActionRow` (the shared row u
 
 The quick paths (swipe + button) fire light haptic feedback and confirm with a brief floating outcome `SnackBar` (the habit name plus a check/cancel icon) so the action is acknowledged instantly, before the provider round-trips and the tab re-renders (the habit moves between buckets / the heatmap recolours).
 
+A **fresh success** also fires the completion celebration **optimistically** — `_recordQuickCompletion` starts the `_celebrate` timeline (the `CompletionBurst`) the instant the tap lands, *before* the persist + recompute, because gating the animation behind the provider round-trip made the burst feel laggy on mobile ("the UI blocks, then particles fly later"). An `_optimisticCelebration` guard then stops `didUpdateWidget` from re-firing the timeline when the `completedToday` flip finally arrives. `PersistenceLogic.createHabitCompletionEntry` logs its own failures and returns `null` rather than throwing; on that `null` the row clears `_optimisticCelebration` (so a later real completion can still celebrate) and skips the success `SnackBar`, since nothing was recorded.
+
 ```mermaid
 flowchart TD
   Row["HabitActionRow"]

--- a/lib/features/habits/README.md
+++ b/lib/features/habits/README.md
@@ -307,7 +307,7 @@ That is easy to miss if you only read the state shape. The controller stores `se
 
 The completion-rate chart lives inside `HabitsChartCard` at the bottom of the page — a titled, bordered `dsCardSurface` card. The card supplies the title (`habitsCompletionRateTitle`), the time-span switch, and the zero-baseline toggle; the chart (`HabitCompletionRateChart`) supplies a headline, a single trend line, and — when a day is tapped — that day's breakdown.
 
-- **Time span** is a `TimeSpanSegmentedControl` over `[7, 14, 30, 90]` days, always visible in the card header (no longer hidden behind a calendar toggle). Selecting a span calls `setTimeSpan`, which refetches the range and recomputes. `HabitsChartCard.timeSpans` is the single source for the offered windows. The chart also drives the day window for each dashboard row's history strip via the page's shared `rangeStart` / `rangeEnd`.
+- **Time span** is a `TimeSpanSegmentedControl` over `[14, 30, 90]` days, always visible in the card header (no longer hidden behind a calendar toggle). Selecting a span calls `setTimeSpan`, which refetches the range and recomputes. `HabitsChartCard.timeSpans` is the single source for the offered windows. The chart also drives the day window for each dashboard row's history strip via the page's shared `rangeStart` / `rangeEnd`.
 - **Zero-baseline toggle** only appears when `state.minY > 20` (i.e. the lowest day clears the 20% floor, where cropping the axis is actually meaningful). It flips `zeroBased`, switching between a zero-based Y axis and the cropped minimum.
 
 ### Headline, trend line, and stats
@@ -515,7 +515,7 @@ Delete is a soft delete via `deletedAt`, not a hard remove.
 - Streaks **are now displayed**: `shortStreakCount` / `longStreakCount` surface in `HabitsSummaryCard`'s streak badge. (Previously these were computed but never rendered.)
 - The tab's per-day history is the combined **consistency heatmap**; the per-row history strip now exists only on the **dashboard** habit chart. Both are **read-only** — backfilling a past day is done through the dialog's date field, not by tapping a cell.
 - The heatmap shades by **success only** and uses the same `activeBy` ∪ recorded denominator as the chart. Weekly/monthly per-period targets (`requiredCompletions`) are still not surfaced — the heatmap measures daily success, not cadence.
-- The chart **time span** lives in the chart card's header (`TimeSpanSegmentedControl`, `[7, 14, 30, 90]`), not behind a calendar/visibility toggle. `state.showTimeSpan` is still in the state but no longer gates the switch.
+- The chart **time span** lives in the chart card's header (`TimeSpanSegmentedControl`, `[14, 30, 90]`), not behind a calendar/visibility toggle. `state.showTimeSpan` is still in the state but no longer gates the switch.
 - Text search is local page filtering (only when `showSearch` is on), not repository querying.
 - The "due now" split is based only on daily `showFrom` and current clock time.
 

--- a/lib/features/habits/state/habits_state.dart
+++ b/lib/features/habits/state/habits_state.dart
@@ -5,7 +5,6 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/utils/date_utils_extension.dart';
-import 'package:lotti/utils/platform.dart';
 import 'package:lotti/widgets/charts/utils.dart';
 
 part 'habits_state.freezed.dart';
@@ -70,7 +69,7 @@ abstract class HabitsState with _$HabitsState {
     openNow: [],
     pendingLater: [],
     completed: [],
-    days: getHabitDays(isDesktop ? 14 : 7),
+    days: getHabitDays(14),
     successfulToday: <String>{},
     successfulByDay: <String, Set<String>>{},
     skippedByDay: <String, Set<String>>{},
@@ -82,7 +81,7 @@ abstract class HabitsState with _$HabitsState {
     failedPercentage: 0,
     shortStreakCount: 0,
     longStreakCount: 0,
-    timeSpanDays: isDesktop ? 14 : 7,
+    timeSpanDays: 14,
     zeroBased: true,
     minY: 0,
     displayFilter: HabitDisplayFilter.openNow,

--- a/lib/features/habits/state/heatmap/habit_heatmap_controller.dart
+++ b/lib/features/habits/state/heatmap/habit_heatmap_controller.dart
@@ -29,6 +29,10 @@ class HabitHeatmapController extends _$HabitHeatmapController {
   StreamSubscription<List<HabitDefinition>>? _definitionsSubscription;
   StreamSubscription<Set<String>>? _updateSubscription;
 
+  /// Debounces the completion-triggered recompute so a burst of completions
+  /// coalesces and the heavy refetch lands off the tap's animation frames.
+  Timer? _refreshDebounce;
+
   late HabitsRepository _repository;
   List<HabitDefinition> _habitDefinitions = [];
   List<JournalEntity> _habitCompletions = [];
@@ -79,15 +83,25 @@ class HabitHeatmapController extends _$HabitHeatmapController {
   }
 
   void _cleanup() {
+    _refreshDebounce?.cancel();
     _definitionsSubscription?.cancel();
     _updateSubscription?.cancel();
   }
 
   Future<void> _startWatching() async {
     if (!ref.mounted) return;
-    _updateSubscription = _repository.updateStream.listen((affectedIds) async {
+    _updateSubscription = _repository.updateStream.listen((affectedIds) {
       if (affectedIds.contains(habitCompletionNotification)) {
-        await _refreshAndRecompute();
+        // Debounce the recompute. The heatmap is a background "seeing" surface,
+        // and refetching a year+ of completions and rebuilding it on every
+        // completion blocks the completion frame — which janked the tap's
+        // celebration on mobile. Coalesce rapid completions and let the heavy
+        // work land after the tap, off the animation's critical frames.
+        _refreshDebounce?.cancel();
+        _refreshDebounce = Timer(
+          const Duration(milliseconds: 350),
+          _refreshAndRecompute,
+        );
       }
     });
   }

--- a/lib/features/habits/ui/widgets/habit_action_row.dart
+++ b/lib/features/habits/ui/widgets/habit_action_row.dart
@@ -181,7 +181,7 @@ class _HabitActionRowState extends State<HabitActionRow>
     }
     await HapticFeedback.lightImpact();
     final now = DateTime.now();
-    await getIt<PersistenceLogic>().createHabitCompletionEntry(
+    final saved = await getIt<PersistenceLogic>().createHabitCompletionEntry(
       data: HabitCompletionData(
         habitId: habitDefinition.id,
         dateFrom: now,
@@ -192,6 +192,15 @@ class _HabitActionRowState extends State<HabitActionRow>
       habitDefinition: habitDefinition,
     );
     if (!mounted) return;
+    if (saved == null) {
+      // The write didn't commit (PersistenceLogic logs the cause and returns
+      // null); the `completedToday` flip that consumes the optimistic flag will
+      // never arrive, so clear it here or a later real completion — and its
+      // celebration — would be suppressed. No success SnackBar either, since
+      // nothing was recorded.
+      _optimisticCelebration = false;
+      return;
+    }
     final tokens = context.designTokens;
     ScaffoldMessenger.maybeOf(context)
       ?..hideCurrentSnackBar()

--- a/lib/features/habits/ui/widgets/habit_action_row.dart
+++ b/lib/features/habits/ui/widgets/habit_action_row.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:lotti/classes/entity_definitions.dart';
@@ -83,6 +85,11 @@ class _HabitActionRowState extends State<HabitActionRow>
   /// time [dispose] runs — even for a missing habit whose `build` returns early.
   late final AnimationController _celebrate;
 
+  /// True between an optimistic (tap-time) celebration and the matching
+  /// data-driven `completedToday` flip, so the flip doesn't restart the
+  /// animation that's already playing.
+  bool _optimisticCelebration = false;
+
   @override
   void initState() {
     super.initState();
@@ -96,10 +103,16 @@ class _HabitActionRowState extends State<HabitActionRow>
   void didUpdateWidget(HabitActionRow oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (!oldWidget.completedToday && widget.completedToday) {
-      // Always run the timeline; the builders decide what it *looks* like. Under
-      // reduced motion that's an opacity-only glow with no particles (see
-      // [build]); otherwise the full staged celebration.
-      _celebrate.forward(from: 0);
+      if (_optimisticCelebration) {
+        // A tap on this row already started the timeline; the provider just
+        // caught up. Don't restart it — let the in-flight animation continue.
+        _optimisticCelebration = false;
+      } else {
+        // Completed from elsewhere (the dialog, a sync). Run the timeline; the
+        // builders decide what it *looks* like — an opacity-only glow under
+        // reduced motion, the full staged celebration otherwise.
+        _celebrate.forward(from: 0);
+      }
     }
   }
 
@@ -155,6 +168,17 @@ class _HabitActionRowState extends State<HabitActionRow>
     HabitCompletionType completionType,
     HabitDefinition habitDefinition,
   ) async {
+    // Fire the celebration first, the instant the tap lands, then persist +
+    // recompute afterwards. Gating the animation behind the provider round-trip
+    // made the burst feel laggy on mobile ("the UI blocks, then particles fly
+    // later"). Only a fresh success flips the row to done, so only that case
+    // celebrates; [didUpdateWidget] won't double-fire it (see
+    // [_optimisticCelebration]).
+    if (completionType == HabitCompletionType.success &&
+        !widget.completedToday) {
+      _optimisticCelebration = true;
+      unawaited(_celebrate.forward(from: 0));
+    }
     await HapticFeedback.lightImpact();
     final now = DateTime.now();
     await getIt<PersistenceLogic>().createHabitCompletionEntry(

--- a/lib/features/habits/ui/widgets/habit_action_row.dart
+++ b/lib/features/habits/ui/widgets/habit_action_row.dart
@@ -284,13 +284,30 @@ class _HabitActionRowState extends State<HabitActionRow>
           if (!reduceMotion)
             Positioned.fill(
               child: IgnorePointer(
-                child: AnimatedBuilder(
-                  animation: _celebrate,
-                  builder: (context, _) {
-                    final p = _stageProgress(_celebrate.value, 0.12, 0.96);
-                    return p == null
-                        ? const SizedBox.shrink()
-                        : CompletionBurst(progress: p);
+                child: LayoutBuilder(
+                  builder: (context, constraints) {
+                    // Centre the burst on the trailing complete button. It sits
+                    // one card padding (step4) plus half a button (step9) in
+                    // from the right edge, so the fractional origin has to track
+                    // the real card width — a fixed value drifts left of the
+                    // button on wide dashboard cards.
+                    final inset =
+                        tokens.spacing.step4 + tokens.spacing.step9 / 2;
+                    final originX = constraints.maxWidth > 0
+                        ? (1 - 2 * inset / constraints.maxWidth).clamp(0.0, 1.0)
+                        : 0.82;
+                    return AnimatedBuilder(
+                      animation: _celebrate,
+                      builder: (context, _) {
+                        final p = _stageProgress(_celebrate.value, 0.12, 0.96);
+                        return p == null
+                            ? const SizedBox.shrink()
+                            : CompletionBurst(
+                                progress: p,
+                                origin: Alignment(originX, 0),
+                              );
+                      },
+                    );
                   },
                 ),
               ),

--- a/lib/features/habits/ui/widgets/habits_chart_card.dart
+++ b/lib/features/habits/ui/widgets/habits_chart_card.dart
@@ -21,9 +21,9 @@ class HabitsChartCard extends ConsumerWidget {
   const HabitsChartCard({super.key});
 
   /// Time spans offered for the habits chart and the per-row history strips —
-  /// short, habit-scale windows, unlike the months/quarters the Insights
-  /// surface uses.
-  static const List<int> timeSpans = [7, 14, 30];
+  /// short-to-quarter, habit-scale windows, unlike the months/quarters the
+  /// Insights surface uses.
+  static const List<int> timeSpans = [7, 14, 30, 90];
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/features/habits/ui/widgets/habits_chart_card.dart
+++ b/lib/features/habits/ui/widgets/habits_chart_card.dart
@@ -21,9 +21,9 @@ class HabitsChartCard extends ConsumerWidget {
   const HabitsChartCard({super.key});
 
   /// Time spans offered for the habits chart and the per-row history strips —
-  /// short-to-quarter, habit-scale windows, unlike the months/quarters the
-  /// Insights surface uses.
-  static const List<int> timeSpans = [7, 14, 30, 90];
+  /// fortnight-to-quarter, habit-scale windows. (7 days was dropped: it's too
+  /// short to read a trend, and the rolling average needs a week just to fill.)
+  static const List<int> timeSpans = [14, 30, 90];
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/widgets/charts/habits/habit_completion_rate_chart.dart
+++ b/lib/widgets/charts/habits/habit_completion_rate_chart.dart
@@ -187,9 +187,11 @@ class HabitCompletionRateChart extends ConsumerWidget
                 ),
                 extraLinesData: ExtraLinesData(
                   horizontalLines: [
-                    // The goal line, drawn where it lives and labelled "Goal"
-                    // at the right so the dashed target reads as the goal, not
-                    // just another gridline.
+                    // The goal line, drawn where it lives and labelled "Goal".
+                    // The label sits at the *left* end: an improving line climbs
+                    // toward the right, so a right-aligned label collides with
+                    // it once the rate clears target (visible on the 90-day
+                    // span); the left end stays clear.
                     HorizontalLine(
                       y: stats.target,
                       color: successColor.withValues(alpha: 0.5),
@@ -197,8 +199,9 @@ class HabitCompletionRateChart extends ConsumerWidget
                       dashArray: const [5, 3],
                       label: HorizontalLineLabel(
                         show: true,
-                        alignment: Alignment.topRight,
-                        padding: const EdgeInsets.only(right: 2, bottom: 2),
+                        // alignment defaults to topLeft — the clear end for a
+                        // line that climbs toward the right.
+                        padding: const EdgeInsets.only(left: 2, bottom: 2),
                         labelResolver: (_) => messages.habitsGoalLineLabel,
                         style: tokens.typography.styles.body.bodySmall.copyWith(
                           color: successColor.withValues(alpha: 0.9),

--- a/test/features/habits/state/heatmap/habit_heatmap_controller_test.dart
+++ b/test/features/habits/state/heatmap/habit_heatmap_controller_test.dart
@@ -262,7 +262,11 @@ void main() {
       );
 
       updateController.add({habitCompletionNotification});
-      async.flushMicrotasks();
+      // The completion-triggered recompute is debounced (350ms) so it lands
+      // off the tap frame; advance past it.
+      async
+        ..elapse(const Duration(milliseconds: 350))
+        ..flushMicrotasks();
 
       verify(
         () => mockRepository.getHabitCompletionsInRange(

--- a/test/features/habits/state/heatmap/habit_heatmap_controller_test.dart
+++ b/test/features/habits/state/heatmap/habit_heatmap_controller_test.dart
@@ -262,10 +262,26 @@ void main() {
       );
 
       updateController.add({habitCompletionNotification});
-      // The completion-triggered recompute is debounced (350ms) so it lands
-      // off the tap frame; advance past it.
+      // The completion-triggered recompute is debounced (350ms) so it lands off
+      // the tap frame. Pin both edges: nothing fires synchronously, nothing
+      // fires just shy of the window, and exactly one refetch fires once it's
+      // crossed — so a regression that dropped the debounce would fail here.
+      async.flushMicrotasks();
+      verifyNever(
+        () => mockRepository.getHabitCompletionsInRange(
+          rangeStart: any(named: 'rangeStart'),
+        ),
+      );
       async
-        ..elapse(const Duration(milliseconds: 350))
+        ..elapse(const Duration(milliseconds: 349))
+        ..flushMicrotasks();
+      verifyNever(
+        () => mockRepository.getHabitCompletionsInRange(
+          rangeStart: any(named: 'rangeStart'),
+        ),
+      );
+      async
+        ..elapse(const Duration(milliseconds: 1))
         ..flushMicrotasks();
 
       verify(

--- a/test/features/habits/ui/widgets/habit_action_row_test.dart
+++ b/test/features/habits/ui/widgets/habit_action_row_test.dart
@@ -51,7 +51,7 @@ void main() {
             comment: any(named: 'comment'),
             habitDefinition: any(named: 'habitDefinition'),
           ),
-        ).thenAnswer((_) async => null);
+        ).thenAnswer((_) async => testHabitCompletionEntry);
 
         getIt
           ..unregister<JournalDb>()
@@ -347,6 +347,38 @@ void main() {
         await tester.pump(const Duration(milliseconds: 1400)); // settle
       },
     );
+
+    testWidgets('a failed persist clears the flag so a later one celebrates', (
+      tester,
+    ) async {
+      // PersistenceLogic returns null when the write doesn't commit (it logs the
+      // cause itself), so the `completedToday` flip that would consume the
+      // optimistic flag never arrives — the row must clear it on its own.
+      when(
+        () => mockPersistenceLogic.createHabitCompletionEntry(
+          data: any(named: 'data'),
+          comment: any(named: 'comment'),
+          habitDefinition: any(named: 'habitDefinition'),
+        ),
+      ).thenAnswer((_) async => null);
+
+      await pumpRow(tester); // not done
+      await tester.tap(find.byIcon(Icons.add_rounded));
+      await tester.pump(); // haptic + the (failing) persist resolve
+      await tester.pump(const Duration(milliseconds: 1400)); // settle the burst
+
+      // A failed write records nothing, so no success SnackBar is shown.
+      expect(find.byType(SnackBar), findsNothing);
+
+      // The flag was cleared, so a later real completion (from the dialog / a
+      // sync) must still celebrate — it isn't suppressed.
+      await pumpRow(tester, completedToday: true);
+      await tester.pump(); // establish
+      await tester.pump(const Duration(milliseconds: 220)); // burst window
+      expect(find.byType(CompletionBurst), findsOneWidget);
+
+      await tester.pump(const Duration(milliseconds: 1400)); // settle
+    });
 
     testWidgets('the icon swap is driven through an AnimatedSwitcher (pop)', (
       tester,

--- a/test/features/habits/ui/widgets/habit_action_row_test.dart
+++ b/test/features/habits/ui/widgets/habit_action_row_test.dart
@@ -242,6 +242,48 @@ void main() {
       expect(flash, findsNothing);
     });
 
+    testWidgets('spark burst origin tracks card width to stay on the button', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(1400, 1000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      Future<double> burstOriginX(double width) async {
+        Widget rowAt({required bool done}) => makeTestableWidgetWithScaffold(
+          SizedBox(
+            width: width,
+            child: HabitActionRow(
+              habitId: habitFlossing.id,
+              completedToday: done,
+            ),
+          ),
+        );
+
+        await tester.pumpWidget(rowAt(done: false));
+        await tester.pump();
+        await tester.pumpWidget(rowAt(done: true)); // flip → celebration starts
+        await tester.pump(const Duration(milliseconds: 220)); // burst window
+        final burst = tester.widget<CompletionBurst>(
+          find.byType(CompletionBurst),
+        );
+        expect(burst.origin.y, 0);
+        await tester.pump(const Duration(milliseconds: 1400)); // settle
+        return burst.origin.x;
+      }
+
+      final narrow = await burstOriginX(500);
+      final wide = await burstOriginX(1000);
+
+      // A wider card pushes the trailing button toward the edge, so the burst
+      // origin shifts right to stay on it — never past the edge, and clearly
+      // rightward of the old fixed 0.82 on a wide card.
+      expect(wide, greaterThan(narrow));
+      expect(wide, lessThanOrEqualTo(1.0));
+      expect(wide, greaterThan(0.9));
+    });
+
     testWidgets('reduced motion: static glow, but no spark burst', (
       tester,
     ) async {

--- a/test/features/habits/ui/widgets/habit_action_row_test.dart
+++ b/test/features/habits/ui/widgets/habit_action_row_test.dart
@@ -328,6 +328,26 @@ void main() {
       );
     });
 
+    testWidgets(
+      'tapping complete fires the celebration before the data flips',
+      (
+        tester,
+      ) async {
+        await pumpRow(tester); // not done
+        expect(find.byType(CompletionBurst), findsNothing);
+
+        await tester.tap(find.byIcon(Icons.add_rounded));
+        await tester.pump(); // establish the animation start
+        // Into the burst window while completedToday is STILL false — the
+        // celebration is optimistic (driven by the tap), not gated on the
+        // provider catching up after the persist + recompute.
+        await tester.pump(const Duration(milliseconds: 220));
+        expect(find.byType(CompletionBurst), findsOneWidget);
+
+        await tester.pump(const Duration(milliseconds: 1400)); // settle
+      },
+    );
+
     testWidgets('the icon swap is driven through an AnimatedSwitcher (pop)', (
       tester,
     ) async {

--- a/test/features/habits/ui/widgets/habits_chart_card_test.dart
+++ b/test/features/habits/ui/widgets/habits_chart_card_test.dart
@@ -48,17 +48,18 @@ void main() {
   });
 
   testWidgets(
-    'renders the time-span control with 7d / 14d / 30d / 90d segments',
+    'renders the time-span control with 14d / 30d / 90d segments',
     (tester) async {
       await pump(tester, HabitsState.initial());
 
       expect(find.byType(TimeSpanSegmentedControl), findsOneWidget);
       // Each segment label is rendered twice (a hidden width-reserving ghost
       // plus the visible label), so assert two matches per span.
-      expect(find.text('7d'), findsNWidgets(2));
       expect(find.text('14d'), findsNWidgets(2));
       expect(find.text('30d'), findsNWidgets(2));
       expect(find.text('90d'), findsNWidgets(2));
+      // 7d was dropped.
+      expect(find.text('7d'), findsNothing);
     },
   );
 

--- a/test/features/habits/ui/widgets/habits_chart_card_test.dart
+++ b/test/features/habits/ui/widgets/habits_chart_card_test.dart
@@ -48,7 +48,7 @@ void main() {
   });
 
   testWidgets(
-    'renders the time-span control with 7d / 14d / 30d segments',
+    'renders the time-span control with 7d / 14d / 30d / 90d segments',
     (tester) async {
       await pump(tester, HabitsState.initial());
 
@@ -58,6 +58,7 @@ void main() {
       expect(find.text('7d'), findsNWidgets(2));
       expect(find.text('14d'), findsNWidgets(2));
       expect(find.text('30d'), findsNWidgets(2));
+      expect(find.text('90d'), findsNWidgets(2));
     },
   );
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optimistic success feedback for habit completions, showing the celebration immediately and reconciling with the final result.
* **Bug Fixes**
  * Improved heatmap responsiveness by batching rapid completion updates into a single refresh.
  * Fixed completion burst positioning so it stays correctly centered across card sizes.
  * Adjusted the completion-rate chart goal line label alignment.
* **Refactor**
  * Updated habits chart time-span options to 14/30/90 days (defaulting to 14).
* **Documentation**
  * Updated the changelog and Habits README to reflect the new chart windows and celebration flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->