### PR TITLE
fix: cap chat audio speech dictionary prompt

### DIFF
--- a/lib/features/ai/README.md
+++ b/lib/features/ai/README.md
@@ -245,10 +245,12 @@ and image recognition, `glm-5.2` for the high-end thinking slot,
 `flux-2-klein-9b` for image generation, and `voxtral-small-24b-2507` for
 transcription — Voxtral runs through Melious' chat-completions audio path so
 the final response includes token usage, billing, and environmental impact
-metadata. Lotti appends the category speech dictionary to the chat-audio prompt
-for those Voxtral calls; Whisper and explicit transcription model IDs still use
-the transcription endpoint. FTUE setup also creates both Whisper rows so users
-can switch between the regular and Turbo variants. Existing untouched default
+metadata. The shared chat-audio fallback appends the category speech dictionary
+to the prompt for Voxtral, OpenAI chat-audio models, Gemini, and other providers
+that accept audio through chat completions; Whisper and explicit transcription
+model IDs still use the transcription endpoint. FTUE setup also creates both
+Whisper rows so users can switch between the regular and Turbo variants.
+Existing untouched default
 Melious profiles chain through the upgrade migrations during
 `upgradeExisting()` after the model backfill has created the rows: profiles
 that predate the image-generation slot, or still point at the legacy Flux 2
@@ -759,10 +761,10 @@ For speech dictionary support, `UnifiedAiInferenceRepository` and
 `SkillInferenceRunner` still resolve category dictionary terms through
 `PromptBuilderHelper.getSpeechDictionaryTerms()`. The MLX Audio branch forwards
 those terms across the channel with the transcription request. Qwen3-ASR uses
-that list as prompt context for post-recording transcription today. Melious
-Voxtral chat-audio requests append the same dictionary block to the user
-message, while Mistral continues to use its dedicated `context_bias` parameter.
-Decoder-level
+that list as prompt context for post-recording transcription today. Chat-audio
+requests that use the OpenAI-compatible fallback append the same dictionary
+block to the user message, while Mistral continues to use its dedicated
+`context_bias` parameter. Decoder-level
 dictionary/G2P integration remains a separate native bridge follow-up once that
 SDK surface is stable.
 

--- a/lib/features/ai/repository/cloud_inference_generate_more.dart
+++ b/lib/features/ai/repository/cloud_inference_generate_more.dart
@@ -273,6 +273,7 @@ class CloudInferenceGenerateMore {
     final terms = speechDictionaryTerms
         ?.map((term) => term.trim())
         .where((term) => term.isNotEmpty)
+        .take(100)
         .toList();
     if (terms == null || terms.isEmpty) {
       return prompt;

--- a/test/features/ai/repository/cloud_inference_generate_more_test.dart
+++ b/test/features/ai/repository/cloud_inference_generate_more_test.dart
@@ -30,16 +30,13 @@ import 'package:openai_dart/openai_dart.dart';
 import '../../../mocks/mocks.dart';
 import '../test_utils.dart';
 
-class _FakeCreateChatCompletionRequest extends Fake
-    implements CreateChatCompletionRequest {}
-
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUpAll(() {
     registerFallbackValue(Uri.parse('http://example.com'));
     registerFallbackValue(FakeBaseRequest());
-    registerFallbackValue(_FakeCreateChatCompletionRequest());
+    registerFallbackValue(FakeCreateChatCompletionRequest());
     registerFallbackValue(FakeAiConfigInferenceProvider());
   });
 
@@ -487,6 +484,43 @@ void main() {
         expect(requestText, contains('IMPORTANT - SPEECH DICTIONARY'));
         expect(requestText, contains('"Lotti"'));
         expect(requestText, isNot(contains(' \n \n\nIMPORTANT')));
+      },
+    );
+
+    test(
+      'caps chat audio speech dictionary terms at 100',
+      () async {
+        final meliousProvider = providerOfType(InferenceProviderType.melious);
+        final openAiClient = MockOpenAIClient();
+
+        stubChatCompletionStream(openAiClient);
+
+        await generateMore
+            .generateWithAudio(
+              prompt,
+              model: 'voxtral-small-24b-2507',
+              audioBase64: 'melious-audio',
+              baseUrl: meliousProvider.baseUrl,
+              apiKey: meliousProvider.apiKey,
+              provider: meliousProvider,
+              overrideClient: openAiClient,
+              speechDictionaryTerms: [
+                for (var i = 0; i < 101; i++) 'Term$i',
+              ],
+            )
+            .toList();
+
+        final request =
+            verify(
+                  () => openAiClient.createChatCompletionStream(
+                    request: captureAny(named: 'request'),
+                  ),
+                ).captured.single
+                as CreateChatCompletionRequest;
+        final requestText = request.toString();
+        expect(requestText, contains('"Term0"'));
+        expect(requestText, contains('"Term99"'));
+        expect(requestText, isNot(contains('"Term100"')));
       },
     );
   });

--- a/test/mocks/mocks.dart
+++ b/test/mocks/mocks.dart
@@ -1221,6 +1221,9 @@ class FakeAiConfigModel extends Fake implements AiConfigModel {}
 class FakeAiConfigInferenceProvider extends Fake
     implements AiConfigInferenceProvider {}
 
+class FakeCreateChatCompletionRequest extends Fake
+    implements CreateChatCompletionRequest {}
+
 class FakeChatSession extends Fake implements ChatSession {}
 
 class FakeChecklistData extends Fake implements ChecklistData {}


### PR DESCRIPTION
## Summary

- cap OpenAI-compatible chat-audio speech dictionary injection at 100 terms
- move the chat completion request fake into centralized test mocks
- clarify the AI README wording for chat-audio dictionary handling across providers

## Validation

- `fvm dart format lib/features/ai/repository/cloud_inference_generate_more.dart test/features/ai/repository/cloud_inference_generate_more_test.dart test/mocks/mocks.dart`
- `fvm flutter test test/features/ai/repository/cloud_inference_generate_more_test.dart`
- `fvm flutter analyze lib/features/ai/repository/cloud_inference_generate_more.dart lib/features/ai/repository/melious_inference_repository.dart test/features/ai/repository/cloud_inference_generate_more_test.dart test/features/ai/repository/melious_inference_repository_test.dart test/mocks/mocks.dart`

Follow-up to CodeRabbit comments from #3425.
