### PR TITLE
fix: seed inference profiles only for configured providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with the same live preview and "Try with your voice" toggle from onboarding —
   and the real recording screen now honors your choice instead of always
   showing the VU meter.
+### Changed
+- **AI profile pickers only show profiles you can actually use.** Default
+  inference profiles are no longer seeded for providers you haven't set up:
+  each bundled profile (Gemini, OpenAI, Mistral, Melious.ai, Chinese AI,
+  Anthropic, Ollama, oMLX) now appears only once a working provider of its
+  type exists — connect Melious.ai and you get exactly the Melious profile,
+  nothing more. Untouched leftover profiles for providers that were never set
+  up (or have since been deleted) are cleaned up on the next launch; any
+  profile you renamed, described, or rewired to another provider is kept.
 ### Fixed
 - **Dashboard chart editing now saves when it should.** Adding measurable
   charts in Settings → Dashboards immediately enables Save, measurable chart

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -48,6 +48,7 @@
           <p>Habit and agent-heavy screens spend less time waiting on the database. Habit heatmaps now load only the latest completion per habit/day, and agent summary/feedback paths batch payload lookups instead of firing many individual reads.</p>
           <p>The debug-only Onboarding animation gallery (Settings → Advanced → Maintenance) no longer leaves the floating bottom navigation bar stacked on top of it on phones. It now escapes onto the root navigator the same way other pushed debug/editor surfaces already do.</p>
           <p>A new Settings → Recording Style page lets you choose the VU meter or energy-orb visualization for the mic — with the same live preview and "Try with your voice" toggle from onboarding — and the real recording screen now honors your choice instead of always showing the VU meter.</p>
+          <p>AI profile pickers only show profiles you can actually use. Default inference profiles are no longer seeded for providers you haven't set up: each bundled profile now appears only once a working provider of its type exists — connect Melious.ai and you get exactly the Melious profile, nothing more. Untouched leftover profiles for providers that were never set up (or have since been deleted) are cleaned up on the next launch; any profile you renamed, described, or rewired to another provider is kept.</p>
       </description>
     </release>
     <release version="0.9.1032" date="2026-07-06">

--- a/lib/features/ai/README.md
+++ b/lib/features/ai/README.md
@@ -6,7 +6,7 @@ The `ai` feature contains the shared AI plumbing used by manual prompts, skill-d
 
 Two startup paths shape the feature:
 
-- `aiConfigInitialization` always runs and seeds default inference profiles plus known models.
+- `aiConfigInitialization` always runs and seeds known models plus the default inference profiles whose provider type has a usable provider, then removes orphaned default seeds.
 - `agentInitialization` also always runs (it is not gated by any flag); it seeds templates and upgrades default profiles with skill assignments.
 
 Skills do **not** participate in seeding — they live as code in `skills/built_in_skills.dart` and are read from `skillRegistryProvider` at runtime. The DB-backed `SkillSeedingService` was removed; a future skill-management feature will introduce a separate per-user override layer rather than re-introducing seeding.
@@ -15,8 +15,9 @@ Skills do **not** participate in seeding — they live as code in `skills/built_
 flowchart TD
   Start["App start"] --> AIInit["aiConfigInitialization"]
   AIInit --> BackfillModels["ModelPrepopulationService.backfillNewModels()"]
-  AIInit --> SeedProfiles["ProfileSeedingService.seedDefaults()"]
+  AIInit --> SeedProfiles["ProfileSeedingService.seedDefaults()<br/>(gated on usable providers)"]
   AIInit --> UpgradeProfilesAI["ProfileSeedingService.upgradeExisting()"]
+  AIInit --> RemoveOrphans["ProfileSeedingService.removeOrphanedDefaultSeeds()"]
 
   Start --> AgentInit["agentInitialization"]
   AgentInit --> SeedTemplates["AgentTemplateService.seedDefaults()"]
@@ -800,20 +801,20 @@ Grounded implementation notes:
 
 ## Seeded Defaults
 
-`ProfileSeedingService.seedDefaults()` currently seeds these profiles:
+`ProfileSeedingService.seedDefaults()` knows these default profile templates, each gated on a provider type (`ProfileSeedingService.providerTypeByProfileId`):
 
-- `Gemini Flash`
-- `Gemini Pro`
-- `OpenAI`
-- `Mistral (EU)`
-- `Melious.ai`
-- `Chinese AI Profile`
-- `Anthropic Claude`
-- `Local (Ollama)`
-- `Local Power (oMLX)`
-- `Local Gemma 4 (oMLX)`
-- `Local Gemma 4 (Ollama)`
-- `Local Gemma 4 Power (Ollama)`
+- `Gemini Flash`, `Gemini Pro` — gated on a Gemini provider
+- `OpenAI` — gated on an OpenAI provider
+- `Mistral (EU)` — gated on a Mistral provider
+- `Melious.ai` — gated on a Melious provider
+- `Chinese AI Profile` — gated on an Alibaba provider
+- `Anthropic Claude` — gated on an Anthropic provider
+- `Local (Ollama)`, `Local Gemma 4 (Ollama)`, `Local Gemma 4 Power (Ollama)` — gated on an Ollama provider
+- `Local Power (oMLX)`, `Local Gemma 4 (oMLX)` — gated on an oMLX provider
+
+A template is only seeded once a **usable** provider of its gate type exists (`isUsable`: non-blank API key, or — for keyless local types — a non-blank base URL). A fresh install therefore starts with zero inference profiles; connecting a provider seeds exactly its own profile(s). Seeding runs at startup and again right after a provider is created (`addConfig`), updated (`updateConfig`, e.g. adding the API key to a draft), or finishes FTUE setup (`runFtueSetupForType`), so onboarding can bind categories to the profile immediately after the key step.
+
+The retroactive counterpart is `removeOrphanedDefaultSeeds()` (startup only, after `upgradeExisting()`): it deletes default seeds whose gate type has no usable provider — installs that seeded the full catalog before the gate existed, and providers deleted since the last launch. It is deliberately conservative: a profile is only removed while it still looks like an untouched seed (template name — or the legacy `Local Power (Ollama)` name — no description, no pinned host, template flags) and none of its model slots resolve to a model row owned by a usable provider. Renamed, described, pinned, or rewired profiles always survive.
 
 Operational details from the seeded definitions:
 
@@ -824,7 +825,7 @@ Operational details from the seeded definitions:
 - `Melious.ai` uses Mistral Small 4 119B Instruct for thinking and image recognition, GLM 5.2 for high-end thinking, Flux 2 Klein 9B for image generation, and Voxtral Small 24B for transcription
 - `Local Gemma 4 Power (Ollama)` currently ships with no default skill assignments
 
-`seedDefaults()` is **strictly seed-on-create**: it looks up each profile by its well-known ID and writes only when the row is missing. Freshly seeded profiles write `AiConfigModel.id` slot values when the corresponding model rows exist. Once a profile exists, the seeder never overwrites user-edited names, descriptions, flags, or skill assignments.
+`seedDefaults()` is **strictly seed-on-create**: it looks up each gated-in profile by its well-known ID and writes only when the row is missing. Freshly seeded profiles write `AiConfigModel.id` slot values when the corresponding model rows exist. Once a profile exists, the seeder never overwrites user-edited names, descriptions, flags, or skill assignments.
 
 `upgradeExisting()` backfills migration-safe pieces after model rows exist: dangling model slots on default profiles are healed (deleting a provider cascade-deletes its model rows, but the seeded profile kept pointing at the dead row IDs — each such slot resets to the seed template's provider-native default and re-resolves once the rows are recreated; catalog-known provider-native values are treated as pending, not dangling), legacy provider-native slot values are rewritten to `AiConfigModel.id` when the match is unambiguous, the untouched old `Local Power (Ollama)` seed is moved to the oMLX `Qwen3.6-35B-A3B-4bit` model, untouched local oMLX profiles gain the `whisper-large-v3-turbo` transcription slot, untouched Melious profiles move to the Flux 2 Klein 9B image-generation slot and Whisper Large v3 transcription slot and then on to the GLM 5.2 high-end thinking and Voxtral Small 24B transcription defaults, and default `skillAssignments` are added only to existing default profiles whose `skillAssignments` are still empty. User-edited names, resolvable model slots, and non-empty assignment lists are preserved. Besides startup, `upgradeExisting()` also runs right after a provider is created or re-verified (`runFtueSetupForType`, provider save in the settings form), so reconnecting a provider heals its profile immediately — onboarding's first capture resolves through the profile seconds after the key step.
 

--- a/lib/features/ai/state/ai_config_initialization.dart
+++ b/lib/features/ai/state/ai_config_initialization.dart
@@ -32,7 +32,18 @@ Future<void> aiConfigInitialization(Ref ref) async {
     );
   }
 
-  await profileService.seedDefaults();
+  // Seeding now reads provider rows for its usable-provider gate, so it gets
+  // its own guard: a failed read must not take down the rest of the app's
+  // startup sequence riding on this provider.
+  try {
+    await profileService.seedDefaults();
+  } catch (error, stackTrace) {
+    developer.log(
+      'Failed to seed inference profiles: $error',
+      name: 'aiConfigInitialization',
+      stackTrace: stackTrace,
+    );
+  }
 
   // Isolated from the backfill try/catch so a flaky backfill never skips
   // the profile upgrade pass.
@@ -41,6 +52,19 @@ Future<void> aiConfigInitialization(Ref ref) async {
   } catch (error, stackTrace) {
     developer.log(
       'Failed to upgrade inference profiles: $error',
+      name: 'aiConfigInitialization',
+      stackTrace: stackTrace,
+    );
+  }
+
+  // After upgrades, shed default seeds whose provider type has no usable
+  // provider — installs that seeded the full catalog before seeding was
+  // gated on provider setup, and providers deleted since the last launch.
+  try {
+    await profileService.removeOrphanedDefaultSeeds();
+  } catch (error, stackTrace) {
+    developer.log(
+      'Failed to remove orphaned default profiles: $error',
       name: 'aiConfigInitialization',
       stackTrace: stackTrace,
     );

--- a/lib/features/ai/state/settings/inference_provider_form_controller.dart
+++ b/lib/features/ai/state/settings/inference_provider_form_controller.dart
@@ -277,9 +277,14 @@ class InferenceProviderFormController
         );
       }
 
-      await ProfileSeedingService(
+      // Seed the profile(s) this provider unlocks before healing existing
+      // ones — profile seeding is gated on a usable provider of the matching
+      // type, so this save may be the moment the profile becomes eligible.
+      final seedingService = ProfileSeedingService(
         aiConfigRepository: repository,
-      ).upgradeExisting();
+      );
+      await seedingService.seedDefaults();
+      await seedingService.upgradeExisting();
     }
   }
 
@@ -293,5 +298,16 @@ class InferenceProviderFormController
         updatedAt: DateTime.now(),
       ),
     );
+
+    // Editing a provider can flip it usable (e.g. adding the API key to a
+    // draft) — seed its gated default profile(s) now and heal existing ones
+    // so the profile appears immediately, not on the next app launch.
+    if (config is AiConfigInferenceProvider) {
+      final seedingService = ProfileSeedingService(
+        aiConfigRepository: repository,
+      );
+      await seedingService.seedDefaults();
+      await seedingService.upgradeExisting();
+    }
   }
 }

--- a/lib/features/ai/state/settings/inference_provider_form_controller.dart
+++ b/lib/features/ai/state/settings/inference_provider_form_controller.dart
@@ -280,11 +280,7 @@ class InferenceProviderFormController
       // Seed the profile(s) this provider unlocks before healing existing
       // ones — profile seeding is gated on a usable provider of the matching
       // type, so this save may be the moment the profile becomes eligible.
-      final seedingService = ProfileSeedingService(
-        aiConfigRepository: repository,
-      );
-      await seedingService.seedDefaults();
-      await seedingService.upgradeExisting();
+      await _seedAndUpgradeProfiles(repository);
     }
   }
 
@@ -303,11 +299,28 @@ class InferenceProviderFormController
     // draft) — seed its gated default profile(s) now and heal existing ones
     // so the profile appears immediately, not on the next app launch.
     if (config is AiConfigInferenceProvider) {
+      await _seedAndUpgradeProfiles(repository);
+    }
+  }
+
+  /// Best-effort profile seeding + healing after a provider save.
+  ///
+  /// The provider row is already persisted when this runs, so a failure here
+  /// must not bubble into the page's save handler — that would turn a
+  /// successful save into an error toast and block navigation. The next
+  /// startup pass retries the same work anyway.
+  Future<void> _seedAndUpgradeProfiles(AiConfigRepository repository) async {
+    try {
       final seedingService = ProfileSeedingService(
         aiConfigRepository: repository,
       );
       await seedingService.seedDefaults();
       await seedingService.upgradeExisting();
+    } catch (error) {
+      DevLogger.log(
+        name: 'InferenceProviderForm',
+        message: 'Profile seeding after provider save failed: $error',
+      );
     }
   }
 }

--- a/lib/features/ai/ui/settings/inference_provider_edit_page.dart
+++ b/lib/features/ai/ui/settings/inference_provider_edit_page.dart
@@ -111,15 +111,19 @@ Future<AiFtueResult?> runFtueSetupForType({
   };
 
   if (result != null) {
-    // The FTUE just created or re-verified this provider's model rows. If a
-    // previous deletion of a same-type provider left seeded default profiles
-    // pointing at dead rows, heal them now — task structuring, transcription,
-    // and agent wakes resolve through the profile the moment onboarding hands
-    // the user their first capture, not on the next app launch.
+    // The FTUE just created or re-verified this provider's model rows. Seed
+    // the profile(s) gated on this provider type (onboarding binds its
+    // categories to the profile ID right after this), then heal profiles a
+    // previous same-type provider deletion left pointing at dead rows — task
+    // structuring, transcription, and agent wakes resolve through the profile
+    // the moment onboarding hands the user their first capture, not on the
+    // next app launch.
     try {
-      await ProfileSeedingService(
+      final seedingService = ProfileSeedingService(
         aiConfigRepository: aiConfigRepository,
-      ).upgradeExisting();
+      );
+      await seedingService.seedDefaults();
+      await seedingService.upgradeExisting();
     } catch (e, stackTrace) {
       developer.log(
         'Profile repair after FTUE setup failed: $e',

--- a/lib/features/ai/ui/settings/services/alibaba_ftue_setup.dart
+++ b/lib/features/ai/ui/settings/services/alibaba_ftue_setup.dart
@@ -25,8 +25,10 @@ extension AlibabaFtueSetup on ProviderPromptSetupService {
   ///    Audio/Qwen3 Omni Flash, Vision/Qwen3 VL Flash, Image/Wan 2.6)
   /// 2. A test category bound to the seeded Chinese AI Profile
   ///
-  /// The Chinese AI Profile (inference profile) is automatically created
-  /// by ProfileSeedingService on app startup and links to these models.
+  /// The Chinese AI Profile (inference profile) is created by
+  /// ProfileSeedingService once a usable Alibaba provider exists — the
+  /// provider save and `runFtueSetupForType` both trigger seeding — and
+  /// links to these models.
   Future<AlibabaFtueResult?> performAlibabaFtueSetup({
     required BuildContext context,
     required WidgetRef ref,

--- a/lib/features/ai/util/profile_seeding_service.dart
+++ b/lib/features/ai/util/profile_seeding_service.dart
@@ -152,6 +152,16 @@ class ProfileSeedingService {
       for (final provider in usableProviders) provider.id,
     };
     final models = await _fetchModelRows();
+    // Every value a profile slot could carry — row ID or legacy
+    // `providerModelId` — for models owned by a usable provider, so the
+    // per-slot check below is a set lookup instead of a scan over all rows.
+    final usableModelSlotValues = <String>{
+      for (final model in models)
+        if (usableProviderIds.contains(model.inferenceProviderId)) ...[
+          model.id,
+          model.providerModelId,
+        ],
+    };
     final templatesById = {
       for (final template in defaultProfiles) template.id: template,
     };
@@ -165,8 +175,7 @@ class ProfileSeedingService {
       if (!_isRemovableOrphanedSeed(
         config,
         template,
-        models: models,
-        usableProviderIds: usableProviderIds,
+        usableModelSlotValues: usableModelSlotValues,
       )) {
         continue;
       }
@@ -688,11 +697,14 @@ class ProfileSeedingService {
   /// Whether [profile] is still an untouched default seed that no usable
   /// provider can serve — the only state [removeOrphanedDefaultSeeds] is
   /// allowed to delete.
+  ///
+  /// A slot value found in [usableModelSlotValues] means the profile can
+  /// still serve requests (e.g. the user rewired it to another provider),
+  /// so the cleanup pass must keep it.
   static bool _isRemovableOrphanedSeed(
     AiConfigInferenceProfile profile,
     AiConfigInferenceProfile template, {
-    required List<AiConfigModel> models,
-    required Set<String> usableProviderIds,
+    required Set<String> usableModelSlotValues,
   }) {
     final nameUntouched =
         profile.name == template.name ||
@@ -714,25 +726,7 @@ class ProfileSeedingService {
       profile.imageGenerationModelId,
     ];
     return !slots.any(
-      (slot) =>
-          _slotResolvesToUsableProviderModel(slot, models, usableProviderIds),
-    );
-  }
-
-  /// True when [slotValue] resolves — by row ID or legacy `providerModelId` —
-  /// to a model row owned by a usable provider. Such a slot means the profile
-  /// can still serve requests (e.g. the user rewired it to another provider),
-  /// so the cleanup pass must keep it.
-  static bool _slotResolvesToUsableProviderModel(
-    String? slotValue,
-    List<AiConfigModel> models,
-    Set<String> usableProviderIds,
-  ) {
-    if (slotValue == null) return false;
-    return models.any(
-      (model) =>
-          (model.id == slotValue || model.providerModelId == slotValue) &&
-          usableProviderIds.contains(model.inferenceProviderId),
+      (slot) => slot != null && usableModelSlotValues.contains(slot),
     );
   }
 

--- a/lib/features/ai/util/profile_seeding_service.dart
+++ b/lib/features/ai/util/profile_seeding_service.dart
@@ -1,5 +1,6 @@
 import 'dart:developer' as developer;
 
+import 'package:lotti/features/ai/constants/provider_config.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/model/skill_assignment.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart';
@@ -51,6 +52,12 @@ const _mistralSkillAssignments = [
 /// when missing. Existing profiles are not overwritten during seeding; targeted
 /// upgrade migrations live in [upgradeExisting] and preserve user-authored
 /// model slots, flags, names, and skill assignments.
+///
+/// Seeding is gated per provider type: a default profile is only created once
+/// a *usable* provider of its type exists (see [providerTypeByProfileId] and
+/// [AiConfigInferenceProviderUsability.isUsable]). Fresh installs therefore
+/// start with zero profiles, and each provider setup surfaces exactly its own
+/// profile(s) instead of the full bundled catalog.
 class ProfileSeedingService {
   const ProfileSeedingService({
     required AiConfigRepository aiConfigRepository,
@@ -58,18 +65,51 @@ class ProfileSeedingService {
 
   final AiConfigRepository _repo;
 
-  /// Seeds all default profiles. Safe to call multiple times.
+  /// The provider type whose setup makes each default profile functional.
+  ///
+  /// [seedDefaults] only seeds a profile when a usable provider of its mapped
+  /// type exists, and [removeOrphanedDefaultSeeds] removes untouched seeds
+  /// whose mapped type has no usable provider left. Every entry in
+  /// [defaultProfiles] must have a mapping here (enforced by test).
+  static const providerTypeByProfileId = <String, InferenceProviderType>{
+    profileGeminiFlashId: InferenceProviderType.gemini,
+    profileGeminiProId: InferenceProviderType.gemini,
+    profileOpenAiId: InferenceProviderType.openAi,
+    profileMistralEuId: InferenceProviderType.mistral,
+    profileMeliousId: InferenceProviderType.melious,
+    profileAlibabaId: InferenceProviderType.alibaba,
+    profileAnthropicId: InferenceProviderType.anthropic,
+    profileLocalId: InferenceProviderType.ollama,
+    profileLocalPowerId: InferenceProviderType.omlx,
+    profileLocalGemmaOmlxId: InferenceProviderType.omlx,
+    profileLocalGemmaId: InferenceProviderType.ollama,
+    profileLocalGemmaPowerId: InferenceProviderType.ollama,
+  };
+
+  /// Seeds the default profiles whose provider type has a usable provider.
+  /// Safe to call multiple times.
   ///
   /// Only creates profiles that do not already exist by ID. Existing
   /// profiles — even if their model IDs or flags differ from the seed
   /// targets in code — are left untouched. This preserves user edits to
   /// the bundled defaults (e.g. swapping the Ollama profile's thinking
   /// model) across app restarts.
+  ///
+  /// Profiles whose provider type has no usable provider row (per
+  /// [AiConfigInferenceProviderUsability.isUsable]) are skipped entirely, so
+  /// the profile picker never fills up with entries that cannot serve a
+  /// single request. Runs at startup and again right after a provider is
+  /// created, updated, or finishes FTUE setup, so completing a provider
+  /// setup surfaces its profile immediately.
   Future<void> seedDefaults() async {
     var seededCount = 0;
     final models = await _fetchModelRows();
+    final usableTypes = await _fetchUsableProviderTypes();
 
     for (final template in defaultProfiles) {
+      if (!usableTypes.contains(providerTypeByProfileId[template.id])) {
+        continue;
+      }
       final existing = await _repo.getConfigById(template.id);
       if (existing != null) continue;
       final profile = _withResolvedModelConfigIds(template, models);
@@ -79,6 +119,66 @@ class ProfileSeedingService {
 
     if (seededCount > 0) {
       developer.log('Profiles: seeded $seededCount', name: _logTag);
+    }
+  }
+
+  /// Removes seeded default profiles that cannot serve any request because
+  /// no usable provider of their mapped type exists (anymore).
+  ///
+  /// This is the retroactive counterpart to the [seedDefaults] gate: installs
+  /// that seeded the full catalog before the gate existed — or that deleted a
+  /// provider after its profile was seeded — shed the dead entries here.
+  ///
+  /// Deliberately conservative: a profile is only removed when it is still
+  /// recognizable as an untouched seed (template name — or the known legacy
+  /// Local Power name — no description, no pinned host, template flags) AND
+  /// none of its model slots resolve to a model row owned by a usable
+  /// provider. Anything the user renamed, described, pinned, or rewired to a
+  /// working provider survives. Skill assignments are not inspected: they are
+  /// inert while no slot can resolve a provider, and re-seeding restores the
+  /// defaults if the provider returns.
+  ///
+  /// Runs at startup only (after [upgradeExisting]), so a mid-session
+  /// provider deletion with undo cannot race the cleanup.
+  Future<void> removeOrphanedDefaultSeeds() async {
+    final providers = await _fetchProviderRows();
+    final usableProviders = providers
+        .where((provider) => provider.isUsable)
+        .toList(growable: false);
+    final usableTypes = {
+      for (final provider in usableProviders) provider.inferenceProviderType,
+    };
+    final usableProviderIds = {
+      for (final provider in usableProviders) provider.id,
+    };
+    final models = await _fetchModelRows();
+    final templatesById = {
+      for (final template in defaultProfiles) template.id: template,
+    };
+    final configs = await _repo.getConfigsByType(AiConfigType.inferenceProfile);
+
+    var removedCount = 0;
+    for (final config in configs.whereType<AiConfigInferenceProfile>()) {
+      final template = templatesById[config.id];
+      if (template == null) continue;
+      if (usableTypes.contains(providerTypeByProfileId[config.id])) continue;
+      if (!_isRemovableOrphanedSeed(
+        config,
+        template,
+        models: models,
+        usableProviderIds: usableProviderIds,
+      )) {
+        continue;
+      }
+      await _repo.deleteConfig(config.id);
+      removedCount++;
+    }
+
+    if (removedCount > 0) {
+      developer.log(
+        'Profiles: removed $removedCount orphaned default seeds',
+        name: _logTag,
+      );
     }
   }
 
@@ -566,6 +666,74 @@ class ProfileSeedingService {
   Future<List<AiConfigModel>> _fetchModelRows() async {
     final configs = await _repo.getConfigsByType(AiConfigType.model);
     return configs.whereType<AiConfigModel>().toList(growable: false);
+  }
+
+  Future<List<AiConfigInferenceProvider>> _fetchProviderRows() async {
+    final configs = await _repo.getConfigsByType(
+      AiConfigType.inferenceProvider,
+    );
+    return configs.whereType<AiConfigInferenceProvider>().toList(
+      growable: false,
+    );
+  }
+
+  Future<Set<InferenceProviderType>> _fetchUsableProviderTypes() async {
+    final providers = await _fetchProviderRows();
+    return {
+      for (final provider in providers)
+        if (provider.isUsable) provider.inferenceProviderType,
+    };
+  }
+
+  /// Whether [profile] is still an untouched default seed that no usable
+  /// provider can serve — the only state [removeOrphanedDefaultSeeds] is
+  /// allowed to delete.
+  static bool _isRemovableOrphanedSeed(
+    AiConfigInferenceProfile profile,
+    AiConfigInferenceProfile template, {
+    required List<AiConfigModel> models,
+    required Set<String> usableProviderIds,
+  }) {
+    final nameUntouched =
+        profile.name == template.name ||
+        (profile.id == profileLocalPowerId &&
+            profile.name == _legacyLocalPowerName);
+    if (!nameUntouched ||
+        profile.description != null ||
+        profile.pinnedHostId != null ||
+        profile.isDefault != template.isDefault ||
+        profile.desktopOnly != template.desktopOnly) {
+      return false;
+    }
+
+    final slots = [
+      profile.thinkingModelId,
+      profile.thinkingHighEndModelId,
+      profile.imageRecognitionModelId,
+      profile.transcriptionModelId,
+      profile.imageGenerationModelId,
+    ];
+    return !slots.any(
+      (slot) =>
+          _slotResolvesToUsableProviderModel(slot, models, usableProviderIds),
+    );
+  }
+
+  /// True when [slotValue] resolves — by row ID or legacy `providerModelId` —
+  /// to a model row owned by a usable provider. Such a slot means the profile
+  /// can still serve requests (e.g. the user rewired it to another provider),
+  /// so the cleanup pass must keep it.
+  static bool _slotResolvesToUsableProviderModel(
+    String? slotValue,
+    List<AiConfigModel> models,
+    Set<String> usableProviderIds,
+  ) {
+    if (slotValue == null) return false;
+    return models.any(
+      (model) =>
+          (model.id == slotValue || model.providerModelId == slotValue) &&
+          usableProviderIds.contains(model.inferenceProviderId),
+    );
   }
 
   static AiConfigInferenceProfile _withResolvedModelConfigIds(

--- a/lib/features/onboarding/README.md
+++ b/lib/features/onboarding/README.md
@@ -198,8 +198,10 @@ stateDiagram-v2
 - **Native provider creation.** Unlike a settings deep-link, the flow creates the
   provider **in place**: `OnboardingApiKeyPanel` runs the existing per-provider
   FTUE setup (`runFtueSetupForType` → `performXxxFtueSetup`), which creates the
-  provider, ensures its known **models** exist, and reuses the startup-seeded
-  inference **profile**. Crucially it passes `createDefaultCategory: false` — the
+  provider, ensures its known **models** exist, and seeds the provider's
+  inference **profile** (profile seeding is gated on a usable provider of the
+  matching type, so this connect step is what makes the profile appear).
+  Crucially it passes `createDefaultCategory: false` — the
   onboarding category step owns category creation instead of auto-seeding a
   throwaway "Test Category".
 - **Connect does not celebrate.** A quiet `OnboardingSuccessView` beat (checkmark

--- a/test/features/ai/state/ai_config_initialization_test.dart
+++ b/test/features/ai/state/ai_config_initialization_test.dart
@@ -16,6 +16,7 @@ void main() {
   setUp(() {
     repo = MockAiConfigRepository();
     when(() => repo.saveConfig(any())).thenAnswer((_) async {});
+    when(() => repo.deleteConfig(any())).thenAnswer((_) async {});
   });
 
   ProviderContainer createContainer() {
@@ -35,55 +36,22 @@ void main() {
   }
 
   group('aiConfigInitialization', () {
-    test('seeds every default profile on first run and queries providers '
-        'for model backfill', () async {
-      // First run: nothing exists yet, so every profile is missing.
+    test('seeds no profiles on first run when no providers exist', () async {
       when(() => repo.getConfigById(any())).thenAnswer((_) async => null);
-      // No providers configured -> backfill saves no models.
+      // No providers configured -> backfill saves no models and the
+      // usable-provider gate keeps every default profile unseeded.
       when(() => repo.getConfigsByType(any())).thenAnswer((_) async => []);
 
       final container = createContainer();
       await container.read(aiConfigInitializationProvider.future);
 
-      // Each default profile was looked up by ID...
-      for (final profile in ProfileSeedingService.defaultProfiles) {
-        verify(() => repo.getConfigById(profile.id)).called(1);
-      }
-
-      // ...and persisted exactly once, with no extra writes (no providers
-      // means model backfill creates nothing).
-      final saved = savedConfigs();
-      expect(saved, hasLength(ProfileSeedingService.defaultProfiles.length));
-      final savedIds = saved.map((c) => c.id).toSet();
-      expect(
-        savedIds,
-        equals(ProfileSeedingService.defaultProfiles.map((p) => p.id).toSet()),
-      );
-
-      // Backfill consulted the inference-provider configs.
-      verify(
-        () => repo.getConfigsByType(AiConfigType.inferenceProvider),
-      ).called(1);
-    });
-
-    test('skips seeding when every default profile already exists', () async {
-      // Every profile ID already resolves to an existing config.
-      when(() => repo.getConfigById(any())).thenAnswer((invocation) async {
-        final id = invocation.positionalArguments.first as String;
-        return AiTestDataFactory.createTestProfile(id: id);
-      });
-      when(() => repo.getConfigsByType(any())).thenAnswer((_) async => []);
-
-      final container = createContainer();
-      await container.read(aiConfigInitializationProvider.future);
-
-      // No profile is overwritten — saveConfig is never called by seeding,
-      // and with no providers the backfill writes nothing either.
       verifyNever(() => repo.saveConfig(any()));
+      verifyNever(() => repo.deleteConfig(any()));
     });
 
     test(
-      'backfills models for an existing provider with known models',
+      'seeds only the profiles of an existing usable provider and '
+      'backfills its known models',
       () async {
         when(() => repo.getConfigById(any())).thenAnswer((_) async => null);
 
@@ -95,6 +63,9 @@ void main() {
         when(
           () => repo.getConfigsByType(AiConfigType.model),
         ).thenAnswer((_) async => []);
+        when(
+          () => repo.getConfigsByType(AiConfigType.inferenceProfile),
+        ).thenAnswer((_) async => []);
 
         final container = createContainer();
         await container.read(aiConfigInitializationProvider.future);
@@ -102,14 +73,14 @@ void main() {
         final saved = savedConfigs();
         final seededProfiles = saved
             .whereType<AiConfigInferenceProfile>()
-            .length;
+            .toList();
         final backfilledModels = saved.whereType<AiConfigModel>().toList();
 
-        // All default profiles seeded plus newly created models, all attached
-        // to the existing provider.
+        // The default anthropic test provider gates in exactly the Anthropic
+        // profile; the rest of the catalog stays unseeded.
         expect(
-          seededProfiles,
-          ProfileSeedingService.defaultProfiles.length,
+          seededProfiles.map((p) => p.id),
+          [profileAnthropicId],
         );
         expect(backfilledModels, isNotEmpty);
         expect(
@@ -119,43 +90,81 @@ void main() {
       },
     );
 
-    test('completes normally and still seeds profiles when model backfill '
-        'throws', () async {
+    test('skips seeding when the gated profile already exists', () async {
+      // The Anthropic profile ID already resolves to an existing config.
+      when(() => repo.getConfigById(any())).thenAnswer((invocation) async {
+        final id = invocation.positionalArguments.first as String;
+        return AiTestDataFactory.createTestProfile(id: id);
+      });
+      when(() => repo.getConfigsByType(any())).thenAnswer((_) async => []);
+      when(
+        () => repo.getConfigsByType(AiConfigType.inferenceProvider),
+      ).thenAnswer((_) async => [AiTestDataFactory.createTestProvider()]);
+
+      final container = createContainer();
+      await container.read(aiConfigInitializationProvider.future);
+
+      // No profile is written — seed-on-create leaves the existing row alone
+      // (model backfill still writes the provider's known models).
+      expect(savedConfigs().whereType<AiConfigInferenceProfile>(), isEmpty);
+    });
+
+    test(
+      'removes an orphaned untouched default seed when its provider '
+      'type has no usable provider',
+      () async {
+        when(() => repo.getConfigById(any())).thenAnswer((_) async => null);
+        when(() => repo.getConfigsByType(any())).thenAnswer((_) async => []);
+        final meliousSeed = ProfileSeedingService.defaultProfiles.firstWhere(
+          (p) => p.id == profileMeliousId,
+        );
+        when(
+          () => repo.getConfigsByType(AiConfigType.inferenceProfile),
+        ).thenAnswer((_) async => [meliousSeed]);
+
+        final container = createContainer();
+        await container.read(aiConfigInitializationProvider.future);
+
+        verify(() => repo.deleteConfig(profileMeliousId)).called(1);
+      },
+    );
+
+    test('completes normally when provider reads throw — the profile '
+        'upgrade pass still runs', () async {
       when(() => repo.getConfigById(any())).thenAnswer((_) async => null);
       when(() => repo.getConfigsByType(any())).thenAnswer((_) async => []);
-      // Backfill reads inference-provider configs first; make that throw.
-      // Seeding and upgrading read model/profile configs, which stay stubbed
-      // above, so they must still run after the backfill failure.
+      // Backfill, the seeding gate, and the orphan cleanup all read the
+      // inference-provider configs; make that throw. Each step is isolated,
+      // so the upgrade pass (models + profiles only) must still run.
       when(
         () => repo.getConfigsByType(AiConfigType.inferenceProvider),
       ).thenThrow(Exception('db unavailable'));
 
       final container = createContainer();
 
-      // The provider future resolves without surfacing the backfill error
-      // (it is caught and logged).
+      // The provider future resolves without surfacing the errors
+      // (they are caught and logged step by step).
       await expectLater(
         container.read(aiConfigInitializationProvider.future),
         completes,
       );
 
-      // Profile seeding ran to completion despite the backfill failure.
-      expect(
-        savedConfigs(),
-        hasLength(ProfileSeedingService.defaultProfiles.length),
-      );
+      verifyNever(() => repo.saveConfig(any()));
 
-      // The upgrade pass also ran: it reads the existing inference profiles.
+      // The upgrade pass ran: it reads the existing inference profiles.
       verify(
         () => repo.getConfigsByType(AiConfigType.inferenceProfile),
       ).called(1);
     });
 
-    test('completes normally and still backfills models when profile '
+    test('completes normally and still seeds profiles when the profile '
         'upgrade throws', () async {
       when(() => repo.getConfigById(any())).thenAnswer((_) async => null);
       when(() => repo.getConfigsByType(any())).thenAnswer((_) async => []);
-      // upgradeExisting() is the only step reading inference profiles.
+      when(
+        () => repo.getConfigsByType(AiConfigType.inferenceProvider),
+      ).thenAnswer((_) async => [AiTestDataFactory.createTestProvider()]);
+      // upgradeExisting() and the orphan cleanup read inference profiles.
       when(
         () => repo.getConfigsByType(AiConfigType.inferenceProfile),
       ).thenThrow(Exception('db unavailable'));
@@ -167,13 +176,10 @@ void main() {
         completes,
       );
 
-      // Backfill and seeding both completed before the upgrade failure.
-      verify(
-        () => repo.getConfigsByType(AiConfigType.inferenceProvider),
-      ).called(1);
+      // Backfill and gated seeding both completed before the upgrade failure.
       expect(
-        savedConfigs(),
-        hasLength(ProfileSeedingService.defaultProfiles.length),
+        savedConfigs().whereType<AiConfigInferenceProfile>().map((p) => p.id),
+        [profileAnthropicId],
       );
     });
   });

--- a/test/features/ai/state/settings/inference_provider_form_controller_test.dart
+++ b/test/features/ai/state/settings/inference_provider_form_controller_test.dart
@@ -6,6 +6,7 @@ import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/model/inference_provider_form_state.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 import 'package:lotti/features/ai/state/settings/inference_provider_form_controller.dart';
+import 'package:lotti/features/ai/util/profile_seeding_service.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../../mocks/mocks.dart';
@@ -293,6 +294,11 @@ void main() {
         (_) async => testConfig,
       );
       when(() => mockRepository.saveConfig(any())).thenAnswer((_) async {});
+      // Provider updates re-run the gated profile seeding + upgrade pass;
+      // no providers/models/profiles exist, so no extra writes happen.
+      when(
+        () => mockRepository.getConfigsByType(any()),
+      ).thenAnswer((_) async => []);
 
       // Load the existing config first
       final controller = container.read(
@@ -1203,12 +1209,96 @@ void main() {
       await controller.addConfig(geminiConfig);
 
       // Assert - should save provider and check for existing models.
-      // Two reads: the model prepopulation pass and the subsequent
-      // profile upgrade pass each fetch the model rows.
+      // Three reads: the model prepopulation pass, the gated profile
+      // seeding, and the profile upgrade pass each fetch the model rows.
       verify(() => mockRepository.saveConfig(geminiConfig)).called(1);
       verify(
         () => mockRepository.getConfigsByType(AiConfigType.model),
-      ).called(2);
+      ).called(3);
+    });
+
+    test('seeds the gated default profiles after adding a usable '
+        'provider', () async {
+      // Arrange
+      when(() => mockRepository.saveConfig(any())).thenAnswer((_) async {});
+      when(
+        () => mockRepository.getConfigsByType(any()),
+      ).thenAnswer((_) async => []);
+      when(
+        () => mockRepository.getConfigById(any()),
+      ).thenAnswer((_) async => null);
+
+      final geminiConfig = AiConfig.inferenceProvider(
+        id: 'gemini-provider-id',
+        baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai',
+        apiKey: 'test-gemini-key',
+        name: 'Gemini',
+        createdAt: DateTime(2024, 3, 15),
+        inferenceProviderType: InferenceProviderType.gemini,
+      );
+      when(
+        () => mockRepository.getConfigsByType(AiConfigType.inferenceProvider),
+      ).thenAnswer((_) async => [geminiConfig]);
+
+      final controller = container.read(
+        inferenceProviderFormControllerProvider(configId: null).notifier,
+      );
+
+      // Act
+      await controller.addConfig(geminiConfig);
+
+      // Assert — the Gemini profiles (and only those) got seeded alongside
+      // the provider save and the prepopulated model rows.
+      final savedProfileIds = verify(
+        () => mockRepository.saveConfig(captureAny()),
+      ).captured.whereType<AiConfigInferenceProfile>().map((p) => p.id);
+      expect(
+        savedProfileIds.toSet(),
+        {profileGeminiFlashId, profileGeminiProId},
+      );
+    });
+
+    test('seeds the gated default profile when a provider update makes it '
+        'usable', () async {
+      // Arrange — editing an existing draft (e.g. pasting the API key).
+      when(() => mockRepository.getConfigById('test-id')).thenAnswer(
+        (_) async => testConfig,
+      );
+      when(() => mockRepository.saveConfig(any())).thenAnswer((_) async {});
+      when(
+        () => mockRepository.getConfigsByType(any()),
+      ).thenAnswer((_) async => []);
+      when(
+        () => mockRepository.getConfigById(profileMeliousId),
+      ).thenAnswer((_) async => null);
+
+      final meliousConfig = AiConfig.inferenceProvider(
+        id: 'test-id',
+        baseUrl: 'https://api.melious.ai/v1',
+        apiKey: 'fresh-key',
+        name: 'Melious.ai',
+        createdAt: DateTime(2024, 3, 15),
+        inferenceProviderType: InferenceProviderType.melious,
+      );
+      when(
+        () => mockRepository.getConfigsByType(AiConfigType.inferenceProvider),
+      ).thenAnswer((_) async => [meliousConfig]);
+
+      final controller = container.read(
+        inferenceProviderFormControllerProvider(configId: 'test-id').notifier,
+      );
+      await container.read(
+        inferenceProviderFormControllerProvider(configId: 'test-id').future,
+      );
+
+      // Act
+      await controller.updateConfig(meliousConfig);
+
+      // Assert — exactly the Melious profile appears with the update.
+      final savedProfileIds = verify(
+        () => mockRepository.saveConfig(captureAny()),
+      ).captured.whereType<AiConfigInferenceProfile>().map((p) => p.id);
+      expect(savedProfileIds, [profileMeliousId]);
     });
   });
 

--- a/test/features/ai/state/settings/inference_provider_form_controller_test.dart
+++ b/test/features/ai/state/settings/inference_provider_form_controller_test.dart
@@ -1300,6 +1300,66 @@ void main() {
       ).captured.whereType<AiConfigInferenceProfile>().map((p) => p.id);
       expect(savedProfileIds, [profileMeliousId]);
     });
+
+    test('a profile seeding failure does not fail the provider save', () async {
+      // Arrange — the gate is open (usable Gemini provider), but the seed
+      // lookup blows up. The provider row is already saved at that point, so
+      // addConfig must swallow the failure instead of surfacing an error
+      // toast for a save that succeeded.
+      when(() => mockRepository.saveConfig(any())).thenAnswer((_) async {});
+      when(
+        () => mockRepository.getConfigsByType(any()),
+      ).thenAnswer((_) async => []);
+      when(
+        () => mockRepository.getConfigById(any()),
+      ).thenThrow(Exception('db unavailable'));
+
+      final geminiConfig = AiConfig.inferenceProvider(
+        id: 'gemini-provider-id',
+        baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai',
+        apiKey: 'test-gemini-key',
+        name: 'Gemini',
+        createdAt: DateTime(2024, 3, 15),
+        inferenceProviderType: InferenceProviderType.gemini,
+      );
+      when(
+        () => mockRepository.getConfigsByType(AiConfigType.inferenceProvider),
+      ).thenAnswer((_) async => [geminiConfig]);
+
+      final controller = container.read(
+        inferenceProviderFormControllerProvider(configId: null).notifier,
+      );
+
+      // Act + Assert — completes despite the seeding failure.
+      await expectLater(controller.addConfig(geminiConfig), completes);
+      verify(() => mockRepository.saveConfig(geminiConfig)).called(1);
+    });
+
+    test(
+      'a profile seeding failure does not fail the provider update',
+      () async {
+        // Arrange — every config-type read throws, so the seeding pass fails
+        // at its first fetch. The update itself must still complete.
+        when(() => mockRepository.getConfigById('test-id')).thenAnswer(
+          (_) async => testConfig,
+        );
+        when(() => mockRepository.saveConfig(any())).thenAnswer((_) async {});
+        when(
+          () => mockRepository.getConfigsByType(any()),
+        ).thenThrow(Exception('db unavailable'));
+
+        final controller = container.read(
+          inferenceProviderFormControllerProvider(configId: 'test-id').notifier,
+        );
+        await container.read(
+          inferenceProviderFormControllerProvider(configId: 'test-id').future,
+        );
+
+        // Act + Assert — completes despite the seeding failure.
+        await expectLater(controller.updateConfig(testConfig), completes);
+        verify(() => mockRepository.saveConfig(any())).called(1);
+      },
+    );
   });
 
   group('Edge Cases', () {

--- a/test/features/ai/util/profile_seeding_service_test.dart
+++ b/test/features/ai/util/profile_seeding_service_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/ai/constants/provider_config.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/model/skill_assignment.dart';
 import 'package:lotti/features/ai/skills/built_in_skills.dart';
@@ -7,6 +8,19 @@ import 'package:lotti/features/ai/util/profile_seeding_service.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../test_utils.dart';
+
+/// Usable provider rows for [types] — non-blank API key for cloud types,
+/// non-blank base URL for keyless local types — so the seeding gate is open
+/// for exactly those provider types.
+List<AiConfig> _usableProvidersFor(Iterable<InferenceProviderType> types) => [
+  for (final type in types)
+    AiTestDataFactory.createTestProvider(
+      id: 'provider-${type.name}',
+      type: type,
+      apiKey: ProviderConfig.requiresApiKey(type) ? 'test-api-key' : '',
+      baseUrl: 'http://localhost:1234',
+    ),
+];
 
 void main() {
   late MockAiConfigRepository mockRepo;
@@ -35,7 +49,17 @@ void main() {
     when(
       () => mockRepo.getConfigsByType(AiConfigType.inferenceProfile),
     ).thenAnswer((_) async => const <AiConfig>[]);
+    // Default: a usable provider exists for every mapped provider type, so
+    // the seeding gate is open for the whole catalog unless a test narrows it.
+    when(
+      () => mockRepo.getConfigsByType(AiConfigType.inferenceProvider),
+    ).thenAnswer(
+      (_) async => _usableProvidersFor(
+        ProfileSeedingService.providerTypeByProfileId.values.toSet(),
+      ),
+    );
     when(() => mockRepo.saveConfig(any())).thenAnswer((_) async {});
+    when(() => mockRepo.deleteConfig(any())).thenAnswer((_) async {});
   });
 
   group('ProfileSeedingService', () {
@@ -469,6 +493,249 @@ void main() {
         localProfile.skillAssignments.first.skillId,
         skillImageAnalysisContextId,
       );
+    });
+  });
+
+  group('provider-gated seeding', () {
+    test('seeds nothing when no providers exist', () async {
+      when(
+        () => mockRepo.getConfigsByType(AiConfigType.inferenceProvider),
+      ).thenAnswer((_) async => const <AiConfig>[]);
+
+      await service.seedDefaults();
+
+      verifyNever(() => mockRepo.saveConfig(any()));
+    });
+
+    test('seeds only the profile of the one usable provider type', () async {
+      when(
+        () => mockRepo.getConfigsByType(AiConfigType.inferenceProvider),
+      ).thenAnswer(
+        (_) async => _usableProvidersFor([InferenceProviderType.melious]),
+      );
+      final captured = <AiConfig>[];
+      when(
+        () => mockRepo.saveConfig(captureAny(that: isA<AiConfig>())),
+      ).thenAnswer((invocation) async {
+        captured.add(invocation.positionalArguments.first as AiConfig);
+      });
+
+      await service.seedDefaults();
+
+      expect(captured.map((c) => c.id), [profileMeliousId]);
+    });
+
+    test(
+      'a draft provider without an API key does not open the gate',
+      () async {
+        when(
+          () => mockRepo.getConfigsByType(AiConfigType.inferenceProvider),
+        ).thenAnswer(
+          (_) async => [
+            AiTestDataFactory.createTestProvider(
+              id: 'melious-draft',
+              type: InferenceProviderType.melious,
+              apiKey: '',
+            ),
+          ],
+        );
+
+        await service.seedDefaults();
+
+        verifyNever(() => mockRepo.saveConfig(any()));
+      },
+    );
+
+    test(
+      'a keyless local provider with a base URL opens the Ollama gate',
+      () async {
+        when(
+          () => mockRepo.getConfigsByType(AiConfigType.inferenceProvider),
+        ).thenAnswer(
+          (_) async => _usableProvidersFor([InferenceProviderType.ollama]),
+        );
+        final captured = <AiConfig>[];
+        when(
+          () => mockRepo.saveConfig(captureAny(that: isA<AiConfig>())),
+        ).thenAnswer((invocation) async {
+          captured.add(invocation.positionalArguments.first as AiConfig);
+        });
+
+        await service.seedDefaults();
+
+        expect(captured.map((c) => c.id).toSet(), {
+          profileLocalId,
+          profileLocalGemmaId,
+          profileLocalGemmaPowerId,
+        });
+      },
+    );
+
+    test('every default profile template has a provider-type mapping', () {
+      expect(
+        ProfileSeedingService.providerTypeByProfileId.keys.toSet(),
+        ProfileSeedingService.defaultProfiles.map((p) => p.id).toSet(),
+      );
+    });
+  });
+
+  group('removeOrphanedDefaultSeeds', () {
+    AiConfigInferenceProfile templateFor(String id) =>
+        ProfileSeedingService.defaultProfiles.firstWhere((p) => p.id == id);
+
+    test(
+      'removes an untouched seed whose provider type has no usable provider',
+      () async {
+        when(
+          () => mockRepo.getConfigsByType(AiConfigType.inferenceProvider),
+        ).thenAnswer(
+          (_) async => _usableProvidersFor([InferenceProviderType.gemini]),
+        );
+        when(
+          () => mockRepo.getConfigsByType(AiConfigType.inferenceProfile),
+        ).thenAnswer((_) async => [templateFor(profileMeliousId)]);
+
+        await service.removeOrphanedDefaultSeeds();
+
+        verify(() => mockRepo.deleteConfig(profileMeliousId)).called(1);
+      },
+    );
+
+    test('keeps the seed while a usable same-type provider exists', () async {
+      when(
+        () => mockRepo.getConfigsByType(AiConfigType.inferenceProvider),
+      ).thenAnswer(
+        (_) async => _usableProvidersFor([InferenceProviderType.melious]),
+      );
+      when(
+        () => mockRepo.getConfigsByType(AiConfigType.inferenceProfile),
+      ).thenAnswer((_) async => [templateFor(profileMeliousId)]);
+
+      await service.removeOrphanedDefaultSeeds();
+
+      verifyNever(() => mockRepo.deleteConfig(any()));
+    });
+
+    test(
+      'keeps a renamed seed — user-touched rows are never removed',
+      () async {
+        when(
+          () => mockRepo.getConfigsByType(AiConfigType.inferenceProvider),
+        ).thenAnswer((_) async => const <AiConfig>[]);
+        when(
+          () => mockRepo.getConfigsByType(AiConfigType.inferenceProfile),
+        ).thenAnswer(
+          (_) async => [
+            templateFor(profileMeliousId).copyWith(name: 'My cloud profile'),
+          ],
+        );
+
+        await service.removeOrphanedDefaultSeeds();
+
+        verifyNever(() => mockRepo.deleteConfig(any()));
+      },
+    );
+
+    test(
+      'keeps a seed rewired to a usable provider of another type',
+      () async {
+        // Anthropic has no usable provider, but the user pointed the
+        // transcription slot at a model row owned by a usable Gemini
+        // provider — the profile can still serve requests, so it stays.
+        when(
+          () => mockRepo.getConfigsByType(AiConfigType.inferenceProvider),
+        ).thenAnswer(
+          (_) async => _usableProvidersFor([InferenceProviderType.gemini]),
+        );
+        when(() => mockRepo.getConfigsByType(AiConfigType.model)).thenAnswer(
+          (_) async => [
+            AiTestDataFactory.createTestModel(
+              id: 'gemini-flash-row',
+              providerModelId: 'models/gemini-3-flash-preview',
+              inferenceProviderId: 'provider-gemini',
+            ),
+          ],
+        );
+        when(
+          () => mockRepo.getConfigsByType(AiConfigType.inferenceProfile),
+        ).thenAnswer(
+          (_) async => [
+            templateFor(
+              profileAnthropicId,
+            ).copyWith(transcriptionModelId: 'gemini-flash-row'),
+          ],
+        );
+
+        await service.removeOrphanedDefaultSeeds();
+
+        verifyNever(() => mockRepo.deleteConfig(any()));
+      },
+    );
+
+    test(
+      'removes the legacy-named Local Power seed when oMLX is gone',
+      () async {
+        when(
+          () => mockRepo.getConfigsByType(AiConfigType.inferenceProvider),
+        ).thenAnswer((_) async => const <AiConfig>[]);
+        when(
+          () => mockRepo.getConfigsByType(AiConfigType.inferenceProfile),
+        ).thenAnswer(
+          (_) async => [
+            templateFor(
+              profileLocalPowerId,
+            ).copyWith(name: 'Local Power (Ollama)'),
+          ],
+        );
+
+        await service.removeOrphanedDefaultSeeds();
+
+        verify(() => mockRepo.deleteConfig(profileLocalPowerId)).called(1);
+      },
+    );
+
+    test('keeps seeds with any user-touched metadata', () async {
+      when(
+        () => mockRepo.getConfigsByType(AiConfigType.inferenceProvider),
+      ).thenAnswer((_) async => const <AiConfig>[]);
+      final template = templateFor(profileMeliousId);
+      final touchedVariants = <String, AiConfigInferenceProfile>{
+        'description': template.copyWith(description: 'my notes'),
+        'pinnedHostId': template.copyWith(pinnedHostId: 'host-1'),
+        'isDefault': template.copyWith(isDefault: false),
+        'desktopOnly': template.copyWith(desktopOnly: true),
+      };
+
+      for (final entry in touchedVariants.entries) {
+        when(
+          () => mockRepo.getConfigsByType(AiConfigType.inferenceProfile),
+        ).thenAnswer((_) async => [entry.value]);
+
+        await service.removeOrphanedDefaultSeeds();
+
+        verifyNever(() => mockRepo.deleteConfig(any()));
+      }
+    });
+
+    test('never touches user-created (non-template) profiles', () async {
+      when(
+        () => mockRepo.getConfigsByType(AiConfigType.inferenceProvider),
+      ).thenAnswer((_) async => const <AiConfig>[]);
+      when(
+        () => mockRepo.getConfigsByType(AiConfigType.inferenceProfile),
+      ).thenAnswer(
+        (_) async => [
+          AiTestDataFactory.createTestProfile(
+            id: 'user-profile',
+            name: 'Mine',
+            description: null,
+          ),
+        ],
+      );
+
+      await service.removeOrphanedDefaultSeeds();
+
+      verifyNever(() => mockRepo.deleteConfig(any()));
     });
   });
 


### PR DESCRIPTION
## Summary

Default inference profiles were seeded unconditionally at startup, so the profile picker filled up with entries for providers that were never set up (Chinese AI Profile, Mistral (EU), etc.). This PR gates seeding on provider setup and cleans up the leftovers:

- **Gated seeding**: `ProfileSeedingService.seedDefaults()` now maps every default profile template to a provider type (`providerTypeByProfileId`) and only seeds a profile once a *usable* provider of that type exists (non-blank API key, or non-blank base URL for keyless local providers). A fresh install starts with zero profiles; connecting Melious.ai seeds exactly the one Melious profile.
- **Immediate seeding on setup**: seeding re-runs after provider create (`addConfig`), update (`updateConfig`, e.g. pasting an API key into a draft), and FTUE setup (`runFtueSetupForType`) — onboarding binds its categories to the profile right after the key step, so the profile must exist by then.
- **Retroactive cleanup**: a new `removeOrphanedDefaultSeeds()` startup pass (after `upgradeExisting()`) deletes default seeds whose provider type has no usable provider — existing installs shed the never-configured profiles, and deleting a provider retires its untouched profile on next launch. Deliberately conservative: only rows still recognizable as untouched seeds (template name/flags, no description, no pinned host) with no model slot resolving to a usable provider's model row are removed; anything renamed, described, pinned, or rewired survives.

Docs updated (AI + onboarding feature READMEs, stale FTUE doc comment), CHANGELOG + flatpak metainfo entry under 0.9.1037.

## Test plan

- New tests: provider-gated seeding (no providers → nothing; one provider → exactly its profiles; drafts don't open the gate; keyless local providers do), orphaned-seed cleanup (removal, all keep-guards, legacy Local Power name), form-controller seeding on add/update, initialization wiring incl. error isolation.
- `dart analyze` clean on `lib/features/ai`, `lib/features/onboarding`, and their tests.
- Full affected suites pass: `test/features/ai/util`, `test/features/ai/state`, `test/features/ai/ui/settings` (841), `test/features/onboarding` (~250), `test/features/agents/state/agent_providers_test.dart`.
- Local patch-coverage check: every changed, instrumented line in `lib/` is hit by the test suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - AI profile pickers now list bundled default inference profiles only when a usable provider of the matching type is already available.
  - Default profile seeding also happens during provider setup/editing when the provider becomes usable.
  - Orphaned, untouched default profiles are cleaned up automatically on next launch when their provider type is no longer usable.
  - User-customized profiles are preserved.
- **Bug Fixes**
  - Startup/config initialization no longer fails if seeding or orphan cleanup encounters errors (continues safely).
- **Documentation**
  - Updated release notes and onboarding/AI docs to reflect provider-gated seeding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->