### PR TITLE
feat: add .heic import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   be installed directly from the provider edit page.
 
 ### Changed
+- On platforms with HEIC/HEIF conversion support, image import now accepts
+  high-efficiency inputs from drag-and-drop, file picker, and clipboard paste.
+  Lotti converts those files to JPEG before creating the image entry, so the
+  internal attachment format stays unchanged.
 - **Choosing a model for a one-off AI run is calmer.** When you run an AI
   action from the sparkle menu (transcribe a voice note, analyze a photo,
   generate a prompt or cover art) and you have more than one capable model, the

--- a/lib/features/journal/README.md
+++ b/lib/features/journal/README.md
@@ -395,6 +395,7 @@ Supported entry points include:
 Two integration details are worth documenting because they are easy to miss:
 
 - image import and paste flows can trigger automatic image-analysis callbacks supplied by the AI feature
+- drag-and-drop and clipboard image imports accept JPEG and PNG everywhere; on platforms with HEIC/HEIF conversion support, high-efficiency inputs are converted to JPEG before the `JournalImage` entry is persisted so stored image paths stay in Lotti's existing image formats
 - creating a timer from a linked context polls for the new linked entry and then publishes a focus intent so the page scrolls to the freshly created timer entry
 - image and audio entries add a desktop-only file-manager reveal action to the
   existing entry Actions sheet without changing the underlying entity model

--- a/lib/features/journal/state/image_paste_controller.dart
+++ b/lib/features/journal/state/image_paste_controller.dart
@@ -20,9 +20,7 @@ class ImagePasteController extends _$ImagePasteController {
       return false;
     }
     final reader = await clipboard.read();
-    return reader.items.any(
-      (item) => item.canProvide(Formats.png) || item.canProvide(Formats.jpeg),
-    );
+    return reader.items.any(_canProvideSupportedImage);
   }
 
   Future<void> paste() async {
@@ -34,15 +32,29 @@ class ImagePasteController extends _$ImagePasteController {
 
     // Process all clipboard items (supports multiple photos)
     final futures = <Future<void>>[];
+    final supportsHighEfficiencyImages =
+        ImageImportConstants.supportsHighEfficiencyImageConversion();
     for (final item in reader.items) {
       if (item.canProvide(Formats.jpeg)) {
         futures.add(_processPastedItem(item, Formats.jpeg, 'jpg'));
       } else if (item.canProvide(Formats.png)) {
         futures.add(_processPastedItem(item, Formats.png, 'png'));
+      } else if (supportsHighEfficiencyImages &&
+          item.canProvide(Formats.heic)) {
+        futures.add(_processPastedItem(item, Formats.heic, 'heic'));
+      } else if (supportsHighEfficiencyImages &&
+          item.canProvide(Formats.heif)) {
+        futures.add(_processPastedItem(item, Formats.heif, 'heif'));
       }
     }
     await Future.wait(futures);
   }
+
+  bool _canProvideSupportedImage(ClipboardDataReader item) =>
+      item.canProvide(Formats.jpeg) ||
+      item.canProvide(Formats.png) ||
+      (ImageImportConstants.supportsHighEfficiencyImageConversion() &&
+          (item.canProvide(Formats.heic) || item.canProvide(Formats.heif)));
 
   Future<void> _processPastedItem(
     ClipboardDataReader item,

--- a/lib/logic/image_import.dart
+++ b/lib/logic/image_import.dart
@@ -4,6 +4,8 @@ import 'dart:typed_data';
 
 import 'package:exif/exif.dart';
 import 'package:file_selector/file_selector.dart';
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, defaultTargetPlatform;
 import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';
 import 'package:lotti/classes/geolocation.dart';
@@ -46,7 +48,51 @@ class ImageImportConstants {
   const ImageImportConstants._();
 
   /// Supported image file extensions for import.
-  static const Set<String> supportedExtensions = {'jpg', 'jpeg', 'png'};
+  static Set<String> get supportedExtensions =>
+      supportedExtensionsForPlatform();
+
+  /// Image file extensions that can be imported without conversion.
+  static const Set<String> standardExtensions = {
+    'jpg',
+    'jpeg',
+    'png',
+  };
+
+  /// HEIC/HEIF extensions accepted only where conversion support is available.
+  static const Set<String> highEfficiencyExtensions = {
+    'heic',
+    'heif',
+  };
+
+  /// Source image extensions that are converted before storage.
+  static const Set<String> sourceExtensionsConvertedToJpeg = {'heic', 'heif'};
+
+  /// Extension used for converted images in Lotti's storage.
+  static const String convertedImageExtension = 'jpg';
+
+  /// Returns image extensions supported on [targetPlatform].
+  static Set<String> supportedExtensionsForPlatform([
+    TargetPlatform? targetPlatform,
+  ]) {
+    if (supportsHighEfficiencyImageConversion(targetPlatform)) {
+      return {...standardExtensions, ...highEfficiencyExtensions};
+    }
+    return standardExtensions;
+  }
+
+  /// Whether HEIC/HEIF inputs can be converted before storage.
+  static bool supportsHighEfficiencyImageConversion([
+    TargetPlatform? targetPlatform,
+  ]) {
+    return switch (targetPlatform ?? defaultTargetPlatform) {
+      TargetPlatform.android ||
+      TargetPlatform.iOS ||
+      TargetPlatform.macOS => true,
+      TargetPlatform.fuchsia ||
+      TargetPlatform.linux ||
+      TargetPlatform.windows => false,
+    };
+  }
 
   /// Directory prefix for storing imported images.
   static const String directoryPrefix = '/images/';
@@ -162,10 +208,12 @@ Future<void> importImagePickerFiles({
   String? categoryId,
   AutomaticImageAnalysisTrigger? analysisTrigger,
 }) async {
-  const group = XTypeGroup(
-    extensions: ['jpg', 'jpeg', 'png'],
+  final group = XTypeGroup(
+    extensions: ImageImportConstants.supportedExtensions.toList(
+      growable: false,
+    ),
   );
-  final files = await openFiles(acceptedTypeGroups: const [group]);
+  final files = await openFiles(acceptedTypeGroups: [group]);
   if (files.isEmpty) return;
   await importImageXFiles(
     files,
@@ -226,10 +274,15 @@ Future<void> importImageXFiles(
       ).format(capturedAt);
       final relativePath = '${ImageImportConstants.directoryPrefix}$day/';
       final directory = await createAssetDirectory(relativePath);
-      final targetFileName = '$id.$fileExtension';
+      final targetFileExtension = _targetImageExtension(fileExtension);
+      final targetFileName = '$id.$targetFileExtension';
       final targetFilePath = p.join(directory, targetFileName);
 
-      await File(srcPath).copy(targetFilePath);
+      await _copyOrConvertImageFile(
+        sourceFile: File(srcPath),
+        sourceExtension: fileExtension,
+        targetFilePath: targetFilePath,
+      );
 
       final imageData = ImageData(
         imageId: id,
@@ -256,6 +309,68 @@ Future<void> importImageXFiles(
         subDomain: 'importDroppedImages',
       );
       // Continue processing other files even if one fails
+    }
+  }
+}
+
+String _targetImageExtension(String sourceExtension) {
+  final normalizedExtension = sourceExtension.toLowerCase();
+  if (_shouldConvertToJpeg(normalizedExtension)) {
+    return ImageImportConstants.convertedImageExtension;
+  }
+  return normalizedExtension;
+}
+
+bool _shouldConvertToJpeg(String sourceExtension) =>
+    ImageImportConstants.sourceExtensionsConvertedToJpeg.contains(
+      sourceExtension.toLowerCase(),
+    );
+
+Future<void> _copyOrConvertImageFile({
+  required File sourceFile,
+  required String sourceExtension,
+  required String targetFilePath,
+}) async {
+  if (!_shouldConvertToJpeg(sourceExtension)) {
+    await sourceFile.copy(targetFilePath);
+    return;
+  }
+
+  final convertedFile = await compressAndSave(sourceFile, targetFilePath);
+  if (convertedFile == null) {
+    throw StateError('Failed to convert $sourceExtension image to JPEG');
+  }
+}
+
+Future<void> _writeOrConvertPastedImageBytes({
+  required Uint8List data,
+  required String sourceExtension,
+  required String targetFilePath,
+}) async {
+  if (!_shouldConvertToJpeg(sourceExtension)) {
+    final file = await File(targetFilePath).create(recursive: true);
+    await file.writeAsBytes(data);
+    return;
+  }
+
+  final tempDirectory = await Directory.systemTemp.createTemp(
+    'lotti_pasted_image_',
+  );
+  try {
+    final sourceFile = File(
+      p.join(tempDirectory.path, 'pasted.$sourceExtension'),
+    );
+    await sourceFile.writeAsBytes(data);
+    await _copyOrConvertImageFile(
+      sourceFile: sourceFile,
+      sourceExtension: sourceExtension,
+      targetFilePath: targetFilePath,
+    );
+  } finally {
+    try {
+      await tempDirectory.delete(recursive: true);
+    } catch (_) {
+      // Best-effort cleanup for a temp file that no longer affects import.
     }
   }
 }
@@ -370,11 +485,16 @@ Future<void> importPastedImages({
   ).format(capturedAt);
   final relativePath = '${ImageImportConstants.directoryPrefix}$day/';
   final directory = await createAssetDirectory(relativePath);
-  final targetFileName = '$id.$fileExtension';
+  final sourceExtension = fileExtension.toLowerCase();
+  final targetFileExtension = _targetImageExtension(fileExtension);
+  final targetFileName = '$id.$targetFileExtension';
   final targetFilePath = p.join(directory, targetFileName);
 
-  final file = await File(targetFilePath).create(recursive: true);
-  await file.writeAsBytes(data);
+  await _writeOrConvertPastedImageBytes(
+    data: data,
+    sourceExtension: sourceExtension,
+    targetFilePath: targetFilePath,
+  );
 
   final imageData = ImageData(
     imageId: id,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1031+4166
+version: 0.9.1031+4167
 
 msix_config:
   display_name: LottiApp

--- a/test/features/ai/ui/unified_ai_skills_modal_test.dart
+++ b/test/features/ai/ui/unified_ai_skills_modal_test.dart
@@ -1603,7 +1603,10 @@ void main() {
             ValueListenableBuilder<bool>(
               valueListenable: showButton,
               builder: (_, show, _) => show
-                  ? UnifiedAiPopUpMenu(journalEntity: entity, linkedFromId: null)
+                  ? UnifiedAiPopUpMenu(
+                      journalEntity: entity,
+                      linkedFromId: null,
+                    )
                   : const SizedBox.shrink(),
             ),
             overrides: [

--- a/test/features/journal/state/image_paste_controller_test.dart
+++ b/test/features/journal/state/image_paste_controller_test.dart
@@ -1,8 +1,8 @@
 // ignore_for_file: unnecessary_lambdas
 
 import 'dart:io';
-import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
@@ -23,7 +23,9 @@ import 'package:path_provider/path_provider.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:super_clipboard/super_clipboard.dart';
 
+import '../../../helpers/fake_image_compress_platform.dart';
 import '../../../helpers/path_provider.dart';
+import '../../../helpers/target_platform.dart';
 import '../../../mocks/mocks.dart';
 
 class MockSystemClipboard extends Mock implements SystemClipboard {}
@@ -257,6 +259,57 @@ void main() {
       expect(result, true);
     });
 
+    for (final scenario in [
+      (format: Formats.heic, name: 'HEIC'),
+      (format: Formats.heif, name: 'HEIF'),
+    ]) {
+      test('build returns true when ${scenario.name} is available', () async {
+        await withTargetPlatform(
+          TargetPlatform.macOS,
+          () async {
+            when(() => mockItem.canProvide(Formats.jpeg)).thenReturn(false);
+            when(() => mockItem.canProvide(Formats.png)).thenReturn(false);
+            when(
+              () => mockItem.canProvide(Formats.heic),
+            ).thenReturn(scenario.format == Formats.heic);
+            when(
+              () => mockItem.canProvide(Formats.heif),
+            ).thenReturn(scenario.format == Formats.heif);
+
+            final result = await container.read(
+              imagePasteControllerProvider(
+                linkedFromId: null,
+                categoryId: null,
+              ).future,
+            );
+
+            expect(result, true);
+          },
+        );
+      });
+    }
+
+    test('build ignores HEIC-only clipboard data on Linux', () async {
+      await withTargetPlatform(
+        TargetPlatform.linux,
+        () async {
+          when(() => mockItem.canProvide(Formats.jpeg)).thenReturn(false);
+          when(() => mockItem.canProvide(Formats.png)).thenReturn(false);
+
+          final result = await container.read(
+            imagePasteControllerProvider(
+              linkedFromId: null,
+              categoryId: null,
+            ).future,
+          );
+
+          expect(result, false);
+          verifyNever(() => mockItem.canProvide(Formats.heic));
+          verifyNever(() => mockItem.canProvide(Formats.heif));
+        },
+      );
+    });
+
     test('paste handles PNG data correctly', () async {
       when(() => mockItem.canProvide(Formats.png)).thenReturn(true);
       when(() => mockItem.canProvide(Formats.jpeg)).thenReturn(false);
@@ -320,6 +373,120 @@ void main() {
 
       verify(() => mockItem.getFile(Formats.jpeg, any())).called(1);
       verify(() => mockFile.readAll()).called(1);
+    });
+
+    for (final scenario in [
+      (format: Formats.heic, name: 'HEIC'),
+      (format: Formats.heif, name: 'HEIF'),
+    ]) {
+      test('paste handles ${scenario.name} data as stored JPEG', () async {
+        await withTargetPlatform(
+          TargetPlatform.macOS,
+          () async {
+            clearInteractions(mockPersistenceLogic);
+            when(() => mockItem.canProvide(Formats.jpeg)).thenReturn(false);
+            when(() => mockItem.canProvide(Formats.png)).thenReturn(false);
+            when(
+              () => mockItem.canProvide(Formats.heic),
+            ).thenReturn(scenario.format == Formats.heic);
+            when(
+              () => mockItem.canProvide(Formats.heif),
+            ).thenReturn(scenario.format == Formats.heif);
+
+            when(
+              () => mockItem.getFile(scenario.format, any()),
+            ).thenAnswer((invocation) {
+              final callback =
+                  invocation.positionalArguments[1]
+                      as void Function(DataReaderFile);
+              callback(mockFile);
+              return null;
+            });
+
+            when(
+              () => mockFile.readAll(),
+            ).thenAnswer((_) async => Uint8List.fromList([1, 2, 3]));
+
+            final controller = container.read(
+              imagePasteControllerProvider(
+                linkedFromId: 'testLink',
+                categoryId: 'testCategory',
+              ).notifier,
+            );
+
+            await withFakeImageCompressPlatform(controller.paste);
+            await pumpEventQueue();
+
+            final capturedImage =
+                verify(
+                      () => mockPersistenceLogic.createDbEntity(
+                        captureAny(that: isA<JournalImage>()),
+                        linkedId: 'testLink',
+                        shouldAddGeolocation: any(
+                          named: 'shouldAddGeolocation',
+                        ),
+                        enqueueSync: any(named: 'enqueueSync'),
+                      ),
+                    ).captured.single
+                    as JournalImage;
+
+            expect(capturedImage.data.imageFile, endsWith('.jpg'));
+            verify(() => mockItem.getFile(scenario.format, any())).called(1);
+            verify(() => mockFile.readAll()).called(1);
+          },
+        );
+      });
+    }
+
+    test('paste skips HEIC-only clipboard data on Linux', () async {
+      await withTargetPlatform(
+        TargetPlatform.linux,
+        () async {
+          when(() => mockItem.canProvide(Formats.jpeg)).thenReturn(false);
+          when(() => mockItem.canProvide(Formats.png)).thenReturn(false);
+
+          final controller = container.read(
+            imagePasteControllerProvider(
+              linkedFromId: 'testLink',
+              categoryId: 'testCategory',
+            ).notifier,
+          );
+
+          await controller.paste();
+          await pumpEventQueue();
+
+          verifyNever(() => mockItem.canProvide(Formats.heic));
+          verifyNever(() => mockItem.canProvide(Formats.heif));
+          verifyNever(() => mockItem.getFile(any(), any()));
+        },
+      );
+    });
+
+    test('paste surfaces errors from clipboard file reads', () async {
+      when(() => mockItem.canProvide(Formats.png)).thenReturn(false);
+      when(() => mockItem.canProvide(Formats.jpeg)).thenReturn(true);
+
+      when(() => mockItem.getFile(Formats.jpeg, any())).thenAnswer((
+        invocation,
+      ) {
+        final callback =
+            invocation.positionalArguments[1] as void Function(DataReaderFile);
+        callback(mockFile);
+        return null;
+      });
+
+      when(
+        () => mockFile.readAll(),
+      ).thenThrow(StateError('clipboard read failed'));
+
+      final controller = container.read(
+        imagePasteControllerProvider(
+          linkedFromId: 'testLink',
+          categoryId: 'testCategory',
+        ).notifier,
+      );
+
+      await expectLater(controller.paste(), throwsA(isA<StateError>()));
     });
 
     test(
@@ -495,8 +662,12 @@ void main() {
       // Both items have no supported formats
       when(() => mockItem1.canProvide(Formats.png)).thenReturn(false);
       when(() => mockItem1.canProvide(Formats.jpeg)).thenReturn(false);
+      when(() => mockItem1.canProvide(Formats.heic)).thenReturn(false);
+      when(() => mockItem1.canProvide(Formats.heif)).thenReturn(false);
       when(() => mockItem2.canProvide(Formats.png)).thenReturn(false);
       when(() => mockItem2.canProvide(Formats.jpeg)).thenReturn(false);
+      when(() => mockItem2.canProvide(Formats.heic)).thenReturn(false);
+      when(() => mockItem2.canProvide(Formats.heif)).thenReturn(false);
 
       final controller = container.read(
         imagePasteControllerProvider(

--- a/test/helpers/fake_image_compress_platform.dart
+++ b/test/helpers/fake_image_compress_platform.dart
@@ -1,0 +1,146 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/services.dart' show MethodChannel;
+import 'package:flutter_image_compress/flutter_image_compress.dart'
+    as image_compress;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+final _fakeJpegBytes = Uint8List.fromList([
+  0xFF,
+  0xD8,
+  0xFF,
+  0xE0,
+  0x00,
+  0x10,
+  0x4A,
+  0x46,
+  0x49,
+  0x46,
+  0x00,
+  0x01,
+  0x01,
+  0x00,
+  0x00,
+  0x01,
+  0x00,
+  0x01,
+  0x00,
+  0x00,
+  0xFF,
+  0xD9,
+]);
+
+class FakeImageCompressPlatform extends Fake
+    with MockPlatformInterfaceMixin
+    implements image_compress.FlutterImageCompressPlatform {
+  @override
+  Future<Uint8List> compressWithList(
+    Uint8List image, {
+    int minWidth = 1920,
+    int minHeight = 1080,
+    int quality = 95,
+    int rotate = 0,
+    int inSampleSize = 1,
+    bool autoCorrectionAngle = true,
+    image_compress.CompressFormat format = image_compress.CompressFormat.jpeg,
+    bool keepExif = false,
+  }) async {
+    return Uint8List.fromList(_fakeJpegBytes);
+  }
+
+  @override
+  Future<Uint8List?> compressWithFile(
+    String path, {
+    int minWidth = 1920,
+    int minHeight = 1080,
+    int inSampleSize = 1,
+    int quality = 95,
+    int rotate = 0,
+    bool autoCorrectionAngle = true,
+    image_compress.CompressFormat format = image_compress.CompressFormat.jpeg,
+    bool keepExif = false,
+    int numberOfRetries = 5,
+  }) async {
+    await _validateSourcePath(path);
+    return Uint8List.fromList(_fakeJpegBytes);
+  }
+
+  @override
+  Future<image_compress.XFile?> compressAndGetFile(
+    String path,
+    String targetPath, {
+    int minWidth = 1920,
+    int minHeight = 1080,
+    int inSampleSize = 1,
+    int quality = 95,
+    int rotate = 0,
+    bool autoCorrectionAngle = true,
+    image_compress.CompressFormat format = image_compress.CompressFormat.jpeg,
+    bool keepExif = false,
+    int numberOfRetries = 5,
+  }) async {
+    await _validateSourcePath(path);
+    final targetFile = File(targetPath);
+    await targetFile.create(recursive: true);
+    await targetFile.writeAsBytes(_fakeJpegBytes);
+    return image_compress.XFile(targetFile.path);
+  }
+
+  @override
+  Future<Uint8List?> compressAssetImage(
+    String assetName, {
+    int minWidth = 1920,
+    int minHeight = 1080,
+    int quality = 95,
+    int rotate = 0,
+    bool autoCorrectionAngle = true,
+    image_compress.CompressFormat format = image_compress.CompressFormat.jpeg,
+    bool keepExif = false,
+  }) async => _fakeJpegBytes;
+
+  @override
+  image_compress.FlutterImageCompressValidator get validator =>
+      image_compress.FlutterImageCompressValidator(
+        const MethodChannel('flutter_image_compress'),
+      );
+
+  @override
+  void ignoreCheckSupportPlatform(bool value) {}
+
+  @override
+  Future<void> showNativeLog(bool value) async {}
+}
+
+Future<void> _validateSourcePath(String path) async {
+  final sourceFile = File(path);
+  if (!sourceFile.existsSync()) {
+    throw FileSystemException('Source image does not exist', path);
+  }
+  await sourceFile.length();
+}
+
+image_compress.FlutterImageCompressPlatform installFakeImageCompressPlatform() {
+  final originalPlatform = image_compress.FlutterImageCompressPlatform.instance;
+  image_compress.FlutterImageCompressPlatform.instance =
+      FakeImageCompressPlatform();
+  return originalPlatform;
+}
+
+void restoreImageCompressPlatform(
+  image_compress.FlutterImageCompressPlatform platform,
+) {
+  image_compress.FlutterImageCompressPlatform.instance = platform;
+}
+
+Future<T> withFakeImageCompressPlatform<T>(
+  Future<T> Function() body,
+) async {
+  final originalPlatform = installFakeImageCompressPlatform();
+  try {
+    return await body();
+  } finally {
+    restoreImageCompressPlatform(originalPlatform);
+  }
+}

--- a/test/helpers/fake_image_compress_platform_test.dart
+++ b/test/helpers/fake_image_compress_platform_test.dart
@@ -1,0 +1,61 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as path;
+
+import 'fake_image_compress_platform.dart';
+
+void main() {
+  group('FakeImageCompressPlatform', () {
+    late Directory tempDir;
+    late FakeImageCompressPlatform platform;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp(
+        'fake_image_compress_platform_test_',
+      );
+      platform = FakeImageCompressPlatform();
+    });
+
+    tearDown(() async {
+      try {
+        await tempDir.delete(recursive: true);
+      } catch (_) {}
+    });
+
+    test('compressWithFile throws when source file is missing', () async {
+      final missingPath = path.join(tempDir.path, 'missing.heic');
+
+      await expectLater(
+        platform.compressWithFile(missingPath),
+        throwsA(isA<FileSystemException>()),
+      );
+    });
+
+    test('compressAndGetFile throws when source file is missing', () async {
+      final missingPath = path.join(tempDir.path, 'missing.heic');
+      final targetPath = path.join(tempDir.path, 'target.jpg');
+
+      await expectLater(
+        platform.compressAndGetFile(missingPath, targetPath),
+        throwsA(isA<FileSystemException>()),
+      );
+    });
+
+    test('compressAndGetFile writes output for an existing source', () async {
+      final sourceFile = File(path.join(tempDir.path, 'source.heic'));
+      final targetPath = path.join(tempDir.path, 'target.jpg');
+      await sourceFile.writeAsBytes([1, 2, 3]);
+
+      final result = await platform.compressAndGetFile(
+        sourceFile.path,
+        targetPath,
+      );
+
+      expect(result, isNotNull);
+      expect(result!.path, targetPath);
+      expect(File(targetPath).existsSync(), isTrue);
+      expect(await File(targetPath).readAsBytes(), isNotEmpty);
+    });
+  });
+}

--- a/test/helpers/target_platform.dart
+++ b/test/helpers/target_platform.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/foundation.dart';
+
+Future<T> withTargetPlatform<T>(
+  TargetPlatform targetPlatform,
+  Future<T> Function() body,
+) async {
+  final previousTargetPlatform = debugDefaultTargetPlatformOverride;
+  debugDefaultTargetPlatformOverride = targetPlatform;
+  try {
+    return await body();
+  } finally {
+    debugDefaultTargetPlatformOverride = previousTargetPlatform;
+  }
+}

--- a/test/logic/image_import_test.dart
+++ b/test/logic/image_import_test.dart
@@ -19,8 +19,10 @@ import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 
+import '../helpers/fake_image_compress_platform.dart';
 import '../helpers/fallbacks.dart';
 import '../helpers/path_provider.dart';
+import '../helpers/target_platform.dart';
 import '../mocks/mocks.dart';
 
 // ---------------------------------------------------------------------------
@@ -443,10 +445,35 @@ void main() {
     group('ImageImportConstants', () {
       test('defines supported extensions', () {
         expect(
-          ImageImportConstants.supportedExtensions,
+          ImageImportConstants.supportedExtensionsForPlatform(
+            TargetPlatform.macOS,
+          ),
+          containsAll(['jpg', 'jpeg', 'png', 'heic', 'heif']),
+        );
+        expect(
+          ImageImportConstants.supportedExtensionsForPlatform(
+            TargetPlatform.macOS,
+          ),
+          hasLength(5),
+        );
+        expect(
+          ImageImportConstants.supportedExtensionsForPlatform(
+            TargetPlatform.linux,
+          ),
           containsAll(['jpg', 'jpeg', 'png']),
         );
-        expect(ImageImportConstants.supportedExtensions, hasLength(3));
+        expect(
+          ImageImportConstants.supportedExtensionsForPlatform(
+            TargetPlatform.linux,
+          ),
+          isNot(contains('heic')),
+        );
+        expect(
+          ImageImportConstants.supportedExtensionsForPlatform(
+            TargetPlatform.linux,
+          ),
+          isNot(contains('heif')),
+        );
       });
 
       test('defines reasonable file size limit', () {
@@ -547,6 +574,64 @@ void main() {
           ),
         ).called(1);
       });
+
+      test('normalizes pasted image extension before storage', () async {
+        final validData = Uint8List.fromList(List<int>.filled(200, 0xBB));
+
+        await importPastedImages(
+          data: validData,
+          fileExtension: 'PNG',
+        );
+
+        final capturedImage =
+            verify(
+                  () => mockPersistenceLogic.createDbEntity(
+                    captureAny(that: isA<JournalImage>()),
+                    linkedId: any(named: 'linkedId'),
+                    shouldAddGeolocation: any(named: 'shouldAddGeolocation'),
+                    enqueueSync: any(named: 'enqueueSync'),
+                  ),
+                ).captured.single
+                as JournalImage;
+
+        expect(capturedImage.data.imageFile, endsWith('.png'));
+        expect(capturedImage.data.imageFile, isNot(endsWith('.PNG')));
+      });
+
+      test('converts pasted HEIC data to stored JPEG', () async {
+        final heicData = Uint8List.fromList(List<int>.filled(200, 0xCC));
+
+        await withTargetPlatform(
+          TargetPlatform.macOS,
+          () => withFakeImageCompressPlatform(
+            () => importPastedImages(
+              data: heicData,
+              fileExtension: 'heic',
+            ),
+          ),
+        );
+
+        final capturedImage =
+            verify(
+                  () => mockPersistenceLogic.createDbEntity(
+                    captureAny(that: isA<JournalImage>()),
+                    linkedId: any(named: 'linkedId'),
+                    shouldAddGeolocation: any(named: 'shouldAddGeolocation'),
+                    enqueueSync: any(named: 'enqueueSync'),
+                  ),
+                ).captured.single
+                as JournalImage;
+
+        expect(capturedImage.data.imageFile, endsWith('.jpg'));
+        expect(
+          File(
+            '${tempDir.path}'
+            '${capturedImage.data.imageDirectory}'
+            '${capturedImage.data.imageFile}',
+          ).existsSync(),
+          isTrue,
+        );
+      });
     });
 
     group('importDroppedImages', () {
@@ -580,6 +665,51 @@ void main() {
             enqueueSync: any(named: 'enqueueSync'),
           ),
         ).called(1);
+      });
+
+      test('converts dropped HEIC file to stored JPEG', () async {
+        final testFile = await createTestImageFile('screenshot.HEIC', 1024);
+
+        await withTargetPlatform(
+          TargetPlatform.macOS,
+          () => withFakeImageCompressPlatform(
+            () => importImageXFiles([XFile(testFile.path)]),
+          ),
+        );
+
+        final capturedImage =
+            verify(
+                  () => mockPersistenceLogic.createDbEntity(
+                    captureAny(that: isA<JournalImage>()),
+                    linkedId: any(named: 'linkedId'),
+                    shouldAddGeolocation: any(named: 'shouldAddGeolocation'),
+                    enqueueSync: any(named: 'enqueueSync'),
+                  ),
+                ).captured.single
+                as JournalImage;
+
+        expect(capturedImage.data.imageFile, endsWith('.jpg'));
+        expect(capturedImage.data.imageFile, isNot(endsWith('.HEIC')));
+      });
+
+      test('skips HEIC files on Linux before conversion', () async {
+        final testFile = await createTestImageFile('screenshot.heic', 1024);
+
+        await withTargetPlatform(
+          TargetPlatform.linux,
+          () => withFakeImageCompressPlatform(
+            () => importImageXFiles([XFile(testFile.path)]),
+          ),
+        );
+
+        verifyNever(
+          () => mockPersistenceLogic.createDbEntity(
+            any(that: isA<JournalImage>()),
+            linkedId: any(named: 'linkedId'),
+            shouldAddGeolocation: any(named: 'shouldAddGeolocation'),
+            enqueueSync: any(named: 'enqueueSync'),
+          ),
+        );
       });
 
       test('skips non-image file silently', () async {
@@ -786,6 +916,48 @@ void main() {
             shouldAddGeolocation: any(named: 'shouldAddGeolocation'),
             enqueueSync: any(named: 'enqueueSync'),
           ),
+        );
+      });
+
+      test('includes HEIC and HEIF in the picker on macOS', () async {
+        final original = FileSelectorPlatform.instance;
+        final fakeSelector = FakeFileSelectorPlatform();
+        FileSelectorPlatform.instance = fakeSelector;
+        addTearDown(() => FileSelectorPlatform.instance = original);
+
+        await withTargetPlatform(
+          TargetPlatform.macOS,
+          importImagePickerFiles,
+        );
+
+        expect(
+          fakeSelector.lastAcceptedTypeGroups?.single.extensions,
+          containsAll(['jpg', 'jpeg', 'png', 'heic', 'heif']),
+        );
+      });
+
+      test('omits HEIC and HEIF from the picker on Linux', () async {
+        final original = FileSelectorPlatform.instance;
+        final fakeSelector = FakeFileSelectorPlatform();
+        FileSelectorPlatform.instance = fakeSelector;
+        addTearDown(() => FileSelectorPlatform.instance = original);
+
+        await withTargetPlatform(
+          TargetPlatform.linux,
+          importImagePickerFiles,
+        );
+
+        expect(
+          fakeSelector.lastAcceptedTypeGroups?.single.extensions,
+          containsAll(['jpg', 'jpeg', 'png']),
+        );
+        expect(
+          fakeSelector.lastAcceptedTypeGroups?.single.extensions,
+          isNot(contains('heic')),
+        );
+        expect(
+          fakeSelector.lastAcceptedTypeGroups?.single.extensions,
+          isNot(contains('heif')),
         );
       });
     });

--- a/test/logic/media_import_test.dart
+++ b/test/logic/media_import_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:cross_file/cross_file.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
 import 'package:lotti/classes/journal_entities.dart';
@@ -15,12 +16,16 @@ import 'package:lotti/services/domain_logging.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as path;
 
+import '../helpers/fake_image_compress_platform.dart';
+import '../helpers/target_platform.dart';
 import '../mocks/mocks.dart';
 
 enum _GeneratedMediaKind {
   jpg,
   jpeg,
   png,
+  heic,
+  heif,
   m4a,
   txt,
   markdown,
@@ -41,7 +46,9 @@ class _GeneratedMediaFile {
   bool get isImage => switch (kind) {
     _GeneratedMediaKind.jpg ||
     _GeneratedMediaKind.jpeg ||
-    _GeneratedMediaKind.png => true,
+    _GeneratedMediaKind.png ||
+    _GeneratedMediaKind.heic ||
+    _GeneratedMediaKind.heif => true,
     _ => false,
   };
 
@@ -60,6 +67,8 @@ class _GeneratedMediaFile {
     _GeneratedMediaKind.jpg => 'jpg',
     _GeneratedMediaKind.jpeg => 'jpeg',
     _GeneratedMediaKind.png => 'png',
+    _GeneratedMediaKind.heic => 'heic',
+    _GeneratedMediaKind.heif => 'heif',
     _GeneratedMediaKind.m4a => 'm4a',
     _GeneratedMediaKind.txt => 'txt',
     _GeneratedMediaKind.markdown => 'md',
@@ -259,6 +268,58 @@ void main() {
       ).called(1);
     });
 
+    test('dispatches HEIF files to the image importer', () async {
+      final imageFile = await createTestFile('screenshot.HEIF', 1024);
+      final dropDetails = createDropDetails([XFile(imageFile.path)]);
+
+      await withTargetPlatform(
+        TargetPlatform.macOS,
+        () => withFakeImageCompressPlatform(
+          () => handleDroppedMediaFiles(
+            dropDetails,
+            linkedId: 'linked-123',
+          ),
+        ),
+      );
+
+      final capturedImage =
+          verify(
+                () => mockPersistenceLogic.createDbEntity(
+                  captureAny(that: isA<JournalImage>()),
+                  linkedId: any(named: 'linkedId'),
+                  shouldAddGeolocation: any(named: 'shouldAddGeolocation'),
+                  enqueueSync: any(named: 'enqueueSync'),
+                ),
+              ).captured.single
+              as JournalImage;
+
+      expect(capturedImage.data.imageFile, endsWith('.jpg'));
+    });
+
+    test('does not route HEIF files as images on Linux', () async {
+      final imageFile = await createTestFile('screenshot.HEIF', 1024);
+      final dropDetails = createDropDetails([XFile(imageFile.path)]);
+
+      await withTargetPlatform(
+        TargetPlatform.linux,
+        () => withFakeImageCompressPlatform(
+          () => handleDroppedMediaFiles(
+            dropDetails,
+            linkedId: 'linked-123',
+          ),
+        ),
+      );
+
+      verifyNever(
+        () => mockPersistenceLogic.createDbEntity(
+          any(that: isA<JournalImage>()),
+          linkedId: any(named: 'linkedId'),
+          shouldAddGeolocation: any(named: 'shouldAddGeolocation'),
+          enqueueSync: any(named: 'enqueueSync'),
+        ),
+      );
+    });
+
     test('dispatches audio files to importDroppedAudio', () async {
       final audioFile = await createTestFile('test.m4a', 1024);
       final dropDetails = createDropDetails([XFile(audioFile.path)]);
@@ -362,8 +423,28 @@ void main() {
 
     test('recognizes all supported image extensions', () {
       expect(
-        ImageImportConstants.supportedExtensions,
+        ImageImportConstants.supportedExtensionsForPlatform(
+          TargetPlatform.macOS,
+        ),
+        containsAll(['jpg', 'jpeg', 'png', 'heic', 'heif']),
+      );
+      expect(
+        ImageImportConstants.supportedExtensionsForPlatform(
+          TargetPlatform.linux,
+        ),
         containsAll(['jpg', 'jpeg', 'png']),
+      );
+      expect(
+        ImageImportConstants.supportedExtensionsForPlatform(
+          TargetPlatform.linux,
+        ),
+        isNot(contains('heic')),
+      );
+      expect(
+        ImageImportConstants.supportedExtensionsForPlatform(
+          TargetPlatform.linux,
+        ),
+        isNot(contains('heif')),
       );
     });
 
@@ -391,10 +472,15 @@ void main() {
         xFiles.add(XFile(file.path));
       }
 
-      await handleDroppedMediaFiles(
-        createDropDetails(xFiles),
-        linkedId: 'linked-generated',
-        categoryId: 'category-generated',
+      await withTargetPlatform(
+        TargetPlatform.macOS,
+        () => withFakeImageCompressPlatform(
+          () => handleDroppedMediaFiles(
+            createDropDetails(xFiles),
+            linkedId: 'linked-generated',
+            categoryId: 'category-generated',
+          ),
+        ),
       );
 
       if (scenario.expectedImageCount == 0) {

--- a/test/mocks/mocks.dart
+++ b/test/mocks/mocks.dart
@@ -1235,13 +1235,17 @@ class FakeFileSelectorPlatform extends Fake
     with MockPlatformInterfaceMixin
     implements FileSelectorPlatform {
   List<XFile> filesToReturn = const [];
+  List<XTypeGroup>? lastAcceptedTypeGroups;
 
   @override
   Future<List<XFile>> openFiles({
     List<XTypeGroup>? acceptedTypeGroups,
     String? initialDirectory,
     String? confirmButtonText,
-  }) async => filesToReturn;
+  }) async {
+    lastAcceptedTypeGroups = acceptedTypeGroups;
+    return filesToReturn;
+  }
 }
 
 /// Mocks for the Supertonic TTS engine's native boundary


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for importing HEIC/HEIF images via drag-and-drop, file picker, and clipboard paste on supported platforms.
  * Imported HEIC/HEIF images are converted to JPEG before being saved, while keeping existing image handling intact.

* **Documentation**
  * Updated release notes and journal docs to reflect the expanded image import support.

* **Bug Fixes**
  * Improved image import behavior so supported formats are detected more reliably across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->