### PR TITLE
perf: improve slow database queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   active filters stay visible, recording/timer/agent cards carry clearer status
   labels, agent rows can open their linked task directly, and the old tiny
   Outbox/Inbox footer is now one compact Sync strip.
+- **Habit and agent-heavy screens spend less time waiting on the database.**
+  Habit heatmaps now load only the latest completion per habit/day, and agent
+  summary/feedback paths batch payload lookups instead of firing many
+  individual reads.
 - **Entry timestamps no longer get cut off on phones.** In a task's linked
   entries, the header's date and time used to be truncated (e.g.
   `2026-07-08 14…`) when the action buttons squeezed the row on a narrow phone.

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -40,6 +40,7 @@
           <p>Choosing an AI profile or model now works on phones. Tapping a choice in an AI picker — a category's default inference profile, a profile slot's model, or an agent template or soul — used to close the whole settings page instead of the picker, so your selection was never saved. The picker now closes on its own and keeps your choice.</p>
           <p>Entry timestamps no longer get cut off on phones. In a task's linked entries, the header's date and time used to be truncated when the action buttons squeezed the row on a narrow phone. The timestamp now stacks the date over the time on two lines when space is tight, so the whole date and time stay readable.</p>
           <p>The desktop sidebar is calmer when Tasks has lots of saved filters. Saved task filters now sit in their own capped Tasks section with a More row, active filters stay visible, recording/timer/agent cards carry clearer status labels, agent rows can open their linked task directly, and the old tiny Outbox/Inbox footer is now one compact Sync strip.</p>
+          <p>Habit and agent-heavy screens spend less time waiting on the database. Habit heatmaps now load only the latest completion per habit/day, and agent summary/feedback paths batch payload lookups instead of firing many individual reads.</p>
       </description>
     </release>
     <release version="0.9.1032" date="2026-07-06">

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -63,10 +63,28 @@ const String _createIdxJournalTaskStatusPrivateSql =
     'private COLLATE BINARY ASC) '
     "WHERE type = 'Task' AND task = 1 AND deleted = FALSE";
 
+const String _createIdxJournalTasksPriorityDateSql =
+    'CREATE INDEX idx_journal_tasks_priority_date '
+    'ON journal(task_priority_rank COLLATE BINARY ASC, '
+    'date_from COLLATE BINARY DESC, '
+    'id COLLATE BINARY ASC) '
+    "WHERE type = 'Task' AND task = 1 AND deleted = FALSE";
+
+const String _createIdxJournalImportFlagDateSql =
+    'CREATE INDEX idx_journal_import_flag_date '
+    'ON journal(flag COLLATE BINARY ASC, '
+    'date_from COLLATE BINARY DESC, '
+    'id COLLATE BINARY ASC) '
+    'WHERE deleted = FALSE';
+
 const String _createIdxJournalQuantLatestSql =
     'CREATE INDEX IF NOT EXISTS idx_journal_quant_latest '
     'ON journal(subtype COLLATE BINARY ASC, date_from COLLATE BINARY DESC) '
     "WHERE type = 'QuantitativeEntry' AND deleted = FALSE";
+
+const String _createIdxConflictsStatusCreatedSql =
+    'CREATE INDEX IF NOT EXISTS idx_conflicts_status_created_at '
+    'ON conflicts(status ASC, created_at DESC)';
 
 /// SQL subquery that resolves the most-recent active ProjectLink for a task.
 /// Used both during migration back-fill and in [JournalDb.upsertJournalDbEntity]
@@ -128,7 +146,7 @@ class JournalDb extends _$JournalDb
   final Directory? _documentsDirectory;
 
   @override
-  int get schemaVersion => 43;
+  int get schemaVersion => 44;
 
   // Check whether a column exists in a given table to make migrations safer
   @override

--- a/lib/database/database.drift
+++ b/lib/database/database.drift
@@ -252,6 +252,13 @@ CREATE INDEX idx_label_definitions_deleted_private_name ON label_definitions(
   private COLLATE BINARY ASC,
   name COLLATE NOCASE ASC
 );
+-- Companion for `allLabelDefinitions`, which filters only deleted rows and
+-- orders by `name COLLATE NOCASE`. The private-aware index above cannot stream
+-- a global name order when `private` is unconstrained.
+CREATE INDEX idx_label_definitions_deleted_name_nocase ON label_definitions(
+  deleted COLLATE BINARY ASC,
+  name COLLATE NOCASE ASC
+);
 
 CREATE TABLE dashboard_definitions (
   id TEXT NOT NULL,

--- a/lib/database/database.drift
+++ b/lib/database/database.drift
@@ -37,6 +37,16 @@ CREATE INDEX idx_journal_date_to_asc ON journal (date_to ASC);
 CREATE INDEX idx_journal_date_to_desc ON journal (date_to DESC);
 
 CREATE INDEX idx_journal_tab ON journal(type COLLATE BINARY ASC, starred COLLATE BINARY ASC, flag COLLATE BINARY ASC, private COLLATE BINARY ASC, date_from COLLATE BINARY DESC);
+-- Supports the import-flag maintenance views: `countImportFlagEntries` filters
+-- by `flag = 1`, while `entriesFlaggedImport` needs the same subset ordered by
+-- newest entry first. The broad tab index leads with type/starred and cannot
+-- serve either shape when no type filter is present.
+CREATE INDEX idx_journal_import_flag_date ON journal(
+  flag COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE deleted = FALSE;
 CREATE INDEX idx_journal_browse ON journal(
   deleted COLLATE BINARY ASC,
   type COLLATE BINARY ASC,
@@ -129,6 +139,20 @@ CREATE INDEX idx_journal_tasks_status_priority_date ON journal(
 WHERE type = 'Task'
   AND task = 1
   AND deleted = FALSE;
+-- Covers broad task lists where the UI selects multiple task statuses and many
+-- categories. The status-leading index above is efficient for single-status
+-- reads, but it cannot satisfy the global `ORDER BY task_priority_rank ASC,
+-- date_from DESC` across several status partitions; this priority-leading
+-- partial lets SQLite stream the UI order directly and apply status/category
+-- filters as residual predicates until LIMIT is satisfied.
+CREATE INDEX idx_journal_tasks_priority_date ON journal(
+  task_priority_rank COLLATE BINARY ASC,
+  date_from COLLATE BINARY DESC,
+  id COLLATE BINARY ASC
+)
+WHERE type = 'Task'
+  AND task = 1
+  AND deleted = FALSE;
 
 -- Partial covering index for the Insights time-analysis query (v43 in
 -- migrations). Only `date_from < :end` can be a seek bound — the
@@ -155,6 +179,9 @@ CREATE TABLE conflicts (
   status INTEGER NOT NULL,
   PRIMARY KEY (id)
 );
+
+CREATE INDEX idx_conflicts_status_created_at
+ON conflicts(status ASC, created_at DESC);
 
 CREATE TABLE measurable_types (
   id TEXT NOT NULL,

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -5653,6 +5653,10 @@ abstract class _$JournalDb extends GeneratedDatabase {
     'idx_label_definitions_deleted_private_name',
     'CREATE INDEX idx_label_definitions_deleted_private_name ON label_definitions (deleted COLLATE BINARY ASC, private COLLATE BINARY ASC, name COLLATE NOCASE ASC)',
   );
+  late final Index idxLabelDefinitionsDeletedNameNocase = Index(
+    'idx_label_definitions_deleted_name_nocase',
+    'CREATE INDEX idx_label_definitions_deleted_name_nocase ON label_definitions (deleted COLLATE BINARY ASC, name COLLATE NOCASE ASC)',
+  );
   late final DashboardDefinitions dashboardDefinitions = DashboardDefinitions(
     this,
   );
@@ -7806,6 +7810,7 @@ abstract class _$JournalDb extends GeneratedDatabase {
     idxLabelDefinitionsName,
     idxLabelDefinitionsPrivate,
     idxLabelDefinitionsDeletedPrivateName,
+    idxLabelDefinitionsDeletedNameNocase,
     dashboardDefinitions,
     idxDashboardDefinitionsId,
     idxDashboardDefinitionsName,

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -5546,6 +5546,10 @@ abstract class _$JournalDb extends GeneratedDatabase {
     'idx_journal_tab',
     'CREATE INDEX idx_journal_tab ON journal (type COLLATE BINARY ASC, starred COLLATE BINARY ASC, flag COLLATE BINARY ASC, private COLLATE BINARY ASC, date_from COLLATE BINARY DESC)',
   );
+  late final Index idxJournalImportFlagDate = Index(
+    'idx_journal_import_flag_date',
+    'CREATE INDEX idx_journal_import_flag_date ON journal (flag COLLATE BINARY ASC, date_from COLLATE BINARY DESC, id COLLATE BINARY ASC) WHERE deleted = FALSE',
+  );
   late final Index idxJournalBrowse = Index(
     'idx_journal_browse',
     'CREATE INDEX idx_journal_browse ON journal (deleted COLLATE BINARY ASC, type COLLATE BINARY ASC, date_from COLLATE BINARY DESC)',
@@ -5586,11 +5590,19 @@ abstract class _$JournalDb extends GeneratedDatabase {
     'idx_journal_tasks_status_priority_date',
     'CREATE INDEX idx_journal_tasks_status_priority_date ON journal (task_status COLLATE BINARY ASC, task_priority_rank COLLATE BINARY ASC, date_from COLLATE BINARY DESC) WHERE type = \'Task\' AND task = 1 AND deleted = FALSE',
   );
+  late final Index idxJournalTasksPriorityDate = Index(
+    'idx_journal_tasks_priority_date',
+    'CREATE INDEX idx_journal_tasks_priority_date ON journal (task_priority_rank COLLATE BINARY ASC, date_from COLLATE BINARY DESC, id COLLATE BINARY ASC) WHERE type = \'Task\' AND task = 1 AND deleted = FALSE',
+  );
   late final Index idxJournalInsightsTime = Index(
     'idx_journal_insights_time',
     'CREATE INDEX idx_journal_insights_time ON journal (date_from COLLATE BINARY ASC, date_to COLLATE BINARY ASC, category COLLATE BINARY ASC, private COLLATE BINARY ASC, id COLLATE BINARY ASC) WHERE type = \'JournalEntry\' AND deleted = FALSE',
   );
   late final Conflicts conflicts = Conflicts(this);
+  late final Index idxConflictsStatusCreatedAt = Index(
+    'idx_conflicts_status_created_at',
+    'CREATE INDEX idx_conflicts_status_created_at ON conflicts (status ASC, created_at DESC)',
+  );
   late final MeasurableTypes measurableTypes = MeasurableTypes(this);
   late final HabitDefinitions habitDefinitions = HabitDefinitions(this);
   late final Index idxHabitDefinitionsId = Index(
@@ -7764,6 +7776,7 @@ abstract class _$JournalDb extends GeneratedDatabase {
     idxJournalDateToAsc,
     idxJournalDateToDesc,
     idxJournalTab,
+    idxJournalImportFlagDate,
     idxJournalBrowse,
     idxJournalTasks,
     idxJournalTasksDate,
@@ -7774,8 +7787,10 @@ abstract class _$JournalDb extends GeneratedDatabase {
     idxJournalProjectId,
     idxJournalProjectTaskStatus,
     idxJournalTasksStatusPriorityDate,
+    idxJournalTasksPriorityDate,
     idxJournalInsightsTime,
     conflicts,
+    idxConflictsStatusCreatedAt,
     measurableTypes,
     habitDefinitions,
     idxHabitDefinitionsId,

--- a/lib/database/database_data_queries.dart
+++ b/lib/database/database_data_queries.dart
@@ -33,14 +33,47 @@ mixin _JournalDbDataQueries on _$JournalDb, _JournalDbConfigFlags {
 
   /// Returns habit completions from [rangeStart] to now.
   ///
-  /// Raw database rows are converted to journal entities and collapsed with
-  /// [latestHabitCompletionsByDay], so callers get one latest write per
-  /// habit/day instead of every stored completion row.
+  /// The SQL ranks writes by the same last-write-wins contract as
+  /// [latestHabitCompletionsByDay] and returns only the winning row per
+  /// habit/day. This keeps the heatmap path from materialising every historic
+  /// habit write when only one row per day can affect the result.
   Future<List<JournalEntity>> getHabitCompletionsInRange({
     required DateTime rangeStart,
   }) async {
-    final res = await habitCompletionsInRange(rangeStart).get();
-    return latestHabitCompletionsByDay(res.map(fromDbEntity));
+    final rows = await customSelect(
+      r'''
+        SELECT *
+        FROM (
+          SELECT
+            journal.*,
+            ROW_NUMBER() OVER (
+              PARTITION BY
+                json_extract(serialized, '$.data.habitId'),
+                date(date_from, 'unixepoch', 'localtime')
+              ORDER BY
+                updated_at DESC,
+                created_at DESC,
+                date_to DESC,
+                id DESC
+            ) AS rn
+          FROM journal
+          WHERE type = 'HabitCompletionEntry'
+            AND private IN (
+              0,
+              (SELECT status FROM config_flags WHERE name = 'private')
+            )
+            AND date_from >= ?
+            AND deleted = FALSE
+        )
+        WHERE rn = 1
+        ORDER BY date_from ASC,
+          json_extract(serialized, '$.data.habitId') ASC
+      ''',
+      variables: [Variable<DateTime>(rangeStart)],
+      readsFrom: {journal, configFlags},
+    ).get();
+
+    return rows.map((row) => fromDbEntity(journal.map(row.data))).toList();
   }
 
   Future<DayPlanEntry?> getDayPlanById(String id) async {

--- a/lib/database/database_insights_queries.dart
+++ b/lib/database/database_insights_queries.dart
@@ -48,6 +48,12 @@ mixin _JournalDbInsightsQueries on _$JournalDb {
   }) async {
     final rows = await customSelect(
       '''
+        WITH private_flag AS (
+          SELECT COALESCE(
+            (SELECT status FROM config_flags WHERE name = 'private'),
+            FALSE
+          ) AS visible
+        )
         SELECT
           j.date_from AS date_from,
           j.date_to AS date_to,
@@ -61,22 +67,20 @@ mixin _JournalDbInsightsQueries on _$JournalDb {
                 AND t.type = 'Task'
                 AND t.deleted = FALSE
                 AND t.category != ''
-                AND COALESCE(t.private, FALSE) IN
-                  (FALSE, (SELECT status FROM config_flags
-                           WHERE name = 'private'))
+                AND COALESCE(t.private, FALSE) IN (FALSE, pf.visible)
               ORDER BY t.date_from DESC, t.id
               LIMIT 1
             ),
             NULLIF(j.category, '')
           ) AS category_id
-        FROM journal j
+        FROM journal j INDEXED BY idx_journal_insights_time
+        CROSS JOIN private_flag pf
         WHERE j.type = 'JournalEntry'
           AND j.deleted = FALSE
           AND j.date_to > ?
           AND j.date_from < ?
           AND j.date_to > j.date_from
-          AND COALESCE(j.private, FALSE) IN
-            (FALSE, (SELECT status FROM config_flags WHERE name = 'private'))
+          AND COALESCE(j.private, FALSE) IN (FALSE, pf.visible)
         ORDER BY j.date_from
       ''',
       variables: [Variable<DateTime>(start), Variable<DateTime>(end)],

--- a/lib/database/database_migration.dart
+++ b/lib/database/database_migration.dart
@@ -19,6 +19,9 @@ mixin _JournalDbMigration on _$JournalDb, _JournalDbMigrationRecent {
         if (await _tableExists('journal')) {
           await customStatement(_createIdxJournalQuantLatestSql);
         }
+        if (await _tableExists('conflicts')) {
+          await customStatement(_createIdxConflictsStatusCreatedSql);
+        }
       },
       onCreate: (Migrator m) async {
         return m.createAll();

--- a/lib/database/database_migration_recent.dart
+++ b/lib/database/database_migration_recent.dart
@@ -174,5 +174,33 @@ mixin _JournalDbMigrationRecent on _$JournalDb {
         }
       }();
     }
+    if (from < 44) {
+      await () async {
+        DevLogger.log(
+          name: 'JournalDb',
+          message:
+              'Adding priority/date partial index for broad task-list reads',
+        );
+        if (await _tableExists('journal') &&
+            await _columnExists('journal', 'task_priority_rank')) {
+          await customStatement(
+            _createIdxJournalTasksPriorityDateSql.replaceFirst(
+              'CREATE INDEX ',
+              'CREATE INDEX IF NOT EXISTS ',
+            ),
+          );
+        }
+        if (await _tableExists('journal') &&
+            await _columnExists('journal', 'flag')) {
+          await customStatement(
+            _createIdxJournalImportFlagDateSql.replaceFirst(
+              'CREATE INDEX ',
+              'CREATE INDEX IF NOT EXISTS ',
+            ),
+          );
+        }
+        await customStatement('ANALYZE');
+      }();
+    }
   }
 }

--- a/lib/database/database_migration_recent.dart
+++ b/lib/database/database_migration_recent.dart
@@ -179,7 +179,8 @@ mixin _JournalDbMigrationRecent on _$JournalDb {
         DevLogger.log(
           name: 'JournalDb',
           message:
-              'Adding priority/date partial index for broad task-list reads',
+              'Adding indexes for broad task-list, import-flag, and '
+              'label-definition reads',
         );
         if (await _tableExists('journal') &&
             await _columnExists('journal', 'task_priority_rank')) {
@@ -197,6 +198,15 @@ mixin _JournalDbMigrationRecent on _$JournalDb {
               'CREATE INDEX ',
               'CREATE INDEX IF NOT EXISTS ',
             ),
+          );
+        }
+        if (await _tableExists('label_definitions')) {
+          await customStatement(
+            'CREATE INDEX IF NOT EXISTS '
+            'idx_label_definitions_deleted_name_nocase '
+            'ON label_definitions('
+            '  deleted COLLATE BINARY ASC, '
+            '  name COLLATE NOCASE ASC)',
           );
         }
         await customStatement('ANALYZE');

--- a/lib/database/database_task_query_builders.dart
+++ b/lib/database/database_task_query_builders.dart
@@ -182,6 +182,22 @@ mixin _JournalDbTaskQueriesBuilders on _$JournalDb, _JournalDbConfigFlags {
     final filterByPriorities = selectedPriorities.isNotEmpty;
     final dbSelectedPriorities = selectedPriorities.cast<String?>();
 
+    if (!sortByDate &&
+        ids == null &&
+        !filterByLabels &&
+        !filterByPriorities &&
+        taskStatuses.length > 1 &&
+        categoryIds.length > 8) {
+      return _selectBroadPriorityOrderedTasks(
+        starredStatuses: starredStatuses,
+        privateStatuses: privateStatuses,
+        taskStatuses: taskStatuses,
+        categoryIds: categoryIds,
+        limit: limit,
+        offset: offset,
+      );
+    }
+
     if (ids == null && matchesAllPrivateStates && matchesAllStarredStates) {
       if (!filterByLabels) {
         if (sortByDate) {
@@ -380,5 +396,54 @@ mixin _JournalDbTaskQueriesBuilders on _$JournalDb, _JournalDbConfigFlags {
               offset,
             );
     }
+  }
+
+  Selectable<JournalDbEntity> _selectBroadPriorityOrderedTasks({
+    required List<bool> starredStatuses,
+    required List<bool> privateStatuses,
+    required List<String> taskStatuses,
+    required List<String> categoryIds,
+    required int limit,
+    required int offset,
+  }) {
+    if (starredStatuses.isEmpty || privateStatuses.isEmpty) {
+      return emptyJournalSelection();
+    }
+
+    final variables = <Variable<Object>>[];
+    final buf = StringBuffer()
+      ..write('SELECT * FROM journal ')
+      ..write('INDEXED BY idx_journal_tasks_priority_date ')
+      ..write("WHERE type = 'Task' AND deleted = FALSE AND task = 1 ");
+
+    void addInClause<T extends Object>(String column, Iterable<T> values) {
+      buf.write('AND $column IN (');
+      var index = 0;
+      for (final value in values) {
+        if (index > 0) buf.write(', ');
+        variables.add(Variable<T>(value));
+        buf.write('?${variables.length}');
+        index++;
+      }
+      buf.write(') ');
+    }
+
+    addInClause<String>('task_status', taskStatuses);
+    addInClause<String>('category', categoryIds);
+    addInClause<bool>('private', privateStatuses);
+    addInClause<bool>('starred', starredStatuses);
+
+    buf
+      ..write('ORDER BY task_priority_rank ASC, date_from DESC ')
+      ..write('LIMIT ')
+      ..write(limit)
+      ..write(' OFFSET ')
+      ..write(offset);
+
+    return customSelect(
+      buf.toString(),
+      variables: variables,
+      readsFrom: {journal},
+    ).asyncMap(journal.mapFromRow);
   }
 }

--- a/lib/database/editor_db.dart
+++ b/lib/database/editor_db.dart
@@ -158,12 +158,23 @@ class EditorDb extends _$EditorDb {
       return null;
     }
 
-    final res = await latestDraft(entryId, lastSaved).get();
-
-    if (res.isNotEmpty) {
-      return res.first;
-    } else {
-      return null;
-    }
+    final row = await customSelect(
+      '''
+      SELECT *
+      FROM editor_drafts INDEXED BY editor_drafts_latest_draft
+      WHERE entry_id = ?
+        AND last_saved = ?
+        AND status = 'DRAFT'
+      ORDER BY created_at DESC
+      LIMIT 1
+      ''',
+      variables: [
+        Variable.withString(entryId),
+        Variable.withDateTime(lastSaved),
+      ],
+      readsFrom: {editorDrafts},
+    ).getSingleOrNull();
+    if (row == null) return null;
+    return editorDrafts.mapFromRow(row);
   }
 }

--- a/lib/database/editor_db.drift
+++ b/lib/database/editor_db.drift
@@ -34,4 +34,5 @@ SELECT * from editor_drafts
   WHERE entry_id = :entry_id
   AND last_saved = :last_saved
   AND status = 'DRAFT'
-  ORDER BY created_at DESC;
+  ORDER BY created_at DESC
+  LIMIT 1;

--- a/lib/database/editor_db.g.dart
+++ b/lib/database/editor_db.g.dart
@@ -450,7 +450,7 @@ abstract class _$EditorDb extends GeneratedDatabase {
 
   Selectable<EditorDraftState> latestDraft(String entryId, DateTime lastSaved) {
     return customSelect(
-      'SELECT * FROM editor_drafts WHERE entry_id = ?1 AND last_saved = ?2 AND status = \'DRAFT\' ORDER BY created_at DESC',
+      'SELECT * FROM editor_drafts WHERE entry_id = ?1 AND last_saved = ?2 AND status = \'DRAFT\' ORDER BY created_at DESC LIMIT 1',
       variables: [Variable<String>(entryId), Variable<DateTime>(lastSaved)],
       readsFrom: {editorDrafts},
     ).asyncMap(editorDrafts.mapFromRow);

--- a/lib/database/sync_db.dart
+++ b/lib/database/sync_db.dart
@@ -24,6 +24,10 @@ const syncDbFileName = 'sync.sqlite';
 
 const _dropIdxOutboxSendingExpiry =
     'DROP INDEX IF EXISTS idx_outbox_sending_expiry';
+const _createIdxOutboxSentUpdatedAt =
+    'CREATE INDEX IF NOT EXISTS idx_outbox_sent_updated_at '
+    'ON outbox (updated_at, id) '
+    'WHERE status = 1';
 
 const _createSyncSequenceWatermarks = '''
 CREATE TABLE IF NOT EXISTS sync_sequence_watermarks (
@@ -77,7 +81,7 @@ class SyncDatabase extends _$SyncDatabase
   bool inMemoryDatabase = false;
 
   @override
-  int get schemaVersion => 24;
+  int get schemaVersion => 26;
 
   @override
   MigrationStrategy get migration {
@@ -85,6 +89,7 @@ class SyncDatabase extends _$SyncDatabase
       onCreate: (Migrator m) async {
         await m.createAll();
         await customStatement(_dropIdxOutboxSendingExpiry);
+        await customStatement(_createIdxOutboxSentUpdatedAt);
         await customStatement(_createSyncSequenceWatermarks);
         await customStatement(_idxInboundEventQueueActiveStatusRoom);
       },
@@ -526,6 +531,43 @@ class SyncDatabase extends _$SyncDatabase
             'WHERE status IN (0, 3, 4, 5, 8)',
           );
           await customStatement('ANALYZE');
+        }
+        if (from < 25) {
+          // `oldestOutboxItems` and both `claimNextOutboxBatch` branches order
+          // by `(priority, created_at, id)`. The previous actionable partial
+          // index omitted `id`, which left the planner free to sort the final
+          // tie-breaker term under high outbox churn. Rebuild it with the full
+          // ordering tuple while keeping the public index name stable.
+          final outboxExists = await customSelect(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' "
+            "AND name = 'outbox'",
+          ).getSingleOrNull();
+          if (outboxExists != null) {
+            await customStatement(
+              'DROP INDEX IF EXISTS idx_outbox_actionable_priority_created_at',
+            );
+            await customStatement(
+              'CREATE INDEX IF NOT EXISTS '
+              'idx_outbox_actionable_priority_created_at '
+              'ON outbox (priority, created_at, id) '
+              'WHERE status IN (0, 3)',
+            );
+            await customStatement('ANALYZE');
+          }
+        }
+        if (from < 26) {
+          // `pruneSentOutboxItemsChunked`, `getSentCountSince`, and daily
+          // outbox volume all filter sent rows by updated_at. The older
+          // status/priority/created index keeps them status-bounded but still
+          // walks large sent ledgers to apply the updated_at range.
+          final outboxExists = await customSelect(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' "
+            "AND name = 'outbox'",
+          ).getSingleOrNull();
+          if (outboxExists != null) {
+            await customStatement(_createIdxOutboxSentUpdatedAt);
+            await customStatement('ANALYZE');
+          }
         }
       },
     );

--- a/lib/database/sync_db.dart
+++ b/lib/database/sync_db.dart
@@ -28,6 +28,10 @@ const _createIdxOutboxSentUpdatedAt =
     'CREATE INDEX IF NOT EXISTS idx_outbox_sent_updated_at '
     'ON outbox (updated_at, id) '
     'WHERE status = 1';
+const _createIdxOutboxActionableSubject =
+    'CREATE INDEX IF NOT EXISTS idx_outbox_actionable_subject '
+    'ON outbox (subject) '
+    'WHERE status IN (0, 3)';
 
 const _createSyncSequenceWatermarks = '''
 CREATE TABLE IF NOT EXISTS sync_sequence_watermarks (
@@ -81,7 +85,7 @@ class SyncDatabase extends _$SyncDatabase
   bool inMemoryDatabase = false;
 
   @override
-  int get schemaVersion => 26;
+  int get schemaVersion => 27;
 
   @override
   MigrationStrategy get migration {
@@ -92,6 +96,7 @@ class SyncDatabase extends _$SyncDatabase
         await customStatement(_createIdxOutboxSentUpdatedAt);
         await customStatement(_createSyncSequenceWatermarks);
         await customStatement(_idxInboundEventQueueActiveStatusRoom);
+        await customStatement(_createIdxOutboxActionableSubject);
       },
       onUpgrade: (Migrator m, int from, int to) async {
         if (from < 2) {
@@ -566,6 +571,22 @@ class SyncDatabase extends _$SyncDatabase
           ).getSingleOrNull();
           if (outboxExists != null) {
             await customStatement(_createIdxOutboxSentUpdatedAt);
+            await customStatement('ANALYZE');
+          }
+        }
+        if (from < 27) {
+          // `getPendingBackfillEntries` checks the outbox for queued
+          // backfillRequest messages on every automatic backfill tick. The
+          // generic actionable index can prove `status IN (0,3)`, but still
+          // has to scan every pending/sending row to apply the subject prefix.
+          // A subject-keyed partial index lets the query range-scan only
+          // `backfillRequest:` rows.
+          final outboxExists = await customSelect(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' "
+            "AND name = 'outbox'",
+          ).getSingleOrNull();
+          if (outboxExists != null) {
+            await customStatement(_createIdxOutboxActionableSubject);
             await customStatement('ANALYZE');
           }
         }

--- a/lib/database/sync_db.g.dart
+++ b/lib/database/sync_db.g.dart
@@ -2943,7 +2943,7 @@ abstract class _$SyncDatabase extends GeneratedDatabase {
   );
   late final Index idxOutboxActionablePriorityCreatedAt = Index(
     'idx_outbox_actionable_priority_created_at',
-    'CREATE INDEX idx_outbox_actionable_priority_created_at ON outbox (priority, created_at) WHERE status IN (0, 3)',
+    'CREATE INDEX idx_outbox_actionable_priority_created_at ON outbox (priority, created_at, id) WHERE status IN (0, 3)',
   );
   late final Index idxOutboxPendingEntryIdCreatedAt = Index(
     'idx_outbox_pending_entry_id_created_at',
@@ -2956,6 +2956,10 @@ abstract class _$SyncDatabase extends GeneratedDatabase {
   late final Index idxOutboxSendingExpiry = Index(
     'idx_outbox_sending_expiry',
     'CREATE INDEX idx_outbox_sending_expiry ON outbox (created_at, id, updated_at) WHERE status = 3',
+  );
+  late final Index idxOutboxSentUpdatedAt = Index(
+    'idx_outbox_sent_updated_at',
+    'CREATE INDEX idx_outbox_sent_updated_at ON outbox (updated_at, id) WHERE status = 1',
   );
   late final Index idxSyncSequenceLogActionableStatusCreatedAt = Index(
     'idx_sync_sequence_log_actionable_status_created_at',
@@ -3040,6 +3044,7 @@ abstract class _$SyncDatabase extends GeneratedDatabase {
     idxOutboxPendingEntryIdCreatedAt,
     idxOutboxPendingCreatedId,
     idxOutboxSendingExpiry,
+    idxOutboxSentUpdatedAt,
     idxSyncSequenceLogActionableStatusCreatedAt,
     idxSyncSequenceLogActionableStatusUpdatedAt,
     idxSyncSequenceLogActionableStatusLastRequestedAt,

--- a/lib/database/sync_db.g.dart
+++ b/lib/database/sync_db.g.dart
@@ -2945,6 +2945,10 @@ abstract class _$SyncDatabase extends GeneratedDatabase {
     'idx_outbox_actionable_priority_created_at',
     'CREATE INDEX idx_outbox_actionable_priority_created_at ON outbox (priority, created_at, id) WHERE status IN (0, 3)',
   );
+  late final Index idxOutboxActionableSubject = Index(
+    'idx_outbox_actionable_subject',
+    'CREATE INDEX idx_outbox_actionable_subject ON outbox (subject) WHERE status IN (0, 3)',
+  );
   late final Index idxOutboxPendingEntryIdCreatedAt = Index(
     'idx_outbox_pending_entry_id_created_at',
     'CREATE INDEX idx_outbox_pending_entry_id_created_at ON outbox (outbox_entry_id, created_at) WHERE status = 0 AND outbox_entry_id IS NOT NULL',
@@ -3041,6 +3045,7 @@ abstract class _$SyncDatabase extends GeneratedDatabase {
     queueMarkers,
     idxOutboxStatusPriorityCreatedAt,
     idxOutboxActionablePriorityCreatedAt,
+    idxOutboxActionableSubject,
     idxOutboxPendingEntryIdCreatedAt,
     idxOutboxPendingCreatedId,
     idxOutboxSendingExpiry,

--- a/lib/database/sync_db_outbox.dart
+++ b/lib/database/sync_db_outbox.dart
@@ -256,12 +256,9 @@ mixin _SyncDbOutbox on _$SyncDatabase {
   /// Used by the badge to show how many items still need to be sent.
   Stream<int> watchOutboxCount() {
     return customSelect(
-      'SELECT COUNT(id) AS cnt FROM outbox '
-      'WHERE status IN (?, ?)',
-      variables: [
-        Variable.withInt(OutboxStatus.pending.index),
-        Variable.withInt(_outboxSendingStatus),
-      ],
+      'SELECT COUNT(*) AS cnt '
+      'FROM outbox INDEXED BY idx_outbox_actionable_priority_created_at '
+      'WHERE status IN (0, 3)',
       readsFrom: {outbox},
     ).watchSingle().map((row) => row.read<int>('cnt'));
   }

--- a/lib/database/sync_db_outbox_dedup.dart
+++ b/lib/database/sync_db_outbox_dedup.dart
@@ -146,12 +146,11 @@ mixin _SyncDbOutboxDedup on _$SyncDatabase {
       "SELECT strftime('%Y-%m-%d', updated_at, 'unixepoch') AS day, "
       'COALESCE(SUM(payload_size), 0) AS total_bytes, '
       'COUNT(*) AS item_count '
-      'FROM outbox '
-      'WHERE status = ? AND updated_at >= ? '
+      'FROM outbox INDEXED BY idx_outbox_sent_updated_at '
+      'WHERE status = 1 AND updated_at >= ? '
       'GROUP BY day '
       'ORDER BY day ASC',
       variables: [
-        Variable.withInt(OutboxStatus.sent.index),
         Variable.withInt(cutoffSeconds),
       ],
     ).get();
@@ -182,13 +181,13 @@ mixin _SyncDbOutboxDedup on _$SyncDatabase {
 
   /// Count of outbox items with status = sent and updatedAt >= [since].
   Future<int> getSentCountSince(DateTime since) async {
-    final query = selectOnly(outbox)
-      ..addColumns([outbox.id.count()])
-      ..where(
-        outbox.status.equals(OutboxStatus.sent.index) &
-            outbox.updatedAt.isBiggerOrEqualValue(since),
-      );
-    final result = await query.getSingle();
-    return result.read(outbox.id.count()) ?? 0;
+    final result = await customSelect(
+      'SELECT COUNT(*) AS cnt '
+      'FROM outbox INDEXED BY idx_outbox_sent_updated_at '
+      'WHERE status = 1 AND updated_at >= ?',
+      variables: [Variable.withDateTime(since)],
+      readsFrom: {outbox},
+    ).getSingle();
+    return result.read<int>('cnt');
   }
 }

--- a/lib/database/sync_db_outbox_dedup.dart
+++ b/lib/database/sync_db_outbox_dedup.dart
@@ -27,21 +27,31 @@ mixin _SyncDbOutboxDedup on _$SyncDatabase {
   ///    `_outboxSendingStatus = 3` — the guard test in
   ///    `test/database/sync_db_test.dart` asserts the partial-index
   ///    declaration stays in sync with this assumption.
-  /// 2. `subject LIKE 'backfillRequest:%'` — `_enqueueBackfillRequest`
-  ///    sets `subject` to `'backfillRequest:batch:N'` for every backfill
-  ///    request enqueue, so the prefix is a reliable marker. Without
-  ///    this filter we materialise every actionable row and JSON-decode
-  ///    each one to find the tiny subset of backfill requests; with it,
-  ///    only the matching rows are decoded.
+  /// 2. Subject prefix range — `_enqueueBackfillRequest` sets `subject` to
+  ///    `'backfillRequest:batch:N'` for every backfill
+  ///    request enqueue, so the prefix is a reliable marker. The SQL uses
+  ///    a bounded prefix range (`>= 'backfillRequest:'` and
+  ///    `< 'backfillRequest;'`) so SQLite can range-scan
+  ///    `idx_outbox_actionable_subject` instead of walking every actionable
+  ///    row and testing `LIKE`.
   Future<Set<({String hostId, int counter})>>
   getPendingBackfillEntries() async {
-    final pendingItems =
-        await (select(outbox)..where(
-              (t) =>
-                  const CustomExpression<bool>('status IN (0, 3)') &
-                  t.subject.like('backfillRequest:%'),
-            ))
-            .get();
+    const prefix = 'backfillRequest:';
+    const upperBound = 'backfillRequest;';
+    final pendingItems = await customSelect(
+      '''
+      SELECT *
+      FROM outbox INDEXED BY idx_outbox_actionable_subject
+      WHERE status IN (0, 3)
+        AND subject >= ?
+        AND subject < ?
+      ''',
+      variables: [
+        const Variable<String>(prefix),
+        const Variable<String>(upperBound),
+      ],
+      readsFrom: {outbox},
+    ).asyncMap(outbox.mapFromRow).get();
 
     final entries = <({String hostId, int counter})>{};
 

--- a/lib/database/sync_db_outbox_prune.dart
+++ b/lib/database/sync_db_outbox_prune.dart
@@ -32,12 +32,12 @@ mixin _SyncDbOutboxPrune on _$SyncDatabase {
   }) {
     final effectiveNow = now ?? DateTime.now();
     final cutoff = effectiveNow.subtract(retention);
-    return (delete(outbox)..where(
-          (t) =>
-              t.status.equals(OutboxStatus.sent.index) &
-              t.updatedAt.isSmallerThanValue(cutoff),
-        ))
-        .go();
+    return customUpdate(
+      'DELETE FROM outbox '
+      'WHERE status = 1 AND updated_at < ?',
+      variables: [Variable.withDateTime(cutoff)],
+      updates: {outbox},
+    );
   }
 
   /// Same retention semantics as [pruneSentOutboxItems], but deletes in
@@ -78,21 +78,18 @@ mixin _SyncDbOutboxPrune on _$SyncDatabase {
     if (chunkSize <= 0) return 0;
     final effectiveNow = now ?? DateTime.now();
     final cutoff = effectiveNow.subtract(retention);
-    final sentStatus = OutboxStatus.sent.index;
     var total = 0;
     while (true) {
       // Subquery on `id` lets us bound a single statement's row count via
       // LIMIT — drift's `delete(...).where(...)` does not expose LIMIT
-      // directly. The inner SELECT walks
-      // `idx_outbox_status_priority_created_at` (status leading column) so
-      // it is index-bounded, not a scan.
+      // directly. The inner SELECT walks the sent-ledger partial index by
+      // `updated_at`, so each pass touches only eligible stale sent rows.
       final n = await customUpdate(
         'DELETE FROM outbox WHERE id IN '
-        '(SELECT id FROM outbox '
-        'WHERE status = ? AND updated_at < ? '
+        '(SELECT id FROM outbox INDEXED BY idx_outbox_sent_updated_at '
+        'WHERE status = 1 AND updated_at < ? '
         'LIMIT ?)',
         variables: [
-          Variable.withInt(sentStatus),
           Variable.withDateTime(cutoff),
           Variable.withInt(chunkSize),
         ],

--- a/lib/database/sync_db_sequence.dart
+++ b/lib/database/sync_db_sequence.dart
@@ -222,16 +222,21 @@ mixin _SyncDbSequenceLog on _$SyncDatabase, _SyncDbSequenceWatermarks {
   Future<List<int>> burnPendingSequenceCountersForHost({
     required String hostId,
   }) async {
-    final rows =
-        await (select(syncSequenceLog)
-              ..where(
-                (t) =>
-                    t.hostId.equals(hostId) &
-                    t.status.equals(SyncSequenceStatus.burnPending.index),
-              )
-              ..orderBy([(t) => OrderingTerm(expression: t.counter)]))
-            .get();
-    return [for (final row in rows) row.counter];
+    final rows = await customSelect(
+      '''
+      SELECT counter
+      FROM sync_sequence_log INDEXED BY idx_sync_sequence_log_host_status
+      WHERE host_id = ?
+        AND status = ?
+      ORDER BY counter
+      ''',
+      variables: [
+        Variable.withString(hostId),
+        Variable.withInt(SyncSequenceStatus.burnPending.index),
+      ],
+      readsFrom: {syncSequenceLog},
+    ).get();
+    return [for (final row in rows) row.read<int>('counter')];
   }
 
   /// Update the status of a sequence log entry.

--- a/lib/database/sync_db_tables.dart
+++ b/lib/database/sync_db_tables.dart
@@ -24,7 +24,7 @@ part of 'sync_db.dart';
 // indexing the wrong rows.
 @TableIndex.sql(
   'CREATE INDEX idx_outbox_actionable_priority_created_at '
-  'ON outbox (priority, created_at) '
+  'ON outbox (priority, created_at, id) '
   'WHERE status IN (0, 3)',
 )
 // Covers `findPendingByEntryId` — the outbox merge-deduplication path
@@ -61,6 +61,15 @@ part of 'sync_db.dart';
   'CREATE INDEX idx_outbox_sending_expiry '
   'ON outbox (created_at, id, updated_at) '
   'WHERE status = 3',
+)
+// Sent-ledger retention and volume queries filter by send time
+// (`updated_at`) after `status = sent`. The generic status/priority index
+// cannot bound the updated-at range, so large sent ledgers still make prune
+// and recent-volume reads walk many irrelevant rows.
+@TableIndex.sql(
+  'CREATE INDEX idx_outbox_sent_updated_at '
+  'ON outbox (updated_at, id) '
+  'WHERE status = 1',
 )
 class Outbox extends Table {
   IntColumn get id => integer().autoIncrement()();

--- a/lib/database/sync_db_tables.dart
+++ b/lib/database/sync_db_tables.dart
@@ -27,6 +27,17 @@ part of 'sync_db.dart';
   'ON outbox (priority, created_at, id) '
   'WHERE status IN (0, 3)',
 )
+// Covers `getPendingBackfillEntries`, which only needs actionable outbox rows
+// whose subject starts with `backfillRequest:`. The priority-ordered
+// actionable index above proves the status predicate but still walks every
+// pending/sending row to apply the subject filter. This subject-keyed partial
+// lets the query perform a tight prefix range scan over only queued backfill
+// requests.
+@TableIndex.sql(
+  'CREATE INDEX idx_outbox_actionable_subject '
+  'ON outbox (subject) '
+  'WHERE status IN (0, 3)',
+)
 // Covers `findPendingByEntryId` — the outbox merge-deduplication path
 // fired on every enqueue. Filter is `status = pending AND
 // outbox_entry_id = ? ORDER BY created_at DESC LIMIT 1`. Without this

--- a/lib/features/agents/database/agent_database.dart
+++ b/lib/features/agents/database/agent_database.dart
@@ -361,8 +361,9 @@ class AgentDatabase extends _$AgentDatabase {
           await customStatement(
             'CREATE INDEX IF NOT EXISTS '
             'idx_agent_entities_active_agent_type_task_created_id '
-            'ON agent_entities(agent_id, type, created_at DESC, id DESC, '
-            r"json_extract(serialized, '$.taskId')) "
+            'ON agent_entities(agent_id, type, '
+            r"json_extract(serialized, '$.taskId'), "
+            'created_at DESC, id DESC) '
             'WHERE deleted_at IS NULL AND json_valid(serialized)',
           );
           await customStatement('ANALYZE');

--- a/lib/features/agents/database/agent_database.dart
+++ b/lib/features/agents/database/agent_database.dart
@@ -30,7 +30,7 @@ class AgentDatabase extends _$AgentDatabase {
   final bool inMemoryDatabase;
 
   @override
-  int get schemaVersion => 14;
+  int get schemaVersion => 16;
 
   @override
   MigrationStrategy get migration {
@@ -357,8 +357,97 @@ class AgentDatabase extends _$AgentDatabase {
           );
           await customStatement('ANALYZE');
         }
+        if (from < 15) {
+          await customStatement(
+            'CREATE INDEX IF NOT EXISTS '
+            'idx_agent_entities_active_agent_type_task_created_id '
+            'ON agent_entities(agent_id, type, created_at DESC, id DESC, '
+            r"json_extract(serialized, '$.taskId')) "
+            'WHERE deleted_at IS NULL AND json_valid(serialized)',
+          );
+          await customStatement('ANALYZE');
+        }
+        if (from < 16) {
+          await customStatement(
+            'CREATE INDEX IF NOT EXISTS '
+            'idx_agent_entities_pending_scheduled_wake_at '
+            r"ON agent_entities(json_extract(serialized, '$.scheduledAt') ASC) "
+            "WHERE type = 'scheduledWake' "
+            'AND deleted_at IS NULL '
+            r"AND json_extract(serialized, '$.status') = 'pending' "
+            r"AND json_extract(serialized, '$.scheduledAt') IS NOT NULL",
+          );
+          await customStatement('ANALYZE');
+        }
       },
     );
+  }
+
+  static const _taskIdJsonExpression = r"json_extract(serialized, '$.taskId')";
+
+  Selectable<AgentEntity> getChangeSetsForAgentAndTask(
+    String agentId,
+    String taskId,
+    int limit,
+  ) => _agentEntitiesByTask(
+    agentId: agentId,
+    entityType: 'changeSet',
+    taskId: taskId,
+    limit: limit,
+  );
+
+  Selectable<AgentEntity> getPendingChangeSetsForAgentAndTask(
+    String agentId,
+    String taskId,
+    int limit,
+  ) => _agentEntitiesByTask(
+    agentId: agentId,
+    entityType: 'changeSet',
+    taskId: taskId,
+    limit: limit,
+    extraPredicate: "AND subtype IN ('pending', 'partiallyResolved')",
+  );
+
+  Selectable<AgentEntity> getRecentDecisionsForAgentAndTask(
+    String agentId,
+    String taskId,
+    int limit,
+  ) => _agentEntitiesByTask(
+    agentId: agentId,
+    entityType: 'changeDecision',
+    taskId: taskId,
+    limit: limit,
+  );
+
+  Selectable<AgentEntity> _agentEntitiesByTask({
+    required String agentId,
+    required String entityType,
+    required String taskId,
+    required int limit,
+    String extraPredicate = '',
+  }) {
+    return customSelect(
+      '''
+        SELECT *
+        FROM agent_entities
+          INDEXED BY idx_agent_entities_active_agent_type_task_created_id
+        WHERE agent_id = ?1
+          AND type = ?2
+          AND json_valid(serialized)
+          AND $_taskIdJsonExpression = ?3
+          AND deleted_at IS NULL
+          $extraPredicate
+        ORDER BY created_at DESC
+        LIMIT ?4
+      ''',
+      variables: [
+        Variable<String>(agentId),
+        Variable<String>(entityType),
+        Variable<String>(taskId),
+        Variable<int>(limit),
+      ],
+      readsFrom: {agentEntities},
+    ).asyncMap(agentEntities.mapFromRow);
   }
 
   /// Stream agent entities with their vector clocks for populating the

--- a/lib/features/agents/database/agent_database.drift
+++ b/lib/features/agents/database/agent_database.drift
@@ -33,9 +33,9 @@ CREATE INDEX idx_agent_entities_token_usage_since ON agent_entities(type, create
 CREATE INDEX idx_agent_entities_active_agent_type_task_created_id ON agent_entities(
   agent_id,
   type,
+  json_extract(serialized, '$.taskId'),
   created_at DESC,
-  id DESC,
-  json_extract(serialized, '$.taskId')
+  id DESC
 )
 WHERE deleted_at IS NULL
   AND json_valid(serialized);

--- a/lib/features/agents/database/agent_database.drift
+++ b/lib/features/agents/database/agent_database.drift
@@ -27,6 +27,18 @@ CREATE INDEX idx_agent_entities_active_agent_type_sub_created_id ON agent_entiti
 CREATE INDEX idx_agent_entities_active_type_created ON agent_entities(type, created_at DESC) WHERE deleted_at IS NULL;
 CREATE INDEX idx_agent_entities_active_type_sub_created_id ON agent_entities(type, subtype, created_at DESC, id DESC) WHERE deleted_at IS NULL;
 CREATE INDEX idx_agent_entities_token_usage_since ON agent_entities(type, created_at DESC) WHERE type = 'wakeTokenUsage' AND deleted_at IS NULL;
+-- Supports task-scoped proposal-ledger reads. Without this expression
+-- index, ledger assembly has to fetch broad per-agent change-set and
+-- decision history before filtering `taskId` from the serialized payload.
+CREATE INDEX idx_agent_entities_active_agent_type_task_created_id ON agent_entities(
+  agent_id,
+  type,
+  created_at DESC,
+  id DESC,
+  json_extract(serialized, '$.taskId')
+)
+WHERE deleted_at IS NULL
+  AND json_valid(serialized);
 -- Expression partial for `getDueScheduledAgentStates`. The query
 -- filters `type = 'agentState' AND deleted_at IS NULL AND
 -- json_extract(serialized, '$.scheduledWakeAt') <= :nowIso` and used
@@ -41,6 +53,20 @@ CREATE INDEX idx_agent_entities_due_wake ON agent_entities(
 WHERE type = 'agentState'
   AND deleted_at IS NULL
   AND json_extract(serialized, '$.scheduledWakeAt') IS NOT NULL;
+-- Expression partial for `getDueScheduledWakeRecords` and
+-- `getPendingScheduledWakeRecords`. These records live in the same
+-- append-only entity table as all agent artifacts, so probing pending
+-- wake rows by `type` still had to JSON-evaluate every active
+-- scheduledWake row and sort pending wakes by the extracted timestamp.
+-- Leading with the extracted `scheduledAt` value turns due probes into
+-- range scans and the pending-wake list into an in-order index walk.
+CREATE INDEX idx_agent_entities_pending_scheduled_wake_at ON agent_entities(
+  json_extract(serialized, '$.scheduledAt') ASC
+)
+WHERE type = 'scheduledWake'
+  AND deleted_at IS NULL
+  AND json_extract(serialized, '$.status') = 'pending'
+  AND json_extract(serialized, '$.scheduledAt') IS NOT NULL;
 
 CREATE TABLE agent_links (
   id TEXT NOT NULL PRIMARY KEY,

--- a/lib/features/agents/database/agent_database.g.dart
+++ b/lib/features/agents/database/agent_database.g.dart
@@ -4418,7 +4418,7 @@ abstract class _$AgentDatabase extends GeneratedDatabase {
   );
   late final Index idxAgentEntitiesActiveAgentTypeTaskCreatedId = Index(
     'idx_agent_entities_active_agent_type_task_created_id',
-    'CREATE INDEX idx_agent_entities_active_agent_type_task_created_id ON agent_entities (agent_id, type, created_at DESC, id DESC, json_extract(serialized, \'\$.taskId\')) WHERE deleted_at IS NULL AND json_valid(serialized)',
+    'CREATE INDEX idx_agent_entities_active_agent_type_task_created_id ON agent_entities (agent_id, type, json_extract(serialized, \'\$.taskId\'), created_at DESC, id DESC) WHERE deleted_at IS NULL AND json_valid(serialized)',
   );
   late final Index idxAgentEntitiesDueWake = Index(
     'idx_agent_entities_due_wake',

--- a/lib/features/agents/database/agent_database.g.dart
+++ b/lib/features/agents/database/agent_database.g.dart
@@ -4416,9 +4416,17 @@ abstract class _$AgentDatabase extends GeneratedDatabase {
     'idx_agent_entities_token_usage_since',
     'CREATE INDEX idx_agent_entities_token_usage_since ON agent_entities (type, created_at DESC) WHERE type = \'wakeTokenUsage\' AND deleted_at IS NULL',
   );
+  late final Index idxAgentEntitiesActiveAgentTypeTaskCreatedId = Index(
+    'idx_agent_entities_active_agent_type_task_created_id',
+    'CREATE INDEX idx_agent_entities_active_agent_type_task_created_id ON agent_entities (agent_id, type, created_at DESC, id DESC, json_extract(serialized, \'\$.taskId\')) WHERE deleted_at IS NULL AND json_valid(serialized)',
+  );
   late final Index idxAgentEntitiesDueWake = Index(
     'idx_agent_entities_due_wake',
     'CREATE INDEX idx_agent_entities_due_wake ON agent_entities (json_extract(serialized, \'\$.scheduledWakeAt\') ASC) WHERE type = \'agentState\' AND deleted_at IS NULL AND json_extract(serialized, \'\$.scheduledWakeAt\') IS NOT NULL',
+  );
+  late final Index idxAgentEntitiesPendingScheduledWakeAt = Index(
+    'idx_agent_entities_pending_scheduled_wake_at',
+    'CREATE INDEX idx_agent_entities_pending_scheduled_wake_at ON agent_entities (json_extract(serialized, \'\$.scheduledAt\') ASC) WHERE type = \'scheduledWake\' AND deleted_at IS NULL AND json_extract(serialized, \'\$.status\') = \'pending\' AND json_extract(serialized, \'\$.scheduledAt\') IS NOT NULL',
   );
   late final AgentLinks agentLinks = AgentLinks(this);
   late final Index idxAgentLinksFrom = Index(
@@ -5127,7 +5135,9 @@ abstract class _$AgentDatabase extends GeneratedDatabase {
     idxAgentEntitiesActiveTypeCreated,
     idxAgentEntitiesActiveTypeSubCreatedId,
     idxAgentEntitiesTokenUsageSince,
+    idxAgentEntitiesActiveAgentTypeTaskCreatedId,
     idxAgentEntitiesDueWake,
+    idxAgentEntitiesPendingScheduledWakeAt,
     agentLinks,
     idxAgentLinksFrom,
     idxAgentLinksTo,

--- a/lib/features/agents/database/agent_proposal_ledger.dart
+++ b/lib/features/agents/database/agent_proposal_ledger.dart
@@ -1,6 +1,5 @@
 import 'package:lotti/features/agents/database/agent_database.dart';
 import 'package:lotti/features/agents/database/agent_db_conversions.dart';
-import 'package:lotti/features/agents/database/agent_repo_internals.dart';
 import 'package:lotti/features/agents/database/agent_repository.dart'
     show AgentRepository;
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
@@ -43,24 +42,28 @@ class AgentProposalLedger {
     int changeSetFetchLimit = 200,
     int resolvedLimit = 50,
   }) async {
-    // Three independent table scans — run in parallel to keep wall-clock
-    // bounded on cold sqlite access. The dedicated pending query is what
-    // guarantees an old-but-still-open consolidated change set is never
-    // dropped by the recent-history cap: `getChangeSetsForAgent` is
+    // Three independent task-scoped reads — run in parallel to keep
+    // wall-clock bounded on cold sqlite access. The dedicated pending query is
+    // what guarantees an old-but-still-open consolidated change set is never
+    // dropped by the recent-history cap: `getChangeSetsForAgentAndTask` is
     // newest-first and would otherwise bury a long-lived open set past
     // `changeSetFetchLimit` once enough resolved history accumulates.
     final results = await Future.wait([
       _db
-          .getPendingChangeSetsForAgent(
+          .getPendingChangeSetsForAgentAndTask(
             agentId,
-            changeSetFetchLimit * overFetchMultiplier,
+            taskId,
+            changeSetFetchLimit,
           )
           .get(),
-      _db.getChangeSetsForAgent(agentId, changeSetFetchLimit).get(),
       _db
-          .getRecentDecisionsForAgent(
+          .getChangeSetsForAgentAndTask(agentId, taskId, changeSetFetchLimit)
+          .get(),
+      _db
+          .getRecentDecisionsForAgentAndTask(
             agentId,
-            resolvedLimit * overFetchMultiplier,
+            taskId,
+            resolvedLimit,
           )
           .get(),
     ]);
@@ -71,12 +74,10 @@ class AgentProposalLedger {
     final rawPendingSets = pendingRows
         .map(AgentDbConversions.fromEntityRow)
         .whereType<ChangeSetEntity>()
-        .where((cs) => cs.taskId == taskId)
         .toList();
     final recentSets = recentRows
         .map(AgentDbConversions.fromEntityRow)
-        .whereType<ChangeSetEntity>()
-        .where((cs) => cs.taskId == taskId);
+        .whereType<ChangeSetEntity>();
 
     final setsById = <String, ChangeSetEntity>{
       for (final cs in recentSets) cs.id: cs,
@@ -92,7 +93,6 @@ class AgentProposalLedger {
     final decisions = decisionRows
         .map(AgentDbConversions.fromEntityRow)
         .whereType<ChangeDecisionEntity>()
-        .where((d) => d.taskId == taskId)
         .toList();
 
     final decisionByKey = <String, ChangeDecisionEntity>{};

--- a/lib/features/agents/database/agent_repo_evolution.dart
+++ b/lib/features/agents/database/agent_repo_evolution.dart
@@ -8,6 +8,7 @@ import 'package:lotti/features/agents/database/agent_repository.dart'
     show AgentRepository;
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/agent_link.dart' as model;
 import 'package:lotti/features/agents/model/proposal_ledger.dart';
 
@@ -84,6 +85,44 @@ class AgentRepoEvolution {
         .map(AgentDbConversions.fromEntityRow)
         .whereType<AgentIdentityEntity>()
         .toList();
+  }
+
+  /// Fetch agent identities filtered by lifecycle in SQL.
+  ///
+  /// Startup restore paths ask for active agents repeatedly. Keeping that
+  /// predicate in SQLite avoids decoding dormant/destroyed identity rows in
+  /// every service that calls `AgentService.listAgents(lifecycle: active)`.
+  Future<List<AgentIdentityEntity>> getAgentIdentitiesByLifecycle(
+    AgentLifecycle lifecycle,
+  ) async {
+    final rows = await _db
+        .customSelect(
+          r'''
+            SELECT *
+            FROM agent_entities INDEXED BY idx_agent_entities_active_type_created
+            WHERE type = ?
+              AND deleted_at IS NULL
+              AND json_extract(serialized, '$.lifecycle') = ?
+            ORDER BY created_at DESC
+          ''',
+          variables: [
+            Variable.withString('agent'),
+            Variable.withString(lifecycle.name),
+          ],
+          readsFrom: {_db.agentEntities},
+        )
+        .get();
+
+    final identities = <AgentIdentityEntity>[];
+    for (final row in rows) {
+      final entity = AgentDbConversions.fromEntityRow(
+        await _db.agentEntities.mapFromRow(row),
+      );
+      if (entity case final AgentIdentityEntity identity) {
+        identities.add(identity);
+      }
+    }
+    return identities;
   }
 
   /// Fetch agent entities (including soft-deleted) whose serialized
@@ -274,29 +313,24 @@ class AgentRepoEvolution {
   /// The persisted field is historically named `taskId`, but stores the target
   /// entity ID for both task-scoped and project-scoped proposals.
   ///
-  /// Returns newest-first, capped at [limit]. The [taskId] filter is applied
-  /// in Dart because it lives inside the serialized JSON data column, not in a
-  /// dedicated indexed column. At current volumes (single agent, limit ≤ 20)
-  /// this is adequate; a dedicated column + DB-level filter is a future
-  /// optimization if query counts grow.
+  /// Returns newest-first, capped at [limit]. The [taskId] filter is backed by
+  /// an expression index over the serialized payload so task-scoped suggestion
+  /// views do not need to over-fetch broad per-agent change-set history.
   Future<List<ChangeSetEntity>> getPendingChangeSets(
     String agentId, {
     String? taskId,
     int limit = 20,
   }) async {
-    // When filtering by taskId in Dart, over-fetch from DB to compensate for
-    // rows that will be discarded. Without a dedicated taskId column we cannot
-    // filter at the SQL level.
-    final dbLimit = taskId != null ? limit * overFetchMultiplier : limit;
-    final rows = await _db.getPendingChangeSetsForAgent(agentId, dbLimit).get();
-    var results = rows
+    final rows = taskId == null
+        ? await _db.getPendingChangeSetsForAgent(agentId, limit).get()
+        : await _db
+              .getPendingChangeSetsForAgentAndTask(agentId, taskId, limit)
+              .get();
+    final results = rows
         .map(AgentDbConversions.fromEntityRow)
         .whereType<ChangeSetEntity>()
         .toList();
-    if (taskId != null) {
-      results = results.where((cs) => cs.taskId == taskId).toList();
-    }
-    return results.take(limit).toList();
+    return results;
   }
 
   /// Fetch recent change decisions for [agentId], optionally filtered by

--- a/lib/features/agents/database/agent_repo_links.dart
+++ b/lib/features/agents/database/agent_repo_links.dart
@@ -137,7 +137,19 @@ class AgentRepoLinks {
   }) async {
     final List<AgentLink> rows;
     if (type != null) {
-      rows = await _db.getAgentLinksByFromIdAndType(fromId, type).get();
+      rows = await _db
+          .customSelect(
+            'SELECT * FROM agent_links '
+            'INDEXED BY idx_agent_links_active_from_type_to '
+            'WHERE from_id = ? AND type = ? AND deleted_at IS NULL',
+            variables: [
+              Variable.withString(fromId),
+              Variable.withString(type),
+            ],
+            readsFrom: {_db.agentLinks},
+          )
+          .asyncMap(_db.agentLinks.mapFromRow)
+          .get();
     } else {
       rows = await _db.getAgentLinksByFromId(fromId).get();
     }
@@ -152,7 +164,19 @@ class AgentRepoLinks {
   }) async {
     final List<AgentLink> rows;
     if (type != null) {
-      rows = await _db.getAgentLinksByToIdAndType(toId, type).get();
+      rows = await _db
+          .customSelect(
+            'SELECT * FROM agent_links '
+            'INDEXED BY idx_agent_links_active_to_type '
+            'WHERE to_id = ? AND type = ? AND deleted_at IS NULL',
+            variables: [
+              Variable.withString(toId),
+              Variable.withString(type),
+            ],
+            readsFrom: {_db.agentLinks},
+          )
+          .asyncMap(_db.agentLinks.mapFromRow)
+          .get();
     } else {
       rows = await _db.getAgentLinksByToId(toId).get();
     }

--- a/lib/features/agents/database/agent_repository.dart
+++ b/lib/features/agents/database/agent_repository.dart
@@ -313,6 +313,10 @@ class AgentRepository {
   Future<List<AgentIdentityEntity>> getAllAgentIdentities() =>
       _evolution.getAllAgentIdentities();
 
+  Future<List<AgentIdentityEntity>> getAgentIdentitiesByLifecycle(
+    AgentLifecycle lifecycle,
+  ) => _evolution.getAgentIdentitiesByLifecycle(lifecycle);
+
   Future<List<AgentDomainEntity>> getEntitiesWithNullVectorClock() =>
       _evolution.getEntitiesWithNullVectorClock();
 

--- a/lib/features/agents/service/agent_service.dart
+++ b/lib/features/agents/service/agent_service.dart
@@ -124,11 +124,10 @@ class AgentService {
   Future<List<AgentIdentityEntity>> listAgents({
     AgentLifecycle? lifecycle,
   }) async {
-    final agents = await repository.getAllAgentIdentities();
     if (lifecycle != null) {
-      return agents.where((a) => a.lifecycle == lifecycle).toList();
+      return repository.getAgentIdentitiesByLifecycle(lifecycle);
     }
-    return agents;
+    return repository.getAllAgentIdentities();
   }
 
   /// Get the latest report for [agentId] in [scope]

--- a/lib/features/agents/service/agent_template_crud.dart
+++ b/lib/features/agents/service/agent_template_crud.dart
@@ -310,14 +310,15 @@ class AgentTemplateCrud {
       templateId,
       type: AgentLinkTypes.templateAssignment,
     );
-    final agents = <AgentIdentityEntity>[];
-    for (final link in links) {
-      final entity = await repository.getEntity(link.toId);
-      if (entity is AgentIdentityEntity) {
-        agents.add(entity);
-      }
-    }
-    return agents;
+    if (links.isEmpty) return const [];
+
+    final entitiesById = await repository.getEntitiesByIds(
+      links.map((link) => link.toId),
+    );
+    return [
+      for (final link in links)
+        if (entitiesById[link.toId] case final AgentIdentityEntity agent) agent,
+    ];
   }
 
   /// List templates whose category IDs contain [categoryId].

--- a/lib/features/agents/service/agent_template_metrics.dart
+++ b/lib/features/agents/service/agent_template_metrics.dart
@@ -173,10 +173,11 @@ class AgentTemplateMetrics {
     // Second batch: depends on first batch results.
     final payloadIds = observations
         .map((obs) => obs.contentEntryId)
-        .whereType<String>();
-    final payloadEntitiesFuture = Future.wait(
-      payloadIds.map(repository.getEntity),
-    );
+        .whereType<String>()
+        .toSet();
+    final payloadEntitiesFuture = payloadIds.isEmpty
+        ? Future.value(const <String, AgentDomainEntity>{})
+        : repository.getEntitiesByIds(payloadIds);
 
     final lastSessionDate = sessions.isNotEmpty
         ? sessions.first.createdAt
@@ -187,7 +188,7 @@ class AgentTemplateMetrics {
 
     final observationPayloads = <String, AgentMessagePayloadEntity>{
       for (final entity
-          in batchResults.$1.whereType<AgentMessagePayloadEntity>())
+          in batchResults.$1.values.whereType<AgentMessagePayloadEntity>())
         entity.id: entity,
     };
 

--- a/lib/features/agents/service/event_agent_service.dart
+++ b/lib/features/agents/service/event_agent_service.dart
@@ -231,18 +231,22 @@ class EventAgentService {
     final activeAgents = await agentService.listAgents(
       lifecycle: AgentLifecycle.active,
     );
+    final eventAgents = activeAgents
+        .where((agent) => agent.kind == _agentKind)
+        .toList(growable: false);
+    final statesByAgentId = await _loadStatesForRestore(eventAgents);
 
     var count = 0;
-    for (final agent in activeAgents) {
-      if (agent.kind != _agentKind) continue;
-
+    for (final agent in eventAgents) {
       try {
         final links = await repository.getLinksFrom(
           agent.agentId,
           type: AgentLinkTypes.agentEvent,
         );
-        await _hydrateThrottleDeadline(agent.agentId);
-        final state = await repository.getAgentState(agent.agentId);
+        final state = statesByAgentId == null
+            ? await repository.getAgentState(agent.agentId)
+            : statesByAgentId[agent.agentId];
+        _hydrateThrottleDeadlineFromState(agent.agentId, state);
         orchestrator.setAwaitingContent(
           agent.agentId,
           awaiting: state?.awaitingContent ?? false,
@@ -297,11 +301,26 @@ class EventAgentService {
     );
   }
 
-  Future<void> _hydrateThrottleDeadline(String agentId) async {
-    final state = await repository.getAgentState(agentId);
+  void _hydrateThrottleDeadlineFromState(
+    String agentId,
+    AgentStateEntity? state,
+  ) {
     final deadline = state?.nextWakeAt;
     if (deadline != null) {
       orchestrator.restorePendingWake(agentId: agentId, dueAt: deadline);
+    }
+  }
+
+  Future<Map<String, AgentStateEntity>?> _loadStatesForRestore(
+    List<AgentIdentityEntity> agents,
+  ) async {
+    if (agents.isEmpty) return const {};
+    try {
+      return await repository.getAgentStatesByAgentIds([
+        for (final agent in agents) agent.agentId,
+      ]);
+    } catch (_) {
+      return null;
     }
   }
 }

--- a/lib/features/agents/service/feedback_extraction_service.dart
+++ b/lib/features/agents/service/feedback_extraction_service.dart
@@ -65,20 +65,23 @@ class FeedbackExtractionService {
         .map((d) => d.changeSetId)
         .toSet();
     var changeSetMap = <String, ChangeSetEntity>{};
-    try {
-      final changeSetEntities = await Future.wait(
-        missingIds.map(agentRepository.getEntity),
-      );
-      changeSetMap = {
-        for (final entity in changeSetEntities.whereType<ChangeSetEntity>())
-          entity.id: entity,
-      };
-    } catch (e) {
-      developer.log(
-        'Failed to fetch change sets (errorType=${e.runtimeType})',
-        name: 'FeedbackExtractionService',
-        error: e.runtimeType,
-      );
+    if (missingIds.isNotEmpty) {
+      try {
+        final changeSetEntities = await agentRepository.getEntitiesByIds(
+          missingIds,
+        );
+        changeSetMap = {
+          for (final entity
+              in changeSetEntities.values.whereType<ChangeSetEntity>())
+            entity.id: entity,
+        };
+      } catch (e) {
+        developer.log(
+          'Failed to fetch change sets (errorType=${e.runtimeType})',
+          name: 'FeedbackExtractionService',
+          error: e.runtimeType,
+        );
+      }
     }
 
     var suppressedChecklistRejectionCount = 0;
@@ -128,35 +131,31 @@ class FeedbackExtractionService {
         .toList();
 
     // Bulk-fetch observation payloads for richer detail text.
-    // Per-ID error handling so one failure doesn't abort the whole run.
     final payloadIds = windowObservations
         .map((obs) => obs.contentEntryId)
         .whereType<String>()
         .toSet();
-    final payloadEntries = await Future.wait(
-      payloadIds.map((id) async {
-        try {
-          final entity = await agentRepository.getEntity(id);
-          if (entity is AgentMessagePayloadEntity) {
-            return MapEntry(id, entity);
-          }
-        } catch (e, s) {
-          developer.log(
-            'Failed to fetch payload ${DomainLogger.sanitizeId(id)}',
-            name: 'FeedbackExtractionService',
-            error: e.runtimeType,
-            stackTrace: s,
-          );
-        }
-        return null;
-      }),
-    );
-    final payloadMap = <String, AgentMessagePayloadEntity>{
-      for (final entry
-          in payloadEntries
-              .whereType<MapEntry<String, AgentMessagePayloadEntity>>())
-        entry.key: entry.value,
-    };
+    var payloadMap = <String, AgentMessagePayloadEntity>{};
+    if (payloadIds.isNotEmpty) {
+      try {
+        final entitiesById = await agentRepository.getEntitiesByIds(
+          payloadIds,
+        );
+        payloadMap = {
+          for (final entity
+              in entitiesById.values.whereType<AgentMessagePayloadEntity>())
+            entity.id: entity,
+        };
+      } catch (e, s) {
+        developer.log(
+          'Failed to fetch observation payloads '
+          '(count=${payloadIds.length}, errorType=${e.runtimeType})',
+          name: 'FeedbackExtractionService',
+          error: e.runtimeType,
+          stackTrace: s,
+        );
+      }
+    }
 
     for (final observation in windowObservations) {
       final payload = observation.contentEntryId != null
@@ -426,11 +425,11 @@ class FeedbackExtractionService {
     if (agents.isEmpty) return [];
 
     // Resolve each agent's target template ID (the template it improves).
-    final states = await Future.wait(
-      agents.map((agent) => agentRepository.getAgentState(agent.agentId)),
+    final statesByAgentId = await agentRepository.getAgentStatesByAgentIds(
+      [for (final agent in agents) agent.agentId],
     );
-    final targetTemplateIds = states
-        .map((state) => state?.slots.activeTemplateId)
+    final targetTemplateIds = statesByAgentId.values
+        .map((state) => state.slots.activeTemplateId)
         .whereType<String>()
         .toSet();
     if (targetTemplateIds.isEmpty) return [];

--- a/lib/features/agents/service/project_agent_service.dart
+++ b/lib/features/agents/service/project_agent_service.dart
@@ -226,17 +226,22 @@ class ProjectAgentService {
     final activeAgents = await agentService.listAgents(
       lifecycle: AgentLifecycle.active,
     );
+    final projectAgents = activeAgents
+        .where((agent) => agent.kind == _agentKind)
+        .toList(growable: false);
+    final statesByAgentId = await _loadStatesForRestore(projectAgents);
 
     var count = 0;
-    for (final agent in activeAgents) {
-      if (agent.kind != _agentKind) continue;
-
+    for (final agent in projectAgents) {
       try {
         final links = await repository.getLinksFrom(
           agent.agentId,
           type: AgentLinkTypes.agentProject,
         );
-        await _hydrateThrottleDeadline(agent.agentId);
+        final state = statesByAgentId == null
+            ? await repository.getAgentState(agent.agentId)
+            : statesByAgentId[agent.agentId];
+        _hydrateThrottleDeadlineFromState(agent.agentId, state);
         for (final link in links) {
           _registerProjectSubscription(agent.agentId, link.toId);
         }
@@ -280,11 +285,26 @@ class ProjectAgentService {
     );
   }
 
-  Future<void> _hydrateThrottleDeadline(String agentId) async {
-    final state = await repository.getAgentState(agentId);
+  void _hydrateThrottleDeadlineFromState(
+    String agentId,
+    AgentStateEntity? state,
+  ) {
     final deadline = state?.nextWakeAt;
     if (deadline != null) {
       orchestrator.restorePendingWake(agentId: agentId, dueAt: deadline);
+    }
+  }
+
+  Future<Map<String, AgentStateEntity>?> _loadStatesForRestore(
+    List<AgentIdentityEntity> agents,
+  ) async {
+    if (agents.isEmpty) return const {};
+    try {
+      return await repository.getAgentStatesByAgentIds([
+        for (final agent in agents) agent.agentId,
+      ]);
+    } catch (_) {
+      return null;
     }
   }
 }

--- a/lib/features/agents/service/task_agent_service.dart
+++ b/lib/features/agents/service/task_agent_service.dart
@@ -303,6 +303,13 @@ class TaskAgentService {
   /// restarts.
   Future<void> _hydrateThrottleDeadline(String agentId) async {
     final state = await repository.getAgentState(agentId);
+    _hydrateThrottleDeadlineFromState(agentId, state);
+  }
+
+  void _hydrateThrottleDeadlineFromState(
+    String agentId,
+    AgentStateEntity? state,
+  ) {
     final deadline = state?.nextWakeAt;
     if (deadline != null) {
       orchestrator.restorePendingWake(agentId: agentId, dueAt: deadline);
@@ -316,6 +323,19 @@ class TaskAgentService {
     // deferred drain timer for this agent (between _registerTaskSubscription
     // and this async call). Calling clearThrottle would cancel that timer
     // and leave the queued job permanently stuck.
+  }
+
+  Future<Map<String, AgentStateEntity>?> _loadStatesForRestore(
+    List<AgentIdentityEntity> agents,
+  ) async {
+    if (agents.isEmpty) return const {};
+    try {
+      return await repository.getAgentStatesByAgentIds([
+        for (final agent in agents) agent.agentId,
+      ]);
+    } catch (_) {
+      return null;
+    }
   }
 
   /// Returns the ID of the best default template, or `null` if none exist.
@@ -349,11 +369,13 @@ class TaskAgentService {
     final activeAgents = await agentService.listAgents(
       lifecycle: AgentLifecycle.active,
     );
+    final taskAgents = activeAgents
+        .where((agent) => agent.kind == _agentKind)
+        .toList(growable: false);
+    final statesByAgentId = await _loadStatesForRestore(taskAgents);
 
     var count = 0;
-    for (final agent in activeAgents) {
-      if (agent.kind != _agentKind) continue;
-
+    for (final agent in taskAgents) {
       try {
         final links = await repository.getLinksFrom(
           agent.agentId,
@@ -367,7 +389,10 @@ class TaskAgentService {
 
         // Restore persisted deferred wake work so due deadlines survive app
         // restarts and backgrounding.
-        await _hydrateThrottleDeadline(agent.agentId);
+        final state = statesByAgentId == null
+            ? await repository.getAgentState(agent.agentId)
+            : statesByAgentId[agent.agentId];
+        _hydrateThrottleDeadlineFromState(agent.agentId, state);
       } catch (e, s) {
         final msg =
             'failed to restore subscriptions '

--- a/lib/features/agents/state/token_stats_providers.dart
+++ b/lib/features/agents/state/token_stats_providers.dart
@@ -213,27 +213,28 @@ Future<Map<String, _SourceInfo>> _resolveSourceInfo(
   AgentRepository repository,
   Set<String> ids,
 ) async {
-  final entries = await Future.wait(
-    ids.map((id) async {
-      try {
-        final entity = await repository.getEntity(id);
-        final info = switch (entity) {
-          AgentTemplateEntity(:final displayName) => (
-            name: displayName,
-            isTemplate: true,
-          ),
-          AgentIdentityEntity(:final displayName) => (
-            name: displayName,
-            isTemplate: false,
-          ),
-          _ => null,
-        };
-        return info != null ? MapEntry(id, info) : null;
-      } on Exception {
-        return null;
-      }
-    }),
-  );
+  if (ids.isEmpty) return const {};
+  Map<String, AgentDomainEntity> entitiesById;
+  try {
+    entitiesById = await repository.getEntitiesByIds(ids);
+  } on Exception {
+    return const {};
+  }
+
+  final entries = entitiesById.entries.map((entry) {
+    final info = switch (entry.value) {
+      AgentTemplateEntity(:final displayName) => (
+        name: displayName,
+        isTemplate: true,
+      ),
+      AgentIdentityEntity(:final displayName) => (
+        name: displayName,
+        isTemplate: false,
+      ),
+      _ => null,
+    };
+    return info != null ? MapEntry(entry.key, info) : null;
+  });
   return Map.fromEntries(entries.nonNulls);
 }
 

--- a/lib/features/agents/sync/agent_input_capture_service.dart
+++ b/lib/features/agents/sync/agent_input_capture_service.dart
@@ -78,11 +78,14 @@ class AgentInputCaptureService {
     );
     if (delta.isEmpty) return delta;
 
+    final existingPayloads = await _repository.getEntitiesByIds(
+      delta.newPayloads.map((payload) => payload.contentDigest),
+    );
     await _sync.runInTransaction(() async {
       for (final payload in delta.newPayloads) {
         // The payload id is its content digest, so a present row is
         // byte-identical — skip the redundant write and its sync echo.
-        if (await _repository.getEntity(payload.contentDigest) != null) {
+        if (existingPayloads.containsKey(payload.contentDigest)) {
           continue;
         }
         await _sync.upsertEntity(

--- a/lib/features/agents/sync/agent_log_compactor.dart
+++ b/lib/features/agents/sync/agent_log_compactor.dart
@@ -77,20 +77,21 @@ class AgentLogCompactor {
       for (final m in messages)
         if (m.deletedAt == null && m.contentEntryId != null) m,
     ];
-    // Load every checkpoint payload concurrently (avoids an N+1 per summary).
-    final payloads = await Future.wait(
-      live.map((m) => _repository.getEntity(m.contentEntryId!)),
+    // Load every checkpoint payload in one round-trip. The prior per-summary
+    // fan-out queued many primary-key lookups behind writer locks.
+    final payloadsById = await _repository.getEntitiesByIds(
+      live.map((m) => m.contentEntryId!),
     );
 
     final checkpoints = <SummaryCheckpoint>[];
-    for (var i = 0; i < live.length; i++) {
-      final payload = payloads[i];
+    for (final message in live) {
+      final payload = payloadsById[message.contentEntryId!];
       if (payload is! AgentMessagePayloadEntity) continue;
       final coveredRaw = payload.content['coveredSources'];
       checkpoints.add(
         SummaryCheckpoint(
-          id: live[i].id,
-          contentDigest: live[i].contentEntryId!,
+          id: message.id,
+          contentDigest: message.contentEntryId!,
           coveredSources: <String, String>{
             if (coveredRaw is Map)
               for (final entry in coveredRaw.entries)
@@ -122,6 +123,17 @@ class AgentLogCompactor {
   /// preserving event order and dropping any whose content is missing.
   Future<List<({InputEvent event, Map<String, Object?> content})>>
   _resolveEventContents(List<InputEvent> events) async {
+    final payloadIds = {
+      for (final event in events)
+        if (event.inlineContent == null &&
+            !event.deferredInline &&
+            event.contentDigest != null)
+          event.contentDigest!,
+    };
+    final payloadsById = payloadIds.isEmpty
+        ? const <String, AgentDomainEntity>{}
+        : await _repository.getEntitiesByIds(payloadIds);
+
     final resolved = await Future.wait([
       for (final event in events)
         () async {
@@ -137,7 +149,7 @@ class AgentLogCompactor {
           }
           final digest = event.contentDigest;
           if (digest == null) return null;
-          final payload = await _repository.getEntity(digest);
+          final payload = payloadsById[digest];
           return payload is AgentMessagePayloadEntity
               ? (event: event, content: payload.content)
               : null;

--- a/lib/features/sync/README.md
+++ b/lib/features/sync/README.md
@@ -963,7 +963,7 @@ stored marker.
 ### UI (`backfill_settings_page.dart`)
 
 - `_QueueDepthScope` (inside `BackfillSettingsBody`) — subscribes to
-  `InboundQueue.depthChanges` (with a one-shot `queue.stats()` seed) and
+  `InboundQueue.depthChanges` (with a one-shot `queue.depthSnapshot()` seed) and
   rebuilds `StatusRow` with the latest total / per-producer breakdown /
   abandoned count.
 - `_AdvancedRecoveryGroup` (`backfill_settings_recovery.dart`) — manual

--- a/lib/features/sync/queue/inbound_event_queue.dart
+++ b/lib/features/sync/queue/inbound_event_queue.dart
@@ -55,6 +55,14 @@ class InboundQueue {
 
   Future<void> dispose() => _depthEmitter.dispose();
 
+  /// Lightweight active-depth snapshot for UI seed values.
+  ///
+  /// Unlike [stats], this deliberately skips the applied ledger and
+  /// ready-now count. Those diagnostics require additional queue scans and
+  /// were showing up in slow-query logs when depth-only surfaces seeded their
+  /// first value.
+  Future<QueueStats> depthSnapshot() => _depthStats();
+
   /// Runs [body] inside a single `sync_db` transaction so a batch of
   /// `commitApplied` / `scheduleRetry` / `markSkipped` calls coalesce
   /// into one write transaction instead of one per entry. Drift nests

--- a/lib/features/sync/queue/inbound_event_queue.dart
+++ b/lib/features/sync/queue/inbound_event_queue.dart
@@ -22,6 +22,9 @@ const _logSubCommit = 'queue.commit';
 const _logSubRetry = 'queue.retry';
 const _logSubSkip = 'queue.skip';
 const _logSubPrune = 'queue.prune';
+const _peekableStatusPredicate = "status IN ('enqueued', 'retrying', 'leased')";
+const _depthStatusPredicate =
+    "status IN ('enqueued', 'leased', 'retrying', 'abandoned')";
 
 /// Durable inbound queue for Matrix sync events. See §3 of
 /// `docs/sync/2026-04-21_inbound_event_queue_implementation_plan.md`.
@@ -39,7 +42,7 @@ class InboundQueue {
   final Duration _leaseDuration;
 
   late final QueueDepthEmitter _depthEmitter = QueueDepthEmitter(
-    loadStats: stats,
+    loadStats: _depthStats,
   );
   late final QueueMarkerAdvancer _markerAdvancer = QueueMarkerAdvancer(_db);
   late final InboundQueueResurrection _resurrection = InboundQueueResurrection(
@@ -249,7 +252,7 @@ class InboundQueue {
     final probe = _db.selectOnly(probeTable)
       ..addColumns([probeTable.queueId])
       ..where(
-        probeTable.status.isIn(InboundQueueStatuses.peekable) &
+        const CustomExpression<bool>(_peekableStatusPredicate) &
             probeTable.nextDueAt.isSmallerOrEqualValue(nowMs) &
             probeTable.leaseUntil.isSmallerOrEqualValue(nowMs),
       )
@@ -262,7 +265,7 @@ class InboundQueue {
       final query = _db.select(_db.inboundEventQueue)
         ..where(
           (t) =>
-              t.status.isIn(InboundQueueStatuses.peekable) &
+              const CustomExpression<bool>(_peekableStatusPredicate) &
               t.nextDueAt.isSmallerOrEqualValue(nowMs) &
               t.leaseUntil.isSmallerOrEqualValue(nowMs),
         )
@@ -547,7 +550,7 @@ class InboundQueue {
         await (_db.selectOnly(table)
               ..addColumns([countCol])
               ..where(
-                table.status.isIn(InboundQueueStatuses.peekable) &
+                const CustomExpression<bool>(_peekableStatusPredicate) &
                     table.nextDueAt.isSmallerOrEqualValue(nowMs) &
                     table.leaseUntil.isSmallerOrEqualValue(nowMs),
               ))
@@ -562,6 +565,55 @@ class InboundQueue {
       applied: applied,
       abandoned: abandoned,
       retrying: retrying,
+    );
+  }
+
+  /// Lightweight snapshot for [depthChanges]. Depth emissions do not expose
+  /// `applied`, `retrying`, or `readyNow`, so this deliberately excludes the
+  /// applied ledger and skips the ready-now probe that made every queue
+  /// mutation pay for diagnostics-only counters.
+  Future<QueueStats> _depthStats() async {
+    final rows = await _db
+        .customSelect(
+          '''
+      SELECT status, producer, COUNT(*) AS cnt, MIN(enqueued_at) AS oldest
+      FROM inbound_event_queue
+      WHERE $_depthStatusPredicate
+      GROUP BY status, producer
+      ''',
+          readsFrom: {_db.inboundEventQueue},
+        )
+        .get();
+
+    var total = 0;
+    var abandoned = 0;
+    int? oldest;
+    final byProducer = <InboundEventProducer, int>{};
+
+    for (final row in rows) {
+      final status = row.read<String>('status');
+      final cnt = row.read<int>('cnt');
+      final rowOldest = row.readNullable<int>('oldest');
+
+      if (status == InboundQueueStatuses.abandoned) {
+        abandoned += cnt;
+        continue;
+      }
+
+      total += cnt;
+      final producer = producerFromName(row.read<String>('producer'));
+      byProducer[producer] = (byProducer[producer] ?? 0) + cnt;
+      if (rowOldest != null && (oldest == null || rowOldest < oldest)) {
+        oldest = rowOldest;
+      }
+    }
+
+    return QueueStats(
+      total: total,
+      byProducer: byProducer,
+      readyNow: 0,
+      oldestEnqueuedAt: oldest,
+      abandoned: abandoned,
     );
   }
 

--- a/lib/features/sync/queue/inbound_event_queue.dart
+++ b/lib/features/sync/queue/inbound_event_queue.dart
@@ -486,67 +486,29 @@ class InboundQueue {
   /// depth (drainable rows); `applied` / `abandoned` / `retrying`
   /// carry the ledger breakdown for UI + diagnostics.
   ///
-  /// Implementation note: a single `GROUP BY status, producer`
-  /// aggregate replaces the prior four selectOnly aggregates. The
-  /// previous shape did three full-table scans plus a TEMP B-TREE on
-  /// every poll because no index covered `(status, producer)` —
-  /// production slow-query log captured 1014 ms / 2244 ms hits at
-  /// depth-emit cadence. The v20 partial index
-  /// `idx_inbound_event_queue_status_producer_enqueued` makes the
-  /// pivot index-only over a tight key range, and Dart pivots the
-  /// (≤ statuses × producers) result rows into the existing
-  /// `QueueStats` shape.
+  /// Implementation note: the active/abandoned/retrying pivot is
+  /// deliberately bounded to the statuses that need producer and oldest-row
+  /// breakdowns. The applied ledger can grow without bound and does not need
+  /// producer bucketing, so it is counted separately through the status index
+  /// instead of participating in the `GROUP BY status, producer` aggregate
+  /// that appeared in the slow-query logs.
   Future<QueueStats> stats() async {
     final nowMs = clock.now().millisecondsSinceEpoch;
     final table = _db.inboundEventQueue;
     final countCol = table.queueId.count();
-    final oldestCol = table.enqueuedAt.min();
 
-    // One aggregate scan: per (status, producer), get COUNT and
-    // MIN(enqueued_at). Pivots into total/byProducer/oldest plus
-    // applied/abandoned/retrying counts on the Dart side.
-    final pivotRows =
-        await (_db.selectOnly(table)
-              ..addColumns([
-                table.status,
-                table.producer,
-                countCol,
-                oldestCol,
-              ])
-              ..groupBy([table.status, table.producer]))
-            .get();
+    final depth = await _depthStats();
 
-    var total = 0;
-    var applied = 0;
-    var abandoned = 0;
-    var retrying = 0;
-    int? oldest;
-    final byProducer = <InboundEventProducer, int>{};
-
-    for (final row in pivotRows) {
-      final status = row.read(table.status);
-      final producerName = row.read(table.producer);
-      final cnt = row.read(countCol) ?? 0;
-      if (cnt <= 0 || status == null || producerName == null) continue;
-      final rowOldest = row.read(oldestCol);
-
-      if (InboundQueueStatuses.active.contains(status)) {
-        total += cnt;
-        final p = producerFromName(producerName);
-        byProducer[p] = (byProducer[p] ?? 0) + cnt;
-        if (rowOldest != null && (oldest == null || rowOldest < oldest)) {
-          oldest = rowOldest;
-        }
-      }
-      switch (status) {
-        case InboundQueueStatuses.applied:
-          applied += cnt;
-        case InboundQueueStatuses.abandoned:
-          abandoned += cnt;
-        case InboundQueueStatuses.retrying:
-          retrying += cnt;
-      }
-    }
+    final appliedRow = await _db
+        .customSelect(
+          'SELECT COUNT(queue_id) AS cnt '
+          'FROM inbound_event_queue '
+          'INDEXED BY idx_inbound_event_queue_status_enqueued '
+          "WHERE status = 'applied'",
+          readsFrom: {_db.inboundEventQueue},
+        )
+        .getSingle();
+    final applied = appliedRow.read<int>('cnt');
 
     // Ready-now keeps its own probe: the predicate is
     // `status IN InboundQueueStatuses.peekable AND next_due_at <= now
@@ -566,20 +528,21 @@ class InboundQueue {
     final readyNow = readyRow.read(countCol) ?? 0;
 
     return QueueStats(
-      total: total,
-      byProducer: byProducer,
+      total: depth.total,
+      byProducer: depth.byProducer,
       readyNow: readyNow,
-      oldestEnqueuedAt: oldest,
+      oldestEnqueuedAt: depth.oldestEnqueuedAt,
       applied: applied,
-      abandoned: abandoned,
-      retrying: retrying,
+      abandoned: depth.abandoned,
+      retrying: depth.retrying,
     );
   }
 
-  /// Lightweight snapshot for [depthChanges]. Depth emissions do not expose
-  /// `applied`, `retrying`, or `readyNow`, so this deliberately excludes the
-  /// applied ledger and skips the ready-now probe that made every queue
-  /// mutation pay for diagnostics-only counters.
+  /// Lightweight active/abandoned/retrying pivot shared by [depthChanges] and
+  /// [stats]. Depth emissions expose only active depth, producer breakdown,
+  /// oldest active enqueue time, and abandoned count, but [stats] reuses the
+  /// retrying count from the same bounded aggregate. The applied ledger and
+  /// ready-now probe stay out of this path.
   Future<QueueStats> _depthStats() async {
     final rows = await _db
         .customSelect(
@@ -595,6 +558,7 @@ class InboundQueue {
 
     var total = 0;
     var abandoned = 0;
+    var retrying = 0;
     int? oldest;
     final byProducer = <InboundEventProducer, int>{};
 
@@ -606,6 +570,9 @@ class InboundQueue {
       if (status == InboundQueueStatuses.abandoned) {
         abandoned += cnt;
         continue;
+      }
+      if (status == InboundQueueStatuses.retrying) {
+        retrying += cnt;
       }
 
       total += cnt;
@@ -622,6 +589,7 @@ class InboundQueue {
       readyNow: 0,
       oldestEnqueuedAt: oldest,
       abandoned: abandoned,
+      retrying: retrying,
     );
   }
 

--- a/lib/features/sync/queue/queue_marker_seeder.dart
+++ b/lib/features/sync/queue/queue_marker_seeder.dart
@@ -26,14 +26,25 @@ class QueueMarkerSeeder {
   final SyncDatabase _syncDb;
   final SettingsDb _settingsDb;
   final DomainLogger _logging;
+  final Set<String> _knownSeededRooms = <String>{};
 
   /// Returns `true` if a new row was seeded, `false` if a row already
   /// existed (or no legacy marker was stored).
   Future<bool> seedIfAbsent(String roomId) async {
+    if (_knownSeededRooms.contains(roomId)) {
+      _logging.log(
+        LogDomain.sync,
+        'queue.markerSeed.skip roomId=$roomId reason=alreadySeededCached',
+        subDomain: _logSub,
+      );
+      return false;
+    }
+
     final existing = await (_syncDb.select(
       _syncDb.queueMarkers,
     )..where((t) => t.roomId.equals(roomId))).getSingleOrNull();
     if (existing != null) {
+      _knownSeededRooms.add(roomId);
       _logging.log(
         LogDomain.sync,
         'queue.markerSeed.skip roomId=$roomId reason=alreadySeeded',
@@ -68,6 +79,7 @@ class QueueMarkerSeeder {
           mode: InsertMode.insertOrIgnore,
         );
 
+    _knownSeededRooms.add(roomId);
     _logging.log(
       LogDomain.sync,
       'queue.markerSeed.done roomId=$roomId '

--- a/lib/features/sync/state/outbox_state_controller.dart
+++ b/lib/features/sync/state/outbox_state_controller.dart
@@ -137,11 +137,11 @@ Stream<int> inboundQueueDepthStream(InboundQueue queue) async* {
   //     that fires during the snapshot computation is dropped and the
   //     UI shows a stale count until the next packet.
   //
-  // (2) The `stats()` snapshot we just awaited is older than any live
-  //     signal that arrived during the await, so emitting `stats.total`
+  // (2) The depth snapshot we just awaited is older than any live
+  //     signal that arrived during the await, so emitting `snapshot.total`
   //     unconditionally and then replaying buffered live values would
   //     step the consumer backwards (e.g. `2 → 1 → 2`). The fix: buffer
-  //     live values until `stats()` resolves, emit the snapshot ONLY
+  //     live values until the snapshot resolves, emit the snapshot ONLY
   //     when the buffer is still empty, otherwise drop the stale
   //     snapshot and emit the buffered live sequence in arrival order
   //     before switching to forwarding the live tail.
@@ -164,7 +164,7 @@ Stream<int> inboundQueueDepthStream(InboundQueue queue) async* {
   try {
     int? snapshot;
     try {
-      final stats = await queue.stats();
+      final stats = await queue.depthSnapshot();
       snapshot = stats.total;
     } catch (_) {
       // Initial paint failures are non-fatal; the live signal below

--- a/lib/features/sync/ui/backfill_settings_page.dart
+++ b/lib/features/sync/ui/backfill_settings_page.dart
@@ -170,7 +170,7 @@ class _QueueDepthScopeState extends State<_QueueDepthScope> {
 
   Future<void> _loadInitial(InboundQueue queue) async {
     try {
-      final stats = await queue.stats();
+      final stats = await queue.depthSnapshot();
       if (!mounted) return;
       // A live emission while the one-shot read was in flight wins —
       // do not overwrite it with the stale snapshot. Also bail if we

--- a/test/database/category_backfill_migration_test.dart
+++ b/test/database/category_backfill_migration_test.dart
@@ -138,7 +138,7 @@ void main() {
 
         final version = await db.customSelect('PRAGMA user_version').get();
         expect(version.first.read<int>('user_version'), db.schemaVersion);
-        expect(db.schemaVersion, 43);
+        expect(db.schemaVersion, 44);
 
         final rows = await db
             .customSelect('SELECT id, category FROM journal ORDER BY id')

--- a/test/database/database_data_queries_test.dart
+++ b/test/database/database_data_queries_test.dart
@@ -361,6 +361,61 @@ void main() {
         },
       );
 
+      test(
+        'getHabitCompletionsInRange preserves write-recency tie breakers',
+        () async {
+          final habitId = habitFlossing.id;
+          final day = DateTime(2024, 4, 16, 21);
+          final updatedAt = DateTime(2024, 4, 16, 23);
+          final earlierCreatedAt = JournalEntity.habitCompletion(
+            meta: Metadata(
+              id: 'habit-created-earlier',
+              createdAt: DateTime(2024, 4, 16, 21),
+              updatedAt: updatedAt,
+              dateFrom: day,
+              dateTo: DateTime(2024, 4, 16, 21),
+              private: false,
+            ),
+            data: HabitCompletionData(
+              habitId: habitId,
+              dateFrom: day,
+              dateTo: DateTime(2024, 4, 16, 21),
+              completionType: HabitCompletionType.success,
+            ),
+          );
+          final laterCreatedAt = JournalEntity.habitCompletion(
+            meta: Metadata(
+              id: 'habit-created-later',
+              createdAt: DateTime(2024, 4, 16, 22),
+              updatedAt: updatedAt,
+              dateFrom: day,
+              dateTo: DateTime(2024, 4, 16, 21),
+              private: false,
+            ),
+            data: HabitCompletionData(
+              habitId: habitId,
+              dateFrom: day,
+              dateTo: DateTime(2024, 4, 16, 21),
+              completionType: HabitCompletionType.fail,
+            ),
+          );
+
+          await db!.updateJournalEntity(earlierCreatedAt);
+          await db!.updateJournalEntity(laterCreatedAt);
+
+          final result = await db!.getHabitCompletionsInRange(
+            rangeStart: DateTime(2024, 4),
+          );
+
+          expect(result, hasLength(1));
+          expect(result.single.meta.id, 'habit-created-later');
+          expect(
+            (result.single as HabitCompletionEntry).data.completionType,
+            HabitCompletionType.fail,
+          );
+        },
+      );
+
       test('getQuantitativeByType filters correctly', () async {
         final weightEntry = buildQuantitativeEntry(
           id: 'weight-1',

--- a/test/database/database_definitions_test.dart
+++ b/test/database/database_definitions_test.dart
@@ -88,6 +88,42 @@ void main() {
 
         expect(await db!.getLabelDefinitionById('nonexistent'), isNull);
       });
+
+      test(
+        'allLabelDefinitions streams name order from the deleted/name index',
+        () async {
+          for (final name in ['Zulu', 'alpha', 'Beta']) {
+            await db!.upsertLabelDefinition(
+              LabelDefinition(
+                id: 'label-plan-${name.toLowerCase()}',
+                createdAt: DateTime(2024, 3, 15),
+                updatedAt: DateTime(2024, 3, 15),
+                name: name,
+                color: '#FF0000',
+                vectorClock: null,
+              ),
+            );
+          }
+          await db!.customStatement('ANALYZE');
+
+          final plan = await db!
+              .customSelect(
+                'EXPLAIN QUERY PLAN '
+                'SELECT * FROM label_definitions '
+                'WHERE deleted = FALSE '
+                'ORDER BY name COLLATE NOCASE',
+              )
+              .get();
+          final detail = plan
+              .map((row) => row.read<String>('detail'))
+              .join('\n');
+          expect(
+            detail,
+            contains('idx_label_definitions_deleted_name_nocase'),
+          );
+          expect(detail, isNot(contains('USE TEMP B-TREE')));
+        },
+      );
     });
 
     group('Upsert helpers -', () {

--- a/test/database/database_entity_ops_test.dart
+++ b/test/database/database_entity_ops_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:drift/drift.dart' show Variable;
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
@@ -327,6 +328,56 @@ void main() {
           ConflictStatus.resolved.index,
         );
       });
+
+      test(
+        'conflictsByStatus uses the status/created_at index for newest-first '
+        'lists',
+        () async {
+          final now = DateTime(2024, 9, 3);
+          for (var i = 0; i < 20; i++) {
+            await db!.addConflict(
+              Conflict(
+                id: 'indexed-conflict-$i',
+                createdAt: now.add(Duration(minutes: i)),
+                updatedAt: now.add(Duration(minutes: i)),
+                serialized: jsonEncode(
+                  buildJournalEntry(
+                    id: 'indexed-conflict-entry-$i',
+                    timestamp: now,
+                    text: 'Conflict $i',
+                  ).toJson(),
+                ),
+                schemaVersion: db!.schemaVersion,
+                status: i.isEven
+                    ? ConflictStatus.unresolved.index
+                    : ConflictStatus.resolved.index,
+              ),
+            );
+          }
+          await db!.customStatement('ANALYZE');
+
+          final rows = await db!
+              .customSelect(
+                '''
+                EXPLAIN QUERY PLAN
+                SELECT *
+                FROM conflicts
+                WHERE status = ?
+                ORDER BY created_at DESC
+                LIMIT ?
+                ''',
+                variables: [
+                  Variable.withInt(ConflictStatus.unresolved.index),
+                  Variable.withInt(10),
+                ],
+              )
+              .get();
+          final details = rows.map((row) => row.data.toString()).join('\n');
+
+          expect(details, contains('idx_conflicts_status_created_at'));
+          expect(details, isNot(contains('USE TEMP B-TREE FOR ORDER BY')));
+        },
+      );
     });
 
     group('purgeDeletedFiles -', () {

--- a/test/database/database_insights_queries_test.dart
+++ b/test/database/database_insights_queries_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:drift/drift.dart' hide isNotNull, isNull;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/entry_text.dart';
@@ -126,6 +127,58 @@ void main() {
   }
 
   group('insightsTimeRows', () {
+    test('query plan uses the covering insights time index', () async {
+      final planRows = await db
+          .customSelect(
+            '''
+            EXPLAIN QUERY PLAN
+            WITH private_flag AS (
+              SELECT COALESCE(
+                (SELECT status FROM config_flags WHERE name = 'private'),
+                FALSE
+              ) AS visible
+            )
+            SELECT
+              j.date_from AS date_from,
+              j.date_to AS date_to,
+              COALESCE(
+                (
+                  SELECT t.category
+                  FROM linked_entries le
+                  INNER JOIN journal t ON t.id = le.from_id
+                  WHERE le.to_id = j.id
+                    AND COALESCE(le.hidden, FALSE) = FALSE
+                    AND t.type = 'Task'
+                    AND t.deleted = FALSE
+                    AND t.category != ''
+                    AND COALESCE(t.private, FALSE) IN (FALSE, pf.visible)
+                  ORDER BY t.date_from DESC, t.id
+                  LIMIT 1
+                ),
+                NULLIF(j.category, '')
+              ) AS category_id
+            FROM journal j INDEXED BY idx_journal_insights_time
+            CROSS JOIN private_flag pf
+            WHERE j.type = 'JournalEntry'
+              AND j.deleted = FALSE
+              AND j.date_to > ?
+              AND j.date_from < ?
+              AND j.date_to > j.date_from
+              AND COALESCE(j.private, FALSE) IN (FALSE, pf.visible)
+            ORDER BY j.date_from
+            ''',
+            variables: [
+              Variable<DateTime>(DateTime(2024, 3)),
+              Variable<DateTime>(DateTime(2024, 4)),
+            ],
+          )
+          .get();
+
+      final plan = planRows.map((row) => row.read<String>('detail')).join('\n');
+      expect(plan, contains('idx_journal_insights_time'));
+      expect(plan, isNot(contains('SCAN j')));
+    });
+
     test(
       'returns spans with entry-own category for unlinked entries',
       () async {

--- a/test/database/database_journal_queries_test.dart
+++ b/test/database/database_journal_queries_test.dart
@@ -1000,6 +1000,47 @@ void main() {
       test('returns zero when no import-flagged entries exist', () async {
         expect(await db!.getCountImportFlagEntries(), 0);
       });
+
+      test('count and list plans use the import-flag partial index', () async {
+        final base = DateTime(2024, 11, 12, 9);
+        for (var i = 0; i < 40; i++) {
+          final entry = buildJournalEntry(
+            id: 'import-flag-plan-$i',
+            timestamp: base.add(Duration(minutes: i)),
+            text: 'Entry $i',
+            flag: i.isEven ? EntryFlag.import : EntryFlag.none,
+          );
+          await db!.upsertJournalDbEntity(toDbEntity(entry));
+        }
+        await db!.customStatement('ANALYZE');
+
+        final countPlan = await db!
+            .customSelect(
+              'EXPLAIN QUERY PLAN '
+              'SELECT COUNT(*) FROM journal '
+              'WHERE deleted = FALSE AND flag = 1',
+            )
+            .get();
+        final countDetail = countPlan
+            .map((row) => row.read<String>('detail'))
+            .join('\n');
+        expect(countDetail, contains('idx_journal_import_flag_date'));
+
+        final listPlan = await db!
+            .customSelect(
+              'EXPLAIN QUERY PLAN '
+              'SELECT * FROM journal '
+              'WHERE deleted = FALSE AND flag = 1 '
+              'ORDER BY date_from DESC '
+              'LIMIT 20',
+            )
+            .get();
+        final listDetail = listPlan
+            .map((row) => row.read<String>('detail'))
+            .join('\n');
+        expect(listDetail, contains('idx_journal_import_flag_date'));
+        expect(listDetail, isNot(contains('USE TEMP B-TREE')));
+      });
     });
 
     group('_extractEntryLinkVectorClock FormatException path -', () {

--- a/test/database/database_task_queries_test.dart
+++ b/test/database/database_task_queries_test.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: avoid_redundant_argument_values
 import 'dart:io';
 
+import 'package:drift/drift.dart' show Variable;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/classes/entry_text.dart';
@@ -929,6 +930,100 @@ void main() {
           ['newest-urgent', 'newer-high', 'older-low'],
         );
       });
+
+      test(
+        'getTasks broad multi-status category fan-out keeps priority/date '
+        'ordering',
+        () async {
+          final base = DateTime(2024, 7, 5, 12);
+          final categories = [
+            for (var i = 0; i < 12; i++) 'broad-cat-$i',
+          ];
+          final tasks = [
+            (
+              id: 'broad-p2-newer',
+              status: TaskStatus.groomed(
+                id: 'status-groomed',
+                createdAt: base,
+                utcOffset: base.timeZoneOffset.inMinutes,
+              ),
+              category: categories[2],
+              rank: 2,
+              minutes: 3,
+            ),
+            (
+              id: 'broad-p0-older',
+              status: TaskStatus.open(
+                id: 'status-open',
+                createdAt: base,
+                utcOffset: base.timeZoneOffset.inMinutes,
+              ),
+              category: categories[0],
+              rank: 0,
+              minutes: 1,
+            ),
+            (
+              id: 'broad-p1-newer',
+              status: TaskStatus.inProgress(
+                id: 'status-progress',
+                createdAt: base,
+                utcOffset: base.timeZoneOffset.inMinutes,
+              ),
+              category: categories[1],
+              rank: 1,
+              minutes: 4,
+            ),
+            (
+              id: 'broad-p0-newer',
+              status: TaskStatus.groomed(
+                id: 'status-groomed-newer',
+                createdAt: base,
+                utcOffset: base.timeZoneOffset.inMinutes,
+              ),
+              category: categories[3],
+              rank: 0,
+              minutes: 5,
+            ),
+          ];
+
+          for (final task in tasks) {
+            final timestamp = base.add(Duration(minutes: task.minutes));
+            await db!.upsertJournalDbEntity(
+              toDbEntity(
+                buildTaskEntry(
+                  id: task.id,
+                  timestamp: timestamp,
+                  status: task.status,
+                  categoryId: task.category,
+                ),
+              ),
+            );
+            await db!.customUpdate(
+              'UPDATE journal SET task_priority_rank = ? WHERE id = ?',
+              variables: [
+                Variable<int>(task.rank),
+                Variable<String>(task.id),
+              ],
+            );
+          }
+
+          final results = await db!.getTasks(
+            starredStatuses: const [true, false],
+            taskStatuses: const ['OPEN', 'IN PROGRESS', 'GROOMED'],
+            categoryIds: categories,
+          );
+
+          expect(
+            results.map((e) => e.meta.id).toList(),
+            [
+              'broad-p0-newer',
+              'broad-p0-older',
+              'broad-p1-newer',
+              'broad-p2-newer',
+            ],
+          );
+        },
+      );
 
       test('getTasks with sortByDate orders by date_from desc only', () async {
         final base = DateTime(2024, 7, 5, 12);

--- a/test/database/definition_indexes_migration_test.dart
+++ b/test/database/definition_indexes_migration_test.dart
@@ -72,7 +72,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').get();
       expect(version.first.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 43);
+      expect(db.schemaVersion, 44);
 
       final indexes = await db.customSelect('''
         SELECT name, sql FROM sqlite_master

--- a/test/database/definition_indexes_migration_test.dart
+++ b/test/database/definition_indexes_migration_test.dart
@@ -80,13 +80,14 @@ void main() {
           AND name IN (
             'idx_habit_definitions_deleted_private',
             'idx_label_definitions_deleted_private_name',
+            'idx_label_definitions_deleted_name_nocase',
             'idx_dashboard_definitions_deleted_private_name',
             'idx_linked_entries_from_id_hidden_created_at_desc'
           )
         ORDER BY name
       ''').get();
 
-      expect(indexes, hasLength(4));
+      expect(indexes, hasLength(5));
 
       final byName = {
         for (final row in indexes)
@@ -99,6 +100,14 @@ void main() {
       );
       expect(
         byName['idx_label_definitions_deleted_private_name'],
+        contains('name COLLATE NOCASE ASC'),
+      );
+      expect(
+        byName['idx_label_definitions_deleted_name_nocase'],
+        contains('deleted COLLATE BINARY ASC'),
+      );
+      expect(
+        byName['idx_label_definitions_deleted_name_nocase'],
         contains('name COLLATE NOCASE ASC'),
       );
       expect(

--- a/test/database/due_at_migration_test.dart
+++ b/test/database/due_at_migration_test.dart
@@ -172,7 +172,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').get();
       expect(version.first.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 43);
+      expect(db.schemaVersion, 44);
 
       final hasColumn = await db.columnExistsForTesting('journal', 'due_at');
       expect(hasColumn, isTrue);

--- a/test/database/editor_db_query_test.dart
+++ b/test/database/editor_db_query_test.dart
@@ -208,6 +208,44 @@ void main() {
       expect(result2!.delta, contains('draft2'));
     });
 
+    test('returns only the newest matching draft row', () async {
+      const entryId = 'test-entry-123';
+      final lastSaved = DateTime(2024, 3, 15, 10, 30);
+      final olderCreatedAt = DateTime(2024, 3, 15, 10, 31);
+      final newerCreatedAt = DateTime(2024, 3, 15, 10, 32);
+
+      await db
+          .into(db.editorDrafts)
+          .insert(
+            EditorDraftState(
+              id: 'older-draft',
+              entryId: entryId,
+              status: 'DRAFT',
+              createdAt: olderCreatedAt,
+              lastSaved: lastSaved,
+              delta: '{"ops":[{"insert":"older"}]}',
+            ),
+          );
+      await db
+          .into(db.editorDrafts)
+          .insert(
+            EditorDraftState(
+              id: 'newer-draft',
+              entryId: entryId,
+              status: 'DRAFT',
+              createdAt: newerCreatedAt,
+              lastSaved: lastSaved,
+              delta: '{"ops":[{"insert":"newer"}]}',
+            ),
+          );
+
+      final result = await db.getLatestDraft(entryId, lastSaved: lastSaved);
+
+      expect(result, isNotNull);
+      expect(result!.id, 'newer-draft');
+      expect(result.delta, contains('newer'));
+    });
+
     test('latestDraft plan uses the composite partial index', () async {
       const entryId = 'test-entry-123';
       final testDate = DateTime(2024, 3, 15, 10, 30);
@@ -231,10 +269,12 @@ void main() {
             '''
             EXPLAIN QUERY PLAN
             SELECT * FROM editor_drafts
+            INDEXED BY editor_drafts_latest_draft
             WHERE entry_id = ?1
               AND last_saved = ?2
               AND status = 'DRAFT'
             ORDER BY created_at DESC
+            LIMIT 1
             ''',
             variables: [
               Variable.withString(entryId),

--- a/test/database/linked_entries_index_migration_test.dart
+++ b/test/database/linked_entries_index_migration_test.dart
@@ -96,7 +96,7 @@ void main() {
       // Schema version advanced to the current schema
       final version = await db.customSelect('PRAGMA user_version').get();
       expect(version.first.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 43);
+      expect(db.schemaVersion, 44);
 
       // The corrected index now references to_id in its column list
       final postMigrationIdx = await db.customSelect("""

--- a/test/database/priority_migration_test.dart
+++ b/test/database/priority_migration_test.dart
@@ -142,7 +142,7 @@ void main() {
 
         final version = await db.customSelect('PRAGMA user_version').get();
         expect(version.first.read<int>('user_version'), db.schemaVersion);
-        expect(db.schemaVersion, 43);
+        expect(db.schemaVersion, 44);
 
         // The non-partial composite `idx_journal_tasks_due_active` was
         // dropped in v41 — its only consumer (`getTasksSortedByDueDate`)
@@ -175,7 +175,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').get();
       expect(version.first.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 43);
+      expect(db.schemaVersion, 44);
 
       final idx = await db.customSelect("""
         SELECT sql FROM sqlite_master
@@ -255,7 +255,7 @@ void main() {
 
         final version = await db.customSelect('PRAGMA user_version').get();
         expect(version.first.read<int>('user_version'), db.schemaVersion);
-        expect(db.schemaVersion, 43);
+        expect(db.schemaVersion, 44);
 
         final idx = await db.customSelect("""
         SELECT sql FROM sqlite_master
@@ -344,7 +344,7 @@ void main() {
 
         final version = await db.customSelect('PRAGMA user_version').get();
         expect(version.first.read<int>('user_version'), db.schemaVersion);
-        expect(db.schemaVersion, 43);
+        expect(db.schemaVersion, 44);
 
         final taskIdx = await db.customSelect("""
         SELECT sql FROM sqlite_master

--- a/test/database/sync_db_lifecycle_test.dart
+++ b/test/database/sync_db_lifecycle_test.dart
@@ -1205,6 +1205,65 @@ void main() {
     );
 
     test(
+      'burnPendingSequenceCountersForHost uses the host/status index before '
+      'ordering counters',
+      () async {
+        final database = SyncDatabase(inMemoryDatabase: true);
+        addTearDown(database.close);
+        const hostId = 'burn-plan-host';
+        final createdAt = DateTime(2026, 5, 24, 11);
+
+        for (var counter = 1; counter <= 200; counter++) {
+          await database.recordSequenceEntry(
+            SyncSequenceLogCompanion(
+              hostId: const Value(hostId),
+              counter: Value(counter),
+              status: Value(
+                counter.isEven
+                    ? SyncSequenceStatus.burnPending.index
+                    : SyncSequenceStatus.received.index,
+              ),
+              createdAt: Value(createdAt.add(Duration(seconds: counter))),
+              updatedAt: Value(createdAt.add(Duration(seconds: counter))),
+            ),
+          );
+        }
+        await database.customStatement('ANALYZE');
+
+        final counters = await database.burnPendingSequenceCountersForHost(
+          hostId: hostId,
+        );
+        expect(counters.take(3), [2, 4, 6]);
+
+        final plan = await database
+            .customSelect(
+              '''
+              EXPLAIN QUERY PLAN
+              SELECT counter
+              FROM sync_sequence_log INDEXED BY idx_sync_sequence_log_host_status
+              WHERE host_id = ?
+                AND status = ?
+              ORDER BY counter
+              ''',
+              variables: [
+                Variable.withString(hostId),
+                Variable.withInt(SyncSequenceStatus.burnPending.index),
+              ],
+            )
+            .get();
+        final details = plan.map((row) => row.data.toString()).join('\n');
+
+        expect(
+          details,
+          contains('idx_sync_sequence_log_host_status'),
+          reason:
+              'startup burn reconciliation should seek the burn-pending '
+              'status partition instead of scanning every counter for host',
+        );
+      },
+    );
+
+    test(
       'recordOwnUnresolvableSequenceCounter inserts absent counters as '
       'burned with no payload mapping',
       () async {

--- a/test/database/sync_db_migration_test.dart
+++ b/test/database/sync_db_migration_test.dart
@@ -93,7 +93,7 @@ void main() {
             .customSelect('PRAGMA user_version')
             .get();
         expect(versionResult.first.read<int>('user_version'), db.schemaVersion);
-        expect(db.schemaVersion, 24);
+        expect(db.schemaVersion, 26);
 
         // Verify sync_sequence_log table exists and has correct schema
         final seqLogResult = await db
@@ -151,7 +151,7 @@ void main() {
 
       // Verify schema version
       final versionResult = await db.customSelect('PRAGMA user_version').get();
-      expect(versionResult.first.read<int>('user_version'), 24);
+      expect(versionResult.first.read<int>('user_version'), 26);
 
       // Verify all tables exist
       final tablesResult = await db
@@ -176,6 +176,7 @@ void main() {
             "SELECT name FROM sqlite_master WHERE type='index' AND name IN ( "
             "'idx_outbox_status_priority_created_at', "
             "'idx_outbox_actionable_priority_created_at', "
+            "'idx_outbox_sent_updated_at', "
             "'idx_sync_sequence_log_actionable_status_created_at', "
             "'idx_sync_sequence_log_actionable_status_updated_at', "
             "'idx_sync_sequence_log_host_status', "
@@ -194,6 +195,7 @@ void main() {
         containsAll(<String>{
           'idx_outbox_status_priority_created_at',
           'idx_outbox_actionable_priority_created_at',
+          'idx_outbox_sent_updated_at',
           'idx_sync_sequence_log_actionable_status_created_at',
           'idx_sync_sequence_log_actionable_status_updated_at',
           'idx_sync_sequence_log_host_status',
@@ -297,7 +299,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 24);
+        expect(versionResult.first.read<int>('user_version'), 26);
 
         // The payload_type column must now exist on the table.
         final columns = await db
@@ -370,7 +372,7 @@ void main() {
 
       // Verify schema version updated
       final versionResult = await db.customSelect('PRAGMA user_version').get();
-      expect(versionResult.first.read<int>('user_version'), 24);
+      expect(versionResult.first.read<int>('user_version'), 26);
 
       // Verify existing row survived with null payload_size
       final items = await db.oldestOutboxItems(10);
@@ -417,7 +419,7 @@ void main() {
 
       // Verify schema version updated
       final versionResult = await db.customSelect('PRAGMA user_version').get();
-      expect(versionResult.first.read<int>('user_version'), 24);
+      expect(versionResult.first.read<int>('user_version'), 26);
 
       // Verify existing row survived with default priority=2 (low)
       final items = await db.oldestOutboxItems(10);
@@ -464,7 +466,7 @@ void main() {
       final db = SyncDatabase(overriddenFilename: 'test_sync_v8.db');
 
       final versionResult = await db.customSelect('PRAGMA user_version').get();
-      expect(versionResult.first.read<int>('user_version'), 24);
+      expect(versionResult.first.read<int>('user_version'), 26);
 
       final indexResults = await db
           .customSelect(
@@ -506,7 +508,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 24);
+        expect(versionResult.first.read<int>('user_version'), 26);
 
         final columns = await db
             .customSelect('PRAGMA table_info(outbox)')
@@ -570,7 +572,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 24);
+        expect(versionResult.first.read<int>('user_version'), 26);
 
         final rows = await db
             .customSelect(
@@ -615,7 +617,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 24);
+        expect(versionResult.first.read<int>('user_version'), 26);
 
         // v12's createTable uses the CURRENT schema, so the queue table
         // must come up with the Phase-3 ledger columns already present and
@@ -673,7 +675,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 24);
+        expect(versionResult.first.read<int>('user_version'), 26);
 
         const expectedIndexes = <String>{
           // v15: retire/stats/claim hotspots from the production slow log.
@@ -681,6 +683,7 @@ void main() {
           'idx_sync_sequence_log_actionable_status_updated_at',
           'idx_sync_sequence_log_host_status',
           'idx_outbox_actionable_priority_created_at',
+          'idx_outbox_sent_updated_at',
           // v16: retireExhausted partial keyed on last_requested_at.
           'idx_sync_sequence_log_actionable_status_last_requested_at',
           // v17: outbox merge-dedup + resurrection partials.
@@ -763,7 +766,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 24);
+        expect(versionResult.first.read<int>('user_version'), 26);
 
         // v11 replaces the v10 index with the covering variant; when the
         // migration steps v9 → v11 in one run, the v10 index must no longer
@@ -841,7 +844,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 24);
+        expect(versionResult.first.read<int>('user_version'), 26);
 
         final oldIndex = await db
             .customSelect(
@@ -918,7 +921,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 24);
+        expect(versionResult.first.read<int>('user_version'), 26);
 
         // All Phase-3 ledger columns must now exist on the queue table.
         final columns = await db
@@ -1000,7 +1003,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 24);
+        expect(versionResult.first.read<int>('user_version'), 26);
 
         final ready = await db
             .customSelect(
@@ -1061,7 +1064,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 24);
+        expect(versionResult.first.read<int>('user_version'), 26);
 
         final pendingIndex = await db
             .customSelect(
@@ -1154,7 +1157,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 24);
+        expect(versionResult.first.read<int>('user_version'), 26);
 
         final newIndices = await db
             .customSelect(
@@ -1221,7 +1224,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 24);
+        expect(versionResult.first.read<int>('user_version'), 26);
 
         final sendingIndex = await db
             .customSelect(
@@ -1262,7 +1265,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 24);
+        expect(versionResult.first.read<int>('user_version'), 26);
 
         final index = await db
             .customSelect(
@@ -1313,7 +1316,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 24);
+        expect(versionResult.first.read<int>('user_version'), 26);
 
         // v24 drops and recreates the partial index so burned (8) joins the
         // resolved set.
@@ -1344,6 +1347,90 @@ void main() {
         await insert(3, SyncSequenceStatus.received.index);
 
         expect(await db.getLastCounterForHost(hostId), 3);
+
+        await db.close();
+      },
+    );
+
+    test(
+      'v25 migration rebuilds actionable outbox index with id tie-breaker',
+      () async {
+        final dbFile = File(
+          path.join(testDirectory!.path, 'test_sync_v25_outbox_id.db'),
+        );
+        final sqlite = sqlite3.open(dbFile.path);
+
+        _createOutboxV6(sqlite);
+        _createSyncSequenceLogV3(sqlite, withJsonPath: true);
+        sqlite
+          ..execute(
+            'CREATE INDEX idx_outbox_actionable_priority_created_at '
+            'ON outbox (priority, created_at) '
+            'WHERE status IN (0, 3)',
+          )
+          ..execute('PRAGMA user_version = 24')
+          ..dispose();
+
+        final db = SyncDatabase(
+          overriddenFilename: 'test_sync_v25_outbox_id.db',
+        );
+
+        final versionResult = await db
+            .customSelect('PRAGMA user_version')
+            .get();
+        expect(versionResult.first.read<int>('user_version'), 26);
+
+        final index = await db
+            .customSelect(
+              "SELECT sql FROM sqlite_master WHERE type='index' "
+              "AND name = 'idx_outbox_actionable_priority_created_at'",
+            )
+            .get();
+        expect(index, hasLength(1));
+        expect(
+          index.first.readNullable<String>('sql'),
+          contains('ON outbox (priority, created_at, id)'),
+        );
+
+        await db.close();
+      },
+    );
+
+    test(
+      'v26 migration adds sent updated-at outbox index for retention pruning',
+      () async {
+        final dbFile = File(
+          path.join(testDirectory!.path, 'test_sync_v26_outbox_sent.db'),
+        );
+        final sqlite = sqlite3.open(dbFile.path);
+
+        _createOutboxV6(sqlite);
+        _createSyncSequenceLogV3(sqlite, withJsonPath: true);
+        sqlite
+          ..execute('PRAGMA user_version = 25')
+          ..dispose();
+
+        final db = SyncDatabase(
+          overriddenFilename: 'test_sync_v26_outbox_sent.db',
+        );
+
+        final versionResult = await db
+            .customSelect('PRAGMA user_version')
+            .get();
+        expect(versionResult.first.read<int>('user_version'), 26);
+
+        final index = await db
+            .customSelect(
+              "SELECT sql FROM sqlite_master WHERE type='index' "
+              "AND name = 'idx_outbox_sent_updated_at'",
+            )
+            .get();
+        expect(index, hasLength(1));
+        expect(
+          index.first.readNullable<String>('sql'),
+          contains('ON outbox (updated_at, id)'),
+        );
+        expect(index.first.readNullable<String>('sql'), contains('status = 1'));
 
         await db.close();
       },

--- a/test/database/sync_db_migration_test.dart
+++ b/test/database/sync_db_migration_test.dart
@@ -93,7 +93,7 @@ void main() {
             .customSelect('PRAGMA user_version')
             .get();
         expect(versionResult.first.read<int>('user_version'), db.schemaVersion);
-        expect(db.schemaVersion, 26);
+        expect(db.schemaVersion, 27);
 
         // Verify sync_sequence_log table exists and has correct schema
         final seqLogResult = await db
@@ -151,7 +151,7 @@ void main() {
 
       // Verify schema version
       final versionResult = await db.customSelect('PRAGMA user_version').get();
-      expect(versionResult.first.read<int>('user_version'), 26);
+      expect(versionResult.first.read<int>('user_version'), 27);
 
       // Verify all tables exist
       final tablesResult = await db
@@ -176,6 +176,7 @@ void main() {
             "SELECT name FROM sqlite_master WHERE type='index' AND name IN ( "
             "'idx_outbox_status_priority_created_at', "
             "'idx_outbox_actionable_priority_created_at', "
+            "'idx_outbox_actionable_subject', "
             "'idx_outbox_sent_updated_at', "
             "'idx_sync_sequence_log_actionable_status_created_at', "
             "'idx_sync_sequence_log_actionable_status_updated_at', "
@@ -195,6 +196,7 @@ void main() {
         containsAll(<String>{
           'idx_outbox_status_priority_created_at',
           'idx_outbox_actionable_priority_created_at',
+          'idx_outbox_actionable_subject',
           'idx_outbox_sent_updated_at',
           'idx_sync_sequence_log_actionable_status_created_at',
           'idx_sync_sequence_log_actionable_status_updated_at',
@@ -299,7 +301,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 26);
+        expect(versionResult.first.read<int>('user_version'), 27);
 
         // The payload_type column must now exist on the table.
         final columns = await db
@@ -372,7 +374,7 @@ void main() {
 
       // Verify schema version updated
       final versionResult = await db.customSelect('PRAGMA user_version').get();
-      expect(versionResult.first.read<int>('user_version'), 26);
+      expect(versionResult.first.read<int>('user_version'), 27);
 
       // Verify existing row survived with null payload_size
       final items = await db.oldestOutboxItems(10);
@@ -419,7 +421,7 @@ void main() {
 
       // Verify schema version updated
       final versionResult = await db.customSelect('PRAGMA user_version').get();
-      expect(versionResult.first.read<int>('user_version'), 26);
+      expect(versionResult.first.read<int>('user_version'), 27);
 
       // Verify existing row survived with default priority=2 (low)
       final items = await db.oldestOutboxItems(10);
@@ -466,7 +468,7 @@ void main() {
       final db = SyncDatabase(overriddenFilename: 'test_sync_v8.db');
 
       final versionResult = await db.customSelect('PRAGMA user_version').get();
-      expect(versionResult.first.read<int>('user_version'), 26);
+      expect(versionResult.first.read<int>('user_version'), 27);
 
       final indexResults = await db
           .customSelect(
@@ -508,7 +510,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 26);
+        expect(versionResult.first.read<int>('user_version'), 27);
 
         final columns = await db
             .customSelect('PRAGMA table_info(outbox)')
@@ -572,7 +574,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 26);
+        expect(versionResult.first.read<int>('user_version'), 27);
 
         final rows = await db
             .customSelect(
@@ -617,7 +619,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 26);
+        expect(versionResult.first.read<int>('user_version'), 27);
 
         // v12's createTable uses the CURRENT schema, so the queue table
         // must come up with the Phase-3 ledger columns already present and
@@ -675,7 +677,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 26);
+        expect(versionResult.first.read<int>('user_version'), 27);
 
         const expectedIndexes = <String>{
           // v15: retire/stats/claim hotspots from the production slow log.
@@ -766,7 +768,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 26);
+        expect(versionResult.first.read<int>('user_version'), 27);
 
         // v11 replaces the v10 index with the covering variant; when the
         // migration steps v9 → v11 in one run, the v10 index must no longer
@@ -844,7 +846,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 26);
+        expect(versionResult.first.read<int>('user_version'), 27);
 
         final oldIndex = await db
             .customSelect(
@@ -921,7 +923,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 26);
+        expect(versionResult.first.read<int>('user_version'), 27);
 
         // All Phase-3 ledger columns must now exist on the queue table.
         final columns = await db
@@ -1003,7 +1005,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 26);
+        expect(versionResult.first.read<int>('user_version'), 27);
 
         final ready = await db
             .customSelect(
@@ -1064,7 +1066,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 26);
+        expect(versionResult.first.read<int>('user_version'), 27);
 
         final pendingIndex = await db
             .customSelect(
@@ -1157,7 +1159,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 26);
+        expect(versionResult.first.read<int>('user_version'), 27);
 
         final newIndices = await db
             .customSelect(
@@ -1224,7 +1226,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 26);
+        expect(versionResult.first.read<int>('user_version'), 27);
 
         final sendingIndex = await db
             .customSelect(
@@ -1265,7 +1267,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 26);
+        expect(versionResult.first.read<int>('user_version'), 27);
 
         final index = await db
             .customSelect(
@@ -1316,7 +1318,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 26);
+        expect(versionResult.first.read<int>('user_version'), 27);
 
         // v24 drops and recreates the partial index so burned (8) joins the
         // resolved set.
@@ -1378,7 +1380,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 26);
+        expect(versionResult.first.read<int>('user_version'), 27);
 
         final index = await db
             .customSelect(
@@ -1417,7 +1419,7 @@ void main() {
         final versionResult = await db
             .customSelect('PRAGMA user_version')
             .get();
-        expect(versionResult.first.read<int>('user_version'), 26);
+        expect(versionResult.first.read<int>('user_version'), 27);
 
         final index = await db
             .customSelect(
@@ -1431,6 +1433,49 @@ void main() {
           contains('ON outbox (updated_at, id)'),
         );
         expect(index.first.readNullable<String>('sql'), contains('status = 1'));
+
+        await db.close();
+      },
+    );
+
+    test(
+      'v27 migration adds actionable subject index for backfill outbox scans',
+      () async {
+        final dbFile = File(
+          path.join(testDirectory!.path, 'test_sync_v27_outbox_subject.db'),
+        );
+        final sqlite = sqlite3.open(dbFile.path);
+
+        _createOutboxV6(sqlite);
+        _createSyncSequenceLogV3(sqlite, withJsonPath: true);
+        sqlite
+          ..execute('PRAGMA user_version = 26')
+          ..dispose();
+
+        final db = SyncDatabase(
+          overriddenFilename: 'test_sync_v27_outbox_subject.db',
+        );
+
+        final versionResult = await db
+            .customSelect('PRAGMA user_version')
+            .get();
+        expect(versionResult.first.read<int>('user_version'), 27);
+
+        final index = await db
+            .customSelect(
+              "SELECT sql FROM sqlite_master WHERE type='index' "
+              "AND name = 'idx_outbox_actionable_subject'",
+            )
+            .get();
+        expect(index, hasLength(1));
+        expect(
+          index.first.readNullable<String>('sql'),
+          contains('ON outbox (subject)'),
+        );
+        expect(
+          index.first.readNullable<String>('sql'),
+          contains('status IN (0, 3)'),
+        );
 
         await db.close();
       },

--- a/test/database/sync_db_outbox_dedup_test.dart
+++ b/test/database/sync_db_outbox_dedup_test.dart
@@ -969,8 +969,8 @@ void main() {
       expect(updated.first.payloadSize, 9999);
     });
 
-    test('schema version is 24', () {
-      expect(db.schemaVersion, 24);
+    test('schema version is 26', () {
+      expect(db.schemaVersion, 26);
     });
 
     test(
@@ -996,6 +996,13 @@ void main() {
               'sending must be index 3 — used as a literal in the '
               'partial-index WHERE clause and as `_outboxSendingStatus` '
               'in sync_db.dart.',
+        );
+        expect(
+          OutboxStatus.sent.index,
+          1,
+          reason:
+              'sent must be index 1 — used as a literal in the '
+              'sent-ledger updated_at partial-index WHERE clause.',
         );
       },
     );

--- a/test/database/sync_db_outbox_dedup_test.dart
+++ b/test/database/sync_db_outbox_dedup_test.dart
@@ -13,9 +13,9 @@ void main() {
 
   group('getPendingBackfillEntries Tests', () {
     // Subject prefix that production `_enqueueBackfillRequest` stamps on
-    // every backfill outbox row. `getPendingBackfillEntries` filters on
-    // `subject LIKE 'backfillRequest:%'` at the SQL level so it can skip
-    // JSON-decoding unrelated pending rows on a million-row outbox.
+    // every backfill outbox row. `getPendingBackfillEntries` filters with a
+    // bounded `backfillRequest:` subject-prefix range at the SQL level so it
+    // can skip JSON-decoding unrelated pending rows on a million-row outbox.
     const backfillSubject = 'backfillRequest:batch:1';
 
     setUpAll(() async {
@@ -333,11 +333,10 @@ void main() {
     });
 
     test(
-      'plan uses an outbox status index (full or partial) rather than '
-      'SCANning the table — load-bearing for the 2-minute backfill tick '
-      'which was the top offender in the 2026-05-12 desktop slow-query '
-      'log when `t.status.isIn([pending, sending])` bound the values '
-      'as parameters and the planner fell back to SCAN outbox',
+      'plan uses the actionable subject index rather than scanning every '
+      'pending/sending outbox row — load-bearing for the 2-minute backfill '
+      'tick that used to filter the backfillRequest subject after scanning '
+      'the actionable queue',
       () async {
         final database = db!;
 
@@ -366,36 +365,28 @@ void main() {
         final rows = await database
             .customSelect(
               'EXPLAIN QUERY PLAN '
-              'SELECT * FROM outbox WHERE status IN (0, 3) '
-              "AND subject LIKE 'backfillRequest:%'",
+              'SELECT * FROM outbox '
+              'INDEXED BY idx_outbox_actionable_subject '
+              'WHERE status IN (0, 3) '
+              "AND subject >= 'backfillRequest:' "
+              "AND subject < 'backfillRequest;'",
             )
             .get();
         final plan = rows.map((r) => r.data.toString()).join('\n');
 
-        // With status values inlined as literals the planner has a real
-        // status filter at plan time and picks either the partial
-        // `idx_outbox_actionable_priority_created_at` (WHERE status IN
-        // (0, 3)) or the full `idx_outbox_status_priority_created_at` for
-        // a two-key seek. Both are correct outcomes; the regression we
-        // are guarding against is the planner falling back to SCAN
-        // outbox, which is what happened with parameterised statuses.
         expect(
           plan,
-          anyOf(
-            contains('idx_outbox_actionable_priority_created_at'),
-            contains('idx_outbox_status_priority_created_at'),
-          ),
+          contains('idx_outbox_actionable_subject'),
           reason:
-              'literal `IN (0, 3)` must let the planner pick a status '
-              'index seek instead of falling back to SCAN outbox',
+              'the backfill-request probe must range-scan the subject '
+              'prefix index instead of walking every actionable row',
         );
         expect(
           plan,
           isNot(matches(RegExp('SCAN outbox(?! USING)'))),
           reason:
-              'no base-table scan once the planner can see the status set '
-              '(an indexed `SCAN outbox USING INDEX <name>` plan is fine — '
-              'only bare `SCAN outbox` is a regression)',
+              'no base-table scan once the planner can see the subject '
+              'prefix range and actionable status set',
         );
 
         final entries = await database.getPendingBackfillEntries();
@@ -969,8 +960,8 @@ void main() {
       expect(updated.first.payloadSize, 9999);
     });
 
-    test('schema version is 26', () {
-      expect(db.schemaVersion, 26);
+    test('schema version is 27', () {
+      expect(db.schemaVersion, 27);
     });
 
     test(

--- a/test/database/sync_db_outbox_prune_test.dart
+++ b/test/database/sync_db_outbox_prune_test.dart
@@ -250,6 +250,34 @@ void main() {
       },
     );
 
+    test(
+      'pruneSentOutboxItemsChunked stale-row probe uses the sent updated-at '
+      'partial index',
+      () async {
+        final database = db!;
+        final cutoff = DateTime(2026, 5, 1);
+
+        final planRows = await database
+            .customSelect(
+              'EXPLAIN QUERY PLAN '
+              'SELECT id FROM outbox INDEXED BY idx_outbox_sent_updated_at '
+              'WHERE status = 1 AND updated_at < ? '
+              'LIMIT ?',
+              variables: [
+                Variable.withDateTime(cutoff),
+                const Variable<int>(50),
+              ],
+            )
+            .get();
+
+        final plan = planRows
+            .map((row) => row.read<String>('detail'))
+            .join('\n');
+        expect(plan, contains('idx_outbox_sent_updated_at'));
+        expect(plan, isNot(contains('SCAN outbox')));
+      },
+    );
+
     Glados(any.pruneScenario, ExploreConfig(numRuns: 80)).test(
       'pruneSentOutboxItemsChunked invariants — for any (rows, chunkSize, '
       'retention): only (sent, old) rows are deleted; live state and forensic '

--- a/test/database/sync_db_outbox_test.dart
+++ b/test/database/sync_db_outbox_test.dart
@@ -1135,6 +1135,53 @@ void main() {
       expect(await database.watchOutboxCount().first, 1);
     });
 
+    test(
+      'watchOutboxCount uses literal actionable statuses so SQLite can '
+      'match the partial index',
+      () async {
+        final database = db!;
+        for (var i = 0; i < 200; i++) {
+          await database.addOutboxItem(
+            buildOutboxCompanion(
+              status: OutboxStatus.sent,
+              subject: 'sent-$i',
+              message: '{"i":$i}',
+              createdAt: DateTime(2024, 5, 1).add(Duration(seconds: i)),
+            ),
+          );
+        }
+        await database.addOutboxItem(
+          buildOutboxCompanion(
+            status: OutboxStatus.pending,
+            createdAt: DateTime(2024, 5, 4),
+          ),
+        );
+        await database.customStatement('ANALYZE');
+
+        final plan = await database
+            .customSelect(
+              'EXPLAIN QUERY PLAN '
+              'SELECT COUNT(*) AS cnt FROM outbox '
+              'INDEXED BY idx_outbox_actionable_priority_created_at '
+              'WHERE status IN (0, 3)',
+            )
+            .get();
+        final details = plan.map((row) => row.data.toString()).join('\n');
+
+        expect(
+          details,
+          contains('idx_outbox_actionable_priority_created_at'),
+          reason:
+              'literal status IN (0, 3) should imply the partial-index '
+              'predicate and count only actionable index entries',
+        );
+        expect(
+          details,
+          isNot(matches(RegExp('SCAN outbox(?! USING)'))),
+        );
+      },
+    );
+
     test('getPendingOutboxCount returns count of pending items', () async {
       final database = db!;
       await database.addOutboxItem(

--- a/test/database/task_indexes_v39_migration_test.dart
+++ b/test/database/task_indexes_v39_migration_test.dart
@@ -128,7 +128,7 @@ void main() {
 
         final version = await db.customSelect('PRAGMA user_version').get();
         expect(version.first.read<int>('user_version'), db.schemaVersion);
-        expect(db.schemaVersion, 43);
+        expect(db.schemaVersion, 44);
 
         // v41 swapped the expression-keyed shape for a column-keyed one.
         final sql = await indexSql(db, 'idx_journal_tasks_due_open');
@@ -272,6 +272,125 @@ void main() {
 
         final detail = plan.map((row) => row.read<String>('detail')).join('\n');
         expect(detail, contains('idx_journal_tasks_due_open'));
+      },
+    );
+
+    test('v44 adds broad task-list and import-flag indexes', () async {
+      final dbFile = File(
+        p.join(testDirectory!.path, 'test_v44_task_priority_date.db'),
+      );
+      final sqlite = sqlite3.open(dbFile.path);
+      createV38Schema(sqlite);
+      sqlite.execute('PRAGMA user_version = 43');
+      sqlite.dispose();
+
+      final db = JournalDb(
+        overriddenFilename: 'test_v44_task_priority_date.db',
+      );
+      addTearDown(db.close);
+
+      final version = await db.customSelect('PRAGMA user_version').get();
+      expect(version.first.read<int>('user_version'), db.schemaVersion);
+      expect(db.schemaVersion, 44);
+
+      final sql = await indexSql(db, 'idx_journal_tasks_priority_date');
+      expect(sql, contains('task_priority_rank COLLATE BINARY ASC'));
+      expect(sql, contains('date_from COLLATE BINARY DESC'));
+      expect(sql, contains('id COLLATE BINARY ASC'));
+      expect(sql, contains("type = 'Task'"));
+      expect(sql, contains('task = 1'));
+      expect(sql, contains('deleted = FALSE'));
+
+      final flagSql = await indexSql(db, 'idx_journal_import_flag_date');
+      expect(flagSql, contains('flag COLLATE BINARY ASC'));
+      expect(flagSql, contains('date_from COLLATE BINARY DESC'));
+      expect(flagSql, contains('id COLLATE BINARY ASC'));
+      expect(flagSql, contains('WHERE deleted = FALSE'));
+    });
+
+    test(
+      'pinned multi-status task-list plan streams priority/date order without temp '
+      'sort',
+      () async {
+        final dbFile = File(
+          p.join(testDirectory!.path, 'test_v44_task_priority_plan.db'),
+        );
+        final sqlite = sqlite3.open(dbFile.path);
+        createV38Schema(sqlite);
+        sqlite.execute('PRAGMA user_version = 38');
+        sqlite.dispose();
+
+        final db = JournalDb(
+          overriddenFilename: 'test_v44_task_priority_plan.db',
+        );
+        addTearDown(db.close);
+
+        const statuses = ['IN PROGRESS', 'OPEN', 'GROOMED', 'DONE'];
+        final categories = [
+          for (var i = 0; i < 32; i++) 'category-$i',
+        ];
+        for (var i = 0; i < 240; i++) {
+          final createdAt =
+              DateTime.utc(
+                2026,
+                6,
+              ).add(Duration(minutes: i)).millisecondsSinceEpoch ~/
+              1000;
+          final isPrivate = i.isEven;
+          await db.customStatement(
+            'INSERT INTO journal '
+            '(id, serialized, created_at, updated_at, date_from, date_to, '
+            'type, deleted, private, starred, task, task_status, '
+            'task_priority_rank, category) '
+            'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            [
+              'task-$i',
+              '{}',
+              createdAt,
+              createdAt,
+              createdAt,
+              createdAt,
+              'Task',
+              0,
+              isPrivate,
+              0,
+              1,
+              statuses[i % statuses.length],
+              i % 4,
+              categories[i % categories.length],
+            ],
+          );
+        }
+        await db.customStatement('ANALYZE');
+
+        final plan = await db
+            .customSelect(
+              '''
+              EXPLAIN QUERY PLAN
+              SELECT * FROM journal
+              INDEXED BY idx_journal_tasks_priority_date
+              WHERE type = 'Task'
+                AND deleted = FALSE
+                AND task = 1
+                AND task_status IN (?, ?, ?)
+                AND category IN (${List.filled(categories.length, '?').join(', ')})
+              ORDER BY task_priority_rank ASC, date_from DESC
+              LIMIT ? OFFSET ?
+            ''',
+              variables: [
+                Variable.withString('IN PROGRESS'),
+                Variable.withString('OPEN'),
+                Variable.withString('GROOMED'),
+                ...categories.map(Variable.withString),
+                const Variable<int>(50),
+                const Variable<int>(0),
+              ],
+            )
+            .get();
+
+        final detail = plan.map((row) => row.read<String>('detail')).join('\n');
+        expect(detail, contains('idx_journal_tasks_priority_date'));
+        expect(detail, isNot(contains('USE TEMP B-TREE')));
       },
     );
 

--- a/test/features/agents/database/agent_database_test.dart
+++ b/test/features/agents/database/agent_database_test.dart
@@ -1524,6 +1524,228 @@ void main() {
         await db.close();
       },
     );
+
+    test(
+      'v14 to v15 adds task-scoped agent entity lookup index',
+      () async {
+        final dbFile = path.join(testDirectory.path, agentDbFileName);
+        final rawDb = sqlite3.open(dbFile);
+
+        rawDb
+          ..execute('''
+            CREATE TABLE agent_entities (
+              id TEXT NOT NULL PRIMARY KEY,
+              agent_id TEXT NOT NULL,
+              type TEXT NOT NULL,
+              subtype TEXT,
+              thread_id TEXT,
+              created_at DATETIME NOT NULL,
+              updated_at DATETIME NOT NULL,
+              deleted_at DATETIME,
+              serialized TEXT NOT NULL,
+              schema_version INTEGER NOT NULL DEFAULT 1
+            )
+          ''')
+          ..execute('''
+            CREATE TABLE agent_links (
+              id TEXT NOT NULL PRIMARY KEY,
+              from_id TEXT NOT NULL,
+              to_id TEXT NOT NULL,
+              type TEXT NOT NULL,
+              created_at DATETIME NOT NULL,
+              updated_at DATETIME NOT NULL,
+              deleted_at DATETIME,
+              serialized TEXT NOT NULL,
+              schema_version INTEGER NOT NULL DEFAULT 1
+            )
+          ''')
+          ..execute('''
+            CREATE TABLE wake_run_log (
+              run_key TEXT NOT NULL PRIMARY KEY,
+              agent_id TEXT NOT NULL,
+              reason TEXT NOT NULL,
+              reason_id TEXT,
+              thread_id TEXT NOT NULL,
+              status TEXT NOT NULL,
+              logical_change_key TEXT,
+              created_at DATETIME NOT NULL,
+              started_at DATETIME,
+              completed_at DATETIME,
+              error_message TEXT,
+              template_id TEXT,
+              template_version_id TEXT,
+              resolved_model_id TEXT,
+              soul_id TEXT,
+              soul_version_id TEXT,
+              user_rating REAL,
+              rated_at DATETIME
+            )
+          ''')
+          ..execute('''
+            CREATE TABLE saga_log (
+              operation_id TEXT NOT NULL PRIMARY KEY,
+              agent_id TEXT NOT NULL,
+              run_key TEXT NOT NULL,
+              phase TEXT NOT NULL,
+              status TEXT NOT NULL,
+              tool_name TEXT NOT NULL,
+              last_error TEXT,
+              created_at DATETIME NOT NULL,
+              updated_at DATETIME NOT NULL
+            )
+          ''')
+          ..execute('''
+            CREATE TABLE attention_claim_index (
+              request_id TEXT NOT NULL PRIMARY KEY,
+              agent_id TEXT NOT NULL,
+              status TEXT NOT NULL,
+              scope_kind TEXT NOT NULL,
+              visibility_start DATETIME NOT NULL,
+              visibility_end DATETIME NOT NULL,
+              deadline DATETIME,
+              next_review_at DATETIME,
+              target_id TEXT,
+              target_kind TEXT,
+              updated_at DATETIME NOT NULL,
+              deleted_at DATETIME
+            )
+          ''')
+          ..execute('''
+            CREATE TABLE standing_agreement_index (
+              agreement_id TEXT NOT NULL PRIMARY KEY,
+              agent_id TEXT NOT NULL,
+              status TEXT NOT NULL,
+              scope TEXT NOT NULL,
+              cadence TEXT NOT NULL,
+              approval_mode TEXT NOT NULL,
+              enforcement TEXT NOT NULL,
+              active_from DATETIME NOT NULL,
+              active_until DATETIME NOT NULL,
+              priority INTEGER NOT NULL,
+              target_id TEXT,
+              target_kind TEXT,
+              updated_at DATETIME NOT NULL,
+              deleted_at DATETIME
+            )
+          ''')
+          ..execute('PRAGMA user_version = 14');
+        rawDb.dispose();
+
+        final db = AgentDatabase(
+          background: false,
+          documentsDirectoryProvider: () async => testDirectory,
+          tempDirectoryProvider: () async => testDirectory,
+        );
+        addTearDown(db.close);
+
+        final versionResult = await db
+            .customSelect('PRAGMA user_version')
+            .get();
+        expect(
+          versionResult.first.read<int>('user_version'),
+          db.schemaVersion,
+        );
+
+        final indexes = await db.customSelect('''
+          SELECT name FROM sqlite_master
+          WHERE type = 'index'
+            AND name = 'idx_agent_entities_active_agent_type_task_created_id'
+        ''').get();
+        expect(indexes, hasLength(1));
+
+        final plan = await db.customSelect(r'''
+          EXPLAIN QUERY PLAN
+          SELECT *
+          FROM agent_entities
+            INDEXED BY idx_agent_entities_active_agent_type_task_created_id
+          WHERE agent_id = 'agent-1'
+            AND type = 'changeSet'
+            AND json_valid(serialized)
+            AND json_extract(serialized, '\$.taskId') = 'task-1'
+            AND deleted_at IS NULL
+          ORDER BY created_at DESC
+          LIMIT 20
+        ''').get();
+        final details = plan
+            .map((row) => row.read<String>('detail'))
+            .join('\n');
+        expect(
+          details,
+          contains('idx_agent_entities_active_agent_type_task_created_id'),
+        );
+        expect(details, isNot(contains('USE TEMP B-TREE')));
+
+        await db.close();
+      },
+    );
+
+    test(
+      'v15 to latest adds pending scheduled-wake timestamp index',
+      () async {
+        final dbFile = path.join(testDirectory.path, agentDbFileName);
+        final rawDb = sqlite3.open(dbFile);
+
+        rawDb
+          ..execute('''
+            CREATE TABLE agent_entities (
+              id TEXT NOT NULL PRIMARY KEY,
+              agent_id TEXT NOT NULL,
+              type TEXT NOT NULL,
+              subtype TEXT,
+              thread_id TEXT,
+              created_at DATETIME NOT NULL,
+              updated_at DATETIME NOT NULL,
+              deleted_at DATETIME,
+              serialized TEXT NOT NULL,
+              schema_version INTEGER NOT NULL DEFAULT 1
+            )
+          ''')
+          ..execute('PRAGMA user_version = 15');
+        rawDb.dispose();
+
+        final db = AgentDatabase(
+          background: false,
+          documentsDirectoryProvider: () async => testDirectory,
+          tempDirectoryProvider: () async => testDirectory,
+        );
+        addTearDown(db.close);
+
+        final versionResult = await db
+            .customSelect('PRAGMA user_version')
+            .get();
+        expect(
+          versionResult.first.read<int>('user_version'),
+          db.schemaVersion,
+        );
+
+        final indexes = await db.customSelect('''
+          SELECT name FROM sqlite_master
+          WHERE type = 'index'
+            AND name = 'idx_agent_entities_pending_scheduled_wake_at'
+        ''').get();
+        expect(indexes, hasLength(1));
+
+        final plan = await db.customSelect(r'''
+          EXPLAIN QUERY PLAN
+          SELECT *
+          FROM agent_entities
+          WHERE type = 'scheduledWake'
+            AND deleted_at IS NULL
+            AND json_extract(serialized, '$.status') = 'pending'
+            AND json_extract(serialized, '$.scheduledAt') IS NOT NULL
+            AND json_extract(serialized, '$.scheduledAt') <= '2026-04-01T12:00:00.000'
+        ''').get();
+        final details = plan
+            .map((row) => row.read<String>('detail'))
+            .join('\n');
+        expect(
+          details,
+          contains('idx_agent_entities_pending_scheduled_wake_at'),
+        );
+
+        await db.close();
+      },
+    );
   });
 
   group('AgentDatabase fresh install', () {
@@ -1866,7 +2088,139 @@ void main() {
           .get();
       final linkDetails = linkPlan.map((r) => r.data.toString()).join('\n');
       expect(linkDetails, contains('idx_agent_links_active_to_type'));
+
+      final taskScopedPlan = await db
+          .customSelect(
+            r'''
+              EXPLAIN QUERY PLAN
+              SELECT * FROM agent_entities
+                INDEXED BY idx_agent_entities_active_agent_type_task_created_id
+              WHERE agent_id = ?1
+                AND type = 'changeSet'
+                AND json_valid(serialized)
+                AND json_extract(serialized, '\$.taskId') = ?2
+                AND deleted_at IS NULL
+              ORDER BY created_at DESC
+              LIMIT ?3
+            ''',
+            variables: [
+              const Variable<String>('agent-1'),
+              const Variable<String>('task-1'),
+              const Variable<int>(20),
+            ],
+          )
+          .get();
+      final taskScopedDetails = taskScopedPlan
+          .map((row) => row.read<String>('detail'))
+          .join('\n');
+      expect(
+        taskScopedDetails,
+        contains('idx_agent_entities_active_agent_type_task_created_id'),
+      );
+      expect(taskScopedDetails, isNot(contains('USE TEMP B-TREE')));
     });
+
+    test(
+      'pending scheduled-wake queries use the JSON timestamp index',
+      () async {
+        final db = AgentDatabase(
+          inMemoryDatabase: true,
+          background: false,
+        );
+        addTearDown(db.close);
+
+        final indexes = await db
+            .customSelect(
+              "SELECT name FROM sqlite_master WHERE type = 'index' "
+              "AND name = 'idx_agent_entities_pending_scheduled_wake_at'",
+            )
+            .get();
+        expect(indexes, hasLength(1));
+
+        for (var i = 0; i < 80; i++) {
+          final ts =
+              DateTime(
+                2026,
+                4,
+              ).add(Duration(minutes: i)).millisecondsSinceEpoch ~/
+              1000;
+          final scheduledAt = DateTime(
+            2026,
+            4,
+            1,
+            8,
+          ).add(Duration(minutes: i)).toIso8601String();
+          final status = i % 5 == 0 ? 'cancelled' : 'pending';
+          final type = i % 7 == 0 ? 'agentState' : 'scheduledWake';
+          await db.customStatement(
+            'INSERT INTO agent_entities '
+            '(id, agent_id, type, created_at, updated_at, serialized, '
+            'schema_version) '
+            'VALUES (?, ?, ?, ?, ?, ?, 1)',
+            [
+              'scheduled-wake-$i',
+              'agent-${i % 4}',
+              type,
+              ts,
+              ts,
+              jsonEncode({
+                'runtimeType': type,
+                'status': status,
+                'scheduledAt': scheduledAt,
+              }),
+            ],
+          );
+        }
+        await db.customStatement('ANALYZE');
+
+        final duePlan = await db
+            .customSelect(
+              r'''
+              EXPLAIN QUERY PLAN
+              SELECT * FROM agent_entities
+              WHERE type = 'scheduledWake'
+                AND deleted_at IS NULL
+                AND json_extract(serialized, '$.status') = 'pending'
+                AND json_extract(serialized, '$.scheduledAt') IS NOT NULL
+                AND json_extract(serialized, '$.scheduledAt') <= ?1
+            ''',
+              variables: [
+                Variable<String>(DateTime(2026, 4, 1, 9).toIso8601String()),
+              ],
+            )
+            .get();
+        final dueDetails = duePlan
+            .map((row) => row.read<String>('detail'))
+            .join('\n');
+        expect(
+          dueDetails,
+          contains('idx_agent_entities_pending_scheduled_wake_at'),
+        );
+        expect(
+          dueDetails,
+          isNot(matches(RegExp('SCAN agent_entities(?! USING)'))),
+        );
+
+        // ignore: use_raw_strings
+        final pendingPlan = await db.customSelect('''
+        EXPLAIN QUERY PLAN
+        SELECT * FROM agent_entities
+        WHERE type = 'scheduledWake'
+          AND deleted_at IS NULL
+          AND json_extract(serialized, '\$.status') = 'pending'
+          AND json_extract(serialized, '\$.scheduledAt') IS NOT NULL
+        ORDER BY json_extract(serialized, '\$.scheduledAt') ASC
+      ''').get();
+        final pendingDetails = pendingPlan
+            .map((row) => row.read<String>('detail'))
+            .join('\n');
+        expect(
+          pendingDetails,
+          contains('idx_agent_entities_pending_scheduled_wake_at'),
+        );
+        expect(pendingDetails, isNot(contains('USE TEMP B-TREE')));
+      },
+    );
 
     test('creates idx_unique_soul_per_template index on new DB', () async {
       final db = AgentDatabase(

--- a/test/features/agents/database/agent_database_test.dart
+++ b/test/features/agents/database/agent_database_test.dart
@@ -1647,11 +1647,18 @@ void main() {
         );
 
         final indexes = await db.customSelect('''
-          SELECT name FROM sqlite_master
+          SELECT sql FROM sqlite_master
           WHERE type = 'index'
             AND name = 'idx_agent_entities_active_agent_type_task_created_id'
         ''').get();
         expect(indexes, hasLength(1));
+        expect(
+          indexes.single.read<String>('sql'),
+          contains(
+            r"agent_id, type, json_extract(serialized, '$.taskId'), "
+            'created_at DESC, id DESC',
+          ),
+        );
 
         final plan = await db.customSelect(r'''
           EXPLAIN QUERY PLAN
@@ -1661,7 +1668,7 @@ void main() {
           WHERE agent_id = 'agent-1'
             AND type = 'changeSet'
             AND json_valid(serialized)
-            AND json_extract(serialized, '\$.taskId') = 'task-1'
+            AND json_extract(serialized, '$.taskId') = 'task-1'
             AND deleted_at IS NULL
           ORDER BY created_at DESC
           LIMIT 20
@@ -2098,7 +2105,7 @@ void main() {
               WHERE agent_id = ?1
                 AND type = 'changeSet'
                 AND json_valid(serialized)
-                AND json_extract(serialized, '\$.taskId') = ?2
+                AND json_extract(serialized, '$.taskId') = ?2
                 AND deleted_at IS NULL
               ORDER BY created_at DESC
               LIMIT ?3

--- a/test/features/agents/database/agent_repo_links_test.dart
+++ b/test/features/agents/database/agent_repo_links_test.dart
@@ -1,3 +1,4 @@
+import 'package:drift/drift.dart' show Variable;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/agents/database/agent_database.dart';
 import 'package:lotti/features/agents/database/agent_repo_links.dart';
@@ -42,6 +43,69 @@ void main() {
       final from = await links.getLinksFrom('from-1');
       expect(to.map((l) => l.id), ['l1']);
       expect(from.map((l) => l.id), ['l1']);
+    });
+
+    test('typed direction reads use active partial indexes', () async {
+      await links.upsertLink(
+        makeTestAgentTaskLink(
+          id: 'lt-index',
+          fromId: 'agent-index',
+          toId: 'task-index',
+          createdAt: testDate,
+          updatedAt: testDate,
+        ),
+      );
+
+      final from = await links.getLinksFrom(
+        'agent-index',
+        type: AgentLinkTypes.agentTask,
+      );
+      final to = await links.getLinksTo(
+        'task-index',
+        type: AgentLinkTypes.agentTask,
+      );
+      expect(from.map((link) => link.id), ['lt-index']);
+      expect(to.map((link) => link.id), ['lt-index']);
+
+      final fromPlan = await db
+          .customSelect(
+            '''
+              EXPLAIN QUERY PLAN
+              SELECT * FROM agent_links
+                INDEXED BY idx_agent_links_active_from_type_to
+              WHERE from_id = ? AND type = ? AND deleted_at IS NULL
+            ''',
+            variables: [
+              Variable.withString('agent-index'),
+              Variable.withString(AgentLinkTypes.agentTask),
+            ],
+            readsFrom: {db.agentLinks},
+          )
+          .get();
+      final fromDetails = fromPlan
+          .map((row) => row.read<String>('detail'))
+          .join('\n');
+      expect(fromDetails, contains('idx_agent_links_active_from_type_to'));
+
+      final toPlan = await db
+          .customSelect(
+            '''
+              EXPLAIN QUERY PLAN
+              SELECT * FROM agent_links
+                INDEXED BY idx_agent_links_active_to_type
+              WHERE to_id = ? AND type = ? AND deleted_at IS NULL
+            ''',
+            variables: [
+              Variable.withString('task-index'),
+              Variable.withString(AgentLinkTypes.agentTask),
+            ],
+            readsFrom: {db.agentLinks},
+          )
+          .get();
+      final toDetails = toPlan
+          .map((row) => row.read<String>('detail'))
+          .join('\n');
+      expect(toDetails, contains('idx_agent_links_active_to_type'));
     });
 
     test(

--- a/test/features/agents/database/agent_repository_test.dart
+++ b/test/features/agents/database/agent_repository_test.dart
@@ -2567,6 +2567,56 @@ void main() {
 
       expect(identities, isEmpty);
     });
+
+    test('filters agent identities by lifecycle in SQL', () async {
+      final active = makeAgent(id: 'agent-active', agentId: 'a-001').copyWith(
+        createdAt: DateTime(2026, 2, 22),
+      );
+      final olderActive =
+          makeAgent(
+            id: 'agent-active-older',
+            agentId: 'a-002',
+          ).copyWith(
+            createdAt: DateTime(2026, 2, 21),
+          );
+      final dormant =
+          makeAgent(
+            id: 'agent-dormant',
+            agentId: 'a-003',
+          ).copyWith(
+            lifecycle: AgentLifecycle.dormant,
+          );
+      final destroyed =
+          makeAgent(
+            id: 'agent-destroyed',
+            agentId: 'a-004',
+          ).copyWith(
+            lifecycle: AgentLifecycle.destroyed,
+          );
+      final deletedActive =
+          makeAgent(
+            id: 'agent-deleted',
+            agentId: 'a-005',
+          ).copyWith(
+            deletedAt: DateTime(2026, 2, 23),
+          );
+
+      await repo.upsertEntity(active);
+      await repo.upsertEntity(olderActive);
+      await repo.upsertEntity(dormant);
+      await repo.upsertEntity(destroyed);
+      await repo.upsertEntity(deletedActive);
+      await repo.upsertEntity(makeAgentState());
+
+      final identities = await repo.getAgentIdentitiesByLifecycle(
+        AgentLifecycle.active,
+      );
+
+      expect(
+        identities.map((identity) => identity.id),
+        ['agent-active', 'agent-active-older'],
+      );
+    });
   });
 
   // ── Link CRUD ───────────────────────────────────────────────────────────────

--- a/test/features/agents/service/agent_service_test.dart
+++ b/test/features/agents/service/agent_service_test.dart
@@ -510,29 +510,30 @@ void main() {
         verify(() => mockRepository.getAllAgentIdentities()).called(1);
       });
 
-      test('filters by lifecycle when provided', () async {
+      test('delegates lifecycle-filtered reads to the repository', () async {
         final activeAgent = makeTestIdentity(
           id: 'a1',
           agentId: 'a1',
           displayName: 'Active',
         );
-        final dormantAgent = makeTestIdentity(
-          id: 'a2',
-          agentId: 'a2',
-          displayName: 'Dormant',
-          lifecycle: AgentLifecycle.dormant,
-        );
 
         when(
-          () => mockRepository.getAllAgentIdentities(),
-        ).thenAnswer((_) async => [activeAgent, dormantAgent]);
+          () => mockRepository.getAgentIdentitiesByLifecycle(
+            AgentLifecycle.active,
+          ),
+        ).thenAnswer((_) async => [activeAgent]);
 
         final result = await service.listAgents(
           lifecycle: AgentLifecycle.active,
         );
 
-        expect(result, hasLength(1));
-        expect(result.first.id, 'a1');
+        expect(result.map((agent) => agent.id), ['a1']);
+        verifyNever(() => mockRepository.getAllAgentIdentities());
+        verify(
+          () => mockRepository.getAgentIdentitiesByLifecycle(
+            AgentLifecycle.active,
+          ),
+        ).called(1);
       });
     });
 

--- a/test/features/agents/service/agent_template_crud_test.dart
+++ b/test/features/agents/service/agent_template_crud_test.dart
@@ -165,13 +165,67 @@ void main() {
         ],
       );
       when(
-        () => mockRepo.getEntity(agent.id),
-      ).thenAnswer((_) async => agent);
+        () => mockRepo.getEntitiesByIds(any()),
+      ).thenAnswer((_) async => {agent.id: agent});
 
       await expectLater(
         () => crud.deleteTemplate(kTestTemplateId),
         throwsA(isA<TemplateInUseException>()),
       );
+      verifyNever(() => mockSync.upsertEntity(any()));
+    });
+
+    test('batch-loads linked agents when checking template usage', () async {
+      final activeAgent = makeTestIdentity(id: 'agent-1', agentId: 'agent-1');
+      final destroyedAgent = makeTestIdentity(
+        id: 'agent-2',
+        agentId: 'agent-2',
+        lifecycle: AgentLifecycle.destroyed,
+      );
+      when(
+        () => mockRepo.getLinksFrom(
+          kTestTemplateId,
+          type: AgentLinkTypes.templateAssignment,
+        ),
+      ).thenAnswer(
+        (_) async => [
+          makeTestTemplateAssignmentLink(
+            fromId: kTestTemplateId,
+            toId: activeAgent.id,
+          ),
+          makeTestTemplateAssignmentLink(
+            fromId: kTestTemplateId,
+            toId: destroyedAgent.id,
+          ),
+          makeTestTemplateAssignmentLink(
+            fromId: kTestTemplateId,
+            toId: 'missing-agent',
+          ),
+        ],
+      );
+      when(
+        () => mockRepo.getEntitiesByIds(any()),
+      ).thenAnswer(
+        (_) async => {
+          activeAgent.id: activeAgent,
+          destroyedAgent.id: destroyedAgent,
+        },
+      );
+
+      await expectLater(
+        () => crud.deleteTemplate(kTestTemplateId),
+        throwsA(isA<TemplateInUseException>()),
+      );
+
+      final captured =
+          verify(
+                () => mockRepo.getEntitiesByIds(captureAny()),
+              ).captured.single
+              as Iterable<String>;
+      expect(captured, ['agent-1', 'agent-2', 'missing-agent']);
+      verifyNever(() => mockRepo.getEntity('agent-1'));
+      verifyNever(() => mockRepo.getEntity('agent-2'));
+      verifyNever(() => mockRepo.getEntity('missing-agent'));
       verifyNever(() => mockSync.upsertEntity(any()));
     });
 

--- a/test/features/agents/service/agent_template_metrics_test.dart
+++ b/test/features/agents/service/agent_template_metrics_test.dart
@@ -14,6 +14,7 @@ import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
 import '../test_data/constants.dart';
 import '../test_data/entity_factories.dart';
+import '../test_data/evolution_factories.dart';
 import '../test_data/link_factories.dart';
 import '../test_data/template_factories.dart';
 
@@ -53,9 +54,16 @@ void main() {
     when(
       () => mockRepo.getLinksFrom(kTestTemplateId, type: 'template_assignment'),
     ).thenAnswer((_) async => links);
-    for (final agent in agents) {
-      when(() => mockRepo.getEntity(agent.id)).thenAnswer((_) async => agent);
-    }
+    when(() => mockRepo.getEntitiesByIds(any<Iterable<String>>())).thenAnswer(
+      (invocation) async {
+        final ids = invocation.positionalArguments.single as Iterable<String>;
+        final agentsById = {for (final agent in agents) agent.id: agent};
+        return <String, AgentDomainEntity>{
+          for (final id in ids)
+            if (agentsById[id] case final AgentIdentityEntity agent) id: agent,
+        };
+      },
+    );
   }
 
   group('computeMetrics', () {
@@ -122,6 +130,95 @@ void main() {
         expect(result.activeInstanceCount, 0);
       },
     );
+  });
+
+  group('gatherEvolutionData', () {
+    test('batch-fetches observation payloads by id', () async {
+      final observationA = makeTestMessage(
+        id: 'obs-a',
+        kind: AgentMessageKind.observation,
+        contentEntryId: 'payload-a',
+      );
+      final observationB = makeTestMessage(
+        id: 'obs-b',
+        kind: AgentMessageKind.observation,
+        contentEntryId: 'payload-b',
+      );
+      final payloadA = makeTestMessagePayload(id: 'payload-a');
+      final payloadB = makeTestMessagePayload(id: 'payload-b');
+
+      when(
+        () => mockRepo.aggregateWakeRunMetrics(kTestTemplateId),
+      ).thenAnswer(
+        (_) async => AggregateWakeRunMetricsByTemplateIdResult(
+          successCount: 0,
+          failureCount: 0,
+          durationSumMs: null,
+          durationCount: 0,
+          firstWakeAt: null,
+          lastWakeAt: null,
+        ),
+      );
+      when(
+        () => mockRepo.countWakeRunsForTemplate(kTestTemplateId),
+      ).thenAnswer((_) async => 0);
+      when(
+        () =>
+            mockRepo.getLinksFrom(kTestTemplateId, type: 'template_assignment'),
+      ).thenAnswer((_) async => []);
+      when(
+        () => mockRepo.getEntitiesByAgentId(
+          kTestTemplateId,
+          type: AgentEntityTypes.agentTemplateVersion,
+          limit: any(named: 'limit'),
+        ),
+      ).thenAnswer((_) async => <AgentDomainEntity>[]);
+      when(
+        () => mockRepo.getRecentReportsByTemplate(
+          kTestTemplateId,
+          limit: any(named: 'limit'),
+        ),
+      ).thenAnswer((_) async => <AgentReportEntity>[]);
+      when(
+        () => mockRepo.getRecentObservationsByTemplate(
+          kTestTemplateId,
+          limit: any(named: 'limit'),
+        ),
+      ).thenAnswer((_) async => [observationA, observationB]);
+      when(
+        () => mockRepo.getEvolutionNotes(kTestTemplateId, limit: 30),
+      ).thenAnswer((_) async => [makeTestEvolutionNote()]);
+      when(
+        () => mockRepo.getEvolutionSessions(kTestTemplateId),
+      ).thenAnswer((_) async => [makeTestEvolutionSession()]);
+      when(
+        () => mockRepo.getEntitiesByIds(any()),
+      ).thenAnswer(
+        (_) async => {
+          payloadA.id: payloadA,
+          payloadB.id: payloadB,
+        },
+      );
+      when(
+        () => mockRepo.countChangedSinceForTemplate(
+          kTestTemplateId,
+          any(),
+        ),
+      ).thenAnswer((_) async => 7);
+
+      final result = await metrics.gatherEvolutionData(kTestTemplateId);
+
+      expect(result.observationPayloads.keys, {'payload-a', 'payload-b'});
+      expect(result.changesSinceLastSession, 7);
+      final capturedIds =
+          verify(
+                () => mockRepo.getEntitiesByIds(captureAny()),
+              ).captured.single
+              as Iterable<String>;
+      expect(capturedIds.toSet(), {'payload-a', 'payload-b'});
+      verifyNever(() => mockRepo.getEntity('payload-a'));
+      verifyNever(() => mockRepo.getEntity('payload-b'));
+    });
   });
 
   group('profileInUse', () {

--- a/test/features/agents/service/agent_template_service_test.dart
+++ b/test/features/agents/service/agent_template_service_test.dart
@@ -26,6 +26,21 @@ const _generatedChangedProfileId = 'generated-profile-updated';
 const _generatedTargetProfileId = 'generated-target-profile';
 const _generatedHeadId = 'generated-template-head';
 
+void _stubEntitiesByIds(
+  MockAgentRepository repository,
+  Map<String, AgentDomainEntity> entitiesById,
+) {
+  when(() => repository.getEntitiesByIds(any<Iterable<String>>())).thenAnswer(
+    (invocation) async {
+      final ids = invocation.positionalArguments.single as Iterable<String>;
+      return <String, AgentDomainEntity>{
+        for (final id in ids)
+          if (entitiesById[id] case final AgentDomainEntity entity) id: entity,
+      };
+    },
+  );
+}
+
 enum _GeneratedTemplateEntitySlot { present, missing, wrongType }
 
 enum _GeneratedTemplateDisplayNameSlot { omitted, same, changed }
@@ -2391,8 +2406,7 @@ void main() {
           type: 'template_assignment',
         ),
       ).thenAnswer((_) async => links);
-      when(() => mockRepo.getEntity('agent-a')).thenAnswer((_) async => agentA);
-      when(() => mockRepo.getEntity('agent-b')).thenAnswer((_) async => agentB);
+      _stubEntitiesByIds(mockRepo, {agentA.id: agentA, agentB.id: agentB});
 
       final result = await service.getAgentsForTemplate(kTestTemplateId);
 
@@ -2423,10 +2437,10 @@ void main() {
           type: 'template_assignment',
         ),
       ).thenAnswer((_) async => links);
-      // Return a template entity instead of an agent.
-      when(
-        () => mockRepo.getEntity('not-an-agent'),
-      ).thenAnswer((_) async => makeTestTemplate(id: 'not-an-agent'));
+      _stubEntitiesByIds(
+        mockRepo,
+        {'not-an-agent': makeTestTemplate(id: 'not-an-agent')},
+      );
 
       final result = await service.getAgentsForTemplate(kTestTemplateId);
 
@@ -2443,7 +2457,7 @@ void main() {
           type: 'template_assignment',
         ),
       ).thenAnswer((_) async => links);
-      when(() => mockRepo.getEntity('gone')).thenAnswer((_) async => null);
+      _stubEntitiesByIds(mockRepo, const {});
 
       final result = await service.getAgentsForTemplate(kTestTemplateId);
 
@@ -2516,11 +2530,12 @@ void main() {
           type: AgentLinkTypes.templateAssignment,
         ),
       ).thenAnswer((_) async => links);
-      for (final (index, slot) in scenario.assignmentSlots.indexed) {
-        when(
-          () => generatedRepository.getEntity('generated-delete-agent-$index'),
-        ).thenAnswer((_) async => scenario.assignmentEntity(slot, index));
-      }
+      _stubEntitiesByIds(generatedRepository, {
+        for (final (index, slot) in scenario.assignmentSlots.indexed)
+          if (scenario.assignmentEntity(slot, index)
+              case final AgentDomainEntity entity)
+            'generated-delete-agent-$index': entity,
+      });
       when(
         () => generatedRepository.getEntity(_generatedTemplateId),
       ).thenAnswer((_) async => scenario.initialTemplateEntity);
@@ -2640,9 +2655,7 @@ void main() {
           type: 'template_assignment',
         ),
       ).thenAnswer((_) async => links);
-      when(
-        () => mockRepo.getEntity('agent-a'),
-      ).thenAnswer((_) async => activeAgent);
+      _stubEntitiesByIds(mockRepo, {'agent-a': activeAgent});
 
       await expectLater(
         service.deleteTemplate(kTestTemplateId),
@@ -2666,9 +2679,7 @@ void main() {
           type: 'template_assignment',
         ),
       ).thenAnswer((_) async => links);
-      when(
-        () => mockRepo.getEntity('agent-a'),
-      ).thenAnswer((_) async => destroyedAgent);
+      _stubEntitiesByIds(mockRepo, {'agent-a': destroyedAgent});
       when(
         () => mockRepo.getTemplateHead(kTestTemplateId),
       ).thenAnswer((_) async => null);
@@ -2758,12 +2769,10 @@ void main() {
           type: 'template_assignment',
         ),
       ).thenAnswer((_) async => links);
-      when(
-        () => mockRepo.getEntity('agent-a'),
-      ).thenAnswer((_) async => activeAgent);
-      when(
-        () => mockRepo.getEntity('agent-b'),
-      ).thenAnswer((_) async => destroyedAgent);
+      _stubEntitiesByIds(
+        mockRepo,
+        {'agent-a': activeAgent, 'agent-b': destroyedAgent},
+      );
 
       await expectLater(
         service.deleteTemplate(kTestTemplateId),
@@ -3872,9 +3881,9 @@ void main() {
           type: 'template_assignment',
         ),
       ).thenAnswer((_) async => links);
-      for (final agent in agents) {
-        when(() => mockRepo.getEntity(agent.id)).thenAnswer((_) async => agent);
-      }
+      _stubEntitiesByIds(mockRepo, {
+        for (final agent in agents) agent.id: agent,
+      });
     }
 
     void stubAggregateMetrics({
@@ -4244,13 +4253,15 @@ void main() {
           type: AgentLinkTypes.templateAssignment,
         ),
       ).thenAnswer((_) async => assignmentLinks);
-      for (final (index, slot) in scenario.agentSlots.indexed) {
-        when(
-          () => generatedRepository.getEntity(
-            'generated-gather-agent-link-$index',
-          ),
-        ).thenAnswer((_) async => slot.entity(index));
-      }
+      _stubEntitiesByIds(generatedRepository, {
+        for (final (index, slot) in scenario.agentSlots.indexed)
+          if (slot.entity(index) case final AgentDomainEntity entity)
+            'generated-gather-agent-link-$index': entity,
+        for (final slot in _GeneratedGatherPayloadSlot.values)
+          if (slot.contentEntryId case final String contentEntryId)
+            if (slot.lookupEntity case final AgentDomainEntity entity)
+              contentEntryId: entity,
+      });
       when(
         () => generatedRepository.getEntitiesByAgentId(
           _generatedTemplateId,
@@ -4282,14 +4293,6 @@ void main() {
           limit: 10,
         ),
       ).thenAnswer((_) async => scenario.sessions);
-      for (final slot in _GeneratedGatherPayloadSlot.values) {
-        final contentEntryId = slot.contentEntryId;
-        if (contentEntryId != null) {
-          when(
-            () => generatedRepository.getEntity(contentEntryId),
-          ).thenAnswer((_) async => slot.lookupEntity);
-        }
-      }
       when(
         () => generatedRepository.countChangedSinceForTemplate(
           _generatedTemplateId,
@@ -4375,19 +4378,20 @@ void main() {
           limit: 5,
         ),
       ).called(1);
-      for (final slot in _GeneratedGatherPayloadSlot.values) {
-        final contentEntryId = slot.contentEntryId;
-        if (contentEntryId == null) {
-          continue;
-        }
-        final lookupCount = scenario.payloadLookupCounts[contentEntryId] ?? 0;
-        if (lookupCount == 0) {
-          verifyNever(() => generatedRepository.getEntity(contentEntryId));
-        } else {
-          verify(
-            () => generatedRepository.getEntity(contentEntryId),
-          ).called(lookupCount);
-        }
+      if (scenario.payloadLookupCounts.isNotEmpty) {
+        final entityBatchIds = verify(
+          () => generatedRepository.getEntitiesByIds(captureAny()),
+        ).captured.cast<Iterable<String>>().map((ids) => ids.toSet()).toList();
+        final expectedPayloadIds = scenario.payloadLookupCounts.keys.toSet();
+        expect(
+          entityBatchIds.any(
+            (ids) =>
+                ids.length == expectedPayloadIds.length &&
+                ids.containsAll(expectedPayloadIds),
+          ),
+          isTrue,
+          reason: '$scenario',
+        );
       }
     }, tags: 'glados');
 
@@ -4459,9 +4463,7 @@ void main() {
         final payload = makeTestMessagePayload(id: 'payload-abc');
 
         stubGatherDependencies(observations: [obs]);
-        when(
-          () => mockRepo.getEntity('payload-abc'),
-        ).thenAnswer((_) async => payload);
+        _stubEntitiesByIds(mockRepo, {'payload-abc': payload});
 
         final bundle = await service.gatherEvolutionData(kTestTemplateId);
 

--- a/test/features/agents/service/event_agent_service_test.dart
+++ b/test/features/agents/service/event_agent_service_test.dart
@@ -116,6 +116,9 @@ void main() {
       ),
     ).thenReturn(null);
     when(() => mockAgentService.cancelPendingWake(any())).thenReturn(null);
+    when(
+      () => mockRepository.getAgentStatesByAgentIds(any()),
+    ).thenAnswer((_) async => const {});
 
     service = EventAgentService(
       agentService: mockAgentService,
@@ -380,12 +383,16 @@ void main() {
           makeTestAgentEventLink(fromId: 'agent-event', toId: eventId),
         ],
       );
-      when(() => mockRepository.getAgentState('agent-event')).thenAnswer(
-        (_) async => makeState(
-          agentId: 'agent-event',
-          awaitingContent: true,
-          nextWakeAt: deadline,
-        ),
+      when(
+        () => mockRepository.getAgentStatesByAgentIds(any()),
+      ).thenAnswer(
+        (_) async => {
+          'agent-event': makeState(
+            agentId: 'agent-event',
+            awaitingContent: true,
+            nextWakeAt: deadline,
+          ),
+        },
       );
 
       await service.restoreSubscriptions();
@@ -419,6 +426,13 @@ void main() {
         subscription.matchEntityIds,
         {eventId},
       );
+      final requestedAgentIds =
+          verify(
+                () => mockRepository.getAgentStatesByAgentIds(captureAny()),
+              ).captured.single
+              as List<String>;
+      expect(requestedAgentIds, ['agent-event']);
+      verifyNever(() => mockRepository.getAgentState('agent-event'));
     });
 
     test('swallows a per-agent restore failure and keeps going (logged via '

--- a/test/features/agents/service/feedback_extraction_service_test.dart
+++ b/test/features/agents/service/feedback_extraction_service_test.dart
@@ -425,10 +425,19 @@ void main() {
     ).thenAnswer((_) async => []);
     // Default: no entity found for payload lookups.
     when(() => mockRepo.getEntity(any())).thenAnswer((_) async => null);
+    when(
+      () => mockRepo.getEntitiesByIds(any()),
+    ).thenAnswer((_) async => const <String, AgentDomainEntity>{});
     // Template kind check: null → not an improver, skips evolution feedback.
     when(
       () => mockTemplateService.getTemplate(any()),
     ).thenAnswer((_) async => null);
+  }
+
+  void stubEntitiesById(Map<String, AgentDomainEntity> entitiesById) {
+    when(
+      () => mockRepo.getEntitiesByIds(any()),
+    ).thenAnswer((_) async => entitiesById);
   }
 
   /// Stubs decisions for decision classification tests.
@@ -866,6 +875,7 @@ void main() {
         }
         stubDecisions(decisions);
 
+        final changeSets = <String, AgentDomainEntity>{};
         for (var index = 0; index < scenario.decisions.length; index += 1) {
           final changeSet = scenario.decisions[index].changeSet(
             index: index,
@@ -875,10 +885,11 @@ void main() {
           if (changeSet == null) {
             continue;
           }
-          when(() => mockRepo.getEntity(changeSet.id)).thenAnswer(
-            (_) async => changeSet,
-          );
+          changeSets[changeSet.id] = changeSet;
         }
+        when(() => mockRepo.getEntitiesByIds(any())).thenAnswer(
+          (_) async => changeSets,
+        );
 
         final expected = scenario.expectedModel(
           since: windowStart,
@@ -992,9 +1003,7 @@ void main() {
           limit: any(named: 'limit'),
         ),
       ).thenAnswer((_) async => [observation]);
-      when(
-        () => mockRepo.getEntity('payload-grievance'),
-      ).thenAnswer((_) async => payload);
+      stubEntitiesById({'payload-grievance': payload});
 
       final result = await service.extract(
         templateId: kTestTemplateId,
@@ -1032,9 +1041,7 @@ void main() {
           limit: any(named: 'limit'),
         ),
       ).thenAnswer((_) async => [observation]);
-      when(
-        () => mockRepo.getEntity('payload-excellence'),
-      ).thenAnswer((_) async => payload);
+      stubEntitiesById({'payload-excellence': payload});
 
       final result = await service.extract(
         templateId: kTestTemplateId,
@@ -1076,9 +1083,7 @@ void main() {
           limit: any(named: 'limit'),
         ),
       ).thenAnswer((_) async => [observation]);
-      when(
-        () => mockRepo.getEntity('payload-improvement'),
-      ).thenAnswer((_) async => payload);
+      stubEntitiesById({'payload-improvement': payload});
 
       final result = await service.extract(
         templateId: kTestTemplateId,
@@ -1121,9 +1126,7 @@ void main() {
           limit: any(named: 'limit'),
         ),
       ).thenAnswer((_) async => [observation]);
-      when(
-        () => mockRepo.getEntity('payload-critical-operational'),
-      ).thenAnswer((_) async => payload);
+      stubEntitiesById({'payload-critical-operational': payload});
 
       final result = await service.extract(
         templateId: kTestTemplateId,
@@ -1167,9 +1170,7 @@ void main() {
           limit: any(named: 'limit'),
         ),
       ).thenAnswer((_) async => [observation]);
-      when(
-        () => mockRepo.getEntity('payload-critical-op-positive'),
-      ).thenAnswer((_) async => payload);
+      stubEntitiesById({'payload-critical-op-positive': payload});
 
       final result = await service.extract(
         templateId: kTestTemplateId,
@@ -1203,9 +1204,7 @@ void main() {
           limit: any(named: 'limit'),
         ),
       ).thenAnswer((_) async => [observation]);
-      when(
-        () => mockRepo.getEntity('payload-routine'),
-      ).thenAnswer((_) async => payload);
+      stubEntitiesById({'payload-routine': payload});
 
       final result = await service.extract(
         templateId: kTestTemplateId,
@@ -1238,9 +1237,7 @@ void main() {
           limit: any(named: 'limit'),
         ),
       ).thenAnswer((_) async => [observation]);
-      when(
-        () => mockRepo.getEntity('payload-enrich-1'),
-      ).thenAnswer((_) async => payload);
+      stubEntitiesById({'payload-enrich-1': payload});
 
       final result = await service.extract(
         templateId: kTestTemplateId,
@@ -1273,9 +1270,7 @@ void main() {
           limit: any(named: 'limit'),
         ),
       ).thenAnswer((_) async => [observation]);
-      when(
-        () => mockRepo.getEntity('payload-long'),
-      ).thenAnswer((_) async => payload);
+      stubEntitiesById({'payload-long': payload});
 
       final result = await service.extract(
         templateId: kTestTemplateId,
@@ -1306,9 +1301,7 @@ void main() {
           limit: any(named: 'limit'),
         ),
       ).thenAnswer((_) async => [observation]);
-      when(
-        () => mockRepo.getEntity('payload-empty'),
-      ).thenAnswer((_) async => payload);
+      stubEntitiesById({'payload-empty': payload});
 
       final result = await service.extract(
         templateId: kTestTemplateId,
@@ -1364,9 +1357,7 @@ void main() {
             limit: any(named: 'limit'),
           ),
         ).thenAnswer((_) async => [observation]);
-        when(
-          () => mockRepo.getEntity('payload-sentiment'),
-        ).thenAnswer((_) async => payload);
+        stubEntitiesById({'payload-sentiment': payload});
 
         final result = await service.extract(
           templateId: kTestTemplateId,
@@ -1411,8 +1402,10 @@ void main() {
         toolName: 'fallback_tool',
       );
       stubDecisions([decision]);
-      when(() => mockRepo.getEntity('cs-summary')).thenAnswer(
-        (_) async => makeTestChangeSet(id: 'cs-summary'),
+      when(() => mockRepo.getEntitiesByIds(any())).thenAnswer(
+        (_) async => {
+          'cs-summary': makeTestChangeSet(id: 'cs-summary'),
+        },
       );
 
       final result = await service.extract(
@@ -1460,7 +1453,9 @@ void main() {
         toolName: 'safe_fallback_tool',
       );
       stubDecisions([decision]);
-      when(() => mockRepo.getEntity('cs-fail')).thenThrow(Exception('db down'));
+      when(() => mockRepo.getEntitiesByIds(any())).thenThrow(
+        Exception('db down'),
+      );
 
       final result = await service.extract(
         templateId: kTestTemplateId,
@@ -1486,7 +1481,7 @@ void main() {
         ),
       ).thenAnswer((_) async => [observation]);
       when(
-        () => mockRepo.getEntity('payload-fail'),
+        () => mockRepo.getEntitiesByIds(any()),
       ).thenThrow(Exception('payload read failed'));
 
       final result = await service.extract(
@@ -1700,11 +1695,13 @@ void main() {
           ),
         ],
       );
-      when(() => mockRepo.getAgentState(agentId)).thenAnswer(
-        (_) async => makeTestState(
-          agentId: agentId,
-          slots: AgentSlots(activeTemplateId: activeTemplateId),
-        ),
+      when(() => mockRepo.getAgentStatesByAgentIds(any())).thenAnswer(
+        (_) async => {
+          agentId: makeTestState(
+            agentId: agentId,
+            slots: AgentSlots(activeTemplateId: activeTemplateId),
+          ),
+        },
       );
     }
 
@@ -2001,8 +1998,10 @@ void main() {
           ),
         ],
       );
-      when(() => mockRepo.getAgentState('agent-no-target')).thenAnswer(
-        (_) async => makeTestState(agentId: 'agent-no-target'),
+      when(() => mockRepo.getAgentStatesByAgentIds(any())).thenAnswer(
+        (_) async => {
+          'agent-no-target': makeTestState(agentId: 'agent-no-target'),
+        },
       );
 
       final result = await service.extract(

--- a/test/features/agents/service/project_agent_service_test.dart
+++ b/test/features/agents/service/project_agent_service_test.dart
@@ -177,6 +177,9 @@ void main() {
     when(() => mockSyncService.upsertEntity(any())).thenAnswer((_) async {});
     when(() => mockSyncService.upsertLink(any())).thenAnswer((_) async {});
     when(() => mockOrchestrator.addSubscription(any())).thenReturn(null);
+    when(
+      () => mockRepository.getAgentStatesByAgentIds(any()),
+    ).thenAnswer((_) async => const {});
 
     service = ProjectAgentService(
       agentService: mockAgentService,
@@ -973,11 +976,13 @@ void main() {
             ),
           ).thenAnswer((_) async => [link]);
           when(
-            () => mockRepository.getAgentState('pa-1'),
+            () => mockRepository.getAgentStatesByAgentIds(any()),
           ).thenAnswer(
-            (_) async => makeState(agentId: 'pa-1').copyWith(
-              nextWakeAt: nextWakeAt,
-            ),
+            (_) async => {
+              'pa-1': makeState(agentId: 'pa-1').copyWith(
+                nextWakeAt: nextWakeAt,
+              ),
+            },
           );
 
           await service.restoreSubscriptions();
@@ -1004,6 +1009,13 @@ void main() {
               type: any(named: 'type'),
             ),
           );
+          final requestedAgentIds =
+              verify(
+                    () => mockRepository.getAgentStatesByAgentIds(captureAny()),
+                  ).captured.single
+                  as List<String>;
+          expect(requestedAgentIds, ['pa-1']);
+          verifyNever(() => mockRepository.getAgentState('pa-1'));
         },
       );
 

--- a/test/features/agents/service/task_agent_service_test.dart
+++ b/test/features/agents/service/task_agent_service_test.dart
@@ -244,6 +244,9 @@ void main() {
     when(
       () => mockRepository.getEntity(kTestTemplateId),
     ).thenAnswer((_) async => makeTestTemplate());
+    when(
+      () => mockRepository.getAgentStatesByAgentIds(any()),
+    ).thenAnswer((_) async => const {});
 
     service = TaskAgentService(
       agentService: mockAgentService,

--- a/test/features/agents/state/agent_query_providers_test.dart
+++ b/test/features/agents/state/agent_query_providers_test.dart
@@ -595,14 +595,24 @@ void main() {
             type: any(named: 'type'),
           ),
         ).thenAnswer((_) async => []);
-        when(() => mockRepository.getEntity(tailDigest)).thenAnswer(
-          (_) async => AgentDomainEntity.agentMessagePayload(
-            id: tailDigest,
-            agentId: 'shared-input-content',
-            createdAt: DateTime(2024, 3, 10),
-            vectorClock: null,
-            content: tailContent,
-          ),
+        when(
+          () => mockRepository.getEntitiesByIds(any<Iterable<String>>()),
+        ).thenAnswer(
+          (invocation) async {
+            final ids =
+                invocation.positionalArguments.single as Iterable<String>;
+            final payload = AgentDomainEntity.agentMessagePayload(
+              id: tailDigest,
+              agentId: 'shared-input-content',
+              createdAt: DateTime(2024, 3, 10),
+              vectorClock: null,
+              content: tailContent,
+            );
+            return <String, AgentDomainEntity>{
+              for (final id in ids)
+                if (id == tailDigest) id: payload,
+            };
+          },
         );
 
         // The reconstructor reads through the sync service's repository.

--- a/test/features/agents/state/token_stats_providers_breakdown_test.dart
+++ b/test/features/agents/state/token_stats_providers_breakdown_test.dart
@@ -30,7 +30,16 @@ void main() {
         until: any(named: 'until'),
       ),
     ).thenAnswer((_) async => <WakeRunLogData>[]);
+    when(
+      () => mockRepository.getEntitiesByIds(any()),
+    ).thenAnswer((_) async => const <String, AgentDomainEntity>{});
   });
+
+  void stubEntitiesById(Map<String, AgentDomainEntity> entitiesById) {
+    when(
+      () => mockRepository.getEntitiesByIds(any()),
+    ).thenAnswer((_) async => entitiesById);
+  }
 
   ProviderContainer createContainer({
     List<WakeTokenUsageEntity> tokenRecords = const [],
@@ -231,13 +240,13 @@ void main() {
               ),
             ];
 
-            when(() => mockRepository.getEntity('tpl-x')).thenAnswer(
-              (_) async => makeTestTemplate(
+            stubEntitiesById({
+              'tpl-x': makeTestTemplate(
                 id: 'tpl-x',
                 agentId: 'tpl-x',
                 displayName: 'Agent X',
               ),
-            );
+            });
 
             final container = createContainer(
               tokenRecords: records,
@@ -276,13 +285,13 @@ void main() {
             ),
           ];
 
-          when(() => mockRepository.getEntity('tpl-y')).thenAnswer(
-            (_) async => makeTestTemplate(
+          stubEntitiesById({
+            'tpl-y': makeTestTemplate(
               id: 'tpl-y',
               agentId: 'tpl-y',
               displayName: 'Agent Y',
             ),
-          );
+          });
 
           final container = createContainer(
             tokenRecords: records,
@@ -325,9 +334,7 @@ void main() {
               displayName: 'Identity Agent',
             );
 
-            when(() => mockRepository.getEntity('agent-identity-1')).thenAnswer(
-              (_) async => identity,
-            );
+            stubEntitiesById({'agent-identity-1': identity});
 
             final container = createContainer(tokenRecords: [record]);
             final result = await container.read(
@@ -363,8 +370,8 @@ void main() {
                   )
                   as WakeTokenUsageEntity;
 
-          // Simulate a repository exception for this agent id.
-          when(() => mockRepository.getEntity('agent-err-1')).thenThrow(
+          // Simulate a repository exception for source hydration.
+          when(() => mockRepository.getEntitiesByIds(any())).thenThrow(
             Exception('entity not found'),
           );
 
@@ -392,13 +399,13 @@ void main() {
             ),
           ];
 
-          when(() => mockRepository.getEntity('tpl-only')).thenAnswer(
-            (_) async => makeTestTemplate(
+          stubEntitiesById({
+            'tpl-only': makeTestTemplate(
               id: 'tpl-only',
               agentId: 'tpl-only',
               displayName: 'Only Source',
             ),
-          );
+          });
 
           final container = createContainer(tokenRecords: records);
           final result = await container.read(

--- a/test/features/agents/state/token_stats_providers_test.dart
+++ b/test/features/agents/state/token_stats_providers_test.dart
@@ -28,7 +28,16 @@ void main() {
         until: any(named: 'until'),
       ),
     ).thenAnswer((_) async => <WakeRunLogData>[]);
+    when(
+      () => mockRepository.getEntitiesByIds(any()),
+    ).thenAnswer((_) async => const <String, AgentDomainEntity>{});
   });
+
+  void stubEntitiesById(Map<String, AgentDomainEntity> entitiesById) {
+    when(
+      () => mockRepository.getEntitiesByIds(any()),
+    ).thenAnswer((_) async => entitiesById);
+  }
 
   ProviderContainer createContainer({
     List<WakeTokenUsageEntity> tokenRecords = const [],
@@ -276,12 +285,7 @@ void main() {
           displayName: 'Agent Beta',
         );
 
-        when(() => mockRepository.getEntity('tpl-a')).thenAnswer(
-          (_) async => templateA,
-        );
-        when(() => mockRepository.getEntity('tpl-b')).thenAnswer(
-          (_) async => templateB,
-        );
+        stubEntitiesById({'tpl-a': templateA, 'tpl-b': templateB});
 
         final container = createContainer(tokenRecords: records);
         final result = await container.read(
@@ -320,15 +324,10 @@ void main() {
           ),
         ];
 
-        for (final id in ['tpl-heavy', 'tpl-light-1', 'tpl-light-2']) {
-          when(() => mockRepository.getEntity(id)).thenAnswer(
-            (_) async => makeTestTemplate(
-              id: id,
-              agentId: id,
-              displayName: id,
-            ),
-          );
-        }
+        stubEntitiesById({
+          for (final id in ['tpl-heavy', 'tpl-light-1', 'tpl-light-2'])
+            id: makeTestTemplate(id: id, agentId: id, displayName: id),
+        });
 
         final container = createContainer(tokenRecords: records);
         final result = await container.read(
@@ -381,20 +380,15 @@ void main() {
               templateId: 'tpl-light-3',
             ),
           ];
-          for (final id in [
-            'tpl-heavy',
-            'tpl-light-1',
-            'tpl-light-2',
-            'tpl-light-3',
-          ]) {
-            when(() => mockRepository.getEntity(id)).thenAnswer(
-              (_) async => makeTestTemplate(
-                id: id,
-                agentId: id,
-                displayName: id,
-              ),
-            );
-          }
+          stubEntitiesById({
+            for (final id in [
+              'tpl-heavy',
+              'tpl-light-1',
+              'tpl-light-2',
+              'tpl-light-3',
+            ])
+              id: makeTestTemplate(id: id, agentId: id, displayName: id),
+          });
 
           // Exactly at the threshold: 625/1000 = 62.5% == 25% * 2.5.
           var container = createContainer(

--- a/test/features/agents/sync/agent_input_capture_service_test.dart
+++ b/test/features/agents/sync/agent_input_capture_service_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_link.dart';
 import 'package:lotti/features/agents/projection/content_digest.dart';
 import 'package:lotti/features/agents/projection/input_capture.dart';
@@ -84,6 +85,39 @@ void main() {
       });
     },
   );
+
+  test('batch-checks payload existence before writing new captures', () async {
+    final countingRepo = _PayloadReadCountingRepository()
+      ..seed([makeTestState(agentId: _agentId)]);
+    final vc = MockVectorClockService();
+    var counter = 0;
+    when(
+      () => vc.getNextVectorClock(previous: any(named: 'previous')),
+    ).thenAnswer((_) async => VectorClock({'h1': ++counter}));
+    final outbox = MockOutboxService();
+    when(() => outbox.enqueueMessage(any())).thenAnswer((_) async {});
+    final localCapture = AgentInputCaptureService(
+      syncService: AgentSyncService(
+        repository: countingRepo,
+        outboxService: outbox,
+        vectorClockService: vc,
+      ),
+    );
+
+    final delta = await localCapture.captureWakeInputs(
+      agentId: _agentId,
+      sources: [
+        source('e1', 'alpha'),
+        source('e2', 'beta'),
+      ],
+      at: DateTime.utc(2024, 3, 10),
+    );
+
+    expect(delta.newPayloads, hasLength(2));
+    expect(countingRepo.getEntitiesByIdsCalls, 1);
+    expect(countingRepo.getEntityCalls, 0);
+    expect(countingRepo.payloads, hasLength(2));
+  });
 
   test(
     'content payloads are owned by the shared sentinel, not the agent',
@@ -273,5 +307,24 @@ class _TransactionCountingRepository extends InMemoryAgentRepository {
   Future<T> runInTransaction<T>(Future<T> Function() action) {
     transactionCount++;
     return super.runInTransaction(action);
+  }
+}
+
+class _PayloadReadCountingRepository extends InMemoryAgentRepository {
+  int getEntityCalls = 0;
+  int getEntitiesByIdsCalls = 0;
+
+  @override
+  Future<AgentDomainEntity?> getEntity(String id) {
+    getEntityCalls++;
+    return super.getEntity(id);
+  }
+
+  @override
+  Future<Map<String, AgentDomainEntity>> getEntitiesByIds(
+    Iterable<String> ids,
+  ) {
+    getEntitiesByIdsCalls++;
+    return super.getEntitiesByIds(ids);
   }
 }

--- a/test/features/agents/sync/in_memory_agent_repository.dart
+++ b/test/features/agents/sync/in_memory_agent_repository.dart
@@ -58,6 +58,20 @@ class InMemoryAgentRepository extends MockAgentRepository {
   Future<AgentDomainEntity?> getEntity(String id) async => _entities[id];
 
   @override
+  Future<Map<String, AgentDomainEntity>> getEntitiesByIds(
+    Iterable<String> ids,
+  ) async {
+    final result = <String, AgentDomainEntity>{};
+    for (final id in ids) {
+      final entity = _entities[id];
+      if (entity != null) {
+        result[id] = entity;
+      }
+    }
+    return result;
+  }
+
+  @override
   Future<AgentStateEntity?> getAgentState(String agentId) async {
     final states = _entities.values
         .whereType<AgentStateEntity>()

--- a/test/features/ai/repository/ai_input_repository_test.dart
+++ b/test/features/ai/repository/ai_input_repository_test.dart
@@ -2425,13 +2425,12 @@ void main() {
       'when AgentDatabase is registered',
       () async {
         // AgentDatabase IS registered -> provider must construct a real
-        // AgentRepository (line 612 branch). We observe this by checking that
-        // a project-context lookup reaches the underlying AgentDatabase query.
+        // AgentRepository. The optimized link path now goes through a custom
+        // indexed query, which touches the registered database's agent_links
+        // table instead of the older generated getAgentLinksByToIdAndType
+        // method.
         final mockAgentDb = MockAgentDatabase();
         getIt.registerSingleton<AgentDatabase>(mockAgentDb);
-        when(
-          () => mockAgentDb.getAgentLinksByToIdAndType(any(), any()),
-        ).thenReturn(MockSelectable<AgentLink>([]));
 
         final repository = buildContainer().read(aiInputRepositoryProvider);
         final result = await repository.buildProjectContextJsonForTask('t-1');
@@ -2439,9 +2438,7 @@ void main() {
         // No links -> no current report -> compact empty context.
         expect(result, equals('{}'));
         // The wired AgentRepository delegated down to the registered DB.
-        verify(
-          () => mockAgentDb.getAgentLinksByToIdAndType('project-123', any()),
-        ).called(1);
+        verify(() => mockAgentDb.agentLinks).called(1);
       },
     );
 

--- a/test/features/daily_os_next/agents/workflow/day_agent_workflow_test.dart
+++ b/test/features/daily_os_next/agents/workflow/day_agent_workflow_test.dart
@@ -270,6 +270,19 @@ void main() {
     ).thenAnswer((_) async => const []);
   }
 
+  void stubEntitiesByIds(Map<String, AgentDomainEntity> entitiesById) {
+    when(() => repository.getEntitiesByIds(any<Iterable<String>>())).thenAnswer(
+      (invocation) async {
+        final ids = invocation.positionalArguments.single as Iterable<String>;
+        return <String, AgentDomainEntity>{
+          for (final id in ids)
+            if (entitiesById[id] case final AgentDomainEntity entity)
+              id: entity,
+        };
+      },
+    );
+  }
+
   setUp(() {
     repository = MockAgentRepository();
     aiConfigRepository = MockAiConfigRepository();
@@ -899,20 +912,14 @@ void main() {
             obs('obs-c', DateTime.utc(2026, 5, 22)),
           ],
         );
-        when(
-          () => repository.getEntity('pl-obs-a'),
-        ).thenAnswer((_) async => payload('obs-a', 'old gym plan'));
-        when(() => repository.getEntity('pl-obs-b')).thenAnswer(
-          (_) async => payload(
+        stubEntitiesByIds({
+          'pl-obs-a': payload('obs-a', 'old gym plan'),
+          'pl-obs-b': payload(
             'obs-b',
             'new gym plan [[supersedes:obs-a]] [[relates:ghost]]',
           ),
-        );
-        when(
-          () => repository.getEntity('pl-obs-c'),
-        ).thenAnswer(
-          (_) async => payload('obs-c', 'gym recap [[relates:obs-a]]'),
-        );
+          'pl-obs-c': payload('obs-c', 'gym recap [[relates:obs-a]]'),
+        });
 
         conversationRepository.toolCalls = [
           _toolCall(
@@ -992,8 +999,8 @@ void main() {
                 as AgentMessageEntity,
           ],
         );
-        when(() => repository.getEntity('pl-obs')).thenAnswer(
-          (_) async =>
+        stubEntitiesByIds({
+          'pl-obs':
               AgentDomainEntity.agentMessagePayload(
                     id: 'pl-obs',
                     agentId: agentId,
@@ -1002,7 +1009,7 @@ void main() {
                     content: const {'text': 'topic map [[relates:deep-work]]'},
                   )
                   as AgentMessagePayloadEntity,
-        );
+        });
 
         conversationRepository.toolCalls = [
           _toolCall(
@@ -1212,15 +1219,15 @@ void main() {
         () =>
             repository.getMessagesByKind(agentId, AgentMessageKind.observation),
       ).thenAnswer((_) async => [obs as AgentMessageEntity]);
-      when(() => repository.getEntity('obs-payload-1')).thenAnswer(
-        (_) async => AgentDomainEntity.agentMessagePayload(
+      stubEntitiesByIds({
+        'obs-payload-1': AgentDomainEntity.agentMessagePayload(
           id: 'obs-payload-1',
           agentId: agentId,
           createdAt: DateTime.utc(2026, 5, 25, 8),
           vectorClock: null,
           content: const {'text': 'a day observation'},
         ),
-      );
+      });
 
       final sut = DayAgentWorkflow(
         agentRepository: repository,

--- a/test/features/sync/queue/inbound_event_queue_test.dart
+++ b/test/features/sync/queue/inbound_event_queue_test.dart
@@ -1072,6 +1072,49 @@ void main() {
     );
 
     test(
+      'depthSnapshot skips the applied ledger and ready-now probe for '
+      'depth-only surfaces',
+      () async {
+        await withClock(
+          Clock.fixed(DateTime.fromMillisecondsSinceEpoch(250000)),
+          () async {
+            Future<InboundQueueEntry> enqueueAndLease(String eventId) async {
+              await queue.enqueueLive(
+                _buildSyncEvent(
+                  eventId: eventId,
+                  roomId: roomA,
+                  originTsMs: 1,
+                ),
+              );
+              return (await queue.peekBatchReady()).single;
+            }
+
+            await queue.commitApplied(await enqueueAndLease(r'$applied'));
+            await queue.markSkipped(
+              await enqueueAndLease(r'$abandoned'),
+              reason: 'poison',
+            );
+            await queue.enqueueLive(
+              _buildSyncEvent(
+                eventId: r'$enqueued',
+                roomId: roomA,
+                originTsMs: 1,
+              ),
+            );
+
+            final snapshot = await queue.depthSnapshot();
+
+            expect(snapshot.total, 1);
+            expect(snapshot.byProducer[InboundEventProducer.live], 1);
+            expect(snapshot.abandoned, 1);
+            expect(snapshot.applied, 0);
+            expect(snapshot.readyNow, 0);
+          },
+        );
+      },
+    );
+
+    test(
       'ready-now probe uses literal peekable statuses so partial indexes '
       'remain provable',
       () async {

--- a/test/features/sync/queue/inbound_event_queue_test.dart
+++ b/test/features/sync/queue/inbound_event_queue_test.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
 
 import 'package:clock/clock.dart';
-import 'package:drift/drift.dart' show Value, Variable;
+import 'package:drift/drift.dart' hide isNotNull, isNull;
+import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
+import 'package:lotti/database/slow_query_logging.dart';
 import 'package:lotti/database/sync_db.dart';
 import 'package:lotti/features/sync/matrix/consts.dart';
 import 'package:lotti/features/sync/queue/inbound_event_queue.dart';
@@ -1066,6 +1068,125 @@ void main() {
           // All rows were enqueued under the frozen clock.
           expect(stats.oldestEnqueuedAt, frozen.millisecondsSinceEpoch);
         });
+      },
+    );
+
+    test(
+      'ready-now probe uses literal peekable statuses so partial indexes '
+      'remain provable',
+      () async {
+        await queue.enqueueBatch(
+          [
+            for (var i = 0; i < 200; i++)
+              _buildSyncEvent(
+                eventId: '\$ready-plan-$i',
+                roomId: roomA,
+                originTsMs: 1000 + i,
+              ),
+          ],
+          producer: InboundEventProducer.live,
+        );
+        await db.customStatement('ANALYZE');
+
+        final rows = await db
+            .customSelect(
+              'EXPLAIN QUERY PLAN '
+              'SELECT COUNT(*) AS cnt FROM inbound_event_queue '
+              "WHERE status IN ('enqueued', 'retrying', 'leased') "
+              'AND next_due_at <= ? '
+              'AND lease_until <= ?',
+              variables: [
+                Variable.withInt(100000),
+                Variable.withInt(100000),
+              ],
+            )
+            .get();
+        final plan = rows.map((row) => row.data.toString()).join('\n');
+
+        expect(
+          plan,
+          anyOf(
+            contains('idx_inbound_event_queue_active_ready_at'),
+            contains('idx_inbound_event_queue_status_due_lease'),
+          ),
+          reason:
+              'literal peekable status predicates must keep ready-now probes '
+              'on queue indexes instead of the applied-ledger table scan',
+        );
+        expect(
+          plan,
+          isNot(matches(RegExp('SCAN inbound_event_queue(?! USING)'))),
+        );
+      },
+    );
+
+    test(
+      'depthChanges emits from a lightweight active-plus-abandoned snapshot',
+      () async {
+        final loggedEntries = <SlowQueryLogEntry>[];
+        SlowQueryLoggingGate.isEnabled = true;
+        addTearDown(SlowQueryLoggingGate.resetForTest);
+
+        final loggedDb = SyncDatabase.connect(
+          DatabaseConnection(
+            NativeDatabase.memory().interceptWith(
+              SlowQueryInterceptor(
+                databaseName: syncDbFileName,
+                threshold: Duration.zero,
+                superSlowThreshold: const Duration(days: 1),
+                reporter: loggedEntries.add,
+              ),
+            ),
+          ),
+        );
+        final loggedQueue = InboundQueue(
+          db: loggedDb,
+          logging: MockDomainLogger(),
+          leaseDuration: const Duration(seconds: 1),
+        );
+        addTearDown(loggedQueue.dispose);
+        addTearDown(loggedDb.close);
+
+        final emissions = <QueueDepthSignal>[];
+        final sub = loggedQueue.depthChanges.listen(emissions.add);
+        addTearDown(sub.cancel);
+
+        await loggedQueue.enqueueLive(
+          _buildSyncEvent(
+            eventId: r'$depth-sql',
+            roomId: roomA,
+            originTsMs: 1000,
+          ),
+        );
+        await pumpEventQueue(times: 10);
+
+        expect(emissions, isNotEmpty);
+        final queueSelects = loggedEntries
+            .map((entry) => entry.formattedStatement)
+            .map((statement) => statement.replaceAll('"', ''))
+            .where(
+              (statement) =>
+                  statement.contains('FROM inbound_event_queue') &&
+                  statement.contains('COUNT(*) AS cnt'),
+            )
+            .toList();
+
+        expect(
+          queueSelects,
+          anyElement(
+            allOf(
+              contains(
+                "status IN ('enqueued', 'leased', 'retrying', 'abandoned')",
+              ),
+              isNot(contains("'applied'")),
+              isNot(contains('next_due_at <=')),
+            ),
+          ),
+          reason:
+              'depth signals do not expose applied or ready-now counts, so '
+              'they should not rescan the applied ledger or run the ready '
+              'probe on every queue mutation',
+        );
       },
     );
   });

--- a/test/features/sync/queue/inbound_event_queue_test.dart
+++ b/test/features/sync/queue/inbound_event_queue_test.dart
@@ -1164,6 +1164,32 @@ void main() {
     );
 
     test(
+      'applied count uses the status index instead of the grouped ledger '
+      'pivot',
+      () async {
+        await db.customStatement('ANALYZE');
+
+        final rows = await db
+            .customSelect(
+              'EXPLAIN QUERY PLAN '
+              'SELECT COUNT(queue_id) AS cnt '
+              'FROM inbound_event_queue '
+              'INDEXED BY idx_inbound_event_queue_status_enqueued '
+              "WHERE status = 'applied'",
+            )
+            .get();
+        final plan = rows.map((row) => row.data.toString()).join('\n');
+
+        expect(plan, contains('idx_inbound_event_queue_status_enqueued'));
+        expect(plan, isNot(contains('GROUP BY')));
+        expect(
+          plan,
+          isNot(matches(RegExp('SCAN inbound_event_queue(?! USING)'))),
+        );
+      },
+    );
+
+    test(
       'depthChanges emits from a lightweight active-plus-abandoned snapshot',
       () async {
         final loggedEntries = <SlowQueryLogEntry>[];

--- a/test/features/sync/queue/queue_marker_seeder_test.dart
+++ b/test/features/sync/queue/queue_marker_seeder_test.dart
@@ -188,6 +188,22 @@ void main() {
     expect(secondRun, isFalse);
   });
 
+  test('caches seeded rooms after the first successful seed', () async {
+    when(
+      () => settingsDb.itemByKey(lastReadMatrixEventId),
+    ).thenAnswer((_) async => r'$anchor');
+    when(
+      () => settingsDb.itemByKey(lastReadMatrixEventTs),
+    ).thenAnswer((_) async => '5000');
+    final seeder = newSeeder();
+
+    expect(await seeder.seedIfAbsent(roomId), isTrue);
+    expect(await seeder.seedIfAbsent(roomId), isFalse);
+
+    verify(() => settingsDb.itemByKey(lastReadMatrixEventId)).called(1);
+    verify(() => settingsDb.itemByKey(lastReadMatrixEventTs)).called(1);
+  });
+
   test('returns false when no legacy marker is stored', () async {
     when(
       () => settingsDb.itemByKey(lastReadMatrixEventId),
@@ -202,6 +218,26 @@ void main() {
         .get()
         .then((rows) => rows.length);
     expect(count, 0);
+  });
+
+  test('does not cache missing legacy marker state', () async {
+    var legacyIdCalls = 0;
+    when(() => settingsDb.itemByKey(lastReadMatrixEventId)).thenAnswer((_) {
+      legacyIdCalls++;
+      return Future.value(legacyIdCalls == 1 ? null : r'$late-anchor');
+    });
+    when(
+      () => settingsDb.itemByKey(lastReadMatrixEventTs),
+    ).thenAnswer((_) async => null);
+    final seeder = newSeeder();
+
+    expect(await seeder.seedIfAbsent(roomId), isFalse);
+    expect(await seeder.seedIfAbsent(roomId), isTrue);
+
+    final marker = await (syncDb.select(
+      syncDb.queueMarkers,
+    )..where((t) => t.roomId.equals(roomId))).getSingle();
+    expect(marker.lastAppliedEventId, r'$late-anchor');
   });
 
   test('does not overwrite an existing queue_markers row', () async {

--- a/test/features/sync/state/outbox_state_controller_queue_test.dart
+++ b/test/features/sync/state/outbox_state_controller_queue_test.dart
@@ -112,12 +112,12 @@ void main() {
     });
 
     test(
-      'seeds with the snapshot from queue.stats() — covers the '
+      'seeds with the snapshot from queue.depthSnapshot() — covers the '
       'subscribe-before-await ordering that prevents signals from being '
       'dropped during the initial snapshot computation',
       () async {
         const roomId = '!room:example.org';
-        // Insert one active row so stats().total reports 1 on seed.
+        // Insert one active row so depthSnapshot().total reports 1 on seed.
         await db
             .into(db.inboundEventQueue)
             .insert(
@@ -280,18 +280,18 @@ void main() {
   });
 
   // Deterministic coverage for the buffer/replay/error branches of
-  // `inboundQueueDepthStream`. The real in-memory `InboundQueue.stats()`
+  // `inboundQueueDepthStream`. The real in-memory `InboundQueue.depthSnapshot()`
   // resolves too fast to reliably land a `depthChanges` signal inside the
-  // generator's `stats()` await, so these tests drive a `MockInboundQueue`
-  // with a manually-controlled `stats()` completer and a hand-fed
+  // generator's snapshot await, so these tests drive a `MockInboundQueue`
+  // with a manually-controlled snapshot completer and a hand-fed
   // `depthChanges` controller. That lets us force the exact interleaving
   // where a live signal arrives BEFORE the consumer subscribes to the
   // internal relay (`relay.hasListener == false`) so the value is captured
-  // in the `buffered` list and replayed once `stats()` resolves.
+  // in the `buffered` list and replayed once the snapshot resolves.
   group('inboundQueueDepthStream — buffered/error branches (mocked queue)', () {
     late MockInboundQueue queue;
     late StreamController<QueueDepthSignal> depthCtl;
-    late Completer<QueueStats> statsCompleter;
+    late Completer<QueueStats> snapshotCompleter;
 
     QueueDepthSignal signal(int total) => QueueDepthSignal(
       total: total,
@@ -313,9 +313,9 @@ void main() {
     setUp(() {
       queue = MockInboundQueue();
       depthCtl = StreamController<QueueDepthSignal>.broadcast();
-      statsCompleter = Completer<QueueStats>();
+      snapshotCompleter = Completer<QueueStats>();
       when(() => queue.depthChanges).thenAnswer((_) => depthCtl.stream);
-      when(queue.stats).thenAnswer((_) => statsCompleter.future);
+      when(queue.depthSnapshot).thenAnswer((_) => snapshotCompleter.future);
     });
 
     tearDown(() async {
@@ -338,13 +338,13 @@ void main() {
         addTearDown(sub.cancel);
 
         // Let the generator subscribe to depthChanges and park on the
-        // (still-pending) stats() future. At this point the consumer has
+        // (still-pending) snapshot future. At this point the consumer has
         // not yet reached `yield* relay.stream`, so `relay.hasListener`
         // is false and any depth signal is captured into `buffered`.
         await Future<void>.value();
         await Future<void>.value();
 
-        // Two live signals arrive DURING the stats() await -> buffered.add
+        // Two live signals arrive DURING the snapshot await -> buffered.add
         // is hit twice (covers line 131).
         depthCtl
           ..add(signal(7))
@@ -356,7 +356,7 @@ void main() {
         // generator takes the else branch: it replays the buffered values
         // in arrival order (the for-loop) and then clears the buffer
         // (covers lines 154 + 157) instead of yielding the stale snapshot.
-        statsCompleter.complete(stats(99));
+        snapshotCompleter.complete(stats(99));
 
         await firstTwo.future.timeout(
           // In-memory SQLite resolves in <5 ms; 200 ms is hang-failure
@@ -388,10 +388,10 @@ void main() {
         );
         addTearDown(sub.cancel);
 
-        // Resolve stats() with an empty snapshot. With no buffered values
+        // Resolve the depth snapshot. With no buffered values
         // the generator yields the snapshot (0) and then enters
         // `yield* relay.stream`, so the relay now HAS a listener.
-        statsCompleter.complete(stats(0));
+        snapshotCompleter.complete(stats(0));
         await Future<void>.value();
         await Future<void>.value();
         expect(received, [0]);

--- a/test/features/sync/ui/backfill_settings_page_test.dart
+++ b/test/features/sync/ui/backfill_settings_page_test.dart
@@ -542,7 +542,7 @@ void main() {
       when(() => matrixService.queueCoordinator).thenReturn(coordinator);
       when(() => coordinator.queue).thenReturn(queue);
       when(() => queue.depthChanges).thenAnswer((_) => depthCtl.stream);
-      when(() => queue.stats()).thenAnswer(
+      when(() => queue.depthSnapshot()).thenAnswer(
         (_) async => const QueueStats(
           total: 0,
           byProducer: {},
@@ -581,24 +581,27 @@ void main() {
       await pumpBody(tester);
     }
 
-    testWidgets('initial paint reads queue.stats() for inbound + skipped', (
-      tester,
-    ) async {
-      when(() => queue.stats()).thenAnswer(
-        (_) async => const QueueStats(
-          total: 4,
-          byProducer: {},
-          readyNow: 4,
-          oldestEnqueuedAt: null,
-          abandoned: 2,
-        ),
-      );
-      await pumpInScaffold(tester);
+    testWidgets(
+      'initial paint reads queue.depthSnapshot() for inbound + skipped',
+      (
+        tester,
+      ) async {
+        when(() => queue.depthSnapshot()).thenAnswer(
+          (_) async => const QueueStats(
+            total: 4,
+            byProducer: {},
+            readyNow: 0,
+            oldestEnqueuedAt: null,
+            abandoned: 2,
+          ),
+        );
+        await pumpInScaffold(tester);
 
-      // Inbound queue cell shows 4; skipped cell shows 2.
-      expect(find.text('4'), findsWidgets);
-      expect(find.text('2'), findsWidgets);
-    });
+        // Inbound queue cell shows 4; skipped cell shows 2.
+        expect(find.text('4'), findsWidgets);
+        expect(find.text('2'), findsWidgets);
+      },
+    );
 
     testWidgets('depthChanges emission updates the status row', (
       tester,
@@ -1032,7 +1035,7 @@ void main() {
       when(() => matrixService.queueCoordinator).thenReturn(coordinator);
       when(() => coordinator.queue).thenReturn(queue);
       when(() => queue.depthChanges).thenAnswer((_) => depthCtl.stream);
-      when(() => queue.stats()).thenAnswer(
+      when(() => queue.depthSnapshot()).thenAnswer(
         (_) async => const QueueStats(
           total: 0,
           byProducer: {},


### PR DESCRIPTION
## Summary

- Batch and index hot agent DB reads from the slow/super-slow logs, including entity hydration, linked-agent/template reads, task-scoped change-set lookups, scheduled wakes, and typed agent link lookups.
- Add journal/sync/editor indexes and query rewrites for habit completions, insights time analysis, broad task lists, label-definition list reads, import-flag counts, outbox retention/volume, inbound queue probes, sequence reads, conflicts, editor latest-draft lookups, and backfill outbox subject-prefix scans.
- Route depth-only sync queue UI seeds through a lightweight active-depth snapshot and split full `QueueStats.stats()` so applied-ledger counts use the status index instead of the full `GROUP BY status, producer` aggregate from the slow logs.
- Add migration and query-plan coverage for the new access paths, plus targeted test updates for the optimized repository and queue call shapes.

## Validation

- `make build_runner`
- `fvm dart analyze ...` targeted database/agent/query/test files touched by this PR
- `fvm dart analyze lib/database/sync_db.dart lib/database/sync_db_tables.dart lib/database/sync_db_outbox_dedup.dart test/database/sync_db_migration_test.dart test/database/sync_db_outbox_dedup_test.dart`
- `fvm dart analyze lib/database/database.dart lib/database/database.drift lib/database/database_migration_recent.dart lib/database/database_definitions.dart test/database/definition_indexes_migration_test.dart test/database/database_definitions_test.dart`
- `fvm dart analyze lib/features/sync/queue/inbound_event_queue.dart lib/features/sync/state/outbox_state_controller.dart lib/features/sync/ui/backfill_settings_page.dart test/features/sync/queue/inbound_event_queue_test.dart test/features/sync/state/outbox_state_controller_queue_test.dart test/features/sync/ui/backfill_settings_page_test.dart`
- `fvm dart analyze lib/features/sync/queue/inbound_event_queue.dart test/features/sync/queue/inbound_event_queue_test.dart`
- `fvm flutter test test/database/sync_db_migration_test.dart test/database/sync_db_outbox_dedup_test.dart`
- `fvm flutter test test/database/task_indexes_v39_migration_test.dart test/database/database_task_queries_test.dart test/database/database_journal_queries_test.dart test/database/category_backfill_migration_test.dart test/database/linked_entries_index_migration_test.dart test/database/priority_migration_test.dart test/database/due_at_migration_test.dart test/database/definition_indexes_migration_test.dart test/features/agents/database/agent_database_test.dart`
- `fvm flutter test test/database/definition_indexes_migration_test.dart test/database/database_definitions_test.dart`
- `fvm flutter test test/features/sync/queue/inbound_event_queue_test.dart test/features/sync/state/outbox_state_controller_queue_test.dart test/features/sync/ui/backfill_settings_page_test.dart`
- `fvm flutter test test/features/sync/queue/inbound_event_queue_test.dart`
- `fvm flutter test test/features/ai/repository/ai_input_repository_test.dart --plain-name 'wires an AgentRepository backed by the registered AgentDatabase when AgentDatabase is registered'`
- `fvm flutter test test/services/logging_service_test.dart --plain-name 'single buffered line is flushed when the 500 ms flush timer fires'`
- Earlier targeted suites for sync outbox/prune/dedup, agent repository/link/service regressions, queue marker seeding, and daily OS workflow failures were also run during the fix pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Queue depth screens now use a faster snapshot view for initial counts and live updates.

* **Bug Fixes**
  * Improved performance on habit heatmaps, agent summaries, and feedback flows.
  * Speeded up task lists, conflict views, label lists, outbox cleanup, and sync-related queries.
  * Fixed latest-draft and habit-completion results to return the most recent matching item.
  * Improved agent and sync restore flows to reduce delays when loading saved state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->