### PR TITLE
feat: add Daily OS inference selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1044]
+### Changed
+- **Daily OS now lets you choose its AI route explicitly.** A discoverable
+  Daily OS settings page owns the default inference profile and preferred name,
+  while the planner instance can override its full profile or only its thinking
+  model. The app states that assembled planning context is sent to the selected
+  provider, identifies local versus remote endpoints, and guides you to setup
+  before the first check-in when no usable profile is configured.
+
 ## [0.9.1043]
 ### Changed
 - **Daily OS is now available to everyone.** The Daily OS day-planning surface
   no longer sits behind a Settings → Advanced → Flags toggle — its calendar tab
   appears in the main navigation for all users.
-- **Daily OS now lets you choose its AI route explicitly.** A discoverable
-  Daily OS settings page owns the default inference profile and preferred name,
-  while the planner instance can override its full profile or only its thinking
-  model. The app
-  states that assembled planning context is sent to the selected provider,
-  identifies local versus remote endpoints, and guides you to setup before the
-  first check-in when no usable profile is configured.
 
 ## [0.9.1042]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Daily OS is now available to everyone.** The Daily OS day-planning surface
   no longer sits behind a Settings → Advanced → Flags toggle — its calendar tab
   appears in the main navigation for all users.
+- **Daily OS now lets you choose its AI route explicitly.** A discoverable
+  Daily OS settings page owns the default inference profile and preferred name,
+  while the planner instance can override its full profile or only its thinking
+  model. The app
+  states that assembled planning context is sent to the selected provider,
+  identifies local versus remote endpoints, and guides you to setup before the
+  first check-in when no usable profile is configured.
 
 ## [0.9.1042]
 ### Added

--- a/docs/implementation_plans/2026-07-14_daily_os_inference_selection.md
+++ b/docs/implementation_plans/2026-07-14_daily_os_inference_selection.md
@@ -160,12 +160,16 @@ selection.
 ### Existing legacy route
 
 An installation can currently resolve the seeded Shepherd template through its
-legacy Gemini model even when no profile has been explicitly selected.
+legacy Gemini model even when no profile has been explicitly selected. The
+runtime resolver keeps this fallback so an already-running planner never breaks.
 
-Preserve this route for backward compatibility, but display it honestly as a
-legacy/default route. Do not describe it as the user’s choice. The contextual
-setup nudge remains eligible until the user selects a Daily OS profile or writes
-an explicit planner override.
+The Daily OS surface, however, treats "resolvable but no explicit profile" as
+unconfigured: `hasInferenceRoute` requires both a resolvable route and an
+explicit `template.profileId`, so the setup gate stays active until the user
+makes a deliberate provider choice. This is the privacy-forward stance — Daily
+OS does not silently route assembled planning context to a default provider the
+user never chose. It blocks the inference-dependent check-in and sends the user
+to setup instead, rather than presenting the legacy model as their selection.
 
 ## Information architecture
 

--- a/docs/implementation_plans/2026-07-14_daily_os_inference_selection.md
+++ b/docs/implementation_plans/2026-07-14_daily_os_inference_selection.md
@@ -1,0 +1,806 @@
+# Daily OS inference selection
+
+**Date:** 2026-07-14
+**Priority:** P1
+**Status:** Implementation plan
+**Scope:** A user-selected default inference profile for Daily OS, a persistent
+planner-instance profile/model override, explicit provider data-transfer
+disclosure, and first-class settings discoverability from Daily OS.
+
+## Outcome
+
+Daily OS gets one coherent inference-routing experience built from the shared
+selection surfaces introduced in PR #3450:
+
+- a default inference profile in a dedicated Daily OS settings panel;
+- an optional profile or thinking-model override for the long-lived Daily OS
+  planner instance;
+- an always-available route to Daily OS settings from the Daily OS header;
+- a contextual setup nudge when the inference route or preferred form of
+  address is missing;
+- exact model, serving-provider, and endpoint disclosure before selection;
+- no provider denylist: every configured provider, including Google Gemini,
+  remains selectable when it satisfies the Daily OS technical contract.
+
+The privacy boundary is informed, explicit user choice. Daily OS **will send**
+the context assembled for an inference run to the selected provider. It must
+never imply that transfer is merely possible, silently choose a different
+provider, or label a provider GDPR-compliant from its brand alone.
+
+## Panel decision
+
+### UX/UI
+
+- Give Daily OS a dedicated Settings V2 destination rather than adding more
+  product configuration to About.
+- Keep the default profile and its effective thinking route visible without
+  opening a modal.
+- Make the instance/default relationship explicit through “Use Daily OS
+  default” and “Override for this planner” modes.
+- Provide a direct Daily OS header entry to settings at all times.
+- When configuration is incomplete, add one calm setup surface inside Daily OS
+  instead of relying on the global settings tree or permanent warning clutter.
+
+### Architecture
+
+- Keep the general default profile on the seeded Shepherd day-agent template,
+  inside the synced agent domain.
+- Keep planner-specific routing on `AgentConfig.inferenceSetup`.
+- Reuse `ProfileResolver` as the single runtime resolution implementation.
+- Generalize the existing task-agent thinking-model capability predicate so
+  task agents and Daily OS consume the same technical eligibility contract.
+- Compose Daily OS UI from `InferenceProfilePickerModal` and
+  `InferenceProviderModelPickerModal`; do not reuse the task-specific
+  `AgentModelSheet` wholesale.
+
+### Data privacy
+
+- Do not filter by provider brand or maintain a Daily OS provider denylist.
+- Filter only for technical fitness and platform availability.
+- Show whether the selected route is embedded/loopback or remote and identify
+  the provider and endpoint host.
+- Never claim GDPR compliance without auditable policy metadata covering the
+  configured endpoint, account, region, contract, scope, and review date.
+- Stop visibly when an explicit selection cannot be resolved. Never fall back
+  to another provider.
+
+## Grounding in the current codebase
+
+### Shared selection surfaces
+
+PR #3450 established the selection language this work must reuse:
+
+- `InferenceProfilePickerModal` and `InferenceProfilePickerList` render
+  inference profiles with design-system list rows and selected-state semantics.
+- `InferenceProviderModelPickerModal` groups models by serving provider and
+  independently marks the profile default and current selection.
+- `SettingsPickerField` is the established closed-field representation.
+- picker consumers preserve established data during background reloads instead
+  of flashing to empty or loading shells.
+
+The model picker currently short-circuits when exactly one model is eligible.
+Daily OS needs an opt-out from that behavior so the provider/model route remains
+visible and explicitly chosen even when there is only one candidate.
+
+### Daily OS settings today
+
+There is no dedicated Daily OS node in the Settings V2 tree. The greeting name
+is rendered as a “Daily OS personalization” card inside `AboutBody` and stored
+through `DailyOsPreferencesController` in device-local `SettingsDb`.
+
+The settings redesign should move the personalization surface to the new Daily
+OS panel. Compatibility can keep the same settings key; moving the UI must not
+reset the value.
+
+### One long-lived planner
+
+`DayAgentService` owns one deterministic planner identity:
+
+```text
+daily_os_planner
+```
+
+Dates are workspaces carried by wake tokens, not separate agent identities.
+The instance override therefore applies to the planner across all dates and
+synced devices. UI copy must say “this planner,” not “this day.”
+
+### Existing runtime resolution
+
+`DayAgentWorkflow` already resolves inference through `ProfileResolver`.
+`ProfileResolver.resolveDetailed` understands:
+
+- typed direct thinking-model override;
+- typed base profile;
+- legacy agent profile;
+- template-version profile;
+- template profile;
+- legacy model fallback.
+
+Typed setups are authoritative and fail closed. This feature should extend the
+write/UI side without adding a Daily OS-specific runtime resolver.
+
+## Product semantics
+
+### General default
+
+The general Daily OS setting is a **default inference profile**. A profile is
+the correct default unit because it:
+
+- preserves the profile’s other capability slots for future Daily OS tools;
+- carries one unambiguous configured `AiConfigModel.id` per slot;
+- avoids overloading the legacy provider-native `modelId` field;
+- stays consistent with category, template, and task-agent configuration.
+
+The default profile’s thinking model and serving provider are shown as resolved
+details. A direct thinking-model choice is an instance override in this P1, not
+a new template-level legacy model mutation.
+
+If a later product requirement needs a direct model as the global default, add
+a typed template inference-selection value first. Do not write a local model
+config ID into `AgentTemplateEntity.modelId`.
+
+### Planner override
+
+The planner has two visible modes:
+
+1. **Use Daily OS default**
+   - uses the current Shepherd default profile;
+   - shows the effective model/provider route;
+   - follows subsequent Daily OS default changes.
+2. **Override for this planner**
+   - chooses a base inference profile;
+   - optionally chooses a direct thinking model;
+   - retains the base profile’s non-thinking slots;
+   - remains unchanged when the Daily OS default changes.
+
+“Use profile default” clears only `thinkingModelOverrideId`. “Reset to Daily OS
+default” replaces the entire planner setup with the current template-derived
+selection.
+
+### Existing legacy route
+
+An installation can currently resolve the seeded Shepherd template through its
+legacy Gemini model even when no profile has been explicitly selected.
+
+Preserve this route for backward compatibility, but display it honestly as a
+legacy/default route. Do not describe it as the user’s choice. The contextual
+setup nudge remains eligible until the user selects a Daily OS profile or writes
+an explicit planner override.
+
+## Information architecture
+
+### Settings tree
+
+Add a top-level `daily-os` leaf after Agents and before Sync:
+
+```mermaid
+flowchart TD
+  Settings --> AI
+  Settings --> Agents
+  Settings --> DailyOS["Daily OS"]
+  Settings --> Sync
+```
+
+Use a stable route such as:
+
+```text
+/settings/daily-os
+```
+
+Register the same body for desktop Settings V2 and the mobile settings route.
+The panel owns its scrolling behavior explicitly in `panel_registry.dart`.
+
+### Daily OS panel layout
+
+Use design-system tokens and established settings components throughout.
+
+1. **Personalization**
+   - “Your name” field using the current `DAILY_OS_USER_NAME` value.
+   - Helper copy explains that it controls how Daily OS addresses the user on
+     this device.
+2. **AI planner**
+   - `SettingsPickerField`: “Default inference profile.”
+   - Effective route: model name, publisher when known, serving provider.
+   - Destination line: embedded/loopback or remote endpoint hostname.
+   - Definitive data-transfer disclosure.
+   - Provider-settings action when the route is missing or broken.
+3. **Data scope**
+   - Keep category inclusion/exclusion discoverable from the panel, reusing the
+     existing preference controller and category selection interaction.
+
+Do not use raw spacing, radius, color, or typography values. Follow the design
+system exports and existing settings abstractions.
+
+### Closed default field
+
+The collapsed profile field should answer all of these without opening it:
+
+- Which profile is selected?
+- Which thinking model will Daily OS use?
+- Which provider will receive the request?
+- Is the endpoint on-device/loopback or remote?
+- Is the saved selection unavailable?
+
+Example:
+
+```text
+Default inference profile
+Local Qwen
+Qwen 3.6 · via Ollama · Runs on this device
+```
+
+Remote example:
+
+```text
+Default inference profile
+Gemini
+Gemini 3 Flash · via Google Gemini · Remote · generativelanguage.googleapis.com
+```
+
+### Data-transfer disclosure
+
+The wording is definitive.
+
+General form:
+
+> Daily OS sends relevant tasks, captures, plans, learned preferences, and
+> other assembled planning context to the selected provider for processing.
+
+Remote route:
+
+> Daily OS sends the assembled planning context to {provider} at {hostname}
+> for remote processing.
+
+Genuinely on-device/loopback route:
+
+> Daily OS sends the assembled planning context to the selected local provider
+> for processing. It remains on this device.
+
+Do not call a private-network host or arbitrary custom base URL “on this
+device.” Only embedded runtimes and validated loopback endpoints qualify.
+
+The disclosure describes the assembled inference context, not the entire
+database. Runtime logs remain content-free under the existing agent logging
+rules.
+
+## Discoverability from Daily OS
+
+Discoverability has two layers: a permanent entry point and a contextual setup
+nudge.
+
+### Permanent entry point
+
+Add “Daily OS settings” to the Day header overflow menu for planned and
+unplanned days. It navigates directly to `/settings/daily-os`.
+
+Keep “Inspect agent” as the diagnostic/internal route. Settings and Agent
+Internals solve different user needs and must remain separate menu actions.
+
+### Contextual readiness state
+
+Replace the onboarding-only readiness boolean with a shared, richer state:
+
+```text
+DailyOsSetupStatus
+  hasResolvableInferenceRoute
+  hasExplicitInferenceChoice
+  inferenceIssue
+  hasPreferredName
+```
+
+Suggested inference issues:
+
+- `none`
+- `notSelected`
+- `providerNotConfigured`
+- `selectionUnavailable`
+- `platformUnavailable`
+
+The onboarding eligibility provider consumes this shared readiness state rather
+than owning a second inference-readiness implementation.
+
+### Missing inference route
+
+A missing or broken inference route is blocking because the create ritual will
+fail when drafting starts.
+
+- Show a high-priority but non-alarmist setup card directly under the Day
+  header.
+- Change the empty-day primary action from “Speak a check-in” to “Set up Daily
+  OS” while the route is unavailable.
+- Tapping it navigates to the AI planner section of Daily OS settings.
+- Do not open Capture and let it fail later.
+- On a planned day, keep the plan readable and show the same repair card; block
+  only actions that require a new inference run.
+
+Suggested copy:
+
+```text
+Choose how Daily OS should think
+Select the profile, model, and provider that will process your Daily OS context.
+[Set up AI]
+```
+
+### Missing preferred name
+
+The preferred name is optional and must never block planning.
+
+- Show a gentle personalization nudge when no name is set.
+- Keep “Speak a check-in” enabled when inference is ready.
+- Action copy: “Add how you’d like to be addressed.”
+- Navigate to the Daily OS personalization section and focus the name field.
+- Retire the nudge reactively as soon as a non-empty name is saved.
+
+### Both values missing
+
+Render one setup card, not two competing banners:
+
+```text
+Finish setting up Daily OS
+○ Choose AI profile and provider — Required
+○ Add how you’d like to be addressed — Optional
+[Open Daily OS settings]
+```
+
+The required inference item determines the primary CTA behavior. The optional
+name item never blocks it once inference becomes ready.
+
+### Nudge lifecycle
+
+- Do not auto-open Settings.
+- Do not repeatedly toast on page entry.
+- Do not permanently occupy the surface after both items are configured.
+- Preserve the last established readiness state during background refreshes so
+  the card and primary CTA do not flash.
+- If a configured provider/profile is later deleted, the repair nudge returns
+  immediately and no remote fallback is selected.
+
+## Technical eligibility and privacy presentation
+
+### Shared technical policy
+
+Extract a generic agentic-thinking predicate from
+`isTaskAgentThinkingModel`:
+
+```text
+isAgenticThinkingModel(model)
+  supports function calling
+  accepts text input
+  produces text output
+```
+
+Build a shared catalog around explicit use-case requirements:
+
+```text
+InferenceUseCaseRequirements
+  required input modalities
+  required output modalities
+  requiresFunctionCalling
+  platform constraints
+
+InferenceSelectionCatalog
+  eligible profiles
+  eligible models
+  referenced providers
+  resolved route details
+  endpoint presentation metadata
+```
+
+The Daily OS policy permits every `InferenceProviderType`. Google Gemini,
+OpenAI, Anthropic, Mistral, Melious, Alibaba, OpenRouter, custom
+OpenAI-compatible endpoints, and local providers remain eligible when their
+configured model satisfies the technical contract.
+
+### Profile eligibility
+
+A profile is offered when:
+
+- its thinking slot resolves to an `AiConfigModel`;
+- that model satisfies the agentic-thinking contract;
+- its `AiConfigInferenceProvider` exists and is usable;
+- it is available on the current platform.
+
+Only the thinking slot is relevant to P1 eligibility because it is the slot the
+current day-agent workflow executes. Preserve optional slots for runtime use and
+future capabilities.
+
+An already-selected profile that becomes invalid stays visible as unavailable
+so the user understands what broke. It is not offered as a new valid choice.
+
+### Endpoint classification
+
+Provider type alone is insufficient for privacy presentation because base URLs
+are configurable.
+
+- embedded runtime: on-device;
+- validated `localhost`, `127.0.0.0/8`, or `::1`: loopback/on-device;
+- every other host: remote or network endpoint;
+- malformed/missing custom host: unknown endpoint, treated as non-local for
+  presentation and safety.
+
+Do not infer contractual privacy or residency from these transport categories.
+
+### Recommendation without exclusion
+
+Local routes can be placed in a “Recommended for privacy” section or sorted
+before remote routes. This affects presentation only:
+
+- every technically eligible provider remains selectable;
+- provider text remains visible;
+- recommendation is never encoded as a hidden filter;
+- no brand receives a GDPR badge without auditable policy metadata.
+
+## Persistence and precedence
+
+### Default source
+
+Persist the Daily OS default as `dayAgentTemplateId`’s `profileId` and create the
+corresponding template version through `AgentTemplateService.updateTemplate`.
+Do not place the inference default in `DailyOsPreferencesController`; that
+controller is device-local and is appropriate for the greeting name and UI
+preferences, not synced execution routing.
+
+### Planner setup
+
+Use the existing `AgentInferenceSetup` fields:
+
+- `baseProfileId`: selected profile config ID;
+- `thinkingModelOverrideId`: direct `AiConfigModel.id`, never
+  `providerModelId`;
+- `origin`: `templateSnapshot` while following the default, `user` for an
+  explicit planner override;
+- `originEntityId`: `dayAgentTemplateId` for a copied default.
+
+Update the type and field docstrings that currently say the typed setup is only
+for task agents. The model and resolver are already generic enough for the day
+agent.
+
+### Default propagation
+
+Create a Daily OS inference settings coordinator that performs the user-visible
+default mutation:
+
+1. validate the selected profile against the current catalog;
+2. update the Shepherd template and version;
+3. load `daily_os_planner`, if it exists;
+4. if its setup is absent/legacy or has `templateSnapshot` origin, copy the new
+   profile into a typed template snapshot and clear its direct model override;
+5. if its setup has `user` origin, leave it unchanged;
+6. publish the existing agent/config update notifications;
+7. complete persistence before closing the picker and showing success.
+
+Nested agent sync transactions already share their buffer, so the coordinator
+should use an outer transaction where the current services permit it. A failed
+write must not leave the UI claiming the new default is active.
+
+### New planner creation
+
+`DayAgentService.getOrCreatePlannerAgent` should create a typed setup when the
+template has a profile:
+
+```text
+mode: configured
+origin: templateSnapshot
+baseProfileId: template.profileId
+originEntityId: dayAgentTemplateId
+```
+
+Retain the legacy model fallback when the template has no profile so existing
+installations keep working until the user selects a route.
+
+### Avoid a new inherit enum
+
+Do not add `AgentInferenceSetupMode.inherit` in this P1. Older clients currently
+deserialize unknown setup modes as `disabled`; syncing a new enum value would
+make the planner unexpectedly stop on those clients. Existing
+`templateSnapshot` origin plus explicit default propagation expresses the
+needed behavior without a cross-version enum hazard.
+
+### Runtime behavior
+
+The runtime stays:
+
+```mermaid
+flowchart LR
+  Default["Shepherd default profile"] --> Snapshot["Planner template snapshot"]
+  Override["Planner user override"] --> Resolver["ProfileResolver"]
+  Snapshot --> Resolver
+  Resolver --> Exact["Exact model + provider"]
+  Exact --> Prompt["Daily OS assembled context"]
+  Prompt --> Provider["Selected provider"]
+```
+
+Rules:
+
+- resolve the exact persisted model/provider;
+- persist `AiConfigModel.id` for direct overrides;
+- never substitute another provider when resolution fails;
+- show a repair state before a user starts another inference-dependent action;
+- keep existing plans and non-inference reads available during repair.
+
+## Picker changes and reuse
+
+### Profile picker
+
+Extend the shared profile picker through optional presentation data rather than
+forking a Daily OS modal. The Daily OS caller needs to show:
+
+- effective thinking-model name;
+- model publisher when known;
+- serving-provider name;
+- local/remote endpoint classification;
+- unavailable state.
+
+Existing callers that pass no presentation data retain the PR #3450 behavior.
+
+### Model picker
+
+Add an option such as:
+
+```text
+autoSelectSingleCandidate: true
+```
+
+Keep `true` as the compatibility default. Daily OS passes `false`, ensuring the
+single candidate still appears with provider identity and definitive transfer
+disclosure before the user selects it.
+
+The provider-first navigation, default marker, selected marker, ordering, and
+modal layout stay shared.
+
+### Save behavior
+
+Match the corrected task-agent flow from PR #3450:
+
+- selection is terminal only after persistence succeeds;
+- success closes the selection/setup surface and shows a scoped toast;
+- failure keeps the surface open and reports the error there;
+- background refresh retains the current rendered data.
+
+## Suggested code organization
+
+Names are illustrative; preserve the existing project naming style during
+implementation.
+
+### New Daily OS files
+
+```text
+lib/features/daily_os_next/state/daily_os_setup_status_provider.dart
+lib/features/daily_os_next/state/daily_os_inference_options_provider.dart
+lib/features/daily_os_next/agents/service/daily_os_inference_settings_service.dart
+lib/features/daily_os_next/ui/settings/daily_os_settings_body.dart
+lib/features/daily_os_next/ui/settings/daily_os_inference_settings_section.dart
+lib/features/daily_os_next/ui/widgets/daily_os_setup_nudge.dart
+```
+
+Each new source file gets one mirrored test file.
+
+### Existing files likely touched
+
+```text
+lib/features/settings_v2/domain/settings_tree_data.dart
+lib/features/settings_v2/ui/detail/panel_registry.dart
+lib/features/settings_v2/ui/labels/settings_tree_labels.dart
+lib/features/settings/settings_location.dart (or the current route mapping)
+lib/features/settings/ui/pages/advanced/about_page.dart
+lib/features/daily_os_next/state/daily_os_preferences_controller.dart
+lib/features/daily_os_next/state/daily_os_onboarding_trigger_service.dart
+lib/features/daily_os_next/agents/service/day_agent_service.dart
+lib/features/daily_os_next/ui/pages/daily_os_next_root.dart
+lib/features/daily_os_next/ui/pages/day_page.dart
+lib/features/daily_os_next/ui/pages/day_page_header.dart
+lib/features/agents/model/agent_config.dart
+lib/features/agents/state/task_agent_model_providers.dart
+lib/features/ai/ui/widgets/inference_profile_picker_modal.dart
+lib/features/ai/ui/widgets/inference_provider_model_picker_modal.dart
+```
+
+Generated `*.g.dart` and `*.freezed.dart` files are regenerated, never edited
+directly.
+
+## Implementation sequence
+
+### Phase 1 — Shared policy and readiness
+
+1. Extract `isAgenticThinkingModel` and keep task-agent behavior unchanged.
+2. Add endpoint classification as pure, tested logic.
+3. Add the Daily OS selection catalog with no provider-type exclusions.
+4. Extract shared Daily OS inference readiness from the onboarding trigger.
+5. Add `DailyOsSetupStatus`, including explicit-choice and preferred-name
+   state.
+6. Keep all Phase 1 tests green before adding UI files.
+
+### Phase 2 — Persistence
+
+1. Generalize `AgentInferenceSetup` documentation beyond task agents.
+2. Add the Daily OS inference settings coordinator.
+3. Write the Shepherd default and version snapshot.
+4. Propagate to template-following planners only.
+5. Update planner creation to write `templateSnapshot` typed setup.
+6. Add profile/model override and reset operations for the planner.
+7. Test transactional failure and no-silent-fallback behavior.
+
+### Phase 3 — Dedicated settings panel
+
+1. Add the Settings V2 tree node, labels, route, and panel registration.
+2. Extract Daily OS personalization from About without changing its stored key.
+3. Add the default profile picker and resolved route summary.
+4. Add definitive local/remote data-transfer disclosure.
+5. Add provider repair/navigation actions.
+6. Preserve established content during background refreshes.
+
+### Phase 4 — Planner override UI
+
+1. Add the inference section to the day-agent instance detail.
+2. Render default vs override mode and origin.
+3. Reuse the profile picker.
+4. Reuse the provider-first model picker with single-candidate auto-selection
+   disabled.
+5. Add “Use profile default” and “Reset to Daily OS default.”
+6. Surface broken and cross-platform unavailable selections.
+
+### Phase 5 — In-product discoverability
+
+1. Add the permanent Day-header “Daily OS settings” action.
+2. Add the combined setup nudge below the Day header.
+3. Guard the empty-day check-in CTA when inference is not ready.
+4. Keep the CTA enabled for missing-name-only state.
+5. Deep-link/focus the relevant settings section.
+6. Return the nudge reactively if a provider/profile is deleted later.
+
+### Phase 6 — Localization, documentation, and release metadata
+
+1. Add all user-visible copy to `app_en.arb`, `app_cs.arb`, `app_de.arb`,
+   `app_es.arb`, `app_fr.arb`, and `app_ro.arb`.
+2. Use informal German/French/Spanish and the established formal Romanian
+   register.
+3. Run `make sort_arb_files` and `make l10n`.
+4. Update `lib/features/daily_os_next/README.md` architecture-first, including
+   setup state and inference precedence diagrams.
+5. Update `lib/features/agents/README.md` for typed day-agent setup and default
+   propagation.
+6. Update `lib/features/ai/README.md` for the new shared picker options and
+   endpoint disclosure.
+7. Add a user-visible CHANGELOG entry under the current pubspec version and the
+   matching Flatpak metainfo release entry.
+
+## Test plan
+
+### Pure policy tests
+
+- every provider enum remains eligible when paired with a technically capable
+  model and usable configuration;
+- Gemini/Google is explicitly included;
+- function-calling, text-input, and text-output requirements are enforced;
+- local recommendation changes ordering/presentation, never membership;
+- embedded, loopback, remote, malformed, and custom endpoint classifications;
+- missing model/provider rows fail closed;
+- selected unavailable rows remain representable;
+- candidate ordering is deterministic.
+
+Use Glados for catalog/filter invariants because this is non-trivial pure logic.
+Tag every property test with `glados`.
+
+### Persistence tests
+
+- changing the general default updates the Shepherd template and active
+  version;
+- a missing planner is not created merely by viewing settings;
+- a newly created planner receives a template snapshot;
+- an absent/legacy or template-snapshot planner follows a default change;
+- a user-origin planner override does not change;
+- changing profile clears a direct model override;
+- direct overrides persist `AiConfigModel.id`;
+- reset copies the latest default;
+- a failed transaction leaves both template and planner unchanged;
+- provider/profile deletion produces a broken state with no fallback.
+
+### Settings UI tests
+
+- the Daily OS node appears in desktop and mobile settings;
+- personalization moved from About without losing the value;
+- default profile, effective model, provider, and endpoint render;
+- definitive transfer copy renders for local and remote routes;
+- Google appears when configured and eligible;
+- a legacy route is labeled as legacy, not user-selected;
+- picker persistence succeeds before close;
+- save failure keeps the picker open;
+- background reload preserves the established field value;
+- unavailable selection exposes a repair action;
+- 200% text scale retains model/provider identity and actions.
+
+### Planner override UI tests
+
+- “Use Daily OS default” renders effective default and origin;
+- choosing a profile writes a user override;
+- choosing a direct model distinguishes “Default” from “Selected”;
+- the single eligible model still opens a visible picker;
+- “Use profile default” clears only the model override;
+- “Reset to Daily OS default” clears the user override;
+- broken/deleted selection remains visible;
+- desktop-only selection is explained on unsupported platforms.
+
+### Discoverability tests
+
+- Day header always exposes “Daily OS settings”;
+- missing inference route renders the setup card;
+- missing inference route changes/guards the empty-day primary CTA;
+- tapping the guarded CTA navigates to settings and does not open Capture;
+- planned-day content remains readable while inference actions are blocked;
+- missing name alone renders a gentle nudge and does not block check-in;
+- both missing values render one combined card;
+- name save retires the optional row reactively;
+- inference save restores the ordinary check-in CTA reactively;
+- deleting the active provider makes the repair nudge return;
+- background refresh does not flash the nudge or CTA state.
+
+### Runtime tests
+
+- DayAgentWorkflow uses the exact selected profile route;
+- direct thinking override replaces only the thinking route;
+- model/provider identity is stable across resolution;
+- missing explicit model/provider stops the wake;
+- no alternate provider is selected automatically;
+- legacy route remains compatible until an explicit selection is written.
+
+## Validation workflow
+
+During implementation:
+
+1. register the repository root with `dart-mcp.add_roots`;
+2. run `dart-mcp.analyze_files` after each coherent slice;
+3. run `fvm dart format .` frequently;
+4. run targeted tests for the touched source/test pairs through
+   `dart-mcp.run_tests`;
+5. run `make build_runner` through MCP only when generated agent models change;
+6. run `make sort_arb_files` and `make l10n` after localization edits;
+7. rerun targeted picker, Daily OS settings, planner service, resolver, and
+   runtime tests;
+8. finish with analyzer zero warnings/infos and all requested tests passing.
+
+Do not run the full test suite unless specifically requested. Do not report
+completion until compilation, analysis, and the relevant tests succeed.
+
+## PR and release workflow
+
+1. Create a focused feature branch and implementation commits using
+   Conventional Commits.
+2. Include desktop and mobile screenshots of:
+   - configured Daily OS settings;
+   - remote-provider disclosure;
+   - missing-provider setup nudge;
+   - missing-name-only nudge;
+   - planner override with profile default vs selected model.
+3. Open the PR with explicit privacy behavior and data-flow notes.
+4. Run local UX/UI, architecture, and privacy panel reviews.
+5. Address Gemini and CodeRabbit comments based on the implemented contract;
+   add regression tests for every behavior-changing fix.
+6. Re-run formatting, targeted tests, localization generation, and analysis.
+7. Merge only with clean CI and zero analyzer findings.
+8. Release through the existing all-platform process with matching CHANGELOG
+   and Flatpak metainfo entries.
+
+## Acceptance criteria
+
+- Daily OS has a dedicated, directly reachable settings panel.
+- Daily OS settings are always reachable from the Daily OS header.
+- The default profile is user-selectable and shows its effective model,
+  provider, and destination.
+- Every technically eligible configured provider remains selectable, including
+  Google Gemini.
+- Local routes can be recommended without hiding remote routes.
+- The UI states definitively that Daily OS sends the assembled planning context
+  to the selected provider.
+- The planner can follow the Daily OS default or retain an explicit profile or
+  thinking-model override.
+- Default changes never overwrite a user-origin planner override.
+- A missing/broken provider redirects the user to setup before a check-in flow
+  that requires inference.
+- A missing preferred name is discoverable but never blocks planning.
+- Both missing values render one coherent setup card.
+- Deleted or unavailable selections never trigger silent provider fallback.
+- Background refresh preserves established UI instead of flashing loading,
+  empty, error, or setup states.
+- All user-visible text is localized in the required ARB files.
+- Feature READMEs, CHANGELOG, and Flatpak metainfo match the shipped behavior.
+- Analyzer output is clean and all targeted tests pass.

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -32,10 +32,14 @@
   <launchable type="desktop-id">com.matthiasn.lotti.desktop</launchable>
   <icon type="stock">com.matthiasn.lotti</icon>
   <releases>
+    <release version="0.9.1044" date="2026-07-14">
+      <description>
+          <p>Daily OS now has a discoverable settings page for choosing its default inference profile and preferred name, plus per-planner profile and thinking-model overrides. Setup explains that assembled planning context is sent to the selected provider and identifies whether its configured endpoint is local or remote.</p>
+      </description>
+    </release>
     <release version="0.9.1043" date="2026-07-14">
       <description>
           <p>Daily OS is now available to everyone. The Daily OS day-planning surface no longer sits behind a feature flag and appears in the main navigation for all users.</p>
-          <p>Daily OS now has a discoverable settings page for choosing its default inference profile and preferred name, plus per-planner profile and thinking-model overrides. Setup explains that assembled planning context is sent to the selected provider and identifies whether its configured endpoint is local or remote.</p>
       </description>
     </release>
     <release version="0.9.1042" date="2026-07-13">

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -35,6 +35,7 @@
     <release version="0.9.1043" date="2026-07-14">
       <description>
           <p>Daily OS is now available to everyone. The Daily OS day-planning surface no longer sits behind a feature flag and appears in the main navigation for all users.</p>
+          <p>Daily OS now has a discoverable settings page for choosing its default inference profile and preferred name, plus per-planner profile and thinking-model overrides. Setup explains that assembled planning context is sent to the selected provider and identifies whether its configured endpoint is local or remote.</p>
       </description>
     </release>
     <release version="0.9.1042" date="2026-07-13">

--- a/lib/beamer/locations/settings_location.dart
+++ b/lib/beamer/locations/settings_location.dart
@@ -15,6 +15,7 @@ import 'package:lotti/features/categories/ui/pages/categories_list_page.dart'
     as new_categories;
 import 'package:lotti/features/categories/ui/pages/category_details_page.dart'
     as new_category_details;
+import 'package:lotti/features/daily_os_next/ui/pages/daily_os_settings_page.dart';
 import 'package:lotti/features/journal/ui/pages/entry_details_page.dart';
 import 'package:lotti/features/labels/ui/pages/label_details_page.dart';
 import 'package:lotti/features/labels/ui/pages/labels_list_page.dart';
@@ -115,6 +116,7 @@ class SettingsLocation extends BeamLocation<BeamState> {
     '/settings/agents/souls/:soulId',
     '/settings/agents/souls/:soulId/review',
     '/settings/agents/instances/:agentId',
+    '/settings/daily-os',
     '/settings/flags',
     '/settings/recording-style',
     '/settings/theming',
@@ -565,6 +567,12 @@ class SettingsLocation extends BeamLocation<BeamState> {
           child: AgentDetailPage(
             agentId: state.pathParameters['agentId']!,
           ),
+        ),
+
+      if (path == '/settings/daily-os')
+        const BeamPage(
+          key: ValueKey('settings-daily-os'),
+          child: DailyOsSettingsPage(),
         ),
 
       // Flags

--- a/lib/features/agents/README.md
+++ b/lib/features/agents/README.md
@@ -155,6 +155,17 @@ the task-details column. A failed write leaves the sheet open and reports the
 error there. Capturing the messenger before opening the root-navigator modal is
 what keeps successful feedback constrained to the task column.
 
+Daily OS uses the same resolution and picker primitives without depending on
+the task-agent service. The planner's Stats tab detects `AgentKinds.dayAgent`
+and opens `DailyOsInferenceSetupSheet`: “Use Daily OS default” clears the
+instance override, “Choose Daily OS profile” opens the shared profile picker,
+and “Choose model override” opens the shared provider-first
+`InferenceProviderModelPickerModal`. All paths persist through
+`DayAgentService` before closing. A profile choice clears the direct model
+override; a later model choice retains that profile as its base. The general
+default remains on the day-agent template, so the instance sheet cannot
+silently change the default for future planner creation.
+
 ```mermaid
 sequenceDiagram
   participant User

--- a/lib/features/agents/model/agent_config.dart
+++ b/lib/features/agents/model/agent_config.dart
@@ -18,7 +18,7 @@ abstract class AgentConfig with _$AgentConfig {
     /// Inference profile ID — takes precedence over [modelId] when set.
     String? profileId,
 
-    /// Typed persistent inference setup for task agents.
+    /// Typed persistent inference setup for agent instances.
     ///
     /// Null preserves the legacy profile/template/model resolution chain.
     /// Once present, this setup is authoritative: configured setups resolve
@@ -53,7 +53,7 @@ extension AgentConfigAutomation on AgentConfig {
   bool get automaticUpdatesEnabledEffective => automaticUpdatesEnabled ?? true;
 }
 
-/// Persistent inference routing owned by one task-agent instance.
+/// Persistent inference routing owned by one agent instance.
 @freezed
 abstract class AgentInferenceSetup with _$AgentInferenceSetup {
   const factory AgentInferenceSetup({
@@ -66,7 +66,7 @@ abstract class AgentInferenceSetup with _$AgentInferenceSetup {
     /// direct thinking-model override is selected.
     String? baseProfileId,
 
-    /// Config-row ID (`AiConfigModel.id`) for the task agent's thinking model.
+    /// Config-row ID (`AiConfigModel.id`) for the agent's thinking model.
     /// This is deliberately not a provider-native `providerModelId`.
     String? thinkingModelOverrideId,
 

--- a/lib/features/agents/state/task_agent_model_providers.dart
+++ b/lib/features/agents/state/task_agent_model_providers.dart
@@ -16,6 +16,10 @@ taskAgentResolvedSetupProvider = FutureProvider.autoDispose
       name: 'taskAgentResolvedSetupProvider',
     );
 
+/// Agent-kind-neutral alias used by Daily OS and other agent surfaces.
+final FutureProviderFamily<ResolvedAgentSetup?, String>
+agentResolvedSetupProvider = taskAgentResolvedSetupProvider;
+
 Future<ResolvedAgentSetup?> taskAgentResolvedSetup(
   Ref ref,
   String agentId,
@@ -65,6 +69,10 @@ final FutureProvider<TaskAgentSetupOptions> taskAgentSetupOptionsProvider =
       name: 'taskAgentSetupOptionsProvider',
     );
 
+/// Shared catalog for agentic inference pickers.
+final FutureProvider<TaskAgentSetupOptions> agentSetupOptionsProvider =
+    taskAgentSetupOptionsProvider;
+
 Future<TaskAgentSetupOptions> taskAgentSetupOptions(Ref ref) async {
   final repository = ref.watch(aiConfigRepositoryProvider);
   final values = await Future.wait([
@@ -76,14 +84,18 @@ Future<TaskAgentSetupOptions> taskAgentSetupOptions(Ref ref) async {
     profiles: values[0].whereType<AiConfigInferenceProfile>().toList(),
     models: values[1]
         .whereType<AiConfigModel>()
-        .where(isTaskAgentThinkingModel)
+        .where(isAgenticThinkingModel)
         .toList(),
     providers: values[2].whereType<AiConfigInferenceProvider>().toList(),
   );
 }
 
-bool isTaskAgentThinkingModel(AiConfigModel model) {
+bool isAgenticThinkingModel(AiConfigModel model) {
   return model.supportsFunctionCalling &&
       model.inputModalities.contains(Modality.text) &&
       model.outputModalities.contains(Modality.text);
 }
+
+/// Backward-compatible name for existing task-agent callers.
+bool isTaskAgentThinkingModel(AiConfigModel model) =>
+    isAgenticThinkingModel(model);

--- a/lib/features/agents/ui/agent_internals_body.dart
+++ b/lib/features/agents/ui/agent_internals_body.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/model/agent_report_provenance.dart';
@@ -14,6 +15,7 @@ import 'package:lotti/features/agents/ui/agent_template_detail_page.dart';
 import 'package:lotti/features/agents/ui/agent_token_usage_section.dart';
 import 'package:lotti/features/agents/ui/task_agent_model_identity.dart';
 import 'package:lotti/features/ai/model/resolved_profile.dart';
+import 'package:lotti/features/daily_os_next/ui/widgets/daily_os_inference_setup_sheet.dart';
 import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
@@ -304,7 +306,12 @@ class _ProfileSection extends ConsumerWidget {
         .watch(agentStateProvider(agentId))
         .value
         ?.mapOrNull(agentState: (value) => value);
-    final setup = ref.watch(taskAgentResolvedSetupProvider(agentId)).value;
+    final identity = ref
+        .watch(agentIdentityProvider(agentId))
+        .value
+        ?.mapOrNull(agent: (value) => value);
+    final isDailyOs = identity?.kind == AgentKinds.dayAgent;
+    final setup = ref.watch(agentResolvedSetupProvider(agentId)).value;
     final route = setup?.profile == null
         ? null
         : formatInferenceRouteIdentity(
@@ -329,7 +336,9 @@ class _ProfileSection extends ConsumerWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            context.messages.taskAgentSetupTitle,
+            isDailyOs
+                ? context.messages.dailyOsSettingsInstanceOverrideTitle
+                : context.messages.taskAgentSetupTitle,
             style: tokens.typography.styles.subtitle.subtitle2,
           ),
           SizedBox(height: tokens.spacing.step3),
@@ -337,6 +346,8 @@ class _ProfileSection extends ConsumerWidget {
             title: route ?? setupTitle,
             subtitle: route == null
                 ? setupSubtitle
+                : isDailyOs
+                ? context.messages.dailyOsSettingsInstanceCurrentSetup
                 : context.messages.taskAgentCurrentSetupLabel,
             subtitleMaxLines: null,
             leading: Icon(
@@ -345,7 +356,9 @@ class _ProfileSection extends ConsumerWidget {
                   : Icons.psychology_outlined,
             ),
             trailing: const Icon(Icons.chevron_right_rounded),
-            onTap: taskId == null
+            onTap: isDailyOs
+                ? () => DailyOsInferenceSetupSheet.show(context)
+                : taskId == null
                 ? null
                 : () => AgentModelSheet.show(
                     context: context,

--- a/lib/features/ai/README.md
+++ b/lib/features/ai/README.md
@@ -54,14 +54,19 @@ than owning feature-specific modal rows:
 
 - `InferenceProfilePickerModal` and its embeddable
   `InferenceProfilePickerList` render named inference profiles for category
-  defaults, template settings, agent creation, and task-agent setup. The list
+  defaults, template settings, agent creation, task-agent setup, and Daily OS
+  defaults. The list
   uses the profile description as secondary text and marks the persisted
   selection without exposing internal model IDs.
 - `InferenceProviderModelPickerModal` renders model choices for inference-profile
-  slots, task-agent overrides, and per-invocation skill overrides. With multiple
+  slots, task-agent overrides, Daily OS planner overrides, and per-invocation
+  skill overrides. With multiple
   providers it drills from provider to model; with one provider it opens the
   model list directly. `selectedModelId` identifies the active choice while
   `defaultModelId` independently marks the profile default.
+  Callers that require an explicit confirmation even when only one compatible
+  model exists pass `autoSelectSingleCandidate: false`; Daily OS uses this so
+  a single configured provider/model is still an informed user choice.
 
 Closed fields use `SettingsPickerField`, so settings pages keep the same label,
 value, disabled, and tap affordances. Async Riverpod consumers retain their last
@@ -70,8 +75,8 @@ an established picker with a full loading shell.
 
 ```mermaid
 flowchart LR
-  Profiles["Category / template / agent creation / task agent"] --> ProfilePicker["InferenceProfilePickerModal or list"]
-  Slots["Profile slots / task override / one-run override"] --> ModelPicker["InferenceProviderModelPickerModal"]
+  Profiles["Category / template / agent creation / task agent / Daily OS"] --> ProfilePicker["InferenceProfilePickerModal or list"]
+  Slots["Profile slots / agent override / one-run override"] --> ModelPicker["InferenceProviderModelPickerModal"]
   ModelPicker --> Providers{"provider count"}
   Providers -->|one| Models["model rows"]
   Providers -->|many| ProviderRows["provider rows"]

--- a/lib/features/ai/ui/widgets/inference_provider_model_picker_modal.dart
+++ b/lib/features/ai/ui/widgets/inference_provider_model_picker_modal.dart
@@ -44,6 +44,7 @@ class InferenceProviderModelPickerModal {
     required String title,
     required String defaultBadgeLabel,
     String? selectedModelId,
+    bool autoSelectSingleCandidate = true,
   }) async {
     final providersById = <String, AiConfigInferenceProvider>{
       for (final provider in providers) provider.id: provider,
@@ -60,7 +61,9 @@ class InferenceProviderModelPickerModal {
         .toList();
     final validModels = withProvider.isEmpty ? models : withProvider;
     if (validModels.isEmpty) return null;
-    if (validModels.length == 1) return validModels.first.id;
+    if (validModels.length == 1 && autoSelectSingleCandidate) {
+      return validModels.first.id;
+    }
     final effectiveSelectedModelId = selectedModelId ?? defaultModelId;
 
     // Group models under their provider, preserving first-seen order so the

--- a/lib/features/daily_os_next/README.md
+++ b/lib/features/daily_os_next/README.md
@@ -87,6 +87,33 @@ Runtime behavior:
   stay visible. Each legacy agent is migrated under its own try/catch, so one
   failure neither blocks planner creation nor stops the others.
 - The shared template service seeds the `Shepherd` day-agent template.
+- Daily OS inference settings are split across two synced ownership levels.
+  The `Shepherd` template's `profileId` is the general default; the
+  `daily_os_planner` identity's typed `AgentInferenceSetup` is the optional
+  instance override. `DayAgentService.updateDefaultInferenceProfile` updates
+  an existing planner only while it still follows a `templateSnapshot`, so a
+  later default change never replaces a user-owned profile or direct model
+  override. Clearing the override copies the current template profile back
+  into the planner as a new template snapshot.
+
+```mermaid
+flowchart LR
+  Settings["Settings → Daily OS"] -->|choose profile| Template["Shepherd template.profileId"]
+  Template -->|template snapshot| Planner["daily_os_planner AgentInferenceSetup"]
+  Internals["Planner internals"] -->|optional profile / direct model| Planner
+  Planner --> Resolver["ProfileResolver"]
+  Resolver --> Context["Assembled tasks, captures, plans, and preferences"]
+  Context --> Provider["User-selected provider endpoint"]
+```
+
+The settings page lists every configured compatible profile/provider route; it
+does not maintain a provider denylist. The selected endpoint determines the
+privacy boundary. Daily OS **sends** its assembled planning context to that
+provider for processing. Loopback and embedded endpoints are described as
+on-device; every other configured endpoint is described as remote with its
+provider and host. The Day surface links to these settings from its overflow
+menu, blocks a new check-in when no route resolves, and shows a non-blocking
+preferred-name prompt when inference is ready but personalization is missing.
 - `DayAgentWorkflow` builds the prompt from template directives, the planner's
   durable knowledge (a compact always-on **hook index** plus scoped full
   statements), recent private observations, the day's `day_log`, and — for

--- a/lib/features/daily_os_next/agents/service/day_agent_service.dart
+++ b/lib/features/daily_os_next/agents/service/day_agent_service.dart
@@ -4,7 +4,12 @@ import 'package:lotti/features/agents/model/agent_config.dart';
 import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart'
-    show AgentLifecycle, AgentTemplateKind, WakeReason;
+    show
+        AgentInferenceSetupMode,
+        AgentInferenceSetupOrigin,
+        AgentLifecycle,
+        AgentTemplateKind,
+        WakeReason;
 import 'package:lotti/features/agents/model/agent_link.dart';
 import 'package:lotti/features/agents/service/agent_service.dart';
 import 'package:lotti/features/agents/service/agent_template_service.dart';
@@ -121,13 +126,22 @@ class DayAgentService {
         );
       }
 
+      final resolvedProfileId = profileId ?? templateEntity.profileId;
       final createdIdentity = await agentService.createAgent(
         agentId: dailyOsPlannerAgentId,
         kind: _agentKind,
         displayName: displayName ?? 'Shepherd',
         config: AgentConfig(
           modelId: templateEntity.modelId,
-          profileId: profileId ?? templateEntity.profileId,
+          profileId: resolvedProfileId,
+          inferenceSetup: resolvedProfileId == null
+              ? null
+              : AgentInferenceSetup(
+                  mode: AgentInferenceSetupMode.configured,
+                  origin: AgentInferenceSetupOrigin.templateSnapshot,
+                  baseProfileId: resolvedProfileId,
+                  originEntityId: resolvedTemplateId,
+                ),
         ),
         allowedCategoryIds: allowedCategoryIds,
       );
@@ -161,6 +175,150 @@ class DayAgentService {
     }
     await _migrateLegacyDayAgents(planner: identity);
     return identity;
+  }
+
+  /// Changes the synced default inference profile for Daily OS.
+  ///
+  /// Existing planners that still follow the template snapshot are updated as
+  /// part of the change. A planner with a user-owned override is deliberately
+  /// left untouched, so changing the default never silently replaces an
+  /// explicit instance choice.
+  Future<void> updateDefaultInferenceProfile(String profileId) async {
+    String? updatedPlannerId;
+    await syncService.runInTransaction(() async {
+      await templateService.updateTemplate(
+        templateId: dayAgentTemplateId,
+        profileId: profileId,
+      );
+
+      final planner = await agentService.getAgent(dailyOsPlannerAgentId);
+      if (planner == null) return;
+
+      final currentSetup = planner.config.inferenceSetup;
+      if (currentSetup != null &&
+          currentSetup.origin != AgentInferenceSetupOrigin.templateSnapshot) {
+        return;
+      }
+
+      final updated = planner.copyWith(
+        config: planner.config.copyWith(
+          profileId: profileId,
+          inferenceSetup: AgentInferenceSetup(
+            mode: AgentInferenceSetupMode.configured,
+            origin: AgentInferenceSetupOrigin.templateSnapshot,
+            baseProfileId: profileId,
+            originEntityId: dayAgentTemplateId,
+          ),
+        ),
+        updatedAt: clock.now(),
+      );
+      await syncService.upsertEntity(updated);
+      updatedPlannerId = planner.agentId;
+    });
+    if (updatedPlannerId case final plannerId?) {
+      onPersistedStateChanged?.call(plannerId);
+    }
+  }
+
+  /// Replaces the planner's inherited setup with a user-owned profile.
+  ///
+  /// Selecting a profile clears any direct thinking-model override so the
+  /// newly selected profile is authoritative in every capability slot.
+  Future<void> updatePlannerProfileOverride(String profileId) async {
+    final planner = await agentService.getAgent(dailyOsPlannerAgentId);
+    if (planner == null) {
+      throw StateError('Daily OS planner has not been created yet');
+    }
+
+    await _persistPlannerInferenceSetup(
+      planner: planner,
+      profileId: profileId,
+      setup: AgentInferenceSetup(
+        mode: AgentInferenceSetupMode.configured,
+        origin: AgentInferenceSetupOrigin.user,
+        baseProfileId: profileId,
+      ),
+    );
+  }
+
+  /// Persists a direct thinking-model override for the Daily OS planner.
+  ///
+  /// The planner's current base profile remains in place so its other
+  /// capability slots stay available.
+  Future<void> updatePlannerThinkingModelOverride(String modelConfigId) async {
+    final planner = await agentService.getAgent(dailyOsPlannerAgentId);
+    if (planner == null) {
+      throw StateError('Daily OS planner has not been created yet');
+    }
+    final template = await templateService.getTemplate(dayAgentTemplateId);
+    if (template == null) {
+      throw StateError('Daily OS template $dayAgentTemplateId not found');
+    }
+    final currentSetup = planner.config.inferenceSetup;
+    final baseProfileId =
+        currentSetup?.mode == AgentInferenceSetupMode.configured
+        ? currentSetup?.baseProfileId ??
+              planner.config.profileId ??
+              template.profileId
+        : planner.config.profileId ?? template.profileId;
+    if (baseProfileId == null) {
+      throw StateError('Choose a Daily OS default profile first');
+    }
+
+    await _persistPlannerInferenceSetup(
+      planner: planner,
+      profileId: baseProfileId,
+      setup: AgentInferenceSetup(
+        mode: AgentInferenceSetupMode.configured,
+        origin: AgentInferenceSetupOrigin.user,
+        baseProfileId: baseProfileId,
+        thinkingModelOverrideId: modelConfigId,
+        originEntityId: currentSetup?.originEntityId,
+      ),
+    );
+  }
+
+  /// Clears every planner override and follows the current Daily OS default.
+  Future<void> resetPlannerInferenceToDefault() async {
+    final planner = await agentService.getAgent(dailyOsPlannerAgentId);
+    if (planner == null) {
+      throw StateError('Daily OS planner has not been created yet');
+    }
+    final template = await templateService.getTemplate(dayAgentTemplateId);
+    if (template == null) {
+      throw StateError('Daily OS template $dayAgentTemplateId not found');
+    }
+    final profileId = template.profileId;
+    if (profileId == null) {
+      throw StateError('Choose a Daily OS default profile first');
+    }
+
+    await _persistPlannerInferenceSetup(
+      planner: planner,
+      profileId: profileId,
+      setup: AgentInferenceSetup(
+        mode: AgentInferenceSetupMode.configured,
+        origin: AgentInferenceSetupOrigin.templateSnapshot,
+        baseProfileId: profileId,
+        originEntityId: dayAgentTemplateId,
+      ),
+    );
+  }
+
+  Future<void> _persistPlannerInferenceSetup({
+    required AgentIdentityEntity planner,
+    required String profileId,
+    required AgentInferenceSetup setup,
+  }) async {
+    final updated = planner.copyWith(
+      config: planner.config.copyWith(
+        profileId: profileId,
+        inferenceSetup: setup,
+      ),
+      updatedAt: clock.now(),
+    );
+    await syncService.upsertEntity(updated);
+    onPersistedStateChanged?.call(planner.agentId);
   }
 
   /// Idempotent, best-effort migration from the old per-day identity model to

--- a/lib/features/daily_os_next/agents/service/day_agent_service.dart
+++ b/lib/features/daily_os_next/agents/service/day_agent_service.dart
@@ -225,20 +225,27 @@ class DayAgentService {
   /// Selecting a profile clears any direct thinking-model override so the
   /// newly selected profile is authoritative in every capability slot.
   Future<void> updatePlannerProfileOverride(String profileId) async {
-    final planner = await agentService.getAgent(dailyOsPlannerAgentId);
-    if (planner == null) {
-      throw StateError('Daily OS planner has not been created yet');
-    }
+    String? updatedPlannerId;
+    await syncService.runInTransaction(() async {
+      final planner = await agentService.getAgent(dailyOsPlannerAgentId);
+      if (planner == null) {
+        throw StateError('Daily OS planner has not been created yet');
+      }
 
-    await _persistPlannerInferenceSetup(
-      planner: planner,
-      profileId: profileId,
-      setup: AgentInferenceSetup(
-        mode: AgentInferenceSetupMode.configured,
-        origin: AgentInferenceSetupOrigin.user,
-        baseProfileId: profileId,
-      ),
-    );
+      await _persistPlannerInferenceSetup(
+        planner: planner,
+        profileId: profileId,
+        setup: AgentInferenceSetup(
+          mode: AgentInferenceSetupMode.configured,
+          origin: AgentInferenceSetupOrigin.user,
+          baseProfileId: profileId,
+        ),
+      );
+      updatedPlannerId = planner.agentId;
+    });
+    if (updatedPlannerId case final plannerId?) {
+      onPersistedStateChanged?.call(plannerId);
+    }
   }
 
   /// Persists a direct thinking-model override for the Daily OS planner.
@@ -246,63 +253,77 @@ class DayAgentService {
   /// The planner's current base profile remains in place so its other
   /// capability slots stay available.
   Future<void> updatePlannerThinkingModelOverride(String modelConfigId) async {
-    final planner = await agentService.getAgent(dailyOsPlannerAgentId);
-    if (planner == null) {
-      throw StateError('Daily OS planner has not been created yet');
-    }
-    final template = await templateService.getTemplate(dayAgentTemplateId);
-    if (template == null) {
-      throw StateError('Daily OS template $dayAgentTemplateId not found');
-    }
-    final currentSetup = planner.config.inferenceSetup;
-    final baseProfileId =
-        currentSetup?.mode == AgentInferenceSetupMode.configured
-        ? currentSetup?.baseProfileId ??
-              planner.config.profileId ??
-              template.profileId
-        : planner.config.profileId ?? template.profileId;
-    if (baseProfileId == null) {
-      throw StateError('Choose a Daily OS default profile first');
-    }
+    String? updatedPlannerId;
+    await syncService.runInTransaction(() async {
+      final planner = await agentService.getAgent(dailyOsPlannerAgentId);
+      if (planner == null) {
+        throw StateError('Daily OS planner has not been created yet');
+      }
+      final template = await templateService.getTemplate(dayAgentTemplateId);
+      if (template == null) {
+        throw StateError('Daily OS template $dayAgentTemplateId not found');
+      }
+      final currentSetup = planner.config.inferenceSetup;
+      final baseProfileId =
+          currentSetup?.mode == AgentInferenceSetupMode.configured
+          ? currentSetup?.baseProfileId ??
+                planner.config.profileId ??
+                template.profileId
+          : planner.config.profileId ?? template.profileId;
+      if (baseProfileId == null) {
+        throw StateError('Choose a Daily OS default profile first');
+      }
 
-    await _persistPlannerInferenceSetup(
-      planner: planner,
-      profileId: baseProfileId,
-      setup: AgentInferenceSetup(
-        mode: AgentInferenceSetupMode.configured,
-        origin: AgentInferenceSetupOrigin.user,
-        baseProfileId: baseProfileId,
-        thinkingModelOverrideId: modelConfigId,
-        originEntityId: currentSetup?.originEntityId,
-      ),
-    );
+      await _persistPlannerInferenceSetup(
+        planner: planner,
+        profileId: baseProfileId,
+        setup: AgentInferenceSetup(
+          mode: AgentInferenceSetupMode.configured,
+          origin: AgentInferenceSetupOrigin.user,
+          baseProfileId: baseProfileId,
+          thinkingModelOverrideId: modelConfigId,
+          originEntityId: currentSetup?.originEntityId,
+        ),
+      );
+      updatedPlannerId = planner.agentId;
+    });
+    if (updatedPlannerId case final plannerId?) {
+      onPersistedStateChanged?.call(plannerId);
+    }
   }
 
   /// Clears every planner override and follows the current Daily OS default.
   Future<void> resetPlannerInferenceToDefault() async {
-    final planner = await agentService.getAgent(dailyOsPlannerAgentId);
-    if (planner == null) {
-      throw StateError('Daily OS planner has not been created yet');
-    }
-    final template = await templateService.getTemplate(dayAgentTemplateId);
-    if (template == null) {
-      throw StateError('Daily OS template $dayAgentTemplateId not found');
-    }
-    final profileId = template.profileId;
-    if (profileId == null) {
-      throw StateError('Choose a Daily OS default profile first');
-    }
+    String? updatedPlannerId;
+    await syncService.runInTransaction(() async {
+      final planner = await agentService.getAgent(dailyOsPlannerAgentId);
+      if (planner == null) {
+        throw StateError('Daily OS planner has not been created yet');
+      }
+      final template = await templateService.getTemplate(dayAgentTemplateId);
+      if (template == null) {
+        throw StateError('Daily OS template $dayAgentTemplateId not found');
+      }
+      final profileId = template.profileId;
+      if (profileId == null) {
+        throw StateError('Choose a Daily OS default profile first');
+      }
 
-    await _persistPlannerInferenceSetup(
-      planner: planner,
-      profileId: profileId,
-      setup: AgentInferenceSetup(
-        mode: AgentInferenceSetupMode.configured,
-        origin: AgentInferenceSetupOrigin.templateSnapshot,
-        baseProfileId: profileId,
-        originEntityId: dayAgentTemplateId,
-      ),
-    );
+      await _persistPlannerInferenceSetup(
+        planner: planner,
+        profileId: profileId,
+        setup: AgentInferenceSetup(
+          mode: AgentInferenceSetupMode.configured,
+          origin: AgentInferenceSetupOrigin.templateSnapshot,
+          baseProfileId: profileId,
+          originEntityId: dayAgentTemplateId,
+        ),
+      );
+      updatedPlannerId = planner.agentId;
+    });
+    if (updatedPlannerId case final plannerId?) {
+      onPersistedStateChanged?.call(plannerId);
+    }
   }
 
   Future<void> _persistPlannerInferenceSetup({
@@ -318,7 +339,6 @@ class DayAgentService {
       updatedAt: clock.now(),
     );
     await syncService.upsertEntity(updated);
-    onPersistedStateChanged?.call(planner.agentId);
   }
 
   /// Idempotent, best-effort migration from the old per-day identity model to

--- a/lib/features/daily_os_next/state/daily_os_inference_providers.dart
+++ b/lib/features/daily_os_next/state/daily_os_inference_providers.dart
@@ -21,7 +21,9 @@ DailyOsInferenceEndpointKind dailyOsInferenceEndpointKind(
     return DailyOsInferenceEndpointKind.onDevice;
   }
 
-  final uri = Uri.tryParse(provider.baseUrl.trim());
+  final baseUrl = provider.baseUrl.trim();
+  final normalizedUrl = baseUrl.contains('://') ? baseUrl : 'http://$baseUrl';
+  final uri = Uri.tryParse(normalizedUrl);
   final host = uri?.host.toLowerCase();
   if (host == 'localhost' || host == '::1' || _isIpv4Loopback(host)) {
     return DailyOsInferenceEndpointKind.onDevice;

--- a/lib/features/daily_os_next/state/daily_os_inference_providers.dart
+++ b/lib/features/daily_os_next/state/daily_os_inference_providers.dart
@@ -45,10 +45,13 @@ String? dailyOsInferenceEndpointHost(AiConfigInferenceProvider provider) {
 bool _isIpv4Loopback(String? host) {
   if (host == null) return false;
   final parts = host.split('.');
-  if (parts.length != 4 || parts.any((part) => int.tryParse(part) == null)) {
+  if (parts.length != 4) return false;
+  final octets = parts.map(int.tryParse).toList();
+  if (octets.any((octet) => octet == null || octet < 0 || octet > 255)) {
     return false;
   }
-  return int.parse(parts.first) == 127;
+  // The entire 127.0.0.0/8 block is loopback (RFC 5735).
+  return octets.first == 127;
 }
 
 /// Setup facts used by the Daily OS surface to make missing configuration

--- a/lib/features/daily_os_next/state/daily_os_inference_providers.dart
+++ b/lib/features/daily_os_next/state/daily_os_inference_providers.dart
@@ -21,14 +21,25 @@ DailyOsInferenceEndpointKind dailyOsInferenceEndpointKind(
     return DailyOsInferenceEndpointKind.onDevice;
   }
 
-  final baseUrl = provider.baseUrl.trim();
-  final normalizedUrl = baseUrl.contains('://') ? baseUrl : 'http://$baseUrl';
-  final uri = Uri.tryParse(normalizedUrl);
-  final host = uri?.host.toLowerCase();
+  final host = dailyOsInferenceEndpointHost(provider)?.toLowerCase();
   if (host == 'localhost' || host == '::1' || _isIpv4Loopback(host)) {
     return DailyOsInferenceEndpointKind.onDevice;
   }
   return DailyOsInferenceEndpointKind.remote;
+}
+
+/// Returns the configured endpoint host after normalizing scheme-less URLs.
+///
+/// Provider settings accept values such as `localhost:11434` and
+/// `inference.example.com:443`. Prefixing a temporary scheme makes Dart parse
+/// those values as authorities instead of treating the text before `:` as a
+/// URI scheme.
+String? dailyOsInferenceEndpointHost(AiConfigInferenceProvider provider) {
+  final baseUrl = provider.baseUrl.trim();
+  if (baseUrl.isEmpty) return null;
+  final normalizedUrl = baseUrl.contains('://') ? baseUrl : 'http://$baseUrl';
+  final host = Uri.tryParse(normalizedUrl)?.host.trim();
+  return host == null || host.isEmpty ? null : host;
 }
 
 bool _isIpv4Loopback(String? host) {

--- a/lib/features/daily_os_next/state/daily_os_inference_providers.dart
+++ b/lib/features/daily_os_next/state/daily_os_inference_providers.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/service/agent_template_service.dart';
+import 'package:lotti/features/agents/state/template_query_providers.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/daily_os_next/state/daily_os_onboarding_trigger_service.dart';
+import 'package:lotti/features/daily_os_next/state/daily_os_preferences_controller.dart';
+
+/// Whether a configured inference endpoint is on this device or remote.
+enum DailyOsInferenceEndpointKind { onDevice, remote }
+
+/// Classifies the actual configured endpoint used by a provider.
+///
+/// Provider brands are intentionally irrelevant. A loopback endpoint is local
+/// even for a generic OpenAI-compatible provider, while a remotely hosted
+/// Ollama endpoint is remote.
+DailyOsInferenceEndpointKind dailyOsInferenceEndpointKind(
+  AiConfigInferenceProvider provider,
+) {
+  if (provider.inferenceProviderType == InferenceProviderType.mlxAudio) {
+    return DailyOsInferenceEndpointKind.onDevice;
+  }
+
+  final uri = Uri.tryParse(provider.baseUrl.trim());
+  final host = uri?.host.toLowerCase();
+  if (host == 'localhost' || host == '::1' || _isIpv4Loopback(host)) {
+    return DailyOsInferenceEndpointKind.onDevice;
+  }
+  return DailyOsInferenceEndpointKind.remote;
+}
+
+bool _isIpv4Loopback(String? host) {
+  if (host == null) return false;
+  final parts = host.split('.');
+  if (parts.length != 4 || parts.any((part) => int.tryParse(part) == null)) {
+    return false;
+  }
+  return int.parse(parts.first) == 127;
+}
+
+/// Setup facts used by the Daily OS surface to make missing configuration
+/// discoverable without replacing already rendered day content during reloads.
+class DailyOsSetupStatus {
+  const DailyOsSetupStatus({
+    required this.hasInferenceRoute,
+    required this.hasPreferredName,
+  });
+
+  final bool hasInferenceRoute;
+  final bool hasPreferredName;
+
+  bool get needsAttention => !hasInferenceRoute || !hasPreferredName;
+}
+
+final FutureProvider<DailyOsSetupStatus> dailyOsSetupStatusProvider =
+    FutureProvider<DailyOsSetupStatus>(
+      (ref) async {
+        final routeReadyFuture = ref.watch(
+          dailyOsOnboardingProviderReadyProvider.future,
+        );
+        final templateFuture = ref.watch(
+          agentTemplateProvider(dayAgentTemplateId).future,
+        );
+        final preferences = ref.watch(dailyOsPreferencesControllerProvider);
+        final routeReady = await routeReadyFuture;
+        final templateEntity = await templateFuture;
+        final template = templateEntity?.mapOrNull(
+          agentTemplate: (value) => value,
+        );
+
+        return DailyOsSetupStatus(
+          hasInferenceRoute: routeReady && template?.profileId != null,
+          hasPreferredName: preferences.hasUserName,
+        );
+      },
+      name: 'dailyOsSetupStatusProvider',
+    );

--- a/lib/features/daily_os_next/ui/pages/daily_os_next_root.dart
+++ b/lib/features/daily_os_next/ui/pages/daily_os_next_root.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
+import 'package:lotti/features/daily_os_next/state/daily_os_inference_providers.dart';
 import 'package:lotti/features/daily_os_next/state/daily_os_onboarding_session_controller.dart';
 import 'package:lotti/features/daily_os_next/state/day_agent_provider.dart';
 import 'package:lotti/features/daily_os_next/state/selected_date_provider.dart';
@@ -13,6 +14,7 @@ import 'package:lotti/features/daily_os_next/ui/pages/day_planning_modal.dart';
 import 'package:lotti/features/daily_os_next/ui/pages/day_planning_result.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/services/nav_service.dart' as nav_service;
 import 'package:lotti/utils/device_region.dart';
 import 'package:lotti/utils/first_day_of_week_picker.dart';
 
@@ -48,6 +50,12 @@ class _DailyOsNextRootState extends ConsumerState<DailyOsNextRoot> {
   /// like the previous fire-and-forget open. During a walkthrough it records
   /// completion (retiring the auto-show cadence) or a dismissal skip.
   Future<void> _runCheckIn(DateTime date) async {
+    final setupStatus = await ref.read(dailyOsSetupStatusProvider.future);
+    if (!mounted) return;
+    if (!setupStatus.hasInferenceRoute) {
+      nav_service.beamToNamed('/settings/daily-os');
+      return;
+    }
     final result = await showDayPlanningModal(
       context: context,
       dayDate: date,

--- a/lib/features/daily_os_next/ui/pages/daily_os_settings_page.dart
+++ b/lib/features/daily_os_next/ui/pages/daily_os_settings_page.dart
@@ -164,6 +164,7 @@ class _DailyOsSettingsBodyState extends ConsumerState<DailyOsSettingsBody> {
                 leading: const SettingsIcon(icon: Icons.account_tree_outlined),
                 trailing: _savingProfile
                     ? SizedBox.square(
+                        key: const Key('daily_os_default_profile_progress'),
                         dimension: tokens.spacing.step5,
                         child: const CircularProgressIndicator(strokeWidth: 2),
                       )

--- a/lib/features/daily_os_next/ui/pages/daily_os_settings_page.dart
+++ b/lib/features/daily_os_next/ui/pages/daily_os_settings_page.dart
@@ -266,25 +266,9 @@ class _Disclosure extends StatelessWidget {
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final route = this.route;
-    final configuredHost = route == null
-        ? null
-        : dailyOsInferenceEndpointHost(route.provider);
-    final configuredEndpoint = route == null
-        ? null
-        : configuredHost?.isNotEmpty ?? false
-        ? configuredHost!
-        : route.provider.baseUrl.trim().isNotEmpty
-        ? route.provider.baseUrl
-        : route.provider.name;
     final endpointText = route == null
         ? null
-        : dailyOsInferenceEndpointKind(route.provider) ==
-              DailyOsInferenceEndpointKind.onDevice
-        ? context.messages.dailyOsSettingsLocalDisclosure
-        : context.messages.dailyOsSettingsRemoteDisclosure(
-            route.provider.name,
-            configuredEndpoint!,
-          );
+        : _endpointDisclosure(context, route.provider);
 
     return DecoratedBox(
       decoration: BoxDecoration(
@@ -317,6 +301,32 @@ class _Disclosure extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  /// Local vs. remote disclosure line for [provider]. Loopback and embedded
+  /// endpoints are described as on-device; everything else is remote and
+  /// names the configured endpoint.
+  String _endpointDisclosure(
+    BuildContext context,
+    AiConfigInferenceProvider provider,
+  ) {
+    if (dailyOsInferenceEndpointKind(provider) ==
+        DailyOsInferenceEndpointKind.onDevice) {
+      return context.messages.dailyOsSettingsLocalDisclosure;
+    }
+    return context.messages.dailyOsSettingsRemoteDisclosure(
+      provider.name,
+      _endpointLabel(provider),
+    );
+  }
+
+  /// Best available identifier for the configured endpoint: the parsed host,
+  /// then the raw base URL, then the provider name.
+  String _endpointLabel(AiConfigInferenceProvider provider) {
+    final host = dailyOsInferenceEndpointHost(provider);
+    if (host != null && host.isNotEmpty) return host;
+    if (provider.baseUrl.trim().isNotEmpty) return provider.baseUrl;
+    return provider.name;
   }
 }
 

--- a/lib/features/daily_os_next/ui/pages/daily_os_settings_page.dart
+++ b/lib/features/daily_os_next/ui/pages/daily_os_settings_page.dart
@@ -1,0 +1,327 @@
+import 'dart:developer' as developer;
+
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_report_provenance.dart';
+import 'package:lotti/features/agents/service/agent_template_service.dart';
+import 'package:lotti/features/agents/state/task_agent_model_providers.dart';
+import 'package:lotti/features/agents/state/template_query_providers.dart';
+import 'package:lotti/features/agents/ui/task_agent_model_identity.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/ui/widgets/inference_profile_picker_modal.dart';
+import 'package:lotti/features/daily_os_next/agents/state/day_agent_providers.dart';
+import 'package:lotti/features/daily_os_next/state/daily_os_inference_providers.dart';
+import 'package:lotti/features/daily_os_next/state/daily_os_preferences_controller.dart';
+import 'package:lotti/features/design_system/components/inputs/design_system_text_input.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_grouped_list.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
+import 'package:lotti/features/design_system/components/toasts/design_system_toast.dart';
+import 'package:lotti/features/design_system/components/toasts/toast_messenger.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/settings/ui/widgets/settings_icon.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/widgets/app_bar/title_app_bar.dart';
+
+/// Mobile route wrapper for the shared Daily OS settings body.
+class DailyOsSettingsPage extends StatelessWidget {
+  const DailyOsSettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: TitleAppBar(title: context.messages.dailyOsSettingsTitle),
+      body: const SingleChildScrollView(child: DailyOsSettingsBody()),
+    );
+  }
+}
+
+/// Default inference and personalization settings for Daily OS.
+class DailyOsSettingsBody extends ConsumerStatefulWidget {
+  const DailyOsSettingsBody({super.key});
+
+  @override
+  ConsumerState<DailyOsSettingsBody> createState() =>
+      _DailyOsSettingsBodyState();
+}
+
+class _DailyOsSettingsBodyState extends ConsumerState<DailyOsSettingsBody> {
+  late final TextEditingController _nameController;
+  bool _savingProfile = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(
+      text: ref.read(dailyOsPreferencesControllerProvider).userName,
+    );
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _chooseDefaultProfile(
+    TaskAgentSetupOptions options,
+    String? selectedProfileId,
+  ) async {
+    if (_savingProfile) return;
+    final profileId = await InferenceProfilePickerModal.show(
+      context: context,
+      profiles: options.profiles,
+      selectedProfileId: selectedProfileId,
+      title: context.messages.dailyOsSettingsChooseProfileTitle,
+    );
+    if (profileId == null || profileId == selectedProfileId || !mounted) {
+      return;
+    }
+    final profile = options.profiles.firstWhereOrNull(
+      (value) => value.id == profileId,
+    );
+    setState(() => _savingProfile = true);
+    try {
+      await ref
+          .read(dayAgentServiceProvider)
+          .updateDefaultInferenceProfile(profileId);
+      if (!mounted) return;
+      ref
+        ..invalidate(agentTemplateProvider(dayAgentTemplateId))
+        ..invalidate(agentResolvedSetupProvider)
+        ..invalidate(dailyOsSetupStatusProvider);
+      context.showToast(
+        tone: DesignSystemToastTone.success,
+        title: context.messages.dailyOsSettingsProfileChanged(
+          profile?.name ?? profileId,
+        ),
+      );
+    } catch (error, stackTrace) {
+      developer.log(
+        'Daily OS default profile update failed',
+        name: 'DailyOsSettingsBody',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      if (mounted) {
+        context.showToast(
+          tone: DesignSystemToastTone.error,
+          title: context.messages.commonError,
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _savingProfile = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final optionsAsync = ref.watch(agentSetupOptionsProvider);
+    final templateAsync = ref.watch(agentTemplateProvider(dayAgentTemplateId));
+    final options = optionsAsync.value;
+    final template = templateAsync.value?.mapOrNull(
+      agentTemplate: (value) => value,
+    );
+    final selectedProfileId = template?.profileId;
+    final selectedProfile = options?.profiles.firstWhereOrNull(
+      (value) => value.id == selectedProfileId,
+    );
+    final route = options == null || selectedProfile == null
+        ? null
+        : _profileRoute(selectedProfile, options);
+
+    return Padding(
+      padding: EdgeInsets.all(tokens.spacing.step5),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            context.messages.dailyOsSettingsSubtitle,
+            style: tokens.typography.styles.body.bodyMedium.copyWith(
+              color: tokens.colors.text.mediumEmphasis,
+            ),
+          ),
+          SizedBox(height: tokens.spacing.sectionGap),
+          _SectionTitle(
+            icon: Icons.psychology_outlined,
+            title: context.messages.dailyOsSettingsInferenceTitle,
+          ),
+          SizedBox(height: tokens.spacing.step3),
+          DesignSystemGroupedList(
+            padding: EdgeInsets.zero,
+            children: [
+              DesignSystemListItem(
+                key: const Key('daily_os_default_profile'),
+                title:
+                    selectedProfile?.name ??
+                    context.messages.dailyOsSettingsDefaultProfileMissing,
+                subtitle:
+                    route?.label ??
+                    context.messages.dailyOsSettingsDefaultProfileDescription,
+                subtitleMaxLines: null,
+                leading: const SettingsIcon(icon: Icons.account_tree_outlined),
+                trailing: _savingProfile
+                    ? SizedBox.square(
+                        dimension: tokens.spacing.step5,
+                        child: const CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : SettingsIcon.trailingChevron(tokens),
+                onTap: options == null || options.profiles.isEmpty
+                    ? null
+                    : () => _chooseDefaultProfile(
+                        options,
+                        selectedProfileId,
+                      ),
+              ),
+            ],
+          ),
+          SizedBox(height: tokens.spacing.step4),
+          _Disclosure(route: route),
+          SizedBox(height: tokens.spacing.sectionGap),
+          _SectionTitle(
+            icon: Icons.person_outline_rounded,
+            title: context.messages.settingsAboutDailyOsPersonalizationTitle,
+          ),
+          SizedBox(height: tokens.spacing.step3),
+          DesignSystemTextInput(
+            key: const Key('daily_os_user_name_field'),
+            controller: _nameController,
+            label: context.messages.settingsAboutDailyOsUserNameLabel,
+            helperText: context.messages.settingsAboutDailyOsUserNameHelper,
+            leadingIcon: Icons.badge_outlined,
+            textCapitalization: TextCapitalization.words,
+            onChanged: ref
+                .read(dailyOsPreferencesControllerProvider.notifier)
+                .setUserName,
+          ),
+        ],
+      ),
+    );
+  }
+
+  _DailyOsRoute? _profileRoute(
+    AiConfigInferenceProfile profile,
+    TaskAgentSetupOptions options,
+  ) {
+    final model = options.models.firstWhereOrNull(
+      (value) =>
+          value.id == profile.thinkingModelId ||
+          value.providerModelId == profile.thinkingModelId,
+    );
+    if (model == null) return null;
+    final provider = options.providers.firstWhereOrNull(
+      (value) => value.id == model.inferenceProviderId,
+    );
+    if (provider == null) return null;
+    final label = formatInferenceRouteIdentity(
+      InferenceRouteSnapshot(
+        modelConfigId: model.id,
+        providerModelId: model.providerModelId,
+        modelName: model.name,
+        publisherName: model.publisher,
+        servingProviderConfigId: provider.id,
+        servingProviderType: provider.inferenceProviderType,
+        servingProviderName: provider.name,
+        runtimeSettings: const <String, Object?>{},
+      ),
+      viaLabel: context.messages.taskAgentRouteVia,
+    );
+    return _DailyOsRoute(label: label, provider: provider);
+  }
+}
+
+class _SectionTitle extends StatelessWidget {
+  const _SectionTitle({required this.icon, required this.title});
+
+  final IconData icon;
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    return Row(
+      children: [
+        Icon(icon, color: tokens.colors.interactive.enabled),
+        SizedBox(width: tokens.spacing.step3),
+        Expanded(
+          child: Text(
+            title,
+            style: tokens.typography.styles.subtitle.subtitle2,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _Disclosure extends StatelessWidget {
+  const _Disclosure({required this.route});
+
+  final _DailyOsRoute? route;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final route = this.route;
+    final configuredHost = route == null
+        ? null
+        : Uri.tryParse(route.provider.baseUrl)?.host;
+    final configuredEndpoint = route == null
+        ? null
+        : configuredHost?.isNotEmpty ?? false
+        ? configuredHost!
+        : route.provider.baseUrl.trim().isNotEmpty
+        ? route.provider.baseUrl
+        : route.provider.name;
+    final endpointText = route == null
+        ? null
+        : dailyOsInferenceEndpointKind(route.provider) ==
+              DailyOsInferenceEndpointKind.onDevice
+        ? context.messages.dailyOsSettingsLocalDisclosure
+        : context.messages.dailyOsSettingsRemoteDisclosure(
+            route.provider.name,
+            configuredEndpoint!,
+          );
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: tokens.colors.background.level02,
+        borderRadius: BorderRadius.circular(tokens.radii.m),
+        border: Border.all(color: tokens.colors.decorative.level01),
+      ),
+      child: Padding(
+        padding: EdgeInsets.all(tokens.spacing.cardPadding),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(
+              Icons.privacy_tip_outlined,
+              color: tokens.colors.text.mediumEmphasis,
+            ),
+            SizedBox(width: tokens.spacing.step3),
+            Expanded(
+              child: Text(
+                [
+                  context.messages.dailyOsSettingsDataDisclosure,
+                  ?endpointText,
+                ].join(' '),
+                style: tokens.typography.styles.body.bodySmall.copyWith(
+                  color: tokens.colors.text.mediumEmphasis,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DailyOsRoute {
+  const _DailyOsRoute({required this.label, required this.provider});
+
+  final String label;
+  final AiConfigInferenceProvider provider;
+}

--- a/lib/features/daily_os_next/ui/pages/daily_os_settings_page.dart
+++ b/lib/features/daily_os_next/ui/pages/daily_os_settings_page.dart
@@ -267,7 +267,7 @@ class _Disclosure extends StatelessWidget {
     final route = this.route;
     final configuredHost = route == null
         ? null
-        : Uri.tryParse(route.provider.baseUrl)?.host;
+        : dailyOsInferenceEndpointHost(route.provider);
     final configuredEndpoint = route == null
         ? null
         : configuredHost?.isNotEmpty ?? false

--- a/lib/features/daily_os_next/ui/pages/day_page.dart
+++ b/lib/features/daily_os_next/ui/pages/day_page.dart
@@ -7,6 +7,7 @@ import 'package:lotti/features/daily_os_next/agents/state/day_agent_providers.da
     as agent_providers;
 import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
 import 'package:lotti/features/daily_os_next/state/actual_time_blocks_provider.dart';
+import 'package:lotti/features/daily_os_next/state/daily_os_inference_providers.dart';
 import 'package:lotti/features/daily_os_next/state/daily_os_preferences_controller.dart';
 import 'package:lotti/features/daily_os_next/state/day_agent_provider.dart';
 import 'package:lotti/features/daily_os_next/ui/daily_os_next_routes.dart';
@@ -222,6 +223,7 @@ class _DayPageState extends ConsumerState<DayPage> {
         .watch(dailyOsActualTimeBlocksProvider(widget.draft.dayDate))
         .value;
     final prefs = ref.watch(dailyOsPreferencesControllerProvider);
+    final setupStatus = ref.watch(dailyOsSetupStatusProvider).value;
     // Inline rename is only offered when a real plan backs the surface.
     final onRenameItem = widget.hasPlan
         ? (AgendaItem item, String title) => unawaited(_renameItem(item, title))
@@ -244,8 +246,15 @@ class _DayPageState extends ConsumerState<DayPage> {
               onViewChanged: (next) => setState(() => _view = next),
               onBack: () => Navigator.of(context).maybePop(),
               onInspectAgent: () => unawaited(_openAgentInternals()),
+              onSettings: () => nav_service.beamToNamed('/settings/daily-os'),
               onDeletePlan: () => unawaited(_confirmDeletePlan()),
             ),
+            if (setupStatus?.needsAttention ?? false)
+              _DailyOsSetupNudge(
+                status: setupStatus!,
+                onOpenSettings: () =>
+                    nav_service.beamToNamed('/settings/daily-os'),
+              ),
             CapturesPanel(date: widget.draft.dayDate),
             // Proposed learnings surface here on both views and both
             // form factors; renders nothing when there is nothing to
@@ -297,7 +306,10 @@ class _DayPageState extends ConsumerState<DayPage> {
               )
             else
               _NoPlanFooter(
-                onCheckIn: widget.onCheckIn,
+                onCheckIn: setupStatus?.hasInferenceRoute == false
+                    ? () => nav_service.beamToNamed('/settings/daily-os')
+                    : widget.onCheckIn,
+                needsInferenceSetup: setupStatus?.hasInferenceRoute == false,
                 ctaKey: _checkInCtaKey,
               ),
           ],
@@ -749,9 +761,14 @@ class _DayFooterActions extends StatelessWidget {
 /// routes to Capture so the assistant can draft a day around the
 /// already-tracked time (handoff v2 item 2).
 class _NoPlanFooter extends StatelessWidget {
-  const _NoPlanFooter({required this.onCheckIn, this.ctaKey});
+  const _NoPlanFooter({
+    required this.onCheckIn,
+    required this.needsInferenceSetup,
+    this.ctaKey,
+  });
 
   final VoidCallback? onCheckIn;
+  final bool needsInferenceSetup;
 
   /// Measurement key for the onboarding spotlight to anchor to. The stable
   /// [Key] used as a test finder stays on the button regardless.
@@ -763,9 +780,14 @@ class _NoPlanFooter extends StatelessWidget {
     final button = FilledButton.icon(
       key: const Key('daily_os_day_check_in_cta'),
       onPressed: onCheckIn,
-      icon: const Icon(Icons.mic_rounded, size: 14),
+      icon: Icon(
+        needsInferenceSetup ? Icons.settings_outlined : Icons.mic_rounded,
+        size: 14,
+      ),
       label: Text(
-        context.messages.dailyOsNextDayCheckInCta,
+        needsInferenceSetup
+            ? context.messages.dailyOsSettingsSetupAction
+            : context.messages.dailyOsNextDayCheckInCta,
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
       ),
@@ -797,6 +819,81 @@ class _NoPlanFooter extends StatelessWidget {
             else
               button,
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DailyOsSetupNudge extends StatelessWidget {
+  const _DailyOsSetupNudge({
+    required this.status,
+    required this.onOpenSettings,
+  });
+
+  final DailyOsSetupStatus status;
+  final VoidCallback onOpenSettings;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final inferenceMissing = !status.hasInferenceRoute;
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: tokens.spacing.step5),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: tokens.colors.background.level02,
+          borderRadius: BorderRadius.circular(tokens.radii.m),
+          border: Border.all(color: tokens.colors.decorative.level01),
+        ),
+        child: Padding(
+          padding: EdgeInsets.all(tokens.spacing.cardPadding),
+          child: Row(
+            children: [
+              Icon(
+                inferenceMissing
+                    ? Icons.warning_amber_rounded
+                    : Icons.person_add_alt_1_outlined,
+                color: tokens.colors.interactive.enabled,
+              ),
+              SizedBox(width: tokens.spacing.step3),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      inferenceMissing
+                          ? context.messages.dailyOsSettingsSetupRequiredTitle
+                          : context.messages.dailyOsSettingsNameNudgeTitle,
+                      style: tokens.typography.styles.subtitle.subtitle2,
+                    ),
+                    SizedBox(height: tokens.spacing.step1),
+                    Text(
+                      inferenceMissing
+                          ? [
+                              context.messages.dailyOsSettingsSetupRequiredBody,
+                              if (!status.hasPreferredName)
+                                context.messages.dailyOsSettingsNameNudgeBody,
+                            ].join(' ')
+                          : context.messages.dailyOsSettingsNameNudgeBody,
+                      style: tokens.typography.styles.body.bodySmall.copyWith(
+                        color: tokens.colors.text.mediumEmphasis,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              SizedBox(width: tokens.spacing.step3),
+              TextButton(
+                onPressed: onOpenSettings,
+                child: Text(
+                  inferenceMissing
+                      ? context.messages.dailyOsSettingsSetupAction
+                      : context.messages.dailyOsSettingsNameNudgeAction,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/daily_os_next/ui/pages/day_page_header.dart
+++ b/lib/features/daily_os_next/ui/pages/day_page_header.dart
@@ -14,7 +14,7 @@ import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/design_system/theme/typography_helpers.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 
-enum _DayMenuAction { inspectAgent, knowledge, deletePlan }
+enum _DayMenuAction { settings, inspectAgent, knowledge, deletePlan }
 
 class DayHeader extends StatelessWidget {
   const DayHeader({
@@ -26,6 +26,7 @@ class DayHeader extends StatelessWidget {
     required this.onBack,
     required this.onInspectAgent,
     required this.onDeletePlan,
+    this.onSettings,
     super.key,
   });
 
@@ -40,6 +41,7 @@ class DayHeader extends StatelessWidget {
   final ValueChanged<PlanView> onViewChanged;
   final VoidCallback onBack;
   final VoidCallback onInspectAgent;
+  final VoidCallback? onSettings;
   final VoidCallback onDeletePlan;
 
   @override
@@ -72,6 +74,8 @@ class DayHeader extends StatelessWidget {
               tooltip: context.messages.dailyOsNextDayMoreTooltip,
               onSelected: (action) {
                 switch (action) {
+                  case _DayMenuAction.settings:
+                    onSettings?.call();
                   case _DayMenuAction.inspectAgent:
                     onInspectAgent();
                   case _DayMenuAction.knowledge:
@@ -81,6 +85,17 @@ class DayHeader extends StatelessWidget {
                 }
               },
               itemBuilder: (popupContext) => [
+                if (onSettings != null)
+                  PopupMenuItem<_DayMenuAction>(
+                    value: _DayMenuAction.settings,
+                    child: ListTile(
+                      leading: const Icon(Icons.settings_outlined),
+                      title: Text(
+                        popupContext.messages.dailyOsNextDayMenuSettings,
+                      ),
+                      contentPadding: EdgeInsets.zero,
+                    ),
+                  ),
                 PopupMenuItem<_DayMenuAction>(
                   value: _DayMenuAction.inspectAgent,
                   child: ListTile(

--- a/lib/features/daily_os_next/ui/widgets/daily_os_inference_setup_sheet.dart
+++ b/lib/features/daily_os_next/ui/widgets/daily_os_inference_setup_sheet.dart
@@ -183,6 +183,10 @@ class _DailyOsInferenceSetupSheetBodyState
     final overrideModel = options?.models.firstWhereOrNull(
       (value) => value.id == overrideId,
     );
+    // A direct model override needs a base profile to attach to; without one
+    // the write would fail closed. Keep the profile row as the path forward.
+    final canOverrideModel =
+        (setup?.baseProfileId ?? config?.profileId) != null;
 
     return Column(
       mainAxisSize: MainAxisSize.min,
@@ -257,7 +261,7 @@ class _DailyOsInferenceSetupSheetBodyState
                 )
               : const Icon(Icons.chevron_right_rounded),
           selected: overrideId != null,
-          onTap: _busy || config == null || options == null
+          onTap: _busy || config == null || options == null || !canOverrideModel
               ? null
               : () => _chooseModel(config, options),
         ),

--- a/lib/features/daily_os_next/ui/widgets/daily_os_inference_setup_sheet.dart
+++ b/lib/features/daily_os_next/ui/widgets/daily_os_inference_setup_sheet.dart
@@ -1,0 +1,258 @@
+import 'dart:developer' as developer;
+
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/features/agents/model/agent_config.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/service/agent_template_service.dart';
+import 'package:lotti/features/agents/state/agent_query_providers.dart';
+import 'package:lotti/features/agents/state/task_agent_model_providers.dart';
+import 'package:lotti/features/ai/ui/widgets/inference_profile_picker_modal.dart';
+import 'package:lotti/features/ai/ui/widgets/inference_provider_model_picker_modal.dart';
+import 'package:lotti/features/daily_os_next/agents/service/day_agent_service.dart';
+import 'package:lotti/features/daily_os_next/agents/state/day_agent_providers.dart';
+import 'package:lotti/features/daily_os_next/state/daily_os_inference_providers.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
+import 'package:lotti/features/design_system/components/toasts/design_system_toast.dart';
+import 'package:lotti/features/design_system/components/toasts/toast_messenger.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/widgets/modal/modal_utils.dart';
+
+/// Instance-level inference controls for the single Daily OS planner.
+class DailyOsInferenceSetupSheet {
+  const DailyOsInferenceSetupSheet._();
+
+  static Future<void> show(BuildContext context) {
+    final messenger = ScaffoldMessenger.of(context);
+    return ModalUtils.showSinglePageModal<void>(
+      context: context,
+      title: context.messages.dailyOsSettingsInstanceOverrideTitle,
+      padding: EdgeInsets.zero,
+      builder: (_) => _DailyOsInferenceSetupSheetBody(messenger: messenger),
+    );
+  }
+}
+
+class _DailyOsInferenceSetupSheetBody extends ConsumerStatefulWidget {
+  const _DailyOsInferenceSetupSheetBody({required this.messenger});
+
+  final ScaffoldMessengerState messenger;
+
+  @override
+  ConsumerState<_DailyOsInferenceSetupSheetBody> createState() =>
+      _DailyOsInferenceSetupSheetBodyState();
+}
+
+class _DailyOsInferenceSetupSheetBodyState
+    extends ConsumerState<_DailyOsInferenceSetupSheetBody> {
+  bool _busy = false;
+
+  Future<void> _persist(
+    Future<void> Function() update, {
+    required String successTitle,
+  }) async {
+    if (_busy) return;
+    setState(() => _busy = true);
+    try {
+      await update();
+      if (!mounted) return;
+      ref
+        ..invalidate(agentIdentityProvider(dailyOsPlannerAgentId))
+        ..invalidate(agentResolvedSetupProvider(dailyOsPlannerAgentId))
+        ..invalidate(dailyOsSetupStatusProvider);
+      Navigator.of(context).pop();
+      if (widget.messenger.mounted) {
+        widget.messenger.showDesignSystemToast(
+          tone: DesignSystemToastTone.success,
+          title: successTitle,
+        );
+      }
+    } catch (error, stackTrace) {
+      developer.log(
+        'Daily OS planner inference update failed',
+        name: 'DailyOsInferenceSetupSheet',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      if (mounted) {
+        context.showToast(
+          tone: DesignSystemToastTone.error,
+          title: context.messages.commonError,
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _chooseProfile(
+    AgentConfig config,
+    TaskAgentSetupOptions options,
+  ) async {
+    final setup = config.inferenceSetup;
+    final hasProfileOverride = _hasProfileOverride(setup);
+    final selectedId = await InferenceProfilePickerModal.show(
+      context: context,
+      profiles: options.profiles,
+      selectedProfileId: hasProfileOverride ? setup?.baseProfileId : null,
+      title: context.messages.dailyOsSettingsChooseProfileTitle,
+    );
+    if (selectedId == null || !mounted) return;
+    final profile = options.profiles.firstWhereOrNull(
+      (value) => value.id == selectedId,
+    );
+    if (hasProfileOverride &&
+        selectedId == setup?.baseProfileId &&
+        setup?.thinkingModelOverrideId == null) {
+      return;
+    }
+    await _persist(
+      () => ref
+          .read(dayAgentServiceProvider)
+          .updatePlannerProfileOverride(selectedId),
+      successTitle: context.messages.dailyOsSettingsProfileChanged(
+        profile?.name ?? selectedId,
+      ),
+    );
+  }
+
+  Future<void> _chooseModel(
+    AgentConfig config,
+    TaskAgentSetupOptions options,
+  ) async {
+    final baseProfileId =
+        config.inferenceSetup?.baseProfileId ?? config.profileId;
+    final profile = options.profiles.firstWhereOrNull(
+      (value) => value.id == baseProfileId,
+    );
+    final selectedId = await InferenceProviderModelPickerModal.show(
+      context: context,
+      defaultModelId: profile?.thinkingModelId,
+      selectedModelId:
+          config.inferenceSetup?.thinkingModelOverrideId ??
+          profile?.thinkingModelId,
+      models: options.models,
+      providers: options.providers,
+      title: context.messages.dailyOsSettingsChooseModelTitle,
+      defaultBadgeLabel: context.messages.taskAgentProfileDefaultBadge,
+      autoSelectSingleCandidate: false,
+    );
+    if (selectedId == null || !mounted) return;
+    final model = options.models.firstWhereOrNull(
+      (value) => value.id == selectedId,
+    );
+    await _persist(
+      () => ref
+          .read(dayAgentServiceProvider)
+          .updatePlannerThinkingModelOverride(selectedId),
+      successTitle: context.messages.dailyOsSettingsModelChanged(
+        model?.name ?? selectedId,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final options = ref.watch(agentSetupOptionsProvider).value;
+    final identity = ref
+        .watch(agentIdentityProvider(dailyOsPlannerAgentId))
+        .value
+        ?.mapOrNull(agent: (value) => value);
+    final config = identity?.config;
+    final setup = config?.inferenceSetup;
+    final overrideId = setup?.thinkingModelOverrideId;
+    final hasProfileOverride = _hasProfileOverride(setup);
+    final currentProfile = options?.profiles.firstWhereOrNull(
+      (value) => value.id == setup?.baseProfileId,
+    );
+    final overrideModel = options?.models.firstWhereOrNull(
+      (value) => value.id == overrideId,
+    );
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: EdgeInsets.all(tokens.spacing.cardPadding),
+          child: Text(
+            context.messages.dailyOsSettingsInstanceOverrideDescription,
+            style: tokens.typography.styles.body.bodyMedium.copyWith(
+              color: tokens.colors.text.mediumEmphasis,
+            ),
+          ),
+        ),
+        DesignSystemListItem(
+          title: context.messages.dailyOsSettingsUseDefault,
+          subtitle: context.messages.dailyOsSettingsUseDefaultDescription,
+          leading: const Icon(Icons.account_tree_outlined),
+          trailing: !hasProfileOverride && overrideId == null
+              ? const Icon(Icons.check_rounded)
+              : null,
+          selected: !hasProfileOverride && overrideId == null,
+          onTap: _busy || config == null
+              ? null
+              : () => _persist(
+                  () => ref
+                      .read(dayAgentServiceProvider)
+                      .resetPlannerInferenceToDefault(),
+                  successTitle: context.messages.dailyOsSettingsDefaultRestored,
+                ),
+          showDivider: true,
+        ),
+        DesignSystemListItem(
+          title: hasProfileOverride
+              ? currentProfile?.name ??
+                    context.messages.dailyOsSettingsChooseProfileTitle
+              : context.messages.dailyOsSettingsChooseProfileTitle,
+          subtitle: hasProfileOverride
+              ? context.messages.dailyOsSettingsProfileOverrideActive
+              : context.messages.dailyOsSettingsChooseProfileDescription,
+          leading: const Icon(Icons.schema_outlined),
+          trailing: const Icon(Icons.chevron_right_rounded),
+          selected: hasProfileOverride,
+          onTap: _busy || config == null || options == null
+              ? null
+              : () => _chooseProfile(config, options),
+          showDivider: true,
+        ),
+        DesignSystemListItem(
+          title:
+              overrideModel?.name ??
+              context.messages.dailyOsSettingsChooseModelTitle,
+          subtitle: overrideId == null
+              ? context.messages.dailyOsSettingsChooseModelDescription
+              : context.messages.dailyOsSettingsDirectOverrideActive,
+          leading: const Icon(Icons.psychology_outlined),
+          trailing: _busy
+              ? SizedBox.square(
+                  dimension: tokens.spacing.step5,
+                  child: const CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.chevron_right_rounded),
+          selected: overrideId != null,
+          onTap: _busy || config == null || options == null
+              ? null
+              : () => _chooseModel(config, options),
+        ),
+        Padding(
+          padding: EdgeInsets.all(tokens.spacing.cardPadding),
+          child: Text(
+            context.messages.dailyOsSettingsDataDisclosure,
+            style: tokens.typography.styles.body.bodySmall.copyWith(
+              color: tokens.colors.text.mediumEmphasis,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+bool _hasProfileOverride(AgentInferenceSetup? setup) =>
+    setup?.origin == AgentInferenceSetupOrigin.user &&
+    setup?.originEntityId != dayAgentTemplateId;

--- a/lib/features/daily_os_next/ui/widgets/daily_os_inference_setup_sheet.dart
+++ b/lib/features/daily_os_next/ui/widgets/daily_os_inference_setup_sheet.dart
@@ -22,9 +22,7 @@ import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/widgets/modal/modal_utils.dart';
 
 /// Instance-level inference controls for the single Daily OS planner.
-class DailyOsInferenceSetupSheet {
-  const DailyOsInferenceSetupSheet._();
-
+abstract final class DailyOsInferenceSetupSheet {
   static Future<void> show(BuildContext context) {
     final messenger = ScaffoldMessenger.of(context);
     return ModalUtils.showSinglePageModal<void>(

--- a/lib/features/daily_os_next/ui/widgets/daily_os_inference_setup_sheet.dart
+++ b/lib/features/daily_os_next/ui/widgets/daily_os_inference_setup_sheet.dart
@@ -48,14 +48,17 @@ class _DailyOsInferenceSetupSheetBody extends ConsumerStatefulWidget {
 
 class _DailyOsInferenceSetupSheetBodyState
     extends ConsumerState<_DailyOsInferenceSetupSheetBody> {
-  bool _busy = false;
+  _PendingInferenceAction? _pendingAction;
+
+  bool get _busy => _pendingAction != null;
 
   Future<void> _persist(
     Future<void> Function() update, {
     required String successTitle,
+    required _PendingInferenceAction action,
   }) async {
     if (_busy) return;
-    setState(() => _busy = true);
+    setState(() => _pendingAction = action);
     try {
       await update();
       if (!mounted) return;
@@ -84,7 +87,7 @@ class _DailyOsInferenceSetupSheetBodyState
         );
       }
     } finally {
-      if (mounted) setState(() => _busy = false);
+      if (mounted) setState(() => _pendingAction = null);
     }
   }
 
@@ -116,6 +119,7 @@ class _DailyOsInferenceSetupSheetBodyState
       successTitle: context.messages.dailyOsSettingsProfileChanged(
         profile?.name ?? selectedId,
       ),
+      action: _PendingInferenceAction.profile,
     );
   }
 
@@ -151,6 +155,15 @@ class _DailyOsInferenceSetupSheetBodyState
       successTitle: context.messages.dailyOsSettingsModelChanged(
         model?.name ?? selectedId,
       ),
+      action: _PendingInferenceAction.model,
+    );
+  }
+
+  Widget _progressIndicator(DsTokens tokens, Key key) {
+    return SizedBox.square(
+      key: key,
+      dimension: tokens.spacing.step5,
+      child: const CircularProgressIndicator(strokeWidth: 2),
     );
   }
 
@@ -190,7 +203,12 @@ class _DailyOsInferenceSetupSheetBodyState
           title: context.messages.dailyOsSettingsUseDefault,
           subtitle: context.messages.dailyOsSettingsUseDefaultDescription,
           leading: const Icon(Icons.account_tree_outlined),
-          trailing: !hasProfileOverride && overrideId == null
+          trailing: _pendingAction == _PendingInferenceAction.reset
+              ? _progressIndicator(
+                  tokens,
+                  const Key('daily_os_inference_reset_progress'),
+                )
+              : !hasProfileOverride && overrideId == null
               ? const Icon(Icons.check_rounded)
               : null,
           selected: !hasProfileOverride && overrideId == null,
@@ -201,6 +219,7 @@ class _DailyOsInferenceSetupSheetBodyState
                       .read(dayAgentServiceProvider)
                       .resetPlannerInferenceToDefault(),
                   successTitle: context.messages.dailyOsSettingsDefaultRestored,
+                  action: _PendingInferenceAction.reset,
                 ),
           showDivider: true,
         ),
@@ -213,7 +232,12 @@ class _DailyOsInferenceSetupSheetBodyState
               ? context.messages.dailyOsSettingsProfileOverrideActive
               : context.messages.dailyOsSettingsChooseProfileDescription,
           leading: const Icon(Icons.schema_outlined),
-          trailing: const Icon(Icons.chevron_right_rounded),
+          trailing: _pendingAction == _PendingInferenceAction.profile
+              ? _progressIndicator(
+                  tokens,
+                  const Key('daily_os_inference_profile_progress'),
+                )
+              : const Icon(Icons.chevron_right_rounded),
           selected: hasProfileOverride,
           onTap: _busy || config == null || options == null
               ? null
@@ -228,10 +252,10 @@ class _DailyOsInferenceSetupSheetBodyState
               ? context.messages.dailyOsSettingsChooseModelDescription
               : context.messages.dailyOsSettingsDirectOverrideActive,
           leading: const Icon(Icons.psychology_outlined),
-          trailing: _busy
-              ? SizedBox.square(
-                  dimension: tokens.spacing.step5,
-                  child: const CircularProgressIndicator(strokeWidth: 2),
+          trailing: _pendingAction == _PendingInferenceAction.model
+              ? _progressIndicator(
+                  tokens,
+                  const Key('daily_os_inference_model_progress'),
                 )
               : const Icon(Icons.chevron_right_rounded),
           selected: overrideId != null,
@@ -252,6 +276,8 @@ class _DailyOsInferenceSetupSheetBodyState
     );
   }
 }
+
+enum _PendingInferenceAction { reset, profile, model }
 
 bool _hasProfileOverride(AgentInferenceSetup? setup) =>
     setup?.origin == AgentInferenceSetupOrigin.user &&

--- a/lib/features/settings/ui/pages/advanced/about_page.dart
+++ b/lib/features/settings/ui/pages/advanced/about_page.dart
@@ -1,9 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/database/database.dart';
-import 'package:lotti/features/daily_os_next/state/daily_os_preferences_controller.dart';
-import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/settings/ui/pages/sliver_box_adapter_page.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
@@ -32,18 +29,16 @@ class AboutPage extends StatelessWidget {
 /// Content body for the About page: gradient header with the app
 /// name + tagline, version info, and entry/task counts. Extracted
 /// from [AboutPage] so the V2 detail pane can host it.
-class AboutBody extends ConsumerStatefulWidget {
+class AboutBody extends StatefulWidget {
   const AboutBody({super.key});
 
   @override
-  ConsumerState<AboutBody> createState() => _AboutBodyState();
+  State<AboutBody> createState() => _AboutBodyState();
 }
 
-class _AboutBodyState extends ConsumerState<AboutBody> {
+class _AboutBodyState extends State<AboutBody> {
   String version = '';
   String buildNumber = '';
-  late final TextEditingController _nameController;
-  late final FocusNode _nameFocusNode;
 
   Future<void> getVersions() async {
     if (!(isWindows && isTestEnv)) {
@@ -58,18 +53,7 @@ class _AboutBodyState extends ConsumerState<AboutBody> {
   @override
   void initState() {
     super.initState();
-    _nameController = TextEditingController(
-      text: ref.read(dailyOsPreferencesControllerProvider).userName,
-    );
-    _nameFocusNode = FocusNode();
     getVersions();
-  }
-
-  @override
-  void dispose() {
-    _nameController.dispose();
-    _nameFocusNode.dispose();
-    super.dispose();
   }
 
   @override
@@ -83,16 +67,6 @@ class _AboutBodyState extends ConsumerState<AboutBody> {
     Widget buildCard({required Widget child}) {
       return ModernBaseCard(child: child);
     }
-
-    final tokens = context.designTokens;
-    ref.listen<String>(
-      dailyOsPreferencesControllerProvider.select((prefs) => prefs.userName),
-      (previous, next) {
-        if (!_nameFocusNode.hasFocus && _nameController.text != next) {
-          _nameController.text = next;
-        }
-      },
-    );
 
     return FutureBuilder<int>(
       future: getIt<JournalDb>().getJournalCount(),
@@ -162,10 +136,6 @@ class _AboutBodyState extends ConsumerState<AboutBody> {
                       ],
                     ),
                   ),
-                ),
-                const SizedBox(height: halfVerticalSpacer),
-                buildCard(
-                  child: _buildDailyOsPersonalizationCard(context, tokens),
                 ),
                 const SizedBox(height: halfVerticalSpacer),
                 // Version Info Card
@@ -263,57 +233,6 @@ class _AboutBodyState extends ConsumerState<AboutBody> {
           },
         );
       },
-    );
-  }
-
-  Widget _buildDailyOsPersonalizationCard(
-    BuildContext context,
-    DsTokens tokens,
-  ) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          children: [
-            Icon(
-              Icons.person_outline_rounded,
-              color: tokens.colors.interactive.enabled,
-              size: tokens.spacing.step6,
-            ),
-            SizedBox(width: tokens.spacing.step3),
-            Expanded(
-              child: Text(
-                context.messages.settingsAboutDailyOsPersonalizationTitle,
-                style: tokens.typography.styles.subtitle.subtitle2.copyWith(
-                  color: tokens.colors.text.highEmphasis,
-                ),
-              ),
-            ),
-          ],
-        ),
-        SizedBox(height: tokens.spacing.step4),
-        TextField(
-          key: const Key('daily_os_user_name_field'),
-          controller: _nameController,
-          focusNode: _nameFocusNode,
-          textInputAction: TextInputAction.done,
-          decoration: InputDecoration(
-            labelText: context.messages.settingsAboutDailyOsUserNameLabel,
-            helperText: context.messages.settingsAboutDailyOsUserNameHelper,
-            filled: true,
-            fillColor: tokens.colors.background.level02,
-            border: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(tokens.radii.m),
-            ),
-          ),
-          style: tokens.typography.styles.body.bodyMedium.copyWith(
-            color: tokens.colors.text.highEmphasis,
-          ),
-          onChanged: ref
-              .read(dailyOsPreferencesControllerProvider.notifier)
-              .setUserName,
-        ),
-      ],
     );
   }
 

--- a/lib/features/settings_v2/domain/settings_tree_data.dart
+++ b/lib/features/settings_v2/domain/settings_tree_data.dart
@@ -144,6 +144,11 @@ List<SettingsNode> buildSettingsTree({
         ),
       ],
     ),
+    leaf(
+      'daily-os',
+      Icons.today_outlined,
+      panel: 'daily-os',
+    ),
     // Sync sits directly below Agents — both are runtime / system
     // concerns and read better as a pair than separated by the
     // taxonomy leaves (habits / categories / labels). The entire Sync

--- a/lib/features/settings_v2/domain/settings_tree_index.dart
+++ b/lib/features/settings_v2/domain/settings_tree_index.dart
@@ -29,6 +29,7 @@ const Map<String, String> settingsNodeUrls = {
   'agents/souls': '/settings/agents/souls',
   'agents/instances': '/settings/agents/instances',
   'agents/pending-wakes': '/settings/agents/pending-wakes',
+  'daily-os': '/settings/daily-os',
   // The `definitions` branch itself maps to `/settings/definitions`
   // so desktop tree selection updates the address bar (and the v1
   // mobile root list beams to the same URL to render the

--- a/lib/features/settings_v2/ui/detail/panel_registry.dart
+++ b/lib/features/settings_v2/ui/detail/panel_registry.dart
@@ -10,6 +10,7 @@ import 'package:lotti/features/ai/ui/settings/ai_settings_page.dart';
 import 'package:lotti/features/ai_consumption/ui/impact_analysis_body.dart';
 import 'package:lotti/features/categories/ui/pages/categories_list_page.dart';
 import 'package:lotti/features/categories/ui/pages/category_details_page.dart';
+import 'package:lotti/features/daily_os_next/ui/pages/daily_os_settings_page.dart';
 import 'package:lotti/features/design_system/components/lists/design_system_grouped_list.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/labels/ui/pages/label_details_page.dart';
@@ -111,6 +112,10 @@ const Map<String, SettingsPanelSpec> kSettingsPanels =
       // detail pane empty.
       'ai': SettingsPanelSpec(build: _aiPanel),
       'agents': SettingsPanelSpec(build: _agentsPanel),
+      'daily-os': SettingsPanelSpec(
+        build: _dailyOsPanel,
+        scrollable: true,
+      ),
 
       // Top-level entry point back to the FTUE welcome flow (plan §12).
       'onboarding': SettingsPanelSpec(
@@ -219,6 +224,7 @@ SettingsPanelSpec? panelSpecFor(String? panelId) {
 const Duration kSettingsPanelSwapDuration = Duration(milliseconds: 180);
 
 Widget _onboardingPanel(BuildContext context) => const OnboardingSettingsBody();
+Widget _dailyOsPanel(BuildContext context) => const DailyOsSettingsBody();
 
 // --- Step 7 builders --------------------------------------------------------
 Widget _flagsPanel(BuildContext context) => const FlagsBody();

--- a/lib/features/settings_v2/ui/labels/settings_tree_labels.dart
+++ b/lib/features/settings_v2/ui/labels/settings_tree_labels.dart
@@ -71,6 +71,11 @@ SettingsTreeLabelResolver settingsTreeLabelsFor(BuildContext context) {
           title: m.agentPendingWakesTitle,
           desc: m.settingsAgentsPendingWakesSubtitle,
         );
+      case 'daily-os':
+        return (
+          title: m.dailyOsSettingsTitle,
+          desc: m.dailyOsSettingsTreeSubtitle,
+        );
       case 'definitions':
         return (
           title: m.settingsDefinitionsTitle,

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -1537,6 +1537,7 @@
   "dailyOsNextDayLockInCta": "Uzamknout",
   "dailyOsNextDayMenuDeletePlan": "Smazat plán",
   "dailyOsNextDayMenuInspectAgent": "Prozkoumat agenta",
+  "dailyOsNextDayMenuSettings": "Nastavení Daily OS",
   "dailyOsNextDayMoreTooltip": "Více",
   "dailyOsNextDayRefineCta": "Upravit",
   "dailyOsNextDayRefineFooterHint": "Mluv a přetvoř plán — každou změnu uvidíš, než se cokoli uloží.",
@@ -1756,6 +1757,59 @@
   "dailyOsOnboardingSpotlightDismiss": "Teď ne",
   "dailyOsOnboardingSpotlightMessage": "Klepni sem a řekni, co ti leží v hlavě – proměním to v úkol a poskládám kolem toho tvůj den.",
   "dailyOsOnboardingSpotlightTitle": "Proměň řeč v plán",
+  "dailyOsSettingsChooseModelDescription": "Přepiš pouze model uvažování plánovače.",
+  "dailyOsSettingsChooseModelTitle": "Vybrat přepsání modelu",
+  "dailyOsSettingsChooseProfileDescription": "Přepiš celý inferenční profil pro tento plánovač.",
+  "dailyOsSettingsChooseProfileTitle": "Vybrat profil Daily OS",
+  "dailyOsSettingsDataDisclosure": "Daily OS odesílá relevantní úkoly, záznamy, plány, naučené preference a další sestavený kontext plánování vybranému poskytovateli ke zpracování.",
+  "dailyOsSettingsDefaultProfileDescription": "Daily OS ho použije, pokud instance plánovače nemá vlastní nastavení.",
+  "dailyOsSettingsDefaultProfileMissing": "Vyber profil",
+  "dailyOsSettingsDefaultRestored": "Výchozí nastavení Daily OS obnoveno",
+  "dailyOsSettingsDirectOverrideActive": "Přímé přepsání modelu je aktivní.",
+  "dailyOsSettingsInferenceTitle": "Výchozí inferenční profil",
+  "dailyOsSettingsInstanceCurrentSetup": "Aktuální nastavení plánovače",
+  "dailyOsSettingsInstanceOverrideDescription": "Použij výchozí profil Daily OS, vyber přepsání profilu nebo přepiš jen model uvažování tohoto plánovače.",
+  "dailyOsSettingsInstanceOverrideTitle": "Inference Daily OS",
+  "dailyOsSettingsLocalDisclosure": "Vybraný koncový bod je na tomto zařízení.",
+  "dailyOsSettingsModelChanged": "Daily OS nyní používá {model}",
+  "@dailyOsSettingsModelChanged": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "dailyOsSettingsNameNudgeAction": "Přidat jméno",
+  "dailyOsSettingsNameNudgeBody": "Preferované jméno udělá check-iny osobnější. Plánovat můžeš i bez něj.",
+  "dailyOsSettingsNameNudgeTitle": "Jak tě má Daily OS oslovovat?",
+  "dailyOsSettingsProfileChanged": "Daily OS nyní používá {profile}",
+  "@dailyOsSettingsProfileChanged": {
+    "placeholders": {
+      "profile": {
+        "type": "String"
+      }
+    }
+  },
+  "dailyOsSettingsProfileOverrideActive": "Přepsání profilu je aktivní",
+  "dailyOsSettingsRemoteDisclosure": "Daily OS odesílá sestavený kontext plánování poskytovateli {provider} na {host} ke vzdálenému zpracování.",
+  "@dailyOsSettingsRemoteDisclosure": {
+    "placeholders": {
+      "provider": {
+        "type": "String"
+      },
+      "host": {
+        "type": "String"
+      }
+    }
+  },
+  "dailyOsSettingsSetupAction": "Nastavit Daily OS",
+  "dailyOsSettingsSetupRequiredBody": "Daily OS potřebuje tvou volbu poskytovatele, než může zpracovat kontext plánování.",
+  "dailyOsSettingsSetupRequiredTitle": "Vyber inferenční profil",
+  "dailyOsSettingsSubtitle": "Zvol, jak tě má Daily OS oslovovat a který inferenční profil má plánovat tvé dny.",
+  "dailyOsSettingsTitle": "Daily OS",
+  "dailyOsSettingsTreeSubtitle": "Plánování, přizpůsobení a poskytovatel AI",
+  "dailyOsSettingsUseDefault": "Použít výchozí nastavení Daily OS",
+  "dailyOsSettingsUseDefaultDescription": "Použije profil vybraný v nastavení Daily OS.",
   "dailyOsTodayButton": "Dnes",
   "dashboardActiveLabel": "Aktivní",
   "dashboardActiveSwitchDescription": "Zobrazuje se v seznamu panelů",

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -1769,7 +1769,7 @@
   "dailyOsSettingsInferenceTitle": "Výchozí inferenční profil",
   "dailyOsSettingsInstanceCurrentSetup": "Aktuální nastavení plánovače",
   "dailyOsSettingsInstanceOverrideDescription": "Použij výchozí profil Daily OS, vyber přepsání profilu nebo přepiš jen model uvažování tohoto plánovače.",
-  "dailyOsSettingsInstanceOverrideTitle": "Inference Daily OS",
+  "dailyOsSettingsInstanceOverrideTitle": "Inference pro Daily OS",
   "dailyOsSettingsLocalDisclosure": "Vybraný koncový bod je na tomto zařízení.",
   "dailyOsSettingsModelChanged": "Daily OS nyní používá {model}",
   "@dailyOsSettingsModelChanged": {

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1728,6 +1728,7 @@
   "dailyOsNextDayLockInCta": "Festmachen",
   "dailyOsNextDayMenuDeletePlan": "Plan löschen",
   "dailyOsNextDayMenuInspectAgent": "Agent prüfen",
+  "dailyOsNextDayMenuSettings": "Daily-OS-Einstellungen",
   "dailyOsNextDayMoreTooltip": "Mehr",
   "dailyOsNextDayRefineCta": "Anpassen",
   "dailyOsNextDayRefineFooterHint": "Sprich, um den Plan umzubauen — du siehst jede Änderung, bevor etwas gespeichert wird.",
@@ -1947,6 +1948,59 @@
   "dailyOsOnboardingSpotlightDismiss": "Nicht jetzt",
   "dailyOsOnboardingSpotlightMessage": "Tippe hier und sag, was dir im Kopf herumgeht – ich mache eine Aufgabe daraus und baue deinen Tag darum herum.",
   "dailyOsOnboardingSpotlightTitle": "Mach aus Worten einen Plan",
+  "dailyOsSettingsChooseModelDescription": "Überschreibe nur das Denkmodell des Planers.",
+  "dailyOsSettingsChooseModelTitle": "Modellüberschreibung auswählen",
+  "dailyOsSettingsChooseProfileDescription": "Überschreibe das gesamte Inferenzprofil für diesen Planer.",
+  "dailyOsSettingsChooseProfileTitle": "Daily-OS-Profil auswählen",
+  "dailyOsSettingsDataDisclosure": "Daily OS sendet relevante Aufgaben, Erfassungen, Pläne, gelernte Präferenzen und weiteren zusammengestellten Planungskontext zur Verarbeitung an den ausgewählten Anbieter.",
+  "dailyOsSettingsDefaultProfileDescription": "Wird von Daily OS verwendet, sofern die Planer-Instanz keine Überschreibung hat.",
+  "dailyOsSettingsDefaultProfileMissing": "Profil auswählen",
+  "dailyOsSettingsDefaultRestored": "Daily-OS-Standard wiederhergestellt",
+  "dailyOsSettingsDirectOverrideActive": "Direkte Modellüberschreibung ist aktiv.",
+  "dailyOsSettingsInferenceTitle": "Standard-Inferenzprofil",
+  "dailyOsSettingsInstanceCurrentSetup": "Aktuelle Planer-Konfiguration",
+  "dailyOsSettingsInstanceOverrideDescription": "Verwende das Daily-OS-Standardprofil, wähle eine Profilüberschreibung oder überschreibe nur das Denkmodell dieses Planers.",
+  "dailyOsSettingsInstanceOverrideTitle": "Daily-OS-Inferenz",
+  "dailyOsSettingsLocalDisclosure": "Der ausgewählte Endpunkt befindet sich auf diesem Gerät.",
+  "dailyOsSettingsModelChanged": "Daily OS verwendet jetzt {model}",
+  "@dailyOsSettingsModelChanged": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "dailyOsSettingsNameNudgeAction": "Namen hinzufügen",
+  "dailyOsSettingsNameNudgeBody": "Mit einem bevorzugten Namen werden Check-ins persönlicher. Du kannst auch ohne ihn weiterplanen.",
+  "dailyOsSettingsNameNudgeTitle": "Wie soll Daily OS dich ansprechen?",
+  "dailyOsSettingsProfileChanged": "Daily OS verwendet jetzt {profile}",
+  "@dailyOsSettingsProfileChanged": {
+    "placeholders": {
+      "profile": {
+        "type": "String"
+      }
+    }
+  },
+  "dailyOsSettingsProfileOverrideActive": "Profilüberschreibung aktiv",
+  "dailyOsSettingsRemoteDisclosure": "Daily OS sendet den zusammengestellten Planungskontext zur entfernten Verarbeitung an {provider} unter {host}.",
+  "@dailyOsSettingsRemoteDisclosure": {
+    "placeholders": {
+      "provider": {
+        "type": "String"
+      },
+      "host": {
+        "type": "String"
+      }
+    }
+  },
+  "dailyOsSettingsSetupAction": "Daily OS einrichten",
+  "dailyOsSettingsSetupRequiredBody": "Daily OS braucht deine Anbieterwahl, bevor dein Planungskontext verarbeitet werden kann.",
+  "dailyOsSettingsSetupRequiredTitle": "Inferenzprofil auswählen",
+  "dailyOsSettingsSubtitle": "Lege fest, wie Daily OS dich anspricht und welches Inferenzprofil deine Tage plant.",
+  "dailyOsSettingsTitle": "Daily OS",
+  "dailyOsSettingsTreeSubtitle": "Planung, Personalisierung und KI-Anbieter",
+  "dailyOsSettingsUseDefault": "Daily-OS-Standard verwenden",
+  "dailyOsSettingsUseDefaultDescription": "Folge dem in den Daily-OS-Einstellungen ausgewählten Profil.",
   "dailyOsTodayButton": "Heute",
   "dashboardActiveLabel": "Aktiv",
   "dashboardActiveSwitchDescription": "Wird in der Dashboard-Liste angezeigt",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2063,6 +2063,7 @@
   "dailyOsNextDayLockInCta": "Lock in",
   "dailyOsNextDayMenuDeletePlan": "Delete plan",
   "dailyOsNextDayMenuInspectAgent": "Inspect agent",
+  "dailyOsNextDayMenuSettings": "Daily OS settings",
   "dailyOsNextDayMoreTooltip": "More",
   "dailyOsNextDayRefineCta": "Refine",
   "dailyOsNextDayRefineFooterHint": "Talk to reshape the plan — you'll see every change before anything is saved.",
@@ -2317,6 +2318,59 @@
   "dailyOsOnboardingSpotlightDismiss": "Not now",
   "dailyOsOnboardingSpotlightMessage": "Tap here and say what's on your mind — I'll turn it into a task and build your day around it.",
   "dailyOsOnboardingSpotlightTitle": "Turn talk into a plan",
+  "dailyOsSettingsChooseModelDescription": "Override only the planner's thinking model.",
+  "dailyOsSettingsChooseModelTitle": "Choose model override",
+  "dailyOsSettingsChooseProfileDescription": "Override the full inference profile for this planner.",
+  "dailyOsSettingsChooseProfileTitle": "Choose Daily OS profile",
+  "dailyOsSettingsDataDisclosure": "Daily OS sends relevant tasks, captures, plans, learned preferences, and other assembled planning context to the selected provider for processing.",
+  "dailyOsSettingsDefaultProfileDescription": "Used by Daily OS unless the planner instance has an override.",
+  "dailyOsSettingsDefaultProfileMissing": "Choose a profile",
+  "dailyOsSettingsDefaultRestored": "Daily OS default restored",
+  "dailyOsSettingsDirectOverrideActive": "Direct model override is active.",
+  "dailyOsSettingsInferenceTitle": "Default inference profile",
+  "dailyOsSettingsInstanceCurrentSetup": "Current planner setup",
+  "dailyOsSettingsInstanceOverrideDescription": "Use the Daily OS default profile, choose a profile override, or override only this planner's thinking model.",
+  "dailyOsSettingsInstanceOverrideTitle": "Daily OS inference",
+  "dailyOsSettingsLocalDisclosure": "The selected endpoint is on this device.",
+  "dailyOsSettingsModelChanged": "Daily OS now uses {model}",
+  "@dailyOsSettingsModelChanged": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "dailyOsSettingsNameNudgeAction": "Add name",
+  "dailyOsSettingsNameNudgeBody": "Adding a preferred name makes check-ins more personal. You can keep planning without it.",
+  "dailyOsSettingsNameNudgeTitle": "How should Daily OS address you?",
+  "dailyOsSettingsProfileChanged": "Daily OS now uses {profile}",
+  "@dailyOsSettingsProfileChanged": {
+    "placeholders": {
+      "profile": {
+        "type": "String"
+      }
+    }
+  },
+  "dailyOsSettingsProfileOverrideActive": "Profile override active",
+  "dailyOsSettingsRemoteDisclosure": "Daily OS sends the assembled planning context to {provider} at {host} for remote processing.",
+  "@dailyOsSettingsRemoteDisclosure": {
+    "placeholders": {
+      "provider": {
+        "type": "String"
+      },
+      "host": {
+        "type": "String"
+      }
+    }
+  },
+  "dailyOsSettingsSetupAction": "Set up Daily OS",
+  "dailyOsSettingsSetupRequiredBody": "Daily OS needs your provider choice before it can process your planning context.",
+  "dailyOsSettingsSetupRequiredTitle": "Choose an inference profile",
+  "dailyOsSettingsSubtitle": "Choose how Daily OS addresses you and which inference profile plans your days.",
+  "dailyOsSettingsTitle": "Daily OS",
+  "dailyOsSettingsTreeSubtitle": "Planning, personalization, and AI provider",
+  "dailyOsSettingsUseDefault": "Use Daily OS default",
+  "dailyOsSettingsUseDefaultDescription": "Follow the profile selected in Daily OS settings.",
   "dailyOsTodayButton": "Today",
   "dashboardActiveLabel": "Active",
   "dashboardActiveSwitchDescription": "Shown in the dashboards list",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1728,6 +1728,7 @@
   "dailyOsNextDayLockInCta": "Confirmar",
   "dailyOsNextDayMenuDeletePlan": "Eliminar plan",
   "dailyOsNextDayMenuInspectAgent": "Inspeccionar agente",
+  "dailyOsNextDayMenuSettings": "Ajustes de Daily OS",
   "dailyOsNextDayMoreTooltip": "Más",
   "dailyOsNextDayRefineCta": "Ajustar",
   "dailyOsNextDayRefineFooterHint": "Habla para reorganizar el plan — verás cada cambio antes de que se guarde nada.",
@@ -1947,6 +1948,59 @@
   "dailyOsOnboardingSpotlightDismiss": "Ahora no",
   "dailyOsOnboardingSpotlightMessage": "Toca aquí y di lo que te ronda la cabeza: lo convierto en una tarea y organizo tu día en torno a ella.",
   "dailyOsOnboardingSpotlightTitle": "Convierte lo que dices en un plan",
+  "dailyOsSettingsChooseModelDescription": "Anula solo el modelo de razonamiento del planificador.",
+  "dailyOsSettingsChooseModelTitle": "Elegir anulación de modelo",
+  "dailyOsSettingsChooseProfileDescription": "Anula el perfil de inferencia completo para este planificador.",
+  "dailyOsSettingsChooseProfileTitle": "Elegir perfil de Daily OS",
+  "dailyOsSettingsDataDisclosure": "Daily OS envía las tareas, capturas, planes, preferencias aprendidas y demás contexto de planificación recopilado al proveedor seleccionado para procesarlo.",
+  "dailyOsSettingsDefaultProfileDescription": "Daily OS lo usa salvo que la instancia del planificador tenga una anulación.",
+  "dailyOsSettingsDefaultProfileMissing": "Elige un perfil",
+  "dailyOsSettingsDefaultRestored": "Valor predeterminado de Daily OS restaurado",
+  "dailyOsSettingsDirectOverrideActive": "La anulación directa del modelo está activa.",
+  "dailyOsSettingsInferenceTitle": "Perfil de inferencia predeterminado",
+  "dailyOsSettingsInstanceCurrentSetup": "Configuración actual del planificador",
+  "dailyOsSettingsInstanceOverrideDescription": "Usa el perfil predeterminado de Daily OS, elige una anulación de perfil o anula solo el modelo de razonamiento de este planificador.",
+  "dailyOsSettingsInstanceOverrideTitle": "Inferencia de Daily OS",
+  "dailyOsSettingsLocalDisclosure": "El punto de conexión seleccionado está en este dispositivo.",
+  "dailyOsSettingsModelChanged": "Daily OS ahora usa {model}",
+  "@dailyOsSettingsModelChanged": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "dailyOsSettingsNameNudgeAction": "Añadir nombre",
+  "dailyOsSettingsNameNudgeBody": "Añadir un nombre preferido hace los check-ins más personales. Puedes seguir planificando sin él.",
+  "dailyOsSettingsNameNudgeTitle": "¿Cómo quieres que te llame Daily OS?",
+  "dailyOsSettingsProfileChanged": "Daily OS ahora usa {profile}",
+  "@dailyOsSettingsProfileChanged": {
+    "placeholders": {
+      "profile": {
+        "type": "String"
+      }
+    }
+  },
+  "dailyOsSettingsProfileOverrideActive": "Anulación de perfil activa",
+  "dailyOsSettingsRemoteDisclosure": "Daily OS envía el contexto de planificación recopilado a {provider} en {host} para su procesamiento remoto.",
+  "@dailyOsSettingsRemoteDisclosure": {
+    "placeholders": {
+      "provider": {
+        "type": "String"
+      },
+      "host": {
+        "type": "String"
+      }
+    }
+  },
+  "dailyOsSettingsSetupAction": "Configurar Daily OS",
+  "dailyOsSettingsSetupRequiredBody": "Daily OS necesita que elijas un proveedor antes de procesar tu contexto de planificación.",
+  "dailyOsSettingsSetupRequiredTitle": "Elige un perfil de inferencia",
+  "dailyOsSettingsSubtitle": "Elige cómo te llama Daily OS y qué perfil de inferencia planifica tus días.",
+  "dailyOsSettingsTitle": "Daily OS",
+  "dailyOsSettingsTreeSubtitle": "Planificación, personalización y proveedor de IA",
+  "dailyOsSettingsUseDefault": "Usar valor predeterminado de Daily OS",
+  "dailyOsSettingsUseDefaultDescription": "Sigue el perfil elegido en los ajustes de Daily OS.",
   "dailyOsTodayButton": "Hoy",
   "dashboardActiveLabel": "Activo",
   "dashboardActiveSwitchDescription": "Se muestra en la lista de paneles",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1728,6 +1728,7 @@
   "dailyOsNextDayLockInCta": "Verrouiller",
   "dailyOsNextDayMenuDeletePlan": "Supprimer le plan",
   "dailyOsNextDayMenuInspectAgent": "Inspecter l'agent",
+  "dailyOsNextDayMenuSettings": "Réglages Daily OS",
   "dailyOsNextDayMoreTooltip": "Plus",
   "dailyOsNextDayRefineCta": "Ajuster",
   "dailyOsNextDayRefineFooterHint": "Parle pour réorganiser le plan — tu verras chaque changement avant qu'il soit enregistré.",
@@ -1947,6 +1948,59 @@
   "dailyOsOnboardingSpotlightDismiss": "Pas maintenant",
   "dailyOsOnboardingSpotlightMessage": "Touche ici et dis ce qui te préoccupe – j'en fais une tâche et j'organise ta journée autour.",
   "dailyOsOnboardingSpotlightTitle": "Transforme tes mots en plan",
+  "dailyOsSettingsChooseModelDescription": "Remplace uniquement le modèle de réflexion du planificateur.",
+  "dailyOsSettingsChooseModelTitle": "Choisir une dérogation de modèle",
+  "dailyOsSettingsChooseProfileDescription": "Remplace le profil d'inférence complet pour ce planificateur.",
+  "dailyOsSettingsChooseProfileTitle": "Choisir le profil Daily OS",
+  "dailyOsSettingsDataDisclosure": "Daily OS envoie les tâches, captures, plans, préférences apprises et autres éléments de contexte de planification assemblés au fournisseur sélectionné pour traitement.",
+  "dailyOsSettingsDefaultProfileDescription": "Utilisé par Daily OS sauf si l’instance du planificateur a une dérogation.",
+  "dailyOsSettingsDefaultProfileMissing": "Choisis un profil",
+  "dailyOsSettingsDefaultRestored": "Réglage Daily OS par défaut rétabli",
+  "dailyOsSettingsDirectOverrideActive": "La dérogation directe du modèle est active.",
+  "dailyOsSettingsInferenceTitle": "Profil d’inférence par défaut",
+  "dailyOsSettingsInstanceCurrentSetup": "Configuration actuelle du planificateur",
+  "dailyOsSettingsInstanceOverrideDescription": "Utilise le profil Daily OS par défaut, choisis une dérogation de profil ou remplace uniquement le modèle de réflexion de ce planificateur.",
+  "dailyOsSettingsInstanceOverrideTitle": "Inférence Daily OS",
+  "dailyOsSettingsLocalDisclosure": "Le point de terminaison sélectionné se trouve sur cet appareil.",
+  "dailyOsSettingsModelChanged": "Daily OS utilise maintenant {model}",
+  "@dailyOsSettingsModelChanged": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "dailyOsSettingsNameNudgeAction": "Ajouter un prénom",
+  "dailyOsSettingsNameNudgeBody": "Ajouter un prénom préféré rend les check-ins plus personnels. Tu peux continuer sans le faire.",
+  "dailyOsSettingsNameNudgeTitle": "Comment Daily OS doit-il t’appeler ?",
+  "dailyOsSettingsProfileChanged": "Daily OS utilise maintenant {profile}",
+  "@dailyOsSettingsProfileChanged": {
+    "placeholders": {
+      "profile": {
+        "type": "String"
+      }
+    }
+  },
+  "dailyOsSettingsProfileOverrideActive": "Dérogation de profil active",
+  "dailyOsSettingsRemoteDisclosure": "Daily OS envoie le contexte de planification assemblé à {provider} sur {host} pour un traitement à distance.",
+  "@dailyOsSettingsRemoteDisclosure": {
+    "placeholders": {
+      "provider": {
+        "type": "String"
+      },
+      "host": {
+        "type": "String"
+      }
+    }
+  },
+  "dailyOsSettingsSetupAction": "Configurer Daily OS",
+  "dailyOsSettingsSetupRequiredBody": "Daily OS a besoin de ton choix de fournisseur avant de pouvoir traiter ton contexte de planification.",
+  "dailyOsSettingsSetupRequiredTitle": "Choisis un profil d’inférence",
+  "dailyOsSettingsSubtitle": "Choisis comment Daily OS s’adresse à toi et quel profil d’inférence planifie tes journées.",
+  "dailyOsSettingsTitle": "Daily OS",
+  "dailyOsSettingsTreeSubtitle": "Planification, personnalisation et fournisseur d’IA",
+  "dailyOsSettingsUseDefault": "Utiliser le réglage Daily OS par défaut",
+  "dailyOsSettingsUseDefaultDescription": "Suis le profil choisi dans les réglages Daily OS.",
   "dailyOsTodayButton": "Aujourd'hui",
   "dashboardActiveLabel": "Actif",
   "dashboardActiveSwitchDescription": "Affiché dans la liste des tableaux de bord",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1949,17 +1949,17 @@
   "dailyOsOnboardingSpotlightMessage": "Touche ici et dis ce qui te préoccupe – j'en fais une tâche et j'organise ta journée autour.",
   "dailyOsOnboardingSpotlightTitle": "Transforme tes mots en plan",
   "dailyOsSettingsChooseModelDescription": "Remplace uniquement le modèle de réflexion du planificateur.",
-  "dailyOsSettingsChooseModelTitle": "Choisir une dérogation de modèle",
+  "dailyOsSettingsChooseModelTitle": "Choisir un remplacement de modèle",
   "dailyOsSettingsChooseProfileDescription": "Remplace le profil d'inférence complet pour ce planificateur.",
   "dailyOsSettingsChooseProfileTitle": "Choisir le profil Daily OS",
   "dailyOsSettingsDataDisclosure": "Daily OS envoie les tâches, captures, plans, préférences apprises et autres éléments de contexte de planification assemblés au fournisseur sélectionné pour traitement.",
-  "dailyOsSettingsDefaultProfileDescription": "Utilisé par Daily OS sauf si l’instance du planificateur a une dérogation.",
+  "dailyOsSettingsDefaultProfileDescription": "Utilisé par Daily OS sauf si l’instance du planificateur a un remplacement.",
   "dailyOsSettingsDefaultProfileMissing": "Choisis un profil",
   "dailyOsSettingsDefaultRestored": "Réglage Daily OS par défaut rétabli",
-  "dailyOsSettingsDirectOverrideActive": "La dérogation directe du modèle est active.",
+  "dailyOsSettingsDirectOverrideActive": "Le remplacement direct du modèle est actif.",
   "dailyOsSettingsInferenceTitle": "Profil d’inférence par défaut",
   "dailyOsSettingsInstanceCurrentSetup": "Configuration actuelle du planificateur",
-  "dailyOsSettingsInstanceOverrideDescription": "Utilise le profil Daily OS par défaut, choisis une dérogation de profil ou remplace uniquement le modèle de réflexion de ce planificateur.",
+  "dailyOsSettingsInstanceOverrideDescription": "Utilise le profil Daily OS par défaut, choisis un remplacement de profil ou remplace uniquement le modèle de réflexion de ce planificateur.",
   "dailyOsSettingsInstanceOverrideTitle": "Inférence Daily OS",
   "dailyOsSettingsLocalDisclosure": "Le point de terminaison sélectionné se trouve sur cet appareil.",
   "dailyOsSettingsModelChanged": "Daily OS utilise maintenant {model}",
@@ -1981,7 +1981,7 @@
       }
     }
   },
-  "dailyOsSettingsProfileOverrideActive": "Dérogation de profil active",
+  "dailyOsSettingsProfileOverrideActive": "Remplacement de profil actif",
   "dailyOsSettingsRemoteDisclosure": "Daily OS envoie le contexte de planification assemblé à {provider} sur {host} pour un traitement à distance.",
   "@dailyOsSettingsRemoteDisclosure": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6294,6 +6294,12 @@ abstract class AppLocalizations {
   /// **'Inspect agent'**
   String get dailyOsNextDayMenuInspectAgent;
 
+  /// No description provided for @dailyOsNextDayMenuSettings.
+  ///
+  /// In en, this message translates to:
+  /// **'Daily OS settings'**
+  String get dailyOsNextDayMenuSettings;
+
   /// No description provided for @dailyOsNextDayMoreTooltip.
   ///
   /// In en, this message translates to:
@@ -7217,6 +7223,180 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Turn talk into a plan'**
   String get dailyOsOnboardingSpotlightTitle;
+
+  /// No description provided for @dailyOsSettingsChooseModelDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Override only the planner\'s thinking model.'**
+  String get dailyOsSettingsChooseModelDescription;
+
+  /// No description provided for @dailyOsSettingsChooseModelTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose model override'**
+  String get dailyOsSettingsChooseModelTitle;
+
+  /// No description provided for @dailyOsSettingsChooseProfileDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Override the full inference profile for this planner.'**
+  String get dailyOsSettingsChooseProfileDescription;
+
+  /// No description provided for @dailyOsSettingsChooseProfileTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose Daily OS profile'**
+  String get dailyOsSettingsChooseProfileTitle;
+
+  /// No description provided for @dailyOsSettingsDataDisclosure.
+  ///
+  /// In en, this message translates to:
+  /// **'Daily OS sends relevant tasks, captures, plans, learned preferences, and other assembled planning context to the selected provider for processing.'**
+  String get dailyOsSettingsDataDisclosure;
+
+  /// No description provided for @dailyOsSettingsDefaultProfileDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Used by Daily OS unless the planner instance has an override.'**
+  String get dailyOsSettingsDefaultProfileDescription;
+
+  /// No description provided for @dailyOsSettingsDefaultProfileMissing.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose a profile'**
+  String get dailyOsSettingsDefaultProfileMissing;
+
+  /// No description provided for @dailyOsSettingsDefaultRestored.
+  ///
+  /// In en, this message translates to:
+  /// **'Daily OS default restored'**
+  String get dailyOsSettingsDefaultRestored;
+
+  /// No description provided for @dailyOsSettingsDirectOverrideActive.
+  ///
+  /// In en, this message translates to:
+  /// **'Direct model override is active.'**
+  String get dailyOsSettingsDirectOverrideActive;
+
+  /// No description provided for @dailyOsSettingsInferenceTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Default inference profile'**
+  String get dailyOsSettingsInferenceTitle;
+
+  /// No description provided for @dailyOsSettingsInstanceCurrentSetup.
+  ///
+  /// In en, this message translates to:
+  /// **'Current planner setup'**
+  String get dailyOsSettingsInstanceCurrentSetup;
+
+  /// No description provided for @dailyOsSettingsInstanceOverrideDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Use the Daily OS default profile, choose a profile override, or override only this planner\'s thinking model.'**
+  String get dailyOsSettingsInstanceOverrideDescription;
+
+  /// No description provided for @dailyOsSettingsInstanceOverrideTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Daily OS inference'**
+  String get dailyOsSettingsInstanceOverrideTitle;
+
+  /// No description provided for @dailyOsSettingsLocalDisclosure.
+  ///
+  /// In en, this message translates to:
+  /// **'The selected endpoint is on this device.'**
+  String get dailyOsSettingsLocalDisclosure;
+
+  /// No description provided for @dailyOsSettingsModelChanged.
+  ///
+  /// In en, this message translates to:
+  /// **'Daily OS now uses {model}'**
+  String dailyOsSettingsModelChanged(String model);
+
+  /// No description provided for @dailyOsSettingsNameNudgeAction.
+  ///
+  /// In en, this message translates to:
+  /// **'Add name'**
+  String get dailyOsSettingsNameNudgeAction;
+
+  /// No description provided for @dailyOsSettingsNameNudgeBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Adding a preferred name makes check-ins more personal. You can keep planning without it.'**
+  String get dailyOsSettingsNameNudgeBody;
+
+  /// No description provided for @dailyOsSettingsNameNudgeTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'How should Daily OS address you?'**
+  String get dailyOsSettingsNameNudgeTitle;
+
+  /// No description provided for @dailyOsSettingsProfileChanged.
+  ///
+  /// In en, this message translates to:
+  /// **'Daily OS now uses {profile}'**
+  String dailyOsSettingsProfileChanged(String profile);
+
+  /// No description provided for @dailyOsSettingsProfileOverrideActive.
+  ///
+  /// In en, this message translates to:
+  /// **'Profile override active'**
+  String get dailyOsSettingsProfileOverrideActive;
+
+  /// No description provided for @dailyOsSettingsRemoteDisclosure.
+  ///
+  /// In en, this message translates to:
+  /// **'Daily OS sends the assembled planning context to {provider} at {host} for remote processing.'**
+  String dailyOsSettingsRemoteDisclosure(String provider, String host);
+
+  /// No description provided for @dailyOsSettingsSetupAction.
+  ///
+  /// In en, this message translates to:
+  /// **'Set up Daily OS'**
+  String get dailyOsSettingsSetupAction;
+
+  /// No description provided for @dailyOsSettingsSetupRequiredBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Daily OS needs your provider choice before it can process your planning context.'**
+  String get dailyOsSettingsSetupRequiredBody;
+
+  /// No description provided for @dailyOsSettingsSetupRequiredTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose an inference profile'**
+  String get dailyOsSettingsSetupRequiredTitle;
+
+  /// No description provided for @dailyOsSettingsSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose how Daily OS addresses you and which inference profile plans your days.'**
+  String get dailyOsSettingsSubtitle;
+
+  /// No description provided for @dailyOsSettingsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Daily OS'**
+  String get dailyOsSettingsTitle;
+
+  /// No description provided for @dailyOsSettingsTreeSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Planning, personalization, and AI provider'**
+  String get dailyOsSettingsTreeSubtitle;
+
+  /// No description provided for @dailyOsSettingsUseDefault.
+  ///
+  /// In en, this message translates to:
+  /// **'Use Daily OS default'**
+  String get dailyOsSettingsUseDefault;
+
+  /// No description provided for @dailyOsSettingsUseDefaultDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Follow the profile selected in Daily OS settings.'**
+  String get dailyOsSettingsUseDefaultDescription;
 
   /// No description provided for @dailyOsTodayButton.
   ///

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -4331,7 +4331,7 @@ class AppLocalizationsCs extends AppLocalizations {
       'Použij výchozí profil Daily OS, vyber přepsání profilu nebo přepiš jen model uvažování tohoto plánovače.';
 
   @override
-  String get dailyOsSettingsInstanceOverrideTitle => 'Inference Daily OS';
+  String get dailyOsSettingsInstanceOverrideTitle => 'Inference pro Daily OS';
 
   @override
   String get dailyOsSettingsLocalDisclosure =>

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3737,6 +3737,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get dailyOsNextDayMenuInspectAgent => 'Prozkoumat agenta';
 
   @override
+  String get dailyOsNextDayMenuSettings => 'Nastavení Daily OS';
+
+  @override
   String get dailyOsNextDayMoreTooltip => 'Více';
 
   @override
@@ -4282,6 +4285,114 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get dailyOsOnboardingSpotlightTitle => 'Proměň řeč v plán';
+
+  @override
+  String get dailyOsSettingsChooseModelDescription =>
+      'Přepiš pouze model uvažování plánovače.';
+
+  @override
+  String get dailyOsSettingsChooseModelTitle => 'Vybrat přepsání modelu';
+
+  @override
+  String get dailyOsSettingsChooseProfileDescription =>
+      'Přepiš celý inferenční profil pro tento plánovač.';
+
+  @override
+  String get dailyOsSettingsChooseProfileTitle => 'Vybrat profil Daily OS';
+
+  @override
+  String get dailyOsSettingsDataDisclosure =>
+      'Daily OS odesílá relevantní úkoly, záznamy, plány, naučené preference a další sestavený kontext plánování vybranému poskytovateli ke zpracování.';
+
+  @override
+  String get dailyOsSettingsDefaultProfileDescription =>
+      'Daily OS ho použije, pokud instance plánovače nemá vlastní nastavení.';
+
+  @override
+  String get dailyOsSettingsDefaultProfileMissing => 'Vyber profil';
+
+  @override
+  String get dailyOsSettingsDefaultRestored =>
+      'Výchozí nastavení Daily OS obnoveno';
+
+  @override
+  String get dailyOsSettingsDirectOverrideActive =>
+      'Přímé přepsání modelu je aktivní.';
+
+  @override
+  String get dailyOsSettingsInferenceTitle => 'Výchozí inferenční profil';
+
+  @override
+  String get dailyOsSettingsInstanceCurrentSetup =>
+      'Aktuální nastavení plánovače';
+
+  @override
+  String get dailyOsSettingsInstanceOverrideDescription =>
+      'Použij výchozí profil Daily OS, vyber přepsání profilu nebo přepiš jen model uvažování tohoto plánovače.';
+
+  @override
+  String get dailyOsSettingsInstanceOverrideTitle => 'Inference Daily OS';
+
+  @override
+  String get dailyOsSettingsLocalDisclosure =>
+      'Vybraný koncový bod je na tomto zařízení.';
+
+  @override
+  String dailyOsSettingsModelChanged(String model) {
+    return 'Daily OS nyní používá $model';
+  }
+
+  @override
+  String get dailyOsSettingsNameNudgeAction => 'Přidat jméno';
+
+  @override
+  String get dailyOsSettingsNameNudgeBody =>
+      'Preferované jméno udělá check-iny osobnější. Plánovat můžeš i bez něj.';
+
+  @override
+  String get dailyOsSettingsNameNudgeTitle => 'Jak tě má Daily OS oslovovat?';
+
+  @override
+  String dailyOsSettingsProfileChanged(String profile) {
+    return 'Daily OS nyní používá $profile';
+  }
+
+  @override
+  String get dailyOsSettingsProfileOverrideActive =>
+      'Přepsání profilu je aktivní';
+
+  @override
+  String dailyOsSettingsRemoteDisclosure(String provider, String host) {
+    return 'Daily OS odesílá sestavený kontext plánování poskytovateli $provider na $host ke vzdálenému zpracování.';
+  }
+
+  @override
+  String get dailyOsSettingsSetupAction => 'Nastavit Daily OS';
+
+  @override
+  String get dailyOsSettingsSetupRequiredBody =>
+      'Daily OS potřebuje tvou volbu poskytovatele, než může zpracovat kontext plánování.';
+
+  @override
+  String get dailyOsSettingsSetupRequiredTitle => 'Vyber inferenční profil';
+
+  @override
+  String get dailyOsSettingsSubtitle =>
+      'Zvol, jak tě má Daily OS oslovovat a který inferenční profil má plánovat tvé dny.';
+
+  @override
+  String get dailyOsSettingsTitle => 'Daily OS';
+
+  @override
+  String get dailyOsSettingsTreeSubtitle =>
+      'Plánování, přizpůsobení a poskytovatel AI';
+
+  @override
+  String get dailyOsSettingsUseDefault => 'Použít výchozí nastavení Daily OS';
+
+  @override
+  String get dailyOsSettingsUseDefaultDescription =>
+      'Použije profil vybraný v nastavení Daily OS.';
 
   @override
   String get dailyOsTodayButton => 'Dnes';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3728,6 +3728,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get dailyOsNextDayMenuInspectAgent => 'Agent prüfen';
 
   @override
+  String get dailyOsNextDayMenuSettings => 'Daily-OS-Einstellungen';
+
+  @override
   String get dailyOsNextDayMoreTooltip => 'Mehr';
 
   @override
@@ -4271,6 +4274,116 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get dailyOsOnboardingSpotlightTitle => 'Mach aus Worten einen Plan';
+
+  @override
+  String get dailyOsSettingsChooseModelDescription =>
+      'Überschreibe nur das Denkmodell des Planers.';
+
+  @override
+  String get dailyOsSettingsChooseModelTitle =>
+      'Modellüberschreibung auswählen';
+
+  @override
+  String get dailyOsSettingsChooseProfileDescription =>
+      'Überschreibe das gesamte Inferenzprofil für diesen Planer.';
+
+  @override
+  String get dailyOsSettingsChooseProfileTitle => 'Daily-OS-Profil auswählen';
+
+  @override
+  String get dailyOsSettingsDataDisclosure =>
+      'Daily OS sendet relevante Aufgaben, Erfassungen, Pläne, gelernte Präferenzen und weiteren zusammengestellten Planungskontext zur Verarbeitung an den ausgewählten Anbieter.';
+
+  @override
+  String get dailyOsSettingsDefaultProfileDescription =>
+      'Wird von Daily OS verwendet, sofern die Planer-Instanz keine Überschreibung hat.';
+
+  @override
+  String get dailyOsSettingsDefaultProfileMissing => 'Profil auswählen';
+
+  @override
+  String get dailyOsSettingsDefaultRestored =>
+      'Daily-OS-Standard wiederhergestellt';
+
+  @override
+  String get dailyOsSettingsDirectOverrideActive =>
+      'Direkte Modellüberschreibung ist aktiv.';
+
+  @override
+  String get dailyOsSettingsInferenceTitle => 'Standard-Inferenzprofil';
+
+  @override
+  String get dailyOsSettingsInstanceCurrentSetup =>
+      'Aktuelle Planer-Konfiguration';
+
+  @override
+  String get dailyOsSettingsInstanceOverrideDescription =>
+      'Verwende das Daily-OS-Standardprofil, wähle eine Profilüberschreibung oder überschreibe nur das Denkmodell dieses Planers.';
+
+  @override
+  String get dailyOsSettingsInstanceOverrideTitle => 'Daily-OS-Inferenz';
+
+  @override
+  String get dailyOsSettingsLocalDisclosure =>
+      'Der ausgewählte Endpunkt befindet sich auf diesem Gerät.';
+
+  @override
+  String dailyOsSettingsModelChanged(String model) {
+    return 'Daily OS verwendet jetzt $model';
+  }
+
+  @override
+  String get dailyOsSettingsNameNudgeAction => 'Namen hinzufügen';
+
+  @override
+  String get dailyOsSettingsNameNudgeBody =>
+      'Mit einem bevorzugten Namen werden Check-ins persönlicher. Du kannst auch ohne ihn weiterplanen.';
+
+  @override
+  String get dailyOsSettingsNameNudgeTitle =>
+      'Wie soll Daily OS dich ansprechen?';
+
+  @override
+  String dailyOsSettingsProfileChanged(String profile) {
+    return 'Daily OS verwendet jetzt $profile';
+  }
+
+  @override
+  String get dailyOsSettingsProfileOverrideActive =>
+      'Profilüberschreibung aktiv';
+
+  @override
+  String dailyOsSettingsRemoteDisclosure(String provider, String host) {
+    return 'Daily OS sendet den zusammengestellten Planungskontext zur entfernten Verarbeitung an $provider unter $host.';
+  }
+
+  @override
+  String get dailyOsSettingsSetupAction => 'Daily OS einrichten';
+
+  @override
+  String get dailyOsSettingsSetupRequiredBody =>
+      'Daily OS braucht deine Anbieterwahl, bevor dein Planungskontext verarbeitet werden kann.';
+
+  @override
+  String get dailyOsSettingsSetupRequiredTitle => 'Inferenzprofil auswählen';
+
+  @override
+  String get dailyOsSettingsSubtitle =>
+      'Lege fest, wie Daily OS dich anspricht und welches Inferenzprofil deine Tage plant.';
+
+  @override
+  String get dailyOsSettingsTitle => 'Daily OS';
+
+  @override
+  String get dailyOsSettingsTreeSubtitle =>
+      'Planung, Personalisierung und KI-Anbieter';
+
+  @override
+  String get dailyOsSettingsUseDefault => 'Daily-OS-Standard verwenden';
+
+  @override
+  String get dailyOsSettingsUseDefaultDescription =>
+      'Folge dem in den Daily-OS-Einstellungen ausgewählten Profil.';
 
   @override
   String get dailyOsTodayButton => 'Heute';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3683,6 +3683,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get dailyOsNextDayMenuInspectAgent => 'Inspect agent';
 
   @override
+  String get dailyOsNextDayMenuSettings => 'Daily OS settings';
+
+  @override
   String get dailyOsNextDayMoreTooltip => 'More';
 
   @override
@@ -4220,6 +4223,112 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get dailyOsOnboardingSpotlightTitle => 'Turn talk into a plan';
+
+  @override
+  String get dailyOsSettingsChooseModelDescription =>
+      'Override only the planner\'s thinking model.';
+
+  @override
+  String get dailyOsSettingsChooseModelTitle => 'Choose model override';
+
+  @override
+  String get dailyOsSettingsChooseProfileDescription =>
+      'Override the full inference profile for this planner.';
+
+  @override
+  String get dailyOsSettingsChooseProfileTitle => 'Choose Daily OS profile';
+
+  @override
+  String get dailyOsSettingsDataDisclosure =>
+      'Daily OS sends relevant tasks, captures, plans, learned preferences, and other assembled planning context to the selected provider for processing.';
+
+  @override
+  String get dailyOsSettingsDefaultProfileDescription =>
+      'Used by Daily OS unless the planner instance has an override.';
+
+  @override
+  String get dailyOsSettingsDefaultProfileMissing => 'Choose a profile';
+
+  @override
+  String get dailyOsSettingsDefaultRestored => 'Daily OS default restored';
+
+  @override
+  String get dailyOsSettingsDirectOverrideActive =>
+      'Direct model override is active.';
+
+  @override
+  String get dailyOsSettingsInferenceTitle => 'Default inference profile';
+
+  @override
+  String get dailyOsSettingsInstanceCurrentSetup => 'Current planner setup';
+
+  @override
+  String get dailyOsSettingsInstanceOverrideDescription =>
+      'Use the Daily OS default profile, choose a profile override, or override only this planner\'s thinking model.';
+
+  @override
+  String get dailyOsSettingsInstanceOverrideTitle => 'Daily OS inference';
+
+  @override
+  String get dailyOsSettingsLocalDisclosure =>
+      'The selected endpoint is on this device.';
+
+  @override
+  String dailyOsSettingsModelChanged(String model) {
+    return 'Daily OS now uses $model';
+  }
+
+  @override
+  String get dailyOsSettingsNameNudgeAction => 'Add name';
+
+  @override
+  String get dailyOsSettingsNameNudgeBody =>
+      'Adding a preferred name makes check-ins more personal. You can keep planning without it.';
+
+  @override
+  String get dailyOsSettingsNameNudgeTitle =>
+      'How should Daily OS address you?';
+
+  @override
+  String dailyOsSettingsProfileChanged(String profile) {
+    return 'Daily OS now uses $profile';
+  }
+
+  @override
+  String get dailyOsSettingsProfileOverrideActive => 'Profile override active';
+
+  @override
+  String dailyOsSettingsRemoteDisclosure(String provider, String host) {
+    return 'Daily OS sends the assembled planning context to $provider at $host for remote processing.';
+  }
+
+  @override
+  String get dailyOsSettingsSetupAction => 'Set up Daily OS';
+
+  @override
+  String get dailyOsSettingsSetupRequiredBody =>
+      'Daily OS needs your provider choice before it can process your planning context.';
+
+  @override
+  String get dailyOsSettingsSetupRequiredTitle => 'Choose an inference profile';
+
+  @override
+  String get dailyOsSettingsSubtitle =>
+      'Choose how Daily OS addresses you and which inference profile plans your days.';
+
+  @override
+  String get dailyOsSettingsTitle => 'Daily OS';
+
+  @override
+  String get dailyOsSettingsTreeSubtitle =>
+      'Planning, personalization, and AI provider';
+
+  @override
+  String get dailyOsSettingsUseDefault => 'Use Daily OS default';
+
+  @override
+  String get dailyOsSettingsUseDefaultDescription =>
+      'Follow the profile selected in Daily OS settings.';
 
   @override
   String get dailyOsTodayButton => 'Today';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3749,6 +3749,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get dailyOsNextDayMenuInspectAgent => 'Inspeccionar agente';
 
   @override
+  String get dailyOsNextDayMenuSettings => 'Ajustes de Daily OS';
+
+  @override
   String get dailyOsNextDayMoreTooltip => 'Más';
 
   @override
@@ -4296,6 +4299,118 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get dailyOsOnboardingSpotlightTitle =>
       'Convierte lo que dices en un plan';
+
+  @override
+  String get dailyOsSettingsChooseModelDescription =>
+      'Anula solo el modelo de razonamiento del planificador.';
+
+  @override
+  String get dailyOsSettingsChooseModelTitle => 'Elegir anulación de modelo';
+
+  @override
+  String get dailyOsSettingsChooseProfileDescription =>
+      'Anula el perfil de inferencia completo para este planificador.';
+
+  @override
+  String get dailyOsSettingsChooseProfileTitle => 'Elegir perfil de Daily OS';
+
+  @override
+  String get dailyOsSettingsDataDisclosure =>
+      'Daily OS envía las tareas, capturas, planes, preferencias aprendidas y demás contexto de planificación recopilado al proveedor seleccionado para procesarlo.';
+
+  @override
+  String get dailyOsSettingsDefaultProfileDescription =>
+      'Daily OS lo usa salvo que la instancia del planificador tenga una anulación.';
+
+  @override
+  String get dailyOsSettingsDefaultProfileMissing => 'Elige un perfil';
+
+  @override
+  String get dailyOsSettingsDefaultRestored =>
+      'Valor predeterminado de Daily OS restaurado';
+
+  @override
+  String get dailyOsSettingsDirectOverrideActive =>
+      'La anulación directa del modelo está activa.';
+
+  @override
+  String get dailyOsSettingsInferenceTitle =>
+      'Perfil de inferencia predeterminado';
+
+  @override
+  String get dailyOsSettingsInstanceCurrentSetup =>
+      'Configuración actual del planificador';
+
+  @override
+  String get dailyOsSettingsInstanceOverrideDescription =>
+      'Usa el perfil predeterminado de Daily OS, elige una anulación de perfil o anula solo el modelo de razonamiento de este planificador.';
+
+  @override
+  String get dailyOsSettingsInstanceOverrideTitle => 'Inferencia de Daily OS';
+
+  @override
+  String get dailyOsSettingsLocalDisclosure =>
+      'El punto de conexión seleccionado está en este dispositivo.';
+
+  @override
+  String dailyOsSettingsModelChanged(String model) {
+    return 'Daily OS ahora usa $model';
+  }
+
+  @override
+  String get dailyOsSettingsNameNudgeAction => 'Añadir nombre';
+
+  @override
+  String get dailyOsSettingsNameNudgeBody =>
+      'Añadir un nombre preferido hace los check-ins más personales. Puedes seguir planificando sin él.';
+
+  @override
+  String get dailyOsSettingsNameNudgeTitle =>
+      '¿Cómo quieres que te llame Daily OS?';
+
+  @override
+  String dailyOsSettingsProfileChanged(String profile) {
+    return 'Daily OS ahora usa $profile';
+  }
+
+  @override
+  String get dailyOsSettingsProfileOverrideActive =>
+      'Anulación de perfil activa';
+
+  @override
+  String dailyOsSettingsRemoteDisclosure(String provider, String host) {
+    return 'Daily OS envía el contexto de planificación recopilado a $provider en $host para su procesamiento remoto.';
+  }
+
+  @override
+  String get dailyOsSettingsSetupAction => 'Configurar Daily OS';
+
+  @override
+  String get dailyOsSettingsSetupRequiredBody =>
+      'Daily OS necesita que elijas un proveedor antes de procesar tu contexto de planificación.';
+
+  @override
+  String get dailyOsSettingsSetupRequiredTitle =>
+      'Elige un perfil de inferencia';
+
+  @override
+  String get dailyOsSettingsSubtitle =>
+      'Elige cómo te llama Daily OS y qué perfil de inferencia planifica tus días.';
+
+  @override
+  String get dailyOsSettingsTitle => 'Daily OS';
+
+  @override
+  String get dailyOsSettingsTreeSubtitle =>
+      'Planificación, personalización y proveedor de IA';
+
+  @override
+  String get dailyOsSettingsUseDefault =>
+      'Usar valor predeterminado de Daily OS';
+
+  @override
+  String get dailyOsSettingsUseDefaultDescription =>
+      'Sigue el perfil elegido en los ajustes de Daily OS.';
 
   @override
   String get dailyOsTodayButton => 'Hoy';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3755,6 +3755,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get dailyOsNextDayMenuInspectAgent => 'Inspecter l\'agent';
 
   @override
+  String get dailyOsNextDayMenuSettings => 'Réglages Daily OS';
+
+  @override
   String get dailyOsNextDayMoreTooltip => 'Plus';
 
   @override
@@ -4304,6 +4307,118 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get dailyOsOnboardingSpotlightTitle => 'Transforme tes mots en plan';
+
+  @override
+  String get dailyOsSettingsChooseModelDescription =>
+      'Remplace uniquement le modèle de réflexion du planificateur.';
+
+  @override
+  String get dailyOsSettingsChooseModelTitle =>
+      'Choisir une dérogation de modèle';
+
+  @override
+  String get dailyOsSettingsChooseProfileDescription =>
+      'Remplace le profil d\'inférence complet pour ce planificateur.';
+
+  @override
+  String get dailyOsSettingsChooseProfileTitle => 'Choisir le profil Daily OS';
+
+  @override
+  String get dailyOsSettingsDataDisclosure =>
+      'Daily OS envoie les tâches, captures, plans, préférences apprises et autres éléments de contexte de planification assemblés au fournisseur sélectionné pour traitement.';
+
+  @override
+  String get dailyOsSettingsDefaultProfileDescription =>
+      'Utilisé par Daily OS sauf si l’instance du planificateur a une dérogation.';
+
+  @override
+  String get dailyOsSettingsDefaultProfileMissing => 'Choisis un profil';
+
+  @override
+  String get dailyOsSettingsDefaultRestored =>
+      'Réglage Daily OS par défaut rétabli';
+
+  @override
+  String get dailyOsSettingsDirectOverrideActive =>
+      'La dérogation directe du modèle est active.';
+
+  @override
+  String get dailyOsSettingsInferenceTitle => 'Profil d’inférence par défaut';
+
+  @override
+  String get dailyOsSettingsInstanceCurrentSetup =>
+      'Configuration actuelle du planificateur';
+
+  @override
+  String get dailyOsSettingsInstanceOverrideDescription =>
+      'Utilise le profil Daily OS par défaut, choisis une dérogation de profil ou remplace uniquement le modèle de réflexion de ce planificateur.';
+
+  @override
+  String get dailyOsSettingsInstanceOverrideTitle => 'Inférence Daily OS';
+
+  @override
+  String get dailyOsSettingsLocalDisclosure =>
+      'Le point de terminaison sélectionné se trouve sur cet appareil.';
+
+  @override
+  String dailyOsSettingsModelChanged(String model) {
+    return 'Daily OS utilise maintenant $model';
+  }
+
+  @override
+  String get dailyOsSettingsNameNudgeAction => 'Ajouter un prénom';
+
+  @override
+  String get dailyOsSettingsNameNudgeBody =>
+      'Ajouter un prénom préféré rend les check-ins plus personnels. Tu peux continuer sans le faire.';
+
+  @override
+  String get dailyOsSettingsNameNudgeTitle =>
+      'Comment Daily OS doit-il t’appeler ?';
+
+  @override
+  String dailyOsSettingsProfileChanged(String profile) {
+    return 'Daily OS utilise maintenant $profile';
+  }
+
+  @override
+  String get dailyOsSettingsProfileOverrideActive =>
+      'Dérogation de profil active';
+
+  @override
+  String dailyOsSettingsRemoteDisclosure(String provider, String host) {
+    return 'Daily OS envoie le contexte de planification assemblé à $provider sur $host pour un traitement à distance.';
+  }
+
+  @override
+  String get dailyOsSettingsSetupAction => 'Configurer Daily OS';
+
+  @override
+  String get dailyOsSettingsSetupRequiredBody =>
+      'Daily OS a besoin de ton choix de fournisseur avant de pouvoir traiter ton contexte de planification.';
+
+  @override
+  String get dailyOsSettingsSetupRequiredTitle =>
+      'Choisis un profil d’inférence';
+
+  @override
+  String get dailyOsSettingsSubtitle =>
+      'Choisis comment Daily OS s’adresse à toi et quel profil d’inférence planifie tes journées.';
+
+  @override
+  String get dailyOsSettingsTitle => 'Daily OS';
+
+  @override
+  String get dailyOsSettingsTreeSubtitle =>
+      'Planification, personnalisation et fournisseur d’IA';
+
+  @override
+  String get dailyOsSettingsUseDefault =>
+      'Utiliser le réglage Daily OS par défaut';
+
+  @override
+  String get dailyOsSettingsUseDefaultDescription =>
+      'Suis le profil choisi dans les réglages Daily OS.';
 
   @override
   String get dailyOsTodayButton => 'Aujourd\'hui';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -4314,7 +4314,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get dailyOsSettingsChooseModelTitle =>
-      'Choisir une dérogation de modèle';
+      'Choisir un remplacement de modèle';
 
   @override
   String get dailyOsSettingsChooseProfileDescription =>
@@ -4329,7 +4329,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get dailyOsSettingsDefaultProfileDescription =>
-      'Utilisé par Daily OS sauf si l’instance du planificateur a une dérogation.';
+      'Utilisé par Daily OS sauf si l’instance du planificateur a un remplacement.';
 
   @override
   String get dailyOsSettingsDefaultProfileMissing => 'Choisis un profil';
@@ -4340,7 +4340,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get dailyOsSettingsDirectOverrideActive =>
-      'La dérogation directe du modèle est active.';
+      'Le remplacement direct du modèle est actif.';
 
   @override
   String get dailyOsSettingsInferenceTitle => 'Profil d’inférence par défaut';
@@ -4351,7 +4351,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get dailyOsSettingsInstanceOverrideDescription =>
-      'Utilise le profil Daily OS par défaut, choisis une dérogation de profil ou remplace uniquement le modèle de réflexion de ce planificateur.';
+      'Utilise le profil Daily OS par défaut, choisis un remplacement de profil ou remplace uniquement le modèle de réflexion de ce planificateur.';
 
   @override
   String get dailyOsSettingsInstanceOverrideTitle => 'Inférence Daily OS';
@@ -4383,7 +4383,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get dailyOsSettingsProfileOverrideActive =>
-      'Dérogation de profil active';
+      'Remplacement de profil actif';
 
   @override
   String dailyOsSettingsRemoteDisclosure(String provider, String host) {

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3761,6 +3761,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get dailyOsNextDayMenuInspectAgent => 'Inspectare agent';
 
   @override
+  String get dailyOsNextDayMenuSettings => 'Setări Daily OS';
+
+  @override
   String get dailyOsNextDayMoreTooltip => 'Mai mult';
 
   @override
@@ -4310,6 +4313,117 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get dailyOsOnboardingSpotlightTitle => 'Transformați vorbele în plan';
+
+  @override
+  String get dailyOsSettingsChooseModelDescription =>
+      'Suprascrieți doar modelul de raționament al planificatorului.';
+
+  @override
+  String get dailyOsSettingsChooseModelTitle =>
+      'Alegeți suprascrierea modelului';
+
+  @override
+  String get dailyOsSettingsChooseProfileDescription =>
+      'Suprascrieți întregul profil de inferență pentru acest planificator.';
+
+  @override
+  String get dailyOsSettingsChooseProfileTitle => 'Alegeți profilul Daily OS';
+
+  @override
+  String get dailyOsSettingsDataDisclosure =>
+      'Daily OS trimite sarcinile, capturile, planurile, preferințele învățate și restul contextului de planificare asamblat către furnizorul selectat pentru procesare.';
+
+  @override
+  String get dailyOsSettingsDefaultProfileDescription =>
+      'Este folosit de Daily OS dacă instanța planificatorului nu are o suprascriere.';
+
+  @override
+  String get dailyOsSettingsDefaultProfileMissing => 'Alegeți un profil';
+
+  @override
+  String get dailyOsSettingsDefaultRestored =>
+      'Setarea implicită Daily OS a fost restaurată';
+
+  @override
+  String get dailyOsSettingsDirectOverrideActive =>
+      'Suprascrierea directă a modelului este activă.';
+
+  @override
+  String get dailyOsSettingsInferenceTitle => 'Profil de inferență implicit';
+
+  @override
+  String get dailyOsSettingsInstanceCurrentSetup =>
+      'Configurația actuală a planificatorului';
+
+  @override
+  String get dailyOsSettingsInstanceOverrideDescription =>
+      'Folosiți profilul Daily OS implicit, alegeți o suprascriere de profil sau suprascrieți doar modelul de raționament al acestui planificator.';
+
+  @override
+  String get dailyOsSettingsInstanceOverrideTitle => 'Inferență Daily OS';
+
+  @override
+  String get dailyOsSettingsLocalDisclosure =>
+      'Punctul final selectat se află pe acest dispozitiv.';
+
+  @override
+  String dailyOsSettingsModelChanged(String model) {
+    return 'Daily OS folosește acum $model';
+  }
+
+  @override
+  String get dailyOsSettingsNameNudgeAction => 'Adăugați numele';
+
+  @override
+  String get dailyOsSettingsNameNudgeBody =>
+      'Un nume preferat face check-in-urile mai personale. Puteți continua planificarea și fără el.';
+
+  @override
+  String get dailyOsSettingsNameNudgeTitle =>
+      'Cum doriți să vi se adreseze Daily OS?';
+
+  @override
+  String dailyOsSettingsProfileChanged(String profile) {
+    return 'Daily OS folosește acum $profile';
+  }
+
+  @override
+  String get dailyOsSettingsProfileOverrideActive =>
+      'Suprascrierea profilului este activă';
+
+  @override
+  String dailyOsSettingsRemoteDisclosure(String provider, String host) {
+    return 'Daily OS trimite contextul de planificare asamblat către $provider, la $host, pentru procesare la distanță.';
+  }
+
+  @override
+  String get dailyOsSettingsSetupAction => 'Configurați Daily OS';
+
+  @override
+  String get dailyOsSettingsSetupRequiredBody =>
+      'Daily OS are nevoie de alegerea dvs. privind furnizorul înainte de a vă procesa contextul de planificare.';
+
+  @override
+  String get dailyOsSettingsSetupRequiredTitle =>
+      'Alegeți un profil de inferență';
+
+  @override
+  String get dailyOsSettingsSubtitle =>
+      'Alegeți cum să vi se adreseze Daily OS și ce profil de inferență să vă planifice zilele.';
+
+  @override
+  String get dailyOsSettingsTitle => 'Daily OS';
+
+  @override
+  String get dailyOsSettingsTreeSubtitle =>
+      'Planificare, personalizare și furnizor AI';
+
+  @override
+  String get dailyOsSettingsUseDefault => 'Folosiți setarea implicită Daily OS';
+
+  @override
+  String get dailyOsSettingsUseDefaultDescription =>
+      'Urmează profilul selectat în setările Daily OS.';
 
   @override
   String get dailyOsTodayButton => 'Astăzi';

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -1728,6 +1728,7 @@
   "dailyOsNextDayLockInCta": "Fixează",
   "dailyOsNextDayMenuDeletePlan": "Ștergere plan",
   "dailyOsNextDayMenuInspectAgent": "Inspectare agent",
+  "dailyOsNextDayMenuSettings": "Setări Daily OS",
   "dailyOsNextDayMoreTooltip": "Mai mult",
   "dailyOsNextDayRefineCta": "Ajustați",
   "dailyOsNextDayRefineFooterHint": "Vorbiți pentru a reorganiza planul — vedeți fiecare schimbare înainte ca ceva să fie salvat.",
@@ -1947,6 +1948,59 @@
   "dailyOsOnboardingSpotlightDismiss": "Nu acum",
   "dailyOsOnboardingSpotlightMessage": "Atingeți aici și spuneți ce vă preocupă – transform totul într-o sarcină și vă construiesc ziua în jurul ei.",
   "dailyOsOnboardingSpotlightTitle": "Transformați vorbele în plan",
+  "dailyOsSettingsChooseModelDescription": "Suprascrieți doar modelul de raționament al planificatorului.",
+  "dailyOsSettingsChooseModelTitle": "Alegeți suprascrierea modelului",
+  "dailyOsSettingsChooseProfileDescription": "Suprascrieți întregul profil de inferență pentru acest planificator.",
+  "dailyOsSettingsChooseProfileTitle": "Alegeți profilul Daily OS",
+  "dailyOsSettingsDataDisclosure": "Daily OS trimite sarcinile, capturile, planurile, preferințele învățate și restul contextului de planificare asamblat către furnizorul selectat pentru procesare.",
+  "dailyOsSettingsDefaultProfileDescription": "Este folosit de Daily OS dacă instanța planificatorului nu are o suprascriere.",
+  "dailyOsSettingsDefaultProfileMissing": "Alegeți un profil",
+  "dailyOsSettingsDefaultRestored": "Setarea implicită Daily OS a fost restaurată",
+  "dailyOsSettingsDirectOverrideActive": "Suprascrierea directă a modelului este activă.",
+  "dailyOsSettingsInferenceTitle": "Profil de inferență implicit",
+  "dailyOsSettingsInstanceCurrentSetup": "Configurația actuală a planificatorului",
+  "dailyOsSettingsInstanceOverrideDescription": "Folosiți profilul Daily OS implicit, alegeți o suprascriere de profil sau suprascrieți doar modelul de raționament al acestui planificator.",
+  "dailyOsSettingsInstanceOverrideTitle": "Inferență Daily OS",
+  "dailyOsSettingsLocalDisclosure": "Punctul final selectat se află pe acest dispozitiv.",
+  "dailyOsSettingsModelChanged": "Daily OS folosește acum {model}",
+  "@dailyOsSettingsModelChanged": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
+  "dailyOsSettingsNameNudgeAction": "Adăugați numele",
+  "dailyOsSettingsNameNudgeBody": "Un nume preferat face check-in-urile mai personale. Puteți continua planificarea și fără el.",
+  "dailyOsSettingsNameNudgeTitle": "Cum doriți să vi se adreseze Daily OS?",
+  "dailyOsSettingsProfileChanged": "Daily OS folosește acum {profile}",
+  "@dailyOsSettingsProfileChanged": {
+    "placeholders": {
+      "profile": {
+        "type": "String"
+      }
+    }
+  },
+  "dailyOsSettingsProfileOverrideActive": "Suprascrierea profilului este activă",
+  "dailyOsSettingsRemoteDisclosure": "Daily OS trimite contextul de planificare asamblat către {provider}, la {host}, pentru procesare la distanță.",
+  "@dailyOsSettingsRemoteDisclosure": {
+    "placeholders": {
+      "provider": {
+        "type": "String"
+      },
+      "host": {
+        "type": "String"
+      }
+    }
+  },
+  "dailyOsSettingsSetupAction": "Configurați Daily OS",
+  "dailyOsSettingsSetupRequiredBody": "Daily OS are nevoie de alegerea dvs. privind furnizorul înainte de a vă procesa contextul de planificare.",
+  "dailyOsSettingsSetupRequiredTitle": "Alegeți un profil de inferență",
+  "dailyOsSettingsSubtitle": "Alegeți cum să vi se adreseze Daily OS și ce profil de inferență să vă planifice zilele.",
+  "dailyOsSettingsTitle": "Daily OS",
+  "dailyOsSettingsTreeSubtitle": "Planificare, personalizare și furnizor AI",
+  "dailyOsSettingsUseDefault": "Folosiți setarea implicită Daily OS",
+  "dailyOsSettingsUseDefaultDescription": "Urmează profilul selectat în setările Daily OS.",
   "dailyOsTodayButton": "Astăzi",
   "dashboardActiveLabel": "Activ",
   "dashboardActiveSwitchDescription": "Afișat în lista panourilor de bord",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1043+4204
+version: 0.9.1044+4205
 
 msix_config:
   display_name: LottiApp

--- a/test/beamer/locations/settings_location_test.dart
+++ b/test/beamer/locations/settings_location_test.dart
@@ -16,6 +16,7 @@ import 'package:lotti/features/ai/ui/settings/inference_model_edit_page.dart';
 import 'package:lotti/features/ai/ui/settings/provider/ai_provider_detail_page.dart';
 import 'package:lotti/features/categories/ui/pages/categories_list_page.dart';
 import 'package:lotti/features/categories/ui/pages/category_details_page.dart';
+import 'package:lotti/features/daily_os_next/ui/pages/daily_os_settings_page.dart';
 import 'package:lotti/features/journal/ui/pages/entry_details_page.dart';
 import 'package:lotti/features/labels/ui/pages/label_details_page.dart';
 import 'package:lotti/features/labels/ui/pages/labels_list_page.dart';
@@ -158,6 +159,7 @@ void main() {
         '/settings/agents/souls/:soulId',
         '/settings/agents/souls/:soulId/review',
         '/settings/agents/instances/:agentId',
+        '/settings/daily-os',
         '/settings/flags',
         '/settings/recording-style',
         '/settings/theming',
@@ -830,6 +832,21 @@ void main() {
       expect(pages.length, 2);
       expect(pages[0].child, isA<SettingsMobileRootPage>());
       expect(pages[1].child, isA<AgentSettingsPage>());
+    });
+
+    test('buildPages builds DailyOsSettingsPage', () {
+      final routeInformation = RouteInformation(
+        uri: Uri.parse('/settings/daily-os'),
+      );
+      final location = SettingsLocation(routeInformation);
+      final beamState = BeamState.fromRouteInformation(routeInformation);
+      final pages = location.buildPages(
+        mockBuildContext,
+        beamState,
+      );
+      expect(pages.length, 2);
+      expect(pages[0].child, isA<SettingsMobileRootPage>());
+      expect(pages[1].child, isA<DailyOsSettingsPage>());
     });
 
     test('buildPages builds AgentTemplateDetailPage for create', () {

--- a/test/features/agents/state/task_agent_model_providers_test.dart
+++ b/test/features/agents/state/task_agent_model_providers_test.dart
@@ -95,11 +95,19 @@ void main() {
   );
 
   test(
-    'setup options filters models to task-agent thinking capabilities',
+    'setup options filters model capabilities without excluding providers',
     () async {
       final repository = MockAiConfigRepository();
       final capable = model();
       final incapable = model(tools: false);
+      final google = AiConfigInferenceProvider(
+        id: 'google',
+        baseUrl: 'https://generativelanguage.googleapis.com',
+        apiKey: 'key',
+        name: 'Google Gemini',
+        createdAt: DateTime(2024),
+        inferenceProviderType: InferenceProviderType.gemini,
+      );
       when(
         () => repository.getConfigsByType(AiConfigType.inferenceProfile),
       ).thenAnswer((_) async => const []);
@@ -108,7 +116,7 @@ void main() {
       ).thenAnswer((_) async => [capable, incapable]);
       when(
         () => repository.getConfigsByType(AiConfigType.inferenceProvider),
-      ).thenAnswer((_) async => const []);
+      ).thenAnswer((_) async => [google]);
       final container = ProviderContainer(
         overrides: [aiConfigRepositoryProvider.overrideWithValue(repository)],
       );
@@ -119,7 +127,7 @@ void main() {
       );
       expect(options.models, [capable]);
       expect(options.profiles, isEmpty);
-      expect(options.providers, isEmpty);
+      expect(options.providers, [google]);
     },
   );
 

--- a/test/features/agents/ui/agent_internals_body_test.dart
+++ b/test/features/agents/ui/agent_internals_body_test.dart
@@ -3,12 +3,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/agents/model/agent_config.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
 import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/agents/state/task_agent_model_providers.dart';
 import 'package:lotti/features/agents/ui/agent_internals_body.dart';
 import 'package:lotti/features/ai/model/resolved_profile.dart';
+import 'package:lotti/features/daily_os_next/agents/service/day_agent_service.dart';
 
 import '../../../test_helper.dart';
 import '../test_data/ai_config_factories.dart';
@@ -242,5 +244,79 @@ void main() {
     );
     expect(find.text('Selected AI setup is unavailable'), findsNWidgets(2));
     expect(find.text('No AI setup'), findsNothing);
+  });
+
+  testWidgets('Daily OS setup row opens the planner override sheet', (
+    tester,
+  ) async {
+    final profile = testInferenceProfile(
+      id: 'profile-1',
+      thinkingModelId: 'model-1',
+    );
+    final model = testAiModel();
+    final provider = testInferenceProvider();
+    final identity = makeTestIdentity(
+      id: dailyOsPlannerAgentId,
+      agentId: dailyOsPlannerAgentId,
+      kind: AgentKinds.dayAgent,
+      config: const AgentConfig(
+        profileId: 'profile-1',
+        inferenceSetup: AgentInferenceSetup(
+          mode: AgentInferenceSetupMode.configured,
+          origin: AgentInferenceSetupOrigin.user,
+          baseProfileId: 'profile-1',
+        ),
+      ),
+    );
+    final resolved = ResolvedAgentSetup(
+      status: AgentSetupResolutionStatus.resolved,
+      profile: ResolvedProfile(
+        thinkingModelId: model.providerModelId,
+        thinkingProvider: provider,
+        thinkingModel: model,
+      ),
+      source: AgentSetupResolutionSource.baseProfile,
+      setupOrigin: AgentInferenceSetupOrigin.user,
+    );
+    await tester.pumpWidget(
+      RiverpodWidgetTestBench(
+        mediaQueryData: const MediaQueryData(size: Size(900, 800)),
+        overrides: [
+          agentIdentityProvider.overrideWith((ref, agentId) async => identity),
+          agentStateProvider.overrideWith((ref, agentId) async => null),
+          templateForAgentProvider.overrideWith((ref, agentId) async => null),
+          taskAgentResolvedSetupProvider.overrideWith(
+            (ref, agentId) async => resolved,
+          ),
+          taskAgentSetupOptionsProvider.overrideWith(
+            (ref) async => TaskAgentSetupOptions(
+              profiles: [profile],
+              models: [model],
+              providers: [provider],
+            ),
+          ),
+        ],
+        child: const SingleChildScrollView(
+          child: AgentInternalsBody(
+            agentId: dailyOsPlannerAgentId,
+            lifecycle: AgentLifecycle.active,
+            stateAsync: AsyncValue.data(null),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.scrollUntilVisible(
+      find.text('Test Model · via Gemini'),
+      200,
+      scrollable: find.byType(Scrollable).at(1),
+    );
+    expect(find.text('Daily OS inference'), findsOneWidget);
+    expect(find.text('Current planner setup'), findsOneWidget);
+    await tester.tap(find.text('Test Model · via Gemini'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Use Daily OS default'), findsOneWidget);
   });
 }

--- a/test/features/ai/ui/widgets/inference_provider_model_picker_modal_test.dart
+++ b/test/features/ai/ui/widgets/inference_provider_model_picker_modal_test.dart
@@ -77,6 +77,7 @@ void main() {
       required void Function(String?) onResult,
       String? defaultModelId,
       String? selectedModelId,
+      bool autoSelectSingleCandidate = true,
     }) async {
       await tester.pumpWidget(
         makeTestableWidget(
@@ -92,6 +93,7 @@ void main() {
                     providers: providers,
                     title: 'Pick a model',
                     defaultBadgeLabel: 'Default',
+                    autoSelectSingleCandidate: autoSelectSingleCandidate,
                   );
                   onResult(picked);
                 },
@@ -141,6 +143,30 @@ void main() {
       expect(called, isTrue);
       expect(result, 'solo');
       expect(find.text('Solo'), findsNothing);
+    });
+
+    testWidgets('can require an explicit tap for the only model', (
+      tester,
+    ) async {
+      String? result;
+      var called = false;
+      await pumpHost(
+        tester,
+        models: [_model(id: 'solo', name: 'Solo')],
+        providers: [_provider(id: 'openai')],
+        autoSelectSingleCandidate: false,
+        onResult: (r) {
+          result = r;
+          called = true;
+        },
+      );
+
+      expect(called, isFalse);
+      expect(find.text('Solo'), findsOneWidget);
+      await tester.tap(find.text('Solo'));
+      await tester.pumpAndSettle();
+      expect(called, isTrue);
+      expect(result, 'solo');
     });
 
     testWidgets(

--- a/test/features/daily_os_next/agents/service/day_agent_service_test.dart
+++ b/test/features/daily_os_next/agents/service/day_agent_service_test.dart
@@ -16,13 +16,30 @@ import '../../../../helpers/fallbacks.dart';
 import '../../../../mocks/mocks.dart';
 import '../../../agents/test_utils.dart';
 
+class _TransactionTrackingAgentSyncService extends MockAgentSyncService {
+  final events = <String>[];
+  bool inTransaction = false;
+
+  @override
+  Future<T> runInTransaction<T>(Future<T> Function() action) async {
+    events.add('transaction:start');
+    inTransaction = true;
+    try {
+      return await action();
+    } finally {
+      inTransaction = false;
+      events.add('transaction:end');
+    }
+  }
+}
+
 void main() {
   setUpAll(registerAllFallbackValues);
 
   late MockAgentService agentService;
   late MockAgentRepository repository;
   late MockWakeOrchestrator orchestrator;
-  late MockAgentSyncService syncService;
+  late _TransactionTrackingAgentSyncService syncService;
   late MockAgentTemplateService templateService;
   late MockDomainLogger domainLogger;
   late DayAgentService service;
@@ -71,7 +88,7 @@ void main() {
     agentService = MockAgentService();
     repository = MockAgentRepository();
     orchestrator = MockWakeOrchestrator();
-    syncService = MockAgentSyncService();
+    syncService = _TransactionTrackingAgentSyncService();
     templateService = MockAgentTemplateService();
     domainLogger = MockDomainLogger();
     changedTokens = [];
@@ -93,7 +110,9 @@ void main() {
         subDomain: any(named: 'subDomain'),
       ),
     ).thenReturn(null);
-    when(() => syncService.upsertEntity(any())).thenAnswer((_) async {});
+    when(() => syncService.upsertEntity(any())).thenAnswer((_) async {
+      syncService.events.add('write');
+    });
     when(() => syncService.upsertLink(any())).thenAnswer((_) async {});
     when(
       () => orchestrator.enqueueManualWake(
@@ -131,7 +150,10 @@ void main() {
       syncService: syncService,
       templateService: templateService,
       domainLogger: domainLogger,
-      onPersistedStateChanged: changedTokens.add,
+      onPersistedStateChanged: (token) {
+        syncService.events.add('notify');
+        changedTokens.add(token);
+      },
     );
   });
 
@@ -1343,7 +1365,11 @@ void main() {
       );
       when(
         () => agentService.getAgent(dailyOsPlannerAgentId),
-      ).thenAnswer((_) async => planner);
+      ).thenAnswer((_) async {
+        expect(syncService.inTransaction, isTrue);
+        syncService.events.add('read:planner');
+        return planner;
+      });
 
       await service.updatePlannerProfileOverride('profile-instance');
 
@@ -1359,6 +1385,13 @@ void main() {
         updated.config.inferenceSetup?.origin,
         AgentInferenceSetupOrigin.user,
       );
+      expect(syncService.events, [
+        'transaction:start',
+        'read:planner',
+        'write',
+        'transaction:end',
+        'notify',
+      ]);
     });
 
     test(
@@ -1377,10 +1410,18 @@ void main() {
         );
         when(
           () => agentService.getAgent(dailyOsPlannerAgentId),
-        ).thenAnswer((_) async => planner);
+        ).thenAnswer((_) async {
+          expect(syncService.inTransaction, isTrue);
+          syncService.events.add('read:planner');
+          return planner;
+        });
         when(
           () => templateService.getTemplate(dayAgentTemplateId),
-        ).thenAnswer((_) async => plannerTemplate);
+        ).thenAnswer((_) async {
+          expect(syncService.inTransaction, isTrue);
+          syncService.events.add('read:template');
+          return plannerTemplate;
+        });
 
         await service.updatePlannerThinkingModelOverride('model-user');
 
@@ -1401,6 +1442,14 @@ void main() {
           updated.config.inferenceSetup?.origin,
           AgentInferenceSetupOrigin.user,
         );
+        expect(syncService.events, [
+          'transaction:start',
+          'read:planner',
+          'read:template',
+          'write',
+          'transaction:end',
+          'notify',
+        ]);
       },
     );
 
@@ -1408,10 +1457,18 @@ void main() {
       final planner = identity(id: dailyOsPlannerAgentId);
       when(
         () => agentService.getAgent(dailyOsPlannerAgentId),
-      ).thenAnswer((_) async => planner);
+      ).thenAnswer((_) async {
+        expect(syncService.inTransaction, isTrue);
+        syncService.events.add('read:planner');
+        return planner;
+      });
       when(
         () => templateService.getTemplate(dayAgentTemplateId),
-      ).thenAnswer((_) async => plannerTemplate);
+      ).thenAnswer((_) async {
+        expect(syncService.inTransaction, isTrue);
+        syncService.events.add('read:template');
+        return plannerTemplate;
+      });
 
       await service.resetPlannerInferenceToDefault();
 
@@ -1425,6 +1482,14 @@ void main() {
         updated.config.inferenceSetup?.origin,
         AgentInferenceSetupOrigin.templateSnapshot,
       );
+      expect(syncService.events, [
+        'transaction:start',
+        'read:planner',
+        'read:template',
+        'write',
+        'transaction:end',
+        'notify',
+      ]);
     });
   });
 }

--- a/test/features/daily_os_next/agents/service/day_agent_service_test.dart
+++ b/test/features/daily_os_next/agents/service/day_agent_service_test.dart
@@ -36,6 +36,7 @@ void main() {
   AgentIdentityEntity identity({
     String id = agentId,
     String kind = AgentKinds.dayAgent,
+    AgentConfig config = const AgentConfig(),
     DateTime? createdAt,
   }) {
     return makeTestIdentity(
@@ -44,6 +45,7 @@ void main() {
       kind: kind,
       displayName: 'Shepherd',
       currentStateId: 'state-$id',
+      config: config,
       createdAt: createdAt ?? now,
       updatedAt: createdAt ?? now,
     );
@@ -873,12 +875,23 @@ void main() {
             agentId: captureAny(named: 'agentId'),
             kind: captureAny(named: 'kind'),
             displayName: any(named: 'displayName'),
-            config: any(named: 'config'),
+            config: captureAny(named: 'config'),
             allowedCategoryIds: any(named: 'allowedCategoryIds'),
           ),
         ).captured;
         expect(createCall[0], AgentKinds.dayAgent);
-        expect(createCall[1], dailyOsPlannerAgentId);
+        final createdConfig = createCall[1] as AgentConfig;
+        expect(createCall[2], dailyOsPlannerAgentId);
+        expect(createdConfig.profileId, 'profile-day');
+        expect(
+          createdConfig.inferenceSetup,
+          const AgentInferenceSetup(
+            mode: AgentInferenceSetupMode.configured,
+            origin: AgentInferenceSetupOrigin.templateSnapshot,
+            baseProfileId: 'profile-day',
+            originEntityId: dayAgentTemplateId,
+          ),
+        );
 
         // The planner gets a template assignment but NO AgentDayLink: a day
         // is a workspace carried by wake tokens, not part of identity.
@@ -1228,6 +1241,190 @@ void main() {
         // The planner is still returned even though migration threw.
         expect(result.agentId, dailyOsPlannerAgentId);
       });
+    });
+  });
+
+  group('Daily OS inference selection', () {
+    final plannerTemplate = makeTestTemplate(
+      id: dayAgentTemplateId,
+      agentId: dayAgentTemplateId,
+      kind: AgentTemplateKind.dayAgent,
+      modelId: 'models/day',
+      profileId: 'profile-old',
+    );
+
+    test('default profile updates a planner following the template', () async {
+      final planner = identity(
+        id: dailyOsPlannerAgentId,
+        config: const AgentConfig(
+          profileId: 'profile-old',
+          inferenceSetup: AgentInferenceSetup(
+            mode: AgentInferenceSetupMode.configured,
+            origin: AgentInferenceSetupOrigin.templateSnapshot,
+            baseProfileId: 'profile-old',
+            originEntityId: dayAgentTemplateId,
+          ),
+        ),
+      );
+      when(
+        () => templateService.updateTemplate(
+          templateId: dayAgentTemplateId,
+          profileId: 'profile-new',
+        ),
+      ).thenAnswer(
+        (_) async => plannerTemplate.copyWith(profileId: 'profile-new'),
+      );
+      when(
+        () => agentService.getAgent(dailyOsPlannerAgentId),
+      ).thenAnswer((_) async => planner);
+
+      await withClock(
+        Clock.fixed(now),
+        () => service.updateDefaultInferenceProfile('profile-new'),
+      );
+
+      final updated =
+          verify(
+                () => syncService.upsertEntity(captureAny()),
+              ).captured.single
+              as AgentIdentityEntity;
+      expect(updated.config.profileId, 'profile-new');
+      expect(updated.config.inferenceSetup?.baseProfileId, 'profile-new');
+      expect(
+        updated.config.inferenceSetup?.origin,
+        AgentInferenceSetupOrigin.templateSnapshot,
+      );
+      expect(changedTokens, [dailyOsPlannerAgentId]);
+    });
+
+    test('default profile preserves a user-owned planner override', () async {
+      final planner = identity(
+        id: dailyOsPlannerAgentId,
+        config: const AgentConfig(
+          profileId: 'profile-old',
+          inferenceSetup: AgentInferenceSetup(
+            mode: AgentInferenceSetupMode.configured,
+            origin: AgentInferenceSetupOrigin.user,
+            baseProfileId: 'profile-old',
+            thinkingModelOverrideId: 'model-user',
+          ),
+        ),
+      );
+      when(
+        () => templateService.updateTemplate(
+          templateId: dayAgentTemplateId,
+          profileId: 'profile-new',
+        ),
+      ).thenAnswer(
+        (_) async => plannerTemplate.copyWith(profileId: 'profile-new'),
+      );
+      when(
+        () => agentService.getAgent(dailyOsPlannerAgentId),
+      ).thenAnswer((_) async => planner);
+
+      await service.updateDefaultInferenceProfile('profile-new');
+
+      verifyNever(() => syncService.upsertEntity(any()));
+      expect(changedTokens, isEmpty);
+    });
+
+    test('profile override is user-owned and clears a direct model', () async {
+      final planner = identity(
+        id: dailyOsPlannerAgentId,
+        config: const AgentConfig(
+          profileId: 'profile-old',
+          inferenceSetup: AgentInferenceSetup(
+            mode: AgentInferenceSetupMode.configured,
+            origin: AgentInferenceSetupOrigin.user,
+            baseProfileId: 'profile-old',
+            thinkingModelOverrideId: 'model-old',
+          ),
+        ),
+      );
+      when(
+        () => agentService.getAgent(dailyOsPlannerAgentId),
+      ).thenAnswer((_) async => planner);
+
+      await service.updatePlannerProfileOverride('profile-instance');
+
+      final updated =
+          verify(
+                () => syncService.upsertEntity(captureAny()),
+              ).captured.single
+              as AgentIdentityEntity;
+      expect(updated.config.profileId, 'profile-instance');
+      expect(updated.config.inferenceSetup?.baseProfileId, 'profile-instance');
+      expect(updated.config.inferenceSetup?.thinkingModelOverrideId, isNull);
+      expect(
+        updated.config.inferenceSetup?.origin,
+        AgentInferenceSetupOrigin.user,
+      );
+    });
+
+    test(
+      'model override keeps the planner profile override as its base',
+      () async {
+        final planner = identity(
+          id: dailyOsPlannerAgentId,
+          config: const AgentConfig(
+            profileId: 'profile-instance',
+            inferenceSetup: AgentInferenceSetup(
+              mode: AgentInferenceSetupMode.configured,
+              origin: AgentInferenceSetupOrigin.user,
+              baseProfileId: 'profile-instance',
+            ),
+          ),
+        );
+        when(
+          () => agentService.getAgent(dailyOsPlannerAgentId),
+        ).thenAnswer((_) async => planner);
+        when(
+          () => templateService.getTemplate(dayAgentTemplateId),
+        ).thenAnswer((_) async => plannerTemplate);
+
+        await service.updatePlannerThinkingModelOverride('model-user');
+
+        final updated =
+            verify(
+                  () => syncService.upsertEntity(captureAny()),
+                ).captured.single
+                as AgentIdentityEntity;
+        expect(
+          updated.config.inferenceSetup?.baseProfileId,
+          'profile-instance',
+        );
+        expect(
+          updated.config.inferenceSetup?.thinkingModelOverrideId,
+          'model-user',
+        );
+        expect(
+          updated.config.inferenceSetup?.origin,
+          AgentInferenceSetupOrigin.user,
+        );
+      },
+    );
+
+    test('reset restores the template snapshot', () async {
+      final planner = identity(id: dailyOsPlannerAgentId);
+      when(
+        () => agentService.getAgent(dailyOsPlannerAgentId),
+      ).thenAnswer((_) async => planner);
+      when(
+        () => templateService.getTemplate(dayAgentTemplateId),
+      ).thenAnswer((_) async => plannerTemplate);
+
+      await service.resetPlannerInferenceToDefault();
+
+      final updated =
+          verify(
+                () => syncService.upsertEntity(captureAny()),
+              ).captured.single
+              as AgentIdentityEntity;
+      expect(updated.config.inferenceSetup?.thinkingModelOverrideId, isNull);
+      expect(
+        updated.config.inferenceSetup?.origin,
+        AgentInferenceSetupOrigin.templateSnapshot,
+      );
     });
   });
 }

--- a/test/features/daily_os_next/agents/service/day_agent_service_test.dart
+++ b/test/features/daily_os_next/agents/service/day_agent_service_test.dart
@@ -1491,5 +1491,150 @@ void main() {
         'notify',
       ]);
     });
+
+    test(
+      'profile override rejects a missing planner inside the transaction',
+      () async {
+        when(
+          () => agentService.getAgent(dailyOsPlannerAgentId),
+        ).thenAnswer((_) async => null);
+
+        await expectLater(
+          service.updatePlannerProfileOverride('profile-instance'),
+          throwsA(
+            isA<StateError>().having(
+              (error) => error.message,
+              'message',
+              'Daily OS planner has not been created yet',
+            ),
+          ),
+        );
+        verifyNever(() => syncService.upsertEntity(any()));
+      },
+    );
+
+    for (final validationCase in [
+      (
+        name: 'missing planner',
+        planner: null,
+        template: plannerTemplate,
+        message: 'Daily OS planner has not been created yet',
+      ),
+      (
+        name: 'missing template',
+        planner: identity(id: dailyOsPlannerAgentId),
+        template: null,
+        message: 'Daily OS template $dayAgentTemplateId not found',
+      ),
+      (
+        name: 'missing default profile',
+        planner: identity(id: dailyOsPlannerAgentId),
+        template: plannerTemplate.copyWith(profileId: null),
+        message: 'Choose a Daily OS default profile first',
+      ),
+    ]) {
+      test('model override rejects a ${validationCase.name}', () async {
+        when(
+          () => agentService.getAgent(dailyOsPlannerAgentId),
+        ).thenAnswer((_) async => validationCase.planner);
+        when(
+          () => templateService.getTemplate(dayAgentTemplateId),
+        ).thenAnswer((_) async => validationCase.template);
+
+        await expectLater(
+          service.updatePlannerThinkingModelOverride('model-user'),
+          throwsA(
+            isA<StateError>().having(
+              (error) => error.message,
+              'message',
+              validationCase.message,
+            ),
+          ),
+        );
+        verifyNever(() => syncService.upsertEntity(any()));
+      });
+
+      test('reset rejects a ${validationCase.name}', () async {
+        when(
+          () => agentService.getAgent(dailyOsPlannerAgentId),
+        ).thenAnswer((_) async => validationCase.planner);
+        when(
+          () => templateService.getTemplate(dayAgentTemplateId),
+        ).thenAnswer((_) async => validationCase.template);
+
+        await expectLater(
+          service.resetPlannerInferenceToDefault(),
+          throwsA(
+            isA<StateError>().having(
+              (error) => error.message,
+              'message',
+              validationCase.message,
+            ),
+          ),
+        );
+        verifyNever(() => syncService.upsertEntity(any()));
+      });
+    }
+
+    for (final baseCase in [
+      (
+        name: 'planner profile',
+        config: const AgentConfig(
+          profileId: 'profile-planner',
+          inferenceSetup: AgentInferenceSetup(
+            mode: AgentInferenceSetupMode.configured,
+            origin: AgentInferenceSetupOrigin.user,
+          ),
+        ),
+        expected: 'profile-planner',
+      ),
+      (
+        name: 'template profile',
+        config: const AgentConfig(
+          inferenceSetup: AgentInferenceSetup(
+            mode: AgentInferenceSetupMode.configured,
+            origin: AgentInferenceSetupOrigin.user,
+          ),
+        ),
+        expected: 'profile-old',
+      ),
+      (
+        name: 'disabled setup planner profile',
+        config: const AgentConfig(
+          profileId: 'profile-disabled',
+          inferenceSetup: AgentInferenceSetup(
+            mode: AgentInferenceSetupMode.disabled,
+            origin: AgentInferenceSetupOrigin.user,
+          ),
+        ),
+        expected: 'profile-disabled',
+      ),
+    ]) {
+      test('model override resolves the ${baseCase.name}', () async {
+        final planner = identity(
+          id: dailyOsPlannerAgentId,
+          config: baseCase.config,
+        );
+        when(
+          () => agentService.getAgent(dailyOsPlannerAgentId),
+        ).thenAnswer((_) async => planner);
+        when(
+          () => templateService.getTemplate(dayAgentTemplateId),
+        ).thenAnswer((_) async => plannerTemplate);
+
+        await service.updatePlannerThinkingModelOverride('model-user');
+
+        final updated =
+            verify(
+                  () => syncService.upsertEntity(captureAny()),
+                ).captured.single
+                as AgentIdentityEntity;
+        expect(updated.config.profileId, baseCase.expected);
+        expect(
+          updated.config.inferenceSetup?.baseProfileId,
+          baseCase.expected,
+        );
+      });
+    }
   });
 }

--- a/test/features/daily_os_next/state/daily_os_inference_providers_test.dart
+++ b/test/features/daily_os_next/state/daily_os_inference_providers_test.dart
@@ -1,6 +1,19 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/service/agent_template_service.dart';
+import 'package:lotti/features/agents/state/template_query_providers.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/daily_os_next/state/daily_os_inference_providers.dart';
+import 'package:lotti/features/daily_os_next/state/daily_os_onboarding_trigger_service.dart';
+import 'package:lotti/features/daily_os_next/state/daily_os_preferences_controller.dart';
+
+import '../../agents/test_utils.dart';
+
+class _PreferencesController extends DailyOsPreferencesController {
+  @override
+  DailyOsPreferences build() => DailyOsPreferences(userName: 'Alex');
+}
 
 AiConfigInferenceProvider _provider({
   required String baseUrl,
@@ -87,4 +100,34 @@ void main() {
     expect(status.hasInferenceRoute, isTrue);
     expect(status.hasPreferredName, isFalse);
   });
+
+  test(
+    'setup provider combines the template route and preferred name',
+    () async {
+      final template = makeTestTemplate(
+        id: dayAgentTemplateId,
+        agentId: dayAgentTemplateId,
+        kind: AgentTemplateKind.dayAgent,
+        profileId: 'profile',
+      );
+      final container = ProviderContainer(
+        overrides: [
+          dailyOsOnboardingProviderReadyProvider.overrideWith(
+            (ref) async => true,
+          ),
+          agentTemplateProvider.overrideWith((ref, id) async => template),
+          dailyOsPreferencesControllerProvider.overrideWith(
+            _PreferencesController.new,
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final status = await container.read(dailyOsSetupStatusProvider.future);
+
+      expect(status.hasInferenceRoute, isTrue);
+      expect(status.hasPreferredName, isTrue);
+      expect(status.needsAttention, isFalse);
+    },
+  );
 }

--- a/test/features/daily_os_next/state/daily_os_inference_providers_test.dart
+++ b/test/features/daily_os_next/state/daily_os_inference_providers_test.dart
@@ -130,4 +130,37 @@ void main() {
       expect(status.needsAttention, isFalse);
     },
   );
+
+  test(
+    'a resolvable legacy route without an explicit profile still needs setup',
+    () async {
+      // The seeded Shepherd template resolves through its legacy Gemini
+      // modelId (routeReady true) but has no explicit profileId. Daily OS
+      // deliberately treats this as unconfigured and blocks check-in until the
+      // user makes an explicit provider choice, rather than silently routing
+      // their planning context to the default provider.
+      final legacyTemplate = makeTestTemplate(
+        id: dayAgentTemplateId,
+        agentId: dayAgentTemplateId,
+        kind: AgentTemplateKind.dayAgent,
+      );
+      final container = ProviderContainer(
+        overrides: [
+          dailyOsOnboardingProviderReadyProvider.overrideWith(
+            (ref) async => true,
+          ),
+          agentTemplateProvider.overrideWith((ref, id) async => legacyTemplate),
+          dailyOsPreferencesControllerProvider.overrideWith(
+            _PreferencesController.new,
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final status = await container.read(dailyOsSetupStatusProvider.future);
+
+      expect(status.hasInferenceRoute, isFalse);
+      expect(status.needsAttention, isTrue);
+    },
+  );
 }

--- a/test/features/daily_os_next/state/daily_os_inference_providers_test.dart
+++ b/test/features/daily_os_next/state/daily_os_inference_providers_test.dart
@@ -20,7 +20,9 @@ void main() {
   group('dailyOsInferenceEndpointKind', () {
     for (final baseUrl in [
       'http://localhost:11434',
+      'localhost:11434',
       'http://127.0.0.1:11434',
+      '127.0.0.1:11434',
       'http://127.12.4.8:8080',
       'http://[::1]:8080',
     ]) {

--- a/test/features/daily_os_next/state/daily_os_inference_providers_test.dart
+++ b/test/features/daily_os_next/state/daily_os_inference_providers_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/daily_os_next/state/daily_os_inference_providers.dart';
+
+AiConfigInferenceProvider _provider({
+  required String baseUrl,
+  InferenceProviderType type = InferenceProviderType.genericOpenAi,
+}) {
+  return AiConfigInferenceProvider(
+    id: 'provider',
+    baseUrl: baseUrl,
+    apiKey: '',
+    name: 'Provider',
+    createdAt: DateTime(2024, 3, 15),
+    inferenceProviderType: type,
+  );
+}
+
+void main() {
+  group('dailyOsInferenceEndpointKind', () {
+    for (final baseUrl in [
+      'http://localhost:11434',
+      'http://127.0.0.1:11434',
+      'http://127.12.4.8:8080',
+      'http://[::1]:8080',
+    ]) {
+      test('classifies $baseUrl as on-device', () {
+        expect(
+          dailyOsInferenceEndpointKind(_provider(baseUrl: baseUrl)),
+          DailyOsInferenceEndpointKind.onDevice,
+        );
+      });
+    }
+
+    test('classifies a remote Ollama endpoint as remote', () {
+      expect(
+        dailyOsInferenceEndpointKind(
+          _provider(
+            baseUrl: 'https://ollama.example.com',
+            type: InferenceProviderType.ollama,
+          ),
+        ),
+        DailyOsInferenceEndpointKind.remote,
+      );
+    });
+
+    test('classifies the embedded MLX Audio provider as on-device', () {
+      expect(
+        dailyOsInferenceEndpointKind(
+          _provider(baseUrl: '', type: InferenceProviderType.mlxAudio),
+        ),
+        DailyOsInferenceEndpointKind.onDevice,
+      );
+    });
+
+    test('does not filter or special-case Google endpoints', () {
+      expect(
+        dailyOsInferenceEndpointKind(
+          _provider(
+            baseUrl: 'https://generativelanguage.googleapis.com',
+            type: InferenceProviderType.gemini,
+          ),
+        ),
+        DailyOsInferenceEndpointKind.remote,
+      );
+    });
+  });
+
+  test('setup status distinguishes required inference from optional name', () {
+    const status = DailyOsSetupStatus(
+      hasInferenceRoute: true,
+      hasPreferredName: false,
+    );
+
+    expect(status.needsAttention, isTrue);
+    expect(status.hasInferenceRoute, isTrue);
+    expect(status.hasPreferredName, isFalse);
+  });
+}

--- a/test/features/daily_os_next/state/daily_os_inference_providers_test.dart
+++ b/test/features/daily_os_next/state/daily_os_inference_providers_test.dart
@@ -46,6 +46,15 @@ void main() {
       );
     });
 
+    test('extracts the host from a scheme-less remote endpoint', () {
+      expect(
+        dailyOsInferenceEndpointHost(
+          _provider(baseUrl: 'inference.example.com:11434/v1'),
+        ),
+        'inference.example.com',
+      );
+    });
+
     test('classifies the embedded MLX Audio provider as on-device', () {
       expect(
         dailyOsInferenceEndpointKind(

--- a/test/features/daily_os_next/ui/pages/daily_os_next_root_test.dart
+++ b/test/features/daily_os_next/ui/pages/daily_os_next_root_test.dart
@@ -14,6 +14,7 @@ import 'package:lotti/features/daily_os_next/ui/pages/capture_page.dart';
 import 'package:lotti/features/daily_os_next/ui/pages/daily_os_next_root.dart';
 import 'package:lotti/features/daily_os_next/ui/pages/day_page.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/services/nav_service.dart' as nav_service;
 import 'package:lotti/utils/device_region.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -28,6 +29,7 @@ Widget _wrap(
   Widget child, {
   List<TimeBlock> actualBlocks = const [],
   List<Override> overrides = const [],
+  DailyOsSetupStatus Function()? setupStatus,
 }) {
   return ProviderScope(
     overrides: [
@@ -36,10 +38,12 @@ Widget _wrap(
       ),
       firstDayOfWeekIndexProvider.overrideWith((ref) async => 1),
       dailyOsSetupStatusProvider.overrideWith(
-        (ref) async => const DailyOsSetupStatus(
-          hasInferenceRoute: true,
-          hasPreferredName: true,
-        ),
+        (ref) async =>
+            setupStatus?.call() ??
+            const DailyOsSetupStatus(
+              hasInferenceRoute: true,
+              hasPreferredName: true,
+            ),
       ),
       ...overrides,
     ],
@@ -75,6 +79,8 @@ DraftPlan _draftPlan() {
 }
 
 void main() {
+  tearDown(() => nav_service.beamToNamedOverride = null);
+
   group('DailyOsNextRoot', () {
     testWidgets('keeps the date strip visible on the capture path', (
       tester,
@@ -179,6 +185,52 @@ void main() {
         });
       },
     );
+
+    testWidgets('a route lost before check-in opens Daily OS settings', (
+      tester,
+    ) async {
+      var hasInferenceRoute = true;
+      String? route;
+      nav_service.beamToNamedOverride = (path) => route = path;
+      final actualBlock = TimeBlock(
+        id: 'actual:entry-setup',
+        title: 'Setup transition',
+        start: DateTime(2026, 5, 26, 9),
+        end: DateTime(2026, 5, 26, 10),
+        type: TimeBlockType.manual,
+        state: TimeBlockState.completed,
+        category: _category,
+      );
+
+      await withClock(Clock.fixed(DateTime(2026, 5, 26, 9)), () async {
+        await tester.pumpWidget(
+          _wrap(
+            const DailyOsNextRoot(),
+            actualBlocks: [actualBlock],
+            setupStatus: () => DailyOsSetupStatus(
+              hasInferenceRoute: hasInferenceRoute,
+              hasPreferredName: true,
+            ),
+            overrides: [
+              currentDraftPlanProvider.overrideWith((ref, _) async => null),
+            ],
+          ),
+        );
+        await tester.pump();
+        await tester.pump();
+
+        final rootContext = tester.element(find.byType(DailyOsNextRoot));
+        hasInferenceRoute = false;
+        ProviderScope.containerOf(rootContext).invalidate(
+          dailyOsSetupStatusProvider,
+        );
+        await tester.tap(find.byKey(const Key('daily_os_day_check_in_cta')));
+        await tester.pump();
+
+        expect(route, '/settings/daily-os');
+        expect(find.byType(CaptureModalContent), findsNothing);
+      });
+    });
 
     testWidgets('AsyncLoading shows the loading shell', (tester) async {
       final realtimeService = MockRealtimeTranscriptionService();

--- a/test/features/daily_os_next/ui/pages/daily_os_next_root_test.dart
+++ b/test/features/daily_os_next/ui/pages/daily_os_next_root_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
 import 'package:lotti/features/daily_os_next/state/actual_time_blocks_provider.dart';
 import 'package:lotti/features/daily_os_next/state/capture_controller.dart';
+import 'package:lotti/features/daily_os_next/state/daily_os_inference_providers.dart';
 import 'package:lotti/features/daily_os_next/state/day_agent_provider.dart';
 import 'package:lotti/features/daily_os_next/ui/pages/capture_page.dart';
 import 'package:lotti/features/daily_os_next/ui/pages/daily_os_next_root.dart';
@@ -34,6 +35,12 @@ Widget _wrap(
         (ref, _) async => actualBlocks,
       ),
       firstDayOfWeekIndexProvider.overrideWith((ref) async => 1),
+      dailyOsSetupStatusProvider.overrideWith(
+        (ref) async => const DailyOsSetupStatus(
+          hasInferenceRoute: true,
+          hasPreferredName: true,
+        ),
+      ),
       ...overrides,
     ],
     child: makeTestableWidget2(

--- a/test/features/daily_os_next/ui/pages/daily_os_settings_page_test.dart
+++ b/test/features/daily_os_next/ui/pages/daily_os_settings_page_test.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/service/agent_template_service.dart';
+import 'package:lotti/features/agents/state/task_agent_model_providers.dart';
+import 'package:lotti/features/agents/state/template_query_providers.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/daily_os_next/agents/state/day_agent_providers.dart';
+import 'package:lotti/features/daily_os_next/state/daily_os_preferences_controller.dart';
+import 'package:lotti/features/daily_os_next/ui/pages/daily_os_settings_page.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../mocks/mocks.dart';
+import '../../../../widget_test_utils.dart';
+import '../../../agents/test_utils.dart';
+
+final _provider = AiConfigInferenceProvider(
+  id: 'provider-remote',
+  baseUrl: 'https://inference.example.com/v1',
+  apiKey: 'secret',
+  name: 'Private Cloud',
+  createdAt: DateTime(2024, 3, 15),
+  inferenceProviderType: InferenceProviderType.genericOpenAi,
+);
+
+AiConfigModel _model(String id, String name) => AiConfigModel(
+  id: id,
+  name: name,
+  providerModelId: 'wire/$id',
+  inferenceProviderId: _provider.id,
+  createdAt: DateTime(2024, 3, 15),
+  inputModalities: const [Modality.text],
+  outputModalities: const [Modality.text],
+  isReasoningModel: true,
+  supportsFunctionCalling: true,
+);
+
+AiConfigInferenceProfile _profile(String id, String name, String modelId) =>
+    AiConfigInferenceProfile(
+      id: id,
+      name: name,
+      createdAt: DateTime(2024, 3, 15),
+      thinkingModelId: modelId,
+    );
+
+class _PreferencesController extends DailyOsPreferencesController {
+  _PreferencesController(this.initial);
+
+  final DailyOsPreferences initial;
+
+  @override
+  DailyOsPreferences build() => initial;
+}
+
+void main() {
+  final modelA = _model('model-a', 'Reasoner A');
+  final modelB = _model('model-b', 'Reasoner B');
+  final profileA = _profile('profile-a', 'Work profile', modelA.id);
+  final profileB = _profile('profile-b', 'Local profile', modelB.id);
+  final template = makeTestTemplate(
+    id: dayAgentTemplateId,
+    agentId: dayAgentTemplateId,
+    kind: AgentTemplateKind.dayAgent,
+    profileId: profileA.id,
+  );
+
+  late MockDayAgentService service;
+
+  setUp(() {
+    service = MockDayAgentService();
+    when(
+      () => service.updateDefaultInferenceProfile(any()),
+    ).thenAnswer((_) async {});
+  });
+
+  Future<void> pumpSettings(WidgetTester tester) async {
+    await tester.pumpWidget(
+      makeTestableWidgetWithScaffold(
+        const DailyOsSettingsBody(),
+        overrides: [
+          dayAgentServiceProvider.overrideWithValue(service),
+          agentTemplateProvider.overrideWith((ref, id) async => template),
+          taskAgentSetupOptionsProvider.overrideWith(
+            (ref) async => TaskAgentSetupOptions(
+              profiles: [profileA, profileB],
+              models: [modelA, modelB],
+              providers: [_provider],
+            ),
+          ),
+          dailyOsPreferencesControllerProvider.overrideWith(
+            () => _PreferencesController(
+              DailyOsPreferences(userName: 'Alex'),
+            ),
+          ),
+        ],
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+  }
+
+  testWidgets('shows the chosen route and definitive remote disclosure', (
+    tester,
+  ) async {
+    await pumpSettings(tester);
+
+    final messages = tester.element(find.byType(DailyOsSettingsBody)).messages;
+    expect(find.text('Work profile'), findsOneWidget);
+    expect(find.textContaining('Reasoner A'), findsOneWidget);
+    expect(
+      find.textContaining(
+        messages.dailyOsSettingsRemoteDisclosure(
+          'Private Cloud',
+          'inference.example.com',
+        ),
+      ),
+      findsOneWidget,
+    );
+    final field = find.descendant(
+      of: find.byKey(const Key('daily_os_user_name_field')),
+      matching: find.byType(TextField),
+    );
+    expect(tester.widget<TextField>(field).controller?.text, 'Alex');
+  });
+
+  testWidgets('persists a profile selected through the shared picker', (
+    tester,
+  ) async {
+    await pumpSettings(tester);
+
+    await tester.tap(find.byKey(const Key('daily_os_default_profile')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Local profile'));
+    await tester.pump();
+
+    verify(
+      () => service.updateDefaultInferenceProfile(profileB.id),
+    ).called(1);
+  });
+}

--- a/test/features/daily_os_next/ui/pages/daily_os_settings_page_test.dart
+++ b/test/features/daily_os_next/ui/pages/daily_os_settings_page_test.dart
@@ -74,7 +74,11 @@ void main() {
     ).thenAnswer((_) async {});
   });
 
-  Future<void> pumpSettings(WidgetTester tester) async {
+  Future<void> pumpSettings(
+    WidgetTester tester, {
+    AiConfigInferenceProvider? provider,
+  }) async {
+    final configuredProvider = provider ?? _provider;
     await tester.pumpWidget(
       makeTestableWidgetWithScaffold(
         const DailyOsSettingsBody(),
@@ -85,7 +89,7 @@ void main() {
             (ref) async => TaskAgentSetupOptions(
               profiles: [profileA, profileB],
               models: [modelA, modelB],
-              providers: [_provider],
+              providers: [configuredProvider],
             ),
           ),
           dailyOsPreferencesControllerProvider.overrideWith(
@@ -122,6 +126,26 @@ void main() {
       matching: find.byType(TextField),
     );
     expect(tester.widget<TextField>(field).controller?.text, 'Alex');
+  });
+
+  testWidgets('normalizes a scheme-less host in the remote disclosure', (
+    tester,
+  ) async {
+    await pumpSettings(
+      tester,
+      provider: _provider.copyWith(baseUrl: 'inference.example.com:11434/v1'),
+    );
+
+    final messages = tester.element(find.byType(DailyOsSettingsBody)).messages;
+    expect(
+      find.textContaining(
+        messages.dailyOsSettingsRemoteDisclosure(
+          'Private Cloud',
+          'inference.example.com',
+        ),
+      ),
+      findsOneWidget,
+    );
   });
 
   testWidgets('persists a profile selected through the shared picker', (

--- a/test/features/daily_os_next/ui/pages/daily_os_settings_page_test.dart
+++ b/test/features/daily_os_next/ui/pages/daily_os_settings_page_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/agents/model/agent_enums.dart';
@@ -8,6 +10,7 @@ import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/daily_os_next/agents/state/day_agent_providers.dart';
 import 'package:lotti/features/daily_os_next/state/daily_os_preferences_controller.dart';
 import 'package:lotti/features/daily_os_next/ui/pages/daily_os_settings_page.dart';
+import 'package:lotti/features/design_system/components/toasts/design_system_toast.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -58,13 +61,6 @@ void main() {
   final modelB = _model('model-b', 'Reasoner B');
   final profileA = _profile('profile-a', 'Work profile', modelA.id);
   final profileB = _profile('profile-b', 'Local profile', modelB.id);
-  final template = makeTestTemplate(
-    id: dayAgentTemplateId,
-    agentId: dayAgentTemplateId,
-    kind: AgentTemplateKind.dayAgent,
-    profileId: profileA.id,
-  );
-
   late MockDayAgentService service;
 
   setUp(() {
@@ -76,19 +72,33 @@ void main() {
 
   Future<void> pumpSettings(
     WidgetTester tester, {
+    Widget child = const DailyOsSettingsBody(),
     AiConfigInferenceProvider? provider,
+    String? templateProfileId,
+    List<AiConfigInferenceProfile>? profiles,
+    List<AiConfigModel>? models,
   }) async {
     final configuredProvider = provider ?? _provider;
+    final configuredProfiles = profiles ?? [profileA, profileB];
+    final configuredModels = models ?? [modelA, modelB];
+    final configuredTemplate = makeTestTemplate(
+      id: dayAgentTemplateId,
+      agentId: dayAgentTemplateId,
+      kind: AgentTemplateKind.dayAgent,
+      profileId: templateProfileId ?? profileA.id,
+    );
     await tester.pumpWidget(
       makeTestableWidgetWithScaffold(
-        const DailyOsSettingsBody(),
+        child,
         overrides: [
           dayAgentServiceProvider.overrideWithValue(service),
-          agentTemplateProvider.overrideWith((ref, id) async => template),
+          agentTemplateProvider.overrideWith(
+            (ref, id) async => configuredTemplate,
+          ),
           taskAgentSetupOptionsProvider.overrideWith(
             (ref) async => TaskAgentSetupOptions(
-              profiles: [profileA, profileB],
-              models: [modelA, modelB],
+              profiles: configuredProfiles,
+              models: configuredModels,
               providers: [configuredProvider],
             ),
           ),
@@ -103,6 +113,24 @@ void main() {
     await tester.pump();
     await tester.pump();
   }
+
+  Future<void> chooseProfileB(WidgetTester tester) async {
+    await tester.tap(find.byKey(const Key('daily_os_default_profile')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Local profile'));
+    await tester.pump();
+  }
+
+  testWidgets('mobile page wraps the shared settings body with its title', (
+    tester,
+  ) async {
+    await pumpSettings(tester, child: const DailyOsSettingsPage());
+
+    final messages = tester.element(find.byType(DailyOsSettingsBody)).messages;
+    expect(find.byType(DailyOsSettingsBody), findsOneWidget);
+    expect(find.text(messages.dailyOsSettingsTitle), findsOneWidget);
+    await tester.pump(const Duration(seconds: 1));
+  });
 
   testWidgets('shows the chosen route and definitive remote disclosure', (
     tester,
@@ -148,15 +176,111 @@ void main() {
     );
   });
 
+  testWidgets('falls back to provider model ids when resolving the route', (
+    tester,
+  ) async {
+    final wireProfile = profileA.copyWith(
+      thinkingModelId: modelA.providerModelId,
+    );
+    await pumpSettings(
+      tester,
+      templateProfileId: wireProfile.id,
+      profiles: [wireProfile, profileB],
+    );
+
+    expect(
+      find.descendant(
+        of: find.byKey(const Key('daily_os_default_profile')),
+        matching: find.textContaining('Reasoner A'),
+      ),
+      findsOneWidget,
+    );
+  });
+
+  for (final endpointCase in [
+    (
+      name: 'unparseable endpoint',
+      baseUrl: 'http://[',
+      disclosureEndpoint: 'http://[',
+      local: false,
+    ),
+    (
+      name: 'empty endpoint',
+      baseUrl: '',
+      disclosureEndpoint: 'Private Cloud',
+      local: false,
+    ),
+    (
+      name: 'local endpoint',
+      baseUrl: 'localhost:11434',
+      disclosureEndpoint: '',
+      local: true,
+    ),
+  ]) {
+    testWidgets('discloses the ${endpointCase.name}', (tester) async {
+      await pumpSettings(
+        tester,
+        provider: _provider.copyWith(baseUrl: endpointCase.baseUrl),
+      );
+
+      final messages = tester
+          .element(find.byType(DailyOsSettingsBody))
+          .messages;
+      final expected = endpointCase.local
+          ? messages.dailyOsSettingsLocalDisclosure
+          : messages.dailyOsSettingsRemoteDisclosure(
+              'Private Cloud',
+              endpointCase.disclosureEndpoint,
+            );
+      expect(find.textContaining(expected), findsOneWidget);
+    });
+  }
+
+  testWidgets('shows profile progress while the update is pending', (
+    tester,
+  ) async {
+    final update = Completer<void>();
+    when(
+      () => service.updateDefaultInferenceProfile(profileB.id),
+    ).thenAnswer((_) => update.future);
+    await pumpSettings(tester);
+
+    await chooseProfileB(tester);
+
+    expect(
+      find.byKey(const Key('daily_os_default_profile_progress')),
+      findsOneWidget,
+    );
+    update.complete();
+    await tester.pump();
+  });
+
+  testWidgets('shows an error toast when profile persistence fails', (
+    tester,
+  ) async {
+    when(
+      () => service.updateDefaultInferenceProfile(profileB.id),
+    ).thenThrow(StateError('write failed'));
+    await pumpSettings(tester);
+
+    await chooseProfileB(tester);
+
+    final toasts = tester.widgetList<DesignSystemToast>(
+      find.byType(DesignSystemToast),
+    );
+    expect(toasts, isNotEmpty);
+    expect(
+      toasts.every((toast) => toast.tone == DesignSystemToastTone.error),
+      isTrue,
+    );
+  });
+
   testWidgets('persists a profile selected through the shared picker', (
     tester,
   ) async {
     await pumpSettings(tester);
 
-    await tester.tap(find.byKey(const Key('daily_os_default_profile')));
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('Local profile'));
-    await tester.pump();
+    await chooseProfileB(tester);
 
     verify(
       () => service.updateDefaultInferenceProfile(profileB.id),

--- a/test/features/daily_os_next/ui/pages/day_page_test.dart
+++ b/test/features/daily_os_next/ui/pages/day_page_test.dart
@@ -9,6 +9,7 @@ import 'package:lotti/features/daily_os_next/agents/state/day_agent_providers.da
 import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
 import 'package:lotti/features/daily_os_next/state/actual_time_blocks_provider.dart';
 import 'package:lotti/features/daily_os_next/state/capture_controller.dart';
+import 'package:lotti/features/daily_os_next/state/daily_os_inference_providers.dart';
 import 'package:lotti/features/daily_os_next/state/day_agent_provider.dart';
 import 'package:lotti/features/daily_os_next/state/refine_controller.dart';
 import 'package:lotti/features/daily_os_next/ui/daily_os_next_routes.dart';
@@ -122,6 +123,10 @@ Widget _wrap(
   Size size = const Size(1400, 1200),
   MediaQueryData? mediaQueryData,
   ThemeData? theme,
+  DailyOsSetupStatus setupStatus = const DailyOsSetupStatus(
+    hasInferenceRoute: true,
+    hasPreferredName: true,
+  ),
 }) {
   return makeTestableWidgetNoScroll(
     child,
@@ -135,6 +140,9 @@ Widget _wrap(
       // RefinePage builds a CaptureController; stub so it doesn't read
       // the realtime service providers during dispose.
       captureControllerProvider.overrideWith(_stubCapture),
+      dailyOsSetupStatusProvider.overrideWith(
+        (ref) async => setupStatus,
+      ),
       ...overrides,
     ],
     mediaQueryData: mediaQueryData ?? MediaQueryData(size: size),
@@ -281,6 +289,75 @@ void main() {
         );
       },
     );
+
+    testWidgets(
+      'missing inference replaces check-in with a discoverable setup action',
+      (tester) async {
+        _setSurface(tester);
+        await tester.pumpWidget(
+          _wrap(
+            DayPage(
+              draft: DraftPlan.emptyForDay(DateTime(2026, 5, 26)),
+              hasPlan: false,
+              onCheckIn: () => fail('check-in must stay blocked'),
+            ),
+            setupStatus: const DailyOsSetupStatus(
+              hasInferenceRoute: false,
+              hasPreferredName: false,
+            ),
+          ),
+        );
+        await tester.pump();
+        await tester.pump();
+
+        final messages = tester.element(find.byType(DayPage)).messages;
+        expect(
+          find.text(messages.dailyOsSettingsSetupRequiredTitle),
+          findsOneWidget,
+        );
+        expect(
+          find.textContaining(messages.dailyOsSettingsNameNudgeBody),
+          findsOneWidget,
+        );
+        expect(
+          find.text(messages.dailyOsSettingsSetupAction),
+          findsNWidgets(2),
+        );
+        expect(find.text(messages.dailyOsNextDayCheckInCta), findsNothing);
+      },
+    );
+
+    testWidgets('missing name stays discoverable without blocking check-in', (
+      tester,
+    ) async {
+      _setSurface(tester);
+      var checkIns = 0;
+      await tester.pumpWidget(
+        _wrap(
+          DayPage(
+            draft: DraftPlan.emptyForDay(DateTime(2026, 5, 26)),
+            hasPlan: false,
+            onCheckIn: () => checkIns++,
+          ),
+          setupStatus: const DailyOsSetupStatus(
+            hasInferenceRoute: true,
+            hasPreferredName: false,
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      final messages = tester.element(find.byType(DayPage)).messages;
+      expect(
+        find.text(messages.dailyOsSettingsNameNudgeTitle),
+        findsOneWidget,
+      );
+      expect(find.text(messages.dailyOsNextDayCheckInCta), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('daily_os_day_check_in_cta')));
+      expect(checkIns, 1);
+    });
 
     testWidgets(
       'a failing inline rename surfaces the error toast instead of an '

--- a/test/features/daily_os_next/ui/pages/day_page_test.dart
+++ b/test/features/daily_os_next/ui/pages/day_page_test.dart
@@ -294,6 +294,8 @@ void main() {
       'missing inference replaces check-in with a discoverable setup action',
       (tester) async {
         _setSurface(tester);
+        final routes = <String>[];
+        nav_service.beamToNamedOverride = routes.add;
         await tester.pumpWidget(
           _wrap(
             DayPage(
@@ -324,6 +326,23 @@ void main() {
           findsNWidgets(2),
         );
         expect(find.text(messages.dailyOsNextDayCheckInCta), findsNothing);
+
+        await tester.tap(find.byIcon(Icons.more_vert_rounded));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 200));
+        await tester.tap(find.text(messages.dailyOsNextDayMenuSettings));
+        await tester.pump();
+        final setupActions = find.text(messages.dailyOsSettingsSetupAction);
+        await tester.tap(setupActions.at(0));
+        await tester.pump();
+        await tester.tap(setupActions.at(1));
+        await tester.pump();
+
+        expect(routes, [
+          '/settings/daily-os',
+          '/settings/daily-os',
+          '/settings/daily-os',
+        ]);
       },
     );
 

--- a/test/features/daily_os_next/ui/widgets/daily_os_inference_setup_sheet_test.dart
+++ b/test/features/daily_os_next/ui/widgets/daily_os_inference_setup_sheet_test.dart
@@ -295,4 +295,31 @@ void main() {
     expect(find.text('Choose Daily OS profile'), findsOneWidget);
     expect(find.text('Profile override active'), findsOneWidget);
   });
+
+  testWidgets('disables the model override until a base profile exists', (
+    tester,
+  ) async {
+    final service = MockDayAgentService();
+    final noProfilePlanner = identity.copyWith(
+      config: const AgentConfig(
+        inferenceSetup: AgentInferenceSetup(
+          mode: AgentInferenceSetupMode.configured,
+          origin: AgentInferenceSetupOrigin.user,
+        ),
+      ),
+    );
+
+    await pumpSheet(tester, service: service, planner: noProfilePlanner);
+    final messages = tester.element(find.byType(FilledButton)).messages;
+
+    // With no base profile the model row is inert: tapping it must not open
+    // the picker or reach the service (which would throw and fail closed).
+    await tester.tap(find.text(messages.dailyOsSettingsChooseModelTitle));
+    await tester.pumpAndSettle();
+    expect(find.text('Direct model'), findsNothing);
+    verifyNever(() => service.updatePlannerThinkingModelOverride(any()));
+
+    // The profile row stays enabled as the path forward.
+    expect(find.text('Choose Daily OS profile'), findsOneWidget);
+  });
 }

--- a/test/features/daily_os_next/ui/widgets/daily_os_inference_setup_sheet_test.dart
+++ b/test/features/daily_os_next/ui/widgets/daily_os_inference_setup_sheet_test.dart
@@ -13,6 +13,8 @@ import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/daily_os_next/agents/service/day_agent_service.dart';
 import 'package:lotti/features/daily_os_next/agents/state/day_agent_providers.dart';
 import 'package:lotti/features/daily_os_next/ui/widgets/daily_os_inference_setup_sheet.dart';
+import 'package:lotti/features/design_system/components/toasts/design_system_toast.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../../mocks/mocks.dart';
@@ -194,5 +196,103 @@ void main() {
     );
     update.complete();
     await tester.pumpAndSettle();
+  });
+
+  testWidgets('shows an error toast and keeps the sheet open on failure', (
+    tester,
+  ) async {
+    final service = MockDayAgentService();
+    when(
+      service.resetPlannerInferenceToDefault,
+    ).thenThrow(StateError('write failed'));
+
+    await pumpSheet(tester, service: service, planner: identity);
+    await tester.tap(find.text('Use Daily OS default'));
+    await tester.pump();
+
+    final messages = tester.element(find.byType(FilledButton)).messages;
+    final toasts = tester.widgetList<DesignSystemToast>(
+      find.byType(DesignSystemToast),
+    );
+    expect(toasts, isNotEmpty);
+    expect(
+      toasts.every((toast) => toast.tone == DesignSystemToastTone.error),
+      isTrue,
+    );
+    expect(
+      find.text(messages.dailyOsSettingsInstanceOverrideTitle),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('reselecting the active profile avoids a redundant write', (
+    tester,
+  ) async {
+    final service = MockDayAgentService();
+    final profileOnlyPlanner = identity.copyWith(
+      config: AgentConfig(
+        profileId: profile.id,
+        inferenceSetup: AgentInferenceSetup(
+          mode: AgentInferenceSetupMode.configured,
+          origin: AgentInferenceSetupOrigin.user,
+          baseProfileId: profile.id,
+        ),
+      ),
+    );
+
+    await pumpSheet(tester, service: service, planner: profileOnlyPlanner);
+    await tester.tap(find.text('Default profile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Default profile').last);
+    await tester.pump();
+
+    verifyNever(() => service.updatePlannerProfileOverride(any()));
+    expect(find.text('Daily OS inference'), findsOneWidget);
+  });
+
+  testWidgets('uses the profile model when no direct model is selected', (
+    tester,
+  ) async {
+    final service = MockDayAgentService();
+    final inheritedPlanner = identity.copyWith(
+      config: AgentConfig(
+        profileId: profile.id,
+        inferenceSetup: AgentInferenceSetup(
+          mode: AgentInferenceSetupMode.configured,
+          origin: AgentInferenceSetupOrigin.templateSnapshot,
+          baseProfileId: profile.id,
+          originEntityId: dayAgentTemplateId,
+        ),
+      ),
+    );
+
+    await pumpSheet(tester, service: service, planner: inheritedPlanner);
+    final messages = tester.element(find.byType(FilledButton)).messages;
+    await tester.tap(find.text(messages.dailyOsSettingsChooseModelTitle));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Direct model'), findsOneWidget);
+    expect(find.text(messages.taskAgentProfileDefaultBadge), findsOneWidget);
+  });
+
+  testWidgets('falls back to the profile action when an override is missing', (
+    tester,
+  ) async {
+    final service = MockDayAgentService();
+    final missingProfilePlanner = identity.copyWith(
+      config: const AgentConfig(
+        profileId: 'missing-profile',
+        inferenceSetup: AgentInferenceSetup(
+          mode: AgentInferenceSetupMode.configured,
+          origin: AgentInferenceSetupOrigin.user,
+          baseProfileId: 'missing-profile',
+        ),
+      ),
+    );
+
+    await pumpSheet(tester, service: service, planner: missingProfilePlanner);
+
+    expect(find.text('Choose Daily OS profile'), findsOneWidget);
+    expect(find.text('Profile override active'), findsOneWidget);
   });
 }

--- a/test/features/daily_os_next/ui/widgets/daily_os_inference_setup_sheet_test.dart
+++ b/test/features/daily_os_next/ui/widgets/daily_os_inference_setup_sheet_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/agents/model/agent_config.dart';
@@ -99,9 +101,10 @@ void main() {
     tester,
   ) async {
     final service = MockDayAgentService();
+    final update = Completer<void>();
     when(
       service.resetPlannerInferenceToDefault,
-    ).thenAnswer((_) async {});
+    ).thenAnswer((_) => update.future);
 
     await pumpSheet(tester, service: service, planner: identity);
     expect(find.text('Direct model'), findsOneWidget);
@@ -112,15 +115,26 @@ void main() {
     await tester.pump();
 
     verify(service.resetPlannerInferenceToDefault).called(1);
+    expect(
+      find.byKey(const Key('daily_os_inference_reset_progress')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('daily_os_inference_model_progress')),
+      findsNothing,
+    );
+    update.complete();
+    await tester.pumpAndSettle();
   });
 
   testWidgets('chooses a persistent profile override for the planner', (
     tester,
   ) async {
     final service = MockDayAgentService();
+    final update = Completer<void>();
     when(
       () => service.updatePlannerProfileOverride(instanceProfile.id),
-    ).thenAnswer((_) async {});
+    ).thenAnswer((_) => update.future);
     final inheritedPlanner = identity.copyWith(
       config: AgentConfig(
         profileId: profile.id,
@@ -142,5 +156,43 @@ void main() {
     verify(
       () => service.updatePlannerProfileOverride(instanceProfile.id),
     ).called(1);
+    expect(
+      find.byKey(const Key('daily_os_inference_profile_progress')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('daily_os_inference_model_progress')),
+      findsNothing,
+    );
+    update.complete();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('shows model progress on the model action only', (tester) async {
+    final service = MockDayAgentService();
+    final update = Completer<void>();
+    when(
+      () => service.updatePlannerThinkingModelOverride(model.id),
+    ).thenAnswer((_) => update.future);
+
+    await pumpSheet(tester, service: service, planner: identity);
+    await tester.tap(find.text('Direct model').first);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Direct model').last);
+    await tester.pump();
+
+    verify(
+      () => service.updatePlannerThinkingModelOverride(model.id),
+    ).called(1);
+    expect(
+      find.byKey(const Key('daily_os_inference_model_progress')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('daily_os_inference_profile_progress')),
+      findsNothing,
+    );
+    update.complete();
+    await tester.pumpAndSettle();
   });
 }

--- a/test/features/daily_os_next/ui/widgets/daily_os_inference_setup_sheet_test.dart
+++ b/test/features/daily_os_next/ui/widgets/daily_os_inference_setup_sheet_test.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/agents/model/agent_config.dart';
+import 'package:lotti/features/agents/model/agent_constants.dart';
+import 'package:lotti/features/agents/model/agent_domain_entity.dart';
+import 'package:lotti/features/agents/model/agent_enums.dart';
+import 'package:lotti/features/agents/service/agent_template_service.dart';
+import 'package:lotti/features/agents/state/agent_query_providers.dart';
+import 'package:lotti/features/agents/state/task_agent_model_providers.dart';
+import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/daily_os_next/agents/service/day_agent_service.dart';
+import 'package:lotti/features/daily_os_next/agents/state/day_agent_providers.dart';
+import 'package:lotti/features/daily_os_next/ui/widgets/daily_os_inference_setup_sheet.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../mocks/mocks.dart';
+import '../../../../widget_test_utils.dart';
+import '../../../agents/test_utils.dart';
+
+void main() {
+  final provider = AiConfigInferenceProvider(
+    id: 'provider',
+    baseUrl: 'https://provider.example.com',
+    apiKey: 'key',
+    name: 'Provider',
+    createdAt: DateTime(2024, 3, 15),
+    inferenceProviderType: InferenceProviderType.genericOpenAi,
+  );
+  final model = AiConfigModel(
+    id: 'model',
+    name: 'Direct model',
+    providerModelId: 'wire/model',
+    inferenceProviderId: provider.id,
+    createdAt: DateTime(2024, 3, 15),
+    inputModalities: const [Modality.text],
+    outputModalities: const [Modality.text],
+    isReasoningModel: true,
+    supportsFunctionCalling: true,
+  );
+  final profile = AiConfigInferenceProfile(
+    id: 'profile',
+    name: 'Default profile',
+    createdAt: DateTime(2024, 3, 15),
+    thinkingModelId: model.id,
+  );
+  final instanceProfile = AiConfigInferenceProfile(
+    id: 'profile-instance',
+    name: 'Instance profile',
+    createdAt: DateTime(2024, 3, 15),
+    thinkingModelId: model.id,
+  );
+  final identity = makeTestIdentity(
+    id: dailyOsPlannerAgentId,
+    agentId: dailyOsPlannerAgentId,
+    kind: AgentKinds.dayAgent,
+    config: AgentConfig(
+      profileId: profile.id,
+      inferenceSetup: AgentInferenceSetup(
+        mode: AgentInferenceSetupMode.configured,
+        origin: AgentInferenceSetupOrigin.user,
+        baseProfileId: profile.id,
+        thinkingModelOverrideId: model.id,
+      ),
+    ),
+  );
+
+  Future<void> pumpSheet(
+    WidgetTester tester, {
+    required MockDayAgentService service,
+    required AgentIdentityEntity planner,
+  }) async {
+    await tester.pumpWidget(
+      makeTestableWidgetWithScaffold(
+        Builder(
+          builder: (context) => FilledButton(
+            onPressed: () => DailyOsInferenceSetupSheet.show(context),
+            child: const Text('Open'),
+          ),
+        ),
+        overrides: [
+          dayAgentServiceProvider.overrideWithValue(service),
+          agentIdentityProvider.overrideWith((ref, id) async => planner),
+          taskAgentSetupOptionsProvider.overrideWith(
+            (ref) async => TaskAgentSetupOptions(
+              profiles: [profile, instanceProfile],
+              models: [model],
+              providers: [provider],
+            ),
+          ),
+        ],
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('shows the active override and restores the Daily OS default', (
+    tester,
+  ) async {
+    final service = MockDayAgentService();
+    when(
+      service.resetPlannerInferenceToDefault,
+    ).thenAnswer((_) async {});
+
+    await pumpSheet(tester, service: service, planner: identity);
+    expect(find.text('Direct model'), findsOneWidget);
+    expect(find.text('Use Daily OS default'), findsOneWidget);
+    expect(find.text('Default profile'), findsOneWidget);
+
+    await tester.tap(find.text('Use Daily OS default'));
+    await tester.pump();
+
+    verify(service.resetPlannerInferenceToDefault).called(1);
+  });
+
+  testWidgets('chooses a persistent profile override for the planner', (
+    tester,
+  ) async {
+    final service = MockDayAgentService();
+    when(
+      () => service.updatePlannerProfileOverride(instanceProfile.id),
+    ).thenAnswer((_) async {});
+    final inheritedPlanner = identity.copyWith(
+      config: AgentConfig(
+        profileId: profile.id,
+        inferenceSetup: AgentInferenceSetup(
+          mode: AgentInferenceSetupMode.configured,
+          origin: AgentInferenceSetupOrigin.templateSnapshot,
+          baseProfileId: profile.id,
+          originEntityId: dayAgentTemplateId,
+        ),
+      ),
+    );
+
+    await pumpSheet(tester, service: service, planner: inheritedPlanner);
+    await tester.tap(find.text('Choose Daily OS profile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Instance profile'));
+    await tester.pump();
+
+    verify(
+      () => service.updatePlannerProfileOverride(instanceProfile.id),
+    ).called(1);
+  });
+}

--- a/test/features/settings/ui/pages/advanced/about_page_test.dart
+++ b/test/features/settings/ui/pages/advanced/about_page_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/database/database.dart';
-import 'package:lotti/features/daily_os_next/state/daily_os_preferences_controller.dart';
 import 'package:lotti/features/settings/ui/pages/advanced/about_page.dart';
 import 'package:lotti/features/user_activity/state/user_activity_service.dart';
 import 'package:lotti/get_it.dart';
@@ -64,77 +63,6 @@ void main() {
 
       expect(find.text('About Lotti'), findsOneWidget);
       expect(find.text('111'), findsOneWidget);
-    });
-  });
-
-  group('AboutBody Daily OS personalization', () {
-    late TestGetItMocks testMocks;
-
-    setUp(() async {
-      testMocks = await setUpTestGetIt();
-      when(testMocks.journalDb.getJournalCount).thenAnswer((_) async => n);
-      when(
-        testMocks.journalDb.getCountImportFlagEntries,
-      ).thenAnswer((_) async => 0);
-      when(
-        () => testMocks.journalDb.linksForEntryIds(any()),
-      ).thenAnswer((_) async => <EntryLink>[]);
-      when(
-        () => testMocks.journalDb.getTasksCount(
-          statuses: any(named: 'statuses'),
-        ),
-      ).thenAnswer((_) async => 10);
-    });
-
-    tearDown(tearDownTestGetIt);
-
-    testWidgets('starts with an empty Daily OS greeting name', (tester) async {
-      await tester.pumpWidget(
-        makeTestableWidgetWithScaffold(
-          ConstrainedBox(
-            constraints: const BoxConstraints(
-              maxHeight: 1000,
-              maxWidth: 1000,
-            ),
-            child: const AboutBody(),
-          ),
-        ),
-      );
-      await tester.pumpAndSettle();
-
-      final nameField = tester.widget<TextField>(
-        find.byKey(const Key('daily_os_user_name_field')),
-      );
-
-      expect(nameField.controller?.text, isEmpty);
-      expect(nameField.decoration?.hintText, isNull);
-    });
-
-    testWidgets('persists the Daily OS greeting name', (tester) async {
-      await tester.pumpWidget(
-        makeTestableWidgetWithScaffold(
-          ConstrainedBox(
-            constraints: const BoxConstraints(
-              maxHeight: 1000,
-              maxWidth: 1000,
-            ),
-            child: const AboutBody(),
-          ),
-        ),
-      );
-      await tester.pumpAndSettle();
-
-      await tester.enterText(
-        find.byKey(const Key('daily_os_user_name_field')),
-        'Daily OS User',
-      );
-
-      verify(
-        () => testMocks.settingsDb.saveSettingsItem(
-          dailyOsUserNameSettingsKey,
-          'Daily OS User',
-        ),
-      ).called(1);
     });
   });
 }

--- a/test/features/settings_v2/domain/settings_tree_data_test.dart
+++ b/test/features/settings_v2/domain/settings_tree_data_test.dart
@@ -86,6 +86,7 @@ void main() {
         'onboarding',
         'ai',
         'agents',
+        'daily-os',
         'sync',
         'definitions',
         'recording-style',
@@ -119,12 +120,13 @@ void main() {
       // Entity definitions (habits / categories / labels / dashboards
       // / measurables) collapse into the single `definitions` branch;
       // config flags reparent under `advanced`. Root reads as
-      // AI · Agents · Sync · Definitions · Theming · Advanced.
+      // AI · Agents · Daily OS · Sync · Definitions · Theming · Advanced.
       final rootIds = _tree().map((n) => n.id).toList();
       expect(rootIds, [
         'whats-new',
         'ai',
         'agents',
+        'daily-os',
         'sync',
         'definitions',
         'recording-style',
@@ -404,6 +406,7 @@ void main() {
         'agents/instances': 'agents-instances',
         'agents/souls': 'agents-souls',
         'agents/pending-wakes': 'agents-pending-wakes',
+        'daily-os': 'daily-os',
         'definitions/habits': 'habits',
         'definitions/categories': 'categories',
         'definitions/labels': 'labels',
@@ -519,6 +522,7 @@ void main() {
       expect(ids, [
         'ai',
         'agents',
+        'daily-os',
         // Sync branch is gated by enableMatrix — flag off drops the
         // entire Sync surface, matching the mobile root list.
         'definitions',

--- a/test/features/settings_v2/ui/detail/panel_registry_test.dart
+++ b/test/features/settings_v2/ui/detail/panel_registry_test.dart
@@ -13,6 +13,7 @@ import 'package:lotti/features/ai/ui/settings/provider/ai_provider_detail_page.d
 import 'package:lotti/features/ai_consumption/ui/impact_analysis_body.dart';
 import 'package:lotti/features/categories/ui/pages/categories_list_page.dart';
 import 'package:lotti/features/categories/ui/pages/category_details_page.dart';
+import 'package:lotti/features/daily_os_next/ui/pages/daily_os_settings_page.dart';
 import 'package:lotti/features/design_system/theme/generated/design_tokens.g.dart';
 import 'package:lotti/features/labels/ui/pages/label_details_page.dart';
 import 'package:lotti/features/labels/ui/pages/labels_list_page.dart';
@@ -222,6 +223,7 @@ void main() {
         Widget build(String id) => kSettingsPanels[id]!.build(capturedContext);
 
         expect(build('onboarding'), isA<OnboardingSettingsBody>());
+        expect(build('daily-os'), isA<DailyOsSettingsBody>());
 
         // Step 7 — simple leaves.
         expect(build('flags'), isA<FlagsBody>());

--- a/test/features/settings_v2/ui/detail/panel_registry_test.dart
+++ b/test/features/settings_v2/ui/detail/panel_registry_test.dart
@@ -57,6 +57,7 @@ void main() {
       // landing panel — its provisioned-sync entry is a leaf below.
       'ai',
       'agents',
+      'daily-os',
       // Top-level entry point back to the FTUE welcome flow.
       'onboarding',
       // Step 7 — simple leaves.

--- a/test/features/settings_v2/ui/settings_tree_builder_test.dart
+++ b/test/features/settings_v2/ui/settings_tree_builder_test.dart
@@ -73,6 +73,7 @@ void main() {
       [
         'ai',
         'agents',
+        'daily-os',
         'sync',
         'definitions',
         'recording-style',

--- a/test/features/settings_v2/ui/tree/settings_tree_view_test.dart
+++ b/test/features/settings_v2/ui/tree/settings_tree_view_test.dart
@@ -117,8 +117,8 @@ void main() {
       'every root node renders through SettingsTreeNodeWidget (not raw rows)',
       (tester) async {
         // With every flag off the root list is the always-on set
-        // declared in `buildSettingsTree`: ai, agents, definitions,
-        // recording-style, theming, advanced. Sync is gated on
+        // declared in `buildSettingsTree`: ai, agents, daily-os,
+        // definitions, recording-style, theming, advanced. Sync is gated on
         // enableMatrix so it drops out when the flag is off. A depth-0
         // `SettingsTreeNodeWidget` per root proves every entry
         // rendered through the widget, not a raw row.
@@ -126,10 +126,11 @@ void main() {
         final rootNodeFinder = find.byWidgetPredicate(
           (w) => w is SettingsTreeNodeWidget && w.depth == 0,
         );
-        expect(rootNodeFinder, findsNWidgets(6));
+        expect(rootNodeFinder, findsNWidgets(7));
         for (final title in const [
           'AI Settings',
           'Agents',
+          'Daily OS',
           'Definitions',
           'Recording Style',
           'Theming',


### PR DESCRIPTION
## Summary

- add a dedicated Daily OS settings destination for the default inference profile and preferred name
- add per-planner profile and thinking-model overrides with an explicit reset to the Daily OS default
- reuse the unified inference profile/provider/model picker components from the task-agent setup
- make setup discoverable from Daily OS and block inference-dependent check-ins until a usable route is selected
- move Daily OS personalization out of About and document the new ownership and resolution flow

## Privacy and provider choice

Daily OS does not maintain a provider-brand denylist. Every configured provider remains available when its model satisfies the existing agentic technical contract, including Google Gemini.

The UI states definitively that Daily OS sends relevant tasks, captures, plans, learned preferences, and other assembled planning context to the selected provider for processing. It identifies validated embedded/loopback endpoints as on-device and all other configured endpoints as remote; it does not infer GDPR compliance from the provider brand.

Default selection is stored on the synced Shepherd template. Planner overrides are stored as typed `AgentInferenceSetup` state and are never replaced by later default changes. Resolution remains fail-closed, with no silent provider fallback.

## Screenshots

### Settings discoverability

![Daily OS in Settings](https://raw.githubusercontent.com/matthiasn/lotti-docs/be373965380fb44571b59ab7f2c51fcd782c58ff/pr-screenshots/daily-os-inference/after/settings_tree_daily_os_after.png)

### Configured Daily OS settings

![Configured Daily OS settings](https://raw.githubusercontent.com/matthiasn/lotti-docs/be373965380fb44571b59ab7f2c51fcd782c58ff/pr-screenshots/daily-os-inference/after/daily_os_settings_configured_after.png)

### Planner override sheet

![Daily OS planner override](https://raw.githubusercontent.com/matthiasn/lotti-docs/be373965380fb44571b59ab7f2c51fcd782c58ff/pr-screenshots/daily-os-inference/after/daily_os_planner_override_after.png)

These are new surfaces, so there is no meaningful before-state screenshot.

## Validation

- `fvm flutter analyze` — no issues
- targeted feature/settings/navigation suite — 322 tests passed
- final persistence, provider-catalog, override-sheet, and setup-nudge regression suite — 73 tests passed
- localization regenerated for English, Czech, German, Spanish, French, and Romanian
- `git diff --check` — clean

## Documentation and release metadata

- add the implementation plan under `docs/implementation_plans/`
- update Daily OS, Agents, and AI feature READMEs
- update CHANGELOG and Flatpak metainfo for 0.9.1043


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Daily OS settings** screen at **/settings/daily-os** to select the default inference profile and preferred name, plus **per-planner overrides** (profile and thinking model) with restore-default.
  * Introduced a **Daily OS instance inference setup sheet** with explicit, user-confirmed profile/model selection.
* **UX Updates**
  * Improved **setup-readiness** behavior: Day-page nudges for missing setup, redirects check-in to settings when needed, and adds a settings action in the Day header. Removed Daily OS personalization from the About page.
  * Added clearer **local vs remote endpoint disclosure** during setup.
* **Documentation**
  * Added an implementation plan and updated Daily OS/settings documentation.
* **Localization**
  * Added Daily OS settings strings across supported languages.
* **Tests**
  * Expanded Daily OS route, settings, readiness, and override-flow widget/service tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->