### PR TITLE
feat: sync the Daily OS preferred name across devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   model. The app states that assembled planning context is sent to the selected
   provider, identifies local versus remote endpoints, and guides you to setup
   before the first check-in when no usable profile is configured.
+- **Your Daily OS name now follows you across devices.** The preferred name you
+  set for Daily OS syncs to your other devices, with the most recent edit
+  winning, so each device greets you the same way.
 
 ## [0.9.1043]
 ### Changed

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -35,6 +35,7 @@
     <release version="0.9.1044" date="2026-07-14">
       <description>
           <p>Daily OS now has a discoverable settings page for choosing its default inference profile and preferred name, plus per-planner profile and thinking-model overrides. Setup explains that assembled planning context is sent to the selected provider and identifies whether its configured endpoint is local or remote.</p>
+          <p>The preferred name you set for Daily OS now syncs across your devices, with the most recent edit winning, so each device greets you the same way.</p>
       </description>
     </release>
     <release version="0.9.1043" date="2026-07-14">

--- a/lib/features/agents/model/agent_config.freezed.dart
+++ b/lib/features/agents/model/agent_config.freezed.dart
@@ -18,7 +18,7 @@ mixin _$AgentConfig {
 /// Maximum number of tool-call turns per wake.
  int get maxTurnsPerWake;/// Model identifier to use for inference.
  String get modelId;/// Inference profile ID — takes precedence over [modelId] when set.
- String? get profileId;/// Typed persistent inference setup for task agents.
+ String? get profileId;/// Typed persistent inference setup for agent instances.
 ///
 /// Null preserves the legacy profile/template/model resolution chain.
 /// Once present, this setup is authoritative: configured setups resolve
@@ -256,7 +256,7 @@ class _AgentConfig implements AgentConfig {
 @override@JsonKey() final  String modelId;
 /// Inference profile ID — takes precedence over [modelId] when set.
 @override final  String? profileId;
-/// Typed persistent inference setup for task agents.
+/// Typed persistent inference setup for agent instances.
 ///
 /// Null preserves the legacy profile/template/model resolution chain.
 /// Once present, this setup is authoritative: configured setups resolve
@@ -362,7 +362,7 @@ mixin _$AgentInferenceSetup {
 
 @JsonKey(unknownEnumValue: AgentInferenceSetupMode.disabled) AgentInferenceSetupMode get mode;@JsonKey(unknownEnumValue: AgentInferenceSetupOrigin.unknown) AgentInferenceSetupOrigin get origin;/// Base inference profile. Its non-thinking slots remain available when a
 /// direct thinking-model override is selected.
- String? get baseProfileId;/// Config-row ID (`AiConfigModel.id`) for the task agent's thinking model.
+ String? get baseProfileId;/// Config-row ID (`AiConfigModel.id`) for the agent's thinking model.
 /// This is deliberately not a provider-native `providerModelId`.
  String? get thinkingModelOverrideId;/// Category/template ID whose default was copied, when applicable.
  String? get originEntityId;
@@ -571,7 +571,7 @@ class _AgentInferenceSetup implements AgentInferenceSetup {
 /// Base inference profile. Its non-thinking slots remain available when a
 /// direct thinking-model override is selected.
 @override final  String? baseProfileId;
-/// Config-row ID (`AiConfigModel.id`) for the task agent's thinking model.
+/// Config-row ID (`AiConfigModel.id`) for the agent's thinking model.
 /// This is deliberately not a provider-native `providerModelId`.
 @override final  String? thinkingModelOverrideId;
 /// Category/template ID whose default was copied, when applicable.

--- a/lib/features/daily_os_next/README.md
+++ b/lib/features/daily_os_next/README.md
@@ -316,11 +316,14 @@ stateDiagram-v2
   for quiet helper lines. No daily-os-next surface uses the legacy
   12/700/+8-tracking overline token directly.
 - `DailyOsPreferencesController` persists Daily OS personalization in
-  `SettingsDb`. The user's display name is edited from Settings > Advanced >
-  About and read by the Capture greeting. Category exclusions are edited from
-  the processing filter button; `ReconcileController` applies the same
-  preference to parsed capture items and pending decisions before the user sees
-  them.
+  `SettingsDb`. The user's display name is edited from the Daily OS settings
+  page (Settings > Daily OS) and read by the Capture greeting. It syncs across
+  the user's devices: an edit stamps a last-write timestamp and enqueues a
+  debounced `SyncMessage.dailyOsUserName`, and an inbound synced change reloads
+  the name here under last-write-wins (mirroring theming). Category exclusions
+  are edited from the processing filter button and stay device-local;
+  `ReconcileController` applies the same preference to parsed capture items and
+  pending decisions before the user sees them.
 - Day-plan category availability is strictly opt-in via the category editor's
   "Day planning" switch (`CategoryDefinition.isAvailableForDayPlan`). The pure
   predicates in `logic/day_plan_availability.dart` define the day-plan

--- a/lib/features/daily_os_next/README.md
+++ b/lib/features/daily_os_next/README.md
@@ -320,7 +320,11 @@ stateDiagram-v2
   page (Settings > Daily OS) and read by the Capture greeting. It syncs across
   the user's devices: an edit stamps a last-write timestamp and enqueues a
   debounced `SyncMessage.dailyOsUserName`, and an inbound synced change reloads
-  the name here under last-write-wins (mirroring theming). Category exclusions
+  the name here under last-write-wins (mirroring theming). A name that exists
+  locally but was never published — a pre-sync name, or one edited while the
+  outbox was unavailable — is bootstrapped once on load (stamped as the
+  oldest-possible write, so an explicit edit elsewhere always wins) so it still
+  reaches other devices without a re-edit. Category exclusions
   are edited from the processing filter button and stay device-local;
   `ReconcileController` applies the same preference to parsed capture items and
   pending decisions before the user sees them.

--- a/lib/features/daily_os_next/state/daily_os_preferences_controller.dart
+++ b/lib/features/daily_os_next/state/daily_os_preferences_controller.dart
@@ -1,18 +1,20 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:clock/clock.dart';
+import 'package:easy_debounce/easy_debounce.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
+import 'package:lotti/features/daily_os_next/state/daily_os_preferences_keys.dart';
+import 'package:lotti/features/sync/model/sync_message.dart';
+import 'package:lotti/features/sync/outbox/outbox_service.dart';
 import 'package:lotti/get_it.dart';
+import 'package:lotti/services/db_notification.dart';
+import 'package:lotti/services/domain_logging.dart';
 
-const dailyOsUserNameSettingsKey = 'DAILY_OS_USER_NAME';
-const dailyOsExcludedCategoryIdsSettingsKey = 'DAILY_OS_EXCLUDED_CATEGORY_IDS';
-const dailyOsTimelineGesturesLearnedSettingsKey =
-    'DAILY_OS_TIMELINE_GESTURES_LEARNED';
-const dailyOsDayFooterHintRetiredSettingsKey =
-    'DAILY_OS_DAY_FOOTER_HINT_RETIRED';
+export 'package:lotti/features/daily_os_next/state/daily_os_preferences_keys.dart';
 
 /// User-scoped Daily OS settings, persisted in [SettingsDb]: the greeting
 /// name, the set of category ids excluded from the day flow, and one-shot
@@ -68,12 +70,32 @@ class DailyOsPreferences {
 /// ensure an in-flight async load never clobbers a value the user has already
 /// changed in this session; coachmark flags need no guard because they only
 /// ever flip false→true.
+///
+/// The greeting name additionally syncs across a user's devices: [setUserName]
+/// stamps a last-write timestamp and enqueues a debounced
+/// `SyncMessage.dailyOsUserName`, and an inbound synced change (surfaced as a
+/// `settingsNotification`) reloads the name here under last-write-wins. The
+/// excluded-category set and coachmark flags remain device-local.
 class DailyOsPreferencesController extends Notifier<DailyOsPreferences> {
   bool _userNameEdited = false;
   bool _categoriesEdited = false;
 
+  /// True while applying a name arriving from another device, so the reload
+  /// does not re-enqueue an outbound sync message (theme-style ping-pong).
+  bool _isApplyingSyncedName = false;
+  StreamSubscription<Set<String>>? _settingsNotificationSub;
+  final _syncDebounceKey =
+      'daily_os.userName.sync.${identityHashCode(Object())}';
+
   @override
   DailyOsPreferences build() {
+    ref.onDispose(() {
+      unawaited(_settingsNotificationSub?.cancel());
+      EasyDebounce.cancel(_syncDebounceKey);
+    });
+    // Subscribe before the initial load so a synced name arriving during the
+    // load window is not missed.
+    _watchSyncedUserName();
     unawaited(_load());
     return DailyOsPreferences();
   }
@@ -136,7 +158,85 @@ class DailyOsPreferencesController extends Notifier<DailyOsPreferences> {
     _userNameEdited = true;
     final trimmed = value.trim();
     state = state.copyWith(userName: trimmed);
+    // Persist the name and a fresh last-write timestamp together so the
+    // outbound sync message and the local settings row agree on the winner.
+    final updatedAt = clock.now().millisecondsSinceEpoch;
     _save(dailyOsUserNameSettingsKey, trimmed);
+    _save(dailyOsUserNameUpdatedAtSettingsKey, updatedAt.toString());
+    _enqueueUserNameSync(trimmed, updatedAt);
+  }
+
+  /// Debounced outbound sync of the greeting name. Coalesces rapid keystrokes
+  /// into one message, skips while applying a synced change, and is a no-op
+  /// before sync is configured (`OutboxService` unregistered).
+  void _enqueueUserNameSync(String userName, int updatedAt) {
+    if (_isApplyingSyncedName) return;
+    EasyDebounce.debounce(
+      _syncDebounceKey,
+      const Duration(milliseconds: 250),
+      () async {
+        if (!getIt.isRegistered<OutboxService>()) return;
+        try {
+          await getIt<OutboxService>().enqueueMessage(
+            SyncMessage.dailyOsUserName(
+              userName: userName,
+              updatedAt: updatedAt,
+              status: SyncEntryStatus.update,
+            ),
+          );
+        } catch (e, st) {
+          if (getIt.isRegistered<DomainLogger>()) {
+            getIt<DomainLogger>().error(
+              LogDomain.dailyOs,
+              e,
+              stackTrace: st,
+              subDomain: 'enqueue',
+            );
+          }
+        }
+      },
+    );
+  }
+
+  /// Reloads the greeting name when a synced settings change lands, so an
+  /// already-open Daily OS surface reflects a name set on another device.
+  void _watchSyncedUserName() {
+    if (!getIt.isRegistered<UpdateNotifications>()) return;
+    _settingsNotificationSub = getIt<UpdateNotifications>().updateStream.listen(
+      (ids) async {
+        if (!ids.contains(settingsNotification) || _isApplyingSyncedName) {
+          return;
+        }
+        _isApplyingSyncedName = true;
+        try {
+          await _reloadUserNameFromSettings();
+        } catch (e, st) {
+          if (getIt.isRegistered<DomainLogger>()) {
+            getIt<DomainLogger>().error(
+              LogDomain.dailyOs,
+              e,
+              stackTrace: st,
+              subDomain: 'reload',
+            );
+          }
+        }
+        _isApplyingSyncedName = false;
+      },
+    );
+  }
+
+  Future<void> _reloadUserNameFromSettings() async {
+    if (!getIt.isRegistered<SettingsDb>()) return;
+    // The apply phase already resolved last-write-wins before writing, so the
+    // stored value is authoritative — override even a locally edited name.
+    final stored = await getIt<SettingsDb>().itemByKey(
+      dailyOsUserNameSettingsKey,
+    );
+    if (!ref.mounted) return;
+    final synced = stored?.trim() ?? '';
+    if (synced != state.userName) {
+      state = state.copyWith(userName: synced);
+    }
   }
 
   void setCategoryEnabled(String categoryId, {required bool enabled}) {

--- a/lib/features/daily_os_next/state/daily_os_preferences_controller.dart
+++ b/lib/features/daily_os_next/state/daily_os_preferences_controller.dart
@@ -80,9 +80,6 @@ class DailyOsPreferencesController extends Notifier<DailyOsPreferences> {
   bool _userNameEdited = false;
   bool _categoriesEdited = false;
 
-  /// True while applying a name arriving from another device, so the reload
-  /// does not re-enqueue an outbound sync message (theme-style ping-pong).
-  bool _isApplyingSyncedName = false;
   StreamSubscription<Set<String>>? _settingsNotificationSub;
   final _syncDebounceKey =
       'daily_os.userName.sync.${identityHashCode(Object())}';
@@ -155,8 +152,12 @@ class DailyOsPreferencesController extends Notifier<DailyOsPreferences> {
   }
 
   void setUserName(String value) {
-    _userNameEdited = true;
     final trimmed = value.trim();
+    // Skip a no-op edit: this avoids a redundant write, timestamp bump, and
+    // outbound sync message, and closes any echo loop when the text field is
+    // repopulated with a name that just arrived from another device.
+    if (trimmed == state.userName) return;
+    _userNameEdited = true;
     state = state.copyWith(userName: trimmed);
     // Persist the name and a fresh last-write timestamp together so the
     // outbound sync message and the local settings row agree on the winner.
@@ -167,10 +168,9 @@ class DailyOsPreferencesController extends Notifier<DailyOsPreferences> {
   }
 
   /// Debounced outbound sync of the greeting name. Coalesces rapid keystrokes
-  /// into one message, skips while applying a synced change, and is a no-op
-  /// before sync is configured (`OutboxService` unregistered).
+  /// into one message and is a no-op before sync is configured
+  /// (`OutboxService` unregistered).
   void _enqueueUserNameSync(String userName, int updatedAt) {
-    if (_isApplyingSyncedName) return;
     EasyDebounce.debounce(
       _syncDebounceKey,
       const Duration(milliseconds: 250),
@@ -204,10 +204,11 @@ class DailyOsPreferencesController extends Notifier<DailyOsPreferences> {
     if (!getIt.isRegistered<UpdateNotifications>()) return;
     _settingsNotificationSub = getIt<UpdateNotifications>().updateStream.listen(
       (ids) async {
-        if (!ids.contains(settingsNotification) || _isApplyingSyncedName) {
-          return;
-        }
-        _isApplyingSyncedName = true;
+        // Reload on every settings notification. Each reload reads the current
+        // stored value, so overlapping notifications never strand the
+        // controller on a stale name — there is no in-flight guard to drop a
+        // newer update.
+        if (!ids.contains(settingsNotification)) return;
         try {
           await _reloadUserNameFromSettings();
         } catch (e, st) {
@@ -220,7 +221,6 @@ class DailyOsPreferencesController extends Notifier<DailyOsPreferences> {
             );
           }
         }
-        _isApplyingSyncedName = false;
       },
     );
   }
@@ -228,7 +228,8 @@ class DailyOsPreferencesController extends Notifier<DailyOsPreferences> {
   Future<void> _reloadUserNameFromSettings() async {
     if (!getIt.isRegistered<SettingsDb>()) return;
     // The apply phase already resolved last-write-wins before writing, so the
-    // stored value is authoritative — override even a locally edited name.
+    // stored value is authoritative — override even a locally edited name. The
+    // reload never enqueues, so it cannot echo back to other devices.
     final stored = await getIt<SettingsDb>().itemByKey(
       dailyOsUserNameSettingsKey,
     );

--- a/lib/features/daily_os_next/state/daily_os_preferences_controller.dart
+++ b/lib/features/daily_os_next/state/daily_os_preferences_controller.dart
@@ -74,8 +74,11 @@ class DailyOsPreferences {
 /// The greeting name additionally syncs across a user's devices: [setUserName]
 /// stamps a last-write timestamp and enqueues a debounced
 /// `SyncMessage.dailyOsUserName`, and an inbound synced change (surfaced as a
-/// `settingsNotification`) reloads the name here under last-write-wins. The
-/// excluded-category set and coachmark flags remain device-local.
+/// `settingsNotification`) reloads the name here under last-write-wins. On load,
+/// a name that exists locally but was never published — a pre-sync name, or one
+/// edited while the outbox was unavailable — is bootstrapped once so it still
+/// reaches other devices without a re-edit. The excluded-category set and
+/// coachmark flags remain device-local.
 class DailyOsPreferencesController extends Notifier<DailyOsPreferences> {
   bool _userNameEdited = false;
   bool _categoriesEdited = false;
@@ -102,6 +105,8 @@ class DailyOsPreferencesController extends Notifier<DailyOsPreferences> {
     final values = await getIt<SettingsDb>().itemsByKeys(
       const [
         dailyOsUserNameSettingsKey,
+        dailyOsUserNameUpdatedAtSettingsKey,
+        dailyOsUserNameSyncedAtSettingsKey,
         dailyOsExcludedCategoryIdsSettingsKey,
         dailyOsTimelineGesturesLearnedSettingsKey,
         dailyOsDayFooterHintRetiredSettingsKey,
@@ -133,6 +138,39 @@ class DailyOsPreferencesController extends Notifier<DailyOsPreferences> {
           values[dailyOsDayFooterHintRetiredSettingsKey] == 'true',
     );
     state = next;
+
+    _bootstrapUserNameSyncIfNeeded(
+      name: values[dailyOsUserNameSettingsKey]?.trim() ?? '',
+      storedUpdatedAt: values[dailyOsUserNameUpdatedAtSettingsKey],
+      storedSyncedAt: values[dailyOsUserNameSyncedAtSettingsKey],
+    );
+  }
+
+  /// Oldest-possible last-write stamp for a name that predates sync. Any real
+  /// edit on any device carries a much larger epoch-millis stamp and so wins
+  /// last-write-wins, meaning bootstrapping never clobbers an explicit choice.
+  static const _bootstrapUpdatedAt = 1;
+
+  /// Publishes a locally stored name this device has never synced — an existing
+  /// pre-sync name, or one edited while the outbox was unavailable — exactly
+  /// once, so it reaches the user's other devices without a re-edit.
+  ///
+  /// [dailyOsUserNameSyncedAtSettingsKey] records the timestamp last actually
+  /// enqueued (written on enqueue success and by inbound apply), so a name is
+  /// bootstrapped only until it has been published, and a name received from
+  /// another device is never re-published.
+  void _bootstrapUserNameSyncIfNeeded({
+    required String name,
+    required String? storedUpdatedAt,
+    required String? storedSyncedAt,
+  }) {
+    // A live edit this session already enqueued through setUserName.
+    if (_userNameEdited || name.isEmpty) return;
+    if (!getIt.isRegistered<OutboxService>()) return;
+    final updatedAt =
+        int.tryParse(storedUpdatedAt ?? '') ?? _bootstrapUpdatedAt;
+    if (int.tryParse(storedSyncedAt ?? '') == updatedAt) return;
+    _enqueueUserNameSync(name, updatedAt);
   }
 
   /// Permanently retires the timeline's gesture hint — called the first
@@ -184,6 +222,8 @@ class DailyOsPreferencesController extends Notifier<DailyOsPreferences> {
               status: SyncEntryStatus.update,
             ),
           );
+          // Record what we published so this name is not bootstrapped again.
+          _save(dailyOsUserNameSyncedAtSettingsKey, updatedAt.toString());
         } catch (e, st) {
           if (getIt.isRegistered<DomainLogger>()) {
             getIt<DomainLogger>().error(

--- a/lib/features/daily_os_next/state/daily_os_preferences_keys.dart
+++ b/lib/features/daily_os_next/state/daily_os_preferences_keys.dart
@@ -12,6 +12,12 @@ const dailyOsUserNameSettingsKey = 'DAILY_OS_USER_NAME';
 /// greeting name is synced across devices.
 const dailyOsUserNameUpdatedAtSettingsKey = 'DAILY_OS_USER_NAME_UPDATED_AT';
 
+/// Key for the timestamp of the greeting name this device has actually
+/// published to sync. When it lags [dailyOsUserNameUpdatedAtSettingsKey] (or is
+/// absent for a pre-sync name), the controller bootstraps a one-time enqueue so
+/// an existing or offline-set name reaches other devices without a re-edit.
+const dailyOsUserNameSyncedAtSettingsKey = 'DAILY_OS_USER_NAME_SYNCED_AT';
+
 /// Key for the JSON-encoded set of category ids excluded from the day flow.
 const dailyOsExcludedCategoryIdsSettingsKey = 'DAILY_OS_EXCLUDED_CATEGORY_IDS';
 

--- a/lib/features/daily_os_next/state/daily_os_preferences_keys.dart
+++ b/lib/features/daily_os_next/state/daily_os_preferences_keys.dart
@@ -1,0 +1,24 @@
+// SettingsDb keys for persisted Daily OS preferences. The wire values are
+// frozen for backward compatibility and must not be renamed without a
+// migration. Kept in a standalone file so the sync layer can reference the
+// keys without importing the Riverpod controller.
+
+/// Key for the Daily OS greeting name. Synced across a user's devices via
+/// `SyncMessage.dailyOsUserName` under last-write-wins.
+const dailyOsUserNameSettingsKey = 'DAILY_OS_USER_NAME';
+
+/// Key for the last-write timestamp (epoch millis) of
+/// [dailyOsUserNameSettingsKey], used to resolve which device wins when the
+/// greeting name is synced across devices.
+const dailyOsUserNameUpdatedAtSettingsKey = 'DAILY_OS_USER_NAME_UPDATED_AT';
+
+/// Key for the JSON-encoded set of category ids excluded from the day flow.
+const dailyOsExcludedCategoryIdsSettingsKey = 'DAILY_OS_EXCLUDED_CATEGORY_IDS';
+
+/// One-shot coachmark flag: the timeline gesture hint has been retired.
+const dailyOsTimelineGesturesLearnedSettingsKey =
+    'DAILY_OS_TIMELINE_GESTURES_LEARNED';
+
+/// One-shot coachmark flag: the day footer coaching line has been retired.
+const dailyOsDayFooterHintRetiredSettingsKey =
+    'DAILY_OS_DAY_FOOTER_HINT_RETIRED';

--- a/lib/features/sync/README.md
+++ b/lib/features/sync/README.md
@@ -90,6 +90,7 @@ Current message families in `model/sync_message.dart`:
 - `savedTaskFilterDelete`
 - `configFlag`
 - `themingSelection`
+- `dailyOsUserName`
 - `notification`
 - `notificationStateUpdate`
 - `backfillRequest`

--- a/lib/features/sync/matrix/matrix_service.dart
+++ b/lib/features/sync/matrix/matrix_service.dart
@@ -398,6 +398,7 @@ class MatrixService {
       savedTaskFilterDelete: (_) => 'savedTaskFilterDelete',
       configFlag: (_) => 'configFlag',
       themingSelection: (_) => 'themingSelection',
+      dailyOsUserName: (_) => 'dailyOsUserName',
       notification: (_) => 'notification',
       notificationStateUpdate: (_) => 'notificationStateUpdate',
       consumptionEvent: (_) => 'consumptionEvent',

--- a/lib/features/sync/matrix/sync_event_processor.dart
+++ b/lib/features/sync/matrix/sync_event_processor.dart
@@ -28,6 +28,7 @@ import 'package:lotti/features/agents/wake/wake_orchestrator.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 import 'package:lotti/features/ai_consumption/model/ai_consumption_event.dart';
 import 'package:lotti/features/ai_consumption/repository/consumption_repository.dart';
+import 'package:lotti/features/daily_os_next/state/daily_os_preferences_keys.dart';
 import 'package:lotti/features/notifications/scheduler/notification_scheduler.dart';
 import 'package:lotti/features/settings/constants/theming_settings_keys.dart';
 import 'package:lotti/features/sync/backfill/backfill_response_handler.dart';

--- a/lib/features/sync/matrix/sync_event_processor_apply.dart
+++ b/lib/features/sync/matrix/sync_event_processor_apply.dart
@@ -199,6 +199,12 @@ extension SyncEventProcessorApply on SyncEventProcessor {
             dailyOsUserNameUpdatedAtSettingsKey,
             updatedAt.toString(),
           );
+          // A name received from another device is already published; mark it
+          // synced so this device does not bootstrap-republish it.
+          await _settingsDb.saveSettingsItem(
+            dailyOsUserNameSyncedAtSettingsKey,
+            updatedAt.toString(),
+          );
 
           _updateNotifications.notify(
             {settingsNotification},

--- a/lib/features/sync/matrix/sync_event_processor_apply.dart
+++ b/lib/features/sync/matrix/sync_event_processor_apply.dart
@@ -172,6 +172,53 @@ extension SyncEventProcessorApply on SyncEventProcessor {
           );
         }
         return null;
+      case SyncDailyOsUserName(:final userName, :final updatedAt):
+        try {
+          // Last-write-wins on the persisted timestamp, mirroring theming.
+          final localUpdatedAtStr = await _settingsDb.itemByKey(
+            dailyOsUserNameUpdatedAtSettingsKey,
+          );
+          final localUpdatedAt = localUpdatedAtStr != null
+              ? int.tryParse(localUpdatedAtStr)
+              : 0;
+
+          if (updatedAt < (localUpdatedAt ?? 0)) {
+            _trace(
+              'dailyOsUserNameSync.ignored.stale incoming=$updatedAt '
+              'local=$localUpdatedAt',
+              subDomain: 'processor.apply',
+            );
+            return null;
+          }
+
+          await _settingsDb.saveSettingsItem(
+            dailyOsUserNameSettingsKey,
+            userName,
+          );
+          await _settingsDb.saveSettingsItem(
+            dailyOsUserNameUpdatedAtSettingsKey,
+            updatedAt.toString(),
+          );
+
+          _updateNotifications.notify(
+            {settingsNotification},
+            fromSync: true,
+          );
+
+          // Content-free: never log the greeting name itself.
+          _trace(
+            'apply dailyOsUserName updatedAt=$updatedAt',
+            subDomain: 'processor.apply',
+          );
+        } catch (e, st) {
+          _loggingService.error(
+            LogDomain.dailyOs,
+            e,
+            stackTrace: st,
+            subDomain: 'apply',
+          );
+        }
+        return null;
       case SyncBackfillRequest():
         // Handle backfill request - another device is asking for a missing entry
         await backfillResponseHandler.handleBackfillRequest(syncMessage);

--- a/lib/features/sync/model/sync_message.dart
+++ b/lib/features/sync/model/sync_message.dart
@@ -132,6 +132,18 @@ sealed class SyncMessage with _$SyncMessage {
     required SyncEntryStatus status,
   }) = SyncThemingSelection;
 
+  /// The Daily OS greeting name, synced across a user's devices.
+  ///
+  /// Carries no vector clock — receivers upsert the `DAILY_OS_USER_NAME`
+  /// settings key under last-write-wins keyed on [updatedAt] (epoch millis),
+  /// mirroring [SyncThemingSelection]. It is a device-preference value, not
+  /// journal data, so it does not participate in gap detection.
+  const factory SyncMessage.dailyOsUserName({
+    required String userName,
+    required int updatedAt,
+    required SyncEntryStatus status,
+  }) = SyncDailyOsUserName;
+
   const factory SyncMessage.notification({
     required String id,
     required String jsonPath,

--- a/lib/features/sync/model/sync_message.freezed.dart
+++ b/lib/features/sync/model/sync_message.freezed.dart
@@ -325,6 +325,10 @@ SyncMessage _$SyncMessageFromJson(
           return SyncThemingSelection.fromJson(
             json
           );
+                case 'dailyOsUserName':
+          return SyncDailyOsUserName.fromJson(
+            json
+          );
                 case 'notification':
           return SyncNotification.fromJson(
             json
@@ -419,7 +423,7 @@ extension SyncMessagePatterns on SyncMessage {
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( SyncJournalEntity value)?  journalEntity,TResult Function( SyncEntityDefinition value)?  entityDefinition,TResult Function( SyncEntryLink value)?  entryLink,TResult Function( SyncAiConfig value)?  aiConfig,TResult Function( SyncSyncNodeProfile value)?  syncNodeProfile,TResult Function( SyncAiConfigDelete value)?  aiConfigDelete,TResult Function( SyncSavedTaskFilter value)?  savedTaskFilter,TResult Function( SyncSavedTaskFilterDelete value)?  savedTaskFilterDelete,TResult Function( SyncConfigFlag value)?  configFlag,TResult Function( SyncThemingSelection value)?  themingSelection,TResult Function( SyncNotification value)?  notification,TResult Function( SyncNotificationStateUpdate value)?  notificationStateUpdate,TResult Function( SyncBackfillRequest value)?  backfillRequest,TResult Function( SyncBackfillResponse value)?  backfillResponse,TResult Function( SyncAgentEntity value)?  agentEntity,TResult Function( SyncAgentLink value)?  agentLink,TResult Function( SyncConsumptionEvent value)?  consumptionEvent,TResult Function( SyncAgentBundle value)?  agentBundle,TResult Function( SyncOutboxBundle value)?  outboxBundle,required TResult orElse(),}){
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( SyncJournalEntity value)?  journalEntity,TResult Function( SyncEntityDefinition value)?  entityDefinition,TResult Function( SyncEntryLink value)?  entryLink,TResult Function( SyncAiConfig value)?  aiConfig,TResult Function( SyncSyncNodeProfile value)?  syncNodeProfile,TResult Function( SyncAiConfigDelete value)?  aiConfigDelete,TResult Function( SyncSavedTaskFilter value)?  savedTaskFilter,TResult Function( SyncSavedTaskFilterDelete value)?  savedTaskFilterDelete,TResult Function( SyncConfigFlag value)?  configFlag,TResult Function( SyncThemingSelection value)?  themingSelection,TResult Function( SyncDailyOsUserName value)?  dailyOsUserName,TResult Function( SyncNotification value)?  notification,TResult Function( SyncNotificationStateUpdate value)?  notificationStateUpdate,TResult Function( SyncBackfillRequest value)?  backfillRequest,TResult Function( SyncBackfillResponse value)?  backfillResponse,TResult Function( SyncAgentEntity value)?  agentEntity,TResult Function( SyncAgentLink value)?  agentLink,TResult Function( SyncConsumptionEvent value)?  consumptionEvent,TResult Function( SyncAgentBundle value)?  agentBundle,TResult Function( SyncOutboxBundle value)?  outboxBundle,required TResult orElse(),}){
 final _that = this;
 switch (_that) {
 case SyncJournalEntity() when journalEntity != null:
@@ -432,7 +436,8 @@ return aiConfigDelete(_that);case SyncSavedTaskFilter() when savedTaskFilter != 
 return savedTaskFilter(_that);case SyncSavedTaskFilterDelete() when savedTaskFilterDelete != null:
 return savedTaskFilterDelete(_that);case SyncConfigFlag() when configFlag != null:
 return configFlag(_that);case SyncThemingSelection() when themingSelection != null:
-return themingSelection(_that);case SyncNotification() when notification != null:
+return themingSelection(_that);case SyncDailyOsUserName() when dailyOsUserName != null:
+return dailyOsUserName(_that);case SyncNotification() when notification != null:
 return notification(_that);case SyncNotificationStateUpdate() when notificationStateUpdate != null:
 return notificationStateUpdate(_that);case SyncBackfillRequest() when backfillRequest != null:
 return backfillRequest(_that);case SyncBackfillResponse() when backfillResponse != null:
@@ -459,7 +464,7 @@ return outboxBundle(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( SyncJournalEntity value)  journalEntity,required TResult Function( SyncEntityDefinition value)  entityDefinition,required TResult Function( SyncEntryLink value)  entryLink,required TResult Function( SyncAiConfig value)  aiConfig,required TResult Function( SyncSyncNodeProfile value)  syncNodeProfile,required TResult Function( SyncAiConfigDelete value)  aiConfigDelete,required TResult Function( SyncSavedTaskFilter value)  savedTaskFilter,required TResult Function( SyncSavedTaskFilterDelete value)  savedTaskFilterDelete,required TResult Function( SyncConfigFlag value)  configFlag,required TResult Function( SyncThemingSelection value)  themingSelection,required TResult Function( SyncNotification value)  notification,required TResult Function( SyncNotificationStateUpdate value)  notificationStateUpdate,required TResult Function( SyncBackfillRequest value)  backfillRequest,required TResult Function( SyncBackfillResponse value)  backfillResponse,required TResult Function( SyncAgentEntity value)  agentEntity,required TResult Function( SyncAgentLink value)  agentLink,required TResult Function( SyncConsumptionEvent value)  consumptionEvent,required TResult Function( SyncAgentBundle value)  agentBundle,required TResult Function( SyncOutboxBundle value)  outboxBundle,}){
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( SyncJournalEntity value)  journalEntity,required TResult Function( SyncEntityDefinition value)  entityDefinition,required TResult Function( SyncEntryLink value)  entryLink,required TResult Function( SyncAiConfig value)  aiConfig,required TResult Function( SyncSyncNodeProfile value)  syncNodeProfile,required TResult Function( SyncAiConfigDelete value)  aiConfigDelete,required TResult Function( SyncSavedTaskFilter value)  savedTaskFilter,required TResult Function( SyncSavedTaskFilterDelete value)  savedTaskFilterDelete,required TResult Function( SyncConfigFlag value)  configFlag,required TResult Function( SyncThemingSelection value)  themingSelection,required TResult Function( SyncDailyOsUserName value)  dailyOsUserName,required TResult Function( SyncNotification value)  notification,required TResult Function( SyncNotificationStateUpdate value)  notificationStateUpdate,required TResult Function( SyncBackfillRequest value)  backfillRequest,required TResult Function( SyncBackfillResponse value)  backfillResponse,required TResult Function( SyncAgentEntity value)  agentEntity,required TResult Function( SyncAgentLink value)  agentLink,required TResult Function( SyncConsumptionEvent value)  consumptionEvent,required TResult Function( SyncAgentBundle value)  agentBundle,required TResult Function( SyncOutboxBundle value)  outboxBundle,}){
 final _that = this;
 switch (_that) {
 case SyncJournalEntity():
@@ -472,7 +477,8 @@ return aiConfigDelete(_that);case SyncSavedTaskFilter():
 return savedTaskFilter(_that);case SyncSavedTaskFilterDelete():
 return savedTaskFilterDelete(_that);case SyncConfigFlag():
 return configFlag(_that);case SyncThemingSelection():
-return themingSelection(_that);case SyncNotification():
+return themingSelection(_that);case SyncDailyOsUserName():
+return dailyOsUserName(_that);case SyncNotification():
 return notification(_that);case SyncNotificationStateUpdate():
 return notificationStateUpdate(_that);case SyncBackfillRequest():
 return backfillRequest(_that);case SyncBackfillResponse():
@@ -495,7 +501,7 @@ return outboxBundle(_that);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( SyncJournalEntity value)?  journalEntity,TResult? Function( SyncEntityDefinition value)?  entityDefinition,TResult? Function( SyncEntryLink value)?  entryLink,TResult? Function( SyncAiConfig value)?  aiConfig,TResult? Function( SyncSyncNodeProfile value)?  syncNodeProfile,TResult? Function( SyncAiConfigDelete value)?  aiConfigDelete,TResult? Function( SyncSavedTaskFilter value)?  savedTaskFilter,TResult? Function( SyncSavedTaskFilterDelete value)?  savedTaskFilterDelete,TResult? Function( SyncConfigFlag value)?  configFlag,TResult? Function( SyncThemingSelection value)?  themingSelection,TResult? Function( SyncNotification value)?  notification,TResult? Function( SyncNotificationStateUpdate value)?  notificationStateUpdate,TResult? Function( SyncBackfillRequest value)?  backfillRequest,TResult? Function( SyncBackfillResponse value)?  backfillResponse,TResult? Function( SyncAgentEntity value)?  agentEntity,TResult? Function( SyncAgentLink value)?  agentLink,TResult? Function( SyncConsumptionEvent value)?  consumptionEvent,TResult? Function( SyncAgentBundle value)?  agentBundle,TResult? Function( SyncOutboxBundle value)?  outboxBundle,}){
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( SyncJournalEntity value)?  journalEntity,TResult? Function( SyncEntityDefinition value)?  entityDefinition,TResult? Function( SyncEntryLink value)?  entryLink,TResult? Function( SyncAiConfig value)?  aiConfig,TResult? Function( SyncSyncNodeProfile value)?  syncNodeProfile,TResult? Function( SyncAiConfigDelete value)?  aiConfigDelete,TResult? Function( SyncSavedTaskFilter value)?  savedTaskFilter,TResult? Function( SyncSavedTaskFilterDelete value)?  savedTaskFilterDelete,TResult? Function( SyncConfigFlag value)?  configFlag,TResult? Function( SyncThemingSelection value)?  themingSelection,TResult? Function( SyncDailyOsUserName value)?  dailyOsUserName,TResult? Function( SyncNotification value)?  notification,TResult? Function( SyncNotificationStateUpdate value)?  notificationStateUpdate,TResult? Function( SyncBackfillRequest value)?  backfillRequest,TResult? Function( SyncBackfillResponse value)?  backfillResponse,TResult? Function( SyncAgentEntity value)?  agentEntity,TResult? Function( SyncAgentLink value)?  agentLink,TResult? Function( SyncConsumptionEvent value)?  consumptionEvent,TResult? Function( SyncAgentBundle value)?  agentBundle,TResult? Function( SyncOutboxBundle value)?  outboxBundle,}){
 final _that = this;
 switch (_that) {
 case SyncJournalEntity() when journalEntity != null:
@@ -508,7 +514,8 @@ return aiConfigDelete(_that);case SyncSavedTaskFilter() when savedTaskFilter != 
 return savedTaskFilter(_that);case SyncSavedTaskFilterDelete() when savedTaskFilterDelete != null:
 return savedTaskFilterDelete(_that);case SyncConfigFlag() when configFlag != null:
 return configFlag(_that);case SyncThemingSelection() when themingSelection != null:
-return themingSelection(_that);case SyncNotification() when notification != null:
+return themingSelection(_that);case SyncDailyOsUserName() when dailyOsUserName != null:
+return dailyOsUserName(_that);case SyncNotification() when notification != null:
 return notification(_that);case SyncNotificationStateUpdate() when notificationStateUpdate != null:
 return notificationStateUpdate(_that);case SyncBackfillRequest() when backfillRequest != null:
 return backfillRequest(_that);case SyncBackfillResponse() when backfillResponse != null:
@@ -534,7 +541,7 @@ return outboxBundle(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( String id,  String jsonPath,  VectorClock? vectorClock,  SyncEntryStatus status,  List<EntryLink>? entryLinks,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)?  journalEntity,TResult Function( EntityDefinition entityDefinition,  SyncEntryStatus status)?  entityDefinition,TResult Function( EntryLink entryLink,  SyncEntryStatus status,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)?  entryLink,TResult Function( AiConfig aiConfig,  SyncEntryStatus status)?  aiConfig,TResult Function( SyncNodeProfile profile)?  syncNodeProfile,TResult Function( String id)?  aiConfigDelete,TResult Function( SavedTaskFilter filter,  SyncEntryStatus status)?  savedTaskFilter,TResult Function( String id)?  savedTaskFilterDelete,TResult Function( String name,  String description,  bool status,  String? originatingHostId)?  configFlag,TResult Function( String lightThemeName,  String darkThemeName,  String themeMode,  int updatedAt,  SyncEntryStatus status)?  themingSelection,TResult Function( String id,  String jsonPath,  VectorClock vectorClock,  String originatingHostId,  List<VectorClock>? coveredVectorClocks)?  notification,TResult Function( String id,  VectorClock vectorClock,  String originatingHostId,  DateTime? seenAt,  DateTime? actedOnAt,  DateTime? deletedAt)?  notificationStateUpdate,TResult Function( List<BackfillRequestEntry> entries,  String requesterId)?  backfillRequest,TResult Function( String hostId,  int counter,  bool deleted,  bool? unresolvable,  String? entryId,  SyncSequencePayloadType? payloadType,  String? payloadId)?  backfillResponse,TResult Function( SyncEntryStatus status,  AgentDomainEntity? agentEntity,  String? jsonPath,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)?  agentEntity,TResult Function( SyncEntryStatus status,  AgentLink? agentLink,  String? jsonPath,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)?  agentLink,TResult Function( AiConsumptionEvent event,  SyncEntryStatus status,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)?  consumptionEvent,TResult Function( String agentId,  String wakeRunKey,  List<SyncAgentEntity> entities,  List<SyncAgentLink> links,  String? jsonPath,  String? originatingHostId)?  agentBundle,TResult Function( List<SyncMessage> children,  String? jsonPath,  String? originatingHostId)?  outboxBundle,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( String id,  String jsonPath,  VectorClock? vectorClock,  SyncEntryStatus status,  List<EntryLink>? entryLinks,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)?  journalEntity,TResult Function( EntityDefinition entityDefinition,  SyncEntryStatus status)?  entityDefinition,TResult Function( EntryLink entryLink,  SyncEntryStatus status,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)?  entryLink,TResult Function( AiConfig aiConfig,  SyncEntryStatus status)?  aiConfig,TResult Function( SyncNodeProfile profile)?  syncNodeProfile,TResult Function( String id)?  aiConfigDelete,TResult Function( SavedTaskFilter filter,  SyncEntryStatus status)?  savedTaskFilter,TResult Function( String id)?  savedTaskFilterDelete,TResult Function( String name,  String description,  bool status,  String? originatingHostId)?  configFlag,TResult Function( String lightThemeName,  String darkThemeName,  String themeMode,  int updatedAt,  SyncEntryStatus status)?  themingSelection,TResult Function( String userName,  int updatedAt,  SyncEntryStatus status)?  dailyOsUserName,TResult Function( String id,  String jsonPath,  VectorClock vectorClock,  String originatingHostId,  List<VectorClock>? coveredVectorClocks)?  notification,TResult Function( String id,  VectorClock vectorClock,  String originatingHostId,  DateTime? seenAt,  DateTime? actedOnAt,  DateTime? deletedAt)?  notificationStateUpdate,TResult Function( List<BackfillRequestEntry> entries,  String requesterId)?  backfillRequest,TResult Function( String hostId,  int counter,  bool deleted,  bool? unresolvable,  String? entryId,  SyncSequencePayloadType? payloadType,  String? payloadId)?  backfillResponse,TResult Function( SyncEntryStatus status,  AgentDomainEntity? agentEntity,  String? jsonPath,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)?  agentEntity,TResult Function( SyncEntryStatus status,  AgentLink? agentLink,  String? jsonPath,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)?  agentLink,TResult Function( AiConsumptionEvent event,  SyncEntryStatus status,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)?  consumptionEvent,TResult Function( String agentId,  String wakeRunKey,  List<SyncAgentEntity> entities,  List<SyncAgentLink> links,  String? jsonPath,  String? originatingHostId)?  agentBundle,TResult Function( List<SyncMessage> children,  String? jsonPath,  String? originatingHostId)?  outboxBundle,required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case SyncJournalEntity() when journalEntity != null:
 return journalEntity(_that.id,_that.jsonPath,_that.vectorClock,_that.status,_that.entryLinks,_that.originatingHostId,_that.coveredVectorClocks);case SyncEntityDefinition() when entityDefinition != null:
@@ -546,7 +553,8 @@ return aiConfigDelete(_that.id);case SyncSavedTaskFilter() when savedTaskFilter 
 return savedTaskFilter(_that.filter,_that.status);case SyncSavedTaskFilterDelete() when savedTaskFilterDelete != null:
 return savedTaskFilterDelete(_that.id);case SyncConfigFlag() when configFlag != null:
 return configFlag(_that.name,_that.description,_that.status,_that.originatingHostId);case SyncThemingSelection() when themingSelection != null:
-return themingSelection(_that.lightThemeName,_that.darkThemeName,_that.themeMode,_that.updatedAt,_that.status);case SyncNotification() when notification != null:
+return themingSelection(_that.lightThemeName,_that.darkThemeName,_that.themeMode,_that.updatedAt,_that.status);case SyncDailyOsUserName() when dailyOsUserName != null:
+return dailyOsUserName(_that.userName,_that.updatedAt,_that.status);case SyncNotification() when notification != null:
 return notification(_that.id,_that.jsonPath,_that.vectorClock,_that.originatingHostId,_that.coveredVectorClocks);case SyncNotificationStateUpdate() when notificationStateUpdate != null:
 return notificationStateUpdate(_that.id,_that.vectorClock,_that.originatingHostId,_that.seenAt,_that.actedOnAt,_that.deletedAt);case SyncBackfillRequest() when backfillRequest != null:
 return backfillRequest(_that.entries,_that.requesterId);case SyncBackfillResponse() when backfillResponse != null:
@@ -573,7 +581,7 @@ return outboxBundle(_that.children,_that.jsonPath,_that.originatingHostId);case 
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( String id,  String jsonPath,  VectorClock? vectorClock,  SyncEntryStatus status,  List<EntryLink>? entryLinks,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)  journalEntity,required TResult Function( EntityDefinition entityDefinition,  SyncEntryStatus status)  entityDefinition,required TResult Function( EntryLink entryLink,  SyncEntryStatus status,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)  entryLink,required TResult Function( AiConfig aiConfig,  SyncEntryStatus status)  aiConfig,required TResult Function( SyncNodeProfile profile)  syncNodeProfile,required TResult Function( String id)  aiConfigDelete,required TResult Function( SavedTaskFilter filter,  SyncEntryStatus status)  savedTaskFilter,required TResult Function( String id)  savedTaskFilterDelete,required TResult Function( String name,  String description,  bool status,  String? originatingHostId)  configFlag,required TResult Function( String lightThemeName,  String darkThemeName,  String themeMode,  int updatedAt,  SyncEntryStatus status)  themingSelection,required TResult Function( String id,  String jsonPath,  VectorClock vectorClock,  String originatingHostId,  List<VectorClock>? coveredVectorClocks)  notification,required TResult Function( String id,  VectorClock vectorClock,  String originatingHostId,  DateTime? seenAt,  DateTime? actedOnAt,  DateTime? deletedAt)  notificationStateUpdate,required TResult Function( List<BackfillRequestEntry> entries,  String requesterId)  backfillRequest,required TResult Function( String hostId,  int counter,  bool deleted,  bool? unresolvable,  String? entryId,  SyncSequencePayloadType? payloadType,  String? payloadId)  backfillResponse,required TResult Function( SyncEntryStatus status,  AgentDomainEntity? agentEntity,  String? jsonPath,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)  agentEntity,required TResult Function( SyncEntryStatus status,  AgentLink? agentLink,  String? jsonPath,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)  agentLink,required TResult Function( AiConsumptionEvent event,  SyncEntryStatus status,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)  consumptionEvent,required TResult Function( String agentId,  String wakeRunKey,  List<SyncAgentEntity> entities,  List<SyncAgentLink> links,  String? jsonPath,  String? originatingHostId)  agentBundle,required TResult Function( List<SyncMessage> children,  String? jsonPath,  String? originatingHostId)  outboxBundle,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( String id,  String jsonPath,  VectorClock? vectorClock,  SyncEntryStatus status,  List<EntryLink>? entryLinks,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)  journalEntity,required TResult Function( EntityDefinition entityDefinition,  SyncEntryStatus status)  entityDefinition,required TResult Function( EntryLink entryLink,  SyncEntryStatus status,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)  entryLink,required TResult Function( AiConfig aiConfig,  SyncEntryStatus status)  aiConfig,required TResult Function( SyncNodeProfile profile)  syncNodeProfile,required TResult Function( String id)  aiConfigDelete,required TResult Function( SavedTaskFilter filter,  SyncEntryStatus status)  savedTaskFilter,required TResult Function( String id)  savedTaskFilterDelete,required TResult Function( String name,  String description,  bool status,  String? originatingHostId)  configFlag,required TResult Function( String lightThemeName,  String darkThemeName,  String themeMode,  int updatedAt,  SyncEntryStatus status)  themingSelection,required TResult Function( String userName,  int updatedAt,  SyncEntryStatus status)  dailyOsUserName,required TResult Function( String id,  String jsonPath,  VectorClock vectorClock,  String originatingHostId,  List<VectorClock>? coveredVectorClocks)  notification,required TResult Function( String id,  VectorClock vectorClock,  String originatingHostId,  DateTime? seenAt,  DateTime? actedOnAt,  DateTime? deletedAt)  notificationStateUpdate,required TResult Function( List<BackfillRequestEntry> entries,  String requesterId)  backfillRequest,required TResult Function( String hostId,  int counter,  bool deleted,  bool? unresolvable,  String? entryId,  SyncSequencePayloadType? payloadType,  String? payloadId)  backfillResponse,required TResult Function( SyncEntryStatus status,  AgentDomainEntity? agentEntity,  String? jsonPath,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)  agentEntity,required TResult Function( SyncEntryStatus status,  AgentLink? agentLink,  String? jsonPath,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)  agentLink,required TResult Function( AiConsumptionEvent event,  SyncEntryStatus status,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)  consumptionEvent,required TResult Function( String agentId,  String wakeRunKey,  List<SyncAgentEntity> entities,  List<SyncAgentLink> links,  String? jsonPath,  String? originatingHostId)  agentBundle,required TResult Function( List<SyncMessage> children,  String? jsonPath,  String? originatingHostId)  outboxBundle,}) {final _that = this;
 switch (_that) {
 case SyncJournalEntity():
 return journalEntity(_that.id,_that.jsonPath,_that.vectorClock,_that.status,_that.entryLinks,_that.originatingHostId,_that.coveredVectorClocks);case SyncEntityDefinition():
@@ -585,7 +593,8 @@ return aiConfigDelete(_that.id);case SyncSavedTaskFilter():
 return savedTaskFilter(_that.filter,_that.status);case SyncSavedTaskFilterDelete():
 return savedTaskFilterDelete(_that.id);case SyncConfigFlag():
 return configFlag(_that.name,_that.description,_that.status,_that.originatingHostId);case SyncThemingSelection():
-return themingSelection(_that.lightThemeName,_that.darkThemeName,_that.themeMode,_that.updatedAt,_that.status);case SyncNotification():
+return themingSelection(_that.lightThemeName,_that.darkThemeName,_that.themeMode,_that.updatedAt,_that.status);case SyncDailyOsUserName():
+return dailyOsUserName(_that.userName,_that.updatedAt,_that.status);case SyncNotification():
 return notification(_that.id,_that.jsonPath,_that.vectorClock,_that.originatingHostId,_that.coveredVectorClocks);case SyncNotificationStateUpdate():
 return notificationStateUpdate(_that.id,_that.vectorClock,_that.originatingHostId,_that.seenAt,_that.actedOnAt,_that.deletedAt);case SyncBackfillRequest():
 return backfillRequest(_that.entries,_that.requesterId);case SyncBackfillResponse():
@@ -608,7 +617,7 @@ return outboxBundle(_that.children,_that.jsonPath,_that.originatingHostId);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( String id,  String jsonPath,  VectorClock? vectorClock,  SyncEntryStatus status,  List<EntryLink>? entryLinks,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)?  journalEntity,TResult? Function( EntityDefinition entityDefinition,  SyncEntryStatus status)?  entityDefinition,TResult? Function( EntryLink entryLink,  SyncEntryStatus status,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)?  entryLink,TResult? Function( AiConfig aiConfig,  SyncEntryStatus status)?  aiConfig,TResult? Function( SyncNodeProfile profile)?  syncNodeProfile,TResult? Function( String id)?  aiConfigDelete,TResult? Function( SavedTaskFilter filter,  SyncEntryStatus status)?  savedTaskFilter,TResult? Function( String id)?  savedTaskFilterDelete,TResult? Function( String name,  String description,  bool status,  String? originatingHostId)?  configFlag,TResult? Function( String lightThemeName,  String darkThemeName,  String themeMode,  int updatedAt,  SyncEntryStatus status)?  themingSelection,TResult? Function( String id,  String jsonPath,  VectorClock vectorClock,  String originatingHostId,  List<VectorClock>? coveredVectorClocks)?  notification,TResult? Function( String id,  VectorClock vectorClock,  String originatingHostId,  DateTime? seenAt,  DateTime? actedOnAt,  DateTime? deletedAt)?  notificationStateUpdate,TResult? Function( List<BackfillRequestEntry> entries,  String requesterId)?  backfillRequest,TResult? Function( String hostId,  int counter,  bool deleted,  bool? unresolvable,  String? entryId,  SyncSequencePayloadType? payloadType,  String? payloadId)?  backfillResponse,TResult? Function( SyncEntryStatus status,  AgentDomainEntity? agentEntity,  String? jsonPath,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)?  agentEntity,TResult? Function( SyncEntryStatus status,  AgentLink? agentLink,  String? jsonPath,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)?  agentLink,TResult? Function( AiConsumptionEvent event,  SyncEntryStatus status,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)?  consumptionEvent,TResult? Function( String agentId,  String wakeRunKey,  List<SyncAgentEntity> entities,  List<SyncAgentLink> links,  String? jsonPath,  String? originatingHostId)?  agentBundle,TResult? Function( List<SyncMessage> children,  String? jsonPath,  String? originatingHostId)?  outboxBundle,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( String id,  String jsonPath,  VectorClock? vectorClock,  SyncEntryStatus status,  List<EntryLink>? entryLinks,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)?  journalEntity,TResult? Function( EntityDefinition entityDefinition,  SyncEntryStatus status)?  entityDefinition,TResult? Function( EntryLink entryLink,  SyncEntryStatus status,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)?  entryLink,TResult? Function( AiConfig aiConfig,  SyncEntryStatus status)?  aiConfig,TResult? Function( SyncNodeProfile profile)?  syncNodeProfile,TResult? Function( String id)?  aiConfigDelete,TResult? Function( SavedTaskFilter filter,  SyncEntryStatus status)?  savedTaskFilter,TResult? Function( String id)?  savedTaskFilterDelete,TResult? Function( String name,  String description,  bool status,  String? originatingHostId)?  configFlag,TResult? Function( String lightThemeName,  String darkThemeName,  String themeMode,  int updatedAt,  SyncEntryStatus status)?  themingSelection,TResult? Function( String userName,  int updatedAt,  SyncEntryStatus status)?  dailyOsUserName,TResult? Function( String id,  String jsonPath,  VectorClock vectorClock,  String originatingHostId,  List<VectorClock>? coveredVectorClocks)?  notification,TResult? Function( String id,  VectorClock vectorClock,  String originatingHostId,  DateTime? seenAt,  DateTime? actedOnAt,  DateTime? deletedAt)?  notificationStateUpdate,TResult? Function( List<BackfillRequestEntry> entries,  String requesterId)?  backfillRequest,TResult? Function( String hostId,  int counter,  bool deleted,  bool? unresolvable,  String? entryId,  SyncSequencePayloadType? payloadType,  String? payloadId)?  backfillResponse,TResult? Function( SyncEntryStatus status,  AgentDomainEntity? agentEntity,  String? jsonPath,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)?  agentEntity,TResult? Function( SyncEntryStatus status,  AgentLink? agentLink,  String? jsonPath,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)?  agentLink,TResult? Function( AiConsumptionEvent event,  SyncEntryStatus status,  String? originatingHostId,  List<VectorClock>? coveredVectorClocks)?  consumptionEvent,TResult? Function( String agentId,  String wakeRunKey,  List<SyncAgentEntity> entities,  List<SyncAgentLink> links,  String? jsonPath,  String? originatingHostId)?  agentBundle,TResult? Function( List<SyncMessage> children,  String? jsonPath,  String? originatingHostId)?  outboxBundle,}) {final _that = this;
 switch (_that) {
 case SyncJournalEntity() when journalEntity != null:
 return journalEntity(_that.id,_that.jsonPath,_that.vectorClock,_that.status,_that.entryLinks,_that.originatingHostId,_that.coveredVectorClocks);case SyncEntityDefinition() when entityDefinition != null:
@@ -620,7 +629,8 @@ return aiConfigDelete(_that.id);case SyncSavedTaskFilter() when savedTaskFilter 
 return savedTaskFilter(_that.filter,_that.status);case SyncSavedTaskFilterDelete() when savedTaskFilterDelete != null:
 return savedTaskFilterDelete(_that.id);case SyncConfigFlag() when configFlag != null:
 return configFlag(_that.name,_that.description,_that.status,_that.originatingHostId);case SyncThemingSelection() when themingSelection != null:
-return themingSelection(_that.lightThemeName,_that.darkThemeName,_that.themeMode,_that.updatedAt,_that.status);case SyncNotification() when notification != null:
+return themingSelection(_that.lightThemeName,_that.darkThemeName,_that.themeMode,_that.updatedAt,_that.status);case SyncDailyOsUserName() when dailyOsUserName != null:
+return dailyOsUserName(_that.userName,_that.updatedAt,_that.status);case SyncNotification() when notification != null:
 return notification(_that.id,_that.jsonPath,_that.vectorClock,_that.originatingHostId,_that.coveredVectorClocks);case SyncNotificationStateUpdate() when notificationStateUpdate != null:
 return notificationStateUpdate(_that.id,_that.vectorClock,_that.originatingHostId,_that.seenAt,_that.actedOnAt,_that.deletedAt);case SyncBackfillRequest() when backfillRequest != null:
 return backfillRequest(_that.entries,_that.requesterId);case SyncBackfillResponse() when backfillResponse != null:
@@ -1485,6 +1495,83 @@ class _$SyncThemingSelectionCopyWithImpl<$Res>
 lightThemeName: null == lightThemeName ? _self.lightThemeName : lightThemeName // ignore: cast_nullable_to_non_nullable
 as String,darkThemeName: null == darkThemeName ? _self.darkThemeName : darkThemeName // ignore: cast_nullable_to_non_nullable
 as String,themeMode: null == themeMode ? _self.themeMode : themeMode // ignore: cast_nullable_to_non_nullable
+as String,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as int,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as SyncEntryStatus,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class SyncDailyOsUserName implements SyncMessage {
+  const SyncDailyOsUserName({required this.userName, required this.updatedAt, required this.status, final  String? $type}): $type = $type ?? 'dailyOsUserName';
+  factory SyncDailyOsUserName.fromJson(Map<String, dynamic> json) => _$SyncDailyOsUserNameFromJson(json);
+
+ final  String userName;
+ final  int updatedAt;
+ final  SyncEntryStatus status;
+
+@JsonKey(name: 'runtimeType')
+final String $type;
+
+
+/// Create a copy of SyncMessage
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SyncDailyOsUserNameCopyWith<SyncDailyOsUserName> get copyWith => _$SyncDailyOsUserNameCopyWithImpl<SyncDailyOsUserName>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SyncDailyOsUserNameToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SyncDailyOsUserName&&(identical(other.userName, userName) || other.userName == userName)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.status, status) || other.status == status));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,userName,updatedAt,status);
+
+@override
+String toString() {
+  return 'SyncMessage.dailyOsUserName(userName: $userName, updatedAt: $updatedAt, status: $status)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SyncDailyOsUserNameCopyWith<$Res> implements $SyncMessageCopyWith<$Res> {
+  factory $SyncDailyOsUserNameCopyWith(SyncDailyOsUserName value, $Res Function(SyncDailyOsUserName) _then) = _$SyncDailyOsUserNameCopyWithImpl;
+@useResult
+$Res call({
+ String userName, int updatedAt, SyncEntryStatus status
+});
+
+
+
+
+}
+/// @nodoc
+class _$SyncDailyOsUserNameCopyWithImpl<$Res>
+    implements $SyncDailyOsUserNameCopyWith<$Res> {
+  _$SyncDailyOsUserNameCopyWithImpl(this._self, this._then);
+
+  final SyncDailyOsUserName _self;
+  final $Res Function(SyncDailyOsUserName) _then;
+
+/// Create a copy of SyncMessage
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? userName = null,Object? updatedAt = null,Object? status = null,}) {
+  return _then(SyncDailyOsUserName(
+userName: null == userName ? _self.userName : userName // ignore: cast_nullable_to_non_nullable
 as String,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
 as int,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
 as SyncEntryStatus,

--- a/lib/features/sync/model/sync_message.g.dart
+++ b/lib/features/sync/model/sync_message.g.dart
@@ -193,6 +193,23 @@ Map<String, dynamic> _$SyncThemingSelectionToJson(
   'runtimeType': instance.$type,
 };
 
+SyncDailyOsUserName _$SyncDailyOsUserNameFromJson(Map<String, dynamic> json) =>
+    SyncDailyOsUserName(
+      userName: json['userName'] as String,
+      updatedAt: (json['updatedAt'] as num).toInt(),
+      status: $enumDecode(_$SyncEntryStatusEnumMap, json['status']),
+      $type: json['runtimeType'] as String?,
+    );
+
+Map<String, dynamic> _$SyncDailyOsUserNameToJson(
+  SyncDailyOsUserName instance,
+) => <String, dynamic>{
+  'userName': instance.userName,
+  'updatedAt': instance.updatedAt,
+  'status': _$SyncEntryStatusEnumMap[instance.status]!,
+  'runtimeType': instance.$type,
+};
+
 SyncNotification _$SyncNotificationFromJson(Map<String, dynamic> json) =>
     SyncNotification(
       id: json['id'] as String,

--- a/lib/features/sync/outbox/outbox_enqueue_writer_simple.dart
+++ b/lib/features/sync/outbox/outbox_enqueue_writer_simple.dart
@@ -146,6 +146,17 @@ extension OutboxEnqueueSimple on OutboxEnqueueWriter {
         'mode=${msg.themeMode}',
   );
 
+  Future<bool> enqueueDailyOsUserName({
+    required SyncDailyOsUserName msg,
+    required OutboxCompanion commonFields,
+  }) => enqueueSimple(
+    commonFields: commonFields,
+    subject: 'dailyOsUserName',
+    logMessage:
+        'enqueue type=SyncDailyOsUserName subject=dailyOsUserName '
+        'updatedAt=${msg.updatedAt}',
+  );
+
   /// Enqueues a notification message: validates the payload path stays within
   /// the documents root, folds the message's own clock into
   /// `coveredVectorClocks`, sizes the row including the on-disk attachment, and

--- a/lib/features/sync/outbox/outbox_scheduling.dart
+++ b/lib/features/sync/outbox/outbox_scheduling.dart
@@ -32,6 +32,7 @@ int priorityForMessage(SyncMessage message) {
     SyncConsumptionEvent() => OutboxPriority.low.index,
     SyncAgentBundle() => OutboxPriority.normal.index,
     SyncThemingSelection() => OutboxPriority.normal.index,
+    SyncDailyOsUserName() => OutboxPriority.normal.index,
     SyncEntityDefinition() => OutboxPriority.low.index,
     SyncAiConfig() => OutboxPriority.low.index,
     SyncAiConfigDelete() => OutboxPriority.low.index,

--- a/lib/features/sync/outbox/outbox_service.dart
+++ b/lib/features/sync/outbox/outbox_service.dart
@@ -430,6 +430,10 @@ class OutboxService extends _OutboxServiceBase with _OutboxSend {
             msg: msg,
             commonFields: commonFields,
           ),
+        final SyncDailyOsUserName msg => _enqueueWriter.enqueueDailyOsUserName(
+          msg: msg,
+          commonFields: commonFields,
+        ),
         final SyncNotification msg => _enqueueWriter.enqueueNotification(
           msg: msg,
           commonFields: commonFields,

--- a/lib/features/sync/queue/queue_apply_adapter.dart
+++ b/lib/features/sync/queue/queue_apply_adapter.dart
@@ -338,6 +338,8 @@ class QueueApplyAdapter {
       configFlag: (_) => true,
       // settings_db.
       themingSelection: (_) => false,
+      // settings_db (Daily OS greeting name).
+      dailyOsUserName: (_) => false,
       // notifications_db.
       notification: (_) => false,
       notificationStateUpdate: (_) => false,

--- a/lib/features/sync/ui/view_models/outbox_list_item_view_model.dart
+++ b/lib/features/sync/ui/view_models/outbox_list_item_view_model.dart
@@ -159,6 +159,7 @@ class OutboxListItemViewModel {
         savedTaskFilterDelete: (_) => messages.syncPayloadSavedTaskFilterDelete,
         configFlag: (_) => messages.syncPayloadConfigFlag,
         themingSelection: (_) => messages.syncPayloadThemingSelection,
+        dailyOsUserName: (_) => messages.syncPayloadDailyOsUserName,
         notification: (_) => messages.syncPayloadNotification,
         notificationStateUpdate: (_) =>
             messages.syncPayloadNotificationStateUpdate,

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -3445,6 +3445,7 @@
   "syncPayloadBackfillResponse": "Odpověď na doplnění",
   "syncPayloadConfigFlag": "Konfigurační příznak",
   "syncPayloadConsumptionEvent": "Spotřeba AI",
+  "syncPayloadDailyOsUserName": "Jméno Daily OS",
   "syncPayloadEntityDefinition": "Definice entity",
   "syncPayloadEntryLink": "Odkaz na položku",
   "syncPayloadJournalEntity": "Položka deníku",

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -3002,7 +3002,7 @@
   "settingsAboutAppTagline": "Váš osobní deník",
   "settingsAboutBuildType": "Typ sestavení",
   "settingsAboutDailyOsPersonalizationTitle": "Přizpůsobení Daily OS",
-  "settingsAboutDailyOsUserNameHelper": "Používá se jen pro pozdrav Daily OS na tomto zařízení.",
+  "settingsAboutDailyOsUserNameHelper": "Používá se pro pozdrav Daily OS a synchronizuje se mezi tvými zařízeními.",
   "settingsAboutDailyOsUserNameLabel": "Tvoje jméno",
   "settingsAboutJournalEntries": "Záznamy v deníku",
   "settingsAboutPlatform": "Platforma",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -3209,7 +3209,7 @@
   "settingsAboutAppTagline": "Dein persönliches Tagebuch",
   "settingsAboutBuildType": "Build-Typ",
   "settingsAboutDailyOsPersonalizationTitle": "Daily-OS-Personalisierung",
-  "settingsAboutDailyOsUserNameHelper": "Wird nur für die Daily-OS-Begrüßung auf diesem Gerät verwendet.",
+  "settingsAboutDailyOsUserNameHelper": "Wird für die Daily-OS-Begrüßung verwendet und mit deinen Geräten synchronisiert.",
   "settingsAboutDailyOsUserNameLabel": "Dein Name",
   "settingsAboutJournalEntries": "Tagebucheinträge",
   "settingsAboutPlatform": "Plattform",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -3660,6 +3660,7 @@
   "syncPayloadBackfillResponse": "Nachfüllantwort",
   "syncPayloadConfigFlag": "Konfigurationsflag",
   "syncPayloadConsumptionEvent": "KI-Verbrauch",
+  "syncPayloadDailyOsUserName": "Daily-OS-Name",
   "syncPayloadEntityDefinition": "Entitätsdefinition",
   "syncPayloadEntryLink": "Eintragsverknüpfung",
   "syncPayloadJournalEntity": "Journaleintrag",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4317,6 +4317,7 @@
   "syncPayloadBackfillResponse": "Backfill response",
   "syncPayloadConfigFlag": "Config flag",
   "syncPayloadConsumptionEvent": "AI consumption",
+  "syncPayloadDailyOsUserName": "Daily OS name",
   "syncPayloadEntityDefinition": "Entity definition",
   "syncPayloadEntryLink": "Entry link",
   "syncPayloadJournalEntity": "Journal entry",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3831,7 +3831,7 @@
   "settingsAboutAppTagline": "Your Personal Journal",
   "settingsAboutBuildType": "Build Type",
   "settingsAboutDailyOsPersonalizationTitle": "Daily OS personalization",
-  "settingsAboutDailyOsUserNameHelper": "Used only for the Daily OS greeting on this device.",
+  "settingsAboutDailyOsUserNameHelper": "Used for the Daily OS greeting and synced across your devices.",
   "settingsAboutDailyOsUserNameLabel": "Your name",
   "settingsAboutJournalEntries": "Journal Entries",
   "settingsAboutPlatform": "Platform",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -3209,7 +3209,7 @@
   "settingsAboutAppTagline": "Tu diario personal",
   "settingsAboutBuildType": "Tipo de compilación",
   "settingsAboutDailyOsPersonalizationTitle": "Personalización de Daily OS",
-  "settingsAboutDailyOsUserNameHelper": "Se usa solo para el saludo de Daily OS en este dispositivo.",
+  "settingsAboutDailyOsUserNameHelper": "Se usa para el saludo de Daily OS y se sincroniza con tus dispositivos.",
   "settingsAboutDailyOsUserNameLabel": "Tu nombre",
   "settingsAboutJournalEntries": "Entradas del diario",
   "settingsAboutPlatform": "Plataforma",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -3660,6 +3660,7 @@
   "syncPayloadBackfillResponse": "Respuesta de relleno",
   "syncPayloadConfigFlag": "Indicador de configuración",
   "syncPayloadConsumptionEvent": "Consumo de IA",
+  "syncPayloadDailyOsUserName": "Nombre de Daily OS",
   "syncPayloadEntityDefinition": "Definición de entidad",
   "syncPayloadEntryLink": "Enlace de entrada",
   "syncPayloadJournalEntity": "Entrada de diario",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -3660,6 +3660,7 @@
   "syncPayloadBackfillResponse": "Réponse de rattrapage",
   "syncPayloadConfigFlag": "Option de configuration",
   "syncPayloadConsumptionEvent": "Consommation IA",
+  "syncPayloadDailyOsUserName": "Nom Daily OS",
   "syncPayloadEntityDefinition": "Définition d'entité",
   "syncPayloadEntryLink": "Lien d'entrée",
   "syncPayloadJournalEntity": "Entrée de journal",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -3209,7 +3209,7 @@
   "settingsAboutAppTagline": "Ton journal personnel",
   "settingsAboutBuildType": "Type de build",
   "settingsAboutDailyOsPersonalizationTitle": "Personnalisation Daily OS",
-  "settingsAboutDailyOsUserNameHelper": "Utilisé seulement pour la salutation Daily OS sur cet appareil.",
+  "settingsAboutDailyOsUserNameHelper": "Utilisé pour la salutation Daily OS et synchronisé sur tes appareils.",
   "settingsAboutDailyOsUserNameLabel": "Ton nom",
   "settingsAboutJournalEntries": "Entrées de journal",
   "settingsAboutPlatform": "Plateforme",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -13039,7 +13039,7 @@ abstract class AppLocalizations {
   /// No description provided for @settingsAboutDailyOsUserNameHelper.
   ///
   /// In en, this message translates to:
-  /// **'Used only for the Daily OS greeting on this device.'**
+  /// **'Used for the Daily OS greeting and synced across your devices.'**
   String get settingsAboutDailyOsUserNameHelper;
 
   /// No description provided for @settingsAboutDailyOsUserNameLabel.

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -15253,6 +15253,12 @@ abstract class AppLocalizations {
   /// **'AI consumption'**
   String get syncPayloadConsumptionEvent;
 
+  /// No description provided for @syncPayloadDailyOsUserName.
+  ///
+  /// In en, this message translates to:
+  /// **'Daily OS name'**
+  String get syncPayloadDailyOsUserName;
+
   /// No description provided for @syncPayloadEntityDefinition.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -8986,6 +8986,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get syncPayloadConsumptionEvent => 'Spotřeba AI';
 
   @override
+  String get syncPayloadDailyOsUserName => 'Jméno Daily OS';
+
+  @override
   String get syncPayloadEntityDefinition => 'Definice entity';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -7727,7 +7727,7 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get settingsAboutDailyOsUserNameHelper =>
-      'Používá se jen pro pozdrav Daily OS na tomto zařízení.';
+      'Používá se pro pozdrav Daily OS a synchronizuje se mezi tvými zařízeními.';
 
   @override
   String get settingsAboutDailyOsUserNameLabel => 'Tvoje jméno';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -8939,6 +8939,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get syncPayloadConsumptionEvent => 'KI-Verbrauch';
 
   @override
+  String get syncPayloadDailyOsUserName => 'Daily-OS-Name';
+
+  @override
   String get syncPayloadEntityDefinition => 'Entitätsdefinition';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -7670,7 +7670,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get settingsAboutDailyOsUserNameHelper =>
-      'Wird nur für die Daily-OS-Begrüßung auf diesem Gerät verwendet.';
+      'Wird für die Daily-OS-Begrüßung verwendet und mit deinen Geräten synchronisiert.';
 
   @override
   String get settingsAboutDailyOsUserNameLabel => 'Dein Name';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -8823,6 +8823,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get syncPayloadConsumptionEvent => 'AI consumption';
 
   @override
+  String get syncPayloadDailyOsUserName => 'Daily OS name';
+
+  @override
   String get syncPayloadEntityDefinition => 'Entity definition';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -7579,7 +7579,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get settingsAboutDailyOsUserNameHelper =>
-      'Used only for the Daily OS greeting on this device.';
+      'Used for the Daily OS greeting and synced across your devices.';
 
   @override
   String get settingsAboutDailyOsUserNameLabel => 'Your name';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -9036,6 +9036,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get syncPayloadConsumptionEvent => 'Consumo de IA';
 
   @override
+  String get syncPayloadDailyOsUserName => 'Nombre de Daily OS';
+
+  @override
   String get syncPayloadEntityDefinition => 'Definición de entidad';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -7759,7 +7759,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get settingsAboutDailyOsUserNameHelper =>
-      'Se usa solo para el saludo de Daily OS en este dispositivo.';
+      'Se usa para el saludo de Daily OS y se sincroniza con tus dispositivos.';
 
   @override
   String get settingsAboutDailyOsUserNameLabel => 'Tu nombre';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -9056,6 +9056,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get syncPayloadConsumptionEvent => 'Consommation IA';
 
   @override
+  String get syncPayloadDailyOsUserName => 'Nom Daily OS';
+
+  @override
   String get syncPayloadEntityDefinition => 'Définition d\'entité';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -7772,7 +7772,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get settingsAboutDailyOsUserNameHelper =>
-      'Utilisé seulement pour la salutation Daily OS sur cet appareil.';
+      'Utilisé pour la salutation Daily OS et synchronisé sur tes appareils.';
 
   @override
   String get settingsAboutDailyOsUserNameLabel => 'Ton nom';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -9047,6 +9047,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get syncPayloadConsumptionEvent => 'Consum AI';
 
   @override
+  String get syncPayloadDailyOsUserName => 'Nume Daily OS';
+
+  @override
   String get syncPayloadEntityDefinition => 'Definiție entitate';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -7770,7 +7770,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get settingsAboutDailyOsUserNameHelper =>
-      'Folosit doar pentru salutul Daily OS pe acest dispozitiv.';
+      'Folosit pentru salutul Daily OS și sincronizat pe dispozitivele dvs.';
 
   @override
   String get settingsAboutDailyOsUserNameLabel => 'Numele dvs.';

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -3209,7 +3209,7 @@
   "settingsAboutAppTagline": "Jurnalul tău personal",
   "settingsAboutBuildType": "Tip build",
   "settingsAboutDailyOsPersonalizationTitle": "Personalizare Daily OS",
-  "settingsAboutDailyOsUserNameHelper": "Folosit doar pentru salutul Daily OS pe acest dispozitiv.",
+  "settingsAboutDailyOsUserNameHelper": "Folosit pentru salutul Daily OS și sincronizat pe dispozitivele dvs.",
   "settingsAboutDailyOsUserNameLabel": "Numele dvs.",
   "settingsAboutJournalEntries": "Intrări jurnal",
   "settingsAboutPlatform": "Platformă",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -3660,6 +3660,7 @@
   "syncPayloadBackfillResponse": "Răspuns de completare",
   "syncPayloadConfigFlag": "Indicator de configurare",
   "syncPayloadConsumptionEvent": "Consum AI",
+  "syncPayloadDailyOsUserName": "Nume Daily OS",
   "syncPayloadEntityDefinition": "Definiție entitate",
   "syncPayloadEntryLink": "Link intrare",
   "syncPayloadJournalEntity": "Intrare jurnal",

--- a/test/features/daily_os_next/state/daily_os_preferences_controller_test.dart
+++ b/test/features/daily_os_next/state/daily_os_preferences_controller_test.dart
@@ -14,6 +14,7 @@ import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/domain_logging.dart';
 import 'package:mocktail/mocktail.dart';
 
+import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
 import '../../../widget_test_utils.dart';
 
@@ -243,16 +244,7 @@ void main() {
     late TestGetItMocks mocks;
     late ProviderContainer container;
 
-    setUpAll(() {
-      registerFallbackValue(
-        const SyncMessage.dailyOsUserName(
-          userName: '',
-          updatedAt: 0,
-          status: SyncEntryStatus.update,
-        ),
-      );
-      registerFallbackValue(StackTrace.empty);
-    });
+    setUpAll(registerAllFallbackValues);
 
     setUp(() async {
       outboxService = MockOutboxService();

--- a/test/features/daily_os_next/state/daily_os_preferences_controller_test.dart
+++ b/test/features/daily_os_next/state/daily_os_preferences_controller_test.dart
@@ -1,10 +1,20 @@
+import 'dart:async';
+
+import 'package:easy_debounce/easy_debounce.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
 import 'package:glados/glados.dart' as glados;
 import 'package:lotti/features/daily_os_next/logic/day_agent_models.dart';
 import 'package:lotti/features/daily_os_next/state/daily_os_preferences_controller.dart';
+import 'package:lotti/features/sync/model/sync_message.dart';
+import 'package:lotti/features/sync/outbox/outbox_service.dart';
+import 'package:lotti/services/db_notification.dart';
+import 'package:lotti/services/domain_logging.dart';
 import 'package:mocktail/mocktail.dart';
 
+import '../../../mocks/mocks.dart';
 import '../../../widget_test_utils.dart';
 
 void main() {
@@ -223,6 +233,180 @@ void main() {
           '[]',
         ),
       ).called(1);
+    });
+  });
+
+  group('DailyOsPreferencesController name sync', () {
+    late MockOutboxService outboxService;
+    late MockDomainLogger domainLogger;
+    late StreamController<Set<String>> notifications;
+    late TestGetItMocks mocks;
+    late ProviderContainer container;
+
+    setUpAll(() {
+      registerFallbackValue(
+        const SyncMessage.dailyOsUserName(
+          userName: '',
+          updatedAt: 0,
+          status: SyncEntryStatus.update,
+        ),
+      );
+      registerFallbackValue(StackTrace.empty);
+    });
+
+    setUp(() async {
+      outboxService = MockOutboxService();
+      domainLogger = MockDomainLogger();
+      notifications = StreamController<Set<String>>.broadcast();
+      mocks = await setUpTestGetIt(
+        additionalSetup: () {
+          GetIt.I.allowReassignment = true;
+          GetIt.I
+            ..registerSingleton<OutboxService>(outboxService)
+            ..registerSingleton<DomainLogger>(domainLogger);
+        },
+      );
+      when(
+        () => mocks.updateNotifications.updateStream,
+      ).thenAnswer((_) => notifications.stream);
+      when(
+        () => outboxService.enqueueMessage(any<SyncMessage>()),
+      ).thenAnswer((_) async {});
+      when(
+        () => domainLogger.error(
+          any<LogDomain>(),
+          any<Object>(),
+          stackTrace: any<StackTrace>(named: 'stackTrace'),
+          subDomain: any<String>(named: 'subDomain'),
+        ),
+      ).thenReturn(null);
+      container = ProviderContainer();
+    });
+
+    tearDown(() async {
+      EasyDebounce.cancelAll();
+      container.dispose();
+      await notifications.close();
+      await tearDownTestGetIt();
+    });
+
+    test('setUserName enqueues a debounced dailyOsUserName message', () {
+      fakeAsync((async) {
+        container
+            .read(dailyOsPreferencesControllerProvider.notifier)
+            .setUserName('Sam');
+        async
+          ..elapse(const Duration(milliseconds: 400))
+          ..flushMicrotasks();
+
+        final captured = verify(
+          () => outboxService.enqueueMessage(captureAny()),
+        ).captured;
+        expect(captured, hasLength(1));
+        final message = captured.single as SyncDailyOsUserName;
+        expect(message.userName, 'Sam');
+        expect(message.status, SyncEntryStatus.update);
+        expect(message.updatedAt, greaterThan(0));
+
+        verify(
+          () => mocks.settingsDb.saveSettingsItem(
+            dailyOsUserNameUpdatedAtSettingsKey,
+            message.updatedAt.toString(),
+          ),
+        ).called(1);
+      });
+    });
+
+    test('rapid edits coalesce into a single message with the last name', () {
+      fakeAsync((async) {
+        final notifier =
+            container.read(
+                dailyOsPreferencesControllerProvider.notifier,
+              )
+              ..setUserName('S')
+              ..setUserName('Sa')
+              ..setUserName('Sam');
+        async
+          ..elapse(const Duration(milliseconds: 400))
+          ..flushMicrotasks();
+
+        final captured = verify(
+          () => outboxService.enqueueMessage(captureAny()),
+        ).captured;
+        expect(captured, hasLength(1));
+        expect((captured.single as SyncDailyOsUserName).userName, 'Sam');
+        // The controller state also reflects the final edit.
+        expect(
+          container.read(dailyOsPreferencesControllerProvider).userName,
+          'Sam',
+        );
+        expect(notifier, isNotNull);
+      });
+    });
+
+    test('a synced settings notification reloads the name without echo', () {
+      when(
+        () => mocks.settingsDb.itemByKey(dailyOsUserNameSettingsKey),
+      ).thenAnswer((_) async => 'Remote Sam');
+
+      fakeAsync((async) {
+        // Build the controller and let its listener subscribe.
+        container.read(dailyOsPreferencesControllerProvider);
+        async
+          ..elapse(const Duration(milliseconds: 100))
+          ..flushMicrotasks();
+        clearInteractions(outboxService);
+
+        notifications.add({settingsNotification});
+        async
+          ..elapse(const Duration(milliseconds: 100))
+          ..flushMicrotasks();
+
+        expect(
+          container.read(dailyOsPreferencesControllerProvider).userName,
+          'Remote Sam',
+        );
+        // Applying a synced name must not re-enqueue an outbound message.
+        verifyNever(() => outboxService.enqueueMessage(any<SyncMessage>()));
+      });
+    });
+
+    test('no message is enqueued before sync is configured', () {
+      fakeAsync((async) {
+        GetIt.I.unregister<OutboxService>();
+        container
+            .read(dailyOsPreferencesControllerProvider.notifier)
+            .setUserName('Sam');
+        async
+          ..elapse(const Duration(milliseconds: 400))
+          ..flushMicrotasks();
+
+        verifyNever(() => outboxService.enqueueMessage(any<SyncMessage>()));
+      });
+    });
+
+    test('an enqueue failure is caught and logged', () {
+      when(
+        () => outboxService.enqueueMessage(any<SyncMessage>()),
+      ).thenThrow(StateError('outbox down'));
+
+      fakeAsync((async) {
+        container
+            .read(dailyOsPreferencesControllerProvider.notifier)
+            .setUserName('Sam');
+        async
+          ..elapse(const Duration(milliseconds: 400))
+          ..flushMicrotasks();
+
+        verify(
+          () => domainLogger.error(
+            LogDomain.dailyOs,
+            any<Object>(),
+            stackTrace: any<StackTrace>(named: 'stackTrace'),
+            subDomain: 'enqueue',
+          ),
+        ).called(1);
+      });
     });
   });
 }

--- a/test/features/daily_os_next/state/daily_os_preferences_controller_test.dart
+++ b/test/features/daily_os_next/state/daily_os_preferences_controller_test.dart
@@ -408,5 +408,58 @@ void main() {
         ).called(1);
       });
     });
+
+    test('re-setting the current name is a no-op with no redundant sync', () {
+      fakeAsync((async) {
+        final notifier = container.read(
+          dailyOsPreferencesControllerProvider.notifier,
+        )..setUserName('Sam');
+        async
+          ..elapse(const Duration(milliseconds: 400))
+          ..flushMicrotasks();
+        clearInteractions(outboxService);
+        clearInteractions(mocks.settingsDb);
+
+        notifier.setUserName('  Sam  '); // trims to the current value
+        async
+          ..elapse(const Duration(milliseconds: 400))
+          ..flushMicrotasks();
+
+        verifyNever(() => outboxService.enqueueMessage(any<SyncMessage>()));
+        verifyNever(
+          () => mocks.settingsDb.saveSettingsItem(
+            dailyOsUserNameSettingsKey,
+            any(),
+          ),
+        );
+      });
+    });
+
+    test('a reload failure is caught and logged', () {
+      when(
+        () => mocks.settingsDb.itemByKey(dailyOsUserNameSettingsKey),
+      ).thenThrow(StateError('db down'));
+
+      fakeAsync((async) {
+        container.read(dailyOsPreferencesControllerProvider);
+        async
+          ..elapse(const Duration(milliseconds: 100))
+          ..flushMicrotasks();
+
+        notifications.add({settingsNotification});
+        async
+          ..elapse(const Duration(milliseconds: 100))
+          ..flushMicrotasks();
+
+        verify(
+          () => domainLogger.error(
+            LogDomain.dailyOs,
+            any<Object>(),
+            stackTrace: any<StackTrace>(named: 'stackTrace'),
+            subDomain: 'reload',
+          ),
+        ).called(1);
+      });
+    });
   });
 }

--- a/test/features/daily_os_next/state/daily_os_preferences_controller_test.dart
+++ b/test/features/daily_os_next/state/daily_os_preferences_controller_test.dart
@@ -453,5 +453,85 @@ void main() {
         ).called(1);
       });
     });
+
+    void stubStored(Map<String, String> stored) {
+      when(
+        () => mocks.settingsDb.itemsByKeys(any()),
+      ).thenAnswer((_) async => stored);
+    }
+
+    SyncDailyOsUserName buildAndDrainBootstrap(FakeAsync async) {
+      container.read(dailyOsPreferencesControllerProvider);
+      async
+        ..elapse(const Duration(milliseconds: 400))
+        ..flushMicrotasks();
+      final captured = verify(
+        () => outboxService.enqueueMessage(captureAny()),
+      ).captured;
+      expect(captured, hasLength(1));
+      return captured.single as SyncDailyOsUserName;
+    }
+
+    test('bootstraps a pre-sync name with the oldest-possible stamp', () {
+      // Existing name, never published (no updatedAt / syncedAt).
+      stubStored(const {dailyOsUserNameSettingsKey: 'Alice'});
+
+      fakeAsync((async) {
+        final message = buildAndDrainBootstrap(async);
+        expect(message.userName, 'Alice');
+        expect(message.updatedAt, 1);
+        verify(
+          () => mocks.settingsDb.saveSettingsItem(
+            dailyOsUserNameSyncedAtSettingsKey,
+            '1',
+          ),
+        ).called(1);
+      });
+    });
+
+    test('bootstraps a name edited while the outbox was unavailable', () {
+      // Has a real timestamp but was never published (no syncedAt).
+      stubStored(const {
+        dailyOsUserNameSettingsKey: 'Bob',
+        dailyOsUserNameUpdatedAtSettingsKey: '500',
+      });
+
+      fakeAsync((async) {
+        final message = buildAndDrainBootstrap(async);
+        expect(message.userName, 'Bob');
+        expect(message.updatedAt, 500);
+      });
+    });
+
+    test('does not bootstrap a name already published from this device', () {
+      stubStored(const {
+        dailyOsUserNameSettingsKey: 'Sam',
+        dailyOsUserNameUpdatedAtSettingsKey: '500',
+        dailyOsUserNameSyncedAtSettingsKey: '500',
+      });
+
+      fakeAsync((async) {
+        container.read(dailyOsPreferencesControllerProvider);
+        async
+          ..elapse(const Duration(milliseconds: 400))
+          ..flushMicrotasks();
+
+        verifyNever(() => outboxService.enqueueMessage(any<SyncMessage>()));
+      });
+    });
+
+    test('does not bootstrap before sync is configured', () {
+      GetIt.I.unregister<OutboxService>();
+      stubStored(const {dailyOsUserNameSettingsKey: 'Alice'});
+
+      fakeAsync((async) {
+        container.read(dailyOsPreferencesControllerProvider);
+        async
+          ..elapse(const Duration(milliseconds: 400))
+          ..flushMicrotasks();
+
+        verifyNever(() => outboxService.enqueueMessage(any<SyncMessage>()));
+      });
+    });
   });
 }

--- a/test/features/sync/matrix/matrix_service_test.dart
+++ b/test/features/sync/matrix/matrix_service_test.dart
@@ -1170,6 +1170,11 @@ void main() {
         updatedAt: 0,
         status: SyncEntryStatus.initial,
       ),
+      'dailyOsUserName': const SyncMessage.dailyOsUserName(
+        userName: 'Sam',
+        updatedAt: 0,
+        status: SyncEntryStatus.initial,
+      ),
       'backfillRequest': const SyncMessage.backfillRequest(
         entries: [],
         requesterId: 'host-1',

--- a/test/features/sync/matrix/sync_event_processor_test.dart
+++ b/test/features/sync/matrix/sync_event_processor_test.dart
@@ -1331,6 +1331,33 @@ void main() {
         () => settingsDb.saveSettingsItem('DAILY_OS_USER_NAME', 'Sam'),
       ).called(1);
     });
+
+    test('catches and logs a persistence failure during apply', () async {
+      when(
+        () => settingsDb.saveSettingsItem(any(), any()),
+      ).thenThrow(Exception('DB error'));
+
+      final message = SyncMessage.dailyOsUserName(
+        userName: 'Sam',
+        updatedAt: DateTime(2024, 3, 15).millisecondsSinceEpoch,
+        status: SyncEntryStatus.update,
+      );
+
+      // Should not throw — the error is caught and logged.
+      await processor.process(
+        event: createNameEvent(message),
+        journalDb: journalDb,
+      );
+
+      verify(
+        () => loggingService.error(
+          LogDomain.dailyOs,
+          any<Object>(),
+          stackTrace: any<StackTrace>(named: 'stackTrace'),
+          subDomain: 'apply',
+        ),
+      ).called(1);
+    });
   });
 
   group('SyncEventProcessor - Backfill Messages', () {

--- a/test/features/sync/matrix/sync_event_processor_test.dart
+++ b/test/features/sync/matrix/sync_event_processor_test.dart
@@ -1284,6 +1284,13 @@ void main() {
           '$timestamp',
         ),
       ).called(1);
+      // A received name is marked synced so this device won't re-publish it.
+      verify(
+        () => settingsDb.saveSettingsItem(
+          'DAILY_OS_USER_NAME_SYNCED_AT',
+          '$timestamp',
+        ),
+      ).called(1);
       verify(
         () => updateNotifications.notify(any(), fromSync: true),
       ).called(1);

--- a/test/features/sync/matrix/sync_event_processor_test.dart
+++ b/test/features/sync/matrix/sync_event_processor_test.dart
@@ -1247,6 +1247,92 @@ void main() {
     });
   });
 
+  group('SyncEventProcessor - SyncDailyOsUserName', () {
+    Event createNameEvent(SyncMessage message) {
+      final event = MockEvent();
+      final encoded = base64.encode(utf8.encode(json.encode(message.toJson())));
+      when(() => event.eventId).thenReturn('event-id');
+      when(() => event.originServerTs).thenReturn(DateTime(2024));
+      when(() => event.content).thenReturn({
+        'msgtype': 'com.lotti.sync.message',
+        'body': 'sync',
+        'data': encoded,
+      });
+      when(() => event.text).thenReturn(encoded);
+      return event;
+    }
+
+    test('applies a newer name and notifies settings listeners', () async {
+      final timestamp = DateTime(2024, 3, 15).millisecondsSinceEpoch;
+      final message = SyncMessage.dailyOsUserName(
+        userName: 'Sam',
+        updatedAt: timestamp,
+        status: SyncEntryStatus.update,
+      );
+
+      await processor.process(
+        event: createNameEvent(message),
+        journalDb: journalDb,
+      );
+
+      verify(
+        () => settingsDb.saveSettingsItem('DAILY_OS_USER_NAME', 'Sam'),
+      ).called(1);
+      verify(
+        () => settingsDb.saveSettingsItem(
+          'DAILY_OS_USER_NAME_UPDATED_AT',
+          '$timestamp',
+        ),
+      ).called(1);
+      verify(
+        () => updateNotifications.notify(any(), fromSync: true),
+      ).called(1);
+    });
+
+    test('ignores a stale name based on the stored timestamp', () async {
+      when(
+        () => settingsDb.itemByKey('DAILY_OS_USER_NAME_UPDATED_AT'),
+      ).thenAnswer((_) async => '9999999999999');
+
+      const message = SyncMessage.dailyOsUserName(
+        userName: 'Stale',
+        updatedAt: 1000000000000,
+        status: SyncEntryStatus.update,
+      );
+
+      await processor.process(
+        event: createNameEvent(message),
+        journalDb: journalDb,
+      );
+
+      verifyNever(
+        () => settingsDb.saveSettingsItem('DAILY_OS_USER_NAME', any()),
+      );
+    });
+
+    test('accepts the name when no local timestamp exists', () async {
+      when(
+        () => settingsDb.itemByKey('DAILY_OS_USER_NAME_UPDATED_AT'),
+      ).thenAnswer((_) async => null);
+
+      final timestamp = DateTime(2024, 3, 15).millisecondsSinceEpoch;
+      final message = SyncMessage.dailyOsUserName(
+        userName: 'Sam',
+        updatedAt: timestamp,
+        status: SyncEntryStatus.update,
+      );
+
+      await processor.process(
+        event: createNameEvent(message),
+        journalDb: journalDb,
+      );
+
+      verify(
+        () => settingsDb.saveSettingsItem('DAILY_OS_USER_NAME', 'Sam'),
+      ).called(1);
+    });
+  });
+
   group('SyncEventProcessor - Backfill Messages', () {
     test('SyncBackfillRequest throws when no handler configured', () async {
       const message = SyncBackfillRequest(

--- a/test/features/sync/model/sync_message_test.dart
+++ b/test/features/sync/model/sync_message_test.dart
@@ -114,6 +114,40 @@ void main() {
     });
   });
 
+  group('SyncMessage.dailyOsUserName', () {
+    test('serializes to JSON correctly', () {
+      const message = SyncMessage.dailyOsUserName(
+        userName: 'Sam',
+        updatedAt: 1234567890,
+        status: SyncEntryStatus.update,
+      );
+
+      final json = message.toJson();
+
+      expect(json['runtimeType'], 'dailyOsUserName');
+      expect(json['userName'], 'Sam');
+      expect(json['updatedAt'], 1234567890);
+      expect(json['status'], 'update');
+    });
+
+    test('round-trip preserves all fields', () {
+      const original =
+          SyncMessage.dailyOsUserName(
+                userName: 'Sam',
+                updatedAt: 9876543210,
+                status: SyncEntryStatus.initial,
+              )
+              as SyncDailyOsUserName;
+
+      final decoded =
+          SyncMessage.fromJson(original.toJson()) as SyncDailyOsUserName;
+
+      expect(decoded.userName, original.userName);
+      expect(decoded.updatedAt, original.updatedAt);
+      expect(decoded.status, original.status);
+    });
+  });
+
   group('SyncMessage.syncNodeProfile', () {
     final updatedAt = DateTime.utc(2026, 3, 15, 12, 30);
 

--- a/test/features/sync/outbox/outbox_scheduling_test.dart
+++ b/test/features/sync/outbox/outbox_scheduling_test.dart
@@ -20,6 +20,7 @@ enum _GeneratedPriorityMessageKind {
   aiConfig,
   aiConfigDelete,
   themingSelection,
+  dailyOsUserName,
   backfillRequest,
   backfillResponse,
   agentEntity,
@@ -104,6 +105,12 @@ class _GeneratedPriorityScenario {
           updatedAt: counterSlot,
           status: status,
         ),
+      _GeneratedPriorityMessageKind.dailyOsUserName =>
+        SyncMessage.dailyOsUserName(
+          userName: 'name-$counterSlot',
+          updatedAt: counterSlot,
+          status: status,
+        ),
       _GeneratedPriorityMessageKind.backfillRequest =>
         SyncMessage.backfillRequest(
           entries: [
@@ -185,6 +192,7 @@ class _GeneratedPriorityScenario {
       _GeneratedPriorityMessageKind.notification ||
       _GeneratedPriorityMessageKind.notificationStateUpdate ||
       _GeneratedPriorityMessageKind.themingSelection ||
+      _GeneratedPriorityMessageKind.dailyOsUserName ||
       _GeneratedPriorityMessageKind.configFlag ||
       _GeneratedPriorityMessageKind.outboxBundle => OutboxPriority.normal.index,
       _GeneratedPriorityMessageKind.entityDefinition ||

--- a/test/features/sync/outbox/outbox_service_test.dart
+++ b/test/features/sync/outbox/outbox_service_test.dart
@@ -3963,6 +3963,26 @@ void main() {
     );
   });
 
+  group('SyncDailyOsUserName', () {
+    test('enqueues the Daily OS name message with correct subject', () async {
+      final message = SyncMessage.dailyOsUserName(
+        userName: 'Sam',
+        updatedAt: DateTime(2024, 3, 15, 10, 30).millisecondsSinceEpoch,
+        status: SyncEntryStatus.update,
+      );
+
+      await service.enqueueMessage(message);
+
+      final captured = verify(
+        () => syncDatabase.addOutboxItem(captureAny<OutboxCompanion>()),
+      ).captured;
+      expect(captured.length, 1);
+
+      final companion = captured.first as OutboxCompanion;
+      expect(companion.subject.value, 'dailyOsUserName');
+    });
+  });
+
   group('SyncThemingSelection', () {
     test('enqueues theming message with correct subject', () async {
       final message = SyncMessage.themingSelection(

--- a/test/features/sync/queue/queue_apply_adapter_handlers_test.dart
+++ b/test/features/sync/queue/queue_apply_adapter_handlers_test.dart
@@ -371,6 +371,15 @@ void main() {
       expect(wraps(message), isFalse);
     });
 
+    test('SyncDailyOsUserName bypasses outer wrap (settings_db)', () {
+      const message = SyncMessage.dailyOsUserName(
+        userName: 'Sam',
+        updatedAt: 1,
+        status: SyncEntryStatus.initial,
+      );
+      expect(wraps(message), isFalse);
+    });
+
     test('SyncBackfillRequest wraps conservatively', () {
       const message = SyncMessage.backfillRequest(
         entries: <BackfillRequestEntry>[],

--- a/test/features/sync/ui/view_models/outbox_list_item_view_model_test.dart
+++ b/test/features/sync/ui/view_models/outbox_list_item_view_model_test.dart
@@ -300,6 +300,19 @@ void main() {
             ),
             expectedLabel: (ctx) => ctx.messages.syncPayloadConsumptionEvent,
           ),
+          (
+            name: 'daily os user name',
+            item: payloadItem(
+              id: 16,
+              message: const SyncMessage.dailyOsUserName(
+                userName: 'Sam',
+                updatedAt: 0,
+                status: SyncEntryStatus.update,
+              ).toJson(),
+              subject: 'dailyOsUserName',
+            ),
+            expectedLabel: (ctx) => ctx.messages.syncPayloadDailyOsUserName,
+          ),
         ];
 
     for (final c in payloadKindCases) {


### PR DESCRIPTION
## Summary

Follow-up to #3455. The Daily OS greeting name was **device-local** (`SettingsDb`, `DAILY_OS_USER_NAME`) while the two inference settings already synced via the agent domain. This makes the name sync across a user's devices too — so you're greeted by the same name on your phone as on your laptop.

It follows the established **theming-sync** pattern (`SyncMessage.themingSelection`) end-to-end: a dedicated payload variant, last-write-wins on a stored timestamp, and a controller that both emits on edit and reloads on inbound changes.

## What changed

- **New sync payload** — `SyncMessage.dailyOsUserName(userName, updatedAt, status)`, wired through every exhaustive site the compiler enumerated: outbox dispatch + enqueue writer (`subject: dailyOsUserName`), scheduler priority (`normal`), matrix sent-type, apply-adapter DB predicate (`settings_db`, no journal wrap), and the outbox-list payload label.
- **Inbound apply** — `SyncEventProcessorApply` writes the name + a new `DAILY_OS_USER_NAME_UPDATED_AT` key under last-write-wins (mirrors theming), then notifies `settingsNotification`. Logs stay content-free (never the name).
- **Controller** — `DailyOsPreferencesController.setUserName` stamps a timestamp and enqueues a debounced message (coalesces keystrokes, no-op before sync is configured); an inbound synced `settingsNotification` reloads the name under last-write-wins, guarded against echo.
- **Keys extracted** to `daily_os_preferences_keys.dart` so the sync layer imports constants, not the Riverpod controller (re-exported from the controller for existing importers).

## Cross-version safety

Older clients that don't know the variant **drop it gracefully** — `SyncMessage.fromJson` throws `CheckedFromJsonException` for an unknown union type, which the inbound pipeline already catches and skips. No crash; they simply keep their local name. This is the same mechanism that made `themingSelection` safe to add.

## Scope

Name only, as requested. The excluded-category set and coachmark flags in the same controller remain **device-local**.

## Tests

- Controller: debounced enqueue, keystroke coalescing, inbound reload without echo, no-op before sync configured, enqueue-failure logging.
- Apply: newer name applied + notifies, stale name ignored, applies when no local timestamp.
- Plumbing: serialization round-trip, scheduler priority, enqueue subject, apply-adapter predicate, matrix sent-type, outbox-list label.

## Validation

- `fvm flutter analyze` — No issues found
- Affected sync suites (processor, matrix, outbox, scheduling, adapter, model, list VM) + Daily OS controller/UI suites green
- l10n regenerated across en/cs/de/es/fr/ro
- READMEs (sync + Daily OS), CHANGELOG, and Flatpak metainfo updated under 0.9.1044

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daily OS preferred display name now syncs across devices using last-write-wins, so the greeting matches everywhere.
  * Sync/outbox UI now labels this preference as **“Daily OS name”** for clearer activity context.
* **Documentation**
  * Updated Daily OS personalization guidance to reflect where to edit the name and that it synchronizes across devices.
* **Tests**
  * Added coverage for name synchronization, coalescing rapid edits, conflict/staleness handling, error logging, and UI labeling.
* **Chores**
  * Updated release notes for the new syncing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->