### PR TITLE
fix: pop cleanly from Sync settings sub-pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Daily OS is now available to everyone.** The Daily OS day-planning surface
   no longer sits behind a Settings → Advanced → Flags toggle — its calendar tab
   appears in the main navigation for all users.
+### Fixed
+- **Sync settings pages now slide back consistently.** Returning from a Sync
+  sub-page (such as Backfill sync) to Sync settings uses the same clean pop
+  animation as every other settings screen, instead of the jarring page-swap
+  transition it played before.
 
 ## [0.9.1042]
 ### Added

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -35,6 +35,7 @@
     <release version="0.9.1043" date="2026-07-14">
       <description>
           <p>Daily OS is now available to everyone. The Daily OS day-planning surface no longer sits behind a feature flag and appears in the main navigation for all users.</p>
+          <p>Returning from a Sync sub-page such as Backfill sync to Sync settings now uses the same clean pop animation as every other settings screen, instead of the jarring page-swap transition it played before.</p>
       </description>
     </release>
     <release version="0.9.1042" date="2026-07-13">

--- a/lib/beamer/locations/settings_location.dart
+++ b/lib/beamer/locations/settings_location.dart
@@ -274,17 +274,18 @@ class SettingsLocation extends BeamLocation<BeamState> {
       // (`/settings/sync/provisioned`), not a branch header, so the bare
       // branch hub just lists its rows. `SyncFeatureGate` preserves the
       // deep-link bounce back to `/settings` when Matrix sync is disabled.
-      if (path == '/settings/sync')
+      //
+      // The hub is emitted with the SAME `ValueKey('settings-sync')` for the
+      // bare `/settings/sync` URL and for every `/settings/sync/*` leaf. A
+      // stable key is what lets the back gesture from a leaf (e.g. Backfill)
+      // pop cleanly to reveal the existing hub page beneath it. Splitting the
+      // key between base and leaf states (the previous `settings-sync-base`)
+      // made Navigator swap the underlying page instead of revealing it,
+      // producing the wrong pop animation. The Definitions/Advanced/AI
+      // branches use the same one-stable-key rule.
+      if (path == '/settings/sync' || path.startsWith('/settings/sync/'))
         const BeamPage(
           key: ValueKey('settings-sync'),
-          title: 'Sync Settings',
-          child: SyncFeatureGate(
-            child: SettingsMobileBranchPage(branchId: 'sync'),
-          ),
-        ),
-      if (path != '/settings/sync' && path.startsWith('/settings/sync/'))
-        const BeamPage(
-          key: ValueKey('settings-sync-base'),
           title: 'Sync Settings',
           child: SyncFeatureGate(
             child: SettingsMobileBranchPage(branchId: 'sync'),

--- a/lib/features/settings_v2/README.md
+++ b/lib/features/settings_v2/README.md
@@ -42,7 +42,14 @@ platform fork point: `isDesktopLayout(context)` renders `SettingsV2Page`, else
   right-hand pane by the panel registry.
 - **Mobile:** `SettingsLocation.buildPages` builds a real Beamer page stack
   starting at `SettingsMobileRootPage`, inserting `SettingsMobileBranchPage`
-  hubs for the two pure-navigation branches (`definitions`, `advanced`).
+  hubs for the two pure-navigation branches (`definitions`, `advanced`) and for
+  the feature-gated `sync` hub. A branch hub that sits beneath its leaves keeps
+  **one stable `ValueKey` across the bare URL and every leaf** (e.g. the sync
+  hub is always `settings-sync` for `/settings/sync` and all `/settings/sync/*`
+  leaves). The stable key is what lets a back tap from a leaf pop cleanly to
+  reveal the existing hub beneath it; a key that changed between the base and
+  leaf states would make Navigator swap the page and play the wrong pop
+  animation.
 
 ## Directory Shape
 

--- a/test/beamer/locations/settings_location_test.dart
+++ b/test/beamer/locations/settings_location_test.dart
@@ -23,6 +23,7 @@ import 'package:lotti/features/onboarding/ui/onboarding_metrics_page.dart';
 import 'package:lotti/features/onboarding/ui/onboarding_settings_panel.dart';
 import 'package:lotti/features/projects/ui/pages/project_detail_page.dart';
 import 'package:lotti/features/settings/ui/pages/advanced/about_page.dart';
+import 'package:lotti/features/settings/ui/pages/advanced/celebration_settings_page.dart';
 import 'package:lotti/features/settings/ui/pages/advanced/logging_settings_page.dart';
 import 'package:lotti/features/settings/ui/pages/advanced/maintenance_page.dart';
 import 'package:lotti/features/settings/ui/pages/dashboards/create_dashboard_page.dart';
@@ -49,6 +50,7 @@ import 'package:lotti/features/sync/ui/pages/outbox/outbox_monitor_page.dart';
 import 'package:lotti/features/sync/ui/provisioned_sync_page.dart';
 import 'package:lotti/features/sync/ui/sync_stats_page.dart';
 import 'package:lotti/features/sync/ui/widgets/sync_feature_gate.dart';
+import 'package:lotti/features/tts/ui/speech_settings_page.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations.dart';
 import 'package:lotti/services/nav_service.dart';
@@ -977,6 +979,41 @@ void main() {
       expect(pages[1].child, isA<ThemingPage>());
     });
 
+    test('buildPages builds SpeechSettingsPage', () {
+      final routeInformation = RouteInformation(
+        uri: Uri.parse('/settings/speech'),
+      );
+      final location = SettingsLocation(routeInformation);
+      final beamState = BeamState.fromRouteInformation(routeInformation);
+      final pages = location.buildPages(mockBuildContext, beamState);
+      // Top-level leaf — opens directly beneath the root, no branch hub.
+      expect(pages.length, 2);
+      expect(pages[0].child, isA<SettingsMobileRootPage>());
+      expect(pages[1].child, isA<SpeechSettingsPage>());
+    });
+
+    test(
+      'buildPages builds CelebrationSettingsPage for advanced/animations',
+      () {
+        final routeInformation = RouteInformation(
+          uri: Uri.parse('/settings/advanced/animations'),
+        );
+        final location = SettingsLocation(routeInformation);
+        final beamState = BeamState.fromRouteInformation(routeInformation);
+        final pages = location.buildPages(mockBuildContext, beamState);
+        // Lives under the Advanced branch, so the hub stays in the stack
+        // beneath it (a back tap returns to Advanced).
+        expect(pages.length, 3);
+        expect(pages[0].child, isA<SettingsMobileRootPage>());
+        expect(pages[1].child, isA<SettingsMobileBranchPage>());
+        expect(
+          (pages[1].child as SettingsMobileBranchPage).branchId,
+          'advanced',
+        );
+        expect(pages[2].child, isA<CelebrationSettingsPage>());
+      },
+    );
+
     test('buildPages builds OnboardingSettingsPage', () {
       final routeInformation = RouteInformation(
         uri: Uri.parse('/settings/onboarding'),
@@ -1337,6 +1374,56 @@ void main() {
       expect(hub, isA<SettingsMobileBranchPage>());
       expect((hub as SettingsMobileBranchPage).branchId, 'sync');
       expect(pages[2].child, isA<BackfillSettingsPage>());
+    });
+
+    group('sync hub keeps a stable page key across the drill-down', () {
+      // The Sync Settings hub must carry the SAME ValueKey for the bare
+      // `/settings/sync` URL and every `/settings/sync/*` leaf. A stable key
+      // is what lets a back tap from a leaf (e.g. Backfill) pop cleanly to
+      // reveal the existing hub beneath it. A key that flipped between the
+      // base and leaf states (the old `settings-sync-base`) made Navigator
+      // swap the underlying page instead of revealing it, playing the wrong
+      // pop animation — the bug this guards against. Definitions/Advanced/AI
+      // already follow this one-stable-key rule.
+      const expectedHubKey = ValueKey('settings-sync');
+
+      List<BeamPage> buildFor(String uri) {
+        final routeInformation = RouteInformation(uri: Uri.parse(uri));
+        final location = SettingsLocation(routeInformation);
+        final beamState = BeamState.fromRouteInformation(routeInformation);
+        return location.buildPages(mockBuildContext, beamState);
+      }
+
+      BeamPage hubPage(List<BeamPage> pages) =>
+          pages.firstWhere((p) => p.child is SyncFeatureGate);
+
+      test('bare /settings/sync uses the settings-sync key', () {
+        expect(hubPage(buildFor('/settings/sync')).key, expectedHubKey);
+      });
+
+      for (final leaf in const [
+        '/settings/sync/provisioned',
+        '/settings/sync/matrix/maintenance',
+        '/settings/sync/node-profile',
+        '/settings/sync/backfill',
+        '/settings/sync/stats',
+        '/settings/sync/outbox',
+      ]) {
+        test('$leaf keeps the hub on the settings-sync key', () {
+          expect(hubPage(buildFor(leaf)).key, expectedHubKey);
+        });
+      }
+
+      test(
+        'hub key is identical between the bare URL and a leaf so back pops '
+        'cleanly instead of swapping the page',
+        () {
+          final baseKey = hubPage(buildFor('/settings/sync')).key;
+          final leafKey = hubPage(buildFor('/settings/sync/backfill')).key;
+          expect(baseKey, leafKey);
+          expect(baseKey, expectedHubKey);
+        },
+      );
     });
 
     test('categories navigation stack has list page', () {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved back navigation from Sync settings sub-pages with a smooth, consistent pop animation instead of a jarring page transition.
  * Ensured returning from pages such as Backfill sync reveals the existing Sync settings screen correctly.

* **Tests**
  * Added coverage for Sync navigation and additional Speech and Animation settings routes.

* **Documentation**
  * Updated release notes and mobile settings navigation documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->