### PR TITLE
test: close task agent coverage gaps

### DIFF
--- a/test/features/agents/state/task_agent_model_providers_test.dart
+++ b/test/features/agents/state/task_agent_model_providers_test.dart
@@ -4,7 +4,9 @@ import 'package:lotti/features/agents/state/agent_query_providers.dart';
 import 'package:lotti/features/agents/state/task_agent_model_providers.dart';
 import 'package:lotti/features/agents/state/template_query_providers.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/model/resolved_profile.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart';
+import 'package:lotti/features/ai/state/profile_automation_providers.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../mocks/mocks.dart';
@@ -120,4 +122,42 @@ void main() {
       expect(options.providers, isEmpty);
     },
   );
+
+  test('resolved setup delegates complete agent context to resolver', () async {
+    final identity = makeTestIdentity();
+    final template = makeTestTemplate();
+    final version = makeTestTemplateVersion(agentId: template.id);
+    final resolver = MockProfileResolver();
+    const expected = ResolvedAgentSetup(
+      status: AgentSetupResolutionStatus.disabled,
+    );
+    when(
+      () => resolver.resolveDetailed(
+        agentConfig: identity.config,
+        template: template,
+        version: version,
+      ),
+    ).thenAnswer((_) async => expected);
+    final container = ProviderContainer(
+      overrides: [
+        agentIdentityProvider.overrideWith((ref, id) async => identity),
+        templateForAgentProvider.overrideWith((ref, id) async => template),
+        activeTemplateVersionProvider.overrideWith((ref, id) async => version),
+        profileResolverProvider.overrideWithValue(resolver),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    expect(
+      await container.read(taskAgentResolvedSetupProvider('agent').future),
+      expected,
+    );
+    verify(
+      () => resolver.resolveDetailed(
+        agentConfig: identity.config,
+        template: template,
+        version: version,
+      ),
+    ).called(1);
+  });
 }

--- a/test/features/agents/ui/agent_internals_body_test.dart
+++ b/test/features/agents/ui/agent_internals_body_test.dart
@@ -204,4 +204,43 @@ void main() {
     expect(find.text('Agent setup'), findsWidgets);
     expect(find.text('You chose this for this agent'), findsOneWidget);
   });
+
+  testWidgets('setup row distinguishes a broken setup from no selection', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      RiverpodWidgetTestBench(
+        mediaQueryData: const MediaQueryData(size: Size(900, 800)),
+        overrides: [
+          agentIdentityProvider.overrideWith(
+            (ref, agentId) async => makeTestIdentity(),
+          ),
+          agentStateProvider.overrideWith((ref, agentId) async => null),
+          templateForAgentProvider.overrideWith((ref, agentId) async => null),
+          taskAgentResolvedSetupProvider.overrideWith(
+            (ref, agentId) async => const ResolvedAgentSetup(
+              status: AgentSetupResolutionStatus.broken,
+              brokenSelectionId: 'missing-profile',
+            ),
+          ),
+        ],
+        child: const SingleChildScrollView(
+          child: AgentInternalsBody(
+            agentId: 'agent-001',
+            lifecycle: AgentLifecycle.active,
+            stateAsync: AsyncValue.data(null),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.scrollUntilVisible(
+      find.text('Selected AI setup is unavailable').first,
+      200,
+      scrollable: find.byType(Scrollable).at(1),
+    );
+    expect(find.text('Selected AI setup is unavailable'), findsNWidgets(2));
+    expect(find.text('No AI setup'), findsNothing);
+  });
 }

--- a/test/features/agents/ui/agent_model_sheet_test.dart
+++ b/test/features/agents/ui/agent_model_sheet_test.dart
@@ -9,6 +9,7 @@ import 'package:lotti/features/agents/state/task_agent_providers.dart';
 import 'package:lotti/features/agents/ui/agent_model_sheet.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/model/resolved_profile.dart';
+import 'package:lotti/features/design_system/components/checkboxes/design_system_checkbox.dart';
 import 'package:lotti/providers/service_providers.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -96,22 +97,33 @@ void main() {
     ).thenAnswer((_) async {});
   });
 
-  List<Override> overrides({bool automaticUpdates = true}) {
+  List<Override> overrides({
+    bool automaticUpdates = true,
+    AgentConfig? config,
+    ResolvedAgentSetup? resolvedSetup,
+    TaskAgentSetupOptions? setupOptions,
+  }) {
     final identity = makeTestIdentity().copyWith(
-      config: AgentConfig(
-        automaticUpdatesEnabled: automaticUpdates,
-        profileId: profile.id,
-        inferenceSetup: AgentInferenceSetup(
-          mode: AgentInferenceSetupMode.configured,
-          origin: AgentInferenceSetupOrigin.user,
-          baseProfileId: profile.id,
-        ),
-      ),
+      config:
+          config ??
+          AgentConfig(
+            automaticUpdatesEnabled: automaticUpdates,
+            profileId: profile.id,
+            inferenceSetup: AgentInferenceSetup(
+              mode: AgentInferenceSetupMode.configured,
+              origin: AgentInferenceSetupOrigin.user,
+              baseProfileId: profile.id,
+            ),
+          ),
     );
     return [
       agentIdentityProvider.overrideWith((ref, id) async => identity),
-      taskAgentResolvedSetupProvider.overrideWith((ref, id) async => resolved),
-      taskAgentSetupOptionsProvider.overrideWith((ref) async => options),
+      taskAgentResolvedSetupProvider.overrideWith(
+        (ref, id) async => resolvedSetup ?? resolved,
+      ),
+      taskAgentSetupOptionsProvider.overrideWith(
+        (ref) async => setupOptions ?? options,
+      ),
       taskAgentServiceProvider.overrideWithValue(service),
       journalDbProvider.overrideWithValue(journalDb),
     ];
@@ -120,6 +132,9 @@ void main() {
   Future<void> openSheet(
     WidgetTester tester, {
     bool automaticUpdates = true,
+    AgentConfig? config,
+    ResolvedAgentSetup? resolvedSetup,
+    TaskAgentSetupOptions? setupOptions,
   }) async {
     await tester.pumpWidget(
       makeTestableWidgetNoScroll(
@@ -135,7 +150,12 @@ void main() {
             ),
           ),
         ),
-        overrides: overrides(automaticUpdates: automaticUpdates),
+        overrides: overrides(
+          automaticUpdates: automaticUpdates,
+          config: config,
+          resolvedSetup: resolvedSetup,
+          setupOptions: setupOptions,
+        ),
       ),
     );
     await tester.tap(find.text('Open'));
@@ -288,5 +308,204 @@ void main() {
     expect(setup.mode, AgentInferenceSetupMode.disabled);
     expect(setup.origin, AgentInferenceSetupOrigin.categorySnapshot);
     expect(setup.originEntityId, 'category-1');
+  });
+
+  testWidgets('category default copies its profile and model snapshot', (
+    tester,
+  ) async {
+    final task = makeTestTask(id: 'task-1').copyWith(
+      meta: makeTestTask(id: 'task-1').meta.copyWith(categoryId: 'category-1'),
+    );
+    when(
+      () => journalDb.journalEntityById('task-1'),
+    ).thenAnswer((_) async => task);
+    when(() => journalDb.getCategoryById('category-1')).thenAnswer(
+      (_) async => CategoryTestUtils.createTestCategory(
+        id: 'category-1',
+        defaultProfileId: profile.id,
+      ),
+    );
+    await openSheet(tester);
+
+    await tester.tap(find.text('Copy category default'));
+    await tester.pump();
+
+    final setup =
+        verify(
+              () => service.updateAgentInferenceSetup(
+                agentId: 'agent-1',
+                setup: captureAny(named: 'setup'),
+              ),
+            ).captured.single
+            as AgentInferenceSetup;
+    expect(setup.mode, AgentInferenceSetupMode.configured);
+    expect(setup.baseProfileId, profile.id);
+    expect(find.textContaining('Using Qwen 3.5 Plus'), findsWidgets);
+  });
+
+  testWidgets('origin labels cover disabled, category, template, and legacy', (
+    tester,
+  ) async {
+    final cases = <(ResolvedAgentSetup, String)>[
+      (
+        const ResolvedAgentSetup(status: AgentSetupResolutionStatus.disabled),
+        'Disabled',
+      ),
+      (
+        ResolvedAgentSetup(
+          status: AgentSetupResolutionStatus.resolved,
+          profile: resolved.profile,
+          setupOrigin: AgentInferenceSetupOrigin.categorySnapshot,
+        ),
+        'Copied from the category default when this agent was created',
+      ),
+      (
+        ResolvedAgentSetup(
+          status: AgentSetupResolutionStatus.resolved,
+          profile: resolved.profile,
+          setupOrigin: AgentInferenceSetupOrigin.templateSnapshot,
+        ),
+        'Copied from the template',
+      ),
+      (
+        ResolvedAgentSetup(
+          status: AgentSetupResolutionStatus.resolved,
+          profile: resolved.profile,
+          setupOrigin: AgentInferenceSetupOrigin.unknown,
+        ),
+        'Legacy setup',
+      ),
+    ];
+
+    for (final (setup, expected) in cases) {
+      await openSheet(tester, resolvedSetup: setup);
+      expect(find.text(expected), findsOneWidget);
+      await tester.tap(find.byTooltip('Close'));
+      await tester.pumpAndSettle();
+    }
+  });
+
+  testWidgets('broken profile routes and empty model state remain explicit', (
+    tester,
+  ) async {
+    await openSheet(
+      tester,
+      setupOptions: TaskAgentSetupOptions(
+        profiles: [profile],
+        models: const [],
+        providers: [provider],
+      ),
+    );
+    expect(find.text('Selected AI setup is unavailable'), findsOneWidget);
+    expect(
+      find.text('No compatible thinking models available'),
+      findsOneWidget,
+    );
+    await tester.tap(find.byTooltip('Close'));
+    await tester.pumpAndSettle();
+
+    await openSheet(
+      tester,
+      setupOptions: TaskAgentSetupOptions(
+        profiles: [profile],
+        models: [model],
+        providers: const [],
+      ),
+    );
+    expect(find.text('Selected AI setup is unavailable'), findsOneWidget);
+  });
+
+  testWidgets('failed save shows an error and restores interaction', (
+    tester,
+  ) async {
+    when(
+      () => service.updateAgentProfile(
+        agentId: any(named: 'agentId'),
+        profileId: any(named: 'profileId'),
+      ),
+    ).thenThrow(StateError('save failed'));
+    await openSheet(tester);
+
+    await tester.tap(find.text('Saved profile'));
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(find.text('Error'), findsWidgets);
+    expect(
+      tester
+          .widgetList<AbsorbPointer>(find.byType(AbsorbPointer))
+          .any((widget) => !widget.absorbing),
+      isTrue,
+    );
+  });
+
+  testWidgets('cancel keeps AI setup and direct override can be cleared', (
+    tester,
+  ) async {
+    await openSheet(
+      tester,
+      config: AgentConfig(
+        automaticUpdatesEnabled: true,
+        inferenceSetup: AgentInferenceSetup(
+          mode: AgentInferenceSetupMode.configured,
+          origin: AgentInferenceSetupOrigin.user,
+          baseProfileId: profile.id,
+          thinkingModelOverrideId: model.id,
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Use profile default'));
+    await tester.pump();
+    verify(
+      () => service.updateAgentThinkingModelOverride(
+        agentId: 'agent-1',
+        modelConfigId: null,
+      ),
+    ).called(1);
+
+    await tester.tap(find.text('No AI setup'));
+    await tester.pump();
+    await tester.tap(find.text('Cancel'));
+    await tester.pump();
+    verifyNever(
+      () => service.updateAgentInferenceSetup(
+        agentId: any(named: 'agentId'),
+        setup: any(named: 'setup'),
+      ),
+    );
+  });
+
+  testWidgets('disabled setup blocks automation and explains remediation', (
+    tester,
+  ) async {
+    await openSheet(
+      tester,
+      config: const AgentConfig(
+        automaticUpdatesEnabled: false,
+        inferenceSetup: AgentInferenceSetup(
+          mode: AgentInferenceSetupMode.disabled,
+          origin: AgentInferenceSetupOrigin.user,
+        ),
+      ),
+      resolvedSetup: const ResolvedAgentSetup(
+        status: AgentSetupResolutionStatus.disabled,
+      ),
+      setupOptions: const TaskAgentSetupOptions(
+        profiles: [],
+        models: [],
+        providers: [],
+      ),
+    );
+
+    expect(find.text('No AI setup'), findsWidgets);
+    expect(find.text('No profiles available on this device'), findsOneWidget);
+    expect(
+      find.text('Choose an AI setup before turning on automatic updates.'),
+      findsOneWidget,
+    );
+    final checkbox = tester.widget<DesignSystemCheckbox>(
+      find.byKey(const Key('taskAgentAutomaticUpdatesCheckbox')),
+    );
+    expect(checkbox.onChanged, isNull);
   });
 }

--- a/test/features/agents/ui/ai_summary_card/test_bench.dart
+++ b/test/features/agents/ui/ai_summary_card/test_bench.dart
@@ -80,7 +80,7 @@ class AgentTestBench {
     this._taskAgentService,
     this._ttsEngine,
     this._mediaQueryData = desktopMediaQueryData,
-    this._provideAgentIdentity = false,
+    this.provideAgentIdentity = false,
     this._isRunningOverride,
     this.suggestionListOverride,
     this._extraOverrides = const [],
@@ -117,7 +117,7 @@ class AgentTestBench {
   /// internals panel) so navigation into the panel resolves without
   /// hitting real infrastructure. The shell otherwise only needs
   /// [taskAgentProvider]; navigation tests opt into this.
-  final bool _provideAgentIdentity;
+  final bool provideAgentIdentity;
 
   /// Replaces the default static `agentIsRunningProvider` override.
   /// Used by lifecycle tests that drive the running flag from a
@@ -151,6 +151,13 @@ class AgentTestBench {
         taskAgentResolvedSetupProvider.overrideWith(
           (ref, id) async => _resolvedSetup ?? defaultResolvedSetup,
         ),
+        taskAgentSetupOptionsProvider.overrideWith(
+          (ref) async => const TaskAgentSetupOptions(
+            profiles: [],
+            models: [],
+            providers: [],
+          ),
+        ),
         agentReportProvider.overrideWith((ref, agentId) async => _report),
         templateForAgentProvider.overrideWith(
           (ref, agentId) async => _template,
@@ -164,7 +171,7 @@ class AgentTestBench {
         unifiedSuggestionListProvider.overrideWith(
           suggestionListOverride ?? (ref, taskId) async => _suggestions,
         ),
-        if (_provideAgentIdentity)
+        if (provideAgentIdentity)
           agentIdentityProvider.overrideWith((ref, id) async => identity),
         if (_confirmationService != null)
           changeSetConfirmationServiceProvider.overrideWith(

--- a/test/features/agents/ui/ai_summary_card/wake_test.dart
+++ b/test/features/agents/ui/ai_summary_card/wake_test.dart
@@ -27,6 +27,23 @@ void main() {
       expect(find.byIcon(Icons.refresh_rounded), findsOneWidget);
     });
 
+    testWidgets('setup identity opens the persistent agent setup sheet', (
+      tester,
+    ) async {
+      final bench = AgentTestBench(
+        provideAgentIdentity: true,
+        report: makeTestReport(tldr: 'Tldr line.'),
+      );
+
+      await tester.pumpWidget(bench.build());
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('test-model · via Test Provider'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(find.text('Agent setup'), findsOneWidget);
+    });
+
     testWidgets(
       'tapping refresh triggers a re-analysis on the task agent service',
       (tester) async {

--- a/test/features/agents/wake/wake_orchestrator_test.dart
+++ b/test/features/agents/wake/wake_orchestrator_test.dart
@@ -1621,6 +1621,37 @@ void main() {
         },
       );
 
+      test(
+        'repository policy lookup failure does not abort the wake',
+        () async {
+          when(
+            () => mockRepository.getEntity('agent-1'),
+          ).thenThrow(StateError('temporary read failure'));
+          var executions = 0;
+          orchestrator.wakeExecutor = (_, _, _, _) async {
+            executions++;
+            return null;
+          };
+          queue.enqueue(
+            WakeJob(
+              runKey: 'policy-read-failure',
+              agentId: 'agent-1',
+              reason: WakeReason.reanalysis.name,
+              initiator: WakeInitiator.user,
+              triggerTokens: const {},
+              createdAt: DateTime(2024, 3, 15),
+            ),
+          );
+
+          await orchestrator.processNext();
+
+          expect(executions, 1);
+          verify(
+            () => mockRepository.insertWakeRun(entry: any(named: 'entry')),
+          ).called(1);
+        },
+      );
+
       test('disabled setup drops user task-agent wake too', () async {
         when(() => mockRepository.getEntity('agent-1')).thenAnswer(
           (_) async => makeTestIdentity(


### PR DESCRIPTION
## Summary
- cover all remaining task-agent setup sheet branches reported by Codecov
- cover successful resolved-setup provider delegation and broken internals presentation
- cover setup navigation and fail-open wake policy lookup behavior

## Verification
- targeted affected suites: 150 tests passed
- agent model sheet suite: 10 tests passed with only the private constructor line uncovered locally
- flutter analyze: zero issues

Follow-up to #3442.