### PR TITLE
feat: redesign date and time pickers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.1044]
 ### Changed
+- **Date and time pickers are clearer and steadier across the app.** Entry
+  ranges now show weekdays, include Start/End **Now** actions, and move into a
+  calendar page within the same sheet. Due dates and project target dates use
+  the same weekday calendar, while tighter wheel controls and stable status
+  spacing keep the layout compact without jumping in light or dark mode.
 - **Daily OS now lets you choose its AI route explicitly.** A discoverable
   Daily OS settings page owns the default inference profile and preferred name,
   while the planner instance can override its full profile or only its thinking

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,7 +1,3 @@
 org.gradle.jvmargs=-Xmx4096M -Djava.net.preferIPv4Stack=true
 android.useAndroidX=true
 android.enableJetifier=true
-# This builtInKotlin flag was added automatically by Flutter migrator
-android.builtInKotlin=false
-# This newDsl flag was added automatically by Flutter migrator
-android.newDsl=false

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx4096M -Djava.net.preferIPv4Stack=true
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -34,6 +34,7 @@
   <releases>
     <release version="0.9.1044" date="2026-07-14">
       <description>
+          <p>Date and time pickers are now clearer and steadier across the app. Entry ranges show weekdays, include Start and End Now actions, and transition to a calendar page within the same sheet. Due dates and project target dates share the same weekday calendar, while tighter wheel controls and stable status spacing keep the layout compact without jumping in light or dark mode.</p>
           <p>Daily OS now has a discoverable settings page for choosing its default inference profile and preferred name, plus per-planner profile and thinking-model overrides. Setup explains that assembled planning context is sent to the selected provider and identifies whether its configured endpoint is local or remote.</p>
           <p>The preferred name you set for Daily OS now syncs across your devices, with the most recent edit winning, so each device greets you the same way.</p>
           <p>AI coding prompts now show up under their task. A generated coding prompt is linked to both its parent task and the audio or text note it came from, and appears in each of their linked-entries lists under the Code activity filter. Previously the prompt was created but stayed hidden from the task timeline.</p>

--- a/lib/features/design_system/README.md
+++ b/lib/features/design_system/README.md
@@ -256,6 +256,8 @@ stateDiagram-v2
   large Linux wheel deltas cannot skip values or lock further input. Drag
   velocity is capped by column: deliberate movement still accelerates across
   several rows, while extreme desktop fling values cannot launch the wheel.
+  Each column participates in focus traversal, uses the interactive accent for
+  visible focus, and handles Up/Down (including key repeat) as one-row changes.
   Looping columns start many cycles from either boundary so hours remain
   reachable in both directions, and cached delegates avoid rebuilding the full
   hour/minute lists on every selection tick. The duration picker keeps

--- a/lib/features/design_system/README.md
+++ b/lib/features/design_system/README.md
@@ -248,8 +248,11 @@ stateDiagram-v2
 - calendar and time pickers (`components/calendar_pickers/` and
   `components/time_pickers/`) — the shared calendar wraps Material's
   locale-aware month grid with a full weekday date readout, a contextual
-  **Today** action, token-backed framing, and the shared modal action bar. The
-  time-of-day picker uses fixed-extent hour/minute wheels with cylindrical
+  **Today** action, `DesignSystemPickerSection` framing, and the shared modal
+  action bar. Calendar inputs are clamped to their configured bounds, and
+  selections retain the caller's UTC/local timezone kind instead of silently
+  converting calendar days. The time-of-day picker uses fixed-extent
+  hour/minute wheels with cylindrical
   perspective, non-bouncing settle behavior, a token-selected row, 12/24-hour
   layouts, and adjustable semantics for each column. Desktop pointer-scroll
   deltas accumulate to a row threshold, with each event limited to one row so

--- a/lib/features/design_system/README.md
+++ b/lib/features/design_system/README.md
@@ -245,7 +245,16 @@ stateDiagram-v2
 ```
 
 
-- calendar and time pickers
+- calendar and time pickers (`components/calendar_pickers/` and
+  `components/time_pickers/`) — the shared calendar wraps Material's
+  locale-aware month grid with a full weekday date readout, a contextual
+  **Today** action, token-backed framing, and the shared modal action bar. The
+  time-of-day picker uses fixed-extent hour/minute wheels with cylindrical
+  perspective, non-bouncing settle behavior, a token-selected row, 12/24-hour
+  layouts, and adjustable semantics for each column. The duration picker keeps
+  Cupertino's hours/minutes wheel while applying the same typography and
+  selected-row treatment. Feature code owns the draft value and persistence;
+  these components own presentation and interaction semantics.
 - file upload surface
 
 The tabs component is intentionally content-sized by default. Segmented tab
@@ -310,6 +319,8 @@ Several components enforce accessible naming at construction time. Examples:
 - `DesignSystemSplitButton` resolves explicit semantics labels for primary and dropdown actions
 - `DesignSystemCheckbox` requires either a visible label or a semantics label
 - `DesignSystemTooltipIcon` maps tooltip text into semantics by default
+- `DesignSystemTimeWheel` exposes hour, minute, and AM/PM columns as separate
+  adjustable semantic controls, including next/previous values
 
 This is not universal policy machinery hidden somewhere central. It is encoded directly in component constructors and `Semantics` wrappers, which is better because the rule stays close to the widget that can violate it.
 

--- a/lib/features/design_system/README.md
+++ b/lib/features/design_system/README.md
@@ -251,7 +251,14 @@ stateDiagram-v2
   **Today** action, token-backed framing, and the shared modal action bar. The
   time-of-day picker uses fixed-extent hour/minute wheels with cylindrical
   perspective, non-bouncing settle behavior, a token-selected row, 12/24-hour
-  layouts, and adjustable semantics for each column. The duration picker keeps
+  layouts, and adjustable semantics for each column. Desktop pointer-scroll
+  deltas accumulate to a row threshold, with each event limited to one row so
+  large Linux wheel deltas cannot skip values or lock further input. Drag
+  velocity is capped by column: deliberate movement still accelerates across
+  several rows, while extreme desktop fling values cannot launch the wheel.
+  Looping columns start many cycles from either boundary so hours remain
+  reachable in both directions, and cached delegates avoid rebuilding the full
+  hour/minute lists on every selection tick. The duration picker keeps
   Cupertino's hours/minutes wheel while applying the same typography and
   selected-row treatment. Feature code owns the draft value and persistence;
   these components own presentation and interaction semantics.

--- a/lib/features/design_system/components/buttons/design_system_modal_action_bar.dart
+++ b/lib/features/design_system/components/buttons/design_system_modal_action_bar.dart
@@ -5,10 +5,10 @@ import 'package:lotti/features/design_system/theme/design_tokens.dart';
 /// The app's standard modal/sheet action bar.
 ///
 /// Layout rule (selected by the design panel as the "dominant primary" / V3
-/// pattern): [secondary] actions keep their intrinsic width on the leading
-/// edge, and the [primary] action flexes to fill the trailing width with its
-/// label centered — so the primary is signalled three ways at once (size,
-/// colour, trailing position) rather than relying on colour alone.
+/// pattern): at comfortable widths [secondary] actions keep their intrinsic
+/// width on the leading edge, and the [primary] action flexes to fill the
+/// trailing width. On narrow or large-text layouts, the secondaries wrap above
+/// a full-width primary so translations never squeeze or clip the actions.
 ///
 /// A larger gutter (`spacing.step5`) separates the last secondary from the
 /// primary so a mildly-destructive secondary (e.g. a "Clear" button) is harder
@@ -49,7 +49,36 @@ class DesignSystemModalActionBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
-    final row = Row(
+    final textScale = MediaQuery.textScalerOf(context).scale(1);
+    final content = LayoutBuilder(
+      builder: (context, constraints) {
+        final narrowBreakpoint = secondary.length > 1
+            ? tokens.spacing.step13 * 2 + tokens.spacing.step11
+            : tokens.spacing.step13 * 2;
+        final stacked =
+            constraints.maxWidth < narrowBreakpoint || textScale > 1.3;
+        return stacked
+            ? _StackedActionLayout(primary: primary, secondary: secondary)
+            : _WideActionLayout(primary: primary, secondary: secondary);
+      },
+    );
+    final padded = padding == null
+        ? content
+        : Padding(padding: padding!, child: content);
+    return glass ? DesignSystemGlassStrip(child: padded) : padded;
+  }
+}
+
+class _WideActionLayout extends StatelessWidget {
+  const _WideActionLayout({required this.primary, required this.secondary});
+
+  final Widget primary;
+  final List<Widget> secondary;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    return Row(
       children: [
         for (var i = 0; i < secondary.length; i++) ...[
           secondary[i],
@@ -64,9 +93,31 @@ class DesignSystemModalActionBar extends StatelessWidget {
         Expanded(child: primary),
       ],
     );
-    final padded = padding == null
-        ? row
-        : Padding(padding: padding!, child: row);
-    return glass ? DesignSystemGlassStrip(child: padded) : padded;
+  }
+}
+
+class _StackedActionLayout extends StatelessWidget {
+  const _StackedActionLayout({required this.primary, required this.secondary});
+
+  final Widget primary;
+  final List<Widget> secondary;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (secondary.isNotEmpty) ...[
+          Wrap(
+            spacing: tokens.spacing.step3,
+            runSpacing: tokens.spacing.step3,
+            children: secondary,
+          ),
+          SizedBox(height: tokens.spacing.step3),
+        ],
+        primary,
+      ],
+    );
   }
 }

--- a/lib/features/design_system/components/calendar_pickers/design_system_date_picker_modal.dart
+++ b/lib/features/design_system/components/calendar_pickers/design_system_date_picker_modal.dart
@@ -5,6 +5,7 @@ import 'package:lotti/features/design_system/components/buttons/design_system_bu
 import 'package:lotti/features/design_system/components/buttons/design_system_modal_action_bar.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/utils/date_utils_extension.dart';
 import 'package:lotti/widgets/modal/modal_utils.dart';
 
 /// The outcome of a design-system calendar modal.
@@ -33,44 +34,68 @@ Future<DesignSystemDatePickerResult?> showDesignSystemDatePicker({
   bool allowClear = false,
 }) async {
   final tokens = context.designTokens;
-  final selectedDate = ValueNotifier(_dateOnly(initialDate));
+  final selectedDate = ValueNotifier(
+    _clampCalendarDate(initialDate, firstDate, lastDate),
+  );
 
-  final result =
-      await ModalUtils.showSinglePageModal<DesignSystemDatePickerResult>(
-        context: context,
-        title: title,
-        padding: EdgeInsets.fromLTRB(
-          tokens.spacing.step5,
-          tokens.spacing.step5,
-          tokens.spacing.step5,
-          tokens.spacing.step11 + tokens.spacing.step6,
+  try {
+    return await ModalUtils.showSinglePageModal<DesignSystemDatePickerResult>(
+      context: context,
+      title: title,
+      padding: EdgeInsets.fromLTRB(
+        tokens.spacing.step5,
+        tokens.spacing.step5,
+        tokens.spacing.step5,
+        tokens.spacing.step11 + tokens.spacing.step6,
+      ),
+      builder: (_) => ValueListenableBuilder(
+        valueListenable: selectedDate,
+        builder: (context, date, _) => DesignSystemCalendarPicker(
+          selectedDate: date,
+          firstDate: firstDate,
+          lastDate: lastDate,
+          onDateChanged: (value) => selectedDate.value = value,
         ),
-        builder: (_) => ValueListenableBuilder(
-          valueListenable: selectedDate,
-          builder: (context, date, _) => DesignSystemCalendarPicker(
-            selectedDate: date,
-            firstDate: firstDate,
-            lastDate: lastDate,
-            onDateChanged: (value) => selectedDate.value = value,
-          ),
+      ),
+      stickyActionBarBuilder: (modalContext) => ValueListenableBuilder(
+        valueListenable: selectedDate,
+        builder: (context, date, _) => DesignSystemDatePickerActionBar(
+          onClear: allowClear
+              ? () => Navigator.of(
+                  modalContext,
+                ).pop(const DesignSystemDatePickerResult.cleared())
+              : null,
+          onDone: () => Navigator.of(
+            modalContext,
+          ).pop(DesignSystemDatePickerResult.selected(date)),
         ),
-        stickyActionBarBuilder: (modalContext) => ValueListenableBuilder(
-          valueListenable: selectedDate,
-          builder: (context, date, _) => DesignSystemDatePickerActionBar(
-            onClear: allowClear
-                ? () => Navigator.of(
-                    modalContext,
-                  ).pop(const DesignSystemDatePickerResult.cleared())
-                : null,
-            onDone: () => Navigator.of(
-              modalContext,
-            ).pop(DesignSystemDatePickerResult.selected(date)),
-          ),
-        ),
-      );
+      ),
+    );
+  } finally {
+    selectedDate.dispose();
+  }
+}
 
-  selectedDate.dispose();
-  return result;
+/// Token-backed frame shared by date/time picker sections.
+class DesignSystemPickerSection extends StatelessWidget {
+  const DesignSystemPickerSection({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(tokens.radii.sectionCards),
+        border: Border.all(color: tokens.colors.decorative.level01),
+      ),
+      child: Padding(
+        padding: EdgeInsets.all(tokens.spacing.cardPadding),
+        child: child,
+      ),
+    );
+  }
 }
 
 /// The token-backed calendar content shared by standalone and multi-page
@@ -92,45 +117,44 @@ class DesignSystemCalendarPicker extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(tokens.radii.sectionCards),
-        border: Border.all(color: tokens.colors.decorative.level01),
-      ),
-      child: Padding(
-        padding: EdgeInsets.all(tokens.spacing.cardPadding),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            _SelectedDateHeader(
-              date: selectedDate,
-              onTodayPressed:
-                  _isToday(selectedDate) || !_containsToday(firstDate, lastDate)
-                  ? null
-                  : () => onDateChanged(_today()),
+    final effectiveSelectedDate = _clampCalendarDate(
+      selectedDate,
+      firstDate,
+      lastDate,
+    );
+    return DesignSystemPickerSection(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _SelectedDateHeader(
+            date: effectiveSelectedDate,
+            onTodayPressed:
+                effectiveSelectedDate.isSameCalendarDay(_today()) ||
+                    !_containsToday(firstDate, lastDate)
+                ? null
+                : () => onDateChanged(
+                    _today().dateOnlyInZoneOf(effectiveSelectedDate),
+                  ),
+          ),
+          SizedBox(height: tokens.spacing.step3),
+          DatePickerTheme(
+            data: DatePickerTheme.of(context).copyWith(
+              toggleButtonTextStyle: tokens.typography.styles.subtitle.subtitle1
+                  .copyWith(color: tokens.colors.text.highEmphasis),
             ),
-            SizedBox(height: tokens.spacing.step3),
-            DatePickerTheme(
-              data: DatePickerTheme.of(context).copyWith(
-                toggleButtonTextStyle: tokens
-                    .typography
-                    .styles
-                    .subtitle
-                    .subtitle1
-                    .copyWith(color: tokens.colors.text.highEmphasis),
-              ),
-              child: CalendarDatePicker(
-                key: ValueKey(selectedDate),
-                initialDate: selectedDate,
-                currentDate: _today(),
-                firstDate: firstDate,
-                lastDate: lastDate,
-                onDateChanged: (value) => onDateChanged(_dateOnly(value)),
+            child: CalendarDatePicker(
+              key: ValueKey(effectiveSelectedDate),
+              initialDate: effectiveSelectedDate,
+              currentDate: _today(),
+              firstDate: firstDate,
+              lastDate: lastDate,
+              onDateChanged: (value) => onDateChanged(
+                value.dateOnlyInZoneOf(effectiveSelectedDate),
               ),
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }
@@ -205,17 +229,24 @@ class DesignSystemDatePickerActionBar extends StatelessWidget {
   }
 }
 
-DateTime _dateOnly(DateTime date) => DateTime(date.year, date.month, date.day);
+DateTime _today() => clock.now().dateOnly;
 
-DateTime _today() => _dateOnly(clock.now());
+DateTime _clampCalendarDate(
+  DateTime date,
+  DateTime firstDate,
+  DateTime lastDate,
+) {
+  if (date.compareCalendarDay(firstDate) < 0) {
+    return firstDate.dateOnlyInZoneOf(date);
+  }
+  if (date.compareCalendarDay(lastDate) > 0) {
+    return lastDate.dateOnlyInZoneOf(date);
+  }
+  return date.dateOnly;
+}
 
 bool _containsToday(DateTime firstDate, DateTime lastDate) {
   final today = _today();
-  return !today.isBefore(_dateOnly(firstDate)) &&
-      !today.isAfter(_dateOnly(lastDate));
+  return today.compareCalendarDay(firstDate) >= 0 &&
+      today.compareCalendarDay(lastDate) <= 0;
 }
-
-bool _isToday(DateTime date) => _sameDate(date, _today());
-
-bool _sameDate(DateTime a, DateTime b) =>
-    a.year == b.year && a.month == b.month && a.day == b.day;

--- a/lib/features/design_system/components/calendar_pickers/design_system_date_picker_modal.dart
+++ b/lib/features/design_system/components/calendar_pickers/design_system_date_picker_modal.dart
@@ -1,0 +1,221 @@
+import 'package:clock/clock.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
+import 'package:lotti/features/design_system/components/buttons/design_system_modal_action_bar.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
+import 'package:lotti/widgets/modal/modal_utils.dart';
+
+/// The outcome of a design-system calendar modal.
+@immutable
+class DesignSystemDatePickerResult {
+  const DesignSystemDatePickerResult.selected(this.date) : cleared = false;
+
+  const DesignSystemDatePickerResult.cleared() : date = null, cleared = true;
+
+  final DateTime? date;
+  final bool cleared;
+}
+
+/// Opens the app-wide date-only picker.
+///
+/// The modal uses Material's accessible calendar engine, including weekday
+/// headers and locale-aware month navigation, inside the app's token-backed
+/// sheet chrome. A null result means the sheet was dismissed; [allowClear]
+/// adds an explicit result that callers can distinguish from cancellation.
+Future<DesignSystemDatePickerResult?> showDesignSystemDatePicker({
+  required BuildContext context,
+  required String title,
+  required DateTime initialDate,
+  required DateTime firstDate,
+  required DateTime lastDate,
+  bool allowClear = false,
+}) async {
+  final tokens = context.designTokens;
+  final selectedDate = ValueNotifier(_dateOnly(initialDate));
+
+  final result =
+      await ModalUtils.showSinglePageModal<DesignSystemDatePickerResult>(
+        context: context,
+        title: title,
+        padding: EdgeInsets.fromLTRB(
+          tokens.spacing.step5,
+          tokens.spacing.step5,
+          tokens.spacing.step5,
+          tokens.spacing.step11 + tokens.spacing.step6,
+        ),
+        builder: (_) => ValueListenableBuilder(
+          valueListenable: selectedDate,
+          builder: (context, date, _) => DesignSystemCalendarPicker(
+            selectedDate: date,
+            firstDate: firstDate,
+            lastDate: lastDate,
+            onDateChanged: (value) => selectedDate.value = value,
+          ),
+        ),
+        stickyActionBarBuilder: (modalContext) => ValueListenableBuilder(
+          valueListenable: selectedDate,
+          builder: (context, date, _) => DesignSystemDatePickerActionBar(
+            onClear: allowClear
+                ? () => Navigator.of(
+                    modalContext,
+                  ).pop(const DesignSystemDatePickerResult.cleared())
+                : null,
+            onDone: () => Navigator.of(
+              modalContext,
+            ).pop(DesignSystemDatePickerResult.selected(date)),
+          ),
+        ),
+      );
+
+  selectedDate.dispose();
+  return result;
+}
+
+/// The token-backed calendar content shared by standalone and multi-page
+/// date-picking sheets.
+class DesignSystemCalendarPicker extends StatelessWidget {
+  const DesignSystemCalendarPicker({
+    required this.selectedDate,
+    required this.firstDate,
+    required this.lastDate,
+    required this.onDateChanged,
+    super.key,
+  });
+
+  final DateTime selectedDate;
+  final DateTime firstDate;
+  final DateTime lastDate;
+  final ValueChanged<DateTime> onDateChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(tokens.radii.sectionCards),
+        border: Border.all(color: tokens.colors.decorative.level01),
+      ),
+      child: Padding(
+        padding: EdgeInsets.all(tokens.spacing.cardPadding),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _SelectedDateHeader(
+              date: selectedDate,
+              onTodayPressed:
+                  _isToday(selectedDate) || !_containsToday(firstDate, lastDate)
+                  ? null
+                  : () => onDateChanged(_today()),
+            ),
+            SizedBox(height: tokens.spacing.step3),
+            DatePickerTheme(
+              data: DatePickerTheme.of(context).copyWith(
+                toggleButtonTextStyle: tokens
+                    .typography
+                    .styles
+                    .subtitle
+                    .subtitle1
+                    .copyWith(color: tokens.colors.text.highEmphasis),
+              ),
+              child: CalendarDatePicker(
+                key: ValueKey(selectedDate),
+                initialDate: selectedDate,
+                currentDate: _today(),
+                firstDate: firstDate,
+                lastDate: lastDate,
+                onDateChanged: (value) => onDateChanged(_dateOnly(value)),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SelectedDateHeader extends StatelessWidget {
+  const _SelectedDateHeader({required this.date, this.onTodayPressed});
+
+  final DateTime date;
+  final VoidCallback? onTodayPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final locale = Localizations.localeOf(context).toLanguageTag();
+    return Row(
+      children: [
+        Expanded(
+          child: Text(
+            DateFormat.yMMMMEEEEd(locale).format(date),
+            style: tokens.typography.styles.subtitle.subtitle1.copyWith(
+              color: tokens.colors.text.highEmphasis,
+            ),
+          ),
+        ),
+        SizedBox(width: tokens.spacing.step2),
+        DesignSystemButton(
+          label: context.messages.journalTodayButton,
+          variant: DesignSystemButtonVariant.tertiary,
+          size: DesignSystemButtonSize.medium,
+          onPressed: onTodayPressed,
+        ),
+      ],
+    );
+  }
+}
+
+/// Calendar footer shared by standalone and embedded date-picker pages.
+class DesignSystemDatePickerActionBar extends StatelessWidget {
+  const DesignSystemDatePickerActionBar({
+    required this.onClear,
+    required this.onDone,
+    super.key,
+  });
+
+  final VoidCallback? onClear;
+  final VoidCallback onDone;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    return DesignSystemModalActionBar(
+      glass: true,
+      padding: EdgeInsets.all(tokens.spacing.step5),
+      secondary: [
+        if (onClear != null)
+          DesignSystemButton(
+            label: context.messages.clearButton,
+            variant: DesignSystemButtonVariant.secondary,
+            size: DesignSystemButtonSize.large,
+            onPressed: onClear,
+          ),
+      ],
+      primary: DesignSystemButton(
+        label: context.messages.doneButton,
+        leadingIcon: Icons.check_rounded,
+        size: DesignSystemButtonSize.large,
+        fullWidth: true,
+        onPressed: onDone,
+      ),
+    );
+  }
+}
+
+DateTime _dateOnly(DateTime date) => DateTime(date.year, date.month, date.day);
+
+DateTime _today() => _dateOnly(clock.now());
+
+bool _containsToday(DateTime firstDate, DateTime lastDate) {
+  final today = _today();
+  return !today.isBefore(_dateOnly(firstDate)) &&
+      !today.isAfter(_dateOnly(lastDate));
+}
+
+bool _isToday(DateTime date) => _sameDate(date, _today());
+
+bool _sameDate(DateTime a, DateTime b) =>
+    a.year == b.year && a.month == b.month && a.day == b.day;

--- a/lib/features/design_system/components/time_pickers/design_system_picker_wheels.dart
+++ b/lib/features/design_system/components/time_pickers/design_system_picker_wheels.dart
@@ -1,0 +1,352 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+
+/// Token-backed time-of-day wheel shared by date/time modals.
+///
+/// It keeps the platform wheel interaction while standardizing value type,
+/// row geometry, selected-row color, and settled-change reporting.
+class DesignSystemTimeWheel extends StatefulWidget {
+  const DesignSystemTimeWheel({
+    required this.initialDateTime,
+    required this.onDateTimeChanged,
+    this.semanticsLabel,
+    this.semanticsLiveRegion = false,
+    this.use24hFormat = false,
+    super.key,
+  });
+
+  final DateTime initialDateTime;
+  final ValueChanged<DateTime> onDateTimeChanged;
+  final String? semanticsLabel;
+  final bool semanticsLiveRegion;
+  final bool use24hFormat;
+
+  @override
+  State<DesignSystemTimeWheel> createState() => _DesignSystemTimeWheelState();
+}
+
+class _DesignSystemTimeWheelState extends State<DesignSystemTimeWheel> {
+  // Flutter's Cupertino picker values, tuned against the native iOS wheel.
+  static const _diameterRatio = 1.07;
+  static const _squeeze = 1.45;
+  static const _overAndUnderCenterOpacity = 0.447;
+
+  late int _hourIndex;
+  late int _minuteIndex;
+  late int _periodIndex;
+
+  @override
+  void initState() {
+    super.initState();
+    final initial = TimeOfDay.fromDateTime(widget.initialDateTime);
+    _hourIndex = widget.use24hFormat
+        ? initial.hour
+        : (initial.hourOfPeriod == 0 ? 12 : initial.hourOfPeriod) - 1;
+    _minuteIndex = initial.minute;
+    _periodIndex = initial.period == DayPeriod.am ? 0 : 1;
+  }
+
+  void _notifyChanged() {
+    final hour = widget.use24hFormat
+        ? _hourIndex
+        : ((_hourIndex + 1) % 12) + _periodIndex * 12;
+    widget.onDateTimeChanged(
+      DateTime(
+        widget.initialDateTime.year,
+        widget.initialDateTime.month,
+        widget.initialDateTime.day,
+        hour,
+        _minuteIndex,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final materialLocalizations = MaterialLocalizations.of(context);
+    final pickerStyle = _pickerTextStyle(tokens);
+    return SizedBox(
+      height: tokens.spacing.step12 + tokens.spacing.step10,
+      child: Semantics(
+        container: true,
+        explicitChildNodes: true,
+        label: widget.semanticsLabel,
+        liveRegion: widget.semanticsLiveRegion,
+        child: Stack(
+          children: [
+            IgnorePointer(
+              child: Center(
+                child: SizedBox(
+                  height: tokens.spacing.step8,
+                  width: double.infinity,
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: tokens.colors.surface.selected,
+                      borderRadius: BorderRadius.circular(tokens.radii.l),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            Row(
+              children: [
+                Expanded(
+                  child: _FixedExtentWheelColumn(
+                    itemCount: widget.use24hFormat ? 24 : 12,
+                    initialItem: _hourIndex,
+                    selectedItem: _hourIndex,
+                    itemExtent: tokens.spacing.step8,
+                    semanticsLabel: materialLocalizations.timePickerHourLabel,
+                    labelBuilder: (index) => widget.use24hFormat
+                        ? index.toString().padLeft(2, '0')
+                        : '${index + 1}',
+                    selectedStyle: pickerStyle,
+                    unselectedStyle: pickerStyle.copyWith(
+                      color: tokens.colors.text.mediumEmphasis,
+                    ),
+                    onSelectedItemChanged: (index) =>
+                        setState(() => _hourIndex = index),
+                    onScrollEnd: _notifyChanged,
+                  ),
+                ),
+                Text(':', style: pickerStyle),
+                Expanded(
+                  child: _FixedExtentWheelColumn(
+                    itemCount: 60,
+                    initialItem: _minuteIndex,
+                    selectedItem: _minuteIndex,
+                    itemExtent: tokens.spacing.step8,
+                    semanticsLabel: materialLocalizations.timePickerMinuteLabel,
+                    labelBuilder: (index) => index.toString().padLeft(2, '0'),
+                    selectedStyle: pickerStyle,
+                    unselectedStyle: pickerStyle.copyWith(
+                      color: tokens.colors.text.mediumEmphasis,
+                    ),
+                    onSelectedItemChanged: (index) =>
+                        setState(() => _minuteIndex = index),
+                    onScrollEnd: _notifyChanged,
+                  ),
+                ),
+                if (!widget.use24hFormat)
+                  Expanded(
+                    child: _FixedExtentWheelColumn(
+                      itemCount: 2,
+                      initialItem: _periodIndex,
+                      selectedItem: _periodIndex,
+                      itemExtent: tokens.spacing.step8,
+                      semanticsLabel:
+                          '${materialLocalizations.anteMeridiemAbbreviation} / '
+                          '${materialLocalizations.postMeridiemAbbreviation}',
+                      looping: false,
+                      labelBuilder: (index) => index == 0
+                          ? MaterialLocalizations.of(
+                              context,
+                            ).anteMeridiemAbbreviation
+                          : MaterialLocalizations.of(
+                              context,
+                            ).postMeridiemAbbreviation,
+                      selectedStyle: pickerStyle,
+                      unselectedStyle: pickerStyle.copyWith(
+                        color: tokens.colors.text.mediumEmphasis,
+                      ),
+                      onSelectedItemChanged: (index) =>
+                          setState(() => _periodIndex = index),
+                      onScrollEnd: _notifyChanged,
+                    ),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _FixedExtentWheelColumn extends StatefulWidget {
+  const _FixedExtentWheelColumn({
+    required this.itemCount,
+    required this.initialItem,
+    required this.selectedItem,
+    required this.itemExtent,
+    required this.semanticsLabel,
+    required this.labelBuilder,
+    required this.selectedStyle,
+    required this.unselectedStyle,
+    required this.onSelectedItemChanged,
+    required this.onScrollEnd,
+    this.looping = true,
+  });
+
+  final int itemCount;
+  final int initialItem;
+  final int selectedItem;
+  final double itemExtent;
+  final String semanticsLabel;
+  final String Function(int) labelBuilder;
+  final TextStyle selectedStyle;
+  final TextStyle unselectedStyle;
+  final ValueChanged<int> onSelectedItemChanged;
+  final VoidCallback onScrollEnd;
+  final bool looping;
+
+  @override
+  State<_FixedExtentWheelColumn> createState() =>
+      _FixedExtentWheelColumnState();
+}
+
+class _FixedExtentWheelColumnState extends State<_FixedExtentWheelColumn> {
+  late final FixedExtentScrollController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = FixedExtentScrollController(initialItem: widget.initialItem);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  int? _adjustedIndex(int delta) {
+    if (widget.looping) {
+      return (widget.selectedItem + delta) % widget.itemCount;
+    }
+    final next = widget.selectedItem + delta;
+    return next >= 0 && next < widget.itemCount ? next : null;
+  }
+
+  void _adjust(int delta) {
+    final next = _adjustedIndex(delta);
+    if (next == null) return;
+    _controller.jumpToItem(next);
+    widget.onSelectedItemChanged(next);
+    widget.onScrollEnd();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final children = List.generate(
+      widget.itemCount,
+      (index) => Center(
+        child: Text(
+          widget.labelBuilder(index),
+          style: index == widget.selectedItem
+              ? widget.selectedStyle
+              : widget.unselectedStyle,
+        ),
+      ),
+    );
+    final increasedIndex = _adjustedIndex(1);
+    final decreasedIndex = _adjustedIndex(-1);
+    return Semantics(
+      container: true,
+      label: widget.semanticsLabel,
+      value: widget.labelBuilder(widget.selectedItem),
+      increasedValue: increasedIndex == null
+          ? null
+          : widget.labelBuilder(increasedIndex),
+      decreasedValue: decreasedIndex == null
+          ? null
+          : widget.labelBuilder(decreasedIndex),
+      selected: true,
+      onIncrease: increasedIndex == null ? null : () => _adjust(1),
+      onDecrease: decreasedIndex == null ? null : () => _adjust(-1),
+      child: ExcludeSemantics(
+        child: NotificationListener<ScrollEndNotification>(
+          onNotification: (_) {
+            widget.onScrollEnd();
+            return false;
+          },
+          child: ListWheelScrollView.useDelegate(
+            controller: _controller,
+            itemExtent: widget.itemExtent,
+            physics: const FixedExtentScrollPhysics(),
+            diameterRatio: _DesignSystemTimeWheelState._diameterRatio,
+            squeeze: _DesignSystemTimeWheelState._squeeze,
+            overAndUnderCenterOpacity:
+                _DesignSystemTimeWheelState._overAndUnderCenterOpacity,
+            onSelectedItemChanged: widget.onSelectedItemChanged,
+            childDelegate: widget.looping
+                ? ListWheelChildLoopingListDelegate(children: children)
+                : ListWheelChildListDelegate(children: children),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Token-backed hour/minute duration wheel used by estimate modals.
+class DesignSystemDurationWheel extends StatelessWidget {
+  const DesignSystemDurationWheel({
+    required this.initialDuration,
+    required this.onDurationChanged,
+    this.semanticsLabel,
+    this.semanticsLiveRegion = false,
+    super.key,
+  });
+
+  final Duration initialDuration;
+  final ValueChanged<Duration> onDurationChanged;
+  final String? semanticsLabel;
+  final bool semanticsLiveRegion;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    return SizedBox(
+      height: tokens.spacing.step12 + tokens.spacing.step9,
+      child: CupertinoTheme(
+        data: CupertinoThemeData(
+          textTheme: CupertinoTextThemeData(
+            pickerTextStyle: _pickerTextStyle(tokens),
+          ),
+        ),
+        child: Semantics(
+          container: true,
+          explicitChildNodes: true,
+          label: semanticsLabel,
+          liveRegion: semanticsLiveRegion,
+          child: CupertinoTimerPicker(
+            initialTimerDuration: initialDuration,
+            mode: CupertinoTimerPickerMode.hm,
+            itemExtent: tokens.spacing.step9,
+            changeReportingBehavior: ChangeReportingBehavior.onScrollEnd,
+            selectionOverlayBuilder:
+                (
+                  context, {
+                  required selectedIndex,
+                  required columnCount,
+                }) => _selectionOverlay(
+                  tokens,
+                  selectedIndex: selectedIndex,
+                  columnCount: columnCount,
+                ),
+            onTimerDurationChanged: onDurationChanged,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+TextStyle _pickerTextStyle(DsTokens tokens) =>
+    tokens.typography.styles.subtitle.subtitle1.copyWith(
+      color: tokens.colors.text.highEmphasis,
+      fontFeatures: const [FontFeature.tabularFigures()],
+    );
+
+Widget _selectionOverlay(
+  DsTokens tokens, {
+  required int selectedIndex,
+  required int columnCount,
+}) => CupertinoPickerDefaultSelectionOverlay(
+  background: tokens.colors.surface.selected,
+  capStartEdge: selectedIndex == 0,
+  capEndEdge: selectedIndex == columnCount - 1,
+);

--- a/lib/features/design_system/components/time_pickers/design_system_picker_wheels.dart
+++ b/lib/features/design_system/components/time_pickers/design_system_picker_wheels.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 
@@ -31,7 +32,8 @@ class _DesignSystemTimeWheelState extends State<DesignSystemTimeWheel> {
   static const _diameterRatio = 1.07;
   static const _squeeze = 1.45;
   static const _overAndUnderCenterOpacity = 0.447;
-
+  static const _hourMaxFlingRowsPerSecond = 8.0;
+  static const _minuteMaxFlingRowsPerSecond = 20.0;
   late int _hourIndex;
   late int _minuteIndex;
   late int _periodIndex;
@@ -98,6 +100,7 @@ class _DesignSystemTimeWheelState extends State<DesignSystemTimeWheel> {
                     initialItem: _hourIndex,
                     selectedItem: _hourIndex,
                     itemExtent: tokens.spacing.step8,
+                    maxFlingRowsPerSecond: _hourMaxFlingRowsPerSecond,
                     semanticsLabel: materialLocalizations.timePickerHourLabel,
                     labelBuilder: (index) => widget.use24hFormat
                         ? index.toString().padLeft(2, '0')
@@ -106,8 +109,7 @@ class _DesignSystemTimeWheelState extends State<DesignSystemTimeWheel> {
                     unselectedStyle: pickerStyle.copyWith(
                       color: tokens.colors.text.mediumEmphasis,
                     ),
-                    onSelectedItemChanged: (index) =>
-                        setState(() => _hourIndex = index),
+                    onSelectedItemChanged: (index) => _hourIndex = index,
                     onScrollEnd: _notifyChanged,
                   ),
                 ),
@@ -118,14 +120,14 @@ class _DesignSystemTimeWheelState extends State<DesignSystemTimeWheel> {
                     initialItem: _minuteIndex,
                     selectedItem: _minuteIndex,
                     itemExtent: tokens.spacing.step8,
+                    maxFlingRowsPerSecond: _minuteMaxFlingRowsPerSecond,
                     semanticsLabel: materialLocalizations.timePickerMinuteLabel,
                     labelBuilder: (index) => index.toString().padLeft(2, '0'),
                     selectedStyle: pickerStyle,
                     unselectedStyle: pickerStyle.copyWith(
                       color: tokens.colors.text.mediumEmphasis,
                     ),
-                    onSelectedItemChanged: (index) =>
-                        setState(() => _minuteIndex = index),
+                    onSelectedItemChanged: (index) => _minuteIndex = index,
                     onScrollEnd: _notifyChanged,
                   ),
                 ),
@@ -136,6 +138,7 @@ class _DesignSystemTimeWheelState extends State<DesignSystemTimeWheel> {
                       initialItem: _periodIndex,
                       selectedItem: _periodIndex,
                       itemExtent: tokens.spacing.step8,
+                      maxFlingRowsPerSecond: 0,
                       semanticsLabel:
                           '${materialLocalizations.anteMeridiemAbbreviation} / '
                           '${materialLocalizations.postMeridiemAbbreviation}',
@@ -151,8 +154,7 @@ class _DesignSystemTimeWheelState extends State<DesignSystemTimeWheel> {
                       unselectedStyle: pickerStyle.copyWith(
                         color: tokens.colors.text.mediumEmphasis,
                       ),
-                      onSelectedItemChanged: (index) =>
-                          setState(() => _periodIndex = index),
+                      onSelectedItemChanged: (index) => _periodIndex = index,
                       onScrollEnd: _notifyChanged,
                     ),
                   ),
@@ -171,6 +173,7 @@ class _FixedExtentWheelColumn extends StatefulWidget {
     required this.initialItem,
     required this.selectedItem,
     required this.itemExtent,
+    required this.maxFlingRowsPerSecond,
     required this.semanticsLabel,
     required this.labelBuilder,
     required this.selectedStyle,
@@ -184,6 +187,7 @@ class _FixedExtentWheelColumn extends StatefulWidget {
   final int initialItem;
   final int selectedItem;
   final double itemExtent;
+  final double maxFlingRowsPerSecond;
   final String semanticsLabel;
   final String Function(int) labelBuilder;
   final TextStyle selectedStyle;
@@ -198,87 +202,206 @@ class _FixedExtentWheelColumn extends StatefulWidget {
 }
 
 class _FixedExtentWheelColumnState extends State<_FixedExtentWheelColumn> {
+  static const _loopingTurns = 1000;
+
   late final FixedExtentScrollController _controller;
+  late final ValueNotifier<int> _selectedItem;
+  late List<Widget> _children;
+  var _pointerScrollDistance = 0.0;
 
   @override
   void initState() {
     super.initState();
-    _controller = FixedExtentScrollController(initialItem: widget.initialItem);
+    _controller = FixedExtentScrollController(
+      initialItem: widget.looping
+          ? widget.itemCount * _loopingTurns + widget.initialItem
+          : widget.initialItem,
+    );
+    _selectedItem = ValueNotifier(widget.selectedItem);
+    _children = _buildChildren();
+  }
+
+  @override
+  void didUpdateWidget(covariant _FixedExtentWheelColumn oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.itemCount != oldWidget.itemCount ||
+        widget.selectedStyle != oldWidget.selectedStyle ||
+        widget.unselectedStyle != oldWidget.unselectedStyle) {
+      _children = _buildChildren();
+    }
   }
 
   @override
   void dispose() {
     _controller.dispose();
+    _selectedItem.dispose();
     super.dispose();
   }
 
   int? _adjustedIndex(int delta) {
     if (widget.looping) {
-      return (widget.selectedItem + delta) % widget.itemCount;
+      return (_selectedItem.value + delta) % widget.itemCount;
     }
-    final next = widget.selectedItem + delta;
+    final next = _selectedItem.value + delta;
     return next >= 0 && next < widget.itemCount ? next : null;
+  }
+
+  void _handleSelectedItemChanged(int index) {
+    if (_selectedItem.value == index) return;
+    _selectedItem.value = index;
+    widget.onSelectedItemChanged(index);
   }
 
   void _adjust(int delta) {
     final next = _adjustedIndex(delta);
     if (next == null) return;
-    _controller.jumpToItem(next);
-    widget.onSelectedItemChanged(next);
+    _controller.jumpToItem(
+      widget.looping ? _controller.selectedItem + delta : next,
+    );
+    _handleSelectedItemChanged(next);
     widget.onScrollEnd();
   }
 
-  @override
-  Widget build(BuildContext context) {
-    final children = List.generate(
-      widget.itemCount,
-      (index) => Center(
-        child: Text(
-          widget.labelBuilder(index),
-          style: index == widget.selectedItem
-              ? widget.selectedStyle
-              : widget.unselectedStyle,
-        ),
-      ),
+  void _handlePointerSignal(PointerSignalEvent event) {
+    if (event is! PointerScrollEvent || event.scrollDelta.dy == 0) return;
+    GestureBinding.instance.pointerSignalResolver.register(
+      event,
+      _handleResolvedPointerScroll,
     );
-    final increasedIndex = _adjustedIndex(1);
-    final decreasedIndex = _adjustedIndex(-1);
-    return Semantics(
-      container: true,
-      label: widget.semanticsLabel,
-      value: widget.labelBuilder(widget.selectedItem),
-      increasedValue: increasedIndex == null
-          ? null
-          : widget.labelBuilder(increasedIndex),
-      decreasedValue: decreasedIndex == null
-          ? null
-          : widget.labelBuilder(decreasedIndex),
-      selected: true,
-      onIncrease: increasedIndex == null ? null : () => _adjust(1),
-      onDecrease: decreasedIndex == null ? null : () => _adjust(-1),
-      child: ExcludeSemantics(
-        child: NotificationListener<ScrollEndNotification>(
-          onNotification: (_) {
-            widget.onScrollEnd();
-            return false;
-          },
-          child: ListWheelScrollView.useDelegate(
-            controller: _controller,
-            itemExtent: widget.itemExtent,
-            physics: const FixedExtentScrollPhysics(),
-            diameterRatio: _DesignSystemTimeWheelState._diameterRatio,
-            squeeze: _DesignSystemTimeWheelState._squeeze,
-            overAndUnderCenterOpacity:
-                _DesignSystemTimeWheelState._overAndUnderCenterOpacity,
-            onSelectedItemChanged: widget.onSelectedItemChanged,
-            childDelegate: widget.looping
-                ? ListWheelChildLoopingListDelegate(children: children)
-                : ListWheelChildListDelegate(children: children),
+  }
+
+  void _handleResolvedPointerScroll(PointerSignalEvent event) {
+    final scrollEvent = event as PointerScrollEvent
+      ..respond(allowPlatformDefault: false);
+    if (!_controller.hasClients) return;
+
+    _pointerScrollDistance += scrollEvent.scrollDelta.dy;
+    if (_pointerScrollDistance.abs() < widget.itemExtent / 2) return;
+
+    final direction = _pointerScrollDistance.sign;
+    _pointerScrollDistance = 0;
+    _controller.position.pointerScroll(direction * widget.itemExtent);
+  }
+
+  List<Widget> _buildChildren() => List.generate(
+    widget.itemCount,
+    (index) => Listener(
+      behavior: HitTestBehavior.translucent,
+      onPointerSignal: _handlePointerSignal,
+      child: SizedBox.expand(
+        child: Center(
+          child: ValueListenableBuilder(
+            valueListenable: _selectedItem,
+            builder: (context, selectedItem, _) => Text(
+              widget.labelBuilder(index),
+              style: index == selectedItem
+                  ? widget.selectedStyle
+                  : widget.unselectedStyle,
+            ),
           ),
         ),
       ),
+    ),
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder(
+      valueListenable: _selectedItem,
+      builder: (context, selectedItem, _) {
+        final increasedIndex = _adjustedIndex(1);
+        final decreasedIndex = _adjustedIndex(-1);
+        return Semantics(
+          container: true,
+          label: widget.semanticsLabel,
+          value: widget.labelBuilder(selectedItem),
+          increasedValue: increasedIndex == null
+              ? null
+              : widget.labelBuilder(increasedIndex),
+          decreasedValue: decreasedIndex == null
+              ? null
+              : widget.labelBuilder(decreasedIndex),
+          selected: true,
+          onIncrease: increasedIndex == null ? null : () => _adjust(1),
+          onDecrease: decreasedIndex == null ? null : () => _adjust(-1),
+          child: ExcludeSemantics(
+            child: NotificationListener<ScrollEndNotification>(
+              onNotification: (_) {
+                widget.onScrollEnd();
+                return false;
+              },
+              child: ListWheelScrollView.useDelegate(
+                controller: _controller,
+                itemExtent: widget.itemExtent,
+                physics: widget.maxFlingRowsPerSecond == 0
+                    ? const _PreciseFixedExtentScrollPhysics()
+                    : _ControlledFixedExtentScrollPhysics(
+                        itemExtent: widget.itemExtent,
+                        maxFlingRowsPerSecond: widget.maxFlingRowsPerSecond,
+                      ),
+                diameterRatio: _DesignSystemTimeWheelState._diameterRatio,
+                squeeze: _DesignSystemTimeWheelState._squeeze,
+                overAndUnderCenterOpacity:
+                    _DesignSystemTimeWheelState._overAndUnderCenterOpacity,
+                onSelectedItemChanged: _handleSelectedItemChanged,
+                dragStartBehavior: DragStartBehavior.down,
+                childDelegate: widget.looping
+                    ? ListWheelChildLoopingListDelegate(children: _children)
+                    : ListWheelChildListDelegate(children: _children),
+              ),
+            ),
+          ),
+        );
+      },
     );
   }
+}
+
+/// Snaps to the nearest row at release without adding slot-machine momentum.
+class _PreciseFixedExtentScrollPhysics extends FixedExtentScrollPhysics {
+  const _PreciseFixedExtentScrollPhysics({super.parent});
+
+  @override
+  _PreciseFixedExtentScrollPhysics applyTo(ScrollPhysics? ancestor) =>
+      _PreciseFixedExtentScrollPhysics(parent: buildParent(ancestor));
+
+  @override
+  Simulation? createBallisticSimulation(
+    ScrollMetrics position,
+    double velocity,
+  ) => super.createBallisticSimulation(position, 0);
+}
+
+/// Preserves wheel momentum while preventing extreme desktop fling velocity.
+class _ControlledFixedExtentScrollPhysics extends FixedExtentScrollPhysics {
+  const _ControlledFixedExtentScrollPhysics({
+    required this.itemExtent,
+    required this.maxFlingRowsPerSecond,
+    super.parent,
+  });
+
+  final double itemExtent;
+  final double maxFlingRowsPerSecond;
+
+  @override
+  double get maxFlingVelocity => itemExtent * maxFlingRowsPerSecond;
+
+  @override
+  _ControlledFixedExtentScrollPhysics applyTo(ScrollPhysics? ancestor) =>
+      _ControlledFixedExtentScrollPhysics(
+        itemExtent: itemExtent,
+        maxFlingRowsPerSecond: maxFlingRowsPerSecond,
+        parent: buildParent(ancestor),
+      );
+
+  @override
+  Simulation? createBallisticSimulation(
+    ScrollMetrics position,
+    double velocity,
+  ) => super.createBallisticSimulation(
+    position,
+    velocity.clamp(-maxFlingVelocity, maxFlingVelocity),
+  );
 }
 
 /// Token-backed hour/minute duration wheel used by estimate modals.

--- a/lib/features/design_system/components/time_pickers/design_system_picker_wheels.dart
+++ b/lib/features/design_system/components/time_pickers/design_system_picker_wheels.dart
@@ -159,12 +159,8 @@ class _DesignSystemTimeWheelState extends State<DesignSystemTimeWheel> {
                           '${materialLocalizations.postMeridiemAbbreviation}',
                       looping: false,
                       labelBuilder: (index) => index == 0
-                          ? MaterialLocalizations.of(
-                              context,
-                            ).anteMeridiemAbbreviation
-                          : MaterialLocalizations.of(
-                              context,
-                            ).postMeridiemAbbreviation,
+                          ? materialLocalizations.anteMeridiemAbbreviation
+                          : materialLocalizations.postMeridiemAbbreviation,
                       selectedStyle: pickerStyle,
                       focusedStyle: pickerStyle.copyWith(
                         color: tokens.colors.interactive.enabled,
@@ -273,9 +269,10 @@ class _FixedExtentWheelColumnState extends State<_FixedExtentWheelColumn> {
   }
 
   void _handleSelectedItemChanged(int index) {
-    if (_selectedItem.value == index) return;
-    _selectedItem.value = index;
-    widget.onSelectedItemChanged(index);
+    final normalizedIndex = widget.looping ? index % widget.itemCount : index;
+    if (_selectedItem.value == normalizedIndex) return;
+    _selectedItem.value = normalizedIndex;
+    widget.onSelectedItemChanged(normalizedIndex);
   }
 
   void _adjust(int delta) {

--- a/lib/features/design_system/components/time_pickers/design_system_picker_wheels.dart
+++ b/lib/features/design_system/components/time_pickers/design_system_picker_wheels.dart
@@ -54,15 +54,23 @@ class _DesignSystemTimeWheelState extends State<DesignSystemTimeWheel> {
     final hour = widget.use24hFormat
         ? _hourIndex
         : ((_hourIndex + 1) % 12) + _periodIndex * 12;
-    widget.onDateTimeChanged(
-      DateTime(
-        widget.initialDateTime.year,
-        widget.initialDateTime.month,
-        widget.initialDateTime.day,
-        hour,
-        _minuteIndex,
-      ),
-    );
+    final initial = widget.initialDateTime;
+    final changed = initial.isUtc
+        ? DateTime.utc(
+            initial.year,
+            initial.month,
+            initial.day,
+            hour,
+            _minuteIndex,
+          )
+        : DateTime(
+            initial.year,
+            initial.month,
+            initial.day,
+            hour,
+            _minuteIndex,
+          );
+    widget.onDateTimeChanged(changed);
   }
 
   @override

--- a/lib/features/design_system/components/time_pickers/design_system_picker_wheels.dart
+++ b/lib/features/design_system/components/time_pickers/design_system_picker_wheels.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 
 /// Token-backed time-of-day wheel shared by date/time modals.
@@ -106,6 +107,9 @@ class _DesignSystemTimeWheelState extends State<DesignSystemTimeWheel> {
                         ? index.toString().padLeft(2, '0')
                         : '${index + 1}',
                     selectedStyle: pickerStyle,
+                    focusedStyle: pickerStyle.copyWith(
+                      color: tokens.colors.interactive.enabled,
+                    ),
                     unselectedStyle: pickerStyle.copyWith(
                       color: tokens.colors.text.mediumEmphasis,
                     ),
@@ -124,6 +128,9 @@ class _DesignSystemTimeWheelState extends State<DesignSystemTimeWheel> {
                     semanticsLabel: materialLocalizations.timePickerMinuteLabel,
                     labelBuilder: (index) => index.toString().padLeft(2, '0'),
                     selectedStyle: pickerStyle,
+                    focusedStyle: pickerStyle.copyWith(
+                      color: tokens.colors.interactive.enabled,
+                    ),
                     unselectedStyle: pickerStyle.copyWith(
                       color: tokens.colors.text.mediumEmphasis,
                     ),
@@ -151,6 +158,9 @@ class _DesignSystemTimeWheelState extends State<DesignSystemTimeWheel> {
                               context,
                             ).postMeridiemAbbreviation,
                       selectedStyle: pickerStyle,
+                      focusedStyle: pickerStyle.copyWith(
+                        color: tokens.colors.interactive.enabled,
+                      ),
                       unselectedStyle: pickerStyle.copyWith(
                         color: tokens.colors.text.mediumEmphasis,
                       ),
@@ -177,6 +187,7 @@ class _FixedExtentWheelColumn extends StatefulWidget {
     required this.semanticsLabel,
     required this.labelBuilder,
     required this.selectedStyle,
+    required this.focusedStyle,
     required this.unselectedStyle,
     required this.onSelectedItemChanged,
     required this.onScrollEnd,
@@ -191,6 +202,7 @@ class _FixedExtentWheelColumn extends StatefulWidget {
   final String semanticsLabel;
   final String Function(int) labelBuilder;
   final TextStyle selectedStyle;
+  final TextStyle focusedStyle;
   final TextStyle unselectedStyle;
   final ValueChanged<int> onSelectedItemChanged;
   final VoidCallback onScrollEnd;
@@ -205,7 +217,9 @@ class _FixedExtentWheelColumnState extends State<_FixedExtentWheelColumn> {
   static const _loopingTurns = 1000;
 
   late final FixedExtentScrollController _controller;
+  late final FocusNode _focusNode;
   late final ValueNotifier<int> _selectedItem;
+  late final Listenable _visualState;
   late List<Widget> _children;
   var _pointerScrollDistance = 0.0;
 
@@ -217,7 +231,9 @@ class _FixedExtentWheelColumnState extends State<_FixedExtentWheelColumn> {
           ? widget.itemCount * _loopingTurns + widget.initialItem
           : widget.initialItem,
     );
+    _focusNode = FocusNode(debugLabel: widget.semanticsLabel);
     _selectedItem = ValueNotifier(widget.selectedItem);
+    _visualState = Listenable.merge([_selectedItem, _focusNode]);
     _children = _buildChildren();
   }
 
@@ -226,6 +242,7 @@ class _FixedExtentWheelColumnState extends State<_FixedExtentWheelColumn> {
     super.didUpdateWidget(oldWidget);
     if (widget.itemCount != oldWidget.itemCount ||
         widget.selectedStyle != oldWidget.selectedStyle ||
+        widget.focusedStyle != oldWidget.focusedStyle ||
         widget.unselectedStyle != oldWidget.unselectedStyle) {
       _children = _buildChildren();
     }
@@ -234,6 +251,7 @@ class _FixedExtentWheelColumnState extends State<_FixedExtentWheelColumn> {
   @override
   void dispose() {
     _controller.dispose();
+    _focusNode.dispose();
     _selectedItem.dispose();
     super.dispose();
   }
@@ -260,6 +278,21 @@ class _FixedExtentWheelColumnState extends State<_FixedExtentWheelColumn> {
     );
     _handleSelectedItemChanged(next);
     widget.onScrollEnd();
+  }
+
+  KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
+    if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+      return KeyEventResult.ignored;
+    }
+    if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+      _adjust(-1);
+      return KeyEventResult.handled;
+    }
+    if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+      _adjust(1);
+      return KeyEventResult.handled;
+    }
+    return KeyEventResult.ignored;
   }
 
   void _handlePointerSignal(PointerSignalEvent event) {
@@ -290,12 +323,14 @@ class _FixedExtentWheelColumnState extends State<_FixedExtentWheelColumn> {
       onPointerSignal: _handlePointerSignal,
       child: SizedBox.expand(
         child: Center(
-          child: ValueListenableBuilder(
-            valueListenable: _selectedItem,
-            builder: (context, selectedItem, _) => Text(
+          child: AnimatedBuilder(
+            animation: _visualState,
+            builder: (context, _) => Text(
               widget.labelBuilder(index),
-              style: index == selectedItem
-                  ? widget.selectedStyle
+              style: index == _selectedItem.value
+                  ? _focusNode.hasFocus
+                        ? widget.focusedStyle
+                        : widget.selectedStyle
                   : widget.unselectedStyle,
             ),
           ),
@@ -306,53 +341,64 @@ class _FixedExtentWheelColumnState extends State<_FixedExtentWheelColumn> {
 
   @override
   Widget build(BuildContext context) {
-    return ValueListenableBuilder(
-      valueListenable: _selectedItem,
-      builder: (context, selectedItem, _) {
-        final increasedIndex = _adjustedIndex(1);
-        final decreasedIndex = _adjustedIndex(-1);
-        return Semantics(
-          container: true,
-          label: widget.semanticsLabel,
-          value: widget.labelBuilder(selectedItem),
-          increasedValue: increasedIndex == null
-              ? null
-              : widget.labelBuilder(increasedIndex),
-          decreasedValue: decreasedIndex == null
-              ? null
-              : widget.labelBuilder(decreasedIndex),
-          selected: true,
-          onIncrease: increasedIndex == null ? null : () => _adjust(1),
-          onDecrease: decreasedIndex == null ? null : () => _adjust(-1),
-          child: ExcludeSemantics(
-            child: NotificationListener<ScrollEndNotification>(
-              onNotification: (_) {
-                widget.onScrollEnd();
-                return false;
-              },
-              child: ListWheelScrollView.useDelegate(
-                controller: _controller,
-                itemExtent: widget.itemExtent,
-                physics: widget.maxFlingRowsPerSecond == 0
-                    ? const _PreciseFixedExtentScrollPhysics()
-                    : _ControlledFixedExtentScrollPhysics(
-                        itemExtent: widget.itemExtent,
-                        maxFlingRowsPerSecond: widget.maxFlingRowsPerSecond,
-                      ),
-                diameterRatio: _DesignSystemTimeWheelState._diameterRatio,
-                squeeze: _DesignSystemTimeWheelState._squeeze,
-                overAndUnderCenterOpacity:
-                    _DesignSystemTimeWheelState._overAndUnderCenterOpacity,
-                onSelectedItemChanged: _handleSelectedItemChanged,
-                dragStartBehavior: DragStartBehavior.down,
-                childDelegate: widget.looping
-                    ? ListWheelChildLoopingListDelegate(children: _children)
-                    : ListWheelChildListDelegate(children: _children),
+    return Focus(
+      focusNode: _focusNode,
+      onKeyEvent: _handleKeyEvent,
+      child: Listener(
+        behavior: HitTestBehavior.translucent,
+        onPointerDown: (_) => _focusNode.requestFocus(),
+        child: AnimatedBuilder(
+          animation: _visualState,
+          builder: (context, _) {
+            final selectedItem = _selectedItem.value;
+            final increasedIndex = _adjustedIndex(1);
+            final decreasedIndex = _adjustedIndex(-1);
+            return Semantics(
+              container: true,
+              label: widget.semanticsLabel,
+              value: widget.labelBuilder(selectedItem),
+              increasedValue: increasedIndex == null
+                  ? null
+                  : widget.labelBuilder(increasedIndex),
+              decreasedValue: decreasedIndex == null
+                  ? null
+                  : widget.labelBuilder(decreasedIndex),
+              focusable: true,
+              focused: _focusNode.hasFocus,
+              selected: true,
+              onIncrease: increasedIndex == null ? null : () => _adjust(1),
+              onDecrease: decreasedIndex == null ? null : () => _adjust(-1),
+              child: ExcludeSemantics(
+                child: NotificationListener<ScrollEndNotification>(
+                  onNotification: (_) {
+                    widget.onScrollEnd();
+                    return false;
+                  },
+                  child: ListWheelScrollView.useDelegate(
+                    controller: _controller,
+                    itemExtent: widget.itemExtent,
+                    physics: widget.maxFlingRowsPerSecond == 0
+                        ? const _PreciseFixedExtentScrollPhysics()
+                        : _ControlledFixedExtentScrollPhysics(
+                            itemExtent: widget.itemExtent,
+                            maxFlingRowsPerSecond: widget.maxFlingRowsPerSecond,
+                          ),
+                    diameterRatio: _DesignSystemTimeWheelState._diameterRatio,
+                    squeeze: _DesignSystemTimeWheelState._squeeze,
+                    overAndUnderCenterOpacity:
+                        _DesignSystemTimeWheelState._overAndUnderCenterOpacity,
+                    onSelectedItemChanged: _handleSelectedItemChanged,
+                    dragStartBehavior: DragStartBehavior.down,
+                    childDelegate: widget.looping
+                        ? ListWheelChildLoopingListDelegate(children: _children)
+                        : ListWheelChildListDelegate(children: _children),
+                  ),
+                ),
               ),
-            ),
-          ),
-        );
-      },
+            );
+          },
+        ),
+      ),
     );
   }
 }

--- a/lib/features/journal/README.md
+++ b/lib/features/journal/README.md
@@ -214,9 +214,28 @@ A few detail-level behaviors are worth calling out because they are easy to miss
 
 ### Start/End Date-Time Editor
 
-[`entry_datetime_multipage_modal.dart`](ui/widgets/entry_details/entry_datetime_multipage_modal.dart) edits an entry's `dateFrom`/`dateTo` and commits them via `EntryController.updateFromTo`. It is a single-page modal: one **Date** wheel over **paired Start/End time wheels**, so the date is entered once and stamped onto both timestamps rather than picked twice.
+[`entry_datetime_multipage_modal.dart`](ui/widgets/entry_details/entry_datetime_multipage_modal.dart) edits an entry's `dateFrom`/`dateTo` and commits them via `EntryController.updateFromTo`. Its Wolt modal has two reusable pages rather than stacking a date dialog over the editor:
 
-The editable model is the pure, testable [`EntryDateTimeRange`](ui/widgets/entry_details/entry_datetime_range.dart) — a `startDate` (day only) + `startTime` + `endTime` + an optional `endDateOverride` — from which `dateFrom`/`dateTo` are *derived* (they can never desync). The pinned glass bar shows a live duration (`formatRangeDuration`, multi-day aware) and disables Save until the range both changed and is valid.
+1. the overview shows a full-weekday date control, optional separate end date,
+   paired Start/End time wheels, endpoint-specific **Now** actions, and the live
+   range status;
+2. activating either date transitions to an in-sheet calendar page with Back,
+   Close, Today, and Done controls.
+
+The editable model is the pure, testable [`EntryDateTimeRange`](ui/widgets/entry_details/entry_datetime_range.dart) — a `startDate` (day only) + `startTime` + `endTime` + an optional `endDateOverride` — from which `dateFrom`/`dateTo` are *derived* (they can never desync). The glass Save footer remains fixed while the regular Wolt page owns overflow scrolling. Its content padding reserves the footer's occupied height, and the status reserves the next-day chip row in both states, so neither crossing midnight nor exposing the chip moves the sheet. Save stays disabled until the range both changed and is valid.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Overview
+    Overview --> StartCalendar: activate start date
+    Overview --> EndCalendar: activate end date
+    StartCalendar --> Overview: Back or Done
+    EndCalendar --> Overview: Back or Done
+    Overview --> Persisted: Save changed valid range
+    Overview --> Dismissed: Close
+    StartCalendar --> Dismissed: Close
+    EndCalendar --> Dismissed: Close
+```
 
 `EntryDateTimeRange.fromBounds` decides which mode an existing entry opens in:
 
@@ -226,19 +245,19 @@ stateDiagram-v2
     [*] --> SharedDate: end day == start+1 AND end clock < start clock (plain overnight)
     [*] --> DifferentDates: otherwise (multi-day, or exact-24h same-clock next day)
 
-    SharedDate --> SharedDate: spin date / times
+    SharedDate --> SharedDate: select date / spin times / use Now
     note right of SharedDate
-      one Date wheel + two time wheels.
+      one date control + two time wheels.
       end clock < start clock auto-rolls
       dateTo to the next day and shows a
-      teal "+1 day" chip (overnightAuto).
+      teal next-day chip (overnightAuto).
     end note
 
-    SharedDate --> DifferentDates: toggle "Ends on another day" ON\n(freeze endDateOverride = current end day)
+    SharedDate --> DifferentDates: toggle separate end date ON\n(freeze endDateOverride = current end day)
     DifferentDates --> SharedDate: toggle OFF\n(clear endDateOverride; end collapses onto start date)
     note right of DifferentDates
-      reveals a second End date wheel;
-      dateTo decomposes independently.
+      reveals a second End date control;
+      either date opens the same calendar page.
       Save is gated on dateTo >= dateFrom.
     end note
 ```

--- a/lib/features/journal/README.md
+++ b/lib/features/journal/README.md
@@ -222,7 +222,7 @@ A few detail-level behaviors are worth calling out because they are easy to miss
 2. activating either date transitions to an in-sheet calendar page with Back,
    Close, Today, and Done controls.
 
-The editable model is the pure, testable [`EntryDateTimeRange`](ui/widgets/entry_details/entry_datetime_range.dart) — a `startDate` (day only) + `startTime` + `endTime` + an optional `endDateOverride` — from which `dateFrom`/`dateTo` are *derived* (they can never desync). Date decomposition and recomposition retain the entry's UTC/local timezone kind. **Now** and **Today** read the injectable clock and normalize it to that same timezone before changing an endpoint, so shortcuts are deterministic in tests and cannot mix UTC and local bounds. The glass Save footer remains fixed while the regular Wolt page owns overflow scrolling. Its content padding reserves the footer's occupied height, and the status reserves the next-day chip row in both states, so neither crossing midnight nor exposing the chip moves the sheet. Save stays disabled until the range both changed and is valid.
+The editable model is the pure, testable [`EntryDateTimeRange`](ui/widgets/entry_details/entry_datetime_range.dart) — a `startDate` (day only) + `startTime` + `endTime` + an optional `endDateOverride` — from which `dateFrom`/`dateTo` are *derived* (they can never desync). Date decomposition and recomposition retain the entry's timezone semantics, including UTC, device-local, and named zones. **Now** and **Today** read the injectable clock and normalize it to that same timezone before changing an endpoint, so shortcuts are deterministic in tests and cannot mix timezone kinds. Endpoint-level **Now** actions preserve the opposite absolute endpoint; if **Start Now** moves past the stored end, the model exposes that exact inverted range as invalid instead of silently rolling the end into tomorrow. The glass Save footer remains fixed while the regular Wolt page owns overflow scrolling. Its content padding reserves the footer's occupied height, and the status reserves the next-day chip row in both states, so neither crossing midnight nor exposing the chip moves the sheet. Save stays disabled until the range both changed and is valid.
 
 ```mermaid
 stateDiagram-v2
@@ -241,9 +241,9 @@ stateDiagram-v2
 
 ```mermaid
 stateDiagram-v2
-    [*] --> SharedDate: end day == start day
+    [*] --> SharedDate: ordered bounds AND end day == start day
     [*] --> SharedDate: end day == start+1 AND end clock < start clock (plain overnight)
-    [*] --> DifferentDates: otherwise (multi-day, or exact-24h same-clock next day)
+    [*] --> DifferentDates: otherwise (inverted, multi-day, or exact-24h same-clock next day)
 
     SharedDate --> SharedDate: select date / spin times / use Now
     note right of SharedDate

--- a/lib/features/journal/README.md
+++ b/lib/features/journal/README.md
@@ -222,7 +222,7 @@ A few detail-level behaviors are worth calling out because they are easy to miss
 2. activating either date transitions to an in-sheet calendar page with Back,
    Close, Today, and Done controls.
 
-The editable model is the pure, testable [`EntryDateTimeRange`](ui/widgets/entry_details/entry_datetime_range.dart) — a `startDate` (day only) + `startTime` + `endTime` + an optional `endDateOverride` — from which `dateFrom`/`dateTo` are *derived* (they can never desync). The glass Save footer remains fixed while the regular Wolt page owns overflow scrolling. Its content padding reserves the footer's occupied height, and the status reserves the next-day chip row in both states, so neither crossing midnight nor exposing the chip moves the sheet. Save stays disabled until the range both changed and is valid.
+The editable model is the pure, testable [`EntryDateTimeRange`](ui/widgets/entry_details/entry_datetime_range.dart) — a `startDate` (day only) + `startTime` + `endTime` + an optional `endDateOverride` — from which `dateFrom`/`dateTo` are *derived* (they can never desync). Date decomposition and recomposition retain the entry's UTC/local timezone kind. **Now** and **Today** read the injectable clock and normalize it to that same timezone before changing an endpoint, so shortcuts are deterministic in tests and cannot mix UTC and local bounds. The glass Save footer remains fixed while the regular Wolt page owns overflow scrolling. Its content padding reserves the footer's occupied height, and the status reserves the next-day chip row in both states, so neither crossing midnight nor exposing the chip moves the sheet. Save stays disabled until the range both changed and is valid.
 
 ```mermaid
 stateDiagram-v2

--- a/lib/features/journal/ui/widgets/entry_details/entry_datetime_multipage_modal.dart
+++ b/lib/features/journal/ui/widgets/entry_details/entry_datetime_multipage_modal.dart
@@ -1,3 +1,4 @@
+import 'package:clock/clock.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -14,6 +15,7 @@ import 'package:lotti/features/journal/ui/widgets/entry_details/entry_datetime_r
 import 'package:lotti/features/journal/ui/widgets/entry_details/entry_datetime_status_bar.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/services/dev_logger.dart';
+import 'package:lotti/utils/date_utils_extension.dart';
 import 'package:lotti/widgets/modal/modal_utils.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
@@ -29,68 +31,74 @@ class EntryDateTimeMultiPageModal {
     final pageIndexNotifier = ValueNotifier(0);
     final activeDateEndpoint = ValueNotifier(_DateEndpoint.start);
 
-    await ModalUtils.showMultiPageModal<void>(
-      context: context,
-      pageIndexNotifier: pageIndexNotifier,
-      modalTypeBuilderOverride: _modalTypeBuilder,
-      pageListBuilder: (modalContext) => [
-        ModalUtils.modalSheetPage(
-          context: modalContext,
-          titleWidget: _modalTitle(modalContext),
-          showCloseButton: true,
-          padding: EdgeInsets.fromLTRB(
-            tokens.spacing.step5,
-            tokens.spacing.step3,
-            tokens.spacing.step5,
-            DesignSystemGlassActionFooter.reservedHeight,
-          ),
-          stickyActionBar: _SaveActionBar(
-            entry: entry,
-            stateNotifier: stateNotifier,
-          ),
-          child: _EntryDateTimeEditor(
-            stateNotifier,
-            onPickStartDate: () {
-              activeDateEndpoint.value = _DateEndpoint.start;
-              pageIndexNotifier.value = 1;
-            },
-            onPickEndDate: () {
-              activeDateEndpoint.value = _DateEndpoint.end;
-              pageIndexNotifier.value = 1;
-            },
-          ),
-        ),
-        ModalUtils.modalSheetPage(
-          context: modalContext,
-          titleWidget: ValueListenableBuilder<_DateEndpoint>(
-            valueListenable: activeDateEndpoint,
-            builder: (context, endpoint, _) => Text(
-              switch (endpoint) {
-                _DateEndpoint.start => context.messages.journalStartDateLabel,
-                _DateEndpoint.end => context.messages.journalEndDateLabel,
+    try {
+      await ModalUtils.showMultiPageModal<void>(
+        context: context,
+        pageIndexNotifier: pageIndexNotifier,
+        modalTypeBuilderOverride: _modalTypeBuilder,
+        pageListBuilder: (modalContext) => [
+          ModalUtils.modalSheetPage(
+            context: modalContext,
+            titleWidget: _modalTitle(modalContext),
+            showCloseButton: true,
+            padding: EdgeInsets.fromLTRB(
+              tokens.spacing.step5,
+              tokens.spacing.step3,
+              tokens.spacing.step5,
+              DesignSystemGlassActionFooter.reservedHeight,
+            ),
+            stickyActionBar: _SaveActionBar(
+              entry: entry,
+              stateNotifier: stateNotifier,
+            ),
+            child: _EntryDateTimeEditor(
+              stateNotifier,
+              onPickStartDate: () {
+                activeDateEndpoint.value = _DateEndpoint.start;
+                pageIndexNotifier.value = 1;
               },
-              style: ModalUtils.modalTitleStyle(context),
+              onPickEndDate: () {
+                activeDateEndpoint.value = _DateEndpoint.end;
+                pageIndexNotifier.value = 1;
+              },
             ),
           ),
-          showCloseButton: true,
-          onTapBack: () => pageIndexNotifier.value = 0,
-          padding: EdgeInsets.fromLTRB(
-            tokens.spacing.step5,
-            tokens.spacing.step5,
-            tokens.spacing.step5,
-            tokens.spacing.step11 + tokens.spacing.step6,
+          ModalUtils.modalSheetPage(
+            context: modalContext,
+            titleWidget: ValueListenableBuilder<_DateEndpoint>(
+              valueListenable: activeDateEndpoint,
+              builder: (context, endpoint, _) => Text(
+                switch (endpoint) {
+                  _DateEndpoint.start => context.messages.journalStartDateLabel,
+                  _DateEndpoint.end => context.messages.journalEndDateLabel,
+                },
+                style: ModalUtils.modalTitleStyle(context),
+              ),
+            ),
+            showCloseButton: true,
+            onTapBack: () => pageIndexNotifier.value = 0,
+            padding: EdgeInsets.fromLTRB(
+              tokens.spacing.step5,
+              tokens.spacing.step5,
+              tokens.spacing.step5,
+              tokens.spacing.step11 + tokens.spacing.step6,
+            ),
+            stickyActionBar: DesignSystemDatePickerActionBar(
+              onClear: null,
+              onDone: () => pageIndexNotifier.value = 0,
+            ),
+            child: _EntryDateCalendarPage(
+              stateNotifier: stateNotifier,
+              activeEndpoint: activeDateEndpoint,
+            ),
           ),
-          stickyActionBar: DesignSystemDatePickerActionBar(
-            onClear: null,
-            onDone: () => pageIndexNotifier.value = 0,
-          ),
-          child: _EntryDateCalendarPage(
-            stateNotifier: stateNotifier,
-            activeEndpoint: activeDateEndpoint,
-          ),
-        ),
-      ],
-    );
+        ],
+      );
+    } finally {
+      stateNotifier.dispose();
+      pageIndexNotifier.dispose();
+      activeDateEndpoint.dispose();
+    }
   }
 
   static Widget _modalTitle(BuildContext context) {
@@ -193,22 +201,23 @@ class _EntryDateTimeEditorState extends State<_EntryDateTimeEditor> {
 
   void _setStartNow() {
     _startTimeSeed += 1;
-    _state = _state.withStart(DateTime.now());
+    _state = _state.withStart(_nowInZoneOf(_state.dateFrom));
   }
 
   void _setEndNow() {
     _endTimeSeed += 1;
-    _state = _state.withEnd(DateTime.now());
+    _state = _state.withEnd(_nowInZoneOf(_state.dateTo));
   }
 
   void _setStartDateToday() {
-    final now = DateTime.now();
-    _state = _state.copyWith(startDate: _dateOnly(now));
+    final today = _nowInZoneOf(_state.startDate).dateOnly;
+    _state = _state.copyWith(startDate: today);
   }
 
   void _setEndDateToday() {
-    final now = DateTime.now();
-    _state = _state.copyWith(endDateOverride: _dateOnly(now));
+    final reference = _state.endDateOverride ?? _state.startDate;
+    final today = _nowInZoneOf(reference).dateOnly;
+    _state = _state.copyWith(endDateOverride: today);
   }
 
   @override
@@ -241,7 +250,7 @@ class _EntryDateTimeEditorState extends State<_EntryDateTimeEditor> {
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        _EditorSection(
+        DesignSystemPickerSection(
           child: Column(
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -298,7 +307,7 @@ class _EntryDateTimeEditorState extends State<_EntryDateTimeEditor> {
           ),
         ),
         SizedBox(height: tokens.spacing.step6),
-        _EditorSection(
+        DesignSystemPickerSection(
           child: stackTimes
               ? Column(
                   mainAxisSize: MainAxisSize.min,
@@ -323,30 +332,6 @@ class _EntryDateTimeEditorState extends State<_EntryDateTimeEditor> {
           child: EntryDateTimeStatusBar(range: state),
         ),
       ],
-    );
-  }
-}
-
-DateTime _dateOnly(DateTime d) => DateTime(d.year, d.month, d.day);
-
-/// Token-spaced grouping shared by the date and time sections.
-class _EditorSection extends StatelessWidget {
-  const _EditorSection({required this.child});
-
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    final tokens = context.designTokens;
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(tokens.radii.sectionCards),
-        border: Border.all(color: tokens.colors.decorative.level01),
-      ),
-      child: Padding(
-        padding: EdgeInsets.all(tokens.spacing.cardPadding),
-        child: child,
-      ),
     );
   }
 }
@@ -518,10 +503,12 @@ class _TimeColumn extends StatelessWidget {
   }
 }
 
-bool _isToday(DateTime date) => _isSameDate(date, DateTime.now());
+DateTime _nowInZoneOf(DateTime reference) {
+  final now = clock.now();
+  return reference.isUtc ? now.toUtc() : now.toLocal();
+}
 
-bool _isSameDate(DateTime a, DateTime b) =>
-    a.year == b.year && a.month == b.month && a.day == b.day;
+bool _isToday(DateTime date) => date.isSameCalendarDay(_nowInZoneOf(date));
 
 class _SaveActionBar extends ConsumerWidget {
   const _SaveActionBar({required this.entry, required this.stateNotifier});

--- a/lib/features/journal/ui/widgets/entry_details/entry_datetime_multipage_modal.dart
+++ b/lib/features/journal/ui/widgets/entry_details/entry_datetime_multipage_modal.dart
@@ -1,11 +1,12 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
-import 'package:lotti/features/design_system/components/chips/ds_pill.dart';
+import 'package:lotti/features/design_system/components/calendar_pickers/design_system_date_picker_modal.dart';
 import 'package:lotti/features/design_system/components/glass_strip.dart';
+import 'package:lotti/features/design_system/components/time_pickers/design_system_picker_wheels.dart';
 import 'package:lotti/features/design_system/components/toggles/design_system_toggle.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/journal/state/entry_controller.dart';
@@ -13,60 +14,148 @@ import 'package:lotti/features/journal/ui/widgets/entry_details/entry_datetime_r
 import 'package:lotti/features/journal/ui/widgets/entry_details/entry_datetime_status_bar.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/services/dev_logger.dart';
-import 'package:lotti/themes/theme.dart';
 import 'package:lotti/widgets/modal/modal_utils.dart';
+import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
 class EntryDateTimeMultiPageModal {
   static Future<void> show({
     required BuildContext context,
     required JournalEntity entry,
   }) async {
+    final tokens = context.designTokens;
     final stateNotifier = ValueNotifier(
       EntryDateTimeRange.fromBounds(entry.meta.dateFrom, entry.meta.dateTo),
     );
+    final pageIndexNotifier = ValueNotifier(0);
+    final activeDateEndpoint = ValueNotifier(_DateEndpoint.start);
 
-    await ModalUtils.showSinglePageModal<void>(
+    await ModalUtils.showMultiPageModal<void>(
       context: context,
-      titleWidget: Builder(
-        builder: (context) => Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(
-              MdiIcons.calendarClock,
-              size: 22,
-              color: context.colorScheme.primary,
-            ),
-            const SizedBox(width: 10),
-            Text(
-              context.messages.journalDateTimeRangeTitle,
-              style: context.textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-          ],
+      pageIndexNotifier: pageIndexNotifier,
+      modalTypeBuilderOverride: _modalTypeBuilder,
+      pageListBuilder: (modalContext) => [
+        ModalUtils.modalSheetPage(
+          context: modalContext,
+          titleWidget: _modalTitle(modalContext),
+          showCloseButton: true,
+          padding: EdgeInsets.fromLTRB(
+            tokens.spacing.step5,
+            tokens.spacing.step3,
+            tokens.spacing.step5,
+            DesignSystemGlassActionFooter.reservedHeight,
+          ),
+          stickyActionBar: _SaveActionBar(
+            entry: entry,
+            stateNotifier: stateNotifier,
+          ),
+          child: _EntryDateTimeEditor(
+            stateNotifier,
+            onPickStartDate: () {
+              activeDateEndpoint.value = _DateEndpoint.start;
+              pageIndexNotifier.value = 1;
+            },
+            onPickEndDate: () {
+              activeDateEndpoint.value = _DateEndpoint.end;
+              pageIndexNotifier.value = 1;
+            },
+          ),
         ),
-      ),
-      navBarHeight: 65,
-      builder: (modalContext) => _EntryDateTimeEditor(stateNotifier),
-      stickyActionBarBuilder: (modalContext) =>
-          _SaveActionBar(entry: entry, stateNotifier: stateNotifier),
+        ModalUtils.modalSheetPage(
+          context: modalContext,
+          titleWidget: ValueListenableBuilder<_DateEndpoint>(
+            valueListenable: activeDateEndpoint,
+            builder: (context, endpoint, _) => Text(
+              switch (endpoint) {
+                _DateEndpoint.start => context.messages.journalStartDateLabel,
+                _DateEndpoint.end => context.messages.journalEndDateLabel,
+              },
+              style: ModalUtils.modalTitleStyle(context),
+            ),
+          ),
+          showCloseButton: true,
+          onTapBack: () => pageIndexNotifier.value = 0,
+          padding: EdgeInsets.fromLTRB(
+            tokens.spacing.step5,
+            tokens.spacing.step5,
+            tokens.spacing.step5,
+            tokens.spacing.step11 + tokens.spacing.step6,
+          ),
+          stickyActionBar: DesignSystemDatePickerActionBar(
+            onClear: null,
+            onDone: () => pageIndexNotifier.value = 0,
+          ),
+          child: _EntryDateCalendarPage(
+            stateNotifier: stateNotifier,
+            activeEndpoint: activeDateEndpoint,
+          ),
+        ),
+      ],
     );
+  }
 
-    stateNotifier.dispose();
+  static Widget _modalTitle(BuildContext context) {
+    final tokens = context.designTokens;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(
+          MdiIcons.calendarClock,
+          size: tokens.spacing.step6,
+          color: tokens.colors.interactive.enabled,
+        ),
+        SizedBox(width: tokens.spacing.step3),
+        Text(
+          context.messages.journalDateTimeRangeTitle,
+          style: ModalUtils.modalTitleStyle(context),
+        ),
+      ],
+    );
+  }
+}
+
+enum _DateEndpoint { start, end }
+
+WoltModalType _modalTypeBuilder(BuildContext context) {
+  if (ModalUtils.shouldUseRootNavigatorForBottomSheet(context)) {
+    return WoltModalType.bottomSheet();
+  }
+  return const _EntryDateTimeDialogType();
+}
+
+/// Uses the screen space available to this dense editor instead of the
+/// standard Wolt dialog's 80% height cap.
+class _EntryDateTimeDialogType extends WoltDialogType {
+  const _EntryDateTimeDialogType();
+
+  @override
+  BoxConstraints layoutModal(Size availableSize) {
+    final base = super.layoutModal(availableSize);
+    final maxHeight = (availableSize.height - WoltDialogType.minPadding).clamp(
+      base.minHeight,
+      availableSize.height,
+    );
+    return base.copyWith(maxHeight: maxHeight);
   }
 }
 
 class _EntryDateTimeEditor extends StatefulWidget {
-  const _EntryDateTimeEditor(this.stateNotifier);
+  const _EntryDateTimeEditor(
+    this.stateNotifier, {
+    required this.onPickStartDate,
+    required this.onPickEndDate,
+  });
 
   final ValueNotifier<EntryDateTimeRange> stateNotifier;
+  final VoidCallback onPickStartDate;
+  final VoidCallback onPickEndDate;
 
   @override
   State<_EntryDateTimeEditor> createState() => _EntryDateTimeEditorState();
 }
 
 class _EntryDateTimeEditorState extends State<_EntryDateTimeEditor> {
-  late bool _differentDates;
+  var _startTimeSeed = 0;
+  var _endTimeSeed = 0;
 
   EntryDateTimeRange get _state => widget.stateNotifier.value;
   set _state(EntryDateTimeRange value) => widget.stateNotifier.value = value;
@@ -74,7 +163,6 @@ class _EntryDateTimeEditorState extends State<_EntryDateTimeEditor> {
   @override
   void initState() {
     super.initState();
-    _differentDates = _state.differentDates;
     widget.stateNotifier.addListener(_onStateChanged);
   }
 
@@ -84,14 +172,10 @@ class _EntryDateTimeEditorState extends State<_EntryDateTimeEditor> {
     super.dispose();
   }
 
-  /// Only the mode flip changes the *layout* (and therefore which wheels exist),
-  /// so only that triggers a rebuild. Time/date spins update the shared state
-  /// for the live readouts without rebuilding — otherwise the uncontrolled
-  /// Cupertino wheels would jump back to their initial position on every tick.
+  /// Rebuilds the draft readout while stateful fixed-extent wheels retain their
+  /// scroll positions across range changes.
   void _onStateChanged() {
-    if (_state.differentDates != _differentDates) {
-      setState(() => _differentDates = _state.differentDates);
-    }
+    setState(() {});
   }
 
   void _toggleDifferentDates({required bool value}) {
@@ -107,147 +191,227 @@ class _EntryDateTimeEditorState extends State<_EntryDateTimeEditor> {
     }
   }
 
+  void _setStartNow() {
+    _startTimeSeed += 1;
+    _state = _state.withStart(DateTime.now());
+  }
+
+  void _setEndNow() {
+    _endTimeSeed += 1;
+    _state = _state.withEnd(DateTime.now());
+  }
+
+  void _setStartDateToday() {
+    final now = DateTime.now();
+    _state = _state.copyWith(startDate: _dateOnly(now));
+  }
+
+  void _setEndDateToday() {
+    final now = DateTime.now();
+    _state = _state.copyWith(endDateOverride: _dateOnly(now));
+  }
+
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final state = _state;
-    // In different-dates mode two date wheels coexist with the time wheels, so
-    // every wheel shrinks to keep the duration + toggle above the sticky bar.
     final compact = state.differentDates;
-    final dateHeight = compact ? 148.0 : 180.0;
-    final timeHeight = compact ? 132.0 : 160.0;
+    final stackTimes = MediaQuery.textScalerOf(context).scale(1) > 1.3;
 
-    return Padding(
-      padding: EdgeInsets.symmetric(horizontal: tokens.spacing.step5),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          _Caption(
-            emphasized: true,
-            label: compact
-                ? context.messages.journalStartDateLabel
-                : context.messages.journalDateLabel,
-            trailing: _TodayPill(
-              onTap: () {
-                final now = DateTime.now();
-                _state = _state.copyWith(
-                  startDate: DateTime(now.year, now.month, now.day),
-                );
-                setState(() {}); // re-seed the date wheel to today
-              },
-            ),
-          ),
-          _DateWheel(
-            key: ValueKey('start-date-${state.startDate}'),
-            height: dateHeight,
-            initial: state.startDate,
-            onChanged: (date) =>
-                _state = _state.copyWith(startDate: _dateOnly(date)),
-          ),
-          SizedBox(height: tokens.spacing.step4),
-          // The toggle sits high — right under the (start) date wheel and where
-          // its revealed End date appears — so the control that drives the mode
-          // is always on screen, never occluded by the pinned bar.
-          DesignSystemToggle(
-            value: state.differentDates,
-            label: context.messages.journalEndsAnotherDayLabel,
-            onChanged: (value) => _toggleDifferentDates(value: value),
-          ),
-          if (!compact)
-            Padding(
-              padding: EdgeInsets.only(top: tokens.spacing.step2),
-              child: Text(
-                context.messages.journalEndsAnotherDayHint,
-                style: context.textTheme.bodySmall?.copyWith(
-                  color: context.colorScheme.onSurfaceVariant,
-                ),
-              ),
-            ),
-          if (compact) ...[
-            SizedBox(height: tokens.spacing.step4),
-            _Caption(
-              emphasized: true,
-              label: context.messages.journalEndDateLabel,
-            ),
-            _DateWheel(
-              key: ValueKey('end-date-${state.endDateOverride}'),
-              height: dateHeight,
-              initial: state.endDateOverride ?? state.startDate,
-              onChanged: (date) =>
-                  _state = _state.copyWith(endDateOverride: _dateOnly(date)),
-            ),
-          ],
-          // A deliberate section gap separates the date block from the time
-          // block (mirrors the same-day rhythm even when stacked in multi-day).
-          SizedBox(height: tokens.spacing.step6),
-          // Start/end times stay paired side by side in both modes — the
-          // standout density + "same range" clarity win from round 1.
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
+    final timeColumns = <Widget>[
+      _TimeColumn(
+        label: context.messages.journalStartTimeLabel,
+        initial: state.startTime,
+        wheelSeed: _startTimeSeed,
+        nowSemanticsLabel: context.messages.journalSetStartDateTimeNowSemantic,
+        onNow: _setStartNow,
+        onChanged: (time) => _state = _state.copyWith(startTime: time),
+      ),
+      _TimeColumn(
+        label: context.messages.journalEndTimeLabel,
+        initial: state.endTime,
+        wheelSeed: _endTimeSeed,
+        nowSemanticsLabel: context.messages.journalSetEndDateTimeNowSemantic,
+        onNow: _setEndNow,
+        onChanged: (time) => _state = _state.copyWith(endTime: time),
+      ),
+    ];
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _EditorSection(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              Expanded(
-                child: _TimeColumn(
-                  label: context.messages.journalStartTimeLabel,
-                  height: timeHeight,
-                  initial: state.startTime,
-                  onChanged: (time) =>
-                      _state = _state.copyWith(startTime: time),
+              _Caption(
+                label: compact
+                    ? context.messages.journalStartDateLabel
+                    : context.messages.journalDateLabel,
+                trailing: _QuickAction(
+                  label: context.messages.journalTodayButton,
+                  semanticsLabel:
+                      '${compact ? context.messages.journalStartDateLabel : context.messages.journalDateLabel}, '
+                      '${context.messages.journalTodayButton}',
+                  onPressed: _isToday(state.startDate)
+                      ? null
+                      : _setStartDateToday,
                 ),
               ),
-              SizedBox(width: tokens.spacing.step4),
-              Expanded(
-                child: _TimeColumn(
-                  label: context.messages.journalEndTimeLabel,
-                  height: timeHeight,
-                  initial: state.endTime,
-                  onChanged: (time) => _state = _state.copyWith(endTime: time),
-                ),
+              _DateSelectionButton(
+                date: state.startDate,
+                onPressed: widget.onPickStartDate,
               ),
+              SizedBox(height: tokens.spacing.step3),
+              Divider(height: 1, color: tokens.colors.decorative.level01),
+              SizedBox(height: tokens.spacing.step3),
+              DesignSystemToggle(
+                value: state.differentDates,
+                label: context.messages.journalEndsAnotherDayHint,
+                onChanged: (value) => _toggleDifferentDates(value: value),
+              ),
+              if (compact) ...[
+                SizedBox(height: tokens.spacing.step6),
+                _Caption(
+                  label: context.messages.journalEndDateLabel,
+                  trailing: _QuickAction(
+                    label: context.messages.journalTodayButton,
+                    semanticsLabel:
+                        '${context.messages.journalEndDateLabel}, '
+                        '${context.messages.journalTodayButton}',
+                    onPressed:
+                        _isToday(
+                          state.endDateOverride ?? state.startDate,
+                        )
+                        ? null
+                        : _setEndDateToday,
+                  ),
+                ),
+                _DateSelectionButton(
+                  date: state.endDateOverride ?? state.startDate,
+                  onPressed: widget.onPickEndDate,
+                ),
+              ],
             ],
           ),
-          // Keep content clear of the glass status + Save bar.
-          const SizedBox(height: 124),
-        ],
-      ),
+        ),
+        SizedBox(height: tokens.spacing.step6),
+        _EditorSection(
+          child: stackTimes
+              ? Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    timeColumns.first,
+                    SizedBox(height: tokens.spacing.sectionGap),
+                    timeColumns.last,
+                  ],
+                )
+              : Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Expanded(child: timeColumns.first),
+                    SizedBox(width: tokens.spacing.step3),
+                    Expanded(child: timeColumns.last),
+                  ],
+                ),
+        ),
+        SizedBox(height: tokens.spacing.step6),
+        Padding(
+          padding: EdgeInsets.symmetric(horizontal: tokens.spacing.cardPadding),
+          child: EntryDateTimeStatusBar(range: state),
+        ),
+      ],
     );
   }
 }
 
 DateTime _dateOnly(DateTime d) => DateTime(d.year, d.month, d.day);
 
-class _Caption extends StatelessWidget {
-  const _Caption({
-    required this.label,
-    this.trailing,
-    this.emphasized = false,
-  });
+/// Token-spaced grouping shared by the date and time sections.
+class _EditorSection extends StatelessWidget {
+  const _EditorSection({required this.child});
 
-  final String label;
-  final Widget? trailing;
-
-  /// Primary captions (the date sections) read a step heavier than the
-  /// secondary time captions, reinforcing the "one date contains the times"
-  /// containment the design relies on.
-  final bool emphasized;
+  final Widget child;
 
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
-    final style = emphasized
-        ? context.textTheme.titleSmall?.copyWith(
-            fontWeight: FontWeight.w600,
-            color: context.colorScheme.onSurface,
-          )
-        : context.textTheme.bodyMedium?.copyWith(
-            color: context.colorScheme.onSurfaceVariant,
-          );
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(tokens.radii.sectionCards),
+        border: Border.all(color: tokens.colors.decorative.level01),
+      ),
+      child: Padding(
+        padding: EdgeInsets.all(tokens.spacing.cardPadding),
+        child: child,
+      ),
+    );
+  }
+}
+
+class _EntryDateCalendarPage extends StatelessWidget {
+  const _EntryDateCalendarPage({
+    required this.stateNotifier,
+    required this.activeEndpoint,
+  });
+
+  final ValueNotifier<EntryDateTimeRange> stateNotifier;
+  final ValueNotifier<_DateEndpoint> activeEndpoint;
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<_DateEndpoint>(
+      valueListenable: activeEndpoint,
+      builder: (context, endpoint, _) {
+        return ValueListenableBuilder<EntryDateTimeRange>(
+          valueListenable: stateNotifier,
+          builder: (context, state, _) {
+            final selectedDate = switch (endpoint) {
+              _DateEndpoint.start => state.startDate,
+              _DateEndpoint.end => state.endDateOverride ?? state.startDate,
+            };
+            return DesignSystemCalendarPicker(
+              selectedDate: selectedDate,
+              firstDate: DateTime(1900),
+              lastDate: DateTime(2100),
+              onDateChanged: (date) {
+                stateNotifier.value = switch (endpoint) {
+                  _DateEndpoint.start => state.copyWith(startDate: date),
+                  _DateEndpoint.end => state.copyWith(endDateOverride: date),
+                };
+              },
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+class _Caption extends StatelessWidget {
+  const _Caption({required this.label, this.trailing});
+
+  final String label;
+  final Widget? trailing;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
     return Padding(
       padding: EdgeInsets.only(bottom: tokens.spacing.step2),
       child: Row(
         children: [
-          Text(label, style: style),
-          const Spacer(),
+          Expanded(
+            child: Text(
+              label,
+              style: tokens.typography.styles.subtitle.subtitle2.copyWith(
+                color: tokens.colors.text.highEmphasis,
+              ),
+            ),
+          ),
+          if (trailing != null) SizedBox(width: tokens.spacing.step2),
           ?trailing,
         ],
       ),
@@ -255,53 +419,51 @@ class _Caption extends StatelessWidget {
   }
 }
 
-class _TodayPill extends StatelessWidget {
-  const _TodayPill({required this.onTap});
+/// Full localized date button that opens the calendar page in this sheet.
+class _DateSelectionButton extends StatelessWidget {
+  const _DateSelectionButton({required this.date, required this.onPressed});
 
-  final VoidCallback onTap;
+  final DateTime date;
+  final VoidCallback onPressed;
 
   @override
   Widget build(BuildContext context) {
-    // A neutral grey pill (high-emphasis white tinted at 18%) — visibly filled
-    // above the sheet background and distinct from the teal overnight chip, so
-    // the two capsules read as one family differentiated by meaning.
-    return DsPill(
-      variant: DsPillVariant.tinted,
-      color: context.designTokens.colors.text.highEmphasis,
-      label: context.messages.journalTodayButton,
-      onTap: onTap,
+    return DesignSystemButton(
+      label: _formatFullDate(context, date),
+      leadingIcon: Icons.calendar_month_rounded,
+      variant: DesignSystemButtonVariant.secondary,
+      size: DesignSystemButtonSize.large,
+      fullWidth: true,
+      onPressed: onPressed,
     );
   }
 }
 
-class _DateWheel extends StatelessWidget {
-  const _DateWheel({
-    required this.height,
-    required this.initial,
-    required this.onChanged,
-    super.key,
+String _formatFullDate(BuildContext context, DateTime date) =>
+    DateFormat.yMMMMEEEEd(
+      Localizations.localeOf(context).toLanguageTag(),
+    ).format(date);
+
+/// Text-first shortcut with a full-size design-system button hit target.
+class _QuickAction extends StatelessWidget {
+  const _QuickAction({
+    required this.label,
+    required this.semanticsLabel,
+    required this.onPressed,
   });
 
-  final double height;
-  final DateTime initial;
-  final ValueChanged<DateTime> onChanged;
+  final String label;
+  final String semanticsLabel;
+  final VoidCallback? onPressed;
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      height: height,
-      child: CupertinoTheme(
-        data: CupertinoThemeData(
-          textTheme: CupertinoTextThemeData(
-            dateTimePickerTextStyle: context.textTheme.titleMedium,
-          ),
-        ),
-        child: CupertinoDatePicker(
-          mode: CupertinoDatePickerMode.date,
-          initialDateTime: initial,
-          onDateTimeChanged: onChanged,
-        ),
-      ),
+    return DesignSystemButton(
+      label: label,
+      semanticsLabel: semanticsLabel,
+      variant: DesignSystemButtonVariant.tertiary,
+      size: DesignSystemButtonSize.medium,
+      onPressed: onPressed,
     );
   }
 }
@@ -309,14 +471,18 @@ class _DateWheel extends StatelessWidget {
 class _TimeColumn extends StatelessWidget {
   const _TimeColumn({
     required this.label,
-    required this.height,
     required this.initial,
+    required this.wheelSeed,
+    required this.nowSemanticsLabel,
+    required this.onNow,
     required this.onChanged,
   });
 
   final String label;
-  final double height;
   final TimeOfDay initial;
+  final int wheelSeed;
+  final String nowSemanticsLabel;
+  final VoidCallback onNow;
   final ValueChanged<TimeOfDay> onChanged;
 
   @override
@@ -324,36 +490,38 @@ class _TimeColumn extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        _Caption(label: label),
-        SizedBox(
-          height: height,
-          child: CupertinoTheme(
-            data: CupertinoThemeData(
-              textTheme: CupertinoTextThemeData(
-                dateTimePickerTextStyle:
-                    context.textTheme.titleLarge?.withTabularFigures,
-              ),
-            ),
-            child: CupertinoDatePicker(
-              mode: CupertinoDatePickerMode.time,
-              use24hFormat: true,
-              initialDateTime: DateTime(
-                2020,
-                1,
-                1,
-                initial.hour,
-                initial.minute,
-              ),
-              onDateTimeChanged: (dateTime) => onChanged(
-                TimeOfDay(hour: dateTime.hour, minute: dateTime.minute),
-              ),
-            ),
+        _Caption(
+          label: label,
+          trailing: _QuickAction(
+            label: context.messages.journalDateNowButton,
+            semanticsLabel: nowSemanticsLabel,
+            onPressed: onNow,
+          ),
+        ),
+        DesignSystemTimeWheel(
+          key: ValueKey('time-wheel-$wheelSeed'),
+          initialDateTime: DateTime(
+            2020,
+            1,
+            1,
+            initial.hour,
+            initial.minute,
+          ),
+          use24hFormat: MediaQuery.alwaysUse24HourFormatOf(context),
+          semanticsLabel: label,
+          onDateTimeChanged: (dateTime) => onChanged(
+            TimeOfDay(hour: dateTime.hour, minute: dateTime.minute),
           ),
         ),
       ],
     );
   }
 }
+
+bool _isToday(DateTime date) => _isSameDate(date, DateTime.now());
+
+bool _isSameDate(DateTime a, DateTime b) =>
+    a.year == b.year && a.month == b.month && a.day == b.day;
 
 class _SaveActionBar extends ConsumerWidget {
   const _SaveActionBar({required this.entry, required this.stateNotifier});
@@ -373,43 +541,32 @@ class _SaveActionBar extends ConsumerWidget {
             state.dateTo != entry.meta.dateTo;
         final canSave = state.valid && changed;
 
-        return DesignSystemGlassStrip(
-          child: Padding(
-            padding: EdgeInsets.all(context.designTokens.spacing.step5),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                EntryDateTimeStatusBar(range: state),
-                SizedBox(height: context.designTokens.spacing.step4),
-                DesignSystemButton(
-                  label: context.messages.journalDateSaveButton,
-                  leadingIcon: Icons.check_rounded,
-                  size: DesignSystemButtonSize.large,
-                  fullWidth: true,
-                  onPressed: canSave
-                      ? () async {
-                          try {
-                            await ref
-                                .read(provider.notifier)
-                                .updateFromTo(
-                                  dateFrom: state.dateFrom,
-                                  dateTo: state.dateTo,
-                                );
-                            if (context.mounted) {
-                              Navigator.of(context).pop();
-                            }
-                          } catch (e) {
-                            DevLogger.warning(
-                              name: 'EntryDateTimeMultiPageModal',
-                              message: 'Error updating date range: $e',
-                            );
-                          }
-                        }
-                      : null,
-                ),
-              ],
-            ),
+        return DesignSystemGlassActionFooter(
+          child: DesignSystemButton(
+            label: context.messages.journalDateSaveButton,
+            leadingIcon: Icons.check_rounded,
+            size: DesignSystemButtonSize.large,
+            fullWidth: true,
+            onPressed: canSave
+                ? () async {
+                    try {
+                      await ref
+                          .read(provider.notifier)
+                          .updateFromTo(
+                            dateFrom: state.dateFrom,
+                            dateTo: state.dateTo,
+                          );
+                      if (context.mounted) {
+                        Navigator.of(context).pop();
+                      }
+                    } catch (e) {
+                      DevLogger.warning(
+                        name: 'EntryDateTimeMultiPageModal',
+                        message: 'Error updating date range: $e',
+                      );
+                    }
+                  }
+                : null,
           ),
         );
       },

--- a/lib/features/journal/ui/widgets/entry_details/entry_datetime_range.dart
+++ b/lib/features/journal/ui/widgets/entry_details/entry_datetime_range.dart
@@ -35,9 +35,7 @@ class EntryDateTimeRange {
     final endDate = dateTo.dateOnly;
     final endBeforeStart = _minutes(endTime) < _minutes(startTime);
     final pureOvernight =
-        endDate.isSameCalendarDay(
-          startDate.add(const Duration(days: 1)),
-        ) &&
+        endDate.isSameCalendarDay(startDate.addCalendarDays(1)) &&
         endBeforeStart;
     final differentDates =
         !endDate.isSameCalendarDay(startDate) && !pureOvernight;
@@ -84,7 +82,7 @@ class EntryDateTimeRange {
     // [endDateOverride], but fall back to the start day rather than crashing if
     // the invariant is ever violated (e.g. a bare copyWith(differentDates: true)).
     if (differentDates) return endDateOverride ?? startDate;
-    return overnightAuto ? startDate.add(const Duration(days: 1)) : startDate;
+    return overnightAuto ? startDate.addCalendarDays(1) : startDate;
   }
 
   DateTime get dateFrom => _dateAndTime(startDate, startTime);

--- a/lib/features/journal/ui/widgets/entry_details/entry_datetime_range.dart
+++ b/lib/features/journal/ui/widgets/entry_details/entry_datetime_range.dart
@@ -90,6 +90,22 @@ class EntryDateTimeRange {
   /// auto-roll guarantees it); only reachable in different-dates mode.
   bool get valid => !dateTo.isBefore(dateFrom);
 
+  /// Replaces the complete start endpoint while preserving the absolute end.
+  ///
+  /// Re-deriving through [EntryDateTimeRange.fromBounds] chooses shared-date,
+  /// automatic-overnight, or explicit-end-date mode from the resulting bounds
+  /// instead of silently moving the end when the start day changes.
+  EntryDateTimeRange withStart(DateTime start) =>
+      EntryDateTimeRange.fromBounds(start, dateTo);
+
+  /// Replaces the complete end endpoint while preserving the absolute start.
+  ///
+  /// This is the endpoint-level operation used by the editor's End Now action:
+  /// a historical start stays historical while the end becomes the supplied
+  /// timestamp, revealing an explicit end date when the two days differ.
+  EntryDateTimeRange withEnd(DateTime end) =>
+      EntryDateTimeRange.fromBounds(dateFrom, end);
+
   EntryDateTimeRange copyWith({
     DateTime? startDate,
     TimeOfDay? startTime,

--- a/lib/features/journal/ui/widgets/entry_details/entry_datetime_range.dart
+++ b/lib/features/journal/ui/widgets/entry_details/entry_datetime_range.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart' show TimeOfDay, immutable;
+import 'package:lotti/utils/date_utils_extension.dart';
 
 /// The editable model behind the start/end date-time editor.
 ///
@@ -28,14 +29,18 @@ class EntryDateTimeRange {
   /// same-clock next-day entry, or a multi-day span) opens in different-dates
   /// mode.
   factory EntryDateTimeRange.fromBounds(DateTime dateFrom, DateTime dateTo) {
-    final startDate = _dateOnly(dateFrom);
+    final startDate = dateFrom.dateOnly;
     final startTime = TimeOfDay(hour: dateFrom.hour, minute: dateFrom.minute);
     final endTime = TimeOfDay(hour: dateTo.hour, minute: dateTo.minute);
-    final endDate = _dateOnly(dateTo);
+    final endDate = dateTo.dateOnly;
     final endBeforeStart = _minutes(endTime) < _minutes(startTime);
     final pureOvernight =
-        endDate == startDate.add(const Duration(days: 1)) && endBeforeStart;
-    final differentDates = endDate != startDate && !pureOvernight;
+        endDate.isSameCalendarDay(
+          startDate.add(const Duration(days: 1)),
+        ) &&
+        endBeforeStart;
+    final differentDates =
+        !endDate.isSameCalendarDay(startDate) && !pureOvernight;
     return EntryDateTimeRange(
       startDate: startDate,
       startTime: startTime,
@@ -51,9 +56,23 @@ class EntryDateTimeRange {
   final bool differentDates;
   final DateTime? endDateOverride;
 
-  static DateTime _dateOnly(DateTime d) => DateTime(d.year, d.month, d.day);
-
   static int _minutes(TimeOfDay t) => t.hour * 60 + t.minute;
+
+  static DateTime _dateAndTime(DateTime date, TimeOfDay time) => date.isUtc
+      ? DateTime.utc(
+          date.year,
+          date.month,
+          date.day,
+          time.hour,
+          time.minute,
+        )
+      : DateTime(
+          date.year,
+          date.month,
+          date.day,
+          time.hour,
+          time.minute,
+        );
 
   /// In shared-date mode, whether the end clock falls before the start clock so
   /// the end is auto-rolled to the next day.
@@ -68,21 +87,9 @@ class EntryDateTimeRange {
     return overnightAuto ? startDate.add(const Duration(days: 1)) : startDate;
   }
 
-  DateTime get dateFrom => DateTime(
-    startDate.year,
-    startDate.month,
-    startDate.day,
-    startTime.hour,
-    startTime.minute,
-  );
+  DateTime get dateFrom => _dateAndTime(startDate, startTime);
 
-  DateTime get dateTo => DateTime(
-    _effectiveEndDate.year,
-    _effectiveEndDate.month,
-    _effectiveEndDate.day,
-    endTime.hour,
-    endTime.minute,
-  );
+  DateTime get dateTo => _dateAndTime(_effectiveEndDate, endTime);
 
   Duration get duration => dateTo.difference(dateFrom);
 

--- a/lib/features/journal/ui/widgets/entry_details/entry_datetime_range.dart
+++ b/lib/features/journal/ui/widgets/entry_details/entry_datetime_range.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart' show TimeOfDay, immutable;
 import 'package:lotti/utils/date_utils_extension.dart';
+import 'package:timezone/timezone.dart' as tz;
 
 /// The editable model behind the start/end date-time editor.
 ///
@@ -23,11 +24,11 @@ class EntryDateTimeRange {
   });
 
   /// Decompose two timestamps into the editor model. Opens in shared-date mode
-  /// when the two fall on the same day, OR form a plain overnight span (end day
-  /// is start day + 1 and the end clock is before the start clock) — that case
-  /// is reproduced exactly by the auto-roll. Anything else (e.g. an exactly-24h
-  /// same-clock next-day entry, or a multi-day span) opens in different-dates
-  /// mode.
+  /// when ordered bounds fall on the same day, OR form a plain overnight span
+  /// (end day is start day + 1 and the end clock is before the start clock) —
+  /// that case is reproduced exactly by the auto-roll. Anything else (e.g. an
+  /// inverted range, exactly-24h same-clock next-day entry, or multi-day span)
+  /// opens in different-dates mode so both absolute endpoints round-trip.
   factory EntryDateTimeRange.fromBounds(DateTime dateFrom, DateTime dateTo) {
     final startDate = dateFrom.dateOnly;
     final startTime = TimeOfDay(hour: dateFrom.hour, minute: dateFrom.minute);
@@ -38,7 +39,8 @@ class EntryDateTimeRange {
         endDate.isSameCalendarDay(startDate.addCalendarDays(1)) &&
         endBeforeStart;
     final differentDates =
-        !endDate.isSameCalendarDay(startDate) && !pureOvernight;
+        dateTo.isBefore(dateFrom) ||
+        (!endDate.isSameCalendarDay(startDate) && !pureOvernight);
     return EntryDateTimeRange(
       startDate: startDate,
       startTime: startTime,
@@ -56,21 +58,33 @@ class EntryDateTimeRange {
 
   static int _minutes(TimeOfDay t) => t.hour * 60 + t.minute;
 
-  static DateTime _dateAndTime(DateTime date, TimeOfDay time) => date.isUtc
-      ? DateTime.utc(
-          date.year,
-          date.month,
-          date.day,
-          time.hour,
-          time.minute,
-        )
-      : DateTime(
-          date.year,
-          date.month,
-          date.day,
-          time.hour,
-          time.minute,
-        );
+  static DateTime _dateAndTime(DateTime date, TimeOfDay time) {
+    if (date is tz.TZDateTime) {
+      return tz.TZDateTime(
+        date.location,
+        date.year,
+        date.month,
+        date.day,
+        time.hour,
+        time.minute,
+      );
+    }
+    return date.isUtc
+        ? DateTime.utc(
+            date.year,
+            date.month,
+            date.day,
+            time.hour,
+            time.minute,
+          )
+        : DateTime(
+            date.year,
+            date.month,
+            date.day,
+            time.hour,
+            time.minute,
+          );
+  }
 
   /// In shared-date mode, whether the end clock falls before the start clock so
   /// the end is auto-rolled to the next day.

--- a/lib/features/journal/ui/widgets/entry_details/entry_datetime_status_bar.dart
+++ b/lib/features/journal/ui/widgets/entry_details/entry_datetime_status_bar.dart
@@ -8,16 +8,15 @@ import 'package:lotti/features/journal/util/entry_tools.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/themes/theme.dart';
 
-/// The pinned readout that sits in the glass sticky bar above Save, so the
-/// duration (the design's primary clarity device) is always visible — even in
-/// the taller different-dates layout.
+/// The duration and endpoint readout shown after the time controls.
 ///
 /// Renders one of three states from [range]:
 /// - invalid (composed end before start, only reachable in different-dates
 ///   mode): a warning row;
 /// - valid: a "Duration" row with the formatted value, plus a teal "+1 day"
 ///   chip when the end was auto-rolled to the next day
-///   ([EntryDateTimeRange.overnightAuto]).
+///   ([EntryDateTimeRange.overnightAuto]). The chip row always reserves its
+///   layout height so crossing midnight never makes the sheet jump.
 class EntryDateTimeStatusBar extends StatelessWidget {
   const EntryDateTimeStatusBar({required this.range, super.key});
 
@@ -26,78 +25,143 @@ class EntryDateTimeStatusBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
-
+    final locale = Localizations.localeOf(context).toLanguageTag();
     if (!range.valid) {
-      return Row(
-        children: [
-          Icon(
-            Icons.warning_rounded,
-            size: 20,
-            color: context.colorScheme.error,
-          ),
-          SizedBox(width: tokens.spacing.step3),
-          Expanded(
-            child: Text(
-              context.messages.journalDateInvalid,
-              style: context.textTheme.bodyMedium?.copyWith(
+      return ConstrainedBox(
+        constraints: BoxConstraints(minHeight: tokens.spacing.step12),
+        child: Semantics(
+          liveRegion: true,
+          label: context.messages.journalDateInvalid,
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(
+                Icons.warning_rounded,
+                size: tokens.spacing.step6,
                 color: context.colorScheme.error,
-                fontWeight: FontWeight.w600,
               ),
-            ),
+              SizedBox(width: tokens.spacing.step3),
+              Expanded(
+                child: Text(
+                  context.messages.journalDateInvalid,
+                  style: tokens.typography.styles.body.bodyMedium.copyWith(
+                    color: context.colorScheme.error,
+                    fontWeight: tokens.typography.weight.semiBold,
+                  ),
+                ),
+              ),
+            ],
           ),
-        ],
+        ),
       );
     }
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Row(
-          children: [
-            Icon(
-              MdiIcons.clockTimeFourOutline,
-              size: 20,
-              color: context.colorScheme.primary,
-            ),
-            SizedBox(width: tokens.spacing.step3),
-            Text(
-              context.messages.journalDurationLabel,
-              style: context.textTheme.bodyMedium?.copyWith(
-                color: context.colorScheme.onSurfaceVariant,
-              ),
-            ),
-            const Spacer(),
-            Text(
-              formatRangeDuration(range.duration),
-              style: context.textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.w600,
-                color: context.colorScheme.primary,
-                fontFeatures: const [FontFeature.tabularFigures()],
-              ),
-            ),
-          ],
-        ),
-        if (range.overnightAuto) ...[
-          SizedBox(height: tokens.spacing.step3),
-          Align(
-            alignment: Alignment.centerLeft,
-            child: DsPill(
-              variant: DsPillVariant.tinted,
-              // Teal (not the brand-purple Duration accent) so it reads as a
-              // distinct "heads up" state badge rather than echoing the value.
-              color: tokens.colors.interactive.enabled,
-              label: context.messages.journalOvernightNextDay(
-                DateFormat('EEE d MMM').format(range.dateTo),
-              ),
-              leading: Icon(
-                MdiIcons.weatherNight,
-                size: 14,
-                color: tokens.colors.interactive.enabled,
-              ),
-            ),
+    final duration = formatRangeDuration(range.duration);
+    final rangeLabel = _formatRangeLabel(context, range);
+    return ConstrainedBox(
+      constraints: BoxConstraints(minHeight: tokens.spacing.step12),
+      child: Semantics(
+        liveRegion: true,
+        label:
+            '${context.messages.journalDurationLabel}: $duration. $rangeLabel',
+        child: ExcludeSemantics(
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final compact = constraints.maxWidth < tokens.spacing.step13 * 4;
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Row(
+                    children: [
+                      Icon(
+                        MdiIcons.clockTimeFourOutline,
+                        size: tokens.spacing.step6,
+                        color: tokens.colors.interactive.enabled,
+                      ),
+                      SizedBox(width: tokens.spacing.step3),
+                      Text(
+                        context.messages.journalDurationLabel,
+                        style: tokens.typography.styles.body.bodyMedium
+                            .copyWith(
+                              color: tokens.colors.text.mediumEmphasis,
+                            ),
+                      ),
+                      const Spacer(),
+                      Text(
+                        duration,
+                        style: tokens.typography.styles.subtitle.subtitle2
+                            .copyWith(
+                              fontWeight: tokens.typography.weight.semiBold,
+                              color: tokens.colors.interactive.enabled,
+                              fontFeatures: const [
+                                FontFeature.tabularFigures(),
+                              ],
+                            ),
+                      ),
+                    ],
+                  ),
+                  SizedBox(height: tokens.spacing.step3),
+                  Text(
+                    _formatRangeLabel(context, range, compact: compact),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: tokens.typography.styles.body.bodySmall.copyWith(
+                      color: tokens.colors.text.highEmphasis,
+                      fontFeatures: const [FontFeature.tabularFigures()],
+                    ),
+                  ),
+                  SizedBox(height: tokens.spacing.step3),
+                  Visibility(
+                    visible: range.overnightAuto,
+                    maintainAnimation: true,
+                    maintainSize: true,
+                    maintainState: true,
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: DsPill(
+                        variant: DsPillVariant.tinted,
+                        color: tokens.colors.interactive.enabled,
+                        label: context.messages.journalOvernightNextDay(
+                          DateFormat('EEE d MMM', locale).format(range.dateTo),
+                        ),
+                        leading: Icon(
+                          MdiIcons.weatherNight,
+                          size: tokens.spacing.step5,
+                          color: tokens.colors.interactive.enabled,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              );
+            },
           ),
-        ],
-      ],
+        ),
+      ),
     );
   }
 }
+
+String _formatRangeLabel(
+  BuildContext context,
+  EntryDateTimeRange range, {
+  bool compact = false,
+}) {
+  final locale = Localizations.localeOf(context).toLanguageTag();
+  final dateFormat = compact
+      ? DateFormat.MMMEd(locale)
+      : DateFormat.yMMMEd(locale);
+  String formatTime(DateTime date) => TimeOfDay.fromDateTime(date).format(
+    context,
+  );
+  final start =
+      '${dateFormat.format(range.dateFrom)} · '
+      '${formatTime(range.dateFrom)}';
+  final end = range.startDate == _dateOnly(range.dateTo)
+      ? formatTime(range.dateTo)
+      : '${dateFormat.format(range.dateTo)} · '
+            '${formatTime(range.dateTo)}';
+  return '$start → $end';
+}
+
+DateTime _dateOnly(DateTime date) => DateTime(date.year, date.month, date.day);

--- a/lib/features/journal/ui/widgets/entry_details/entry_datetime_status_bar.dart
+++ b/lib/features/journal/ui/widgets/entry_details/entry_datetime_status_bar.dart
@@ -7,6 +7,7 @@ import 'package:lotti/features/journal/ui/widgets/entry_details/entry_datetime_r
 import 'package:lotti/features/journal/util/entry_tools.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/themes/theme.dart';
+import 'package:lotti/utils/date_utils_extension.dart';
 
 /// The duration and endpoint readout shown after the time controls.
 ///
@@ -32,25 +33,27 @@ class EntryDateTimeStatusBar extends StatelessWidget {
         child: Semantics(
           liveRegion: true,
           label: context.messages.journalDateInvalid,
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Icon(
-                Icons.warning_rounded,
-                size: tokens.spacing.step6,
-                color: context.colorScheme.error,
-              ),
-              SizedBox(width: tokens.spacing.step3),
-              Expanded(
-                child: Text(
-                  context.messages.journalDateInvalid,
-                  style: tokens.typography.styles.body.bodyMedium.copyWith(
-                    color: context.colorScheme.error,
-                    fontWeight: tokens.typography.weight.semiBold,
+          child: ExcludeSemantics(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(
+                  Icons.warning_rounded,
+                  size: tokens.spacing.step6,
+                  color: context.colorScheme.error,
+                ),
+                SizedBox(width: tokens.spacing.step3),
+                Expanded(
+                  child: Text(
+                    context.messages.journalDateInvalid,
+                    style: tokens.typography.styles.body.bodyMedium.copyWith(
+                      color: context.colorScheme.error,
+                      fontWeight: tokens.typography.weight.semiBold,
+                    ),
                   ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       );
@@ -157,11 +160,9 @@ String _formatRangeLabel(
   final start =
       '${dateFormat.format(range.dateFrom)} · '
       '${formatTime(range.dateFrom)}';
-  final end = range.startDate == _dateOnly(range.dateTo)
+  final end = range.startDate.isSameCalendarDay(range.dateTo)
       ? formatTime(range.dateTo)
       : '${dateFormat.format(range.dateTo)} · '
             '${formatTime(range.dateTo)}';
   return '$start → $end';
 }
-
-DateTime _dateOnly(DateTime date) => DateTime(date.year, date.month, date.day);

--- a/lib/features/projects/README.md
+++ b/lib/features/projects/README.md
@@ -157,7 +157,8 @@ shows weekday headers, renders the selected date with its full weekday, and
 offers Today without introducing a project-specific picker model. Confirmation
 updates the create-form draft or calls the relevant detail controller;
 dismissal leaves the target date unchanged, and the surrounding project field
-owns clearing where that action is available.
+owns clearing where that action is available. A result arriving after the
+detail page is disposed is ignored.
 
 ```mermaid
 flowchart LR

--- a/lib/features/projects/README.md
+++ b/lib/features/projects/README.md
@@ -149,6 +149,24 @@ The modal resolves to the freshly created `ProjectEntry` (or `null` when
 dismissed); the list refreshes on its own because it watches
 `projectsOverviewProvider`.
 
+### Target Date Selection
+
+Project creation and both project detail routes use
+`showDesignSystemDatePicker` for `ProjectData.targetDate`. The shared calendar
+shows weekday headers, renders the selected date with its full weekday, and
+offers Today without introducing a project-specific picker model. Confirmation
+updates the create-form draft or calls the relevant detail controller;
+dismissal leaves the target date unchanged, and the surrounding project field
+owns clearing where that action is available.
+
+```mermaid
+flowchart LR
+  Field["Project target-date field"] --> Calendar["Shared design-system calendar"]
+  Calendar -->|Done| Draft["Create draft or detail controller"]
+  Calendar -->|Dismiss| Unchanged["Existing target date unchanged"]
+  Draft --> Persist["ProjectRepository persistence path"]
+```
+
 ## Repository Responsibilities
 
 `ProjectRepository` owns the data-heavy part of the feature:

--- a/lib/features/projects/ui/pages/project_detail_page.dart
+++ b/lib/features/projects/ui/pages/project_detail_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/agents/ui/change_set_summary_card.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
+import 'package:lotti/features/design_system/components/calendar_pickers/design_system_date_picker_modal.dart';
 import 'package:lotti/features/design_system/components/toasts/design_system_toast.dart';
 import 'package:lotti/features/design_system/components/toasts/toast_messenger.dart';
 import 'package:lotti/features/projects/state/project_detail_controller.dart';
@@ -140,15 +141,16 @@ class _ProjectDetailPageState extends ConsumerState<ProjectDetailPage> {
         ? lastDate
         : initialDate;
 
-    final picked = await showDatePicker(
+    final result = await showDesignSystemDatePicker(
       context: context,
+      title: context.messages.projectTargetDateLabel,
       initialDate: clampedInitial,
       firstDate: firstDate,
       lastDate: lastDate,
+      allowClear: currentDate != null,
     );
-    if (picked != null) {
-      controller.updateTargetDate(picked);
-    }
+    if (result == null) return;
+    controller.updateTargetDate(result.cleared ? null : result.date);
   }
 
   @override

--- a/lib/features/projects/ui/pages/project_detail_page.dart
+++ b/lib/features/projects/ui/pages/project_detail_page.dart
@@ -149,7 +149,7 @@ class _ProjectDetailPageState extends ConsumerState<ProjectDetailPage> {
       lastDate: lastDate,
       allowClear: currentDate != null,
     );
-    if (result == null) return;
+    if (!mounted || result == null) return;
     controller.updateTargetDate(result.cleared ? null : result.date);
   }
 

--- a/lib/features/projects/ui/pages/project_details_page.dart
+++ b/lib/features/projects/ui/pages/project_details_page.dart
@@ -7,6 +7,7 @@ import 'package:lotti/features/agents/model/agent_domain_entity.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/agents/state/project_agent_providers.dart';
 import 'package:lotti/features/categories/ui/widgets/category_picker_sheet.dart';
+import 'package:lotti/features/design_system/components/calendar_pickers/design_system_date_picker_modal.dart';
 import 'package:lotti/features/projects/state/project_detail_controller.dart';
 import 'package:lotti/features/projects/state/project_detail_record_provider.dart';
 import 'package:lotti/features/projects/ui/widgets/project_mobile_detail_content.dart';
@@ -150,21 +151,22 @@ class ProjectDetailsPage extends ConsumerWidget {
         ? lastDate
         : initialDate;
 
-    final picked = await showDatePicker(
+    final result = await showDesignSystemDatePicker(
       context: context,
+      title: context.messages.projectTargetDateLabel,
       initialDate: clampedInitial,
       firstDate: firstDate,
       lastDate: lastDate,
+      allowClear: currentDate != null,
     );
 
-    if (picked == null) {
-      return;
-    }
+    if (result == null) return;
 
     final controller = ref.read(
       projectDetailControllerProvider(projectId).notifier,
     );
-    await (controller..updateTargetDate(picked)).saveChanges();
+    await (controller..updateTargetDate(result.cleared ? null : result.date))
+        .saveChanges();
   }
 
   Future<void> _pickStatus(

--- a/lib/features/projects/ui/widgets/project_create_modal.dart
+++ b/lib/features/projects/ui/widgets/project_create_modal.dart
@@ -13,6 +13,7 @@ import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/agents/state/project_agent_providers.dart';
 import 'package:lotti/features/categories/ui/widgets/category_field.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
+import 'package:lotti/features/design_system/components/calendar_pickers/design_system_date_picker_modal.dart';
 import 'package:lotti/features/design_system/components/toasts/design_system_toast.dart';
 import 'package:lotti/features/design_system/components/toasts/toast_messenger.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
@@ -190,14 +191,16 @@ class _ProjectCreateFormState extends ConsumerState<ProjectCreateForm> {
   Future<void> _pickTargetDate() async {
     final today = DateTime.now();
     final baseDate = DateTime(today.year, today.month, today.day);
-    final picked = await showDatePicker(
+    final result = await showDesignSystemDatePicker(
       context: context,
+      title: context.messages.projectTargetDateLabel,
       initialDate: _targetDate ?? baseDate,
       firstDate: baseDate,
       lastDate: DateTime(baseDate.year + 5, baseDate.month, baseDate.day),
+      allowClear: _targetDate != null,
     );
-    if (!mounted || picked == null) return;
-    setState(() => _targetDate = picked);
+    if (!mounted || result == null) return;
+    setState(() => _targetDate = result.cleared ? null : result.date);
   }
 
   /// Finds the first available projectAgent template and provisions an agent.

--- a/lib/features/tasks/README.md
+++ b/lib/features/tasks/README.md
@@ -166,6 +166,23 @@ Two important boundaries:
 
 Checklist content is modeled separately through checklist entities and linked checklist-item entities. That split matters because the UI allows drag, drop, reorder, export, and cross-checklist movement without flattening everything into one giant task row.
 
+### Due Date and Estimate Pickers
+
+The detail header routes due-date edits through `showDueDatePicker` and
+estimate edits through `showEstimatePicker`:
+
+- due dates use the shared `DesignSystemCalendarPicker`, so the selected value
+  includes its weekday and the month grid exposes weekday headers. **Today**
+  updates the draft, **Clear** produces an explicit null result, and dismissal
+  remains distinct from either action;
+- estimates use `DesignSystemDurationWheel` in the same token-backed frame and
+  shared glass action footer. The draft is committed only when Done confirms a
+  changed duration; Clear resets a non-zero estimate.
+
+Both pickers use the responsive modal contract: a bottom sheet on narrow
+layouts and a dialog on wide layouts, with the same surface color inside the
+subtle frame in light and dark themes.
+
 ## Task Detail Composition
 
 `TaskDetailsPage` is the main task surface. It composes:

--- a/lib/features/tasks/ui/header/estimated_time_widget.dart
+++ b/lib/features/tasks/ui/header/estimated_time_widget.dart
@@ -1,8 +1,9 @@
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_modal_action_bar.dart';
+import 'package:lotti/features/design_system/components/time_pickers/design_system_picker_wheels.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
-import 'package:lotti/themes/theme.dart';
 import 'package:lotti/widgets/modal/modal_utils.dart';
 
 Future<void> showEstimatePicker({
@@ -10,6 +11,7 @@ Future<void> showEstimatePicker({
   required Duration initialDuration,
   required Future<void> Function(Duration newDuration) onEstimateChanged,
 }) async {
+  final tokens = context.designTokens;
   var selectedDuration = initialDuration;
 
   await ModalUtils.showSinglePageModal<void>(
@@ -22,9 +24,20 @@ Future<void> showEstimatePicker({
         },
       );
     },
-    title: context.messages.taskEstimateLabel,
+    title: context.messages.taskEstimateModalTitle,
+    padding: EdgeInsets.fromLTRB(
+      tokens.spacing.step5,
+      tokens.spacing.step5,
+      tokens.spacing.step5,
+      tokens.spacing.step11 + tokens.spacing.step6,
+    ),
     stickyActionBarBuilder: (modalContext) => _EstimatedTimeStickyActionBar(
-      onCancel: () => Navigator.of(modalContext).pop(),
+      onClear: initialDuration == Duration.zero
+          ? null
+          : () async {
+              Navigator.of(modalContext).pop();
+              await onEstimateChanged(Duration.zero);
+            },
       onDone: () async {
         Navigator.of(modalContext).pop();
         if (selectedDuration != initialDuration) {
@@ -32,7 +45,6 @@ Future<void> showEstimatePicker({
         }
       },
     ),
-    padding: const EdgeInsets.only(bottom: 40),
   );
 }
 
@@ -51,9 +63,12 @@ class _EstimatedTimePicker extends StatefulWidget {
 }
 
 class _EstimatedTimePickerState extends State<_EstimatedTimePicker> {
+  late Duration _selectedDuration;
+
   @override
   void initState() {
     super.initState();
+    _selectedDuration = widget.initialDuration;
     // Pass initial value to callback
     WidgetsBinding.instance.addPostFrameCallback((_) {
       widget.onDurationChanged(widget.initialDuration);
@@ -62,18 +77,28 @@ class _EstimatedTimePickerState extends State<_EstimatedTimePicker> {
 
   @override
   Widget build(BuildContext context) {
-    return CupertinoTheme(
-      data: CupertinoThemeData(
-        textTheme: CupertinoTextThemeData(
-          pickerTextStyle: context.textTheme.titleLarge?.withTabularFigures,
-        ),
+    final tokens = context.designTokens;
+    final durationLabel = context.messages
+        .designSystemMyDailyDurationHoursMinutesCompact(
+          _selectedDuration.inHours,
+          _selectedDuration.inMinutes.remainder(60),
+        );
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(tokens.radii.sectionCards),
+        border: Border.all(color: tokens.colors.decorative.level01),
       ),
-      child: SizedBox(
-        height: 265,
-        child: CupertinoTimerPicker(
-          onTimerDurationChanged: widget.onDurationChanged,
-          initialTimerDuration: widget.initialDuration,
-          mode: CupertinoTimerPickerMode.hm,
+      child: Padding(
+        padding: EdgeInsets.all(tokens.spacing.cardPadding),
+        child: DesignSystemDurationWheel(
+          initialDuration: widget.initialDuration,
+          semanticsLabel:
+              '${context.messages.taskEstimateModalTitle}: $durationLabel',
+          semanticsLiveRegion: true,
+          onDurationChanged: (duration) {
+            setState(() => _selectedDuration = duration);
+            widget.onDurationChanged(duration);
+          },
         ),
       ),
     );
@@ -83,28 +108,34 @@ class _EstimatedTimePickerState extends State<_EstimatedTimePicker> {
 /// Sticky action bar for the estimated time selection modal
 class _EstimatedTimeStickyActionBar extends StatelessWidget {
   const _EstimatedTimeStickyActionBar({
-    required this.onCancel,
+    required this.onClear,
     required this.onDone,
   });
 
-  final VoidCallback onCancel;
+  final VoidCallback? onClear;
   final VoidCallback onDone;
 
   @override
   Widget build(BuildContext context) {
+    final tokens = context.designTokens;
     return DesignSystemModalActionBar(
       glass: true,
-      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+      padding: EdgeInsets.all(tokens.spacing.step5),
       secondary: [
-        DesignSystemButton(
-          label: context.messages.cancelButton,
-          variant: DesignSystemButtonVariant.secondary,
-          size: DesignSystemButtonSize.large,
-          onPressed: onCancel,
-        ),
+        if (onClear != null)
+          DesignSystemButton(
+            label: context.messages.clearButton,
+            semanticsLabel:
+                '${context.messages.clearButton} '
+                '${context.messages.taskEstimateModalTitle}',
+            variant: DesignSystemButtonVariant.secondary,
+            size: DesignSystemButtonSize.large,
+            onPressed: onClear,
+          ),
       ],
       primary: DesignSystemButton(
         label: context.messages.doneButton,
+        leadingIcon: Icons.check_rounded,
         size: DesignSystemButtonSize.large,
         fullWidth: true,
         onPressed: onDone,

--- a/lib/features/tasks/ui/header/task_due_date_widget.dart
+++ b/lib/features/tasks/ui/header/task_due_date_widget.dart
@@ -1,143 +1,34 @@
-import 'package:flutter/cupertino.dart';
-import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
-import 'package:lotti/features/design_system/components/buttons/design_system_modal_action_bar.dart';
+import 'package:flutter/material.dart';
+import 'package:lotti/features/design_system/components/calendar_pickers/design_system_date_picker_modal.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
-import 'package:lotti/themes/theme.dart';
-import 'package:lotti/widgets/modal/modal_utils.dart';
 
-/// Opens a single-page modal with a Cupertino date wheel to set, change, or
-/// clear a task's due date. Defaults the wheel to [initialDate] (or now when
-/// null). Done invokes [onDueDateChanged] with the picked date only if the
-/// user scrolled the wheel or no date existed yet; Clear invokes it with null;
-/// Cancel closes without changes.
+/// Opens the shared calendar to set, change, or clear a task's due date.
+///
+/// Dismissal leaves the task unchanged. Done always confirms the selected date,
+/// including today's date when the task did not previously have a due date.
 Future<void> showDueDatePicker({
   required BuildContext context,
   required DateTime? initialDate,
   required Future<void> Function(DateTime? newDate) onDueDateChanged,
 }) async {
-  final effectiveInitialDate = initialDate ?? DateTime.now();
-  var selectedDate = effectiveInitialDate;
-  var userHasChangedDate = false;
-
-  await ModalUtils.showSinglePageModal<void>(
+  final now = DateTime.now();
+  final result = await showDesignSystemDatePicker(
     context: context,
-    builder: (modalContext) {
-      return _DueDatePicker(
-        initialDate: effectiveInitialDate,
-        onDateChanged: (date) {
-          selectedDate = date;
-          userHasChangedDate = true;
-        },
-      );
-    },
     title: context.messages.taskDueDateLabel,
-    stickyActionBarBuilder: (modalContext) => _DueDateStickyActionBar(
-      onCancel: () => Navigator.of(modalContext).pop(),
-      onClear: () async {
-        Navigator.of(modalContext).pop();
-        await onDueDateChanged(null);
-      },
-      onDone: () async {
-        Navigator.of(modalContext).pop();
-        // Update if:
-        // 1. User interacted with the picker (scrolled/selected), OR
-        // 2. There was no initial date (user is explicitly setting a date for
-        //    the first time by clicking Done).
-        if (userHasChangedDate || initialDate == null) {
-          await onDueDateChanged(selectedDate);
-        }
-      },
-    ),
-    padding: const EdgeInsets.only(bottom: 40),
+    initialDate: initialDate ?? now,
+    firstDate: DateTime(1900),
+    lastDate: DateTime(2100),
+    allowClear: initialDate != null,
   );
-}
 
-/// The date picker widget for selecting due date
-class _DueDatePicker extends StatefulWidget {
-  const _DueDatePicker({
-    required this.initialDate,
-    required this.onDateChanged,
-  });
-
-  final DateTime initialDate;
-  final void Function(DateTime) onDateChanged;
-
-  @override
-  State<_DueDatePicker> createState() => _DueDatePickerState();
-}
-
-class _DueDatePickerState extends State<_DueDatePicker> {
-  late DateTime _selectedDate;
-
-  @override
-  void initState() {
-    super.initState();
-    _selectedDate = widget.initialDate;
-    // Note: We no longer call onDateChanged here to avoid triggering
-    // userHasChangedDate when the widget initializes
+  if (result == null) return;
+  if (result.cleared) {
+    await onDueDateChanged(null);
+    return;
   }
-
-  @override
-  Widget build(BuildContext context) {
-    return CupertinoTheme(
-      data: CupertinoThemeData(
-        textTheme: CupertinoTextThemeData(
-          dateTimePickerTextStyle:
-              context.textTheme.titleLarge?.withTabularFigures,
-        ),
-      ),
-      child: SizedBox(
-        height: 265,
-        child: CupertinoDatePicker(
-          mode: CupertinoDatePickerMode.date,
-          initialDateTime: _selectedDate,
-          onDateTimeChanged: (date) {
-            _selectedDate = date;
-            widget.onDateChanged(date);
-          },
-        ),
-      ),
-    );
-  }
+  if (initialDate != null && _sameDate(initialDate, result.date!)) return;
+  await onDueDateChanged(result.date);
 }
 
-/// Sticky action bar for the due date selection modal
-class _DueDateStickyActionBar extends StatelessWidget {
-  const _DueDateStickyActionBar({
-    required this.onCancel,
-    required this.onClear,
-    required this.onDone,
-  });
-
-  final VoidCallback onCancel;
-  final VoidCallback onClear;
-  final VoidCallback onDone;
-
-  @override
-  Widget build(BuildContext context) {
-    return DesignSystemModalActionBar(
-      glass: true,
-      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
-      secondary: [
-        DesignSystemButton(
-          label: context.messages.cancelButton,
-          variant: DesignSystemButtonVariant.secondary,
-          size: DesignSystemButtonSize.large,
-          onPressed: onCancel,
-        ),
-        DesignSystemButton(
-          label: context.messages.clearButton,
-          variant: DesignSystemButtonVariant.secondary,
-          size: DesignSystemButtonSize.large,
-          onPressed: onClear,
-        ),
-      ],
-      primary: DesignSystemButton(
-        label: context.messages.doneButton,
-        size: DesignSystemButtonSize.large,
-        fullWidth: true,
-        onPressed: onDone,
-      ),
-    );
-  }
-}
+bool _sameDate(DateTime a, DateTime b) =>
+    a.year == b.year && a.month == b.month && a.day == b.day;

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -2340,7 +2340,7 @@
   "journalDateInvalid": "Neplatné časové rozmezí",
   "journalDateLabel": "Datum",
   "journalDateNowButton": "Nyní",
-  "journalDateSaveButton": "ULOŽIT",
+  "journalDateSaveButton": "Uložit",
   "journalDateTimeRangeTitle": "Datum a čas",
   "journalDateToLabel": "Datum do:",
   "journalDeleteConfirm": "ANO, SMAZAT TENTO ZÁZNAM",
@@ -2374,6 +2374,8 @@
   "journalOvernightNextDay": "Končí {date} (další den)",
   "journalPrivateTooltip": "pouze soukromé",
   "journalSearchHint": "Hledat deník...",
+  "journalSetEndDateTimeNowSemantic": "Nastavit koncové datum a čas na teď",
+  "journalSetStartDateTimeNowSemantic": "Nastavit počáteční datum a čas na teď",
   "journalShareHint": "Sdílet",
   "journalShowLinkHint": "Zobrazit odkaz",
   "journalShowMapHint": "Zobrazit mapu",
@@ -3563,6 +3565,7 @@
   "taskDueYesterday": "Včera splatné",
   "taskEditTitleLabel": "Upravit název úkolu",
   "taskEstimateLabel": "Odhad:",
+  "taskEstimateModalTitle": "Odhad",
   "taskEstimateProgressLabel": "{tracked} z {estimate}",
   "@taskEstimateProgressLabel": {
     "placeholders": {

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2547,7 +2547,7 @@
   "journalDateInvalid": "Ungültiger Datumsbereich",
   "journalDateLabel": "Datum",
   "journalDateNowButton": "Jetzt",
-  "journalDateSaveButton": "SPEICHERN",
+  "journalDateSaveButton": "Speichern",
   "journalDateTimeRangeTitle": "Datum & Uhrzeit",
   "journalDateToLabel": "Datum bis:",
   "journalDeleteConfirm": "JA, DIESEN EINTRAG LÖSCHEN",
@@ -2581,6 +2581,8 @@
   "journalOvernightNextDay": "Endet {date} (nächster Tag)",
   "journalPrivateTooltip": "nur privat",
   "journalSearchHint": "Tagebuch durchsuchen...",
+  "journalSetEndDateTimeNowSemantic": "Enddatum und -zeit auf jetzt setzen",
+  "journalSetStartDateTimeNowSemantic": "Startdatum und -zeit auf jetzt setzen",
   "journalShareHint": "Teilen",
   "journalShowLinkHint": "Link anzeigen",
   "journalShowMapHint": "Karte anzeigen",
@@ -3778,6 +3780,7 @@
   "taskDueYesterday": "Gestern fällig",
   "taskEditTitleLabel": "Aufgabentitel bearbeiten",
   "taskEstimateLabel": "Schätzung:",
+  "taskEstimateModalTitle": "Schätzung",
   "taskEstimateProgressLabel": "{tracked} von {estimate}",
   "@taskEstimateProgressLabel": {
     "placeholders": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3061,7 +3061,7 @@
   "journalDateInvalid": "Invalid Date Range",
   "journalDateLabel": "Date",
   "journalDateNowButton": "Now",
-  "journalDateSaveButton": "SAVE",
+  "journalDateSaveButton": "Save",
   "journalDateTimeRangeTitle": "Date & Time",
   "journalDateToLabel": "Date to:",
   "journalDeleteConfirm": "YES, DELETE THIS ENTRY",
@@ -3104,6 +3104,8 @@
   },
   "journalPrivateTooltip": "private only",
   "journalSearchHint": "Search journal...",
+  "journalSetEndDateTimeNowSemantic": "Set end date and time to now",
+  "journalSetStartDateTimeNowSemantic": "Set start date and time to now",
   "journalShareHint": "Share",
   "journalShowLinkHint": "Show link",
   "journalShowMapHint": "Show map",
@@ -4456,6 +4458,7 @@
   "taskDueYesterday": "Due Yesterday",
   "taskEditTitleLabel": "Edit task title",
   "taskEstimateLabel": "Estimate:",
+  "taskEstimateModalTitle": "Estimate",
   "taskEstimateProgressLabel": "{tracked} of {estimate}",
   "@taskEstimateProgressLabel": {
     "placeholders": {

--- a/lib/l10n/app_en_GB.arb
+++ b/lib/l10n/app_en_GB.arb
@@ -78,7 +78,7 @@
   "journalDateFromLabel": "Date from:",
   "journalDateInvalid": "Invalid Date Range",
   "journalDateNowButton": "Now",
-  "journalDateSaveButton": "SAVE",
+  "journalDateSaveButton": "Save",
   "journalDateToLabel": "Date to:",
   "journalDeleteConfirm": "YES, DELETE THIS ENTRY",
   "journalDeleteHint": "Delete entry",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2547,7 +2547,7 @@
   "journalDateInvalid": "Intervalo de fechas no válido",
   "journalDateLabel": "Fecha",
   "journalDateNowButton": "Ahora",
-  "journalDateSaveButton": "GUARDAR",
+  "journalDateSaveButton": "Guardar",
   "journalDateTimeRangeTitle": "Fecha y hora",
   "journalDateToLabel": "Fecha hasta:",
   "journalDeleteConfirm": "SÍ, BORRAR ESTA ENTRADA",
@@ -2581,6 +2581,8 @@
   "journalOvernightNextDay": "Termina {date} (día siguiente)",
   "journalPrivateTooltip": "solo privado",
   "journalSearchHint": "Buscar en el diario...",
+  "journalSetEndDateTimeNowSemantic": "Establecer la fecha y hora de fin al momento actual",
+  "journalSetStartDateTimeNowSemantic": "Establecer la fecha y hora de inicio al momento actual",
   "journalShareHint": "Compartir",
   "journalShowLinkHint": "Mostrar enlace",
   "journalShowMapHint": "Mostrar mapa",
@@ -3778,6 +3780,7 @@
   "taskDueYesterday": "Venció ayer",
   "taskEditTitleLabel": "Editar título de la tarea",
   "taskEstimateLabel": "Estimación:",
+  "taskEstimateModalTitle": "Estimación",
   "taskEstimateProgressLabel": "{tracked} de {estimate}",
   "@taskEstimateProgressLabel": {
     "placeholders": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -2547,7 +2547,7 @@
   "journalDateInvalid": "Plage de dates invalide",
   "journalDateLabel": "Date",
   "journalDateNowButton": "maintenant",
-  "journalDateSaveButton": "ENREGISTRER",
+  "journalDateSaveButton": "Enregistrer",
   "journalDateTimeRangeTitle": "Date et heure",
   "journalDateToLabel": "Date de fin :",
   "journalDeleteConfirm": "OUI, SUPPRIMER CETTE ENTRÉE",
@@ -2581,6 +2581,8 @@
   "journalOvernightNextDay": "Fin {date} (jour suivant)",
   "journalPrivateTooltip": "Privé",
   "journalSearchHint": "Rechercher journal...",
+  "journalSetEndDateTimeNowSemantic": "Définir la date et l’heure de fin sur maintenant",
+  "journalSetStartDateTimeNowSemantic": "Définir la date et l’heure de début sur maintenant",
   "journalShareHint": "Partager",
   "journalShowLinkHint": "Afficher le lien",
   "journalShowMapHint": "Afficher la carte",
@@ -3778,6 +3780,7 @@
   "taskDueYesterday": "Échéance hier",
   "taskEditTitleLabel": "Modifier le titre de la tâche",
   "taskEstimateLabel": "Temps estimé :",
+  "taskEstimateModalTitle": "Temps estimé",
   "taskEstimateProgressLabel": "{tracked} sur {estimate}",
   "@taskEstimateProgressLabel": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -10281,7 +10281,7 @@ abstract class AppLocalizations {
   /// No description provided for @journalDateSaveButton.
   ///
   /// In en, this message translates to:
-  /// **'SAVE'**
+  /// **'Save'**
   String get journalDateSaveButton;
 
   /// No description provided for @journalDateTimeRangeTitle.
@@ -10481,6 +10481,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Search journal...'**
   String get journalSearchHint;
+
+  /// No description provided for @journalSetEndDateTimeNowSemantic.
+  ///
+  /// In en, this message translates to:
+  /// **'Set end date and time to now'**
+  String get journalSetEndDateTimeNowSemantic;
+
+  /// No description provided for @journalSetStartDateTimeNowSemantic.
+  ///
+  /// In en, this message translates to:
+  /// **'Set start date and time to now'**
+  String get journalSetStartDateTimeNowSemantic;
 
   /// No description provided for @journalShareHint.
   ///
@@ -15750,6 +15762,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Estimate:'**
   String get taskEstimateLabel;
+
+  /// No description provided for @taskEstimateModalTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Estimate'**
+  String get taskEstimateModalTitle;
 
   /// No description provided for @taskEstimateProgressLabel.
   ///

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -5990,7 +5990,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get journalDateNowButton => 'Nyní';
 
   @override
-  String get journalDateSaveButton => 'ULOŽIT';
+  String get journalDateSaveButton => 'Uložit';
 
   @override
   String get journalDateTimeRangeTitle => 'Datum a čas';
@@ -6094,6 +6094,14 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get journalSearchHint => 'Hledat deník...';
+
+  @override
+  String get journalSetEndDateTimeNowSemantic =>
+      'Nastavit koncové datum a čas na teď';
+
+  @override
+  String get journalSetStartDateTimeNowSemantic =>
+      'Nastavit počáteční datum a čas na teď';
 
   @override
   String get journalShareHint => 'Sdílet';
@@ -9272,6 +9280,9 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get taskEstimateLabel => 'Odhad:';
+
+  @override
+  String get taskEstimateModalTitle => 'Odhad';
 
   @override
   String taskEstimateProgressLabel(String tracked, String estimate) {

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -5974,7 +5974,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get journalDateNowButton => 'Jetzt';
 
   @override
-  String get journalDateSaveButton => 'SPEICHERN';
+  String get journalDateSaveButton => 'Speichern';
 
   @override
   String get journalDateTimeRangeTitle => 'Datum & Uhrzeit';
@@ -6078,6 +6078,14 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get journalSearchHint => 'Tagebuch durchsuchen...';
+
+  @override
+  String get journalSetEndDateTimeNowSemantic =>
+      'Enddatum und -zeit auf jetzt setzen';
+
+  @override
+  String get journalSetStartDateTimeNowSemantic =>
+      'Startdatum und -zeit auf jetzt setzen';
 
   @override
   String get journalShareHint => 'Teilen';
@@ -9227,6 +9235,9 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get taskEstimateLabel => 'Schätzung:';
+
+  @override
+  String get taskEstimateModalTitle => 'Schätzung';
 
   @override
   String taskEstimateProgressLabel(String tracked, String estimate) {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -5903,7 +5903,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get journalDateNowButton => 'Now';
 
   @override
-  String get journalDateSaveButton => 'SAVE';
+  String get journalDateSaveButton => 'Save';
 
   @override
   String get journalDateTimeRangeTitle => 'Date & Time';
@@ -6006,6 +6006,13 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get journalSearchHint => 'Search journal...';
+
+  @override
+  String get journalSetEndDateTimeNowSemantic => 'Set end date and time to now';
+
+  @override
+  String get journalSetStartDateTimeNowSemantic =>
+      'Set start date and time to now';
 
   @override
   String get journalShareHint => 'Share';
@@ -9107,6 +9114,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get taskEstimateLabel => 'Estimate:';
 
   @override
+  String get taskEstimateModalTitle => 'Estimate';
+
+  @override
   String taskEstimateProgressLabel(String tracked, String estimate) {
     return '$tracked of $estimate';
   }
@@ -9928,7 +9938,7 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
   String get journalDateNowButton => 'Now';
 
   @override
-  String get journalDateSaveButton => 'SAVE';
+  String get journalDateSaveButton => 'Save';
 
   @override
   String get journalDateToLabel => 'Date to:';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -6021,7 +6021,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get journalDateNowButton => 'Ahora';
 
   @override
-  String get journalDateSaveButton => 'GUARDAR';
+  String get journalDateSaveButton => 'Guardar';
 
   @override
   String get journalDateTimeRangeTitle => 'Fecha y hora';
@@ -6125,6 +6125,14 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get journalSearchHint => 'Buscar en el diario...';
+
+  @override
+  String get journalSetEndDateTimeNowSemantic =>
+      'Establecer la fecha y hora de fin al momento actual';
+
+  @override
+  String get journalSetStartDateTimeNowSemantic =>
+      'Establecer la fecha y hora de inicio al momento actual';
 
   @override
   String get journalShareHint => 'Compartir';
@@ -9327,6 +9335,9 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get taskEstimateLabel => 'Estimación:';
+
+  @override
+  String get taskEstimateModalTitle => 'Estimación';
 
   @override
   String taskEstimateProgressLabel(String tracked, String estimate) {

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -6028,7 +6028,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get journalDateNowButton => 'maintenant';
 
   @override
-  String get journalDateSaveButton => 'ENREGISTRER';
+  String get journalDateSaveButton => 'Enregistrer';
 
   @override
   String get journalDateTimeRangeTitle => 'Date et heure';
@@ -6132,6 +6132,14 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get journalSearchHint => 'Rechercher journal...';
+
+  @override
+  String get journalSetEndDateTimeNowSemantic =>
+      'Définir la date et l’heure de fin sur maintenant';
+
+  @override
+  String get journalSetStartDateTimeNowSemantic =>
+      'Définir la date et l’heure de début sur maintenant';
 
   @override
   String get journalShareHint => 'Partager';
@@ -9345,6 +9353,9 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get taskEstimateLabel => 'Temps estimé :';
+
+  @override
+  String get taskEstimateModalTitle => 'Temps estimé';
 
   @override
   String taskEstimateProgressLabel(String tracked, String estimate) {

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -6038,7 +6038,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get journalDateNowButton => 'acum';
 
   @override
-  String get journalDateSaveButton => 'SALVEAZĂ';
+  String get journalDateSaveButton => 'Salvează';
 
   @override
   String get journalDateTimeRangeTitle => 'Dată și oră';
@@ -6142,6 +6142,14 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get journalSearchHint => 'Cautare jurnal...';
+
+  @override
+  String get journalSetEndDateTimeNowSemantic =>
+      'Setați data și ora de final la momentul actual';
+
+  @override
+  String get journalSetStartDateTimeNowSemantic =>
+      'Setați data și ora de început la momentul actual';
 
   @override
   String get journalShareHint => 'Partajează';
@@ -9339,6 +9347,9 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get taskEstimateLabel => 'Timp Estimat:';
+
+  @override
+  String get taskEstimateModalTitle => 'Timp estimat';
 
   @override
   String taskEstimateProgressLabel(String tracked, String estimate) {

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -2547,7 +2547,7 @@
   "journalDateInvalid": "Dată invalidă",
   "journalDateLabel": "Dată",
   "journalDateNowButton": "acum",
-  "journalDateSaveButton": "SALVEAZĂ",
+  "journalDateSaveButton": "Salvează",
   "journalDateTimeRangeTitle": "Dată și oră",
   "journalDateToLabel": "Până la:",
   "journalDeleteConfirm": "DA, ȘTERGE ACEASTĂ INTRARE",
@@ -2581,6 +2581,8 @@
   "journalOvernightNextDay": "Se termină {date} (ziua următoare)",
   "journalPrivateTooltip": "Privat",
   "journalSearchHint": "Cautare jurnal...",
+  "journalSetEndDateTimeNowSemantic": "Setați data și ora de final la momentul actual",
+  "journalSetStartDateTimeNowSemantic": "Setați data și ora de început la momentul actual",
   "journalShareHint": "Partajează",
   "journalShowLinkHint": "Arată linkul",
   "journalShowMapHint": "Arată harta",
@@ -3778,6 +3780,7 @@
   "taskDueYesterday": "Scadent ieri",
   "taskEditTitleLabel": "Editați titlul sarcinii",
   "taskEstimateLabel": "Timp Estimat:",
+  "taskEstimateModalTitle": "Timp estimat",
   "taskEstimateProgressLabel": "{tracked} din {estimate}",
   "@taskEstimateProgressLabel": {
     "placeholders": {

--- a/lib/utils/date_utils_extension.dart
+++ b/lib/utils/date_utils_extension.dart
@@ -3,5 +3,26 @@ extension DateUtilsExtension on DateTime {
 
   DateTime get dayAtMidnight => DateTime(year, month, day);
 
+  /// Removes the time while retaining whether this value is UTC or local.
+  DateTime get dateOnly =>
+      isUtc ? DateTime.utc(year, month, day) : DateTime(year, month, day);
+
+  /// Copies this calendar day into the timezone kind used by [reference].
+  DateTime dateOnlyInZoneOf(DateTime reference) => reference.isUtc
+      ? DateTime.utc(year, month, day)
+      : DateTime(year, month, day);
+
+  /// Compares calendar components without converting either timezone.
+  bool isSameCalendarDay(DateTime other) =>
+      year == other.year && month == other.month && day == other.day;
+
+  /// Orders calendar components without converting either timezone.
+  int compareCalendarDay(DateTime other) {
+    final yearComparison = year.compareTo(other.year);
+    if (yearComparison != 0) return yearComparison;
+    final monthComparison = month.compareTo(other.month);
+    return monthComparison != 0 ? monthComparison : day.compareTo(other.day);
+  }
+
   String get ymd => toIso8601String().substring(0, 10);
 }

--- a/lib/utils/date_utils_extension.dart
+++ b/lib/utils/date_utils_extension.dart
@@ -12,6 +12,29 @@ extension DateUtilsExtension on DateTime {
       ? DateTime.utc(year, month, day)
       : DateTime(year, month, day);
 
+  /// Moves by calendar days without assuming every local day is 24 hours.
+  DateTime addCalendarDays(int days) => isUtc
+      ? DateTime.utc(
+          year,
+          month,
+          day + days,
+          hour,
+          minute,
+          second,
+          millisecond,
+          microsecond,
+        )
+      : DateTime(
+          year,
+          month,
+          day + days,
+          hour,
+          minute,
+          second,
+          millisecond,
+          microsecond,
+        );
+
   /// Compares calendar components without converting either timezone.
   bool isSameCalendarDay(DateTime other) =>
       year == other.year && month == other.month && day == other.day;

--- a/lib/utils/date_utils_extension.dart
+++ b/lib/utils/date_utils_extension.dart
@@ -1,39 +1,65 @@
+import 'package:timezone/timezone.dart' as tz;
+
 extension DateUtilsExtension on DateTime {
   DateTime get dayAtNoon => DateTime(year, month, day, 12);
 
   DateTime get dayAtMidnight => DateTime(year, month, day);
 
-  /// Removes the time while retaining whether this value is UTC or local.
-  DateTime get dateOnly =>
-      isUtc ? DateTime.utc(year, month, day) : DateTime(year, month, day);
+  /// Removes the time while retaining this value's timezone semantics.
+  DateTime get dateOnly {
+    if (this is tz.TZDateTime) {
+      return tz.TZDateTime((this as tz.TZDateTime).location, year, month, day);
+    }
+    return isUtc ? DateTime.utc(year, month, day) : DateTime(year, month, day);
+  }
 
-  /// Copies this calendar day into the timezone kind used by [reference].
-  DateTime dateOnlyInZoneOf(DateTime reference) => reference.isUtc
-      ? DateTime.utc(year, month, day)
-      : DateTime(year, month, day);
+  /// Copies this calendar day into the timezone used by [reference].
+  DateTime dateOnlyInZoneOf(DateTime reference) {
+    if (reference is tz.TZDateTime) {
+      return tz.TZDateTime(reference.location, year, month, day);
+    }
+    return reference.isUtc
+        ? DateTime.utc(year, month, day)
+        : DateTime(year, month, day);
+  }
 
   /// Moves by calendar days without assuming every local day is 24 hours.
-  DateTime addCalendarDays(int days) => isUtc
-      ? DateTime.utc(
-          year,
-          month,
-          day + days,
-          hour,
-          minute,
-          second,
-          millisecond,
-          microsecond,
-        )
-      : DateTime(
-          year,
-          month,
-          day + days,
-          hour,
-          minute,
-          second,
-          millisecond,
-          microsecond,
-        );
+  DateTime addCalendarDays(int days) {
+    if (this is tz.TZDateTime) {
+      return tz.TZDateTime(
+        (this as tz.TZDateTime).location,
+        year,
+        month,
+        day + days,
+        hour,
+        minute,
+        second,
+        millisecond,
+        microsecond,
+      );
+    }
+    return isUtc
+        ? DateTime.utc(
+            year,
+            month,
+            day + days,
+            hour,
+            minute,
+            second,
+            millisecond,
+            microsecond,
+          )
+        : DateTime(
+            year,
+            month,
+            day + days,
+            hour,
+            minute,
+            second,
+            millisecond,
+            microsecond,
+          );
+  }
 
   /// Compares calendar components without converting either timezone.
   bool isSameCalendarDay(DateTime other) =>

--- a/lib/widgets/modal/README.md
+++ b/lib/widgets/modal/README.md
@@ -37,7 +37,9 @@ app's styling and responsive behavior. Key static members:
 - `showSinglePageModal<T>({...})` — show a single styled page.
 - `showSingleSliverPageModal<T>({...})` — show a single sliver-based page.
 - `showMultiPageModal<T>({...})` — show a multi-page modal with an optional
-  `pageIndexNotifier`.
+  `pageIndexNotifier`; `modalTypeBuilderOverride` lets a dense flow keep the
+  shared Wolt page/navigation behavior while supplying a flow-specific
+  responsive dialog constraint.
 - `showBottomSheet<T>({...})` — thin wrapper over `showModalBottomSheet` that
   applies the root-navigator heuristic.
 

--- a/lib/widgets/modal/modal_utils.dart
+++ b/lib/widgets/modal/modal_utils.dart
@@ -215,6 +215,7 @@ class ModalUtils {
     ValueNotifier<int>? pageIndexNotifier,
     bool barrierDismissible = true,
     Widget Function(Widget)? modalDecorator,
+    WoltModalType Function(BuildContext)? modalTypeBuilderOverride,
   }) async {
     final isDark = Theme.of(context).brightness == Brightness.dark;
 
@@ -223,7 +224,7 @@ class ModalUtils {
       useRootNavigator: shouldUseRootNavigatorForBottomSheet(context),
       modalDecorator: modalDecorator,
       pageListBuilder: pageListBuilder,
-      modalTypeBuilder: modalTypeBuilder,
+      modalTypeBuilder: modalTypeBuilderOverride ?? modalTypeBuilder,
       pageIndexNotifier: pageIndexNotifier,
       barrierDismissible: barrierDismissible,
       modalBarrierColor: getModalBarrierColor(isDark: isDark, context: context),

--- a/test/features/design_system/components/buttons/design_system_modal_action_bar_test.dart
+++ b/test/features/design_system/components/buttons/design_system_modal_action_bar_test.dart
@@ -21,9 +21,13 @@ void main() {
     onPressed: () {},
   );
 
-  Future<void> pumpBar(WidgetTester tester, DesignSystemModalActionBar bar) {
+  Future<void> pumpBar(
+    WidgetTester tester,
+    DesignSystemModalActionBar bar, {
+    double width = 600,
+  }) {
     return tester.pumpWidget(
-      makeTestableWidgetWithScaffold(SizedBox(width: 600, child: bar)),
+      makeTestableWidgetWithScaffold(SizedBox(width: width, child: bar)),
     );
   }
 
@@ -140,6 +144,34 @@ void main() {
       greaterThan(500),
       reason: 'a lone primary should fill most of the 600px row',
     );
+  });
+
+  testWidgets('narrow layouts wrap secondaries above a full-width primary', (
+    tester,
+  ) async {
+    await pumpBar(
+      tester,
+      DesignSystemModalActionBar(
+        secondary: [secondaryBtn('Cancel'), secondaryBtn('Clear')],
+        primary: primaryBtn('Done'),
+      ),
+      width: 320,
+    );
+    await tester.pump();
+
+    final cancelCenter = tester.getCenter(
+      find.widgetWithText(DesignSystemButton, 'Cancel'),
+    );
+    final doneCenter = tester.getCenter(
+      find.widgetWithText(DesignSystemButton, 'Done'),
+    );
+    final doneWidth = tester
+        .getSize(find.widgetWithText(DesignSystemButton, 'Done'))
+        .width;
+
+    expect(doneCenter.dy, greaterThan(cancelCenter.dy));
+    expect(doneWidth, 320);
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('glass: true renders the bar on a DesignSystemGlassStrip', (

--- a/test/features/design_system/components/calendar_pickers/design_system_date_picker_modal_test.dart
+++ b/test/features/design_system/components/calendar_pickers/design_system_date_picker_modal_test.dart
@@ -1,0 +1,108 @@
+import 'package:clock/clock.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
+import 'package:lotti/features/design_system/components/calendar_pickers/design_system_date_picker_modal.dart';
+
+import '../../../../test_helper.dart';
+
+void main() {
+  testWidgets('calendar confirms a weekday-visible selected date', (
+    tester,
+  ) async {
+    DesignSystemDatePickerResult? result;
+    await _pumpLauncher(
+      tester,
+      onPressed: (context) async {
+        result = await showDesignSystemDatePicker(
+          context: context,
+          title: 'Target date',
+          initialDate: DateTime(2025, 6, 15),
+          firstDate: DateTime(2020),
+          lastDate: DateTime(2030),
+        );
+      },
+    );
+
+    expect(find.text('Target date'), findsOneWidget);
+    expect(find.text('Sunday, June 15, 2025'), findsOneWidget);
+    expect(find.text('June 2025'), findsOneWidget);
+    expect(find.byType(CalendarDatePicker), findsOneWidget);
+    expect(find.text('Today'), findsOneWidget);
+    expect(find.text('Done'), findsOneWidget);
+    expect(find.text('Clear'), findsNothing);
+
+    await tester.tap(find.text('16'));
+    await tester.pump();
+    expect(find.text('Monday, June 16, 2025'), findsOneWidget);
+    await tester.tap(find.text('Done'));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(result?.date, DateTime(2025, 6, 16));
+    expect(result?.cleared, isFalse);
+  });
+
+  testWidgets('optional Clear is distinct from dismissing the modal', (
+    tester,
+  ) async {
+    DesignSystemDatePickerResult? result;
+    await _pumpLauncher(
+      tester,
+      onPressed: (context) async {
+        result = await showDesignSystemDatePicker(
+          context: context,
+          title: 'Due date',
+          initialDate: DateTime(2025, 6, 15),
+          firstDate: DateTime(2020),
+          lastDate: DateTime(2030),
+          allowClear: true,
+        );
+      },
+    );
+
+    await tester.tap(find.text('Clear'));
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(result?.cleared, isTrue);
+    expect(result?.date, isNull);
+  });
+
+  testWidgets('Today is disabled when it is already selected', (tester) async {
+    final today = DateTime(2026, 7, 14);
+    await withClock(Clock.fixed(today), () async {
+      await _pumpLauncher(
+        tester,
+        onPressed: (context) => showDesignSystemDatePicker(
+          context: context,
+          title: 'Due date',
+          initialDate: today,
+          firstDate: DateTime(2020),
+          lastDate: DateTime(2030),
+        ),
+      );
+    });
+
+    final todayButton = tester.widget<DesignSystemButton>(
+      find.widgetWithText(DesignSystemButton, 'Today'),
+    );
+    expect(todayButton.onPressed, isNull);
+  });
+}
+
+Future<void> _pumpLauncher(
+  WidgetTester tester, {
+  required Future<void> Function(BuildContext context) onPressed,
+}) async {
+  await tester.pumpWidget(
+    WidgetTestBench(
+      child: Builder(
+        builder: (context) => ElevatedButton(
+          onPressed: () => onPressed(context),
+          child: const Text('Open picker'),
+        ),
+      ),
+    ),
+  );
+  await tester.tap(find.text('Open picker'));
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 300));
+}

--- a/test/features/design_system/components/calendar_pickers/design_system_date_picker_modal_test.dart
+++ b/test/features/design_system/components/calendar_pickers/design_system_date_picker_modal_test.dart
@@ -28,6 +28,7 @@ void main() {
     expect(find.text('Sunday, June 15, 2025'), findsOneWidget);
     expect(find.text('June 2025'), findsOneWidget);
     expect(find.byType(CalendarDatePicker), findsOneWidget);
+    expect(find.byType(DesignSystemPickerSection), findsOneWidget);
     expect(find.text('Today'), findsOneWidget);
     expect(find.text('Done'), findsOneWidget);
     expect(find.text('Clear'), findsNothing);
@@ -85,6 +86,70 @@ void main() {
       find.widgetWithText(DesignSystemButton, 'Today'),
     );
     expect(todayButton.onPressed, isNull);
+  });
+
+  for (final scenario in [
+    (
+      name: 'before first date',
+      initial: DateTime(2010, 6, 15),
+      expected: DateTime(2020),
+      label: 'Wednesday, January 1, 2020',
+    ),
+    (
+      name: 'after last date in UTC',
+      initial: DateTime.utc(2040, 6, 15),
+      expected: DateTime.utc(2030),
+      label: 'Tuesday, January 1, 2030',
+    ),
+  ]) {
+    testWidgets('clamps an initial date ${scenario.name}', (tester) async {
+      DesignSystemDatePickerResult? result;
+      await _pumpLauncher(
+        tester,
+        onPressed: (context) async {
+          result = await showDesignSystemDatePicker(
+            context: context,
+            title: 'Due date',
+            initialDate: scenario.initial,
+            firstDate: DateTime(2020),
+            lastDate: DateTime(2030),
+          );
+        },
+      );
+
+      expect(find.text(scenario.label), findsOneWidget);
+      await tester.tap(find.text('Done'));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(result?.date, scenario.expected);
+      expect(result?.date?.isUtc, scenario.expected.isUtc);
+    });
+  }
+
+  testWidgets('calendar selection preserves a UTC initial value', (
+    tester,
+  ) async {
+    DesignSystemDatePickerResult? result;
+    await _pumpLauncher(
+      tester,
+      onPressed: (context) async {
+        result = await showDesignSystemDatePicker(
+          context: context,
+          title: 'Due date',
+          initialDate: DateTime.utc(2025, 6, 15),
+          firstDate: DateTime(2020),
+          lastDate: DateTime(2030),
+        );
+      },
+    );
+
+    await tester.tap(find.text('16'));
+    await tester.pump();
+    await tester.tap(find.text('Done'));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(result?.date, DateTime.utc(2025, 6, 16));
+    expect(result?.date?.isUtc, isTrue);
   });
 }
 

--- a/test/features/design_system/components/time_pickers/design_system_picker_wheels_test.dart
+++ b/test/features/design_system/components/time_pickers/design_system_picker_wheels_test.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/cupertino.dart' show CupertinoTimerPicker;
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/components/time_pickers/design_system_picker_wheels.dart';
+
+import '../../../../widget_test_utils.dart';
+
+void main() {
+  testWidgets(
+    'time wheel uses the requested clock format and forwards changes',
+    (
+      tester,
+    ) async {
+      final semanticsHandle = tester.ensureSemantics();
+      DateTime? changed;
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          DesignSystemTimeWheel(
+            initialDateTime: DateTime(2024, 6, 15, 14, 30),
+            use24hFormat: true,
+            onDateTimeChanged: (value) => changed = value,
+          ),
+        ),
+      );
+
+      final picker = tester.widget<DesignSystemTimeWheel>(
+        find.byType(DesignSystemTimeWheel),
+      );
+      expect(picker.use24hFormat, isTrue);
+      expect(find.byType(ListWheelScrollView), findsNWidgets(2));
+      expect(find.text(':'), findsOneWidget);
+
+      final wheel = tester.widget<ListWheelScrollView>(
+        find.byType(ListWheelScrollView).first,
+      );
+      expect(wheel.physics, isA<FixedExtentScrollPhysics>());
+      expect(wheel.itemExtent, 40);
+      expect(wheel.diameterRatio, 1.07);
+      expect(wheel.squeeze, 1.45);
+      expect(wheel.overAndUnderCenterOpacity, 0.447);
+
+      final hour = tester.getSemantics(find.bySemanticsLabel('Hour'));
+      tester.binding.performSemanticsAction(
+        SemanticsActionEvent(
+          type: SemanticsAction.increase,
+          nodeId: hour.id,
+          viewId: tester.view.viewId,
+        ),
+      );
+      await tester.pump();
+      expect(changed, DateTime(2024, 6, 15, 15, 30));
+
+      final minute = tester.getSemantics(find.bySemanticsLabel('Minute'));
+      tester.binding.performSemanticsAction(
+        SemanticsActionEvent(
+          type: SemanticsAction.increase,
+          nodeId: minute.id,
+          viewId: tester.view.viewId,
+        ),
+      );
+      await tester.pump();
+      expect(changed, DateTime(2024, 6, 15, 15, 31));
+
+      final updatedMinute = tester.getSemantics(
+        find.bySemanticsLabel('Minute'),
+      );
+      tester.binding.performSemanticsAction(
+        SemanticsActionEvent(
+          type: SemanticsAction.decrease,
+          nodeId: updatedMinute.id,
+          viewId: tester.view.viewId,
+        ),
+      );
+      await tester.pump();
+      expect(changed, DateTime(2024, 6, 15, 15, 30));
+      semanticsHandle.dispose();
+    },
+  );
+
+  testWidgets('12-hour wheel includes a fixed AM/PM column', (tester) async {
+    DateTime? changed;
+    await tester.pumpWidget(
+      makeTestableWidgetWithScaffold(
+        DesignSystemTimeWheel(
+          initialDateTime: DateTime(2024, 6, 15, 14, 30),
+          onDateTimeChanged: (value) => changed = value,
+        ),
+      ),
+    );
+
+    expect(find.byType(ListWheelScrollView), findsNWidgets(3));
+    expect(find.text('PM'), findsWidgets);
+
+    await tester.drag(
+      find.byType(ListWheelScrollView).at(2),
+      const Offset(0, 48),
+    );
+    await tester.pump(const Duration(milliseconds: 800));
+    expect(changed, DateTime(2024, 6, 15, 2, 30));
+  });
+
+  testWidgets('time columns expose localized adjustable semantics', (
+    tester,
+  ) async {
+    final semanticsHandle = tester.ensureSemantics();
+    DateTime? changed;
+    await tester.pumpWidget(
+      makeTestableWidgetWithScaffold(
+        DesignSystemTimeWheel(
+          initialDateTime: DateTime(2024, 6, 15, 14, 30),
+          onDateTimeChanged: (value) => changed = value,
+        ),
+      ),
+    );
+
+    final hour = tester.getSemantics(find.bySemanticsLabel('Hour'));
+    final minute = tester.getSemantics(find.bySemanticsLabel('Minute'));
+    final period = tester.getSemantics(find.bySemanticsLabel('AM / PM'));
+    expect(hour.value, '2');
+    expect(hour.increasedValue, '3');
+    expect(minute.value, '30');
+    expect(period.value, 'PM');
+
+    tester.binding.performSemanticsAction(
+      SemanticsActionEvent(
+        type: SemanticsAction.increase,
+        nodeId: hour.id,
+        viewId: tester.view.viewId,
+      ),
+    );
+    await tester.pump();
+    expect(changed, DateTime(2024, 6, 15, 15, 30));
+    semanticsHandle.dispose();
+  });
+
+  testWidgets('duration wheel exposes composed live semantics', (tester) async {
+    await tester.pumpWidget(
+      makeTestableWidgetWithScaffold(
+        DesignSystemDurationWheel(
+          initialDuration: const Duration(minutes: 30),
+          semanticsLabel: 'Estimate: 0h 30m',
+          semanticsLiveRegion: true,
+          onDurationChanged: (_) {},
+        ),
+      ),
+    );
+
+    final semantics = tester.getSemantics(
+      find.byWidgetPredicate(
+        (widget) => widget is Semantics && widget.properties.liveRegion == true,
+      ),
+    );
+    expect(semantics.label, 'Estimate: 0h 30m');
+    expect(find.byType(CupertinoTimerPicker), findsOneWidget);
+  });
+}

--- a/test/features/design_system/components/time_pickers/design_system_picker_wheels_test.dart
+++ b/test/features/design_system/components/time_pickers/design_system_picker_wheels_test.dart
@@ -238,11 +238,17 @@ void main() {
     await tester.pump();
     expect(changed, DateTime(2024, 6, 15, 15, 30));
 
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.arrowDown);
+    await tester.sendKeyRepeatEvent(LogicalKeyboardKey.arrowDown);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pump();
+    expect(changed, DateTime(2024, 6, 15, 17, 30));
+
     await tester.sendKeyEvent(LogicalKeyboardKey.tab);
     await tester.pump();
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
     await tester.pump();
-    expect(changed, DateTime(2024, 6, 15, 15, 29));
+    expect(changed, DateTime(2024, 6, 15, 17, 29));
   });
 
   testWidgets('settled selection does not rebuild the wheel delegate', (

--- a/test/features/design_system/components/time_pickers/design_system_picker_wheels_test.dart
+++ b/test/features/design_system/components/time_pickers/design_system_picker_wheels_test.dart
@@ -163,6 +163,42 @@ void main() {
     expect(changed, DateTime(2024, 6, 15, 23));
   });
 
+  testWidgets('looping columns defensively normalize absolute indices', (
+    tester,
+  ) async {
+    final semanticsHandle = tester.ensureSemantics();
+    DateTime? changed;
+    await tester.pumpWidget(
+      makeTestableWidgetWithScaffold(
+        DesignSystemTimeWheel(
+          initialDateTime: DateTime(2024, 6, 15, 14, 30),
+          use24hFormat: true,
+          onDateTimeChanged: (value) => changed = value,
+        ),
+      ),
+    );
+
+    final hourWheel = tester.widget<ListWheelScrollView>(
+      find.byType(ListWheelScrollView).first,
+    );
+    hourWheel.onSelectedItemChanged!(12005);
+    await tester.pump();
+
+    final hour = tester.getSemantics(find.bySemanticsLabel('Hour'));
+    expect(hour.value, '05');
+    tester.binding.performSemanticsAction(
+      SemanticsActionEvent(
+        type: SemanticsAction.increase,
+        nodeId: hour.id,
+        viewId: tester.view.viewId,
+      ),
+    );
+    await tester.pump();
+
+    expect(changed, DateTime(2024, 6, 15, 6, 30));
+    semanticsHandle.dispose();
+  });
+
   testWidgets(
     'Linux pointer scroll accumulates fine deltas and keeps accepting '
     'large events',

--- a/test/features/design_system/components/time_pickers/design_system_picker_wheels_test.dart
+++ b/test/features/design_system/components/time_pickers/design_system_picker_wheels_test.dart
@@ -109,6 +109,34 @@ void main() {
     expect(changed, DateTime(2024, 6, 15, 2, 30));
   });
 
+  testWidgets('time changes preserve a UTC initial value', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+    DateTime? changed;
+    await tester.pumpWidget(
+      makeTestableWidgetWithScaffold(
+        DesignSystemTimeWheel(
+          initialDateTime: DateTime.utc(2024, 6, 15, 14, 30),
+          use24hFormat: true,
+          onDateTimeChanged: (value) => changed = value,
+        ),
+      ),
+    );
+
+    final hour = tester.getSemantics(find.bySemanticsLabel('Hour'));
+    tester.binding.performSemanticsAction(
+      SemanticsActionEvent(
+        type: SemanticsAction.increase,
+        nodeId: hour.id,
+        viewId: tester.view.viewId,
+      ),
+    );
+    await tester.pump();
+
+    expect(changed, DateTime.utc(2024, 6, 15, 15, 30));
+    expect(changed!.isUtc, isTrue);
+    semanticsHandle.dispose();
+  });
+
   testWidgets('looping hour wheel can move backwards from midnight', (
     tester,
   ) async {

--- a/test/features/design_system/components/time_pickers/design_system_picker_wheels_test.dart
+++ b/test/features/design_system/components/time_pickers/design_system_picker_wheels_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/cupertino.dart' show CupertinoTimerPicker;
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -34,7 +35,13 @@ void main() {
       final wheel = tester.widget<ListWheelScrollView>(
         find.byType(ListWheelScrollView).first,
       );
+      final minuteWheel = tester.widget<ListWheelScrollView>(
+        find.byType(ListWheelScrollView).at(1),
+      );
       expect(wheel.physics, isA<FixedExtentScrollPhysics>());
+      expect(wheel.physics!.maxFlingVelocity, 320);
+      expect(minuteWheel.physics!.maxFlingVelocity, 800);
+      expect(wheel.dragStartBehavior, DragStartBehavior.down);
       expect(wheel.itemExtent, 40);
       expect(wheel.diameterRatio, 1.07);
       expect(wheel.squeeze, 1.45);
@@ -98,6 +105,164 @@ void main() {
     );
     await tester.pump(const Duration(milliseconds: 800));
     expect(changed, DateTime(2024, 6, 15, 2, 30));
+  });
+
+  testWidgets('looping hour wheel can move backwards from midnight', (
+    tester,
+  ) async {
+    DateTime? changed;
+    await tester.pumpWidget(
+      makeTestableWidgetWithScaffold(
+        DesignSystemTimeWheel(
+          initialDateTime: DateTime(2024, 6, 15),
+          use24hFormat: true,
+          onDateTimeChanged: (value) => changed = value,
+        ),
+      ),
+    );
+
+    final hourWheel = find.byType(ListWheelScrollView).first;
+    final controller =
+        tester.widget<ListWheelScrollView>(hourWheel).controller!
+            as FixedExtentScrollController;
+    expect(controller.selectedItem, greaterThan(24));
+
+    await tester.drag(hourWheel, const Offset(0, 40));
+    await tester.pump(const Duration(milliseconds: 800));
+
+    expect(changed, DateTime(2024, 6, 15, 23));
+  });
+
+  testWidgets(
+    'Linux pointer scroll accumulates fine deltas and keeps accepting '
+    'large events',
+    (
+      tester,
+    ) async {
+      DateTime? changed;
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          DesignSystemTimeWheel(
+            initialDateTime: DateTime(2024, 6, 15, 14, 30),
+            use24hFormat: true,
+            onDateTimeChanged: (value) => changed = value,
+          ),
+        ),
+      );
+
+      final hourWheel = find.byType(ListWheelScrollView).first;
+      Future<void> scrollBy(double delta, Duration timeStamp) =>
+          tester.sendEventToBinding(
+            PointerScrollEvent(
+              position: tester.getCenter(hourWheel),
+              scrollDelta: Offset(0, delta),
+              timeStamp: timeStamp,
+            ),
+          );
+
+      await scrollBy(10, Duration.zero);
+      await tester.pump();
+      expect(changed, isNull);
+
+      await scrollBy(10, const Duration(milliseconds: 10));
+      await tester.pump();
+      expect(changed, DateTime(2024, 6, 15, 15, 30));
+
+      for (var i = 0; i < 2; i++) {
+        await scrollBy(400, Duration(milliseconds: 20 + i * 10));
+        await tester.pump();
+      }
+      expect(changed, DateTime(2024, 6, 15, 17, 30));
+
+      for (var i = 0; i < 8; i++) {
+        await scrollBy(400, Duration(milliseconds: 40 + i * 10));
+        await tester.pump();
+      }
+      expect(changed, DateTime(2024, 6, 15, 1, 30));
+    },
+  );
+
+  testWidgets('fast hour drag accelerates without an unbounded fling', (
+    tester,
+  ) async {
+    DateTime? changed;
+    await tester.pumpWidget(
+      makeTestableWidgetWithScaffold(
+        DesignSystemTimeWheel(
+          initialDateTime: DateTime(2024, 6, 15, 14, 30),
+          use24hFormat: true,
+          onDateTimeChanged: (value) => changed = value,
+        ),
+      ),
+    );
+
+    await tester.fling(
+      find.byType(ListWheelScrollView).first,
+      const Offset(0, -80),
+      10000,
+    );
+    await tester.pumpAndSettle();
+
+    expect(changed, isNotNull);
+    final advancedHours = (changed!.hour - 14 + 24) % 24;
+    expect(advancedHours, inInclusiveRange(2, 4));
+  });
+
+  testWidgets('settled selection does not rebuild the wheel delegate', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      makeTestableWidgetWithScaffold(
+        DesignSystemTimeWheel(
+          initialDateTime: DateTime(2024, 6, 15, 14, 30),
+          use24hFormat: true,
+          onDateTimeChanged: (_) {},
+        ),
+      ),
+    );
+
+    final hourWheel = find.byType(ListWheelScrollView).first;
+    final initialDelegate = tester
+        .widget<ListWheelScrollView>(hourWheel)
+        .childDelegate;
+
+    await tester.sendEventToBinding(
+      PointerScrollEvent(
+        position: tester.getCenter(hourWheel),
+        scrollDelta: const Offset(0, 40),
+      ),
+    );
+    await tester.pump();
+
+    final updatedDelegate = tester
+        .widget<ListWheelScrollView>(hourWheel)
+        .childDelegate;
+    expect(updatedDelegate.shouldRebuild(initialDelegate), isFalse);
+  });
+
+  testWidgets('theme change refreshes cached wheel children', (tester) async {
+    Widget buildWheel(Brightness brightness) => makeTestableWidgetWithScaffold(
+      DesignSystemTimeWheel(
+        initialDateTime: DateTime(2024, 6, 15, 14, 30),
+        use24hFormat: true,
+        onDateTimeChanged: (_) {},
+      ),
+      theme: ThemeData(brightness: brightness),
+    );
+
+    await tester.pumpWidget(buildWheel(Brightness.light));
+    final hourWheel = find.byType(ListWheelScrollView).first;
+    final initialDelegate = tester
+        .widget<ListWheelScrollView>(hourWheel)
+        .childDelegate;
+
+    await tester.pumpWidget(buildWheel(Brightness.dark));
+    await tester.pump(kThemeAnimationDuration);
+    final updatedDelegate = tester
+        .widget<ListWheelScrollView>(hourWheel)
+        .childDelegate;
+
+    expect(updatedDelegate.shouldRebuild(initialDelegate), isTrue);
   });
 
   testWidgets('time columns expose localized adjustable semantics', (

--- a/test/features/design_system/components/time_pickers/design_system_picker_wheels_test.dart
+++ b/test/features/design_system/components/time_pickers/design_system_picker_wheels_test.dart
@@ -2,8 +2,10 @@ import 'package:flutter/cupertino.dart' show CupertinoTimerPicker;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/design_system/components/time_pickers/design_system_picker_wheels.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 
 import '../../../../widget_test_utils.dart';
 
@@ -206,6 +208,41 @@ void main() {
     expect(changed, isNotNull);
     final advancedHours = (changed!.hour - 14 + 24) % 24;
     expect(advancedHours, inInclusiveRange(2, 4));
+  });
+
+  testWidgets('keyboard arrows adjust focused columns one row at a time', (
+    tester,
+  ) async {
+    DateTime? changed;
+    await tester.pumpWidget(
+      makeTestableWidgetWithScaffold(
+        DesignSystemTimeWheel(
+          initialDateTime: DateTime(2024, 6, 15, 14, 30),
+          use24hFormat: true,
+          onDateTimeChanged: (value) => changed = value,
+        ),
+      ),
+    );
+
+    final wheels = find.byType(ListWheelScrollView);
+    await tester.tap(wheels.first);
+    await tester.pump();
+
+    final tokens = tester.element(wheels.first).designTokens;
+    expect(
+      tester.widget<Text>(find.text('14').first).style!.color,
+      tokens.colors.interactive.enabled,
+    );
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pump();
+    expect(changed, DateTime(2024, 6, 15, 15, 30));
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pump();
+    expect(changed, DateTime(2024, 6, 15, 15, 29));
   });
 
   testWidgets('settled selection does not rebuild the wheel delegate', (

--- a/test/features/journal/ui/widgets/entry_details/entry_datetime_multipage_modal_test.dart
+++ b/test/features/journal/ui/widgets/entry_details/entry_datetime_multipage_modal_test.dart
@@ -1,3 +1,4 @@
+import 'package:clock/clock.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
@@ -57,6 +58,16 @@ final JournalEntry _multiDay = _entry(
   id: 'e-multi',
   from: DateTime(2024, 6, 14, 9),
   to: DateTime(2024, 6, 16, 11),
+);
+final JournalEntry _utcSameDay = _entry(
+  id: 'e-utc-same',
+  from: DateTime.utc(2024, 6, 15, 14, 30),
+  to: DateTime.utc(2024, 6, 15, 15, 15),
+);
+final JournalEntry _utcMultiDay = _entry(
+  id: 'e-utc-multi',
+  from: DateTime.utc(2024, 6, 14, 9),
+  to: DateTime.utc(2024, 6, 16, 11),
 );
 
 class _Launcher extends StatelessWidget {
@@ -346,22 +357,28 @@ void main() {
 
     testWidgets('Save is disabled until the range changes, then persists and '
         'pops', (tester) async {
-      final tracker = await openModal(tester, _sameDay);
+      await withClock(Clock.fixed(DateTime.utc(2024, 6, 20, 8)), () async {
+        final tracker = await openModal(tester, _utcSameDay);
 
-      // Unchanged on open.
-      expect(saveButton(tester).onPressed, isNull);
+        // Unchanged on open.
+        expect(saveButton(tester).onPressed, isNull);
 
-      // Tapping Today moves the (2024) date to today — a real change.
-      await tester.tap(find.text('Today'));
-      await tester.pumpAndSettle();
-      expect(saveButton(tester).onPressed, isNotNull);
+        await tester.tap(find.text('Today'));
+        await tester.pumpAndSettle();
+        expect(saveButton(tester).onPressed, isNotNull);
 
-      await tester.tap(find.widgetWithText(DesignSystemButton, 'Save'));
-      await tester.pumpAndSettle();
+        await tester.tap(find.widgetWithText(DesignSystemButton, 'Save'));
+        await tester.pumpAndSettle();
 
-      expect(tracker.updateFromToCalls, hasLength(1));
-      // The modal popped.
-      expect(find.text('Date & Time'), findsNothing);
+        expect(tracker.updateFromToCalls, hasLength(1));
+        expect(
+          tracker.updateFromToCalls.single['dateFrom'],
+          DateTime.utc(2024, 6, 20, 14, 30),
+        );
+        expect(tracker.updateFromToCalls.single['dateFrom']!.isUtc, isTrue);
+        // The modal popped.
+        expect(find.text('Date & Time'), findsNothing);
+      });
     });
 
     testWidgets('a failing save logs and keeps the modal open', (tester) async {
@@ -387,33 +404,30 @@ void main() {
       (
         tester,
       ) async {
-        final tracker = await openModal(tester, _sameDay);
+        await withClock(
+          Clock.fixed(DateTime.utc(2024, 6, 15, 16, 45)),
+          () async {
+            final tracker = await openModal(tester, _utcSameDay);
 
-        await tester.tap(quickAction('Set end date and time to now'));
-        await tester.pumpAndSettle();
+            await tester.tap(quickAction('Set end date and time to now'));
+            await tester.pumpAndSettle();
 
-        expect(
-          tester
-              .widget<DesignSystemToggle>(find.byType(DesignSystemToggle))
-              .value,
-          isTrue,
-        );
-        expect(find.text('End date'), findsOneWidget);
-        expect(saveButton(tester).onPressed, isNotNull);
+            expect(saveButton(tester).onPressed, isNotNull);
 
-        await tester.tap(find.widgetWithText(DesignSystemButton, 'Save'));
-        await tester.pumpAndSettle();
+            await tester.tap(find.widgetWithText(DesignSystemButton, 'Save'));
+            await tester.pumpAndSettle();
 
-        expect(tracker.updateFromToCalls, hasLength(1));
-        expect(
-          tracker.updateFromToCalls.single['dateFrom'],
-          _sameDay.meta.dateFrom,
-        );
-        expect(
-          tracker.updateFromToCalls.single['dateTo']!.isAfter(
-            _sameDay.meta.dateTo,
-          ),
-          isTrue,
+            expect(tracker.updateFromToCalls, hasLength(1));
+            expect(
+              tracker.updateFromToCalls.single['dateFrom'],
+              _utcSameDay.meta.dateFrom,
+            );
+            expect(
+              tracker.updateFromToCalls.single['dateTo'],
+              DateTime.utc(2024, 6, 15, 16, 45),
+            );
+            expect(tracker.updateFromToCalls.single['dateTo']!.isUtc, isTrue);
+          },
         );
       },
     );
@@ -421,22 +435,41 @@ void main() {
     testWidgets('Start Now changes the complete start endpoint', (
       tester,
     ) async {
-      await openModal(tester, _futureEntry);
+      await withClock(Clock.fixed(DateTime(2026, 7, 14, 12, 34)), () async {
+        final tracker = await openModal(tester, _futureEntry);
 
-      await tester.tap(quickAction('Set start date and time to now'));
-      await tester.pump();
+        await tester.tap(quickAction('Set start date and time to now'));
+        await tester.pump();
 
-      expect(saveButton(tester).onPressed, isNotNull);
+        expect(saveButton(tester).onPressed, isNotNull);
+        await tester.tap(find.widgetWithText(DesignSystemButton, 'Save'));
+        await tester.pumpAndSettle();
+
+        expect(
+          tracker.updateFromToCalls.single['dateFrom'],
+          DateTime(2026, 7, 14, 12, 34),
+        );
+      });
     });
 
     testWidgets('Today can update an explicit end date', (tester) async {
-      await openModal(tester, _multiDay);
+      await withClock(Clock.fixed(DateTime.utc(2024, 6, 20, 8)), () async {
+        final tracker = await openModal(tester, _utcMultiDay);
 
-      final endToday = quickAction('End date, Today');
-      await tester.tap(endToday);
-      await tester.pump();
+        final endToday = quickAction('End date, Today');
+        await tester.tap(endToday);
+        await tester.pump();
 
-      expect(saveButton(tester).onPressed, isNotNull);
+        expect(saveButton(tester).onPressed, isNotNull);
+        await tester.tap(find.widgetWithText(DesignSystemButton, 'Save'));
+        await tester.pumpAndSettle();
+
+        expect(
+          tracker.updateFromToCalls.single['dateTo'],
+          DateTime.utc(2024, 6, 20, 11),
+        );
+        expect(tracker.updateFromToCalls.single['dateTo']!.isUtc, isTrue);
+      });
     });
 
     testWidgets('end time wheel callback updates the range', (tester) async {

--- a/test/features/journal/ui/widgets/entry_details/entry_datetime_multipage_modal_test.dart
+++ b/test/features/journal/ui/widgets/entry_details/entry_datetime_multipage_modal_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
@@ -8,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
+import 'package:lotti/features/design_system/components/time_pickers/design_system_picker_wheels.dart';
 import 'package:lotti/features/design_system/components/toggles/design_system_toggle.dart';
 import 'package:lotti/features/journal/model/entry_state.dart';
 import 'package:lotti/features/journal/state/entry_controller.dart';
@@ -42,6 +42,11 @@ final JournalEntry _sameDay = _entry(
   id: 'e-same',
   from: DateTime(2024, 6, 15, 14, 30),
   to: DateTime(2024, 6, 15, 15, 15),
+);
+final JournalEntry _futureEntry = _entry(
+  id: 'e-future',
+  from: DateTime(2100, 6, 15, 14, 30),
+  to: DateTime(2100, 6, 15, 15, 15),
 );
 final JournalEntry _overnight = _entry(
   id: 'e-night',
@@ -144,6 +149,7 @@ void main() {
       WidgetTester tester,
       JournalEntity entry, {
       Override? overrideController,
+      MediaQueryData? mediaQueryData,
     }) async {
       final (
         trackedOverride,
@@ -156,6 +162,7 @@ void main() {
         makeTestableWidgetWithScaffold(
           _Launcher(entry: entry),
           overrides: [overrideController ?? trackedOverride],
+          mediaQueryData: mediaQueryData,
         ),
       );
       await tester.pump();
@@ -166,24 +173,122 @@ void main() {
 
     DesignSystemButton saveButton(WidgetTester tester) =>
         tester.widget<DesignSystemButton>(
-          find.widgetWithText(DesignSystemButton, 'SAVE'),
+          find.widgetWithText(DesignSystemButton, 'Save'),
         );
+
+    Finder quickAction(String semanticsLabel) => find.byWidgetPredicate(
+      (widget) =>
+          widget is DesignSystemButton &&
+          widget.semanticsLabel == semanticsLabel,
+    );
 
     testWidgets('renders the title and the one-date / two-times controls', (
       tester,
     ) async {
-      await openModal(tester, _sameDay);
+      await openModal(
+        tester,
+        _sameDay,
+        mediaQueryData: const MediaQueryData(size: Size(800, 900)),
+      );
 
       expect(find.text('Date & Time'), findsOneWidget);
-      expect(find.text('Date'), findsOneWidget);
       expect(find.text('Start time'), findsOneWidget);
       expect(find.text('End time'), findsOneWidget);
-      // The shared date affordance and the different-dates toggle.
+      expect(find.text('Saturday, June 15, 2024'), findsOneWidget);
+      // The shared date affordance, endpoint shortcuts, and explicit-date mode.
       expect(find.text('Today'), findsOneWidget);
+      expect(find.text('Now'), findsNWidgets(2));
+      expect(find.text('Pick a separate end date'), findsOneWidget);
       expect(find.byType(DesignSystemToggle), findsOneWidget);
-      // The pinned duration readout (45m for 14:30 -> 15:15).
+      expect(
+        quickAction('Set start date and time to now'),
+        findsOneWidget,
+      );
+      expect(quickAction('Set end date and time to now'), findsOneWidget);
+      // The pinned duration and absolute endpoint readout.
       expect(find.text('Duration'), findsOneWidget);
       expect(find.text('45m'), findsOneWidget);
+      expect(find.textContaining('Sat, Jun 15'), findsOneWidget);
+
+      final pickers = find.byType(DesignSystemTimeWheel);
+      expect(pickers, findsNWidgets(2));
+      expect(find.byType(CalendarDatePicker), findsNothing);
+      expect(find.byType(ListWheelScrollView), findsNWidgets(6));
+    });
+
+    testWidgets('date button transitions to the shared weekday calendar and '
+        'back', (
+      tester,
+    ) async {
+      await openModal(tester, _sameDay);
+      final modalBarrierCount = find.byType(ModalBarrier).evaluate().length;
+
+      await tester.tap(find.text('Saturday, June 15, 2024'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CalendarDatePicker), findsOneWidget);
+      expect(find.byType(ModalBarrier), findsNWidgets(modalBarrierCount));
+      expect(find.byTooltip('Back'), findsOneWidget);
+      expect(find.text('Start date'), findsOneWidget);
+      expect(find.text('Saturday, June 15, 2024'), findsWidgets);
+      expect(find.text('Done'), findsOneWidget);
+
+      await tester.tap(
+        find.descendant(
+          of: find.byType(CalendarDatePicker),
+          matching: find.text('16'),
+        ),
+      );
+      await tester.pump();
+      expect(find.text('Sunday, June 16, 2024'), findsOneWidget);
+
+      await tester.tap(find.text('Done'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Date & Time'), findsOneWidget);
+      expect(find.text('Sunday, June 16, 2024'), findsOneWidget);
+      expect(saveButton(tester).onPressed, isNotNull);
+    });
+
+    testWidgets('the reusable calendar page edits the explicit end date', (
+      tester,
+    ) async {
+      await openModal(tester, _sameDay);
+
+      await tester.tap(find.byType(DesignSystemToggle));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Saturday, June 15, 2024').last);
+      await tester.pumpAndSettle();
+
+      expect(find.text('End date'), findsWidgets);
+      expect(find.byType(CalendarDatePicker), findsOneWidget);
+
+      await tester.tap(
+        find.descendant(
+          of: find.byType(CalendarDatePicker),
+          matching: find.text('17'),
+        ),
+      );
+      await tester.pump();
+      await tester.tap(find.text('Done'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Monday, June 17, 2024'), findsOneWidget);
+      expect(saveButton(tester).onPressed, isNotNull);
+    });
+
+    testWidgets('calendar Back returns to the unchanged overview', (
+      tester,
+    ) async {
+      await openModal(tester, _sameDay);
+      await tester.tap(find.text('Saturday, June 15, 2024'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('Back'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Date & Time'), findsOneWidget);
+      expect(saveButton(tester).onPressed, isNull);
     });
 
     testWidgets('same-day opens with the toggle off and reveals an End date '
@@ -251,7 +356,7 @@ void main() {
       await tester.pumpAndSettle();
       expect(saveButton(tester).onPressed, isNotNull);
 
-      await tester.tap(find.widgetWithText(DesignSystemButton, 'SAVE'));
+      await tester.tap(find.widgetWithText(DesignSystemButton, 'Save'));
       await tester.pumpAndSettle();
 
       expect(tracker.updateFromToCalls, hasLength(1));
@@ -270,42 +375,140 @@ void main() {
 
       await tester.tap(find.text('Today'));
       await tester.pumpAndSettle();
-      await tester.tap(find.widgetWithText(DesignSystemButton, 'SAVE'));
+      await tester.tap(find.widgetWithText(DesignSystemButton, 'Save'));
       await tester.pumpAndSettle();
 
       // updateFromTo threw → caught → the modal stays open.
       expect(find.text('Date & Time'), findsOneWidget);
     });
 
-    testWidgets('spinning the date and time wheels changes the range and '
+    testWidgets(
+      'End Now preserves the start and sets a complete end endpoint',
+      (
+        tester,
+      ) async {
+        final tracker = await openModal(tester, _sameDay);
+
+        await tester.tap(quickAction('Set end date and time to now'));
+        await tester.pumpAndSettle();
+
+        expect(
+          tester
+              .widget<DesignSystemToggle>(find.byType(DesignSystemToggle))
+              .value,
+          isTrue,
+        );
+        expect(find.text('End date'), findsOneWidget);
+        expect(saveButton(tester).onPressed, isNotNull);
+
+        await tester.tap(find.widgetWithText(DesignSystemButton, 'Save'));
+        await tester.pumpAndSettle();
+
+        expect(tracker.updateFromToCalls, hasLength(1));
+        expect(
+          tracker.updateFromToCalls.single['dateFrom'],
+          _sameDay.meta.dateFrom,
+        );
+        expect(
+          tracker.updateFromToCalls.single['dateTo']!.isAfter(
+            _sameDay.meta.dateTo,
+          ),
+          isTrue,
+        );
+      },
+    );
+
+    testWidgets('Start Now changes the complete start endpoint', (
+      tester,
+    ) async {
+      await openModal(tester, _futureEntry);
+
+      await tester.tap(quickAction('Set start date and time to now'));
+      await tester.pump();
+
+      expect(saveButton(tester).onPressed, isNotNull);
+    });
+
+    testWidgets('Today can update an explicit end date', (tester) async {
+      await openModal(tester, _multiDay);
+
+      final endToday = quickAction('End date, Today');
+      await tester.tap(endToday);
+      await tester.pump();
+
+      expect(saveButton(tester).onPressed, isNotNull);
+    });
+
+    testWidgets('end time wheel callback updates the range', (tester) async {
+      await openModal(tester, _sameDay);
+      final endWheel = tester.widget<DesignSystemTimeWheel>(
+        find.byType(DesignSystemTimeWheel).last,
+      );
+
+      endWheel.onDateTimeChanged(DateTime(2024, 6, 15, 16));
+      await tester.pump();
+
+      expect(saveButton(tester).onPressed, isNotNull);
+    });
+
+    testWidgets('iPhone-width layout keeps paired times readable', (
+      tester,
+    ) async {
+      await openModal(
+        tester,
+        _sameDay,
+        mediaQueryData: const MediaQueryData(
+          size: Size(402, 874),
+          padding: EdgeInsets.only(top: 47, bottom: 34),
+          alwaysUse24HourFormat: true,
+        ),
+      );
+
+      final startCenter = tester.getCenter(find.text('Start time'));
+      final endCenter = tester.getCenter(find.text('End time'));
+      expect((startCenter.dy - endCenter.dy).abs(), lessThan(1));
+      expect(endCenter.dx, greaterThan(startCenter.dx));
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('large text stacks endpoint time controls on narrow screens', (
+      tester,
+    ) async {
+      await openModal(
+        tester,
+        _sameDay,
+        mediaQueryData: const MediaQueryData(
+          size: Size(402, 874),
+          padding: EdgeInsets.only(top: 47, bottom: 34),
+          alwaysUse24HourFormat: true,
+          textScaler: TextScaler.linear(2),
+        ),
+      );
+
+      final startCenter = tester.getCenter(find.text('Start time'));
+      final endCenter = tester.getCenter(find.text('End time'));
+      expect(endCenter.dy, greaterThan(startCenter.dy));
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('spinning the time wheels changes the range and '
         'enables Save', (tester) async {
       await openModal(tester, _sameDay);
       expect(saveButton(tester).onPressed, isNull);
 
-      // Large drags cross several wheel items so each wheel's onDateTimeChanged
-      // fires and the derived range actually changes.
-      final pickers = find.byType(CupertinoDatePicker);
-      await tester.drag(pickers.at(0), const Offset(0, -120)); // shared date
-      await tester.pumpAndSettle();
-      await tester.drag(pickers.at(1), const Offset(0, -100)); // start time
-      await tester.pumpAndSettle();
-      await tester.drag(pickers.at(2), const Offset(0, -100)); // end time
+      // Large drags cross several items so each settled-change callback fires.
+      final wheels = find.byType(ListWheelScrollView);
+      await tester.drag(wheels.at(0), const Offset(0, -100)); // start hour
       await tester.pumpAndSettle();
 
       expect(saveButton(tester).onPressed, isNotNull);
     });
 
-    testWidgets('multi-day: spinning the end date works and toggling off '
-        'collapses back to a single date', (tester) async {
+    testWidgets('multi-day toggling off collapses back to a single date', (
+      tester,
+    ) async {
       await openModal(tester, _multiDay);
       expect(find.text('End date'), findsOneWidget);
-
-      // The end-date wheel is the second CupertinoDatePicker in this layout.
-      await tester.drag(
-        find.byType(CupertinoDatePicker).at(1),
-        const Offset(0, -120),
-      );
-      await tester.pumpAndSettle();
 
       // Toggling off clears the override and collapses to a single shared date.
       await tester.tap(find.byType(DesignSystemToggle));
@@ -318,7 +521,7 @@ void main() {
         isFalse,
       );
       expect(find.text('End date'), findsNothing);
-      expect(find.text('Date'), findsOneWidget);
+      expect(find.textContaining('Friday, June 14, 2024'), findsOneWidget);
     });
   });
 }

--- a/test/features/journal/ui/widgets/entry_details/entry_datetime_multipage_modal_test.dart
+++ b/test/features/journal/ui/widgets/entry_details/entry_datetime_multipage_modal_test.dart
@@ -452,6 +452,22 @@ void main() {
       });
     });
 
+    testWidgets('Start Now preserves an earlier end and disables Save', (
+      tester,
+    ) async {
+      await withClock(Clock.fixed(DateTime(2024, 6, 15, 16, 45)), () async {
+        final tracker = await openModal(tester, _sameDay);
+
+        await tester.tap(quickAction('Set start date and time to now'));
+        await tester.pump();
+
+        expect(find.text('Invalid Date Range'), findsOneWidget);
+        expect(find.textContaining('Ends Sun 16 Jun'), findsNothing);
+        expect(saveButton(tester).onPressed, isNull);
+        expect(tracker.updateFromToCalls, isEmpty);
+      });
+    });
+
     testWidgets('Today can update an explicit end date', (tester) async {
       await withClock(Clock.fixed(DateTime.utc(2024, 6, 20, 8)), () async {
         final tracker = await openModal(tester, _utcMultiDay);

--- a/test/features/journal/ui/widgets/entry_details/entry_datetime_range_test.dart
+++ b/test/features/journal/ui/widgets/entry_details/entry_datetime_range_test.dart
@@ -165,6 +165,43 @@ void main() {
     });
   });
 
+  group('endpoint replacement', () {
+    final base = EntryDateTimeRange.fromBounds(
+      DateTime(2024, 6, 15, 9),
+      DateTime(2024, 6, 15, 10),
+    );
+
+    test('withStart changes only the absolute start endpoint', () {
+      final next = base.withStart(DateTime(2024, 6, 16, 8, 30));
+
+      expect(next.dateFrom, DateTime(2024, 6, 16, 8, 30));
+      expect(next.dateTo, base.dateTo);
+      expect(next.differentDates, isTrue);
+      expect(next.valid, isFalse);
+    });
+
+    test('withEnd changes only the absolute end endpoint', () {
+      final next = base.withEnd(DateTime(2024, 6, 17, 18, 45));
+
+      expect(next.dateFrom, base.dateFrom);
+      expect(next.dateTo, DateTime(2024, 6, 17, 18, 45));
+      expect(next.differentDates, isTrue);
+      expect(next.valid, isTrue);
+    });
+
+    test(
+      'endpoint replacement keeps a representable same-day range compact',
+      () {
+        final next = base.withEnd(DateTime(2024, 6, 15, 11, 30));
+
+        expect(next.dateFrom, base.dateFrom);
+        expect(next.dateTo, DateTime(2024, 6, 15, 11, 30));
+        expect(next.differentDates, isFalse);
+        expect(next.overnightAuto, isFalse);
+      },
+    );
+  });
+
   // Glados property: fromBounds() round-trips any start <= end pair back to the
   // same two timestamps (at minute precision), and the result is always valid —
   // regardless of whether it lands in shared, overnight, or different-dates mode.

--- a/test/features/journal/ui/widgets/entry_details/entry_datetime_range_test.dart
+++ b/test/features/journal/ui/widgets/entry_details/entry_datetime_range_test.dart
@@ -74,6 +74,21 @@ void main() {
         expect(r.valid, isTrue);
       },
     );
+
+    test('UTC bounds round-trip without changing timezone kind', () {
+      final from = DateTime.utc(2024, 6, 15, 23, 30);
+      final to = DateTime.utc(2024, 6, 16, 0, 30);
+
+      final range = EntryDateTimeRange.fromBounds(from, to);
+
+      expect(range.startDate, DateTime.utc(2024, 6, 15));
+      expect(range.startDate.isUtc, isTrue);
+      expect(range.dateFrom, from);
+      expect(range.dateTo, to);
+      expect(range.dateFrom.isUtc, isTrue);
+      expect(range.dateTo.isUtc, isTrue);
+      expect(range.duration, const Duration(hours: 1));
+    });
   });
 
   group('derivation', () {

--- a/test/features/journal/ui/widgets/entry_details/entry_datetime_range_test.dart
+++ b/test/features/journal/ui/widgets/entry_details/entry_datetime_range_test.dart
@@ -2,8 +2,12 @@ import 'package:flutter/material.dart' show TimeOfDay;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
 import 'package:lotti/features/journal/ui/widgets/entry_details/entry_datetime_range.dart';
+import 'package:timezone/data/latest.dart' as tz_data;
+import 'package:timezone/timezone.dart' as tz;
 
 void main() {
+  setUpAll(tz_data.initializeTimeZones);
+
   group('EntryDateTimeRange.fromBounds', () {
     test('same-day entry opens in shared-date mode', () {
       final r = EntryDateTimeRange.fromBounds(
@@ -39,16 +43,20 @@ void main() {
       },
     );
 
-    test('plain overnight span survives a local DST-ending day', () {
-      final range = EntryDateTimeRange.fromBounds(
-        DateTime(2024, 10, 27, 23, 30),
-        DateTime(2024, 10, 28, 0, 30),
-      );
+    test('plain overnight span crosses a controlled DST fallback', () {
+      final berlin = tz.getLocation('Europe/Berlin');
+      final start = tz.TZDateTime(berlin, 2024, 10, 26, 23, 30);
+      final end = tz.TZDateTime(berlin, 2024, 10, 27, 4, 30);
+
+      expect(start.timeZoneOffset, const Duration(hours: 2));
+      expect(end.timeZoneOffset, const Duration(hours: 1));
+
+      final range = EntryDateTimeRange.fromBounds(start, end);
 
       expect(range.differentDates, isFalse);
       expect(range.overnightAuto, isTrue);
-      expect(range.dateTo, DateTime(2024, 10, 28, 0, 30));
-      expect(range.duration, const Duration(hours: 1));
+      expect(range.dateTo, end);
+      expect(range.duration, const Duration(hours: 6));
     });
 
     test(
@@ -204,6 +212,17 @@ void main() {
       expect(next.dateFrom, DateTime(2024, 6, 16, 8, 30));
       expect(next.dateTo, base.dateTo);
       expect(next.differentDates, isTrue);
+      expect(next.valid, isFalse);
+    });
+
+    test('withStart preserves an earlier same-day end as an invalid range', () {
+      final next = base.withStart(DateTime(2024, 6, 15, 14));
+
+      expect(next.dateFrom, DateTime(2024, 6, 15, 14));
+      expect(next.dateTo, base.dateTo);
+      expect(next.endDateOverride, DateTime(2024, 6, 15));
+      expect(next.differentDates, isTrue);
+      expect(next.duration, const Duration(hours: -4));
       expect(next.valid, isFalse);
     });
 

--- a/test/features/journal/ui/widgets/entry_details/entry_datetime_range_test.dart
+++ b/test/features/journal/ui/widgets/entry_details/entry_datetime_range_test.dart
@@ -39,6 +39,18 @@ void main() {
       },
     );
 
+    test('plain overnight span survives a local DST-ending day', () {
+      final range = EntryDateTimeRange.fromBounds(
+        DateTime(2024, 10, 27, 23, 30),
+        DateTime(2024, 10, 28, 0, 30),
+      );
+
+      expect(range.differentDates, isFalse);
+      expect(range.overnightAuto, isTrue);
+      expect(range.dateTo, DateTime(2024, 10, 28, 0, 30));
+      expect(range.duration, const Duration(hours: 1));
+    });
+
     test(
       'exactly-24h same-clock next-day entry opens in different-dates mode',
       () {

--- a/test/features/journal/ui/widgets/entry_details/entry_datetime_status_bar_test.dart
+++ b/test/features/journal/ui/widgets/entry_details/entry_datetime_status_bar_test.dart
@@ -27,7 +27,11 @@ void main() {
 
     expect(find.text('Duration'), findsOneWidget);
     expect(find.text('45m'), findsOneWidget);
-    expect(find.byType(DsPill), findsNothing);
+    expect(find.byType(DsPill), findsOneWidget);
+    expect(
+      tester.widget<Visibility>(find.byType(Visibility)).visible,
+      isFalse,
+    );
     expect(find.text('Invalid Date Range'), findsNothing);
   });
 
@@ -49,6 +53,40 @@ void main() {
     expect(find.textContaining('(next day)'), findsOneWidget);
   });
 
+  testWidgets('crossing midnight does not change the status height', (
+    tester,
+  ) async {
+    await pump(
+      tester,
+      EntryDateTimeRange(
+        startDate: _date,
+        startTime: const TimeOfDay(hour: 14, minute: 30),
+        endTime: const TimeOfDay(hour: 15, minute: 15),
+        differentDates: false,
+      ),
+    );
+    final sameDayHeight = tester
+        .getSize(
+          find.byType(EntryDateTimeStatusBar),
+        )
+        .height;
+
+    await pump(
+      tester,
+      EntryDateTimeRange(
+        startDate: _date,
+        startTime: const TimeOfDay(hour: 23, minute: 30),
+        endTime: const TimeOfDay(hour: 0, minute: 30),
+        differentDates: false,
+      ),
+    );
+
+    expect(
+      tester.getSize(find.byType(EntryDateTimeStatusBar)).height,
+      sameDayHeight,
+    );
+  });
+
   testWidgets('an invalid range shows the warning instead of a duration', (
     tester,
   ) async {
@@ -66,6 +104,27 @@ void main() {
     expect(find.text('Invalid Date Range'), findsOneWidget);
     expect(find.text('Duration'), findsNothing);
     expect(find.byType(DsPill), findsNothing);
+  });
+
+  testWidgets('narrow layouts omit the repeated year from the range label', (
+    tester,
+  ) async {
+    tester.view
+      ..physicalSize = const Size(320, 640)
+      ..devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    await pump(
+      tester,
+      EntryDateTimeRange(
+        startDate: _date,
+        startTime: const TimeOfDay(hour: 14, minute: 30),
+        endTime: const TimeOfDay(hour: 15, minute: 15),
+        differentDates: false,
+      ),
+    );
+
+    expect(find.textContaining('Sat, Jun 15 ·'), findsOneWidget);
+    expect(find.textContaining('2024'), findsNothing);
   });
 }
 

--- a/test/features/journal/ui/widgets/entry_details/entry_datetime_status_bar_test.dart
+++ b/test/features/journal/ui/widgets/entry_details/entry_datetime_status_bar_test.dart
@@ -90,6 +90,7 @@ void main() {
   testWidgets('an invalid range shows the warning instead of a duration', (
     tester,
   ) async {
+    final semanticsHandle = tester.ensureSemantics();
     await pump(
       tester,
       EntryDateTimeRange(
@@ -102,8 +103,31 @@ void main() {
     );
 
     expect(find.text('Invalid Date Range'), findsOneWidget);
+    expect(find.bySemanticsLabel('Invalid Date Range'), findsOneWidget);
     expect(find.text('Duration'), findsNothing);
     expect(find.byType(DsPill), findsNothing);
+    semanticsHandle.dispose();
+  });
+
+  testWidgets('UTC same-day range does not repeat the end date', (
+    tester,
+  ) async {
+    await pump(
+      tester,
+      EntryDateTimeRange(
+        startDate: DateTime.utc(2024, 6, 15),
+        startTime: const TimeOfDay(hour: 14, minute: 30),
+        endTime: const TimeOfDay(hour: 15, minute: 15),
+        differentDates: false,
+      ),
+    );
+
+    final rangeLabel = tester
+        .widgetList<Text>(find.byType(Text))
+        .map((text) => text.data)
+        .whereType<String>()
+        .singleWhere((text) => text.contains('→'));
+    expect('Jun 15'.allMatches(rangeLabel), hasLength(1));
   });
 
   testWidgets('narrow layouts omit the repeated year from the range label', (

--- a/test/features/projects/ui/pages/project_detail_page_test.dart
+++ b/test/features/projects/ui/pages/project_detail_page_test.dart
@@ -986,10 +986,10 @@ void main() {
           matching: find.byType(InkWell),
         );
         await tester.tap(inkWell.first);
+        await tester.pump();
         await tester.pump(const Duration(milliseconds: 300));
 
-        // A date picker dialog should appear
-        expect(find.byType(DatePickerDialog), findsOneWidget);
+        expect(find.byType(CalendarDatePicker), findsOneWidget);
       });
 
       testWidgets(
@@ -1007,10 +1007,10 @@ void main() {
             matching: find.byType(InkWell),
           );
           await tester.tap(inkWell.first);
+          await tester.pump();
           await tester.pump(const Duration(milliseconds: 300));
 
-          // Tap OK in the date picker to confirm
-          await tester.tap(find.text('OK'));
+          await tester.tap(find.text('Done'));
           await tester.pump(const Duration(milliseconds: 300));
 
           // updateTargetDate should have been called

--- a/test/features/projects/ui/pages/project_details_page_test.dart
+++ b/test/features/projects/ui/pages/project_details_page_test.dart
@@ -912,9 +912,10 @@ void main() {
 
           // Invoke the onTargetDateTap callback.
           content.onTargetDateTap!();
+          await tester.pump();
           await tester.pump(const Duration(milliseconds: 300));
 
-          expect(find.byType(DatePickerDialog), findsOneWidget);
+          expect(find.byType(CalendarDatePicker), findsOneWidget);
         },
       );
 
@@ -977,14 +978,14 @@ void main() {
 
               // Open the date picker.
               content.onTargetDateTap!();
+              await tester.pump();
               await tester.pump(const Duration(milliseconds: 300));
 
-              expect(find.byType(DatePickerDialog), findsOneWidget);
+              expect(find.byType(CalendarDatePicker), findsOneWidget);
 
-              // Tap "OK" to confirm the default date selection.
-              final okButton = find.text('OK');
-              await tester.ensureVisible(okButton);
-              await tester.tap(okButton);
+              final doneButton = find.text('Done');
+              await tester.ensureVisible(doneButton);
+              await tester.tap(doneButton);
               await tester.pump();
               await tester.pump(const Duration(milliseconds: 300));
 

--- a/test/features/projects/ui/widgets/project_create_modal_test.dart
+++ b/test/features/projects/ui/widgets/project_create_modal_test.dart
@@ -479,9 +479,9 @@ void main() {
       await tester.tap(find.byIcon(Icons.calendar_today));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
-      expect(find.byType(DatePickerDialog), findsOneWidget);
+      expect(find.byType(CalendarDatePicker), findsOneWidget);
 
-      await tester.tap(find.text('OK'));
+      await tester.tap(find.text('Done'));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
 

--- a/test/features/tasks/ui/header/estimated_time_widget_test.dart
+++ b/test/features/tasks/ui/header/estimated_time_widget_test.dart
@@ -64,6 +64,15 @@ void main() {
       await tester.tap(find.text('open'));
       await tester.pumpAndSettle();
 
+      expect(find.text('Estimate'), findsOneWidget);
+      expect(find.text('Estimate:'), findsNothing);
+      expect(find.text('Clear'), findsOneWidget);
+      final picker = tester.widget<CupertinoTimerPicker>(
+        find.byType(CupertinoTimerPicker),
+      );
+      expect(picker.itemExtent, 48);
+      expect(picker.selectionOverlayBuilder, isNotNull);
+
       // Without changing the picker value, tapping Done should not call callback.
       await tester.tap(find.text('Done'));
       await tester.pumpAndSettle();
@@ -110,6 +119,7 @@ void main() {
         find.byType(CupertinoTimerPicker),
       );
       expect(picker.initialTimerDuration, Duration.zero);
+      expect(find.text('Clear'), findsNothing);
 
       await tester.tap(find.text('Done'));
       await tester.pumpAndSettle();
@@ -161,5 +171,38 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(selected, equals(const Duration(hours: 3)));
+  });
+
+  testWidgets('Clear resets a non-zero estimate without wheel manipulation', (
+    tester,
+  ) async {
+    Duration? selected;
+
+    await tester.pumpWidget(
+      WidgetTestBench(
+        child: Builder(
+          builder: (context) => Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                onPressed: () => showEstimatePicker(
+                  context: context,
+                  initialDuration: const Duration(minutes: 30),
+                  onEstimateChanged: (duration) async => selected = duration,
+                ),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Clear'));
+    await tester.pumpAndSettle();
+
+    expect(selected, Duration.zero);
+    expect(find.text('Estimate'), findsNothing);
   });
 }

--- a/test/features/tasks/ui/header/task_due_date_widget_test.dart
+++ b/test/features/tasks/ui/header/task_due_date_widget_test.dart
@@ -1,6 +1,6 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/tasks/ui/header/task_due_date_widget.dart';
 
 import '../../../../test_helper.dart';
@@ -35,13 +35,17 @@ void main() {
 
       // Verify modal elements are shown
       expect(find.text('Due Date'), findsOneWidget);
-      expect(find.text('Cancel'), findsOneWidget);
+      expect(find.text('Cancel'), findsNothing);
       expect(find.text('Clear'), findsOneWidget);
       expect(find.text('Done'), findsOneWidget);
-      expect(find.byType(CupertinoDatePicker), findsOneWidget);
+      expect(find.text('Today'), findsOneWidget);
+      expect(find.text('Sunday, June 15, 2025'), findsOneWidget);
+      expect(find.byType(CalendarDatePicker), findsOneWidget);
     });
 
-    testWidgets('Cancel button closes modal without callback', (tester) async {
+    testWidgets('Close button dismisses modal without callback', (
+      tester,
+    ) async {
       var callbackCalled = false;
 
       await tester.pumpWidget(
@@ -69,7 +73,7 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
 
-      await tester.tap(find.text('Cancel'));
+      await tester.tap(find.byTooltip('Close'));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
 
@@ -168,8 +172,44 @@ void main() {
       await tester.pump(const Duration(milliseconds: 300));
 
       // Verify picker is shown (will use DateTime.now as default)
-      expect(find.byType(CupertinoDatePicker), findsOneWidget);
+      expect(find.byType(CalendarDatePicker), findsOneWidget);
+      expect(find.text('Clear'), findsNothing);
     });
+
+    testWidgets(
+      'Today updates the complete due date and enables confirmation',
+      (
+        tester,
+      ) async {
+        DateTime? resultDate;
+        final initialDate = DateTime(2025, 6, 15);
+        await tester.pumpWidget(
+          WidgetTestBench(
+            child: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () => showDueDatePicker(
+                  context: context,
+                  initialDate: initialDate,
+                  onDueDateChanged: (date) async => resultDate = date,
+                ),
+                child: const Text('Open Picker'),
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('Open Picker'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.tap(find.text('Today'));
+        await tester.pump();
+        await tester.tap(find.text('Done'));
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(resultDate, isNotNull);
+        expect(resultDate, isNot(initialDate));
+      },
+    );
 
     testWidgets('Done does not call callback if date unchanged', (
       tester,
@@ -242,14 +282,9 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
 
-      // Simulate user scrolling the date picker by dragging
-      final pickerFinder = find.byType(CupertinoDatePicker);
-      expect(pickerFinder, findsOneWidget);
-
-      // Drag down to change the date (simulates user interaction)
-      await tester.drag(pickerFinder, const Offset(0, -50));
+      expect(find.byType(CalendarDatePicker), findsOneWidget);
+      await tester.tap(find.text('16'));
       await tester.pump();
-      await tester.pump(const Duration(milliseconds: 300));
 
       // Tap Done after changing date
       await tester.tap(find.text('Done'));
@@ -291,11 +326,8 @@ void main() {
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 300));
 
-        // Scroll to change the date
-        final pickerFinder = find.byType(CupertinoDatePicker);
-        await tester.drag(pickerFinder, const Offset(0, -100));
+        await tester.tap(find.text('16'));
         await tester.pump();
-        await tester.pump(const Duration(milliseconds: 300));
 
         await tester.tap(find.text('Done'));
         await tester.pump();
@@ -350,7 +382,14 @@ void main() {
       },
     );
 
-    testWidgets('modal has proper layout with three buttons', (tester) async {
+    testWidgets('phone layout keeps Clear and dominant Done action visible', (
+      tester,
+    ) async {
+      tester.view
+        ..physicalSize = const Size(402, 874)
+        ..devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+
       await tester.pumpWidget(
         WidgetTestBench(
           child: Builder(
@@ -374,21 +413,19 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
 
-      // All three buttons should be in the same Row
-      final cancelButton = find.text('Cancel');
-      final clearButton = find.text('Clear');
-      final doneButton = find.text('Done');
+      final clearButton = find.widgetWithText(DesignSystemButton, 'Clear');
+      final doneButton = find.widgetWithText(DesignSystemButton, 'Done');
 
-      expect(cancelButton, findsOneWidget);
+      expect(find.text('Cancel'), findsNothing);
       expect(clearButton, findsOneWidget);
       expect(doneButton, findsOneWidget);
 
-      // Verify they share a common Row ancestor
-      final rowFinder = find.ancestor(
-        of: cancelButton,
-        matching: find.byType(Row),
+      expect(tester.getCenter(doneButton).dy, tester.getCenter(clearButton).dy);
+      expect(
+        tester.getSize(doneButton).width,
+        greaterThan(tester.getSize(clearButton).width),
       );
-      expect(rowFinder, findsWidgets);
+      expect(tester.takeException(), isNull);
     });
   });
 }

--- a/test/utils/date_utils_extension_test.dart
+++ b/test/utils/date_utils_extension_test.dart
@@ -114,6 +114,16 @@ void main() {
       expect(nextDayUtc.compareCalendarDay(testDate), isPositive);
     });
 
+    test('addCalendarDays preserves wall time and timezone kind', () {
+      final local = DateTime(2024, 10, 27, 23, 30);
+      final utc = DateTime.utc(2024, 10, 27, 23, 30);
+
+      expect(local.addCalendarDays(1), DateTime(2024, 10, 28, 23, 30));
+      expect(local.addCalendarDays(1).isUtc, isFalse);
+      expect(utc.addCalendarDays(1), DateTime.utc(2024, 10, 28, 23, 30));
+      expect(utc.addCalendarDays(1).isUtc, isTrue);
+    });
+
     test('ymd returns date in YYYY-MM-DD format', () {
       expect(testDate.ymd, '2024-07-27');
     });

--- a/test/utils/date_utils_extension_test.dart
+++ b/test/utils/date_utils_extension_test.dart
@@ -83,6 +83,37 @@ void main() {
       expect(testDate.dayAtMidnight, expected);
     });
 
+    test('dateOnly preserves local and UTC timezone kinds', () {
+      final utc = DateTime.utc(2024, 7, 27, 18, 30);
+
+      expect(testDate.dateOnly, DateTime(2024, 7, 27));
+      expect(testDate.dateOnly.isUtc, isFalse);
+      expect(utc.dateOnly, DateTime.utc(2024, 7, 27));
+      expect(utc.dateOnly.isUtc, isTrue);
+    });
+
+    test('dateOnlyInZoneOf copies the day into the reference zone', () {
+      expect(
+        testDate.dateOnlyInZoneOf(DateTime.utc(2000)),
+        DateTime.utc(2024, 7, 27),
+      );
+      expect(
+        DateTime.utc(2024, 7, 27, 18).dateOnlyInZoneOf(DateTime(2000)),
+        DateTime(2024, 7, 27),
+      );
+    });
+
+    test('calendar comparison ignores timezone kind and time', () {
+      final sameDayUtc = DateTime.utc(2024, 7, 27, 23, 59);
+      final nextDayUtc = DateTime.utc(2024, 7, 28);
+
+      expect(testDate.isSameCalendarDay(sameDayUtc), isTrue);
+      expect(testDate.isSameCalendarDay(nextDayUtc), isFalse);
+      expect(testDate.compareCalendarDay(sameDayUtc), 0);
+      expect(testDate.compareCalendarDay(nextDayUtc), isNegative);
+      expect(nextDayUtc.compareCalendarDay(testDate), isPositive);
+    });
+
     test('ymd returns date in YYYY-MM-DD format', () {
       expect(testDate.ymd, '2024-07-27');
     });

--- a/test/utils/date_utils_extension_test.dart
+++ b/test/utils/date_utils_extension_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glados/glados.dart' as glados;
 import 'package:lotti/utils/date_utils_extension.dart';
+import 'package:timezone/data/latest.dart' as tz_data;
+import 'package:timezone/timezone.dart' as tz;
 
 class _GeneratedDateTimeParts {
   const _GeneratedDateTimeParts({
@@ -70,6 +72,8 @@ extension _AnyDateTimeParts on glados.Any {
 }
 
 void main() {
+  setUpAll(tz_data.initializeTimeZones);
+
   group('DateUtilsExtension', () {
     final testDate = DateTime(2024, 7, 27, 18, 30, 15);
 
@@ -122,6 +126,25 @@ void main() {
       expect(local.addCalendarDays(1).isUtc, isFalse);
       expect(utc.addCalendarDays(1), DateTime.utc(2024, 10, 28, 23, 30));
       expect(utc.addCalendarDays(1).isUtc, isTrue);
+    });
+
+    test('calendar helpers preserve a named timezone across DST fallback', () {
+      final berlin = tz.getLocation('Europe/Berlin');
+      final beforeFallback = tz.TZDateTime(berlin, 2024, 10, 26, 23, 30);
+      final afterFallback = beforeFallback.addCalendarDays(1);
+
+      expect(beforeFallback.timeZoneOffset, const Duration(hours: 2));
+      expect(afterFallback, tz.TZDateTime(berlin, 2024, 10, 27, 23, 30));
+      expect(afterFallback.timeZoneOffset, const Duration(hours: 1));
+      expect(
+        afterFallback.difference(beforeFallback),
+        const Duration(hours: 25),
+      );
+      expect(beforeFallback.dateOnly, tz.TZDateTime(berlin, 2024, 10, 26));
+      expect(
+        DateTime.utc(2024, 10, 27).dateOnlyInZoneOf(beforeFallback),
+        tz.TZDateTime(berlin, 2024, 10, 27),
+      );
     });
 
     test('ymd returns date in YYYY-MM-DD format', () {


### PR DESCRIPTION
## Summary

- redesign the entry start/end editor as a stable two-page Wolt sheet with weekday-visible dates, Start/End **Now** actions, and an in-sheet calendar transition
- add shared token-backed calendar and time-wheel components, including localized adjustable semantics and compact cylindrical wheel geometry
- align task due date, task estimate, and project target-date flows with the same modal shell, subtle same-surface framing, and glass action hierarchy
- reserve the overnight status slot and sticky-footer clearance so changing dates or crossing midnight does not move or obscure content
- update localization, feature architecture documentation, CHANGELOG, and Flatpak metadata

## Why

The previous picker family mixed date/time typography, omitted weekdays and endpoint-specific Now actions, and opened date selection as a nested modal. Its content sizing also allowed the overnight status and sticky footer to change the visible geometry. This consolidates the behavior into shared design-system primitives and gives the dense entry editor a predictable responsive layout on desktop and narrow mobile sheets.

## Result

| Surface | Light | Dark |
| --- | --- | --- |
| Entry — same day | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d9937dd062857c30f95eef0a5fc04f7fed35ce88/pr-screenshots/date-time-picker-family/after/picker_entryDateTime_pro_light_after.png" width="360" alt="Entry — same day, narrow light mode"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d9937dd062857c30f95eef0a5fc04f7fed35ce88/pr-screenshots/date-time-picker-family/after/picker_entryDateTime_pro_dark_after.png" width="360" alt="Entry — same day, narrow dark mode"> |
| Entry — overnight | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d9937dd062857c30f95eef0a5fc04f7fed35ce88/pr-screenshots/date-time-picker-family/after/picker_entryOvernight_pro_light_after.png" width="360" alt="Entry — overnight, narrow light mode"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d9937dd062857c30f95eef0a5fc04f7fed35ce88/pr-screenshots/date-time-picker-family/after/picker_entryOvernight_pro_dark_after.png" width="360" alt="Entry — overnight, narrow dark mode"> |
| Entry — separate dates | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d9937dd062857c30f95eef0a5fc04f7fed35ce88/pr-screenshots/date-time-picker-family/after/picker_entryDateRange_pro_light_after.png" width="360" alt="Entry — separate dates, narrow light mode"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d9937dd062857c30f95eef0a5fc04f7fed35ce88/pr-screenshots/date-time-picker-family/after/picker_entryDateRange_pro_dark_after.png" width="360" alt="Entry — separate dates, narrow dark mode"> |
| Entry — calendar page | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d9937dd062857c30f95eef0a5fc04f7fed35ce88/pr-screenshots/date-time-picker-family/after/picker_entryDateCalendar_pro_light_after.png" width="360" alt="Entry — calendar page, narrow light mode"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d9937dd062857c30f95eef0a5fc04f7fed35ce88/pr-screenshots/date-time-picker-family/after/picker_entryDateCalendar_pro_dark_after.png" width="360" alt="Entry — calendar page, narrow dark mode"> |
| Task due date | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d9937dd062857c30f95eef0a5fc04f7fed35ce88/pr-screenshots/date-time-picker-family/after/picker_dueDate_pro_light_after.png" width="360" alt="Task due date, narrow light mode"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d9937dd062857c30f95eef0a5fc04f7fed35ce88/pr-screenshots/date-time-picker-family/after/picker_dueDate_pro_dark_after.png" width="360" alt="Task due date, narrow dark mode"> |
| Task estimate | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d9937dd062857c30f95eef0a5fc04f7fed35ce88/pr-screenshots/date-time-picker-family/after/picker_estimate_pro_light_after.png" width="360" alt="Task estimate, narrow light mode"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d9937dd062857c30f95eef0a5fc04f7fed35ce88/pr-screenshots/date-time-picker-family/after/picker_estimate_pro_dark_after.png" width="360" alt="Task estimate, narrow dark mode"> |
| Project target date | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d9937dd062857c30f95eef0a5fc04f7fed35ce88/pr-screenshots/date-time-picker-family/after/picker_projectTargetDate_pro_light_after.png" width="360" alt="Project target date, narrow light mode"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d9937dd062857c30f95eef0a5fc04f7fed35ce88/pr-screenshots/date-time-picker-family/after/picker_projectTargetDate_pro_dark_after.png" width="360" alt="Project target date, narrow dark mode"> |

<details>
<summary>Desktop light/dark inventory</summary>

| Surface | Light | Dark |
| --- | --- | --- |
| Entry — same day | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d9937dd062857c30f95eef0a5fc04f7fed35ce88/pr-screenshots/date-time-picker-family/after/picker_entryDateTime_desktop_light_after.png" width="420" alt="Entry — same day, desktop light mode"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d9937dd062857c30f95eef0a5fc04f7fed35ce88/pr-screenshots/date-time-picker-family/after/picker_entryDateTime_desktop_dark_after.png" width="420" alt="Entry — same day, desktop dark mode"> |
| Entry — overnight | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d9937dd062857c30f95eef0a5fc04f7fed35ce88/pr-screenshots/date-time-picker-family/after/picker_entryOvernight_desktop_light_after.png" width="420" alt="Entry — overnight, desktop light mode"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d9937dd062857c30f95eef0a5fc04f7fed35ce88/pr-screenshots/date-time-picker-family/after/picker_entryOvernight_desktop_dark_after.png" width="420" alt="Entry — overnight, desktop dark mode"> |
| Entry — separate dates | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d9937dd062857c30f95eef0a5fc04f7fed35ce88/pr-screenshots/date-time-picker-family/after/picker_entryDateRange_desktop_light_after.png" width="420" alt="Entry — separate dates, desktop light mode"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d9937dd062857c30f95eef0a5fc04f7fed35ce88/pr-screenshots/date-time-picker-family/after/picker_entryDateRange_desktop_dark_after.png" width="420" alt="Entry — separate dates, desktop dark mode"> |
| Entry — calendar page | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d9937dd062857c30f95eef0a5fc04f7fed35ce88/pr-screenshots/date-time-picker-family/after/picker_entryDateCalendar_desktop_light_after.png" width="420" alt="Entry — calendar page, desktop light mode"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d9937dd062857c30f95eef0a5fc04f7fed35ce88/pr-screenshots/date-time-picker-family/after/picker_entryDateCalendar_desktop_dark_after.png" width="420" alt="Entry — calendar page, desktop dark mode"> |
| Task due date | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d9937dd062857c30f95eef0a5fc04f7fed35ce88/pr-screenshots/date-time-picker-family/after/picker_dueDate_desktop_light_after.png" width="420" alt="Task due date, desktop light mode"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d9937dd062857c30f95eef0a5fc04f7fed35ce88/pr-screenshots/date-time-picker-family/after/picker_dueDate_desktop_dark_after.png" width="420" alt="Task due date, desktop dark mode"> |
| Task estimate | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d9937dd062857c30f95eef0a5fc04f7fed35ce88/pr-screenshots/date-time-picker-family/after/picker_estimate_desktop_light_after.png" width="420" alt="Task estimate, desktop light mode"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d9937dd062857c30f95eef0a5fc04f7fed35ce88/pr-screenshots/date-time-picker-family/after/picker_estimate_desktop_dark_after.png" width="420" alt="Task estimate, desktop dark mode"> |
| Project target date | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d9937dd062857c30f95eef0a5fc04f7fed35ce88/pr-screenshots/date-time-picker-family/after/picker_projectTargetDate_desktop_light_after.png" width="420" alt="Project target date, desktop light mode"> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/d9937dd062857c30f95eef0a5fc04f7fed35ce88/pr-screenshots/date-time-picker-family/after/picker_projectTargetDate_desktop_dark_after.png" width="420" alt="Project target date, desktop dark mode"> |

</details>

Screenshots are stored outside the app repository at immutable commit [`d9937dd`](https://github.com/matthiasn/lotti-docs/commit/d9937dd062857c30f95eef0a5fc04f7fed35ce88).

## Validation

- `fvm flutter analyze` — no issues
- targeted picker, journal, task, project, and modal suites — 178 tests passed
- patch coverage — **634/634 changed executable lines (100.00%)**
- `fvm dart format` — clean
- `git diff --check` — clean
- final visual/UX/accessibility panel review — 9.4 / 9.4 / 9.2, unanimous ship

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared design-system date picker (weekday-aware calendar, Today, Done, optional Clear) and rolled it out across journal and project flows.
  * Upgraded time/duration selection with design-system wheels, improved “Estimate” modal, and “Clear/Done” behaviors.
  * Reworked the journal date/time editor into a multi-page flow with an in-sheet calendar.
* **Bug Fixes**
  * Reduced light/dark layout jumping, tightened picker/wheel spacing, and improved stable status bar sizing/accessibility.
* **Documentation**
  * Expanded design-system and picker modal documentation; added/updated localization for “Estimate” and “set to now” semantics.
* **Tests**
  * Added/updated widget and unit tests for pickers, wheels, responsive layouts, and calendar/range behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->