### PR TITLE
CI: increase coverage target to 99%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -21,7 +21,7 @@ coverage:
         threshold: 0.1%
     patch:
       default:
-        target: 93%
+        target: 99%
 ignore:
   - "**/*.g.dart"
   - "**/*.freezed.dart"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the required patch coverage threshold from 93% to 99%, strengthening coverage reporting standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->