### PR TITLE
test: cover events round-2 changes flagged by Codecov

### DIFF
--- a/lib/features/events/ui/pages/event_detail_page.dart
+++ b/lib/features/events/ui/pages/event_detail_page.dart
@@ -146,16 +146,14 @@ class EventDetailPage extends ConsumerWidget {
       beamToNamed('/tasks/${task.meta.id}');
     }
 
-    // The event's linked photos, any of which can become the cover.
+    // The event's linked photos, any of which can become the cover. Only wired
+    // up (via onChangeCover) once a cover exists, which implies at least one
+    // linked photo — so the picker always has something to choose from.
     final linkedImages = linked.whereType<JournalImage>().toList();
 
     // Opens a sheet to pick a different linked photo as the cover (or add a new
-    // one). Falls back to adding a photo when none are linked yet.
+    // one).
     void changeCover() {
-      if (linkedImages.isEmpty) {
-        addLinkedEntry();
-        return;
-      }
       showEventCoverPicker(
         context: context,
         currentCoverId: entry.data.coverArtId,

--- a/test/features/events/state/events_overview_controller_test.dart
+++ b/test/features/events/state/events_overview_controller_test.dart
@@ -176,6 +176,30 @@ void main() {
   });
 
   test(
+    'refresh reloads the full window when the loaded page is full',
+    () async {
+      final master = [for (var i = 0; i < eventsPageSize; i++) _event('e$i')];
+      stubPaged(master);
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final first = await container.read(
+        eventsOverviewControllerProvider.future,
+      );
+      expect(first.events, hasLength(eventsPageSize));
+
+      // A newer event arrives; refresh reloads the full loaded window
+      // (count == events.length — the >= eventsPageSize branch).
+      master.insert(0, _event('newest'));
+      updates.add({eventNotification});
+      await pumpEventQueue();
+
+      final state = container.read(eventsOverviewControllerProvider).value!;
+      expect(state.events.first.event.meta.id, 'newest');
+      expect(state.events, hasLength(eventsPageSize));
+    },
+  );
+
+  test(
     'loadMore clears the loading flag and keeps paging open on error',
     () async {
       // First page (build) succeeds and is full; the next page (loadMore) throws.
@@ -217,4 +241,22 @@ void main() {
       expect(state.events, hasLength(eventsPageSize));
     },
   );
+
+  test('copyWith preserves fields that are not overridden', () {
+    const base = EventsOverviewState(
+      events: [],
+      hasMore: true,
+      isLoadingMore: true,
+      categoryId: 'cat-x',
+    );
+
+    final copy = base.copyWith(hasMore: false);
+
+    // Only hasMore changed; the rest (including isLoadingMore) fall back to the
+    // original via `?? this.x`.
+    expect(copy.hasMore, isFalse);
+    expect(copy.isLoadingMore, isTrue);
+    expect(copy.events, same(base.events));
+    expect(copy.categoryId, 'cat-x');
+  });
 }

--- a/test/features/events/ui/widgets/event_cover_picker_test.dart
+++ b/test/features/events/ui/widgets/event_cover_picker_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/events/ui/widgets/event_cover_image.dart';
 import 'package:lotti/features/events/ui/widgets/event_cover_picker.dart';
 
+import '../../../../widget_test_utils.dart';
 import '../../test_utils.dart';
 
 void main() {
@@ -69,6 +70,87 @@ void main() {
       );
 
       expect(find.byIcon(Icons.add_a_photo_outlined), findsNothing);
+    });
+
+    testWidgets('rings the current cover with a thicker border', (
+      tester,
+    ) async {
+      await pumpEventComponent(
+        tester,
+        EventCoverPicker(
+          choices: choices(),
+          currentCoverId: 'a',
+          onSelect: (_) {},
+          onAddPhoto: () {},
+        ),
+        height: 240,
+      );
+
+      // The selected tile carries a 3px ring; the unselected one a hairline.
+      final borderWidths = tester
+          .widgetList<Container>(find.byType(Container))
+          .map((c) => c.decoration)
+          .whereType<BoxDecoration>()
+          .map((d) => d.border)
+          .whereType<Border>()
+          .map((b) => b.top.width)
+          .toList();
+      expect(borderWidths, containsAll(<double>[3, 1]));
+    });
+
+    group('showEventCoverPicker', () {
+      Future<void> open(
+        WidgetTester tester, {
+        required ValueChanged<String> onSelect,
+        required VoidCallback onAddPhoto,
+      }) async {
+        await tester.pumpWidget(
+          makeTestableWidget2(
+            Scaffold(
+              body: Builder(
+                builder: (context) => ElevatedButton(
+                  onPressed: () => showEventCoverPicker(
+                    context: context,
+                    choices: choices(),
+                    onSelect: onSelect,
+                    onAddPhoto: onAddPhoto,
+                  ),
+                  child: const Text('open'),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.tap(find.text('open'));
+        await tester.pumpAndSettle();
+      }
+
+      testWidgets('selecting a tile reports the id and dismisses the sheet', (
+        tester,
+      ) async {
+        final selected = <String>[];
+        await open(tester, onSelect: selected.add, onAddPhoto: () {});
+        expect(find.byType(EventCoverPicker), findsOneWidget);
+
+        await tester.tap(find.byType(EventCoverImage).first);
+        await tester.pumpAndSettle();
+
+        expect(selected, ['a']);
+        expect(find.byType(EventCoverPicker), findsNothing);
+      });
+
+      testWidgets('tapping add invokes onAddPhoto and dismisses the sheet', (
+        tester,
+      ) async {
+        var added = 0;
+        await open(tester, onSelect: (_) {}, onAddPhoto: () => added++);
+
+        await tester.tap(find.byIcon(Icons.add_a_photo_outlined));
+        await tester.pumpAndSettle();
+
+        expect(added, 1);
+        expect(find.byType(EventCoverPicker), findsNothing);
+      });
     });
   });
 }

--- a/test/features/events/ui/widgets/event_cover_picker_test.dart
+++ b/test/features/events/ui/widgets/event_cover_picker_test.dart
@@ -86,16 +86,25 @@ void main() {
         height: 240,
       );
 
-      // The selected tile carries a 3px ring; the unselected one a hairline.
-      final borderWidths = tester
-          .widgetList<Container>(find.byType(Container))
-          .map((c) => c.decoration)
-          .whereType<BoxDecoration>()
-          .map((d) => d.border)
-          .whereType<Border>()
-          .map((b) => b.top.width)
-          .toList();
-      expect(borderWidths, containsAll(<double>[3, 1]));
+      // Scope to each tile's own Container so an unrelated widget's border
+      // can't satisfy the check: the selected tile ('a') carries a 3px ring,
+      // the unselected one ('b') a hairline.
+      double tileBorderWidth(int index) {
+        final container = tester.widget<Container>(
+          find
+              .ancestor(
+                of: find.byType(EventCoverImage).at(index),
+                matching: find.byType(Container),
+              )
+              .first,
+        );
+        final border =
+            (container.decoration! as BoxDecoration).border! as Border;
+        return border.top.width;
+      }
+
+      expect(tileBorderWidth(0), 3);
+      expect(tileBorderWidth(1), 1);
     });
 
     group('showEventCoverPicker', () {

--- a/test/features/events/ui/widgets/event_detail_view_test.dart
+++ b/test/features/events/ui/widgets/event_detail_view_test.dart
@@ -145,6 +145,34 @@ void main() {
       expect(find.text('Wandered the festival.'), findsOneWidget);
     });
 
+    testWidgets(
+      'a time-recording beat without span labels falls back to text',
+      (
+        tester,
+      ) async {
+        await pumpEventScreen(
+          tester,
+          EventDetailView(
+            data: buildEventDetailData(
+              timeline: const [
+                EventTimelineEntry(
+                  timeLabel: '13:00',
+                  kind: EventTimelineKind.timeRecording,
+                  entryId: 'tr-x',
+                  text: 'A note with no span labels.',
+                  // endTimeLabel / durationLabel intentionally omitted.
+                ),
+              ],
+            ),
+          ),
+          size: _tallMobile,
+        );
+
+        expect(find.text('A note with no span labels.'), findsOneWidget);
+        expect(find.byType(TimeSpanBar), findsNothing);
+      },
+    );
+
     testWidgets('renders tasks with done/undone states and due labels', (
       tester,
     ) async {

--- a/test/features/events/ui/widgets/linked_event_card_test.dart
+++ b/test/features/events/ui/widgets/linked_event_card_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/event_data.dart';
 import 'package:lotti/classes/event_status.dart';
 import 'package:lotti/classes/journal_entities.dart';
@@ -17,7 +18,7 @@ import 'package:mocktail/mocktail.dart';
 import '../../../../mocks/mocks.dart';
 import '../../../../widget_test_utils.dart';
 
-JournalEvent _event(String id) {
+JournalEvent _event(String id, {String? categoryId}) {
   final now = DateTime(2026, 5, 12);
   return JournalEvent(
     meta: Metadata(
@@ -26,11 +27,31 @@ JournalEvent _event(String id) {
       updatedAt: now,
       dateFrom: now,
       dateTo: now,
+      categoryId: categoryId,
     ),
     data: const EventData(
       title: 'Summer Festival',
       stars: 0,
       status: EventStatus.completed,
+    ),
+  );
+}
+
+JournalImage _image(String id) {
+  final now = DateTime(2026, 5, 12);
+  return JournalImage(
+    meta: Metadata(
+      id: id,
+      createdAt: now,
+      updatedAt: now,
+      dateFrom: now,
+      dateTo: now,
+    ),
+    data: ImageData(
+      capturedAt: now,
+      imageId: id,
+      imageFile: '$id.jpg',
+      imageDirectory: '/images/2026/',
     ),
   );
 }
@@ -78,5 +99,43 @@ void main() {
     await tester.tap(find.byType(EventSummaryCard));
     await tester.pump();
     expect(beamed, ['/events/evt-1']);
+  });
+
+  testWidgets('resolves the category name and a linked-photo cover', (
+    tester,
+  ) async {
+    when(() => cache.getCategoryById('cat-1')).thenReturn(
+      CategoryDefinition(
+        id: 'cat-1',
+        createdAt: DateTime(2026),
+        updatedAt: DateTime(2026),
+        name: 'Friends',
+        vectorClock: null,
+        private: false,
+        active: true,
+        color: '#E91E63',
+      ),
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          resolvedOutgoingLinkedEntriesProvider(
+            'evt-2',
+          ).overrideWithValue([_image('img-1')]),
+        ],
+        child: makeTestableWidget2(
+          Scaffold(
+            body: LinkedEventCard(event: _event('evt-2', categoryId: 'cat-1')),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byType(EventSummaryCard), findsOneWidget);
+    // The resolved category name renders in the card's meta line
+    // ("Friends · <date>"), confirming the category lookup ran.
+    expect(find.textContaining('Friends'), findsOneWidget);
   });
 }


### PR DESCRIPTION
Follow-up to #3360 (now merged) — adds tests for the lines Codecov reported as uncovered in the events round-2 work, and removes one dead branch.

## Tests added
- **event_cover_picker**: the selected-cover ring; `showEventCoverPicker`'s select-tile and add-photo paths (modal launch + dismiss).
- **event_detail_view**: a time-recording beat falling back to plain note text when span labels are absent.
- **linked_event_card**: resolving a category name and a linked-photo cover.
- **events_overview_controller**: the full-window refresh branch, `loadMore` error recovery (clears the loading flag, keeps paging open), and `copyWith` field preservation.

## Cleanup
- Dropped a dead branch in `event_detail_page.changeCover` — unreachable because `onChangeCover` is only wired once a cover (hence a linked photo) exists, and the picker handles empty choices anyway.

Patch coverage for the five flagged files is now complete; analyzer clean; affected suites green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened the event cover selection flow to only proceed when there are already linked photos available.

* **Tests**
  * Added widget/controller coverage for event overview `refresh`, ensuring the full loaded window is retained and newest items remain first.
  * Extended `EventCoverPicker` tests to validate selected styling and `showEventCoverPicker` behaviors for selecting a cover and adding a photo.
  * Added `EventDetailView` tests for `timeRecording` timeline entries that omit end/duration labels without rendering the `TimeSpanBar`.
  * Improved `LinkedEventCard` tests to verify category name resolution and linked-photo display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->