### PR TITLE
fix: relocate AI impact under Insights

### DIFF
--- a/lib/beamer/beamer_app.dart
+++ b/lib/beamer/beamer_app.dart
@@ -855,7 +855,6 @@ class _AppScreenState extends ConsumerState<AppScreen> {
           children: [
             DailyOsSidebarCalendar(),
             InsightsSidebarEntry(),
-            ImpactSidebarEntry(),
           ],
         ),
       ),
@@ -878,6 +877,7 @@ class _AppScreenState extends ConsumerState<AppScreen> {
         iconBuilder: ({required active}) => Icon(
           active ? Icons.insert_chart_rounded : Icons.insert_chart_outlined,
         ),
+        expandedChildBuilder: () => const ImpactSidebarEntry(),
       ),
       _AppNavigationDestination(
         kind: _AppNavigationDestinationKind.journal,

--- a/lib/beamer/locations/calendar_location.dart
+++ b/lib/beamer/locations/calendar_location.dart
@@ -2,7 +2,6 @@ import 'package:beamer/beamer.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/database/database.dart';
-import 'package:lotti/features/ai_consumption/ui/impact_analysis_page.dart';
 import 'package:lotti/features/daily_os/ui/pages/daily_os_page.dart';
 import 'package:lotti/features/daily_os/ui/pages/set_time_blocks_page.dart';
 import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
@@ -27,7 +26,6 @@ class CalendarLocation extends BeamLocation<BeamState> {
   List<String> get pathPatterns => [
     '/calendar',
     '/calendar/time',
-    '/calendar/impact',
     '/calendar/set-time-blocks',
     '/calendar/refine/:date',
     '/calendar/commit/:date',
@@ -38,14 +36,13 @@ class CalendarLocation extends BeamLocation<BeamState> {
   List<BeamPage> buildPages(BuildContext context, BeamState state) {
     final dailyOsNextRoute = _dailyOsNextRouteFrom(state.uri);
     final isTimeAnalysis = state.uri.path == '/calendar/time';
-    final isAiImpact = state.uri.path == '/calendar/impact';
     // Single writer for the sidebar sub-entry highlights: the URL.
     // Registration-guarded for location-level tests that build pages
     // without the service locator.
     if (getIt.isRegistered<NavService>()) {
       getIt<NavService>()
         ..desktopShowTimeAnalysis.value = isTimeAnalysis
-        ..desktopShowAiImpact.value = isAiImpact;
+        ..desktopShowAiImpact.value = false;
     }
 
     final pages = [
@@ -62,17 +59,6 @@ class CalendarLocation extends BeamLocation<BeamState> {
         const BeamPage(
           key: ValueKey('calendar_time_analysis'),
           child: TimeAnalysisPage(),
-        ),
-      );
-    }
-
-    if (isAiImpact) {
-      // AI Impact dashboard — same full-screen push pattern as the
-      // Time Analysis surface it sits beside in the sidebar.
-      pages.add(
-        const BeamPage(
-          key: ValueKey('calendar_ai_impact'),
-          child: ImpactAnalysisPage(),
         ),
       );
     }

--- a/lib/beamer/locations/dashboards_location.dart
+++ b/lib/beamer/locations/dashboards_location.dart
@@ -1,5 +1,6 @@
 import 'package:beamer/beamer.dart';
 import 'package:flutter/material.dart';
+import 'package:lotti/features/ai_consumption/ui/impact_analysis_page.dart';
 import 'package:lotti/features/dashboards/ui/pages/dashboard_page.dart';
 import 'package:lotti/features/dashboards/ui/pages/dashboards_list_page.dart';
 import 'package:lotti/get_it.dart';
@@ -12,6 +13,7 @@ class DashboardsLocation extends BeamLocation<BeamState> {
   @override
   List<String> get pathPatterns => [
     '/dashboards',
+    '/dashboards/impact',
     '/dashboards/:dashboardId',
   ];
 
@@ -20,11 +22,13 @@ class DashboardsLocation extends BeamLocation<BeamState> {
     final dashboardId = state.pathParameters['dashboardId'];
     final navService = getIt<NavService>();
     final isDesktop = navService.isDesktopMode;
+    final isAiImpact = state.uri.path == '/dashboards/impact';
+
+    navService.desktopShowAiImpact.value = isAiImpact;
 
     if (isDesktop) {
-      navService.desktopSelectedDashboardId.value = isUuid(dashboardId)
-          ? dashboardId
-          : null;
+      navService.desktopSelectedDashboardId.value =
+          isUuid(dashboardId) && !isAiImpact ? dashboardId : null;
     }
 
     return [
@@ -33,6 +37,11 @@ class DashboardsLocation extends BeamLocation<BeamState> {
         title: 'Dashboards',
         child: DashboardsListPage(),
       ),
+      if (isAiImpact)
+        const BeamPage(
+          key: ValueKey('dashboards_ai_impact'),
+          child: ImpactAnalysisPage(),
+        ),
       if (!isDesktop && isUuid(dashboardId))
         BeamPage(
           key: ValueKey('dashboards-$dashboardId'),

--- a/lib/features/ai_consumption/ui/widgets/impact_sidebar_entry.dart
+++ b/lib/features/ai_consumption/ui/widgets/impact_sidebar_entry.dart
@@ -4,12 +4,11 @@ import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/services/nav_service.dart';
 
-/// Sidebar sub-entry under the Daily OS destination, directly beneath the
-/// Time Analysis entry it mirrors.
+/// Sidebar sub-entry under the Insights destination.
 ///
 /// Highlights via [NavService.desktopShowAiImpact] (written by
-/// `CalendarLocation`, so the URL stays the single source of truth) and opens
-/// the full-screen AI Impact dashboard at `/calendar/impact`.
+/// `DashboardsLocation`, so the URL stays the single source of truth) and opens
+/// the full-screen AI Impact dashboard at `/dashboards/impact`.
 class ImpactSidebarEntry extends StatelessWidget {
   const ImpactSidebarEntry({super.key});
 
@@ -26,7 +25,7 @@ class ImpactSidebarEntry extends StatelessWidget {
             color: active ? tokens.colors.surface.selected : Colors.transparent,
             borderRadius: BorderRadius.circular(tokens.radii.s),
             child: InkWell(
-              onTap: () => beamToNamed('/calendar/impact'),
+              onTap: () => beamToNamed('/dashboards/impact'),
               borderRadius: BorderRadius.circular(tokens.radii.s),
               hoverColor: tokens.colors.surface.hover,
               child: Padding(

--- a/lib/services/nav_service.dart
+++ b/lib/services/nav_service.dart
@@ -104,9 +104,9 @@ class NavService {
     false,
   );
 
-  /// Whether the AI Impact dashboard (`/calendar/impact`) is showing.
-  /// Written exclusively by `CalendarLocation` from the URL, mirroring
-  /// [desktopShowTimeAnalysis]; the sidebar sub-entry only reads it.
+  /// Whether the AI Impact dashboard (`/dashboards/impact`) is showing.
+  /// Written by route locations from the URL so the Insights sidebar
+  /// sub-entry only reads it for its highlight.
   final ValueNotifier<bool> desktopShowAiImpact = ValueNotifier<bool>(
     false,
   );

--- a/test/beamer/beamer_app_test.dart
+++ b/test/beamer/beamer_app_test.dart
@@ -21,6 +21,7 @@ import 'package:lotti/features/ai/repository/ai_config_repository.dart'
     as ai_repo;
 import 'package:lotti/features/ai/ui/settings/services/ai_setup_prompt_service.dart';
 import 'package:lotti/features/ai/ui/settings/widgets/ai_provider_selection_modal.dart';
+import 'package:lotti/features/ai_consumption/ui/widgets/impact_sidebar_entry.dart';
 import 'package:lotti/features/daily_os_next/ui/widgets/sidebar_calendar.dart';
 import 'package:lotti/features/design_system/components/navigation/design_system_five_slot_nav_bar.dart';
 import 'package:lotti/features/design_system/components/navigation/desktop_navigation_sidebar.dart';
@@ -238,8 +239,8 @@ Future<void> _stubNavService(
   when(
     () => navService.desktopSelectedTaskId,
   ).thenReturn(ValueNotifier<String?>(null));
-  // The Time Analysis and AI Impact sidebar sub-entries (under the Daily
-  // OS calendar) read these for their active-route highlights.
+  // The Time Analysis and AI Impact sidebar sub-entries read these for their
+  // active-route highlights.
   when(
     () => navService.desktopShowTimeAnalysis,
   ).thenReturn(ValueNotifier<bool>(false));
@@ -1340,6 +1341,61 @@ void main() {
             .dy;
         expect(calendarY, greaterThan(dailyOsRowY));
         expect(calendarY, lessThan(habitsRowY));
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump();
+      },
+    );
+
+    testWidgets(
+      'AI Impact sidebar entry renders under Insights, not Daily OS',
+      (tester) async {
+        Future<void> pumpWithActiveIndex(int index) async {
+          final mockNavService = MockNavService();
+          await _stubNavService(
+            mockNavService,
+            indexStream: Stream.value(index),
+            isProjectsEnabled: () => true,
+            isDailyOsEnabled: () => true,
+            isHabitsEnabled: () => true,
+            isDashboardsEnabled: () => true,
+          );
+          await _registerAppScreenGetIt(mockNavService);
+          addTearDown(tearDownTestGetIt);
+
+          await _pumpAppScreen(
+            tester,
+            navService: mockNavService,
+            viewportSize: _desktopViewportSize,
+          );
+        }
+
+        await pumpWithActiveIndex(1);
+        expect(find.byType(DailyOsSidebarCalendar), findsOneWidget);
+        expect(find.byType(ImpactSidebarEntry), findsNothing);
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump();
+        await tearDownTestGetIt();
+
+        await pumpWithActiveIndex(4);
+        expect(find.byType(DailyOsSidebarCalendar), findsNothing);
+        expect(find.byType(ImpactSidebarEntry), findsOneWidget);
+
+        final sidebar = find.byType(DesktopNavigationSidebar);
+        final impactY = tester.getTopLeft(find.byType(ImpactSidebarEntry)).dy;
+        final insightsRowY = tester
+            .getCenter(
+              find.descendant(of: sidebar, matching: find.text('Insights')),
+            )
+            .dy;
+        final journalRowY = tester
+            .getCenter(
+              find.descendant(of: sidebar, matching: find.text('Logbook')),
+            )
+            .dy;
+
+        expect(impactY, greaterThan(insightsRowY));
+        expect(impactY, lessThan(journalRowY));
 
         await tester.pumpWidget(const SizedBox.shrink());
         await tester.pump();

--- a/test/beamer/locations/calendar_location_test.dart
+++ b/test/beamer/locations/calendar_location_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
 import 'package:lotti/beamer/locations/calendar_location.dart';
-import 'package:lotti/features/ai_consumption/ui/impact_analysis_page.dart';
 import 'package:lotti/features/daily_os/state/daily_os_controller.dart';
 import 'package:lotti/features/daily_os/state/time_budget_progress_controller.dart';
 import 'package:lotti/features/daily_os/state/time_history_header_controller.dart';
@@ -166,7 +165,6 @@ void main() {
       expect(location.pathPatterns, [
         '/calendar',
         '/calendar/time',
-        '/calendar/impact',
         '/calendar/set-time-blocks',
         '/calendar/refine/:date',
         '/calendar/commit/:date',
@@ -180,7 +178,7 @@ void main() {
       () async {
         final navService = MockNavService();
         final showTimeAnalysis = ValueNotifier<bool>(false);
-        final showAiImpact = ValueNotifier<bool>(false);
+        final showAiImpact = ValueNotifier<bool>(true);
         when(
           () => navService.desktopShowTimeAnalysis,
         ).thenReturn(showTimeAnalysis);
@@ -209,59 +207,15 @@ void main() {
         expect(pages[0].child, isA<CalendarRoot>());
         expect(pages[1].child, isA<TimeAnalysisPage>());
         expect(showTimeAnalysis.value, isTrue);
-
-        // Navigating back to the root clears the highlight.
-        final rootInformation = RouteInformation(uri: Uri.parse('/calendar'));
-        CalendarLocation(rootInformation).buildPages(
-          mockBuildContext,
-          BeamState.fromRouteInformation(rootInformation),
-        );
-        expect(showTimeAnalysis.value, isFalse);
-      },
-    );
-
-    test(
-      'pushes the full-screen AI Impact page on /calendar/impact and '
-      'mirrors the route into desktopShowAiImpact',
-      () async {
-        final navService = MockNavService();
-        final showTimeAnalysis = ValueNotifier<bool>(false);
-        final showAiImpact = ValueNotifier<bool>(false);
-        when(
-          () => navService.desktopShowTimeAnalysis,
-        ).thenReturn(showTimeAnalysis);
-        when(
-          () => navService.desktopShowAiImpact,
-        ).thenReturn(showAiImpact);
-        await setUpTestGetIt(
-          additionalSetup: () {
-            getIt.registerSingleton<NavService>(navService);
-          },
-        );
-        addTearDown(tearDownTestGetIt);
-        addTearDown(showTimeAnalysis.dispose);
-        addTearDown(showAiImpact.dispose);
-
-        final routeInformation = RouteInformation(
-          uri: Uri.parse('/calendar/impact'),
-        );
-        final location = CalendarLocation(routeInformation);
-        final beamState = BeamState.fromRouteInformation(routeInformation);
-        final pages = location.buildPages(mockBuildContext, beamState);
-
-        expect(pages.length, 2);
-        expect(pages[0].child, isA<CalendarRoot>());
-        expect(pages[1].child, isA<ImpactAnalysisPage>());
-        expect(showAiImpact.value, isTrue);
-        expect(showTimeAnalysis.value, isFalse);
-
-        // Navigating back to the root clears the highlight.
-        final rootInformation = RouteInformation(uri: Uri.parse('/calendar'));
-        CalendarLocation(rootInformation).buildPages(
-          mockBuildContext,
-          BeamState.fromRouteInformation(rootInformation),
-        );
         expect(showAiImpact.value, isFalse);
+
+        // Navigating back to the root clears the highlight.
+        final rootInformation = RouteInformation(uri: Uri.parse('/calendar'));
+        CalendarLocation(rootInformation).buildPages(
+          mockBuildContext,
+          BeamState.fromRouteInformation(rootInformation),
+        );
+        expect(showTimeAnalysis.value, isFalse);
       },
     );
 

--- a/test/beamer/locations/dashboards_location_test.dart
+++ b/test/beamer/locations/dashboards_location_test.dart
@@ -2,6 +2,7 @@ import 'package:beamer/beamer.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/beamer/locations/dashboards_location.dart';
+import 'package:lotti/features/ai_consumption/ui/impact_analysis_page.dart';
 import 'package:lotti/features/dashboards/ui/pages/dashboard_page.dart';
 import 'package:lotti/features/dashboards/ui/pages/dashboards_list_page.dart';
 import 'package:lotti/get_it.dart';
@@ -10,27 +11,33 @@ import 'package:mocktail/mocktail.dart';
 import 'package:uuid/uuid.dart';
 
 import '../../mocks/mocks.dart';
+import '../../widget_test_utils.dart';
 
 void main() {
   group('DashboardsLocation', () {
     late MockBuildContext mockBuildContext;
 
     late MockNavService mockNavService;
+    late ValueNotifier<bool> desktopShowAiImpact;
 
-    setUp(() {
+    setUp(() async {
       mockBuildContext = MockBuildContext();
       mockNavService = MockNavService();
+      desktopShowAiImpact = ValueNotifier<bool>(false);
       when(() => mockNavService.isDesktopMode).thenReturn(false);
-      if (getIt.isRegistered<NavService>()) {
-        getIt.unregister<NavService>();
-      }
-      getIt.registerSingleton<NavService>(mockNavService);
+      when(
+        () => mockNavService.desktopShowAiImpact,
+      ).thenReturn(desktopShowAiImpact);
+      await setUpTestGetIt(
+        additionalSetup: () {
+          getIt.registerSingleton<NavService>(mockNavService);
+        },
+      );
     });
 
-    tearDown(() {
-      if (getIt.isRegistered<NavService>()) {
-        getIt.unregister<NavService>();
-      }
+    tearDown(() async {
+      desktopShowAiImpact.dispose();
+      await tearDownTestGetIt();
     });
 
     test('pathPatterns are correct', () {
@@ -39,6 +46,7 @@ void main() {
       );
       expect(location.pathPatterns, [
         '/dashboards',
+        '/dashboards/impact',
         '/dashboards/:dashboardId',
       ]);
     });
@@ -91,6 +99,7 @@ void main() {
       () {
         final dashboardId = const Uuid().v4();
         final desktopSelectedDashboardId = ValueNotifier<String?>(null);
+        addTearDown(desktopSelectedDashboardId.dispose);
 
         when(() => mockNavService.isDesktopMode).thenReturn(true);
         when(
@@ -121,6 +130,7 @@ void main() {
       () {
         final dashboardId = const Uuid().v4();
         final desktopSelectedDashboardId = ValueNotifier<String?>(null);
+        addTearDown(desktopSelectedDashboardId.dispose);
 
         when(() => mockNavService.isDesktopMode).thenReturn(true);
         when(
@@ -142,6 +152,32 @@ void main() {
         location.buildPages(mockBuildContext, newBeamState);
 
         expect(desktopSelectedDashboardId.value, dashboardId);
+      },
+    );
+
+    test(
+      'buildPages pushes AI Impact page on /dashboards/impact and '
+      'mirrors the route into desktopShowAiImpact',
+      () {
+        final routeInformation = RouteInformation(
+          uri: Uri.parse('/dashboards/impact'),
+        );
+        final location = DashboardsLocation(routeInformation);
+        final beamState = BeamState.fromRouteInformation(routeInformation);
+        final pages = location.buildPages(mockBuildContext, beamState);
+
+        expect(pages.length, 2);
+        expect(pages[0].child, isA<DashboardsListPage>());
+        expect(pages[1].child, isA<ImpactAnalysisPage>());
+        expect(desktopShowAiImpact.value, isTrue);
+
+        final rootInformation = RouteInformation(uri: Uri.parse('/dashboards'));
+        DashboardsLocation(rootInformation).buildPages(
+          mockBuildContext,
+          BeamState.fromRouteInformation(rootInformation),
+        );
+
+        expect(desktopShowAiImpact.value, isFalse);
       },
     );
   });

--- a/test/features/ai_consumption/ui/widgets/impact_sidebar_entry_test.dart
+++ b/test/features/ai_consumption/ui/widgets/impact_sidebar_entry_test.dart
@@ -50,7 +50,7 @@ void main() {
     expect(label.style?.fontWeight, isNotNull);
   });
 
-  testWidgets('beams to /calendar/impact on tap', (tester) async {
+  testWidgets('beams to /dashboards/impact on tap', (tester) async {
     final beamed = <String>[];
     beamToNamedOverride = beamed.add;
     addTearDown(() => beamToNamedOverride = null);
@@ -60,7 +60,7 @@ void main() {
 
     await tester.tap(find.text('AI Impact'));
     await tester.pump();
-    expect(beamed, ['/calendar/impact']);
+    expect(beamed, ['/dashboards/impact']);
   });
 
   testWidgets('reacts to highlight flips without a rebuild from above', (


### PR DESCRIPTION
## Summary
- move the AI Impact sidebar entry from DailyOS to the Insights top-level area
- route the top-level AI Impact surface through /dashboards/impact so the active tab is Insights
- keep the Settings > AI Settings > Usage & Impact placement unchanged
- update navigation and sidebar tests for the new location

## Validation
- CI will run the full required checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new AI Impact destination under Dashboards, with desktop sidebar placement updated accordingly.
  * The AI Impact page now opens from the Dashboards area instead of the Calendar area.

* **Bug Fixes**
  * Removed the old calendar AI Impact route and related navigation behavior.
  * Improved sidebar highlighting so the AI Impact entry follows the correct dashboard route on desktop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->