### PR TITLE
fix: platform-aware image viewer save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   available. When the provider reports data-center metadata, it also groups
   environmental impact by country/data center and shows the renewable-energy
   share for each location.
+### Fixed
+- **The image viewer's save button now works everywhere.** On iPhone and
+  Android it saves the photo to your photo library; on macOS, Windows and Linux
+  it opens a native save dialog so you choose where the image goes. Previously
+  it always tried to write into `Downloads/Lotti`, which failed with an error on
+  iPhone and on the sandboxed macOS build.
 
 ## [0.9.1032]
 ### Added

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -35,6 +35,7 @@
     <release version="0.9.1034" date="2026-07-07">
       <description>
           <p>The AI Impact dashboard now includes a Running total chart mode for cumulative cost, energy, CO2e and token usage over the selected period. Voxtral transcription records token usage when the server returns it in final accounting chunks, and transcription calls whose provider reports no token, cost or energy metrics are labelled instead of leaving a blank ledger row. AI Impact also adds a model breakdown for the selected metric, using provider-native model IDs when available. When the provider reports data-center metadata, AI Impact groups environmental impact by country/data center and shows the renewable-energy share for each location.</p>
+          <p>The image viewer's save button now works on every platform: on iPhone and Android it saves the photo to your photo library, and on macOS, Windows and Linux it opens a native save dialog so you choose where the image goes. Previously it always tried to write into Downloads/Lotti, which failed with an error on iPhone and on the sandboxed macOS build.</p>
       </description>
     </release>
     <release version="0.9.1032" date="2026-07-06">

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -57,6 +57,8 @@
 	<string>Obtain location for journal entries</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Record audio notes</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>Save images from your journal to your photo library</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Import photos and videos</string>
 	<key>UIApplicationSupportsIndirectInputEvents</key>

--- a/lib/features/journal/README.md
+++ b/lib/features/journal/README.md
@@ -124,11 +124,18 @@ flowchart LR
   Route --> PhotoView["PhotoView\npinch + pan"]
   Route --> Chrome["overlay chrome\nclose, download, zoom"]
   Chrome --> Controller["PhotoView controllers"]
-  Chrome --> Downloads["Downloads/Lotti\nunique filename copy"]
+  Chrome --> Exporter["ImageExporter\nplatform-aware save"]
   Chrome --> Pop["root Navigator pop\nclose or Escape"]
+  Exporter --> Gallery["mobile: photo library\n(gal)"]
+  Exporter --> Dialog["desktop: native save panel\n(file_selector)"]
 ```
 
-The download action copies the original image file, not the resized preview, into the platform downloads directory under `Lotti/`. Existing filenames are preserved with a numeric suffix (`photo 2.png`, etc.) rather than overwritten.
+The save action always copies the original image file, not the resized preview, to a platform-appropriate destination via the [`ImageExporter`](util/image_export_service.dart) typedef (`defaultImageExporter()` picks the implementation; the widget accepts an injected one for tests):
+
+- **mobile** (`saveImageToGallery`) writes to the OS photo library / camera roll through the `gal` plugin, requesting photo-add permission first and surfacing a "permission denied" message if it is refused;
+- **desktop** (`saveImageViaDialog`) opens the native save panel through `file_selector`, so the user chooses the folder and filename and the sandbox grants write access to exactly that location. Dismissing the panel is treated as a silent cancellation, not an error.
+
+The earlier `getDownloadsDirectory()` + `Downloads/Lotti` copy was desktop-only: it failed on iOS (no user-facing downloads directory) and on the sandboxed macOS build (no write access to `~/Downloads`). Any unexpected save error is logged through `LoggingService` and shown to the user as a generic failure snackbar.
 
 ## Entry Controller
 

--- a/lib/features/journal/ui/widgets/entry_image_widget.dart
+++ b/lib/features/journal/ui/widgets/entry_image_widget.dart
@@ -7,11 +7,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/journal/state/entry_controller.dart';
+import 'package:lotti/features/journal/util/image_export_service.dart';
+import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/utils/image_utils.dart';
 import 'package:lotti/utils/platform.dart';
-import 'package:path/path.dart' as p;
-import 'package:path_provider/path_provider.dart';
 import 'package:photo_view/photo_view.dart';
 
 /// Inline image for a [JournalImage] entry in the detail view.
@@ -83,27 +84,21 @@ class EntryImageWidget extends ConsumerWidget {
   }
 }
 
-typedef ImageViewerDownloadsDirectoryResolver = Future<Directory?> Function();
-typedef ImageViewerFileCopier =
-    Future<File> Function(File sourceFile, File targetFile);
-
-Future<File> _copyImageFile(File sourceFile, File targetFile) =>
-    sourceFile.copy(targetFile.path);
-
 // from https://github.com/bluefireteam/photo_view/blob/master/example/lib/screens/examples/hero_example.dart
 class HeroPhotoViewRouteWrapper extends StatefulWidget {
   const HeroPhotoViewRouteWrapper({
     required this.file,
     super.key,
     this.backgroundDecoration,
-    this.downloadsDirectoryResolver = getDownloadsDirectory,
-    this.fileCopier = _copyImageFile,
+    this.imageExporter,
   });
 
   final File file;
   final BoxDecoration? backgroundDecoration;
-  final ImageViewerDownloadsDirectoryResolver downloadsDirectoryResolver;
-  final ImageViewerFileCopier fileCopier;
+
+  /// Saves the image to a platform-appropriate destination. Defaults to
+  /// [defaultImageExporter]; injected in tests to avoid real platform channels.
+  final ImageExporter? imageExporter;
 
   @override
   State<HeroPhotoViewRouteWrapper> createState() =>
@@ -117,6 +112,8 @@ class _HeroPhotoViewRouteWrapperState extends State<HeroPhotoViewRouteWrapper> {
   late final PhotoViewController _photoController;
   late final PhotoViewScaleStateController _scaleStateController;
   late final StreamSubscription<PhotoViewControllerValue> _photoSubscription;
+  late final ImageExporter _exporter =
+      widget.imageExporter ?? defaultImageExporter();
 
   double _scale = 1;
   double? _minimumScale;
@@ -189,14 +186,30 @@ class _HeroPhotoViewRouteWrapperState extends State<HeroPhotoViewRouteWrapper> {
 
     setState(() => _isDownloading = true);
     try {
-      final target = await _copyImageToDownloads();
+      final result = await _exporter(widget.file);
       if (!mounted) {
         return;
       }
-      _showSnackBar(
-        context.messages.imageViewerDownloadSaved(p.basename(target.path)),
+      switch (result.status) {
+        case ImageExportStatus.savedToFile:
+          _showSnackBar(
+            context.messages.imageViewerDownloadSaved(result.savedName ?? ''),
+          );
+        case ImageExportStatus.savedToGallery:
+          _showSnackBar(context.messages.imageViewerDownloadSavedToGallery);
+        case ImageExportStatus.permissionDenied:
+          _showSnackBar(context.messages.imageViewerDownloadPermissionDenied);
+        case ImageExportStatus.cancelled:
+          // User dismissed the save panel; no feedback needed.
+          break;
+      }
+    } on Object catch (error, stackTrace) {
+      getIt<LoggingService>().captureException(
+        error,
+        domain: 'entry_image_widget',
+        subDomain: 'downloadImage',
+        stackTrace: stackTrace,
       );
-    } on Object {
       if (!mounted) {
         return;
       }
@@ -206,45 +219,6 @@ class _HeroPhotoViewRouteWrapperState extends State<HeroPhotoViewRouteWrapper> {
         setState(() => _isDownloading = false);
       }
     }
-  }
-
-  Future<File> _copyImageToDownloads() async {
-    final downloadsDirectory = await widget.downloadsDirectoryResolver();
-    if (downloadsDirectory == null) {
-      throw const FileSystemException('Downloads directory is unavailable');
-    }
-
-    final lottiDirectory = await Directory(
-      p.join(downloadsDirectory.path, 'Lotti'),
-    ).create(recursive: true);
-    final target = await _uniqueDownloadFile(
-      directory: lottiDirectory,
-      sourceFile: widget.file,
-    );
-    return widget.fileCopier(widget.file, target);
-  }
-
-  Future<File> _uniqueDownloadFile({
-    required Directory directory,
-    required File sourceFile,
-  }) async {
-    final sourceName = p.basename(sourceFile.path);
-    final extension = p.extension(sourceName);
-    final baseName = p.basenameWithoutExtension(sourceName);
-    final existingNames = <String>{};
-    await for (final entity in directory.list()) {
-      existingNames.add(p.basename(entity.path));
-    }
-
-    var candidateName = sourceName;
-    var suffix = 2;
-
-    while (existingNames.contains(candidateName)) {
-      candidateName = '$baseName $suffix$extension';
-      suffix++;
-    }
-
-    return File(p.join(directory.path, candidateName));
   }
 
   void _showSnackBar(String message) {

--- a/lib/features/journal/util/image_export_service.dart
+++ b/lib/features/journal/util/image_export_service.dart
@@ -1,0 +1,105 @@
+import 'dart:io';
+
+import 'package:file_selector/file_selector.dart';
+import 'package:gal/gal.dart';
+import 'package:lotti/utils/platform.dart';
+import 'package:path/path.dart' as p;
+
+/// How an image save attempt resolved, mapped to a user-facing message by the
+/// image viewer.
+enum ImageExportStatus {
+  /// Copied to a user-chosen file location via the desktop save panel.
+  savedToFile,
+
+  /// Saved to the platform photo library / camera roll on mobile.
+  savedToGallery,
+
+  /// The user dismissed the save panel without choosing a location.
+  cancelled,
+
+  /// The OS denied photo-library access on mobile.
+  permissionDenied,
+}
+
+/// Result of an [ImageExporter] call.
+///
+/// [savedName] is only populated for [ImageExportStatus.savedToFile], where the
+/// viewer echoes the chosen file name back to the user.
+class ImageExportResult {
+  const ImageExportResult(this.status, {this.savedName});
+
+  const ImageExportResult.savedToFile(String name)
+    : this(ImageExportStatus.savedToFile, savedName: name);
+
+  const ImageExportResult.savedToGallery()
+    : this(ImageExportStatus.savedToGallery);
+
+  const ImageExportResult.cancelled() : this(ImageExportStatus.cancelled);
+
+  const ImageExportResult.permissionDenied()
+    : this(ImageExportStatus.permissionDenied);
+
+  final ImageExportStatus status;
+
+  /// File name shown back to the user for [ImageExportStatus.savedToFile].
+  final String? savedName;
+}
+
+/// Saves a source image [file] to a platform-appropriate destination.
+///
+/// `getDownloadsDirectory()` is desktop-only, so the previous single-path
+/// implementation always failed on iOS (no user-facing downloads directory) and
+/// on the sandboxed macOS build (no write access to `~/Downloads`). The two
+/// real destinations are split into separate implementations:
+///
+/// * mobile → the OS photo library / camera roll ([saveImageToGallery]),
+/// * desktop → a user-chosen location via the native save panel
+///   ([saveImageViaDialog]).
+///
+/// Implementations let genuinely unexpected errors propagate so the caller can
+/// distinguish a real failure from a user cancellation via [ImageExportResult].
+typedef ImageExporter = Future<ImageExportResult> Function(File file);
+
+/// Saves to the OS photo library via `gal` (iOS camera roll / Android gallery).
+Future<ImageExportResult> saveImageToGallery(File file) async {
+  try {
+    if (!await Gal.hasAccess()) {
+      final granted = await Gal.requestAccess();
+      if (!granted) {
+        return const ImageExportResult.permissionDenied();
+      }
+    }
+    await Gal.putImage(file.path);
+    return const ImageExportResult.savedToGallery();
+  } on GalException catch (e) {
+    if (e.type == GalExceptionType.accessDenied) {
+      return const ImageExportResult.permissionDenied();
+    }
+    rethrow;
+  }
+}
+
+/// Copies the image to a user-chosen location via the native save panel
+/// (`file_selector`), the sandbox-friendly way to write files on desktop: the
+/// OS grants write access to exactly the location the user picked.
+Future<ImageExportResult> saveImageViaDialog(File file) async {
+  final suggestedName = p.basename(file.path);
+  final extension = p.extension(suggestedName).replaceFirst('.', '');
+  final location = await getSaveLocation(
+    suggestedName: suggestedName,
+    acceptedTypeGroups: [
+      if (extension.isNotEmpty)
+        XTypeGroup(label: 'Image', extensions: [extension]),
+    ],
+  );
+  if (location == null) {
+    return const ImageExportResult.cancelled();
+  }
+  final saved = await file.copy(location.path);
+  return ImageExportResult.savedToFile(p.basename(saved.path));
+}
+
+/// The exporter appropriate for the current platform: the photo library on
+/// mobile, the native save panel on desktop.
+ImageExporter defaultImageExporter() =>
+    isMobile ? saveImageToGallery : saveImageViaDialog;

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -2220,7 +2220,8 @@
   "images": "Obrázky",
   "imageViewerDownloadFailed": "Obrázek se nepodařilo uložit",
   "imageViewerDownloadingTooltip": "Ukládám obrázek",
-  "imageViewerDownloadSaved": "Uloženo {fileName} do Stažené/Lotti",
+  "imageViewerDownloadPermissionDenied": "Přístup k fotkám zamítnut – povol jej v Nastavení",
+  "imageViewerDownloadSaved": "Uloženo {fileName}",
   "@imageViewerDownloadSaved": {
     "placeholders": {
       "fileName": {
@@ -2228,6 +2229,7 @@
       }
     }
   },
+  "imageViewerDownloadSavedToGallery": "Uloženo do Fotek",
   "imageViewerDownloadTooltip": "Stáhnout obrázek",
   "inactiveLabel": "Neaktivní",
   "inactiveSwitchDescription": "Lze vybrat pro nové záznamy, když je zapnuto",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2411,7 +2411,8 @@
   "images": "Bilder",
   "imageViewerDownloadFailed": "Bild konnte nicht gespeichert werden",
   "imageViewerDownloadingTooltip": "Bild wird gespeichert",
-  "imageViewerDownloadSaved": "{fileName} wurde in Downloads/Lotti gespeichert",
+  "imageViewerDownloadPermissionDenied": "Fotozugriff verweigert – aktiviere ihn in den Einstellungen",
+  "imageViewerDownloadSaved": "{fileName} gespeichert",
   "@imageViewerDownloadSaved": {
     "placeholders": {
       "fileName": {
@@ -2419,6 +2420,7 @@
       }
     }
   },
+  "imageViewerDownloadSavedToGallery": "In Fotos gespeichert",
   "imageViewerDownloadTooltip": "Bild herunterladen",
   "inactiveLabel": "Inaktiv",
   "inactiveSwitchDescription": "Kann für neue Einträge gewählt werden, wenn aktiv",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2873,7 +2873,8 @@
   "images": "Images",
   "imageViewerDownloadFailed": "Could not save image",
   "imageViewerDownloadingTooltip": "Saving image",
-  "imageViewerDownloadSaved": "Saved {fileName} to Downloads/Lotti",
+  "imageViewerDownloadPermissionDenied": "Photo access denied — enable it in Settings",
+  "imageViewerDownloadSaved": "Saved {fileName}",
   "@imageViewerDownloadSaved": {
     "placeholders": {
       "fileName": {
@@ -2881,6 +2882,7 @@
       }
     }
   },
+  "imageViewerDownloadSavedToGallery": "Saved to Photos",
   "imageViewerDownloadTooltip": "Download image",
   "inactiveLabel": "Inactive",
   "inactiveSwitchDescription": "Can be chosen for new entries when on",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2411,7 +2411,8 @@
   "images": "Imágenes",
   "imageViewerDownloadFailed": "No se pudo guardar la imagen",
   "imageViewerDownloadingTooltip": "Guardando imagen",
-  "imageViewerDownloadSaved": "Se guardó {fileName} en Descargas/Lotti",
+  "imageViewerDownloadPermissionDenied": "Acceso a fotos denegado: actívalo en Ajustes",
+  "imageViewerDownloadSaved": "Se guardó {fileName}",
   "@imageViewerDownloadSaved": {
     "placeholders": {
       "fileName": {
@@ -2419,6 +2420,7 @@
       }
     }
   },
+  "imageViewerDownloadSavedToGallery": "Guardado en Fotos",
   "imageViewerDownloadTooltip": "Descargar imagen",
   "inactiveLabel": "Inactivo",
   "inactiveSwitchDescription": "Se puede elegir para nuevas entradas cuando está activo",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -2411,7 +2411,8 @@
   "images": "Images",
   "imageViewerDownloadFailed": "Impossible d'enregistrer l'image",
   "imageViewerDownloadingTooltip": "Enregistrement de l'image",
-  "imageViewerDownloadSaved": "{fileName} enregistré dans Téléchargements/Lotti",
+  "imageViewerDownloadPermissionDenied": "Accès aux photos refusé — active-le dans les Réglages",
+  "imageViewerDownloadSaved": "{fileName} enregistré",
   "@imageViewerDownloadSaved": {
     "placeholders": {
       "fileName": {
@@ -2419,6 +2420,7 @@
       }
     }
   },
+  "imageViewerDownloadSavedToGallery": "Enregistré dans Photos",
   "imageViewerDownloadTooltip": "Télécharger l'image",
   "inactiveLabel": "Inactif",
   "inactiveSwitchDescription": "Peut être choisi pour de nouvelles entrées si actif",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -9504,11 +9504,23 @@ abstract class AppLocalizations {
   /// **'Saving image'**
   String get imageViewerDownloadingTooltip;
 
+  /// No description provided for @imageViewerDownloadPermissionDenied.
+  ///
+  /// In en, this message translates to:
+  /// **'Photo access denied — enable it in Settings'**
+  String get imageViewerDownloadPermissionDenied;
+
   /// No description provided for @imageViewerDownloadSaved.
   ///
   /// In en, this message translates to:
-  /// **'Saved {fileName} to Downloads/Lotti'**
+  /// **'Saved {fileName}'**
   String imageViewerDownloadSaved(String fileName);
+
+  /// No description provided for @imageViewerDownloadSavedToGallery.
+  ///
+  /// In en, this message translates to:
+  /// **'Saved to Photos'**
+  String get imageViewerDownloadSavedToGallery;
 
   /// No description provided for @imageViewerDownloadTooltip.
   ///

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -5544,9 +5544,16 @@ class AppLocalizationsCs extends AppLocalizations {
   String get imageViewerDownloadingTooltip => 'Ukládám obrázek';
 
   @override
+  String get imageViewerDownloadPermissionDenied =>
+      'Přístup k fotkám zamítnut – povol jej v Nastavení';
+
+  @override
   String imageViewerDownloadSaved(String fileName) {
-    return 'Uloženo $fileName do Stažené/Lotti';
+    return 'Uloženo $fileName';
   }
+
+  @override
+  String get imageViewerDownloadSavedToGallery => 'Uloženo do Fotek';
 
   @override
   String get imageViewerDownloadTooltip => 'Stáhnout obrázek';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -5537,9 +5537,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get imageViewerDownloadingTooltip => 'Bild wird gespeichert';
 
   @override
+  String get imageViewerDownloadPermissionDenied =>
+      'Fotozugriff verweigert – aktiviere ihn in den Einstellungen';
+
+  @override
   String imageViewerDownloadSaved(String fileName) {
-    return '$fileName wurde in Downloads/Lotti gespeichert';
+    return '$fileName gespeichert';
   }
+
+  @override
+  String get imageViewerDownloadSavedToGallery => 'In Fotos gespeichert';
 
   @override
   String get imageViewerDownloadTooltip => 'Bild herunterladen';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -5466,9 +5466,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get imageViewerDownloadingTooltip => 'Saving image';
 
   @override
+  String get imageViewerDownloadPermissionDenied =>
+      'Photo access denied — enable it in Settings';
+
+  @override
   String imageViewerDownloadSaved(String fileName) {
-    return 'Saved $fileName to Downloads/Lotti';
+    return 'Saved $fileName';
   }
+
+  @override
+  String get imageViewerDownloadSavedToGallery => 'Saved to Photos';
 
   @override
   String get imageViewerDownloadTooltip => 'Download image';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -5579,9 +5579,16 @@ class AppLocalizationsEs extends AppLocalizations {
   String get imageViewerDownloadingTooltip => 'Guardando imagen';
 
   @override
+  String get imageViewerDownloadPermissionDenied =>
+      'Acceso a fotos denegado: actívalo en Ajustes';
+
+  @override
   String imageViewerDownloadSaved(String fileName) {
-    return 'Se guardó $fileName en Descargas/Lotti';
+    return 'Se guardó $fileName';
   }
+
+  @override
+  String get imageViewerDownloadSavedToGallery => 'Guardado en Fotos';
 
   @override
   String get imageViewerDownloadTooltip => 'Descargar imagen';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -5586,9 +5586,16 @@ class AppLocalizationsFr extends AppLocalizations {
   String get imageViewerDownloadingTooltip => 'Enregistrement de l\'image';
 
   @override
+  String get imageViewerDownloadPermissionDenied =>
+      'Accès aux photos refusé — active-le dans les Réglages';
+
+  @override
   String imageViewerDownloadSaved(String fileName) {
-    return '$fileName enregistré dans Téléchargements/Lotti';
+    return '$fileName enregistré';
   }
+
+  @override
+  String get imageViewerDownloadSavedToGallery => 'Enregistré dans Photos';
 
   @override
   String get imageViewerDownloadTooltip => 'Télécharger l\'image';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -5590,9 +5590,16 @@ class AppLocalizationsRo extends AppLocalizations {
   String get imageViewerDownloadingTooltip => 'Se salvează imaginea';
 
   @override
+  String get imageViewerDownloadPermissionDenied =>
+      'Acces la fotografii refuzat — activați-l în Setări';
+
+  @override
   String imageViewerDownloadSaved(String fileName) {
-    return '$fileName a fost salvat în Descărcări/Lotti';
+    return '$fileName a fost salvat';
   }
+
+  @override
+  String get imageViewerDownloadSavedToGallery => 'Salvat în Fotografii';
 
   @override
   String get imageViewerDownloadTooltip => 'Descărcați imaginea';

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -2411,7 +2411,8 @@
   "images": "Imagini",
   "imageViewerDownloadFailed": "Nu s-a putut salva imaginea",
   "imageViewerDownloadingTooltip": "Se salvează imaginea",
-  "imageViewerDownloadSaved": "{fileName} a fost salvat în Descărcări/Lotti",
+  "imageViewerDownloadPermissionDenied": "Acces la fotografii refuzat — activați-l în Setări",
+  "imageViewerDownloadSaved": "{fileName} a fost salvat",
   "@imageViewerDownloadSaved": {
     "placeholders": {
       "fileName": {
@@ -2419,6 +2420,7 @@
       }
     }
   },
+  "imageViewerDownloadSavedToGallery": "Salvat în Fotografii",
   "imageViewerDownloadTooltip": "Descărcați imaginea",
   "inactiveLabel": "Inactiv",
   "inactiveSwitchDescription": "Poate fi ales pentru intrări noi când este activ",

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -14,6 +14,7 @@ import flutter_image_compress_macos
 import flutter_local_notifications
 import flutter_onnxruntime
 import flutter_secure_storage_darwin
+import gal
 import hotkey_manager_macos
 import irondash_engine_context
 import just_audio
@@ -47,6 +48,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterOnnxruntimePlugin.register(with: registry.registrar(forPlugin: "FlutterOnnxruntimePlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
+  GalPlugin.register(with: registry.registrar(forPlugin: "GalPlugin"))
   HotkeyManagerMacosPlugin.register(with: registry.registrar(forPlugin: "HotkeyManagerMacosPlugin"))
   IrondashEngineContextPlugin.register(with: registry.registrar(forPlugin: "IrondashEngineContextPlugin"))
   JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -6,6 +6,8 @@
 	<true/>
 	<key>com.apple.security.assets.pictures.read-only</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.device.audio-input</key>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -6,6 +6,8 @@
 	<true/>
 	<key>com.apple.security.assets.pictures.read-only</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
 	<key>com.apple.security.device.camera</key>

--- a/macos/Runner/RunnerDebug.entitlements
+++ b/macos/Runner/RunnerDebug.entitlements
@@ -6,6 +6,8 @@
 	<true/>
 	<key>com.apple.security.assets.pictures.read-only</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.device.audio-input</key>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1232,6 +1232,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  gal:
+    dependency: "direct main"
+    description:
+      name: gal
+      sha256: "969598f986789127fd407a750413249e1352116d4c2be66e81837ffeeaafdfee"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
   genai_primitives:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1034+4184
+version: 0.9.1034+4185
 
 msix_config:
   display_name: LottiApp
@@ -69,6 +69,7 @@ dependencies:
   form_builder_validators: ^11.0.0
   formz: ^0.8.0
   freezed_annotation: ^3.1.0
+  gal: ^2.3.2
   genui: ^0.9.0
   get_it: ^9.2.1
   glass_kit: ^4.0.1

--- a/test/features/journal/ui/widgets/entry_image_widget_test.dart
+++ b/test/features/journal/ui/widgets/entry_image_widget_test.dart
@@ -8,10 +8,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/journal/ui/widgets/entry_image_widget.dart';
+import 'package:lotti/features/journal/util/image_export_service.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations.dart';
 import 'package:lotti/services/editor_state_service.dart';
+import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/utils/image_utils.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:photo_view/photo_view.dart';
 
 import '../../../../helpers/fake_entry_controller.dart';
@@ -94,19 +97,6 @@ void _pressIconButton(WidgetTester tester, IconData icon) {
   );
   expect(button.onPressed, isNotNull);
   button.onPressed!();
-}
-
-Future<void> _runAndWaitForFileSystem(
-  WidgetTester tester,
-  VoidCallback action,
-  bool Function() isReady,
-) async {
-  await tester.runAsync(() async {
-    action();
-    for (var i = 0; i < 250 && !isReady(); i++) {
-      await Future<void>.delayed(const Duration(milliseconds: 1));
-    }
-  });
 }
 
 void main() {
@@ -306,6 +296,7 @@ void main() {
   group('HeroPhotoViewRouteWrapper', () {
     late Directory tempDir;
     late File imageFile;
+    late MockLoggingService mockLoggingService;
 
     setUp(() async {
       tempDir = Directory.systemTemp.createTempSync(
@@ -313,9 +304,15 @@ void main() {
       );
       imageFile = File('${tempDir.path}/photo.png')
         ..writeAsBytesSync(_transparentPng);
+      // The viewer logs a swallowed save failure through getIt; register a mock
+      // so that path can be asserted without a real logging backend.
+      mockLoggingService = MockLoggingService();
+      await getIt.reset();
+      getIt.registerSingleton<LoggingService>(mockLoggingService);
     });
 
     tearDown(() async {
+      await getIt.reset();
       try {
         tempDir.deleteSync(recursive: true);
       } catch (_) {
@@ -325,32 +322,8 @@ void main() {
 
     Widget buildWrapper({
       BoxDecoration? backgroundDecoration,
-      ImageViewerDownloadsDirectoryResolver? downloadsDirectoryResolver,
-      ImageViewerFileCopier? fileCopier,
+      ImageExporter? imageExporter,
     }) {
-      final wrapper = switch ((downloadsDirectoryResolver, fileCopier)) {
-        (null, null) => HeroPhotoViewRouteWrapper(
-          file: imageFile,
-          backgroundDecoration: backgroundDecoration,
-        ),
-        (final resolver?, null) => HeroPhotoViewRouteWrapper(
-          file: imageFile,
-          backgroundDecoration: backgroundDecoration,
-          downloadsDirectoryResolver: resolver,
-        ),
-        (null, final copier?) => HeroPhotoViewRouteWrapper(
-          file: imageFile,
-          backgroundDecoration: backgroundDecoration,
-          fileCopier: copier,
-        ),
-        (final resolver?, final copier?) => HeroPhotoViewRouteWrapper(
-          file: imageFile,
-          backgroundDecoration: backgroundDecoration,
-          downloadsDirectoryResolver: resolver,
-          fileCopier: copier,
-        ),
-      };
-
       return ProviderScope(
         child: MaterialApp(
           theme: resolveTestTheme(),
@@ -361,7 +334,11 @@ void main() {
             GlobalCupertinoLocalizations.delegate,
           ],
           supportedLocales: AppLocalizations.supportedLocales,
-          home: wrapper,
+          home: HeroPhotoViewRouteWrapper(
+            file: imageFile,
+            backgroundDecoration: backgroundDecoration,
+            imageExporter: imageExporter,
+          ),
         ),
       );
     }
@@ -591,98 +568,105 @@ void main() {
     );
 
     testWidgets(
-      'download button copies the image to Downloads/Lotti with a unique name',
+      'download button echoes the saved file name after a desktop save',
       (tester) async {
-        final downloadsDir = Directory('${tempDir.path}/Downloads')
-          ..createSync();
-        final lottiDownloads = Directory('${downloadsDir.path}/Lotti')
-          ..createSync();
-        File('${lottiDownloads.path}/photo.png').writeAsBytesSync([0x01]);
-        File('${lottiDownloads.path}/photo 2.png').writeAsBytesSync([0x02]);
-
+        File? savedFile;
         await tester.pumpWidget(
           buildWrapper(
-            downloadsDirectoryResolver: () => Future.value(downloadsDir),
-            fileCopier: (sourceFile, targetFile) {
-              targetFile.writeAsBytesSync(sourceFile.readAsBytesSync());
-              return Future.value(targetFile);
+            imageExporter: (file) async {
+              savedFile = file;
+              return const ImageExportResult.savedToFile('photo 3.png');
             },
           ),
         );
         await tester.pump();
 
-        final copied = File('${lottiDownloads.path}/photo 3.png');
-        final downloadButton = tester.widget<IconButton>(
-          find.widgetWithIcon(IconButton, Icons.download_rounded),
-        );
-        expect(downloadButton.onPressed, isNotNull);
-        await _runAndWaitForFileSystem(
-          tester,
-          downloadButton.onPressed!,
-          copied.existsSync,
-        );
+        _pressIconButton(tester, Icons.download_rounded);
         await tester.pump();
         await tester.pump();
 
-        expect(copied.existsSync(), isTrue);
-        expect(copied.readAsBytesSync(), _transparentPng);
+        // The original file is handed to the exporter untouched.
+        expect(savedFile?.path, imageFile.path);
+        expect(find.text('Saved photo 3.png'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'download button confirms a photo-library save on mobile',
+      (tester) async {
+        await tester.pumpWidget(
+          buildWrapper(
+            imageExporter: (_) async =>
+                const ImageExportResult.savedToGallery(),
+          ),
+        );
+        await tester.pump();
+
+        _pressIconButton(tester, Icons.download_rounded);
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.text('Saved to Photos'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'download button surfaces a permission-denied message',
+      (tester) async {
+        await tester.pumpWidget(
+          buildWrapper(
+            imageExporter: (_) async =>
+                const ImageExportResult.permissionDenied(),
+          ),
+        );
+        await tester.pump();
+
+        _pressIconButton(tester, Icons.download_rounded);
+        await tester.pump();
+        await tester.pump();
+
         expect(
-          find.text('Saved photo 3.png to Downloads/Lotti'),
+          find.text('Photo access denied — enable it in Settings'),
           findsOneWidget,
         );
       },
     );
 
     testWidgets(
-      'download button uses the default copier when the file name is free',
+      'download button stays silent and re-enables when the save is cancelled',
       (tester) async {
-        final downloadsDir = Directory('${tempDir.path}/Downloads')
-          ..createSync();
-        final lottiDownloads = Directory('${downloadsDir.path}/Lotti')
-          ..createSync();
-        final copied = File('${lottiDownloads.path}/photo.png');
-
         await tester.pumpWidget(
           buildWrapper(
-            downloadsDirectoryResolver: () => Future.value(downloadsDir),
+            imageExporter: (_) async => const ImageExportResult.cancelled(),
           ),
         );
         await tester.pump();
 
+        _pressIconButton(tester, Icons.download_rounded);
+        await tester.pump();
+        await tester.pump();
+
+        // A dismissed save panel is not an error: no feedback, button ready.
+        expect(find.byType(SnackBar), findsNothing);
+        expect(find.byIcon(Icons.hourglass_top_rounded), findsNothing);
         final downloadButton = tester.widget<IconButton>(
           find.widgetWithIcon(IconButton, Icons.download_rounded),
         );
         expect(downloadButton.onPressed, isNotNull);
-        await _runAndWaitForFileSystem(
-          tester,
-          downloadButton.onPressed!,
-          copied.existsSync,
-        );
-        await tester.pump();
-        await tester.pump();
-
-        expect(copied.existsSync(), isTrue);
-        expect(copied.readAsBytesSync(), _transparentPng);
       },
     );
 
     testWidgets(
-      'download button disables while copying and ignores duplicate taps',
+      'download button disables while saving and ignores duplicate taps',
       (tester) async {
-        final downloadsDir = Directory('${tempDir.path}/Downloads')
-          ..createSync();
-        Directory('${downloadsDir.path}/Lotti').createSync();
-        final copyCompleter = Completer<File>();
-        var copyCalls = 0;
-        late File pendingTarget;
+        final completer = Completer<ImageExportResult>();
+        var calls = 0;
 
         await tester.pumpWidget(
           buildWrapper(
-            downloadsDirectoryResolver: () => Future.value(downloadsDir),
-            fileCopier: (sourceFile, targetFile) {
-              copyCalls++;
-              pendingTarget = targetFile;
-              return copyCompleter.future;
+            imageExporter: (_) {
+              calls++;
+              return completer.future;
             },
           ),
         );
@@ -692,41 +676,34 @@ void main() {
           find.widgetWithIcon(IconButton, Icons.download_rounded),
         );
         expect(downloadButton.onPressed, isNotNull);
-        await _runAndWaitForFileSystem(
-          tester,
-          () {
-            downloadButton.onPressed!();
-            downloadButton.onPressed!();
-          },
-          () => copyCalls == 1,
-        );
+        // Two taps in the same frame: the second must be ignored while saving.
+        downloadButton.onPressed!();
+        downloadButton.onPressed!();
         await tester.pump();
 
-        expect(copyCalls, 1);
+        expect(calls, 1);
         expect(find.byTooltip('Saving image'), findsOneWidget);
         final savingButton = tester.widget<IconButton>(
           find.widgetWithIcon(IconButton, Icons.hourglass_top_rounded),
         );
         expect(savingButton.onPressed, isNull);
 
-        pendingTarget.writeAsBytesSync(imageFile.readAsBytesSync());
-        copyCompleter.complete(pendingTarget);
+        completer.complete(const ImageExportResult.savedToFile('photo.png'));
+        await tester.pump();
         await tester.pump();
 
-        expect(
-          find.text('Saved photo.png to Downloads/Lotti'),
-          findsOneWidget,
-        );
-        expect(copyCalls, 1);
+        expect(calls, 1);
+        expect(find.text('Saved photo.png'), findsOneWidget);
       },
     );
 
     testWidgets(
-      'download button reports failure when downloads are unavailable',
+      'download button reports failure and logs when the exporter throws',
       (tester) async {
         await tester.pumpWidget(
           buildWrapper(
-            downloadsDirectoryResolver: () async => null,
+            imageExporter: (_) async =>
+                throw const FileSystemException('save failed'),
           ),
         );
         await tester.pump();
@@ -736,41 +713,16 @@ void main() {
         await tester.pump();
 
         expect(find.text('Could not save image'), findsOneWidget);
-      },
-    );
-
-    testWidgets(
-      'download button reports failure when copying throws',
-      (tester) async {
-        final downloadsDir = Directory('${tempDir.path}/Downloads')
-          ..createSync();
-        Directory('${downloadsDir.path}/Lotti').createSync();
-        var copyAttempted = false;
-
-        await tester.pumpWidget(
-          buildWrapper(
-            downloadsDirectoryResolver: () => Future.value(downloadsDir),
-            fileCopier: (sourceFile, targetFile) {
-              copyAttempted = true;
-              throw const FileSystemException('copy failed');
-            },
+        verify(
+          () => mockLoggingService.captureException(
+            any<dynamic>(),
+            domain: 'entry_image_widget',
+            subDomain: 'downloadImage',
+            stackTrace: any<dynamic>(named: 'stackTrace'),
+            level: any(named: 'level'),
+            type: any(named: 'type'),
           ),
-        );
-        await tester.pump();
-
-        final downloadButton = tester.widget<IconButton>(
-          find.widgetWithIcon(IconButton, Icons.download_rounded),
-        );
-        expect(downloadButton.onPressed, isNotNull);
-        await _runAndWaitForFileSystem(
-          tester,
-          downloadButton.onPressed!,
-          () => copyAttempted,
-        );
-        await tester.pump();
-
-        expect(copyAttempted, isTrue);
-        expect(find.text('Could not save image'), findsOneWidget);
+        ).called(1);
       },
     );
 

--- a/test/features/journal/util/image_export_service_test.dart
+++ b/test/features/journal/util/image_export_service_test.dart
@@ -1,0 +1,158 @@
+import 'dart:io';
+
+import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gal/gal.dart';
+import 'package:lotti/features/journal/util/image_export_service.dart';
+
+import '../../../mocks/mocks.dart';
+
+void main() {
+  final binding = TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('saveImageViaDialog', () {
+    late Directory tempDir;
+    late File sourceFile;
+    late FakeFileSelectorPlatform fakeSelector;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('image_export_dialog_');
+      sourceFile = File('${tempDir.path}/photo.png')
+        ..writeAsBytesSync([1, 2, 3, 4]);
+      fakeSelector = FakeFileSelectorPlatform();
+      FileSelectorPlatform.instance = fakeSelector;
+    });
+
+    tearDown(() {
+      try {
+        tempDir.deleteSync(recursive: true);
+      } catch (_) {
+        // Ignore cleanup errors.
+      }
+    });
+
+    test(
+      'copies the image to the chosen location and returns its name',
+      () async {
+        final destination = Directory('${tempDir.path}/out')..createSync();
+        final target = '${destination.path}/renamed.png';
+        fakeSelector.saveLocationToReturn = FileSaveLocation(target);
+
+        final result = await saveImageViaDialog(sourceFile);
+
+        expect(result.status, ImageExportStatus.savedToFile);
+        expect(result.savedName, 'renamed.png');
+        expect(File(target).readAsBytesSync(), [1, 2, 3, 4]);
+        // The panel is seeded with the source name and scoped to its extension.
+        expect(fakeSelector.lastSuggestedName, 'photo.png');
+        expect(fakeSelector.lastAcceptedTypeGroups, hasLength(1));
+        expect(fakeSelector.lastAcceptedTypeGroups!.single.extensions, ['png']);
+      },
+    );
+
+    test('returns cancelled when the user dismisses the save panel', () async {
+      fakeSelector.saveLocationToReturn = null;
+
+      final result = await saveImageViaDialog(sourceFile);
+
+      expect(result.status, ImageExportStatus.cancelled);
+      expect(result.savedName, isNull);
+    });
+  });
+
+  group('saveImageToGallery', () {
+    const channel = MethodChannel('gal');
+    late Directory tempDir;
+    late File sourceFile;
+    late List<MethodCall> invocations;
+    late bool hasAccessResult;
+    late bool requestAccessResult;
+    PlatformException? putImageError;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('image_export_gallery_');
+      sourceFile = File('${tempDir.path}/photo.png')
+        ..writeAsBytesSync([1, 2, 3, 4]);
+      invocations = [];
+      hasAccessResult = true;
+      requestAccessResult = true;
+      putImageError = null;
+
+      binding.defaultBinaryMessenger.setMockMethodCallHandler(channel, (
+        call,
+      ) async {
+        invocations.add(call);
+        switch (call.method) {
+          case 'hasAccess':
+            return hasAccessResult;
+          case 'requestAccess':
+            return requestAccessResult;
+          case 'putImage':
+            final error = putImageError;
+            if (error != null) {
+              throw error;
+            }
+            return null;
+          default:
+            return null;
+        }
+      });
+    });
+
+    tearDown(() {
+      binding.defaultBinaryMessenger.setMockMethodCallHandler(channel, null);
+      try {
+        tempDir.deleteSync(recursive: true);
+      } catch (_) {
+        // Ignore cleanup errors.
+      }
+    });
+
+    test('saves to the gallery when access is already granted', () async {
+      final result = await saveImageToGallery(sourceFile);
+
+      expect(result.status, ImageExportStatus.savedToGallery);
+      final putImage = invocations.firstWhere((c) => c.method == 'putImage');
+      expect((putImage.arguments as Map)['path'], sourceFile.path);
+    });
+
+    test('requests access first when not yet granted, then saves', () async {
+      hasAccessResult = false;
+
+      final result = await saveImageToGallery(sourceFile);
+
+      expect(result.status, ImageExportStatus.savedToGallery);
+      expect(invocations.map((c) => c.method), contains('requestAccess'));
+      expect(invocations.map((c) => c.method), contains('putImage'));
+    });
+
+    test('returns permissionDenied when access is refused', () async {
+      hasAccessResult = false;
+      requestAccessResult = false;
+
+      final result = await saveImageToGallery(sourceFile);
+
+      expect(result.status, ImageExportStatus.permissionDenied);
+      // Access was refused, so nothing is written to the library.
+      expect(invocations.map((c) => c.method), isNot(contains('putImage')));
+    });
+
+    test('maps a gal accessDenied error to permissionDenied', () async {
+      putImageError = PlatformException(code: 'ACCESS_DENIED');
+
+      final result = await saveImageToGallery(sourceFile);
+
+      expect(result.status, ImageExportStatus.permissionDenied);
+    });
+
+    test('rethrows non-permission gal errors', () async {
+      putImageError = PlatformException(code: 'NOT_ENOUGH_SPACE');
+
+      await expectLater(
+        saveImageToGallery(sourceFile),
+        throwsA(isA<GalException>()),
+      );
+    });
+  });
+}

--- a/test/features/journal/util/image_export_service_test.dart
+++ b/test/features/journal/util/image_export_service_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:gal/gal.dart';
 import 'package:lotti/features/journal/util/image_export_service.dart';
+import 'package:lotti/utils/platform.dart';
 
 import '../../../mocks/mocks.dart';
 
@@ -15,16 +16,21 @@ void main() {
     late Directory tempDir;
     late File sourceFile;
     late FakeFileSelectorPlatform fakeSelector;
+    late FileSelectorPlatform originalPlatform;
 
     setUp(() {
       tempDir = Directory.systemTemp.createTempSync('image_export_dialog_');
       sourceFile = File('${tempDir.path}/photo.png')
         ..writeAsBytesSync([1, 2, 3, 4]);
       fakeSelector = FakeFileSelectorPlatform();
+      // Capture the real platform so the global instance can be restored,
+      // avoiding leakage into other file_selector tests in the same process.
+      originalPlatform = FileSelectorPlatform.instance;
       FileSelectorPlatform.instance = fakeSelector;
     });
 
     tearDown(() {
+      FileSelectorPlatform.instance = originalPlatform;
       try {
         tempDir.deleteSync(recursive: true);
       } catch (_) {
@@ -153,6 +159,23 @@ void main() {
         saveImageToGallery(sourceFile),
         throwsA(isA<GalException>()),
       );
+    });
+  });
+
+  group('defaultImageExporter', () {
+    late bool originalIsMobile;
+
+    setUp(() => originalIsMobile = isMobile);
+    tearDown(() => isMobile = originalIsMobile);
+
+    test('routes to the photo library on mobile', () {
+      isMobile = true;
+      expect(defaultImageExporter(), same(saveImageToGallery));
+    });
+
+    test('routes to the native save dialog on desktop', () {
+      isMobile = false;
+      expect(defaultImageExporter(), same(saveImageViaDialog));
     });
   });
 }

--- a/test/mocks/mocks.dart
+++ b/test/mocks/mocks.dart
@@ -1277,14 +1277,20 @@ class MockPathProviderPlatform extends Mock
     implements PathProviderPlatform {}
 
 /// Fake [FileSelectorPlatform] for tests that exercise the desktop file
-/// picker (`openFiles`) without hitting the native plugin. Defaults to
-/// returning no files (as if the user cancelled the dialog); set
-/// [filesToReturn] to simulate a selection.
+/// picker (`openFiles`) or save panel (`getSaveLocation`) without hitting the
+/// native plugin. Defaults to returning nothing (as if the user cancelled the
+/// dialog); set [filesToReturn] / [saveLocationToReturn] to simulate a
+/// selection.
 class FakeFileSelectorPlatform extends Fake
     with MockPlatformInterfaceMixin
     implements FileSelectorPlatform {
   List<XFile> filesToReturn = const [];
   List<XTypeGroup>? lastAcceptedTypeGroups;
+
+  /// Location returned by [getSaveLocation]; `null` simulates the user
+  /// dismissing the save panel.
+  FileSaveLocation? saveLocationToReturn;
+  String? lastSuggestedName;
 
   @override
   Future<List<XFile>> openFiles({
@@ -1294,6 +1300,16 @@ class FakeFileSelectorPlatform extends Fake
   }) async {
     lastAcceptedTypeGroups = acceptedTypeGroups;
     return filesToReturn;
+  }
+
+  @override
+  Future<FileSaveLocation?> getSaveLocation({
+    List<XTypeGroup>? acceptedTypeGroups,
+    SaveDialogOptions options = const SaveDialogOptions(),
+  }) async {
+    lastAcceptedTypeGroups = acceptedTypeGroups;
+    lastSuggestedName = options.suggestedName;
+    return saveLocationToReturn;
   }
 }
 

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -11,6 +11,7 @@
 #include <file_selector_windows/file_selector_windows.h>
 #include <flutter_onnxruntime/flutter_onnxruntime_plugin.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
+#include <gal/gal_plugin_c_api.h>
 #include <hotkey_manager_windows/hotkey_manager_windows_plugin_c_api.h>
 #include <irondash_engine_context/irondash_engine_context_plugin_c_api.h>
 #include <media_kit_libs_windows_audio/media_kit_libs_windows_audio_plugin_c_api.h>
@@ -36,6 +37,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FlutterOnnxruntimePlugin"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
+  GalPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("GalPluginCApi"));
   HotkeyManagerWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("HotkeyManagerWindowsPluginCApi"));
   IrondashEngineContextPluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -8,6 +8,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_windows
   flutter_onnxruntime
   flutter_secure_storage_windows
+  gal
   hotkey_manager_windows
   irondash_engine_context
   media_kit_libs_windows_audio


### PR DESCRIPTION
## Problem

The reworked image viewer's save/download button failed with an error on **iPhone** and **macOS**. It used one desktop-only path on every platform — `path_provider.getDownloadsDirectory()` + `File.copy` into `~/Downloads/Lotti`:

- **iPhone** — iOS has no user-facing downloads directory, so `getDownloadsDirectory()` returns null/unsupported → threw → generic "Could not save image".
- **macOS** — the app is sandboxed with no `files.downloads` write entitlement, so writing `~/Downloads/Lotti` was denied → same error.
- The `on Object` catch hid the real cause.

## Fix

Route the save through an injectable `ImageExporter` (`lib/features/journal/util/image_export_service.dart`) that picks the destination per platform:

- **iPhone / Android** → `saveImageToGallery` saves to the camera roll / gallery via the new `gal` dependency, requesting photo-add permission and reporting denials with a distinct message.
- **macOS / Windows / Linux** → `saveImageViaDialog` opens the native save panel via the existing `file_selector`, so the user picks the folder + filename and the sandbox grants write access to exactly that location. A dismissed panel is a silent cancellation, not an error.

Genuine save failures are now logged via `LoggingService` instead of being swallowed.

### Native config
- `ios/Runner/Info.plist`: add `NSPhotoLibraryAddUsageDescription`.
- `macos/Runner/*.entitlements` (all three): add `com.apple.security.files.user-selected.read-write`.

### Also
- l10n across all 6 arb files (`Saved {fileName}`, `Saved to Photos`, permission-denied message).
- Rewrote the widget download tests against a fake exporter; added `image_export_service_test.dart` covering both real exporters (mocked `file_selector` + `gal` method channel); extended the central `FakeFileSelectorPlatform`.
- CHANGELOG (under 0.9.1034), flatpak metainfo, and journal README updated.

## Verification
- `dart analyze lib` and the changed test dirs: zero warnings/infos.
- All affected tests pass (24 widget + 7 exporter unit).
- `gal` declares no Linux platform, so the Linux build/CI is unaffected; `gal` is only called on mobile.

> [!NOTE]
> The native camera-roll and save-panel flows can only be exercised on real iOS/macOS — the tests cover the logic with mocked platform layers. Worth a manual pass on an iPhone and a Mac to confirm the native behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a cross-platform image export flow: mobile saves to the photo library, while desktop opens a native save dialog.
  * Updated save notifications with separate “saved” and “saved to Photos” messaging.

* **Bug Fixes**
  * Fixed the image viewer Save button to avoid broken “Downloads/Lotti” behavior on iPhone and sandboxed macOS.
  * Improved handling for permission-denied and cancelled saves with appropriate user feedback.

* **Documentation**
  * Updated the Image Viewer save/export documentation to reflect the new mobile vs desktop behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->