### PR TITLE
fix: share Melious audio timeout across stages

### DIFF
--- a/lib/features/ai/repository/melious_inference_repository.dart
+++ b/lib/features/ai/repository/melious_inference_repository.dart
@@ -682,17 +682,24 @@ class MeliousInferenceRepository extends TranscriptionRepository {
 
     try {
       final deadline = _clock.now().add(timeout);
-      Duration remainingTimeout() {
+      Duration remainingTimeoutOrThrow() {
         final remaining = deadline.difference(_clock.now());
-        return remaining.isNegative ? Duration.zero : remaining;
+        if (remaining <= Duration.zero) {
+          throw TimeoutException('Melious chat-audio deadline exhausted');
+        }
+        return remaining;
       }
 
       final sourceBytes = base64Decode(audioBase64);
-      final wavBytes = _isWavAudio(sourceBytes)
-          ? sourceBytes
-          : await _m4aToWavConverter(
-              sourceBytes,
-            ).timeout(remainingTimeout());
+      late final Uint8List wavBytes;
+      if (_isWavAudio(sourceBytes)) {
+        wavBytes = sourceBytes;
+      } else {
+        final conversionTimeout = remainingTimeoutOrThrow();
+        wavBytes = await _m4aToWavConverter(
+          sourceBytes,
+        ).timeout(conversionTimeout);
+      }
       final messageContent = [
         {
           'type': 'input_audio',
@@ -718,6 +725,7 @@ class MeliousInferenceRepository extends TranscriptionRepository {
         'temperature': 0.0,
         'max_tokens': ?maxCompletionTokens,
       };
+      final requestTimeout = remainingTimeoutOrThrow();
       final response = await httpClient
           .post(
             uri,
@@ -728,7 +736,7 @@ class MeliousInferenceRepository extends TranscriptionRepository {
             },
             body: jsonEncode(body),
           )
-          .timeout(remainingTimeout());
+          .timeout(requestTimeout);
 
       if (response.statusCode < 200 || response.statusCode >= 300) {
         throw TranscriptionException(

--- a/lib/features/ai/repository/melious_inference_repository.dart
+++ b/lib/features/ai/repository/melious_inference_repository.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:developer' as developer;
 import 'dart:typed_data';
 
+import 'package:clock/clock.dart';
 import 'package:http/http.dart' as http;
 import 'package:lotti/features/ai/model/ai_call_impact.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
@@ -39,10 +40,12 @@ class MeliousInferenceRepository extends TranscriptionRepository {
     CloudInferenceRequestHelpers? helpers,
     MeliousChatCompletionStreamFactory? chatCompletionStreamFactory,
     MeliousM4aToWavConverter? m4aToWavConverter,
+    Clock? clockSource,
   }) : _helpers = helpers ?? const CloudInferenceRequestHelpers(),
        _chatCompletionStreamFactory =
            chatCompletionStreamFactory ?? _createChatCompletionStream,
-       _m4aToWavConverter = m4aToWavConverter ?? convertM4aBytesToTemporaryWav;
+       _m4aToWavConverter = m4aToWavConverter ?? convertM4aBytesToTemporaryWav,
+       _clock = clockSource ?? clock;
 
   static const _providerName = 'MeliousInferenceRepository';
   static const _modelListTimeout = Duration(seconds: 15);
@@ -63,6 +66,7 @@ class MeliousInferenceRepository extends TranscriptionRepository {
   final CloudInferenceRequestHelpers _helpers;
   final MeliousChatCompletionStreamFactory _chatCompletionStreamFactory;
   final MeliousM4aToWavConverter _m4aToWavConverter;
+  final Clock _clock;
 
   /// Fetches the live Melious model catalog and maps `_meta` capability data
   /// into the app's [KnownModel] shape.
@@ -677,10 +681,18 @@ class MeliousInferenceRepository extends TranscriptionRepository {
     final requestId = 'melious-audio-${const Uuid().v4()}';
 
     try {
+      final deadline = _clock.now().add(timeout);
+      Duration remainingTimeout() {
+        final remaining = deadline.difference(_clock.now());
+        return remaining.isNegative ? Duration.zero : remaining;
+      }
+
       final sourceBytes = base64Decode(audioBase64);
       final wavBytes = _isWavAudio(sourceBytes)
           ? sourceBytes
-          : await _m4aToWavConverter(sourceBytes).timeout(timeout);
+          : await _m4aToWavConverter(
+              sourceBytes,
+            ).timeout(remainingTimeout());
       final messageContent = [
         {
           'type': 'input_audio',
@@ -716,7 +728,7 @@ class MeliousInferenceRepository extends TranscriptionRepository {
             },
             body: jsonEncode(body),
           )
-          .timeout(timeout);
+          .timeout(remainingTimeout());
 
       if (response.statusCode < 200 || response.statusCode >= 300) {
         throw TranscriptionException(

--- a/lib/features/ai/util/audio_converter_channel.dart
+++ b/lib/features/ai/util/audio_converter_channel.dart
@@ -60,11 +60,13 @@ class AudioConverterChannel {
   }) async {
     try {
       await AudioDecoder.convertToWav(inputPath, outputPath);
-    } catch (error) {
-      getIt<DomainLogger>().log(
+    } catch (error, stackTrace) {
+      getIt<DomainLogger>().error(
         LogDomain.speech,
-        'Native M4A-to-WAV conversion failed: $error',
+        error,
+        stackTrace: stackTrace,
         subDomain: 'convertM4aToWav',
+        message: 'Native M4A-to-WAV conversion failed',
       );
       rethrow;
     }

--- a/test/features/ai/repository/melious_inference_repository_test.dart
+++ b/test/features/ai/repository/melious_inference_repository_test.dart
@@ -1193,6 +1193,57 @@ void main() {
       });
     });
 
+    test(
+      'transcribeChatAudio skips HTTP after conversion exhausts timeout',
+      () {
+        fakeAsync((async) {
+          final startedAt = DateTime(2024, 3, 15, 12);
+          var currentTime = startedAt;
+          var requestSent = false;
+          final repository = MeliousInferenceRepository(
+            clockSource: Clock(() => currentTime),
+            httpClient: MockClient((_) async {
+              requestSent = true;
+              return _voxtralChatResponse();
+            }),
+            m4aToWavConverter: (_) async {
+              currentTime = startedAt.add(const Duration(seconds: 60));
+              return base64Decode('UklGRgAAAABXQVZF');
+            },
+          );
+          Object? failure;
+
+          repository
+              .transcribeChatAudio(
+                model: 'voxtral-small-24b-2507',
+                audioBase64: base64Encode([1, 2, 3]),
+                baseUrl: baseUrl,
+                apiKey: apiKey,
+                prompt: 'Transcribe.',
+              )
+              .toList()
+              .then<void>(
+                (_) {},
+                onError: (Object error, StackTrace _) {
+                  failure = error;
+                },
+              );
+          async.flushMicrotasks();
+
+          expect(requestSent, isFalse);
+          expect(
+            failure,
+            isA<TranscriptionException>().having(
+              (error) => error.message,
+              'message',
+              allOf(contains('timed out'), contains('request melious-audio-')),
+            ),
+          );
+          repository.close();
+        });
+      },
+    );
+
     test('transcribeChatAudio prefixes conversion status detail', () {
       final repository = MeliousInferenceRepository(
         m4aToWavConverter: (_) async => throw TranscriptionException(

--- a/test/features/ai/repository/melious_inference_repository_test.dart
+++ b/test/features/ai/repository/melious_inference_repository_test.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:clock/clock.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
@@ -1137,6 +1139,58 @@ void main() {
           ),
         ),
       );
+    });
+
+    test('transcribeChatAudio shares its timeout across both stages', () {
+      fakeAsync((async) {
+        final startedAt = DateTime(2024, 3, 15, 12);
+        var currentTime = startedAt;
+        final repository = MeliousInferenceRepository(
+          clockSource: Clock(() => currentTime),
+          httpClient: MockClient((_) => Completer<http.Response>().future),
+          m4aToWavConverter: (_) async {
+            currentTime = startedAt.add(const Duration(seconds: 40));
+            return base64Decode('UklGRgAAAABXQVZF');
+          },
+        );
+        Object? failure;
+        var completed = false;
+
+        repository
+            .transcribeChatAudio(
+              model: 'voxtral-small-24b-2507',
+              audioBase64: base64Encode([1, 2, 3]),
+              baseUrl: baseUrl,
+              apiKey: apiKey,
+              prompt: 'Transcribe.',
+            )
+            .toList()
+            .then<void>(
+              (_) {
+                completed = true;
+              },
+              onError: (Object error, StackTrace _) {
+                failure = error;
+                completed = true;
+              },
+            );
+        async
+          ..flushMicrotasks()
+          ..elapse(const Duration(seconds: 19));
+        expect(completed, isFalse);
+
+        async.elapse(const Duration(seconds: 1));
+        expect(completed, isTrue);
+        expect(
+          failure,
+          isA<TranscriptionException>().having(
+            (error) => error.message,
+            'message',
+            allOf(contains('timed out'), contains('request melious-audio-')),
+          ),
+        );
+        repository.close();
+      });
     });
 
     test('transcribeChatAudio prefixes conversion status detail', () {

--- a/test/features/ai/util/audio_converter_channel_test.dart
+++ b/test/features/ai/util/audio_converter_channel_test.dart
@@ -12,6 +12,8 @@ import '../../../widget_test_utils.dart';
 
 class _FakeDomainLogger extends Fake implements DomainLogger {
   String? lastEvent;
+  Object? lastError;
+  StackTrace? lastStackTrace;
 
   @override
   void log(
@@ -31,6 +33,8 @@ class _FakeDomainLogger extends Fake implements DomainLogger {
     String? subDomain,
     String? message,
   }) {
+    lastError = error;
+    lastStackTrace = stackTrace;
     lastEvent = message ?? '$error';
   }
 }
@@ -118,7 +122,16 @@ void main() {
           ),
         ),
       );
-      expect(fakeLogging.lastEvent, contains('AAC decoder unavailable'));
+      expect(fakeLogging.lastEvent, 'Native M4A-to-WAV conversion failed');
+      expect(
+        fakeLogging.lastError,
+        isA<AudioConversionException>().having(
+          (error) => error.message,
+          'message',
+          'AAC decoder unavailable',
+        ),
+      );
+      expect(fakeLogging.lastStackTrace, isNotNull);
     });
 
     test('logs and rethrows unexpected platform failures', () async {
@@ -129,7 +142,9 @@ void main() {
         ),
         throwsA(isA<MissingPluginException>()),
       );
-      expect(fakeLogging.lastEvent, contains('MissingPluginException'));
+      expect(fakeLogging.lastEvent, 'Native M4A-to-WAV conversion failed');
+      expect(fakeLogging.lastError, isA<MissingPluginException>());
+      expect(fakeLogging.lastStackTrace, isNotNull);
     });
 
     test('temporary conversion uses native defaults and cleans up', () async {


### PR DESCRIPTION
## Summary

- enforce one shared 60-second deadline across temporary WAV conversion and the subsequent Melious request
- log native conversion failures at error severity with the original exception and stack trace
- add deterministic fake-time coverage proving conversion time is deducted from the HTTP timeout budget
- strengthen converter logging tests for package-specific and missing-plugin failures

## Why

This is a follow-up to #3453. Its conversion and HTTP stages each received the full timeout independently, allowing the combined operation to run for almost twice the advertised limit. Conversion failures also lost structured error and stack-trace detail in domain logs.

## Validation

- `fvm dart format` on all four changed files
- `fvm flutter test test/features/ai/util/audio_converter_channel_test.dart test/features/ai/repository/melious_inference_repository_test.dart` — 70 tests passed
- `fvm flutter analyze` — no issues found

## Visual changes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio transcription timeout handling by using a single shared deadline across both M4A→WAV conversion and the subsequent transcription request.
  * Ensured conversion time consumption reduces the remaining request budget, and conversion exhaustion now fails with a clear timeout error.
  * Enhanced native audio conversion failure reporting with more precise messages and captured diagnostic details.
* **Tests**
  * Added deterministic timeout-focused unit coverage to verify correct shared-budget behavior and that no request is made when conversion uses the full budget.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->