### PR TITLE
ci: increase Linux test shards

### DIFF
--- a/.github/workflows/flutter-test-linux-faster.yml
+++ b/.github/workflows/flutter-test-linux-faster.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   test:
-    name: Unit & Widget Tests (Linux, shard ${{ matrix.shard_label }}/5)
+    name: Unit & Widget Tests (Linux, shard ${{ matrix.shard_label }}/10)
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -28,6 +28,16 @@ jobs:
             shard_label: 4
           - shard_index: 4
             shard_label: 5
+          - shard_index: 5
+            shard_label: 6
+          - shard_index: 6
+            shard_label: 7
+          - shard_index: 7
+            shard_label: 8
+          - shard_index: 8
+            shard_label: 9
+          - shard_index: 9
+            shard_label: 10
     steps:
       - uses: actions/checkout@v5
       - name: Cache Pub Packages
@@ -49,7 +59,7 @@ jobs:
       - name: Run Flutter tests (standard)
         run: |
           very_good test --coverage --exclude-tags glados -- \
-            --total-shards=5 \
+            --total-shards=10 \
             --shard-index=${{ matrix.shard_index }}
       - uses: codecov/codecov-action@v7
         with:

--- a/test/README.md
+++ b/test/README.md
@@ -160,11 +160,11 @@ The `tags` argument is a passthrough to `package:test`'s `test()`. It works the 
 
 ### Why the tag matters for CI
 
-CI runs two parallel test lanes — a five-shard standard matrix plus a Glados job — followed by a final Codecov status job gated on both:
-- **Unit & Widget Tests** — five shards of `very_good test --coverage --exclude-tags glados -- --total-shards=5 --shard-index=N` (fast feedback, all non-property tests)
+CI runs two parallel test lanes — a ten-shard standard matrix plus a Glados job — followed by a final Codecov status job gated on both:
+- **Unit & Widget Tests** — ten shards of `very_good test --coverage --exclude-tags glados -- --total-shards=10 --shard-index=N` (fast feedback, all non-property tests)
 - **Glados Property Tests** — `very_good test --coverage --tags glados` (CPU-bound, runs longer in parallel)
 
-A new Glados test without `tags: 'glados'` will run in the standard suite, slowing fast feedback for everyone. The split also lets us upload separate codecov flags (`standard`, `glados`) while still merging all five standard shards plus Glados into the project total. Codecov status publishing is manually triggered by a final CI job after every coverage upload job succeeds, so PRs do not show transient project coverage from only the Glados report or a partial standard shard set.
+A new Glados test without `tags: 'glados'` will run in the standard suite, slowing fast feedback for everyone. The split also lets us upload separate codecov flags (`standard`, `glados`) while still merging all ten standard shards plus Glados into the project total. Codecov status publishing is manually triggered by a final CI job after every coverage upload job succeeds, so PRs do not show transient project coverage from only the Glados report or a partial standard shard set.
 
 ### Local commands
 
@@ -179,10 +179,10 @@ make test               # full suite, no filtering — same as before
 To reproduce one standard CI shard locally, run:
 
 ```bash
-very_good test --coverage --exclude-tags glados -- --total-shards=5 --shard-index=0
+very_good test --coverage --exclude-tags glados -- --total-shards=10 --shard-index=0
 ```
 
-Replace `0` with `1`, `2`, `3`, or `4` for the other shards. The `--` terminator forwards the sharding arguments to the underlying `flutter test` command; the equals-form arguments keep Very Good's test optimizer enabled because no forwarded argument looks like a positional test-file target. The Make test-suite targets (`test`, `test_standard`, `test_glados`, and their `coverage_*` variants) use `very_good test` to match CI behavior. Run `make activate_very_good` once on a fresh checkout.
+Replace `0` with any shard index from `1` through `9` for the other shards. The `--` terminator forwards the sharding arguments to the underlying `flutter test` command; the equals-form arguments keep Very Good's test optimizer enabled because no forwarded argument looks like a positional test-file target. The Make test-suite targets (`test`, `test_standard`, `test_glados`, and their `coverage_*` variants) use `very_good test` to match CI behavior. Run `make activate_very_good` once on a fresh checkout.
 
 ### Picking `numRuns`
 


### PR DESCRIPTION
## Summary

- Increase the Linux standard Flutter test matrix from 5 shards to 10 shards.
- Update the test README so the documented CI layout and local shard reproduction command match the workflow.

## Impact

This should reduce wall-clock time for the standard Linux Flutter test lane by splitting the non-Glados suite across more GitHub-hosted runners. The workflow now runs 10 standard shards plus the existing Glados job before the Codecov status job.

## Validation

- `actionlint .github/workflows/flutter-test-linux-faster.yml`
- `git diff --check`

Flutter tests were not run locally because this change only adjusts CI sharding and documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated test documentation to reflect the current CI setup with ten standard test shards.
  * Revised local test examples and guidance so they match the latest shard-based workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->