### PR TITLE
Improve journal image viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1032]
+### Added
+- **A calmer image viewer.** Tapping a journal photo now opens it over a
+  dimmed version of the app instead of a stark full-screen shell. The viewer
+  keeps a visible margin around the photo, has persistent top-right Download
+  and Close buttons, closes with Escape, and adds a bottom zoom control while
+  preserving pinch-to-zoom and panning. Download saves the original image into
+  `Downloads/Lotti` with a unique filename.
+
 ## [0.9.1031]
 ### Added
 - **See what your AI actually costs — in money, energy, and CO₂e.** Lotti now

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -32,6 +32,11 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="0.9.1032" date="2026-07-06">
+      <description>
+          <p>The journal image viewer is calmer and easier to use. Tapping a photo now opens it over a dimmed version of the app instead of a stark full-screen shell, keeps a visible margin around the image, has persistent top-right Download and Close buttons, closes with Escape, and adds a bottom zoom control while preserving pinch-to-zoom and panning. Download saves the original image into Downloads/Lotti with a unique filename.</p>
+      </description>
+    </release>
     <release version="0.9.1031" date="2026-06-20">
       <description>
           <p>Lotti now shows what your AI actually costs — in money, energy, and CO2e. Every AI call (agent turns, transcription, image analysis, cover art, text generation) is recorded with its cost in credits, energy use, CO2 footprint, water use, tokens, and the data center it ran in — measured per call by Melious for Melious-hosted models. A new AI Impact dashboard (next to Time Analysis in the sidebar, and under Settings → AI → Usage &amp; Impact) lets you switch between Cost, Energy, CO2e and Tokens, browse by week, month or year, and see stacked per-category charts, period totals, a ranked category breakdown, and a ledger of your most recent individual calls. Tasks that used AI carry a quiet header chip with their lifetime footprint, with the full breakdown a hover away. Consumption records sync across your devices, so the numbers cover everything, not just one machine.</p>

--- a/lib/features/journal/README.md
+++ b/lib/features/journal/README.md
@@ -114,6 +114,22 @@ It composes:
 
 That is the real boundary: the journal feature owns the page frame and the switching logic, while other features supply some of the per-type payload UI.
 
+### Image Viewer
+
+[`EntryImageWidget`](ui/widgets/entry_image_widget.dart) renders a downsampled inline `JournalImage` preview and pushes `HeroPhotoViewRouteWrapper` on tap. The route is non-opaque with a scrim barrier, so the detail page remains visible but darkened behind the viewer. `PhotoView` still owns pinch-zoom and panning; the viewer chrome drives the same `PhotoViewController` and `PhotoViewScaleStateController` for button zoom, reset, and the visible scale readout.
+
+```mermaid
+flowchart LR
+  Inline["EntryImageWidget preview"] --> Route["non-opaque image route"]
+  Route --> PhotoView["PhotoView\npinch + pan"]
+  Route --> Chrome["overlay chrome\nclose, download, zoom"]
+  Chrome --> Controller["PhotoView controllers"]
+  Chrome --> Downloads["Downloads/Lotti\nunique filename copy"]
+  Chrome --> Pop["root Navigator pop\nclose or Escape"]
+```
+
+The download action copies the original image file, not the resized preview, into the platform downloads directory under `Lotti/`. Existing filenames are preserved with a numeric suffix (`photo 2.png`, etc.) rather than overwritten.
+
 ## Entry Controller
 
 [`entry_controller.dart`](state/entry_controller.dart) is the detail-side brain for one entry.

--- a/lib/features/journal/ui/widgets/entry_image_widget.dart
+++ b/lib/features/journal/ui/widgets/entry_image_widget.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/journal/state/entry_controller.dart';
@@ -120,6 +120,7 @@ class _HeroPhotoViewRouteWrapperState extends State<HeroPhotoViewRouteWrapper> {
 
   double _scale = 1;
   double? _minimumScale;
+  Size? _lastSize;
   bool _isDownloading = false;
 
   @override
@@ -174,7 +175,7 @@ class _HeroPhotoViewRouteWrapperState extends State<HeroPhotoViewRouteWrapper> {
   void _setZoom(double scale) {
     final minimumScale = _minimumScale ?? _scale;
     _minimumScale ??= minimumScale;
-    final nextScale = scale.clamp(minimumScale, _maxZoomScale).toDouble();
+    final nextScale = scale.clamp(minimumScale, _maxZoomScale);
     _photoController.updateMultiple(
       position: Offset.zero,
       scale: nextScale,
@@ -216,31 +217,34 @@ class _HeroPhotoViewRouteWrapperState extends State<HeroPhotoViewRouteWrapper> {
     final lottiDirectory = await Directory(
       p.join(downloadsDirectory.path, 'Lotti'),
     ).create(recursive: true);
-    final target = _uniqueDownloadFile(
+    final target = await _uniqueDownloadFile(
       directory: lottiDirectory,
       sourceFile: widget.file,
     );
     return widget.fileCopier(widget.file, target);
   }
 
-  File _uniqueDownloadFile({
+  Future<File> _uniqueDownloadFile({
     required Directory directory,
     required File sourceFile,
-  }) {
+  }) async {
     final sourceName = p.basename(sourceFile.path);
     final extension = p.extension(sourceName);
     final baseName = p.basenameWithoutExtension(sourceName);
-    var candidate = File(p.join(directory.path, sourceName));
+    final existingNames = <String>{};
+    await for (final entity in directory.list()) {
+      existingNames.add(p.basename(entity.path));
+    }
+
+    var candidateName = sourceName;
     var suffix = 2;
 
-    while (candidate.existsSync()) {
-      candidate = File(
-        p.join(directory.path, '$baseName $suffix$extension'),
-      );
+    while (existingNames.contains(candidateName)) {
+      candidateName = '$baseName $suffix$extension';
       suffix++;
     }
 
-    return candidate;
+    return File(p.join(directory.path, candidateName));
   }
 
   void _showSnackBar(String message) {
@@ -251,6 +255,12 @@ class _HeroPhotoViewRouteWrapperState extends State<HeroPhotoViewRouteWrapper> {
 
   @override
   Widget build(BuildContext context) {
+    final size = MediaQuery.sizeOf(context);
+    if (_lastSize != size) {
+      _lastSize = size;
+      _minimumScale = null;
+    }
+
     final imageProvider = FileImage(widget.file);
     final tokens = context.designTokens;
     final padding = MediaQuery.paddingOf(context);

--- a/lib/features/journal/ui/widgets/entry_image_widget.dart
+++ b/lib/features/journal/ui/widgets/entry_image_widget.dart
@@ -1,12 +1,17 @@
+import 'dart:async';
 import 'dart:io';
-import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/services.dart';
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/journal/state/entry_controller.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/utils/image_utils.dart';
 import 'package:lotti/utils/platform.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
 import 'package:photo_view/photo_view.dart';
 
 /// Inline image for a [JournalImage] entry in the detail view.
@@ -44,10 +49,15 @@ class EntryImageWidget extends ConsumerWidget {
       onTap: () {
         focusNode.unfocus();
         Navigator.of(context, rootNavigator: true).push(
-          MaterialPageRoute<HeroPhotoViewRouteWrapper>(
-            builder: (_) => HeroPhotoViewRouteWrapper(
-              file: file,
-            ),
+          PageRouteBuilder<void>(
+            opaque: false,
+            barrierColor: Theme.of(
+              context,
+            ).colorScheme.scrim.withValues(alpha: 0.82),
+            pageBuilder: (context, animation, secondaryAnimation) =>
+                HeroPhotoViewRouteWrapper(
+                  file: file,
+                ),
           ),
         );
       },
@@ -73,66 +83,399 @@ class EntryImageWidget extends ConsumerWidget {
   }
 }
 
+typedef ImageViewerDownloadsDirectoryResolver = Future<Directory?> Function();
+typedef ImageViewerFileCopier =
+    Future<File> Function(File sourceFile, File targetFile);
+
+Future<File> _copyImageFile(File sourceFile, File targetFile) =>
+    sourceFile.copy(targetFile.path);
+
 // from https://github.com/bluefireteam/photo_view/blob/master/example/lib/screens/examples/hero_example.dart
-class HeroPhotoViewRouteWrapper extends StatelessWidget {
+class HeroPhotoViewRouteWrapper extends StatefulWidget {
   const HeroPhotoViewRouteWrapper({
     required this.file,
     super.key,
     this.backgroundDecoration,
+    this.downloadsDirectoryResolver = getDownloadsDirectory,
+    this.fileCopier = _copyImageFile,
   });
 
   final File file;
   final BoxDecoration? backgroundDecoration;
+  final ImageViewerDownloadsDirectoryResolver downloadsDirectoryResolver;
+  final ImageViewerFileCopier fileCopier;
+
+  @override
+  State<HeroPhotoViewRouteWrapper> createState() =>
+      _HeroPhotoViewRouteWrapperState();
+}
+
+class _HeroPhotoViewRouteWrapperState extends State<HeroPhotoViewRouteWrapper> {
+  static const double _zoomFactor = 1.25;
+  static const double _maxZoomScale = 8;
+
+  late final PhotoViewController _photoController;
+  late final PhotoViewScaleStateController _scaleStateController;
+  late final StreamSubscription<PhotoViewControllerValue> _photoSubscription;
+
+  double _scale = 1;
+  double? _minimumScale;
+  bool _isDownloading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _photoController = PhotoViewController();
+    _photoSubscription = _photoController.outputStateStream.listen(
+      _handlePhotoViewValue,
+    );
+    _scaleStateController = PhotoViewScaleStateController();
+  }
+
+  @override
+  void dispose() {
+    unawaited(_photoSubscription.cancel());
+    _photoController.dispose();
+    _scaleStateController.dispose();
+    super.dispose();
+  }
+
+  void _handlePhotoViewValue(PhotoViewControllerValue value) {
+    final nextScale = value.scale;
+    if (nextScale == null || !mounted) {
+      return;
+    }
+
+    setState(() {
+      _scale = nextScale;
+      _minimumScale ??= nextScale;
+    });
+  }
+
+  void _close() => Navigator.of(context, rootNavigator: true).pop();
+
+  void _zoomIn() {
+    _setZoom(_scale * _zoomFactor);
+  }
+
+  void _zoomOut() {
+    _setZoom(_scale / _zoomFactor);
+  }
+
+  void _resetZoom() {
+    _scaleStateController.reset();
+    _photoController.updateMultiple(
+      position: Offset.zero,
+      rotation: 0,
+      scale: _minimumScale ?? _scale,
+    );
+  }
+
+  void _setZoom(double scale) {
+    final minimumScale = _minimumScale ?? _scale;
+    _minimumScale ??= minimumScale;
+    final nextScale = scale.clamp(minimumScale, _maxZoomScale).toDouble();
+    _photoController.updateMultiple(
+      position: Offset.zero,
+      scale: nextScale,
+    );
+  }
+
+  Future<void> _downloadImage() async {
+    if (_isDownloading) {
+      return;
+    }
+
+    setState(() => _isDownloading = true);
+    try {
+      final target = await _copyImageToDownloads();
+      if (!mounted) {
+        return;
+      }
+      _showSnackBar(
+        context.messages.imageViewerDownloadSaved(p.basename(target.path)),
+      );
+    } on Object {
+      if (!mounted) {
+        return;
+      }
+      _showSnackBar(context.messages.imageViewerDownloadFailed);
+    } finally {
+      if (mounted) {
+        setState(() => _isDownloading = false);
+      }
+    }
+  }
+
+  Future<File> _copyImageToDownloads() async {
+    final downloadsDirectory = await widget.downloadsDirectoryResolver();
+    if (downloadsDirectory == null) {
+      throw const FileSystemException('Downloads directory is unavailable');
+    }
+
+    final lottiDirectory = await Directory(
+      p.join(downloadsDirectory.path, 'Lotti'),
+    ).create(recursive: true);
+    final target = _uniqueDownloadFile(
+      directory: lottiDirectory,
+      sourceFile: widget.file,
+    );
+    return widget.fileCopier(widget.file, target);
+  }
+
+  File _uniqueDownloadFile({
+    required Directory directory,
+    required File sourceFile,
+  }) {
+    final sourceName = p.basename(sourceFile.path);
+    final extension = p.extension(sourceName);
+    final baseName = p.basenameWithoutExtension(sourceName);
+    var candidate = File(p.join(directory.path, sourceName));
+    var suffix = 2;
+
+    while (candidate.existsSync()) {
+      candidate = File(
+        p.join(directory.path, '$baseName $suffix$extension'),
+      );
+      suffix++;
+    }
+
+    return candidate;
+  }
+
+  void _showSnackBar(String message) {
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text(message)));
+  }
 
   @override
   Widget build(BuildContext context) {
-    final imageProvider = FileImage(file);
+    final imageProvider = FileImage(widget.file);
+    final tokens = context.designTokens;
+    final padding = MediaQuery.paddingOf(context);
+    final edge = isMobile ? tokens.spacing.step3 : tokens.spacing.step8;
+    final top = tokens.spacing.step5;
+    final bottom = tokens.spacing.step11;
+    final minimumScale = _minimumScale ?? _scale;
+    final canZoomOut = _scale > minimumScale * 1.01;
 
-    return Scaffold(
-      body: Stack(
-        children: [
-          Container(
-            constraints: BoxConstraints.expand(
-              height: MediaQuery.of(context).size.height,
-            ),
-            child: PhotoView(
-              imageProvider: imageProvider,
-              backgroundDecoration: backgroundDecoration,
-              heroAttributes: const PhotoViewHeroAttributes(tag: 'entry_img'),
-              minScale: PhotoViewComputedScale.contained,
-            ),
+    return CallbackShortcuts(
+      bindings: {
+        const SingleActivator(LogicalKeyboardKey.escape): _close,
+      },
+      child: Focus(
+        autofocus: true,
+        child: Scaffold(
+          backgroundColor: Colors.transparent,
+          body: Stack(
+            children: [
+              Positioned.fill(
+                child: SafeArea(
+                  child: Padding(
+                    padding: EdgeInsets.fromLTRB(edge, top, edge, bottom),
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(tokens.radii.m),
+                      child: DecoratedBox(
+                        decoration: BoxDecoration(
+                          color: Theme.of(context).colorScheme.scrim,
+                          border: Border.all(
+                            color: tokens.colors.decorative.level02,
+                          ),
+                        ),
+                        child: PhotoView(
+                          imageProvider: imageProvider,
+                          backgroundDecoration:
+                              widget.backgroundDecoration ??
+                              BoxDecoration(
+                                color: Theme.of(context).colorScheme.scrim,
+                              ),
+                          controller: _photoController,
+                          scaleStateController: _scaleStateController,
+                          heroAttributes: const PhotoViewHeroAttributes(
+                            tag: 'entry_img',
+                          ),
+                          minScale: PhotoViewComputedScale.contained,
+                          maxScale: PhotoViewComputedScale.covered * 4,
+                          initialScale: PhotoViewComputedScale.contained,
+                          strictScale: true,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              Positioned(
+                right: edge,
+                top: padding.top + tokens.spacing.step3,
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    _ImageViewerIconButton(
+                      tooltip: _isDownloading
+                          ? context.messages.imageViewerDownloadingTooltip
+                          : context.messages.imageViewerDownloadTooltip,
+                      icon: _isDownloading
+                          ? Icons.hourglass_top_rounded
+                          : Icons.download_rounded,
+                      onPressed: _isDownloading
+                          ? null
+                          : () => unawaited(_downloadImage()),
+                    ),
+                    SizedBox(width: tokens.spacing.step2),
+                    _ImageViewerIconButton(
+                      tooltip: MaterialLocalizations.of(
+                        context,
+                      ).closeButtonTooltip,
+                      icon: Icons.close_rounded,
+                      onPressed: _close,
+                    ),
+                  ],
+                ),
+              ),
+              Positioned(
+                left: 0,
+                right: 0,
+                bottom: padding.bottom + tokens.spacing.step4,
+                child: Center(
+                  child: _ImageViewerZoomControls(
+                    scale: _scale,
+                    canZoomOut: canZoomOut,
+                    onZoomOut: canZoomOut ? _zoomOut : null,
+                    onZoomReset: _resetZoom,
+                    onZoomIn: _zoomIn,
+                  ),
+                ),
+              ),
+            ],
           ),
-          Positioned(
-            right: 0,
-            top: 0,
-            child: IconButton(
-              padding: const EdgeInsets.all(48),
-              onPressed: () {
-                Navigator.of(context, rootNavigator: true).pop();
-              },
-              icon: Stack(
-                children: [
-                  ImageFiltered(
-                    imageFilter: ImageFilter.blur(
-                      sigmaX: 12,
-                      sigmaY: 12,
-                    ),
-                    child: const Icon(
-                      Icons.close_rounded,
-                      size: 32,
+        ),
+      ),
+    );
+  }
+}
+
+class _ImageViewerIconButton extends StatelessWidget {
+  const _ImageViewerIconButton({
+    required this.tooltip,
+    required this.icon,
+    required this.onPressed,
+  });
+
+  final String tooltip;
+  final IconData icon;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    return Material(
+      color: Theme.of(context).colorScheme.scrim.withValues(alpha: 0.46),
+      shape: const CircleBorder(),
+      clipBehavior: Clip.antiAlias,
+      child: IconButton(
+        tooltip: tooltip,
+        color: Colors.white,
+        disabledColor: Colors.white.withValues(alpha: 0.45),
+        padding: EdgeInsets.all(tokens.spacing.step3),
+        onPressed: onPressed,
+        icon: Icon(icon),
+      ),
+    );
+  }
+}
+
+class _ImageViewerZoomControls extends StatelessWidget {
+  const _ImageViewerZoomControls({
+    required this.scale,
+    required this.canZoomOut,
+    required this.onZoomOut,
+    required this.onZoomReset,
+    required this.onZoomIn,
+  });
+
+  final double scale;
+  final bool canZoomOut;
+  final VoidCallback? onZoomOut;
+  final VoidCallback onZoomReset;
+  final VoidCallback onZoomIn;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final percent = '${(scale * 100).round()}%';
+
+    return Material(
+      color: Theme.of(context).colorScheme.scrim.withValues(alpha: 0.62),
+      borderRadius: BorderRadius.circular(tokens.radii.badgesPills),
+      clipBehavior: Clip.antiAlias,
+      child: Padding(
+        padding: EdgeInsets.all(tokens.spacing.step1),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _ImageViewerZoomButton(
+              tooltip: context.messages.viewMenuZoomOut,
+              icon: Icons.remove_rounded,
+              onPressed: canZoomOut ? onZoomOut : null,
+            ),
+            Tooltip(
+              message: context.messages.viewMenuZoomReset,
+              child: InkWell(
+                onTap: onZoomReset,
+                borderRadius: BorderRadius.circular(tokens.radii.badgesPills),
+                child: Padding(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: tokens.spacing.step4,
+                    vertical: tokens.spacing.step2,
+                  ),
+                  child: Text(
+                    percent,
+                    textAlign: TextAlign.center,
+                    style: tokens.typography.styles.body.bodyMedium.copyWith(
+                      color: Colors.white,
                     ),
                   ),
-                  const Icon(
-                    Icons.close_rounded,
-                    size: 32,
-                    color: Colors.white,
-                  ),
-                ],
+                ),
               ),
             ),
-          ),
-        ],
+            _ImageViewerZoomButton(
+              tooltip: context.messages.viewMenuZoomIn,
+              icon: Icons.add_rounded,
+              onPressed: onZoomIn,
+            ),
+          ],
+        ),
       ),
+    );
+  }
+}
+
+class _ImageViewerZoomButton extends StatelessWidget {
+  const _ImageViewerZoomButton({
+    required this.tooltip,
+    required this.icon,
+    required this.onPressed,
+  });
+
+  final String tooltip;
+  final IconData icon;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    return IconButton(
+      tooltip: tooltip,
+      color: Colors.white,
+      disabledColor: Colors.white.withValues(alpha: 0.45),
+      padding: EdgeInsets.all(tokens.spacing.step2),
+      constraints: BoxConstraints.tightFor(
+        width: tokens.spacing.step8,
+        height: tokens.spacing.step8,
+      ),
+      onPressed: onPressed,
+      icon: Icon(icon),
     );
   }
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -2210,6 +2210,17 @@
   "imagePromptGenerationExpandTooltip": "Zobrazit celý prompt",
   "imagePromptGenerationFullPromptLabel": "Celý prompt obrázku:",
   "images": "Obrázky",
+  "imageViewerDownloadFailed": "Obrázek se nepodařilo uložit",
+  "imageViewerDownloadingTooltip": "Ukládám obrázek",
+  "imageViewerDownloadSaved": "Uloženo {fileName} do Stažené/Lotti",
+  "@imageViewerDownloadSaved": {
+    "placeholders": {
+      "fileName": {
+        "type": "String"
+      }
+    }
+  },
+  "imageViewerDownloadTooltip": "Stáhnout obrázek",
   "inactiveLabel": "Neaktivní",
   "inactiveSwitchDescription": "Lze vybrat pro nové záznamy, když je zapnuto",
   "inferenceProfileDetailLoadError": "Profil se nepodařilo načíst: {error}",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2401,6 +2401,17 @@
   "imagePromptGenerationExpandTooltip": "Vollständigen Prompt anzeigen",
   "imagePromptGenerationFullPromptLabel": "Vollständiger Bild-Prompt:",
   "images": "Bilder",
+  "imageViewerDownloadFailed": "Bild konnte nicht gespeichert werden",
+  "imageViewerDownloadingTooltip": "Bild wird gespeichert",
+  "imageViewerDownloadSaved": "{fileName} wurde in Downloads/Lotti gespeichert",
+  "@imageViewerDownloadSaved": {
+    "placeholders": {
+      "fileName": {
+        "type": "String"
+      }
+    }
+  },
+  "imageViewerDownloadTooltip": "Bild herunterladen",
   "inactiveLabel": "Inaktiv",
   "inactiveSwitchDescription": "Kann für neue Einträge gewählt werden, wenn aktiv",
   "inferenceProfileCreateTitle": "Profil erstellen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2863,6 +2863,17 @@
   "imagePromptGenerationExpandTooltip": "Show full prompt",
   "imagePromptGenerationFullPromptLabel": "Full Image Prompt:",
   "images": "Images",
+  "imageViewerDownloadFailed": "Could not save image",
+  "imageViewerDownloadingTooltip": "Saving image",
+  "imageViewerDownloadSaved": "Saved {fileName} to Downloads/Lotti",
+  "@imageViewerDownloadSaved": {
+    "placeholders": {
+      "fileName": {
+        "type": "String"
+      }
+    }
+  },
+  "imageViewerDownloadTooltip": "Download image",
   "inactiveLabel": "Inactive",
   "inactiveSwitchDescription": "Can be chosen for new entries when on",
   "inferenceProfileCreateTitle": "Create Profile",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2401,6 +2401,17 @@
   "imagePromptGenerationExpandTooltip": "Mostrar prompt completo",
   "imagePromptGenerationFullPromptLabel": "Prompt de Imagen Completo:",
   "images": "Imágenes",
+  "imageViewerDownloadFailed": "No se pudo guardar la imagen",
+  "imageViewerDownloadingTooltip": "Guardando imagen",
+  "imageViewerDownloadSaved": "Se guardó {fileName} en Descargas/Lotti",
+  "@imageViewerDownloadSaved": {
+    "placeholders": {
+      "fileName": {
+        "type": "String"
+      }
+    }
+  },
+  "imageViewerDownloadTooltip": "Descargar imagen",
   "inactiveLabel": "Inactivo",
   "inactiveSwitchDescription": "Se puede elegir para nuevas entradas cuando está activo",
   "inferenceProfileCreateTitle": "Crear perfil",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -2401,6 +2401,17 @@
   "imagePromptGenerationExpandTooltip": "Afficher le prompt complet",
   "imagePromptGenerationFullPromptLabel": "Prompt image complet :",
   "images": "Images",
+  "imageViewerDownloadFailed": "Impossible d'enregistrer l'image",
+  "imageViewerDownloadingTooltip": "Enregistrement de l'image",
+  "imageViewerDownloadSaved": "{fileName} enregistré dans Téléchargements/Lotti",
+  "@imageViewerDownloadSaved": {
+    "placeholders": {
+      "fileName": {
+        "type": "String"
+      }
+    }
+  },
+  "imageViewerDownloadTooltip": "Télécharger l'image",
   "inactiveLabel": "Inactif",
   "inactiveSwitchDescription": "Peut être choisi pour de nouvelles entrées si actif",
   "inferenceProfileCreateTitle": "Créer un profil",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -9444,6 +9444,30 @@ abstract class AppLocalizations {
   /// **'Images'**
   String get images;
 
+  /// No description provided for @imageViewerDownloadFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not save image'**
+  String get imageViewerDownloadFailed;
+
+  /// No description provided for @imageViewerDownloadSaved.
+  ///
+  /// In en, this message translates to:
+  /// **'Saved {fileName} to Downloads/Lotti'**
+  String imageViewerDownloadSaved(String fileName);
+
+  /// No description provided for @imageViewerDownloadTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Download image'**
+  String get imageViewerDownloadTooltip;
+
+  /// No description provided for @imageViewerDownloadingTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Saving image'**
+  String get imageViewerDownloadingTooltip;
+
   /// No description provided for @inactiveLabel.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -5514,6 +5514,20 @@ class AppLocalizationsCs extends AppLocalizations {
   String get images => 'Obrázky';
 
   @override
+  String get imageViewerDownloadFailed => 'Obrázek se nepodařilo uložit';
+
+  @override
+  String imageViewerDownloadSaved(String fileName) {
+    return 'Uloženo $fileName do Stažené/Lotti';
+  }
+
+  @override
+  String get imageViewerDownloadTooltip => 'Stáhnout obrázek';
+
+  @override
+  String get imageViewerDownloadingTooltip => 'Ukládám obrázek';
+
+  @override
   String get inactiveLabel => 'Neaktivní';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -5506,6 +5506,21 @@ class AppLocalizationsDe extends AppLocalizations {
   String get images => 'Bilder';
 
   @override
+  String get imageViewerDownloadFailed =>
+      'Bild konnte nicht gespeichert werden';
+
+  @override
+  String imageViewerDownloadSaved(String fileName) {
+    return '$fileName wurde in Downloads/Lotti gespeichert';
+  }
+
+  @override
+  String get imageViewerDownloadTooltip => 'Bild herunterladen';
+
+  @override
+  String get imageViewerDownloadingTooltip => 'Bild wird gespeichert';
+
+  @override
   String get inactiveLabel => 'Inaktiv';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -5436,6 +5436,20 @@ class AppLocalizationsEn extends AppLocalizations {
   String get images => 'Images';
 
   @override
+  String get imageViewerDownloadFailed => 'Could not save image';
+
+  @override
+  String imageViewerDownloadSaved(String fileName) {
+    return 'Saved $fileName to Downloads/Lotti';
+  }
+
+  @override
+  String get imageViewerDownloadTooltip => 'Download image';
+
+  @override
+  String get imageViewerDownloadingTooltip => 'Saving image';
+
+  @override
   String get inactiveLabel => 'Inactive';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -5549,6 +5549,20 @@ class AppLocalizationsEs extends AppLocalizations {
   String get images => 'Imágenes';
 
   @override
+  String get imageViewerDownloadFailed => 'No se pudo guardar la imagen';
+
+  @override
+  String imageViewerDownloadSaved(String fileName) {
+    return 'Se guardó $fileName en Descargas/Lotti';
+  }
+
+  @override
+  String get imageViewerDownloadTooltip => 'Descargar imagen';
+
+  @override
+  String get imageViewerDownloadingTooltip => 'Guardando imagen';
+
+  @override
   String get inactiveLabel => 'Inactivo';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -5556,6 +5556,20 @@ class AppLocalizationsFr extends AppLocalizations {
   String get images => 'Images';
 
   @override
+  String get imageViewerDownloadFailed => 'Impossible d\'enregistrer l\'image';
+
+  @override
+  String imageViewerDownloadSaved(String fileName) {
+    return '$fileName enregistré dans Téléchargements/Lotti';
+  }
+
+  @override
+  String get imageViewerDownloadTooltip => 'Télécharger l\'image';
+
+  @override
+  String get imageViewerDownloadingTooltip => 'Enregistrement de l\'image';
+
+  @override
   String get inactiveLabel => 'Inactif';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -5560,6 +5560,20 @@ class AppLocalizationsRo extends AppLocalizations {
   String get images => 'Imagini';
 
   @override
+  String get imageViewerDownloadFailed => 'Nu s-a putut salva imaginea';
+
+  @override
+  String imageViewerDownloadSaved(String fileName) {
+    return '$fileName a fost salvat în Descărcări/Lotti';
+  }
+
+  @override
+  String get imageViewerDownloadTooltip => 'Descărcați imaginea';
+
+  @override
+  String get imageViewerDownloadingTooltip => 'Se salvează imaginea';
+
+  @override
   String get inactiveLabel => 'Inactiv';
 
   @override

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -2401,6 +2401,17 @@
   "imagePromptGenerationExpandTooltip": "Afișează promptul complet",
   "imagePromptGenerationFullPromptLabel": "Prompt Imagine Complet:",
   "images": "Imagini",
+  "imageViewerDownloadFailed": "Nu s-a putut salva imaginea",
+  "imageViewerDownloadingTooltip": "Se salvează imaginea",
+  "imageViewerDownloadSaved": "{fileName} a fost salvat în Descărcări/Lotti",
+  "@imageViewerDownloadSaved": {
+    "placeholders": {
+      "fileName": {
+        "type": "String"
+      }
+    }
+  },
+  "imageViewerDownloadTooltip": "Descărcați imaginea",
   "inactiveLabel": "Inactiv",
   "inactiveSwitchDescription": "Poate fi ales pentru intrări noi când este activ",
   "inferenceProfileCreateTitle": "Creați un profil",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1031+4180
+version: 0.9.1032+4181
 
 msix_config:
   display_name: LottiApp

--- a/test/features/journal/ui/widgets/entry_image_widget_test.dart
+++ b/test/features/journal/ui/widgets/entry_image_widget_test.dart
@@ -1,8 +1,10 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/journal/ui/widgets/entry_image_widget.dart';
@@ -15,6 +17,95 @@ import 'package:photo_view/photo_view.dart';
 import '../../../../helpers/fake_entry_controller.dart';
 import '../../../../mocks/mocks.dart';
 import '../../../../widget_test_utils.dart';
+
+const _transparentPng = <int>[
+  0x89,
+  0x50,
+  0x4E,
+  0x47,
+  0x0D,
+  0x0A,
+  0x1A,
+  0x0A,
+  0x00,
+  0x00,
+  0x00,
+  0x0D,
+  0x49,
+  0x48,
+  0x44,
+  0x52,
+  0x00,
+  0x00,
+  0x00,
+  0x01,
+  0x00,
+  0x00,
+  0x00,
+  0x01,
+  0x08,
+  0x06,
+  0x00,
+  0x00,
+  0x00,
+  0x1F,
+  0x15,
+  0xC4,
+  0x89,
+  0x00,
+  0x00,
+  0x00,
+  0x0A,
+  0x49,
+  0x44,
+  0x41,
+  0x54,
+  0x78,
+  0x9C,
+  0x63,
+  0x00,
+  0x01,
+  0x00,
+  0x00,
+  0x05,
+  0x00,
+  0x01,
+  0x0D,
+  0x0A,
+  0x2D,
+  0xB4,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x49,
+  0x45,
+  0x4E,
+  0x44,
+  0xAE,
+  0x42,
+  0x60,
+  0x82,
+];
+
+void _pressIconButton(WidgetTester tester, IconData icon) {
+  final button = tester.widget<IconButton>(
+    find.widgetWithIcon(IconButton, icon),
+  );
+  expect(button.onPressed, isNotNull);
+  button.onPressed!();
+}
+
+Future<void> _waitForFileSystem(
+  WidgetTester tester,
+  bool Function() isReady,
+) async {
+  await tester.runAsync(() async {
+    for (var i = 0; i < 250 && !isReady(); i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 1));
+    }
+  });
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -172,6 +263,7 @@ void main() {
         final subject = ProviderScope(
           overrides: [createEntryControllerOverride(image)],
           child: MaterialApp(
+            theme: resolveTestTheme(),
             localizationsDelegates: const [
               AppLocalizations.delegate,
               GlobalMaterialLocalizations.delegate,
@@ -217,8 +309,8 @@ void main() {
       tempDir = Directory.systemTemp.createTempSync(
         'hero_photo_view_test_',
       );
-      imageFile = File('${tempDir.path}/photo.jpg')
-        ..writeAsBytesSync([0xFF, 0xD8, 0xFF, 0xE0]);
+      imageFile = File('${tempDir.path}/photo.png')
+        ..writeAsBytesSync(_transparentPng);
     });
 
     tearDown(() async {
@@ -229,9 +321,37 @@ void main() {
       }
     });
 
-    Widget buildWrapper({BoxDecoration? backgroundDecoration}) {
+    Widget buildWrapper({
+      BoxDecoration? backgroundDecoration,
+      ImageViewerDownloadsDirectoryResolver? downloadsDirectoryResolver,
+      ImageViewerFileCopier? fileCopier,
+    }) {
+      final wrapper = switch ((downloadsDirectoryResolver, fileCopier)) {
+        (null, null) => HeroPhotoViewRouteWrapper(
+          file: imageFile,
+          backgroundDecoration: backgroundDecoration,
+        ),
+        (final resolver?, null) => HeroPhotoViewRouteWrapper(
+          file: imageFile,
+          backgroundDecoration: backgroundDecoration,
+          downloadsDirectoryResolver: resolver,
+        ),
+        (null, final copier?) => HeroPhotoViewRouteWrapper(
+          file: imageFile,
+          backgroundDecoration: backgroundDecoration,
+          fileCopier: copier,
+        ),
+        (final resolver?, final copier?) => HeroPhotoViewRouteWrapper(
+          file: imageFile,
+          backgroundDecoration: backgroundDecoration,
+          downloadsDirectoryResolver: resolver,
+          fileCopier: copier,
+        ),
+      };
+
       return ProviderScope(
         child: MaterialApp(
+          theme: resolveTestTheme(),
           localizationsDelegates: const [
             AppLocalizations.delegate,
             GlobalMaterialLocalizations.delegate,
@@ -239,16 +359,13 @@ void main() {
             GlobalCupertinoLocalizations.delegate,
           ],
           supportedLocales: AppLocalizations.supportedLocales,
-          home: HeroPhotoViewRouteWrapper(
-            file: imageFile,
-            backgroundDecoration: backgroundDecoration,
-          ),
+          home: wrapper,
         ),
       );
     }
 
     testWidgets(
-      'renders Scaffold with PhotoView and close IconButton',
+      'renders PhotoView with download, close, and zoom controls',
       (tester) async {
         await tester.pumpWidget(buildWrapper());
         await tester.pump();
@@ -261,15 +378,30 @@ void main() {
         final photoView = tester.widget<PhotoView>(find.byType(PhotoView));
         expect(photoView.imageProvider, isA<FileImage>());
         expect(photoView.minScale, PhotoViewComputedScale.contained);
+        expect(photoView.initialScale, PhotoViewComputedScale.contained);
+        expect(photoView.maxScale, PhotoViewComputedScale.covered * 4);
+        expect(photoView.strictScale, isTrue);
+        expect(photoView.controller, isA<PhotoViewController>());
+        expect(
+          photoView.scaleStateController,
+          isA<PhotoViewScaleStateController>(),
+        );
         expect(
           photoView.heroAttributes?.tag,
           'entry_img',
         );
 
-        // Close button is rendered in the top-right Positioned widget.
-        expect(find.byType(IconButton), findsOneWidget);
-        // Two close icons: one blurred behind, one white on top.
-        expect(find.byIcon(Icons.close_rounded), findsNWidgets(2));
+        expect(find.byTooltip('Download image'), findsOneWidget);
+        expect(find.byTooltip('Close'), findsOneWidget);
+        expect(find.byTooltip('Zoom In'), findsOneWidget);
+        expect(find.byTooltip('Zoom Out'), findsOneWidget);
+        expect(find.byTooltip('Actual Size'), findsOneWidget);
+        expect(find.text('100%'), findsOneWidget);
+
+        final zoomOutButton = tester.widget<IconButton>(
+          find.widgetWithIcon(IconButton, Icons.remove_rounded),
+        );
+        expect(zoomOutButton.onPressed, isNull);
       },
     );
 
@@ -288,8 +420,6 @@ void main() {
     testWidgets(
       'close button pops the route when tapped',
       (tester) async {
-        // The close IconButton has padding: EdgeInsets.all(48); use a large
-        // viewport so its hit target falls within bounds.
         tester.view.physicalSize = const Size(1200, 900);
         tester.view.devicePixelRatio = 1;
         addTearDown(tester.view.reset);
@@ -299,6 +429,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             child: MaterialApp(
+              theme: resolveTestTheme(),
               localizationsDelegates: const [
                 AppLocalizations.delegate,
                 GlobalMaterialLocalizations.delegate,
@@ -337,11 +468,7 @@ void main() {
         // Wrapper is visible.
         expect(find.byType(HeroPhotoViewRouteWrapper), findsOneWidget);
 
-        // Invoke the close button's onPressed callback directly to avoid
-        // off-screen hit-testing issues caused by the large 48px padding on
-        // the Positioned close button.
-        final iconButton = tester.widget<IconButton>(find.byType(IconButton));
-        iconButton.onPressed?.call();
+        _pressIconButton(tester, Icons.close_rounded);
         await tester.pump();
         await tester.pump();
 
@@ -349,6 +476,248 @@ void main() {
         expect(find.byType(HeroPhotoViewRouteWrapper), findsNothing);
         // We're back on the home screen.
         expect(find.text('Open'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'escape key pops the route',
+      (tester) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            child: MaterialApp(
+              theme: resolveTestTheme(),
+              localizationsDelegates: const [
+                AppLocalizations.delegate,
+                GlobalMaterialLocalizations.delegate,
+                GlobalWidgetsLocalizations.delegate,
+                GlobalCupertinoLocalizations.delegate,
+              ],
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Builder(
+                builder: (context) {
+                  return Scaffold(
+                    body: ElevatedButton(
+                      onPressed: () {
+                        Navigator.of(context, rootNavigator: true).push(
+                          PageRouteBuilder<void>(
+                            opaque: false,
+                            pageBuilder:
+                                (context, animation, secondaryAnimation) =>
+                                    HeroPhotoViewRouteWrapper(
+                                      file: imageFile,
+                                    ),
+                          ),
+                        );
+                      },
+                      child: const Text('Open'),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        await tester.tap(find.text('Open'));
+        await tester.pump();
+        await tester.pump();
+        expect(find.byType(HeroPhotoViewRouteWrapper), findsOneWidget);
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.byType(HeroPhotoViewRouteWrapper), findsNothing);
+        expect(find.text('Open'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'zoom controls update the visible scale and reset to actual size',
+      (tester) async {
+        await tester.pumpWidget(buildWrapper());
+        await tester.pump();
+
+        expect(find.text('100%'), findsOneWidget);
+
+        _pressIconButton(tester, Icons.add_rounded);
+        await tester.pump();
+        expect(find.text('125%'), findsOneWidget);
+
+        _pressIconButton(tester, Icons.remove_rounded);
+        await tester.pump();
+        expect(find.text('100%'), findsOneWidget);
+
+        _pressIconButton(tester, Icons.add_rounded);
+        await tester.pump();
+        expect(find.text('125%'), findsOneWidget);
+
+        await tester.tap(find.text('125%'));
+        await tester.pump();
+        expect(find.text('100%'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'download button copies the image to Downloads/Lotti with a unique name',
+      (tester) async {
+        final downloadsDir = Directory('${tempDir.path}/Downloads')
+          ..createSync();
+        final lottiDownloads = Directory('${downloadsDir.path}/Lotti')
+          ..createSync();
+        File('${lottiDownloads.path}/photo.png').writeAsBytesSync([0x01]);
+        File('${lottiDownloads.path}/photo 2.png').writeAsBytesSync([0x02]);
+
+        await tester.pumpWidget(
+          buildWrapper(
+            downloadsDirectoryResolver: () => Future.value(downloadsDir),
+            fileCopier: (sourceFile, targetFile) {
+              targetFile.writeAsBytesSync(sourceFile.readAsBytesSync());
+              return Future.value(targetFile);
+            },
+          ),
+        );
+        await tester.pump();
+
+        final copied = File('${lottiDownloads.path}/photo 3.png');
+        _pressIconButton(tester, Icons.download_rounded);
+        await tester.pump();
+        await _waitForFileSystem(tester, copied.existsSync);
+        await tester.pump();
+        await tester.pump();
+
+        expect(copied.existsSync(), isTrue);
+        expect(copied.readAsBytesSync(), _transparentPng);
+        expect(
+          find.text('Saved photo 3.png to Downloads/Lotti'),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'download button uses the default copier when the file name is free',
+      (tester) async {
+        final downloadsDir = Directory('${tempDir.path}/Downloads')
+          ..createSync();
+        final lottiDownloads = Directory('${downloadsDir.path}/Lotti')
+          ..createSync();
+        final copied = File('${lottiDownloads.path}/photo.png');
+
+        await tester.pumpWidget(
+          buildWrapper(
+            downloadsDirectoryResolver: () => Future.value(downloadsDir),
+          ),
+        );
+        await tester.pump();
+
+        _pressIconButton(tester, Icons.download_rounded);
+        await tester.pump();
+        await _waitForFileSystem(tester, copied.existsSync);
+        await tester.pump();
+        await tester.pump();
+
+        expect(copied.existsSync(), isTrue);
+        expect(copied.readAsBytesSync(), _transparentPng);
+      },
+    );
+
+    testWidgets(
+      'download button disables while copying and ignores duplicate taps',
+      (tester) async {
+        final downloadsDir = Directory('${tempDir.path}/Downloads')
+          ..createSync();
+        Directory('${downloadsDir.path}/Lotti').createSync();
+        final copyCompleter = Completer<File>();
+        var copyCalls = 0;
+        late File pendingTarget;
+
+        await tester.pumpWidget(
+          buildWrapper(
+            downloadsDirectoryResolver: () => Future.value(downloadsDir),
+            fileCopier: (sourceFile, targetFile) {
+              copyCalls++;
+              pendingTarget = targetFile;
+              return copyCompleter.future;
+            },
+          ),
+        );
+        await tester.pump();
+
+        final downloadButton = tester.widget<IconButton>(
+          find.widgetWithIcon(IconButton, Icons.download_rounded),
+        );
+        expect(downloadButton.onPressed, isNotNull);
+        downloadButton.onPressed!();
+        downloadButton.onPressed!();
+        await tester.pump();
+        await _waitForFileSystem(tester, () => copyCalls == 1);
+        await tester.pump();
+
+        expect(copyCalls, 1);
+        expect(find.byTooltip('Saving image'), findsOneWidget);
+        final savingButton = tester.widget<IconButton>(
+          find.widgetWithIcon(IconButton, Icons.hourglass_top_rounded),
+        );
+        expect(savingButton.onPressed, isNull);
+
+        pendingTarget.writeAsBytesSync(imageFile.readAsBytesSync());
+        copyCompleter.complete(pendingTarget);
+        await tester.pump();
+
+        expect(
+          find.text('Saved photo.png to Downloads/Lotti'),
+          findsOneWidget,
+        );
+        expect(copyCalls, 1);
+      },
+    );
+
+    testWidgets(
+      'download button reports failure when downloads are unavailable',
+      (tester) async {
+        await tester.pumpWidget(
+          buildWrapper(
+            downloadsDirectoryResolver: () async => null,
+          ),
+        );
+        await tester.pump();
+
+        _pressIconButton(tester, Icons.download_rounded);
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.text('Could not save image'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'download button reports failure when copying throws',
+      (tester) async {
+        final downloadsDir = Directory('${tempDir.path}/Downloads')
+          ..createSync();
+        Directory('${downloadsDir.path}/Lotti').createSync();
+        var copyAttempted = false;
+
+        await tester.pumpWidget(
+          buildWrapper(
+            downloadsDirectoryResolver: () => Future.value(downloadsDir),
+            fileCopier: (sourceFile, targetFile) {
+              copyAttempted = true;
+              throw const FileSystemException('copy failed');
+            },
+          ),
+        );
+        await tester.pump();
+
+        _pressIconButton(tester, Icons.download_rounded);
+        await tester.pump();
+        await _waitForFileSystem(tester, () => copyAttempted);
+        await tester.pump();
+
+        expect(copyAttempted, isTrue);
+        expect(find.text('Could not save image'), findsOneWidget);
       },
     );
 

--- a/test/features/journal/ui/widgets/entry_image_widget_test.dart
+++ b/test/features/journal/ui/widgets/entry_image_widget_test.dart
@@ -2,9 +2,9 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/journal/ui/widgets/entry_image_widget.dart';
@@ -96,11 +96,13 @@ void _pressIconButton(WidgetTester tester, IconData icon) {
   button.onPressed!();
 }
 
-Future<void> _waitForFileSystem(
+Future<void> _runAndWaitForFileSystem(
   WidgetTester tester,
+  VoidCallback action,
   bool Function() isReady,
 ) async {
   await tester.runAsync(() async {
+    action();
     for (var i = 0; i < 250 && !isReady(); i++) {
       await Future<void>.delayed(const Duration(milliseconds: 1));
     }
@@ -560,6 +562,35 @@ void main() {
     );
 
     testWidgets(
+      'layout size changes reset the cached minimum zoom scale',
+      (tester) async {
+        tester.view
+          ..physicalSize = const Size(1200, 900)
+          ..devicePixelRatio = 1;
+        addTearDown(tester.view.reset);
+
+        await tester.pumpWidget(buildWrapper());
+        await tester.pump();
+
+        _pressIconButton(tester, Icons.add_rounded);
+        await tester.pump();
+        expect(find.text('125%'), findsOneWidget);
+        var zoomOutButton = tester.widget<IconButton>(
+          find.widgetWithIcon(IconButton, Icons.remove_rounded),
+        );
+        expect(zoomOutButton.onPressed, isNotNull);
+
+        tester.view.physicalSize = const Size(900, 1200);
+        await tester.pump();
+
+        zoomOutButton = tester.widget<IconButton>(
+          find.widgetWithIcon(IconButton, Icons.remove_rounded),
+        );
+        expect(zoomOutButton.onPressed, isNull);
+      },
+    );
+
+    testWidgets(
       'download button copies the image to Downloads/Lotti with a unique name',
       (tester) async {
         final downloadsDir = Directory('${tempDir.path}/Downloads')
@@ -581,9 +612,15 @@ void main() {
         await tester.pump();
 
         final copied = File('${lottiDownloads.path}/photo 3.png');
-        _pressIconButton(tester, Icons.download_rounded);
-        await tester.pump();
-        await _waitForFileSystem(tester, copied.existsSync);
+        final downloadButton = tester.widget<IconButton>(
+          find.widgetWithIcon(IconButton, Icons.download_rounded),
+        );
+        expect(downloadButton.onPressed, isNotNull);
+        await _runAndWaitForFileSystem(
+          tester,
+          downloadButton.onPressed!,
+          copied.existsSync,
+        );
         await tester.pump();
         await tester.pump();
 
@@ -612,9 +649,15 @@ void main() {
         );
         await tester.pump();
 
-        _pressIconButton(tester, Icons.download_rounded);
-        await tester.pump();
-        await _waitForFileSystem(tester, copied.existsSync);
+        final downloadButton = tester.widget<IconButton>(
+          find.widgetWithIcon(IconButton, Icons.download_rounded),
+        );
+        expect(downloadButton.onPressed, isNotNull);
+        await _runAndWaitForFileSystem(
+          tester,
+          downloadButton.onPressed!,
+          copied.existsSync,
+        );
         await tester.pump();
         await tester.pump();
 
@@ -649,10 +692,14 @@ void main() {
           find.widgetWithIcon(IconButton, Icons.download_rounded),
         );
         expect(downloadButton.onPressed, isNotNull);
-        downloadButton.onPressed!();
-        downloadButton.onPressed!();
-        await tester.pump();
-        await _waitForFileSystem(tester, () => copyCalls == 1);
+        await _runAndWaitForFileSystem(
+          tester,
+          () {
+            downloadButton.onPressed!();
+            downloadButton.onPressed!();
+          },
+          () => copyCalls == 1,
+        );
         await tester.pump();
 
         expect(copyCalls, 1);
@@ -711,9 +758,15 @@ void main() {
         );
         await tester.pump();
 
-        _pressIconButton(tester, Icons.download_rounded);
-        await tester.pump();
-        await _waitForFileSystem(tester, () => copyAttempted);
+        final downloadButton = tester.widget<IconButton>(
+          find.widgetWithIcon(IconButton, Icons.download_rounded),
+        );
+        expect(downloadButton.onPressed, isNotNull);
+        await _runAndWaitForFileSystem(
+          tester,
+          downloadButton.onPressed!,
+          () => copyAttempted,
+        );
         await tester.pump();
 
         expect(copyAttempted, isTrue);


### PR DESCRIPTION
## Summary

- Rework the journal image viewer into a dimmed overlay with persistent close and download controls.
- Add visible zoom controls while preserving PhotoView pinch-to-zoom and panning.
- Save downloaded originals into `Downloads/Lotti` with unique filenames, with localized feedback.
- Update journal docs, changelog/metainfo, and version metadata for 0.9.1032.

## Validation

- `fvm flutter test test/features/journal/ui/widgets/entry_image_widget_test.dart`
- Dart MCP analyzer on touched Dart files
- `git diff --cached --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the image viewer with a softer in-app overlay, persistent download/close controls, Escape-to-close, and bottom zoom controls.
  * Added image download support that saves the original file with a unique name in the Downloads/Lotti folder.
* **Bug Fixes**
  * Improved image viewing so pinch-to-zoom and panning remain available while using the new controls.
  * Added clearer success and failure messages when downloading images.
* **Documentation**
  * Refreshed release notes and journal image viewer docs to describe the new behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->