### PR TITLE
fix: stabilize Linux audio recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pausing AI entirely. Reports keep immutable model/provider attribution after
   later setup changes. Automatic task-related updates can also be switched off
   without removing the manual Run now action or the existing report.
+### Fixed
+- **The energy-orb recording visualization no longer overwhelms Linux
+  rendering.** The orb now compiles only its production shader and reuses the
+  loaded fragment shader as live audio levels change, avoiding the prolonged
+  Settings stall and recording crash seen on affected Linux graphics stacks.
+  Finishing a recording also dismisses its sheet exactly once before opening
+  the saved entry, avoiding a nested-navigator teardown failure.
 
 ## [0.9.1039]
 ### Added

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -35,6 +35,7 @@
     <release version="0.9.1040" date="2026-07-13">
       <description>
           <p>Task agents now show their thinking model, model publisher, and serving provider directly in the AI summary. The identity opens a persistent setup sheet for choosing a profile or model, returning to the profile default, copying the category default, or pausing AI. Reports retain immutable attribution after setup changes, and automatic task-related updates can be disabled while Run now remains available.</p>
+          <p>The energy-orb recording visualization now compiles only its production shader and reuses the loaded fragment shader as live audio levels change, avoiding prolonged stalls and recording crashes on affected Linux graphics stacks. Finishing a recording also dismisses its sheet exactly once before opening the saved entry, avoiding a nested-navigator teardown failure.</p>
       </description>
     </release>
     <release version="0.9.1039" date="2026-07-12">

--- a/lib/features/ai/README.md
+++ b/lib/features/ai/README.md
@@ -694,11 +694,11 @@ Implementation details that matter:
 ## AI Activity Visualization
 
 `ui/animation/ai_state_shader_animation.dart` is the barrel for the
-shader-based AI activity visualizations. It holds the shader routes, assets,
+shader-based AI activity visualizations. It holds the shader assets,
 the program cache, and the shared `aiSetShaderColor` uniform helper, and it
 re-exports the voice and thinking widget/painter families from the standalone
 `ai_voice_input_shader.dart` and `ai_thinking_line_shader.dart` libraries
-(each imports the barrel back for the shared routes/cache/helper).
+(each imports the barrel back for the shared cache/helper and thinking routes).
 Widgetbook remains the tuning surface via
 `widgetbook/ai_shader_animations_widgetbook.dart`; production task details use
 the decoder-bars thinking shader in the task action bar while inference is
@@ -707,15 +707,23 @@ button while capture or refine listening is active.
 
 Two Flutter runtime-effect shaders are registered in `pubspec.yaml`:
 
-- `shaders/ai_voice_input.frag` renders five transparent elastic-circle voice
-  routes: elastic membrane, impact ripples, tension loop, liquid pulse, and
-  resonance braid. The public widget accepts a dBFS value (`-80..0` by default),
-  matching `record.Amplitude.current` and `computeDbfsFromPcm16`. The routes use
-  localized pressure fields, delayed contour layers, edge traces, and traveling
-  highlights instead of radial zig-zag spokes, pinwheel-like symmetry, globe
-  grids, or filled shader backgrounds. The tension-loop route derives its hot
-  bands from the primary teal toward translucent white rather than using an
-  alert/red accent.
+- `shaders/ai_voice_input.frag` renders the transparent tension-loop voice orb.
+  It contains only that production program: unused experimental variants are
+  not compiled into the runtime effect. `AiVoiceInputShader` creates one
+  `FragmentShader` for the loaded program and reuses it while animation time and
+  live dBFS uniforms change, rather than allocating a native shader every frame.
+  The public widget accepts a dBFS value (`-80..0` by default), matching
+  `record.Amplitude.current` and `computeDbfsFromPcm16`. Five shared quadrature
+  harmonic pairs and four bounded pressure lobes drive every contour; each
+  ribbon gets a different phase by mixing those bases rather than evaluating a
+  new trigonometric pressure field. The render path contains no `exp` or `pow`.
+  It composites two hero ribbons, secondary contours, hairlines, and reusable
+  halos into a transparent premultiplied result. The production recording modal
+  supplies the design-system interactive teal as the body color and the
+  high-emphasis text color to two broader pressure-lit ribbons, resolving those
+  tokens through the ambient design-system theme. The accent therefore blooms
+  white in dark mode and dark in light mode while the fine structure remains
+  teal.
 - `shaders/ai_thinking_line.frag` renders five horizontal thinking routes:
   quiet thread, packet scan, circuit trace, probability band, and decoder bars,
   sized for action-bar use. `AiRunningDecoderBars` selects the decoder-bars
@@ -724,15 +732,14 @@ Two Flutter runtime-effect shaders are registered in `pubspec.yaml`:
   shader amplitude and opacity when activity starts or stops, then removes the
   shader subtree once the exit animation is fully collapsed.
 
-The Widgetbook use cases expose route pickers plus knobs for speed, intensity,
-geometry, colors, randomness, and dBFS. Matrix use cases render every route at
-once for side-by-side comparison; the voice playground opens on the tension loop
-route because that is the current lead candidate. The voice playground also has a
+The Widgetbook use cases expose knobs for speed, intensity,
+geometry, colors, randomness, and dBFS. The thinking matrix renders every
+thinking route at once for side-by-side comparison. The voice playground has a
 Widgetbook-only recorder control that starts a `record.AudioRecorder` metered
 mic session and polls `AudioRecorder.getAmplitude()` every 20ms for
 package-reported dBFS. The shader input runs through a dBFS envelope with
 instant attack and slower release so voice onsets stay responsive while short
-  dips do not make the rings collapse abruptly.
+dips do not make the rings collapse abruptly.
 The default metered path writes only to a temporary file and deletes it when
 recording stops. A PCM stream mode remains available as a diagnostic and
 fallback dBFS source, with input-device selection and raw peak/RMS diagnostics
@@ -749,7 +756,8 @@ flowchart LR
   VoiceWidget --> ProgramCache["AiStateShaderProgramCache"]
   ThinkWidget --> ProgramCache
   ProgramCache --> FragmentProgram["FragmentProgram.fromAsset"]
-  FragmentProgram --> Painter["CustomPainter uniforms"]
+  FragmentProgram --> FragmentShader["One cached FragmentShader per widget"]
+  FragmentShader --> Painter["CustomPainter updates uniforms"]
   Painter --> Canvas["Widgetbook canvas"]
 ```
 

--- a/lib/features/ai/ui/animation/ai_state_shader_animation.dart
+++ b/lib/features/ai/ui/animation/ai_state_shader_animation.dart
@@ -19,26 +19,6 @@ void aiSetShaderColor(ui.FragmentShader shader, int index, Color color) {
     ..setFloat(index + 3, color.a);
 }
 
-enum AiVoiceShaderRoute {
-  elasticMembrane,
-  impactRipples,
-  tensionLoop,
-  liquidPulse,
-  resonanceBraid,
-}
-
-extension AiVoiceShaderRouteLabel on AiVoiceShaderRoute {
-  String get label {
-    return switch (this) {
-      AiVoiceShaderRoute.elasticMembrane => 'Elastic membrane',
-      AiVoiceShaderRoute.impactRipples => 'Impact ripples',
-      AiVoiceShaderRoute.tensionLoop => 'Tension loop',
-      AiVoiceShaderRoute.liquidPulse => 'Liquid pulse',
-      AiVoiceShaderRoute.resonanceBraid => 'Resonance braid',
-    };
-  }
-}
-
 enum AiThinkingShaderRoute {
   quietThread,
   packetScan,

--- a/lib/features/ai/ui/animation/ai_voice_input_shader.dart
+++ b/lib/features/ai/ui/animation/ai_voice_input_shader.dart
@@ -23,7 +23,6 @@ class AiVoiceInputShader extends StatefulWidget {
     this.intensity = 0.78,
     this.lineDensity = 19,
     this.orbitalMix = 0.55,
-    this.route = AiVoiceShaderRoute.tensionLoop,
     this.timeOverride,
     this.programLoader,
     this.semanticsLabel,
@@ -38,7 +37,6 @@ class AiVoiceInputShader extends StatefulWidget {
   final double intensity;
   final double lineDensity;
   final double orbitalMix;
-  final AiVoiceShaderRoute route;
   final Color primaryColor;
   final Color secondaryColor;
   final Color backgroundColor;
@@ -56,6 +54,8 @@ class _AiVoiceInputShaderState extends State<AiVoiceInputShader>
 
   late final AnimationController _controller;
   late Future<ui.FragmentProgram> _programFuture;
+  ui.FragmentProgram? _shaderProgram;
+  ui.FragmentShader? _fragmentShader;
 
   /// Whether the OS "reduce motion" accessibility setting is on. When true the
   /// continuous time ticker is held still and the shader renders one calm
@@ -85,12 +85,14 @@ class _AiVoiceInputShaderState extends State<AiVoiceInputShader>
     super.didUpdateWidget(oldWidget);
     if (oldWidget.programLoader != widget.programLoader) {
       _programFuture = _loadProgram();
+      _disposeFragmentShader();
     }
     _syncController();
   }
 
   @override
   void dispose() {
+    _disposeFragmentShader();
     _controller.dispose();
     super.dispose();
   }
@@ -99,6 +101,21 @@ class _AiVoiceInputShaderState extends State<AiVoiceInputShader>
     final loader =
         widget.programLoader ?? AiStateShaderProgramCache.loadVoiceInput;
     return loader();
+  }
+
+  ui.FragmentShader _shaderFor(ui.FragmentProgram program) {
+    if (!identical(_shaderProgram, program)) {
+      _disposeFragmentShader();
+      _shaderProgram = program;
+      _fragmentShader = program.fragmentShader();
+    }
+    return _fragmentShader!;
+  }
+
+  void _disposeFragmentShader() {
+    _fragmentShader?.dispose();
+    _fragmentShader = null;
+    _shaderProgram = null;
   }
 
   void _syncController() {
@@ -146,20 +163,18 @@ class _AiVoiceInputShaderState extends State<AiVoiceInputShader>
                               intensity: widget.intensity,
                               lineDensity: widget.lineDensity,
                               orbitalMix: widget.orbitalMix,
-                              route: widget.route,
                               primaryColor: widget.primaryColor,
                               secondaryColor: widget.secondaryColor,
                               backgroundColor: widget.backgroundColor,
                             )
                           : AiVoiceInputShaderPainter(
-                              program: program,
+                              shader: _shaderFor(program),
                               dbfs: widget.dbfs,
                               dbfsFloor: widget.dbfsFloor,
                               time: time,
                               intensity: widget.intensity,
                               lineDensity: widget.lineDensity,
                               orbitalMix: widget.orbitalMix,
-                              route: widget.route,
                               primaryColor: widget.primaryColor,
                               secondaryColor: widget.secondaryColor,
                               backgroundColor: widget.backgroundColor,
@@ -176,31 +191,29 @@ class _AiVoiceInputShaderState extends State<AiVoiceInputShader>
   }
 }
 
-/// Drives the loaded fragment [program] for [AiVoiceInputShader] — maps the
-/// voice level and animation params to shader uniforms and paints them.
+/// Drives the loaded fragment shader for [AiVoiceInputShader], mapping the
+/// voice level and animation parameters to uniforms before painting it.
 class AiVoiceInputShaderPainter extends CustomPainter {
   AiVoiceInputShaderPainter({
-    required this.program,
+    required this.shader,
     required this.dbfs,
     required this.dbfsFloor,
     required this.time,
     required this.intensity,
     required this.lineDensity,
     required this.orbitalMix,
-    required this.route,
     required this.primaryColor,
     required this.secondaryColor,
     required this.backgroundColor,
   });
 
-  final ui.FragmentProgram program;
+  final ui.FragmentShader shader;
   final double dbfs;
   final double dbfsFloor;
   final double time;
   final double intensity;
   final double lineDensity;
   final double orbitalMix;
-  final AiVoiceShaderRoute route;
   final Color primaryColor;
   final Color secondaryColor;
   final Color backgroundColor;
@@ -209,7 +222,7 @@ class AiVoiceInputShaderPainter extends CustomPainter {
   void paint(Canvas canvas, Size size) {
     if (size.isEmpty) return;
 
-    final shader = program.fragmentShader()
+    shader
       ..setFloat(0, size.width)
       ..setFloat(1, size.height)
       ..setFloat(2, time)
@@ -217,11 +230,10 @@ class AiVoiceInputShaderPainter extends CustomPainter {
       ..setFloat(4, dbfsFloor)
       ..setFloat(5, intensity)
       ..setFloat(6, lineDensity)
-      ..setFloat(7, orbitalMix)
-      ..setFloat(8, route.index.toDouble());
-    aiSetShaderColor(shader, 9, primaryColor);
-    aiSetShaderColor(shader, 13, secondaryColor);
-    aiSetShaderColor(shader, 17, backgroundColor);
+      ..setFloat(7, orbitalMix);
+    aiSetShaderColor(shader, 8, primaryColor);
+    aiSetShaderColor(shader, 12, secondaryColor);
+    aiSetShaderColor(shader, 16, backgroundColor);
 
     canvas.drawRect(
       Offset.zero & size,
@@ -231,14 +243,13 @@ class AiVoiceInputShaderPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(AiVoiceInputShaderPainter oldDelegate) {
-    return oldDelegate.program != program ||
+    return oldDelegate.shader != shader ||
         oldDelegate.dbfs != dbfs ||
         oldDelegate.dbfsFloor != dbfsFloor ||
         oldDelegate.time != time ||
         oldDelegate.intensity != intensity ||
         oldDelegate.lineDensity != lineDensity ||
         oldDelegate.orbitalMix != orbitalMix ||
-        oldDelegate.route != route ||
         oldDelegate.primaryColor != primaryColor ||
         oldDelegate.secondaryColor != secondaryColor ||
         oldDelegate.backgroundColor != backgroundColor;
@@ -256,7 +267,6 @@ class AiVoiceInputFallbackPainter extends CustomPainter {
     required this.intensity,
     required this.lineDensity,
     required this.orbitalMix,
-    required this.route,
     required this.primaryColor,
     required this.secondaryColor,
     required this.backgroundColor,
@@ -268,7 +278,6 @@ class AiVoiceInputFallbackPainter extends CustomPainter {
   final double intensity;
   final double lineDensity;
   final double orbitalMix;
-  final AiVoiceShaderRoute route;
   final Color primaryColor;
   final Color secondaryColor;
   final Color backgroundColor;
@@ -347,7 +356,6 @@ class AiVoiceInputFallbackPainter extends CustomPainter {
         oldDelegate.intensity != intensity ||
         oldDelegate.lineDensity != lineDensity ||
         oldDelegate.orbitalMix != orbitalMix ||
-        oldDelegate.route != route ||
         oldDelegate.primaryColor != primaryColor ||
         oldDelegate.secondaryColor != secondaryColor ||
         oldDelegate.backgroundColor != backgroundColor;

--- a/lib/features/ai/widgetbook/ai_shader_animation_configs.dart
+++ b/lib/features/ai/widgetbook/ai_shader_animation_configs.dart
@@ -12,7 +12,6 @@ class _VoiceShaderConfig {
     required this.intensity,
     required this.lineDensity,
     required this.orbitalMix,
-    required this.route,
     required this.primaryColor,
     required this.secondaryColor,
     required this.backgroundColor,
@@ -28,7 +27,6 @@ class _VoiceShaderConfig {
   final double intensity;
   final double lineDensity;
   final double orbitalMix;
-  final AiVoiceShaderRoute route;
   final Color primaryColor;
   final Color secondaryColor;
   final Color backgroundColor;
@@ -77,12 +75,6 @@ _VoiceShaderConfig _voiceConfigFromKnobs(BuildContext context) {
     ),
     useRecorderVoiceProcessing: context.knobs.boolean(
       label: 'Voice / recorder voice processing',
-    ),
-    route: context.knobs.object.dropdown(
-      label: 'Voice / route',
-      options: AiVoiceShaderRoute.values,
-      initialOption: AiVoiceShaderRoute.tensionLoop,
-      labelBuilder: (route) => route.label,
     ),
     manualDbfs: context.knobs.double.slider(
       label: 'Voice / manual dBFS',

--- a/lib/features/ai/widgetbook/ai_shader_animation_recorder_preview.dart
+++ b/lib/features/ai/widgetbook/ai_shader_animation_recorder_preview.dart
@@ -468,7 +468,6 @@ class _VoiceRecorderDrivenPreviewState
       intensity: widget.config.intensity,
       lineDensity: widget.config.lineDensity,
       orbitalMix: widget.config.orbitalMix,
-      route: widget.config.route,
       primaryColor: widget.config.primaryColor,
       secondaryColor: widget.config.secondaryColor,
       backgroundColor: widget.config.backgroundColor,

--- a/lib/features/ai/widgetbook/ai_shader_animation_use_cases.dart
+++ b/lib/features/ai/widgetbook/ai_shader_animation_use_cases.dart
@@ -43,46 +43,6 @@ class _ThinkingLineUseCase extends StatelessWidget {
   }
 }
 
-class _VoiceRouteMatrixUseCase extends StatelessWidget {
-  const _VoiceRouteMatrixUseCase({required this.config});
-
-  final _VoiceShaderConfig config;
-
-  @override
-  Widget build(BuildContext context) {
-    final tokens = context.designTokens;
-    final spacing = tokens.spacing;
-
-    return _WidgetbookCanvas(
-      child: Wrap(
-        spacing: spacing.step8,
-        runSpacing: spacing.step7,
-        children: [
-          for (final route in AiVoiceShaderRoute.values)
-            _RoutePreview(
-              label: route.label,
-              width: 180,
-              child: AiVoiceInputShader(
-                dbfs: config.manualDbfs,
-                dbfsFloor: config.dbfsFloor,
-                size: 180,
-                speed: config.speed,
-                intensity: config.intensity,
-                lineDensity: config.lineDensity,
-                orbitalMix: config.orbitalMix,
-                route: route,
-                primaryColor: config.primaryColor,
-                secondaryColor: config.secondaryColor,
-                backgroundColor: config.backgroundColor,
-                semanticsLabel: '${route.label} voice shader preview',
-              ),
-            ),
-        ],
-      ),
-    );
-  }
-}
-
 class _ThinkingRouteMatrixUseCase extends StatelessWidget {
   const _ThinkingRouteMatrixUseCase({required this.config});
 
@@ -164,7 +124,6 @@ class _ActionBarStudyUseCase extends StatelessWidget {
                     intensity: voiceConfig.intensity,
                     lineDensity: voiceConfig.lineDensity,
                     orbitalMix: voiceConfig.orbitalMix,
-                    route: voiceConfig.route,
                     primaryColor: voiceConfig.primaryColor,
                     secondaryColor: voiceConfig.secondaryColor,
                     backgroundColor: voiceConfig.backgroundColor,

--- a/lib/features/ai/widgetbook/ai_shader_animations_widgetbook.dart
+++ b/lib/features/ai/widgetbook/ai_shader_animations_widgetbook.dart
@@ -38,12 +38,6 @@ WidgetbookComponent buildAiShaderAnimationsWidgetbookComponent() {
         ),
       ),
       WidgetbookUseCase(
-        name: 'Voice route matrix',
-        builder: (context) => _VoiceRouteMatrixUseCase(
-          config: _voiceConfigFromKnobs(context),
-        ),
-      ),
-      WidgetbookUseCase(
         name: 'Thinking playground',
         builder: (context) => _ThinkingLineUseCase(
           config: _thinkingConfigFromKnobs(context),

--- a/lib/features/speech/README.md
+++ b/lib/features/speech/README.md
@@ -102,6 +102,14 @@ audio file, and creates no entry — nothing is transcribed and no task agent is
 woken). The controller also has `pause()` and `resume()`, but that branch is
 not surfaced by the current modal UI.
 
+`AudioRecordingModal.show()` hosts the Wolt sheet on the root navigator by
+default; callers can explicitly opt into their local navigator. Finishing a
+recording returns the created entry ID through that modal route. The content
+pops the route exactly once, and an unlinked recording navigates to its new
+journal entry only after the Wolt route has completed. Keeping navigation out
+of the sheet's teardown prevents nested task navigators from trying to
+reactivate an element that has already been removed.
+
 ### Recorder state
 
 `AudioRecorderState` currently carries:
@@ -147,13 +155,17 @@ mobile `AudioRecordingIndicator` derive visibility from
 ```mermaid
 sequenceDiagram
   participant User as "User"
-  participant Modal as "AudioRecordingModal"
+  participant Presenter as "AudioRecordingModal.show"
+  participant Modal as "AudioRecordingModalContent"
+  participant Navigator as "selected Navigator"
   participant Sidebar as "SidebarAudioRecordingSection"
   participant Ctl as "AudioRecorderController"
   participant Repo as "AudioRecorderRepository"
   participant Speech as "SpeechRepository"
   participant Persist as "PersistenceLogic"
+  participant AppNav as "NavService"
 
+  Presenter->>Navigator: show Wolt sheet (root by default)
   User->>Modal: tap record
   Modal->>Ctl: record(linkedId)
   Ctl->>Ctl: pause active AudioPlayerController if needed
@@ -169,6 +181,12 @@ sequenceDiagram
   Ctl->>Speech: createAudioEntry(audioNote, linkedId, categoryId)
   Speech->>Persist: createDbEntity(JournalAudio)
   Ctl->>Ctl: reset recorder state
+  Ctl-->>Modal: created entry ID
+  Modal->>Navigator: pop(created entry ID) once
+  Navigator-->>Presenter: Wolt route completed
+  opt recording is not linked to an existing entry
+    Presenter->>AppNav: open /journal/created-entry-ID
+  end
 ```
 
 The persisted `JournalAudio` is created from `AudioData` and stored through

--- a/lib/features/speech/ui/widgets/recording/README.md
+++ b/lib/features/speech/ui/widgets/recording/README.md
@@ -1,8 +1,9 @@
 # Audio Recording UI Components
 
 This directory contains the UI components for audio recording functionality in
-Lotti. The recording system provides a visual VU meter, recording controls, and
-status indicators driven by the same live dBFS stream.
+Lotti. The recording system provides a selectable analog VU meter or energy
+orb, recording controls, and status indicators driven by the same live dBFS
+stream.
 
 ## Components Overview
 
@@ -32,13 +33,18 @@ AnalogVuMeter(
 The main recording interface presented as a modal bottom sheet.
 
 **Features:**
-- Displays the VU meter for visual audio feedback
+- Displays the persisted recording-style choice: analog VU meter or the
+  dBFS-reactive energy orb
 - Shows recording duration in H:MM:SS format
 - Standard/Realtime transcription mode toggle (shown when realtime transcription
   is available and recording has not started)
 - Record/Stop button with recording status indicator
 - Integrates with Riverpod state management via `AudioRecorderController`
 - Automatically pauses any playing audio when recording starts
+- Uses the root navigator by default so the sheet remains stable above nested
+  desktop task navigators
+- Returns the created entry ID through the modal result, dismisses the sheet
+  once, and only then opens an unlinked recording's journal entry
 
 **Usage:**
 ```dart
@@ -46,7 +52,26 @@ AudioRecordingModal.show(
   context,
   linkedId: entryId,      // Optional: Link recording to existing entry
   categoryId: categoryId, // Optional: Assign category
+  useRootNavigator: true, // Default: host above nested task navigators
 )
+```
+
+```mermaid
+sequenceDiagram
+  participant Caller
+  participant Sheet as AudioRecordingModalContent
+  participant Controller as AudioRecorderController
+  participant Navigator
+  participant AppNav as NavService
+
+  Caller->>Navigator: show Wolt sheet
+  Sheet->>Controller: stop() or stopRealtime()
+  Controller-->>Sheet: created entry ID
+  Sheet->>Navigator: pop(created entry ID) once
+  Navigator-->>Caller: modal future completes
+  opt unlinked recording produced an entry
+    Caller->>AppNav: open journal entry
+  end
 ```
 
 ### 3. AudioRecordingOrb
@@ -210,12 +235,14 @@ The recording system uses:
 ## Usage Flow
 
 1. User taps "Audio Recording" in create entry modal
-2. `AudioRecordingModal` opens showing VU meter
+2. `AudioRecordingModal` opens showing the selected VU meter or energy orb
 3. User taps record button to start
-4. VU meter shows real-time audio levels
+4. The selected visualizer shows real-time audio levels
 5. Persistent indicators appear if user navigates away: the desktop sidebar
    card sits above the running timer card; the mobile pill sits in the bottom
    navigation overlay
-6. User taps stop to end recording
-7. If auto-transcribe enabled, transcription begins
-8. Audio entry is created and saved
+6. User taps stop to end recording; the created ID is returned while the sheet
+   is dismissed exactly once
+7. An unlinked recording opens only after the modal route has completed
+8. If auto-transcribe is enabled, transcription begins
+9. The audio entry is created and saved

--- a/lib/features/speech/ui/widgets/recording/audio_recording_modal.dart
+++ b/lib/features/speech/ui/widgets/recording/audio_recording_modal.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/ai/ui/animation/ai_voice_input_shader.dart';
 import 'package:lotti/features/ai_chat/services/realtime_transcription_service.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/onboarding/state/recording_style.dart';
 import 'package:lotti/features/speech/state/checkbox_visibility_provider.dart';
 import 'package:lotti/features/speech/state/recorder_controller.dart';
@@ -40,9 +41,11 @@ class AudioRecordingModal {
       controller.setCategoryId(categoryId);
     }
 
+    String? createdId;
     try {
-      await ModalUtils.showSinglePageModal<void>(
+      createdId = await ModalUtils.showSinglePageModal<String>(
         context: context,
+        useRootNavigator: useRootNavigator,
         hasTopBarLayer: false,
         showCloseButton: false,
         padding: ModalUtils.defaultPadding.copyWith(bottom: 20),
@@ -57,6 +60,13 @@ class AudioRecordingModal {
       // Modal has been dismissed (either by stop button, back gesture, or tapping outside)
       // Always set modal visibility to false after dismissal
       controller.setModalVisible(modalVisible: false);
+    }
+
+    // Navigate only after Wolt has completed the modal route. Starting a page
+    // navigation from inside the sheet's own teardown can make Flutter try to
+    // reactivate an element that the nested navigator has already removed.
+    if (linkedId == null && createdId != null) {
+      beamToNamed('/journal/$createdId');
     }
   }
 }
@@ -187,11 +197,13 @@ class _AudioRecordingModalContentState
     ThemeData theme,
   ) {
     if (style == RecordingStyle.modern) {
+      final tokens = context.designTokens;
       return AiVoiceInputShader(
         dbfs: state.dBFS,
         size: 220,
-        primaryColor: theme.colorScheme.primary,
-        secondaryColor: theme.colorScheme.onSurface,
+        intensity: 1,
+        primaryColor: tokens.colors.interactive.enabled,
+        secondaryColor: tokens.colors.text.highEmphasis,
         backgroundColor: Colors.transparent,
       );
     }
@@ -215,25 +227,21 @@ class _AudioRecordingModalContentState
     final controller = ref.read(audioRecorderControllerProvider.notifier);
     final state = ref.read(audioRecorderControllerProvider);
 
+    String? createdId;
     try {
-      final String? createdId;
       if (state.isRealtimeMode) {
         createdId = await controller.stopRealtime();
       } else {
         createdId = await controller.stop();
       }
+    } catch (_) {}
 
-      if (mounted) {
-        Navigator.of(context).pop();
-      }
-      if (widget.linkedId == null && createdId != null) {
-        beamToNamed('/journal/$createdId');
-      }
-    } catch (_) {
-      if (mounted) {
-        Navigator.of(context).pop();
-      }
-    }
+    if (!mounted) return;
+
+    // Pop exactly once and return the created entry to [AudioRecordingModal].
+    // The previous catch-all called pop a second time when the first pop or the
+    // following navigation failed, racing Wolt's inactive-element teardown.
+    Navigator.of(context).pop(createdId);
   }
 
   /// Discards the in-progress recording entirely and closes the sheet.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1040+4198
+version: 0.9.1040+4199
 
 msix_config:
   display_name: LottiApp

--- a/shaders/ai_voice_input.frag
+++ b/shaders/ai_voice_input.frag
@@ -9,7 +9,6 @@ uniform float uDbfsFloor;
 uniform float uIntensity;
 uniform float uLineDensity;
 uniform float uOrbitalMix;
-uniform float uVariant;
 uniform vec4 uPrimaryColor;
 uniform vec4 uSecondaryColor;
 uniform vec4 uBackgroundColor;
@@ -20,760 +19,212 @@ float saturate(float value) {
   return clamp(value, 0.0, 1.0);
 }
 
-float glow(float distanceToShape, float radius) {
-  float safeRadius = max(radius, 0.0001);
-  float normalized = distanceToShape / safeRadius;
-  return exp(-normalized * normalized);
+float filament(float distanceToContour, float width) {
+  return 1.0 - smoothstep(0.0, width, abs(distanceToContour));
 }
 
-float ring(float radius, float target, float width) {
-  return glow(abs(radius - target), width);
-}
-
-float angleDistance(float left, float right) {
-  return abs(atan(sin(left - right), cos(left - right)));
-}
-
-float angularGlow(float angle, float center, float width) {
-  return glow(angleDistance(angle, center), width);
-}
-
-float hash(vec2 point) {
-  return fract(sin(dot(point, vec2(127.1, 311.7))) * 43758.5453123);
-}
-
-float noise(vec2 point) {
-  vec2 cell = floor(point);
-  vec2 local = fract(point);
-  vec2 eased = local * local * (3.0 - 2.0 * local);
-
-  float a = hash(cell);
-  float b = hash(cell + vec2(1.0, 0.0));
-  float c = hash(cell + vec2(0.0, 1.0));
-  float d = hash(cell + vec2(1.0, 1.0));
-
-  return mix(mix(a, b, eased.x), mix(c, d, eased.x), eased.y);
-}
-
-float softMode(float angle, float time, float seed) {
-  float a = sin(angle * 2.0 + time * 0.38 + seed) * 0.42;
-  float b = sin(angle * 3.0 - time * 0.27 + seed * 1.7) * 0.30;
-  float c = sin(angle * 4.0 + time * 0.19 - seed * 0.8) * 0.18;
-  return a + b + c;
-}
-
-float pressureField(float angle, float time, float seed) {
-  float centerA = time * 0.74 + seed;
-  float centerB = -time * 0.51 + seed * 1.91 + 2.05;
-  float centerC = time * 0.31 - seed * 0.62 - 2.36;
-
-  float pushA = angularGlow(angle, centerA, 0.54);
-  float pushB = angularGlow(angle, centerB, 0.42);
-  float pullC = angularGlow(angle, centerC, 0.62);
-  float traveling = angularGlow(angle, time * 1.12 + seed * 0.37, 0.18);
-
-  return pushA * 1.05 + pushB * 0.62 - pullC * 0.52 + traveling * 0.26;
-}
-
-float contourOffset(float angle, float time, float level, float seed, float force) {
-  float idle = 0.010 + 0.006 * sin(time * 0.17 + seed);
-  float voice = level * level * 0.078;
-  float field = pressureField(angle, time, seed);
-  float modes = softMode(angle, time, seed) * 0.48;
-  return (field + modes) * (idle + voice) * force;
-}
-
-float contourRadius(
-    float angle,
-    float time,
-    float level,
-    float baseRadius,
-    float seed,
-    float force) {
-  return baseRadius + contourOffset(angle, time, level, seed, force);
-}
-
-float contourRing(
-    float radius,
-    float angle,
-    float time,
-    float level,
-    float baseRadius,
-    float width,
-    float seed,
-    float force) {
-  float target = contourRadius(angle, time, level, baseRadius, seed, force);
-  return ring(radius, target, width);
-}
-
-float contourAura(
-    float radius,
-    float angle,
-    float time,
-    float level,
-    float baseRadius,
-    float seed,
-    float force) {
-  float target = contourRadius(angle, time, level, baseRadius, seed, force);
-  return ring(radius, target, 0.055 + level * 0.022);
-}
-
-float edgeTrace(
-    float radius,
-    float angle,
-    float time,
-    float level,
-    float baseRadius,
-    float seed,
-    float force) {
-  float target = contourRadius(angle, time, level, baseRadius, seed, force);
-  float line = ring(radius, target, 0.004 + level * 0.003);
-  float traceA = angularGlow(angle, time * 1.18 + seed * 0.74, 0.23);
-  float traceB = angularGlow(angle, -time * 0.82 + seed * 1.33, 0.18);
-  return line * (traceA + traceB * 0.72) * (0.32 + level * 0.92);
-}
-
-float delayedContour(
-    float radius,
-    float angle,
-    float time,
-    float level,
-    float baseRadius,
-    float width,
-    float seed,
-    float force,
-    float delay) {
-  return contourRing(
-      radius,
-      angle,
-      time - delay,
-      level,
-      baseRadius,
-      width,
-      seed + delay,
-      force);
-}
-
-vec4 compose(vec3 color, float alpha, float radius) {
-  float crop = 1.0 - smoothstep(0.49, 0.59, radius);
-  alpha = saturate(alpha * crop);
-  alpha = alpha < 0.002 ? 0.0 : alpha;
-  return vec4(color * alpha, alpha);
-}
-
-vec4 elasticMembrane(
-    vec2 uv,
-    float radius,
-    float angle,
-    float time,
-    float level,
-    float intensity,
-    float force,
-    vec3 primary,
-    vec3 secondary,
-    vec3 background,
-    float backgroundAlpha) {
-  float contour = contourRing(
-      radius,
-      angle,
-      time,
-      level,
-      0.326 + level * 0.016,
-      0.009 + level * 0.011,
-      0.6,
-      force);
-  float innerShadow = contourRing(
-      radius,
-      angle,
-      time * 0.82,
-      level,
-      0.274 - level * 0.010,
-      0.010 + level * 0.006,
-      2.1,
-      force * 0.48);
-  float pressureA = angularGlow(angle, time * 0.74 + 0.6, 0.50);
-  float pressureB = angularGlow(angle, -time * 0.51 + 3.2, 0.44);
-  float activeEdge = contour * (0.42 + pressureA * 0.86 + pressureB * 0.52);
-  float delayedA = delayedContour(
-      radius,
-      angle,
-      time,
-      level,
-      0.336 + level * 0.018,
-      0.005 + level * 0.004,
-      3.8,
-      force * 0.62,
-      0.58);
-  float delayedB = delayedContour(
-      radius,
-      angle,
-      time,
-      level,
-      0.288 - level * 0.006,
-      0.006 + level * 0.004,
-      5.5,
-      force * 0.38,
-      1.05);
-  float trace = edgeTrace(radius, angle, time, level, 0.326, 6.4, force * 0.88);
-  float aura = contourAura(radius, angle, time, level, 0.326, 0.6, force);
-  float core = exp(-radius * radius * (72.0 - level * 16.0)) * (0.05 + level * 0.14);
-
-  vec3 color = primary * (activeEdge * 1.28 + innerShadow * 0.34 + delayedA * 0.36);
-  color += secondary * (contour * pressureA * 0.72 + delayedB * 0.32 + trace * 0.90 + core * 0.42);
-  color += background * backgroundAlpha * aura * 0.12;
-
-  float alpha = (activeEdge * 0.84 + innerShadow * 0.26 + aura * 0.12 +
-      delayedA * 0.24 + delayedB * 0.18 + trace * 0.44 + core * 0.14) * intensity;
-  return compose(color * intensity, alpha, radius);
-}
-
-vec4 impactRipples(
-    vec2 uv,
-    float radius,
-    float angle,
-    float time,
-    float level,
-    float intensity,
-    float force,
-    vec3 primary,
-    vec3 secondary,
-    vec3 background,
-    float backgroundAlpha) {
-  float forceAngle = time * 0.68 + 1.1;
-  float hit = angularGlow(angle, forceAngle, 0.36);
-  float counterHit = angularGlow(angle, forceAngle + 3.04, 0.58);
-  float ringA = contourRing(
-      radius,
-      angle,
-      time,
-      level,
-      0.300 + level * 0.018,
-      0.012 + level * 0.009,
-      1.4,
-      force * 1.08);
-  float ringB = contourRing(
-      radius,
-      angle,
-      time * 0.76,
-      level,
-      0.358 + level * 0.028,
-      0.006 + level * 0.005,
-      3.7,
-      force * 0.72);
-  float ringC = contourRing(
-      radius,
-      angle,
-      -time * 0.50,
-      level,
-      0.236 - level * 0.006,
-      0.008 + level * 0.005,
-      5.2,
-      force * 0.48);
-  float wake = (hit * ringA + counterHit * ringB) * (0.35 + level * 0.92);
-  float shock = ring(radius, 0.416 + level * 0.030, 0.006 + level * 0.004) *
-      angularGlow(angle, forceAngle - 0.35, 0.42) * (0.30 + level * 0.90);
-  float trace = edgeTrace(radius, angle, time, level, 0.300, 0.7, force * 0.84);
-  float after = delayedContour(
-      radius,
-      angle,
-      time,
-      level,
-      0.334 + level * 0.012,
-      0.005 + level * 0.004,
-      4.6,
-      force * 0.48,
-      0.72);
-  float aura = contourAura(radius, angle, time, level, 0.300, 1.4, force * 0.70);
-
-  vec3 color = primary * (ringA * 0.92 + ringB * 0.46 + ringC * 0.26 + after * 0.34);
-  color += secondary * (wake * 1.05 + ringC * hit * 0.56 + shock * 0.78 + trace * 0.74);
-  color += background * backgroundAlpha * aura * 0.10;
-
-  float alpha = (ringA * 0.66 + ringB * 0.34 + ringC * 0.20 +
-      wake * 0.62 + shock * 0.46 + trace * 0.36 + after * 0.22 + aura * 0.10) * intensity;
-  return compose(color * intensity, alpha, radius);
-}
-
-vec4 tensionLoop(
-    vec2 uv,
-    float radius,
-    float angle,
-    float time,
-    float level,
-    float intensity,
-    float force,
-    vec3 primary,
-    vec3 secondary,
-    vec3 background,
-    float backgroundAlpha) {
-  vec3 paleTeal = mix(primary, vec3(1.0), 0.34 + level * 0.10);
-  vec3 hot = mix(primary, vec3(1.0), 0.76 + level * 0.18);
-  vec3 whiteHot = mix(primary, vec3(1.0), 0.92);
-  vec3 fineTeal = mix(primary, paleTeal, 0.18);
-  float heatA = angularGlow(angle, time * 0.46 + 0.3, 0.42);
-  float heatB = angularGlow(angle, -time * 0.34 - 2.2, 0.44);
-  float heatC = angularGlow(angle, time * 0.25 + 2.8, 0.58);
-  float heatD = angularGlow(angle, -time * 0.22 + 1.4, 0.50);
-  float heatE = angularGlow(angle, time * 0.31 - 2.7, 0.46);
-  float loopA = contourRing(
-      radius,
-      angle,
-      time * 0.58,
-      level,
-      0.320,
-      0.009 + level * 0.008,
-      2.6,
-      force * 0.92);
-  float loopB = contourRing(
-      radius,
-      angle,
-      -time * 0.43,
-      level,
-      0.322 + level * 0.018,
-      0.010 + level * 0.009,
-      4.0,
-      force * 0.86);
-  float loopC = contourRing(
-      radius,
-      angle,
-      time * 0.36,
-      level,
-      0.382 + level * 0.014,
-      0.007 + level * 0.006,
-      7.4,
-      force * 0.58);
-  float loopD = contourRing(
-      radius,
-      angle,
-      -time * 0.52,
-      level,
-      0.250 - level * 0.006,
-      0.006 + level * 0.005,
-      8.6,
-      force * 0.50);
-  float hotLoopA = contourRing(
-      radius,
-      angle,
-      time * 0.50,
-      level,
-      0.332 + level * 0.010,
-      0.018 + level * 0.014,
-      0.9,
-      force * 0.58);
-  float hotLoopB = contourRing(
-      radius,
-      angle,
-      -time * 0.38,
-      level,
-      0.304 - level * 0.006,
-      0.015 + level * 0.010,
-      5.7,
-      force * 0.50);
-  float hotLoopC = contourRing(
-      radius,
-      angle,
-      time * 0.44,
-      level,
-      0.368 + level * 0.010,
-      0.012 + level * 0.008,
-      3.3,
-      force * 0.42);
-  float hotLoopD = contourRing(
-      radius,
-      angle,
-      -time * 0.48,
-      level,
-      0.268 - level * 0.005,
-      0.011 + level * 0.007,
-      6.9,
-      force * 0.38);
-  float glowLoopA = contourRing(
-      radius,
-      angle,
-      time * 0.46,
-      level,
-      0.334 + level * 0.012,
-      0.040 + level * 0.020,
-      0.9,
-      force * 0.42);
-  float glowLoopB = contourRing(
-      radius,
-      angle,
-      -time * 0.32,
-      level,
-      0.304 - level * 0.006,
-      0.034 + level * 0.018,
-      5.7,
-      force * 0.36);
-  float glowLoopC = contourRing(
-      radius,
-      angle,
-      time * 0.40,
-      level,
-      0.372 + level * 0.012,
-      0.032 + level * 0.016,
-      3.3,
-      force * 0.30);
-  float glowLoopD = contourRing(
-      radius,
-      angle,
-      -time * 0.42,
-      level,
-      0.266 - level * 0.006,
-      0.030 + level * 0.014,
-      6.9,
-      force * 0.28);
-  float thinLoopA = contourRing(
-      radius,
-      angle,
-      time * 0.82,
-      level,
-      0.354 + level * 0.010,
-      0.0060 + level * 0.0038,
-      7.1,
-      force * 0.72);
-  float thinLoopB = contourRing(
-      radius,
-      angle,
-      -time * 0.68,
-      level,
-      0.284 - level * 0.004,
-      0.0060 + level * 0.0038,
-      1.6,
-      force * 0.62);
-  float thinLoopC = contourRing(
-      radius,
-      angle,
-      time * 0.96,
-      level,
-      0.394 + level * 0.008,
-      0.0056 + level * 0.0034,
-      4.4,
-      force * 0.52);
-  float thinLoopD = contourRing(
-      radius,
-      angle,
-      -time * 0.88,
-      level,
-      0.244 - level * 0.004,
-      0.0056 + level * 0.0034,
-      8.1,
-      force * 0.46);
-  float thinLoopE = contourRing(
-      radius,
-      angle,
-      time * 1.10,
-      level,
-      0.336 + level * 0.007,
-      0.0054 + level * 0.0032,
-      9.5,
-      force * 0.50);
-  float thinLoopF = contourRing(
-      radius,
-      angle,
-      -time * 0.98,
-      level,
-      0.306 - level * 0.004,
-      0.0054 + level * 0.0032,
-      2.9,
-      force * 0.48);
-  float thinLoopG = contourRing(
-      radius,
-      angle,
-      time * 0.72,
-      level,
-      0.414 + level * 0.006,
-      0.0050 + level * 0.0029,
-      5.9,
-      force * 0.38);
-  float thinLoopH = contourRing(
-      radius,
-      angle,
-      -time * 0.74,
-      level,
-      0.224 - level * 0.002,
-      0.0050 + level * 0.0029,
-      7.7,
-      force * 0.36);
-  float tensionA = angularGlow(angle, time * 0.36 + 0.3, 0.46);
-  float tensionB = angularGlow(angle, -time * 0.27 - 2.2, 0.48);
-  float overlap = min(loopA, loopB) * (0.65 + level * 0.76);
-  float outerOverlap = min(loopC, loopA) * (0.42 + level * 0.54);
-  float innerOverlap = min(loopD, loopB) * (0.38 + level * 0.48);
-  float highlight = loopA * tensionA + loopB * tensionB +
-      loopC * heatD * 0.62 + loopD * heatE * 0.58;
-  float heat = hotLoopA * heatA + hotLoopB * heatB +
-      hotLoopC * heatD + hotLoopD * heatE +
-      overlap * heatC + outerOverlap * heatD + innerOverlap * heatE;
-  float threadA = edgeTrace(radius, angle, time, level, 0.320, 5.2, force * 0.78);
-  float threadB = edgeTrace(radius, angle, -time * 0.70, level, 0.344, 1.2, force * 0.62);
-  float threadC = edgeTrace(radius, angle, time * 1.16, level, 0.286, 3.5, force * 0.58);
-  float threadD = edgeTrace(radius, angle, -time * 1.04, level, 0.356, 6.0, force * 0.50);
-  float ghost = delayedContour(
-      radius,
-      angle,
-      time,
-      level,
-      0.302,
-      0.006 + level * 0.004,
-      6.7,
-      force * 0.46,
-      0.86);
-  float ember = delayedContour(
-      radius,
-      angle,
-      time,
-      level,
-      0.336 + level * 0.008,
-      0.010 + level * 0.006,
-      2.4,
-      force * 0.36,
-      1.18);
-  float aura = contourAura(radius, angle, time, level, 0.321, 2.6, force * 0.52);
-
-  vec3 color = primary * (
-      threadA * 0.78 + threadB * 0.68 + threadC * 0.58 + threadD * 0.52 +
-      ghost * 0.20);
-  color += fineTeal * (thinLoopA * 1.02 + thinLoopB * 0.94 +
-      thinLoopC * 0.74 + thinLoopD * 0.68 +
-      thinLoopE * 0.78 + thinLoopF * 0.74 +
-      thinLoopG * 0.52 + thinLoopH * 0.48);
-  color += paleTeal * (loopA * 0.38 + loopB * 0.34 +
-      loopC * 0.34 + loopD * 0.28 + highlight * 0.46);
-  color += hot * (glowLoopA * heatA * 0.22 + glowLoopB * heatB * 0.18 +
-      glowLoopC * heatD * 0.16 + glowLoopD * heatE * 0.14 +
-      heat * 0.86 + overlap * 0.44 +
-      outerOverlap * 0.30 + innerOverlap * 0.26 + ember * 0.28);
-  color += whiteHot * (hotLoopA * heatA * 0.34 + hotLoopB * heatB * 0.30 +
-      hotLoopC * heatD * 0.24 + hotLoopD * heatE * 0.22);
-  color += background * backgroundAlpha * aura * 0.08;
-
-  float alpha = (loopA * 0.32 + loopB * 0.30 + loopC * 0.24 + loopD * 0.22 +
-      glowLoopA * heatA * 0.10 + glowLoopB * heatB * 0.09 +
-      glowLoopC * heatD * 0.07 + glowLoopD * heatE * 0.06 +
-      hotLoopA * heatA * 0.40 + hotLoopB * heatB * 0.36 +
-      hotLoopC * heatD * 0.26 + hotLoopD * heatE * 0.24 +
-      thinLoopA * 0.24 + thinLoopB * 0.22 +
-      thinLoopC * 0.17 + thinLoopD * 0.16 +
-      thinLoopE * 0.18 + thinLoopF * 0.17 +
-      thinLoopG * 0.13 + thinLoopH * 0.12 +
-      overlap * 0.56 + outerOverlap * 0.32 + innerOverlap * 0.28 +
-      highlight * 0.36 + heat * 0.38 +
-      threadA * 0.34 + threadB * 0.30 + threadC * 0.24 + threadD * 0.22 +
-      ghost * 0.16 + ember * 0.20 + aura * 0.08) * intensity;
-  return compose(color * intensity, alpha, radius);
-}
-
-vec4 liquidPulse(
-    vec2 uv,
-    float radius,
-    float angle,
-    float time,
-    float level,
-    float intensity,
-    float force,
-    vec3 primary,
-    vec3 secondary,
-    vec3 background,
-    float backgroundAlpha) {
-  float pulse = 0.5 + 0.5 * sin(time * 1.15);
-  float mouthRadius = 0.300 + level * 0.042 + pulse * 0.010;
-  float rim = contourRing(
-      radius,
-      angle,
-      time * 0.66,
-      level,
-      mouthRadius,
-      0.017 + level * 0.010,
-      3.1,
-      force * 1.00);
-  float lip = contourRing(
-      radius,
-      angle,
-      -time * 0.34,
-      level,
-      mouthRadius + 0.054 + level * 0.006,
-      0.007 + level * 0.004,
-      0.8,
-      force * 0.54);
-  float interior = contourRing(
-      radius,
-      angle,
-      time * 0.45,
-      level,
-      mouthRadius - 0.058 - level * 0.012,
-      0.010 + level * 0.005,
-      5.1,
-      force * 0.38);
-  float glint = angularGlow(angle, time * 0.28 - 1.0, 0.34) * lip;
-  float pressure = angularGlow(angle, -time * 0.25 + 2.2, 0.48) * rim;
-  float surfaceTrace = edgeTrace(radius, angle, time, level, mouthRadius, 2.7, force * 0.74);
-  float after = delayedContour(
-      radius,
-      angle,
-      time,
-      level,
-      mouthRadius + 0.026,
-      0.006 + level * 0.004,
-      4.8,
-      force * 0.50,
-      0.64);
-  float aura = contourAura(radius, angle, time, level, mouthRadius, 3.1, force * 0.55);
-
-  vec3 color = primary * (rim * 0.90 + lip * 0.42 + pressure * 0.52 + after * 0.28);
-  color += secondary * (glint * 1.08 + interior * 0.34 + surfaceTrace * 0.78);
-  color += background * backgroundAlpha * aura * 0.10;
-
-  float alpha = (rim * 0.66 + lip * 0.34 + interior * 0.20 +
-      glint * 0.62 + pressure * 0.44 + surfaceTrace * 0.38 + after * 0.22 + aura * 0.09) * intensity;
-  return compose(color * intensity, alpha, radius);
-}
-
-vec4 resonanceBraid(
-    vec2 uv,
-    float radius,
-    float angle,
-    float time,
-    float level,
-    float intensity,
-    float force,
-    vec3 primary,
-    vec3 secondary,
-    vec3 background,
-    float backgroundAlpha) {
-  float braidA = contourRing(
-      radius,
-      angle,
-      time * 0.72,
-      level,
-      0.316,
-      0.006 + level * 0.005,
-      4.7,
-      force * 1.02);
-  float braidB = contourRing(
-      radius,
-      angle,
-      time * 0.72 + 1.8,
-      level,
-      0.346 + level * 0.012,
-      0.006 + level * 0.006,
-      1.9,
-      force * 0.88);
-  float braidC = contourRing(
-      radius,
-      angle,
-      -time * 0.52,
-      level,
-      0.276 - level * 0.006,
-      0.005 + level * 0.004,
-      6.2,
-      force * 0.54);
-  float phaseA = angularGlow(angle, time * 0.42 + 0.6, 0.42);
-  float phaseB = angularGlow(angle, -time * 0.33 + 3.0, 0.40);
-  float braid = braidA * (0.58 + phaseA * 0.82) +
-      braidB * (0.46 + phaseB * 0.74) + braidC * 0.30;
-  float traceA = edgeTrace(radius, angle, time, level, 0.316, 7.2, force * 0.86);
-  float traceB = edgeTrace(radius, angle, -time * 0.64, level, 0.346, 2.8, force * 0.72);
-  float delayed = delayedContour(
-      radius,
-      angle,
-      time,
-      level,
-      0.304,
-      0.005 + level * 0.004,
-      5.6,
-      force * 0.46,
-      0.78);
-  float aura = contourAura(radius, angle, time, level, 0.322, 4.7, force * 0.46);
-
-  vec3 color = primary * (braid * 0.86 + braidC * 0.18 + delayed * 0.24);
-  color += secondary * (braidA * phaseA * 0.62 + braidB * phaseB * 0.72 + traceA * 0.58 + traceB * 0.52);
-  color += background * backgroundAlpha * aura * 0.08;
-
-  float alpha = (braid * 0.62 + braidA * phaseA * 0.34 +
-      braidB * phaseB * 0.34 + traceA * 0.30 + traceB * 0.28 + delayed * 0.18 + aura * 0.08) * intensity;
-  return compose(color * intensity, alpha, radius);
+float boundedField(float value) {
+  return clamp(value, -1.0, 1.0);
 }
 
 void main() {
   vec2 fragCoord = FlutterFragCoord().xy;
   float scale = max(min(uResolution.x, uResolution.y), 1.0);
   vec2 uv = (fragCoord - 0.5 * uResolution) / scale;
-
   float radius = length(uv);
   float angle = atan(uv.y, uv.x);
+  float shapeAngle = angle - uTime * 0.07;
+  float pixel = 1.0 / scale;
+
   float dbfsFloor = min(uDbfsFloor, -0.001);
   float dbfsLevel = saturate((uDbfs - dbfsFloor) / abs(dbfsFloor));
   float level = smoothstep(0.02, 1.0, dbfsLevel);
   float intensity = saturate(uIntensity);
   float tension = saturate((uLineDensity - 8.0) / 26.0);
-  float force = mix(0.82, 1.62, tension) * mix(0.84, 1.42, saturate(uOrbitalMix));
-  float variant = floor(uVariant + 0.5);
+  float orbital = saturate(uOrbitalMix);
+  // The loop must remain visibly alive in silence. Voice adds force, but it
+  // does not switch the shape from a dead circle to an active one.
+  float deformation = mix(0.030, 0.118, level * level) *
+      mix(0.88, 1.42, tension) * mix(0.90, 1.24, orbital);
 
-  if (variant < 0.5) {
-    fragColor = elasticMembrane(
-        uv,
-        radius,
-        angle,
-        uTime,
-        level,
-        intensity,
-        force,
-        uPrimaryColor.rgb,
-        uSecondaryColor.rgb,
-        uBackgroundColor.rgb,
-        uBackgroundColor.a);
-  } else if (variant < 1.5) {
-    fragColor = impactRipples(
-        uv,
-        radius,
-        angle,
-        uTime,
-        level,
-        intensity,
-        force,
-        uPrimaryColor.rgb,
-        uSecondaryColor.rgb,
-        uBackgroundColor.rgb,
-        uBackgroundColor.a);
-  } else if (variant < 2.5) {
-    fragColor = tensionLoop(
-        uv,
-        radius,
-        angle,
-        uTime,
-        level,
-        intensity,
-        force,
-        uPrimaryColor.rgb,
-        uSecondaryColor.rgb,
-        uBackgroundColor.rgb,
-        uBackgroundColor.a);
-  } else if (variant < 3.5) {
-    fragColor = liquidPulse(
-        uv,
-        radius,
-        angle,
-        uTime,
-        level,
-        intensity,
-        force,
-        uPrimaryColor.rgb,
-        uSecondaryColor.rgb,
-        uBackgroundColor.rgb,
-        uBackgroundColor.a);
-  } else {
-    fragColor = resonanceBraid(
-        uv,
-        radius,
-        angle,
-        uTime,
-        level,
-        intensity,
-        force,
-        uPrimaryColor.rgb,
-        uSecondaryColor.rgb,
-        uBackgroundColor.rgb,
-        uBackgroundColor.a);
-  }
+  // Quadrature harmonic pairs are calculated once. A contour gets an
+  // independent phase by rotating these shared sine/cosine bases with cheap
+  // constant coefficients rather than evaluating another trigonometric field.
+  float phaseA = shapeAngle * 2.0 + uTime * 0.45;
+  float phaseB = shapeAngle * 3.0 - uTime * 0.39 + 1.3;
+  float phaseC = shapeAngle * 4.0 + uTime * 0.31 - 0.7;
+  float phaseD = shapeAngle * 5.0 - uTime * 0.57 + 2.1;
+  float phaseE = shapeAngle * 7.0 + uTime * 0.36 - 1.8;
+  vec4 harmonicsA = vec4(sin(phaseA), cos(phaseA),
+      sin(phaseB), cos(phaseB));
+  vec4 harmonicsB = vec4(sin(phaseC), cos(phaseC),
+      sin(phaseD), cos(phaseD));
+  vec2 harmonicsC = vec2(sin(phaseE), cos(phaseE));
+
+  // Four compact pressure events: a broad slow push, a tight counter-pull,
+  // and two weaker travelers. Explicit multiply chains avoid pow/exp and are
+  // predictable on the affected virtualized Linux graphics stack.
+  float broadWave = 0.5 + 0.5 * cos(angle - uTime * 0.34 - 0.4);
+  float broad = broadWave * broadWave;
+  float tightWave = 0.5 + 0.5 * cos(angle + uTime * 0.82 + 2.2);
+  float tight2 = tightWave * tightWave;
+  float tight4 = tight2 * tight2;
+  float tight = tight4 * tight4;
+  float travelWave = 0.5 + 0.5 * cos(angle - uTime * 0.68 + 2.7);
+  float travel2 = travelWave * travelWave;
+  float travel = travel2 * travel2;
+  float echoWave = 0.5 + 0.5 * cos(angle + uTime * 0.51 - 1.1);
+  float echo2 = echoWave * echoWave;
+  float echo = echo2 * echo2 * echo2;
+  vec4 pressure = vec4(broad, tight, travel, echo);
+
+  float heroFieldA = boundedField(
+      dot(harmonicsA, vec4(0.30, 0.08, 0.18, -0.12)) +
+      dot(harmonicsB, vec4(0.12, 0.06, -0.08, 0.04)) +
+      dot(harmonicsC, vec2(0.06, -0.04)) +
+      dot(pressure, vec4(0.34, -0.22, 0.16, -0.10)));
+  float heroFieldB = boundedField(
+      dot(harmonicsA, vec4(-0.14, 0.24, 0.08, 0.20)) +
+      dot(harmonicsB, vec4(-0.10, 0.14, 0.06, -0.08)) +
+      dot(harmonicsC, vec2(-0.05, 0.07)) +
+      dot(pressure, vec4(-0.24, 0.32, -0.12, 0.18)));
+  float secondaryFieldA = boundedField(
+      dot(harmonicsA, vec4(0.10, -0.20, 0.22, 0.04)) +
+      dot(harmonicsB, vec4(0.14, -0.08, 0.08, 0.10)) +
+      dot(harmonicsC, vec2(0.08, 0.04)) +
+      dot(pressure, vec4(0.16, 0.08, -0.24, 0.12)));
+  float secondaryFieldB = boundedField(
+      dot(harmonicsA, vec4(-0.22, -0.06, 0.10, -0.16)) +
+      dot(harmonicsB, vec4(0.04, 0.18, -0.10, 0.08)) +
+      dot(harmonicsC, vec2(-0.06, -0.08)) +
+      dot(pressure, vec4(-0.10, -0.18, 0.28, -0.12)));
+  float secondaryFieldC = boundedField(
+      dot(harmonicsA, vec4(0.16, 0.12, -0.14, 0.18)) +
+      dot(harmonicsB, vec4(-0.16, 0.06, 0.12, 0.04)) +
+      dot(harmonicsC, vec2(0.04, -0.10)) +
+      dot(pressure, vec4(0.12, -0.10, 0.08, 0.22)));
+  float secondaryFieldD = boundedField(
+      dot(harmonicsA, vec4(-0.08, 0.18, -0.20, -0.04)) +
+      dot(harmonicsB, vec4(0.10, 0.12, 0.04, -0.16)) +
+      dot(harmonicsC, vec2(0.10, 0.04)) +
+      dot(pressure, vec4(-0.16, 0.14, -0.08, 0.20)));
+
+  // Hairlines reuse the independent fields with phase-lagged cross-mixes.
+  float hairFieldA = boundedField(heroFieldA * 0.42 +
+      secondaryFieldB * 0.58 + harmonicsC.y * 0.18);
+  float hairFieldB = boundedField(heroFieldB * 0.38 +
+      secondaryFieldA * 0.62 - harmonicsB.x * 0.16);
+  float hairFieldC = boundedField(secondaryFieldC * 0.54 -
+      heroFieldA * 0.30 + harmonicsA.w * 0.20);
+  float hairFieldD = boundedField(secondaryFieldD * 0.56 -
+      heroFieldB * 0.28 - harmonicsA.x * 0.18);
+  float hairFieldE = boundedField(secondaryFieldA * 0.44 +
+      secondaryFieldD * 0.40 + harmonicsB.w * 0.18);
+  float hairFieldF = boundedField(secondaryFieldB * 0.46 +
+      secondaryFieldC * 0.38 - harmonicsC.x * 0.20);
+
+  float heroDistanceA = radius - (0.316 + deformation * heroFieldA);
+  float heroDistanceB = radius -
+      (0.336 + level * 0.006 + deformation * 0.94 * heroFieldB);
+  // Keep the supporting filaments close enough to read as one energy ring.
+  // Their independent fields still cross and breathe, but the base radii are
+  // compressed toward the two hero contours instead of filling the whole orb.
+  float secondaryDistanceA = radius -
+      (0.370 + level * 0.006 + deformation * 0.66 * secondaryFieldA);
+  float secondaryDistanceB = radius -
+      (0.267 - level * 0.006 + deformation * 0.80 * secondaryFieldB);
+  float secondaryDistanceC = radius -
+      (0.350 + deformation * 0.70 * secondaryFieldC);
+  float secondaryDistanceD = radius -
+      (0.296 + deformation * 0.66 * secondaryFieldD);
+  float hairDistanceA = radius - (0.387 + deformation * 0.49 * hairFieldA);
+  float hairDistanceB = radius - (0.250 + deformation * 0.66 * hairFieldB);
+  float hairDistanceC = radius - (0.363 + deformation * 0.53 * hairFieldC);
+  float hairDistanceD = radius - (0.282 + deformation * 0.49 * hairFieldD);
+  float hairDistanceE = radius - (0.340 + deformation * 0.57 * hairFieldE);
+  float hairDistanceF = radius - (0.308 + deformation * 0.55 * hairFieldF);
+
+  float heroWidth = max(0.0120 + level * 0.0030, pixel * 1.44);
+  float secondaryWidth = max(0.0064 + level * 0.0012, pixel * 0.82);
+  float hairWidth = max(0.0036 + level * 0.0006, pixel * 0.54);
+  float heroA = filament(heroDistanceA, heroWidth);
+  float heroB = filament(heroDistanceB, heroWidth * 0.94);
+  float secondaryA = filament(secondaryDistanceA, secondaryWidth);
+  float secondaryB = filament(secondaryDistanceB, secondaryWidth * 0.94);
+  float secondaryC = filament(secondaryDistanceC, secondaryWidth * 0.90);
+  float secondaryD = filament(secondaryDistanceD, secondaryWidth * 0.88);
+  float hairA = filament(hairDistanceA, hairWidth * 0.88);
+  float hairB = filament(hairDistanceB, hairWidth * 0.84);
+  float hairC = filament(hairDistanceC, hairWidth * 0.78);
+  float hairD = filament(hairDistanceD, hairWidth * 0.76);
+  float hairE = filament(hairDistanceE, hairWidth * 0.72);
+  float hairF = filament(hairDistanceF, hairWidth * 0.70);
+
+  // Geometry is reused for halos instead of recomputing another contour.
+  float heroHaloA = filament(heroDistanceA, heroWidth * 5.8);
+  float heroHaloB = filament(heroDistanceB, heroWidth * 5.4);
+  float outerHalo = filament(secondaryDistanceA, secondaryWidth * 6.2);
+  float innerHalo = filament(secondaryDistanceB, secondaryWidth * 5.8);
+  float hotRibbonA = filament(heroDistanceB, heroWidth * 3.0);
+  float hotRibbonB = filament(secondaryDistanceC, secondaryWidth * 4.0);
+  float heroMask = max(heroA, heroB);
+  float secondaryMask = max(max(secondaryA, secondaryB),
+      max(secondaryC, secondaryD));
+  float hairMask = max(
+      max(max(hairA * 0.92, hairB * 0.82),
+          max(hairC * 0.72, hairD * 0.64)),
+      max(hairE * 0.56, hairF * 0.48));
+  float haloMask = max(
+      max(heroHaloA, heroHaloB),
+      max(outerHalo * 0.78, innerHalo * 0.66));
+  float crossingMask = max(
+      max(min(heroHaloA, heroB), min(heroA, heroHaloB)),
+      max(min(heroHaloA, secondaryC), min(heroHaloB, secondaryD)));
+
+  // The four pressure events double as travelling light sources. Most of the
+  // structure stays teal; two broader high-emphasis ribbons bloom only where
+  // pressure passes through them, restoring depth without a white wash.
+  float heroEnergy = saturate(0.66 + broad * 0.30 + travel * 0.18);
+  float secondaryEnergy = saturate(0.54 + tight * 0.34 + echo * 0.20);
+  float hairEnergy = saturate(0.42 + travel * 0.24 + echo * 0.18);
+  float heroAlpha = heroMask * mix(0.90, 1.00, level) * heroEnergy;
+  float secondaryAlpha = secondaryMask * 0.72 * secondaryEnergy;
+  float hairAlpha = hairMask * 0.50 * hairEnergy;
+  float haloAlpha = haloMask * mix(0.16, 0.30, level);
+  float glintAlpha = crossingMask * mix(0.48, 0.92, level);
+  // The broad ribbons stay quiet until a pressure lobe reaches them. This
+  // produces a few thick, soft white blooms instead of tinting every contour
+  // toward mint at all times.
+  float hotRibbonAlpha = max(
+      hotRibbonA * (tight * 0.44 + broad * 0.16),
+      hotRibbonB * (travel * 0.40 + echo * 0.14));
+  float alphaUnion = 1.0 -
+      (1.0 - heroAlpha) * (1.0 - secondaryAlpha) *
+      (1.0 - hairAlpha) * (1.0 - haloAlpha) *
+      (1.0 - glintAlpha) * (1.0 - hotRibbonAlpha);
+
+  vec3 atmosphere = uPrimaryColor.rgb * 0.72;
+  vec3 bodyPrimary = uPrimaryColor.rgb;
+  vec3 energizedEdge = mix(uPrimaryColor.rgb, uSecondaryColor.rgb, 0.15);
+  vec3 crossingGlint = mix(uPrimaryColor.rgb, uSecondaryColor.rgb, 0.54);
+  float deepWeight = haloAlpha * 0.92;
+  float bodyWeight = heroAlpha + secondaryAlpha * 0.72 + hairAlpha * 0.28;
+  float edgeWeight = secondaryAlpha * 0.28 + hairAlpha * 0.72;
+  float glintWeight = glintAlpha * 0.92;
+  float hotRibbonWeight = hotRibbonAlpha * 1.04;
+  float colorWeight = max(
+      deepWeight + bodyWeight + edgeWeight + glintWeight + hotRibbonWeight,
+      0.0001);
+  vec3 hue = (atmosphere * deepWeight + bodyPrimary * bodyWeight +
+      energizedEdge * edgeWeight + crossingGlint * glintWeight +
+      uSecondaryColor.rgb * hotRibbonWeight) / colorWeight;
+  float whiteBloom = saturate(
+      hotRibbonAlpha * mix(1.10, 1.45, level) + glintAlpha * 0.08);
+  hue = mix(hue, uSecondaryColor.rgb, whiteBloom * 0.78);
+
+  float crop = 1.0 - smoothstep(0.485, 0.555, radius);
+  float alpha = saturate(alphaUnion * intensity * crop);
+  alpha = alpha < 0.002 ? 0.0 : alpha;
+  vec3 premultiplied = min(hue * alpha, vec3(alpha));
+  fragColor = vec4(premultiplied, alpha);
 }

--- a/test/features/ai/ui/animation/ai_state_shader_animation_painters_test.dart
+++ b/test/features/ai/ui/animation/ai_state_shader_animation_painters_test.dart
@@ -12,12 +12,14 @@ void main() {
   group('AI state shader painters', () {
     // One shared load per program instead of per-test asset reads.
     late ui.FragmentProgram voiceProgram;
+    late ui.FragmentShader voiceShader;
     late ui.FragmentProgram thinkingProgram;
 
     setUpAll(() async {
       voiceProgram = await ui.FragmentProgram.fromAsset(
         AiStateShaderAssets.voiceInput,
       );
+      voiceShader = voiceProgram.fragmentShader();
       thinkingProgram = await ui.FragmentProgram.fromAsset(
         AiStateShaderAssets.thinkingLine,
       );
@@ -27,40 +29,37 @@ void main() {
       _,
     ) async {
       final painter = AiVoiceInputShaderPainter(
-        program: voiceProgram,
+        shader: voiceShader,
         dbfs: -18,
         dbfsFloor: -80,
         time: 1.4,
         intensity: 0.9,
         lineDensity: 24,
         orbitalMix: 0.55,
-        route: AiVoiceShaderRoute.tensionLoop,
         primaryColor: const Color(0xFF63D7C7),
         secondaryColor: const Color(0xFFE9EEF2),
         backgroundColor: const Color(0x00000000),
       );
       final samePainter = AiVoiceInputShaderPainter(
-        program: voiceProgram,
+        shader: voiceShader,
         dbfs: -18,
         dbfsFloor: -80,
         time: 1.4,
         intensity: 0.9,
         lineDensity: 24,
         orbitalMix: 0.55,
-        route: AiVoiceShaderRoute.tensionLoop,
         primaryColor: const Color(0xFF63D7C7),
         secondaryColor: const Color(0xFFE9EEF2),
         backgroundColor: const Color(0x00000000),
       );
       final changedPainter = AiVoiceInputShaderPainter(
-        program: voiceProgram,
+        shader: voiceShader,
         dbfs: -12,
         dbfsFloor: -80,
         time: 1.4,
         intensity: 0.9,
         lineDensity: 24,
         orbitalMix: 0.55,
-        route: AiVoiceShaderRoute.tensionLoop,
         primaryColor: const Color(0xFF63D7C7),
         secondaryColor: const Color(0xFFE9EEF2),
         backgroundColor: const Color(0x00000000),
@@ -136,25 +135,11 @@ void main() {
       expect(changedOpacityPainter.shouldRepaint(painter), isTrue);
     });
 
-    testWidgets('changing only the shader route forces a repaint', (
+    testWidgets('changing only the thinking shader route forces a repaint', (
       _,
     ) async {
-      // The route selects a different visual program branch inside the shader,
-      // so two painters that differ in nothing but their route must repaint.
-      AiVoiceInputShaderPainter voice(AiVoiceShaderRoute route) =>
-          AiVoiceInputShaderPainter(
-            program: voiceProgram,
-            dbfs: -18,
-            dbfsFloor: -80,
-            time: 1.4,
-            intensity: 0.9,
-            lineDensity: 24,
-            orbitalMix: 0.55,
-            route: route,
-            primaryColor: const Color(0xFF63D7C7),
-            secondaryColor: const Color(0xFFE9EEF2),
-            backgroundColor: const Color(0x00000000),
-          );
+      // The route selects a different visual program branch inside the
+      // thinking shader, so changing only that input must repaint.
       AiThinkingLineShaderPainter thinking(AiThinkingShaderRoute route) =>
           AiThinkingLineShaderPainter(
             program: thinkingProgram,
@@ -169,21 +154,6 @@ void main() {
             secondaryColor: const Color(0xFFE9EEF2),
             backgroundColor: const Color(0x00000000),
           );
-
-      for (final route in AiVoiceShaderRoute.values) {
-        final other = AiVoiceShaderRoute
-            .values[(route.index + 1) % AiVoiceShaderRoute.values.length];
-        expect(
-          voice(route).shouldRepaint(voice(other)),
-          isTrue,
-          reason: 'voice $route vs $other must repaint',
-        );
-        expect(
-          voice(route).shouldRepaint(voice(route)),
-          isFalse,
-          reason: 'voice $route vs itself must not repaint',
-        );
-      }
 
       for (final route in AiThinkingShaderRoute.values) {
         final other = AiThinkingShaderRoute
@@ -209,7 +179,6 @@ void main() {
         intensity: 0.8,
         lineDensity: 20,
         orbitalMix: 0.5,
-        route: AiVoiceShaderRoute.elasticMembrane,
         primaryColor: const Color(0xFF63D7C7),
         secondaryColor: const Color(0xFFE9EEF2),
         backgroundColor: const Color(0x11000000),
@@ -221,7 +190,6 @@ void main() {
         intensity: 0.8,
         lineDensity: 20,
         orbitalMix: 0.5,
-        route: AiVoiceShaderRoute.elasticMembrane,
         primaryColor: const Color(0xFF63D7C7),
         secondaryColor: const Color(0xFFE9EEF2),
         backgroundColor: const Color(0x11000000),
@@ -233,7 +201,6 @@ void main() {
         intensity: 0.8,
         lineDensity: 20,
         orbitalMix: 0.5,
-        route: AiVoiceShaderRoute.elasticMembrane,
         primaryColor: const Color(0xFF63D7C7),
         secondaryColor: const Color(0xFFE9EEF2),
         backgroundColor: const Color(0x11000000),
@@ -317,12 +284,14 @@ void main() {
 
   group('shouldRepaint properties', () {
     late ui.FragmentProgram voiceProgram;
+    late ui.FragmentShader voiceShader;
     late ui.FragmentProgram thinkingProgram;
 
     setUpAll(() async {
       voiceProgram = await ui.FragmentProgram.fromAsset(
         AiStateShaderAssets.voiceInput,
       );
+      voiceShader = voiceProgram.fragmentShader();
       thinkingProgram = await ui.FragmentProgram.fromAsset(
         AiStateShaderAssets.thinkingLine,
       );
@@ -341,19 +310,16 @@ void main() {
                 (bumpField == i ? 1 : 0)),
       );
       return AiVoiceInputShaderPainter(
-        program: voiceProgram,
+        shader: voiceShader,
         dbfs: f(0),
         dbfsFloor: f(1),
         time: f(2),
         intensity: f(3),
         lineDensity: f(4),
         orbitalMix: f(5),
-        route:
-            AiVoiceShaderRoute.values[(seed + (bumpField == 6 ? 1 : 0)) %
-                AiVoiceShaderRoute.values.length],
-        primaryColor: c(7),
-        secondaryColor: c(8),
-        backgroundColor: c(9),
+        primaryColor: c(6),
+        secondaryColor: c(7),
+        backgroundColor: c(8),
       );
     }
 
@@ -387,7 +353,7 @@ void main() {
 
     glados.Glados2<int, int>(
       glados.IntAnys(glados.any).intInRange(0, 1 << 16),
-      glados.IntAnys(glados.any).intInRange(0, 10),
+      glados.IntAnys(glados.any).intInRange(0, 9),
       glados.ExploreConfig(numRuns: 120),
     ).test(
       'voice painter repaints iff any field differs',

--- a/test/features/ai/ui/animation/ai_state_shader_animation_test.dart
+++ b/test/features/ai/ui/animation/ai_state_shader_animation_test.dart
@@ -18,6 +18,25 @@ void main() {
       expect(pubspec, contains('shaders:'));
     });
 
+    test('voice shader ships the bounded shared-field production program', () {
+      final source = File(AiStateShaderAssets.voiceInput).readAsStringSync();
+
+      expect(source, contains('vec4 pressure = vec4('));
+      expect(source, contains('float crossingMask = max('));
+      expect(source, isNot(contains('uVariant')));
+      expect(source, isNot(contains('vec4 elasticMembrane(')));
+      expect(source, isNot(contains('vec4 impactRipples(')));
+      expect(source, isNot(contains('vec4 liquidPulse(')));
+      expect(source, isNot(contains('vec4 resonanceBraid(')));
+      expect(source, isNot(contains('pressureField(')));
+      expect(source, isNot(contains('contourRing(')));
+      expect(RegExp(r'\bsin\(').allMatches(source), hasLength(5));
+      expect(RegExp(r'\bcos\(').allMatches(source), hasLength(9));
+      expect(source, isNot(contains('pow(')));
+      expect(source, isNot(contains('exp(')));
+      expect(source.length, lessThan(13000));
+    });
+
     testWidgets('compile as Flutter runtime-effect shaders', (tester) async {
       final voiceProgram = await ui.FragmentProgram.fromAsset(
         AiStateShaderAssets.voiceInput,
@@ -57,18 +76,7 @@ void main() {
   });
 
   group('AiVoiceInputShader', () {
-    test('exposes five deformed-circle voice routes', () {
-      expect(AiVoiceShaderRoute.values, hasLength(5));
-      expect(AiVoiceShaderRoute.values.map((route) => route.label), [
-        'Elastic membrane',
-        'Impact ripples',
-        'Tension loop',
-        'Liquid pulse',
-        'Resonance braid',
-      ]);
-    });
-
-    test('defaults to the hotter tension loop route at production speed', () {
+    test('uses the production tension-loop speed', () {
       const shader = AiVoiceInputShader(
         dbfs: -24,
         size: 160,
@@ -77,7 +85,6 @@ void main() {
         backgroundColor: Color(0x00000000),
       );
 
-      expect(shader.route, AiVoiceShaderRoute.tensionLoop);
       expect(shader.speed, 2);
     });
 
@@ -96,7 +103,6 @@ void main() {
             intensity: 0.9,
             lineDensity: 24,
             orbitalMix: 0.6,
-            route: AiVoiceShaderRoute.resonanceBraid,
             primaryColor: const Color(0xFF63D7C7),
             secondaryColor: const Color(0xFFE9EEF2),
             backgroundColor: const Color(0x00000000),
@@ -112,6 +118,46 @@ void main() {
         isA<AiVoiceInputShaderPainter>(),
       );
       expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('reuses one fragment shader across widget updates', (
+      tester,
+    ) async {
+      final program = await ui.FragmentProgram.fromAsset(
+        AiStateShaderAssets.voiceInput,
+      );
+      Future<ui.FragmentProgram> loadProgram() async => program;
+
+      Widget build(double dbfs) => TestSurface(
+        child: AiVoiceInputShader(
+          dbfs: dbfs,
+          size: 160,
+          primaryColor: const Color(0xFF63D7C7),
+          secondaryColor: const Color(0xFFE9EEF2),
+          backgroundColor: const Color(0x00000000),
+          timeOverride: 1.25,
+          programLoader: loadProgram,
+        ),
+      );
+
+      await tester.pumpWidget(build(-24));
+      await tester.pump();
+      final first =
+          hCustomPaintUnder<AiVoiceInputShader>(tester).painter!
+              as AiVoiceInputShaderPainter;
+
+      await tester.pumpWidget(build(-12));
+      await tester.pump();
+      final second =
+          hCustomPaintUnder<AiVoiceInputShader>(tester).painter!
+              as AiVoiceInputShaderPainter;
+
+      expect(identical(second.shader, first.shader), isTrue);
+      expect(second.dbfs, -12);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+
+      expect(second.shader.debugDisposed, isTrue);
     });
 
     testWidgets('wraps output in Semantics with the provided label', (

--- a/test/features/ai/widgetbook/ai_shader_animations_widgetbook_test.dart
+++ b/test/features/ai/widgetbook/ai_shader_animations_widgetbook_test.dart
@@ -18,7 +18,6 @@ void main() {
       expect(component.name, 'State shader animations');
       expect(component.useCases.map((useCase) => useCase.name), [
         'Voice playground',
-        'Voice route matrix',
         'Thinking playground',
         'Thinking route matrix',
         'Action bar study',

--- a/test/features/daily_os_next/ui/widgets/voice_button_test.dart
+++ b/test/features/daily_os_next/ui/widgets/voice_button_test.dart
@@ -71,7 +71,6 @@ void main() {
 
     final shaderFinder = find.byType(AiVoiceInputShader);
     final shader = tester.widget<AiVoiceInputShader>(shaderFinder);
-    expect(shader.route, AiVoiceShaderRoute.tensionLoop);
     expect(shader.dbfs, -18);
     expect(shader.dbfsFloor, -72);
     expect(shader.size, VoiceButton.shaderSizeFor(buttonSize));

--- a/test/features/speech/ui/widgets/recording/audio_recording_modal_test.dart
+++ b/test/features/speech/ui/widgets/recording/audio_recording_modal_test.dart
@@ -17,6 +17,8 @@ import 'package:lotti/features/ai_chat/services/realtime_transcription_service.d
 import 'package:lotti/features/categories/domain/category_icon.dart';
 import 'package:lotti/features/categories/repository/categories_repository.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
+import 'package:lotti/features/design_system/theme/design_system_theme.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/journal/model/entry_state.dart';
 import 'package:lotti/features/journal/state/entry_controller.dart';
 import 'package:lotti/features/onboarding/state/recording_style.dart';
@@ -41,6 +43,7 @@ import 'package:lotti/widgets/ui/lotti_animated_checkbox.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:record/record.dart';
 import 'package:uuid/uuid.dart';
+import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
 import '../../../../../mocks/mocks.dart';
 import '../../../../../widget_test_utils.dart';
@@ -356,6 +359,7 @@ void main() {
           }
 
           return MaterialApp(
+            theme: DesignSystemTheme.light(),
             home: Scaffold(
               body: AudioRecordingModalContent(
                 categoryId: provideCategory ? 'test-category' : null,
@@ -506,6 +510,7 @@ void main() {
       String categoryId = 'test-category',
       String? linkedId,
       List<Override> extraOverrides = const [],
+      ThemeData? theme,
     }) async {
       await tester.pumpWidget(
         ProviderScope(
@@ -514,7 +519,7 @@ void main() {
             ...extraOverrides,
           ],
           child: MaterialApp(
-            theme: resolveTestTheme(),
+            theme: theme ?? resolveTestTheme(),
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: Scaffold(
@@ -571,6 +576,92 @@ void main() {
     }
 
     group('AudioRecordingModal.show() - Static Method Coverage', () {
+      testWidgets(
+        'default root modal finishes cleanly above a nested task navigator',
+        (tester) async {
+          tester.view
+            ..physicalSize = const Size(1000, 800)
+            ..devicePixelRatio = 1;
+          addTearDown(tester.view.resetPhysicalSize);
+          addTearDown(tester.view.resetDevicePixelRatio);
+
+          final rootObserver = _TestNavigatorObserver();
+          final nestedObserver = _TestNavigatorObserver();
+          final navigatedPaths = <String>[];
+          var modalHadPoppedWhenNavigating = false;
+          beamToNamedOverride = (path) {
+            navigatedPaths.add(path);
+            modalHadPoppedWhenNavigating = rootObserver.poppedRoutes
+                .whereType<WoltModalSheetRoute<String>>()
+                .isNotEmpty;
+          };
+          addTearDown(() => beamToNamedOverride = null);
+          final recordingState = AudioRecorderState(
+            status: AudioRecorderStatus.recording,
+            progress: const Duration(seconds: 8),
+            vu: 1,
+            dBFS: -24,
+            showIndicator: false,
+            modalVisible: true,
+          );
+
+          await tester.pumpWidget(
+            ProviderScope(
+              overrides: [
+                ...baseOverrides(),
+                realtimeAvailableProvider.overrideWith((_) async => false),
+                audioRecorderControllerProvider.overrideWith(
+                  () => _CallbackTrackingController(
+                    fixedState: recordingState,
+                    createdId: 'audio-entry-1',
+                  ),
+                ),
+              ],
+              child: MaterialApp(
+                theme: resolveTestTheme(),
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                navigatorObservers: [rootObserver],
+                home: Navigator(
+                  observers: [nestedObserver],
+                  onGenerateRoute: (_) => MaterialPageRoute<void>(
+                    builder: (context) => Scaffold(
+                      body: ElevatedButton(
+                        onPressed: () => AudioRecordingModal.show(context),
+                        child: const Text('Show Modal'),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          await tester.tap(find.text('Show Modal'));
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 300));
+
+          expect(
+            rootObserver.pushedRoutes.whereType<WoltModalSheetRoute<String>>(),
+            hasLength(1),
+          );
+          expect(
+            nestedObserver.pushedRoutes
+                .whereType<WoltModalSheetRoute<String>>(),
+            isEmpty,
+          );
+
+          await tester.tap(find.text('STOP'));
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 300));
+
+          expect(find.byType(AudioRecordingModalContent), findsNothing);
+          expect(navigatedPaths, ['/journal/audio-entry-1']);
+          expect(modalHadPoppedWhenNavigating, isTrue);
+          expect(tester.takeException(), isNull);
+        },
+      );
+
       testWidgets(
         'should set modal visible and category when show() is called',
         (tester) async {
@@ -1389,8 +1480,56 @@ void main() {
         final shader = tester.widget<AiVoiceInputShader>(
           find.byType(AiVoiceInputShader),
         );
+        final shaderContext = tester.element(find.byType(AiVoiceInputShader));
+        final theme = Theme.of(shaderContext);
+        final tokens =
+            theme.extension<DsTokens>() ??
+            (theme.brightness == Brightness.dark
+                ? dsTokensDark
+                : dsTokensLight);
         expect(shader.dbfs, -7);
+        expect(shader.intensity, 1);
+        expect(shader.primaryColor, tokens.colors.interactive.enabled);
+        expect(shader.secondaryColor, tokens.colors.text.highEmphasis);
       });
+
+      testWidgets(
+        'light and dark design-system themes provide the orb colors',
+        (tester) async {
+          stubCategory();
+          for (final scenario in <(ThemeData, DsTokens)>[
+            (DesignSystemTheme.light(), dsTokensLight),
+            (DesignSystemTheme.dark(), dsTokensDark),
+          ]) {
+            await pumpModalContent(
+              tester,
+              theme: scenario.$1,
+              extraOverrides: [
+                realtimeAvailableProvider.overrideWith((_) async => false),
+                audioRecorderControllerProvider.overrideWith(
+                  () => TestAudioRecorderController(restingState),
+                ),
+                recordingStyleAppPrefsProvider.overrideWithValue(
+                  _fakeRecordingStylePrefs('modern'),
+                ),
+              ],
+            );
+            await tester.pump();
+            await tester.pump();
+
+            final shader = tester.widget<AiVoiceInputShader>(
+              find.byType(AiVoiceInputShader),
+            );
+            expect(shader.primaryColor, scenario.$2.colors.interactive.enabled);
+            expect(
+              shader.secondaryColor,
+              scenario.$2.colors.text.highEmphasis,
+            );
+            await tester.pumpWidget(const SizedBox.shrink());
+            await tester.pump();
+          }
+        },
+      );
     });
   });
 
@@ -1450,6 +1589,7 @@ void main() {
             });
 
             return MaterialApp(
+              theme: DesignSystemTheme.light(),
               home: Scaffold(
                 body: AudioRecordingModalContent(
                   categoryId: 'test-category',
@@ -1560,8 +1700,9 @@ void main() {
                 });
               }
 
-              return const MaterialApp(
-                home: Scaffold(
+              return MaterialApp(
+                theme: DesignSystemTheme.light(),
+                home: const Scaffold(
                   body: AudioRecordingModalContent(
                     categoryId: 'test-category',
                     linkedId: 'event-123',
@@ -1639,8 +1780,9 @@ void main() {
                 });
               }
 
-              return const MaterialApp(
-                home: Scaffold(
+              return MaterialApp(
+                theme: DesignSystemTheme.light(),
+                home: const Scaffold(
                   body: AudioRecordingModalContent(
                     categoryId: 'test-category',
                     linkedId: 'journal-123',
@@ -1713,8 +1855,9 @@ void main() {
                 });
               }
 
-              return const MaterialApp(
-                home: Scaffold(
+              return MaterialApp(
+                theme: DesignSystemTheme.light(),
+                home: const Scaffold(
                   body: AudioRecordingModalContent(
                     categoryId: 'test-category',
                     linkedId: 'nonexistent-123',
@@ -1789,8 +1932,9 @@ void main() {
                   });
                 }
 
-                return const MaterialApp(
-                  home: Scaffold(
+                return MaterialApp(
+                  theme: DesignSystemTheme.light(),
+                  home: const Scaffold(
                     body: AudioRecordingModalContent(
                       categoryId: 'test-category',
                       linkedId: 'null-value-123',
@@ -1866,8 +2010,9 @@ void main() {
                 });
               }
 
-              return const MaterialApp(
-                home: Scaffold(
+              return MaterialApp(
+                theme: DesignSystemTheme.light(),
+                home: const Scaffold(
                   body: AudioRecordingModalContent(
                     categoryId: 'test-category',
                     linkedId: 'loading-123',
@@ -1941,8 +2086,9 @@ void main() {
                 });
               }
 
-              return const MaterialApp(
-                home: Scaffold(
+              return MaterialApp(
+                theme: DesignSystemTheme.light(),
+                home: const Scaffold(
                   body: AudioRecordingModalContent(
                     categoryId: 'test-category',
                     linkedId: 'error-123',
@@ -2038,8 +2184,9 @@ void main() {
                   });
                 }
 
-                return const MaterialApp(
-                  home: Scaffold(
+                return MaterialApp(
+                  theme: DesignSystemTheme.light(),
+                  home: const Scaffold(
                     body: AudioRecordingModalContent(
                       categoryId: 'test-category',
                       linkedId: 'task-123',
@@ -2074,6 +2221,7 @@ class _CallbackTrackingController extends AudioRecorderController {
     this.onStopRealtimeCalled,
     this.onCancelRealtimeCalled,
     this.onRecordRealtimeCalled,
+    this.createdId,
   });
 
   final AudioRecorderState fixedState;
@@ -2082,6 +2230,7 @@ class _CallbackTrackingController extends AudioRecorderController {
   final VoidCallback? onStopRealtimeCalled;
   final VoidCallback? onCancelRealtimeCalled;
   final VoidCallback? onRecordRealtimeCalled;
+  final String? createdId;
 
   @override
   AudioRecorderState build() => fixedState;
@@ -2093,7 +2242,7 @@ class _CallbackTrackingController extends AudioRecorderController {
       status: AudioRecorderStatus.stopped,
       modalVisible: false,
     );
-    return null;
+    return createdId;
   }
 
   @override
@@ -2116,7 +2265,7 @@ class _CallbackTrackingController extends AudioRecorderController {
   @override
   Future<String?> stop() async {
     onStopCalled?.call();
-    return null;
+    return createdId;
   }
 
   @override
@@ -2126,5 +2275,22 @@ class _CallbackTrackingController extends AudioRecorderController {
       status: AudioRecorderStatus.stopped,
       modalVisible: false,
     );
+  }
+}
+
+class _TestNavigatorObserver extends NavigatorObserver {
+  final List<Route<dynamic>> pushedRoutes = <Route<dynamic>>[];
+  final List<Route<dynamic>> poppedRoutes = <Route<dynamic>>[];
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    pushedRoutes.add(route);
+    super.didPush(route, previousRoute);
+  }
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    poppedRoutes.add(route);
+    super.didPop(route, previousRoute);
   }
 }

--- a/test/logic/create/entry_creation_service_test.dart
+++ b/test/logic/create/entry_creation_service_test.dart
@@ -39,6 +39,7 @@ import 'package:record/record.dart' show Amplitude;
 import '../../helpers/fallbacks.dart';
 import '../../helpers/path_provider.dart';
 import '../../mocks/mocks.dart';
+import '../../widget_test_utils.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -403,6 +404,7 @@ void main() {
             ...overrides,
           ],
           child: MaterialApp(
+            theme: resolveTestTheme(),
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: Consumer(


### PR DESCRIPTION
## Summary

- replace the oversized multi-variant voice runtime effect with one bounded production tension-loop shader
- cache and reuse the loaded fragment shader while live dBFS uniforms change
- refine the production orb into a compact teal ring with localized pressure-driven white blooms
- keep Widgetbook and tests aligned with the single production configuration
- make the recording sheet use the requested navigator, pop exactly once, and navigate to an unlinked saved entry only after the Wolt route has completed
- update speech/AI architecture documentation and the 0.9.1040 release notes

## Root cause

The Linux stall and recording crash came from an unnecessarily large runtime-effect source plus repeated native shader allocation as audio levels changed. Finishing a recording had a separate lifecycle hazard: the sheet did not forward `useRootNavigator`, and its catch-all stop path could pop again or start page navigation while Wolt was still tearing down a nested task navigator.

## Impact

Affected Linux systems can render the modern recording orb without the prolonged Settings stall or recording-time freeze. Stopping a recording no longer races Flutter's inactive-element teardown. The visual remains audio-reactive and now has a clearer teal/white depth hierarchy.

## Validation

- `fvm flutter test test/features/ai/ui/animation/ai_state_shader_animation_test.dart test/features/ai/ui/animation/ai_state_shader_animation_painters_test.dart test/features/speech/ui/widgets/recording/audio_recording_modal_test.dart` — 61 tests passed
- `fvm flutter analyze` — no issues
- Linux runtime-effect compilation and dark-mode recorder capture passed via `flutter drive -d linux`
- final panel scores: visual polish 9.2/10, UX/product 9.3/10, motion/shader 9.3/10, Linux safety 9.6/10


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced stalls and Linux recording crashes by improving the energy-orb visualizer’s shader handling.
  * Prevented double-dismiss issues when finishing an audio recording before opening the saved journal entry.
* **Improvements**
  * Refreshed the AI voice visualization with unified rendering, smoother audio-responsive behavior, and new tuning controls in preview tools.
  * Updated visualizer styling to stay consistent across light and dark themes.
* **Documentation**
  * Clarified audio recording modal navigation/dismissal behavior and updated AI visualization documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->