### PR TITLE
fix: link coding prompts to both task and source entry, and show them under the task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Your Daily OS name now follows you across devices.** The preferred name you
   set for Daily OS syncs to your other devices, with the most recent edit
   winning, so each device greets you the same way.
+### Fixed
+- **AI coding prompts now show up under their task.** A generated coding prompt
+  is linked to both its parent task and the audio or text note it came from, and
+  appears in each of their linked-entries lists (under the Code activity
+  filter). Previously the prompt was created but stayed hidden from the task
+  timeline.
 
 ## [0.9.1043]
 ### Changed

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -36,6 +36,7 @@
       <description>
           <p>Daily OS now has a discoverable settings page for choosing its default inference profile and preferred name, plus per-planner profile and thinking-model overrides. Setup explains that assembled planning context is sent to the selected provider and identifies whether its configured endpoint is local or remote.</p>
           <p>The preferred name you set for Daily OS now syncs across your devices, with the most recent edit winning, so each device greets you the same way.</p>
+          <p>AI coding prompts now show up under their task. A generated coding prompt is linked to both its parent task and the audio or text note it came from, and appears in each of their linked-entries lists under the Code activity filter. Previously the prompt was created but stayed hidden from the task timeline.</p>
       </description>
     </release>
     <release version="0.9.1043" date="2026-07-14">

--- a/lib/features/ai/README.md
+++ b/lib/features/ai/README.md
@@ -164,7 +164,7 @@ The automatic branch is intentionally strict:
 
 - transcription updates `JournalAudio.transcripts` and `entryText`
 - image analysis appends text to the `JournalImage` entry
-- coding/design/research prompt generation creates an `AiResponseEntry` linked to the parent task when a task can be resolved; image-prompt generation keeps the entry link
+- coding/design/research prompt generation creates an `AiResponseEntry` linked to the parent task when one resolves, and additionally links it back to the source audio/text entry so the prompt appears in both linked-entries lists (falling back to a single link on the source entry when no task resolves); image-prompt generation keeps the entry link. In linked-entries lists these prompts render under the `Code` activity-filter pill and are exempt from the generic `showAiEntry` gate that keeps transcripts and image analyses collapsed
 - image generation imports a generated image, sets it as task cover art, then triggers automatic image analysis on the generated image
 
 #### Context injection

--- a/lib/features/ai/repository/ai_input_repository.dart
+++ b/lib/features/ai/repository/ai_input_repository.dart
@@ -79,6 +79,19 @@ class AiInputRepository {
     );
   }
 
+  /// Creates a directed link from [fromId] to [toId].
+  ///
+  /// Used to give a generated response a second parent beyond the one
+  /// established at creation time — e.g. a coding prompt is created linked to
+  /// its parent task and then additionally linked from the source audio/text
+  /// entry so it surfaces in both linked-entries lists.
+  Future<bool> createLink({
+    required String fromId,
+    required String toId,
+  }) async {
+    return getIt<PersistenceLogic>().createLink(fromId: fromId, toId: toId);
+  }
+
   Future<AiInputTaskObject?> generate(String id) async {
     // Provider is keepAlive, so ref is always valid - no keepAlive() needed
     final progressRepository = ref.read(taskProgressRepositoryProvider);

--- a/lib/features/ai/repository/unified_ai_inference_repository.dart
+++ b/lib/features/ai/repository/unified_ai_inference_repository.dart
@@ -605,25 +605,54 @@ class UnifiedAiInferenceRepository {
 
     if (shouldSaveEntry) {
       try {
-        // Coding prompts attach to the parent task (like cover art) rather
-        // than the triggering audio/image entry. This makes each generated
-        // prompt part of the task context, so later prompts can build on
-        // earlier ones. Reuses the parent task already resolved for tool
-        // calls above; falls back to the source entity when no parent task
-        // can be resolved (e.g. an unlinked entry).
+        // Coding prompts attach to the parent task (like cover art). This
+        // makes each generated prompt part of the task context, so later
+        // prompts can build on earlier ones. Reuses the parent task already
+        // resolved for tool calls above; falls back to the source entity when
+        // no parent task can be resolved (e.g. an unlinked entry).
         var linkedId = entity.id;
         if (promptConfig.aiResponseType == AiResponseType.promptGeneration &&
             taskForToolCalls != null) {
           linkedId = taskForToolCalls.id;
         }
-        aiResponseEntry = await ref
-            .read(aiInputRepositoryProvider)
-            .createAiResponseEntry(
-              data: data,
-              start: start,
-              linkedId: linkedId,
-              categoryId: entity.meta.categoryId,
+        final aiInputRepository = ref.read(aiInputRepositoryProvider);
+        aiResponseEntry = await aiInputRepository.createAiResponseEntry(
+          data: data,
+          start: start,
+          linkedId: linkedId,
+          categoryId: entity.meta.categoryId,
+        );
+
+        // Additionally link the coding prompt back to the source entry so it
+        // shows in both the task's and the originating audio/text entry's
+        // linked-entries lists. Skipped when the primary link already IS the
+        // source entry (no parent task), which would create a duplicate
+        // self-link.
+        //
+        // Isolated in its own try/catch so a back-link failure is not
+        // misattributed to `createAiResponseEntry` in the shared catch below
+        // (the primary write already succeeded) and does not mask it.
+        if (aiResponseEntry != null && linkedId != entity.id) {
+          try {
+            final linked = await aiInputRepository.createLink(
+              fromId: entity.id,
+              toId: aiResponseEntry.id,
             );
+            if (!linked) {
+              developer.log(
+                'Secondary link from ${entity.id} to '
+                '${aiResponseEntry.id} not created',
+                name: 'UnifiedAiInferenceRepository',
+              );
+            }
+          } catch (linkError) {
+            developer.log(
+              'createLink failed: $linkError',
+              name: 'UnifiedAiInferenceRepository',
+              error: linkError,
+            );
+          }
+        }
         developer.log(
           'createAiResponseEntry result: ${aiResponseEntry?.id ?? "null"}',
           name: 'UnifiedAiInferenceRepository',

--- a/lib/features/ai/services/skill_inference_runner.dart
+++ b/lib/features/ai/services/skill_inference_runner.dart
@@ -560,24 +560,60 @@ class SkillInferenceRunner {
           type: skill.skillType.toResponseType,
         );
 
-        // Coding prompts attach to the parent task (like cover art) rather
-        // than the triggering audio/text entry, so each generated prompt
-        // becomes part of the task context and later prompts can build on
-        // earlier ones. Scoped to `SkillType.promptGeneration` (coding /
-        // design / research); image-prompt generation keeps its entry link.
-        // Falls back to the source entry when there is no parent task.
+        // Coding prompts attach to the parent task (like cover art) so each
+        // generated prompt becomes part of the task context and later prompts
+        // can build on earlier ones. Scoped to `SkillType.promptGeneration`
+        // (coding / design / research); image-prompt generation keeps its
+        // entry link. Falls back to the source entry when there is no parent
+        // task.
         final linkedId =
             skill.skillType == SkillType.promptGeneration &&
                 linkedTaskId != null
             ? linkedTaskId
             : entryId;
 
-        await _aiInputRepository.createAiResponseEntry(
+        final aiResponse = await _aiInputRepository.createAiResponseEntry(
           data: data,
           start: start,
           linkedId: linkedId,
           categoryId: entity.meta.categoryId,
         );
+
+        // Additionally link the coding prompt back to the source entry so it
+        // shows in both the task's and the originating audio/text entry's
+        // linked-entries lists. Skipped when the primary link already IS the
+        // source entry (no parent task, or image-prompt generation), which
+        // would otherwise create a duplicate self-link.
+        //
+        // Isolated in its own try/catch: the prompt is already persisted and
+        // linked to the task, so a failed back-link must not propagate to
+        // `_withStatusTracking` and mark the whole run as `error` — that would
+        // risk a user-triggered retry creating a duplicate prompt. Log and
+        // move on instead.
+        if (aiResponse != null && linkedId != entryId) {
+          try {
+            final linked = await _aiInputRepository.createLink(
+              fromId: entryId,
+              toId: aiResponse.id,
+            );
+            if (!linked) {
+              _loggingService.log(
+                LogDomain.ai,
+                'Secondary link from $entryId to ${aiResponse.id} not created',
+                subDomain: 'runPromptGeneration',
+              );
+            }
+          } catch (error, stackTrace) {
+            _loggingService.error(
+              LogDomain.ai,
+              error,
+              stackTrace: stackTrace,
+              subDomain: 'runPromptGeneration',
+              message:
+                  'Secondary link from $entryId to ${aiResponse.id} failed',
+            );
+          }
+        }
 
         _loggingService.log(
           LogDomain.ai,

--- a/lib/features/journal/ui/widgets/entry_details_widget.dart
+++ b/lib/features/journal/ui/widgets/entry_details_widget.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/state/config_flag_provider.dart';
+import 'package:lotti/features/ai/state/consts.dart';
 import 'package:lotti/features/ai/ui/ai_response_summary.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/events/ui/widgets/linked_event_card.dart';
@@ -82,9 +83,19 @@ class EntryDetailsWidget extends ConsumerWidget {
     final entryState = ref.watch(provider).value;
 
     final item = entryState?.entry;
+
+    // Coding prompts are first-class task activities gated by the "Code"
+    // activity-filter pill, not by the generic `showAiEntry` flag (which
+    // hides transcripts, image analyses, and image prompts in linked lists).
+    // Exempt them here so a prompt linked to its task actually renders; other
+    // AiResponseEntry kinds stay gated by `showAiEntry` as before.
+    final isCodingPrompt =
+        item is AiResponseEntry &&
+        item.data.type == AiResponseType.promptGeneration;
+
     if (item == null ||
         item.meta.deletedAt != null ||
-        (item is AiResponseEntry && !showAiEntry)) {
+        (item is AiResponseEntry && !showAiEntry && !isCodingPrompt)) {
       return const SizedBox.shrink();
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1044+4205
+version: 0.9.1044+4206
 
 msix_config:
   display_name: LottiApp

--- a/test/features/ai/repository/ai_input_repository_test.dart
+++ b/test/features/ai/repository/ai_input_repository_test.dart
@@ -1731,6 +1731,49 @@ void main() {
       });
     });
 
+    group('createLink', () {
+      test(
+        'delegates to PersistenceLogic.createLink with fromId/toId',
+        () async {
+          when(
+            () => mockPersistenceLogic.createLink(
+              fromId: any(named: 'fromId'),
+              toId: any(named: 'toId'),
+            ),
+          ).thenAnswer((_) async => true);
+
+          final result = await repository.createLink(
+            fromId: 'from-1',
+            toId: 'to-1',
+          );
+
+          expect(result, isTrue);
+          verify(
+            () => mockPersistenceLogic.createLink(
+              fromId: 'from-1',
+              toId: 'to-1',
+            ),
+          ).called(1);
+        },
+      );
+
+      test('propagates a false result from PersistenceLogic', () async {
+        when(
+          () => mockPersistenceLogic.createLink(
+            fromId: any(named: 'fromId'),
+            toId: any(named: 'toId'),
+          ),
+        ).thenAnswer((_) async => false);
+
+        final result = await repository.createLink(
+          fromId: 'from-2',
+          toId: 'to-2',
+        );
+
+        expect(result, isFalse);
+      });
+    });
+
     // Tests for buildTaskDetailsJson method
     group('buildTaskDetailsJson', () {
       test('returns JSON string for valid task', () async {

--- a/test/features/ai/repository/unified_ai_inference_repository_test.dart
+++ b/test/features/ai/repository/unified_ai_inference_repository_test.dart
@@ -1585,6 +1585,172 @@ void main() {
             ).called(1);
           },
         );
+
+        // Beyond the primary task link, the prompt is additionally linked back
+        // to the source entry so it shows in both linked-entries lists. These
+        // tests need a non-null response entry (the shared helper stubs null),
+        // so they set the create/link stubs directly.
+        group('dual link to source entry', () {
+          AiResponseEntry responseEntry() => AiResponseEntry(
+            meta: _createMetadata(id: 'resp-1'),
+            data: const AiResponseData(
+              model: 'gpt-4',
+              systemMessage: '',
+              prompt: 'p',
+              thoughts: '',
+              response: 'r',
+              type: AiResponseType.promptGeneration,
+            ),
+          );
+
+          Future<void> runReturningEntry({
+            required JournalEntity entity,
+            Object linkOutcome = true,
+          }) async {
+            _stubInferenceContext(
+              mockAiInputRepo: mockAiInputRepo,
+              mockAiConfigRepo: mockAiConfigRepo,
+              entity: entity,
+              model: model,
+              provider: provider,
+            );
+            _stubGenerate(
+              mockCloudInferenceRepo,
+              stream: _createMockTextStream(['Generated prompt']),
+            );
+            when(
+              () => mockAiInputRepo.createAiResponseEntry(
+                data: any(named: 'data'),
+                start: any(named: 'start'),
+                linkedId: any(named: 'linkedId'),
+                categoryId: any(named: 'categoryId'),
+              ),
+            ).thenAnswer((_) async => responseEntry());
+            final linkStub = when(
+              () => mockAiInputRepo.createLink(
+                fromId: any(named: 'fromId'),
+                toId: any(named: 'toId'),
+              ),
+            );
+            if (linkOutcome is bool) {
+              linkStub.thenAnswer((_) async => linkOutcome);
+            } else {
+              linkStub.thenThrow(linkOutcome);
+            }
+            when(
+              () => mockJournalDb.getConfigFlag(enableAiStreamingFlag),
+            ).thenAnswer((_) async => true);
+
+            await repository!.runInference(
+              entityId: 'test-id',
+              promptConfig: codingPrompt(),
+              onProgress: (_) {},
+              onStatusChange: (_) {},
+            );
+          }
+
+          test(
+            'links prompt to the parent task and back to the source entry',
+            () async {
+              when(
+                () => mockJournalRepo.getLinkedToEntities(linkedTo: 'test-id'),
+              ).thenAnswer((_) async => [parentTask()]);
+
+              await runReturningEntry(entity: audioEntity());
+
+              verify(
+                () => mockAiInputRepo.createAiResponseEntry(
+                  data: any(named: 'data'),
+                  start: any(named: 'start'),
+                  linkedId: 'task-id',
+                  categoryId: any(named: 'categoryId'),
+                ),
+              ).called(1);
+              verify(
+                () => mockAiInputRepo.createLink(
+                  fromId: 'test-id',
+                  toId: 'resp-1',
+                ),
+              ).called(1);
+            },
+          );
+
+          test(
+            'does not add a second link when no parent task resolves',
+            () async {
+              when(
+                () => mockJournalRepo.getLinkedToEntities(linkedTo: 'test-id'),
+              ).thenAnswer((_) async => <JournalEntity>[]);
+
+              await runReturningEntry(entity: audioEntity());
+
+              verifyNever(
+                () => mockAiInputRepo.createLink(
+                  fromId: any(named: 'fromId'),
+                  toId: any(named: 'toId'),
+                ),
+              );
+            },
+          );
+
+          test(
+            'a false link result is tolerated and the run still completes',
+            () async {
+              when(
+                () => mockJournalRepo.getLinkedToEntities(linkedTo: 'test-id'),
+              ).thenAnswer((_) async => [parentTask()]);
+
+              await runReturningEntry(
+                entity: audioEntity(),
+                linkOutcome: false,
+              );
+
+              // Primary write still happened; the false back-link is swallowed.
+              verify(
+                () => mockAiInputRepo.createAiResponseEntry(
+                  data: any(named: 'data'),
+                  start: any(named: 'start'),
+                  linkedId: 'task-id',
+                  categoryId: any(named: 'categoryId'),
+                ),
+              ).called(1);
+              verify(
+                () => mockAiInputRepo.createLink(
+                  fromId: 'test-id',
+                  toId: 'resp-1',
+                ),
+              ).called(1);
+            },
+          );
+
+          test(
+            'a thrown link failure is isolated and does not fail the run',
+            () async {
+              when(
+                () => mockJournalRepo.getLinkedToEntities(linkedTo: 'test-id'),
+              ).thenAnswer((_) async => [parentTask()]);
+
+              // The secondary link throws, but the primary prompt is already
+              // persisted, so runInference must complete without rethrowing.
+              await expectLater(
+                runReturningEntry(
+                  entity: audioEntity(),
+                  linkOutcome: Exception('db down'),
+                ),
+                completes,
+              );
+
+              verify(
+                () => mockAiInputRepo.createAiResponseEntry(
+                  data: any(named: 'data'),
+                  start: any(named: 'start'),
+                  linkedId: 'task-id',
+                  categoryId: any(named: 'categoryId'),
+                ),
+              ).called(1);
+            },
+          );
+        });
       });
 
       test(

--- a/test/features/ai/services/skill_inference_runner_test.dart
+++ b/test/features/ai/services/skill_inference_runner_test.dart
@@ -3520,6 +3520,283 @@ void main() {
           expect(data.type, AiResponseType.imagePromptGeneration);
         },
       );
+
+      // Dual-link behaviour: a coding prompt is created linked to its parent
+      // task AND additionally linked back to the source entry.
+      group('dual link to task and source entry', () {
+        AiResponseEntry makeResponseEntry(String id) => AiResponseEntry(
+          meta: Metadata(
+            id: id,
+            createdAt: DateTime(2024),
+            updatedAt: DateTime(2024),
+            dateFrom: DateTime(2024),
+            dateTo: DateTime(2024),
+          ),
+          data: const AiResponseData(
+            model: 'models/gemini-flash',
+            systemMessage: '',
+            prompt: 'p',
+            thoughts: '',
+            response: 'r',
+            type: AiResponseType.promptGeneration,
+          ),
+        );
+
+        void stubGenerate() {
+          when(
+            () => mockCloudRepo.generate(
+              any(),
+              model: any(named: 'model'),
+              temperature: any(named: 'temperature'),
+              baseUrl: any(named: 'baseUrl'),
+              apiKey: any(named: 'apiKey'),
+              provider: any(named: 'provider'),
+              systemMessage: any(named: 'systemMessage'),
+              impactCollector: any(named: 'impactCollector'),
+            ),
+          ).thenAnswer(
+            (_) => Stream.fromIterable([
+              makeStreamChunk('## Summary\nX\n\n## Prompt\nDo the work'),
+            ]),
+          );
+        }
+
+        void stubCreateResponse(AiResponseEntry? entry) {
+          when(
+            () => mockAiInputRepo.createAiResponseEntry(
+              data: any(named: 'data'),
+              start: any(named: 'start'),
+              linkedId: any(named: 'linkedId'),
+              categoryId: any(named: 'categoryId'),
+            ),
+          ).thenAnswer((_) async => entry);
+        }
+
+        test(
+          'links prompt to parent task and back to the source entry',
+          () async {
+            final audio = makeAudioEntity(
+              id: 'audio-dual',
+              plainText: 'notes',
+              markdown: 'notes',
+              categoryId: 'cat-dual',
+            );
+            when(
+              () => mockAiInputRepo.getEntity('audio-dual'),
+            ).thenAnswer((_) async => audio);
+            when(
+              () => mockAiInputRepo.buildTaskDetailsJson(id: 'task-dual'),
+            ).thenAnswer((_) async => '{"id": "task-dual"}');
+            when(
+              () => mockAiInputRepo.buildLinkedTasksJson('task-dual'),
+            ).thenAnswer((_) async => '{"linked": []}');
+            stubGenerate();
+            stubCreateResponse(makeResponseEntry('resp-dual'));
+            when(
+              () => mockAiInputRepo.createLink(
+                fromId: any(named: 'fromId'),
+                toId: any(named: 'toId'),
+              ),
+            ).thenAnswer((_) async => true);
+            stubLoggingEvent();
+
+            await runner.runPromptGeneration(
+              entryId: 'audio-dual',
+              automationResult: makePromptGenerationResult(),
+              linkedTaskId: 'task-dual',
+            );
+
+            // Primary link → parent task.
+            final captured = verify(
+              () => mockAiInputRepo.createAiResponseEntry(
+                data: any(named: 'data'),
+                start: any(named: 'start'),
+                linkedId: captureAny(named: 'linkedId'),
+                categoryId: any(named: 'categoryId'),
+              ),
+            ).captured;
+            expect(captured.single, 'task-dual');
+
+            // Secondary link → source entry, pointing at the new response.
+            verify(
+              () => mockAiInputRepo.createLink(
+                fromId: 'audio-dual',
+                toId: 'resp-dual',
+              ),
+            ).called(1);
+          },
+        );
+
+        test(
+          'does not add a second link when there is no parent task',
+          () async {
+            final audio = makeAudioEntity(
+              id: 'audio-solo',
+              plainText: 'notes',
+              markdown: 'notes',
+              categoryId: 'cat-solo',
+            );
+            when(
+              () => mockAiInputRepo.getEntity('audio-solo'),
+            ).thenAnswer((_) async => audio);
+            stubGenerate();
+            stubCreateResponse(makeResponseEntry('resp-solo'));
+            stubLoggingEvent();
+
+            await runner.runPromptGeneration(
+              entryId: 'audio-solo',
+              automationResult: makePromptGenerationResult(),
+            );
+
+            // Primary link falls back to the source entry itself…
+            final captured = verify(
+              () => mockAiInputRepo.createAiResponseEntry(
+                data: any(named: 'data'),
+                start: any(named: 'start'),
+                linkedId: captureAny(named: 'linkedId'),
+                categoryId: any(named: 'categoryId'),
+              ),
+            ).captured;
+            expect(captured.single, 'audio-solo');
+
+            // …so no duplicate self-link is created.
+            verifyNever(
+              () => mockAiInputRepo.createLink(
+                fromId: any(named: 'fromId'),
+                toId: any(named: 'toId'),
+              ),
+            );
+          },
+        );
+
+        test(
+          'does not add a second link when the response entry is null',
+          () async {
+            final audio = makeAudioEntity(
+              id: 'audio-null',
+              plainText: 'notes',
+              markdown: 'notes',
+              categoryId: 'cat-null',
+            );
+            when(
+              () => mockAiInputRepo.getEntity('audio-null'),
+            ).thenAnswer((_) async => audio);
+            when(
+              () => mockAiInputRepo.buildTaskDetailsJson(id: 'task-null'),
+            ).thenAnswer((_) async => '{"id": "task-null"}');
+            when(
+              () => mockAiInputRepo.buildLinkedTasksJson('task-null'),
+            ).thenAnswer((_) async => '{"linked": []}');
+            stubGenerate();
+            stubCreateResponse(null);
+            stubLoggingEvent();
+
+            await runner.runPromptGeneration(
+              entryId: 'audio-null',
+              automationResult: makePromptGenerationResult(),
+              linkedTaskId: 'task-null',
+            );
+
+            verifyNever(
+              () => mockAiInputRepo.createLink(
+                fromId: any(named: 'fromId'),
+                toId: any(named: 'toId'),
+              ),
+            );
+          },
+        );
+
+        // Sets up a task-linked audio prompt whose secondary link fails, so the
+        // failure-handling branches can be exercised. Returns after the run.
+        Future<void> runWithFailingLink({
+          required Object linkOutcome,
+        }) async {
+          final audio = makeAudioEntity(
+            id: 'audio-fail',
+            plainText: 'notes',
+            markdown: 'notes',
+            categoryId: 'cat-fail',
+          );
+          when(
+            () => mockAiInputRepo.getEntity('audio-fail'),
+          ).thenAnswer((_) async => audio);
+          when(
+            () => mockAiInputRepo.buildTaskDetailsJson(id: 'task-fail'),
+          ).thenAnswer((_) async => '{"id": "task-fail"}');
+          when(
+            () => mockAiInputRepo.buildLinkedTasksJson('task-fail'),
+          ).thenAnswer((_) async => '{"linked": []}');
+          stubGenerate();
+          stubCreateResponse(makeResponseEntry('resp-fail'));
+          final linkStub = when(
+            () => mockAiInputRepo.createLink(
+              fromId: any(named: 'fromId'),
+              toId: any(named: 'toId'),
+            ),
+          );
+          if (linkOutcome is bool) {
+            linkStub.thenAnswer((_) async => linkOutcome);
+          } else {
+            linkStub.thenThrow(linkOutcome);
+          }
+          stubLoggingEvent();
+          _stubLoggingExceptionFor(mockLoggingService);
+
+          await runner.runPromptGeneration(
+            entryId: 'audio-fail',
+            automationResult: makePromptGenerationResult(),
+            linkedTaskId: 'task-fail',
+          );
+        }
+
+        test(
+          'logs and completes when the secondary link returns false',
+          () async {
+            await runWithFailingLink(linkOutcome: false);
+
+            // Primary write still succeeded; the failed back-link is logged,
+            // not surfaced as a run failure.
+            verify(
+              () => mockAiInputRepo.createLink(
+                fromId: 'audio-fail',
+                toId: 'resp-fail',
+              ),
+            ).called(1);
+            verify(
+              () => mockLoggingService.log(
+                LogDomain.ai,
+                any<String>(that: contains('not created')),
+                subDomain: 'runPromptGeneration',
+              ),
+            ).called(1);
+          },
+        );
+
+        test(
+          'logs and does not rethrow when the secondary link throws',
+          () async {
+            // Must not throw: the prompt is already persisted, so a link
+            // failure cannot be allowed to fail the whole run.
+            await expectLater(
+              runWithFailingLink(linkOutcome: Exception('db down')),
+              completes,
+            );
+
+            verify(
+              () => mockLoggingService.error(
+                LogDomain.ai,
+                any<Object>(),
+                stackTrace: any<StackTrace?>(named: 'stackTrace'),
+                subDomain: 'runPromptGeneration',
+                message: any<String>(
+                  named: 'message',
+                  that: contains('failed'),
+                ),
+              ),
+            ).called(1);
+          },
+        );
+      });
     });
 
     group('runImageGeneration', () {

--- a/test/features/journal/ui/widgets/entry_details_widget_test.dart
+++ b/test/features/journal/ui/widgets/entry_details_widget_test.dart
@@ -793,6 +793,114 @@ void main() {
       },
     );
 
+    // Coding prompts (AiResponseType.promptGeneration) are exempt from the
+    // `showAiEntry` gate so they render in a task's linked-entries list, which
+    // always passes `showAiEntry: false`. Every other AiResponseEntry kind
+    // stays gated.
+    group('coding-prompt visibility gate', () {
+      Future<void> pumpAiResponse(
+        WidgetTester tester, {
+        required AiResponseType? type,
+        required bool showAiEntry,
+      }) async {
+        final aiEntry = JournalEntity.aiResponse(
+          meta: Metadata(
+            id: 'ai-gate-id',
+            createdAt: DateTime(2024, 3, 15),
+            updatedAt: DateTime(2024, 3, 15),
+            dateFrom: DateTime(2024, 3, 15),
+            dateTo: DateTime(2024, 3, 15),
+          ),
+          data: AiResponseData(
+            model: 'test-model',
+            systemMessage: '',
+            prompt: 'test prompt',
+            thoughts: '',
+            response: '## Prompt\nDo the work',
+            type: type,
+          ),
+        );
+
+        await tester.pumpWidget(
+          makeTestableWidgetWithScaffold(
+            ProviderScope(
+              overrides: [
+                entryControllerProvider('ai-gate-id').overrideWith(
+                  () => _FakeEntryController(aiEntry),
+                ),
+              ],
+              child: EntryDetailsWidget(
+                itemId: 'ai-gate-id',
+                showAiEntry: showAiEntry,
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+      }
+
+      testWidgets(
+        'coding prompt renders even when showAiEntry=false',
+        (tester) async {
+          await pumpAiResponse(
+            tester,
+            type: AiResponseType.promptGeneration,
+            showAiEntry: false,
+          );
+          expect(find.byType(EntryDetailsContent), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'coding prompt renders when showAiEntry=true',
+        (tester) async {
+          await pumpAiResponse(
+            tester,
+            type: AiResponseType.promptGeneration,
+            showAiEntry: true,
+          );
+          expect(find.byType(EntryDetailsContent), findsOneWidget);
+        },
+      );
+
+      // Non-coding AiResponse kinds must stay behind the `showAiEntry` gate:
+      // hidden when off, visible when on. imagePromptGeneration is included to
+      // prove only `promptGeneration` (not the sibling image variant) is
+      // exempt.
+      final gatedTypes = <AiResponseType>[
+        AiResponseType.audioTranscription,
+        AiResponseType.imageAnalysis,
+        AiResponseType.imagePromptGeneration,
+      ];
+
+      for (final type in gatedTypes) {
+        testWidgets(
+          '$type stays hidden when showAiEntry=false',
+          (tester) async {
+            await pumpAiResponse(tester, type: type, showAiEntry: false);
+            expect(find.byType(EntryDetailsContent), findsNothing);
+          },
+        );
+
+        testWidgets(
+          '$type renders when showAiEntry=true',
+          (tester) async {
+            await pumpAiResponse(tester, type: type, showAiEntry: true);
+            expect(find.byType(EntryDetailsContent), findsOneWidget);
+          },
+        );
+      }
+
+      // A null type (legacy/unset) is not a coding prompt, so it stays gated.
+      testWidgets(
+        'null-type AiResponse stays hidden when showAiEntry=false',
+        (tester) async {
+          await pumpAiResponse(tester, type: null, showAiEntry: false);
+          expect(find.byType(EntryDetailsContent), findsNothing);
+        },
+      );
+    });
+
     group('JournalEvent', () {
       JournalEvent buildEvent() {
         final now = DateTime(2026, 5, 12);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * AI-generated coding prompts are now properly surfaced in the task timeline (not hidden).
  * Coding prompts are linked to both the originating audio/text note and the parent task.
  * Prompts appear when the **Code** activity filter is selected.
  * Coding prompts remain visible even when other AI entries are hidden.

* **Documentation**
  * Updated “What’s New” and AI prompt-generation documentation to reflect the corrected linking and visibility behavior.

* **Tests**
  * Added coverage for the dual-link behavior and for secondary-link failures during prompt generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->