### PR TITLE
fix: lift sync conflict cards off the near-black scaffold

### DIFF
--- a/lib/features/sync/ui/widgets/conflicts/conflict_list_item.dart
+++ b/lib/features/sync/ui/widgets/conflicts/conflict_list_item.dart
@@ -27,31 +27,47 @@ class ConflictListItem extends StatelessWidget {
     final tokens = context.designTokens;
     final colors = tokens.colors;
 
+    final radius = BorderRadius.circular(tokens.radii.m);
     return Semantics(
       button: onTap != null,
       label: viewModel.semanticsLabel,
-      child: Material(
-        color: Colors.transparent,
-        borderRadius: BorderRadius.circular(tokens.radii.s),
-        child: InkWell(
-          borderRadius: BorderRadius.circular(tokens.radii.s),
-          hoverColor: colors.surface.hover,
-          onTap: onTap,
-          child: Padding(
-            padding: EdgeInsets.symmetric(
-              horizontal: tokens.spacing.step4,
-              vertical: tokens.spacing.step3,
-            ),
-            child: LayoutBuilder(
-              builder: (context, constraints) {
-                final isCompact = constraints.maxWidth < _compactBreakpoint;
-                return isCompact
-                    ? _CompactLayout(
-                        viewModel: viewModel,
-                        hasTap: onTap != null,
-                      )
-                    : _WideLayout(viewModel: viewModel, hasTap: onTap != null);
-              },
+      // A `level02` fill with a `decorative.level01` hairline (the shared
+      // design-system card treatment, e.g. the dashboard chart cards) lifts
+      // each conflict off the near-black `level01` scaffold. Without the
+      // border the row's fill is almost indistinguishable from the background
+      // in dark mode, so the list read as one flat, almost-black sheet.
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: colors.background.level02,
+          borderRadius: radius,
+          border: Border.all(color: colors.decorative.level01),
+        ),
+        child: Material(
+          color: Colors.transparent,
+          borderRadius: radius,
+          child: InkWell(
+            borderRadius: radius,
+            hoverColor: colors.surface.hover,
+            onTap: onTap,
+            child: Padding(
+              padding: EdgeInsets.symmetric(
+                horizontal: tokens.spacing.step4,
+                vertical: tokens.spacing.step3,
+              ),
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  final isCompact = constraints.maxWidth < _compactBreakpoint;
+                  return isCompact
+                      ? _CompactLayout(
+                          viewModel: viewModel,
+                          hasTap: onTap != null,
+                        )
+                      : _WideLayout(
+                          viewModel: viewModel,
+                          hasTap: onTap != null,
+                        );
+                },
+              ),
             ),
           ),
         ),

--- a/lib/features/sync/ui/widgets/conflicts/conflict_list_item.dart
+++ b/lib/features/sync/ui/widgets/conflicts/conflict_list_item.dart
@@ -35,39 +35,33 @@ class ConflictListItem extends StatelessWidget {
       // design-system card treatment, e.g. the dashboard chart cards) lifts
       // each conflict off the near-black `level01` scaffold. Without the
       // border the row's fill is almost indistinguishable from the background
-      // in dark mode, so the list read as one flat, almost-black sheet.
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          color: colors.background.level02,
+      // in dark mode, so the list read as one flat, almost-black sheet. The
+      // border rides on the Material's shape so the ink splash clips to it.
+      child: Material(
+        color: colors.background.level02,
+        clipBehavior: Clip.antiAlias,
+        shape: RoundedRectangleBorder(
           borderRadius: radius,
-          border: Border.all(color: colors.decorative.level01),
+          side: BorderSide(color: colors.decorative.level01),
         ),
-        child: Material(
-          color: Colors.transparent,
-          borderRadius: radius,
-          child: InkWell(
-            borderRadius: radius,
-            hoverColor: colors.surface.hover,
-            onTap: onTap,
-            child: Padding(
-              padding: EdgeInsets.symmetric(
-                horizontal: tokens.spacing.step4,
-                vertical: tokens.spacing.step3,
-              ),
-              child: LayoutBuilder(
-                builder: (context, constraints) {
-                  final isCompact = constraints.maxWidth < _compactBreakpoint;
-                  return isCompact
-                      ? _CompactLayout(
-                          viewModel: viewModel,
-                          hasTap: onTap != null,
-                        )
-                      : _WideLayout(
-                          viewModel: viewModel,
-                          hasTap: onTap != null,
-                        );
-                },
-              ),
+        child: InkWell(
+          hoverColor: colors.surface.hover,
+          onTap: onTap,
+          child: Padding(
+            padding: EdgeInsets.symmetric(
+              horizontal: tokens.spacing.step4,
+              vertical: tokens.spacing.step3,
+            ),
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                final isCompact = constraints.maxWidth < _compactBreakpoint;
+                return isCompact
+                    ? _CompactLayout(
+                        viewModel: viewModel,
+                        hasTap: onTap != null,
+                      )
+                    : _WideLayout(viewModel: viewModel, hasTap: onTap != null);
+              },
             ),
           ),
         ),

--- a/lib/features/sync/ui/widgets/conflicts/entry_diff_view.dart
+++ b/lib/features/sync/ui/widgets/conflicts/entry_diff_view.dart
@@ -53,8 +53,13 @@ class _FieldDiffRow extends StatelessWidget {
     return Container(
       padding: EdgeInsets.all(tokens.spacing.step3),
       decoration: BoxDecoration(
+        // `level02` fill plus the `decorative.level01` hairline — the shared
+        // design-system card treatment — so each field reads as a distinct
+        // card against the near-black `level01` scaffold instead of blending
+        // into it.
         color: colors.background.level02,
         borderRadius: BorderRadius.circular(tokens.radii.m),
+        border: Border.all(color: colors.decorative.level01),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/test/features/sync/ui/widgets/conflicts/conflict_list_item_test.dart
+++ b/test/features/sync/ui/widgets/conflicts/conflict_list_item_test.dart
@@ -6,6 +6,7 @@ import 'package:lotti/classes/entry_text.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/features/design_system/components/badges/design_system_badge.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/sync/ui/widgets/conflicts/conflict_list_item.dart';
 import 'package:lotti/features/sync/vector_clock.dart';
 import 'package:lotti/l10n/app_localizations_en.dart';
@@ -150,6 +151,36 @@ void main() {
       // The full id never appears as visible text (only inside the tooltip).
       expect(find.text(conflict.id), findsNothing);
     });
+  });
+
+  group('ConflictListItem (card surface)', () {
+    testWidgets(
+      'renders a level02 card with a decorative hairline border so the row '
+      'lifts off the near-black scaffold',
+      (tester) async {
+        final conflict = _buildConflict(status: ConflictStatus.unresolved);
+        await _pump(tester, conflict: conflict, surface: _wideSurface);
+
+        const tokens = dsTokensLight;
+        final decoration = tester
+            .widgetList<DecoratedBox>(
+              find.descendant(
+                of: find.byType(ConflictListItem),
+                matching: find.byType(DecoratedBox),
+              ),
+            )
+            .map((d) => d.decoration)
+            .whereType<BoxDecoration>()
+            .firstWhere(
+              (d) => d.border != null,
+              orElse: () => throw StateError('no bordered card surface found'),
+            );
+
+        expect(decoration.color, tokens.colors.background.level02);
+        final side = (decoration.border! as Border).top;
+        expect(side.color, tokens.colors.decorative.level01);
+      },
+    );
   });
 
   group('ConflictListItem (status tone)', () {

--- a/test/features/sync/ui/widgets/conflicts/conflict_list_item_test.dart
+++ b/test/features/sync/ui/widgets/conflicts/conflict_list_item_test.dart
@@ -162,23 +162,16 @@ void main() {
         await _pump(tester, conflict: conflict, surface: _wideSurface);
 
         const tokens = dsTokensLight;
-        final decoration = tester
-            .widgetList<DecoratedBox>(
-              find.descendant(
-                of: find.byType(ConflictListItem),
-                matching: find.byType(DecoratedBox),
-              ),
-            )
-            .map((d) => d.decoration)
-            .whereType<BoxDecoration>()
-            .firstWhere(
-              (d) => d.border != null,
-              orElse: () => throw StateError('no bordered card surface found'),
-            );
+        final material = tester.widget<Material>(
+          find.descendant(
+            of: find.byType(ConflictListItem),
+            matching: find.byType(Material),
+          ),
+        );
 
-        expect(decoration.color, tokens.colors.background.level02);
-        final side = (decoration.border! as Border).top;
-        expect(side.color, tokens.colors.decorative.level01);
+        expect(material.color, tokens.colors.background.level02);
+        final shape = material.shape! as RoundedRectangleBorder;
+        expect(shape.side.color, tokens.colors.decorative.level01);
       },
     );
   });

--- a/test/features/sync/ui/widgets/conflicts/entry_diff_view_test.dart
+++ b/test/features/sync/ui/widgets/conflicts/entry_diff_view_test.dart
@@ -1,5 +1,7 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/sync/ui/widgets/conflicts/entry_diff_view.dart';
 import 'package:lotti/features/sync/ui/widgets/conflicts/entry_field_diff.dart';
 
@@ -28,6 +30,38 @@ void main() {
     // 'brave' is the remote-introduced word, rendered as a highlight pill.
     expect(find.text('brave'), findsOneWidget);
   });
+
+  testWidgets(
+    'each field renders on a level02 card with a decorative hairline border '
+    'so it lifts off the near-black scaffold',
+    (tester) async {
+      final diff = computeEntryDiff(
+        entryOf(text: 'hello world'),
+        entryOf(text: 'hello brave world'),
+      );
+
+      await _pump(tester, diff);
+
+      const tokens = dsTokensLight;
+      final decoration = tester
+          .widgetList<Container>(
+            find.descendant(
+              of: find.byType(EntryDiffView),
+              matching: find.byType(Container),
+            ),
+          )
+          .map((c) => c.decoration)
+          .whereType<BoxDecoration>()
+          .firstWhere(
+            (d) => d.border != null,
+            orElse: () => throw StateError('no bordered field card found'),
+          );
+
+      expect(decoration.color, tokens.colors.background.level02);
+      final side = (decoration.border! as Border).top;
+      expect(side.color, tokens.colors.decorative.level01);
+    },
+  );
 
   testWidgets('boolean fields render localized Yes/No values', (tester) async {
     final diff = computeEntryDiff(


### PR DESCRIPTION
## What

In dark mode the sync **conflict list** and **conflict detail** pages read as a flat, almost-black sheet — not like the rest of the app.

- The conflict **list** rows were `Colors.transparent`, so the bare near-black `level01` scaffold showed straight through.
- The detail **field-diff** cards had a `level02` fill but no border, and `level02` (#222222) is barely distinguishable from `level01` (#181818) in dark mode — so the cards blended into the background.

## Change

Apply the shared design-system card treatment — `background.level02` fill **plus** a `decorative.level01` hairline border, the same combination the dashboard chart cards use — to both surfaces:

- `conflict_list_item.dart`: each row is now a bordered `level02` card.
- `entry_diff_view.dart`: each field-diff card gains the hairline border.

This delineates each surface against the dark scaffold so the pages read as cards-on-background like the rest of the app, without introducing any non-design-system colors.

## Before / after

Verified with the offline screenshot harness (dark mode, desktop): the list rows and detail field cards now have visible edges and lift off the scaffold.

## Tests

- Added a card-surface assertion to `conflict_list_item_test.dart` and `entry_diff_view_test.dart` verifying the `level02` fill + `decorative.level01` border.
- All conflict list-item and entry-diff tests pass; analyzer clean; formatted.

No CHANGELOG entry: this is visual polish on the sync-conflicts redesign that merged the same day (#3347) and hasn't shipped to users yet.
