### PR TITLE
feat: improve AI impact usage stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and Close buttons, closes with Escape, and adds a bottom zoom control while
   preserving pinch-to-zoom and panning. Download saves the original image into
   `Downloads/Lotti` with a unique filename.
+- **Better AI Impact accounting for transcription.** The AI Impact dashboard
+  now has a **Running total** chart mode for cumulative cost, energy, CO₂e and
+  token usage over the selected period. Voxtral transcription records token
+  usage when the server returns it in final accounting chunks, and transcription
+  calls whose provider reports no token, cost or energy metrics are labelled
+  instead of leaving a blank ledger row.
 
 ## [0.9.1031]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1033]
+### Added
+- **Better AI Impact accounting for transcription.** The AI Impact dashboard
+  now has a **Running total** chart mode for cumulative cost, energy, CO₂e and
+  token usage over the selected period. Voxtral transcription records token
+  usage when the server returns it in final accounting chunks, and transcription
+  calls whose provider reports no token, cost or energy metrics are labelled
+  instead of leaving a blank ledger row.
+
 ## [0.9.1032]
 ### Added
 - **A calmer image viewer.** Tapping a journal photo now opens it over a
@@ -12,12 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and Close buttons, closes with Escape, and adds a bottom zoom control while
   preserving pinch-to-zoom and panning. Download saves the original image into
   `Downloads/Lotti` with a unique filename.
-- **Better AI Impact accounting for transcription.** The AI Impact dashboard
-  now has a **Running total** chart mode for cumulative cost, energy, CO₂e and
-  token usage over the selected period. Voxtral transcription records token
-  usage when the server returns it in final accounting chunks, and transcription
-  calls whose provider reports no token, cost or energy metrics are labelled
-  instead of leaving a blank ledger row.
 
 ## [0.9.1031]
 ### Added

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -32,10 +32,14 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="0.9.1033" date="2026-07-07">
+      <description>
+          <p>The AI Impact dashboard now includes a Running total chart mode for cumulative cost, energy, CO2e and token usage over the selected period. Voxtral transcription records token usage when the server returns it in final accounting chunks, and transcription calls whose provider reports no token, cost or energy metrics are labelled instead of leaving a blank ledger row.</p>
+      </description>
+    </release>
     <release version="0.9.1032" date="2026-07-06">
       <description>
           <p>The journal image viewer is calmer and easier to use. Tapping a photo now opens it over a dimmed version of the app instead of a stark full-screen shell, keeps a visible margin around the image, has persistent top-right Download and Close buttons, closes with Escape, and adds a bottom zoom control while preserving pinch-to-zoom and panning. Download saves the original image into Downloads/Lotti with a unique filename.</p>
-          <p>The AI Impact dashboard now includes a Running total chart mode for cumulative cost, energy, CO2e and token usage over the selected period. Voxtral transcription records token usage when the server returns it in final accounting chunks, and transcription calls whose provider reports no token, cost or energy metrics are labelled instead of leaving a blank ledger row.</p>
       </description>
     </release>
     <release version="0.9.1031" date="2026-06-20">

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -35,6 +35,7 @@
     <release version="0.9.1032" date="2026-07-06">
       <description>
           <p>The journal image viewer is calmer and easier to use. Tapping a photo now opens it over a dimmed version of the app instead of a stark full-screen shell, keeps a visible margin around the image, has persistent top-right Download and Close buttons, closes with Escape, and adds a bottom zoom control while preserving pinch-to-zoom and panning. Download saves the original image into Downloads/Lotti with a unique filename.</p>
+          <p>The AI Impact dashboard now includes a Running total chart mode for cumulative cost, energy, CO2e and token usage over the selected period. Voxtral transcription records token usage when the server returns it in final accounting chunks, and transcription calls whose provider reports no token, cost or energy metrics are labelled instead of leaving a blank ledger row.</p>
       </description>
     </release>
     <release version="0.9.1031" date="2026-06-20">

--- a/lib/features/ai/README.md
+++ b/lib/features/ai/README.md
@@ -624,6 +624,17 @@ It is now a thin **facade**: every public method delegates to one of two collabo
 
 This routing is implemented in code, not inferred from documentation. If a provider type is not branched explicitly for an operation, it falls through to the compatibility client or throws `UnsupportedError`.
 
+Audio transcription responses are normalized into chat-completion stream chunks
+so downstream skill/unified consumers can collect text and `usage` the same way
+for every provider. `completion_usage_parser.dart` accepts the common
+OpenAI-compatible token shapes (`prompt_tokens` / `completion_tokens`,
+input/output aliases, cached and reasoning token details). Duration-only audio
+usage is intentionally ignored because it cannot be represented as token
+consumption. Whisper-style `/audio/transcriptions` responses therefore carry
+token usage only when the endpoint actually reports it. Voxtral's streaming
+adapter also emits final usage-only SSE frames, which lets AI Consumption record
+tokens even when the final accounting chunk contains no text delta.
+
 For oMLX, the audio branch is model-sensitive. Regular oMLX Qwen and Gemma
 rows still use OpenAI-compatible chat or vision chat routes, while
 Whisper/ASR/STT-shaped oMLX model ids use the configured provider base URL plus

--- a/lib/features/ai/repository/completion_usage_parser.dart
+++ b/lib/features/ai/repository/completion_usage_parser.dart
@@ -7,8 +7,8 @@ import 'package:openai_dart/openai_dart.dart';
 /// use input/output naming or camelCase keys. Unsupported duration-only usage
 /// payloads (for example audio seconds without token counts) return null.
 CompletionUsage? parseCompletionUsage(Object? raw) {
-  if (raw is! Map) return null;
-  final usage = raw.cast<String, dynamic>();
+  if (raw is! Map<dynamic, dynamic>) return null;
+  final usage = raw;
 
   final promptTokens = _integerValue(
     usage['prompt_tokens'] ?? usage['input_tokens'] ?? usage['promptTokens'],
@@ -59,9 +59,9 @@ CompletionUsage? parseCompletionUsage(Object? raw) {
   );
 }
 
-Map<String, dynamic>? _mapValue(Object? value) {
-  if (value is! Map) return null;
-  return value.cast<String, dynamic>();
+Map<dynamic, dynamic>? _mapValue(Object? value) {
+  if (value is! Map<dynamic, dynamic>) return null;
+  return value;
 }
 
 int? _integerValue(Object? value) {

--- a/lib/features/ai/repository/completion_usage_parser.dart
+++ b/lib/features/ai/repository/completion_usage_parser.dart
@@ -1,0 +1,72 @@
+import 'package:openai_dart/openai_dart.dart';
+
+/// Parses OpenAI-compatible `usage` payloads into [CompletionUsage].
+///
+/// Providers are not perfectly consistent: streamed chat completions usually
+/// report `prompt_tokens`/`completion_tokens`, while a few compatible servers
+/// use input/output naming or camelCase keys. Unsupported duration-only usage
+/// payloads (for example audio seconds without token counts) return null.
+CompletionUsage? parseCompletionUsage(Object? raw) {
+  if (raw is! Map) return null;
+  final usage = raw.cast<String, dynamic>();
+
+  final promptTokens = _integerValue(
+    usage['prompt_tokens'] ?? usage['input_tokens'] ?? usage['promptTokens'],
+  );
+  final completionTokens = _integerValue(
+    usage['completion_tokens'] ??
+        usage['output_tokens'] ??
+        usage['completionTokens'],
+  );
+  final totalTokens = _integerValue(
+    usage['total_tokens'] ?? usage['totalTokens'],
+  );
+  final cachedTokens =
+      _integerValue(usage['cached_tokens'] ?? usage['cachedTokens']) ??
+      _integerValue(
+        _mapValue(usage['prompt_tokens_details'])?['cached_tokens'] ??
+            _mapValue(usage['promptTokensDetails'])?['cachedTokens'] ??
+            _mapValue(usage['input_tokens_details'])?['cached_tokens'] ??
+            _mapValue(usage['inputTokensDetails'])?['cachedTokens'],
+      );
+  final reasoningTokens =
+      _integerValue(usage['reasoning_tokens'] ?? usage['reasoningTokens']) ??
+      _integerValue(
+        _mapValue(usage['completion_tokens_details'])?['reasoning_tokens'] ??
+            _mapValue(usage['completionTokensDetails'])?['reasoningTokens'] ??
+            _mapValue(usage['output_tokens_details'])?['reasoning_tokens'] ??
+            _mapValue(usage['outputTokensDetails'])?['reasoningTokens'],
+      );
+
+  final hasTokenData =
+      promptTokens != null ||
+      completionTokens != null ||
+      totalTokens != null ||
+      cachedTokens != null ||
+      reasoningTokens != null;
+  if (!hasTokenData) return null;
+
+  return CompletionUsage(
+    promptTokens: promptTokens,
+    completionTokens: completionTokens,
+    totalTokens: totalTokens ?? (promptTokens ?? 0) + (completionTokens ?? 0),
+    promptTokensDetails: cachedTokens != null
+        ? PromptTokensDetails(cachedTokens: cachedTokens)
+        : null,
+    completionTokensDetails: reasoningTokens != null
+        ? CompletionTokensDetails(reasoningTokens: reasoningTokens)
+        : null,
+  );
+}
+
+Map<String, dynamic>? _mapValue(Object? value) {
+  if (value is! Map) return null;
+  return value.cast<String, dynamic>();
+}
+
+int? _integerValue(Object? value) {
+  if (value is int) return value;
+  if (value is num) return value.toInt();
+  if (value is String) return int.tryParse(value);
+  return null;
+}

--- a/lib/features/ai/repository/transcription_repository.dart
+++ b/lib/features/ai/repository/transcription_repository.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:developer' as developer;
 
 import 'package:http/http.dart' as http;
+import 'package:lotti/features/ai/repository/completion_usage_parser.dart';
 import 'package:lotti/features/ai/repository/transcription_exception.dart';
 import 'package:lotti/features/ai/state/consts.dart';
 import 'package:openai_dart/openai_dart.dart';
@@ -106,6 +107,7 @@ class TranscriptionRepository {
           }
 
           final text = result['text'] as String;
+          final usage = parseCompletionUsage(result['usage']);
 
           developer.log(
             'Successfully transcribed audio - '
@@ -125,6 +127,7 @@ class TranscriptionRepository {
             ],
             object: 'chat.completion.chunk',
             created: 0,
+            usage: usage,
           );
         } on TranscriptionException {
           rethrow;

--- a/lib/features/ai/repository/voxtral_inference_repository.dart
+++ b/lib/features/ai/repository/voxtral_inference_repository.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:developer' as developer;
 
 import 'package:http/http.dart' as http;
+import 'package:lotti/features/ai/repository/completion_usage_parser.dart';
 import 'package:lotti/features/ai/state/consts.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/domain_logging.dart';
@@ -205,6 +206,7 @@ class VoxtralInferenceRepository {
         );
 
         final json = jsonDecode(response.body) as Map<String, dynamic>;
+        final usage = parseCompletionUsage(json['usage']);
         final choices = json['choices'] as List<dynamic>?;
         if (choices != null && choices.isNotEmpty) {
           final choice = choices[0] as Map<String, dynamic>;
@@ -226,8 +228,25 @@ class VoxtralInferenceRepository {
               created:
                   json['created'] as int? ??
                   DateTime.now().millisecondsSinceEpoch ~/ 1000,
+              model: json['model'] as String?,
+              usage: usage,
             );
+            return;
           }
+        }
+        if (usage != null) {
+          yield CreateChatCompletionStreamResponse(
+            id:
+                json['id'] as String? ??
+                'voxtral-${DateTime.now().millisecondsSinceEpoch}',
+            choices: const [],
+            object: 'chat.completion.chunk',
+            created:
+                json['created'] as int? ??
+                DateTime.now().millisecondsSinceEpoch ~/ 1000,
+            model: json['model'] as String?,
+            usage: usage,
+          );
         }
         return;
       }
@@ -283,6 +302,7 @@ class VoxtralInferenceRepository {
 
             try {
               final json = jsonDecode(data) as Map<String, dynamic>;
+              final usage = parseCompletionUsage(json['usage']);
               final choices = json['choices'] as List<dynamic>?;
 
               if (choices != null && choices.isNotEmpty) {
@@ -291,36 +311,49 @@ class VoxtralInferenceRepository {
                 final content = delta?['content'] as String?;
                 final finishReason = choice['finish_reason'] as String?;
 
-                // Only yield chunks with actual content
-                if (content != null && content.isNotEmpty) {
-                  chunksReceived++;
-                  developer.log(
-                    'Received chunk $chunksReceived: ${content.length} chars',
-                    name: 'VoxtralInferenceRepository',
-                  );
+                final hasContent = content != null && content.isNotEmpty;
+
+                // Yield content chunks and final usage-only chunks. Some
+                // OpenAI-compatible servers put usage on a terminal SSE event
+                // with no text delta, and the recorder consumes usage from
+                // any chunk in the stream.
+                if (hasContent || usage != null) {
+                  if (hasContent) {
+                    chunksReceived++;
+                    developer.log(
+                      'Received chunk $chunksReceived: ${content.length} chars',
+                      name: 'VoxtralInferenceRepository',
+                    );
+                  }
 
                   yield CreateChatCompletionStreamResponse(
                     id:
                         json['id'] as String? ??
                         'voxtral-${DateTime.now().millisecondsSinceEpoch}',
-                    choices: [
-                      ChatCompletionStreamResponseChoice(
-                        delta: ChatCompletionStreamResponseDelta(
-                          content: content,
-                        ),
-                        index: 0,
-                        finishReason: finishReason != null
-                            ? ChatCompletionFinishReason.values.firstWhere(
-                                (e) => e.name == finishReason,
-                                orElse: () => ChatCompletionFinishReason.stop,
-                              )
-                            : null,
-                      ),
-                    ],
+                    choices: hasContent
+                        ? [
+                            ChatCompletionStreamResponseChoice(
+                              delta: ChatCompletionStreamResponseDelta(
+                                content: content,
+                              ),
+                              index: 0,
+                              finishReason: finishReason != null
+                                  ? ChatCompletionFinishReason.values
+                                        .firstWhere(
+                                          (e) => e.name == finishReason,
+                                          orElse: () =>
+                                              ChatCompletionFinishReason.stop,
+                                        )
+                                  : null,
+                            ),
+                          ]
+                        : const [],
                     object: 'chat.completion.chunk',
                     created:
                         json['created'] as int? ??
                         DateTime.now().millisecondsSinceEpoch ~/ 1000,
+                    model: json['model'] as String?,
+                    usage: usage,
                   );
                 }
 
@@ -332,6 +365,19 @@ class VoxtralInferenceRepository {
                     name: 'VoxtralInferenceRepository',
                   );
                 }
+              } else if (usage != null) {
+                yield CreateChatCompletionStreamResponse(
+                  id:
+                      json['id'] as String? ??
+                      'voxtral-${DateTime.now().millisecondsSinceEpoch}',
+                  choices: const [],
+                  object: 'chat.completion.chunk',
+                  created:
+                      json['created'] as int? ??
+                      DateTime.now().millisecondsSinceEpoch ~/ 1000,
+                  model: json['model'] as String?,
+                  usage: usage,
+                );
               }
             } on FormatException catch (e) {
               developer.log(

--- a/lib/features/ai/repository/voxtral_inference_repository.dart
+++ b/lib/features/ai/repository/voxtral_inference_repository.dart
@@ -338,12 +338,7 @@ class VoxtralInferenceRepository {
                               ),
                               index: 0,
                               finishReason: finishReason != null
-                                  ? ChatCompletionFinishReason.values
-                                        .firstWhere(
-                                          (e) => e.name == finishReason,
-                                          orElse: () =>
-                                              ChatCompletionFinishReason.stop,
-                                        )
+                                  ? _chatFinishReasonFromApi(finishReason)
                                   : null,
                             ),
                           ]
@@ -494,6 +489,14 @@ class VoxtralInferenceRepository {
 
   /// Closes the underlying HTTP client and any keep-alive connections.
   void close() => _httpClient.close();
+}
+
+ChatCompletionFinishReason _chatFinishReasonFromApi(String finishReason) {
+  final normalized = finishReason.replaceAll('_', '').toLowerCase();
+  return ChatCompletionFinishReason.values.firstWhere(
+    (value) => value.name.toLowerCase() == normalized,
+    orElse: () => ChatCompletionFinishReason.stop,
+  );
 }
 
 /// Health status of the Voxtral server

--- a/lib/features/ai_consumption/README.md
+++ b/lib/features/ai_consumption/README.md
@@ -151,7 +151,7 @@ flowchart TD
   Cat[categoriesStreamProvider] -->|id → CategoryDefinition| Body
   Body --> D1[impactTotalsInRange → ImpactKpiRow]
   Body --> D2[dailyMetricTotals + rankedImpactCategoryTotals → ImpactRankedTable]
-  Body --> D3[buildImpactChartData → ImpactChartCard]
+  Body --> D3[buildImpactChartData → ImpactChartCard<br/>per-bucket / cumulative]
   Body --> D4[ImpactCallLedger<br/>range-scoped]
   LP[consumptionLedgerProvider<br/>InsightsRange family] -->|newest calls| D4
   Toggle[DsSegmentedToggle<br/>Cost · Energy · CO₂e · Tokens] -->|local state| Body
@@ -175,9 +175,13 @@ The body is the single provider consumer; the children are dumb value widgets:
   day-keyed, so a 1-day range renders one day bucket. The Y axis snaps to a
   1/2/5 × 10ⁿ nice ceiling (`impactNiceCeiling`), not the Insights hour
   ladder.
-- **Chart** — `ui/widgets/impact_chart_card.dart`: fl_chart stacked bars,
-  axis/tooltip/legend all formatted through the metric lens; elapsed-buckets
-  trimming and a quiet today-bar edge, like the Insights chart.
+- **Chart** — `ui/widgets/impact_chart_card.dart`: a stateful fl_chart card
+  with the same mode switch as Time Analysis: per-bucket stacked bars or a
+  cumulative stacked area ("Running total") over elapsed buckets. Both modes use
+  the same ranked series, "Other" rollup, axis/tooltip/legend formatting through
+  the metric lens, elapsed-buckets trimming, and quiet today-bar edge / area
+  trimming rules as the Insights chart. Cumulative mode falls back to bars until
+  at least two elapsed buckets exist, so the toggle never produces a lone point.
 - **Category identity** — reuses `InsightsCategoryResolver` +
   `chartColorFor`/`swatchColorFor`, so both dashboards speak the same
   color/label language ("Uncategorized", "Other", "Deleted category").
@@ -189,7 +193,10 @@ The body is the single provider consumer; the children are dumb value widgets:
   `ConsumptionRepository.newestEventsInRange`, capped at
   `kConsumptionLedgerLimit` = 100 with an explicit "newest N" caption — never
   a silent truncation) itself, so the body integrates it as one child.
-  Unmeasured calls simply omit the cost/energy parts of the row.
+  Calls with tokens but no Melious impact omit cost/energy; calls whose provider
+  reports no token/cost/energy metrics (for example duration-only local
+  transcription endpoints) show "Not reported" rather than leaving the trailing
+  cell blank.
 - **keepPreviousData** — the buckets provider is year-window keyed; the body
   retains the last fully-loaded generation (buckets + the selection they
   cover) so window switches and failed refetches never flash a loading
@@ -243,9 +250,9 @@ Delivered and tested: the storage schema, repository, aggregation query layer,
 full Matrix sync integration, the Melious non-streaming impact-capture mechanism
 (`MeliousCallImpact` + `InferenceImpactCollector`), the `AiConsumptionRecorder`,
 end-to-end capture on the unified inference path, the skill runner, and
-task-agent turns, and the AI Impact dashboard (KPI row, stacked metric chart,
-ranked table, period stepper). The remaining agent workflows above are the
-follow-on work.
+task-agent turns, and the AI Impact dashboard (KPI row, per-bucket/cumulative
+metric chart, ranked table, period stepper, call ledger). The remaining agent
+workflows above are the follow-on work.
 
 ## Testing
 
@@ -257,9 +264,10 @@ follow-on work.
   ceiling expectations plus Glados properties (chart columns sum to range
   totals, monotone ranking, never-hourly granularity, ceiling bounds).
 - `test/features/ai_consumption/ui/` — widget tests for the KPI row, chart
-  card, ranked table, and the full body (provider-driven: stubbed repository
-  rows → formatter-exact KPI/table figures, metric toggle, empty state,
-  first-load error).
+  card (including cumulative running-total tooltip), ranked table, ledger
+  missing-metric fallback, and the full body (provider-driven: stubbed
+  repository rows → formatter-exact KPI/table figures, metric toggle, empty
+  state, first-load error).
 - `test/features/ai/model/ai_call_impact_test.dart` — the Melious impact
   contract parsing.
 - `test/features/sync/…` — `SyncMessage.consumptionEvent` round-trip, inbound

--- a/lib/features/ai_consumption/ui/widgets/impact_call_ledger.dart
+++ b/lib/features/ai_consumption/ui/widgets/impact_call_ledger.dart
@@ -113,6 +113,7 @@ class _LedgerRow extends StatelessWidget {
       if (event.credits != null) formatCredits(event.credits!),
       if (event.energyKwh != null) formatEnergyKwh(event.energyKwh!),
     ];
+    if (parts.isEmpty) return context.messages.aiConsumptionMetricsNotReported;
     return parts.join(' · ');
   }
 

--- a/lib/features/ai_consumption/ui/widgets/impact_chart_card.dart
+++ b/lib/features/ai_consumption/ui/widgets/impact_chart_card.dart
@@ -441,7 +441,8 @@ class _ImpactStackedArea extends StatelessWidget {
         if (stackedTops.last[i] > maxTop) maxTop = stackedTops.last[i];
       }
     }
-    final maxY = impactNiceCeiling(maxTop * 1.08);
+    final niceCeiling = impactNiceCeiling(maxTop * 1.08);
+    final maxY = niceCeiling <= 0 ? 1.0 : niceCeiling;
     final interval = maxY / 4;
     final labelEvery = lastDrawnBucket <= 7
         ? 1

--- a/lib/features/ai_consumption/ui/widgets/impact_chart_card.dart
+++ b/lib/features/ai_consumption/ui/widgets/impact_chart_card.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:lotti/features/ai_consumption/logic/impact_dashboard_data.dart';
 import 'package:lotti/features/ai_consumption/model/impact_dashboard_models.dart';
+import 'package:lotti/features/design_system/components/buttons/ds_segmented_toggle.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/design_system/theme/typography_helpers.dart';
 import 'package:lotti/features/insights/logic/chart_colors.dart';
@@ -19,6 +20,16 @@ import 'package:lotti/l10n/app_localizations_context.dart';
 /// Fixed plot height, matching the Insights chart card so the two
 /// dashboards read as siblings.
 const double _chartHeight = 260;
+
+/// Chart mode: per-bucket values or running cumulative totals.
+enum ImpactChartMode { perBucket, cumulative }
+
+/// How many leading buckets of [data] have elapsed (start on or before today).
+///
+/// A cumulative running total needs at least two points to draw a line; the
+/// chart card falls back to bars below this.
+int elapsedImpactBucketCount(ImpactChartData data) =>
+    _firstFutureBucket(data, epochDay(clock.now()));
 
 /// Display label for a metric — shared by the chart card title and the
 /// dashboard's metric toggle so the two always agree.
@@ -40,7 +51,7 @@ String consumptionMetricLabel(
 /// series on the baseline, "Other" rollup, exhaustive tooltip), but every
 /// number is formatted through the metric's own adaptive-unit formatter
 /// instead of the Insights seconds/duration helpers.
-class ImpactChartCard extends StatelessWidget {
+class ImpactChartCard extends StatefulWidget {
   const ImpactChartCard({
     required this.chartData,
     required this.resolver,
@@ -59,9 +70,34 @@ class ImpactChartCard extends StatelessWidget {
   final ConsumptionMetric metric;
 
   @override
+  State<ImpactChartCard> createState() => _ImpactChartCardState();
+}
+
+class _ImpactChartCardState extends State<ImpactChartCard> {
+  ImpactChartMode _mode = ImpactChartMode.perBucket;
+
+  bool get _cumulativeFallsBack =>
+      _mode == ImpactChartMode.cumulative &&
+      elapsedImpactBucketCount(widget.chartData) < 2;
+
+  String _perBucketLabel(AppLocalizations messages) =>
+      widget.chartData.granularity == InsightsGranularity.week
+      ? messages.insightsChartPerWeek
+      : messages.insightsChartPerDay;
+
+  String _captionText(AppLocalizations messages) {
+    if (_cumulativeFallsBack) return messages.insightsChartCumulativeShort;
+    if (_mode == ImpactChartMode.cumulative) {
+      return messages.insightsChartCumulativeCaption;
+    }
+    return _perBucketLabel(messages);
+  }
+
+  @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final messages = context.messages;
+    final showBars = _mode == ImpactChartMode.perBucket || _cumulativeFallsBack;
 
     return DecoratedBox(
       decoration: BoxDecoration(
@@ -74,30 +110,49 @@ class ImpactChartCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-              messages.aiImpactChartTitle(
-                consumptionMetricLabel(messages, metric),
-              ),
-              style: tokens.typography.styles.subtitle.subtitle1.copyWith(
-                color: tokens.colors.text.highEmphasis,
-              ),
-            ),
-            SizedBox(height: tokens.spacing.step1),
-            Text(
-              // Names the bucket the bars represent so weekly bars are never
-              // misread as daily magnitudes.
-              chartData.granularity == InsightsGranularity.week
-                  ? messages.insightsChartPerWeek
-                  : messages.insightsChartPerDay,
-              style: tokens.typography.styles.others.caption.copyWith(
-                color: tokens.colors.text.mediumEmphasis,
-              ),
-              overflow: TextOverflow.ellipsis,
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  messages.aiImpactChartTitle(
+                    consumptionMetricLabel(messages, widget.metric),
+                  ),
+                  style: tokens.typography.styles.subtitle.subtitle1.copyWith(
+                    color: tokens.colors.text.highEmphasis,
+                  ),
+                ),
+                SizedBox(height: tokens.spacing.step1),
+                Text(
+                  _captionText(messages),
+                  style: tokens.typography.styles.others.caption.copyWith(
+                    color: tokens.colors.text.mediumEmphasis,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+                SizedBox(height: tokens.spacing.step3),
+                SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  child: DsSegmentedToggle<ImpactChartMode>(
+                    selected: _mode,
+                    onChanged: (mode) => setState(() => _mode = mode),
+                    segments: [
+                      DsSegment(
+                        ImpactChartMode.perBucket,
+                        _perBucketLabel(messages),
+                      ),
+                      DsSegment(
+                        ImpactChartMode.cumulative,
+                        messages.insightsChartRunningTotal,
+                      ),
+                    ],
+                  ),
+                ),
+              ],
             ),
             SizedBox(height: tokens.spacing.step5),
             SizedBox(
               height: _chartHeight,
-              child: chartData.isEmpty
+              child: widget.chartData.isEmpty
                   ? Center(
                       child: Text(
                         messages.insightsEmptyChart,
@@ -106,20 +161,26 @@ class ImpactChartCard extends StatelessWidget {
                         ),
                       ),
                     )
-                  : _ImpactStackedBars(
-                      data: chartData,
-                      resolver: resolver,
-                      metric: metric,
+                  : showBars
+                  ? _ImpactStackedBars(
+                      data: widget.chartData,
+                      resolver: widget.resolver,
+                      metric: widget.metric,
+                    )
+                  : _ImpactStackedArea(
+                      data: widget.chartData,
+                      resolver: widget.resolver,
+                      metric: widget.metric,
                     ),
             ),
             // A one-item legend restates the obvious — only render when
             // there is more than one category to disambiguate.
-            if (chartData.seriesKeys.length > 1) ...[
+            if (widget.chartData.seriesKeys.length > 1) ...[
               SizedBox(height: tokens.spacing.step4),
               _ImpactChartLegend(
-                seriesKeys: chartData.seriesKeys,
-                rolledUpCount: chartData.rolledUpCount,
-                resolver: resolver,
+                seriesKeys: widget.chartData.seriesKeys,
+                rolledUpCount: widget.chartData.rolledUpCount,
+                resolver: widget.resolver,
               ),
             ],
           ],
@@ -331,6 +392,184 @@ class _ImpactStackedBars extends StatelessWidget {
   }
 }
 
+/// Cumulative running-total area chart: draws pre-stacked category series as
+/// filled areas across elapsed buckets. The card falls back to bars when fewer
+/// than two buckets have elapsed.
+class _ImpactStackedArea extends StatelessWidget {
+  const _ImpactStackedArea({
+    required this.data,
+    required this.resolver,
+    required this.metric,
+  });
+
+  final ImpactChartData data;
+  final InsightsCategoryResolver resolver;
+  final ConsumptionMetric metric;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final brightness = Theme.of(context).brightness;
+    final bucketCount = data.bucketStarts.length;
+    final axisStyle = monoMetaStyle(
+      tokens,
+      tokens.colors,
+      color: tokens.colors.text.mediumEmphasis,
+    );
+
+    final cumulative = _accumulateImpactValues(data.values);
+    final stackedTops = List.generate(
+      data.seriesKeys.length,
+      (s) => List.generate(bucketCount, (i) {
+        var top = 0.0;
+        for (var j = 0; j <= s; j++) {
+          top += cumulative[j][i];
+        }
+        return top;
+      }),
+    );
+
+    final today = epochDay(clock.now());
+    final firstFutureIndex = _firstFutureBucket(data, today);
+    final lastDrawnBucket = firstFutureIndex == 0
+        ? bucketCount
+        : firstFutureIndex;
+
+    var maxTop = 0.0;
+    if (stackedTops.isNotEmpty) {
+      for (var i = 0; i < lastDrawnBucket; i++) {
+        if (stackedTops.last[i] > maxTop) maxTop = stackedTops.last[i];
+      }
+    }
+    final maxY = impactNiceCeiling(maxTop * 1.08);
+    final interval = maxY / 4;
+    final labelEvery = lastDrawnBucket <= 7
+        ? 1
+        : (lastDrawnBucket / 6).ceil().clamp(1, lastDrawnBucket);
+
+    return LineChart(
+      LineChartData(
+        minY: 0,
+        maxY: maxY,
+        borderData: FlBorderData(show: false),
+        gridData: FlGridData(
+          drawVerticalLine: false,
+          horizontalInterval: interval,
+          getDrawingHorizontalLine: (_) => FlLine(
+            color: tokens.colors.decorative.level01,
+            strokeWidth: 1,
+          ),
+        ),
+        titlesData: FlTitlesData(
+          topTitles: const AxisTitles(),
+          rightTitles: const AxisTitles(),
+          leftTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              reservedSize: 56,
+              interval: interval,
+              getTitlesWidget: (value, meta) => SideTitleWidget(
+                meta: meta,
+                child: Text(
+                  value == 0 ? '' : metric.formatValue(value),
+                  style: axisStyle,
+                ),
+              ),
+            ),
+          ),
+          bottomTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              reservedSize: 28,
+              interval: 1,
+              getTitlesWidget: (value, meta) {
+                if (!value.isFinite) return const SizedBox.shrink();
+                final index = value.toInt();
+                if (index < 0 || index >= lastDrawnBucket) {
+                  return const SizedBox.shrink();
+                }
+                final label = _bottomAxisLabel(
+                  context,
+                  data,
+                  index,
+                  labelEvery,
+                );
+                if (label == null) return const SizedBox.shrink();
+                return SideTitleWidget(
+                  meta: meta,
+                  child: Text(label, style: axisStyle),
+                );
+              },
+            ),
+          ),
+        ),
+        lineTouchData: LineTouchData(
+          touchTooltipData: LineTouchTooltipData(
+            getTooltipColor: (_) => tokens.colors.background.level03,
+            tooltipBorderRadius: BorderRadius.circular(tokens.radii.s),
+            maxContentWidth: tokens.spacing.step13 * 1.5,
+            fitInsideVertically: true,
+            fitInsideHorizontally: true,
+            getTooltipItems: (spots) {
+              if (spots.isEmpty) return const [];
+              final index = spots.first.x.toInt();
+              if (index < 0 || index >= lastDrawnBucket) {
+                return [for (final _ in spots) null];
+              }
+              final style = tokens.typography.styles.others.caption.copyWith(
+                color: tokens.colors.text.highEmphasis,
+              );
+              return [
+                for (var i = 0; i < spots.length; i++)
+                  if (i == 0)
+                    LineTooltipItem(
+                      '${_bucketLabel(context, data, index)}  '
+                      '${metric.formatValue(stackedTops.last[index])}',
+                      style.copyWith(
+                        fontWeight: tokens.typography.weight.semiBold,
+                      ),
+                      textAlign: TextAlign.left,
+                      children: _tooltipRows(
+                        data,
+                        resolver,
+                        metric,
+                        index,
+                        style,
+                        brightness,
+                        values: cumulative,
+                      ),
+                    )
+                  else
+                    null,
+              ];
+            },
+          ),
+        ),
+        lineBarsData: [
+          for (var s = data.seriesKeys.length - 1; s >= 0; s--)
+            () {
+              final fill = chartColorFor(
+                resolver.colorHexFor(data.seriesKeys[s]),
+                brightness,
+                seriesKey: data.seriesKeys[s],
+              );
+              return LineChartBarData(
+                spots: [
+                  for (var i = 0; i < lastDrawnBucket; i++)
+                    FlSpot(i.toDouble(), stackedTops[s][i]),
+                ],
+                color: bandEdgeColor(fill, brightness),
+                barWidth: 1.5,
+                dotData: const FlDotData(show: false),
+                belowBarData: BarAreaData(show: true, color: fill),
+              );
+            }(),
+        ],
+      ),
+    );
+  }
+}
+
 /// Legend: a saturated swatch + label per series, plus a "+N" rollup note
 /// disclosing how many smaller categories were folded into "Other".
 class _ImpactChartLegend extends StatelessWidget {
@@ -460,12 +699,13 @@ List<TextSpan> _tooltipRows(
   ConsumptionMetric metric,
   int index,
   TextStyle style,
-  Brightness brightness,
-) {
+  Brightness brightness, {
+  List<List<double>>? values,
+}) {
+  final rowValues = values ?? data.values;
   final rows = <(String?, double)>[
     for (var s = 0; s < data.seriesKeys.length; s++)
-      if (data.values[s][index] > 0)
-        (data.seriesKeys[s], data.values[s][index]),
+      if (rowValues[s][index] > 0) (data.seriesKeys[s], rowValues[s][index]),
   ]..sort((a, b) => b.$2.compareTo(a.$2));
 
   return [
@@ -487,4 +727,22 @@ List<TextSpan> _tooltipRows(
         ],
       ),
   ];
+}
+
+List<List<double>> _accumulateImpactValues(List<List<double>> values) {
+  return [
+    for (final row in values) _accumulateImpactValueRow(row),
+  ];
+}
+
+List<double> _accumulateImpactValueRow(List<double> row) {
+  final result = <double>[];
+  var running = 0.0;
+
+  for (final value in row) {
+    running += value;
+    result.add(running);
+  }
+
+  return result;
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -389,6 +389,7 @@
   "aiConsumptionImpactLine": "Dopad: {energy} · {carbon} CO₂e · {water} vody",
   "aiConsumptionLedgerCap": "Zobrazuje nejnovějších {limit} volání v tomto období",
   "aiConsumptionLedgerTitle": "Nedávná volání",
+  "aiConsumptionMetricsNotReported": "Nenahlášeno",
   "aiConsumptionTokensLabel": "{tokens} tokenů",
   "aiConsumptionTokensLine": "Tokeny: {input} vstup · {output} výstup",
   "aiConsumptionTypeAgentTurn": "Tah agenta",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -549,6 +549,7 @@
   "aiConsumptionImpactLine": "Impact: {energy} · {carbon} CO₂e · {water} Wasser",
   "aiConsumptionLedgerCap": "Zeigt die neuesten {limit} Aufrufe in diesem Zeitraum",
   "aiConsumptionLedgerTitle": "Letzte Aufrufe",
+  "aiConsumptionMetricsNotReported": "Nicht gemeldet",
   "aiConsumptionTokensLabel": "{tokens} Tokens",
   "aiConsumptionTokensLine": "Tokens: {input} rein · {output} raus",
   "aiConsumptionTypeAgentTurn": "Agenten-Turn",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -774,6 +774,7 @@
     }
   },
   "aiConsumptionLedgerTitle": "Recent calls",
+  "aiConsumptionMetricsNotReported": "Not reported",
   "aiConsumptionTokensLabel": "{tokens} tokens",
   "@aiConsumptionTokensLabel": {
     "placeholders": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -549,6 +549,7 @@
   "aiConsumptionImpactLine": "Impacto: {energy} · {carbon} CO₂e · {water} de agua",
   "aiConsumptionLedgerCap": "Mostrando las {limit} llamadas más recientes de este período",
   "aiConsumptionLedgerTitle": "Llamadas recientes",
+  "aiConsumptionMetricsNotReported": "No informado",
   "aiConsumptionTokensLabel": "{tokens} tokens",
   "aiConsumptionTokensLine": "Tokens: {input} entrada · {output} salida",
   "aiConsumptionTypeAgentTurn": "Turno de agente",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -549,6 +549,7 @@
   "aiConsumptionImpactLine": "Impact : {energy} · {carbon} CO₂e · {water} d'eau",
   "aiConsumptionLedgerCap": "Affiche les {limit} appels les plus récents de cette période",
   "aiConsumptionLedgerTitle": "Appels récents",
+  "aiConsumptionMetricsNotReported": "Non renseigné",
   "aiConsumptionTokensLabel": "{tokens} jetons",
   "aiConsumptionTokensLine": "Jetons : {input} entrée · {output} sortie",
   "aiConsumptionTypeAgentTurn": "Tour d'agent",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2269,6 +2269,12 @@ abstract class AppLocalizations {
   /// **'Recent calls'**
   String get aiConsumptionLedgerTitle;
 
+  /// No description provided for @aiConsumptionMetricsNotReported.
+  ///
+  /// In en, this message translates to:
+  /// **'Not reported'**
+  String get aiConsumptionMetricsNotReported;
+
   /// No description provided for @aiConsumptionTokensLabel.
   ///
   /// In en, this message translates to:
@@ -9450,6 +9456,12 @@ abstract class AppLocalizations {
   /// **'Could not save image'**
   String get imageViewerDownloadFailed;
 
+  /// No description provided for @imageViewerDownloadingTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Saving image'**
+  String get imageViewerDownloadingTooltip;
+
   /// No description provided for @imageViewerDownloadSaved.
   ///
   /// In en, this message translates to:
@@ -9461,12 +9473,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Download image'**
   String get imageViewerDownloadTooltip;
-
-  /// No description provided for @imageViewerDownloadingTooltip.
-  ///
-  /// In en, this message translates to:
-  /// **'Saving image'**
-  String get imageViewerDownloadingTooltip;
 
   /// No description provided for @inactiveLabel.
   ///

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1259,6 +1259,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get aiConsumptionLedgerTitle => 'Nedávná volání';
 
   @override
+  String get aiConsumptionMetricsNotReported => 'Nenahlášeno';
+
+  @override
   String aiConsumptionTokensLabel(String tokens) {
     return '$tokens tokenů';
   }
@@ -5517,15 +5520,15 @@ class AppLocalizationsCs extends AppLocalizations {
   String get imageViewerDownloadFailed => 'Obrázek se nepodařilo uložit';
 
   @override
+  String get imageViewerDownloadingTooltip => 'Ukládám obrázek';
+
+  @override
   String imageViewerDownloadSaved(String fileName) {
     return 'Uloženo $fileName do Stažené/Lotti';
   }
 
   @override
   String get imageViewerDownloadTooltip => 'Stáhnout obrázek';
-
-  @override
-  String get imageViewerDownloadingTooltip => 'Ukládám obrázek';
 
   @override
   String get inactiveLabel => 'Neaktivní';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1265,6 +1265,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get aiConsumptionLedgerTitle => 'Letzte Aufrufe';
 
   @override
+  String get aiConsumptionMetricsNotReported => 'Nicht gemeldet';
+
+  @override
   String aiConsumptionTokensLabel(String tokens) {
     return '$tokens Tokens';
   }
@@ -5510,15 +5513,15 @@ class AppLocalizationsDe extends AppLocalizations {
       'Bild konnte nicht gespeichert werden';
 
   @override
+  String get imageViewerDownloadingTooltip => 'Bild wird gespeichert';
+
+  @override
   String imageViewerDownloadSaved(String fileName) {
     return '$fileName wurde in Downloads/Lotti gespeichert';
   }
 
   @override
   String get imageViewerDownloadTooltip => 'Bild herunterladen';
-
-  @override
-  String get imageViewerDownloadingTooltip => 'Bild wird gespeichert';
 
   @override
   String get inactiveLabel => 'Inaktiv';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1247,6 +1247,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get aiConsumptionLedgerTitle => 'Recent calls';
 
   @override
+  String get aiConsumptionMetricsNotReported => 'Not reported';
+
+  @override
   String aiConsumptionTokensLabel(String tokens) {
     return '$tokens tokens';
   }
@@ -5439,15 +5442,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get imageViewerDownloadFailed => 'Could not save image';
 
   @override
+  String get imageViewerDownloadingTooltip => 'Saving image';
+
+  @override
   String imageViewerDownloadSaved(String fileName) {
     return 'Saved $fileName to Downloads/Lotti';
   }
 
   @override
   String get imageViewerDownloadTooltip => 'Download image';
-
-  @override
-  String get imageViewerDownloadingTooltip => 'Saving image';
 
   @override
   String get inactiveLabel => 'Inactive';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1263,6 +1263,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get aiConsumptionLedgerTitle => 'Llamadas recientes';
 
   @override
+  String get aiConsumptionMetricsNotReported => 'No informado';
+
+  @override
   String aiConsumptionTokensLabel(String tokens) {
     return '$tokens tokens';
   }
@@ -5552,15 +5555,15 @@ class AppLocalizationsEs extends AppLocalizations {
   String get imageViewerDownloadFailed => 'No se pudo guardar la imagen';
 
   @override
+  String get imageViewerDownloadingTooltip => 'Guardando imagen';
+
+  @override
   String imageViewerDownloadSaved(String fileName) {
     return 'Se guardó $fileName en Descargas/Lotti';
   }
 
   @override
   String get imageViewerDownloadTooltip => 'Descargar imagen';
-
-  @override
-  String get imageViewerDownloadingTooltip => 'Guardando imagen';
 
   @override
   String get inactiveLabel => 'Inactivo';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1271,6 +1271,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get aiConsumptionLedgerTitle => 'Appels récents';
 
   @override
+  String get aiConsumptionMetricsNotReported => 'Non renseigné';
+
+  @override
   String aiConsumptionTokensLabel(String tokens) {
     return '$tokens jetons';
   }
@@ -5559,15 +5562,15 @@ class AppLocalizationsFr extends AppLocalizations {
   String get imageViewerDownloadFailed => 'Impossible d\'enregistrer l\'image';
 
   @override
+  String get imageViewerDownloadingTooltip => 'Enregistrement de l\'image';
+
+  @override
   String imageViewerDownloadSaved(String fileName) {
     return '$fileName enregistré dans Téléchargements/Lotti';
   }
 
   @override
   String get imageViewerDownloadTooltip => 'Télécharger l\'image';
-
-  @override
-  String get imageViewerDownloadingTooltip => 'Enregistrement de l\'image';
 
   @override
   String get inactiveLabel => 'Inactif';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1270,6 +1270,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get aiConsumptionLedgerTitle => 'Apeluri recente';
 
   @override
+  String get aiConsumptionMetricsNotReported => 'Neraportat';
+
+  @override
   String aiConsumptionTokensLabel(String tokens) {
     return '$tokens tokenuri';
   }
@@ -5563,15 +5566,15 @@ class AppLocalizationsRo extends AppLocalizations {
   String get imageViewerDownloadFailed => 'Nu s-a putut salva imaginea';
 
   @override
+  String get imageViewerDownloadingTooltip => 'Se salvează imaginea';
+
+  @override
   String imageViewerDownloadSaved(String fileName) {
     return '$fileName a fost salvat în Descărcări/Lotti';
   }
 
   @override
   String get imageViewerDownloadTooltip => 'Descărcați imaginea';
-
-  @override
-  String get imageViewerDownloadingTooltip => 'Se salvează imaginea';
 
   @override
   String get inactiveLabel => 'Inactiv';

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -549,6 +549,7 @@
   "aiConsumptionImpactLine": "Impact: {energy} · {carbon} CO₂e · {water} apă",
   "aiConsumptionLedgerCap": "Se afișează cele mai noi {limit} apeluri din această perioadă",
   "aiConsumptionLedgerTitle": "Apeluri recente",
+  "aiConsumptionMetricsNotReported": "Neraportat",
   "aiConsumptionTokensLabel": "{tokens} tokenuri",
   "aiConsumptionTokensLine": "Tokenuri: {input} intrare · {output} ieșire",
   "aiConsumptionTypeAgentTurn": "Tur de agent",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1032+4181
+version: 0.9.1033+4182
 
 msix_config:
   display_name: LottiApp

--- a/test/features/ai/repository/completion_usage_parser_test.dart
+++ b/test/features/ai/repository/completion_usage_parser_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/ai/repository/completion_usage_parser.dart';
+
+void main() {
+  group('parseCompletionUsage', () {
+    test('parses token usage without casting map keys', () {
+      final ignoredKey = Object();
+
+      final usage = parseCompletionUsage({
+        ignoredKey: 'ignored',
+        'prompt_tokens': 12,
+        'completion_tokens': '8',
+        'prompt_tokens_details': {
+          ignoredKey: 'ignored',
+          'cached_tokens': '3',
+        },
+        'completion_tokens_details': {
+          ignoredKey: 'ignored',
+          'reasoning_tokens': 5,
+        },
+      });
+
+      expect(usage, isNotNull);
+      expect(usage!.promptTokens, 12);
+      expect(usage.completionTokens, 8);
+      expect(usage.totalTokens, 20);
+      expect(usage.promptTokensDetails?.cachedTokens, 3);
+      expect(usage.completionTokensDetails?.reasoningTokens, 5);
+    });
+
+    test('uses camelCase and input/output token aliases', () {
+      final usage = parseCompletionUsage({
+        'input_tokens': 4,
+        'output_tokens': 6,
+        'promptTokensDetails': {'cachedTokens': 2},
+        'outputTokensDetails': {'reasoningTokens': 1},
+      });
+
+      expect(usage, isNotNull);
+      expect(usage!.promptTokens, 4);
+      expect(usage.completionTokens, 6);
+      expect(usage.totalTokens, 10);
+      expect(usage.promptTokensDetails?.cachedTokens, 2);
+      expect(usage.completionTokensDetails?.reasoningTokens, 1);
+    });
+
+    test('ignores non-token usage payloads', () {
+      expect(parseCompletionUsage({'duration': 1.25}), isNull);
+      expect(parseCompletionUsage('not a map'), isNull);
+    });
+  });
+}

--- a/test/features/ai/repository/voxtral_inference_repository_test.dart
+++ b/test/features/ai/repository/voxtral_inference_repository_test.dart
@@ -163,6 +163,51 @@ void main() {
         );
       });
 
+      test('should emit token usage from a usage-only SSE chunk', () async {
+        // Arrange - common OpenAI-compatible streaming shape: text chunks
+        // first, then final accounting with no content delta.
+        final events = [
+          createSseChunkEvent(content: 'Transcribed text.'),
+          {
+            'id': 'chatcmpl-usage',
+            'object': 'chat.completion.chunk',
+            'created': 1234567890,
+            'model': 'test-model',
+            'choices': <dynamic>[],
+            'usage': {
+              'prompt_tokens': 42,
+              'completion_tokens': 9,
+              'total_tokens': 51,
+            },
+          },
+        ];
+
+        when(() => mockHttpClient.send(any())).thenAnswer(
+          (_) async => createSseStreamedResponse(events: events),
+        );
+
+        // Act
+        final results = await repository
+            .transcribeAudio(
+              model: model,
+              audioBase64: audioBase64,
+              baseUrl: baseUrl,
+              prompt: prompt,
+            )
+            .toList();
+
+        // Assert
+        expect(results.length, 2);
+        expect(
+          results.first.choices?.first.delta?.content,
+          equals('Transcribed text.'),
+        );
+        expect(results.last.choices, isEmpty);
+        expect(results.last.usage?.promptTokens, 42);
+        expect(results.last.usage?.completionTokens, 9);
+        expect(results.last.usage?.totalTokens, 51);
+      });
+
       test('should use custom max completion tokens', () async {
         // Arrange
         final events = [
@@ -532,6 +577,7 @@ data: [DONE]
             'id': 'chatcmpl-test',
             'object': 'chat.completion',
             'created': 1234567890,
+            'model': 'test-model',
             'choices': [
               {
                 'index': 0,
@@ -542,6 +588,11 @@ data: [DONE]
                 'finish_reason': 'stop',
               },
             ],
+            'usage': {
+              'prompt_tokens': 21,
+              'completion_tokens': 7,
+              'total_tokens': 28,
+            },
           };
 
           when(
@@ -572,6 +623,9 @@ data: [DONE]
             equals('Transcribed text.'),
           );
           expect(results[0].id, equals('chatcmpl-test'));
+          expect(results[0].usage?.promptTokens, 21);
+          expect(results[0].usage?.completionTokens, 7);
+          expect(results[0].usage?.totalTokens, 28);
 
           // Verify request body has stream: false
           final captured = verify(

--- a/test/features/ai/repository/voxtral_inference_repository_test.dart
+++ b/test/features/ai/repository/voxtral_inference_repository_test.dart
@@ -41,6 +41,12 @@ void main() {
       const audioBase64 = 'base64_audio_data';
       const prompt = 'Test context';
 
+      test('default constructor creates a closable HTTP client', () {
+        final repository = VoxtralInferenceRepository();
+
+        expect(repository.close, returnsNormally);
+      });
+
       test('should transcribe audio with streaming', () async {
         // Arrange - simulate multiple chunks being streamed
         const chunk1 = 'This is the first chunk.';
@@ -207,6 +213,41 @@ void main() {
         expect(results.last.usage?.completionTokens, 9);
         expect(results.last.usage?.totalTokens, 51);
       });
+
+      test(
+        'should emit fallback metadata from a usage-only SSE chunk',
+        () async {
+          final events = [
+            {
+              'object': 'chat.completion.chunk',
+              'usage': {
+                'prompt_tokens': 7,
+                'completion_tokens': 2,
+                'total_tokens': 9,
+              },
+            },
+          ];
+
+          when(() => mockHttpClient.send(any())).thenAnswer(
+            (_) async => createSseStreamedResponse(events: events),
+          );
+
+          final results = await repository
+              .transcribeAudio(
+                model: model,
+                audioBase64: audioBase64,
+                baseUrl: baseUrl,
+                prompt: prompt,
+              )
+              .toList();
+
+          expect(results, hasLength(1));
+          expect(results.single.id, startsWith('voxtral-'));
+          expect(results.single.created, isPositive);
+          expect(results.single.choices, isEmpty);
+          expect(results.single.usage?.totalTokens, 9);
+        },
+      );
 
       test('should use custom max completion tokens', () async {
         // Arrange
@@ -728,6 +769,46 @@ data: [DONE]
           final results = await stream.toList();
           expect(results, isEmpty);
         });
+
+        test(
+          'should emit usage-only chunks in non-streaming mode',
+          () async {
+            final responseBody = {
+              'object': 'chat.completion',
+              'choices': <dynamic>[],
+              'usage': {
+                'prompt_tokens': 5,
+                'completion_tokens': 3,
+                'total_tokens': 8,
+              },
+            };
+
+            when(
+              () => mockHttpClient.post(
+                any(),
+                headers: any(named: 'headers'),
+                body: any(named: 'body'),
+              ),
+            ).thenAnswer(
+              (_) async => http.Response(jsonEncode(responseBody), 200),
+            );
+
+            final stream = repository.transcribeAudio(
+              model: model,
+              audioBase64: audioBase64,
+              baseUrl: baseUrl,
+              stream: false,
+            );
+
+            final results = await stream.toList();
+
+            expect(results, hasLength(1));
+            expect(results.single.id, startsWith('voxtral-'));
+            expect(results.single.created, isPositive);
+            expect(results.single.choices, isEmpty);
+            expect(results.single.usage?.totalTokens, 8);
+          },
+        );
 
         test(
           'should use fallback id when missing in non-streaming mode',
@@ -1311,6 +1392,45 @@ data: [DONE]
         expect(
           results[0].choices?.first.finishReason,
           equals(ChatCompletionFinishReason.stop),
+        );
+      });
+
+      test('should normalize snake_case finish_reason values', () async {
+        final events = [
+          {
+            'id': 'test-id',
+            'object': 'chat.completion.chunk',
+            'created': 1234567890,
+            'choices': [
+              {
+                'index': 0,
+                'delta': {'content': 'Filtered text'},
+                'finish_reason': 'content_filter',
+              },
+            ],
+          },
+        ];
+
+        final sseData =
+            '${events.map((e) => 'data: ${jsonEncode(e)}\n\n').join()}data: [DONE]\n\n';
+
+        final stream = Stream.fromIterable([utf8.encode(sseData)]);
+        when(() => mockHttpClient.send(any())).thenAnswer(
+          (_) async => http.StreamedResponse(stream, 200),
+        );
+
+        final transcriptionStream = repository.transcribeAudio(
+          model: model,
+          audioBase64: audioBase64,
+          baseUrl: baseUrl,
+        );
+
+        final results = await transcriptionStream.toList();
+
+        expect(results.length, equals(1));
+        expect(
+          results[0].choices?.first.finishReason,
+          equals(ChatCompletionFinishReason.contentFilter),
         );
       });
 

--- a/test/features/ai/repository/whisper_inference_repository_test.dart
+++ b/test/features/ai/repository/whisper_inference_repository_test.dart
@@ -55,6 +55,13 @@ void main() {
     const audioBase64 = 'base64-encoded-audio-data';
 
     group('transcribeAudio', () {
+      test('default constructor creates a closable HTTP client', () {
+        final repository = WhisperInferenceRepository();
+
+        expect(repository.httpClient, isA<http.Client>());
+        expect(repository.close, returnsNormally);
+      });
+
       test('successfully transcribes audio', () async {
         // Arrange
         const transcribedText = 'This is the transcribed text from audio.';
@@ -184,6 +191,38 @@ void main() {
                   contains('Failed to transcribe audio (HTTP 500)'),
                 )
                 .having((e) => e.statusCode, 'statusCode', 500),
+          ),
+        );
+      });
+
+      test('uses structured provider error messages when available', () async {
+        // Arrange
+        stubPost(
+          body: jsonEncode({
+            'error': {'message': 'Provider quota exceeded'},
+          }),
+          statusCode: 429,
+        );
+
+        // Act
+        final stream = repository.transcribeAudio(
+          model: model,
+          audioBase64: audioBase64,
+          baseUrl: baseUrl,
+          prompt: prompt,
+        );
+
+        // Assert
+        await expectLater(
+          stream.first,
+          throwsA(
+            isA<TranscriptionException>()
+                .having(
+                  (e) => e.message,
+                  'message',
+                  contains('Provider quota exceeded'),
+                )
+                .having((e) => e.statusCode, 'statusCode', 429),
           ),
         );
       });

--- a/test/features/ai/repository/whisper_inference_repository_test.dart
+++ b/test/features/ai/repository/whisper_inference_repository_test.dart
@@ -127,6 +127,40 @@ void main() {
         expect(response.choices?[0].delta?.content, equals(transcribedText));
       });
 
+      test('passes through token usage when the endpoint reports it', () async {
+        // Arrange
+        stubPost(
+          body: jsonEncode({
+            'text': 'Transcribed text',
+            'usage': {
+              'prompt_tokens': 12,
+              'completion_tokens': 8,
+              'total_tokens': 20,
+              'prompt_tokens_details': {'cached_tokens': 3},
+              'completion_tokens_details': {'reasoning_tokens': 2},
+            },
+          }),
+        );
+
+        // Act
+        final response = await repository
+            .transcribeAudio(
+              model: model,
+              audioBase64: audioBase64,
+              baseUrl: baseUrl,
+              prompt: prompt,
+            )
+            .first;
+
+        // Assert
+        expect(response.choices?[0].delta?.content, equals('Transcribed text'));
+        expect(response.usage?.promptTokens, 12);
+        expect(response.usage?.completionTokens, 8);
+        expect(response.usage?.totalTokens, 20);
+        expect(response.usage?.promptTokensDetails?.cachedTokens, 3);
+        expect(response.usage?.completionTokensDetails?.reasoningTokens, 2);
+      });
+
       test('throws TranscriptionException on HTTP error', () async {
         // Arrange
         stubPost(body: 'Internal Server Error', statusCode: 500);

--- a/test/features/ai_consumption/ui/widgets/impact_call_ledger_test.dart
+++ b/test/features/ai_consumption/ui/widgets/impact_call_ledger_test.dart
@@ -115,6 +115,27 @@ void main() {
     expect(find.byIcon(Icons.mic_outlined), findsOneWidget);
   });
 
+  testWidgets('labels calls whose provider did not report metrics', (
+    tester,
+  ) async {
+    stubEvents([
+      makeConsumptionEvent(
+        id: 'evt-usage-missing',
+        createdAt: DateTime(2026, 6, 4, 9, 5),
+        providerModelId: 'whisper-1',
+        responseType: AiConsumptionResponseType.audioTranscription,
+        totalTokens: null,
+        credits: null,
+        energyKwh: null,
+      ),
+    ]);
+    await pumpLedger(tester);
+
+    expect(find.text('whisper-1'), findsOneWidget);
+    expect(find.text('Not reported'), findsOneWidget);
+    expect(find.byIcon(Icons.mic_outlined), findsOneWidget);
+  });
+
   testWidgets('maps every response type to its icon and localized label', (
     tester,
   ) async {

--- a/test/features/ai_consumption/ui/widgets/impact_chart_card_test.dart
+++ b/test/features/ai_consumption/ui/widgets/impact_chart_card_test.dart
@@ -59,8 +59,9 @@ void main() {
     WidgetTester tester, {
     required ImpactChartData chartData,
     ConsumptionMetric metric = ConsumptionMetric.cost,
+    DateTime? now,
   }) async {
-    await withClock(Clock.fixed(fixedNow), () async {
+    await withClock(Clock.fixed(now ?? fixedNow), () async {
       await tester.pumpWidget(
         makeTestableWidget(
           ImpactChartCard(
@@ -146,6 +147,33 @@ void main() {
     expect(rows, contains('Research  €1.00'));
     expect(rows.indexOf('Agents'), lessThan(rows.indexOf('Research')));
   });
+
+  testWidgets(
+    'cumulative chart keeps a positive axis when elapsed totals are zero',
+    (tester) async {
+      final chartData = buildImpactChartData(
+        bucketsWith({
+          4: {'cat-a': 2.0},
+        }),
+        range,
+        ConsumptionMetric.cost,
+      );
+      await pumpCard(
+        tester,
+        chartData: chartData,
+        now: DateTime(2024, 3, 5, 12),
+      );
+
+      await tester.tap(toggle('Running total'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 600));
+
+      expect(find.byType(LineChart), findsOneWidget);
+      final chart = tester.widget<LineChart>(find.byType(LineChart));
+      expect(chart.data.maxY, greaterThan(0));
+      expect(tester.takeException(), isNull);
+    },
+  );
 
   testWidgets('title follows the selected metric', (tester) async {
     final chartData = buildImpactChartData(
@@ -273,6 +301,44 @@ void main() {
       expect(find.text('Mar 5'), findsNothing);
       expect(find.text('Mar 14'), findsOneWidget);
       expect(find.textContaining('Mon'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'month-long cumulative chart thins labels and guards invalid tooltips',
+    (tester) async {
+      final monthRange = InsightsRange(
+        startDay: day0,
+        endDayExclusive: day0 + 30,
+      );
+      final chartData = buildImpactChartData(
+        bucketsWith({
+          0: {'cat-a': 2.0},
+          5: {'cat-b': 1.0},
+        }),
+        monthRange,
+        ConsumptionMetric.cost,
+      );
+      await pumpCard(tester, chartData: chartData);
+
+      await tester.tap(toggle('Running total'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 600));
+
+      final chart = tester.widget<LineChart>(find.byType(LineChart));
+      final tooltipData = chart.data.lineTouchData.touchTooltipData;
+      final barData = chart.data.lineBarsData.first;
+      final spot = LineBarSpot(barData, 0, barData.spots.first);
+
+      expect(tooltipData.getTooltipColor(spot), isA<Color>());
+      expect(find.text('Mar 4'), findsOneWidget);
+      expect(find.text('Mar 5'), findsNothing);
+      expect(
+        tooltipData.getTooltipItems([
+          LineBarSpot(barData, 0, const FlSpot(-1, 0)),
+        ]),
+        equals([null]),
+      );
     },
   );
 

--- a/test/features/ai_consumption/ui/widgets/impact_chart_card_test.dart
+++ b/test/features/ai_consumption/ui/widgets/impact_chart_card_test.dart
@@ -75,6 +75,8 @@ void main() {
     });
   }
 
+  Finder toggle(String label) => find.text(label).last;
+
   testWidgets('renders metric title, bucket caption, bars, and legend', (
     tester,
   ) async {
@@ -89,12 +91,60 @@ void main() {
     await pumpCard(tester, chartData: chartData);
 
     expect(find.text('Cost by category'), findsOneWidget);
-    expect(find.text('Per day'), findsOneWidget);
+    expect(find.text('Per day'), findsWidgets);
+    expect(toggle('Running total'), findsOneWidget);
     expect(find.byType(BarChart), findsOneWidget);
+    expect(find.byType(LineChart), findsNothing);
     // Legend names every series, including uncategorized.
     expect(find.text('Agents'), findsOneWidget);
     expect(find.text('Research'), findsOneWidget);
     expect(find.text('Uncategorized'), findsOneWidget);
+  });
+
+  testWidgets('toggle switches to cumulative running totals', (tester) async {
+    final chartData = buildImpactChartData(
+      bucketsWith({
+        0: {'cat-a': 2.0},
+        1: {'cat-b': 1.0},
+        2: {'cat-a': 3.0},
+      }),
+      range,
+      ConsumptionMetric.cost,
+    );
+    await pumpCard(tester, chartData: chartData);
+
+    await tester.tap(toggle('Running total'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 600));
+
+    expect(find.byType(LineChart), findsOneWidget);
+    expect(find.byType(BarChart), findsNothing);
+    expect(find.text('Running total over the range'), findsOneWidget);
+
+    final chart = tester.widget<LineChart>(find.byType(LineChart));
+    final tooltipData = chart.data.lineTouchData.touchTooltipData;
+    final spots = [
+      for (
+        var barIndex = 0;
+        barIndex < chart.data.lineBarsData.length;
+        barIndex++
+      )
+        LineBarSpot(
+          chart.data.lineBarsData[barIndex],
+          barIndex,
+          chart.data.lineBarsData[barIndex].spots[2],
+        ),
+    ];
+    final items = tooltipData.getTooltipItems(spots);
+    expect(items, hasLength(spots.length));
+    expect(items.skip(1), everyElement(isNull));
+    final item = items.first!;
+    expect(item.text, contains('Wed 6'));
+    expect(item.text, contains('€6.00'));
+    final rows = item.children!.map((span) => span.toPlainText()).join();
+    expect(rows, contains('Agents  €5.00'));
+    expect(rows, contains('Research  €1.00'));
+    expect(rows.indexOf('Agents'), lessThan(rows.indexOf('Research')));
   });
 
   testWidgets('title follows the selected metric', (tester) async {
@@ -184,7 +234,7 @@ void main() {
       );
       await pumpCard(tester, chartData: chartData);
 
-      expect(find.text('Per week'), findsOneWidget);
+      expect(find.text('Per week'), findsWidgets);
       expect(find.text('Per day'), findsNothing);
       // No elapsed bucket → the chart still draws the whole range.
       final chart = tester.widget<BarChart>(find.byType(BarChart));


### PR DESCRIPTION
## Summary

- Parse OpenAI-compatible token usage payloads from transcription endpoints and pass them through to the AI consumption recorder.
- Capture Voxtral final usage-only SSE chunks and non-streaming usage payloads so transcription calls can be costed when the provider reports tokens.
- Add an AI Impact Running total chart mode, plus a localized Not reported ledger fallback for calls whose provider does not return token/cost/energy metrics.

## Why

Voxtral transcription could return accounting data in chunks that carried no text delta, but the stream adapter dropped those chunks before the consumption recorder could see them. Whisper-compatible endpoints may not report token usage at all, so the dashboard now makes that missing-provider-data state explicit instead of rendering a blank metrics cell.

## User impact

The Usage & Impact view can now show cumulative cost, energy, CO2e, and token usage over the selected period. Voxtral transcription usage is included when available, and transcription rows without provider metrics are labelled clearly.

## Validation

- `make l10n`
- `make sort_arb_files`
- full-project Dart MCP analysis: no errors
- `fvm flutter test test/features/ai/repository/whisper_inference_repository_test.dart test/features/ai/repository/voxtral_inference_repository_test.dart test/features/ai_consumption/ui/widgets/impact_call_ledger_test.dart test/features/ai_consumption/ui/widgets/impact_chart_card_test.dart`
- `fvm flutter test test/features/ai_consumption/ui/impact_analysis_body_test.dart test/features/ai_consumption/ui/widgets/impact_call_ledger_test.dart test/features/ai_consumption/ui/widgets/impact_chart_card_test.dart`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Running total” view to the AI Impact dashboard, letting users see cumulative cost, energy, CO₂e, and token usage over time.
  * Improved transcription and usage tracking so completed usage details are recorded more reliably, including cases where only final accounting data is returned.

* **Bug Fixes**
  * Calls with missing impact metrics now show a clear “Not reported” label instead of a blank entry.
  * Better handling of transcription results and streaming updates when usage data appears without a text delta.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->