### PR TITLE
fix: patch flutter_lame for CMake 4

### DIFF
--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -10,9 +10,27 @@ cd flatpak
 # Output in direct-build/output/
 ```
 
-## How It Works
+## Runtime Architecture
 
 The script uses [flatpak-flutter](https://github.com/TheAppgineer/flatpak-flutter) (pinned to v0.11.0) to generate offline build manifests. This replaces the complex 12,000+ line `manifest_tool` Python orchestrator with a ~110-line bash wrapper plus a local foreign-dependency overlay.
+
+```mermaid
+flowchart LR
+    Release[Tag or manual release] --> Workflow[flathub-release-pr.yml]
+    Workflow --> Prepare[prepare_flathub_build.sh]
+    Template[Manifest template] --> Prepare
+    Lock[pubspec.lock] --> Generator[flatpak-flutter 0.11.0]
+    Overlay[flatpak_flutter_extra] --> Generator
+    Prepare --> Generator
+    Generator --> Output[Offline manifest and sources]
+    Output --> FlathubPR[Flathub release branch and PR]
+    FlathubPR --> Builder[Flathub x86_64 and aarch64 builds]
+```
+
+The overlay is part of the release input, not a post-processing step in the
+Flathub repository. Versioned entries add offline sources or patches for
+hosted Pub packages before `flatpak-flutter` emits
+`generated/sources/pubspec.json`.
 
 ### What It Does
 
@@ -191,6 +209,16 @@ dependency files.
 Some upstream packages ship patched files with CRLF line endings. Keep those
 patches generated from the upstream file's real line endings so the Flathub
 builder's plain `patch -p1` invocation applies them.
+
+Current version-specific native patches include:
+
+- `sqlite3_flutter_libs 0.5.42`: pins the SQLite archive hash so CMake uses the
+  source downloaded during Flatpak's network-enabled source phase.
+- `objectbox_flutter_libs 5.3.1` and `5.3.2`: pins the per-architecture
+  ObjectBox archive hashes for the same offline build flow.
+- `flutter_lame 1.0.3`: raises bundled LAME's CMake compatibility floor from
+  3.0 to 3.5. CMake 4.x in the Flathub 25.08 SDK no longer accepts compatibility
+  levels below 3.5.
 
 ### com.matthiasn.lotti.flatpak-flutter.yml
 

--- a/flatpak/flatpak_flutter_extra/flutter_lame/1.0.3-CMakeLists.txt.patch
+++ b/flatpak/flatpak_flutter_extra/flutter_lame/1.0.3-CMakeLists.txt.patch
@@ -1,0 +1,5 @@
+--- a/src/lame/CMakeLists.txt
++++ b/src/lame/CMakeLists.txt
+@@ -1 +1 @@
+-cmake_minimum_required(VERSION 3.0)
++cmake_minimum_required(VERSION 3.5)

--- a/flatpak/flatpak_flutter_extra/foreign_deps.json
+++ b/flatpak/flatpak_flutter_extra/foreign_deps.json
@@ -90,5 +90,18 @@
                 ]
             }
         }
+    },
+    "flutter_lame": {
+        "1.0.3": {
+            "manifest": {
+                "sources": [
+                    {
+                        "type": "patch",
+                        "path": "flutter_lame/1.0.3-CMakeLists.txt.patch",
+                        "dest": "$PUB_DEV"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1045+4207
+version: 0.9.1045+4208
 
 msix_config:
   display_name: LottiApp


### PR DESCRIPTION
## Summary

- add a version-specific `flatpak-flutter` overlay for `flutter_lame 1.0.3`
- patch bundled LAME's CMake compatibility floor from 3.0 to 3.5
- document how release inputs flow into generated Flathub manifests

## Root cause

Flathub PR 206 fails while configuring `flutter_lame` on aarch64. The Flathub 25.08 SDK uses CMake 4.3, which no longer accepts compatibility levels below 3.5, while the bundled LAME source declares CMake 3.0.

Keeping the patch in Lotti's versioned foreign-dependency overlay makes `flathub-release-pr.yml` include it in every subsequently generated Flathub release PR.

## Impact

Future Flathub release builds can configure `flutter_lame` with the current SDK. This changes packaging only; application behavior is unchanged.

## Verification

- `fvm flutter pub get --enforce-lockfile`
- `python3 flatpak/check_foreign_deps.py`
- generated the release sources with pinned `flatpak-flutter 0.11.0` and confirmed `generated/sources/pubspec.json` references the emitted patch
- dry-ran the emitted patch against the locked `flutter_lame 1.0.3` Pub package
- `FLUTTER='fvm flutter' ./tool/analyze.sh` — no issues
- `git diff --check`

A full Flatpak compile is left to CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Flatpak runtime architecture documentation, including the offline manifest generation flow.
  * Documented version-specific native dependency patches and release inputs.

* **Bug Fixes**
  * Improved compatibility when building the flutter_lame dependency by updating its minimum CMake requirement.

* **Chores**
  * Updated the application build version to `0.9.1045+4208`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->