### PR TITLE
fix: address usage stats review follow-up

### DIFF
--- a/lib/features/ai/repository/completion_usage_parser.dart
+++ b/lib/features/ai/repository/completion_usage_parser.dart
@@ -47,7 +47,7 @@ CompletionUsage? parseCompletionUsage(Object? raw) {
   if (!hasTokenData) return null;
 
   return CompletionUsage(
-    promptTokens: promptTokens,
+    promptTokens: promptTokens ?? 0,
     completionTokens: completionTokens,
     totalTokens: totalTokens ?? (promptTokens ?? 0) + (completionTokens ?? 0),
     promptTokensDetails: cachedTokens != null

--- a/lib/features/ai/repository/completion_usage_parser.dart
+++ b/lib/features/ai/repository/completion_usage_parser.dart
@@ -46,10 +46,13 @@ CompletionUsage? parseCompletionUsage(Object? raw) {
       reasoningTokens != null;
   if (!hasTokenData) return null;
 
+  final promptTokenCount = promptTokens ?? 0;
+  final completionTokenCount = completionTokens ?? 0;
+
   return CompletionUsage(
-    promptTokens: promptTokens ?? 0,
-    completionTokens: completionTokens,
-    totalTokens: totalTokens ?? (promptTokens ?? 0) + (completionTokens ?? 0),
+    promptTokens: promptTokenCount,
+    completionTokens: completionTokenCount,
+    totalTokens: totalTokens ?? promptTokenCount + completionTokenCount,
     promptTokensDetails: cachedTokens != null
         ? PromptTokensDetails(cachedTokens: cachedTokens)
         : null,

--- a/lib/features/ai_consumption/ui/widgets/impact_chart_card.dart
+++ b/lib/features/ai_consumption/ui/widgets/impact_chart_card.dart
@@ -524,8 +524,13 @@ class _ImpactStackedArea extends StatelessWidget {
                 for (var i = 0; i < spots.length; i++)
                   if (i == 0)
                     LineTooltipItem(
-                      '${_bucketLabel(context, data, index)}  '
-                      '${metric.formatValue(stackedTops.last[index])}',
+                      _tooltipHeader(
+                        context,
+                        data,
+                        metric,
+                        index,
+                        totalOverride: stackedTops.last[index],
+                      ),
                       style.copyWith(
                         fontWeight: tokens.typography.weight.semiBold,
                       ),
@@ -679,11 +684,12 @@ String _tooltipHeader(
   BuildContext context,
   ImpactChartData data,
   ConsumptionMetric metric,
-  int index,
-) {
+  int index, {
+  double? totalOverride,
+}) {
   final base =
       '${_bucketLabel(context, data, index)}  '
-      '${metric.formatValue(impactBucketTotal(data, index))}';
+      '${metric.formatValue(totalOverride ?? impactBucketTotal(data, index))}';
   final isPartial =
       data.granularity == InsightsGranularity.week &&
       ((index == 0 && data.partialFirstBucket) ||

--- a/test/features/ai/repository/completion_usage_parser_test.dart
+++ b/test/features/ai/repository/completion_usage_parser_test.dart
@@ -44,6 +44,20 @@ void main() {
       expect(usage.completionTokensDetails?.reasoningTokens, 1);
     });
 
+    test(
+      'defaults prompt tokens when only completion-side data is reported',
+      () {
+        final usage = parseCompletionUsage({
+          'completion_tokens': 6,
+        });
+
+        expect(usage, isNotNull);
+        expect(usage!.promptTokens, 0);
+        expect(usage.completionTokens, 6);
+        expect(usage.totalTokens, 6);
+      },
+    );
+
     test('ignores non-token usage payloads', () {
       expect(parseCompletionUsage({'duration': 1.25}), isNull);
       expect(parseCompletionUsage('not a map'), isNull);

--- a/test/features/ai/repository/completion_usage_parser_test.dart
+++ b/test/features/ai/repository/completion_usage_parser_test.dart
@@ -58,6 +58,20 @@ void main() {
       },
     );
 
+    test(
+      'defaults completion tokens when only prompt-side data is reported',
+      () {
+        final usage = parseCompletionUsage({
+          'prompt_tokens': 9,
+        });
+
+        expect(usage, isNotNull);
+        expect(usage!.promptTokens, 9);
+        expect(usage.completionTokens, 0);
+        expect(usage.totalTokens, 9);
+      },
+    );
+
     test('ignores non-token usage payloads', () {
       expect(parseCompletionUsage({'duration': 1.25}), isNull);
       expect(parseCompletionUsage('not a map'), isNull);

--- a/test/features/ai_consumption/ui/widgets/impact_chart_card_test.dart
+++ b/test/features/ai_consumption/ui/widgets/impact_chart_card_test.dart
@@ -471,5 +471,59 @@ void main() {
       expect(headerFor(1), isNot(contains('partial week')));
       expect(headerFor(2), contains('partial week'));
     });
+
+    testWidgets(
+      'weekly cumulative tooltip flags truncated edge weeks as partial',
+      (tester) async {
+        final chartData = ImpactChartData(
+          granularity: InsightsGranularity.week,
+          bucketStarts: [
+            DateTime(2024, 2),
+            DateTime(2024, 2, 5),
+            DateTime(2024, 2, 12),
+          ],
+          seriesKeys: const ['cat-a'],
+          values: const [
+            [1, 2, 3],
+          ],
+          partialFirstBucket: true,
+          partialLastBucket: true,
+        );
+        await pumpCard(tester, chartData: chartData);
+
+        await tester.tap(toggle('Running total'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 600));
+
+        final chart = tester.widget<LineChart>(find.byType(LineChart));
+        final tooltipData = chart.data.lineTouchData.touchTooltipData;
+
+        String headerFor(int index) {
+          final spots = [
+            for (
+              var barIndex = 0;
+              barIndex < chart.data.lineBarsData.length;
+              barIndex++
+            )
+              LineBarSpot(
+                chart.data.lineBarsData[barIndex],
+                barIndex,
+                chart.data.lineBarsData[barIndex].spots[index],
+              ),
+          ];
+          return tooltipData.getTooltipItems(spots).first!.text;
+        }
+
+        expect(headerFor(0), contains('Feb 1'));
+        expect(headerFor(0), contains('€1.00'));
+        expect(headerFor(0), contains('partial week'));
+        expect(headerFor(1), contains('Feb 5'));
+        expect(headerFor(1), contains('€3.00'));
+        expect(headerFor(1), isNot(contains('partial week')));
+        expect(headerFor(2), contains('Feb 12'));
+        expect(headerFor(2), contains('€6.00'));
+        expect(headerFor(2), contains('partial week'));
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary
- Default completion usage prompt tokens to zero when providers only report completion-side token counts
- Reuse the shared tooltip header for cumulative AI impact tooltips so partial-week labels stay consistent
- Add parser and cumulative-tooltip regression tests

## Validation
- fvm dart format lib/features/ai/repository/completion_usage_parser.dart lib/features/ai_consumption/ui/widgets/impact_chart_card.dart test/features/ai/repository/completion_usage_parser_test.dart test/features/ai_consumption/ui/widgets/impact_chart_card_test.dart
- dart-mcp analyze_files on changed files
- fvm flutter test test/features/ai/repository/completion_usage_parser_test.dart test/features/ai_consumption/ui/widgets/impact_chart_card_test.dart
- focused coverage: 100% lines for touched production files (686/686)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI consumption chart tooltips in cumulative running-total view, including more consistent date/header formatting and correct cumulative totals.
  * Fixed token usage parsing so missing prompt/completion token counts are treated as zero, producing complete total usage values.

* **Tests**
  * Added/extended tests to verify defaulting behavior for token parsing (prompt-only or completion-only inputs).
  * Added a widget test covering cumulative running-total tooltip behavior when switching from bar to line mode, including partial-week labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->