### PR TITLE
fix: unify AI configuration pickers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   later setup changes. Automatic task-related updates can also be switched off
   without removing the manual Run now action or the existing report.
 ### Fixed
+- **AI profile and model choices now use one consistent picker flow.** Task-agent
+  profile and model changes finish saving before the setup sheet closes, and
+  their confirmation stays inside the task column instead of spanning the app.
+  Category defaults, agent creation, agent templates, inference-profile slots,
+  and task-agent setup now share the same design-system selection language.
 - **The energy-orb recording visualization no longer overwhelms Linux
   rendering.** The orb now compiles only its production shader and reuses the
   loaded fragment shader as live audio levels change, avoiding the prolonged

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -35,6 +35,7 @@
     <release version="0.9.1040" date="2026-07-13">
       <description>
           <p>Task agents now show their thinking model, model publisher, and serving provider directly in the AI summary. The identity opens a persistent setup sheet for choosing a profile or model, returning to the profile default, copying the category default, or pausing AI. Reports retain immutable attribution after setup changes, and automatic task-related updates can be disabled while Run now remains available.</p>
+          <p>AI profile and model choices now use one consistent design-system picker flow. Task-agent choices finish saving before the setup sheet closes, and their confirmation stays inside the task column instead of spanning the application.</p>
           <p>The energy-orb recording visualization now compiles only its production shader and reuses the loaded fragment shader as live audio levels change, avoiding prolonged stalls and recording crashes on affected Linux graphics stacks. Finishing a recording also dismisses its sheet exactly once before opening the saved entry, avoiding a nested-navigator teardown failure.</p>
       </description>
     </release>

--- a/lib/features/agents/README.md
+++ b/lib/features/agents/README.md
@@ -145,6 +145,35 @@ identity line. Different routes render separate `Current setup` and `This
 report` lines. Agent Internals opens the same `AgentModelSheet`; it does not own
 a second profile mutation path.
 
+`AgentModelSheet` uses the shared AI selection surfaces. Profile choices render
+through `InferenceProfilePickerList`; direct model choices render through
+`InferenceProviderModelPickerModal`, which separates the current task override
+from the base profile's default model. Both are terminal choices: the controller
+persists the new `AgentInferenceSetup` first, then closes the setup sheet and
+shows the localized confirmation through the `ScaffoldMessenger` captured from
+the task-details column. A failed write leaves the sheet open and reports the
+error there. Capturing the messenger before opening the root-navigator modal is
+what keeps successful feedback constrained to the task column.
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant Sheet as AgentModelSheet
+  participant Controller as AgentInstanceController
+  participant TaskUI as Task-column ScaffoldMessenger
+
+  User->>Sheet: choose profile or model
+  Sheet->>Controller: persist inference setup
+  alt write succeeds
+    Controller-->>Sheet: true
+    Sheet->>Sheet: close setup route
+    Sheet->>TaskUI: show scoped confirmation
+  else write fails
+    Controller-->>Sheet: false / throws
+    Sheet->>Sheet: remain open and show error
+  end
+```
+
 ```mermaid
 flowchart TD
   Init["agentInitializationProvider"]

--- a/lib/features/agents/ui/agent_creation_modal.dart
+++ b/lib/features/agents/ui/agent_creation_modal.dart
@@ -4,10 +4,10 @@ import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/state/inference_profile_controller.dart';
+import 'package:lotti/features/ai/ui/widgets/inference_profile_picker_modal.dart';
 import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
-import 'package:lotti/themes/theme.dart';
 import 'package:lotti/utils/platform.dart';
 import 'package:lotti/widgets/modal/modal_utils.dart';
 
@@ -55,7 +55,7 @@ class AgentCreationModal {
         // Page 1: Profile selection
         ModalUtils.modalSheetPage(
           context: modalContext,
-          title: modalContext.messages.inferenceProfilesTitle,
+          title: modalContext.messages.inferenceProfileChooseTitle,
           padding: const EdgeInsets.symmetric(vertical: 20),
           onTapBack: singleTemplate != null
               ? null
@@ -174,110 +174,21 @@ class _ProfileSelectionPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final profilesAsync = ref.watch(inferenceProfileControllerProvider);
+    final profiles = (profilesAsync.value ?? const <AiConfig>[])
+        .whereType<AiConfigInferenceProfile>()
+        .where((profile) => isDesktop || !profile.desktopOnly)
+        .toList();
 
-    return switch (profilesAsync) {
-      AsyncData(:final value) => _ProfileList(
-        configs: value,
-        onProfileSelected: onProfileSelected,
-      ),
-      AsyncLoading() => const Center(child: CircularProgressIndicator()),
-      AsyncError() => Center(child: Text(context.messages.commonError)),
-    };
-  }
-}
-
-class _ProfileList extends StatefulWidget {
-  const _ProfileList({
-    required this.configs,
-    required this.onProfileSelected,
-  });
-
-  final List<AiConfig> configs;
-  final ValueChanged<String> onProfileSelected;
-
-  @override
-  State<_ProfileList> createState() => _ProfileListState();
-}
-
-class _ProfileListState extends State<_ProfileList> {
-  String? _hoveredId;
-
-  List<AiConfigInferenceProfile> _filteredProfiles(List<AiConfig> configs) {
-    final profiles = configs.whereType<AiConfigInferenceProfile>().toList();
-    return isDesktop
-        ? profiles
-        : profiles.where((p) => !p.desktopOnly).toList();
-  }
-
-  @override
-  void didUpdateWidget(covariant _ProfileList oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (!identical(widget.configs, oldWidget.configs) && _hoveredId != null) {
-      final filtered = _filteredProfiles(widget.configs);
-      if (!filtered.any((p) => p.id == _hoveredId)) {
-        _hoveredId = null;
-      }
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final tokens = context.designTokens;
-    final filtered = _filteredProfiles(widget.configs);
-
-    if (filtered.isEmpty) {
-      return Center(
-        child: Text(
-          context.messages.inferenceProfilesEmpty,
-          style: context.textTheme.bodyLarge?.copyWith(
-            color: context.colorScheme.onSurfaceVariant,
-          ),
-        ),
+    if (profiles.isNotEmpty || profilesAsync.hasValue) {
+      return InferenceProfilePickerList(
+        profiles: profiles,
+        selectedProfileId: null,
+        onSelected: onProfileSelected,
       );
     }
-
-    return SingleChildScrollView(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          for (final (index, profile) in filtered.indexed)
-            DesignSystemListItem(
-              key: ValueKey(profile.id),
-              title: profile.name,
-              subtitle: profile.thinkingModelId,
-              leading: Icon(
-                Icons.tune,
-                size: 20,
-                color: tokens.colors.interactive.enabled,
-              ),
-              trailing: profile.desktopOnly
-                  ? Icon(
-                      Icons.desktop_windows_outlined,
-                      size: 16,
-                      color: tokens.colors.text.mediumEmphasis,
-                    )
-                  : null,
-              showDivider: index < filtered.length - 1,
-              dividerColor:
-                  index < filtered.length - 1 &&
-                      (_hoveredId == profile.id ||
-                          _hoveredId == filtered[index + 1].id)
-                  ? Colors.transparent
-                  : null,
-              onTap: () => widget.onProfileSelected(profile.id),
-              onHoverChanged: (hovered) {
-                setState(() {
-                  if (hovered) {
-                    _hoveredId = profile.id;
-                  } else if (_hoveredId == profile.id) {
-                    _hoveredId = null;
-                  }
-                });
-              },
-            ),
-        ],
-      ),
-    );
+    if (profilesAsync.isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    return Center(child: Text(context.messages.commonError));
   }
 }

--- a/lib/features/agents/ui/agent_model_sheet.dart
+++ b/lib/features/agents/ui/agent_model_sheet.dart
@@ -157,7 +157,10 @@ class _AgentModelSheetBodyState extends ConsumerState<_AgentModelSheetBody> {
           ),
         );
     if (model == null) {
-      await _persist(action);
+      final persisted = await _persist(action);
+      if (persisted && mounted) {
+        Navigator.of(context).pop();
+      }
       return;
     }
     final successTitle = messages.taskAgentSetupChangedToast(

--- a/lib/features/agents/ui/agent_model_sheet.dart
+++ b/lib/features/agents/ui/agent_model_sheet.dart
@@ -156,15 +156,15 @@ class _AgentModelSheetBodyState extends ConsumerState<_AgentModelSheetBody> {
             originEntityId: categoryId,
           ),
         );
-    if (model == null) {
+    if (profile == null || model == null) {
       final persisted = await _persist(action);
       if (persisted && mounted) {
         Navigator.of(context).pop();
       }
       return;
     }
-    final successTitle = messages.taskAgentSetupChangedToast(
-      model.name,
+    final successTitle = messages.taskAgentProfileChangedToast(
+      profile.name,
     );
     await _persistTerminalChoice(
       action,

--- a/lib/features/agents/ui/agent_model_sheet.dart
+++ b/lib/features/agents/ui/agent_model_sheet.dart
@@ -17,6 +17,7 @@ import 'package:lotti/features/ai/model/resolved_profile.dart';
 import 'package:lotti/features/ai/ui/widgets/inference_provider_model_picker_modal.dart';
 import 'package:lotti/features/design_system/components/checkboxes/design_system_checkbox.dart';
 import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_list_palette.dart';
 import 'package:lotti/features/design_system/components/toasts/design_system_toast.dart';
 import 'package:lotti/features/design_system/components/toasts/toast_messenger.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
@@ -33,20 +34,30 @@ class AgentModelSheet {
     required String taskId,
     required String agentId,
   }) {
+    final taskMessenger = ScaffoldMessenger.of(context);
     return ModalUtils.showSinglePageModal<void>(
       context: context,
       title: context.messages.taskAgentSetupTitle,
       padding: EdgeInsets.zero,
-      builder: (_) => _AgentModelSheetBody(taskId: taskId, agentId: agentId),
+      builder: (_) => _AgentModelSheetBody(
+        taskId: taskId,
+        agentId: agentId,
+        taskMessenger: taskMessenger,
+      ),
     );
   }
 }
 
 class _AgentModelSheetBody extends ConsumerStatefulWidget {
-  const _AgentModelSheetBody({required this.taskId, required this.agentId});
+  const _AgentModelSheetBody({
+    required this.taskId,
+    required this.agentId,
+    required this.taskMessenger,
+  });
 
   final String taskId;
   final String agentId;
+  final ScaffoldMessengerState taskMessenger;
 
   @override
   ConsumerState<_AgentModelSheetBody> createState() =>
@@ -72,23 +83,16 @@ class _AgentModelSheetBodyState extends ConsumerState<_AgentModelSheetBody> {
     };
   }
 
-  Future<void> _persist(
-    Future<void> Function() action, {
-    String? modelName,
-  }) async {
-    if (_busy) return;
+  Future<bool> _persist(Future<void> Function() action) async {
+    if (_busy) return false;
     setState(() => _busy = true);
     try {
       await action();
-      if (!mounted) return;
+      if (!mounted) return false;
       ref
         ..invalidate(agentIdentityProvider(widget.agentId))
         ..invalidate(taskAgentResolvedSetupProvider(widget.agentId));
-      if (modelName == null) return;
-      context.showToast(
-        tone: DesignSystemToastTone.success,
-        title: context.messages.taskAgentSetupChangedToast(modelName),
-      );
+      return true;
     } catch (error, stackTrace) {
       developer.log(
         'Task-agent setup update failed',
@@ -96,17 +100,34 @@ class _AgentModelSheetBodyState extends ConsumerState<_AgentModelSheetBody> {
         error: error,
         stackTrace: stackTrace,
       );
-      if (!mounted) return;
+      if (!mounted) return false;
       context.showToast(
         tone: DesignSystemToastTone.error,
         title: context.messages.commonError,
       );
+      return false;
     } finally {
       if (mounted) setState(() => _busy = false);
     }
   }
 
+  Future<void> _persistTerminalChoice(
+    Future<void> Function() action, {
+    required String successTitle,
+  }) async {
+    final persisted = await _persist(action);
+    if (!persisted || !mounted) return;
+    Navigator.of(context).pop();
+    if (widget.taskMessenger.mounted) {
+      widget.taskMessenger.showDesignSystemToast(
+        tone: DesignSystemToastTone.success,
+        title: successTitle,
+      );
+    }
+  }
+
   Future<void> _useCategoryDefault(TaskAgentSetupOptions options) async {
+    final messages = context.messages;
     final journalDb = ref.read(journalDbProvider);
     final entity = await journalDb.journalEntityById(widget.taskId);
     final categoryId = entity is Task ? entity.categoryId : null;
@@ -122,36 +143,40 @@ class _AgentModelSheetBodyState extends ConsumerState<_AgentModelSheetBody> {
         : options.models
               .where((value) => value.id == profile.thinkingModelId)
               .firstOrNull;
-    await _persist(
-      () => ref
-          .read(taskAgentServiceProvider)
-          .updateAgentInferenceSetup(
-            agentId: widget.agentId,
-            setup: AgentInferenceSetup(
-              mode: profileId == null
-                  ? AgentInferenceSetupMode.disabled
-                  : AgentInferenceSetupMode.configured,
-              origin: AgentInferenceSetupOrigin.categorySnapshot,
-              baseProfileId: profileId,
-              originEntityId: categoryId,
-            ),
+    Future<void> action() => ref
+        .read(taskAgentServiceProvider)
+        .updateAgentInferenceSetup(
+          agentId: widget.agentId,
+          setup: AgentInferenceSetup(
+            mode: profileId == null
+                ? AgentInferenceSetupMode.disabled
+                : AgentInferenceSetupMode.configured,
+            origin: AgentInferenceSetupOrigin.categorySnapshot,
+            baseProfileId: profileId,
+            originEntityId: categoryId,
           ),
-      modelName: model?.name,
+        );
+    if (model == null) {
+      await _persist(action);
+      return;
+    }
+    final successTitle = messages.taskAgentSetupChangedToast(
+      model.name,
+    );
+    await _persistTerminalChoice(
+      action,
+      successTitle: successTitle,
     );
   }
 
   Future<void> _chooseProfile(
     AiConfigInferenceProfile profile,
-    TaskAgentSetupOptions options,
   ) async {
-    final model = options.models
-        .where((value) => value.id == profile.thinkingModelId)
-        .firstOrNull;
-    await _persist(
+    await _persistTerminalChoice(
       () => ref
           .read(taskAgentServiceProvider)
           .updateAgentProfile(agentId: widget.agentId, profileId: profile.id),
-      modelName: model?.name ?? profile.thinkingModelId,
+      successTitle: context.messages.taskAgentProfileChangedToast(profile.name),
     );
   }
 
@@ -194,6 +219,9 @@ class _AgentModelSheetBodyState extends ConsumerState<_AgentModelSheetBody> {
     final selectedId = await InferenceProviderModelPickerModal.show(
       context: context,
       defaultModelId: profile?.thinkingModelId,
+      selectedModelId:
+          config.inferenceSetup?.thinkingModelOverrideId ??
+          profile?.thinkingModelId,
       models: options.models,
       providers: options.providers,
       title: context.messages.taskAgentModelPickerTitle,
@@ -203,14 +231,16 @@ class _AgentModelSheetBodyState extends ConsumerState<_AgentModelSheetBody> {
     final model = options.models
         .where((value) => value.id == selectedId)
         .firstOrNull;
-    await _persist(
+    await _persistTerminalChoice(
       () => ref
           .read(taskAgentServiceProvider)
           .updateAgentThinkingModelOverride(
             agentId: widget.agentId,
             modelConfigId: selectedId,
           ),
-      modelName: model?.name ?? selectedId,
+      successTitle: context.messages.taskAgentSetupChangedToast(
+        model?.name ?? selectedId,
+      ),
     );
   }
 
@@ -365,7 +395,14 @@ class _AgentModelSheetBodyState extends ConsumerState<_AgentModelSheetBody> {
                   trailing: config?.inferenceSetup?.baseProfileId == profile.id
                       ? const Icon(Icons.check_rounded)
                       : null,
-                  onTap: () => _chooseProfile(profile, options),
+                  activated:
+                      config?.inferenceSetup?.baseProfileId == profile.id,
+                  selected: config?.inferenceSetup?.baseProfileId == profile.id,
+                  activatedBackgroundColor:
+                      config?.inferenceSetup?.baseProfileId == profile.id
+                      ? DesignSystemListPalette.activatedFillStrong(tokens)
+                      : null,
+                  onTap: () => _chooseProfile(profile),
                   showDivider: true,
                 ),
             ],

--- a/lib/features/agents/ui/profile_selector.dart
+++ b/lib/features/agents/ui/profile_selector.dart
@@ -1,13 +1,12 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/state/inference_profile_controller.dart';
-import 'package:lotti/features/design_system/theme/design_tokens.dart';
-import 'package:lotti/features/design_system/theme/typography_helpers.dart';
+import 'package:lotti/features/ai/ui/widgets/inference_profile_picker_modal.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
-import 'package:lotti/themes/theme.dart';
 import 'package:lotti/utils/platform.dart';
-import 'package:lotti/widgets/selection/selection_modal_base.dart';
 import 'package:lotti/widgets/settings/settings_picker_field.dart';
 
 /// Inference profiles usable on this platform: `desktopOnly` profiles are
@@ -25,31 +24,27 @@ List<AiConfigInferenceProfile> _platformProfiles(
 
 /// Opens the shared profile-selection modal; selecting a profile invokes
 /// [onProfileSelected] and pops the modal.
-void _showProfilePicker({
+Future<void> _showProfilePicker({
   required BuildContext context,
   required List<AiConfigInferenceProfile> profiles,
   required String? selectedProfileId,
   required ValueChanged<String?> onProfileSelected,
-}) {
-  SelectionModalBase.show(
+}) async {
+  final selectedId = await InferenceProfilePickerModal.show(
     context: context,
-    title: context.messages.agentDefaultProfileLabel,
-    builder: (modalContext) => _ProfilePickerContent(
-      profiles: profiles,
-      selectedProfileId: selectedProfileId,
-      onSelected: (id) {
-        onProfileSelected(id);
-        Navigator.of(modalContext).pop();
-      },
-    ),
+    profiles: profiles,
+    selectedProfileId: selectedProfileId,
   );
+  if (selectedId != null && context.mounted) {
+    onProfileSelected(selectedId);
+  }
 }
 
 /// Lists inference profiles for selection in agent/template contexts.
 ///
 /// Filters out `desktopOnly` profiles on non-desktop platforms.
 /// Pre-selects the given [selectedProfileId] if provided.
-class ProfileSelector extends ConsumerWidget {
+class ProfileSelector extends StatelessWidget {
   const ProfileSelector({
     required this.selectedProfileId,
     required this.onProfileSelected,
@@ -65,56 +60,11 @@ class ProfileSelector extends ConsumerWidget {
   final String? hintText;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final filtered = _platformProfiles(
-      ref.watch(inferenceProfileControllerProvider),
-    );
-
-    final selected = selectedProfileId != null
-        ? filtered.where((p) => p.id == selectedProfileId).firstOrNull
-        : null;
-
-    return InkWell(
-      onTap: filtered.isNotEmpty
-          ? () => _showProfilePicker(
-              context: context,
-              profiles: filtered,
-              selectedProfileId: selectedProfileId,
-              onProfileSelected: onProfileSelected,
-            )
-          : null,
-      borderRadius: BorderRadius.circular(12),
-      child: InputDecorator(
-        decoration: InputDecoration(
-          labelText: context.messages.agentDefaultProfileLabel,
-          border: const OutlineInputBorder(
-            borderRadius: BorderRadius.all(Radius.circular(12)),
-          ),
-          suffixIcon: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              if (selectedProfileId != null)
-                IconButton(
-                  icon: const Icon(Icons.clear, size: 18),
-                  onPressed: () => onProfileSelected(null),
-                ),
-              const Icon(Icons.arrow_drop_down),
-            ],
-          ),
-          enabled: filtered.isNotEmpty,
-        ),
-        child: selected != null
-            ? Text(
-                selected.name,
-                style: context.textTheme.bodyLarge,
-              )
-            : Text(
-                hintText ?? context.messages.inferenceProfileSelectProfile,
-                style: context.textTheme.bodyLarge?.copyWith(
-                  color: context.colorScheme.onSurface.withValues(alpha: 0.5),
-                ),
-              ),
-      ),
+  Widget build(BuildContext context) {
+    return SettingsProfilePickerField(
+      selectedProfileId: selectedProfileId,
+      onProfileSelected: onProfileSelected,
+      hintText: hintText,
     );
   }
 }
@@ -153,110 +103,18 @@ class SettingsProfilePickerField extends ConsumerWidget {
       label: context.messages.agentDefaultProfileLabel,
       valueText: selected?.name,
       hintText: hintText ?? context.messages.inferenceProfileSelectProfile,
+      enabled: filtered.isNotEmpty,
       onClear: selected != null ? () => onProfileSelected(null) : null,
       onTap: () {
-        if (filtered.isNotEmpty) {
+        unawaited(
           _showProfilePicker(
             context: context,
             profiles: filtered,
             selectedProfileId: selectedProfileId,
             onProfileSelected: onProfileSelected,
-          );
-        }
+          ),
+        );
       },
-    );
-  }
-}
-
-class _ProfilePickerContent extends StatelessWidget {
-  const _ProfilePickerContent({
-    required this.profiles,
-    required this.selectedProfileId,
-    required this.onSelected,
-  });
-
-  final List<AiConfigInferenceProfile> profiles;
-  final String? selectedProfileId;
-  final ValueChanged<String> onSelected;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.all(20),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: profiles.map((profile) {
-          final isSelected = profile.id == selectedProfileId;
-          return Padding(
-            padding: const EdgeInsets.symmetric(vertical: 4),
-            child: Material(
-              color: isSelected
-                  ? context.colorScheme.primaryContainer.withValues(alpha: 0.15)
-                  : Colors.transparent,
-              borderRadius: BorderRadius.circular(12),
-              child: InkWell(
-                onTap: () => onSelected(profile.id),
-                borderRadius: BorderRadius.circular(12),
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 16,
-                    vertical: 12,
-                  ),
-                  child: Row(
-                    children: [
-                      Expanded(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              profile.name,
-                              style: context.textTheme.bodyLarge?.copyWith(
-                                fontWeight: isSelected
-                                    ? FontWeight.w600
-                                    : FontWeight.normal,
-                                color: isSelected
-                                    ? context.colorScheme.primary
-                                    : context.colorScheme.onSurface,
-                              ),
-                            ),
-                            const SizedBox(height: 2),
-                            Text(
-                              profile.thinkingModelId,
-                              style: monoMetaStyle(
-                                context.designTokens,
-                                context.designTokens.colors,
-                                base: context.textTheme.bodySmall,
-                                color: context.colorScheme.onSurface.withValues(
-                                  alpha: 0.6,
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                      if (profile.desktopOnly)
-                        Padding(
-                          padding: const EdgeInsets.only(right: 8),
-                          child: Icon(
-                            Icons.desktop_windows_outlined,
-                            size: 16,
-                            color: context.colorScheme.onSurfaceVariant,
-                          ),
-                        ),
-                      if (isSelected)
-                        Icon(
-                          Icons.check_rounded,
-                          color: context.colorScheme.primary,
-                          size: 20,
-                        ),
-                    ],
-                  ),
-                ),
-              ),
-            ),
-          );
-        }).toList(),
-      ),
     );
   }
 }

--- a/lib/features/agents/ui/profile_selector.dart
+++ b/lib/features/agents/ui/profile_selector.dart
@@ -101,10 +101,14 @@ class SettingsProfilePickerField extends ConsumerWidget {
 
     return SettingsPickerField(
       label: context.messages.agentDefaultProfileLabel,
-      valueText: selected?.name,
+      valueText:
+          selected?.name ??
+          (selectedProfileId != null
+              ? context.messages.inferenceProfileUnavailable
+              : null),
       hintText: hintText ?? context.messages.inferenceProfileSelectProfile,
-      enabled: filtered.isNotEmpty,
-      onClear: selected != null ? () => onProfileSelected(null) : null,
+      enabled: filtered.isNotEmpty || selectedProfileId != null,
+      onClear: selectedProfileId != null ? () => onProfileSelected(null) : null,
       onTap: () {
         unawaited(
           _showProfilePicker(

--- a/lib/features/ai/README.md
+++ b/lib/features/ai/README.md
@@ -47,6 +47,37 @@ The key split is between skills and profiles:
 
 That split is what lets the app move the same skill between providers without rewriting the prompt contract.
 
+## Configuration Selection UI
+
+AI configuration editors share two design-system selection primitives rather
+than owning feature-specific modal rows:
+
+- `InferenceProfilePickerModal` and its embeddable
+  `InferenceProfilePickerList` render named inference profiles for category
+  defaults, template settings, agent creation, and task-agent setup. The list
+  uses the profile description as secondary text and marks the persisted
+  selection without exposing internal model IDs.
+- `InferenceProviderModelPickerModal` renders model choices for inference-profile
+  slots, task-agent overrides, and per-invocation skill overrides. With multiple
+  providers it drills from provider to model; with one provider it opens the
+  model list directly. `selectedModelId` identifies the active choice while
+  `defaultModelId` independently marks the profile default.
+
+Closed fields use `SettingsPickerField`, so settings pages keep the same label,
+value, disabled, and tap affordances. Async Riverpod consumers retain their last
+rendered values during background reloads; a provider refresh does not replace
+an established picker with a full loading shell.
+
+```mermaid
+flowchart LR
+  Profiles["Category / template / agent creation / task agent"] --> ProfilePicker["InferenceProfilePickerModal or list"]
+  Slots["Profile slots / task override / one-run override"] --> ModelPicker["InferenceProviderModelPickerModal"]
+  ModelPicker --> Providers{"provider count"}
+  Providers -->|one| Models["model rows"]
+  Providers -->|many| ProviderRows["provider rows"]
+  ProviderRows --> Models
+```
+
 ## Main Execution Paths
 
 ### Legacy prompt path

--- a/lib/features/ai/ui/inference_profile_slot_field.dart
+++ b/lib/features/ai/ui/inference_profile_slot_field.dart
@@ -1,16 +1,16 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/state/settings/ai_config_by_type_controller.dart';
 import 'package:lotti/features/ai/ui/inference_profile_form.dart';
-import 'package:lotti/features/design_system/components/search/design_system_search.dart';
-import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/ai/ui/widgets/inference_provider_model_picker_modal.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
-import 'package:lotti/themes/theme.dart';
-import 'package:lotti/widgets/selection/selection_modal_base.dart';
+import 'package:lotti/widgets/settings/settings_picker_field.dart';
 
 /// One skill-slot row in the profile form: shows the model currently assigned
-/// to the slot ([modelId]) and opens a searchable picker on tap.
+/// to the slot ([modelId]) and opens the shared provider/model picker on tap.
 ///
 /// The picker is restricted to models matching [filter] (e.g. "audio in / text
 /// out" for the transcription slot). When [required] is true an empty slot is
@@ -41,268 +41,55 @@ class ModelSlotField extends ConsumerWidget {
       aiConfigByTypeControllerProvider(AiConfigType.inferenceProvider),
     );
 
-    final allModels = switch (modelsAsync) {
-      AsyncData(:final value) => value.whereType<AiConfigModel>().toList(),
-      _ => <AiConfigModel>[],
-    };
-    final providers = switch (providersAsync) {
-      AsyncData(:final value) =>
-        value.whereType<AiConfigInferenceProvider>().toList(),
-      _ => <AiConfigInferenceProvider>[],
-    };
+    final allModels = (modelsAsync.value ?? const <AiConfig>[])
+        .whereType<AiConfigModel>()
+        .toList();
+    final providers = (providersAsync.value ?? const <AiConfig>[])
+        .whereType<AiConfigInferenceProvider>()
+        .toList();
 
     final filteredModels = allModels.where(filter).toList();
 
     final selectedModel = resolveModelSlot(modelId, allModels);
 
-    return InkWell(
-      onTap: filteredModels.isNotEmpty
-          ? () => _showModelPicker(
-              context,
-              filteredModels,
-              providers,
-            )
-          : null,
-      borderRadius: BorderRadius.circular(12),
-      child: InputDecorator(
-        decoration: InputDecoration(
-          labelText: '$label${required ? ' *' : ''}',
-          border: const OutlineInputBorder(
-            borderRadius: BorderRadius.all(Radius.circular(12)),
-          ),
-          suffixIcon: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              if (modelId != null)
-                IconButton(
-                  icon: const Icon(Icons.clear, size: 18),
-                  onPressed: () => onModelSelected(null),
-                ),
-              const Icon(Icons.arrow_drop_down),
-            ],
-          ),
-          enabled: filteredModels.isNotEmpty,
+    return SettingsPickerField(
+      label: '$label${required ? ' *' : ''}',
+      valueText:
+          selectedModel?.name ??
+          (modelId != null
+              ? context.messages.inferenceProfileModelUnavailable
+              : null),
+      hintText: context.messages.inferenceProfileSelectModel,
+      enabled: filteredModels.isNotEmpty,
+      onClear: modelId != null ? () => onModelSelected(null) : null,
+      onTap: () => unawaited(
+        _showModelPicker(
+          context,
+          filteredModels,
+          providers,
+          selectedModel?.id,
         ),
-        child: selectedModel != null
-            ? Text(
-                selectedModel.name,
-                style: context.textTheme.bodyLarge,
-              )
-            : modelId != null
-            // The slot holds a model id that no longer resolves to a row —
-            // typically because the model's inference provider was deleted,
-            // which cascade-deletes its models. Show a clear "unavailable"
-            // message instead of the raw composite id, and keep the clear
-            // (×) action so the dangling slot can be reset.
-            ? Text(
-                context.messages.inferenceProfileModelUnavailable,
-                style: context.textTheme.bodyLarge?.copyWith(
-                  color: context.colorScheme.error,
-                ),
-              )
-            : Text(
-                context.messages.inferenceProfileSelectModel,
-                style: context.textTheme.bodyLarge?.copyWith(
-                  color: context.colorScheme.onSurface.withValues(alpha: 0.5),
-                ),
-              ),
       ),
     );
   }
 
-  void _showModelPicker(
+  Future<void> _showModelPicker(
     BuildContext context,
     List<AiConfigModel> models,
     List<AiConfigInferenceProvider> providers,
-  ) {
-    SelectionModalBase.show(
+    String? selectedModelId,
+  ) async {
+    final selectedId = await InferenceProviderModelPickerModal.show(
       context: context,
-      title: label,
-      builder: (modalContext) => _SlotModelPickerContent(
-        models: models,
-        providers: providers,
-        selectedModelId: modelId,
-        onSelected: (id) {
-          onModelSelected(id);
-          Navigator.of(modalContext).pop();
-        },
-      ),
+      defaultModelId: null,
+      selectedModelId: selectedModelId,
+      models: models,
+      providers: providers,
+      title: context.messages.inferenceProfileChooseModelTitle,
+      defaultBadgeLabel: context.messages.designSystemSelectedLabel,
     );
-  }
-}
-
-/// Body of the slot-picker modal. Stateful so the search field can
-/// filter the list reactively without rebuilding the surrounding
-/// `SelectionModalBase` chrome on every keystroke. The substring
-/// match runs against the model display name, the wire-level
-/// `providerModelId`, and the resolved provider name — so a query
-/// like "gemini" finds every Gemini-owned row even when the model's
-/// display name doesn't start with the provider's name.
-class _SlotModelPickerContent extends StatefulWidget {
-  const _SlotModelPickerContent({
-    required this.models,
-    required this.providers,
-    required this.selectedModelId,
-    required this.onSelected,
-  });
-
-  final List<AiConfigModel> models;
-  final List<AiConfigInferenceProvider> providers;
-  final String? selectedModelId;
-  final ValueChanged<String> onSelected;
-
-  @override
-  State<_SlotModelPickerContent> createState() =>
-      _SlotModelPickerContentState();
-}
-
-class _SlotModelPickerContentState extends State<_SlotModelPickerContent> {
-  String _query = '';
-
-  @override
-  Widget build(BuildContext context) {
-    final tokens = context.designTokens;
-    final messages = context.messages;
-    final queryLower = _query.trim().toLowerCase();
-    // Build the id→name lookup once per build instead of doing a
-    // linear scan of `widget.providers` for every model during the
-    // filter pass and again when rendering each row. Filter runs on
-    // every keystroke, so the prior O(N·M) shape became visible on
-    // longer model lists.
-    final providerNamesById = <String, String>{
-      for (final p in widget.providers) p.id: p.name,
-    };
-
-    final filteredModels = widget.models.where((m) {
-      if (queryLower.isEmpty) return true;
-      if (m.name.toLowerCase().contains(queryLower)) return true;
-      if (m.providerModelId.toLowerCase().contains(queryLower)) return true;
-      final providerLabel = providerNamesById[m.inferenceProviderId];
-      return providerLabel != null &&
-          providerLabel.toLowerCase().contains(queryLower);
-    }).toList();
-
-    // Resolve the slot value with the shared exact-id/unique-provider-id
-    // rule so an ambiguous legacy id never marks multiple rows selected.
-    final resolvedSelectedId = resolveModelSlot(
-      widget.selectedModelId,
-      widget.models,
-    )?.id;
-
-    return Padding(
-      padding: const EdgeInsets.all(20),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          DesignSystemSearch(
-            hintText: messages.aiProfileModelPickerSearchHint,
-            onChanged: (value) => setState(() => _query = value),
-            onClear: () => setState(() => _query = ''),
-          ),
-          SizedBox(height: tokens.spacing.step5),
-          if (filteredModels.isEmpty)
-            Padding(
-              padding: EdgeInsets.symmetric(vertical: tokens.spacing.step6),
-              child: Text(
-                messages.filterSelectionNoMatches,
-                style: context.textTheme.bodyMedium?.copyWith(
-                  color: context.colorScheme.onSurface.withValues(alpha: 0.7),
-                ),
-              ),
-            )
-          else
-            for (final model in filteredModels)
-              _SlotModelPickerRow(
-                model: model,
-                providerLabel: providerNamesById[model.inferenceProviderId],
-                selected: model.id == resolvedSelectedId,
-                onTap: () => widget.onSelected(model.id),
-              ),
-        ],
-      ),
-    );
-  }
-}
-
-/// Single row inside the slot picker. Extracted so the search filter
-/// can rebuild the parent's row list without churning each row's
-/// internal layout — the row only rebuilds when its own props
-/// (selection, provider label) change.
-class _SlotModelPickerRow extends StatelessWidget {
-  const _SlotModelPickerRow({
-    required this.model,
-    required this.providerLabel,
-    required this.selected,
-    required this.onTap,
-  });
-
-  final AiConfigModel model;
-  final String? providerLabel;
-  final bool selected;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final subtitle = [
-      ?providerLabel,
-      model.providerModelId,
-    ].join(' — ');
-
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 4),
-      child: Material(
-        color: selected
-            ? context.colorScheme.primaryContainer.withValues(alpha: 0.15)
-            : Colors.transparent,
-        borderRadius: BorderRadius.circular(12),
-        child: InkWell(
-          onTap: onTap,
-          borderRadius: BorderRadius.circular(12),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(
-              horizontal: 16,
-              vertical: 12,
-            ),
-            child: Row(
-              children: [
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        model.name,
-                        style: context.textTheme.bodyLarge?.copyWith(
-                          fontWeight: selected
-                              ? FontWeight.w600
-                              : FontWeight.normal,
-                          color: selected
-                              ? context.colorScheme.primary
-                              : context.colorScheme.onSurface,
-                        ),
-                      ),
-                      const SizedBox(height: 2),
-                      Text(
-                        subtitle,
-                        style: context.textTheme.bodySmall?.copyWith(
-                          color: context.colorScheme.onSurface.withValues(
-                            alpha: 0.6,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                if (selected)
-                  Icon(
-                    Icons.check_rounded,
-                    color: context.colorScheme.primary,
-                    size: 20,
-                  ),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
+    if (selectedId != null && context.mounted) {
+      onModelSelected(selectedId);
+    }
   }
 }

--- a/lib/features/ai/ui/inference_profile_slot_field.dart
+++ b/lib/features/ai/ui/inference_profile_slot_field.dart
@@ -60,7 +60,7 @@ class ModelSlotField extends ConsumerWidget {
               ? context.messages.inferenceProfileModelUnavailable
               : null),
       hintText: context.messages.inferenceProfileSelectModel,
-      enabled: filteredModels.isNotEmpty,
+      enabled: filteredModels.isNotEmpty || modelId != null,
       onClear: modelId != null ? () => onModelSelected(null) : null,
       onTap: () => unawaited(
         _showModelPicker(

--- a/lib/features/ai/ui/widgets/inference_profile_picker_modal.dart
+++ b/lib/features/ai/ui/widgets/inference_profile_picker_modal.dart
@@ -1,0 +1,171 @@
+import 'package:flutter/material.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_list_palette.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/widgets/modal/modal_utils.dart';
+
+/// Shared inference-profile picker used by settings forms and agent flows.
+///
+/// The modal returns the selected profile id. Callers decide whether that
+/// selection updates a draft, advances a wizard, or persists immediately.
+class InferenceProfilePickerModal {
+  const InferenceProfilePickerModal._();
+
+  static Future<String?> show({
+    required BuildContext context,
+    required List<AiConfigInferenceProfile> profiles,
+    required String? selectedProfileId,
+    String? title,
+  }) {
+    if (profiles.isEmpty) return Future<String?>.value();
+
+    return ModalUtils.showSinglePageModal<String>(
+      context: context,
+      title: title ?? context.messages.inferenceProfileChooseTitle,
+      padding: EdgeInsets.zero,
+      builder: (modalContext) => InferenceProfilePickerList(
+        profiles: profiles,
+        selectedProfileId: selectedProfileId,
+        onSelected: (id) => Navigator.of(modalContext).pop(id),
+      ),
+    );
+  }
+}
+
+/// Full-bleed profile list shared by standalone pickers and wizard pages.
+class InferenceProfilePickerList extends StatelessWidget {
+  const InferenceProfilePickerList({
+    required this.profiles,
+    required this.selectedProfileId,
+    required this.onSelected,
+    this.emptyLabel,
+    super.key,
+  });
+
+  final List<AiConfigInferenceProfile> profiles;
+  final String? selectedProfileId;
+  final ValueChanged<String> onSelected;
+  final String? emptyLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    if (profiles.isEmpty) {
+      return Padding(
+        padding: EdgeInsets.all(tokens.spacing.step5),
+        child: Center(
+          child: Text(
+            emptyLabel ?? context.messages.inferenceProfilesEmpty,
+            style: tokens.typography.styles.body.bodyMedium.copyWith(
+              color: tokens.colors.text.mediumEmphasis,
+            ),
+          ),
+        ),
+      );
+    }
+
+    return SingleChildScrollView(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          for (final (index, profile) in profiles.indexed)
+            _InferenceProfileRow(
+              profile: profile,
+              selected: profile.id == selectedProfileId,
+              showDivider: index < profiles.length - 1,
+              onTap: () => onSelected(profile.id),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InferenceProfileRow extends StatelessWidget {
+  const _InferenceProfileRow({
+    required this.profile,
+    required this.selected,
+    required this.showDivider,
+    required this.onTap,
+  });
+
+  final AiConfigInferenceProfile profile;
+  final bool selected;
+  final bool showDivider;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final description = profile.description?.trim();
+    final desktopOnlyLabel = context.messages.inferenceProfileDesktopOnly;
+    final selectedLabel = context.messages.designSystemSelectedLabel;
+    final semanticsParts = <String>[
+      profile.name,
+      if (description != null && description.isNotEmpty) description,
+      if (profile.desktopOnly) desktopOnlyLabel,
+      if (selected) selectedLabel,
+    ];
+
+    return DesignSystemListItem(
+      key: ValueKey(profile.id),
+      size: DesignSystemListItemSize.small,
+      title: profile.name,
+      subtitle: description == null || description.isEmpty ? null : description,
+      subtitleMaxLines: 2,
+      leading: SizedBox(
+        width: tokens.spacing.step8,
+        child: Center(
+          child: Icon(
+            Icons.account_tree_outlined,
+            color: selected
+                ? tokens.colors.interactive.enabled
+                : tokens.colors.text.mediumEmphasis,
+            size: tokens.spacing.step6,
+          ),
+        ),
+      ),
+      trailingExtra: profile.desktopOnly
+          ? Tooltip(
+              message: desktopOnlyLabel,
+              child: Icon(
+                Icons.desktop_windows_outlined,
+                color: tokens.colors.text.mediumEmphasis,
+                size: tokens.spacing.step5,
+              ),
+            )
+          : null,
+      trailing: selected
+          ? Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  selectedLabel,
+                  style: tokens.typography.styles.others.caption.copyWith(
+                    color: tokens.colors.interactive.enabled,
+                    fontWeight: tokens.typography.weight.semiBold,
+                  ),
+                ),
+                SizedBox(width: tokens.spacing.step2),
+                Icon(
+                  Icons.check_rounded,
+                  color: tokens.colors.interactive.enabled,
+                  size: tokens.spacing.step6,
+                ),
+              ],
+            )
+          : null,
+      showDivider: showDivider,
+      activated: selected,
+      selected: selected,
+      activatedBackgroundColor: selected
+          ? DesignSystemListPalette.activatedFillStrong(tokens)
+          : null,
+      semanticsLabel: semanticsParts.join(', '),
+      onTap: onTap,
+    );
+  }
+}

--- a/lib/features/ai/ui/widgets/inference_profile_picker_modal.dart
+++ b/lib/features/ai/ui/widgets/inference_profile_picker_modal.dart
@@ -10,9 +10,7 @@ import 'package:lotti/widgets/modal/modal_utils.dart';
 ///
 /// The modal returns the selected profile id. Callers decide whether that
 /// selection updates a draft, advances a wizard, or persists immediately.
-class InferenceProfilePickerModal {
-  const InferenceProfilePickerModal._();
-
+abstract final class InferenceProfilePickerModal {
   static Future<String?> show({
     required BuildContext context,
     required List<AiConfigInferenceProfile> profiles,

--- a/lib/features/ai/ui/widgets/inference_provider_model_picker_modal.dart
+++ b/lib/features/ai/ui/widgets/inference_provider_model_picker_modal.dart
@@ -26,13 +26,12 @@ import 'package:lotti/widgets/modal/modal_utils.dart';
 ///   one-tap "Current default" shortcut at the top), page 2 lists the chosen
 ///   provider's models with a back button.
 ///
-/// The profile default is rendered as a **model row** (a single-accent
-/// `interactive` selection dot + name + wire id + a `Default ✓` marker + a
-/// stronger activated tint) identically wherever it appears — pinned on page 1
-/// and first in its provider's list on page 2 — so it reads as one model with a
-/// shortcut rather than a duplicate provider entry. Non-default model rows lead
-/// with their provider's brand-accent dot instead. The body is full-bleed,
-/// aligned with the modal's top bar, on every layout.
+/// The profile default is rendered as the same model row wherever it appears
+/// and carries a `Default` marker. The currently selected override is rendered
+/// with the activated tint and check mark, so a task override remains distinct
+/// from the profile default. Non-selected model rows lead with their provider's
+/// brand-accent dot. The body is full-bleed, aligned with the modal's top bar,
+/// on every layout.
 class InferenceProviderModelPickerModal {
   /// Opens the picker and resolves with the chosen model's id, or `null` when
   /// the user dismisses it (or there was nothing to pick). See the class doc
@@ -44,6 +43,7 @@ class InferenceProviderModelPickerModal {
     required List<AiConfigInferenceProvider> providers,
     required String title,
     required String defaultBadgeLabel,
+    String? selectedModelId,
   }) async {
     final providersById = <String, AiConfigInferenceProvider>{
       for (final provider in providers) provider.id: provider,
@@ -61,6 +61,7 @@ class InferenceProviderModelPickerModal {
     final validModels = withProvider.isEmpty ? models : withProvider;
     if (validModels.isEmpty) return null;
     if (validModels.length == 1) return validModels.first.id;
+    final effectiveSelectedModelId = selectedModelId ?? defaultModelId;
 
     // Group models under their provider, preserving first-seen order so the
     // provider list is stable and matches the order the caller supplied.
@@ -90,6 +91,7 @@ class InferenceProviderModelPickerModal {
           models: orderModelsDefaultFirst(validModels, defaultModelId),
           providerType: onlyProvider?.inferenceProviderType,
           defaultModelId: defaultModelId,
+          selectedModelId: effectiveSelectedModelId,
           defaultBadgeLabel: defaultBadgeLabel,
           onSelected: (id) => Navigator.of(modalContext).pop(id),
         ),
@@ -105,68 +107,69 @@ class InferenceProviderModelPickerModal {
         ? null
         : validModels.firstWhereOrNull((model) => model.id == defaultModelId);
 
-    try {
-      return await ModalUtils.showMultiPageModal<String>(
-        context: context,
-        pageIndexNotifier: pageIndexNotifier,
-        pageListBuilder: (modalContext) => [
-          ModalUtils.modalSheetPage(
-            context: modalContext,
-            title: title,
-            showCloseButton: true,
-            padding: const EdgeInsets.symmetric(vertical: 20),
-            child: _ProviderPage(
-              providerOrder: providerOrder,
-              modelsByProvider: modelsByProvider,
-              providersById: providersById,
-              defaultModel: defaultModel,
-              defaultProvider: defaultModel == null
-                  ? null
-                  : providersById[defaultModel.inferenceProviderId],
-              defaultBadgeLabel: defaultBadgeLabel,
-              onDefaultSelected: () =>
-                  Navigator.of(modalContext).pop(defaultModel!.id),
-              onProviderSelected: (provider) {
-                selectedProvider.value = provider;
-                pageIndexNotifier.value = 1;
-              },
-            ),
+    // Wolt completes its route future before every reverse-transition widget
+    // has been unmounted. These notifiers therefore must remain usable through
+    // the route's teardown; once the modal releases them they are garbage
+    // collected with the page closures.
+    return ModalUtils.showMultiPageModal<String>(
+      context: context,
+      pageIndexNotifier: pageIndexNotifier,
+      pageListBuilder: (modalContext) => [
+        ModalUtils.modalSheetPage(
+          context: modalContext,
+          title: title,
+          showCloseButton: true,
+          padding: const EdgeInsets.symmetric(vertical: 20),
+          child: _ProviderPage(
+            providerOrder: providerOrder,
+            modelsByProvider: modelsByProvider,
+            providersById: providersById,
+            defaultModel: defaultModel,
+            defaultProvider: defaultModel == null
+                ? null
+                : providersById[defaultModel.inferenceProviderId],
+            selectedModelId: effectiveSelectedModelId,
+            defaultBadgeLabel: defaultBadgeLabel,
+            onDefaultSelected: () =>
+                Navigator.of(modalContext).pop(defaultModel!.id),
+            onProviderSelected: (provider) {
+              selectedProvider.value = provider;
+              pageIndexNotifier.value = 1;
+            },
           ),
-          ModalUtils.modalSheetPage(
-            context: modalContext,
-            // Same dismiss affordance as page 1 so the two pages read as one
-            // picker (back arrow + branded title + close).
-            showCloseButton: true,
-            padding: const EdgeInsets.symmetric(vertical: 20),
-            onTapBack: () => pageIndexNotifier.value = 0,
-            titleWidget: ValueListenableBuilder<AiConfigInferenceProvider?>(
-              valueListenable: selectedProvider,
-              builder: (context, provider, _) =>
-                  _ProviderPageTitle(provider: provider),
-            ),
-            child: ValueListenableBuilder<AiConfigInferenceProvider?>(
-              valueListenable: selectedProvider,
-              builder: (context, provider, _) {
-                if (provider == null) return const SizedBox.shrink();
-                return _ModelList(
-                  models: orderModelsDefaultFirst(
-                    modelsByProvider[provider.id] ?? const [],
-                    defaultModelId,
-                  ),
-                  providerType: provider.inferenceProviderType,
-                  defaultModelId: defaultModelId,
-                  defaultBadgeLabel: defaultBadgeLabel,
-                  onSelected: (id) => Navigator.of(modalContext).pop(id),
-                );
-              },
-            ),
+        ),
+        ModalUtils.modalSheetPage(
+          context: modalContext,
+          // Same dismiss affordance as page 1 so the two pages read as one
+          // picker (back arrow + branded title + close).
+          showCloseButton: true,
+          padding: const EdgeInsets.symmetric(vertical: 20),
+          onTapBack: () => pageIndexNotifier.value = 0,
+          titleWidget: ValueListenableBuilder<AiConfigInferenceProvider?>(
+            valueListenable: selectedProvider,
+            builder: (context, provider, _) =>
+                _ProviderPageTitle(provider: provider),
           ),
-        ],
-      );
-    } finally {
-      selectedProvider.dispose();
-      pageIndexNotifier.dispose();
-    }
+          child: ValueListenableBuilder<AiConfigInferenceProvider?>(
+            valueListenable: selectedProvider,
+            builder: (context, provider, _) {
+              if (provider == null) return const SizedBox.shrink();
+              return _ModelList(
+                models: orderModelsDefaultFirst(
+                  modelsByProvider[provider.id] ?? const [],
+                  defaultModelId,
+                ),
+                providerType: provider.inferenceProviderType,
+                defaultModelId: defaultModelId,
+                selectedModelId: effectiveSelectedModelId,
+                defaultBadgeLabel: defaultBadgeLabel,
+                onSelected: (id) => Navigator.of(modalContext).pop(id),
+              );
+            },
+          ),
+        ),
+      ],
+    );
   }
 
   /// Returns [models] with the default (if present) moved to the front, the
@@ -212,6 +215,7 @@ class _ProviderPage extends StatelessWidget {
     required this.providersById,
     required this.defaultModel,
     required this.defaultProvider,
+    required this.selectedModelId,
     required this.defaultBadgeLabel,
     required this.onDefaultSelected,
     required this.onProviderSelected,
@@ -222,6 +226,7 @@ class _ProviderPage extends StatelessWidget {
   final Map<String, AiConfigInferenceProvider> providersById;
   final AiConfigModel? defaultModel;
   final AiConfigInferenceProvider? defaultProvider;
+  final String? selectedModelId;
   final String defaultBadgeLabel;
   final VoidCallback onDefaultSelected;
   final ValueChanged<AiConfigInferenceProvider> onProviderSelected;
@@ -247,6 +252,7 @@ class _ProviderPage extends StatelessWidget {
               model: defaultModel,
               providerType: defaultProvider?.inferenceProviderType,
               isDefault: true,
+              isSelected: defaultModel.id == selectedModelId,
               defaultBadgeLabel: defaultBadgeLabel,
               onTap: onDefaultSelected,
             ),
@@ -323,6 +329,7 @@ class _ModelList extends StatelessWidget {
     required this.models,
     required this.providerType,
     required this.defaultModelId,
+    required this.selectedModelId,
     required this.defaultBadgeLabel,
     required this.onSelected,
   });
@@ -330,6 +337,7 @@ class _ModelList extends StatelessWidget {
   final List<AiConfigModel> models;
   final InferenceProviderType? providerType;
   final String? defaultModelId;
+  final String? selectedModelId;
   final String defaultBadgeLabel;
   final ValueChanged<String> onSelected;
 
@@ -348,6 +356,7 @@ class _ModelList extends StatelessWidget {
               model: model,
               providerType: providerType,
               isDefault: model.id == defaultModelId,
+              isSelected: model.id == selectedModelId,
               defaultBadgeLabel: defaultBadgeLabel,
               onTap: () => onSelected(model.id),
             ),
@@ -367,6 +376,7 @@ class _ModelRow extends StatelessWidget {
     required this.model,
     required this.providerType,
     required this.isDefault,
+    required this.isSelected,
     required this.defaultBadgeLabel,
     required this.onTap,
   });
@@ -374,6 +384,7 @@ class _ModelRow extends StatelessWidget {
   final AiConfigModel model;
   final InferenceProviderType? providerType;
   final bool isDefault;
+  final bool isSelected;
   final String defaultBadgeLabel;
   final VoidCallback onTap;
 
@@ -389,14 +400,21 @@ class _ModelRow extends StatelessWidget {
       // + marker) so the strongest scan position reinforces "selected"; other
       // rows lead with their provider's brand accent for grouping.
       leading: _LeadingDot(
-        color: isDefault
+        color: isSelected
             ? tokens.colors.interactive.enabled
             : aiProviderAccent(type: providerType, tokens: tokens),
       ),
-      trailing: isDefault ? _DefaultMarker(label: defaultBadgeLabel) : null,
-      activated: isDefault,
-      selected: isDefault,
-      activatedBackgroundColor: isDefault
+      trailing: isSelected || isDefault
+          ? _ModelStatusMarker(
+              label: isDefault
+                  ? defaultBadgeLabel
+                  : context.messages.designSystemSelectedLabel,
+              showCheck: isSelected,
+            )
+          : null,
+      activated: isSelected,
+      selected: isSelected,
+      activatedBackgroundColor: isSelected
           ? DesignSystemListPalette.activatedFillStrong(tokens)
           : null,
       onTap: onTap,
@@ -494,10 +512,11 @@ class _ProviderPageTitle extends StatelessWidget {
 
 /// Single-accent default marker: the badge label + a check, both in the
 /// interactive accent. Deliberately not a filled pill (no second hue).
-class _DefaultMarker extends StatelessWidget {
-  const _DefaultMarker({required this.label});
+class _ModelStatusMarker extends StatelessWidget {
+  const _ModelStatusMarker({required this.label, required this.showCheck});
 
   final String label;
+  final bool showCheck;
 
   @override
   Widget build(BuildContext context) {
@@ -513,8 +532,10 @@ class _DefaultMarker extends StatelessWidget {
             fontWeight: tokens.typography.weight.semiBold,
           ),
         ),
-        SizedBox(width: tokens.spacing.step2),
-        Icon(Icons.check_rounded, color: accent, size: tokens.spacing.step6),
+        if (showCheck) ...[
+          SizedBox(width: tokens.spacing.step2),
+          Icon(Icons.check_rounded, color: accent, size: tokens.spacing.step6),
+        ],
       ],
     );
   }

--- a/lib/features/categories/README.md
+++ b/lib/features/categories/README.md
@@ -150,7 +150,10 @@ Both modes of `CategoryDetailsPage` render inside the shared settings-detail kit
   - basic settings (name, color, icon)
   - options (the `CategorySwitchTiles` switch rows in the shared definitions-editor order: favorite, private, active, day planning)
   - default language
-  - AI defaults via `SettingsProfilePickerField` and `TemplateSelector`
+  - AI defaults via `SettingsProfilePickerField` and `TemplateSelector`; the
+    profile field opens the shared `InferenceProfilePickerModal` used by agent
+    configuration surfaces and preserves its rendered value during background
+    provider reloads
   - speech dictionary
   - checklist correction examples
 

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -2164,6 +2164,8 @@
   "imageViewerDownloadTooltip": "Stáhnout obrázek",
   "inactiveLabel": "Neaktivní",
   "inactiveSwitchDescription": "Lze vybrat pro nové záznamy, když je zapnuto",
+  "inferenceProfileChooseModelTitle": "Vyber model",
+  "inferenceProfileChooseTitle": "Vyber profil inference",
   "inferenceProfileDetailLoadError": "Profil se nepodařilo načíst: {error}",
   "@inferenceProfileDetailLoadError": {
     "placeholders": {
@@ -2180,7 +2182,7 @@
   "inferenceProfilePinnedHostNoneHelper": "Synchronizované zvukové záznamy se nebudou automaticky přepisovat, dokud nebude připnuté nějaké zařízení.",
   "inferenceProfilePinnedHostNoneLabel": "Nepřipnuto (bez automatického spuštění)",
   "inferenceProfilePinnedHostThisDeviceSuffix": " (toto zařízení)",
-  "inferenceProfileSelectProfile": "Vyberte profil…",
+  "inferenceProfileSelectProfile": "Vyber profil…",
   "inferenceProfileSkillModelRequired": "Vyžaduje nastavení modelu {slotName}",
   "@inferenceProfileSkillModelRequired": {
     "placeholders": {
@@ -3413,7 +3415,7 @@
   "taskAgentAutomaticUpdatesOnDescription": "Když se změní něco souvisejícího s tímto úkolem, spustí se dvouminutový odpočet. Změny během odpočtu se sloučí do jedné aktualizace.",
   "taskAgentCancelTimerTooltip": "Zrušit čekající automatickou aktualizaci",
   "taskAgentChooseModel": "Vybrat model pro uvažování",
-  "taskAgentChooseProfile": "Vybrat uložené nastavení",
+  "taskAgentChooseProfile": "Vyber profil inference",
   "taskAgentCountdownTooltip": "Příští automatické spuštění za {countdown}",
   "@taskAgentCountdownTooltip": {
     "placeholders": {
@@ -3444,9 +3446,17 @@
   "taskAgentNoProfilesAvailable": "Na tomto zařízení nejsou dostupné žádné profily",
   "taskAgentNoProfileSelected": "Žádné nastavení AI",
   "taskAgentNoProfileSelectedDescription": "Než agenta spustíš, vyber uložené nastavení nebo model.",
+  "taskAgentProfileChangedToast": "Pro všechny budoucí aktualizace agenta se bude používat {profile}, dokud ho nezměníš.",
+  "@taskAgentProfileChangedToast": {
+    "placeholders": {
+      "profile": {
+        "type": "String"
+      }
+    }
+  },
   "taskAgentProfileDefaultBadge": "Výchozí model profilu",
-  "taskAgentRunNowTooltip": "Spustit nyní",
   "taskAgentRouteVia": "přes",
+  "taskAgentRunNowTooltip": "Spustit nyní",
   "taskAgentSetupAndReportSemantics": "Tato zpráva i aktuální nastavení používají {identity}. Aktivuj pro změnu nastavení.",
   "taskAgentSetupBroken": "Vybrané nastavení AI není dostupné",
   "taskAgentSetupChangedToast": "Pro všechny budoucí aktualizace se bude používat {model}, dokud ho nezměníš.",

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -2200,6 +2200,7 @@
       }
     }
   },
+  "inferenceProfileUnavailable": "Inferenční profil není k dispozici",
   "inputDataTypeAudioFilesDescription": "Použijte audio soubory jako vstup",
   "inputDataTypeAudioFilesName": "Audio soubory",
   "inputDataTypeImagesDescription": "Použijte obrázky jako vstup",

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -2182,6 +2182,7 @@
   "inferenceProfilePinnedHostNoneHelper": "Synchronizované zvukové záznamy se nebudou automaticky přepisovat, dokud nebude připnuté nějaké zařízení.",
   "inferenceProfilePinnedHostNoneLabel": "Nepřipnuto (bez automatického spuštění)",
   "inferenceProfilePinnedHostThisDeviceSuffix": " (toto zařízení)",
+  "inferenceProfileSelectModel": "Vyber model…",
   "inferenceProfileSelectProfile": "Vyber profil…",
   "inferenceProfileSkillModelRequired": "Vyžaduje nastavení modelu {slotName}",
   "@inferenceProfileSkillModelRequired": {

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2408,6 +2408,7 @@
   "inferenceProfileThinkingHighEnd": "Denken (High-End)",
   "inferenceProfileThinkingRequired": "Ein Denk-Modell ist erforderlich",
   "inferenceProfileTranscription": "Transkription",
+  "inferenceProfileUnavailable": "Inferenzprofil nicht verfügbar",
   "inputDataTypeAudioFilesDescription": "Audiodateien als Eingabe verwenden",
   "inputDataTypeAudioFilesName": "Audiodateien",
   "inputDataTypeImagesDescription": "Bilder als Eingabe verwenden",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2355,6 +2355,8 @@
   "imageViewerDownloadTooltip": "Bild herunterladen",
   "inactiveLabel": "Inaktiv",
   "inactiveSwitchDescription": "Kann für neue Einträge gewählt werden, wenn aktiv",
+  "inferenceProfileChooseModelTitle": "Modell auswählen",
+  "inferenceProfileChooseTitle": "Inferenzprofil auswählen",
   "inferenceProfileCreateTitle": "Profil erstellen",
   "inferenceProfileDescriptionLabel": "Beschreibung",
   "inferenceProfileDesktopOnly": "Nur Desktop",
@@ -3629,7 +3631,7 @@
   "taskAgentAutomaticUpdatesOnDescription": "Wenn sich etwas an oder im Zusammenhang mit dieser Aufgabe ändert, startet ein zweiminütiger Countdown. Änderungen währenddessen werden in einem Update gebündelt.",
   "taskAgentCancelTimerTooltip": "Ausstehendes automatisches Update abbrechen",
   "taskAgentChooseModel": "Denkmodell wählen",
-  "taskAgentChooseProfile": "Gespeicherte Einrichtung wählen",
+  "taskAgentChooseProfile": "Inferenzprofil auswählen",
   "taskAgentCountdownTooltip": "Nächster automatischer Lauf in {countdown}",
   "@taskAgentCountdownTooltip": {
     "placeholders": {
@@ -3660,9 +3662,17 @@
   "taskAgentNoProfilesAvailable": "Auf diesem Gerät sind keine Profile verfügbar",
   "taskAgentNoProfileSelected": "Kein KI-Setup",
   "taskAgentNoProfileSelectedDescription": "Wähle eine gespeicherte Einrichtung oder ein Denkmodell, bevor der Agent laufen kann.",
+  "taskAgentProfileChangedToast": "Für alle zukünftigen Agenten-Aktualisierungen wird {profile} verwendet, bis du es änderst.",
+  "@taskAgentProfileChangedToast": {
+    "placeholders": {
+      "profile": {
+        "type": "String"
+      }
+    }
+  },
   "taskAgentProfileDefaultBadge": "Profilstandard",
-  "taskAgentRunNowTooltip": "Jetzt ausführen",
   "taskAgentRouteVia": "über",
+  "taskAgentRunNowTooltip": "Jetzt ausführen",
   "taskAgentSetupAndReportSemantics": "Dieser Bericht und die aktuelle Einrichtung verwenden {identity}. Aktivieren, um die Einrichtung zu ändern.",
   "taskAgentSetupBroken": "Die ausgewählte KI-Einrichtung ist nicht verfügbar",
   "taskAgentSetupChangedToast": "{model} wird für jedes zukünftige Agent-Update verwendet, bis du es änderst.",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -3663,7 +3663,7 @@
   "taskAgentNoProfilesAvailable": "Auf diesem Gerät sind keine Profile verfügbar",
   "taskAgentNoProfileSelected": "Kein KI-Setup",
   "taskAgentNoProfileSelectedDescription": "Wähle eine gespeicherte Einrichtung oder ein Denkmodell, bevor der Agent laufen kann.",
-  "taskAgentProfileChangedToast": "Für alle zukünftigen Agenten-Aktualisierungen wird {profile} verwendet, bis du es änderst.",
+  "taskAgentProfileChangedToast": "{profile} wird für jedes zukünftige Agent-Update verwendet, bis du es änderst.",
   "@taskAgentProfileChangedToast": {
     "placeholders": {
       "profile": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2912,6 +2912,7 @@
   "inferenceProfileThinkingHighEnd": "Thinking (High-End)",
   "inferenceProfileThinkingRequired": "A thinking model is required",
   "inferenceProfileTranscription": "Transcription",
+  "inferenceProfileUnavailable": "Inference profile unavailable",
   "inputDataTypeAudioFilesDescription": "Use audio files as input",
   "inputDataTypeAudioFilesName": "Audio Files",
   "inputDataTypeImagesDescription": "Use images as input",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2859,6 +2859,8 @@
   "imageViewerDownloadTooltip": "Download image",
   "inactiveLabel": "Inactive",
   "inactiveSwitchDescription": "Can be chosen for new entries when on",
+  "inferenceProfileChooseModelTitle": "Choose a model",
+  "inferenceProfileChooseTitle": "Choose an inference profile",
   "inferenceProfileCreateTitle": "Create Profile",
   "inferenceProfileDescriptionLabel": "Description",
   "inferenceProfileDesktopOnly": "Desktop Only",
@@ -2885,8 +2887,8 @@
   "inferenceProfilePinnedHostNoneLabel": "Not pinned (no auto-trigger)",
   "inferenceProfilePinnedHostThisDeviceSuffix": " (this device)",
   "inferenceProfileSaveButton": "Save",
-  "inferenceProfileSelectModel": "Select a model…",
-  "inferenceProfileSelectProfile": "Select a profile…",
+  "inferenceProfileSelectModel": "Choose a model…",
+  "inferenceProfileSelectProfile": "Choose a profile…",
   "inferenceProfilesEmpty": "No inference profiles yet",
   "inferenceProfileSkillModelRequired": "Requires {slotName} model to be set",
   "@inferenceProfileSkillModelRequired": {
@@ -4286,7 +4288,7 @@
   "taskAgentAutomaticUpdatesOnDescription": "When anything related to this task changes, a two-minute countdown starts. Changes during the countdown are bundled into one update.",
   "taskAgentCancelTimerTooltip": "Cancel pending automatic update",
   "taskAgentChooseModel": "Choose a thinking model",
-  "taskAgentChooseProfile": "Choose a saved setup",
+  "taskAgentChooseProfile": "Choose an inference profile",
   "taskAgentCountdownTooltip": "Next auto-run in {countdown}",
   "@taskAgentCountdownTooltip": {
     "placeholders": {
@@ -4317,9 +4319,17 @@
   "taskAgentNoProfilesAvailable": "No profiles available on this device",
   "taskAgentNoProfileSelected": "No AI setup",
   "taskAgentNoProfileSelectedDescription": "Choose a saved setup or thinking model before this agent can run.",
+  "taskAgentProfileChangedToast": "Using {profile} for every future agent update until you change it.",
+  "@taskAgentProfileChangedToast": {
+    "placeholders": {
+      "profile": {
+        "type": "String"
+      }
+    }
+  },
   "taskAgentProfileDefaultBadge": "Profile default",
-  "taskAgentRunNowTooltip": "Run now",
   "taskAgentRouteVia": "via",
+  "taskAgentRunNowTooltip": "Run now",
   "taskAgentSetupAndReportSemantics": "This report and current setup use {identity}. Activate to change setup.",
   "@taskAgentSetupAndReportSemantics": {
     "placeholders": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2355,6 +2355,8 @@
   "imageViewerDownloadTooltip": "Descargar imagen",
   "inactiveLabel": "Inactivo",
   "inactiveSwitchDescription": "Se puede elegir para nuevas entradas cuando está activo",
+  "inferenceProfileChooseModelTitle": "Elige un modelo",
+  "inferenceProfileChooseTitle": "Elige un perfil de inferencia",
   "inferenceProfileCreateTitle": "Crear perfil",
   "inferenceProfileDescriptionLabel": "Descripción",
   "inferenceProfileDesktopOnly": "Solo escritorio",
@@ -2381,8 +2383,8 @@
   "inferenceProfilePinnedHostNoneLabel": "Sin fijar (sin auto-disparador)",
   "inferenceProfilePinnedHostThisDeviceSuffix": " (este dispositivo)",
   "inferenceProfileSaveButton": "Guardar",
-  "inferenceProfileSelectModel": "Seleccionar un modelo…",
-  "inferenceProfileSelectProfile": "Seleccionar un perfil…",
+  "inferenceProfileSelectModel": "Elige un modelo…",
+  "inferenceProfileSelectProfile": "Elige un perfil…",
   "inferenceProfilesEmpty": "Aún no hay perfiles de inferencia",
   "inferenceProfileSkillModelRequired": "Requiere modelo de {slotName}",
   "@inferenceProfileSkillModelRequired": {
@@ -3629,7 +3631,7 @@
   "taskAgentAutomaticUpdatesOnDescription": "Cuando cambia algo relacionado con esta tarea, empieza una cuenta atrás de dos minutos. Los cambios durante la cuenta atrás se agrupan en una sola actualización.",
   "taskAgentCancelTimerTooltip": "Cancelar la actualización automática pendiente",
   "taskAgentChooseModel": "Elegir un modelo de razonamiento",
-  "taskAgentChooseProfile": "Elegir una configuración guardada",
+  "taskAgentChooseProfile": "Elige un perfil de inferencia",
   "taskAgentCountdownTooltip": "Próxima ejecución automática en {countdown}",
   "@taskAgentCountdownTooltip": {
     "placeholders": {
@@ -3660,9 +3662,17 @@
   "taskAgentNoProfilesAvailable": "No hay perfiles disponibles en este dispositivo",
   "taskAgentNoProfileSelected": "Sin configuración de IA",
   "taskAgentNoProfileSelectedDescription": "Elige una configuración guardada o un modelo antes de ejecutar el agente.",
+  "taskAgentProfileChangedToast": "Se usará {profile} para todas las futuras actualizaciones del agente hasta que lo cambies.",
+  "@taskAgentProfileChangedToast": {
+    "placeholders": {
+      "profile": {
+        "type": "String"
+      }
+    }
+  },
   "taskAgentProfileDefaultBadge": "Predeterminado del perfil",
-  "taskAgentRunNowTooltip": "Ejecutar ahora",
   "taskAgentRouteVia": "vía",
+  "taskAgentRunNowTooltip": "Ejecutar ahora",
   "taskAgentSetupAndReportSemantics": "Este informe y la configuración actual usan {identity}. Activa para cambiarla.",
   "taskAgentSetupBroken": "La configuración de IA seleccionada no está disponible",
   "taskAgentSetupChangedToast": "Se usará {model} para cada actualización futura hasta que lo cambies.",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2408,6 +2408,7 @@
   "inferenceProfileThinkingHighEnd": "Pensamiento (alta gama)",
   "inferenceProfileThinkingRequired": "Se requiere un modelo de pensamiento",
   "inferenceProfileTranscription": "Transcripción",
+  "inferenceProfileUnavailable": "Perfil de inferencia no disponible",
   "inputDataTypeAudioFilesDescription": "Usar archivos de audio como entrada",
   "inputDataTypeAudioFilesName": "Archivos de audio",
   "inputDataTypeImagesDescription": "Usar imágenes como entrada",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -2355,6 +2355,8 @@
   "imageViewerDownloadTooltip": "Télécharger l'image",
   "inactiveLabel": "Inactif",
   "inactiveSwitchDescription": "Peut être choisi pour de nouvelles entrées si actif",
+  "inferenceProfileChooseModelTitle": "Choisis un modèle",
+  "inferenceProfileChooseTitle": "Choisis un profil d’inférence",
   "inferenceProfileCreateTitle": "Créer un profil",
   "inferenceProfileDescriptionLabel": "Description",
   "inferenceProfileDesktopOnly": "Bureau uniquement",
@@ -2381,8 +2383,8 @@
   "inferenceProfilePinnedHostNoneLabel": "Non épinglé (pas de déclenchement auto)",
   "inferenceProfilePinnedHostThisDeviceSuffix": " (cet appareil)",
   "inferenceProfileSaveButton": "Enregistrer",
-  "inferenceProfileSelectModel": "Sélectionner un modèle…",
-  "inferenceProfileSelectProfile": "Sélectionner un profil…",
+  "inferenceProfileSelectModel": "Choisis un modèle…",
+  "inferenceProfileSelectProfile": "Choisis un profil…",
   "inferenceProfilesEmpty": "Aucun profil d'inférence",
   "inferenceProfileSkillModelRequired": "Nécessite le modèle {slotName}",
   "@inferenceProfileSkillModelRequired": {
@@ -3629,7 +3631,7 @@
   "taskAgentAutomaticUpdatesOnDescription": "Quand quelque chose lié à cette tâche change, un compte à rebours de deux minutes démarre. Les changements effectués pendant ce délai sont regroupés dans une seule mise à jour.",
   "taskAgentCancelTimerTooltip": "Annuler la mise à jour automatique en attente",
   "taskAgentChooseModel": "Choisir un modèle de réflexion",
-  "taskAgentChooseProfile": "Choisir une configuration enregistrée",
+  "taskAgentChooseProfile": "Choisis un profil d’inférence",
   "taskAgentCountdownTooltip": "Prochaine exécution auto dans {countdown}",
   "@taskAgentCountdownTooltip": {
     "placeholders": {
@@ -3660,9 +3662,17 @@
   "taskAgentNoProfilesAvailable": "Aucun profil disponible sur cet appareil",
   "taskAgentNoProfileSelected": "Aucune configuration IA",
   "taskAgentNoProfileSelectedDescription": "Choisis une configuration enregistrée ou un modèle avant de lancer l’agent.",
+  "taskAgentProfileChangedToast": "{profile} sera utilisé pour toutes les futures mises à jour de l’agent jusqu’à ce que tu le changes.",
+  "@taskAgentProfileChangedToast": {
+    "placeholders": {
+      "profile": {
+        "type": "String"
+      }
+    }
+  },
   "taskAgentProfileDefaultBadge": "Réglage du profil",
-  "taskAgentRunNowTooltip": "Exécuter maintenant",
   "taskAgentRouteVia": "via",
+  "taskAgentRunNowTooltip": "Exécuter maintenant",
   "taskAgentSetupAndReportSemantics": "Ce rapport et la configuration actuelle utilisent {identity}. Active pour la modifier.",
   "taskAgentSetupBroken": "La configuration IA sélectionnée est indisponible",
   "taskAgentSetupChangedToast": "{model} sera utilisé pour chaque future mise à jour jusqu’à ce que tu le changes.",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -2408,6 +2408,7 @@
   "inferenceProfileThinkingHighEnd": "Réflexion (haut de gamme)",
   "inferenceProfileThinkingRequired": "Un modèle de réflexion est requis",
   "inferenceProfileTranscription": "Transcription",
+  "inferenceProfileUnavailable": "Profil d’inférence indisponible",
   "inputDataTypeAudioFilesDescription": "Utiliser des fichiers audio comme entrée",
   "inputDataTypeAudioFilesName": "Fichiers audio",
   "inputDataTypeImagesDescription": "Utiliser des images comme entrée",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -9588,6 +9588,12 @@ abstract class AppLocalizations {
   /// **'Transcription'**
   String get inferenceProfileTranscription;
 
+  /// No description provided for @inferenceProfileUnavailable.
+  ///
+  /// In en, this message translates to:
+  /// **'Inference profile unavailable'**
+  String get inferenceProfileUnavailable;
+
   /// No description provided for @inputDataTypeAudioFilesDescription.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -9396,6 +9396,18 @@ abstract class AppLocalizations {
   /// **'Can be chosen for new entries when on'**
   String get inactiveSwitchDescription;
 
+  /// No description provided for @inferenceProfileChooseModelTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose a model'**
+  String get inferenceProfileChooseModelTitle;
+
+  /// No description provided for @inferenceProfileChooseTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose an inference profile'**
+  String get inferenceProfileChooseTitle;
+
   /// No description provided for @inferenceProfileCreateTitle.
   ///
   /// In en, this message translates to:
@@ -9513,13 +9525,13 @@ abstract class AppLocalizations {
   /// No description provided for @inferenceProfileSelectModel.
   ///
   /// In en, this message translates to:
-  /// **'Select a model…'**
+  /// **'Choose a model…'**
   String get inferenceProfileSelectModel;
 
   /// No description provided for @inferenceProfileSelectProfile.
   ///
   /// In en, this message translates to:
-  /// **'Select a profile…'**
+  /// **'Choose a profile…'**
   String get inferenceProfileSelectProfile;
 
   /// No description provided for @inferenceProfilesEmpty.
@@ -15214,7 +15226,7 @@ abstract class AppLocalizations {
   /// No description provided for @taskAgentChooseProfile.
   ///
   /// In en, this message translates to:
-  /// **'Choose a saved setup'**
+  /// **'Choose an inference profile'**
   String get taskAgentChooseProfile;
 
   /// No description provided for @taskAgentCountdownTooltip.
@@ -15313,23 +15325,29 @@ abstract class AppLocalizations {
   /// **'Choose a saved setup or thinking model before this agent can run.'**
   String get taskAgentNoProfileSelectedDescription;
 
+  /// No description provided for @taskAgentProfileChangedToast.
+  ///
+  /// In en, this message translates to:
+  /// **'Using {profile} for every future agent update until you change it.'**
+  String taskAgentProfileChangedToast(String profile);
+
   /// No description provided for @taskAgentProfileDefaultBadge.
   ///
   /// In en, this message translates to:
   /// **'Profile default'**
   String get taskAgentProfileDefaultBadge;
 
-  /// No description provided for @taskAgentRunNowTooltip.
-  ///
-  /// In en, this message translates to:
-  /// **'Run now'**
-  String get taskAgentRunNowTooltip;
-
   /// No description provided for @taskAgentRouteVia.
   ///
   /// In en, this message translates to:
   /// **'via'**
   String get taskAgentRouteVia;
+
+  /// No description provided for @taskAgentRunNowTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Run now'**
+  String get taskAgentRunNowTooltip;
 
   /// No description provided for @taskAgentSetupAndReportSemantics.
   ///

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -5611,6 +5611,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get inferenceProfileTranscription => 'Transcription';
 
   @override
+  String get inferenceProfileUnavailable =>
+      'Inferenční profil není k dispozici';
+
+  @override
   String get inputDataTypeAudioFilesDescription =>
       'Použijte audio soubory jako vstup';
 

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -5574,7 +5574,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get inferenceProfileSaveButton => 'Save';
 
   @override
-  String get inferenceProfileSelectModel => 'Choose a model…';
+  String get inferenceProfileSelectModel => 'Vyber model…';
 
   @override
   String get inferenceProfileSelectProfile => 'Vyber profil…';

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -5503,6 +5503,12 @@ class AppLocalizationsCs extends AppLocalizations {
       'Lze vybrat pro nové záznamy, když je zapnuto';
 
   @override
+  String get inferenceProfileChooseModelTitle => 'Vyber model';
+
+  @override
+  String get inferenceProfileChooseTitle => 'Vyber profil inference';
+
+  @override
   String get inferenceProfileCreateTitle => 'Create Profile';
 
   @override
@@ -5568,10 +5574,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get inferenceProfileSaveButton => 'Save';
 
   @override
-  String get inferenceProfileSelectModel => 'Select a model…';
+  String get inferenceProfileSelectModel => 'Choose a model…';
 
   @override
-  String get inferenceProfileSelectProfile => 'Vyberte profil…';
+  String get inferenceProfileSelectProfile => 'Vyber profil…';
 
   @override
   String get inferenceProfilesEmpty => 'No inference profiles yet';
@@ -8947,7 +8953,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get taskAgentChooseModel => 'Vybrat model pro uvažování';
 
   @override
-  String get taskAgentChooseProfile => 'Vybrat uložené nastavení';
+  String get taskAgentChooseProfile => 'Vyber profil inference';
 
   @override
   String taskAgentCountdownTooltip(String countdown) {
@@ -9007,13 +9013,18 @@ class AppLocalizationsCs extends AppLocalizations {
       'Než agenta spustíš, vyber uložené nastavení nebo model.';
 
   @override
+  String taskAgentProfileChangedToast(String profile) {
+    return 'Pro všechny budoucí aktualizace agenta se bude používat $profile, dokud ho nezměníš.';
+  }
+
+  @override
   String get taskAgentProfileDefaultBadge => 'Výchozí model profilu';
 
   @override
-  String get taskAgentRunNowTooltip => 'Spustit nyní';
+  String get taskAgentRouteVia => 'přes';
 
   @override
-  String get taskAgentRouteVia => 'přes';
+  String get taskAgentRunNowTooltip => 'Spustit nyní';
 
   @override
   String taskAgentSetupAndReportSemantics(String identity) {

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -8971,7 +8971,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String taskAgentProfileChangedToast(String profile) {
-    return 'Für alle zukünftigen Agenten-Aktualisierungen wird $profile verwendet, bis du es änderst.';
+    return '$profile wird für jedes zukünftige Agent-Update verwendet, bis du es änderst.';
   }
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -5485,6 +5485,12 @@ class AppLocalizationsDe extends AppLocalizations {
       'Kann für neue Einträge gewählt werden, wenn aktiv';
 
   @override
+  String get inferenceProfileChooseModelTitle => 'Modell auswählen';
+
+  @override
+  String get inferenceProfileChooseTitle => 'Inferenzprofil auswählen';
+
+  @override
   String get inferenceProfileCreateTitle => 'Profil erstellen';
 
   @override
@@ -8901,7 +8907,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get taskAgentChooseModel => 'Denkmodell wählen';
 
   @override
-  String get taskAgentChooseProfile => 'Gespeicherte Einrichtung wählen';
+  String get taskAgentChooseProfile => 'Inferenzprofil auswählen';
 
   @override
   String taskAgentCountdownTooltip(String countdown) {
@@ -8961,13 +8967,18 @@ class AppLocalizationsDe extends AppLocalizations {
       'Wähle eine gespeicherte Einrichtung oder ein Denkmodell, bevor der Agent laufen kann.';
 
   @override
+  String taskAgentProfileChangedToast(String profile) {
+    return 'Für alle zukünftigen Agenten-Aktualisierungen wird $profile verwendet, bis du es änderst.';
+  }
+
+  @override
   String get taskAgentProfileDefaultBadge => 'Profilstandard';
 
   @override
-  String get taskAgentRunNowTooltip => 'Jetzt ausführen';
+  String get taskAgentRouteVia => 'über';
 
   @override
-  String get taskAgentRouteVia => 'über';
+  String get taskAgentRunNowTooltip => 'Jetzt ausführen';
 
   @override
   String taskAgentSetupAndReportSemantics(String identity) {

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -5594,6 +5594,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get inferenceProfileTranscription => 'Transkription';
 
   @override
+  String get inferenceProfileUnavailable => 'Inferenzprofil nicht verfügbar';
+
+  @override
   String get inputDataTypeAudioFilesDescription =>
       'Audiodateien als Eingabe verwenden';
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -5528,6 +5528,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get inferenceProfileTranscription => 'Transcription';
 
   @override
+  String get inferenceProfileUnavailable => 'Inference profile unavailable';
+
+  @override
   String get inputDataTypeAudioFilesDescription => 'Use audio files as input';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -5420,6 +5420,12 @@ class AppLocalizationsEn extends AppLocalizations {
       'Can be chosen for new entries when on';
 
   @override
+  String get inferenceProfileChooseModelTitle => 'Choose a model';
+
+  @override
+  String get inferenceProfileChooseTitle => 'Choose an inference profile';
+
+  @override
   String get inferenceProfileCreateTitle => 'Create Profile';
 
   @override
@@ -5485,10 +5491,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get inferenceProfileSaveButton => 'Save';
 
   @override
-  String get inferenceProfileSelectModel => 'Select a model…';
+  String get inferenceProfileSelectModel => 'Choose a model…';
 
   @override
-  String get inferenceProfileSelectProfile => 'Select a profile…';
+  String get inferenceProfileSelectProfile => 'Choose a profile…';
 
   @override
   String get inferenceProfilesEmpty => 'No inference profiles yet';
@@ -8784,7 +8790,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get taskAgentChooseModel => 'Choose a thinking model';
 
   @override
-  String get taskAgentChooseProfile => 'Choose a saved setup';
+  String get taskAgentChooseProfile => 'Choose an inference profile';
 
   @override
   String taskAgentCountdownTooltip(String countdown) {
@@ -8844,13 +8850,18 @@ class AppLocalizationsEn extends AppLocalizations {
       'Choose a saved setup or thinking model before this agent can run.';
 
   @override
+  String taskAgentProfileChangedToast(String profile) {
+    return 'Using $profile for every future agent update until you change it.';
+  }
+
+  @override
   String get taskAgentProfileDefaultBadge => 'Profile default';
 
   @override
-  String get taskAgentRunNowTooltip => 'Run now';
+  String get taskAgentRouteVia => 'via';
 
   @override
-  String get taskAgentRouteVia => 'via';
+  String get taskAgentRunNowTooltip => 'Run now';
 
   @override
   String taskAgentSetupAndReportSemantics(String identity) {

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -5637,6 +5637,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get inferenceProfileTranscription => 'Transcripción';
 
   @override
+  String get inferenceProfileUnavailable =>
+      'Perfil de inferencia no disponible';
+
+  @override
   String get inputDataTypeAudioFilesDescription =>
       'Usar archivos de audio como entrada';
 

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -5527,6 +5527,12 @@ class AppLocalizationsEs extends AppLocalizations {
       'Se puede elegir para nuevas entradas cuando está activo';
 
   @override
+  String get inferenceProfileChooseModelTitle => 'Elige un modelo';
+
+  @override
+  String get inferenceProfileChooseTitle => 'Elige un perfil de inferencia';
+
+  @override
   String get inferenceProfileCreateTitle => 'Crear perfil';
 
   @override
@@ -5593,10 +5599,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get inferenceProfileSaveButton => 'Guardar';
 
   @override
-  String get inferenceProfileSelectModel => 'Seleccionar un modelo…';
+  String get inferenceProfileSelectModel => 'Elige un modelo…';
 
   @override
-  String get inferenceProfileSelectProfile => 'Seleccionar un perfil…';
+  String get inferenceProfileSelectProfile => 'Elige un perfil…';
 
   @override
   String get inferenceProfilesEmpty => 'Aún no hay perfiles de inferencia';
@@ -8994,7 +9000,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get taskAgentChooseModel => 'Elegir un modelo de razonamiento';
 
   @override
-  String get taskAgentChooseProfile => 'Elegir una configuración guardada';
+  String get taskAgentChooseProfile => 'Elige un perfil de inferencia';
 
   @override
   String taskAgentCountdownTooltip(String countdown) {
@@ -9055,13 +9061,18 @@ class AppLocalizationsEs extends AppLocalizations {
       'Elige una configuración guardada o un modelo antes de ejecutar el agente.';
 
   @override
+  String taskAgentProfileChangedToast(String profile) {
+    return 'Se usará $profile para todas las futuras actualizaciones del agente hasta que lo cambies.';
+  }
+
+  @override
   String get taskAgentProfileDefaultBadge => 'Predeterminado del perfil';
 
   @override
-  String get taskAgentRunNowTooltip => 'Ejecutar ahora';
+  String get taskAgentRouteVia => 'vía';
 
   @override
-  String get taskAgentRouteVia => 'vía';
+  String get taskAgentRunNowTooltip => 'Ejecutar ahora';
 
   @override
   String taskAgentSetupAndReportSemantics(String identity) {

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -5642,6 +5642,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get inferenceProfileTranscription => 'Transcription';
 
   @override
+  String get inferenceProfileUnavailable => 'Profil d’inférence indisponible';
+
+  @override
   String get inputDataTypeAudioFilesDescription =>
       'Utiliser des fichiers audio comme entrée';
 

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -5533,6 +5533,12 @@ class AppLocalizationsFr extends AppLocalizations {
       'Peut être choisi pour de nouvelles entrées si actif';
 
   @override
+  String get inferenceProfileChooseModelTitle => 'Choisis un modèle';
+
+  @override
+  String get inferenceProfileChooseTitle => 'Choisis un profil d’inférence';
+
+  @override
   String get inferenceProfileCreateTitle => 'Créer un profil';
 
   @override
@@ -5598,10 +5604,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get inferenceProfileSaveButton => 'Enregistrer';
 
   @override
-  String get inferenceProfileSelectModel => 'Sélectionner un modèle…';
+  String get inferenceProfileSelectModel => 'Choisis un modèle…';
 
   @override
-  String get inferenceProfileSelectProfile => 'Sélectionner un profil…';
+  String get inferenceProfileSelectProfile => 'Choisis un profil…';
 
   @override
   String get inferenceProfilesEmpty => 'Aucun profil d\'inférence';
@@ -9017,7 +9023,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get taskAgentChooseModel => 'Choisir un modèle de réflexion';
 
   @override
-  String get taskAgentChooseProfile => 'Choisir une configuration enregistrée';
+  String get taskAgentChooseProfile => 'Choisis un profil d’inférence';
 
   @override
   String taskAgentCountdownTooltip(String countdown) {
@@ -9077,13 +9083,18 @@ class AppLocalizationsFr extends AppLocalizations {
       'Choisis une configuration enregistrée ou un modèle avant de lancer l’agent.';
 
   @override
+  String taskAgentProfileChangedToast(String profile) {
+    return '$profile sera utilisé pour toutes les futures mises à jour de l’agent jusqu’à ce que tu le changes.';
+  }
+
+  @override
   String get taskAgentProfileDefaultBadge => 'Réglage du profil';
 
   @override
-  String get taskAgentRunNowTooltip => 'Exécuter maintenant';
+  String get taskAgentRouteVia => 'via';
 
   @override
-  String get taskAgentRouteVia => 'via';
+  String get taskAgentRunNowTooltip => 'Exécuter maintenant';
 
   @override
   String taskAgentSetupAndReportSemantics(String identity) {

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -5652,6 +5652,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get inferenceProfileTranscription => 'Transcriere';
 
   @override
+  String get inferenceProfileUnavailable => 'Profil de inferență indisponibil';
+
+  @override
   String get inputDataTypeAudioFilesDescription =>
       'Folosește fișiere audio ca intrare';
 

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -5542,6 +5542,12 @@ class AppLocalizationsRo extends AppLocalizations {
       'Poate fi ales pentru intrări noi când este activ';
 
   @override
+  String get inferenceProfileChooseModelTitle => 'Alegeți un model';
+
+  @override
+  String get inferenceProfileChooseTitle => 'Alegeți un profil de inferență';
+
+  @override
   String get inferenceProfileCreateTitle => 'Creați un profil';
 
   @override
@@ -9010,7 +9016,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get taskAgentChooseModel => 'Alegeți un model de raționament';
 
   @override
-  String get taskAgentChooseProfile => 'Alegeți o configurare salvată';
+  String get taskAgentChooseProfile => 'Alegeți un profil de inferență';
 
   @override
   String taskAgentCountdownTooltip(String countdown) {
@@ -9070,13 +9076,18 @@ class AppLocalizationsRo extends AppLocalizations {
       'Alegeți o configurare salvată sau un model înainte ca agentul să poată rula.';
 
   @override
+  String taskAgentProfileChangedToast(String profile) {
+    return '$profile va fi utilizat pentru toate actualizările viitoare ale agentului până când îl schimbați.';
+  }
+
+  @override
   String get taskAgentProfileDefaultBadge => 'Modelul implicit al profilului';
 
   @override
-  String get taskAgentRunNowTooltip => 'Rulează acum';
+  String get taskAgentRouteVia => 'prin';
 
   @override
-  String get taskAgentRouteVia => 'prin';
+  String get taskAgentRunNowTooltip => 'Rulează acum';
 
   @override
   String taskAgentSetupAndReportSemantics(String identity) {

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -2408,6 +2408,7 @@
   "inferenceProfileThinkingHighEnd": "Gândire (nivel înalt)",
   "inferenceProfileThinkingRequired": "Este necesar un model de gândire",
   "inferenceProfileTranscription": "Transcriere",
+  "inferenceProfileUnavailable": "Profil de inferență indisponibil",
   "inputDataTypeAudioFilesDescription": "Folosește fișiere audio ca intrare",
   "inputDataTypeAudioFilesName": "Fișiere audio",
   "inputDataTypeImagesDescription": "Folosește imagini ca intrare",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -2355,6 +2355,8 @@
   "imageViewerDownloadTooltip": "Descărcați imaginea",
   "inactiveLabel": "Inactiv",
   "inactiveSwitchDescription": "Poate fi ales pentru intrări noi când este activ",
+  "inferenceProfileChooseModelTitle": "Alegeți un model",
+  "inferenceProfileChooseTitle": "Alegeți un profil de inferență",
   "inferenceProfileCreateTitle": "Creați un profil",
   "inferenceProfileDescriptionLabel": "Descriere",
   "inferenceProfileDesktopOnly": "Doar desktop",
@@ -3629,7 +3631,7 @@
   "taskAgentAutomaticUpdatesOnDescription": "Când se modifică ceva legat de această sarcină, începe o numărătoare inversă de două minute. Modificările din acest interval sunt grupate într-o singură actualizare.",
   "taskAgentCancelTimerTooltip": "Anulați actualizarea automată în așteptare",
   "taskAgentChooseModel": "Alegeți un model de raționament",
-  "taskAgentChooseProfile": "Alegeți o configurare salvată",
+  "taskAgentChooseProfile": "Alegeți un profil de inferență",
   "taskAgentCountdownTooltip": "Următoarea rulare automată în {countdown}",
   "@taskAgentCountdownTooltip": {
     "placeholders": {
@@ -3660,9 +3662,17 @@
   "taskAgentNoProfilesAvailable": "Nu există profiluri disponibile pe acest dispozitiv",
   "taskAgentNoProfileSelected": "Nicio configurare AI",
   "taskAgentNoProfileSelectedDescription": "Alegeți o configurare salvată sau un model înainte ca agentul să poată rula.",
+  "taskAgentProfileChangedToast": "{profile} va fi utilizat pentru toate actualizările viitoare ale agentului până când îl schimbați.",
+  "@taskAgentProfileChangedToast": {
+    "placeholders": {
+      "profile": {
+        "type": "String"
+      }
+    }
+  },
   "taskAgentProfileDefaultBadge": "Modelul implicit al profilului",
-  "taskAgentRunNowTooltip": "Rulează acum",
   "taskAgentRouteVia": "prin",
+  "taskAgentRunNowTooltip": "Rulează acum",
   "taskAgentSetupAndReportSemantics": "Acest raport și configurarea curentă folosesc {identity}. Activați pentru a modifica configurarea.",
   "taskAgentSetupBroken": "Configurarea AI selectată nu este disponibilă",
   "taskAgentSetupChangedToast": "{model} va fi folosit pentru toate actualizările viitoare până când îl schimbați.",

--- a/test/features/agents/test_data/ai_config_factories.dart
+++ b/test/features/agents/test_data/ai_config_factories.dart
@@ -42,6 +42,7 @@ AiConfigInferenceProvider testLocalInferenceProvider({
 AiConfigInferenceProfile testInferenceProfile({
   String id = 'profile-001',
   String name = 'Test Profile',
+  String? description,
   String thinkingModelId = 'models/gemini-3-flash-preview',
   String? thinkingHighEndModelId,
   String? imageRecognitionModelId,
@@ -55,6 +56,7 @@ AiConfigInferenceProfile testInferenceProfile({
   return AiConfig.inferenceProfile(
         id: id,
         name: name,
+        description: description,
         thinkingModelId: thinkingModelId,
         thinkingHighEndModelId: thinkingHighEndModelId,
         imageRecognitionModelId: imageRecognitionModelId,

--- a/test/features/agents/ui/agent_creation_modal_test.dart
+++ b/test/features/agents/ui/agent_creation_modal_test.dart
@@ -182,7 +182,7 @@ void main() {
 
     // Profile page is shown directly (skipped template page).
     expect(
-      find.text(context.messages.inferenceProfilesTitle),
+      find.text(context.messages.inferenceProfileChooseTitle),
       findsOneWidget,
     );
     expect(find.text('Fast Flash'), findsOneWidget);
@@ -300,12 +300,13 @@ void main() {
     );
   });
 
-  testWidgets('profile page shows thinking model ID as subtitle', (
+  testWidgets('profile page shows description without exposing model ID', (
     tester,
   ) async {
     final resultNotifier = ValueNotifier<AgentCreationResult?>(null);
     final profile = testInferenceProfile(
       name: 'Test Prof',
+      description: 'Private profile for sensitive work',
       thinkingModelId: 'gemini-2.5-pro',
     );
 
@@ -324,7 +325,8 @@ void main() {
     await tester.pump(const Duration(milliseconds: 300));
 
     expect(find.text('Test Prof'), findsOneWidget);
-    expect(find.text('gemini-2.5-pro'), findsOneWidget);
+    expect(find.text('Private profile for sensitive work'), findsOneWidget);
+    expect(find.text('gemini-2.5-pro'), findsNothing);
   });
 
   testWidgets('returns null when templates list is empty', (tester) async {
@@ -385,7 +387,7 @@ void main() {
 
     // Page 1: profile selection.
     expect(
-      find.text(context.messages.inferenceProfilesTitle),
+      find.text(context.messages.inferenceProfileChooseTitle),
       findsOneWidget,
     );
 
@@ -446,7 +448,7 @@ void main() {
   );
 
   testWidgets(
-    'hovering a profile row turns the divider above it transparent',
+    'shared profile rows keep stable dividers during hover',
     (tester) async {
       final resultNotifier = ValueNotifier<AgentCreationResult?>(null);
 
@@ -490,8 +492,8 @@ void main() {
       final dividersAfter = tester
           .widgetList<Divider>(find.byType(Divider))
           .toList();
-      expect(dividersAfter[0].color, Colors.transparent);
-      expect(dividersAfter[1].color, Colors.transparent);
+      expect(dividersAfter[0].color, isNot(Colors.transparent));
+      expect(dividersAfter[1].color, isNot(Colors.transparent));
 
       // Pointer leaves — dividers return to default color.
       await gesture.moveTo(const Offset(-100, -100));
@@ -729,8 +731,7 @@ void main() {
   );
 
   testWidgets(
-    '_ProfileListState.didUpdateWidget clears hoveredId when hovered profile '
-    'disappears from the updated list',
+    'profile stream updates replace rows without leaving the picker',
     (tester) async {
       final resultNotifier = ValueNotifier<AgentCreationResult?>(null);
       final streamController = StreamController<List<AiConfig>>();
@@ -776,32 +777,11 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
 
-      // Hover the top row 'Alpha' so _hoveredId = 'p-a'. The single divider
-      // (between Alpha and Beta, index 0) turns transparent.
-      final gesture = await tester.createGesture(
-        kind: PointerDeviceKind.mouse,
-      );
-      addTearDown(gesture.removePointer);
-      await gesture.addPointer(location: Offset.zero);
-      final topRowCenter = tester.getCenter(find.text('Alpha'));
-      await gesture.moveTo(topRowCenter);
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 300));
+      expect(find.text('Alpha'), findsOneWidget);
+      expect(find.text('Beta'), findsOneWidget);
 
-      final dividersHovered = tester
-          .widgetList<Divider>(find.byType(Divider))
-          .toList();
-      expect(dividersHovered, hasLength(1));
-      expect(dividersHovered[0].color, Colors.transparent);
-
-      // Emit a new same-length list that drops 'Alpha' (id 'p-a') while the
-      // mouse stays at the top row's screen position. This fires
-      // _ProfileListState.didUpdateWidget (line 213): configs changed AND
-      // _hoveredId == 'p-a', which is now absent from the filtered list, so
-      // lines 214-216 reset _hoveredId to null. The pointer then re-enters the
-      // new top row 'Beta' (id 'p-b'), so the surviving divider — now between
-      // Beta (index 0) and Gamma (index 1) — is transparent because Beta is
-      // hovered, NOT because the stale 'p-a' leaked.
+      // A background refresh replaces the rows in place. The profile page
+      // remains visible instead of flashing a loading shell.
       streamController.add([
         testInferenceProfile(id: 'p-b', name: 'Beta'),
         testInferenceProfile(id: 'p-c', name: 'Gamma'),
@@ -812,20 +792,7 @@ void main() {
       expect(find.text('Alpha'), findsNothing);
       expect(find.text('Beta'), findsOneWidget);
       expect(find.text('Gamma'), findsOneWidget);
-
-      // Move the pointer fully off the list: Beta's hover-exit clears
-      // _hoveredId, and because the stale 'p-a' was already cleared by
-      // didUpdateWidget there is nothing else hovered — the divider returns to
-      // its opaque default, proving no stale hover id survived the list change.
-      await gesture.moveTo(const Offset(-300, -300));
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 300));
-
-      final dividersAfterExit = tester
-          .widgetList<Divider>(find.byType(Divider))
-          .toList();
-      expect(dividersAfterExit, hasLength(1));
-      expect(dividersAfterExit[0].color, isNot(Colors.transparent));
+      expect(find.text('Choose an inference profile'), findsOneWidget);
     },
   );
 

--- a/test/features/agents/ui/agent_model_sheet_test.dart
+++ b/test/features/agents/ui/agent_model_sheet_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -10,6 +12,7 @@ import 'package:lotti/features/agents/ui/agent_model_sheet.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/model/resolved_profile.dart';
 import 'package:lotti/features/design_system/components/checkboxes/design_system_checkbox.dart';
+import 'package:lotti/features/design_system/components/toasts/design_system_toast.dart';
 import 'package:lotti/providers/service_providers.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -67,10 +70,12 @@ void main() {
 
   late MockTaskAgentService service;
   late MockJournalDb journalDb;
+  late GlobalKey<ScaffoldMessengerState> taskMessengerKey;
 
   setUp(() {
     service = MockTaskAgentService();
     journalDb = MockJournalDb();
+    taskMessengerKey = GlobalKey<ScaffoldMessengerState>();
     when(
       () => service.updateAutomaticUpdates(
         agentId: any(named: 'agentId'),
@@ -138,15 +143,18 @@ void main() {
   }) async {
     await tester.pumpWidget(
       makeTestableWidgetNoScroll(
-        Scaffold(
-          body: Builder(
-            builder: (context) => FilledButton(
-              onPressed: () => AgentModelSheet.show(
-                context: context,
-                taskId: 'task-1',
-                agentId: 'agent-1',
+        ScaffoldMessenger(
+          key: taskMessengerKey,
+          child: Scaffold(
+            body: Builder(
+              builder: (context) => FilledButton(
+                onPressed: () => AgentModelSheet.show(
+                  context: context,
+                  taskId: 'task-1',
+                  agentId: 'agent-1',
+                ),
+                child: const Text('Open'),
               ),
-              child: const Text('Open'),
             ),
           ),
         ),
@@ -214,30 +222,11 @@ void main() {
   );
 
   testWidgets(
-    'automation checkbox persists off and profile/model choices save',
+    'automation checkbox persists off',
     (
       tester,
     ) async {
       await openSheet(tester);
-
-      await tester.tap(find.text('Saved profile'));
-      await tester.pump();
-      await tester.pump();
-      verify(
-        () => service.updateAgentProfile(
-          agentId: 'agent-1',
-          profileId: 'profile-1',
-        ),
-      ).called(1);
-
-      await tester.tap(find.text('Choose a thinking model'));
-      await tester.pump();
-      verify(
-        () => service.updateAgentThinkingModelOverride(
-          agentId: 'agent-1',
-          modelConfigId: 'model-1',
-        ),
-      ).called(1);
 
       await tester.drag(
         find.byType(Scrollable).last,
@@ -254,6 +243,73 @@ void main() {
       ).called(1);
     },
   );
+
+  testWidgets(
+    'profile choice waits for persistence, closes, and toasts in task scope',
+    (tester) async {
+      final saveCompleter = Completer<void>();
+      when(
+        () => service.updateAgentProfile(
+          agentId: any(named: 'agentId'),
+          profileId: any(named: 'profileId'),
+        ),
+      ).thenAnswer((_) => saveCompleter.future);
+      await openSheet(tester);
+
+      await tester.tap(find.text('Saved profile'));
+      await tester.pump();
+
+      expect(find.text('Agent setup'), findsOneWidget);
+      expect(find.byType(DesignSystemToast), findsNothing);
+
+      saveCompleter.complete();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      verify(
+        () => service.updateAgentProfile(
+          agentId: 'agent-1',
+          profileId: 'profile-1',
+        ),
+      ).called(1);
+      expect(find.text('Agent setup'), findsNothing);
+      expect(
+        find.text(
+          'Using Saved profile for every future agent update until you change it.',
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+          of: find.byKey(taskMessengerKey),
+          matching: find.byType(DesignSystemToast),
+        ),
+        findsOneWidget,
+      );
+    },
+  );
+
+  testWidgets('model choice persists and closes the outer setup modal', (
+    tester,
+  ) async {
+    await openSheet(tester);
+
+    await tester.tap(find.text('Choose a thinking model'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    verify(
+      () => service.updateAgentThinkingModelOverride(
+        agentId: 'agent-1',
+        modelConfigId: 'model-1',
+      ),
+    ).called(1);
+    expect(find.text('Agent setup'), findsNothing);
+    expect(
+      find.textContaining('Using Qwen 3.5 Plus'),
+      findsOneWidget,
+    );
+  });
 
   testWidgets('No AI setup requires confirmation and persists disabled mode', (
     tester,

--- a/test/features/agents/ui/agent_model_sheet_test.dart
+++ b/test/features/agents/ui/agent_model_sheet_test.dart
@@ -410,7 +410,7 @@ void main() {
             as AgentInferenceSetup;
     expect(setup.mode, AgentInferenceSetupMode.configured);
     expect(setup.baseProfileId, profile.id);
-    expect(find.textContaining('Using Qwen 3.5 Plus'), findsWidgets);
+    expect(find.textContaining('Using Saved profile'), findsWidgets);
   });
 
   testWidgets('origin labels cover disabled, category, template, and legacy', (

--- a/test/features/agents/ui/agent_model_sheet_test.dart
+++ b/test/features/agents/ui/agent_model_sheet_test.dart
@@ -337,6 +337,13 @@ void main() {
   testWidgets('category without a default persists visible no-setup state', (
     tester,
   ) async {
+    final saveCompleter = Completer<void>();
+    when(
+      () => service.updateAgentInferenceSetup(
+        agentId: any(named: 'agentId'),
+        setup: any(named: 'setup'),
+      ),
+    ).thenAnswer((_) => saveCompleter.future);
     final task = makeTestTask(id: 'task-1').copyWith(
       meta: makeTestTask(id: 'task-1').meta.copyWith(categoryId: 'category-1'),
     );
@@ -353,6 +360,12 @@ void main() {
     await tester.tap(find.text('Copy category default'));
     await tester.pump();
 
+    expect(find.text('Agent setup'), findsOneWidget);
+
+    saveCompleter.complete();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
     final setup =
         verify(
               () => service.updateAgentInferenceSetup(
@@ -364,6 +377,7 @@ void main() {
     expect(setup.mode, AgentInferenceSetupMode.disabled);
     expect(setup.origin, AgentInferenceSetupOrigin.categorySnapshot);
     expect(setup.originEntityId, 'category-1');
+    expect(find.text('Agent setup'), findsNothing);
   });
 
   testWidgets('category default copies its profile and model snapshot', (

--- a/test/features/agents/ui/agent_template_detail_page_test.dart
+++ b/test/features/agents/ui/agent_template_detail_page_test.dart
@@ -16,6 +16,7 @@ import 'package:lotti/features/agents/state/soul_query_providers.dart';
 import 'package:lotti/features/agents/state/wake_run_chart_providers.dart';
 import 'package:lotti/features/agents/ui/agent_report_section.dart';
 import 'package:lotti/features/agents/ui/agent_template_detail_page.dart';
+import 'package:lotti/features/agents/ui/profile_selector.dart';
 import 'package:lotti/features/agents/ui/soul_selector.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/state/inference_profile_controller.dart';
@@ -236,8 +237,7 @@ void main() {
       await tester.pump();
 
       // Select a profile via the profile picker
-      final profileDropdown = find.byIcon(Icons.arrow_drop_down);
-      await tester.tap(profileDropdown.first);
+      await tester.tap(find.byType(SettingsProfilePickerField));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 350));
       await tester.tap(find.text('Test Profile'));
@@ -2148,8 +2148,7 @@ void main() {
         await tester.pump();
 
         // Select a profile via the profile picker
-        final profileDropdown = find.byIcon(Icons.arrow_drop_down);
-        await tester.tap(profileDropdown.first);
+        await tester.tap(find.byType(SettingsProfilePickerField));
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 350));
         await tester.tap(find.text('Test Profile'));

--- a/test/features/agents/ui/profile_selector_test.dart
+++ b/test/features/agents/ui/profile_selector_test.dart
@@ -153,9 +153,9 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.byIcon(Icons.clear), findsOneWidget);
+    expect(find.byIcon(Icons.close_rounded), findsOneWidget);
 
-    await tester.tap(find.byIcon(Icons.clear));
+    await tester.tap(find.byIcon(Icons.close_rounded));
     await tester.pumpAndSettle();
 
     expect(clearedTo, isNull);
@@ -252,7 +252,7 @@ void main() {
       findsOneWidget,
     );
     // The dropdown arrow is still visible but InkWell.onTap is null.
-    expect(find.byIcon(Icons.arrow_drop_down), findsOneWidget);
+    expect(find.byIcon(Icons.keyboard_arrow_down_rounded), findsOneWidget);
   });
 
   group('SettingsProfilePickerField', () {

--- a/test/features/agents/ui/profile_selector_test.dart
+++ b/test/features/agents/ui/profile_selector_test.dart
@@ -4,6 +4,7 @@ import 'package:lotti/features/agents/ui/profile_selector.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/state/inference_profile_controller.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/widgets/settings/settings_picker_field.dart';
 
 import '../../../test_helper.dart';
 import '../test_utils.dart';
@@ -334,6 +335,39 @@ void main() {
       // The kit field renders the clear affordance as a close icon.
       await tester.tap(find.byIcon(Icons.close_rounded));
       await tester.pumpAndSettle();
+
+      expect(clearedTo, isNull);
+    });
+
+    testWidgets('dangling selection stays enabled and can be cleared', (
+      tester,
+    ) async {
+      String? clearedTo = 'not-cleared';
+
+      await tester.pumpWidget(
+        _buildSettingsField(
+          selectedProfileId: 'missing-profile',
+          onProfileSelected: (id) => clearedTo = id,
+          profiles: [],
+        ),
+      );
+      await tester.pump();
+
+      final context = tester.element(
+        find.byType(SettingsProfilePickerField),
+      );
+      final field = tester.widget<SettingsPickerField>(
+        find.byType(SettingsPickerField),
+      );
+      expect(field.enabled, isTrue);
+      expect(
+        find.text(context.messages.inferenceProfileUnavailable),
+        findsOneWidget,
+      );
+      expect(find.text('missing-profile'), findsNothing);
+
+      await tester.tap(find.byIcon(Icons.close_rounded));
+      await tester.pump();
 
       expect(clearedTo, isNull);
     });

--- a/test/features/ai/ui/inference_profile_form_test.dart
+++ b/test/features/ai/ui/inference_profile_form_test.dart
@@ -12,10 +12,11 @@ import 'package:lotti/features/ai/state/settings/ai_config_by_type_controller.da
 import 'package:lotti/features/ai/ui/inference_profile_form.dart';
 import 'package:lotti/features/ai/ui/widgets/profile_pinning_selector.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
-import 'package:lotti/features/design_system/components/search/design_system_search.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
 import 'package:lotti/features/design_system/components/toggles/design_system_toggle.dart';
 import 'package:lotti/features/sync/model/sync_node_profile.dart';
 import 'package:lotti/features/sync/state/synced_audio_inference_providers.dart';
+import 'package:lotti/widgets/settings/settings_picker_field.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../mocks/mocks.dart';
@@ -26,6 +27,16 @@ DesignSystemToggle _toggleIn(WidgetTester tester, Finder rowFinder) =>
     tester.widget<DesignSystemToggle>(
       find.descendant(of: rowFinder, matching: find.byType(DesignSystemToggle)),
     );
+
+Finder _pickerField(String label) => find.ancestor(
+  of: find.text(label, skipOffstage: false),
+  matching: find.byType(SettingsPickerField),
+);
+
+Finder _pickerTapTarget(String label) => find.descendant(
+  of: _pickerField(label),
+  matching: find.byType(InkWell),
+);
 
 void main() {
   late StreamController<List<AiConfig>> profileStreamController;
@@ -138,11 +149,19 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
 
-      expect(find.text('Thinking *'), findsOneWidget);
-      expect(find.text('Thinking (High-End)'), findsOneWidget);
-      expect(find.text('Image Recognition'), findsOneWidget);
-      expect(find.text('Transcription'), findsOneWidget);
-      expect(find.text('Image Generation'), findsOneWidget);
+      expect(
+        find.byType(SettingsPickerField, skipOffstage: false),
+        findsNWidgets(5),
+      );
+      for (final label in [
+        'Thinking *',
+        'Thinking (High-End)',
+        'Image Recognition',
+        'Transcription',
+        'Image Generation',
+      ]) {
+        expect(find.text(label, skipOffstage: false), findsOneWidget);
+      }
     });
 
     testWidgets('shows save button in app bar', (tester) async {
@@ -273,7 +292,7 @@ void main() {
         expect(find.text(label), findsOneWidget);
       }
       // At least the visible slots should show placeholders.
-      expect(find.text('Select a model…'), findsAtLeastNWidgets(1));
+      expect(find.text('Choose a model…'), findsAtLeastNWidgets(1));
     });
 
     testWidgets('shows snackbar when saving without thinking model', (
@@ -487,7 +506,7 @@ void main() {
 
         // Clearing the slot drops the dangling id and reveals the
         // placeholder again.
-        await tester.tap(find.byIcon(Icons.clear).first);
+        await tester.tap(find.byIcon(Icons.close_rounded).first);
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 300));
 
@@ -495,7 +514,7 @@ void main() {
           find.text('Model unavailable — its provider may have been removed'),
           findsNothing,
         );
-        expect(find.text('Select a model…'), findsAtLeastNWidgets(1));
+        expect(find.text('Choose a model…'), findsAtLeastNWidgets(1));
       },
     );
 
@@ -533,14 +552,14 @@ void main() {
       expect(find.text('Flash'), findsOneWidget);
 
       // Tap the clear button.
-      await tester.tap(find.byIcon(Icons.clear));
+      await tester.tap(find.byIcon(Icons.close_rounded));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
 
       // Model name should be gone, placeholder shown.
       expect(find.text('Flash'), findsNothing);
       // Should now show placeholder or raw ID gone.
-      expect(find.text('Select a model…'), findsAtLeastNWidgets(1));
+      expect(find.text('Choose a model…'), findsAtLeastNWidgets(1));
     });
 
     testWidgets('desktop-only toggle changes value', (tester) async {
@@ -683,11 +702,24 @@ void main() {
       expect(find.text('Other Model'), findsNothing);
     });
 
-    testWidgets('model picker shows provider name in subtitle', (tester) async {
+    testWidgets('model picker shows branded provider header and wire IDs', (
+      tester,
+    ) async {
       final thinkingModel = AiConfig.model(
         id: 'tm-1',
         name: 'Flash',
         providerModelId: 'models/flash',
+        inferenceProviderId: 'prov-1',
+        createdAt: DateTime(2024),
+        inputModalities: const [Modality.text],
+        outputModalities: const [Modality.text],
+        isReasoningModel: false,
+        supportsFunctionCalling: true,
+      );
+      final secondModel = AiConfig.model(
+        id: 'tm-2',
+        name: 'Pro',
+        providerModelId: 'models/pro',
         inferenceProviderId: 'prov-1',
         createdAt: DateTime(2024),
         inputModalities: const [Modality.text],
@@ -707,7 +739,7 @@ void main() {
 
       await tester.pumpWidget(
         buildSubject(
-          models: [thinkingModel],
+          models: [thinkingModel, secondModel],
           providers: [provider],
         ),
       );
@@ -719,9 +751,9 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
 
-      // Provider name should appear as part of the subtitle.
-      expect(find.textContaining('Google AI'), findsOneWidget);
+      expect(find.text('Google Gemini'), findsOneWidget);
       expect(find.textContaining('models/flash'), findsOneWidget);
+      expect(find.textContaining('models/pro'), findsOneWidget);
     });
 
     testWidgets('model picker shows checkmark for selected model', (
@@ -731,6 +763,17 @@ void main() {
         id: 'tm-1',
         name: 'Flash',
         providerModelId: 'models/flash',
+        inferenceProviderId: 'prov-1',
+        createdAt: DateTime(2024),
+        inputModalities: const [Modality.text],
+        outputModalities: const [Modality.text],
+        isReasoningModel: false,
+        supportsFunctionCalling: true,
+      );
+      final secondModel = AiConfig.model(
+        id: 'tm-2',
+        name: 'Pro',
+        providerModelId: 'models/pro',
         inferenceProviderId: 'prov-1',
         createdAt: DateTime(2024),
         inputModalities: const [Modality.text],
@@ -749,7 +792,7 @@ void main() {
       await tester.pumpWidget(
         buildSubject(
           existingProfile: profile,
-          models: [thinkingModel],
+          models: [thinkingModel, secondModel],
         ),
       );
       await tester.pump();
@@ -764,12 +807,9 @@ void main() {
       expect(find.byIcon(Icons.check_rounded), findsOneWidget);
     });
 
-    group('model picker search field', () {
-      // Three thinking-eligible models across two providers — the
-      // shared fixture lets the search tests assert filter narrowing
-      // (one match), filter widening via clear, provider-name match
-      // (cross-row scoping), and the no-match empty state without
-      // re-declaring rows in every test.
+    group('shared provider/model picker integration', () {
+      // Three thinking-eligible models across two providers exercise the
+      // provider-first navigation used everywhere model selection appears.
       final flashModel = AiConfig.model(
         id: 'm-1',
         name: 'Gemini Flash',
@@ -822,24 +862,17 @@ void main() {
       );
 
       Future<void> openThinkingPicker(WidgetTester tester) async {
+        tester.view.physicalSize = const Size(1000, 900);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
         await tester.tap(find.byType(InkWell).first);
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 300));
       }
 
-      // Scope the TextField finder to the search field inside the
-      // picker — the underlying profile form also renders TextFields
-      // (name, description, …) which would otherwise satisfy a bare
-      // `find.byType(TextField)` and trip "Too many elements".
-      Finder searchTextField() => find.descendant(
-        of: find.byType(DesignSystemSearch),
-        matching: find.byType(TextField),
-      );
-
       testWidgets(
-        'typing a query that matches one model by display name '
-        'narrows the list to that row — proves the substring filter '
-        'runs against AiConfigModel.name',
+        'opens with provider rows instead of a mixed flat model list',
         (tester) async {
           await tester.pumpWidget(
             buildSubject(
@@ -851,68 +884,8 @@ void main() {
           await tester.pump(const Duration(milliseconds: 300));
           await openThinkingPicker(tester);
 
-          // All three rows visible before any input.
-          expect(find.text('Gemini Flash'), findsOneWidget);
-          expect(find.text('Gemini Pro'), findsOneWidget);
-          expect(find.text('Claude Sonnet'), findsOneWidget);
-
-          await tester.enterText(searchTextField(), 'sonnet');
-          await tester.pump();
-
-          // Only the Sonnet row remains; the Gemini rows are filtered out.
-          expect(find.text('Claude Sonnet'), findsOneWidget);
-          expect(find.text('Gemini Flash'), findsNothing);
-          expect(find.text('Gemini Pro'), findsNothing);
-        },
-      );
-
-      testWidgets(
-        'typing a provider name surfaces every model owned by that '
-        'provider — proves the filter widens to the resolved provider '
-        'label, not just the model row text, so users can pivot by '
-        'provider without remembering each model name',
-        (tester) async {
-          await tester.pumpWidget(
-            buildSubject(
-              models: [flashModel, proModel, sonnetModel],
-              providers: [googleProvider, anthropicProvider],
-            ),
-          );
-          await tester.pump();
-          await tester.pump(const Duration(milliseconds: 300));
-          await openThinkingPicker(tester);
-
-          await tester.enterText(searchTextField(), 'Google');
-          await tester.pump();
-
-          // Both Gemini rows match via the Google AI provider label.
-          // Claude Sonnet (Anthropic) is filtered out.
-          expect(find.text('Gemini Flash'), findsOneWidget);
-          expect(find.text('Gemini Pro'), findsOneWidget);
-          expect(find.text('Claude Sonnet'), findsNothing);
-        },
-      );
-
-      testWidgets(
-        'a query that matches no model surfaces the localised '
-        '"No matches" empty state instead of leaving the list region '
-        'blank — the user gets explicit feedback that the filter, not '
-        'the data, is responsible for the empty surface',
-        (tester) async {
-          await tester.pumpWidget(
-            buildSubject(
-              models: [flashModel, proModel, sonnetModel],
-              providers: [googleProvider, anthropicProvider],
-            ),
-          );
-          await tester.pump();
-          await tester.pump(const Duration(milliseconds: 300));
-          await openThinkingPicker(tester);
-
-          await tester.enterText(searchTextField(), 'zzz-nope');
-          await tester.pump();
-
-          expect(find.text('No matches'), findsOneWidget);
+          expect(find.text('Google Gemini'), findsWidgets);
+          expect(find.text('Anthropic Claude'), findsOneWidget);
           expect(find.text('Gemini Flash'), findsNothing);
           expect(find.text('Gemini Pro'), findsNothing);
           expect(find.text('Claude Sonnet'), findsNothing);
@@ -920,9 +893,7 @@ void main() {
       );
 
       testWidgets(
-        'clearing the query via the search field clear affordance '
-        'restores every model — proves the filter state resets to the '
-        'unfiltered list rather than leaving stale matches on screen',
+        'choosing a provider shows only that provider models',
         (tester) async {
           await tester.pumpWidget(
             buildSubject(
@@ -934,18 +905,90 @@ void main() {
           await tester.pump(const Duration(milliseconds: 300));
           await openThinkingPicker(tester);
 
-          await tester.enterText(searchTextField(), 'sonnet');
-          await tester.pump();
-          expect(find.text('Gemini Flash'), findsNothing);
-
-          // DesignSystemSearch renders the clear affordance as
-          // Icons.cancel_rounded inside its decoration.
-          await tester.tap(find.byIcon(Icons.cancel_rounded));
-          await tester.pump();
+          await tester.tap(find.text('Google Gemini'));
+          await tester.pump(const Duration(milliseconds: 300));
 
           expect(find.text('Gemini Flash'), findsOneWidget);
           expect(find.text('Gemini Pro'), findsOneWidget);
-          expect(find.text('Claude Sonnet'), findsOneWidget);
+          expect(find.text('Claude Sonnet'), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'choosing a model closes the picker and updates the slot field',
+        (tester) async {
+          await tester.pumpWidget(
+            buildSubject(
+              models: [flashModel, proModel, sonnetModel],
+              providers: [googleProvider, anthropicProvider],
+            ),
+          );
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 300));
+          await openThinkingPicker(tester);
+
+          await tester.tap(find.text('Anthropic Claude'));
+          await tester.pump(const Duration(milliseconds: 300));
+          final sonnetRow = tester
+              .widgetList<DesignSystemListItem>(
+                find.byType(DesignSystemListItem),
+              )
+              .singleWhere((row) => row.title == 'Claude Sonnet');
+          sonnetRow.onTap!();
+          await tester.pump(const Duration(seconds: 1));
+
+          final thinkingField = tester.widget<SettingsPickerField>(
+            _pickerField('Thinking *'),
+          );
+          expect(thinkingField.valueText, 'Claude Sonnet');
+          expect(find.text('Choose a model').hitTestable(), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'provider model page can return to the provider list',
+        (tester) async {
+          await tester.pumpWidget(
+            buildSubject(
+              models: [flashModel, proModel, sonnetModel],
+              providers: [googleProvider, anthropicProvider],
+            ),
+          );
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 300));
+          await openThinkingPicker(tester);
+
+          await tester.tap(find.text('Google Gemini'));
+          await tester.pump(const Duration(milliseconds: 300));
+          final backButton = tester.widget<IconButton>(
+            find
+                .ancestor(
+                  of: find.byIcon(Icons.arrow_back_rounded).last,
+                  matching: find.byType(IconButton),
+                )
+                .first,
+          );
+          backButton.onPressed!();
+          // The first frame starts Wolt's page transition; the second lets the
+          // newly active page become interactive.
+          await tester.pump(const Duration(milliseconds: 300));
+          await tester.pump(const Duration(milliseconds: 300));
+
+          final providerRows = tester
+              .widgetList<DesignSystemListItem>(
+                find.byType(DesignSystemListItem),
+              )
+              .where(
+                (row) =>
+                    row.title == 'Google Gemini' ||
+                    row.title == 'Anthropic Claude',
+              )
+              .toList();
+          expect(
+            providerRows.map((row) => row.title),
+            containsAll(<String>['Google Gemini', 'Anthropic Claude']),
+          );
+          expect(find.text('Gemini Flash').hitTestable(), findsNothing);
         },
       );
     });
@@ -1519,7 +1562,7 @@ void main() {
 
       // Scroll to the high-end slot and select a model.
       await tester.scrollUntilVisible(
-        find.text('Thinking (High-End)'),
+        find.text('Thinking (High-End)', skipOffstage: false),
         200,
         scrollable: find.byType(Scrollable).first,
       );
@@ -1527,11 +1570,7 @@ void main() {
       await tester.pump(const Duration(milliseconds: 300));
 
       // Tap the high-end thinking slot (second InkWell).
-      final highEndSlot = find.ancestor(
-        of: find.text('Thinking (High-End)'),
-        matching: find.byType(InkWell),
-      );
-      await tester.tap(highEndSlot.first);
+      await tester.tap(_pickerTapTarget('Thinking (High-End)').first);
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
 
@@ -1662,7 +1701,7 @@ void main() {
 
         // Scroll to the Image Recognition slot.
         await tester.scrollUntilVisible(
-          find.text('Image Recognition'),
+          find.text('Image Recognition', skipOffstage: false),
           200,
           scrollable: find.byType(Scrollable).first,
         );
@@ -1670,12 +1709,9 @@ void main() {
         await tester.pump(const Duration(milliseconds: 300));
 
         // Open the image recognition picker.
-        final irSlot = find.ancestor(
-          of: find.text('Image Recognition'),
-          matching: find.byType(InkWell),
-        );
-        await tester.ensureVisible(irSlot.first);
-        await tester.tap(irSlot.first);
+        final irSlot = _pickerTapTarget('Image Recognition').first;
+        await tester.ensureVisible(irSlot);
+        await tester.tap(irSlot);
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 300));
 
@@ -1726,7 +1762,7 @@ void main() {
 
         // Scroll to the Transcription slot.
         await tester.scrollUntilVisible(
-          find.text('Transcription'),
+          find.text('Transcription', skipOffstage: false),
           200,
           scrollable: find.byType(Scrollable).first,
         );
@@ -1734,12 +1770,9 @@ void main() {
         await tester.pump(const Duration(milliseconds: 300));
 
         // Open the transcription picker.
-        final trSlot = find.ancestor(
-          of: find.text('Transcription'),
-          matching: find.byType(InkWell),
-        );
-        await tester.ensureVisible(trSlot.first);
-        await tester.tap(trSlot.first);
+        final trSlot = _pickerTapTarget('Transcription').first;
+        await tester.ensureVisible(trSlot);
+        await tester.tap(trSlot);
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 300));
 
@@ -1790,7 +1823,7 @@ void main() {
 
         // Scroll to the Image Generation slot.
         await tester.scrollUntilVisible(
-          find.text('Image Generation'),
+          find.text('Image Generation', skipOffstage: false),
           200,
           scrollable: find.byType(Scrollable).first,
         );
@@ -1798,12 +1831,9 @@ void main() {
         await tester.pump(const Duration(milliseconds: 300));
 
         // Open the image generation picker.
-        final igSlot = find.ancestor(
-          of: find.text('Image Generation'),
-          matching: find.byType(InkWell),
-        );
-        await tester.ensureVisible(igSlot.first);
-        await tester.tap(igSlot.first);
+        final igSlot = _pickerTapTarget('Image Generation').first;
+        await tester.ensureVisible(igSlot);
+        await tester.tap(igSlot);
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 300));
 

--- a/test/features/ai/ui/inference_profile_form_test.dart
+++ b/test/features/ai/ui/inference_profile_form_test.dart
@@ -945,7 +945,15 @@ void main() {
             _pickerField('Thinking *'),
           );
           expect(thinkingField.valueText, 'Claude Sonnet');
-          expect(find.text('Choose a model').hitTestable(), findsNothing);
+          expect(
+            find
+                .descendant(
+                  of: _pickerField('Thinking *'),
+                  matching: find.text('Choose a model…'),
+                )
+                .hitTestable(),
+            findsNothing,
+          );
         },
       );
 

--- a/test/features/ai/ui/inference_profile_form_test.dart
+++ b/test/features/ai/ui/inference_profile_form_test.dart
@@ -503,6 +503,10 @@ void main() {
           find.text('Model unavailable — its provider may have been removed'),
           findsOneWidget,
         );
+        final field = tester.widget<SettingsPickerField>(
+          _pickerField('Thinking *'),
+        );
+        expect(field.enabled, isTrue);
 
         // Clearing the slot drops the dangling id and reveals the
         // placeholder again.

--- a/test/features/ai/ui/widgets/inference_profile_picker_modal_test.dart
+++ b/test/features/ai/ui/widgets/inference_profile_picker_modal_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/ui/widgets/inference_profile_picker_modal.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
+
+import '../../../../test_helper.dart';
+
+AiConfigInferenceProfile _profile({
+  required String id,
+  required String name,
+  String? description,
+  bool desktopOnly = false,
+}) => AiConfigInferenceProfile(
+  id: id,
+  name: name,
+  description: description,
+  createdAt: DateTime(2024, 3, 15),
+  thinkingModelId: 'internal-$id',
+  desktopOnly: desktopOnly,
+);
+
+void main() {
+  testWidgets(
+    'renders descriptions, selected semantics, and desktop-only context',
+    (tester) async {
+      final selected = _profile(
+        id: 'private',
+        name: 'Private profile',
+        description: 'No data retention',
+        desktopOnly: true,
+      );
+      final other = _profile(id: 'fast', name: 'Fast profile');
+
+      await tester.pumpWidget(
+        WidgetTestBench(
+          child: InferenceProfilePickerList(
+            profiles: [selected, other],
+            selectedProfileId: selected.id,
+            onSelected: (_) {},
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Private profile'), findsOneWidget);
+      expect(find.text('No data retention'), findsOneWidget);
+      expect(find.text('Selected'), findsOneWidget);
+      expect(find.byTooltip('Desktop Only'), findsOneWidget);
+      expect(find.text('internal-private'), findsNothing);
+
+      final selectedRow = tester.widget<DesignSystemListItem>(
+        find.byKey(const ValueKey('private')),
+      );
+      expect(selectedRow.selected, isTrue);
+      expect(selectedRow.activated, isTrue);
+      expect(selectedRow.semanticsLabel, contains('Desktop Only'));
+    },
+  );
+
+  testWidgets('returns the selected id and dismisses the modal', (
+    tester,
+  ) async {
+    String? result;
+    final profiles = [
+      _profile(id: 'private', name: 'Private profile'),
+      _profile(id: 'fast', name: 'Fast profile'),
+    ];
+
+    await tester.pumpWidget(
+      WidgetTestBench(
+        child: Builder(
+          builder: (context) => FilledButton(
+            onPressed: () async {
+              result = await InferenceProfilePickerModal.show(
+                context: context,
+                profiles: profiles,
+                selectedProfileId: profiles.first.id,
+              );
+            },
+            child: const Text('Open'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(find.text('Choose an inference profile'), findsOneWidget);
+
+    await tester.tap(find.text('Fast profile'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(result, 'fast');
+    expect(find.text('Choose an inference profile'), findsNothing);
+  });
+
+  testWidgets('empty input returns null without opening a modal', (
+    tester,
+  ) async {
+    String? result = 'pending';
+    await tester.pumpWidget(
+      WidgetTestBench(
+        child: Builder(
+          builder: (context) => FilledButton(
+            onPressed: () async {
+              result = await InferenceProfilePickerModal.show(
+                context: context,
+                profiles: const [],
+                selectedProfileId: null,
+              );
+            },
+            child: const Text('Open'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pump();
+
+    expect(result, isNull);
+    expect(find.text('Choose an inference profile'), findsNothing);
+  });
+}

--- a/test/features/ai/ui/widgets/inference_provider_model_picker_modal_test.dart
+++ b/test/features/ai/ui/widgets/inference_provider_model_picker_modal_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/ui/widgets/inference_provider_model_picker_modal.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
 
 import '../../../../widget_test_utils.dart';
 
@@ -75,6 +76,7 @@ void main() {
       required List<AiConfigInferenceProvider> providers,
       required void Function(String?) onResult,
       String? defaultModelId,
+      String? selectedModelId,
     }) async {
       await tester.pumpWidget(
         makeTestableWidget(
@@ -85,6 +87,7 @@ void main() {
                   final picked = await InferenceProviderModelPickerModal.show(
                     context: context,
                     defaultModelId: defaultModelId,
+                    selectedModelId: selectedModelId,
                     models: models,
                     providers: providers,
                     title: 'Pick a model',
@@ -196,6 +199,39 @@ void main() {
         await tester.tap(find.text('Model Two'));
         await tester.pumpAndSettle();
         expect(result, 'm2');
+      },
+    );
+
+    testWidgets(
+      'separates the selected override from the profile default',
+      (tester) async {
+        await pumpHost(
+          tester,
+          models: [
+            _model(id: 'm1', name: 'Profile Model'),
+            _model(id: 'm2', name: 'Override Model'),
+          ],
+          providers: [_provider(id: 'openai')],
+          defaultModelId: 'm1',
+          selectedModelId: 'm2',
+          onResult: (_) {},
+        );
+
+        expect(find.text('Default'), findsOneWidget);
+        expect(find.text('Selected'), findsOneWidget);
+        final rows = tester.widgetList<DesignSystemListItem>(
+          find.byType(DesignSystemListItem),
+        );
+        final defaultRow = rows.singleWhere(
+          (row) => row.title == 'Profile Model',
+        );
+        final selectedRow = rows.singleWhere(
+          (row) => row.title == 'Override Model',
+        );
+        expect(defaultRow.selected, isFalse);
+        expect(defaultRow.activated, isFalse);
+        expect(selectedRow.selected, isTrue);
+        expect(selectedRow.activated, isTrue);
       },
     );
 


### PR DESCRIPTION
## Summary

- add one shared design-system inference-profile picker for category defaults, agent templates, agent creation, and task-agent setup
- reuse the provider-first model picker for inference-profile slots and task-agent overrides
- distinguish the active model override from the profile default
- persist task-agent profile/model changes before closing the setup sheet
- route success confirmation through the task-column ScaffoldMessenger
- standardize localized picker language across all supported locales
- update feature architecture documentation and release metadata

## Why

AI profile and model selection had drifted into several visually and behaviorally different implementations. In task-agent setup, a successful profile change left the modal open, while its confirmation toast used the application-level messenger and spanned the full window.

The shared pickers establish one interaction model and one design-system vocabulary. Task-agent choices are now terminal only after persistence succeeds; failed writes keep the sheet open.

## User impact

Profile and model selection now looks and behaves consistently across AI settings and agent configuration. Task-agent changes close when finished, and their confirmation remains constrained to the task column.

## Screenshots

### Task-agent profile selection bug

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/33124c51e6081a6392933c298ba4c61c2ddd47a6/pr-screenshots/ai-picker-unification/before/task_agent_profile_selection_bug_before.png" width="480" alt="Task-agent profile picker remains open before the fix"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/33124c51e6081a6392933c298ba4c61c2ddd47a6/pr-screenshots/ai-picker-unification/after/task_agent_profile_selection_after.png" width="480" alt="Task-agent picker closes and confirmation stays in the task column after the fix"> |

<details>
<summary>Complete AI picker inventory</summary>

#### Category default inference profile

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/33124c51e6081a6392933c298ba4c61c2ddd47a6/pr-screenshots/ai-picker-unification/before/category_default_profile_picker_before.png" width="480" alt="Category inference-profile picker before unification"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/33124c51e6081a6392933c298ba4c61c2ddd47a6/pr-screenshots/ai-picker-unification/after/category_default_profile_picker_after.png" width="480" alt="Category inference-profile picker after unification"> |

#### Agent-template inference profile

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/33124c51e6081a6392933c298ba4c61c2ddd47a6/pr-screenshots/ai-picker-unification/before/agent_template_profile_picker_before.png" width="480" alt="Agent-template profile picker before unification"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/33124c51e6081a6392933c298ba4c61c2ddd47a6/pr-screenshots/ai-picker-unification/after/agent_template_profile_picker_after.png" width="480" alt="Agent-template profile picker after unification"> |

#### Agent creation inference profile

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/33124c51e6081a6392933c298ba4c61c2ddd47a6/pr-screenshots/ai-picker-unification/before/agent_creation_profile_picker_before.png" width="480" alt="Agent-creation profile picker before unification"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/33124c51e6081a6392933c298ba4c61c2ddd47a6/pr-screenshots/ai-picker-unification/after/agent_creation_profile_picker_after.png" width="480" alt="Agent-creation profile picker after unification"> |

#### Inference-profile model slot

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/33124c51e6081a6392933c298ba4c61c2ddd47a6/pr-screenshots/ai-picker-unification/before/inference_profile_model_slot_picker_before.png" width="480" alt="Inference-profile model slot before provider-first picker reuse"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/33124c51e6081a6392933c298ba4c61c2ddd47a6/pr-screenshots/ai-picker-unification/after/inference_profile_model_provider_picker_after.png" width="480" alt="Inference-profile model slot after provider-first picker reuse"> |

#### Task-agent setup

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/33124c51e6081a6392933c298ba4c61c2ddd47a6/pr-screenshots/ai-picker-unification/before/task_agent_setup_before.png" width="480" alt="Task-agent setup before unification"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/33124c51e6081a6392933c298ba4c61c2ddd47a6/pr-screenshots/ai-picker-unification/after/task_agent_setup_after.png" width="480" alt="Task-agent setup after unification"> |

#### Task-agent provider step

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/33124c51e6081a6392933c298ba4c61c2ddd47a6/pr-screenshots/ai-picker-unification/before/task_agent_model_provider_picker_before.png" width="480" alt="Task-agent provider picker before unification"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/33124c51e6081a6392933c298ba4c61c2ddd47a6/pr-screenshots/ai-picker-unification/after/task_agent_model_provider_picker_after.png" width="480" alt="Task-agent provider picker after unification"> |

#### Task-agent model step

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/33124c51e6081a6392933c298ba4c61c2ddd47a6/pr-screenshots/ai-picker-unification/before/task_agent_model_picker_before.png" width="480" alt="Task-agent model picker before unification"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/33124c51e6081a6392933c298ba4c61c2ddd47a6/pr-screenshots/ai-picker-unification/after/task_agent_model_picker_after.png" width="480" alt="Task-agent model picker after unification"> |

</details>

Images are hosted in the external [lotti-docs screenshot commit](https://github.com/matthiasn/lotti-docs/commit/33124c51e6081a6392933c298ba4c61c2ddd47a6); no generated PNGs or screenshot harness remain in the application repository.

## Validation

- `make analyze` — no issues
- 112 targeted picker, form, and task-agent tests
- 12 final task-agent persistence/toast regression tests
- opt-in screenshot harness — 6 tests, before/after captures validated
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a shared inference-profile picker modal with consistent design-system styling for profile and model selection (including overrides).
* **Bug Fixes**
  * Ensured task-agent profile/model choices persist before closing setup and show confirmation scoped to the task column; improved success/error feedback behavior.
  * Kept picker selection stable during background refreshes.
* **Documentation**
  * Added end-to-end documentation for the updated profile/model selection flows.
* **Localization**
  * Updated picker titles/labels, added an “unavailable” message, and added a task-agent profile-change toast across languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->