### PR TITLE
fix: fade Maintenance list dividers on hover to match Config Flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.1047]
 ### Changed
+- **Maintenance settings dividers fade on hover.** Hovering a row on the
+  Advanced Settings → Maintenance page now fades the hairline dividers above
+  and below it, so the hovered row is never bisected — matching the existing
+  Config Flags behaviour. The row layout stays fixed; only the divider colour
+  changes.
 - **AI agents respond sooner when several are active.** Up to three different
   agent wake cycles now run at once by default instead of waiting in one global
   line, while each individual agent remains single-flight. AI Settings lets

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -34,6 +34,7 @@
   <releases>
     <release version="0.9.1047" date="2026-07-15">
       <description>
+          <p>Hovering a row on the Advanced Settings Maintenance page now fades the dividers above and below it, so the hovered row is never bisected by a hairline — matching the existing Config Flags behaviour. The row layout stays fixed while only the divider colour changes.</p>
           <p>AI agents now respond sooner when several are active. Up to three different agent wake cycles run concurrently by default instead of waiting in one global line, while each individual agent remains single-flight. The device-local limit can be tuned from one through eight in AI Settings.</p>
           <p>Task and project filters now share one coherent, accessible flow. Status, category, label, and project choices stay inside the same smoothly resizing sheet or desktop dialog, with consistent full-width selection states, responsive actions, keyboard focus restoration, and clearer activity and sort controls. Task filters open immediately while project data refreshes in place, and active filters remain visible as compact chips on the task page.</p>
       </description>

--- a/lib/features/design_system/components/lists/hover_divider_index.dart
+++ b/lib/features/design_system/components/lists/hover_divider_index.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+/// Coordinates hover-driven divider fading across a vertical run of
+/// `DesignSystemListItem`s (or any list of rows that expose `onHoverChanged`
+/// and a `dividerColor`).
+///
+/// Mix this into the `State` of a widget that lays out indexed rows. Track
+/// each row's hover with [onRowHoverChanged] and colour each row's divider
+/// with [hoverDividerColorFor]. The hovered row's bracketing hairlines (the
+/// divider beneath it and the divider beneath the row above it) both fade to
+/// [Colors.transparent], so the hovered row is never bisected by a hairline.
+///
+/// Crucially the caller keeps `showDivider` stable and only swaps the
+/// colour, so hovering never adds/removes a 1&nbsp;px divider and the layout
+/// never shifts. Shared by the Config Flags list (`_FlagsList`) and the
+/// Advanced → Maintenance list (`MaintenanceBody`).
+mixin HoverDividerIndex<T extends StatefulWidget> on State<T> {
+  /// Index of the currently-hovered row, or `null` when no row is hovered.
+  int? _hoveredIndex;
+
+  /// The divider beneath [index] fades whenever either that row or the row
+  /// below it (`index + 1`) is hovered, so both hairlines bracketing a
+  /// hovered row disappear. Returns `null` to keep the caller's default
+  /// divider colour when neither side is hovered.
+  Color? hoverDividerColorFor(int index) =>
+      (_hoveredIndex == index || _hoveredIndex == index + 1)
+      ? Colors.transparent
+      : null;
+
+  /// Records pointer enter/leave for the row at [index]. Retargets rather
+  /// than accumulates: entering a row overrides the previous one, and a
+  /// leave only clears state when it matches the currently-hovered row. That
+  /// makes it order-independent across a row-to-row move — whether the enter
+  /// or the leave fires first, the state settles on the newly entered row.
+  void onRowHoverChanged(int index, {required bool hovered}) {
+    // A MouseRegion/InkWell can dispatch a hover-exit callback while the
+    // row is being torn down (e.g. during a settings route transition),
+    // so guard against `setState()` after dispose.
+    if (!mounted) return;
+    setState(() {
+      if (hovered) {
+        _hoveredIndex = index;
+      } else if (_hoveredIndex == index) {
+        _hoveredIndex = null;
+      }
+    });
+  }
+}

--- a/lib/features/settings/README.md
+++ b/lib/features/settings/README.md
@@ -478,6 +478,18 @@ Each visible flag has:
 
 The Flags entry is reached through Advanced; the `/settings/flags` URL itself is unchanged so existing deep links keep resolving.
 
+The flag rows share a hover-divider treatment with the Maintenance list
+([`ui/pages/advanced/maintenance_page.dart`](ui/pages/advanced/maintenance_page.dart)).
+Both states mix in `HoverDividerIndex`
+([`design_system/components/lists/hover_divider_index.dart`](../../design_system/components/lists/hover_divider_index.dart)),
+which tracks the hovered row index and exposes `onRowHoverChanged` /
+`hoverDividerColorFor`. Rather than toggling `DesignSystemListItem.showDivider`
+(which would shift layout by 1&nbsp;px), each list keeps `showDivider` stable
+and fades the divider to `Colors.transparent` for the hovered row and the row
+above it, so the hovered row is never bisected by a hairline. Maintenance folds
+its final diagnostic repaint-rainbow tile into the same index model so the
+divider between the last action row and the tile fades from either side.
+
 ### Advanced
 
 Advanced is also no longer a Settings-owned page. On mobile it is rendered by

--- a/lib/features/settings/ui/pages/advanced/maintenance_page.dart
+++ b/lib/features/settings/ui/pages/advanced/maintenance_page.dart
@@ -9,6 +9,7 @@ import 'package:lotti/features/ai/ui/settings/embedding_backfill_modal.dart';
 import 'package:lotti/features/ai/ui/settings/services/gemini_setup_prompt_service.dart';
 import 'package:lotti/features/design_system/components/lists/design_system_grouped_list.dart';
 import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
+import 'package:lotti/features/design_system/components/lists/hover_divider_index.dart';
 import 'package:lotti/features/design_system/components/toasts/design_system_toast.dart';
 import 'package:lotti/features/design_system/components/toasts/toast_messenger.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
@@ -47,11 +48,17 @@ class MaintenancePage extends StatelessWidget {
 /// Owns its own vertical padding so both hosts (sliver page and V2
 /// detail pane) get the same chrome-independent spacing — matching
 /// the `LoggingSettingsBody` pattern.
-class MaintenanceBody extends ConsumerWidget {
+class MaintenanceBody extends ConsumerStatefulWidget {
   const MaintenanceBody({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<MaintenanceBody> createState() => _MaintenanceBodyState();
+}
+
+class _MaintenanceBodyState extends ConsumerState<MaintenanceBody>
+    with HoverDividerIndex<MaintenanceBody> {
+  @override
+  Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final maintenance = getIt<Maintenance>();
 
@@ -175,24 +182,37 @@ class MaintenanceBody extends ConsumerWidget {
             ),
         ];
 
+    // The repaint-rainbow diagnostic tile is the final row; index it
+    // right after the action rows so hovering it fades the divider
+    // above it in the same fashion as the dividers between action rows.
+    final rainbowIndex = items.length;
+
     return Padding(
       padding: EdgeInsets.symmetric(vertical: tokens.spacing.step4),
       child: DesignSystemGroupedList(
         children: [
-          for (final item in items)
+          for (final (index, item) in items.indexed)
             DesignSystemListItem(
               title: item.title,
               subtitle: item.subtitle,
               leading: SettingsIcon(icon: item.icon),
               trailing: SettingsIcon.trailingChevron(tokens),
-              // Always draw a divider; the diagnostic
-              // [_RepaintRainbowTile] below is the new last item and
-              // owns the bottom-of-list (no-divider) slot.
+              // Keep `showDivider` stable so hover never shifts layout
+              // by 1 px; the divider is suppressed by fading it to
+              // transparent instead. The diagnostic [_RepaintRainbowTile]
+              // below owns the bottom-of-list (no-divider) slot, so every
+              // action row always draws a divider beneath it.
               showDivider: true,
+              dividerColor: hoverDividerColorFor(index),
               dividerIndent: SettingsIcon.dividerIndent(tokens),
+              onHoverChanged: (hovered) =>
+                  onRowHoverChanged(index, hovered: hovered),
               onTap: item.onTap,
             ),
-          const _RepaintRainbowTile(),
+          _RepaintRainbowTile(
+            onHoverChanged: (hovered) =>
+                onRowHoverChanged(rainbowIndex, hovered: hovered),
+          ),
         ],
       ),
     );
@@ -209,7 +229,12 @@ class MaintenanceBody extends ConsumerWidget {
 /// the change is visible immediately. Resets to off on every relaunch
 /// — the flag is never persisted.
 class _RepaintRainbowTile extends StatelessWidget {
-  const _RepaintRainbowTile();
+  const _RepaintRainbowTile({this.onHoverChanged});
+
+  /// Reports pointer enter/leave to the parent list so the divider
+  /// above this tile fades on hover in the same fashion as the dividers
+  /// between the action rows.
+  final ValueChanged<bool>? onHoverChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -228,6 +253,7 @@ class _RepaintRainbowTile extends StatelessWidget {
             onChanged: (value) => repaintRainbowEnabled.value = value,
           ),
           dividerIndent: SettingsIcon.dividerIndent(tokens),
+          onHoverChanged: onHoverChanged,
           onTap: () => repaintRainbowEnabled.value = !enabled,
         );
       },

--- a/lib/features/settings/ui/pages/flags_page.dart
+++ b/lib/features/settings/ui/pages/flags_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
+import 'package:lotti/features/design_system/components/lists/hover_divider_index.dart';
 import 'package:lotti/features/design_system/components/search/design_system_search.dart';
 import 'package:lotti/features/design_system/components/toggles/design_system_toggle.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
@@ -409,12 +410,8 @@ class _FlagsList extends StatefulWidget {
   State<_FlagsList> createState() => _FlagsListState();
 }
 
-class _FlagsListState extends State<_FlagsList> {
-  /// Index of the currently-hovered flag row, or `null` when no row is
-  /// hovered. Used to fade the divider between the hovered row and the
-  /// row below it so the hovered row is never bisected by a hairline.
-  int? _hoveredIndex;
-
+class _FlagsListState extends State<_FlagsList>
+    with HoverDividerIndex<_FlagsList> {
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
@@ -454,24 +451,14 @@ class _FlagsListState extends State<_FlagsList> {
                     flag.copyWith(status: !flag.status),
                   );
                 },
-                onHoverChanged: (hovered) {
-                  setState(() {
-                    if (hovered) {
-                      _hoveredIndex = index;
-                    } else if (_hoveredIndex == index) {
-                      _hoveredIndex = null;
-                    }
-                  });
-                },
+                onHoverChanged: (hovered) =>
+                    onRowHoverChanged(index, hovered: hovered),
                 // Keep `showDivider` stable so layout doesn't shift by
                 // 1 px on hover; fade the divider to transparent when
                 // either this row or the row below it is hovered, so
                 // the hovered row is never bisected by a hairline.
                 showDivider: index < flags.length - 1,
-                dividerColor:
-                    (_hoveredIndex == index || _hoveredIndex == index + 1)
-                    ? Colors.transparent
-                    : null,
+                dividerColor: hoverDividerColorFor(index),
                 dividerIndent: SettingsIcon.dividerIndent(tokens),
               ),
           ],

--- a/test/features/design_system/components/lists/hover_divider_index_test.dart
+++ b/test/features/design_system/components/lists/hover_divider_index_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/components/lists/hover_divider_index.dart';
+
+/// Minimal host that mixes in [HoverDividerIndex] and exposes its API so the
+/// mixin's fade logic and hover bookkeeping can be exercised in isolation,
+/// independent of any list widget that consumes it.
+class _Host extends StatefulWidget {
+  const _Host({super.key});
+
+  @override
+  State<_Host> createState() => _HostState();
+}
+
+class _HostState extends State<_Host> with HoverDividerIndex<_Host> {
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}
+
+void main() {
+  group('HoverDividerIndex', () {
+    late GlobalKey<_HostState> key;
+
+    Future<_HostState> pumpHost(WidgetTester tester) async {
+      key = GlobalKey<_HostState>();
+      await tester.pumpWidget(_Host(key: key));
+      return key.currentState!;
+    }
+
+    /// The set of row indices in `0..<count>` whose divider currently fades.
+    Set<int> fadedRows(_HostState state, {required int count}) => {
+      for (var i = 0; i < count; i++)
+        if (state.hoverDividerColorFor(i) == Colors.transparent) i,
+    };
+
+    testWidgets('idle: every divider keeps the default (null) colour', (
+      tester,
+    ) async {
+      final state = await pumpHost(tester);
+      for (var i = 0; i < 5; i++) {
+        expect(state.hoverDividerColorFor(i), isNull);
+      }
+    });
+
+    testWidgets('hovering a row fades its own divider and the one above', (
+      tester,
+    ) async {
+      final state = await pumpHost(tester);
+
+      state.onRowHoverChanged(2, hovered: true);
+      await tester.pump();
+
+      // Row 2's own bottom divider (index 2) plus row 1's bottom divider
+      // (the divider directly above row 2) fade — the hovered row is
+      // bracketed by invisible hairlines, nothing else changes.
+      expect(fadedRows(state, count: 5), {1, 2});
+    });
+
+    testWidgets('hovering row 0 fades only its own divider (no row above)', (
+      tester,
+    ) async {
+      final state = await pumpHost(tester);
+
+      state.onRowHoverChanged(0, hovered: true);
+      await tester.pump();
+
+      expect(fadedRows(state, count: 5), {0});
+    });
+
+    testWidgets('leaving the hovered row clears every fade', (tester) async {
+      final state = await pumpHost(tester);
+
+      state.onRowHoverChanged(2, hovered: true);
+      await tester.pump();
+      expect(fadedRows(state, count: 5), isNotEmpty);
+
+      state.onRowHoverChanged(2, hovered: false);
+      await tester.pump();
+      expect(fadedRows(state, count: 5), isEmpty);
+    });
+
+    testWidgets(
+      'a stale leave for a non-current row does not clear the active fade',
+      (tester) async {
+        final state = await pumpHost(tester);
+
+        // Enter row 3, then a leave arrives for the previously-hovered row 1
+        // (out-of-order during a row-to-row move). The leave must be ignored
+        // because row 1 is no longer the hovered index.
+        state
+          ..onRowHoverChanged(3, hovered: true)
+          ..onRowHoverChanged(1, hovered: false);
+        await tester.pump();
+
+        expect(fadedRows(state, count: 6), {2, 3});
+      },
+    );
+
+    testWidgets('entering a new row retargets the fade', (tester) async {
+      final state = await pumpHost(tester);
+
+      state.onRowHoverChanged(1, hovered: true);
+      await tester.pump();
+      expect(fadedRows(state, count: 6), {0, 1});
+
+      state.onRowHoverChanged(4, hovered: true);
+      await tester.pump();
+      expect(fadedRows(state, count: 6), {3, 4});
+    });
+
+    testWidgets(
+      'a hover callback after dispose is a no-op (no setState after dispose)',
+      (tester) async {
+        final state = await pumpHost(tester);
+
+        // Tear the host down; a MouseRegion/InkWell can still dispatch a
+        // hover-exit callback while the row is being disposed.
+        await tester.pumpWidget(const SizedBox.shrink());
+        expect(state.mounted, isFalse);
+
+        // The guard must swallow the late callback instead of throwing a
+        // "setState() called after dispose()" error.
+        expect(
+          () => state.onRowHoverChanged(2, hovered: false),
+          returnsNormally,
+        );
+      },
+    );
+  });
+}

--- a/test/features/settings/ui/pages/advanced/maintenance_page_test.dart
+++ b/test/features/settings/ui/pages/advanced/maintenance_page_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:drift/drift.dart' as drift;
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -548,6 +549,182 @@ void main() {
         // Final reset before the binding's invariant check.
         repaintRainbowEnabled.value = false;
         debugRepaintRainbowEnabled = false;
+      },
+    );
+  });
+
+  group('MaintenancePage - hover divider fade', () {
+    setUp(() {
+      final mockJournalDb = MockJournalDb();
+      when(mockJournalDb.watchConfigFlags).thenAnswer(
+        (_) => Stream<Set<ConfigFlag>>.fromIterable([]),
+      );
+
+      final mockMaintenance = MockMaintenance();
+      when(mockMaintenance.deleteEditorDb).thenAnswer((_) async {});
+      when(mockMaintenance.deleteAgentDb).thenAnswer((_) async {});
+
+      getIt
+        ..registerSingleton<JournalDb>(mockJournalDb)
+        ..registerSingleton<UserActivityService>(UserActivityService())
+        ..registerSingleton<Maintenance>(mockMaintenance)
+        ..registerSingleton<NotificationService>(MockNotificationService());
+      ensureThemingServicesRegistered();
+    });
+
+    tearDown(getIt.reset);
+
+    /// Pumps the desktop body inside a viewport tall enough that every
+    /// row — including the bottom repaint-rainbow tile — is on-screen and
+    /// therefore hit-testable by a synthetic mouse pointer.
+    Future<List<DesignSystemListItem>> pumpBody(WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1000, 2400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(makeTestableWidget(const MaintenanceBody()));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      return tester
+          .widgetList<DesignSystemListItem>(find.byType(DesignSystemListItem))
+          .toList();
+    }
+
+    List<DesignSystemListItem> rows(WidgetTester tester) => tester
+        .widgetList<DesignSystemListItem>(find.byType(DesignSystemListItem))
+        .toList();
+
+    bool isFaded(DesignSystemListItem item) =>
+        item.dividerColor == Colors.transparent;
+
+    /// Drives a synthetic mouse hover onto the row at [index] and returns
+    /// the live row list after the resulting rebuild. Hover events require
+    /// pointer kind `mouse` — `tester.tap` won't fire the InkWell's
+    /// `onHover`.
+    Future<TestGesture> hoverRow(WidgetTester tester, int index) async {
+      final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      addTearDown(gesture.removePointer);
+      await gesture.addPointer();
+      await gesture.moveTo(
+        tester.getCenter(find.byType(DesignSystemListItem).at(index)),
+      );
+      await tester.pump();
+      return gesture;
+    }
+
+    /// Asserts the set of rows whose divider is currently faded equals
+    /// [expected], and that `showDivider` is stable — true for every row
+    /// except the final (rainbow) row, regardless of hover state.
+    void expectFadedRows(
+      List<DesignSystemListItem> items,
+      Set<int> expected,
+    ) {
+      for (final (index, row) in items.indexed) {
+        expect(
+          row.showDivider,
+          index < items.length - 1,
+          reason: 'showDivider must stay stable across hover (row $index)',
+        );
+        expect(
+          isFaded(row),
+          expected.contains(index),
+          reason: 'row $index faded expectation',
+        );
+      }
+    }
+
+    testWidgets('idle: no divider is faded and showDivider is stable', (
+      tester,
+    ) async {
+      final items = await pumpBody(tester);
+      expect(
+        items.length,
+        greaterThanOrEqualTo(3),
+        reason: 'test relies on at least 3 rows',
+      );
+      expectFadedRows(items, const <int>{});
+    });
+
+    testWidgets(
+      'hovering a middle row fades the dividers above AND below it',
+      (tester) async {
+        await pumpBody(tester);
+        await hoverRow(tester, 2);
+
+        // Row 2 fades its own bottom divider (below) and row 1 fades its
+        // bottom divider (above row 2) — the hovered row is bracketed by
+        // invisible hairlines. Nothing else changes.
+        expectFadedRows(rows(tester), const {1, 2});
+      },
+    );
+
+    testWidgets(
+      'hovering the first row fades only its own divider (no row above)',
+      (tester) async {
+        await pumpBody(tester);
+        await hoverRow(tester, 0);
+
+        // No index -1 exists, so only row 0's own divider fades.
+        expectFadedRows(rows(tester), const {0});
+      },
+    );
+
+    testWidgets(
+      'hovering the last action row fades the divider shared with the '
+      'repaint-rainbow tile',
+      (tester) async {
+        final items = await pumpBody(tester);
+        // The last action row sits directly above the rainbow tile (the
+        // final row). Hovering it must fade the boundary divider between
+        // the two, exactly as between any other pair.
+        final lastAction = items.length - 2;
+        await hoverRow(tester, lastAction);
+
+        expectFadedRows(rows(tester), {lastAction - 1, lastAction});
+      },
+    );
+
+    testWidgets(
+      'hovering the repaint-rainbow tile fades the divider above it',
+      (tester) async {
+        final items = await pumpBody(tester);
+        // The rainbow tile is the final, dividerless row; hovering it
+        // must still fade the last action row's divider so the tile is
+        // not visually separated on hover.
+        final rainbowIndex = items.length - 1;
+        await hoverRow(tester, rainbowIndex);
+
+        expectFadedRows(rows(tester), {rainbowIndex - 1});
+      },
+    );
+
+    testWidgets('moving the pointer off the row clears every fade', (
+      tester,
+    ) async {
+      await pumpBody(tester);
+      final gesture = await hoverRow(tester, 2);
+      expect(rows(tester).where(isFaded), isNotEmpty);
+
+      await gesture.moveTo(Offset.zero);
+      await tester.pump();
+      expectFadedRows(rows(tester), const <int>{});
+    });
+
+    testWidgets(
+      'moving between rows re-targets the fade to the newly hovered row',
+      (tester) async {
+        await pumpBody(tester);
+        final gesture = await hoverRow(tester, 1);
+        expectFadedRows(rows(tester), const {0, 1});
+
+        // Move to a non-adjacent row: the exit from row 1 and the enter
+        // onto row 3 leave exactly row 3's pair faded, proving the
+        // hovered index is retargeted rather than accumulated.
+        await gesture.moveTo(
+          tester.getCenter(find.byType(DesignSystemListItem).at(3)),
+        );
+        await tester.pump();
+        expectFadedRows(rows(tester), const {2, 3});
       },
     );
   });

--- a/test/features/speech/ui/widgets/recording/audio_recording_indicator_test.dart
+++ b/test/features/speech/ui/widgets/recording/audio_recording_indicator_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/classes/journal_entities.dart';
-import 'package:lotti/database/database.dart';
 import 'package:lotti/features/journal/model/entry_state.dart';
 import 'package:lotti/features/journal/state/entry_controller.dart';
 import 'package:lotti/features/speech/repository/audio_recorder_repository.dart';
@@ -12,9 +11,7 @@ import 'package:lotti/features/speech/ui/widgets/recording/audio_recording_indic
 import 'package:lotti/features/speech/ui/widgets/recording/audio_recording_orb.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/logic/persistence_logic.dart';
-import 'package:lotti/services/db_notification.dart';
 import 'package:lotti/services/editor_state_service.dart';
-import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/nav_service.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:record/record.dart' show Amplitude;
@@ -54,33 +51,28 @@ class MockEntryController extends EntryController {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  late MockJournalDb mockJournalDb;
   late MockNavService mockNavService;
   late MockAudioRecorderRepository mockRecorderRepository;
-  late MockLoggingService mockLoggingService;
   late MockEditorStateService mockEditorStateService;
   late MockPersistenceLogic mockPersistenceLogic;
-  late MockUpdateNotifications mockUpdateNotifications;
 
-  setUp(() {
-    mockJournalDb = MockJournalDb();
+  setUp(() async {
     mockNavService = MockNavService();
     mockRecorderRepository = MockAudioRecorderRepository();
-    mockLoggingService = MockLoggingService();
     mockEditorStateService = MockEditorStateService();
     mockPersistenceLogic = MockPersistenceLogic();
-    mockUpdateNotifications = MockUpdateNotifications();
 
-    getIt
-      ..registerSingleton<JournalDb>(mockJournalDb)
-      ..registerSingleton<NavService>(mockNavService)
-      ..registerSingleton<LoggingService>(mockLoggingService)
-      ..registerSingleton<EditorStateService>(mockEditorStateService)
-      ..registerSingleton<PersistenceLogic>(mockPersistenceLogic)
-      ..registerSingleton<UpdateNotifications>(mockUpdateNotifications);
+    final getItMocks = await setUpTestGetIt(
+      additionalSetup: () {
+        getIt
+          ..registerSingleton<NavService>(mockNavService)
+          ..registerSingleton<EditorStateService>(mockEditorStateService)
+          ..registerSingleton<PersistenceLogic>(mockPersistenceLogic);
+      },
+    );
 
     when(
-      () => mockJournalDb.getConfigFlag(any()),
+      () => getItMocks.journalDb.getConfigFlag(any()),
     ).thenAnswer((_) async => false);
     when(() => mockNavService.beamBack()).thenReturn(null);
     when(
@@ -89,7 +81,7 @@ void main() {
     when(() => mockRecorderRepository.dispose()).thenAnswer((_) async {});
   });
 
-  tearDown(getIt.reset);
+  tearDown(tearDownTestGetIt);
 
   Widget makeTestableWidget(
     AudioRecorderState state, {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Maintenance settings dividers (including the diagnostic tile) now fade above/below the hovered row, avoiding visual bisecting while keeping the list layout stable.
  * Configuration flags use the same hover-divider fade behavior.

* **Documentation**
  * Updated flags/help documentation to describe the shared hover-divider fade and fixed-row layout.

* **Tests**
  * Added widget/integration coverage for hover transitions (enter/leave/retarget) and disposal safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->