### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -89,7 +89,7 @@ PODS:
     - FlutterMacOS
   - quill_native_bridge_ios (0.0.1):
     - Flutter
-  - record_ios (1.2.1):
+  - record_ios (2.0.0):
     - Flutter
   - SDWebImage (5.21.7):
     - SDWebImage/Core (= 5.21.7)
@@ -297,7 +297,7 @@ SPEC CHECKSUMS:
   permission_handler_apple: 92d754bbaa7361d436db2d6c3c1c2a0fdcec462e
   photo_manager: 25fd77df14f4f0ba5ef99e2c61814dde77e2bceb
   quill_native_bridge_ios: f47af4b14e7757968486641656c5d23250cee521
-  record_ios: 980fd386a97a35987d0fce3dfda4b26a38c90f4c
+  record_ios: 390a30c7caaf8b5d0fb1cb1d2fd5064b48b4520c
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   SDWebImageWebPCoder: 0e06e365080397465cc73a7a9b472d8a3bd0f377
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: c209688d9f5a5f26b2fb47a188131a6fb9e876ae9e47af3737c0b4f58a93470d
+      sha256: "5b7468c326d2f8a4f630056404ca0d291ade42918f4a3c6233618e724f39da8e"
       url: "https://pub.dev"
     source: hosted
-    version: "91.0.0"
+    version: "92.0.0"
   accessibility_tools:
     dependency: transitive
     description:
@@ -21,18 +21,18 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: a40a0cee526a7e1f387c6847bd8a5ccbf510a75952ef8a28338e989558072cb0
+      sha256: "70e4b1ef8003c64793a9e268a551a82869a8a96f39deb73dea28084b0e8bf75e"
       url: "https://pub.dev"
     source: hosted
-    version: "8.4.0"
+    version: "9.0.0"
   analyzer_plugin:
     dependency: "direct overridden"
     description:
       name: analyzer_plugin
-      sha256: "08cfefa90b4f4dd3b447bda831cecf644029f9f8e22820f6ee310213ebe2dd53"
+      sha256: "6645a029da947ffd823d98118f385d4bd26b54eb069c006b22e0b94e451814b5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.10"
+    version: "0.13.11"
   ansicolor:
     dependency: transitive
     description:
@@ -349,10 +349,10 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: "62ffa266d9a23b79fb3fcbc206afc00bb979417ba57b1324c546b5aab95ba057"
+      sha256: cad0e811a289ea2a941119dc483c204ec1684cbb9a8fc7351fe4a230b8313160
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.1"
+    version: "7.2.0"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -1077,10 +1077,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_riverpod
-      sha256: "38ec6c303e2c83ee84512f5fc2a82ae311531021938e63d7137eccc107bf3c02"
+      sha256: "9255e1e3ad6e38906a1b4f8287678f95f378744c5b46b1985588543f3f19046e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.3.2"
   flutter_rust_bridge:
     dependency: transitive
     description:
@@ -1199,10 +1199,10 @@ packages:
     dependency: "direct dev"
     description:
       name: freezed
-      sha256: "13065f10e135263a4f5a4391b79a8efc5fb8106f8dd555a9e49b750b45393d77"
+      sha256: f23ea33b3863f119b58ed1b586e881a46bd28715ddcc4dbc33104524e3434131
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.3"
+    version: "3.2.5"
   freezed_annotation:
     dependency: "direct main"
     description:
@@ -1529,10 +1529,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.20.3"
   intl_utils:
     dependency: transitive
     description:
@@ -1625,10 +1625,10 @@ packages:
     dependency: "direct main"
     description:
       name: json_annotation
-      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
+      sha256: cb09e7dac6210041fad964ed7fbee004f14258b4eca4040f72d1234062ace4c8
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.0"
+    version: "4.11.0"
   json_schema_builder:
     dependency: "direct main"
     description:
@@ -1641,10 +1641,10 @@ packages:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: c5b2ee75210a0f263c6c7b9eeea80553dbae96ea1bf57f02484e806a3ffdffa3
+      sha256: "44729f5c45748e6748f6b9a57ab8f7e4336edc8ae41fc295070e3814e616a6c0"
       url: "https://pub.dev"
     source: hosted
-    version: "6.11.2"
+    version: "6.13.0"
   just_audio:
     dependency: transitive
     description:
@@ -2450,10 +2450,10 @@ packages:
     dependency: "direct main"
     description:
       name: riverpod
-      sha256: "16ff608d21e8ea64364f2b7c049c94a02ab81668f78845862b6e88b71dd4935a"
+      sha256: "17100416c51db7810c71a7bb2c34d1f881faa0074fd452afb0c4db6f8f126c76"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.3.2"
   rxdart:
     dependency: "direct main"
     description:
@@ -2695,10 +2695,10 @@ packages:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "6a3c6cc82073a8797f8c4dc4572146114a39652851c157db37e964d9c7038723"
+      sha256: "4227d54ceefd0bb8ca4c8fcb96e1719dc53f1ee1b6e2ca9d7a6069da160e4eae"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.8"
+    version: "1.3.12"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -3151,26 +3151,26 @@ packages:
     dependency: transitive
     description:
       name: video_player_android
-      sha256: "5d18d04084cc0cfc7afde39d0a308d4041e8ae6e9d5255bc086c263998dd1201"
+      sha256: "8401adac6f33e78a0f255a75a7e7c9e2f9713ffcd87ff4e6c00d9bd92b5d99db"
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.6"
+    version: "2.9.7"
   video_player_avfoundation:
     dependency: transitive
     description:
       name: video_player_avfoundation
-      sha256: "9338f3ec22774f88146b22f13273a446719b1da010fd200c4d1d97802156ac58"
+      sha256: "76097729ef0c976937945afa53f1ca3afa9b50c9a95909ba347bcf93270466fd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.7"
+    version: "2.10.0"
   video_player_platform_interface:
     dependency: transitive
     description:
       name: video_player_platform_interface
-      sha256: "16eaed5268c571c31840dc58ef8da5f0cd4db2a98490c3b8f1cf70122546c6e0"
+      sha256: e4ae5bc934b528e5b95c5e47be2812860186260cd3eed3ac62f5ed380fdd1613
       url: "https://pub.dev"
     source: hosted
-    version: "6.7.0"
+    version: "6.8.0"
   video_player_web:
     dependency: transitive
     description:
@@ -3287,10 +3287,10 @@ packages:
     dependency: "direct main"
     description:
       name: widgetbook
-      sha256: "7ce2a15c59990610aefb0a8a4d69f67dd842d41676b7af6b5b746aa3371d32cf"
+      sha256: "88b10102d294d0bec64ca294c81f15b1a620ce66df950067ff8f89274f1c95e8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.24.0"
+    version: "3.25.0"
   widgetbook_annotation:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1031+4167
+version: 0.9.1031+4168
 
 msix_config:
   display_name: LottiApp

--- a/test/features/agents/ui/evolution/evolution_chat_page_more_test.dart
+++ b/test/features/agents/ui/evolution/evolution_chat_page_more_test.dart
@@ -55,8 +55,8 @@ void main() {
         templatePerformanceMetricsProvider.overrideWith(
           (ref, id) async => makeTestMetrics(templateId: templateId),
         ),
-        evolutionChatStateProvider.overrideWith(
-          () => FakeEvolutionChatState(
+        evolutionChatStateProvider.overrideWith2(
+          (_) => FakeEvolutionChatState(
             chatStateBuilder ?? (_) async => defaultChatData,
           ),
         ),
@@ -104,7 +104,7 @@ void main() {
           templatePerformanceMetricsProvider.overrideWith(
             (ref, id) async => makeTestMetrics(),
           ),
-          evolutionChatStateProvider.overrideWith(() {
+          evolutionChatStateProvider.overrideWith2((_) {
             capturedNotifier = CapturingSendEvolutionChatState(
               EvolutionChatData(
                 sessionId: 'session-1',
@@ -147,7 +147,7 @@ void main() {
             templatePerformanceMetricsProvider.overrideWith(
               (ref, id) async => makeTestMetrics(),
             ),
-            evolutionChatStateProvider.overrideWith(() {
+            evolutionChatStateProvider.overrideWith2((_) {
               capturedNotifier = CapturingSendEvolutionChatState(
                 EvolutionChatData(
                   sessionId: 'session-1',
@@ -190,8 +190,8 @@ void main() {
             templatePerformanceMetricsProvider.overrideWith(
               (ref, id) async => makeTestMetrics(),
             ),
-            evolutionChatStateProvider.overrideWith(
-              () => FakeEvolutionChatState(
+            evolutionChatStateProvider.overrideWith2(
+              (_) => FakeEvolutionChatState(
                 (_) async => EvolutionChatData(
                   sessionId: 'session-1',
                   messages: [
@@ -254,7 +254,7 @@ void main() {
             templatePerformanceMetricsProvider.overrideWith(
               (ref, id) async => makeTestMetrics(),
             ),
-            evolutionChatStateProvider.overrideWith(() {
+            evolutionChatStateProvider.overrideWith2((_) {
               capturedNotifier = MutableEvolutionChatState(initialData);
               return capturedNotifier!;
             }),
@@ -314,7 +314,7 @@ void main() {
             templatePerformanceMetricsProvider.overrideWith(
               (ref, id) async => makeTestMetrics(),
             ),
-            evolutionChatStateProvider.overrideWith(() {
+            evolutionChatStateProvider.overrideWith2((_) {
               capturedNotifier = MutableEvolutionChatState(initialData);
               return capturedNotifier!;
             }),

--- a/test/features/agents/ui/evolution/evolution_chat_page_test.dart
+++ b/test/features/agents/ui/evolution/evolution_chat_page_test.dart
@@ -56,8 +56,8 @@ void main() {
         templatePerformanceMetricsProvider.overrideWith(
           (ref, id) async => makeTestMetrics(templateId: templateId),
         ),
-        evolutionChatStateProvider.overrideWith(
-          () => FakeEvolutionChatState(
+        evolutionChatStateProvider.overrideWith2(
+          (_) => FakeEvolutionChatState(
             chatStateBuilder ?? (_) async => defaultChatData,
           ),
         ),
@@ -131,7 +131,7 @@ void main() {
             templatePerformanceMetricsProvider.overrideWith(
               (ref, id) async => makeTestMetrics(),
             ),
-            evolutionChatStateProvider.overrideWith(() => chatState),
+            evolutionChatStateProvider.overrideWith2((_) => chatState),
           ],
         ),
       );

--- a/test/features/agents/ui/evolution/evolution_review_page_test.dart
+++ b/test/features/agents/ui/evolution/evolution_review_page_test.dart
@@ -482,7 +482,9 @@ void main() {
             ),
             // pendingOverride returns null → _StartCard shown (line 54).
             extraOverrides: [
-              evolutionChatStateProvider.overrideWith(_LoadingChatState.new),
+              evolutionChatStateProvider.overrideWith2(
+                (_) => _LoadingChatState(),
+              ),
             ],
           ),
         );
@@ -519,7 +521,9 @@ void main() {
             ),
             pendingOverride: () async => session,
             extraOverrides: [
-              evolutionChatStateProvider.overrideWith(_LoadingChatState.new),
+              evolutionChatStateProvider.overrideWith2(
+                (_) => _LoadingChatState(),
+              ),
             ],
           ),
         );

--- a/test/features/agents/ui/evolution/soul_evolution_chat_page_test.dart
+++ b/test/features/agents/ui/evolution/soul_evolution_chat_page_test.dart
@@ -59,8 +59,8 @@ void main() {
         soulDocumentProvider.overrideWith(
           soulOverride ?? (ref, id) async => defaultSoul,
         ),
-        soulEvolutionChatStateProvider.overrideWith(
-          () => FakeSoulEvolutionChatState(
+        soulEvolutionChatStateProvider.overrideWith2(
+          (_) => FakeSoulEvolutionChatState(
             chatStateBuilder ?? (_) async => defaultChatData,
           ),
         ),
@@ -347,8 +347,8 @@ void main() {
             ),
             overrides: [
               soulDocumentProvider.overrideWith((ref, id) async => defaultSoul),
-              soulEvolutionChatStateProvider.overrideWith(
-                () => FakeSoulEvolutionChatState((_) async => defaultChatData),
+              soulEvolutionChatStateProvider.overrideWith2(
+                (_) => FakeSoulEvolutionChatState((_) async => defaultChatData),
               ),
             ],
           ),
@@ -391,7 +391,7 @@ void main() {
           const SoulEvolutionChatPage(soulId: kTestSoulId),
           overrides: [
             soulDocumentProvider.overrideWith((ref, id) async => defaultSoul),
-            soulEvolutionChatStateProvider.overrideWith(() {
+            soulEvolutionChatStateProvider.overrideWith2((_) {
               final n = TrackingSoulEvolutionChatState(
                 (_) async => initialData,
               );
@@ -435,8 +435,8 @@ void main() {
             const SoulEvolutionChatPage(soulId: kTestSoulId),
             overrides: [
               soulDocumentProvider.overrideWith((ref, id) async => defaultSoul),
-              soulEvolutionChatStateProvider.overrideWith(
-                () => ControllableSoulEvolutionChatState(
+              soulEvolutionChatStateProvider.overrideWith2(
+                (_) => ControllableSoulEvolutionChatState(
                   (_) async => initialData,
                 ),
               ),
@@ -495,8 +495,8 @@ void main() {
             const SoulEvolutionChatPage(soulId: kTestSoulId),
             overrides: [
               soulDocumentProvider.overrideWith((ref, id) async => defaultSoul),
-              soulEvolutionChatStateProvider.overrideWith(
-                () => ControllableSoulEvolutionChatState(
+              soulEvolutionChatStateProvider.overrideWith2(
+                (_) => ControllableSoulEvolutionChatState(
                   (_) async => initialData,
                 ),
               ),
@@ -554,8 +554,8 @@ void main() {
           const SoulEvolutionChatPage(soulId: kTestSoulId),
           overrides: [
             soulDocumentProvider.overrideWith((ref, id) async => defaultSoul),
-            soulEvolutionChatStateProvider.overrideWith(
-              () => FakeSoulEvolutionChatState(
+            soulEvolutionChatStateProvider.overrideWith2(
+              (_) => FakeSoulEvolutionChatState(
                 (_) async => EvolutionChatData(
                   sessionId: 'session-1',
                   messages: [

--- a/test/features/agents/ui/evolution/soul_evolution_review_page_test.dart
+++ b/test/features/agents/ui/evolution/soul_evolution_review_page_test.dart
@@ -58,7 +58,9 @@ void main() {
         ),
         // Keep the destination chat page in a loading state so navigation
         // assertions don't depend on the chat page's real dependencies.
-        soulEvolutionChatStateProvider.overrideWith(_LoadingChatState.new),
+        soulEvolutionChatStateProvider.overrideWith2(
+          (_) => _LoadingChatState(),
+        ),
         ...extraOverrides,
       ],
     );

--- a/test/features/ai/ui/ollama_model_install_dialog_test.dart
+++ b/test/features/ai/ui/ollama_model_install_dialog_test.dart
@@ -161,9 +161,20 @@ void main() {
     await tester.pump(const Duration(milliseconds: 300));
   }
 
+  Future<void> pumpUntilFound(WidgetTester tester, Finder finder) async {
+    for (var i = 0; i < 20; i++) {
+      if (finder.evaluate().isNotEmpty) return;
+      await tester.pump(const Duration(milliseconds: 50));
+    }
+  }
+
   group('OllamaModelInstallDialog - initial state', () {
     testWidgets('displays correct initial state', (tester) async {
-      await pumpDialog(tester);
+      await pumpInstallDialog(
+        tester,
+        modelName: testModelName,
+        providers: [testOllamaProvider],
+      );
 
       expect(find.text('Model Not Installed'), findsOneWidget);
       expect(
@@ -226,33 +237,45 @@ void main() {
     testWidgets('shows installation UI when install button is pressed', (
       tester,
     ) async {
-      final progressStream = Stream<OllamaPullProgress>.fromIterable([
-        const OllamaPullProgress(status: 'pulling manifest', progress: 0),
-      ]);
+      final progressController = StreamController<OllamaPullProgress>();
 
       when(
-        () => mockCloudRepository.installModel(testModelName, any()),
-      ).thenAnswer((_) => progressStream);
+        () => mockCloudRepository.installModel(any(), any()),
+      ).thenAnswer((_) => progressController.stream);
 
-      await pumpDialog(tester);
+      final ollamaProvider = AiTestDataFactory.createTestProvider(
+        id: 'ollama-installing',
+        name: 'Ollama',
+        type: InferenceProviderType.ollama,
+        baseUrl: 'http://localhost:11434/',
+      );
+
+      await pumpInstallDialog(
+        tester,
+        modelName: testModelName,
+        providers: [ollamaProvider],
+      );
 
       // Act - Press install button
       await tester.tap(find.text('Install'));
-      await tester.pump();
+      await pumpUntilFound(tester, find.text('Installing model...'));
 
       // Assert - Should show installation UI
       expect(find.text('Installing model...'), findsOneWidget);
       expect(find.byType(LinearProgressIndicator), findsOneWidget);
+
+      progressController.addError(Exception('stop install'));
+      await progressController.close();
+      await tester.pump();
     });
 
     testWidgets(
       'resets to install state when install fails',
       (tester) async {
-        // thenThrow drives the catch block synchronously so bounded pumps
-        // complete the full async chain.
+        final progressController = StreamController<OllamaPullProgress>();
         when(
           () => mockCloudRepository.installModel(any(), any()),
-        ).thenThrow(Exception('Installation failed'));
+        ).thenAnswer((_) => progressController.stream);
 
         final ollamaProvider = AiTestDataFactory.createTestProvider(
           id: 'ollama-test',
@@ -261,32 +284,23 @@ void main() {
           baseUrl: 'http://localhost:11434/',
         );
 
-        await tester.pumpWidget(
-          buildTestWidget(
-            const OllamaModelInstallDialog(modelName: 'phi3'),
-            overrides: [
-              aiConfigByTypeControllerProvider(
-                AiConfigType.inferenceProvider,
-              ).overrideWith(
-                () => _ImmediateAiConfigByTypeController([ollamaProvider]),
-              ),
-            ],
-          ),
+        await pumpInstallDialog(
+          tester,
+          modelName: 'phi3',
+          providers: [ollamaProvider],
         );
-
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 300));
 
         // Tap install – the "Installing model..." state is set first.
         await tester.tap(find.text('Install'));
-        await tester.pump();
+        await pumpUntilFound(tester, find.text('Installing model...'));
         // _isInstalling = true: the installing state is active.
         expect(find.text('Installing model...'), findsOneWidget);
 
-        // Drive the async chain: provider.future → installModel throws
+        // Drive the async chain: provider.future → installModel emits error
         // → catch strips 'Exception: ', sets _error, _isInstalling=false.
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 300));
+        progressController.addError(Exception('Installation failed'));
+        await progressController.close();
+        await pumpUntilFound(tester, find.text('Install'));
 
         // After error: _isInstalling=false so Install button is back.
         expect(find.text('Install'), findsOneWidget);
@@ -308,43 +322,44 @@ void main() {
           baseUrl: 'http://localhost:11434/',
         );
 
+        final progressControllers = <StreamController<OllamaPullProgress>>[];
         when(
           () => mockCloudRepository.installModel(any(), any()),
-        ).thenThrow(Exception('fail'));
+        ).thenAnswer((_) {
+          final controller = StreamController<OllamaPullProgress>();
+          progressControllers.add(controller);
+          return controller.stream;
+        });
 
-        await tester.pumpWidget(
-          buildTestWidget(
-            const OllamaModelInstallDialog(modelName: 'gemma'),
-            overrides: [
-              aiConfigByTypeControllerProvider(
-                AiConfigType.inferenceProvider,
-              ).overrideWith(
-                () => _ImmediateAiConfigByTypeController([ollamaProvider]),
-              ),
-            ],
-          ),
+        await pumpInstallDialog(
+          tester,
+          modelName: 'gemma',
+          providers: [ollamaProvider],
         );
-
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 300));
 
         // First install attempt
         await tester.tap(find.text('Install'));
-        await tester.pump();
+        await pumpUntilFound(tester, find.text('Installing model...'));
         // _isInstalling=true: Install button is hidden, "Installing model..." shows
         expect(find.text('Install'), findsNothing);
         expect(find.text('Installing model...'), findsOneWidget);
 
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 300));
+        progressControllers.single.addError(Exception('fail'));
+        await progressControllers.single.close();
+        await pumpUntilFound(tester, find.text('Install'));
         // After error: _isInstalling=false, Install button re-appears
         expect(find.text('Install'), findsOneWidget);
 
         // Second tap re-invokes _installModel (install button enables retry)
         await tester.tap(find.text('Install'));
-        await tester.pump();
+        await pumpUntilFound(tester, find.text('Installing model...'));
         // _isInstalling=true again: showing "Installing model..."
         expect(find.text('Installing model...'), findsOneWidget);
+        expect(progressControllers, hasLength(2));
+
+        progressControllers.last.addError(Exception('fail again'));
+        await progressControllers.last.close();
+        await tester.pump();
       },
     );
   });

--- a/test/features/daily_os_next/ui/pages/capture_page_test.dart
+++ b/test/features/daily_os_next/ui/pages/capture_page_test.dart
@@ -1036,8 +1036,8 @@ void main() {
               ),
               // Keep the pushed ReconcilePage on its loading shell so it
               // does not reach into GetIt-backed services.
-              reconcileControllerProvider.overrideWith(
-                _PendingReconcileController.new,
+              reconcileControllerProvider.overrideWith2(
+                (_) => _PendingReconcileController(),
               ),
             ],
           ),

--- a/test/features/habits/ui/widgets/habit_completion_card_test.dart
+++ b/test/features/habits/ui/widgets/habit_completion_card_test.dart
@@ -93,7 +93,9 @@ void main() {
           showLinkedDashboard: showLinkedDashboard,
         ),
         overrides: [
-          habitCompletionControllerProvider.overrideWith(_FakeController.new),
+          habitCompletionControllerProvider.overrideWith2(
+            (_) => _FakeController(),
+          ),
         ],
       ),
     );
@@ -205,7 +207,9 @@ void main() {
             rangeEnd: _rangeEnd,
           ),
           overrides: [
-            habitCompletionControllerProvider.overrideWith(_FakeController.new),
+            habitCompletionControllerProvider.overrideWith2(
+              (_) => _FakeController(),
+            ),
           ],
         ),
       );
@@ -222,7 +226,9 @@ void main() {
             rangeEnd: _rangeEnd,
           ),
           overrides: [
-            habitCompletionControllerProvider.overrideWith(_FakeController.new),
+            habitCompletionControllerProvider.overrideWith2(
+              (_) => _FakeController(),
+            ),
           ],
         ),
       );

--- a/test/features/journal/state/image_paste_controller_test.dart
+++ b/test/features/journal/state/image_paste_controller_test.dart
@@ -277,10 +277,10 @@ void main() {
             ).thenReturn(scenario.format == Formats.heif);
 
             final result = await container.read(
-              imagePasteControllerProvider(
+              imagePasteControllerProvider((
                 linkedFromId: null,
                 categoryId: null,
-              ).future,
+              )).future,
             );
 
             expect(result, true);
@@ -297,10 +297,10 @@ void main() {
           when(() => mockItem.canProvide(Formats.png)).thenReturn(false);
 
           final result = await container.read(
-            imagePasteControllerProvider(
+            imagePasteControllerProvider((
               linkedFromId: null,
               categoryId: null,
-            ).future,
+            )).future,
           );
 
           expect(result, false);
@@ -408,10 +408,10 @@ void main() {
             ).thenAnswer((_) async => Uint8List.fromList([1, 2, 3]));
 
             final controller = container.read(
-              imagePasteControllerProvider(
+              imagePasteControllerProvider((
                 linkedFromId: 'testLink',
                 categoryId: 'testCategory',
-              ).notifier,
+              )).notifier,
             );
 
             await withFakeImageCompressPlatform(controller.paste);
@@ -446,10 +446,10 @@ void main() {
           when(() => mockItem.canProvide(Formats.png)).thenReturn(false);
 
           final controller = container.read(
-            imagePasteControllerProvider(
+            imagePasteControllerProvider((
               linkedFromId: 'testLink',
               categoryId: 'testCategory',
-            ).notifier,
+            )).notifier,
           );
 
           await controller.paste();
@@ -480,10 +480,10 @@ void main() {
       ).thenThrow(StateError('clipboard read failed'));
 
       final controller = container.read(
-        imagePasteControllerProvider(
+        imagePasteControllerProvider((
           linkedFromId: 'testLink',
           categoryId: 'testCategory',
-        ).notifier,
+        )).notifier,
       );
 
       await expectLater(controller.paste(), throwsA(isA<StateError>()));

--- a/test/features/labels/ui/label_details_page_test.dart
+++ b/test/features/labels/ui/label_details_page_test.dart
@@ -221,7 +221,7 @@ void main() {
       await pumpPage(
         tester,
         overrides: [
-          labelEditorControllerProvider.overrideWith(() => fakeController),
+          labelEditorControllerProvider.overrideWith2((_) => fakeController),
         ],
       );
 
@@ -347,7 +347,9 @@ void main() {
       await pumpPage(
         tester,
         overrides: [
-          labelEditorControllerProvider.overrideWith(() => colorSpyController),
+          labelEditorControllerProvider.overrideWith2(
+            (_) => colorSpyController,
+          ),
         ],
       );
 
@@ -438,7 +440,7 @@ void main() {
       await pumpPage(
         tester,
         overrides: [
-          labelEditorControllerProvider.overrideWith(() => fakeController),
+          labelEditorControllerProvider.overrideWith2((_) => fakeController),
         ],
       );
 
@@ -471,7 +473,7 @@ void main() {
       await pumpPage(
         tester,
         overrides: [
-          labelEditorControllerProvider.overrideWith(() => fakeController),
+          labelEditorControllerProvider.overrideWith2((_) => fakeController),
         ],
       );
 
@@ -538,7 +540,7 @@ void main() {
         await pumpPage(
           tester,
           overrides: [
-            labelEditorControllerProvider.overrideWith(() => fakeController),
+            labelEditorControllerProvider.overrideWith2((_) => fakeController),
           ],
         );
 
@@ -887,7 +889,7 @@ void main() {
         await pumpPage(
           tester,
           overrides: [
-            labelEditorControllerProvider.overrideWith(() => controller),
+            labelEditorControllerProvider.overrideWith2((_) => controller),
           ],
         );
 

--- a/test/features/labels/ui/widgets/label_editor_sheet_test.dart
+++ b/test/features/labels/ui/widgets/label_editor_sheet_test.dart
@@ -81,8 +81,8 @@ void main() {
   List<Override> overrides({bool recordController = false}) => [
     labelsRepositoryProvider.overrideWithValue(repository),
     if (recordController)
-      labelEditorControllerProvider.overrideWith(
-        _RecordingLabelEditorController.new,
+      labelEditorControllerProvider.overrideWith2(
+        (_) => _RecordingLabelEditorController(),
       ),
   ];
 

--- a/test/features/tasks/ui/checklists/checklist_item_row_test.dart
+++ b/test/features/tasks/ui/checklists/checklist_item_row_test.dart
@@ -251,8 +251,8 @@ _pumpWithControllers(
           id: 'item-1',
           taskId: 'task-1',
         )).overrideWith(() => itemCtrl),
-        checklistControllerProvider.overrideWith(
-          () => FakeChecklistController(tracker),
+        checklistControllerProvider.overrideWith2(
+          (_) => FakeChecklistController(tracker),
         ),
         checklistCompletionServiceProvider.overrideWith(
           () => completionSvc,
@@ -656,8 +656,8 @@ void main() {
                 id: 'item-1',
                 taskId: 'task-1',
               )).overrideWith(() => itemCtrl),
-              checklistControllerProvider.overrideWith(
-                () => FakeChecklistController(tracker),
+              checklistControllerProvider.overrideWith2(
+                (_) => FakeChecklistController(tracker),
               ),
               checklistCompletionServiceProvider.overrideWith(
                 () => completionSvc,
@@ -950,8 +950,8 @@ void main() {
                   id: 'item-1',
                   taskId: 'task-1',
                 )).overrideWith(() => itemCtrl),
-                checklistControllerProvider.overrideWith(
-                  () => FakeChecklistController(tracker),
+                checklistControllerProvider.overrideWith2(
+                  (_) => FakeChecklistController(tracker),
                 ),
                 checklistCompletionServiceProvider.overrideWith(
                   () => completionSvc,
@@ -1049,8 +1049,8 @@ void main() {
                 id: 'item-1',
                 taskId: 'task-1',
               )).overrideWith(() => itemCtrl),
-              checklistControllerProvider.overrideWith(
-                FakeChecklistController.new,
+              checklistControllerProvider.overrideWith2(
+                (_) => FakeChecklistController(),
               ),
               checklistCompletionServiceProvider.overrideWith(
                 FakeChecklistCompletionService.new,
@@ -1478,8 +1478,8 @@ void main() {
                 id: 'item-1',
                 taskId: 'task-1',
               )).overrideWith(() => FakeChecklistItemController(_makeItem())),
-              checklistControllerProvider.overrideWith(
-                FakeChecklistController.new,
+              checklistControllerProvider.overrideWith2(
+                (_) => FakeChecklistController(),
               ),
               checklistCompletionServiceProvider.overrideWith(
                 () => completionSvc,
@@ -1535,8 +1535,8 @@ void main() {
               id: 'item-1',
               taskId: 'task-1',
             )).overrideWith(() => itemCtrl),
-            checklistControllerProvider.overrideWith(
-              FakeChecklistController.new,
+            checklistControllerProvider.overrideWith2(
+              (_) => FakeChecklistController(),
             ),
             checklistCompletionServiceProvider.overrideWith(
               FakeChecklistCompletionService.new,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped the app version to `0.9.1031+4168`.
* **Tests**
  * Updated widget/controller tests to use the newer Riverpod provider override API (`overrideWith2`) for consistent state injection.
  * Improved Ollama model installation dialog tests with a new bounded `pumpUntilFound` helper and more deterministic async-flow handling (including retry and failure cases).
* **Style**
  * Applied formatting-only changes in a few tests without altering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->