### PR TITLE
feat: expand knowledge graph while walking tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1029]
+### Changed
+- The experimental task knowledge graph now keeps expanding as you walk through
+  project tasks. When you walk from a project to one of its tasks, Lotti loads
+  that task's own linked neighborhood, adds the new nodes and links to the graph
+  already on screen, and recomputes the merged layout so the world stays
+  explorable instead of turning sibling tasks into dead ends.
+
 ## [0.9.1028]
 ### Changed
 - The Task details page got a high-end, celebratory rework. The task title is

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -32,6 +32,11 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="0.9.1029" date="2026-06-19">
+      <description>
+          <p>The experimental task knowledge graph now keeps expanding as you walk through project tasks. When you walk from a project to one of its tasks, Lotti loads that task's own linked neighbourhood, adds the new nodes and links to the graph already on screen, and recomputes the merged layout so the world stays explorable instead of turning sibling tasks into dead ends.</p>
+      </description>
+    </release>
     <release version="0.9.1028" date="2026-06-18">
       <description>
           <p>The Task details page got a high-end, celebratory rework. The task title is the clear focal point, and the AI "Proposed changes" read as clean, colour-coded cards — on a phone each shows its change type above full-width text with visible accept/reject buttons (you can still swipe to confirm or dismiss), with a glowing sparkle badge and a clear "Confirm all" button. Your checklists now sit above the AI suggestions. Completing things is celebrated: checking a checklist item pops and strikes through left-to-right, and finishing a checklist or marking the task Done blooms a soft glow with a ring of sparks around the progress ring / status pill — tuned so it never covers the text it celebrates. Sections fade in as the page opens, everything respects the system "reduce motion" setting, and on wide screens the content sits in a centred reading column.</p>

--- a/lib/features/knowledge_graph_poc/README.md
+++ b/lib/features/knowledge_graph_poc/README.md
@@ -67,16 +67,18 @@ renders cleanly outside a `Scaffold`.
 | `ui/graph_style.dart` | Token-backed `GraphStyle`, node glyphs, type labels, and the relation-class → `EdgeVisual` mapping. |
 | `ui/graph_motion_controller.dart` | Event-driven local force island: edge springs, local separation, damping, anchored offsets, graph-surface repaint ticker, and settle/stop logic. |
 | `ui/knowledge_graph_painter.dart` | The `CustomPainter`: atmosphere, biome haze, edges, walk trail, lit nodes, ghost ring, labels. |
-| `ui/knowledge_graph_view.dart` | Host: layout choice, fit/walk camera, pan/zoom/tap, history, title + controls + inspector + legend. Uses a pre-computed `layout` when given (provider path) and only relaxes the graph itself as a fallback (synthetic scenarios / tests). |
-| `state/task_graph_provider.dart` | **Real-data adapter** (Phase 1): `taskGraphProvider` loads a task's real `linked_entries` (depth-2 BFS + project + checklists), maps entities→node types and links→relation kinds, resolves real category colors, and relaxes the layout **on a background isolate** (`Isolate.run`) so opening the page never blocks the UI thread — the result rides in `TaskGraphData.layout`. Pure helpers `graphNodeTypeFor` / `graphNodeLabelFor` / `edgeKindFor` are unit-tested. |
-| `ui/task_knowledge_graph_page.dart` | **In-app page** (Phase 1): hosts the view full-bleed in a `Stack` with a compact, transparent top-left header (back + "Knowledge graph" title) floated over the graph — no banded app-bar row. Reserves the header's height in the view's `MediaQuery` top padding (so the view's own top-left chrome clears it) rather than a full-width bar that would swallow taps over the inspector. Loading / empty / error states; reached from a hub icon on the task app bar. |
+| `ui/knowledge_graph_view.dart` | Host: layout choice, fit/walk camera, pan/zoom/tap, history, title + controls + inspector + legend. Uses a pre-computed `layout` when given (provider path) and only relaxes the graph itself as a fallback (synthetic scenarios / tests). Reports walked-to task nodes to the page so real-data graphs can expand lazily. |
+| `state/task_graph_provider.dart` | **Real-data adapter** (Phase 1): `taskGraphProvider` loads a task's real `linked_entries` (depth-2 BFS + project + checklists), maps entities→node types and links→relation kinds, resolves real category colors, and relaxes the layout **on a background isolate** (`Isolate.run`) so opening the page never blocks the UI thread — the result rides in `TaskGraphData.layout`. The same off-thread layout entry point is reused after additive expansions. Pure helpers `graphNodeTypeFor` / `graphNodeLabelFor` / `edgeKindFor` are unit-tested. |
+| `ui/task_knowledge_graph_page.dart` | **In-app page** (Phase 1): hosts the view full-bleed in a `Stack` with a compact, transparent top-left header (back + "Knowledge graph" title) floated over the graph — no banded app-bar row. Reserves the header's height in the view's `MediaQuery` top padding (so the view's own top-left chrome clears it) rather than a full-width bar that would swallow taps over the inspector. Loading / empty / error states; reached from a hub icon on the task app bar. When the user walks onto a task that was only present as a project sibling, the page reads that task's graph, merges its nodes/edges into the graph already on screen, and swaps in a freshly relaxed merged layout. |
 | `dev_main.dart` | Standalone dev entrypoint to explore the synthetic worlds interactively. |
 
 ## Pipeline
 
 ```mermaid
 flowchart LR
-  S[GraphScenario] --> L{size > 40?}
+  P[taskGraphProvider(seed task)] --> D[TaskGraphData]
+  D --> S[GraphScenario]
+  S --> L{size > 40?}
   L -- yes --> W[computeWorldLayout]
   L -- no --> E[computeGraphLayout]
   W --> V[KnowledgeGraphView]
@@ -88,6 +90,11 @@ flowchart LR
   Y --> PA
   PA --> O["Canvas: vignette → biome haze → edges → trail → nodes → labels"]
   V -.->|tap| WK[walk: re-focus + glide + wake + spring kick] --> V
+  V -.->|walked-to task| X[TaskKnowledgeGraphPage expansion]
+  X --> XP[taskGraphProvider(walked task)]
+  XP --> XM[merge nodes + edges into current graph]
+  XM --> XR[layoutTaskGraphOffThread]
+  XR --> V
 ```
 
 ## Previewing
@@ -120,7 +127,13 @@ real `linked_entries` neighborhood via `taskGraphProvider` and renders it with
 real `CategoryDefinition` colors. The relation mapping is validated against the
 live `db.sqlite` schema (`BasicLink`→association/provenance, `ProjectLink`→
 containment, `RatingLink`→evaluation, plus embedded project + checklists). The
-expert panel scored the integration **9/10 in full app-scaffold screenshots**
+view is additive after the initial load: walking from a project to a sibling
+task triggers a second `taskGraphProvider` read for that task, deduplicates and
+merges the returned nodes/edges into the current scenario, then recomputes
+layout for the merged graph on the same background isolate path. The route does
+not switch to a new base task, so the already visible world stays on screen
+while new links become explorable. The expert panel scored the integration
+**9/10 in full app-scaffold screenshots**
 (every reviewer ≥ 9).
 
 ### Feature flag
@@ -143,12 +156,13 @@ default.
 ## Status & next steps
 
 The view (interaction + looks) and the app integration are both panel-approved.
-Still a Phase-0/1 spike in scope: the data load is a bounded depth-2 BFS with
-per-id (coalesced) fetches — fine for a task neighborhood. The layout already
-runs off the main thread (`Isolate.run` in the provider); the remaining perf
+Still a Phase-0/1 spike in scope: the initial data load is a bounded depth-2 BFS
+with per-id (coalesced) fetches, and walked-to tasks can lazily add another
+bounded task neighborhood to the visible graph. Layout already runs off the main
+thread (`Isolate.run` in the provider and expansion merge); the remaining perf
 spike (Barnes–Hut to drop the relax from O(N²), `drawRawAtlas` batching,
-viewport culling, batched DB reads) is needed before scaling past the local
-neighborhood. Non-blocking polish the panel flagged: biome haze legibility at
-the pulled-back zoom, a touch more ghost-ring contrast, larger control hit
-targets, and a phone bottom-sheet inspector (the detail panel is desktop-only
-today).
+viewport culling, batched DB reads, and pruning/compaction for long exploration
+sessions) is needed before scaling past a handful of local neighborhoods.
+Non-blocking polish the panel flagged: biome haze legibility at the pulled-back
+zoom, a touch more ghost-ring contrast, larger control hit targets, and a phone
+bottom-sheet inspector (the detail panel is desktop-only today).

--- a/lib/features/knowledge_graph_poc/state/task_graph_provider.dart
+++ b/lib/features/knowledge_graph_poc/state/task_graph_provider.dart
@@ -131,7 +131,7 @@ bool _isLive(EntryLink link) => link.hidden != true && link.deletedAt == null;
 /// (rather than an inline closure in the provider) so the isolate entry point
 /// captures only [scenario] — an inline closure would capture the whole
 /// provider body, including the unsendable riverpod `Ref`/`Future`.
-Future<GraphLayout> _layoutOffThread(GraphScenario scenario) =>
+Future<GraphLayout> layoutTaskGraphOffThread(GraphScenario scenario) =>
     Isolate.run(() => computeLayoutForScenario(scenario));
 
 /// Loads the knowledge graph around a task (focus) — its links (depth 2),
@@ -357,7 +357,7 @@ final FutureProviderFamily<TaskGraphData?, String> taskGraphProvider =
       // of iterations for world-scale graphs) — run it on a background isolate
       // so opening the page never blocks the UI thread. The scenario is plain
       // sendable data and the layout is pure/deterministic.
-      final layout = await _layoutOffThread(scenario);
+      final layout = await layoutTaskGraphOffThread(scenario);
 
       return TaskGraphData(
         scenario: scenario,

--- a/lib/features/knowledge_graph_poc/ui/knowledge_graph_view.dart
+++ b/lib/features/knowledge_graph_poc/ui/knowledge_graph_view.dart
@@ -31,6 +31,7 @@ class KnowledgeGraphView extends StatefulWidget {
     this.initialFocusId,
     this.initialPreviousFocusId,
     this.layout,
+    this.onTaskFocusChanged,
     this.showTitle = true,
     this.showLegend = true,
     this.showInspector = true,
@@ -59,6 +60,12 @@ class KnowledgeGraphView extends StatefulWidget {
   /// `taskGraphProvider`). When null the view computes it synchronously in
   /// `initState` — fine for the small synthetic scenarios and tests.
   final GraphLayout? layout;
+
+  /// Called after walk navigation lands on a task node. The page-level real-data
+  /// host uses this to reload the graph around the newly focused task.
+  final void Function(String taskId, String previousFocusId)?
+  onTaskFocusChanged;
+
   final bool showTitle;
   final bool showLegend;
   final bool showInspector;
@@ -330,6 +337,9 @@ class _KnowledgeGraphViewState extends State<KnowledgeGraphView>
     _hops = _bfs(id);
     _syncMotionWindow(id);
     _kickWalkMotion(fromId, id);
+    if (_scenario.nodeById(id).type == GraphNodeType.task) {
+      widget.onTaskFocusChanged?.call(id, fromId);
+    }
     _focusWorld = _layout.positions[id] ?? Offset.zero;
     final (ts, tp) = _framedTransform(_lastSize, id);
     _fromScale = _scale;

--- a/lib/features/knowledge_graph_poc/ui/task_knowledge_graph_page.dart
+++ b/lib/features/knowledge_graph_poc/ui/task_knowledge_graph_page.dart
@@ -3,27 +3,287 @@
 /// [taskGraphProvider] and renders it with real category colors.
 library;
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/knowledge_graph_poc/domain/graph_layout_engine.dart';
+import 'package:lotti/features/knowledge_graph_poc/domain/graph_models.dart';
 import 'package:lotti/features/knowledge_graph_poc/state/task_graph_provider.dart';
 import 'package:lotti/features/knowledge_graph_poc/ui/knowledge_graph_view.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/services/logging_service.dart';
 
-class TaskKnowledgeGraphPage extends ConsumerWidget {
-  const TaskKnowledgeGraphPage({required this.taskId, super.key});
+/// Adds [expansion]'s nodes and edges to [current] without changing the
+/// scenario seed, then recomputes layout for the combined graph.
+Future<TaskGraphData> mergeTaskGraphData(
+  TaskGraphData current,
+  TaskGraphData expansion, {
+  Future<GraphLayout> Function(GraphScenario scenario)? layoutBuilder,
+}) async {
+  final nodeById = <String, GraphNode>{};
+  final orderedNodeIds = <String>[];
+  void addNode(GraphNode node) {
+    if (!nodeById.containsKey(node.id)) {
+      orderedNodeIds.add(node.id);
+    }
+    nodeById[node.id] = node;
+  }
+
+  current.scenario.nodes.forEach(addNode);
+  expansion.scenario.nodes.forEach(addNode);
+
+  final edgeByKey = <String, GraphEdge>{};
+  final orderedEdgeKeys = <String>[];
+  void addEdge(GraphEdge edge) {
+    if (!nodeById.containsKey(edge.fromId) ||
+        !nodeById.containsKey(edge.toId)) {
+      return;
+    }
+    final key = '${edge.fromId}|${edge.toId}|${edge.kind.name}';
+    if (!edgeByKey.containsKey(key)) {
+      orderedEdgeKeys.add(key);
+    }
+    edgeByKey[key] = edge;
+  }
+
+  current.scenario.edges.forEach(addEdge);
+  expansion.scenario.edges.forEach(addEdge);
+
+  final scenario = GraphScenario(
+    name: current.scenario.name,
+    seedId: current.scenario.seedId,
+    nodes: [for (final id in orderedNodeIds) nodeById[id]!],
+    edges: [for (final key in orderedEdgeKeys) edgeByKey[key]!],
+    now: current.scenario.now,
+  );
+  final layout = await (layoutBuilder ?? layoutTaskGraphOffThread)(scenario);
+  return TaskGraphData(
+    scenario: scenario,
+    categoryColors: {
+      ...current.categoryColors,
+      ...expansion.categoryColors,
+    },
+    categoryNames: {
+      ...current.categoryNames,
+      ...expansion.categoryNames,
+    },
+    layout: layout,
+  );
+}
+
+class TaskKnowledgeGraphPage extends ConsumerStatefulWidget {
+  const TaskKnowledgeGraphPage({
+    required this.taskId,
+    this.mergeGraphData,
+    super.key,
+  });
 
   final String taskId;
 
+  /// Optional test hook for making additive expansion layout deterministic in
+  /// widget tests. Production uses [mergeTaskGraphData].
+  final Future<TaskGraphData> Function(
+    TaskGraphData current,
+    TaskGraphData expansion,
+  )?
+  mergeGraphData;
+
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<TaskKnowledgeGraphPage> createState() =>
+      _TaskKnowledgeGraphPageState();
+}
+
+class _TaskKnowledgeGraphPageState
+    extends ConsumerState<TaskKnowledgeGraphPage> {
+  TaskGraphData? _visibleData;
+  TaskGraphData? _seedData;
+  final Map<String, TaskGraphData> _expansions = {};
+  final Map<String, ProviderSubscription<AsyncValue<TaskGraphData?>>>
+  _expansionSubscriptions = {};
+  String? _initialFocusId;
+  String? _initialPreviousFocusId;
+  TaskGraphData? _lastMergeSeedData;
+  int _expansionVersion = 0;
+  int _lastMergeExpansionVersion = -1;
+  int _mergeRequestId = 0;
+
+  @override
+  void didUpdateWidget(TaskKnowledgeGraphPage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.taskId != widget.taskId) {
+      _visibleData = null;
+      _seedData = null;
+      _clearExpansions();
+      _initialFocusId = null;
+      _initialPreviousFocusId = null;
+    }
+  }
+
+  @override
+  void dispose() {
+    _clearExpansions();
+    super.dispose();
+  }
+
+  void _clearExpansions() {
+    for (final sub in _expansionSubscriptions.values) {
+      sub.close();
+    }
+    _expansionSubscriptions.clear();
+    _expansions.clear();
+    _expansionVersion++;
+    _lastMergeSeedData = null;
+    _lastMergeExpansionVersion = -1;
+    _mergeRequestId++;
+  }
+
+  void _handleTaskFocusChanged(String taskId, String previousFocusId) {
+    if (taskId == widget.taskId ||
+        _expansionSubscriptions.containsKey(taskId)) {
+      return;
+    }
+    _initialFocusId = taskId;
+    _initialPreviousFocusId = previousFocusId;
+    _listenToExpansion(taskId);
+  }
+
+  void _listenToExpansion(String taskId) {
+    final subscription = ref.listenManual(
+      taskGraphProvider(taskId),
+      (_, next) => _handleExpansionUpdate(taskId, next),
+    );
+    _expansionSubscriptions[taskId] = subscription;
+    _handleExpansionUpdate(taskId, ref.read(taskGraphProvider(taskId)));
+  }
+
+  void _handleExpansionUpdate(
+    String taskId,
+    AsyncValue<TaskGraphData?> next,
+  ) {
+    if (!_expansionSubscriptions.containsKey(taskId)) return;
+
+    if (next.hasError) {
+      _logExpansionError(next.error!, next.stackTrace ?? StackTrace.current);
+      _removeExpansion(taskId);
+      return;
+    }
+
+    final expansion = next.asData?.value;
+    if (expansion == null) return;
+
+    _expansions[taskId] = expansion;
+    _expansionVersion++;
+    final seedData =
+        _seedData ?? ref.read(taskGraphProvider(widget.taskId)).asData?.value;
+    if (seedData != null) {
+      _scheduleRemerge(seedData);
+    }
+  }
+
+  void _logExpansionError(Object error, StackTrace stackTrace) {
+    if (!mounted) return;
+    getIt<LoggingService>().captureException(
+      error,
+      domain: 'KNOWLEDGE_GRAPH',
+      subDomain: 'taskGraphProvider.expand',
+      stackTrace: stackTrace,
+    );
+  }
+
+  void _removeExpansion(String taskId) {
+    _expansionSubscriptions.remove(taskId)?.close();
+    if (_expansions.remove(taskId) != null) {
+      _expansionVersion++;
+      final seedData = _seedData;
+      if (seedData != null) {
+        _scheduleRemerge(seedData);
+      }
+    }
+  }
+
+  void _scheduleRemerge(TaskGraphData seedData) {
+    if (identical(_lastMergeSeedData, seedData) &&
+        _lastMergeExpansionVersion == _expansionVersion) {
+      return;
+    }
+    _lastMergeSeedData = seedData;
+    _lastMergeExpansionVersion = _expansionVersion;
+    final requestId = ++_mergeRequestId;
+    unawaited(_remergeWithSeed(seedData, requestId, _expansionVersion));
+  }
+
+  Future<void> _remergeWithSeed(
+    TaskGraphData seedData,
+    int requestId,
+    int expansionVersion,
+  ) async {
+    try {
+      final merge = widget.mergeGraphData ?? mergeTaskGraphData;
+      final expansions = List<TaskGraphData>.of(_expansions.values);
+      var merged = seedData;
+      for (final expansion in expansions) {
+        merged = await merge(merged, expansion);
+      }
+      if (!mounted ||
+          requestId != _mergeRequestId ||
+          expansionVersion != _expansionVersion) {
+        return;
+      }
+      setState(() => _visibleData = merged);
+    } on Object catch (error, stackTrace) {
+      getIt<LoggingService>().captureException(
+        error,
+        domain: 'KNOWLEDGE_GRAPH',
+        subDomain: 'taskGraphProvider.merge',
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  void _setVisibleData(TaskGraphData data) {
+    _seedData = data;
+    if (_expansions.isEmpty) {
+      _visibleData = data;
+      _lastMergeSeedData = null;
+      _lastMergeExpansionVersion = -1;
+      return;
+    }
+    _scheduleRemerge(data);
+  }
+
+  Widget _graphContent(TaskGraphData? data) {
+    // Only the focus node and nothing linked -> nothing to explore.
+    if (data == null || data.scenario.nodes.length <= 1) {
+      return const _EmptyState();
+    }
+    _setVisibleData(data);
+    final visibleData = _visibleData ?? data;
+    // The view derives its state once in initState, so key it on the
+    // scenario to rebuild from scratch when fresh data arrives.
+    return KnowledgeGraphView(
+      key: ValueKey(visibleData.scenario),
+      scenario: visibleData.scenario,
+      categoryColors: visibleData.categoryColors,
+      categoryNames: visibleData.categoryNames,
+      initialFocusId: _initialFocusId,
+      initialPreviousFocusId: _initialPreviousFocusId,
+      onTaskFocusChanged: _handleTaskFocusChanged,
+      // Relaxed off the main thread in the provider so the first frame
+      // renders without a layout pass on the UI thread.
+      layout: visibleData.layout,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final tokens = context.designTokens;
 
     // Log provider failures with full detail for developers; the UI only ever
     // shows a generic, localized message (never raw exception text).
-    ref.listen(taskGraphProvider(taskId), (_, next) {
+    ref.listen(taskGraphProvider(widget.taskId), (_, next) {
       if (next case AsyncError(:final error, :final stackTrace)) {
         getIt<LoggingService>().captureException(
           error,
@@ -34,31 +294,17 @@ class TaskKnowledgeGraphPage extends ConsumerWidget {
       }
     });
 
-    final graph = ref.watch(taskGraphProvider(taskId));
+    final graph = ref.watch(taskGraphProvider(widget.taskId));
     final mediaQuery = MediaQuery.of(context);
 
     final content = graph.when(
       // Keep the last rendered graph while a background refresh (sync / db
       // notification) reloads, instead of flashing the spinner.
       skipLoadingOnReload: true,
-      data: (data) {
-        // Only the focus node and nothing linked → nothing to explore.
-        if (data == null || data.scenario.nodes.length <= 1) {
-          return const _EmptyState();
-        }
-        // The view derives its state once in initState, so key it on the
-        // scenario to rebuild from scratch when fresh data arrives.
-        return KnowledgeGraphView(
-          key: ValueKey(data.scenario),
-          scenario: data.scenario,
-          categoryColors: data.categoryColors,
-          categoryNames: data.categoryNames,
-          // Relaxed off the main thread in the provider so the first frame
-          // renders without a layout pass on the UI thread.
-          layout: data.layout,
-        );
-      },
-      loading: () => const Center(child: CircularProgressIndicator()),
+      data: _graphContent,
+      loading: () => _visibleData == null
+          ? const Center(child: CircularProgressIndicator())
+          : _graphContent(_visibleData),
       error: (_, _) => const _ErrorState(),
     );
 
@@ -69,7 +315,7 @@ class TaskKnowledgeGraphPage extends ConsumerWidget {
           // The graph fills the whole body, full-bleed under the floating
           // header. Reserving the header's height in the child's top padding
           // (the same contract `extendBodyBehindAppBar` uses) keeps the view's
-          // own top-left chrome below the header — without banding off a header
+          // own top-left chrome below the header - without banding off a header
           // row, and without a full-width bar that would swallow taps over the
           // inspector docked on the right.
           Positioned.fill(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1029+4154
+version: 0.9.1029+4155
 
 msix_config:
   display_name: LottiApp

--- a/test/features/knowledge_graph_poc/ui/knowledge_graph_view_test.dart
+++ b/test/features/knowledge_graph_poc/ui/knowledge_graph_view_test.dart
@@ -45,6 +45,7 @@ void main() {
     bool showTitle = true,
     bool showLegend = true,
     bool disableAnimations = false,
+    void Function(String taskId, String previousFocusId)? onTaskFocusChanged,
     Size size = desktopSize,
     List<Override> extraOverrides = const [],
   }) async {
@@ -62,6 +63,7 @@ void main() {
           initialFocusId: initialFocusId,
           initialPreviousFocusId: initialPreviousFocusId,
           layout: layout,
+          onTaskFocusChanged: onTaskFocusChanged,
           showInspector: showInspector,
           showTitle: showTitle,
           showLegend: showLegend,
@@ -982,6 +984,30 @@ void main() {
       expect(afterTime.scale, jumped.scale);
       expect(afterTime.pan, jumped.pan);
       expect(afterTime.wake, 0);
+    });
+
+    testWidgets('walking to a task reports the task focus change', (
+      tester,
+    ) async {
+      final scenario = taskEgoNetworkScenario();
+      final calls = <({String taskId, String previousFocusId})>[];
+      await pumpView(
+        tester,
+        scenario: scenario,
+        onTaskFocusChanged: (taskId, previousFocusId) {
+          calls.add((taskId: taskId, previousFocusId: previousFocusId));
+        },
+      );
+
+      await tester.ensureVisible(inspectorText('Fix sync race condition'));
+      await tester.pump();
+      await tester.tap(inspectorText('Fix sync race condition'));
+      await tester.pump();
+
+      expect(calls, [
+        (taskId: 't1', previousFocusId: scenario.seedId),
+      ]);
+      expect(painterFocusId(tester), 't1');
     });
 
     testWidgets('tapping empty space leaves the focus unchanged', (

--- a/test/features/knowledge_graph_poc/ui/task_knowledge_graph_page_test.dart
+++ b/test/features/knowledge_graph_poc/ui/task_knowledge_graph_page_test.dart
@@ -1,13 +1,16 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/journal/model/entry_state.dart';
 import 'package:lotti/features/journal/state/entry_controller.dart';
+import 'package:lotti/features/knowledge_graph_poc/domain/graph_layout_engine.dart';
 import 'package:lotti/features/knowledge_graph_poc/domain/graph_models.dart';
 import 'package:lotti/features/knowledge_graph_poc/state/task_graph_provider.dart';
 import 'package:lotti/features/knowledge_graph_poc/ui/entry_detail_sidebar.dart';
+import 'package:lotti/features/knowledge_graph_poc/ui/knowledge_graph_painter.dart';
 import 'package:lotti/features/knowledge_graph_poc/ui/knowledge_graph_view.dart';
 import 'package:lotti/features/knowledge_graph_poc/ui/task_knowledge_graph_page.dart';
 import 'package:lotti/get_it.dart';
@@ -25,6 +28,15 @@ import '../../../widget_test_utils.dart';
 class _NullEntryController extends EntryController {
   @override
   Future<EntryState?> build({required String id}) async => null;
+}
+
+class _BoolNotifier extends Notifier<bool> {
+  @override
+  bool build() => false;
+
+  bool get value => state;
+
+  set value(bool value) => state = value;
 }
 
 void main() {
@@ -96,6 +108,130 @@ void main() {
     categoryColors: const {},
   );
 
+  TaskGraphData projectHubData({
+    bool includeSeedNote = false,
+    bool includeThirdTask = false,
+  }) => TaskGraphData(
+    scenario: GraphScenario(
+      name: 'Seed task',
+      seedId: taskId,
+      nodes: [
+        node(taskId),
+        node('project', type: GraphNodeType.project),
+        node('task-2'),
+        if (includeThirdTask) node('task-3'),
+        if (includeSeedNote) node('seed-note', type: GraphNodeType.textEntry),
+      ],
+      edges: [
+        const GraphEdge(
+          fromId: 'project',
+          toId: taskId,
+          kind: GraphEdgeKind.containment,
+        ),
+        const GraphEdge(
+          fromId: 'project',
+          toId: 'task-2',
+          kind: GraphEdgeKind.containment,
+        ),
+        if (includeThirdTask)
+          const GraphEdge(
+            fromId: 'project',
+            toId: 'task-3',
+            kind: GraphEdgeKind.containment,
+          ),
+        if (includeSeedNote)
+          const GraphEdge(
+            fromId: taskId,
+            toId: 'seed-note',
+            kind: GraphEdgeKind.association,
+          ),
+      ],
+      now: fixedNow,
+    ),
+    categoryColors: const {},
+  );
+
+  TaskGraphData taskTwoExpansionData({bool includeExtraNote = false}) =>
+      TaskGraphData(
+        scenario: GraphScenario(
+          name: 'Second task',
+          seedId: 'task-2',
+          nodes: [
+            node('task-2'),
+            node('project', type: GraphNodeType.project),
+            node('note-2', type: GraphNodeType.textEntry),
+            if (includeExtraNote) node('note-3', type: GraphNodeType.textEntry),
+          ],
+          edges: [
+            const GraphEdge(
+              fromId: 'project',
+              toId: 'task-2',
+              kind: GraphEdgeKind.containment,
+            ),
+            const GraphEdge(
+              fromId: 'task-2',
+              toId: 'note-2',
+              kind: GraphEdgeKind.association,
+            ),
+            if (includeExtraNote)
+              const GraphEdge(
+                fromId: 'task-2',
+                toId: 'note-3',
+                kind: GraphEdgeKind.association,
+              ),
+          ],
+          now: fixedNow,
+        ),
+        categoryColors: const {kUncategorized: Colors.purple},
+        categoryNames: const {kUncategorized: 'Inbox'},
+      );
+
+  TaskGraphData taskThreeExpansionData() => TaskGraphData(
+    scenario: GraphScenario(
+      name: 'Third task',
+      seedId: 'task-3',
+      nodes: [
+        node('task-3'),
+        node('project', type: GraphNodeType.project),
+        node('note-4', type: GraphNodeType.textEntry),
+      ],
+      edges: [
+        const GraphEdge(
+          fromId: 'project',
+          toId: 'task-3',
+          kind: GraphEdgeKind.containment,
+        ),
+        const GraphEdge(
+          fromId: 'task-3',
+          toId: 'note-4',
+          kind: GraphEdgeKind.association,
+        ),
+      ],
+      now: fixedNow,
+    ),
+    categoryColors: const {},
+  );
+
+  TaskGraphData alternateTaskData() => TaskGraphData(
+    scenario: GraphScenario(
+      name: 'Fresh task',
+      seedId: 'task-fresh',
+      nodes: [
+        node('task-fresh'),
+        node('fresh-note', type: GraphNodeType.textEntry),
+      ],
+      edges: [
+        const GraphEdge(
+          fromId: 'task-fresh',
+          toId: 'fresh-note',
+          kind: GraphEdgeKind.association,
+        ),
+      ],
+      now: fixedNow,
+    ),
+    categoryColors: const {},
+  );
+
   /// A scenario containing only the seed node — proves the `<= 1` empty guard.
   TaskGraphData seedOnlyData() => TaskGraphData(
     scenario: GraphScenario(
@@ -115,16 +251,138 @@ void main() {
     // Phone-sized surface keeps the page off the desktop inspector path; either
     // is fine for the page-level branches we assert.
     Size surface = const Size(390, 844),
+    Future<TaskGraphData> Function(TaskGraphData, TaskGraphData)?
+    mergeGraphData,
     List<Override> extraOverrides = const [],
   }) async {
     await tester.pumpWidget(
       makeTestableWidgetNoScroll(
-        const TaskKnowledgeGraphPage(taskId: taskId),
+        TaskKnowledgeGraphPage(
+          taskId: taskId,
+          mergeGraphData: mergeGraphData,
+        ),
         mediaQueryData: MediaQueryData(size: surface),
         overrides: [providerOverride, ...extraOverrides],
       ),
     );
   }
+
+  KnowledgeGraphPainter painterOf(WidgetTester tester) {
+    final paint = tester.widget<CustomPaint>(
+      find.descendant(
+        of: find.byType(KnowledgeGraphView),
+        matching: find.byWidgetPredicate(
+          (w) => w is CustomPaint && w.painter is KnowledgeGraphPainter,
+        ),
+      ),
+    );
+    return paint.painter! as KnowledgeGraphPainter;
+  }
+
+  Set<String> paintedNodeIds(WidgetTester tester) => {
+    for (final node in painterOf(tester).scenario.nodes) node.id,
+  };
+
+  Offset screenPosOf(WidgetTester tester, String nodeId) {
+    final painter = painterOf(tester);
+    final viewTopLeft = tester.getTopLeft(find.byType(KnowledgeGraphView));
+    return viewTopLeft +
+        painter.positions[nodeId]! * painter.scale +
+        painter.pan;
+  }
+
+  bool graphContainsNode(WidgetTester tester, String id) =>
+      find.byType(KnowledgeGraphView).evaluate().isNotEmpty &&
+      paintedNodeIds(tester).contains(id);
+
+  Future<void> pumpUntil(
+    WidgetTester tester,
+    bool Function() condition, {
+    String reason = 'condition',
+  }) async {
+    for (var i = 0; i < 12 && !condition(); i++) {
+      await tester.pump(const Duration(milliseconds: 100));
+    }
+    if (!condition()) {
+      fail('Timed out waiting for $reason');
+    }
+  }
+
+  test(
+    'mergeTaskGraphData adds expansion nodes without changing base seed',
+    () async {
+      final merged = await mergeTaskGraphData(
+        projectHubData(),
+        taskTwoExpansionData(),
+        layoutBuilder: (scenario) async => computeLayoutForScenario(scenario),
+      );
+
+      expect(merged.scenario.seedId, taskId);
+      expect(merged.scenario.name, 'Seed task');
+      expect(
+        merged.scenario.nodes.map((node) => node.id),
+        containsAllInOrder(['task-1', 'project', 'task-2', 'note-2']),
+      );
+      expect(
+        merged.scenario.edges.where(
+          (edge) =>
+              edge.fromId == 'project' &&
+              edge.toId == 'task-2' &&
+              edge.kind == GraphEdgeKind.containment,
+        ),
+        hasLength(1),
+      );
+      expect(
+        merged.scenario.edges.any(
+          (edge) =>
+              edge.fromId == 'task-2' &&
+              edge.toId == 'note-2' &&
+              edge.kind == GraphEdgeKind.association,
+        ),
+        isTrue,
+      );
+      expect(merged.categoryColors[kUncategorized], Colors.purple);
+      expect(merged.categoryNames[kUncategorized], 'Inbox');
+      expect(merged.layout!.positions.keys, contains('note-2'));
+    },
+  );
+
+  test(
+    'mergeTaskGraphData drops expansion edges with missing endpoints',
+    () async {
+      final expansion = TaskGraphData(
+        scenario: GraphScenario(
+          name: 'Orphan edge',
+          seedId: 'task-2',
+          nodes: [node('task-2')],
+          edges: const [
+            GraphEdge(
+              fromId: 'task-2',
+              toId: 'missing-note',
+              kind: GraphEdgeKind.association,
+            ),
+          ],
+          now: fixedNow,
+        ),
+        categoryColors: const {},
+      );
+
+      final merged = await mergeTaskGraphData(
+        projectHubData(),
+        expansion,
+        layoutBuilder: (scenario) async => computeLayoutForScenario(scenario),
+      );
+
+      expect(
+        merged.scenario.nodes.map((node) => node.id),
+        isNot(contains('missing-note')),
+      );
+      expect(
+        merged.scenario.edges.where((edge) => edge.toId == 'missing-note'),
+        isEmpty,
+      );
+    },
+  );
 
   testWidgets(
     'renders KnowledgeGraphView for a multi-node graph (no empty/error)',
@@ -203,6 +461,548 @@ void main() {
     expect(find.text(l10n.knowledgeGraphError), findsNothing);
     expect(find.text(l10n.knowledgeGraphTitle), findsOneWidget);
   });
+
+  testWidgets(
+    'keeps the cached graph visible when a fresh provider is loading',
+    (tester) async {
+      final pageKey = GlobalKey();
+      final loadingCompleter = Completer<TaskGraphData?>();
+      addTearDown(() {
+        if (!loadingCompleter.isCompleted) loadingCompleter.complete(null);
+      });
+
+      Widget buildPage(Override providerOverride) => makeTestableWidgetNoScroll(
+        TaskKnowledgeGraphPage(key: pageKey, taskId: taskId),
+        mediaQueryData: const MediaQueryData(size: Size(390, 844)),
+        overrides: [providerOverride],
+      );
+
+      await tester.pumpWidget(
+        buildPage(
+          taskGraphProvider(taskId).overrideWith(
+            (ref) async => multiNodeData(),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(paintedNodeIds(tester), containsAll([taskId, 'linked-1']));
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+
+      await tester.pumpWidget(
+        buildPage(
+          taskGraphProvider(
+            taskId,
+          ).overrideWith((ref) => loadingCompleter.future),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(KnowledgeGraphView), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(paintedNodeIds(tester), containsAll([taskId, 'linked-1']));
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'walking project then sibling task additively loads the task neighborhood',
+    (tester) async {
+      var expansionReads = 0;
+      await pumpPage(
+        tester,
+        taskGraphProvider(taskId).overrideWith(
+          (ref) async => projectHubData(),
+        ),
+        surface: const Size(1280, 800),
+        mergeGraphData: (current, expansion) => mergeTaskGraphData(
+          current,
+          expansion,
+          layoutBuilder: (scenario) async => computeLayoutForScenario(scenario),
+        ),
+        extraOverrides: [
+          taskGraphProvider('task-2').overrideWith((ref) async {
+            expansionReads++;
+            return taskTwoExpansionData();
+          }),
+        ],
+      );
+      await tester.pump();
+
+      expect(find.text('Node note-2'), findsNothing);
+
+      await tester.tap(find.text('Node project').last);
+      await tester.pump();
+      expect(expansionReads, 0);
+      expect(find.text('Node task-2'), findsWidgets);
+
+      await tester.tap(find.text('Node task-2').last);
+      await tester.pump();
+      expect(expansionReads, 1);
+
+      for (
+        var i = 0;
+        i < 10 && find.text('Node note-2').evaluate().isEmpty;
+        i++
+      ) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+
+      expect(find.text('Node note-2'), findsWidgets);
+      expect(find.text('Node project'), findsWidgets);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'ignores seed-task focus callbacks',
+    (tester) async {
+      var expansionReads = 0;
+      await pumpPage(
+        tester,
+        taskGraphProvider(taskId).overrideWith(
+          (ref) async => projectHubData(),
+        ),
+        surface: const Size(1280, 800),
+        mergeGraphData: (current, expansion) => mergeTaskGraphData(
+          current,
+          expansion,
+          layoutBuilder: (scenario) async => computeLayoutForScenario(scenario),
+        ),
+        extraOverrides: [
+          taskGraphProvider('task-2').overrideWith((ref) async {
+            expansionReads++;
+            return taskTwoExpansionData();
+          }),
+        ],
+      );
+      await tester.pump();
+
+      await tester.tap(find.text('Node project').last);
+      await tester.pump();
+      await tester.tap(find.text('Node task-1').last);
+      await tester.pump();
+      expect(expansionReads, 0);
+
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'expanded graph remerges seed and expanded task provider updates',
+    (tester) async {
+      var seedHasNote = false;
+      var expansionHasExtraNote = false;
+      var expansionReads = 0;
+
+      final result = makeTestableWidgetWithContainer(
+        TaskKnowledgeGraphPage(
+          taskId: taskId,
+          mergeGraphData: (current, expansion) => mergeTaskGraphData(
+            current,
+            expansion,
+            layoutBuilder: (scenario) async =>
+                computeLayoutForScenario(scenario),
+          ),
+        ),
+        mediaQueryData: const MediaQueryData(size: Size(1280, 800)),
+        overrides: [
+          taskGraphProvider(taskId).overrideWith(
+            (ref) async => projectHubData(includeSeedNote: seedHasNote),
+          ),
+          taskGraphProvider('task-2').overrideWith((ref) async {
+            expansionReads++;
+            return taskTwoExpansionData(
+              includeExtraNote: expansionHasExtraNote,
+            );
+          }),
+        ],
+      );
+      addTearDown(result.container.dispose);
+
+      await tester.pumpWidget(result.widget);
+      await tester.pump();
+
+      await tester.tap(find.text('Node project').last);
+      await tester.pump();
+      await tester.tap(find.text('Node task-2').last);
+      await tester.pump();
+
+      await pumpUntil(
+        tester,
+        () => paintedNodeIds(tester).contains('note-2'),
+        reason: 'task-2 expansion to render note-2',
+      );
+      expect(paintedNodeIds(tester), contains('note-2'));
+      expect(expansionReads, 1);
+
+      seedHasNote = true;
+      await tester.runAsync(() async {
+        result.container.invalidate(taskGraphProvider(taskId));
+        await result.container.read(taskGraphProvider(taskId).future);
+      });
+      await tester.pump();
+      await pumpUntil(
+        tester,
+        () => paintedNodeIds(tester).contains('seed-note'),
+        reason: 'seed refresh to preserve expansion and render seed-note',
+      );
+
+      final afterSeedRefresh = paintedNodeIds(tester);
+      expect(afterSeedRefresh, contains('seed-note'));
+      expect(afterSeedRefresh, contains('note-2'));
+
+      expansionHasExtraNote = true;
+      await tester.runAsync(() async {
+        result.container.invalidate(taskGraphProvider('task-2'));
+        await result.container.read(taskGraphProvider('task-2').future);
+      });
+      await tester.pump();
+      await pumpUntil(
+        tester,
+        () => paintedNodeIds(tester).contains('note-3'),
+        reason: 'expanded task refresh to render note-3',
+      );
+
+      final afterExpansionRefresh = paintedNodeIds(tester);
+      expect(afterExpansionRefresh, contains('seed-note'));
+      expect(afterExpansionRefresh, contains('note-2'));
+      expect(afterExpansionRefresh, contains('note-3'));
+      expect(expansionReads, 2);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'ignores expanded task provider results with no graph data',
+    (tester) async {
+      var expansionReads = 0;
+
+      final result = makeTestableWidgetWithContainer(
+        const TaskKnowledgeGraphPage(taskId: taskId),
+        mediaQueryData: const MediaQueryData(size: Size(1280, 800)),
+        overrides: [
+          taskGraphProvider(taskId).overrideWith(
+            (ref) async => projectHubData(),
+          ),
+          taskGraphProvider(
+            'task-2',
+          ).overrideWith((ref) {
+            expansionReads++;
+            return null;
+          }),
+        ],
+      );
+      addTearDown(result.container.dispose);
+
+      await tester.pumpWidget(result.widget);
+      await tester.pump();
+
+      await tester.tap(find.text('Node project').last);
+      await tester.pump();
+      await tester.tap(find.text('Node task-2').last);
+      await tester.pump();
+      await tester.pump();
+
+      expect(expansionReads, greaterThan(0));
+      expect(paintedNodeIds(tester), isNot(contains('note-2')));
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'logs expansion provider failures and removes the cached expansion',
+    (tester) async {
+      final failure = Exception('expanded task failed');
+      final expansionShouldThrowProvider =
+          NotifierProvider<_BoolNotifier, bool>(_BoolNotifier.new);
+      var expansionReads = 0;
+
+      final result = makeTestableWidgetWithContainer(
+        TaskKnowledgeGraphPage(
+          taskId: taskId,
+          mergeGraphData: (current, expansion) => mergeTaskGraphData(
+            current,
+            expansion,
+            layoutBuilder: (scenario) async =>
+                computeLayoutForScenario(scenario),
+          ),
+        ),
+        mediaQueryData: const MediaQueryData(size: Size(1280, 800)),
+        overrides: [
+          taskGraphProvider.overrideWith((ref, visibleTaskId) {
+            if (visibleTaskId == taskId) {
+              return projectHubData();
+            }
+            if (visibleTaskId == 'task-2') {
+              expansionReads++;
+              if (ref.watch(expansionShouldThrowProvider)) throw failure;
+              return taskTwoExpansionData();
+            }
+            return null;
+          }),
+        ],
+      );
+      addTearDown(result.container.dispose);
+
+      await tester.pumpWidget(result.widget);
+      await tester.pump();
+
+      await tester.tap(find.text('Node project').last);
+      await tester.pump();
+      await tester.tap(find.text('Node task-2').last);
+      await tester.pump();
+      await pumpUntil(
+        tester,
+        () => graphContainsNode(tester, 'note-2'),
+        reason: 'task-2 expansion to render before failing',
+      );
+      expect(expansionReads, 1);
+
+      result.container.read(expansionShouldThrowProvider.notifier).value = true;
+      await tester.pump();
+      await tester.pump();
+
+      await pumpUntil(
+        tester,
+        () => !graphContainsNode(tester, 'note-2'),
+        reason: 'failed expansion to be removed from the visible graph',
+      );
+
+      final nodeIds = paintedNodeIds(tester);
+      expect(nodeIds, containsAll([taskId, 'project', 'task-2']));
+      expect(nodeIds, isNot(contains('note-2')));
+      expect(expansionReads, greaterThan(1));
+
+      final captured = verify(
+        () => mockLoggingService.captureException(
+          captureAny<Object>(),
+          domain: 'KNOWLEDGE_GRAPH',
+          subDomain: 'taskGraphProvider.expand',
+          stackTrace: any<dynamic>(named: 'stackTrace'),
+        ),
+      ).captured;
+      expect(captured.single, same(failure));
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'logs merge failures without replacing the visible seed graph',
+    (tester) async {
+      final failure = Exception('merge failed');
+
+      await pumpPage(
+        tester,
+        taskGraphProvider(taskId).overrideWith(
+          (ref) async => projectHubData(),
+        ),
+        surface: const Size(1280, 800),
+        mergeGraphData: (current, expansion) async => throw failure,
+        extraOverrides: [
+          taskGraphProvider('task-2').overrideWith(
+            (ref) async => taskTwoExpansionData(),
+          ),
+        ],
+      );
+      await tester.pump();
+
+      await tester.tap(find.text('Node project').last);
+      await tester.pump();
+      await tester.tap(find.text('Node task-2').last);
+      await tester.pump();
+      await tester.pump();
+
+      expect(
+        paintedNodeIds(tester),
+        containsAll([taskId, 'project', 'task-2']),
+      );
+      expect(paintedNodeIds(tester), isNot(contains('note-2')));
+      final captured = verify(
+        () => mockLoggingService.captureException(
+          captureAny<Object>(),
+          domain: 'KNOWLEDGE_GRAPH',
+          subDomain: 'taskGraphProvider.merge',
+          stackTrace: any<dynamic>(named: 'stackTrace'),
+        ),
+      ).captured;
+      expect(captured.single, same(failure));
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'ignores an in-flight expansion merge after the page task changes',
+    (tester) async {
+      final currentTaskId = ValueNotifier(taskId);
+      final staleMergeGate = Completer<void>();
+      var staleMergeStarted = false;
+
+      Future<TaskGraphData> mergeGraphData(
+        TaskGraphData current,
+        TaskGraphData expansion,
+      ) async {
+        if (expansion.scenario.seedId == 'task-2' && !staleMergeStarted) {
+          staleMergeStarted = true;
+          await staleMergeGate.future;
+        }
+        return mergeTaskGraphData(
+          current,
+          expansion,
+          layoutBuilder: (scenario) async => computeLayoutForScenario(scenario),
+        );
+      }
+
+      final result = makeTestableWidgetWithContainer(
+        ValueListenableBuilder<String>(
+          valueListenable: currentTaskId,
+          builder: (context, visibleTaskId, child) => TaskKnowledgeGraphPage(
+            taskId: visibleTaskId,
+            mergeGraphData: mergeGraphData,
+          ),
+        ),
+        mediaQueryData: const MediaQueryData(size: Size(1280, 800)),
+        overrides: [
+          taskGraphProvider(taskId).overrideWith(
+            (ref) async => projectHubData(),
+          ),
+          taskGraphProvider('task-2').overrideWith(
+            (ref) async => taskTwoExpansionData(),
+          ),
+          taskGraphProvider('task-fresh').overrideWith(
+            (ref) async => alternateTaskData(),
+          ),
+        ],
+      );
+      addTearDown(result.container.dispose);
+      addTearDown(currentTaskId.dispose);
+
+      await tester.pumpWidget(result.widget);
+      await tester.pump();
+      await tester.tap(find.text('Node project').last);
+      await tester.pump();
+      await tester.tap(find.text('Node task-2').last);
+      await tester.pump();
+      await pumpUntil(
+        tester,
+        () => staleMergeStarted,
+        reason: 'stale merge to start before switching tasks',
+      );
+
+      currentTaskId.value = 'task-fresh';
+      await tester.pump();
+      await pumpUntil(
+        tester,
+        () => graphContainsNode(tester, 'fresh-note'),
+        reason: 'fresh task graph to replace old task graph',
+      );
+
+      expect(paintedNodeIds(tester), contains('fresh-note'));
+      expect(paintedNodeIds(tester), isNot(contains('note-2')));
+
+      staleMergeGate.complete();
+      await tester.pump();
+      await pumpUntil(
+        tester,
+        () => graphContainsNode(tester, 'fresh-note'),
+        reason: 'stale merge completion to keep fresh task graph',
+      );
+
+      expect(paintedNodeIds(tester), contains('fresh-note'));
+      expect(paintedNodeIds(tester), isNot(contains('note-2')));
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'keeps both expansions when back-to-back merges complete out of order',
+    (tester) async {
+      final mergeGates = <Completer<void>>[];
+
+      Future<TaskGraphData> controlledMerge(
+        TaskGraphData current,
+        TaskGraphData expansion,
+      ) async {
+        final gate = Completer<void>();
+        mergeGates.add(gate);
+        await gate.future;
+        return mergeTaskGraphData(
+          current,
+          expansion,
+          layoutBuilder: (scenario) async => computeLayoutForScenario(scenario),
+        );
+      }
+
+      await pumpPage(
+        tester,
+        taskGraphProvider(taskId).overrideWith(
+          (ref) async => projectHubData(includeThirdTask: true),
+        ),
+        surface: const Size(1280, 800),
+        mergeGraphData: controlledMerge,
+        extraOverrides: [
+          taskGraphProvider('task-2').overrideWith(
+            (ref) async => taskTwoExpansionData(),
+          ),
+          taskGraphProvider('task-3').overrideWith(
+            (ref) async => taskThreeExpansionData(),
+          ),
+        ],
+      );
+      await tester.pump();
+
+      await tester.tapAt(screenPosOf(tester, 'project'));
+      await tester.pump();
+      await tester.tapAt(screenPosOf(tester, 'task-2'));
+      await tester.pump();
+      await pumpUntil(
+        tester,
+        () => mergeGates.isNotEmpty,
+        reason: 'first merge gate',
+      );
+
+      await tester.tapAt(screenPosOf(tester, 'task-3'));
+      await tester.pump();
+      await pumpUntil(
+        tester,
+        () => mergeGates.length >= 2,
+        reason: 'second merge gate',
+      );
+
+      mergeGates[1].complete();
+      await tester.pump();
+      await pumpUntil(
+        tester,
+        () => mergeGates.length >= 3,
+        reason: 'remerge gate for both expansions',
+      );
+
+      mergeGates[2].complete();
+      await tester.pump();
+      await pumpUntil(
+        tester,
+        () =>
+            graphContainsNode(tester, 'note-2') &&
+            graphContainsNode(tester, 'note-4'),
+        reason: 'both out-of-order expansions to render',
+      );
+
+      expect(paintedNodeIds(tester), containsAll(['note-2', 'note-4']));
+
+      mergeGates[0].complete();
+      await tester.pump();
+      await pumpUntil(
+        tester,
+        () =>
+            graphContainsNode(tester, 'note-2') &&
+            graphContainsNode(tester, 'note-4'),
+        reason: 'stale first merge to leave both expansions visible',
+      );
+
+      expect(paintedNodeIds(tester), containsAll(['note-2', 'note-4']));
+      expect(tester.takeException(), isNull);
+    },
+  );
 
   testWidgets(
     'renders error state and logs the failure with KNOWLEDGE_GRAPH domain',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The experimental task knowledge graph now expands dynamically when navigating from projects to tasks, loading each task’s linked neighborhood and merging it into the current on-screen view.
  * Layout is recomputed after each expansion merge to keep sibling tasks from becoming dead ends.
  * Added an optional callback to notify when navigation focus lands on a task node.

* **Bug Fixes**
  * Graph loading now keeps the last visible view while updates complete in the background.

* **Documentation**
  * Updated the changelog, Flatpak release notes, and knowledge-graph explorer documentation to reflect the additive expansion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->