### PR TITLE
feat: run agent wake cycles concurrently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.1047]
 ### Changed
+- **AI agents respond sooner when several are active.** Up to three different
+  agent wake cycles now run at once by default instead of waiting in one global
+  line, while each individual agent remains single-flight. AI Settings lets
+  you tune the device-local limit from one through eight for local hardware or
+  provider capacity.
 - **Task and project filters now share one coherent, accessible flow.** Status,
   category, label, and project choices stay inside the same smoothly resizing
   sheet or desktop dialog, with consistent full-width selection states,

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -34,6 +34,7 @@
   <releases>
     <release version="0.9.1047" date="2026-07-15">
       <description>
+          <p>AI agents now respond sooner when several are active. Up to three different agent wake cycles run concurrently by default instead of waiting in one global line, while each individual agent remains single-flight. The device-local limit can be tuned from one through eight in AI Settings.</p>
           <p>Task and project filters now share one coherent, accessible flow. Status, category, label, and project choices stay inside the same smoothly resizing sheet or desktop dialog, with consistent full-width selection states, responsive actions, keyboard focus restoration, and clearer activity and sort controls. Task filters open immediately while project data refreshes in place, and active filters remain visible as compact chips on the task page.</p>
       </description>
     </release>

--- a/lib/features/agents/README.md
+++ b/lib/features/agents/README.md
@@ -862,7 +862,9 @@ stateDiagram-v2
   in the manual run-key hash (`RunKeyFactory.forManual`), so two day-scoped
   manual wakes enqueued in the same tick get distinct run keys instead of the
   second being deduped away.
-- enforces single-flight execution per agent through `WakeRunner`
+- dispatches up to the device-local AI concurrency limit (three by default)
+- enforces single-flight execution per agent through `WakeRunner`, so two
+  wakes for the same agent never overlap even when global capacity is free
 - persists wake-run entries before execution
 - suppresses self-notifications using vector clocks
 - persists and restores deferred subscription wake deadlines through
@@ -900,14 +902,34 @@ flowchart TD
   Suppress -->|no| Merge{"Queued job for same agent + workspace?"}
   Merge -->|yes| Coalesce["Merge trigger tokens"]
   Merge -->|no| Queue["WakeQueue.enqueue(runKey)"]
-  Queue --> Drain["WakeOrchestrator.processNext()"]
-  Drain --> Busy{"WakeRunner lock available?"}
-  Busy -->|no| Requeue["Requeue job"]
-  Busy -->|yes| Content{"awaitingContent gate?"}
+  Queue --> Drain["Single bounded queue scheduler"]
+  Drain --> Capacity{"Active wakes below AI setting?"}
+  Capacity -->|no| WaitSlot["Wait for a wake to finish or new drain signal"]
+  WaitSlot --> Capacity
+  Capacity -->|yes| Busy{"Agent already running?"}
+  Busy -->|yes| KeepQueued["Keep same-agent follow-up visible in FIFO queue"]
+  KeepQueued --> Capacity
+  Busy -->|no| Content{"awaitingContent gate?"}
   Content -->|skip| Wait["Leave agent dormant until content exists"]
   Content -->|run| Persist["Persist wake_run_log row"]
-  Persist --> Exec["Dispatch workflow by agent kind"]
+  Persist --> Exec["Dispatch workflow by agent kind in a capacity slot"]
+  Exec --> Capacity
 ```
+
+The concurrency setting is device-local, lives in AI Settings, accepts values
+from 1 through 8, and defaults to 3 when no stored value exists. The scheduler
+reads it whenever capacity is available, so tuning it affects subsequent
+dispatches without an app restart. Setting it to 1 retains the former global
+sequential behavior.
+
+Only the scheduler mutates `WakeQueue`, suppression state, throttle state, and
+run-key history. Concurrent work begins after a job has acquired its
+`WakeRunner` agent lock. Workflows and conversation managers are created per
+wake/conversation; agent sync transaction buffers are zone-local; and Drift
+serializes database work on its connection. The bounded upper limit also keeps
+provider/API and database pressure finite. Downstream provider rate-limit or
+connection failures continue through the existing per-wake failure path and do
+not cancel other active wakes.
 
 ### Why the wake design is this defensive
 
@@ -921,7 +943,8 @@ modes:
 Current mitigations are:
 
 - `WakeQueue` deduplicates by run key and merges trigger tokens
-- `WakeRunner` enforces single-flight execution per agent
+- the bounded scheduler caps total active wakes while `WakeRunner` enforces
+  single-flight execution per agent
 - `WakeOrchestrator` persists deferred wake deadlines through `nextWakeAt` and
   reconstructs the in-memory wake job during startup restoration
 - suppression is pre-registered before execution starts, then replaced with the

--- a/lib/features/agents/state/agent_providers.dart
+++ b/lib/features/agents/state/agent_providers.dart
@@ -25,6 +25,7 @@ import 'package:lotti/features/agents/wake/wake_orchestrator.dart';
 import 'package:lotti/features/agents/wake/wake_queue.dart';
 import 'package:lotti/features/agents/wake/wake_runner.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart';
+import 'package:lotti/features/ai/state/ai_runtime_settings_controller.dart';
 import 'package:lotti/features/ai/util/profile_seeding_service.dart';
 import 'package:lotti/features/daily_os_next/agents/state/day_agent_providers.dart';
 import 'package:lotti/features/projects/repository/project_repository.dart';
@@ -244,6 +245,8 @@ WakeOrchestrator wakeOrchestrator(Ref ref) {
     queue: ref.watch(wakeQueueProvider),
     runner: ref.watch(wakeRunnerProvider),
     domainLogger: ref.watch(domainLoggerProvider),
+    maxConcurrentWakes: () =>
+        ref.read(aiRuntimeSettingsControllerProvider).agentWakeConcurrency,
     onPersistedStateChanged: onPersistedStateChanged,
     syncEntityWriter: (entity) =>
         ref.read(agentSyncServiceProvider).upsertEntity(entity),

--- a/lib/features/agents/wake/wake_drain_engine.dart
+++ b/lib/features/agents/wake/wake_drain_engine.dart
@@ -225,12 +225,6 @@ extension WakeDrainEngine on WakeOrchestrator {
           Future.any(activeExecutions.values),
           wakeSignal.future.then((_) => wakeSentinel),
         ]);
-        if (identical(_drainWakeSignal, wakeSignal)) {
-          _drainWakeSignal = null;
-        }
-        if (identical(ownedWakeSignal, wakeSignal)) {
-          ownedWakeSignal = null;
-        }
         if (identical(completedRunKey, wakeSentinel)) {
           _drainRequested = false;
           continue;

--- a/lib/features/agents/wake/wake_drain_engine.dart
+++ b/lib/features/agents/wake/wake_drain_engine.dart
@@ -86,6 +86,7 @@ extension WakeDrainEngine on WakeOrchestrator {
   Future<void> _drain(int generation) async {
     final deferred = <WakeJob>[];
     final activeExecutions = <String, Future<String>>{};
+    Completer<void>? ownedWakeSignal;
 
     try {
       while (true) {
@@ -217,6 +218,7 @@ extension WakeDrainEngine on WakeOrchestrator {
         }
 
         final wakeSignal = Completer<void>();
+        ownedWakeSignal = wakeSignal;
         _drainWakeSignal = wakeSignal;
         final wakeSentinel = Object();
         final completedRunKey = await Future.any<Object>([
@@ -225,6 +227,9 @@ extension WakeDrainEngine on WakeOrchestrator {
         ]);
         if (identical(_drainWakeSignal, wakeSignal)) {
           _drainWakeSignal = null;
+        }
+        if (identical(ownedWakeSignal, wakeSignal)) {
+          ownedWakeSignal = null;
         }
         if (identical(completedRunKey, wakeSentinel)) {
           _drainRequested = false;
@@ -236,7 +241,10 @@ extension WakeDrainEngine on WakeOrchestrator {
         if (completedExecution != null) await completedExecution;
       }
     } finally {
-      _drainWakeSignal = null;
+      final wakeSignal = ownedWakeSignal;
+      if (wakeSignal != null && identical(_drainWakeSignal, wakeSignal)) {
+        _drainWakeSignal = null;
+      }
 
       // Re-enqueue deferred jobs without dedup checks.
       deferred.forEach(queue.requeue);

--- a/lib/features/agents/wake/wake_drain_engine.dart
+++ b/lib/features/agents/wake/wake_drain_engine.dart
@@ -184,9 +184,23 @@ extension WakeDrainEngine on WakeOrchestrator {
             continue;
           }
 
-          activeExecutions[job.runKey] = _executeJob(
-            job,
-          ).then((_) => job.runKey);
+          activeExecutions[job.runKey] = _executeJob(job).then(
+            (_) => job.runKey,
+            onError: (Object error, StackTrace stackTrace) {
+              // `_executeJob` owns its normal error boundary and lock release,
+              // but keep the scheduler resilient if an unexpected failure
+              // escapes that boundary (for example, a logging implementation
+              // throwing before `_executeJob` enters its outer try/finally).
+              runner.release(job.agentId);
+              _logError(
+                'unexpected wake execution failure for '
+                '${DomainLogger.sanitizeId(job.runKey)}',
+                error: error,
+                stackTrace: stackTrace,
+              );
+              return job.runKey;
+            },
+          );
         }
 
         // Requeue skipped busy/throttled jobs before waiting. Active wakes use

--- a/lib/features/agents/wake/wake_drain_engine.dart
+++ b/lib/features/agents/wake/wake_drain_engine.dart
@@ -35,10 +35,18 @@ extension WakeDrainEngine on WakeOrchestrator {
         );
         // Increment generation so the old drain's loop bails out.
         _drainGeneration++;
+        final wakeSignal = _drainWakeSignal;
+        if (wakeSignal != null && !wakeSignal.isCompleted) {
+          wakeSignal.complete();
+        }
         _isDraining = false;
         _drainStartedAt = null;
       } else {
         _drainRequested = true;
+        final wakeSignal = _drainWakeSignal;
+        if (wakeSignal != null && !wakeSignal.isCompleted) {
+          wakeSignal.complete();
+        }
         return;
       }
     }
@@ -70,85 +78,161 @@ extension WakeDrainEngine on WakeOrchestrator {
     }
   }
 
-  /// Single pass: dequeue and execute all ready jobs.
+  /// Bounded dispatch pass: execute ready jobs up to the configured limit.
   ///
   /// [generation] is the drain generation at the time this pass was started.
   /// If a newer generation supersedes us (via stale-lock recovery), the loop
   /// bails out early to avoid overlapping mutations.
   Future<void> _drain(int generation) async {
     final deferred = <WakeJob>[];
+    final activeExecutions = <String, Future<String>>{};
 
     try {
       while (true) {
         // Bail out if a newer drain superseded us.
         if (_drainGeneration != generation) return;
 
-        final job = queue.dequeue();
-        if (job == null) break;
+        final concurrency = AiRuntimeSettings.normalizeAgentWakeConcurrency(
+          maxConcurrentWakes(),
+        );
+        final jobsToInspect = queue.length;
+        var inspectedJobs = 0;
 
-        if (!await _wakeAllowedByCurrentPolicy(job)) {
-          _log(
-            'drain policy dropped automatic/disabled wake for '
-            '${DomainLogger.sanitizeId(job.agentId)}',
-            subDomain: 'drain',
+        while (inspectedJobs < jobsToInspect &&
+            runner.activeAgentIds.length < concurrency) {
+          if (_drainGeneration != generation) return;
+
+          final job = queue.dequeueFirstWhere(
+            (candidate) {
+              if (runner.isRunning(candidate.agentId)) return false;
+              if (candidate.reason != WakeReason.subscription.name) {
+                return true;
+              }
+              final suppressed = _isSuppressed(
+                candidate.agentId,
+                candidate.triggerTokens,
+              );
+              final preRegistered = _isPreRegisteredSuppressed(
+                candidate.agentId,
+                candidate.triggerTokens,
+              );
+              return suppressed ||
+                  preRegistered ||
+                  !_isThrottled(candidate.agentId);
+            },
           );
-          continue;
-        }
+          if (job == null) break;
+          inspectedJobs++;
 
-        final acquired = await runner.tryAcquire(job.agentId);
-        if (!acquired) {
-          // Agent is already running; defer for re-enqueue after loop.
-          deferred.add(job);
-          continue;
-        }
-
-        // Re-check suppression and throttle for subscription jobs that were
-        // enqueued during an agent's execution — before the throttle deadline
-        // or recordMutatedEntities was set.
-        if (job.reason == WakeReason.subscription.name) {
-          // Self-notification: drop the job entirely.
-          final suppressed = _isSuppressed(job.agentId, job.triggerTokens);
-          final preRegSuppressed = _isPreRegisteredSuppressed(
-            job.agentId,
-            job.triggerTokens,
-          );
-          if (suppressed || preRegSuppressed) {
+          if (!await _wakeAllowedByCurrentPolicy(job)) {
             _log(
-              'drain re-check: dropped '
-              '(suppressed=$suppressed, preReg=$preRegSuppressed) '
-              'for ${DomainLogger.sanitizeId(job.agentId)}',
+              'drain policy dropped automatic/disabled wake for '
+              '${DomainLogger.sanitizeId(job.agentId)}',
               subDomain: 'drain',
             );
-            runner.release(job.agentId);
             continue;
           }
 
-          // Throttled: defer the job so the deferred drain timer can pick
-          // it up after the throttle window expires.
-          if (_isThrottled(job.agentId)) {
-            _log(
-              'drain re-check: throttled=true '
-              'for ${DomainLogger.sanitizeId(job.agentId)}',
-              subDomain: 'drain',
-            );
-            runner.release(job.agentId);
+          final acquired = await runner.tryAcquire(job.agentId);
+          if (!acquired) {
+            // Keep same-agent work queued while its active wake executes. The
+            // active wake uses queue visibility to decide whether to arm its
+            // existing follow-up throttle deadline.
             deferred.add(job);
             continue;
           }
+
+          // Re-check suppression and throttle for subscription jobs that were
+          // enqueued during an agent's execution — before the throttle
+          // deadline or recordMutatedEntities was set.
+          if (job.reason == WakeReason.subscription.name) {
+            // Self-notification: drop the job entirely.
+            final suppressed = _isSuppressed(job.agentId, job.triggerTokens);
+            final preRegSuppressed = _isPreRegisteredSuppressed(
+              job.agentId,
+              job.triggerTokens,
+            );
+            if (suppressed || preRegSuppressed) {
+              _log(
+                'drain re-check: dropped '
+                '(suppressed=$suppressed, preReg=$preRegSuppressed) '
+                'for ${DomainLogger.sanitizeId(job.agentId)}',
+                subDomain: 'drain',
+              );
+              runner.release(job.agentId);
+              continue;
+            }
+
+            // Throttled: defer the job so the deferred drain timer can pick
+            // it up after the throttle window expires.
+            if (_isThrottled(job.agentId)) {
+              _log(
+                'drain re-check: throttled=true '
+                'for ${DomainLogger.sanitizeId(job.agentId)}',
+                subDomain: 'drain',
+              );
+              runner.release(job.agentId);
+              deferred.add(job);
+              continue;
+            }
+          }
+
+          // Content-gating: agents auto-assigned from category defaults wait
+          // for the task to have meaningful content before their first run.
+          if (await _shouldSkipForAwaitingContent(job)) {
+            runner.release(job.agentId);
+            continue;
+          }
+
+          activeExecutions[job.runKey] = _executeJob(
+            job,
+          ).then((_) => job.runKey);
         }
 
-        // Content-gating: agents auto-assigned from category defaults wait
-        // for the task to have meaningful content before their first run.
-        if (await _shouldSkipForAwaitingContent(job)) {
-          runner.release(job.agentId);
+        // Requeue skipped busy/throttled jobs before waiting. Active wakes use
+        // these queued follow-ups to preserve existing throttle semantics.
+        deferred
+          ..forEach(queue.requeue)
+          ..clear();
+
+        if (activeExecutions.isEmpty) break;
+
+        if (_drainRequested) {
+          _drainRequested = false;
           continue;
         }
 
-        await _executeJob(job);
+        final wakeSignal = Completer<void>();
+        _drainWakeSignal = wakeSignal;
+        final wakeSentinel = Object();
+        final completedRunKey = await Future.any<Object>([
+          Future.any(activeExecutions.values),
+          wakeSignal.future.then((_) => wakeSentinel),
+        ]);
+        if (identical(_drainWakeSignal, wakeSignal)) {
+          _drainWakeSignal = null;
+        }
+        if (identical(completedRunKey, wakeSentinel)) {
+          _drainRequested = false;
+          continue;
+        }
+        final completedExecution = activeExecutions.remove(
+          completedRunKey as String,
+        );
+        if (completedExecution != null) await completedExecution;
       }
     } finally {
-      // Re-enqueue deferred jobs (busy agents) without dedup checks.
+      _drainWakeSignal = null;
+
+      // Re-enqueue deferred jobs without dedup checks.
       deferred.forEach(queue.requeue);
+
+      // A stale generation can supersede this scheduler while several wakes
+      // are still active. Keep awaiting those futures so this drain never
+      // leaks errors or loses their lock-release finalizers.
+      if (activeExecutions.isNotEmpty) {
+        await Future.wait(activeExecutions.values);
+      }
 
       // Clear run-key history only when the queue is fully drained (no
       // deferred jobs left). This prevents stale keys from blocking future

--- a/lib/features/agents/wake/wake_orchestrator.dart
+++ b/lib/features/agents/wake/wake_orchestrator.dart
@@ -14,6 +14,7 @@ import 'package:lotti/features/agents/wake/wake_queue.dart';
 import 'package:lotti/features/agents/wake/wake_runner.dart';
 import 'package:lotti/features/agents/wake/wake_suppression_tracker.dart';
 import 'package:lotti/features/agents/wake/wake_throttle_coordinator.dart';
+import 'package:lotti/features/ai/model/ai_runtime_settings.dart';
 import 'package:lotti/features/sync/vector_clock.dart';
 import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/domain_logging.dart';
@@ -91,6 +92,11 @@ typedef WakeExecutor =
       String threadId,
     );
 
+/// Returns the current global limit for simultaneously executing wake cycles.
+typedef MaxConcurrentWakes = int Function();
+
+int _defaultMaxConcurrentWakes() => defaultAgentWakeConcurrency;
+
 /// Notification-driven wake orchestrator.
 ///
 /// Responsibilities:
@@ -116,6 +122,7 @@ class WakeOrchestrator {
     this.eventContentChecker,
     this.syncEntityWriter,
     this.onWakeStart,
+    this.maxConcurrentWakes = _defaultMaxConcurrentWakes,
   }) {
     _throttle = WakeThrottleCoordinator(
       repository: repository,
@@ -129,6 +136,11 @@ class WakeOrchestrator {
   final AgentRepository repository;
   final WakeQueue queue;
   final WakeRunner runner;
+
+  /// Reads the current global concurrency limit whenever the dispatcher has
+  /// capacity. This makes a persisted settings change effective without
+  /// rebuilding the orchestrator or restarting the app.
+  final MaxConcurrentWakes maxConcurrentWakes;
 
   /// Optional domain logger for structured, PII-safe logging.
   final DomainLogger? domainLogger;
@@ -218,16 +230,20 @@ class WakeOrchestrator {
   /// lifecycle.
   final _wakeCounters = <String, int>{};
 
-  /// Single-flight guard for [processNext].
+  /// Single-scheduler guard for [processNext].
   ///
-  /// Prevents overlapping drain loops that could clear queue history while
-  /// another drain still holds deferred jobs in its local list.  When a drain
-  /// is already in progress, new [_onBatch] / [enqueueManualWake] callers
-  /// set [_drainRequested] so the active drain re-checks after finishing.
+  /// The scheduler itself may dispatch several wake cycles concurrently, but
+  /// only one scheduler may mutate [queue] and clear its run-key history. New
+  /// drain requests wake that scheduler so it can fill any free slot.
   bool _isDraining = false;
 
   /// Set when a drain is requested while one is already in progress.
   bool _drainRequested = false;
+
+  /// Completes when new work arrives while the scheduler is waiting for an
+  /// active wake to finish. This lets newly queued work use idle capacity
+  /// immediately instead of waiting behind an unrelated long inference.
+  Completer<void>? _drainWakeSignal;
 
   /// Timestamp when the current drain started, for stale-drain detection.
   DateTime? _drainStartedAt;

--- a/lib/features/agents/wake/wake_queue.dart
+++ b/lib/features/agents/wake/wake_queue.dart
@@ -99,6 +99,17 @@ class WakeQueue {
     return _queue.removeAt(0);
   }
 
+  /// Remove and return the first queued job accepted by [predicate].
+  ///
+  /// Jobs skipped by [predicate] keep their relative FIFO order. The bounded
+  /// wake dispatcher uses this to leave same-agent follow-ups visible in the
+  /// queue while that agent is active, preserving post-run throttle decisions.
+  WakeJob? dequeueFirstWhere(bool Function(WakeJob job) predicate) {
+    final index = _queue.indexWhere(predicate);
+    if (index < 0) return null;
+    return _queue.removeAt(index);
+  }
+
   /// Merge [tokens] into the `triggerTokens` of the first queued job that
   /// matches [agentId] **and** [workspaceKey].
   ///

--- a/lib/features/ai/README.md
+++ b/lib/features/ai/README.md
@@ -29,7 +29,11 @@ flowchart TD
 
 ## Configuration Model
 
-`AiConfigRepository` persists all AI configuration objects in `AiConfigDb` and syncs changes through the outbox layer. The runtime is built from five config variants plus one resolved runtime object:
+`AiConfigRepository` persists provider-facing AI configuration objects in
+`AiConfigDb` and syncs changes through the outbox layer. Device-local runtime
+controls use `AiRuntimeSettingsController` and `SettingsDb` instead. The
+runtime is built from five config variants, one resolved runtime object, and
+the local dispatch settings:
 
 | Object | Stored as | Used by |
 | --- | --- | --- |
@@ -39,6 +43,7 @@ flowchart TD
 | Profile | `AiConfig.inferenceProfile` | Capability slots for thinking, transcription, vision, and image generation |
 | Skill | `AiConfig.skill` (defined in code) | Capability contract plus `ContextPolicy`. Built-ins live in `skills/built_in_skills.dart`; not persisted in the DB |
 | Resolved profile | `ResolvedProfile` | Runtime profile with providers hydrated from configured model IDs |
+| Runtime settings | `SettingsDb` (device-local) | Bounded agent-wake concurrency; defaults to 3 and supports 1 through 8 |
 
 The key split is between skills and profiles:
 
@@ -46,6 +51,22 @@ The key split is between skills and profiles:
 - a profile defines which configured model/provider slot executes that skill
 
 That split is what lets the app move the same skill between providers without rewriting the prompt contract.
+
+The agent-wake concurrency setting is intentionally local because device and
+provider capacity differ. `WakeOrchestrator` reads the controller through a
+callback at dispatch time, so changing AI Settings affects new wake cycles
+without rebuilding the provider graph. A missing or malformed stored value
+uses the default of 3, while out-of-range values are clamped to the supported
+range.
+
+```mermaid
+flowchart LR
+  UI["AI Settings concurrency dropdown"] --> Controller["AiRuntimeSettingsController"]
+  Controller --> SettingsDb["SettingsDb<br/>device-local value"]
+  Controller --> Orchestrator["WakeOrchestrator capacity callback"]
+  Orchestrator --> Pool["1-8 concurrent agent wakes<br/>default 3"]
+  Pool --> Runner["WakeRunner<br/>single-flight per agent"]
+```
 
 ## Configuration Selection UI
 

--- a/lib/features/ai/model/ai_runtime_settings.dart
+++ b/lib/features/ai/model/ai_runtime_settings.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/foundation.dart';
+
+/// Local settings key for the maximum number of agent wakes dispatched at
+/// once.
+const agentWakeConcurrencySettingsKey = 'AI_AGENT_WAKE_CONCURRENCY';
+
+/// Default number of agent wake cycles that may execute concurrently.
+const defaultAgentWakeConcurrency = 3;
+
+/// Smallest supported agent wake concurrency.
+const minAgentWakeConcurrency = 1;
+
+/// Largest supported agent wake concurrency.
+///
+/// The upper bound keeps a malformed or manually edited setting from flooding
+/// inference providers and the database with an unbounded number of requests.
+const maxAgentWakeConcurrency = 8;
+
+/// Device-local AI runtime settings that affect inference dispatch rather than
+/// a particular provider, model, or profile.
+@immutable
+class AiRuntimeSettings {
+  const AiRuntimeSettings({
+    this.agentWakeConcurrency = defaultAgentWakeConcurrency,
+  });
+
+  /// Restores settings from the value persisted in `SettingsDb`.
+  factory AiRuntimeSettings.fromStoredAgentWakeConcurrency(String? raw) {
+    final parsed = int.tryParse(raw ?? '');
+    return AiRuntimeSettings(
+      agentWakeConcurrency: parsed == null
+          ? defaultAgentWakeConcurrency
+          : normalizeAgentWakeConcurrency(parsed),
+    );
+  }
+
+  /// Maximum number of different agents whose wake cycles may run at once.
+  ///
+  /// `WakeRunner` separately keeps each individual agent single-flight.
+  final int agentWakeConcurrency;
+
+  /// Clamps [value] to the supported concurrency range.
+  static int normalizeAgentWakeConcurrency(int value) => value.clamp(
+    minAgentWakeConcurrency,
+    maxAgentWakeConcurrency,
+  );
+
+  AiRuntimeSettings copyWith({int? agentWakeConcurrency}) {
+    return AiRuntimeSettings(
+      agentWakeConcurrency: agentWakeConcurrency == null
+          ? this.agentWakeConcurrency
+          : normalizeAgentWakeConcurrency(agentWakeConcurrency),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is AiRuntimeSettings &&
+      other.agentWakeConcurrency == agentWakeConcurrency;
+
+  @override
+  int get hashCode => agentWakeConcurrency.hashCode;
+}

--- a/lib/features/ai/state/ai_runtime_settings_controller.dart
+++ b/lib/features/ai/state/ai_runtime_settings_controller.dart
@@ -1,0 +1,49 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lotti/database/settings_db.dart';
+import 'package:lotti/features/ai/model/ai_runtime_settings.dart';
+import 'package:lotti/get_it.dart';
+
+/// Holds device-local AI runtime settings and persists user changes.
+final aiRuntimeSettingsControllerProvider =
+    NotifierProvider<AiRuntimeSettingsController, AiRuntimeSettings>(
+      AiRuntimeSettingsController.new,
+      name: 'aiRuntimeSettingsControllerProvider',
+    );
+
+/// Loads, exposes, and persists the device-local AI runtime settings.
+class AiRuntimeSettingsController extends Notifier<AiRuntimeSettings> {
+  bool _userChanged = false;
+
+  @override
+  AiRuntimeSettings build() {
+    unawaited(_load());
+    return const AiRuntimeSettings();
+  }
+
+  Future<void> _load() async {
+    try {
+      final raw = await getIt<SettingsDb>().itemByKey(
+        agentWakeConcurrencySettingsKey,
+      );
+      if (!ref.mounted || _userChanged) return;
+      state = AiRuntimeSettings.fromStoredAgentWakeConcurrency(raw);
+    } on Object {
+      // Keep defaults when settings storage is unavailable. Agent wakes must
+      // remain functional even when a local preference read fails.
+    }
+  }
+
+  /// Updates and persists the maximum number of concurrent agent wakes.
+  void setAgentWakeConcurrency(int value) {
+    _userChanged = true;
+    state = state.copyWith(agentWakeConcurrency: value);
+    unawaited(
+      getIt<SettingsDb>().saveSettingsItem(
+        agentWakeConcurrencySettingsKey,
+        state.agentWakeConcurrency.toString(),
+      ),
+    );
+  }
+}

--- a/lib/features/ai/ui/settings/README.md
+++ b/lib/features/ai/ui/settings/README.md
@@ -79,7 +79,7 @@ lib/features/ai/ui/settings/
 │   │   ├── ai_provider_setup_preview_models.dart
 │   │   └── ai_provider_setup_result_modal.dart # Step 3: result
 │   └── v2/                                 # Live card chrome
-│       ├── ai_settings_header_bar.dart     # Search row
+│       ├── ai_settings_header_bar.dart     # Search + agent concurrency
 │       ├── ai_settings_tab_bar.dart        # Providers/Models/Profiles tabs
 │       ├── ai_settings_cards.dart          # Card barrel: AiProviderIconTile + re-exports
 │       ├── ai_provider_card.dart           # Providers-tab card (standalone)
@@ -95,7 +95,7 @@ lib/features/ai/ui/settings/
 ### Sliver-Based Layout
 
 The AI Settings page renders as a single `CustomScrollView`. None of the
-slivers are pinned/sticky — the title strip, search row, and tab bar all
+slivers are pinned/sticky — the title strip, header controls, and tab bar all
 scroll with the content.
 
 **Key Benefits:**
@@ -107,7 +107,7 @@ scroll with the content.
 CustomScrollView(
   slivers: [
     SettingsPageHeader(...),            // Shared settings title strip
-    SliverToBoxAdapter(                 // Search row (not pinned)
+    SliverToBoxAdapter(                 // Search + concurrency (not pinned)
       child: AiSettingsHeaderBar(...),
     ),
     // _buildBodySlivers():
@@ -290,13 +290,32 @@ Deletion is wired through the per-card `⋯` overflow menu's `Delete` action
 
 #### `AiSettingsHeaderBar` + `AiSettingsTabBar` (v2)
 
-Search and tab navigation are two separate, non-pinned slivers:
+Search/runtime controls and tab navigation are two separate, non-pinned
+slivers:
 
 - `AiSettingsHeaderBar` (`widgets/v2/ai_settings_header_bar.dart`) — the
-  search row only. The "Add" affordance moved to the per-tab
-  `AiSettingsFloatingActionButton`.
+  search row plus a design-system dropdown for the device-local maximum number
+  of concurrent agent wake cycles. It offers 1 through 8, defaults to 3 when
+  no setting exists, persists through `AiRuntimeSettingsController`, and takes
+  effect for newly dispatched wakes without a restart. The "Add" affordance
+  lives in the per-tab `AiSettingsFloatingActionButton`.
 - `AiSettingsTabBar` (`widgets/v2/ai_settings_tab_bar.dart`) — the
   Providers / Models / Profiles tab strip, with per-tab counts.
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant Header as AiSettingsHeaderBar
+  participant State as AiRuntimeSettingsController
+  participant DB as SettingsDb
+  participant Wake as WakeOrchestrator
+
+  User->>Header: choose concurrency 1-8
+  Header->>State: setAgentWakeConcurrency(value)
+  State->>DB: persist device-local value
+  Wake->>State: read capacity before dispatch
+  State-->>Wake: current value
+```
 
 > Note: `AiSettingsConfigSliver` (`widgets/ai_settings_config_sliver.dart`,
 > with its `ConfigEmptyState` / `DismissibleConfigCard` / swipe-to-delete

--- a/lib/features/ai/ui/settings/ai_settings_page.dart
+++ b/lib/features/ai/ui/settings/ai_settings_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/state/ai_runtime_settings_controller.dart';
 import 'package:lotti/features/ai/state/inference_profile_controller.dart';
 import 'package:lotti/features/ai/state/settings/ai_config_by_type_controller.dart';
 import 'package:lotti/features/ai/ui/settings/ai_settings_filter_service.dart';
@@ -84,8 +85,8 @@ class AiSettingsBody extends StatelessWidget {
 /// `/Desktop/ai-settings-images`. Layered top-to-bottom:
 ///
 /// 1. SettingsPageHeader — "AI Settings" title strip with back nav.
-/// 2. AiSettingsHeaderBar — subtitle paragraph + search field + green
-///    "+ Add provider" CTA. Replaces the v1 floating action button.
+/// 2. AiSettingsHeaderBar — search field plus the device-local agent-wake
+///    concurrency control.
 /// 3. AiSettingsFtueBanner — visible only when zero providers exist.
 /// 4. AiSettingsTabBar — Providers / Models / Profiles with counters
 ///    baked into each label.
@@ -96,9 +97,8 @@ class AiSettingsBody extends StatelessWidget {
 ///    - Models tab: single-column list of AiModelCard.
 ///    - Profiles tab: 2-column responsive grid of AiProfileCard.
 ///
-/// State management (tab controller, search debounce, filter state,
-/// navigation service) is preserved verbatim from the v1 page; only
-/// the rendering layer is new.
+/// State management combines the tab controller, search debounce, filter
+/// state, navigation service, and persisted AI runtime settings.
 class AiSettingsPage extends ConsumerStatefulWidget {
   const AiSettingsPage({
     this.initialTab,
@@ -360,6 +360,7 @@ class _AiSettingsPageState extends ConsumerState<AiSettingsPage>
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
+    final aiRuntimeSettings = ref.watch(aiRuntimeSettingsControllerProvider);
     return Scaffold(
       backgroundColor: tokens.colors.background.level01,
       floatingActionButton: AiSettingsFloatingActionButton(
@@ -389,6 +390,10 @@ class _AiSettingsPageState extends ConsumerState<AiSettingsPage>
               child: AiSettingsHeaderBar(
                 searchController: _searchController,
                 onSearchClear: _handleSearchClear,
+                agentWakeConcurrency: aiRuntimeSettings.agentWakeConcurrency,
+                onAgentWakeConcurrencyChanged: (value) => ref
+                    .read(aiRuntimeSettingsControllerProvider.notifier)
+                    .setAgentWakeConcurrency(value),
               ),
             ),
           ),

--- a/lib/features/ai/ui/settings/widgets/v2/ai_settings_header_bar.dart
+++ b/lib/features/ai/ui/settings/widgets/v2/ai_settings_header_bar.dart
@@ -1,19 +1,17 @@
 import 'package:flutter/material.dart';
+import 'package:lotti/features/ai/model/ai_runtime_settings.dart';
 import 'package:lotti/features/ai/ui/settings/widgets/ai_settings_search_bar.dart';
+import 'package:lotti/features/design_system/components/dropdowns/design_system_dropdown.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 
-/// Page-header search row shown directly below the page's
-/// `SettingsPageHeader` title. Just a single `AiSettingsSearchBar`
-/// (the same widget the pre-v3 page used, which now wraps the design
-/// system's `DesignSystemSearch`) so the search styling and placeholder match
-/// every other search field in the app. The previous v3 prototype
-/// shipped a subtitle paragraph and a custom design-system text
-/// input here — both removed: the subtitle is duplicative of the
-/// page title + sidebar leaf, and the custom input had a different
-/// hint than what users see across the rest of the app.
+/// Page-header controls shown directly below the page's `SettingsPageHeader`.
 ///
-/// The "Add" affordance moved to a per-tab
+/// The search field uses the same design-system search widget as the rest of
+/// the app. The concurrency dropdown edits the device-local bounded agent-wake
+/// capacity and applies to newly dispatched wakes immediately.
+///
+/// The "Add" affordance lives in a per-tab
 /// `DesignSystemFloatingActionButton` on the page's
 /// `Scaffold.floatingActionButton` slot — same FAB pattern the
 /// inference profile / habit / measurable list pages already use.
@@ -21,11 +19,15 @@ class AiSettingsHeaderBar extends StatelessWidget {
   const AiSettingsHeaderBar({
     required this.searchController,
     required this.onSearchClear,
+    required this.agentWakeConcurrency,
+    required this.onAgentWakeConcurrencyChanged,
     super.key,
   });
 
   final TextEditingController searchController;
   final VoidCallback onSearchClear;
+  final int agentWakeConcurrency;
+  final ValueChanged<int> onAgentWakeConcurrencyChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -37,10 +39,43 @@ class AiSettingsHeaderBar extends StatelessWidget {
         tokens.spacing.step5,
         tokens.spacing.step4,
       ),
-      child: AiSettingsSearchBar(
-        controller: searchController,
-        hintText: context.messages.aiSettingsSearchHint,
-        onClear: onSearchClear,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          AiSettingsSearchBar(
+            controller: searchController,
+            hintText: context.messages.aiSettingsSearchHint,
+            onClear: onSearchClear,
+          ),
+          SizedBox(height: tokens.spacing.step3),
+          DesignSystemDropdown(
+            label: context.messages.aiSettingsAgentWakeConcurrencyLabel,
+            inputLabel: agentWakeConcurrency.toString(),
+            items: [
+              for (
+                var value = minAgentWakeConcurrency;
+                value <= maxAgentWakeConcurrency;
+                value++
+              )
+                DesignSystemDropdownItem(
+                  id: value.toString(),
+                  label: value.toString(),
+                  selected: value == agentWakeConcurrency,
+                ),
+            ],
+            onItemPressed: (item) {
+              final value = int.tryParse(item.id);
+              if (value != null) onAgentWakeConcurrencyChanged(value);
+            },
+          ),
+          SizedBox(height: tokens.spacing.step2),
+          Text(
+            context.messages.aiSettingsAgentWakeConcurrencyDescription,
+            style: tokens.typography.styles.body.bodySmall.copyWith(
+              color: tokens.colors.text.mediumEmphasis,
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -750,6 +750,8 @@
   "aiSettingsAddModelTooltip": "Přidat tento model ke svému poskytovateli",
   "aiSettingsAddProfileButton": "Přidat profil",
   "aiSettingsAddProviderButton": "Přidat poskytovatele",
+  "aiSettingsAgentWakeConcurrencyDescription": "Zvol, kolik různých agentů může současně spouštět inferenci. Vyšší hodnoty zrychlí odpovědi, ale více zatíží poskytovatele i zařízení.",
+  "aiSettingsAgentWakeConcurrencyLabel": "Souběžná probuzení agentů",
   "aiSettingsClearAllFiltersTooltip": "Vymazat všechny filtry",
   "aiSettingsClearFiltersButton": "Vymazat",
   "aiSettingsCounterModels": "Modely",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -910,6 +910,8 @@
   "aiSettingsAddModelTooltip": "Dieses Modell zu deinem Anbieter hinzufügen",
   "aiSettingsAddProfileButton": "Profil hinzufügen",
   "aiSettingsAddProviderButton": "Anbieter hinzufügen",
+  "aiSettingsAgentWakeConcurrencyDescription": "Wähle, wie viele verschiedene Agenten gleichzeitig Inferenz ausführen dürfen. Höhere Werte liefern schnellere Antworten, beanspruchen aber mehr Kapazität beim Anbieter und auf deinem Gerät.",
+  "aiSettingsAgentWakeConcurrencyLabel": "Parallele Agenten-Aktivierungen",
   "aiSettingsClearAllFiltersTooltip": "Alle Filter zurücksetzen",
   "aiSettingsClearFiltersButton": "Löschen",
   "aiSettingsCounterModels": "Modelle",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1195,6 +1195,8 @@
   "aiSettingsAddModelTooltip": "Add this model to your provider",
   "aiSettingsAddProfileButton": "Add Profile",
   "aiSettingsAddProviderButton": "Add provider",
+  "aiSettingsAgentWakeConcurrencyDescription": "Choose how many different agents can run inference at once. Higher values respond faster but use more provider and device capacity.",
+  "aiSettingsAgentWakeConcurrencyLabel": "Concurrent agent wakes",
   "aiSettingsClearAllFiltersTooltip": "Clear all filters",
   "aiSettingsClearFiltersButton": "Clear",
   "aiSettingsCounterModels": "Models",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -910,6 +910,8 @@
   "aiSettingsAddModelTooltip": "Añadir este modelo a tu proveedor",
   "aiSettingsAddProfileButton": "Añadir perfil",
   "aiSettingsAddProviderButton": "Añadir proveedor",
+  "aiSettingsAgentWakeConcurrencyDescription": "Elige cuántos agentes distintos pueden ejecutar inferencias a la vez. Los valores altos aceleran las respuestas, pero usan más capacidad del proveedor y del dispositivo.",
+  "aiSettingsAgentWakeConcurrencyLabel": "Activaciones simultáneas de agentes",
   "aiSettingsClearAllFiltersTooltip": "Borrar todos los filtros",
   "aiSettingsClearFiltersButton": "Limpiar",
   "aiSettingsCounterModels": "Modelos",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -910,6 +910,8 @@
   "aiSettingsAddModelTooltip": "Ajouter ce modèle à ton fournisseur",
   "aiSettingsAddProfileButton": "Ajouter un profil",
   "aiSettingsAddProviderButton": "Ajouter un fournisseur",
+  "aiSettingsAgentWakeConcurrencyDescription": "Choisis combien d’agents différents peuvent lancer une inférence en même temps. Une valeur élevée accélère les réponses, mais utilise plus de capacité chez le fournisseur et sur ton appareil.",
+  "aiSettingsAgentWakeConcurrencyLabel": "Réveils d’agents simultanés",
   "aiSettingsClearAllFiltersTooltip": "Effacer tous les filtres",
   "aiSettingsClearFiltersButton": "Effacer",
   "aiSettingsCounterModels": "Modèles",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3607,6 +3607,18 @@ abstract class AppLocalizations {
   /// **'Add provider'**
   String get aiSettingsAddProviderButton;
 
+  /// No description provided for @aiSettingsAgentWakeConcurrencyDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose how many different agents can run inference at once. Higher values respond faster but use more provider and device capacity.'**
+  String get aiSettingsAgentWakeConcurrencyDescription;
+
+  /// No description provided for @aiSettingsAgentWakeConcurrencyLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Concurrent agent wakes'**
+  String get aiSettingsAgentWakeConcurrencyLabel;
+
   /// No description provided for @aiSettingsClearAllFiltersTooltip.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -2073,6 +2073,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get aiSettingsAddProviderButton => 'Přidat poskytovatele';
 
   @override
+  String get aiSettingsAgentWakeConcurrencyDescription =>
+      'Zvol, kolik různých agentů může současně spouštět inferenci. Vyšší hodnoty zrychlí odpovědi, ale více zatíží poskytovatele i zařízení.';
+
+  @override
+  String get aiSettingsAgentWakeConcurrencyLabel => 'Souběžná probuzení agentů';
+
+  @override
   String get aiSettingsClearAllFiltersTooltip => 'Vymazat všechny filtry';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2074,6 +2074,14 @@ class AppLocalizationsDe extends AppLocalizations {
   String get aiSettingsAddProviderButton => 'Anbieter hinzufügen';
 
   @override
+  String get aiSettingsAgentWakeConcurrencyDescription =>
+      'Wähle, wie viele verschiedene Agenten gleichzeitig Inferenz ausführen dürfen. Höhere Werte liefern schnellere Antworten, beanspruchen aber mehr Kapazität beim Anbieter und auf deinem Gerät.';
+
+  @override
+  String get aiSettingsAgentWakeConcurrencyLabel =>
+      'Parallele Agenten-Aktivierungen';
+
+  @override
   String get aiSettingsClearAllFiltersTooltip => 'Alle Filter zurücksetzen';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2048,6 +2048,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get aiSettingsAddProviderButton => 'Add provider';
 
   @override
+  String get aiSettingsAgentWakeConcurrencyDescription =>
+      'Choose how many different agents can run inference at once. Higher values respond faster but use more provider and device capacity.';
+
+  @override
+  String get aiSettingsAgentWakeConcurrencyLabel => 'Concurrent agent wakes';
+
+  @override
   String get aiSettingsClearAllFiltersTooltip => 'Clear all filters';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2076,6 +2076,14 @@ class AppLocalizationsEs extends AppLocalizations {
   String get aiSettingsAddProviderButton => 'Añadir proveedor';
 
   @override
+  String get aiSettingsAgentWakeConcurrencyDescription =>
+      'Elige cuántos agentes distintos pueden ejecutar inferencias a la vez. Los valores altos aceleran las respuestas, pero usan más capacidad del proveedor y del dispositivo.';
+
+  @override
+  String get aiSettingsAgentWakeConcurrencyLabel =>
+      'Activaciones simultáneas de agentes';
+
+  @override
   String get aiSettingsClearAllFiltersTooltip => 'Borrar todos los filtros';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2086,6 +2086,14 @@ class AppLocalizationsFr extends AppLocalizations {
   String get aiSettingsAddProviderButton => 'Ajouter un fournisseur';
 
   @override
+  String get aiSettingsAgentWakeConcurrencyDescription =>
+      'Choisis combien d’agents différents peuvent lancer une inférence en même temps. Une valeur élevée accélère les réponses, mais utilise plus de capacité chez le fournisseur et sur ton appareil.';
+
+  @override
+  String get aiSettingsAgentWakeConcurrencyLabel =>
+      'Réveils d’agents simultanés';
+
+  @override
   String get aiSettingsClearAllFiltersTooltip => 'Effacer tous les filtres';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -2086,6 +2086,14 @@ class AppLocalizationsRo extends AppLocalizations {
   String get aiSettingsAddProviderButton => 'Adaugă furnizor';
 
   @override
+  String get aiSettingsAgentWakeConcurrencyDescription =>
+      'Alegeți câți agenți diferiți pot rula inferențe simultan. Valorile mai mari oferă răspunsuri mai rapide, dar folosesc mai multă capacitate a furnizorului și a dispozitivului dvs.';
+
+  @override
+  String get aiSettingsAgentWakeConcurrencyLabel =>
+      'Activări simultane ale agenților';
+
+  @override
   String get aiSettingsClearAllFiltersTooltip => 'Șterge toate filtrele';
 
   @override

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -910,6 +910,8 @@
   "aiSettingsAddModelTooltip": "Adaugă acest model la furnizorul tău",
   "aiSettingsAddProfileButton": "Adaugă profil",
   "aiSettingsAddProviderButton": "Adaugă furnizor",
+  "aiSettingsAgentWakeConcurrencyDescription": "Alegeți câți agenți diferiți pot rula inferențe simultan. Valorile mai mari oferă răspunsuri mai rapide, dar folosesc mai multă capacitate a furnizorului și a dispozitivului dvs.",
+  "aiSettingsAgentWakeConcurrencyLabel": "Activări simultane ale agenților",
   "aiSettingsClearAllFiltersTooltip": "Șterge toate filtrele",
   "aiSettingsClearFiltersButton": "Șterge",
   "aiSettingsCounterModels": "Modele",

--- a/test/features/agents/state/agent_providers_test.dart
+++ b/test/features/agents/state/agent_providers_test.dart
@@ -30,6 +30,7 @@ import 'package:lotti/features/agents/workflow/task_agent_workflow.dart';
 import 'package:lotti/features/agents/workflow/template_evolution_workflow.dart';
 import 'package:lotti/features/ai/conversation/conversation_repository.dart';
 import 'package:lotti/features/ai/database/embedding_store.dart';
+import 'package:lotti/features/ai/model/ai_runtime_settings.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart';
 import 'package:lotti/features/ai/repository/ai_input_repository.dart';
 import 'package:lotti/features/ai/repository/cloud_inference_repository.dart';
@@ -1682,6 +1683,10 @@ void main() {
       expect(orchestrator.repository, same(mockRepo));
       expect(orchestrator.queue, same(queue));
       expect(orchestrator.runner, same(runner));
+      expect(
+        orchestrator.maxConcurrentWakes(),
+        defaultAgentWakeConcurrency,
+      );
     });
 
     test(

--- a/test/features/agents/wake/wake_orchestrator_test.dart
+++ b/test/features/agents/wake/wake_orchestrator_test.dart
@@ -1827,7 +1827,7 @@ void main() {
             final expected = scenario.expectedModel();
             expect(
               entries.map((entry) => entry.runKey).toList(),
-              expected.insertRunKeys,
+              unorderedEquals(expected.insertRunKeys),
               reason: '$scenario',
             );
             for (final entry in entries) {
@@ -1846,7 +1846,7 @@ void main() {
 
             expect(
               executions.map((execution) => execution.runKey).toList(),
-              expected.executedRunKeys,
+              unorderedEquals(expected.executedRunKeys),
               reason: '$scenario',
             );
             for (final execution in executions) {
@@ -1862,9 +1862,12 @@ void main() {
             }
 
             expect(statusUpdates, hasLength(expected.statusUpdates.length));
-            for (var index = 0; index < statusUpdates.length; index += 1) {
-              final actual = statusUpdates[index];
-              final expectedUpdate = expected.statusUpdates[index];
+            final expectedStatusByRunKey = {
+              for (final update in expected.statusUpdates)
+                update.runKey: update,
+            };
+            for (final actual in statusUpdates) {
+              final expectedUpdate = expectedStatusByRunKey[actual.runKey]!;
               expect(actual.runKey, expectedUpdate.runKey, reason: '$scenario');
               expect(actual.status, expectedUpdate.status, reason: '$scenario');
               if (expectedUpdate.status == WakeRunStatus.failed.name) {
@@ -2061,6 +2064,240 @@ void main() {
             captured.map((e) => e.agentId).toSet(),
             containsAll(['agent-1', 'agent-2']),
           );
+        });
+      });
+
+      test('runs three agents concurrently by default and queues a fourth', () {
+        fakeAsync((async) {
+          final gates = <String, Completer<Map<String, VectorClock>?>>{
+            for (var index = 1; index <= 4; index++)
+              'agent-$index': Completer<Map<String, VectorClock>?>(),
+          };
+          final started = <String>[];
+          orchestrator.wakeExecutor = (agentId, runKey, triggers, threadId) {
+            started.add(agentId);
+            return gates[agentId]!.future;
+          };
+          for (var index = 1; index <= 4; index++) {
+            queue.enqueue(
+              makeJob(
+                runKey: 'rk-$index',
+                agentId: 'agent-$index',
+                reason: 'test',
+              ),
+            );
+          }
+
+          unawaited(orchestrator.processNext());
+          async.flushMicrotasks();
+
+          expect(started, ['agent-1', 'agent-2', 'agent-3']);
+          expect(runner.activeAgentIds, hasLength(3));
+          expect(queue.length, 1);
+
+          gates['agent-1']!.complete(null);
+          async.flushMicrotasks();
+
+          expect(started, ['agent-1', 'agent-2', 'agent-3', 'agent-4']);
+          expect(runner.activeAgentIds, hasLength(3));
+
+          for (final agentId in ['agent-2', 'agent-3', 'agent-4']) {
+            gates[agentId]!.complete(null);
+          }
+          async.flushMicrotasks();
+          expect(runner.activeAgentIds, isEmpty);
+        });
+      });
+
+      test('configured concurrency one preserves sequential execution', () {
+        fakeAsync((async) {
+          final firstGate = Completer<Map<String, VectorClock>?>();
+          final started = <String>[];
+          orchestrator = WakeOrchestrator(
+            repository: mockRepository,
+            queue: queue,
+            runner: runner,
+            maxConcurrentWakes: () => 1,
+            wakeExecutor: (agentId, runKey, triggers, threadId) {
+              started.add(agentId);
+              return agentId == 'agent-1' ? firstGate.future : Future.value();
+            },
+          );
+          queue
+            ..enqueue(makeJob(reason: 'test'))
+            ..enqueue(
+              makeJob(
+                runKey: 'rk-2',
+                agentId: 'agent-2',
+                reason: 'test',
+              ),
+            );
+
+          unawaited(orchestrator.processNext());
+          async.flushMicrotasks();
+
+          expect(started, ['agent-1']);
+          expect(queue.length, 1);
+
+          firstGate.complete(null);
+          async.flushMicrotasks();
+
+          expect(started, ['agent-1', 'agent-2']);
+          expect(queue.isEmpty, isTrue);
+        });
+      });
+
+      test('configured higher concurrency starts four agents together', () {
+        fakeAsync((async) {
+          final gates = <String, Completer<Map<String, VectorClock>?>>{
+            for (var index = 1; index <= 4; index++)
+              'agent-$index': Completer<Map<String, VectorClock>?>(),
+          };
+          final started = <String>[];
+          orchestrator = WakeOrchestrator(
+            repository: mockRepository,
+            queue: queue,
+            runner: runner,
+            maxConcurrentWakes: () => 4,
+            wakeExecutor: (agentId, runKey, triggers, threadId) {
+              started.add(agentId);
+              return gates[agentId]!.future;
+            },
+          );
+          for (var index = 1; index <= 4; index++) {
+            queue.enqueue(
+              makeJob(
+                runKey: 'rk-$index',
+                agentId: 'agent-$index',
+                reason: 'test',
+              ),
+            );
+          }
+
+          unawaited(orchestrator.processNext());
+          async.flushMicrotasks();
+
+          expect(started, ['agent-1', 'agent-2', 'agent-3', 'agent-4']);
+          expect(runner.activeAgentIds, hasLength(4));
+          expect(queue.isEmpty, isTrue);
+
+          for (final gate in gates.values) {
+            gate.complete(null);
+          }
+          async.flushMicrotasks();
+          expect(runner.activeAgentIds, isEmpty);
+        });
+      });
+
+      test('global concurrency keeps each agent single-flight', () {
+        fakeAsync((async) {
+          final firstAgentGate = Completer<Map<String, VectorClock>?>();
+          final otherAgentGate = Completer<Map<String, VectorClock>?>();
+          final startedRunKeys = <String>[];
+          orchestrator.wakeExecutor = (agentId, runKey, triggers, threadId) {
+            startedRunKeys.add(runKey);
+            return switch (runKey) {
+              'rk-1' => firstAgentGate.future,
+              'rk-2' => Future.value(),
+              _ => otherAgentGate.future,
+            };
+          };
+          queue
+            ..enqueue(makeJob(reason: 'test'))
+            ..enqueue(
+              makeJob(
+                runKey: 'rk-2',
+                reason: 'test',
+              ),
+            )
+            ..enqueue(
+              makeJob(
+                runKey: 'rk-3',
+                agentId: 'agent-2',
+                reason: 'test',
+              ),
+            );
+
+          unawaited(orchestrator.processNext());
+          async.flushMicrotasks();
+
+          expect(startedRunKeys, ['rk-1', 'rk-3']);
+          expect(queue.length, 1);
+
+          firstAgentGate.complete(null);
+          async.flushMicrotasks();
+
+          expect(startedRunKeys, ['rk-1', 'rk-3', 'rk-2']);
+          otherAgentGate.complete(null);
+          async.flushMicrotasks();
+          expect(runner.activeAgentIds, isEmpty);
+        });
+      });
+
+      test('requeues a job when its agent starts during policy lookup', () {
+        fakeAsync((async) {
+          final policyLookup = Completer<AgentDomainEntity?>();
+          when(
+            () => mockRepository.getEntity('agent-1'),
+          ).thenAnswer((_) => policyLookup.future);
+          var executions = 0;
+          orchestrator.wakeExecutor = (agentId, runKey, triggers, threadId) {
+            executions++;
+            return Future.value();
+          };
+          queue.enqueue(makeJob(reason: 'test'));
+
+          unawaited(orchestrator.processNext());
+          async.flushMicrotasks();
+          expect(queue.isEmpty, isTrue);
+
+          var acquired = false;
+          unawaited(
+            runner.tryAcquire('agent-1').then((value) => acquired = value),
+          );
+          async.flushMicrotasks();
+          expect(acquired, isTrue);
+
+          policyLookup.complete(null);
+          async.flushMicrotasks();
+
+          expect(executions, 0);
+          expect(queue.length, 1);
+          expect(queue.dequeue()!.agentId, 'agent-1');
+          runner.release('agent-1');
+        });
+      });
+
+      test('defers a subscription throttled during policy lookup', () {
+        fakeAsync((async) {
+          final policyLookup = Completer<AgentDomainEntity?>();
+          when(
+            () => mockRepository.getEntity('agent-1'),
+          ).thenAnswer((_) => policyLookup.future);
+          var executions = 0;
+          orchestrator.wakeExecutor = (agentId, runKey, triggers, threadId) {
+            executions++;
+            return Future.value();
+          };
+          queue.enqueue(
+            makeJob(reason: WakeReason.subscription.name),
+          );
+
+          unawaited(orchestrator.processNext());
+          async.flushMicrotasks();
+          expect(queue.isEmpty, isTrue);
+
+          orchestrator.setThrottleDeadline(
+            'agent-1',
+            clock.now().add(WakeOrchestrator.throttleWindow),
+          );
+          policyLookup.complete(null);
+          async.flushMicrotasks();
+
+          expect(executions, 0);
+          expect(runner.isRunning('agent-1'), isFalse);
+          expect(queue.length, 1);
+          expect(queue.dequeue()!.agentId, 'agent-1');
         });
       });
 
@@ -2527,7 +2764,7 @@ void main() {
         });
       });
 
-      test('single-flight guard processes jobs enqueued during drain', () {
+      test('active drain fills available concurrency with newly queued work', () {
         fakeAsync((async) {
           // Use a completer to pause the first job mid-execution so we can
           // enqueue a second job while the drain is in-flight.
@@ -2558,8 +2795,9 @@ void main() {
           orchestrator.processNext();
           async.flushMicrotasks();
 
-          // Only the first job should have started so far.
-          expect(executionCount, 1);
+          // The second agent can start immediately because the default global
+          // concurrency is three, while the per-agent lock remains independent.
+          expect(executionCount, 2);
 
           // Complete the first job — the drain should pick up the second.
           gate.complete(null);

--- a/test/features/agents/wake/wake_orchestrator_test.dart
+++ b/test/features/agents/wake/wake_orchestrator_test.dart
@@ -5055,6 +5055,7 @@ void main() {
             final stuckRunner = WakeRunner();
             // Completer that gates the hung aborted-status write.
             final abortedStatusGate = Completer<void>();
+            final replacementDrainGate = Completer<Map<String, VectorClock>?>();
             final executedAgentIds = <String>[];
 
             when(
@@ -5091,6 +5092,9 @@ void main() {
                     executedAgentIds.add(agentId);
                     if (agentId == 'stuck-agent') {
                       return Completer<Map<String, VectorClock>?>().future;
+                    }
+                    if (agentId == 'new-agent') {
+                      return replacementDrainGate.future;
                     }
                     return Future.value();
                   },
@@ -5163,6 +5167,17 @@ void main() {
                 level: any(named: 'level'),
               ),
             ).called(1);
+
+            // The replacement drain is still waiting on new-agent and has one
+            // free global slot. Releasing the old drain must not clear the
+            // replacement drain's wake signal, otherwise this newly queued
+            // agent would wait for new-agent despite the available capacity.
+            stuck.enqueueManualWake(agentId: 'third-agent', reason: 'manual');
+            async.flushMicrotasks();
+            expect(executedAgentIds, contains('third-agent'));
+
+            replacementDrainGate.complete(null);
+            async.flushMicrotasks();
 
             stuck.stop();
             controller.close();

--- a/test/features/agents/wake/wake_orchestrator_test.dart
+++ b/test/features/agents/wake/wake_orchestrator_test.dart
@@ -2674,6 +2674,84 @@ void main() {
         },
       );
 
+      test('continues drain when an unexpected execution error escapes', () {
+        fakeAsync((async) {
+          final logger = MockDomainLogger();
+          var executionLogCount = 0;
+          when(
+            () => logger.log(
+              any(),
+              any(),
+              subDomain: any(named: 'subDomain'),
+              level: any(named: 'level'),
+            ),
+          ).thenAnswer((invocation) {
+            final message = invocation.positionalArguments[1] as String;
+            if (message.startsWith('executing runKey=')) {
+              executionLogCount++;
+              if (executionLogCount == 1) {
+                throw StateError('unexpected logger failure');
+              }
+            }
+          });
+          when(
+            () => logger.error(
+              any(),
+              any(),
+              message: any(named: 'message'),
+              subDomain: any(named: 'subDomain'),
+              stackTrace: any(named: 'stackTrace'),
+            ),
+          ).thenReturn(null);
+
+          final localQueue = WakeQueue();
+          final localRunner = WakeRunner();
+          final executedAgentIds = <String>[];
+          final localOrchestrator = WakeOrchestrator(
+            repository: mockRepository,
+            queue: localQueue,
+            runner: localRunner,
+            domainLogger: logger,
+            wakeExecutor: (agentId, runKey, triggers, threadId) async {
+              executedAgentIds.add(agentId);
+              return null;
+            },
+          );
+
+          localQueue
+            ..enqueue(makeJob())
+            ..enqueue(
+              makeJob(
+                runKey: 'rk-2',
+                agentId: 'agent-2',
+                triggerTokens: {'tok-b'},
+              ),
+            );
+
+          localOrchestrator.processNext();
+          async.flushMicrotasks();
+
+          expect(executedAgentIds, ['agent-2']);
+          expect(localRunner.activeAgentIds, isEmpty);
+          expect(localQueue, hasLength(0));
+          verify(
+            () => logger.error(
+              LogDomain.agentRuntime,
+              any(that: isA<StateError>()),
+              message: any(
+                named: 'message',
+                that: contains('unexpected wake execution failure'),
+              ),
+              subDomain: any(named: 'subDomain'),
+              stackTrace: any(named: 'stackTrace'),
+            ),
+          ).called(1);
+
+          localOrchestrator.stop();
+          localRunner.dispose();
+        });
+      });
+
       test('continues drain when updateWakeRunStatus throws on completion', () {
         fakeAsync((async) {
           var executorCallCount = 0;

--- a/test/features/agents/wake/wake_queue_test.dart
+++ b/test/features/agents/wake/wake_queue_test.dart
@@ -133,6 +133,33 @@ void main() {
       });
     });
 
+    group('dequeueFirstWhere', () {
+      test('takes the first matching job and preserves skipped FIFO order', () {
+        queue
+          ..enqueue(makeJob(runKey: 'rk-1', agentId: 'busy'))
+          ..enqueue(makeJob(runKey: 'rk-2', agentId: 'ready'))
+          ..enqueue(makeJob(runKey: 'rk-3', agentId: 'busy'));
+
+        final ready = queue.dequeueFirstWhere(
+          (job) => job.agentId == 'ready',
+        );
+
+        expect(ready?.runKey, 'rk-2');
+        expect(queue.dequeue()?.runKey, 'rk-1');
+        expect(queue.dequeue()?.runKey, 'rk-3');
+      });
+
+      test('returns null without changing the queue when no job matches', () {
+        queue.enqueue(makeJob(runKey: 'rk-1', agentId: 'busy'));
+
+        expect(
+          queue.dequeueFirstWhere((job) => job.agentId == 'ready'),
+          isNull,
+        );
+        expect(queue.dequeue()?.runKey, 'rk-1');
+      });
+    });
+
     group('mergeTokens', () {
       test('merges tokens into first matching job and returns true', () {
         final job = makeJob(

--- a/test/features/ai/model/ai_runtime_settings_test.dart
+++ b/test/features/ai/model/ai_runtime_settings_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/ai/model/ai_runtime_settings.dart';
+
+void main() {
+  group('AiRuntimeSettings', () {
+    test('defaults agent wake concurrency to three when storage is absent', () {
+      expect(
+        AiRuntimeSettings.fromStoredAgentWakeConcurrency(null),
+        const AiRuntimeSettings(),
+      );
+      expect(
+        const AiRuntimeSettings().agentWakeConcurrency,
+        defaultAgentWakeConcurrency,
+      );
+    });
+
+    test('loads valid stored concurrency values', () {
+      expect(
+        AiRuntimeSettings.fromStoredAgentWakeConcurrency('4'),
+        const AiRuntimeSettings(agentWakeConcurrency: 4),
+      );
+    });
+
+    test('falls back to the default for malformed stored values', () {
+      for (final raw in ['', 'not-a-number']) {
+        expect(
+          AiRuntimeSettings.fromStoredAgentWakeConcurrency(raw),
+          const AiRuntimeSettings(),
+          reason: 'raw=$raw',
+        );
+      }
+    });
+
+    test('clamps stored concurrency to the supported safe range', () {
+      expect(
+        AiRuntimeSettings.fromStoredAgentWakeConcurrency('0'),
+        const AiRuntimeSettings(
+          agentWakeConcurrency: minAgentWakeConcurrency,
+        ),
+      );
+      expect(
+        AiRuntimeSettings.fromStoredAgentWakeConcurrency('99'),
+        const AiRuntimeSettings(
+          agentWakeConcurrency: maxAgentWakeConcurrency,
+        ),
+      );
+    });
+
+    test('copyWith normalizes requested concurrency', () {
+      expect(
+        const AiRuntimeSettings().copyWith(agentWakeConcurrency: 4),
+        const AiRuntimeSettings(agentWakeConcurrency: 4),
+      );
+      expect(
+        const AiRuntimeSettings().copyWith(agentWakeConcurrency: -1),
+        const AiRuntimeSettings(
+          agentWakeConcurrency: minAgentWakeConcurrency,
+        ),
+      );
+    });
+
+    test('copyWith preserves values and equality includes hashCode', () {
+      const settings = AiRuntimeSettings(agentWakeConcurrency: 4);
+      final copy = settings.copyWith();
+
+      expect(copy, settings);
+      expect(copy.hashCode, settings.hashCode);
+    });
+  });
+}

--- a/test/features/ai/state/ai_runtime_settings_controller_test.dart
+++ b/test/features/ai/state/ai_runtime_settings_controller_test.dart
@@ -1,0 +1,89 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/ai/model/ai_runtime_settings.dart';
+import 'package:lotti/features/ai/state/ai_runtime_settings_controller.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../widget_test_utils.dart';
+
+void main() {
+  late TestGetItMocks mocks;
+
+  setUp(() async {
+    mocks = await setUpTestGetIt();
+  });
+  tearDown(tearDownTestGetIt);
+
+  ProviderContainer makeContainer() {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  test('starts at three before persisted settings load', () {
+    final container = makeContainer();
+
+    expect(
+      container.read(aiRuntimeSettingsControllerProvider),
+      const AiRuntimeSettings(),
+    );
+  });
+
+  test('loads persisted wake concurrency', () async {
+    when(
+      () => mocks.settingsDb.itemByKey(agentWakeConcurrencySettingsKey),
+    ).thenAnswer((_) async => '4');
+
+    final container = makeContainer();
+    expect(
+      container.read(aiRuntimeSettingsControllerProvider),
+      const AiRuntimeSettings(),
+    );
+    await pumpEventQueue();
+
+    expect(
+      container.read(aiRuntimeSettingsControllerProvider),
+      const AiRuntimeSettings(agentWakeConcurrency: 4),
+    );
+  });
+
+  test('updates state and persists a normalized wake concurrency', () {
+    final container = makeContainer();
+
+    container
+        .read(aiRuntimeSettingsControllerProvider.notifier)
+        .setAgentWakeConcurrency(99);
+
+    expect(
+      container.read(aiRuntimeSettingsControllerProvider).agentWakeConcurrency,
+      maxAgentWakeConcurrency,
+    );
+    verify(
+      () => mocks.settingsDb.saveSettingsItem(
+        agentWakeConcurrencySettingsKey,
+        maxAgentWakeConcurrency.toString(),
+      ),
+    ).called(1);
+  });
+
+  test('a user change made during loading is not overwritten', () async {
+    final stored = Completer<String?>();
+    when(
+      () => mocks.settingsDb.itemByKey(agentWakeConcurrencySettingsKey),
+    ).thenAnswer((_) => stored.future);
+
+    final container = makeContainer();
+    container
+        .read(aiRuntimeSettingsControllerProvider.notifier)
+        .setAgentWakeConcurrency(2);
+    stored.complete('4');
+    await pumpEventQueue();
+
+    expect(
+      container.read(aiRuntimeSettingsControllerProvider).agentWakeConcurrency,
+      2,
+    );
+  });
+}

--- a/test/features/ai/ui/settings/ai_settings_page_test.dart
+++ b/test/features/ai/ui/settings/ai_settings_page_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/database/settings_db.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
+import 'package:lotti/features/ai/model/ai_runtime_settings.dart';
 import 'package:lotti/features/ai/repository/ai_config_repository.dart'
     show CascadeDeletionResult, aiConfigRepositoryProvider;
 import 'package:lotti/features/ai/ui/inference_profile_form.dart';
@@ -22,6 +23,7 @@ import 'package:lotti/features/ai/ui/settings/widgets/v2/ai_settings_tab_bar.dar
 import 'package:lotti/features/ai/util/known_models.dart';
 import 'package:lotti/features/ai/util/mlx_audio_channel.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
+import 'package:lotti/features/design_system/components/dropdowns/design_system_dropdown.dart';
 import 'package:lotti/features/design_system/theme/generated/design_tokens.g.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/l10n/app_localizations.dart';
@@ -267,6 +269,45 @@ void main() {
         await settleTimers(tester);
       },
     );
+  });
+
+  group('AiSettingsPage — runtime settings', () {
+    testWidgets('persists a selected agent wake concurrency', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(900, 1600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      final mockSettingsDb = getIt<SettingsDb>() as MockSettingsDb;
+
+      await pumpWith(
+        tester: tester,
+        providers: [
+          buildProvider(id: 'p1', type: InferenceProviderType.gemini),
+        ],
+        models: const <AiConfig>[],
+        profiles: const <AiConfig>[],
+      );
+
+      final dropdown = find.byType(DesignSystemDropdown);
+      await tester.tap(
+        find.descendant(of: dropdown, matching: find.byType(InkWell)).first,
+      );
+      await tester.pump();
+      await tester.tap(
+        find.descendant(of: dropdown, matching: find.text('4')),
+      );
+      await tester.pump();
+
+      expect(
+        tester.widget<DesignSystemDropdown>(dropdown).inputLabel,
+        '4',
+      );
+      verify(
+        () => mockSettingsDb.saveSettingsItem(
+          agentWakeConcurrencySettingsKey,
+          '4',
+        ),
+      ).called(1);
+      await settleTimers(tester);
+    });
   });
 
   group('AiSettingsPage — populated', () {

--- a/test/features/ai/ui/settings/widgets/v2/ai_settings_header_bar_test.dart
+++ b/test/features/ai/ui/settings/widgets/v2/ai_settings_header_bar_test.dart
@@ -2,15 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/ai/ui/settings/widgets/ai_settings_search_bar.dart';
 import 'package:lotti/features/ai/ui/settings/widgets/v2/ai_settings_header_bar.dart';
+import 'package:lotti/features/design_system/components/dropdowns/design_system_dropdown.dart';
+import 'package:lotti/l10n/app_localizations_context.dart';
 
 import '../../../../../../widget_test_utils.dart';
 
 void main() {
   group('AiSettingsHeaderBar', () {
     testWidgets(
-      'renders an AiSettingsSearchBar (the existing app-wide search '
-      'component) and nothing else — no subtitle paragraph, no '
-      'inline Add CTA',
+      'renders the shared search and configured wake concurrency',
       (tester) async {
         final controller = TextEditingController();
         addTearDown(controller.dispose);
@@ -21,12 +21,26 @@ void main() {
               child: AiSettingsHeaderBar(
                 searchController: controller,
                 onSearchClear: () {},
+                agentWakeConcurrency: 3,
+                onAgentWakeConcurrencyChanged: (_) {},
               ),
             ),
           ),
         );
         await tester.pump();
         expect(find.byType(AiSettingsSearchBar), findsOneWidget);
+        expect(find.byType(DesignSystemDropdown), findsOneWidget);
+        final messages = tester
+            .element(find.byType(AiSettingsHeaderBar))
+            .messages;
+        expect(
+          find.text(messages.aiSettingsAgentWakeConcurrencyLabel),
+          findsOneWidget,
+        );
+        expect(
+          find.text(messages.aiSettingsAgentWakeConcurrencyDescription),
+          findsOneWidget,
+        );
         // The legacy v3 prototype shipped a "Configure AI providers, "
         // subtitle paragraph + an inline Add CTA; both are gone now —
         // guard against regressions that re-add either.
@@ -51,6 +65,8 @@ void main() {
               child: AiSettingsHeaderBar(
                 searchController: controller,
                 onSearchClear: () => clears++,
+                agentWakeConcurrency: 3,
+                onAgentWakeConcurrencyChanged: (_) {},
               ),
             ),
           ),
@@ -68,5 +84,36 @@ void main() {
         expect(clears, equals(1));
       },
     );
+
+    testWidgets('selecting a concurrency value reports the chosen limit', (
+      tester,
+    ) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+      int? selectedConcurrency;
+      await tester.pumpWidget(
+        makeTestableWidgetWithScaffold(
+          SizedBox(
+            width: 600,
+            child: AiSettingsHeaderBar(
+              searchController: controller,
+              onSearchClear: () {},
+              agentWakeConcurrency: 3,
+              onAgentWakeConcurrencyChanged: (value) {
+                selectedConcurrency = value;
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.tap(find.widgetWithText(InkWell, '3'));
+      await tester.pump();
+      await tester.tap(find.text('4').last);
+      await tester.pump();
+
+      expect(selectedConcurrency, 4);
+    });
   });
 }


### PR DESCRIPTION
## Summary

- replace the serial wake-drain loop with a bounded dispatcher that runs independent agent wake cycles concurrently
- add a device-local AI runtime setting with a default concurrency of 3 and a supported range of 1–8
- expose the setting in AI Settings, persist it in `SettingsDb`, and apply changes without restarting the app
- preserve per-agent single-flight, FIFO visibility for same-agent follow-ups, subscription suppression/throttling, and stale-drain recovery

## Architecture and root cause

`WakeOrchestrator` already had one scheduler guard and `WakeRunner` already prevented two wakes for the same agent. The global bottleneck lived in `WakeDrainEngine._drain`: it dequeued one job and awaited `_executeJob` before looking at the next job, so unrelated agents could not begin inference until the previous request completed.

The new dispatcher keeps queue mutation under the existing single scheduler while tracking active executions separately. It fills capacity up to the current AI runtime setting, waits for either an execution to finish or new work to arrive, and immediately fills newly available slots. `WakeRunner` remains the per-agent lock, so concurrency only applies across different agents.

## Concurrency safety

- the queue, suppression tracker, and throttle coordinator remain owned by one scheduler on the Dart isolate
- the global limit counts all active `WakeRunner` agents and is normalized to the safe 1–8 range before every dispatch pass
- same-agent follow-ups stay visible in the FIFO queue while their agent runs, preserving existing post-run throttle behavior
- policy, suppression, throttle, and content gates are rechecked before execution; race tests cover state changing while an async policy lookup is in flight
- each execution retains its existing error boundary and lock-release finalizer; stale scheduler generations await their active futures before retiring
- downstream LLM and database load is bounded by the configured value, with a conservative default of 3

## Validation and performance

- `fvm flutter analyze` — no issues
- `make test VERY_GOOD_CMD='fvm dart pub global run very_good_cli:very_good'` — 26,623 tests passed, 19 skipped
- changed executable Dart lines — 129/129 covered (`100.00%` patch coverage)
- deterministic scheduler tests verify:
  - default 3 starts three different agents while a fourth remains queued, then fills the released slot immediately
  - concurrency 1 preserves the previous sequential behavior
  - concurrency 4 starts four different agents together
  - an agent remains single-flight even when global capacity is available

These execution-gate tests demonstrate the latency improvement without wall-clock sleeps: four equal-duration independent wakes require four serial waves at concurrency 1, two waves at the default concurrency 3, and one wave at concurrency 4. Single-agent execution follows the unchanged one-wake path.

## Screenshots

| Before | After |
| --- | --- |
| ![AI settings before the agent concurrency control](https://raw.githubusercontent.com/matthiasn/lotti-docs/f13532d442b57829400443aaa4949c96eaa4ceca/pr-screenshots/agent-concurrency/before/ai_settings_agent_concurrency_desktop_before.png) | ![AI settings with the new concurrent-agent-wakes control set to 3](https://raw.githubusercontent.com/matthiasn/lotti-docs/f13532d442b57829400443aaa4949c96eaa4ceca/pr-screenshots/agent-concurrency/after/ai_settings_agent_concurrency_desktop_after.png) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AI Settings control for **concurrent agent wakes** (1–8, default: 3).
  * When multiple agents are active, up to three different agents can run wake cycles concurrently, while keeping per-agent execution single-flight.
* **Bug Fixes**
  * Improved wake draining resilience so queued work continues even if an individual wake execution errors.
* **Documentation**
  * Updated release notes and AI/wake scheduling docs to describe bounded concurrency behavior and the new setting.
* **Tests**
  * Expanded tests for concurrency limits, UI selection, and runtime settings persistence/clamping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->