### PR TITLE
refactor: unify mobile sync settings with the shared settings tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,11 +95,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - On phones, the Sync settings list now follows the same order and layout as the
-  desktop settings tree (Node profile, Backfill, Stats, Outbox, Conflicts,
-  Matrix maintenance), so the two surfaces no longer disagree. The
-  provisioned-sync QR pairing entry stays at the top, and the Outbox row shows
-  the live count of items still waiting to sync — now on desktop too, not just
-  mobile.
+  desktop settings tree, so the two surfaces no longer disagree. The
+  provisioned-sync QR pairing entry is the first row in the list (Provisioned
+  Sync, This device, Backfill, Stats, Outbox, Conflicts, Matrix maintenance);
+  the Sync rows keep their teal icons, and the Outbox row shows the teal postbox
+  with its live pending-sync count badge — now on desktop too, not just mobile.
 
 ## [0.9.1024]
 ### Changed

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -50,7 +50,7 @@
     <release version="0.9.1025" date="2026-06-15">
       <description>
           <p>Experimental on-device text-to-speech is now available on Linux too: with the "Enable local AI summary playback" flag on, the AI summary card's play button reads a task's TL;DR aloud, synthesized locally with the Supertonic model — no cloud. Still off by default; the model (~400 MB) downloads once on first use.</p>
-          <p>On phones, the Sync settings list now follows the same order and layout as the desktop settings tree, so the two surfaces no longer disagree. The provisioned-sync QR pairing entry stays at the top, and the Outbox row shows the live count of items still waiting to sync — now on desktop too, not just mobile.</p>
+          <p>On phones, the Sync settings list now follows the same order and layout as the desktop settings tree, so the two surfaces no longer disagree. The provisioned-sync QR pairing entry is the first row in the list (Provisioned Sync, This device, Backfill, Stats, Outbox, Conflicts, Matrix maintenance); the Sync rows keep their teal icons, and the Outbox row shows the teal postbox with its live pending-sync count badge — now on desktop too, not just mobile.</p>
       </description>
     </release>
     <release version="0.9.1024" date="2026-06-15">

--- a/lib/beamer/locations/settings_location.dart
+++ b/lib/beamer/locations/settings_location.dart
@@ -43,6 +43,7 @@ import 'package:lotti/features/sync/ui/pages/conflicts/conflict_detail_route.dar
 import 'package:lotti/features/sync/ui/pages/conflicts/conflicts_page.dart';
 import 'package:lotti/features/sync/ui/pages/outbox/outbox_monitor_page.dart';
 import 'package:lotti/features/sync/ui/pages/sync_node_profile_page.dart';
+import 'package:lotti/features/sync/ui/provisioned_sync_page.dart';
 import 'package:lotti/features/sync/ui/sync_stats_page.dart';
 import 'package:lotti/features/sync/ui/widgets/sync_feature_gate.dart';
 import 'package:lotti/features/tts/ui/speech_settings_page.dart';
@@ -67,6 +68,7 @@ class SettingsLocation extends BeamLocation<BeamState> {
     '/settings/ai/model/:modelId',
     '/settings/ai/profile/:profileId',
     '/settings/sync',
+    '/settings/sync/provisioned',
     '/settings/sync/matrix/maintenance',
     '/settings/sync/node-profile',
     '/settings/sync/backfill',
@@ -260,9 +262,10 @@ class SettingsLocation extends BeamLocation<BeamState> {
       // Sync Settings — the list, ordering, copy, and feature-flag gating
       // all come from the shared settings tree (`buildSettingsTree`), so
       // mobile renders the exact same `sync` branch the desktop V2 sidebar
-      // does, including the provisioned-sync QR card as its landing-panel
-      // header. `SyncFeatureGate` preserves the deep-link bounce back to
-      // `/settings` when Matrix sync is disabled.
+      // does. The provisioned-sync QR card is the first child leaf
+      // (`/settings/sync/provisioned`), not a branch header, so the bare
+      // branch hub just lists its rows. `SyncFeatureGate` preserves the
+      // deep-link bounce back to `/settings` when Matrix sync is disabled.
       if (path == '/settings/sync')
         const BeamPage(
           key: ValueKey('settings-sync'),
@@ -278,6 +281,16 @@ class SettingsLocation extends BeamLocation<BeamState> {
           child: SyncFeatureGate(
             child: SettingsMobileBranchPage(branchId: 'sync'),
           ),
+        ),
+
+      // Provisioned-sync leaf. The body is the same QR-pairing card the
+      // desktop `sync-provisioned` panel renders; the wrapper supplies the
+      // mobile page chrome (title + back button) and the sync feature gate.
+      if (path == '/settings/sync/provisioned')
+        const BeamPage(
+          key: ValueKey('settings-sync-provisioned'),
+          title: 'Provisioned Sync',
+          child: ProvisionedSyncPage(),
         ),
 
       if (path == '/settings/sync/matrix/maintenance')

--- a/lib/features/settings/README.md
+++ b/lib/features/settings/README.md
@@ -212,15 +212,18 @@ AI and Agents keep their own rich mobile pages (tabbed `AiSettingsPage` /
 `AgentSettingsPage`) and open directly, so e.g. `/settings/ai/...` stacks that
 page rather than a hub.
 
-Sync is also a branch with `panel != null`, but its landing panel is just the
-provisioned-sync QR card, so it drills into the same `SettingsMobileBranchPage`
-hub as Definitions/Advanced — the hub renders the branch's landing panel
-(`panelSpecFor(node.panel)`) as a header above the child rows. The sync child
-list, ordering, and copy therefore come from `buildSettingsTree`, shared with
-the desktop sidebar, so the two surfaces can no longer drift. `/settings/sync`
-and `/settings/sync/...` stack `SettingsMobileBranchPage(sync)` (wrapped in
-`SyncFeatureGate` so the route bounces back to `/settings` when Matrix sync is
-disabled).
+Sync is a pure-navigation branch like Definitions/Advanced — it has no landing
+panel, so selecting it leaves the desktop detail pane empty. The provisioned-sync
+QR card is its first child leaf (`sync/provisioned`, URL `/settings/sync/provisioned`)
+instead of a branch header, so the hub just lists the branch's child rows
+(Provisioned Sync, This device, Backfill, Stats, Outbox, Conflicts, Matrix
+maintenance). The child list, ordering, and copy come from `buildSettingsTree`,
+shared with the desktop sidebar, so the two surfaces can no longer drift.
+`/settings/sync` and `/settings/sync/...` stack `SettingsMobileBranchPage(sync)`
+(wrapped in `SyncFeatureGate` so the route bounces back to `/settings` when
+Matrix sync is disabled). The Sync hub passes `accentIcons: true` so its rows
+keep the teal icon treatment the standalone `SyncSettingsPage` had — other
+branches stay grey-unless-selected.
 
 That stacked model is why detail pages feel like descendants of a section instead of random teleports. Beamer is doing real work here, which is nice for once.
 
@@ -257,7 +260,8 @@ flowchart LR
   Definitions --> Measurables["Measurables"]
 
   Categories --> Projects["Project detail route (/settings/projects/:projectId)"]
-  Sync --> NodeProfile["Node profile"]
+  Sync --> Provisioned["Provisioned Sync"]
+  Sync --> NodeProfile["This device (node profile)"]
   Sync --> Backfill["Backfill settings"]
   Sync --> Stats["Sync stats"]
   Sync --> Outbox["Outbox monitor"]
@@ -503,8 +507,8 @@ Key facts:
 
 - the `/settings` landing page only shows Sync when `enableMatrixFlag` is on
 - [`lib/features/sync/ui/widgets/sync_feature_gate.dart`](../sync/ui/widgets/sync_feature_gate.dart) guards sync pages and redirects back to `/settings` if sync is disabled
-- the sync landing page is the shared `SettingsMobileBranchPage(branchId: 'sync')` hub: it lists the `sync` branch's children from `buildSettingsTree` and renders the branch's landing panel (the provisioned-sync QR card) as a header, so mobile and desktop V2 share one definition
-- the `sync/outbox` row carries a live pending-count indicator (`OutboxCountIndicator`, registered in `settings_node_indicators.dart` and rendered through `SettingsTreeRow.trailing`); because the row is shared, the count now shows on the desktop V2 sidebar too, not just mobile
+- the sync landing page is the shared `SettingsMobileBranchPage(branchId: 'sync')` hub: it lists the `sync` branch's children from `buildSettingsTree`, so mobile and desktop V2 share one definition. The branch carries no panel, so its `/settings/sync` pane is empty; the provisioned-sync QR card is the first child leaf (`sync/provisioned` → `ProvisionedSyncPage` on mobile, the `sync-provisioned` panel on desktop)
+- the `sync/outbox` row carries a live trailing indicator (`OutboxCountIndicator`, registered in `settings_node_indicators.dart` and rendered through `SettingsTreeRow.trailing`); it reuses the live `OutboxBadgeIcon` to show the teal postbox glyph plus a pending-sync count badge, so the at-a-glance backlog the standalone Sync page showed now appears on the desktop V2 sidebar too, not just mobile
 - sync maintenance, node profile, outbox, stats, and backfill each get their own leaf routes
 
 This split keeps app-wide maintenance in Advanced and sync-specific maintenance with Sync, which is the correct kind of boring.

--- a/lib/features/settings_v2/domain/settings_tree_data.dart
+++ b/lib/features/settings_v2/domain/settings_tree_data.dart
@@ -141,13 +141,19 @@ List<SettingsNode> buildSettingsTree({
       branch(
         'sync',
         Icons.sync_rounded,
-        // Landing panel surfaces the provisioned-sync (QR-pairing)
-        // entry point on desktop V2 — the mobile sync settings page
-        // already shows it via SyncSettingsPage; on desktop the bare
-        // Sync branch used to be leafless so provisioned setup was
-        // unreachable.
-        panel: 'sync',
+        // The Sync branch has no landing panel of its own — selecting it
+        // leaves the desktop detail pane empty. The provisioned-sync
+        // (QR-pairing) entry point is the first child leaf instead, so it
+        // reads as a normal row in the list (Provisioned Sync · This
+        // device · Backfill · …) rather than as a default pane body.
         children: [
+          // QR-pairing / provisioning-bundle setup. First in the list so
+          // it stays the natural starting point for a fresh device.
+          leaf(
+            'sync/provisioned',
+            Icons.qr_code_scanner,
+            panel: 'sync-provisioned',
+          ),
           leaf(
             'sync/node-profile',
             Icons.devices_rounded,
@@ -159,7 +165,11 @@ List<SettingsNode> buildSettingsTree({
             panel: 'sync-backfill',
           ),
           leaf('sync/stats', Icons.bar_chart_rounded, panel: 'sync-stats'),
-          leaf('sync/outbox', Icons.outbox_rounded, panel: 'sync-outbox'),
+          // Mail-envelope leading glyph (as the standalone Sync page used),
+          // rounded to match the other tree icons; the teal postbox +
+          // pending-count badge lives in the row's trailing slot via
+          // OutboxCountIndicator.
+          leaf('sync/outbox', Icons.mail_rounded, panel: 'sync-outbox'),
           // The Beamer URL is still `/settings/advanced/conflicts`
           // for legacy-deep-link compatibility — the URL ↔ id mapping
           // in `settingsNodeUrls` does the translation, and the

--- a/lib/features/settings_v2/domain/settings_tree_index.dart
+++ b/lib/features/settings_v2/domain/settings_tree_index.dart
@@ -42,6 +42,7 @@ const Map<String, String> settingsNodeUrls = {
   'definitions/categories': '/settings/categories',
   'definitions/labels': '/settings/labels',
   'sync': '/settings/sync',
+  'sync/provisioned': '/settings/sync/provisioned',
   'sync/node-profile': '/settings/sync/node-profile',
   'sync/backfill': '/settings/sync/backfill',
   'sync/stats': '/settings/sync/stats',

--- a/lib/features/settings_v2/ui/detail/panel_registry.dart
+++ b/lib/features/settings_v2/ui/detail/panel_registry.dart
@@ -100,11 +100,12 @@ class SettingsPanelSpec {
 const Map<String, SettingsPanelSpec> kSettingsPanels =
     <String, SettingsPanelSpec>{
       // Branches that carry their own landing page. AI / Agents
-      // render full pages with their own scroll machinery; Sync is a
-      // light grouped-list body so the host wraps it.
+      // render full pages with their own scroll machinery. Sync has no
+      // landing panel — its provisioned-sync entry is a leaf
+      // (`sync-provisioned`) instead, so selecting the branch leaves the
+      // detail pane empty.
       'ai': SettingsPanelSpec(build: _aiPanel),
       'agents': SettingsPanelSpec(build: _agentsPanel),
-      'sync': SettingsPanelSpec(build: _syncPanel, scrollable: true),
 
       // Step 7 — simple leaves.
       // FlagsBody is `Column[fixed search, Expanded(scrollable list)]`
@@ -124,6 +125,12 @@ const Map<String, SettingsPanelSpec> kSettingsPanels =
       ),
       'advanced-logging': SettingsPanelSpec(
         build: _advancedLoggingPanel,
+        scrollable: true,
+      ),
+      // Light grouped-list body (the provisioned-sync QR card), so the
+      // host wraps it in a scroll view.
+      'sync-provisioned': SettingsPanelSpec(
+        build: _syncProvisionedPanel,
         scrollable: true,
       ),
       // SyncNodeProfilePage owns its Scaffold; don't wrap.
@@ -196,25 +203,19 @@ Widget _advancedMaintenancePanel(BuildContext context) =>
 Widget _advancedLoggingPanel(BuildContext context) =>
     const LoggingSettingsBody();
 
-/// Landing panel for the Sync branch on V2 desktop. Surfaces the
-/// provisioned-sync (QR-pairing) entry point that the mobile
-/// SyncSettingsPage already shows but that desktop V2 used to omit
-/// because the Sync branch was leafless.
+/// Leaf panel for the `sync/provisioned` entry. Surfaces the
+/// provisioned-sync (QR-pairing) card — the first row under the Sync
+/// branch, replacing the old branch-level landing panel.
 ///
 /// The card is matrix-only, so we gate it on `enableMatrixFlag` —
 /// but unlike `SyncFeatureGate` we DON'T redirect away when the flag
-/// is off. The Sync branch stays visible even with Matrix disabled
-/// (the conflicts leaf still needs to be reachable for legacy /
-/// local-only conflicts), so a parent-branch click must not bounce
-/// the user out of `/settings/sync`. With Matrix off the panel
-/// renders as an empty placeholder and the user can still drill into
-/// `sync-conflicts` via the sidebar tree.
+/// is off. With Matrix off the panel renders as an empty placeholder.
 ///
 /// Wired through Riverpod's `configFlagProvider` rather than a raw
 /// `StreamBuilder` so the underlying flag stream is cached across
 /// rebuilds — a fresh `watchConfigFlag(...)` subscription on every
 /// rebuild would resubscribe + re-emit the loading state unnecessarily.
-Widget _syncPanel(BuildContext context) {
+Widget _syncProvisionedPanel(BuildContext context) {
   return Consumer(
     builder: (context, ref, _) {
       final tokens = context.designTokens;
@@ -233,7 +234,19 @@ Widget _syncPanel(BuildContext context) {
   );
 }
 
-Widget _syncBackfillPanel(BuildContext context) => const BackfillSettingsBody();
+// Desktop-only: the legacy mobile `BackfillSettingsPage` supplies its own
+// horizontal gutter, but the V2 detail pane embeds `BackfillSettingsBody`
+// bare. Add a horizontal inset so the content doesn't run edge-to-edge and
+// instead matches the breathing room the Stats panel gets from
+// `SyncStatsBody`'s card margin (`tokens.spacing.step3`).
+Widget _syncBackfillPanel(BuildContext context) {
+  final tokens = context.designTokens;
+  return Padding(
+    padding: EdgeInsets.symmetric(horizontal: tokens.spacing.step3),
+    child: const BackfillSettingsBody(),
+  );
+}
+
 Widget _syncStatsPanel(BuildContext context) => const SyncStatsBody();
 Widget _syncOutboxPanel(BuildContext context) => const OutboxMonitorBody();
 Widget _syncNodeProfilePanel(BuildContext context) =>

--- a/lib/features/settings_v2/ui/labels/settings_tree_labels.dart
+++ b/lib/features/settings_v2/ui/labels/settings_tree_labels.dart
@@ -80,6 +80,11 @@ SettingsTreeLabelResolver settingsTreeLabelsFor(BuildContext context) {
         );
       case 'sync':
         return (title: m.settingsMatrixTitle, desc: m.settingsSyncSubtitle);
+      case 'sync/provisioned':
+        return (
+          title: m.provisionedSyncTitle,
+          desc: m.provisionedSyncSubtitle,
+        );
       case 'sync/backfill':
         return (
           title: m.backfillSettingsTitle,

--- a/lib/features/settings_v2/ui/mobile/settings_mobile_branch_page.dart
+++ b/lib/features/settings_v2/ui/mobile/settings_mobile_branch_page.dart
@@ -53,6 +53,9 @@ class SettingsMobileBranchPage extends ConsumerWidget {
       nodes: node?.children ?? const <SettingsNode>[],
       header: panelSpec == null ? null : panelSpec.build(context),
       showBack: true,
+      // Sync keeps the teal icon treatment its standalone page had before
+      // it was folded into the shared tree (other branches stay grey).
+      accentIcons: branchId == 'sync',
       onNodeTap: (child) => handleSettingsNodeTap(context, ref, child),
     );
   }

--- a/lib/features/settings_v2/ui/mobile/settings_mobile_tree_page.dart
+++ b/lib/features/settings_v2/ui/mobile/settings_mobile_tree_page.dart
@@ -16,11 +16,10 @@ import 'package:lotti/features/settings_v2/ui/tree/settings_tree_row.dart';
 /// route-agnostic is what lets the same widget render the root and every
 /// branch hub, and makes it trivial to screenshot in isolation.
 ///
-/// A branch that carries its own landing panel (currently only `sync`)
-/// passes that panel body as [header] so its content — e.g. the
-/// provisioned-sync QR card — renders above the child rows, mirroring the
-/// desktop detail pane. Branches without a landing panel pass `null` and
-/// render the bare row list.
+/// A branch that carries its own landing panel passes that panel body as
+/// [header] so its content renders above the child rows, mirroring the
+/// desktop detail pane. No branch attaches one today (Sync's provisioned
+/// card is a leaf row), so [header] is `null` and the bare row list shows.
 class SettingsMobileTreePage extends StatelessWidget {
   const SettingsMobileTreePage({
     required this.title,
@@ -28,6 +27,7 @@ class SettingsMobileTreePage extends StatelessWidget {
     required this.onNodeTap,
     this.header,
     this.showBack = false,
+    this.accentIcons = false,
     super.key,
   });
 
@@ -39,6 +39,11 @@ class SettingsMobileTreePage extends StatelessWidget {
   /// panel body when it has one. `null` for pure-navigation branches.
   final Widget? header;
   final bool showBack;
+
+  /// When `true`, every row in this level paints its icon in the teal
+  /// accent (see [SettingsTreeRow.accentIcon]). Used by the Sync branch to
+  /// keep the teal-icon look its standalone page had before unification.
+  final bool accentIcons;
 
   @override
   Widget build(BuildContext context) {
@@ -66,6 +71,7 @@ class SettingsMobileTreePage extends StatelessWidget {
                 onActivePath: false,
                 isExpanded: false,
                 trailing: settingsNodeIndicatorFor(node.id),
+                accentIcon: accentIcons,
                 showActiveRail: false,
                 showLeafChevron: true,
                 // 3 lines so even the longest section summary stays fully

--- a/lib/features/settings_v2/ui/settings_v2_constants.dart
+++ b/lib/features/settings_v2/ui/settings_v2_constants.dart
@@ -41,6 +41,12 @@ class SettingsV2Constants {
   /// Icon tile fill alpha when on the active path.
   static const double activeTileFillAlpha = 0.16;
 
+  /// Icon tile fill alpha for rows rendered with an always-accent
+  /// (teal) icon. Matches the legacy `SettingsIcon` tile treatment the
+  /// mobile Sync list used before it was folded into the shared tree, so
+  /// the Sync rows keep their teal-on-tinted-tile look.
+  static const double accentTileFillAlpha = 0.12;
+
   /// Badge background alpha (all tones share the same fill-to-text
   /// contrast ratio).
   static const double badgeBackgroundAlpha = 0.16;

--- a/lib/features/settings_v2/ui/tree/outbox_count_indicator.dart
+++ b/lib/features/settings_v2/ui/tree/outbox_count_indicator.dart
@@ -1,65 +1,31 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
-import 'package:lotti/features/settings_v2/ui/settings_v2_constants.dart';
-import 'package:lotti/features/sync/state/matrix_login_controller.dart';
-import 'package:lotti/features/sync/state/outbox_state_controller.dart';
-import 'package:matrix/matrix.dart';
+import 'package:lotti/features/settings/ui/pages/outbox/outbox_badge.dart';
 
 /// Live trailing indicator for the `sync/outbox` settings-tree row.
 ///
-/// Restores the at-a-glance pending-sync count that the old mobile
-/// `SyncSettingsPage` showed via `OutboxBadgeIcon`, now driven through the
-/// shared `SettingsTreeRow` trailing slot so both the desktop V2 sidebar
-/// and the mobile drill-down surface it from one definition.
+/// Restores the teal postbox glyph + pending-count badge the standalone
+/// mobile `SyncSettingsPage` showed before sync was folded into the shared
+/// tree. Renders through the same [OutboxBadgeIcon] the live bottom nav
+/// uses, wired into the shared `SettingsTreeRow` trailing slot so both the
+/// desktop V2 sidebar and the mobile drill-down surface it from one
+/// definition.
 ///
-/// Renders nothing unless the outbox is online and has pending items —
-/// matching the old badge's `isLabelVisible: count > 0` rule (an empty,
-/// online, idle outbox is silent). When sync is online but the device is
-/// not logged in, the pill is muted rather than alarming-red, mirroring
-/// the old grayscale-dimmed treatment.
+/// [OutboxBadgeIcon] owns the reactive behaviour: the postbox always
+/// shows, a red count badge overlays it when the outbox is online with a
+/// backlog, the glyph mutes to grayscale when online but logged out, and
+/// the badge stays hidden when the queue is empty.
 class OutboxCountIndicator extends ConsumerWidget {
   const OutboxCountIndicator({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final online =
-        ref.watch(outboxConnectionStateProvider).value ==
-        OutboxConnectionState.online;
-    if (!online) return const SizedBox.shrink();
-
-    final count = ref.watch(outboxPendingCountProvider).value ?? 0;
-    if (count <= 0) return const SizedBox.shrink();
-
-    final loggedIn =
-        ref.watch(loginStateStreamProvider).value == LoginState.loggedIn;
-
-    final tokens = context.designTokens;
-    const bgAlpha = SettingsV2Constants.badgeBackgroundAlpha;
-    final (bg, fg) = loggedIn
-        ? (
-            tokens.colors.alert.error.defaultColor.withValues(alpha: bgAlpha),
-            tokens.colors.alert.error.defaultColor,
-          )
-        : (
-            tokens.colors.text.lowEmphasis.withValues(alpha: bgAlpha),
-            tokens.colors.text.mediumEmphasis,
-          );
-
-    return Container(
-      height: SettingsV2Constants.badgeHeight,
-      padding: EdgeInsets.symmetric(horizontal: tokens.spacing.step3),
-      decoration: BoxDecoration(
-        color: bg,
-        borderRadius: BorderRadius.circular(tokens.radii.xl),
-      ),
-      alignment: Alignment.center,
-      child: Text(
-        '$count',
-        style: tokens.typography.styles.others.caption.copyWith(
-          color: fg,
-          fontWeight: FontWeight.w600,
-        ),
+    return OutboxBadgeIcon(
+      icon: Icon(
+        MdiIcons.mailboxOutline,
+        color: context.designTokens.colors.interactive.enabled,
       ),
     );
   }

--- a/lib/features/settings_v2/ui/tree/settings_tree_row.dart
+++ b/lib/features/settings_v2/ui/tree/settings_tree_row.dart
@@ -21,11 +21,19 @@ class SettingsTreeRow extends StatelessWidget {
     this.showLeafChevron = false,
     this.descMaxLines = 1,
     this.showActiveRail = true,
+    this.accentIcon = false,
     super.key,
   });
 
   final SettingsNode node;
   final int depth;
+
+  /// When `true`, the leading icon tile is always painted in the teal
+  /// accent (teal glyph on a teal-tinted tile) regardless of selection,
+  /// restoring the legacy `SettingsIcon` look the mobile Sync list used.
+  /// Defaults to `false`, so every other surface keeps the grey-tile /
+  /// teal-when-active treatment.
+  final bool accentIcon;
 
   /// Optional live trailing widget (e.g. the `sync/outbox` pending count),
   /// rendered between the static [NodeBadge] and the chevron. Supplied by
@@ -76,10 +84,12 @@ class SettingsTreeRow extends StatelessWidget {
     final rowFill = onActivePath
         ? accent.withValues(alpha: SettingsV2Constants.activeRowFillAlpha)
         : Colors.transparent;
-    final tileBg = onActivePath
+    final tileBg = accentIcon
+        ? accent.withValues(alpha: SettingsV2Constants.accentTileFillAlpha)
+        : onActivePath
         ? accent.withValues(alpha: SettingsV2Constants.activeTileFillAlpha)
         : tokens.colors.background.level02;
-    final tileGlyph = onActivePath ? accent : textMid;
+    final tileGlyph = accentIcon || onActivePath ? accent : textMid;
 
     // MergeSemantics collapses the InkWell's auto-emitted button node
     // into the outer selected+expanded+label wrapper so screen readers

--- a/lib/features/sync/ui/provisioned_sync_page.dart
+++ b/lib/features/sync/ui/provisioned_sync_page.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/settings/ui/pages/sliver_box_adapter_page.dart';
+import 'package:lotti/features/sync/ui/provisioned/provisioned_sync_modal.dart';
+import 'package:lotti/features/sync/ui/widgets/sync_feature_gate.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+
+/// Mobile / Beamer wrapper for the provisioned-sync (QR-pairing) entry.
+///
+/// Mirrors `SyncStatsPage` / `BackfillSettingsPage`: adds the
+/// [SliverBoxAdapterPage] chrome + the [SyncFeatureGate] flag check and
+/// delegates the content to [ProvisionedSyncSettingsCard]. On desktop the
+/// same card is embedded directly by the `sync-provisioned` panel, which
+/// supplies its own chrome — so the wrapper exists only for the mobile
+/// drill-down's `/settings/sync/provisioned` leaf.
+class ProvisionedSyncPage extends StatelessWidget {
+  const ProvisionedSyncPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SyncFeatureGate(
+      child: SliverBoxAdapterPage(
+        title: context.messages.provisionedSyncTitle,
+        subtitle: context.messages.provisionedSyncSubtitle,
+        showBackButton: true,
+        padding: EdgeInsets.symmetric(
+          horizontal: context.designTokens.spacing.step5,
+        ),
+        child: const ProvisionedSyncSettingsCard(showDivider: false),
+      ),
+    );
+  }
+}

--- a/test/beamer/locations/settings_location_test.dart
+++ b/test/beamer/locations/settings_location_test.dart
@@ -43,6 +43,7 @@ import 'package:lotti/features/sync/ui/matrix_sync_maintenance_page.dart';
 import 'package:lotti/features/sync/ui/pages/conflicts/conflict_detail_route.dart';
 import 'package:lotti/features/sync/ui/pages/conflicts/conflicts_page.dart';
 import 'package:lotti/features/sync/ui/pages/outbox/outbox_monitor_page.dart';
+import 'package:lotti/features/sync/ui/provisioned_sync_page.dart';
 import 'package:lotti/features/sync/ui/sync_stats_page.dart';
 import 'package:lotti/features/sync/ui/widgets/sync_feature_gate.dart';
 import 'package:lotti/get_it.dart';
@@ -114,6 +115,7 @@ void main() {
         '/settings/ai/model/:modelId',
         '/settings/ai/profile/:profileId',
         '/settings/sync',
+        '/settings/sync/provisioned',
         '/settings/sync/matrix/maintenance',
         '/settings/sync/node-profile',
         '/settings/sync/backfill',
@@ -1049,6 +1051,30 @@ void main() {
       expect((hub as SettingsMobileBranchPage).branchId, 'sync');
       expect(pages[2].child, isA<SyncStatsPage>());
     });
+
+    test(
+      'buildPages stacks the provisioned-sync leaf under the sync hub',
+      () {
+        final routeInformation = RouteInformation(
+          uri: Uri.parse('/settings/sync/provisioned'),
+        );
+        final location = SettingsLocation(routeInformation);
+        final beamState = BeamState.fromRouteInformation(routeInformation);
+        final pages = location.buildPages(mockBuildContext, beamState);
+        expect(pages.length, 3);
+        expect(pages[0].child, isA<SettingsMobileRootPage>());
+        // The hub base sits beneath the leaf so back returns to the list.
+        final hubGate = pages[1].child;
+        expect(hubGate, isA<SyncFeatureGate>());
+        expect(
+          ((hubGate as SyncFeatureGate).child as SettingsMobileBranchPage)
+              .branchId,
+          'sync',
+        );
+        // The leaf renders the provisioned-sync wrapper page.
+        expect(pages[2].child, isA<ProvisionedSyncPage>());
+      },
+    );
 
     test('buildPages builds LoggingSettingsPage', () {
       final routeInformation = RouteInformation(

--- a/test/features/settings_v2/domain/settings_tree_data_test.dart
+++ b/test/features/settings_v2/domain/settings_tree_data_test.dart
@@ -316,12 +316,13 @@ void main() {
     });
 
     test(
-      'emits Sync with exactly node-profile/backfill/stats/outbox/conflicts/ '
-      'matrix-maintenance when on',
+      'emits Sync with exactly provisioned/node-profile/backfill/stats/ '
+      'outbox/conflicts/matrix-maintenance when on',
       () {
         final sync = _tree().firstWhere((n) => n.id == 'sync');
         expect(sync.hasChildren, isTrue);
         expect(sync.children!.map((n) => n.id).toList(), [
+          'sync/provisioned',
           'sync/node-profile',
           'sync/backfill',
           'sync/stats',
@@ -366,6 +367,7 @@ void main() {
         'definitions/habits': 'habits',
         'definitions/categories': 'categories',
         'definitions/labels': 'labels',
+        'sync/provisioned': 'sync-provisioned',
         'sync/node-profile': 'sync-node-profile',
         'sync/backfill': 'sync-backfill',
         'sync/stats': 'sync-stats',
@@ -383,10 +385,12 @@ void main() {
     });
 
     test('pure branch nodes have no panel', () {
-      // `advanced` and `definitions` are pure (landing-page-less)
-      // branches. `ai`, `agents`, and `sync` carry their own landing
-      // panel (asserted separately below).
-      for (final id in ['advanced', 'definitions']) {
+      // `advanced`, `definitions`, and `sync` are pure
+      // (landing-page-less) branches — selecting them leaves the detail
+      // pane empty. `ai` and `agents` carry their own landing panel
+      // (asserted separately below). Sync's provisioned-sync entry is a
+      // leaf (`sync/provisioned`) rather than a branch panel.
+      for (final id in ['advanced', 'definitions', 'sync']) {
         final tree = _tree();
         final node = SettingsTreeIndexTestHelper.findInTree(tree, id);
         expect(node, isNotNull, reason: 'expected $id to be present');
@@ -395,12 +399,11 @@ void main() {
     });
 
     test('branches that carry a landing panel expose it', () {
-      // AI / Agents / Sync branches render their own detail panel
-      // when the user lands on the branch itself (not a descendant
-      // leaf). For Sync, the landing panel surfaces the
-      // ProvisionedSyncSettingsCard so QR-pairing is reachable on
-      // desktop V2 the same way it is on mobile.
-      const expected = {'ai': 'ai', 'agents': 'agents', 'sync': 'sync'};
+      // AI / Agents branches render their own detail panel when the
+      // user lands on the branch itself (not a descendant leaf). Sync
+      // no longer carries a landing panel — its ProvisionedSyncSettingsCard
+      // is the first leaf (`sync/provisioned`) instead.
+      const expected = {'ai': 'ai', 'agents': 'agents'};
       for (final entry in expected.entries) {
         final tree = _tree();
         final node = SettingsTreeIndexTestHelper.findInTree(tree, entry.key);
@@ -438,11 +441,12 @@ void main() {
     });
 
     test(
-      'Sync has node-profile / backfill / stats / outbox / conflicts / '
-      'matrix-maintenance in order',
+      'Sync has provisioned / node-profile / backfill / stats / outbox / '
+      'conflicts / matrix-maintenance in order',
       () {
         final sync = _tree().firstWhere((n) => n.id == 'sync');
         expect(sync.children!.map((n) => n.id).toList(), [
+          'sync/provisioned',
           'sync/node-profile',
           'sync/backfill',
           'sync/stats',

--- a/test/features/settings_v2/domain/settings_tree_index_test.dart
+++ b/test/features/settings_v2/domain/settings_tree_index_test.dart
@@ -454,8 +454,9 @@ void main() {
       final node = index.findById('sync');
       expect(node, isNotNull);
       expect(node!.hasChildren, isTrue);
-      // node-profile / backfill / stats / outbox / conflicts / matrix-maintenance.
-      expect(node.children!.length, 6);
+      // provisioned / node-profile / backfill / stats / outbox / conflicts /
+      // matrix-maintenance.
+      expect(node.children!.length, 7);
     });
 
     test('returns null for an id that was never in the tree', () {

--- a/test/features/settings_v2/ui/detail/panel_registry_test.dart
+++ b/test/features/settings_v2/ui/detail/panel_registry_test.dart
@@ -49,10 +49,10 @@ void main() {
     /// removal and surfaces additions that weren't deliberately
     /// signed off. Grouped by the plan step that introduced each id.
     const expectedIds = <String>{
-      // Branches that carry their own landing page.
+      // Branches that carry their own landing page. Sync has no
+      // landing panel — its provisioned-sync entry is a leaf below.
       'ai',
       'agents',
-      'sync',
       // Step 7 — simple leaves.
       'flags',
       'theming',
@@ -60,6 +60,7 @@ void main() {
       'advanced-about',
       'advanced-maintenance',
       'advanced-logging',
+      'sync-provisioned',
       'sync-node-profile',
       'sync-backfill',
       'sync-stats',
@@ -178,6 +179,10 @@ void main() {
         late BuildContext capturedContext;
         await tester.pumpWidget(
           MaterialApp(
+            // The sync-backfill builder reads design tokens eagerly to
+            // compute its desktop inset, so the host theme must carry the
+            // DsTokens extension.
+            theme: resolveTestTheme(),
             home: Builder(
               builder: (context) {
                 capturedContext = context;
@@ -195,7 +200,11 @@ void main() {
         expect(build('advanced-about'), isA<AboutBody>());
         expect(build('advanced-maintenance'), isA<MaintenanceBody>());
         expect(build('advanced-logging'), isA<LoggingSettingsBody>());
-        expect(build('sync-backfill'), isA<BackfillSettingsBody>());
+        // Backfill is wrapped in a desktop-only horizontal inset so its
+        // content doesn't run edge-to-edge (matching the Stats card margin).
+        final backfill = build('sync-backfill');
+        expect(backfill, isA<Padding>());
+        expect((backfill as Padding).child, isA<BackfillSettingsBody>());
         expect(build('sync-stats'), isA<SyncStatsBody>());
         expect(build('sync-outbox'), isA<OutboxMonitorBody>());
         expect(
@@ -294,9 +303,9 @@ void main() {
         expect(build('agents-instances'), isA<DetailIdDispatch>());
 
         // The remaining two registered builders: the node-profile page and
-        // the sync consumer wrapper.
+        // the provisioned-sync consumer wrapper.
         expect(build('sync-node-profile'), isA<SyncNodeProfilePage>());
-        expect(build('sync'), isA<Consumer>());
+        expect(build('sync-provisioned'), isA<Consumer>());
       },
     );
   });

--- a/test/features/settings_v2/ui/detail/settings_detail_pane_test.dart
+++ b/test/features/settings_v2/ui/detail/settings_detail_pane_test.dart
@@ -78,9 +78,9 @@ void main() {
       'dispatches to CategoryEmpty when a pure branch (no landing panel) '
       'is selected',
       (tester) async {
-        // `advanced` is the only remaining root branch without its own
-        // landing panel — `ai`, `agents`, and `sync` all carry one and
-        // therefore fall through to the LeafPanel dispatch.
+        // `advanced`, `definitions`, and `sync` are pure branches without
+        // their own landing panel — only `ai` and `agents` carry one and
+        // fall through to the LeafPanel dispatch.
         await _pumpPane(
           tester,
           initialPath: ['advanced'],
@@ -92,8 +92,8 @@ void main() {
     );
 
     testWidgets(
-      'dispatches to LeafPanel when a branch that carries its own '
-      'landing panel is selected (sync after the desktop QR-pairing fix)',
+      'leaves the detail pane empty when the Sync branch itself is selected '
+      '(its provisioned-sync entry is a leaf, not a branch panel)',
       (tester) async {
         await _pumpPane(
           tester,
@@ -101,8 +101,8 @@ void main() {
           initialPath: ['sync'],
         );
         await tester.pump(const Duration(milliseconds: 200));
-        expect(find.byType(LeafPanel), findsOneWidget);
-        expect(find.byType(CategoryEmpty), findsNothing);
+        expect(find.byType(CategoryEmpty), findsOneWidget);
+        expect(find.byType(LeafPanel), findsNothing);
       },
     );
   });

--- a/test/features/settings_v2/ui/labels/settings_tree_labels_test.dart
+++ b/test/features/settings_v2/ui/labels/settings_tree_labels_test.dart
@@ -79,6 +79,7 @@ void main() {
       tester,
     ) async {
       final resolve = await _buildResolver(tester);
+      expect(resolve('sync/provisioned').title, 'Provisioned Sync');
       expect(resolve('sync/backfill').title, 'Backfill sync');
       expect(resolve('sync/stats').title, 'Matrix Stats');
       expect(resolve('sync/matrix-maintenance').title, 'Maintenance');

--- a/test/features/settings_v2/ui/mobile/settings_mobile_branch_page_test.dart
+++ b/test/features/settings_v2/ui/mobile/settings_mobile_branch_page_test.dart
@@ -102,23 +102,25 @@ void main() {
   );
 
   testWidgets(
-    'sync hub renders its landing panel (provisioned card) as a header '
-    'above the children, in the shared-tree order',
+    'sync hub renders its children with no landing-panel header, in the '
+    'shared-tree order with provisioned first',
     (tester) async {
       await _pump(tester, branchId: 'sync', overrides: _flags());
 
-      // The `sync` branch carries `panel: 'sync'`, whose body is the
-      // provisioned-sync QR card — it must render once, at the top.
-      expect(find.byType(ProvisionedSyncSettingsCard), findsOneWidget);
+      // The `sync` branch no longer carries a landing panel, so the
+      // provisioned card is not rendered as a header here — it is reached
+      // via the `sync/provisioned` leaf row instead.
+      expect(find.byType(ProvisionedSyncSettingsCard), findsNothing);
 
       // Children come straight from `buildSettingsTree`, so the mobile
-      // order now matches the desktop sidebar instead of the old
-      // hand-maintained SyncSettingsPage order.
+      // order matches the desktop sidebar. Provisioned Sync is the first
+      // row, replacing the old header.
       final rowIds = tester
           .widgetList<SettingsTreeRow>(find.byType(SettingsTreeRow))
           .map((row) => row.node.id)
           .toList();
       expect(rowIds, [
+        'sync/provisioned',
         'sync/node-profile',
         'sync/backfill',
         'sync/stats',
@@ -131,6 +133,33 @@ void main() {
       // settingsNodeIndicatorFor) so the at-a-glance backlog count the old
       // SyncSettingsPage showed is preserved on the unified row.
       expect(find.byType(OutboxCountIndicator), findsOneWidget);
+
+      // Sync rows keep the teal icon treatment the standalone page had.
+      final rows = tester.widgetList<SettingsTreeRow>(
+        find.byType(SettingsTreeRow),
+      );
+      expect(rows.every((row) => row.accentIcon), isTrue);
+    },
+  );
+
+  testWidgets(
+    'non-sync hubs render grey (non-accent) icons',
+    (tester) async {
+      await _pump(tester, branchId: 'definitions', overrides: _flags());
+      final rows = tester.widgetList<SettingsTreeRow>(
+        find.byType(SettingsTreeRow),
+      );
+      expect(rows.every((row) => !row.accentIcon), isTrue);
+    },
+  );
+
+  testWidgets(
+    'tapping the provisioned-sync row beams to its leaf URL',
+    (tester) async {
+      await _pump(tester, branchId: 'sync', overrides: _flags());
+      await tester.tap(find.byKey(const ValueKey('sync/provisioned')));
+      await tester.pump();
+      expect(beamed, '/settings/sync/provisioned');
     },
   );
 

--- a/test/features/settings_v2/ui/tree/outbox_count_indicator_test.dart
+++ b/test/features/settings_v2/ui/tree/outbox_count_indicator_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/settings_v2/ui/tree/outbox_count_indicator.dart';
 import 'package:lotti/features/sync/state/matrix_login_controller.dart';
@@ -6,6 +7,8 @@ import 'package:lotti/features/sync/state/outbox_state_controller.dart';
 import 'package:matrix/matrix.dart';
 
 import '../../../../widget_test_utils.dart';
+
+Finder _postbox() => find.byIcon(MdiIcons.mailboxOutline);
 
 void main() {
   Future<void> pump(
@@ -42,7 +45,7 @@ void main() {
   }
 
   group('OutboxCountIndicator', () {
-    testWidgets('shows the pending count when online and items are queued', (
+    testWidgets('renders the postbox glyph + count when items are queued', (
       tester,
     ) async {
       await pump(
@@ -51,19 +54,26 @@ void main() {
         loginState: LoginState.loggedIn,
         pendingCount: 7,
       );
+      expect(_postbox(), findsOneWidget);
       expect(find.text('7'), findsOneWidget);
     });
 
-    testWidgets('renders nothing when the outbox is empty', (tester) async {
-      await pump(
+    testWidgets(
+      'shows the bare postbox with no count when the outbox is empty',
+      (
         tester,
-        connectionState: OutboxConnectionState.online,
-        loginState: LoginState.loggedIn,
-      );
-      expect(find.byType(Text), findsNothing);
-    });
+      ) async {
+        await pump(
+          tester,
+          connectionState: OutboxConnectionState.online,
+          loginState: LoginState.loggedIn,
+        );
+        expect(_postbox(), findsOneWidget);
+        expect(find.byType(Text), findsNothing);
+      },
+    );
 
-    testWidgets('renders nothing while sync is offline, even with a backlog', (
+    testWidgets('shows the bare postbox (no count) while sync is offline', (
       tester,
     ) async {
       await pump(
@@ -72,6 +82,7 @@ void main() {
         loginState: LoginState.loggedIn,
         pendingCount: 12,
       );
+      expect(_postbox(), findsOneWidget);
       expect(find.text('12'), findsNothing);
     });
 
@@ -87,6 +98,7 @@ void main() {
         loginState: LoginState.loggedOut,
         pendingCount: 3,
       );
+      expect(_postbox(), findsOneWidget);
       expect(find.text('3'), findsOneWidget);
     });
   });

--- a/test/features/settings_v2/ui/tree/settings_tree_row_test.dart
+++ b/test/features/settings_v2/ui/tree/settings_tree_row_test.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/settings_v2/domain/settings_node.dart';
 import 'package:lotti/features/settings_v2/ui/settings_v2_constants.dart';
 import 'package:lotti/features/settings_v2/ui/tree/settings_tree_row.dart';
@@ -42,6 +43,7 @@ Future<void> _pumpRow(
   bool isExpanded = false,
   bool showLeafChevron = false,
   int descMaxLines = 1,
+  bool accentIcon = false,
   Widget? trailing,
   VoidCallback? onTap,
 }) async {
@@ -57,6 +59,7 @@ Future<void> _pumpRow(
             isExpanded: isExpanded,
             showLeafChevron: showLeafChevron,
             descMaxLines: descMaxLines,
+            accentIcon: accentIcon,
             trailing: trailing,
             onTap: onTap ?? () {},
           ),
@@ -93,6 +96,24 @@ void main() {
     testWidgets('renders the node icon', (tester) async {
       await _pumpRow(tester, node: _leaf());
       expect(find.byIcon(Icons.flag_outlined), findsOneWidget);
+    });
+
+    testWidgets('icon glyph is grey (medium emphasis) when idle', (
+      tester,
+    ) async {
+      await _pumpRow(tester, node: _leaf());
+      final context = tester.element(find.byType(SettingsTreeRow));
+      final icon = tester.widget<Icon>(find.byIcon(Icons.flag_outlined));
+      expect(icon.color, context.designTokens.colors.text.mediumEmphasis);
+    });
+
+    testWidgets('accentIcon paints the glyph in the teal accent', (
+      tester,
+    ) async {
+      await _pumpRow(tester, node: _leaf(), accentIcon: true);
+      final context = tester.element(find.byType(SettingsTreeRow));
+      final icon = tester.widget<Icon>(find.byIcon(Icons.flag_outlined));
+      expect(icon.color, context.designTokens.colors.interactive.enabled);
     });
 
     testWidgets('description is omitted when the node desc is empty', (

--- a/test/features/sync/ui/provisioned_sync_page_test.dart
+++ b/test/features/sync/ui/provisioned_sync_page_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/sync/ui/provisioned/provisioned_sync_modal.dart';
+import 'package:lotti/features/sync/ui/provisioned_sync_page.dart';
+import 'package:lotti/features/user_activity/state/user_activity_service.dart';
+import 'package:lotti/get_it.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/providers/service_providers.dart';
+import 'package:lotti/utils/consts.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../mocks/mocks.dart';
+import '../../../test_helper.dart';
+import '../../../widget_test_utils.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late TestGetItMocks mocks;
+  late MockMatrixService mockMatrixService;
+  late MockMatrixClient mockClient;
+  late MockUserActivityService mockUserActivityService;
+
+  setUp(() async {
+    mocks = await setUpTestGetIt();
+    mockMatrixService = MockMatrixService();
+    mockClient = MockMatrixClient();
+    mockUserActivityService = MockUserActivityService();
+    when(mockMatrixService.isLoggedIn).thenReturn(false);
+    when(() => mockMatrixService.syncRoomId).thenReturn(null);
+    when(() => mockMatrixService.client).thenReturn(mockClient);
+    when(() => mockClient.userID).thenReturn(null);
+    when(() => mockUserActivityService.updateActivity()).thenReturn(null);
+    // SliverBoxAdapterPage wires a scroll listener to UserActivityService.
+    getIt.registerSingleton<UserActivityService>(mockUserActivityService);
+  });
+
+  tearDown(tearDownTestGetIt);
+
+  Future<void> pump(WidgetTester tester, {required bool enabled}) async {
+    when(
+      () => mocks.journalDb.watchConfigFlag(enableMatrixFlag),
+    ).thenAnswer((_) => Stream<bool>.value(enabled));
+    await tester.pumpWidget(
+      RiverpodWidgetTestBench(
+        overrides: [
+          matrixServiceProvider.overrideWithValue(mockMatrixService),
+        ],
+        child: const ProvisionedSyncPage(),
+      ),
+    );
+    await tester.pump();
+    // Drain the page chrome's back-button fade-in so no timer is left
+    // pending at teardown.
+    await tester.pump(const Duration(seconds: 1));
+  }
+
+  testWidgets(
+    'renders the provisioned-sync card when matrix sync is enabled',
+    (tester) async {
+      await pump(tester, enabled: true);
+
+      final context = tester.element(find.byType(ProvisionedSyncPage));
+      expect(find.byType(ProvisionedSyncSettingsCard), findsOneWidget);
+      // Both the page header and the card surface the same title.
+      expect(find.text(context.messages.provisionedSyncTitle), findsWidgets);
+    },
+  );
+
+  testWidgets(
+    'feature gate hides the card when matrix sync is disabled',
+    (tester) async {
+      await pump(tester, enabled: false);
+
+      expect(find.byType(ProvisionedSyncSettingsCard), findsNothing);
+    },
+  );
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Provisioned Sync (QR pairing) page accessible from Sync settings.

* **Improvements**
  * Updated Sync navigation so the row order matches desktop on mobile, starting with Provisioned Sync.
  * Restored the legacy teal accent look for Sync entries across views.
  * Show the Outbox row’s live pending-sync count badge on desktop as well (with updated outbox icon/badge behavior).

* **Documentation**
  * Updated release notes and Settings V2 Sync documentation to reflect the revised navigation and indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->