### PR TITLE
fix: hide bottom nav onboarding gallery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it opens a native save dialog so you choose where the image goes. Previously
   it always tried to write into `Downloads/Lotti`, which failed with an error on
   iPhone and on the sandboxed macOS build.
+- The debug-only Onboarding animation gallery (Settings → Advanced →
+  Maintenance) no longer leaves the floating bottom navigation bar stacked on
+  top of it on phones. It now escapes onto the root navigator the same way
+  other pushed debug/editor surfaces already do.
 
 ## [0.9.1032]
 ### Added

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -41,6 +41,7 @@
           <p>Entry timestamps no longer get cut off on phones. In a task's linked entries, the header's date and time used to be truncated when the action buttons squeezed the row on a narrow phone. The timestamp now stacks the date over the time on two lines when space is tight, so the whole date and time stay readable.</p>
           <p>The desktop sidebar is calmer when Tasks has lots of saved filters. Saved task filters now sit in their own capped Tasks section with a More row, active filters stay visible, recording/timer/agent cards carry clearer status labels, agent rows can open their linked task directly, and the old tiny Outbox/Inbox footer is now one compact Sync strip.</p>
           <p>Habit and agent-heavy screens spend less time waiting on the database. Habit heatmaps now load only the latest completion per habit/day, and agent summary/feedback paths batch payload lookups instead of firing many individual reads.</p>
+          <p>The debug-only Onboarding animation gallery (Settings → Advanced → Maintenance) no longer leaves the floating bottom navigation bar stacked on top of it on phones. It now escapes onto the root navigator the same way other pushed debug/editor surfaces already do.</p>
       </description>
     </release>
     <release version="0.9.1032" date="2026-07-06">

--- a/lib/features/settings/ui/pages/advanced/maintenance_page.dart
+++ b/lib/features/settings/ui/pages/advanced/maintenance_page.dart
@@ -23,6 +23,7 @@ import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/services/app_prefs_service.dart';
 import 'package:lotti/services/debug_overlays.dart';
 import 'package:lotti/widgets/modal/confirmation_modal.dart';
+import 'package:lotti/widgets/nav_bar/bottom_nav_safe_navigator.dart';
 
 /// Mobile / legacy wrapper — keeps the `SliverBoxAdapterPage` chrome
 /// and delegates content to [MaintenanceBody] so the same widget can
@@ -69,7 +70,12 @@ class MaintenanceBody extends ConsumerWidget {
             subtitle: 'Compare welcome animations + connect page live (debug)',
             icon: Icons.animation_rounded,
             onTap: () => unawaited(
-              Navigator.of(context).push(
+              // Root navigator on mobile so the gallery covers the shell's
+              // floating bottom nav instead of leaving it stacked on top —
+              // this debug screen is pushed on top of a settings route, so
+              // it can't be matched (and slid away) by the route-based
+              // `settingsRouteHidesBottomNav`. See `bottom_nav_safe_navigator.dart`.
+              bottomNavSafeNavigatorOf(context).push(
                 MaterialPageRoute<void>(
                   builder: (_) => const OnboardingAnimationGalleryPage(),
                 ),

--- a/lib/widgets/README.md
+++ b/lib/widgets/README.md
@@ -270,12 +270,14 @@ motion.
 
 Editor surfaces that are *pushed* on top of another settings route rather
 than being routes of their own (the AI provider connect form, the agent
-template editor opened from an instance's internals, the evolution chat)
-keep the URL of the page they were pushed from, so the route-based slide
-can't see them. They instead push onto the root navigator on mobile via
-`bottomNavSafeNavigatorOf` (`lib/widgets/nav_bar/bottom_nav_safe_navigator.dart`),
-covering the whole shell — including the bar — so their bottom action bar
-or chat input stays reachable.
+template editor opened from an instance's internals, the evolution chat,
+the debug-only onboarding animation gallery reached from Settings →
+Advanced → Maintenance) keep the URL of the page they were pushed from, so
+the route-based slide can't see them. They instead push onto the root
+navigator on mobile via `bottomNavSafeNavigatorOf`
+(`lib/widgets/nav_bar/bottom_nav_safe_navigator.dart`), covering the whole
+shell — including the bar — so their bottom action bar or chat input stays
+reachable.
 
 ### showMobileNavMoreSheet / MobileNavMoreSheetItem
 `WoltModalSheet`-based overflow sheet listing the destinations without a

--- a/test/features/settings/ui/pages/advanced/maintenance_page_test.dart
+++ b/test/features/settings/ui/pages/advanced/maintenance_page_test.dart
@@ -17,6 +17,7 @@ import 'package:lotti/features/user_activity/state/user_activity_service.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/debug_overlays.dart';
 import 'package:lotti/services/entities_cache_service.dart';
+import 'package:lotti/services/nav_service.dart';
 import 'package:lotti/services/notification_service.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -184,6 +185,82 @@ void main() {
       expect(find.text('Constellation'), findsOneWidget);
       expect(find.text('API key'), findsOneWidget);
     });
+
+    testWidgets(
+      'Onboarding animation gallery escapes onto the root navigator, not '
+      "the nested tab navigator, so it covers the shell's floating bottom "
+      'nav instead of leaving it stacked on top (bottomNavSafeNavigatorOf)',
+      (tester) async {
+        final mockNavService = MockNavService();
+        when(() => mockNavService.isDesktopMode).thenReturn(false);
+        getIt.registerSingleton<NavService>(mockNavService);
+        addTearDown(() {
+          if (getIt.isRegistered<NavService>()) {
+            getIt.unregister<NavService>();
+          }
+        });
+
+        final rootNavigatorKey = GlobalKey<NavigatorState>();
+        final nestedNavigatorKey = GlobalKey<NavigatorState>();
+
+        // Mirrors the production mobile shell (`AppScreen._buildMobileLayout`):
+        // a root MaterialApp navigator whose single page is a Stack holding
+        // both the active tab's own nested Navigator (standing in for a
+        // Beamer tab delegate — the nearest ancestor `Navigator.of(context)`
+        // would find) and a Positioned marker standing in for the floating
+        // `DesignSystemBottomNavigationBar`.
+        await tester.pumpWidget(
+          makeTestableWidgetNoScroll(
+            Stack(
+              children: [
+                Navigator(
+                  key: nestedNavigatorKey,
+                  onGenerateRoute: (_) => MaterialPageRoute<void>(
+                    builder: (_) => _constrainedMaintenancePage(),
+                  ),
+                ),
+                const Positioned(
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  child: Text('BOTTOM_NAV_MARKER'),
+                ),
+              ],
+            ),
+            navigatorKey: rootNavigatorKey,
+            mediaQueryData: const MediaQueryData(
+              size: Size(800, 1200),
+              disableAnimations: true,
+            ),
+          ),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(rootNavigatorKey.currentState!.canPop(), isFalse);
+        expect(nestedNavigatorKey.currentState!.canPop(), isFalse);
+        expect(find.text('BOTTOM_NAV_MARKER').hitTestable(), findsOneWidget);
+
+        await tester.tap(find.text('Onboarding animation gallery'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        expect(find.text('Onboarding animations'), findsOneWidget);
+        // The push landed on the ROOT navigator, above the whole shell —
+        // not on the nested tab navigator, which would leave the shell's
+        // floating bottom nav bar stacked on top of the gallery.
+        expect(rootNavigatorKey.currentState!.canPop(), isTrue);
+        expect(nestedNavigatorKey.currentState!.canPop(), isFalse);
+        // The marker sits in the same root-navigator page as the nested
+        // Navigator: it's still mounted (a covered route isn't removed from
+        // the tree), but a real hit test at its location now resolves to the
+        // opaque gallery page painted on top of it instead — `hitTestable()`
+        // performs that same z-order-aware hit test, so this proves the
+        // marker is actually covered from the user's point of view, not just
+        // that some push happened somewhere.
+        expect(find.text('BOTTOM_NAV_MARKER').hitTestable(), findsNothing);
+      },
+    );
 
     testWidgets('page displays expected maintenance options', (tester) async {
       await tester.pumpWidget(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a mobile layout issue where the debug-only Onboarding animation gallery could appear underneath the floating bottom navigation bar.
  * The gallery now opens in a way that keeps it above the bottom navigation, matching other similar screens.

* **Documentation**
  * Updated release notes and related documentation to reflect the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->