### PR TITLE
fix: keep backfill missing count live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   their confirmation stays inside the task column instead of spanning the app.
   Category defaults, agent creation, agent templates, inference-profile slots,
   and task-agent setup now share the same design-system selection language.
+- **Backfill Sync now shows its progress as it happens.** The Missing counters
+  in the status row and statistics ledger update as sequence-log rows resolve,
+  keeping pace with the inbound queue countdown during large backfills instead
+  of waiting for the slower diagnostics refresh.
 - **The energy-orb recording visualization no longer overwhelms Linux
   rendering.** The orb now compiles only its production shader and reuses the
   loaded fragment shader as live audio levels change, avoiding the prolonged

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -36,6 +36,7 @@
       <description>
           <p>Task agents now show their thinking model, model publisher, and serving provider directly in the AI summary. The identity opens a persistent setup sheet for choosing a profile or model, returning to the profile default, copying the category default, or pausing AI. Reports retain immutable attribution after setup changes, and automatic task-related updates can be disabled while Run now remains available.</p>
           <p>AI profile and model choices now use one consistent design-system picker flow. Task-agent choices finish saving before the setup sheet closes, and their confirmation stays inside the task column instead of spanning the application.</p>
+          <p>Backfill Sync now updates both Missing counters as sequence-log rows resolve, keeping them in step with the inbound queue countdown during large backfills instead of waiting for the slower diagnostics refresh.</p>
           <p>The energy-orb recording visualization now compiles only its production shader and reuses the loaded fragment shader as live audio levels change, avoiding prolonged stalls and recording crashes on affected Linux graphics stacks. Finishing a recording also dismisses its sheet exactly once before opening the saved entry, avoiding a nested-navigator teardown failure.</p>
       </description>
     </release>

--- a/lib/database/sync_db_backfill.dart
+++ b/lib/database/sync_db_backfill.dart
@@ -5,6 +5,30 @@ part of 'sync_db.dart';
 /// limits), request-count bookkeeping, the actionable-row probe, and
 /// per-host status aggregation.
 mixin _SyncDbBackfill on _$SyncDatabase {
+  /// Watch the number of sequence-log rows that are still genuinely missing.
+  ///
+  /// This is intentionally narrower than [getBackfillStats]: the Backfill
+  /// Settings status row needs to move at the same cadence as the inbound
+  /// queue while it drains, but recomputing every per-host status bucket for
+  /// each commit would be unnecessary work. Drift invalidates this count when
+  /// `sync_sequence_log` changes, and SQLite can satisfy the status predicate
+  /// from the actionable status indexes.
+  Stream<int> watchBackfillMissingCount() {
+    return customSelect(
+      '''
+      SELECT COUNT(*) AS cnt
+      FROM sync_sequence_log
+        INDEXED BY idx_sync_sequence_log_actionable_status_created_at
+      WHERE status IN (
+        ${SyncSequenceStatus.missing.index},
+        ${SyncSequenceStatus.requested.index}
+      )
+        AND status = ${SyncSequenceStatus.missing.index}
+      ''',
+      readsFrom: {syncSequenceLog},
+    ).watchSingle().map((row) => row.read<int>('cnt'));
+  }
+
   /// Get entries with status 'missing' or 'requested' that haven't
   /// exceeded maxRequestCount, ordered by creation time (oldest first).
   /// Return rows in `missing` / `requested` state that are still eligible

--- a/lib/features/sync/README.md
+++ b/lib/features/sync/README.md
@@ -1074,6 +1074,24 @@ Important implementation details:
 counters, supports manual full historical backfill, and can re-request entries
 that were previously requested but never resolved.
 
+The Backfill Settings page deliberately uses two statistics paths. The full
+per-host `getBackfillStats()` aggregate refreshes at a throttled 30-second
+cadence for diagnostics. The two visible Missing values instead watch the
+focused `watchBackfillMissingCount()` query while the page is mounted. Drift
+re-runs that indexed count after committed `sync_sequence_log` changes, so it
+tracks the inbound queue during a large drain without repeatedly rebuilding
+every host/status bucket. Closing the page auto-disposes the provider and its
+database subscription.
+
+```mermaid
+flowchart LR
+  Commit["Sequence-log write commits"] --> Drift["Drift invalidates missing-count query"]
+  Drift --> Provider["backfillMissingCountProvider"]
+  Provider --> Status["Status row: Missing"]
+  Provider --> Ledger["Sync statistics: Missing"]
+  Timer["30-second foreground timer"] --> Aggregate["Full per-host diagnostics aggregate"]
+```
+
 Own-host reservation lifecycle:
 
 ```mermaid

--- a/lib/features/sync/sequence/sync_sequence_backfill_queries.dart
+++ b/lib/features/sync/sequence/sync_sequence_backfill_queries.dart
@@ -109,6 +109,11 @@ class SyncSequenceBackfillQueries {
     return _syncDatabase.getBackfillStats();
   }
 
+  /// Watch the lightweight aggregate used by the live Backfill status row.
+  Stream<int> watchBackfillMissingCount() {
+    return _syncDatabase.watchBackfillMissingCount();
+  }
+
   /// Get missing entries with age and per-host limits for automatic backfill.
   /// This is used for bounded automatic backfill that only looks at recent gaps.
   ///

--- a/lib/features/sync/sequence/sync_sequence_log_service.dart
+++ b/lib/features/sync/sequence/sync_sequence_log_service.dart
@@ -289,6 +289,10 @@ class SyncSequenceLogService {
   Future<BackfillStats> getBackfillStats() =>
       _backfillQueries.getBackfillStats();
 
+  /// Watch the current number of sequence-log rows in `missing` state.
+  Stream<int> watchBackfillMissingCount() =>
+      _backfillQueries.watchBackfillMissingCount();
+
   /// Get missing entries with age and per-host limits for automatic backfill.
   Future<List<SyncSequenceLogItem>> getMissingEntriesWithLimits({
     int limit = 50,

--- a/lib/features/sync/state/backfill_stats_controller.dart
+++ b/lib/features/sync/state/backfill_stats_controller.dart
@@ -106,6 +106,18 @@ class BackfillStatsState {
 /// the timer on `onHide` and re-arms it on `onShow`.
 const Duration _autoRefreshInterval = Duration(seconds: 30);
 
+/// Live missing-row count for the Backfill Settings page.
+///
+/// The full per-host stats aggregate remains throttled because it is intended
+/// for diagnostics. This focused reactive query is cheap enough to follow
+/// committed sequence-log changes, keeping the prominent missing counters in
+/// step with the inbound queue while a large backfill drains.
+final StreamProvider<int> backfillMissingCountProvider =
+    StreamProvider.autoDispose<int>(
+      (ref) => getIt<SyncSequenceLogService>().watchBackfillMissingCount(),
+      name: 'backfillMissingCountProvider',
+    );
+
 /// Backs the Backfill Settings page: loads and auto-refreshes [BackfillStats]
 /// (throttled, foreground-only — see [_autoRefreshInterval]) and exposes the
 /// manual operations (full backfill, re-request, reset/retire of stuck and

--- a/lib/features/sync/ui/backfill_settings_page.dart
+++ b/lib/features/sync/ui/backfill_settings_page.dart
@@ -63,6 +63,8 @@ class BackfillSettingsBody extends ConsumerWidget {
     final tokens = context.designTokens;
     final config = ref.watch(backfillConfigControllerProvider);
     final stats = ref.watch(backfillStatsControllerProvider);
+    final liveMissing = ref.watch(backfillMissingCountProvider).value;
+    final missing = liveMissing ?? stats.stats?.totalMissing ?? 0;
     final matrixService = getIt.isRegistered<MatrixService>()
         ? getIt<MatrixService>()
         : null;
@@ -80,12 +82,13 @@ class BackfillSettingsBody extends ConsumerWidget {
             children: [
               StatusRow(
                 inbound: depth?.total ?? 0,
-                missing: stats.stats?.totalMissing ?? 0,
+                missing: missing,
                 skipped: depth?.abandoned ?? 0,
               ),
               SizedBox(height: tokens.spacing.step4),
               SyncStatsCard(
                 stats: stats.stats,
+                missingCount: missing,
                 isLoading: stats.isLoading,
                 onRefresh: () => ref
                     .read(backfillStatsControllerProvider.notifier)

--- a/lib/features/sync/ui/backfill_settings_stats.dart
+++ b/lib/features/sync/ui/backfill_settings_stats.dart
@@ -146,12 +146,14 @@ class _StatusCell extends StatelessWidget {
 class SyncStatsCard extends StatelessWidget {
   const SyncStatsCard({
     required this.stats,
+    required this.missingCount,
     required this.isLoading,
     required this.onRefresh,
     super.key,
   });
 
   final BackfillStats? stats;
+  final int missingCount;
   final bool isLoading;
   final VoidCallback onRefresh;
 
@@ -214,7 +216,7 @@ class SyncStatsCard extends StatelessWidget {
               ),
             )
           else
-            _Ledger(stats: stats!),
+            _Ledger(stats: stats!, missingCount: missingCount),
         ],
       ),
     );
@@ -222,9 +224,10 @@ class SyncStatsCard extends StatelessWidget {
 }
 
 class _Ledger extends StatelessWidget {
-  const _Ledger({required this.stats});
+  const _Ledger({required this.stats, required this.missingCount});
 
   final BackfillStats stats;
+  final int missingCount;
 
   @override
   Widget build(BuildContext context) {
@@ -237,7 +240,7 @@ class _Ledger extends StatelessWidget {
     final interactive = tokens.colors.interactive.enabled;
     final error = tokens.colors.alert.error.defaultColor;
 
-    final missingTone = stats.totalMissing > 0 ? warning : lowEmphasis;
+    final missingTone = missingCount > 0 ? warning : lowEmphasis;
     final requestedTone = stats.totalRequested > 0 ? interactive : lowEmphasis;
     final unresolvableTone = stats.totalUnresolvable > 0 ? error : lowEmphasis;
 
@@ -260,7 +263,7 @@ class _Ledger extends StatelessWidget {
         ),
         _LedgerRow(
           label: messages.backfillStatsMissing,
-          value: stats.totalMissing,
+          value: missingCount,
           color: missingTone,
         ),
         _LedgerRow(

--- a/test/database/sync_db_backfill_test.dart
+++ b/test/database/sync_db_backfill_test.dart
@@ -1,6 +1,8 @@
 // Tests for the backfill sweep queries and statistics
 // (`lib/database/sync_db_backfill.dart`).
 // ignore_for_file: avoid_redundant_argument_values
+import 'dart:async';
+
 import 'package:drift/drift.dart' hide isNotNull, isNull;
 import 'package:glados/glados.dart';
 import 'package:lotti/database/sync_db.dart';
@@ -377,6 +379,68 @@ void main() {
       expect(stats.totalUnresolvable, 1);
       expect(stats.totalBurned, 3);
       expect(stats.totalEntries, 4);
+    });
+  });
+
+  group('watchBackfillMissingCount', () {
+    setUpAll(() async {
+      db = SyncDatabase(inMemoryDatabase: true);
+    });
+    setUp(() async {
+      await clearAllSyncTables(db!);
+    });
+    tearDownAll(() async {
+      await db?.close();
+    });
+
+    test('emits as missing rows are added and resolved', () async {
+      final database = db!;
+      final counts = StreamIterator(database.watchBackfillMissingCount());
+      addTearDown(counts.cancel);
+
+      expect(await counts.moveNext(), isTrue);
+      expect(counts.current, 0);
+
+      await _insertSequenceRow(
+        database,
+        hostId: 'host-live-count',
+        counter: 1,
+        status: SyncSequenceStatus.missing,
+        createdAt: DateTime(2024, 3, 15),
+      );
+      expect(await counts.moveNext(), isTrue);
+      expect(counts.current, 1);
+
+      await database.updateSequenceStatus(
+        'host-live-count',
+        1,
+        SyncSequenceStatus.received,
+      );
+      expect(await counts.moveNext(), isTrue);
+      expect(counts.current, 0);
+    });
+
+    test('uses the actionable status index for the live count', () async {
+      final plan = await db!.customSelect(
+        '''
+            EXPLAIN QUERY PLAN
+            SELECT COUNT(*) AS cnt
+            FROM sync_sequence_log
+              INDEXED BY idx_sync_sequence_log_actionable_status_created_at
+            WHERE status IN (
+              ${SyncSequenceStatus.missing.index},
+              ${SyncSequenceStatus.requested.index}
+            )
+              AND status = ${SyncSequenceStatus.missing.index}
+            ''',
+      ).get();
+
+      expect(
+        plan.map((row) => row.data['detail'] as String),
+        anyElement(
+          contains('idx_sync_sequence_log_actionable_status_created_at'),
+        ),
+      );
     });
   });
 

--- a/test/features/sync/sequence/sync_sequence_backfill_queries_test.dart
+++ b/test/features/sync/sequence/sync_sequence_backfill_queries_test.dart
@@ -141,6 +141,17 @@ void main() {
       expect(await queries.getBackfillStats(), same(stats));
     });
 
+    test('watchBackfillMissingCount returns the database stream', () async {
+      final counts = Stream<int>.fromIterable(const [8, 3, 0]);
+      when(db.watchBackfillMissingCount).thenAnswer((_) => counts);
+
+      expect(
+        await queries.watchBackfillMissingCount().toList(),
+        const [8, 3, 0],
+      );
+      verify(db.watchBackfillMissingCount).called(1);
+    });
+
     test('getNearestCoveringEntry forwards hostId and counter', () async {
       when(
         () => db.getNearestCoveringEntry(alice, 7),

--- a/test/features/sync/sequence/sync_sequence_log_service_test.dart
+++ b/test/features/sync/sequence/sync_sequence_log_service_test.dart
@@ -3538,6 +3538,19 @@ void main() {
     });
   });
 
+  group('watchBackfillMissingCount', () {
+    test('delegates to database', () async {
+      final counts = Stream<int>.fromIterable(const [12, 6, 0]);
+      when(mockDb.watchBackfillMissingCount).thenAnswer((_) => counts);
+
+      expect(
+        await service.watchBackfillMissingCount().toList(),
+        const [12, 6, 0],
+      );
+      verify(mockDb.watchBackfillMissingCount).called(1);
+    });
+  });
+
   group('getRequestedEntries', () {
     test('delegates to database with default limit', () async {
       when(

--- a/test/features/sync/ui/backfill_settings_page_test.dart
+++ b/test/features/sync/ui/backfill_settings_page_test.dart
@@ -64,6 +64,9 @@ void main() {
       () => mockSequenceService.getBackfillStats(),
     ).thenAnswer((_) async => populatedStats);
     when(
+      () => mockSequenceService.watchBackfillMissingCount(),
+    ).thenAnswer((_) => Stream<int>.value(5));
+    when(
       () => mockBackfillService.processFullBackfill(),
     ).thenAnswer((_) async => 5);
     when(
@@ -124,6 +127,9 @@ void main() {
       when(
         () => mockSequenceService.getBackfillStats(),
       ).thenAnswer((_) async => emptyStats);
+      when(
+        () => mockSequenceService.watchBackfillMissingCount(),
+      ).thenAnswer((_) => Stream<int>.value(0));
       await pumpBody(tester);
 
       // missing = 0 → check icon (not bolt)
@@ -138,6 +144,23 @@ void main() {
       // up now / Manual backfill) are NOT in the tree. The only bolt
       // is in the status row.
       expect(find.byIcon(Icons.bolt_outlined), findsOneWidget);
+    });
+
+    testWidgets('live missing count updates the status row and ledger', (
+      tester,
+    ) async {
+      final missingCounts = StreamController<int>();
+      addTearDown(missingCounts.close);
+      when(
+        () => mockSequenceService.watchBackfillMissingCount(),
+      ).thenAnswer((_) => missingCounts.stream);
+
+      await pumpBody(tester);
+      missingCounts.add(4);
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('4'), findsNWidgets(2));
     });
   });
 


### PR DESCRIPTION
## What changed

- add a page-scoped reactive count for sequence-log rows still in `missing` state
- drive both Backfill Sync “Missing” values from that live count
- keep the heavier per-host diagnostics aggregate on its existing throttled cadence
- use the actionable partial index and pin the query plan in a database test
- update sync architecture docs and 0.9.1040 release notes

## Why

The inbound queue countdown updates from live queue-depth signals, but the Missing count came from the full backfill statistics aggregate, which refreshes only every 30 seconds. During a large backfill this made the UI look stalled even while thousands of messages were being processed.

The focused Drift query is active only while the Backfill Settings page is mounted. It is invalidated after committed sequence-log writes, so the Missing counters track the drain without repeatedly rebuilding every per-host/status bucket.

## User impact

Large backfills now visibly count down in real time: inbound queue and missing-message progress move together, making sync throughput immediately apparent.

There is no static visual redesign to screenshot; the improvement is the live update behavior on the existing counters.

## Validation

- `fvm flutter test test/database/sync_db_backfill_test.dart test/features/sync/sequence/sync_sequence_backfill_queries_test.dart test/features/sync/sequence/sync_sequence_log_service_test.dart test/features/sync/ui/backfill_settings_page_test.dart` (254 tests)
- `fvm flutter analyze <10 affected Dart/test files>`
- repository-wide `fvm flutter analyze` before rebase
- `git diff --check`