### PR TITLE
fix: send temporary MP3 to Voxtral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   set for Daily OS syncs to your other devices, with the most recent edit
   winning, so each device greets you the same way.
 ### Fixed
+- **Long Voxtral recordings transcribe without oversized WAV uploads.** Melious
+  Voxtral requests now encode a temporary MP3 from the compact M4A recording,
+  keeping the archived audio unchanged while avoiding the request-size failures
+  that affected recordings longer than roughly one or two minutes. Temporary
+  decoder and MP3 files are removed after both successful and failed requests.
 - **AI coding prompts now show up under their task.** A generated coding prompt
   is linked to both its parent task and the audio or text note it came from, and
   appears in each of their linked-entries lists (under the Code activity

--- a/README.md
+++ b/README.md
@@ -267,13 +267,17 @@ For developers:
 - `make l10n` — regenerate localizations
 - `fvm flutter run -d macos` — run on macOS (or `-d <device>` for others)
 
-**Linux only** — install emoji font support for proper rendering:
+**Linux only** — install the AAC decoder used to prepare temporary Voxtral MP3
+uploads, plus emoji font support for proper rendering:
 ```bash
-# Debian/Ubuntu: sudo apt install fonts-noto-color-emoji
-# Fedora: sudo dnf install google-noto-emoji-color-fonts
-# Arch:   sudo pacman -S noto-fonts-emoji
+# Debian/Ubuntu: sudo apt install gstreamer1.0-libav fonts-noto-color-emoji
+# Fedora: sudo dnf install gstreamer1-plugin-libav google-noto-emoji-color-fonts
+# Arch:   sudo pacman -S gst-libav noto-fonts-emoji
 ./linux/install_emoji_fonts.sh
 ```
+
+The Flatpak runtime already supplies the AAC decoder; no host package is needed
+for the Flatpak build.
 
 See [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) for the full developer setup.
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -31,7 +31,21 @@ After installation, run `make coverage` and open `coverage/index.html`.
 
 ## Running the App
 - macOS: `fvm flutter run -d macos`
-- Other platforms: `flutter run -d <device>`
+- Other platforms: `fvm flutter run -d <device>`
+
+### Linux audio codecs
+
+Linux development and unpackaged release builds use GStreamer to decode Lotti's
+archived AAC/M4A recordings before temporary Voxtral MP3 encoding. Install the
+libav plugin that provides the AAC decoder:
+
+- Ubuntu/Debian: `sudo apt install gstreamer1.0-libav`
+- Fedora: `sudo dnf install gstreamer1-plugin-libav`
+- Arch: `sudo pacman -S gst-libav`
+
+The Flatpak 25.08 runtime already includes this decoder. A missing decoder does
+not prevent compilation, but Voxtral transcription fails immediately with an
+installation hint instead of waiting for the request timeout.
 
 ## Localization
 - ARB files live under `lib/l10n/`

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -37,6 +37,7 @@
           <p>Date and time pickers are now clearer and steadier across the app. Entry ranges show weekdays, include Start and End Now actions, and transition to a calendar page within the same sheet. Due dates and project target dates share the same weekday calendar, while tighter wheel controls and stable status spacing keep the layout compact without jumping in light or dark mode.</p>
           <p>Daily OS now has a discoverable settings page for choosing its default inference profile and preferred name, plus per-planner profile and thinking-model overrides. Setup explains that assembled planning context is sent to the selected provider and identifies whether its configured endpoint is local or remote.</p>
           <p>The preferred name you set for Daily OS now syncs across your devices, with the most recent edit winning, so each device greets you the same way.</p>
+          <p>Long Melious Voxtral recordings now use a temporary MP3 for transcription instead of an oversized WAV upload. The archived M4A remains unchanged, and temporary decoder and MP3 files are removed after successful and failed requests.</p>
           <p>AI coding prompts now show up under their task. A generated coding prompt is linked to both its parent task and the audio or text note it came from, and appears in each of their linked-entries lists under the Code activity filter. Previously the prompt was created but stayed hidden from the task timeline.</p>
       </description>
     </release>

--- a/lib/features/ai/README.md
+++ b/lib/features/ai/README.md
@@ -306,9 +306,11 @@ to `LameMp3Encoder`; the package keeps synchronous native encoding on a worker
 isolate. No FFmpeg binary is bundled. Conversion failure aborts the request and
 surfaces decoder or encoder detail because a transcription-endpoint fallback
 cannot apply task context during recognition. Requests reject empty responses,
-share one 60-second deadline across preparation and HTTP, and surface
-structured provider detail with a correlation id. `flutter_lame` does not ship
-a Web backend; Lotti currently has no Web application target.
+share one 15-minute long-audio deadline across preparation and HTTP, and
+surface structured provider detail with a correlation id. Domain logs record
+temporary-MP3 preparation and buffered Voxtral response time separately so a
+slow provider response is distinguishable from local encoding. `flutter_lame`
+does not ship a Web backend; Lotti currently has no Web application target.
 
 ```mermaid
 sequenceDiagram

--- a/lib/features/ai/README.md
+++ b/lib/features/ai/README.md
@@ -288,30 +288,44 @@ The default Melious profile uses `mistral-small-4-119b-instruct` for thinking
 and image recognition, `glm-5.2` for the high-end thinking slot,
 `flux-2-klein-9b` for image generation, and `voxtral-small-24b-2507` for
 transcription. Melious' chat adapter stalls on the archived M4A bytes produced
-by Lotti, so the provider route converts a temporary copy to PCM WAV and sends
-that through buffered `/chat/completions`; the original M4A is never modified,
-and both scratch files are deleted in `finally`. The audio block precedes the
-text block so the task prompt and category speech dictionary guide recognition.
-Conversion is implemented by `audio_decoder`: AVFoundation on iOS and macOS,
+by Lotti. Sending decoded PCM WAV fixed short recordings but exceeded the
+provider request-size limit for longer recordings, so the provider route now
+decodes a temporary copy to PCM WAV, streams normalized samples through LAME in
+one-second chunks, and sends a 64 kbps temporary MP3 through buffered
+`/chat/completions`. The original M4A is never modified. M4A and WAV decoder
+scratch files are removed as soon as decoding finishes, and the MP3 is deleted
+after success, provider failure, transport failure, or timeout. The audio block
+precedes the text block so the task prompt and category speech dictionary guide
+recognition.
+
+Decoding is implemented by `audio_decoder`: AVFoundation on iOS and macOS,
 MediaCodec on Android, Media Foundation on Windows, and GStreamer on Linux.
-No FFmpeg binary is bundled. Conversion failure aborts the request and surfaces
-the native decoder detail because a transcription-endpoint fallback cannot
-apply task context during recognition. Requests reject empty responses, time
-out after 60 seconds, and surface structured provider detail with a correlation
-id.
+MP3 encoding uses the LAME C source bundled by `flutter_lame` on Android, iOS,
+Linux, macOS, and Windows. Lotti feeds normalized `Float64List` channel samples
+to `LameMp3Encoder`; the package keeps synchronous native encoding on a worker
+isolate. No FFmpeg binary is bundled. Conversion failure aborts the request and
+surfaces decoder or encoder detail because a transcription-endpoint fallback
+cannot apply task context during recognition. Requests reject empty responses,
+share one 60-second deadline across preparation and HTTP, and surface
+structured provider detail with a correlation id. `flutter_lame` does not ship
+a Web backend; Lotti currently has no Web application target.
 
 ```mermaid
 sequenceDiagram
   participant Archive as M4A master
   participant Scratch as Temporary files
   participant Decoder as Native decoder
+  participant LAME as Bundled LAME worker
   participant Melious as Voxtral chat
   Archive->>Scratch: copy bytes to unique .m4a
   Scratch->>Decoder: decode .m4a to PCM .wav
   Decoder-->>Scratch: write RIFF/WAVE output
-  Scratch->>Melious: WAV audio block + task/dictionary context
+  Scratch->>LAME: normalized PCM chunks (one second/channel)
+  LAME-->>Scratch: write 64 kbps .mp3
+  Scratch->>Scratch: delete decoder .m4a and .wav
+  Scratch->>Melious: MP3 audio block + task/dictionary context
   Melious-->>Scratch: contextual transcript or provider error
-  Scratch->>Scratch: delete .m4a and .wav in finally
+  Scratch->>Scratch: delete .mp3 in finally
 ```
 
 Whisper and explicit transcription model IDs still use the transcription

--- a/lib/features/ai/README.md
+++ b/lib/features/ai/README.md
@@ -313,10 +313,8 @@ isolate. No FFmpeg binary is bundled. Conversion failure aborts the request and
 surfaces decoder or encoder detail because a transcription-endpoint fallback
 cannot apply task context during recognition. Requests reject empty responses,
 share one 15-minute long-audio deadline across preparation and HTTP, and
-surface structured provider detail with a correlation id. Domain logs record
-temporary-MP3 preparation and buffered Voxtral response time separately so a
-slow provider response is distinguishable from local encoding. `flutter_lame`
-does not ship a Web backend; Lotti currently has no Web application target.
+surface structured provider detail with a correlation id. `flutter_lame` does
+not ship a Web backend; Lotti currently has no Web application target.
 
 ```mermaid
 sequenceDiagram

--- a/lib/features/ai/README.md
+++ b/lib/features/ai/README.md
@@ -298,8 +298,14 @@ after success, provider failure, transport failure, or timeout. The audio block
 precedes the text block so the task prompt and category speech dictionary guide
 recognition.
 
-Decoding is implemented by `audio_decoder`: AVFoundation on iOS and macOS,
-MediaCodec on Android, Media Foundation on Windows, and GStreamer on Linux.
+Decoding uses `audio_decoder` with AVFoundation on iOS and macOS, MediaCodec on
+Android, and Media Foundation on Windows. Linux uses Lotti's GStreamer pipeline,
+which writes PCM WAV directly and monitors the pipeline bus so missing codecs
+cannot leave transcription waiting indefinitely. AAC/M4A decoding requires the
+`gstreamer1.0-libav` package on Ubuntu/Debian (`gstreamer1-plugin-libav` on
+Fedora and `gst-libav` on Arch); the Flatpak runtime already includes it. When
+the decoder is absent, the native channel returns an immediate installation
+hint that is surfaced by the transcription request.
 MP3 encoding uses the LAME C source bundled by `flutter_lame` on Android, iOS,
 Linux, macOS, and Windows. Lotti feeds normalized `Float64List` channel samples
 to `LameMp3Encoder`; the package keeps synchronous native encoding on a worker

--- a/lib/features/ai/repository/melious_inference_repository.dart
+++ b/lib/features/ai/repository/melious_inference_repository.dart
@@ -61,7 +61,10 @@ class MeliousInferenceRepository extends TranscriptionRepository {
   static const _providerName = 'MeliousInferenceRepository';
   static const _modelListTimeout = Duration(seconds: 15);
   static const _imageGenerationTimeout = Duration(seconds: 180);
-  static const _chatAudioTimeout = Duration(seconds: 60);
+  // Voxtral can process recordings up to 30 minutes, and local preparation is
+  // included in this deadline. Match the native Voxtral route's long-audio
+  // allowance instead of applying the general short-request timeout.
+  static const _chatAudioTimeout = Duration(minutes: 15);
   // Generous because the non-streaming impact path buffers the entire
   // response: nothing is emitted (and no onProgress fires) until the full
   // body arrives or this timeout trips.
@@ -695,6 +698,7 @@ class MeliousInferenceRepository extends TranscriptionRepository {
     final requestId = 'melious-audio-${const Uuid().v4()}';
 
     File? temporaryMp3File;
+    var timeoutStage = 'preparing the temporary MP3';
     try {
       final deadline = _clock.now().add(timeout);
       Duration remainingTimeoutOrThrow() {
@@ -706,10 +710,12 @@ class MeliousInferenceRepository extends TranscriptionRepository {
       }
 
       final sourceBytes = base64Decode(audioBase64);
+      final preparationStopwatch = Stopwatch()..start();
       final conversionTimeout = remainingTimeoutOrThrow();
       temporaryMp3File = await _audioToTemporaryMp3Encoder(
         sourceBytes,
       ).timeout(conversionTimeout);
+      timeoutStage = 'reading the temporary MP3';
       final mp3Bytes = await _temporaryFileReader(temporaryMp3File).timeout(
         remainingTimeoutOrThrow(),
       );
@@ -718,6 +724,13 @@ class MeliousInferenceRepository extends TranscriptionRepository {
           'Temporary MP3 encoder produced an empty file',
         );
       }
+      preparationStopwatch.stop();
+      developer.log(
+        'Prepared Voxtral MP3 in ${preparationStopwatch.elapsedMilliseconds} '
+        'ms (${sourceBytes.length} source bytes, ${mp3Bytes.length} MP3 bytes; '
+        'request $requestId)',
+        name: _providerName,
+      );
       final messageContent = [
         {
           'type': 'input_audio',
@@ -743,6 +756,8 @@ class MeliousInferenceRepository extends TranscriptionRepository {
         'temperature': 0.0,
         'max_tokens': ?maxCompletionTokens,
       };
+      timeoutStage = 'waiting for the Voxtral response';
+      final requestStopwatch = Stopwatch()..start();
       final requestTimeout = remainingTimeoutOrThrow();
       final response = await httpClient
           .post(
@@ -755,6 +770,12 @@ class MeliousInferenceRepository extends TranscriptionRepository {
             body: jsonEncode(body),
           )
           .timeout(requestTimeout);
+      requestStopwatch.stop();
+      developer.log(
+        'Received Voxtral response in ${requestStopwatch.elapsedMilliseconds} '
+        'ms with HTTP ${response.statusCode} (request $requestId)',
+        name: _providerName,
+      );
 
       if (response.statusCode < 200 || response.statusCode >= 300) {
         throw TranscriptionException(
@@ -824,7 +845,7 @@ class MeliousInferenceRepository extends TranscriptionRepository {
       );
     } on TimeoutException catch (error) {
       throw TranscriptionException(
-        'Melious chat-audio request timed out after '
+        'Melious chat-audio request timed out while $timeoutStage after '
         '${timeout.inSeconds} seconds (request $requestId)',
         provider: _providerName,
         statusCode: httpStatusRequestTimeout,

--- a/lib/features/ai/repository/melious_inference_repository.dart
+++ b/lib/features/ai/repository/melious_inference_repository.dart
@@ -2,9 +2,9 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:developer' as developer;
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:clock/clock.dart';
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:lotti/features/ai/model/ai_call_impact.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
@@ -710,6 +710,10 @@ class MeliousInferenceRepository extends TranscriptionRepository {
       }
 
       final sourceBytes = base64Decode(audioBase64);
+      _logChatAudioTiming(
+        'Preparing Voxtral MP3 from ${sourceBytes.length} source bytes '
+        '(request $requestId)',
+      );
       final preparationStopwatch = Stopwatch()..start();
       final conversionTimeout = remainingTimeoutOrThrow();
       temporaryMp3File = await _audioToTemporaryMp3Encoder(
@@ -725,11 +729,10 @@ class MeliousInferenceRepository extends TranscriptionRepository {
         );
       }
       preparationStopwatch.stop();
-      developer.log(
+      _logChatAudioTiming(
         'Prepared Voxtral MP3 in ${preparationStopwatch.elapsedMilliseconds} '
         'ms (${sourceBytes.length} source bytes, ${mp3Bytes.length} MP3 bytes; '
         'request $requestId)',
-        name: _providerName,
       );
       final messageContent = [
         {
@@ -757,6 +760,10 @@ class MeliousInferenceRepository extends TranscriptionRepository {
         'max_tokens': ?maxCompletionTokens,
       };
       timeoutStage = 'waiting for the Voxtral response';
+      _logChatAudioTiming(
+        'Sending ${mp3Bytes.length} MP3 bytes to Voxtral as format=mp3 '
+        '(request $requestId)',
+      );
       final requestStopwatch = Stopwatch()..start();
       final requestTimeout = remainingTimeoutOrThrow();
       final response = await httpClient
@@ -771,10 +778,9 @@ class MeliousInferenceRepository extends TranscriptionRepository {
           )
           .timeout(requestTimeout);
       requestStopwatch.stop();
-      developer.log(
+      _logChatAudioTiming(
         'Received Voxtral response in ${requestStopwatch.elapsedMilliseconds} '
         'ms with HTTP ${response.statusCode} (request $requestId)',
-        name: _providerName,
       );
 
       if (response.statusCode < 200 || response.statusCode >= 300) {
@@ -1372,6 +1378,14 @@ class MeliousInferenceRepository extends TranscriptionRepository {
     return value.length > maxLength
         ? '${value.substring(0, maxLength)}...'
         : value;
+  }
+
+  static void _logChatAudioTiming(String message) {
+    developer.log(message, name: _providerName);
+    assert(() {
+      debugPrint('$_providerName: $message');
+      return true;
+    }(), 'Melious chat-audio timing log must complete');
   }
 
   static String _extractErrorMessage(String body, int statusCode) {

--- a/lib/features/ai/repository/melious_inference_repository.dart
+++ b/lib/features/ai/repository/melious_inference_repository.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:developer' as developer;
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:clock/clock.dart';
@@ -12,9 +13,9 @@ import 'package:lotti/features/ai/repository/completion_usage_parser.dart';
 import 'package:lotti/features/ai/repository/gemini_inference_payloads.dart';
 import 'package:lotti/features/ai/repository/transcription_repository.dart';
 import 'package:lotti/features/ai/state/consts.dart';
-import 'package:lotti/features/ai/util/audio_converter_channel.dart';
 import 'package:lotti/features/ai/util/image_processing_utils.dart';
 import 'package:lotti/features/ai/util/known_models.dart';
+import 'package:lotti/features/ai/util/temporary_mp3_encoder.dart';
 import 'package:openai_dart/openai_dart.dart';
 import 'package:uuid/uuid.dart';
 
@@ -25,7 +26,10 @@ typedef MeliousChatCompletionStreamFactory =
       required CreateChatCompletionRequest request,
     });
 
-typedef MeliousM4aToWavConverter = Future<Uint8List> Function(Uint8List bytes);
+typedef MeliousAudioToTemporaryMp3Encoder =
+    Future<File> Function(Uint8List bytes);
+typedef MeliousTemporaryFileReader = Future<Uint8List> Function(File file);
+typedef MeliousTemporaryFileDeleter = void Function(File file);
 
 /// Melious.ai inference repository.
 ///
@@ -39,12 +43,19 @@ class MeliousInferenceRepository extends TranscriptionRepository {
     super.httpClient,
     CloudInferenceRequestHelpers? helpers,
     MeliousChatCompletionStreamFactory? chatCompletionStreamFactory,
-    MeliousM4aToWavConverter? m4aToWavConverter,
+    MeliousAudioToTemporaryMp3Encoder? audioToTemporaryMp3Encoder,
+    MeliousTemporaryFileReader? temporaryFileReader,
+    MeliousTemporaryFileDeleter? temporaryFileDeleter,
     Clock? clockSource,
   }) : _helpers = helpers ?? const CloudInferenceRequestHelpers(),
        _chatCompletionStreamFactory =
            chatCompletionStreamFactory ?? _createChatCompletionStream,
-       _m4aToWavConverter = m4aToWavConverter ?? convertM4aBytesToTemporaryWav,
+       _audioToTemporaryMp3Encoder =
+           audioToTemporaryMp3Encoder ?? encodeAudioBytesToTemporaryMp3,
+       _temporaryFileReader =
+           temporaryFileReader ?? ((file) => file.readAsBytes()),
+       _temporaryFileDeleter =
+           temporaryFileDeleter ?? ((file) => file.deleteSync()),
        _clock = clockSource ?? clock;
 
   static const _providerName = 'MeliousInferenceRepository';
@@ -65,7 +76,9 @@ class MeliousInferenceRepository extends TranscriptionRepository {
 
   final CloudInferenceRequestHelpers _helpers;
   final MeliousChatCompletionStreamFactory _chatCompletionStreamFactory;
-  final MeliousM4aToWavConverter _m4aToWavConverter;
+  final MeliousAudioToTemporaryMp3Encoder _audioToTemporaryMp3Encoder;
+  final MeliousTemporaryFileReader _temporaryFileReader;
+  final MeliousTemporaryFileDeleter _temporaryFileDeleter;
   final Clock _clock;
 
   /// Fetches the live Melious model catalog and maps `_meta` capability data
@@ -645,14 +658,15 @@ class MeliousInferenceRepository extends TranscriptionRepository {
     );
   }
 
-  /// Transcribes with Voxtral using temporary WAV audio plus task and
+  /// Transcribes with Voxtral using temporary MP3 audio plus task and
   /// speech-dictionary context in one buffered chat request.
   ///
   /// Melious' chat adapter currently stalls when Lotti's M4A recording bytes
   /// are sent as an audio content block. Lotti therefore preserves M4A as its
-  /// compact archive format and converts only a temporary copy to PCM WAV.
-  /// Conversion is platform-native and failures are surfaced rather than
-  /// falling back to a request that cannot apply context during recognition.
+  /// compact archive format, decodes only a temporary copy to PCM, and encodes
+  /// a much smaller temporary MP3 for transmission. Conversion failures are
+  /// surfaced rather than falling back to a request that cannot apply context
+  /// during recognition. The MP3 is deleted after every request outcome.
   Stream<CreateChatCompletionStreamResponse> transcribeChatAudio({
     required String model,
     required String audioBase64,
@@ -680,6 +694,7 @@ class MeliousInferenceRepository extends TranscriptionRepository {
 
     final requestId = 'melious-audio-${const Uuid().v4()}';
 
+    File? temporaryMp3File;
     try {
       final deadline = _clock.now().add(timeout);
       Duration remainingTimeoutOrThrow() {
@@ -691,21 +706,24 @@ class MeliousInferenceRepository extends TranscriptionRepository {
       }
 
       final sourceBytes = base64Decode(audioBase64);
-      late final Uint8List wavBytes;
-      if (_isWavAudio(sourceBytes)) {
-        wavBytes = sourceBytes;
-      } else {
-        final conversionTimeout = remainingTimeoutOrThrow();
-        wavBytes = await _m4aToWavConverter(
-          sourceBytes,
-        ).timeout(conversionTimeout);
+      final conversionTimeout = remainingTimeoutOrThrow();
+      temporaryMp3File = await _audioToTemporaryMp3Encoder(
+        sourceBytes,
+      ).timeout(conversionTimeout);
+      final mp3Bytes = await _temporaryFileReader(temporaryMp3File).timeout(
+        remainingTimeoutOrThrow(),
+      );
+      if (mp3Bytes.isEmpty) {
+        throw const TemporaryMp3EncodingException(
+          'Temporary MP3 encoder produced an empty file',
+        );
       }
       final messageContent = [
         {
           'type': 'input_audio',
           'input_audio': {
-            'data': base64Encode(wavBytes),
-            'format': 'wav',
+            'data': base64Encode(mp3Bytes),
+            'format': 'mp3',
           },
         },
         {'type': 'text', 'text': prompt},
@@ -825,19 +843,21 @@ class MeliousInferenceRepository extends TranscriptionRepository {
         provider: _providerName,
         originalError: error,
       );
+    } finally {
+      final file = temporaryMp3File;
+      if (file != null) {
+        try {
+          if (file.existsSync()) _temporaryFileDeleter(file);
+        } on FileSystemException catch (error, stackTrace) {
+          developer.log(
+            'Failed to delete temporary Voxtral MP3 file',
+            name: _providerName,
+            error: error,
+            stackTrace: stackTrace,
+          );
+        }
+      }
     }
-  }
-
-  static bool _isWavAudio(Uint8List bytes) {
-    return bytes.length >= 12 &&
-        bytes[0] == 0x52 &&
-        bytes[1] == 0x49 &&
-        bytes[2] == 0x46 &&
-        bytes[3] == 0x46 &&
-        bytes[8] == 0x57 &&
-        bytes[9] == 0x41 &&
-        bytes[10] == 0x56 &&
-        bytes[11] == 0x45;
   }
 
   /// Generates an image through Melious' `/images/generations` endpoint.

--- a/lib/features/ai/repository/melious_inference_repository.dart
+++ b/lib/features/ai/repository/melious_inference_repository.dart
@@ -2,9 +2,9 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:developer' as developer;
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:clock/clock.dart';
-import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:lotti/features/ai/model/ai_call_impact.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
@@ -710,11 +710,6 @@ class MeliousInferenceRepository extends TranscriptionRepository {
       }
 
       final sourceBytes = base64Decode(audioBase64);
-      _logChatAudioTiming(
-        'Preparing Voxtral MP3 from ${sourceBytes.length} source bytes '
-        '(request $requestId)',
-      );
-      final preparationStopwatch = Stopwatch()..start();
       final conversionTimeout = remainingTimeoutOrThrow();
       temporaryMp3File = await _audioToTemporaryMp3Encoder(
         sourceBytes,
@@ -728,12 +723,6 @@ class MeliousInferenceRepository extends TranscriptionRepository {
           'Temporary MP3 encoder produced an empty file',
         );
       }
-      preparationStopwatch.stop();
-      _logChatAudioTiming(
-        'Prepared Voxtral MP3 in ${preparationStopwatch.elapsedMilliseconds} '
-        'ms (${sourceBytes.length} source bytes, ${mp3Bytes.length} MP3 bytes; '
-        'request $requestId)',
-      );
       final messageContent = [
         {
           'type': 'input_audio',
@@ -760,11 +749,6 @@ class MeliousInferenceRepository extends TranscriptionRepository {
         'max_tokens': ?maxCompletionTokens,
       };
       timeoutStage = 'waiting for the Voxtral response';
-      _logChatAudioTiming(
-        'Sending ${mp3Bytes.length} MP3 bytes to Voxtral as format=mp3 '
-        '(request $requestId)',
-      );
-      final requestStopwatch = Stopwatch()..start();
       final requestTimeout = remainingTimeoutOrThrow();
       final response = await httpClient
           .post(
@@ -777,11 +761,6 @@ class MeliousInferenceRepository extends TranscriptionRepository {
             body: jsonEncode(body),
           )
           .timeout(requestTimeout);
-      requestStopwatch.stop();
-      _logChatAudioTiming(
-        'Received Voxtral response in ${requestStopwatch.elapsedMilliseconds} '
-        'ms with HTTP ${response.statusCode} (request $requestId)',
-      );
 
       if (response.statusCode < 200 || response.statusCode >= 300) {
         throw TranscriptionException(
@@ -1378,14 +1357,6 @@ class MeliousInferenceRepository extends TranscriptionRepository {
     return value.length > maxLength
         ? '${value.substring(0, maxLength)}...'
         : value;
-  }
-
-  static void _logChatAudioTiming(String message) {
-    developer.log(message, name: _providerName);
-    assert(() {
-      debugPrint('$_providerName: $message');
-      return true;
-    }(), 'Melious chat-audio timing log must complete');
   }
 
   static String _extractErrorMessage(String body, int statusCode) {

--- a/lib/features/ai/util/audio_converter_channel.dart
+++ b/lib/features/ai/util/audio_converter_channel.dart
@@ -52,14 +52,35 @@ class AudioConverterChannel {
 
   /// Converts an M4A file at [inputPath] to PCM WAV at [outputPath].
   ///
-  /// Uses the platform's native decoder and rethrows conversion or platform
-  /// failures after logging them. The caller owns both paths and their cleanup.
+  /// Uses Lotti's fail-fast GStreamer pipeline on Linux and `audio_decoder` on
+  /// other platforms. Conversion failures are normalized and logged. The
+  /// caller owns both paths and their cleanup.
   static Future<void> convertM4aToWav({
     required String inputPath,
     required String outputPath,
   }) async {
     try {
-      await AudioDecoder.convertToWav(inputPath, outputPath);
+      if (Platform.isLinux) {
+        await _channel.invokeMethod<bool>('convertM4aToWav', {
+          'inputPath': inputPath,
+          'outputPath': outputPath,
+        });
+      } else {
+        await AudioDecoder.convertToWav(inputPath, outputPath);
+      }
+    } on PlatformException catch (error, stackTrace) {
+      final conversionError = AudioConversionException(
+        error.message ?? error.code,
+        details: error.details?.toString(),
+      );
+      getIt<DomainLogger>().error(
+        LogDomain.speech,
+        conversionError,
+        stackTrace: stackTrace,
+        subDomain: 'convertM4aToWav',
+        message: 'Native M4A-to-WAV conversion failed',
+      );
+      throw conversionError;
     } catch (error, stackTrace) {
       getIt<DomainLogger>().error(
         LogDomain.speech,

--- a/lib/features/ai/util/temporary_mp3_encoder.dart
+++ b/lib/features/ai/util/temporary_mp3_encoder.dart
@@ -1,0 +1,430 @@
+import 'dart:io';
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter_lame/flutter_lame.dart';
+import 'package:lotti/features/ai/util/audio_converter_channel.dart';
+import 'package:path/path.dart' as p;
+import 'package:uuid/uuid.dart';
+
+/// Converts encoded M4A bytes to PCM WAV bytes without changing the archive.
+typedef M4aBytesToWavConverter = Future<Uint8List> Function(Uint8List bytes);
+
+/// Creates the sample encoder used to emit MP3 frames.
+typedef Mp3FrameEncoderFactory =
+    Mp3FrameEncoder Function({
+      required int sampleRate,
+      required int numChannels,
+      required int bitRate,
+    });
+
+/// Minimal encoder surface used by the temporary-file pipeline.
+abstract interface class Mp3FrameEncoder {
+  /// Encodes one chunk of normalized PCM samples.
+  Future<Uint8List> encode({
+    required Float64List leftChannel,
+    Float64List? rightChannel,
+  });
+
+  /// Flushes the encoder's buffered MP3 frames.
+  Future<Uint8List> flush();
+
+  /// Releases the encoder and its worker isolate.
+  Future<void> close();
+}
+
+/// Error raised when temporary MP3 preparation fails.
+final class TemporaryMp3EncodingException implements Exception {
+  /// Creates an encoding error with the original [cause].
+  const TemporaryMp3EncodingException(this.message, {this.cause});
+
+  /// Human-readable failure detail.
+  final String message;
+
+  /// Original decoder, encoder, or filesystem failure.
+  final Object? cause;
+
+  @override
+  String toString() => cause == null ? message : '$message: $cause';
+}
+
+/// Converts M4A or WAV bytes to a temporary MP3 file for API transmission.
+///
+/// M4A input is first decoded to PCM WAV through Lotti's cross-platform native
+/// decoder. The archived source bytes are never modified. The caller owns the
+/// returned file and must delete it after the API request completes.
+Future<File> encodeAudioBytesToTemporaryMp3(
+  Uint8List sourceBytes, {
+  M4aBytesToWavConverter? m4aToWavConverter,
+  Mp3FrameEncoderFactory? encoderFactory,
+  Directory? temporaryDirectory,
+  String? fileStem,
+  int bitRate = 64,
+}) async {
+  if (sourceBytes.isEmpty) {
+    throw const TemporaryMp3EncodingException('Audio data cannot be empty');
+  }
+
+  try {
+    final wavBytes = _isWavAudio(sourceBytes)
+        ? sourceBytes
+        : await (m4aToWavConverter ?? convertM4aBytesToTemporaryWav)(
+            sourceBytes,
+          );
+    return await encodeWavBytesToTemporaryMp3(
+      wavBytes,
+      encoderFactory: encoderFactory,
+      temporaryDirectory: temporaryDirectory,
+      fileStem: fileStem,
+      bitRate: bitRate,
+    );
+  } on TemporaryMp3EncodingException {
+    rethrow;
+  } on Exception catch (error) {
+    throw TemporaryMp3EncodingException(
+      'Failed to prepare temporary MP3 audio',
+      cause: error,
+    );
+  }
+}
+
+/// Encodes PCM WAV bytes to a temporary MP3 file in bounded sample chunks.
+///
+/// The WAV parser accepts mono or stereo PCM and IEEE-float samples, including
+/// WAVE_FORMAT_EXTENSIBLE files. Only one second of samples per channel is
+/// materialized at a time, so long recordings do not require a second full PCM
+/// copy in memory. Partial MP3 files are removed before failures propagate.
+Future<File> encodeWavBytesToTemporaryMp3(
+  Uint8List wavBytes, {
+  Mp3FrameEncoderFactory? encoderFactory,
+  Directory? temporaryDirectory,
+  String? fileStem,
+  int bitRate = 64,
+}) async {
+  if (bitRate <= 0) {
+    throw ArgumentError.value(bitRate, 'bitRate', 'must be positive');
+  }
+
+  final wav = _WavPcmSource.parse(wavBytes);
+  final directory = temporaryDirectory ?? Directory.systemTemp;
+  final stem = fileStem ?? 'lotti_voxtral_${const Uuid().v4()}';
+  final outputFile = File(p.join(directory.path, '$stem.mp3'));
+  final createEncoder = encoderFactory ?? _createBundledLameEncoder;
+
+  Mp3FrameEncoder? encoder;
+  IOSink? sink;
+  var completed = false;
+  try {
+    await directory.create(recursive: true);
+    sink = outputFile.openWrite();
+    encoder = createEncoder(
+      sampleRate: wav.sampleRate,
+      numChannels: wav.numChannels,
+      bitRate: bitRate,
+    );
+
+    for (var frameOffset = 0; frameOffset < wav.frameCount;) {
+      final frameLength = math.min(
+        wav.sampleRate,
+        wav.frameCount - frameOffset,
+      );
+      final leftChannel = wav.readChannel(
+        channel: 0,
+        frameOffset: frameOffset,
+        frameLength: frameLength,
+      );
+      final rightChannel = wav.numChannels == 2
+          ? wav.readChannel(
+              channel: 1,
+              frameOffset: frameOffset,
+              frameLength: frameLength,
+            )
+          : null;
+      sink.add(
+        await encoder.encode(
+          leftChannel: leftChannel,
+          rightChannel: rightChannel,
+        ),
+      );
+      frameOffset += frameLength;
+    }
+
+    sink.add(await encoder.flush());
+    await sink.flush();
+    await sink.close();
+    sink = null;
+    await encoder.close();
+    encoder = null;
+
+    if (!outputFile.existsSync() || outputFile.lengthSync() == 0) {
+      throw const TemporaryMp3EncodingException(
+        'LAME completed without producing MP3 data',
+      );
+    }
+    completed = true;
+    return outputFile;
+  } on TemporaryMp3EncodingException {
+    rethrow;
+  } on Exception catch (error) {
+    throw TemporaryMp3EncodingException(
+      'Failed to encode temporary MP3 audio',
+      cause: error,
+    );
+  } finally {
+    try {
+      await encoder?.close();
+    } on Exception {
+      // The primary encoding failure is more useful than a close failure.
+    }
+    try {
+      await sink?.close();
+    } on Exception {
+      // The primary encoding failure is more useful than a close failure.
+    }
+    if (!completed) {
+      try {
+        if (outputFile.existsSync()) outputFile.deleteSync();
+      } on FileSystemException {
+        // Partial-file cleanup is best-effort.
+      }
+    }
+  }
+}
+
+Mp3FrameEncoder _createBundledLameEncoder({
+  required int sampleRate,
+  required int numChannels,
+  required int bitRate,
+}) => _FlutterLameFrameEncoder(
+  sampleRate: sampleRate,
+  numChannels: numChannels,
+  bitRate: bitRate,
+);
+
+final class _FlutterLameFrameEncoder implements Mp3FrameEncoder {
+  _FlutterLameFrameEncoder({
+    required int sampleRate,
+    required int numChannels,
+    required int bitRate,
+  }) : _encoder = LameMp3Encoder(
+         sampleRate: sampleRate,
+         numChannels: numChannels,
+         bitRate: bitRate,
+       );
+
+  final LameMp3Encoder _encoder;
+
+  @override
+  Future<Uint8List> encode({
+    required Float64List leftChannel,
+    Float64List? rightChannel,
+  }) => _encoder.encodeDouble(
+    leftChannel: leftChannel,
+    rightChannel: rightChannel,
+  );
+
+  @override
+  Future<Uint8List> flush() => _encoder.flush();
+
+  @override
+  Future<void> close() async {
+    await _encoder.close();
+  }
+}
+
+bool _isWavAudio(Uint8List bytes) =>
+    bytes.length >= 12 &&
+    _hasFourCc(bytes, 0, 0x52, 0x49, 0x46, 0x46) &&
+    _hasFourCc(bytes, 8, 0x57, 0x41, 0x56, 0x45);
+
+bool _hasFourCc(
+  Uint8List bytes,
+  int offset,
+  int first,
+  int second,
+  int third,
+  int fourth,
+) =>
+    bytes[offset] == first &&
+    bytes[offset + 1] == second &&
+    bytes[offset + 2] == third &&
+    bytes[offset + 3] == fourth;
+
+enum _WavSampleEncoding { pcm, ieeeFloat }
+
+final class _WavPcmSource {
+  const _WavPcmSource({
+    required this.bytes,
+    required this.sampleRate,
+    required this.numChannels,
+    required this.bitsPerSample,
+    required this.blockAlign,
+    required this.dataOffset,
+    required this.frameCount,
+    required this.sampleEncoding,
+  });
+
+  factory _WavPcmSource.parse(Uint8List bytes) {
+    if (!_isWavAudio(bytes)) {
+      throw const TemporaryMp3EncodingException(
+        'Audio decoder output is not a RIFF/WAVE file',
+      );
+    }
+
+    final data = ByteData.sublistView(bytes);
+    int? formatOffset;
+    int? formatLength;
+    int? audioDataOffset;
+    int? audioDataLength;
+    var chunkOffset = 12;
+    while (chunkOffset + 8 <= bytes.length) {
+      final chunkLength = data.getUint32(chunkOffset + 4, Endian.little);
+      final contentOffset = chunkOffset + 8;
+      final contentEnd = contentOffset + chunkLength;
+      if (contentEnd > bytes.length) {
+        throw const TemporaryMp3EncodingException(
+          'WAV contains a truncated chunk',
+        );
+      }
+      if (_hasFourCc(bytes, chunkOffset, 0x66, 0x6D, 0x74, 0x20)) {
+        formatOffset = contentOffset;
+        formatLength = chunkLength;
+      } else if (_hasFourCc(
+        bytes,
+        chunkOffset,
+        0x64,
+        0x61,
+        0x74,
+        0x61,
+      )) {
+        audioDataOffset = contentOffset;
+        audioDataLength = chunkLength;
+      }
+      chunkOffset = contentEnd + (chunkLength.isOdd ? 1 : 0);
+    }
+
+    if (formatOffset == null || formatLength == null || formatLength < 16) {
+      throw const TemporaryMp3EncodingException(
+        'WAV is missing a valid fmt chunk',
+      );
+    }
+    if (audioDataOffset == null ||
+        audioDataLength == null ||
+        audioDataLength == 0) {
+      throw const TemporaryMp3EncodingException(
+        'WAV is missing non-empty PCM data',
+      );
+    }
+
+    var audioFormat = data.getUint16(formatOffset, Endian.little);
+    final numChannels = data.getUint16(formatOffset + 2, Endian.little);
+    final sampleRate = data.getUint32(formatOffset + 4, Endian.little);
+    final blockAlign = data.getUint16(formatOffset + 12, Endian.little);
+    final bitsPerSample = data.getUint16(formatOffset + 14, Endian.little);
+    if (audioFormat == 0xFFFE) {
+      if (formatLength < 40) {
+        throw const TemporaryMp3EncodingException(
+          'WAVE_FORMAT_EXTENSIBLE fmt chunk is truncated',
+        );
+      }
+      audioFormat = data.getUint16(formatOffset + 24, Endian.little);
+    }
+
+    final sampleEncoding = switch (audioFormat) {
+      1 => _WavSampleEncoding.pcm,
+      3 => _WavSampleEncoding.ieeeFloat,
+      _ => throw TemporaryMp3EncodingException(
+        'Unsupported WAV sample format: $audioFormat',
+      ),
+    };
+    if (numChannels < 1 || numChannels > 2) {
+      throw TemporaryMp3EncodingException(
+        'LAME supports mono or stereo WAV input, got $numChannels channels',
+      );
+    }
+    if (sampleRate == 0) {
+      throw const TemporaryMp3EncodingException(
+        'WAV sample rate must be positive',
+      );
+    }
+    final supportedBits = switch (sampleEncoding) {
+      _WavSampleEncoding.pcm => const {8, 16, 24, 32},
+      _WavSampleEncoding.ieeeFloat => const {32, 64},
+    };
+    if (!supportedBits.contains(bitsPerSample)) {
+      throw TemporaryMp3EncodingException(
+        'Unsupported WAV bit depth: $bitsPerSample',
+      );
+    }
+    final bytesPerSample = bitsPerSample ~/ 8;
+    if (blockAlign < numChannels * bytesPerSample) {
+      throw const TemporaryMp3EncodingException(
+        'WAV block alignment is smaller than one sample frame',
+      );
+    }
+
+    return _WavPcmSource(
+      bytes: data,
+      sampleRate: sampleRate,
+      numChannels: numChannels,
+      bitsPerSample: bitsPerSample,
+      blockAlign: blockAlign,
+      dataOffset: audioDataOffset,
+      frameCount: audioDataLength ~/ blockAlign,
+      sampleEncoding: sampleEncoding,
+    );
+  }
+
+  final ByteData bytes;
+  final int sampleRate;
+  final int numChannels;
+  final int bitsPerSample;
+  final int blockAlign;
+  final int dataOffset;
+  final int frameCount;
+  final _WavSampleEncoding sampleEncoding;
+
+  Float64List readChannel({
+    required int channel,
+    required int frameOffset,
+    required int frameLength,
+  }) {
+    final samples = Float64List(frameLength);
+    final bytesPerSample = bitsPerSample ~/ 8;
+    for (var index = 0; index < frameLength; index++) {
+      final sampleOffset =
+          dataOffset +
+          (frameOffset + index) * blockAlign +
+          channel * bytesPerSample;
+      samples[index] = _readNormalizedSample(sampleOffset);
+    }
+    return samples;
+  }
+
+  double _readNormalizedSample(int offset) {
+    if (sampleEncoding == _WavSampleEncoding.ieeeFloat) {
+      final sample = bitsPerSample == 32
+          ? bytes.getFloat32(offset, Endian.little)
+          : bytes.getFloat64(offset, Endian.little);
+      if (!sample.isFinite) return 0;
+      return sample.clamp(-1.0, 1.0);
+    }
+
+    return switch (bitsPerSample) {
+      8 => (bytes.getUint8(offset) - 128) / 128,
+      16 => bytes.getInt16(offset, Endian.little) / 32768,
+      24 => _readSignedInt24(offset) / 8388608,
+      32 => bytes.getInt32(offset, Endian.little) / 2147483648,
+      _ => throw StateError('Validated WAV bit depth changed unexpectedly'),
+    };
+  }
+
+  int _readSignedInt24(int offset) {
+    var sample =
+        bytes.getUint8(offset) |
+        (bytes.getUint8(offset + 1) << 8) |
+        (bytes.getUint8(offset + 2) << 16);
+    if ((sample & 0x800000) != 0) sample |= ~0xFFFFFF;
+    return sample;
+  }
+}

--- a/lib/features/ai_chat/README.md
+++ b/lib/features/ai_chat/README.md
@@ -287,11 +287,12 @@ is treated as a failure rather than a successful empty dictation.
 - prefers Mistral offline transcription models first, so their `context_bias`
   parameter can receive the category speech dictionary terms
 - then any configured Mistral audio model
-- then Melious Voxtral models: a temporary WAV copy goes to contextual
-  `/chat/completions` while the M4A master remains untouched; native conversion
-  covers Android, iOS, Linux, macOS, and Windows without bundled FFmpeg, and a
-  decoder failure is surfaced because fallback transcription would lose task
-  context during recognition
+- then Melious Voxtral models: the M4A master remains untouched while a native
+  decoder produces temporary PCM and bundled LAME emits a 64 kbps temporary MP3
+  for contextual `/chat/completions`; decoder scratch files and the MP3 are
+  cleaned up independently on every outcome, and decoder/encoder failures are
+  surfaced because fallback transcription would lose task context during
+  recognition
 - then Melious Whisper/STT models through `/audio/transcriptions`
 - then local MLX Qwen3-ASR models, which receive the same speech dictionary as
   prompt context
@@ -308,6 +309,8 @@ sequenceDiagram
   participant Batch as "AudioTranscriptionService"
   participant Cloud as "CloudInferenceRepository"
   participant MLX as "MlxAudioChannel"
+  participant LAME as "Temporary MP3 encoder"
+  participant Melious as "Melious Voxtral"
 
   UI->>File: record m4a in temp dir
   UI->>Batch: transcribeStream(filePath)
@@ -315,6 +318,14 @@ sequenceDiagram
   alt MLX Audio provider
     Batch->>MLX: transcribeFile(filePath, modelId)
     MLX-->>Batch: final transcript
+  else Melious Voxtral
+    Batch->>Cloud: generateWithAudio(m4a bytes, prompt context)
+    Cloud->>LAME: decode PCM and encode 64 kbps MP3
+    LAME-->>Cloud: temporary .mp3 path
+    Cloud->>Melious: input_audio format=mp3
+    Melious-->>Cloud: contextual transcript or provider error
+    Cloud->>Cloud: delete temporary .mp3 in finally
+    Cloud-->>Batch: transcript chunk or detailed error
   else HTTP provider
     Batch->>Cloud: generateWithAudio(...)
     Cloud-->>Batch: text chunks or detailed provider error

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -21,6 +21,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  flutter_lame
   flutter_vodozemac
   jni
 )

--- a/linux/runner/CMakeLists.txt
+++ b/linux/runner/CMakeLists.txt
@@ -7,6 +7,7 @@ project(runner LANGUAGES CXX)
 #
 # Any new source files that you add to the application should be added here.
 add_executable(${BINARY_NAME}
+  "audio_converter.cc"
   "main.cc"
   "my_application.cc"
   "${FLUTTER_MANAGED_DIR}/generated_plugin_registrant.cc"
@@ -22,5 +23,7 @@ add_definitions(-DAPPLICATION_ID="${APPLICATION_ID}")
 # Add dependency libraries. Add any application-specific dependencies here.
 target_link_libraries(${BINARY_NAME} PRIVATE flutter)
 target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::GTK)
+pkg_check_modules(GSTREAMER REQUIRED IMPORTED_TARGET gstreamer-1.0)
+target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::GSTREAMER)
 
 target_include_directories(${BINARY_NAME} PRIVATE "${CMAKE_SOURCE_DIR}")

--- a/linux/runner/audio_converter.cc
+++ b/linux/runner/audio_converter.cc
@@ -1,0 +1,237 @@
+#include "audio_converter.h"
+
+#include <gst/gst.h>
+
+#include <cstdio>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+namespace {
+
+constexpr char kChannelName[] = "com.matthiasn.lotti/audio_converter";
+constexpr char kConvertMethod[] = "convertM4aToWav";
+
+bool HasAacDecoder() {
+  constexpr const char* kAacDecoderNames[] = {
+      "avdec_aac",
+      "avdec_aac_fixed",
+      "faad",
+      "fdkaacdec",
+  };
+  for (const char* name : kAacDecoderNames) {
+    GstElementFactory* factory = gst_element_factory_find(name);
+    if (factory != nullptr) {
+      gst_object_unref(factory);
+      return true;
+    }
+  }
+  return false;
+}
+
+void LinkDecodedAudioPad(GstElement* /* source */, GstPad* pad,
+                         gpointer user_data) {
+  GstElement* converter = GST_ELEMENT(user_data);
+  GstCaps* caps = gst_pad_get_current_caps(pad);
+  if (caps == nullptr) {
+    caps = gst_pad_query_caps(pad, nullptr);
+  }
+  if (caps == nullptr || gst_caps_is_empty(caps)) {
+    if (caps != nullptr) {
+      gst_caps_unref(caps);
+    }
+    return;
+  }
+
+  const GstStructure* structure = gst_caps_get_structure(caps, 0);
+  const char* media_type = gst_structure_get_name(structure);
+  if (g_str_has_prefix(media_type, "audio/")) {
+    GstPad* sink_pad = gst_element_get_static_pad(converter, "sink");
+    if (!gst_pad_is_linked(sink_pad)) {
+      gst_pad_link(pad, sink_pad);
+    }
+    gst_object_unref(sink_pad);
+  }
+  gst_caps_unref(caps);
+}
+
+std::string PipelineErrorMessage(GstMessage* message) {
+  GError* error = nullptr;
+  gchar* debug = nullptr;
+  gst_message_parse_error(message, &error, &debug);
+  const std::string result =
+      error != nullptr ? error->message : "Unknown GStreamer decoding error";
+  if (error != nullptr) {
+    g_error_free(error);
+  }
+  g_free(debug);
+  return result;
+}
+
+void ConvertM4aToWav(const std::string& input_path,
+                     const std::string& output_path) {
+  if (!HasAacDecoder()) {
+    throw std::runtime_error(
+        "No GStreamer AAC decoder is installed. On Ubuntu/Debian, install "
+        "gstreamer1.0-libav and restart Lotti.");
+  }
+
+  GstElement* pipeline = gst_pipeline_new("lotti-m4a-to-wav");
+  GstElement* decoder = gst_element_factory_make("uridecodebin", "decoder");
+  GstElement* converter =
+      gst_element_factory_make("audioconvert", "converter");
+  GstElement* resampler =
+      gst_element_factory_make("audioresample", "resampler");
+  GstElement* caps_filter =
+      gst_element_factory_make("capsfilter", "pcm-format");
+  GstElement* wav_encoder = gst_element_factory_make("wavenc", "wav-encoder");
+  GstElement* file_sink = gst_element_factory_make("filesink", "file-sink");
+
+  if (pipeline == nullptr || decoder == nullptr || converter == nullptr ||
+      resampler == nullptr || caps_filter == nullptr || wav_encoder == nullptr ||
+      file_sink == nullptr) {
+    GstElement* elements[] = {decoder,      converter,   resampler,
+                              caps_filter, wav_encoder, file_sink};
+    for (GstElement* element : elements) {
+      if (element != nullptr) {
+        gst_object_unref(element);
+      }
+    }
+    gst_clear_object(&pipeline);
+    throw std::runtime_error(
+        "Required GStreamer audio conversion elements are unavailable.");
+  }
+
+  gst_bin_add_many(GST_BIN(pipeline), decoder, converter, resampler,
+                   caps_filter, wav_encoder, file_sink, nullptr);
+
+  GError* uri_error = nullptr;
+  gchar* input_uri =
+      g_filename_to_uri(input_path.c_str(), nullptr, &uri_error);
+  if (input_uri == nullptr) {
+    const std::string message = uri_error != nullptr
+                                    ? uri_error->message
+                                    : "Unable to create the input file URI";
+    if (uri_error != nullptr) {
+      g_error_free(uri_error);
+    }
+    gst_object_unref(pipeline);
+    throw std::runtime_error(message);
+  }
+
+  GstCaps* pcm_caps = gst_caps_new_simple(
+      "audio/x-raw", "format", G_TYPE_STRING, "S16LE", "layout",
+      G_TYPE_STRING, "interleaved", nullptr);
+  g_object_set(decoder, "uri", input_uri, nullptr);
+  g_object_set(caps_filter, "caps", pcm_caps, nullptr);
+  g_object_set(file_sink, "location", output_path.c_str(), nullptr);
+  g_free(input_uri);
+  gst_caps_unref(pcm_caps);
+
+  if (!gst_element_link_many(converter, resampler, caps_filter, wav_encoder,
+                             file_sink, nullptr)) {
+    gst_object_unref(pipeline);
+    throw std::runtime_error("Failed to link the GStreamer WAV pipeline.");
+  }
+  g_signal_connect(decoder, "pad-added", G_CALLBACK(LinkDecodedAudioPad),
+                   converter);
+
+  GstStateChangeReturn state =
+      gst_element_set_state(pipeline, GST_STATE_PLAYING);
+  if (state == GST_STATE_CHANGE_FAILURE) {
+    gst_element_set_state(pipeline, GST_STATE_NULL);
+    gst_object_unref(pipeline);
+    throw std::runtime_error("Failed to start the GStreamer WAV pipeline.");
+  }
+
+  GstBus* bus = gst_element_get_bus(pipeline);
+  GstMessage* message = gst_bus_timed_pop_filtered(
+      bus, 15 * 60 * GST_SECOND,
+      static_cast<GstMessageType>(GST_MESSAGE_ERROR | GST_MESSAGE_EOS));
+
+  std::string failure;
+  if (message == nullptr) {
+    failure = "GStreamer audio conversion timed out.";
+  } else if (GST_MESSAGE_TYPE(message) == GST_MESSAGE_ERROR) {
+    failure = PipelineErrorMessage(message);
+  }
+
+  if (message != nullptr) {
+    gst_message_unref(message);
+  }
+  gst_object_unref(bus);
+  gst_element_set_state(pipeline, GST_STATE_NULL);
+  gst_object_unref(pipeline);
+
+  if (!failure.empty()) {
+    std::remove(output_path.c_str());
+    throw std::runtime_error("M4A-to-WAV conversion failed: " + failure);
+  }
+}
+
+void RespondWithError(FlMethodCall* method_call, const char* code,
+                      const char* message) {
+  g_autoptr(FlMethodResponse) response = FL_METHOD_RESPONSE(
+      fl_method_error_response_new(code, message, nullptr));
+  fl_method_call_respond(method_call, response, nullptr);
+}
+
+void HandleMethodCall(FlMethodCall* method_call) {
+  const gchar* method = fl_method_call_get_name(method_call);
+  if (std::strcmp(method, kConvertMethod) != 0) {
+    g_autoptr(FlMethodResponse) response =
+        FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
+    fl_method_call_respond(method_call, response, nullptr);
+    return;
+  }
+
+  FlValue* arguments = fl_method_call_get_args(method_call);
+  if (fl_value_get_type(arguments) != FL_VALUE_TYPE_MAP) {
+    RespondWithError(method_call, "INVALID_ARGUMENTS",
+                     "Arguments map is required.");
+    return;
+  }
+  FlValue* input = fl_value_lookup_string(arguments, "inputPath");
+  FlValue* output = fl_value_lookup_string(arguments, "outputPath");
+  if (input == nullptr || output == nullptr ||
+      fl_value_get_type(input) != FL_VALUE_TYPE_STRING ||
+      fl_value_get_type(output) != FL_VALUE_TYPE_STRING) {
+    RespondWithError(method_call, "INVALID_ARGUMENTS",
+                     "inputPath and outputPath are required.");
+    return;
+  }
+
+  const std::string input_path = fl_value_get_string(input);
+  const std::string output_path = fl_value_get_string(output);
+  g_object_ref(method_call);
+  std::thread([method_call, input_path, output_path]() {
+    try {
+      ConvertM4aToWav(input_path, output_path);
+      g_autoptr(FlValue) result = fl_value_new_bool(true);
+      g_autoptr(FlMethodResponse) response =
+          FL_METHOD_RESPONSE(fl_method_success_response_new(result));
+      fl_method_call_respond(method_call, response, nullptr);
+    } catch (const std::exception& error) {
+      RespondWithError(method_call, "CONVERSION_ERROR", error.what());
+    }
+    g_object_unref(method_call);
+  }).detach();
+}
+
+void MethodCallCallback(FlMethodChannel* /* channel */,
+                        FlMethodCall* method_call, gpointer /* user_data */) {
+  HandleMethodCall(method_call);
+}
+
+}  // namespace
+
+void audio_converter_register_with_registrar(FlPluginRegistrar* registrar) {
+  gst_init(nullptr, nullptr);
+  g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
+  g_autoptr(FlMethodChannel) channel = fl_method_channel_new(
+      fl_plugin_registrar_get_messenger(registrar), kChannelName,
+      FL_METHOD_CODEC(codec));
+  fl_method_channel_set_method_call_handler(channel, MethodCallCallback,
+                                            nullptr, nullptr);
+}

--- a/linux/runner/audio_converter.h
+++ b/linux/runner/audio_converter.h
@@ -1,0 +1,9 @@
+#ifndef FLUTTER_AUDIO_CONVERTER_H_
+#define FLUTTER_AUDIO_CONVERTER_H_
+
+#include <flutter_linux/flutter_linux.h>
+
+// Registers Lotti's Linux audio conversion method channel.
+void audio_converter_register_with_registrar(FlPluginRegistrar* registrar);
+
+#endif  // FLUTTER_AUDIO_CONVERTER_H_

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -7,6 +7,7 @@
 
 #include <glib/gstdio.h>
 
+#include "audio_converter.h"
 #include "flutter/generated_plugin_registrant.h"
 
 struct _MyApplication {
@@ -154,6 +155,10 @@ static void my_application_activate(GApplication* application) {
   gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
 
   fl_register_plugins(FL_PLUGIN_REGISTRY(view));
+  FlPluginRegistrar* audio_converter_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(
+          FL_PLUGIN_REGISTRY(view), "LottiAudioConverter");
+  audio_converter_register_with_registrar(audio_converter_registrar);
 
   gtk_widget_grab_focus(GTK_WIDGET(view));
 }

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,4 +1,7 @@
 PODS:
+  - audio_decoder (0.7.4):
+    - Flutter
+    - FlutterMacOS
   - audio_session (0.0.1):
     - FlutterMacOS
   - audioplayers_darwin (0.0.1):
@@ -11,6 +14,8 @@ PODS:
   - file_selector_macos (0.0.1):
     - FlutterMacOS
   - flutter_image_compress_macos (1.0.0):
+    - FlutterMacOS
+  - flutter_lame (1.0.0):
     - FlutterMacOS
   - flutter_local_notifications (0.0.1):
     - FlutterMacOS
@@ -113,12 +118,14 @@ PODS:
     - FlutterMacOS
 
 DEPENDENCIES:
+  - audio_decoder (from `Flutter/ephemeral/.symlinks/plugins/audio_decoder/darwin`)
   - audio_session (from `Flutter/ephemeral/.symlinks/plugins/audio_session/macos`)
   - audioplayers_darwin (from `Flutter/ephemeral/.symlinks/plugins/audioplayers_darwin/darwin`)
   - connectivity_plus (from `Flutter/ephemeral/.symlinks/plugins/connectivity_plus/macos`)
   - device_info_plus (from `Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos`)
   - file_selector_macos (from `Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos`)
   - flutter_image_compress_macos (from `Flutter/ephemeral/.symlinks/plugins/flutter_image_compress_macos/macos`)
+  - flutter_lame (from `Flutter/ephemeral/.symlinks/plugins/flutter_lame/macos`)
   - flutter_local_notifications (from `Flutter/ephemeral/.symlinks/plugins/flutter_local_notifications/macos`)
   - flutter_onnxruntime (from `Flutter/ephemeral/.symlinks/plugins/flutter_onnxruntime/macos`)
   - flutter_secure_storage_darwin (from `Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
@@ -159,6 +166,8 @@ SPEC REPOS:
     - sqlite3
 
 EXTERNAL SOURCES:
+  audio_decoder:
+    :path: Flutter/ephemeral/.symlinks/plugins/audio_decoder/darwin
   audio_session:
     :path: Flutter/ephemeral/.symlinks/plugins/audio_session/macos
   audioplayers_darwin:
@@ -171,6 +180,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos
   flutter_image_compress_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/flutter_image_compress_macos/macos
+  flutter_lame:
+    :path: Flutter/ephemeral/.symlinks/plugins/flutter_lame/macos
   flutter_local_notifications:
     :path: Flutter/ephemeral/.symlinks/plugins/flutter_local_notifications/macos
   flutter_onnxruntime:
@@ -229,12 +240,14 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/window_manager/macos
 
 SPEC CHECKSUMS:
+  audio_decoder: 9d20f77489715b63730ff64bbef05aa68190c2e0
   audio_session: eaca2512cf2b39212d724f35d11f46180ad3a33e
   audioplayers_darwin: 835ced6edd4c9fc8ebb0a7cc9e294a91d99917d5
   connectivity_plus: 4adf20a405e25b42b9c9f87feff8f4b6fde18a4e
   device_info_plus: 4fb280989f669696856f8b129e4a5e3cd6c48f76
   file_selector_macos: 9e9e068e90ebee155097d00e89ae91edb2374db7
   flutter_image_compress_macos: e68daf54bb4bf2144c580fd4d151c949cbf492f0
+  flutter_lame: 448a855118053dae751b58bf4ffd614c0e9ee518
   flutter_local_notifications: 1fc7ffb10a83d6a2eeeeddb152d43f1944b0aad0
   flutter_onnxruntime: fb7bede79ac00a8e129c95d7e6b99c0f4e960d98
   flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -457,6 +457,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  dart_lame:
+    dependency: transitive
+    description:
+      name: dart_lame
+      sha256: "5f0e00e54d0d5f0334940fd95f59fbb359f9febc4d3359886e18b48861b60b18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
   dart_polylabel2:
     dependency: transitive
     description:
@@ -924,6 +932,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  flutter_lame:
+    dependency: "direct main"
+    description:
+      name: flutter_lame
+      sha256: "3a1353fc1ec84b631e950e42a6f5a9630b92d386788f2ed9cd8192603cb4d1e2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,7 @@ dependencies:
   flutter_colorpicker: ^1.1.0
   flutter_form_builder: ^10.0.1
   flutter_image_compress: ^2.0.3
+  flutter_lame: 1.0.3
   flutter_linkify: ^6.0.0
   flutter_local_notifications: ^22.0.1
   flutter_localizations:

--- a/test/features/ai/repository/melious_inference_repository_test.dart
+++ b/test/features/ai/repository/melious_inference_repository_test.dart
@@ -973,7 +973,9 @@ void main() {
         expect(chunks.single.created, 0);
         expect(chunks.single.model, 'voxtral-small-24b-2507');
         expect(captured?.url.toString(), '$baseUrl/chat/completions');
+        expect(captured?.headers['Accept'], 'application/json');
         final body = jsonDecode(captured!.body) as Map<String, dynamic>;
+        expect(body['stream'], isFalse);
         final messages = body['messages']! as List<dynamic>;
         final content =
             (messages.single as Map<String, dynamic>)['content']!

--- a/test/features/ai/repository/melious_inference_repository_test.dart
+++ b/test/features/ai/repository/melious_inference_repository_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:clock/clock.dart';
@@ -74,6 +75,19 @@ http.Response _voxtralChatResponse({
   }),
   200,
 );
+
+var _temporaryMp3Sequence = 0;
+
+File _temporaryMp3File([List<int> bytes = const [0x49, 0x44, 0x33]]) {
+  final file = File(
+    '${Directory.systemTemp.path}/lotti_melious_test_${pid}_'
+    '${_temporaryMp3Sequence++}.mp3',
+  )..writeAsBytesSync(bytes);
+  addTearDown(() {
+    if (file.existsSync()) file.deleteSync();
+  });
+  return file;
+}
 
 void main() {
   group('MeliousInferenceRepository', () {
@@ -923,10 +937,11 @@ void main() {
     );
 
     test(
-      'transcribeChatAudio sends temporary WAV directly with context',
+      'transcribeChatAudio sends temporary MP3 and deletes it after success',
       () async {
         http.Request? captured;
-        final wavBytes = base64Decode('UklGRgAAAABXQVZF');
+        const mp3Bytes = [0x49, 0x44, 0x33, 0x04];
+        late File temporaryMp3;
         final repository = MeliousInferenceRepository(
           httpClient: MockClient((request) async {
             captured = request;
@@ -936,7 +951,10 @@ void main() {
               created: 'not-an-integer',
             );
           }),
-          m4aToWavConverter: (_) async => wavBytes,
+          audioToTemporaryMp3Encoder: (sourceBytes) async {
+            expect(sourceBytes, [1, 2, 3]);
+            return temporaryMp3 = _temporaryMp3File(mp3Bytes);
+          },
         );
         addTearDown(repository.close);
 
@@ -963,8 +981,8 @@ void main() {
         expect(content.first, {
           'type': 'input_audio',
           'input_audio': {
-            'data': base64Encode(wavBytes),
-            'format': 'wav',
+            'data': base64Encode(mp3Bytes),
+            'format': 'mp3',
           },
         });
         expect(content.last, {
@@ -972,34 +990,38 @@ void main() {
           'text': 'Transcribe exactly. Required spelling: Lotti.',
         });
         expect(body['max_tokens'], 321);
+        expect(temporaryMp3.existsSync(), isFalse);
       },
     );
 
-    test('transcribeChatAudio reuses WAV input without conversion', () async {
-      final wavBytes = base64Decode('UklGRgAAAABXQVZF');
-      var conversionCalled = false;
-      final repository = MeliousInferenceRepository(
-        httpClient: MockClient((_) async => _voxtralChatResponse()),
-        m4aToWavConverter: (_) async {
-          conversionCalled = true;
-          throw StateError('WAV input must bypass conversion');
-        },
-      );
-      addTearDown(repository.close);
+    test(
+      'transcribeChatAudio passes source audio to the MP3 encoder',
+      () async {
+        final wavBytes = base64Decode('UklGRgAAAABXQVZF');
+        Uint8List? encodedSource;
+        final repository = MeliousInferenceRepository(
+          httpClient: MockClient((_) async => _voxtralChatResponse()),
+          audioToTemporaryMp3Encoder: (bytes) async {
+            encodedSource = bytes;
+            return _temporaryMp3File();
+          },
+        );
+        addTearDown(repository.close);
 
-      final chunks = await repository
-          .transcribeChatAudio(
-            model: 'voxtral-small-24b-2507',
-            audioBase64: base64Encode(wavBytes),
-            baseUrl: baseUrl,
-            apiKey: apiKey,
-            prompt: 'Transcribe.',
-          )
-          .toList();
+        final chunks = await repository
+            .transcribeChatAudio(
+              model: 'voxtral-small-24b-2507',
+              audioBase64: base64Encode(wavBytes),
+              baseUrl: baseUrl,
+              apiKey: apiKey,
+              prompt: 'Transcribe.',
+            )
+            .toList();
 
-      expect(chunks.single.id, 'chatcmpl-voxtral');
-      expect(conversionCalled, isFalse);
-    });
+        expect(chunks.single.id, 'chatcmpl-voxtral');
+        expect(encodedSource, wavBytes);
+      },
+    );
 
     test('transcribeChatAudio surfaces native conversion failures', () async {
       var requestSent = false;
@@ -1008,7 +1030,7 @@ void main() {
           requestSent = true;
           return _voxtralChatResponse();
         }),
-        m4aToWavConverter: (_) async =>
+        audioToTemporaryMp3Encoder: (_) async =>
             throw Exception('GStreamer AAC decoder unavailable'),
       );
       addTearDown(repository.close);
@@ -1037,10 +1059,47 @@ void main() {
       expect(requestSent, isFalse);
     });
 
+    test('transcribeChatAudio rejects and removes an empty MP3', () async {
+      var requestSent = false;
+      late File temporaryMp3;
+      final repository = MeliousInferenceRepository(
+        httpClient: MockClient((_) async {
+          requestSent = true;
+          return _voxtralChatResponse();
+        }),
+        audioToTemporaryMp3Encoder: (_) async {
+          return temporaryMp3 = _temporaryMp3File([]);
+        },
+      );
+      addTearDown(repository.close);
+
+      await expectLater(
+        repository
+            .transcribeChatAudio(
+              model: 'voxtral-small-24b-2507',
+              audioBase64: base64Encode([1, 2, 3]),
+              baseUrl: baseUrl,
+              apiKey: apiKey,
+              prompt: 'Transcribe.',
+            )
+            .toList(),
+        throwsA(
+          isA<TranscriptionException>().having(
+            (error) => error.message,
+            'message',
+            contains('Temporary MP3 encoder produced an empty file'),
+          ),
+        ),
+      );
+
+      expect(requestSent, isFalse);
+      expect(temporaryMp3.existsSync(), isFalse);
+    });
+
     test(
       'transcribeChatAudio preserves structured provider error detail',
       () async {
-        final wavBytes = base64Decode('UklGRgAAAABXQVZF');
+        late File temporaryMp3;
         final repository = MeliousInferenceRepository(
           httpClient: MockClient(
             (_) async => http.Response(
@@ -1053,7 +1112,9 @@ void main() {
               503,
             ),
           ),
-          m4aToWavConverter: (_) async => wavBytes,
+          audioToTemporaryMp3Encoder: (_) async {
+            return temporaryMp3 = _temporaryMp3File();
+          },
         );
         addTearDown(repository.close);
 
@@ -1082,14 +1143,14 @@ void main() {
                 ),
           ),
         );
+        expect(temporaryMp3.existsSync(), isFalse);
       },
     );
 
     test('transcribeChatAudio times out with a request id', () async {
-      final wavBytes = base64Decode('UklGRgAAAABXQVZF');
       final repository = MeliousInferenceRepository(
         httpClient: MockClient((_) => Completer<http.Response>().future),
-        m4aToWavConverter: (_) async => wavBytes,
+        audioToTemporaryMp3Encoder: (_) async => _temporaryMp3File(),
       );
       addTearDown(repository.close);
 
@@ -1114,9 +1175,9 @@ void main() {
       );
     });
 
-    test('transcribeChatAudio bounds native conversion time', () async {
+    test('transcribeChatAudio bounds MP3 encoding time', () async {
       final repository = MeliousInferenceRepository(
-        m4aToWavConverter: (_) => Completer<Uint8List>().future,
+        audioToTemporaryMp3Encoder: (_) => Completer<File>().future,
       );
       addTearDown(repository.close);
 
@@ -1145,13 +1206,15 @@ void main() {
       fakeAsync((async) {
         final startedAt = DateTime(2024, 3, 15, 12);
         var currentTime = startedAt;
+        late File temporaryMp3;
         final repository = MeliousInferenceRepository(
           clockSource: Clock(() => currentTime),
           httpClient: MockClient((_) => Completer<http.Response>().future),
-          m4aToWavConverter: (_) async {
+          audioToTemporaryMp3Encoder: (_) async {
             currentTime = startedAt.add(const Duration(seconds: 40));
-            return base64Decode('UklGRgAAAABXQVZF');
+            return temporaryMp3 = _temporaryMp3File();
           },
+          temporaryFileReader: (file) async => file.readAsBytesSync(),
         );
         Object? failure;
         var completed = false;
@@ -1189,26 +1252,28 @@ void main() {
             allOf(contains('timed out'), contains('request melious-audio-')),
           ),
         );
+        expect(temporaryMp3.existsSync(), isFalse);
         repository.close();
       });
     });
 
     test(
-      'transcribeChatAudio skips HTTP after conversion exhausts timeout',
+      'transcribeChatAudio skips HTTP after MP3 encoding exhausts timeout',
       () {
         fakeAsync((async) {
           final startedAt = DateTime(2024, 3, 15, 12);
           var currentTime = startedAt;
           var requestSent = false;
+          late File temporaryMp3;
           final repository = MeliousInferenceRepository(
             clockSource: Clock(() => currentTime),
             httpClient: MockClient((_) async {
               requestSent = true;
               return _voxtralChatResponse();
             }),
-            m4aToWavConverter: (_) async {
+            audioToTemporaryMp3Encoder: (_) async {
               currentTime = startedAt.add(const Duration(seconds: 60));
-              return base64Decode('UklGRgAAAABXQVZF');
+              return temporaryMp3 = _temporaryMp3File();
             },
           );
           Object? failure;
@@ -1239,6 +1304,7 @@ void main() {
               allOf(contains('timed out'), contains('request melious-audio-')),
             ),
           );
+          expect(temporaryMp3.existsSync(), isFalse);
           repository.close();
         });
       },
@@ -1246,7 +1312,7 @@ void main() {
 
     test('transcribeChatAudio prefixes conversion status detail', () {
       final repository = MeliousInferenceRepository(
-        m4aToWavConverter: (_) async => throw TranscriptionException(
+        audioToTemporaryMp3Encoder: (_) async => throw TranscriptionException(
           'Native audio decoder rejected the recording',
           provider: 'audio_decoder',
           statusCode: 422,
@@ -1299,7 +1365,7 @@ void main() {
       test('transcribeChatAudio ${testCase.description}', () {
         final repository = MeliousInferenceRepository(
           httpClient: MockClient((_) async => testCase.response),
-          m4aToWavConverter: (_) async => base64Decode('UklGRgAAAABXQVZF'),
+          audioToTemporaryMp3Encoder: (_) async => _temporaryMp3File(),
         );
         addTearDown(repository.close);
 
@@ -1327,7 +1393,7 @@ void main() {
     test('transcribeChatAudio wraps transport failures', () {
       final repository = MeliousInferenceRepository(
         httpClient: MockClient((_) async => throw Exception('network down')),
-        m4aToWavConverter: (_) async => base64Decode('UklGRgAAAABXQVZF'),
+        audioToTemporaryMp3Encoder: (_) async => _temporaryMp3File(),
       );
       addTearDown(repository.close);
 

--- a/test/features/ai/repository/melious_inference_repository_test.dart
+++ b/test/features/ai/repository/melious_inference_repository_test.dart
@@ -1169,7 +1169,11 @@ void main() {
           isA<TranscriptionException>().having(
             (error) => error.message,
             'message',
-            allOf(contains('timed out'), contains('request melious-audio-')),
+            allOf(
+              contains('timed out'),
+              contains('preparing the temporary MP3'),
+              contains('request melious-audio-'),
+            ),
           ),
         ),
       );
@@ -1202,7 +1206,46 @@ void main() {
       );
     });
 
-    test('transcribeChatAudio shares its timeout across both stages', () {
+    test(
+      'transcribeChatAudio default permits preparation longer than 60 seconds',
+      () async {
+        final startedAt = DateTime(2024, 3, 15, 12);
+        var currentTime = startedAt;
+        var requestSent = false;
+        late File temporaryMp3;
+        final repository = MeliousInferenceRepository(
+          clockSource: Clock(() => currentTime),
+          httpClient: MockClient((_) async {
+            requestSent = true;
+            return _voxtralChatResponse();
+          }),
+          audioToTemporaryMp3Encoder: (_) async {
+            currentTime = startedAt.add(const Duration(seconds: 61));
+            return temporaryMp3 = _temporaryMp3File();
+          },
+        );
+        addTearDown(repository.close);
+
+        final responses = await repository
+            .transcribeChatAudio(
+              model: 'voxtral-small-24b-2507',
+              audioBase64: base64Encode([1, 2, 3]),
+              baseUrl: baseUrl,
+              apiKey: apiKey,
+              prompt: 'Transcribe.',
+            )
+            .toList();
+
+        expect(requestSent, isTrue);
+        expect(
+          responses.single.choices?.single.delta?.content,
+          'Lotti uses Voxtral.',
+        );
+        expect(temporaryMp3.existsSync(), isFalse);
+      },
+    );
+
+    test('transcribeChatAudio shares an explicit timeout across stages', () {
       fakeAsync((async) {
         final startedAt = DateTime(2024, 3, 15, 12);
         var currentTime = startedAt;
@@ -1226,6 +1269,7 @@ void main() {
               baseUrl: baseUrl,
               apiKey: apiKey,
               prompt: 'Transcribe.',
+              timeout: const Duration(seconds: 60),
             )
             .toList()
             .then<void>(
@@ -1249,7 +1293,11 @@ void main() {
           isA<TranscriptionException>().having(
             (error) => error.message,
             'message',
-            allOf(contains('timed out'), contains('request melious-audio-')),
+            allOf(
+              contains('timed out'),
+              contains('waiting for the Voxtral response'),
+              contains('request melious-audio-'),
+            ),
           ),
         );
         expect(temporaryMp3.existsSync(), isFalse);
@@ -1285,6 +1333,7 @@ void main() {
                 baseUrl: baseUrl,
                 apiKey: apiKey,
                 prompt: 'Transcribe.',
+                timeout: const Duration(seconds: 60),
               )
               .toList()
               .then<void>(

--- a/test/features/ai/util/audio_converter_channel_test.dart
+++ b/test/features/ai/util/audio_converter_channel_test.dart
@@ -46,6 +46,14 @@ void main() {
   const decoderChannel = MethodChannel('audio_decoder');
   late _FakeDomainLogger fakeLogging;
 
+  void setMockM4aDecoderHandler(
+    Future<Object?> Function(MethodCall call) handler,
+  ) {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      ..setMockMethodCallHandler(channel, handler)
+      ..setMockMethodCallHandler(decoderChannel, handler);
+  }
+
   group('AudioConverterChannel', () {
     setUp(() async {
       fakeLogging = _FakeDomainLogger();
@@ -83,15 +91,14 @@ void main() {
       expect(result, isTrue);
     });
 
-    test('converts M4A to WAV through the cross-platform decoder', () async {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(decoderChannel, (call) async {
-            expect(call.method, 'convertToWav');
-            final args = call.arguments as Map<dynamic, dynamic>;
-            expect(args['inputPath'], '/tmp/input.m4a');
-            expect(args['outputPath'], '/tmp/output.wav');
-            return '/tmp/output.wav';
-          });
+    test('converts M4A to WAV through the platform decoder', () async {
+      setMockM4aDecoderHandler((call) async {
+        expect(call.method, anyOf('convertM4aToWav', 'convertToWav'));
+        final args = call.arguments as Map<dynamic, dynamic>;
+        expect(args['inputPath'], '/tmp/input.m4a');
+        expect(args['outputPath'], '/tmp/output.wav');
+        return call.method == 'convertM4aToWav' ? true : '/tmp/output.wav';
+      });
 
       await AudioConverterChannel.convertM4aToWav(
         inputPath: '/tmp/input.m4a',
@@ -99,15 +106,13 @@ void main() {
       );
     });
 
-    test('logs and rethrows cross-platform decoder failures', () async {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-            decoderChannel,
-            (_) async => throw PlatformException(
-              code: 'CONVERSION_ERROR',
-              message: 'AAC decoder unavailable',
-            ),
-          );
+    test('logs and normalizes platform decoder failures', () async {
+      setMockM4aDecoderHandler(
+        (_) async => throw PlatformException(
+          code: 'CONVERSION_ERROR',
+          message: 'AAC decoder unavailable',
+        ),
+      );
 
       await expectLater(
         AudioConverterChannel.convertM4aToWav(
@@ -150,17 +155,14 @@ void main() {
     test('temporary conversion uses native defaults and cleans up', () async {
       late String inputPath;
       late String outputPath;
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(decoderChannel, (call) async {
-            inputPath =
-                (call.arguments as Map<dynamic, dynamic>)['inputPath']
-                    as String;
-            outputPath =
-                (call.arguments as Map<dynamic, dynamic>)['outputPath']
-                    as String;
-            await File(outputPath).writeAsBytes([82, 73, 70, 70]);
-            return outputPath;
-          });
+      setMockM4aDecoderHandler((call) async {
+        inputPath =
+            (call.arguments as Map<dynamic, dynamic>)['inputPath'] as String;
+        outputPath =
+            (call.arguments as Map<dynamic, dynamic>)['outputPath'] as String;
+        await File(outputPath).writeAsBytes([82, 73, 70, 70]);
+        return call.method == 'convertM4aToWav' ? true : outputPath;
+      });
 
       final wavBytes = await convertM4aBytesToTemporaryWav(
         Uint8List.fromList([1, 2, 3]),

--- a/test/features/ai/util/temporary_mp3_encoder_test.dart
+++ b/test/features/ai/util/temporary_mp3_encoder_test.dart
@@ -1,0 +1,318 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/ai/util/temporary_mp3_encoder.dart';
+
+void main() {
+  late Directory temporaryDirectory;
+
+  setUp(() {
+    temporaryDirectory = Directory.systemTemp.createTempSync(
+      'lotti_temporary_mp3_encoder_test_',
+    );
+  });
+
+  tearDown(() {
+    if (temporaryDirectory.existsSync()) {
+      temporaryDirectory.deleteSync(recursive: true);
+    }
+  });
+
+  test(
+    'decodes M4A, normalizes PCM samples, and returns temporary MP3',
+    () async {
+      final wavBytes = _pcm16Wav(
+        sampleRate: 16000,
+        samples: [-32768, 0, 32767],
+      );
+      final encoders = <_RecordingMp3FrameEncoder>[];
+      var converterCalled = false;
+
+      final file = await encodeAudioBytesToTemporaryMp3(
+        Uint8List.fromList([1, 2, 3]),
+        temporaryDirectory: temporaryDirectory,
+        fileStem: 'converted',
+        m4aToWavConverter: (bytes) async {
+          converterCalled = true;
+          expect(bytes, [1, 2, 3]);
+          return wavBytes;
+        },
+        encoderFactory: _recordingEncoderFactory(encoders),
+      );
+
+      expect(converterCalled, isTrue);
+      expect(file.path, endsWith('converted.mp3'));
+      expect(file.readAsBytesSync(), [0xA0, 0xFF]);
+      expect(encoders, hasLength(1));
+      final encoder = encoders.single;
+      expect(encoder.sampleRate, 16000);
+      expect(encoder.numChannels, 1);
+      expect(encoder.bitRate, 64);
+      expect(encoder.closed, isTrue);
+      expect(encoder.leftChunks.single[0], -1);
+      expect(encoder.leftChunks.single[1], 0);
+      expect(encoder.leftChunks.single[2], closeTo(0.99997, 0.00001));
+      expect(encoder.rightChunks.single, isNull);
+    },
+  );
+
+  test('reuses WAV input without invoking the M4A decoder', () async {
+    final wavBytes = _pcm16Wav(sampleRate: 8000, samples: [0, 1]);
+    var converterCalled = false;
+
+    final file = await encodeAudioBytesToTemporaryMp3(
+      wavBytes,
+      temporaryDirectory: temporaryDirectory,
+      fileStem: 'wav-input',
+      m4aToWavConverter: (_) async {
+        converterCalled = true;
+        throw StateError('WAV input must bypass M4A decoding');
+      },
+      encoderFactory: _recordingEncoderFactory([]),
+    );
+
+    expect(converterCalled, isFalse);
+    expect(file.readAsBytesSync(), [0xA0, 0xFF]);
+  });
+
+  test('passes normalized stereo channels to the encoder', () async {
+    final wavBytes = _pcm16Wav(
+      sampleRate: 44100,
+      numChannels: 2,
+      samples: [-32768, 32767, 16384, -16384],
+    );
+    final encoders = <_RecordingMp3FrameEncoder>[];
+
+    await encodeWavBytesToTemporaryMp3(
+      wavBytes,
+      temporaryDirectory: temporaryDirectory,
+      encoderFactory: _recordingEncoderFactory(encoders),
+    );
+
+    final encoder = encoders.single;
+    expect(encoder.numChannels, 2);
+    expect(encoder.leftChunks.single, [-1, 0.5]);
+    expect(encoder.rightChunks.single, [closeTo(0.99997, 0.00001), -0.5]);
+  });
+
+  test('encodes audio longer than two minutes in bounded chunks', () async {
+    const sampleRate = 8000;
+    const durationSeconds = 121;
+    const frameCount = sampleRate * durationSeconds;
+    final wavBytes = _pcm16Wav(
+      sampleRate: sampleRate,
+      frameCount: frameCount,
+    );
+    final encoders = <_RecordingMp3FrameEncoder>[];
+
+    final file = await encodeWavBytesToTemporaryMp3(
+      wavBytes,
+      temporaryDirectory: temporaryDirectory,
+      fileStem: 'long-recording',
+      encoderFactory: _recordingEncoderFactory(encoders),
+    );
+
+    final encoder = encoders.single;
+    expect(encoder.leftChunks, hasLength(durationSeconds));
+    expect(
+      encoder.leftChunks.fold<int>(0, (sum, samples) => sum + samples.length),
+      frameCount,
+    );
+    expect(
+      encoder.leftChunks.map((samples) => samples.length),
+      everyElement(lessThanOrEqualTo(sampleRate)),
+    );
+    expect(file.lengthSync(), lessThan(wavBytes.length ~/ 1000));
+  });
+
+  test('removes a partial MP3 and closes LAME when encoding fails', () async {
+    final wavBytes = _pcm16Wav(
+      sampleRate: 2,
+      frameCount: 5,
+    );
+    late _RecordingMp3FrameEncoder encoder;
+    final outputFile = File('${temporaryDirectory.path}/failed.mp3');
+
+    await expectLater(
+      encodeWavBytesToTemporaryMp3(
+        wavBytes,
+        temporaryDirectory: temporaryDirectory,
+        fileStem: 'failed',
+        encoderFactory:
+            ({
+              required sampleRate,
+              required numChannels,
+              required bitRate,
+            }) {
+              return encoder = _RecordingMp3FrameEncoder(
+                sampleRate: sampleRate,
+                numChannels: numChannels,
+                bitRate: bitRate,
+                failAtEncodeCall: 2,
+              );
+            },
+      ),
+      throwsA(
+        isA<TemporaryMp3EncodingException>().having(
+          (error) => error.toString(),
+          'message',
+          contains('synthetic LAME failure'),
+        ),
+      ),
+    );
+
+    expect(encoder.closed, isTrue);
+    expect(outputFile.existsSync(), isFalse);
+  });
+
+  test('surfaces decoder failures as MP3 preparation errors', () async {
+    await expectLater(
+      encodeAudioBytesToTemporaryMp3(
+        Uint8List.fromList([1, 2, 3]),
+        temporaryDirectory: temporaryDirectory,
+        m4aToWavConverter: (_) async =>
+            throw Exception('GStreamer AAC decoder unavailable'),
+        encoderFactory: _recordingEncoderFactory([]),
+      ),
+      throwsA(
+        isA<TemporaryMp3EncodingException>().having(
+          (error) => error.toString(),
+          'message',
+          allOf(
+            contains('Failed to prepare temporary MP3 audio'),
+            contains('GStreamer AAC decoder unavailable'),
+          ),
+        ),
+      ),
+    );
+  });
+
+  test('rejects invalid WAV output before creating a file', () async {
+    final outputFile = File('${temporaryDirectory.path}/invalid.mp3');
+
+    await expectLater(
+      encodeWavBytesToTemporaryMp3(
+        Uint8List.fromList([1, 2, 3]),
+        temporaryDirectory: temporaryDirectory,
+        fileStem: 'invalid',
+        encoderFactory: _recordingEncoderFactory([]),
+      ),
+      throwsA(
+        isA<TemporaryMp3EncodingException>().having(
+          (error) => error.message,
+          'message',
+          contains('not a RIFF/WAVE file'),
+        ),
+      ),
+    );
+    expect(outputFile.existsSync(), isFalse);
+  });
+
+  test('rejects empty audio and invalid bit rates', () async {
+    await expectLater(
+      encodeAudioBytesToTemporaryMp3(
+        Uint8List(0),
+        temporaryDirectory: temporaryDirectory,
+        encoderFactory: _recordingEncoderFactory([]),
+      ),
+      throwsA(isA<TemporaryMp3EncodingException>()),
+    );
+
+    expect(
+      () => encodeWavBytesToTemporaryMp3(
+        _pcm16Wav(sampleRate: 8000, samples: [0]),
+        temporaryDirectory: temporaryDirectory,
+        bitRate: 0,
+        encoderFactory: _recordingEncoderFactory([]),
+      ),
+      throwsArgumentError,
+    );
+  });
+}
+
+Mp3FrameEncoderFactory _recordingEncoderFactory(
+  List<_RecordingMp3FrameEncoder> encoders,
+) {
+  return ({
+    required int sampleRate,
+    required int numChannels,
+    required int bitRate,
+  }) {
+    final encoder = _RecordingMp3FrameEncoder(
+      sampleRate: sampleRate,
+      numChannels: numChannels,
+      bitRate: bitRate,
+    );
+    encoders.add(encoder);
+    return encoder;
+  };
+}
+
+final class _RecordingMp3FrameEncoder implements Mp3FrameEncoder {
+  _RecordingMp3FrameEncoder({
+    required this.sampleRate,
+    required this.numChannels,
+    required this.bitRate,
+    this.failAtEncodeCall,
+  });
+
+  final int sampleRate;
+  final int numChannels;
+  final int bitRate;
+  final int? failAtEncodeCall;
+  final leftChunks = <Float64List>[];
+  final rightChunks = <Float64List?>[];
+  bool closed = false;
+
+  @override
+  Future<Uint8List> encode({
+    required Float64List leftChannel,
+    Float64List? rightChannel,
+  }) async {
+    leftChunks.add(Float64List.fromList(leftChannel));
+    rightChunks.add(
+      rightChannel == null ? null : Float64List.fromList(rightChannel),
+    );
+    if (leftChunks.length == failAtEncodeCall) {
+      throw Exception('synthetic LAME failure');
+    }
+    return Uint8List.fromList([0xA0]);
+  }
+
+  @override
+  Future<Uint8List> flush() async => Uint8List.fromList([0xFF]);
+
+  @override
+  Future<void> close() async {
+    closed = true;
+  }
+}
+
+Uint8List _pcm16Wav({
+  required int sampleRate,
+  int numChannels = 1,
+  int? frameCount,
+  List<int>? samples,
+}) {
+  final resolvedFrameCount = frameCount ?? samples!.length ~/ numChannels;
+  final dataLength = resolvedFrameCount * numChannels * 2;
+  final wav = ByteData(44 + dataLength)
+    ..setUint32(0, 0x52494646)
+    ..setUint32(4, 36 + dataLength, Endian.little)
+    ..setUint32(8, 0x57415645)
+    ..setUint32(12, 0x666D7420)
+    ..setUint32(16, 16, Endian.little)
+    ..setUint16(20, 1, Endian.little)
+    ..setUint16(22, numChannels, Endian.little)
+    ..setUint32(24, sampleRate, Endian.little)
+    ..setUint32(28, sampleRate * numChannels * 2, Endian.little)
+    ..setUint16(32, numChannels * 2, Endian.little)
+    ..setUint16(34, 16, Endian.little)
+    ..setUint32(36, 0x64617461)
+    ..setUint32(40, dataLength, Endian.little);
+  for (var index = 0; index < resolvedFrameCount * numChannels; index++) {
+    wav.setInt16(44 + index * 2, samples?[index] ?? 0, Endian.little);
+  }
+  return wav.buffer.asUint8List();
+}

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -26,6 +26,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  flutter_lame
   flutter_local_notifications_windows
   flutter_vodozemac
   jni


### PR DESCRIPTION
## Summary

- add `flutter_lame` 1.0.3 and a bounded-chunk PCM/WAV-to-MP3 encoder
- preserve AAC/M4A as the archive format while sending temporary 64 kbps MP3 files to Voxtral
- keep the Melious chat-audio request buffered (`stream: false`) and send the audio block as `format: mp3`
- delete decoder scratch files and temporary MP3 files after success, provider failure, transport failure, or timeout
- replace the blocking Linux decode call with a Lotti-owned GStreamer WAV pipeline that reports codec errors immediately
- allow up to 15 minutes for long-audio preparation and Voxtral processing
- document the Linux AAC runtime package and the complete transcription lifecycle

## Root cause

Melious' Voxtral chat endpoint cannot reliably process Lotti's archived M4A bytes. Converting recordings to WAV fixed short clips, but PCM WAV payloads exceed the provider request-size limit for recordings longer than roughly one or two minutes.

The first MP3 implementation exposed a separate Linux failure before any HTTP request was made. `audio_decoder` uses a blocking GStreamer appsink pull loop and does not monitor the pipeline bus. When the host had GStreamer core but no AAC decoder, GStreamer reported a missing decoder on the bus while the plugin waited forever for a sample. The outer request then appeared to time out even though no MP3 had been produced or uploaded.

## Implementation

Lotti now decodes only a temporary copy of the M4A archive, feeds normalized PCM samples to the bundled LAME encoder in one-second chunks, and sends the resulting MP3 through `/chat/completions`. The archive remains M4A.

On Linux, Lotti's native runner uses `uridecodebin -> audioconvert -> audioresample -> wavenc -> filesink` and waits for GStreamer `ERROR` or `EOS` bus messages. A missing AAC decoder returns an immediate error instructing Ubuntu/Debian users to install `gstreamer1.0-libav`. Fedora uses `gstreamer1-plugin-libav`, Arch uses `gst-libav`, and the Flatpak 25.08 runtime already provides `avdec_aac`. This does not add an FFmpeg executable or a Flutter FFmpeg dependency.

## Impact

Long Voxtral recordings remain compact during API transmission, temporary files cannot accumulate, and Linux no longer hangs silently when AAC support is missing.

The normal GitHub unit/build jobs do not need the runtime codec because they do not execute native M4A decoding. Installing the package in the release runner would not bundle it into the downloadable tar archive, so the unpackaged runtime requirement is documented instead; Flatpak is self-contained.

## Validation

- `fvm flutter analyze` — no issues
- affected Flutter test files — 81 tests passed, including the 121-second bounded-chunk fixture, request payload/cleanup/error paths, `stream: false`, and `Accept: application/json`
- `fvm flutter build linux --debug --no-pub` — succeeded
- native Linux success probe — 39 seconds: 91 ms decode + 648 ms MP3 encoding
- native Linux long-audio probe — 4 minutes: 240 ms decode + 3.89 s MP3 encoding; 1.92 MB MP3
- native Linux missing-codec probe — immediate `install gstreamer1.0-libav` error with GStreamer plugins hidden
- live buffered Melious probe with the generated four-minute MP3 — HTTP 200 in 17.64 seconds
