### PR TITLE
fix: abort timed out Voxtral chat requests

### DIFF
--- a/lib/features/ai/repository/melious_inference_repository.dart
+++ b/lib/features/ai/repository/melious_inference_repository.dart
@@ -55,9 +55,6 @@ class MeliousInferenceRepository extends TranscriptionRepository {
   static const _providerName = 'MeliousInferenceRepository';
   static const _modelListTimeout = Duration(seconds: 15);
   static const _imageGenerationTimeout = Duration(seconds: 180);
-  // Voxtral can process recordings up to 30 minutes, and local preparation is
-  // included in this deadline. Match the native Voxtral route's long-audio
-  // allowance instead of applying the general short-request timeout.
   // Generous because the non-streaming impact path buffers the entire
   // response: nothing is emitted (and no onProgress fires) until the full
   // body arrives or this timeout trips.

--- a/lib/features/ai/repository/temporary_mp3_chat_audio_transcriber.dart
+++ b/lib/features/ai/repository/temporary_mp3_chat_audio_transcriber.dart
@@ -157,17 +157,31 @@ Stream<CreateChatCompletionStreamResponse> transcribeTemporaryMp3ChatAudio({
 
     timeoutStage = 'waiting for the Voxtral response';
     final requestTimeout = remainingTimeoutOrThrow();
-    final response = await httpClient
-        .post(
-          _buildEndpointUri(normalizedBaseUrl, 'chat/completions'),
-          headers: {
+    final abortTrigger = Completer<void>();
+    final request =
+        http.AbortableRequest(
+            'POST',
+            _buildEndpointUri(normalizedBaseUrl, 'chat/completions'),
+            abortTrigger: abortTrigger.future,
+          )
+          ..headers.addAll({
             'Content-Type': 'application/json',
             'Accept': 'application/json',
             'Authorization': 'Bearer $normalizedApiKey',
+          })
+          ..body = jsonEncode(body);
+    final response = await httpClient
+        .send(request)
+        .then(http.Response.fromStream)
+        .timeout(
+          requestTimeout,
+          onTimeout: () {
+            abortTrigger.complete();
+            throw TimeoutException(
+              '${provider.displayName} chat-audio HTTP request timed out',
+            );
           },
-          body: jsonEncode(body),
-        )
-        .timeout(requestTimeout);
+        );
 
     if (response.statusCode < 200 || response.statusCode >= 300) {
       throw TranscriptionException(

--- a/lib/features/ai/repository/temporary_mp3_chat_audio_transcriber.dart
+++ b/lib/features/ai/repository/temporary_mp3_chat_audio_transcriber.dart
@@ -79,7 +79,63 @@ Stream<CreateChatCompletionStreamResponse> transcribeTemporaryMp3ChatAudio({
   TemporaryAudioFileReader temporaryFileReader = _readTemporaryFile,
   TemporaryAudioFileDeleter temporaryFileDeleter = _deleteTemporaryFile,
   Clock? clockSource,
-}) async* {
+}) {
+  final abortTrigger = Completer<void>();
+  var canceled = false;
+  late final StreamController<CreateChatCompletionStreamResponse> controller;
+
+  Future<void> transcribe() async {
+    try {
+      final chunk = await _transcribeTemporaryMp3ChatAudio(
+        httpClient: httpClient,
+        provider: provider,
+        model: model,
+        audioBase64: audioBase64,
+        baseUrl: baseUrl,
+        apiKey: apiKey,
+        prompt: prompt,
+        maxCompletionTokens: maxCompletionTokens,
+        timeout: timeout,
+        audioToTemporaryMp3Encoder: audioToTemporaryMp3Encoder,
+        temporaryFileReader: temporaryFileReader,
+        temporaryFileDeleter: temporaryFileDeleter,
+        clockSource: clockSource,
+        abortTrigger: abortTrigger,
+      );
+      if (!canceled) controller.add(chunk);
+    } catch (error, stackTrace) {
+      if (!canceled) controller.addError(error, stackTrace);
+    } finally {
+      if (!canceled) await controller.close();
+    }
+  }
+
+  controller = StreamController<CreateChatCompletionStreamResponse>(
+    onListen: () => unawaited(transcribe()),
+    onCancel: () {
+      canceled = true;
+      if (!abortTrigger.isCompleted) abortTrigger.complete();
+    },
+  );
+  return controller.stream;
+}
+
+Future<CreateChatCompletionStreamResponse> _transcribeTemporaryMp3ChatAudio({
+  required http.Client httpClient,
+  required TemporaryMp3ChatAudioProvider provider,
+  required String model,
+  required String audioBase64,
+  required String baseUrl,
+  required String apiKey,
+  required String prompt,
+  required Duration timeout,
+  required AudioToTemporaryMp3Encoder audioToTemporaryMp3Encoder,
+  required TemporaryAudioFileReader temporaryFileReader,
+  required TemporaryAudioFileDeleter temporaryFileDeleter,
+  required Completer<void> abortTrigger,
+  int? maxCompletionTokens,
+  Clock? clockSource,
+}) async {
   final normalizedModel = model.trim();
   final normalizedBaseUrl = baseUrl.trim();
   final normalizedApiKey = apiKey.trim();
@@ -157,7 +213,6 @@ Stream<CreateChatCompletionStreamResponse> transcribeTemporaryMp3ChatAudio({
 
     timeoutStage = 'waiting for the Voxtral response';
     final requestTimeout = remainingTimeoutOrThrow();
-    final abortTrigger = Completer<void>();
     final request =
         http.AbortableRequest(
             'POST',
@@ -170,18 +225,23 @@ Stream<CreateChatCompletionStreamResponse> transcribeTemporaryMp3ChatAudio({
             'Authorization': 'Bearer $normalizedApiKey',
           })
           ..body = jsonEncode(body);
-    final response = await httpClient
-        .send(request)
-        .then(http.Response.fromStream)
-        .timeout(
-          requestTimeout,
-          onTimeout: () {
-            abortTrigger.complete();
-            throw TimeoutException(
-              '${provider.displayName} chat-audio HTTP request timed out',
-            );
-          },
-        );
+    late final http.Response response;
+    try {
+      response = await httpClient
+          .send(request)
+          .then(http.Response.fromStream)
+          .timeout(
+            requestTimeout,
+            onTimeout: () {
+              if (!abortTrigger.isCompleted) abortTrigger.complete();
+              throw TimeoutException(
+                '${provider.displayName} chat-audio HTTP request timed out',
+              );
+            },
+          );
+    } finally {
+      if (!abortTrigger.isCompleted) abortTrigger.complete();
+    }
 
     if (response.statusCode < 200 || response.statusCode >= 300) {
       throw TranscriptionException(
@@ -214,7 +274,7 @@ Stream<CreateChatCompletionStreamResponse> transcribeTemporaryMp3ChatAudio({
     final responseId = decoded['id'];
     final responseCreated = decoded['created'];
     final responseModel = decoded['model'];
-    yield CreateChatCompletionStreamResponse(
+    return CreateChatCompletionStreamResponse(
       id: responseId is String ? responseId : requestId,
       choices: [
         ChatCompletionStreamResponseChoice(

--- a/test/features/ai/repository/temporary_mp3_chat_audio_transcriber_test.dart
+++ b/test/features/ai/repository/temporary_mp3_chat_audio_transcriber_test.dart
@@ -375,6 +375,55 @@ void main() {
     });
   });
 
+  test('stream cancellation aborts the request and removes the MP3', () async {
+    final requestStarted = Completer<http.AbortableRequest>();
+    final responseCompleter = Completer<http.StreamedResponse>();
+    final cleanupCompleted = Completer<void>();
+    final client = MockClient.streaming((request, _) {
+      final abortableRequest = request as http.AbortableRequest;
+      requestStarted.complete(abortableRequest);
+      abortableRequest.abortTrigger!.then((_) {
+        if (!responseCompleter.isCompleted) {
+          responseCompleter.completeError(
+            http.RequestAbortedException(request.url),
+          );
+        }
+      });
+      return responseCompleter.future;
+    });
+    addTearDown(client.close);
+    late File encodedFile;
+    Object? failure;
+
+    final subscription = transcribeTemporaryMp3ChatAudio(
+      httpClient: client,
+      provider: mistralProvider,
+      model: model,
+      audioBase64: base64Encode(sourceBytes),
+      baseUrl: baseUrl,
+      apiKey: apiKey,
+      prompt: prompt,
+      audioToTemporaryMp3Encoder: (_) async {
+        return encodedFile = temporaryMp3();
+      },
+      temporaryFileReader: (_) async => Uint8List.fromList([1, 2, 3]),
+      temporaryFileDeleter: (file) {
+        file.deleteSync();
+        cleanupCompleted.complete();
+      },
+    ).listen((_) {}, onError: (Object error) => failure = error);
+
+    final request = await requestStarted.future;
+    expect(request.abortTrigger, isNotNull);
+
+    await subscription.cancel();
+    await request.abortTrigger;
+    await cleanupCompleted.future;
+
+    expect(failure, isNull);
+    expect(encodedFile.existsSync(), isFalse);
+  });
+
   test('rejects malformed input audio before MP3 encoding', () async {
     var encoderCalled = false;
     final client = MockClient((_) async => http.Response('', 200));

--- a/test/features/ai/repository/temporary_mp3_chat_audio_transcriber_test.dart
+++ b/test/features/ai/repository/temporary_mp3_chat_audio_transcriber_test.dart
@@ -1,7 +1,9 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
@@ -308,6 +310,69 @@ void main() {
 
     expect(chunks.single.choices?.single.delta?.content, 'the transcript');
     expect(encodedFile.existsSync(), isTrue);
+  });
+
+  test('request timeout signals HTTP abortion and removes the MP3', () {
+    fakeAsync((async) {
+      http.AbortableRequest? capturedRequest;
+      final client = MockClient.streaming((request, _) {
+        capturedRequest = request as http.AbortableRequest;
+        return Completer<http.StreamedResponse>().future;
+      });
+      late File encodedFile;
+      Object? failure;
+      var completed = false;
+      var aborted = false;
+
+      transcribeTemporaryMp3ChatAudio(
+        httpClient: client,
+        provider: mistralProvider,
+        model: model,
+        audioBase64: base64Encode(sourceBytes),
+        baseUrl: baseUrl,
+        apiKey: apiKey,
+        prompt: prompt,
+        timeout: const Duration(seconds: 1),
+        audioToTemporaryMp3Encoder: (_) async {
+          return encodedFile = temporaryMp3();
+        },
+        temporaryFileReader: (_) async => Uint8List.fromList([1, 2, 3]),
+      ).toList().then<void>(
+        (_) {
+          completed = true;
+        },
+        onError: (Object error, StackTrace _) {
+          failure = error;
+          completed = true;
+        },
+      );
+
+      async.flushMicrotasks();
+      capturedRequest!.abortTrigger!.then((_) => aborted = true);
+      async.flushMicrotasks();
+      expect(aborted, isFalse);
+      expect(completed, isFalse);
+
+      async
+        ..elapse(const Duration(seconds: 1))
+        ..flushMicrotasks();
+
+      expect(aborted, isTrue);
+      expect(completed, isTrue);
+      expect(
+        failure,
+        isA<TranscriptionException>().having(
+          (error) => error.message,
+          'message',
+          allOf(
+            contains('timed out'),
+            contains('waiting for the Voxtral response'),
+          ),
+        ),
+      );
+      expect(encodedFile.existsSync(), isFalse);
+      client.close();
+    });
   });
 
   test('rejects malformed input audio before MP3 encoding', () async {


### PR DESCRIPTION
## Summary

Follow-up to #3463, which auto-merged before the final CodeRabbit review arrived.

- remove the stale Voxtral timeout comment above the unrelated chat-completion timeout
- send Voxtral chat audio through an `http.AbortableRequest`, so the 15-minute timeout aborts the in-flight upload/response without closing the shared HTTP client
- add a fake-time test covering request abortion, the staged timeout error, and temporary MP3 cleanup

## Validation

- `fvm flutter analyze`
- `fvm flutter test --coverage test/features/ai/repository/temporary_mp3_chat_audio_transcriber_test.dart`
- local patch coverage: **100% (13/13 changed coverable lines)**
- Melious and Mistral repository suites passed against the same implementation before splitting this clean follow-up commit