### PR TITLE
chore(deps): upgrade sync and platform packages

### DIFF
--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -154,17 +154,17 @@ This file tells flatpak-flutter about plugins not in its built-in database.
 {
     "flutter_vodozemac": {
         "cargo_locks": [
-            ".pub-cache/hosted/pub.dev/flutter_vodozemac-0.5.0/rust"
+            ".pub-cache/hosted/pub.dev/flutter_vodozemac-0.6.0/rust"
         ],
         "extra_pubspecs": [
-            ".pub-cache/hosted/pub.dev/flutter_vodozemac-0.5.0/cargokit/build_tool"
+            ".pub-cache/hosted/pub.dev/flutter_vodozemac-0.6.0/cargokit/build_tool"
         ],
         "manifest": {
             "sources": [
                 {
                     "type": "patch",
                     "path": "cargokit/run_build_tool.sh.patch",
-                    "dest": ".pub-cache/hosted/pub.dev/flutter_vodozemac-0.5.0/cargokit"
+                    "dest": ".pub-cache/hosted/pub.dev/flutter_vodozemac-0.6.0/cargokit"
                 }
             ]
         }
@@ -174,7 +174,7 @@ This file tells flatpak-flutter about plugins not in its built-in database.
 
 **When to update:**
 - When `flutter_vodozemac` version changes in `pubspec.lock`
-- Update all paths from `flutter_vodozemac-0.5.0` to the new version
+- Update all `flutter_vodozemac-<version>` paths to the new locked version
 
 **How to check current version:**
 ```bash
@@ -266,7 +266,7 @@ The ideal fix is adding `flutter_vodozemac` to flatpak-flutter's built-in `forei
 
 ```json
 "flutter_vodozemac": {
-    "0.5.0": {
+    "0.6.0": {
         "cargo_locks": ["$PUB_DEV/rust"],
         "extra_pubspecs": ["$PUB_DEV/cargokit/build_tool"],
         "manifest": {

--- a/flatpak/foreign.json
+++ b/flatpak/foreign.json
@@ -1,17 +1,17 @@
 {
     "flutter_vodozemac": {
         "cargo_locks": [
-            ".pub-cache/hosted/pub.dev/flutter_vodozemac-0.5.0/rust"
+            ".pub-cache/hosted/pub.dev/flutter_vodozemac-0.6.0/rust"
         ],
         "extra_pubspecs": [
-            ".pub-cache/hosted/pub.dev/flutter_vodozemac-0.5.0/cargokit/build_tool"
+            ".pub-cache/hosted/pub.dev/flutter_vodozemac-0.6.0/cargokit/build_tool"
         ],
         "manifest": {
             "sources": [
                 {
                     "type": "patch",
                     "path": "cargokit/run_build_tool.sh.patch",
-                    "dest": ".pub-cache/hosted/pub.dev/flutter_vodozemac-0.5.0/cargokit"
+                    "dest": ".pub-cache/hosted/pub.dev/flutter_vodozemac-0.6.0/cargokit"
                 }
             ]
         }

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -13,6 +13,7 @@
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <hotkey_manager_linux/hotkey_manager_linux_plugin.h>
 #include <irondash_engine_context/irondash_engine_context_plugin.h>
+#include <location/location_plugin.h>
 #include <media_kit_libs_linux/media_kit_libs_linux_plugin.h>
 #include <objectbox_flutter_libs/objectbox_flutter_libs_plugin.h>
 #include <record_linux/record_linux_plugin.h>
@@ -44,6 +45,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) irondash_engine_context_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "IrondashEngineContextPlugin");
   irondash_engine_context_plugin_register_with_registrar(irondash_engine_context_registrar);
+  g_autoptr(FlPluginRegistrar) location_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "LocationPlugin");
+  location_plugin_register_with_registrar(location_registrar);
   g_autoptr(FlPluginRegistrar) media_kit_libs_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "MediaKitLibsLinuxPlugin");
   media_kit_libs_linux_plugin_register_with_registrar(media_kit_libs_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -10,6 +10,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_linux
   hotkey_manager_linux
   irondash_engine_context
+  location
   media_kit_libs_linux
   objectbox_flutter_libs
   record_linux

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "5b7468c326d2f8a4f630056404ca0d291ade42918f4a3c6233618e724f39da8e"
+      sha256: "3b19a47f6ea7c2632760777c78174f47f6aec1e05f0cd611380d4593b8af1dbc"
       url: "https://pub.dev"
     source: hosted
-    version: "92.0.0"
+    version: "96.0.0"
   accessibility_tools:
     dependency: transitive
     description:
@@ -21,18 +21,18 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "70e4b1ef8003c64793a9e268a551a82869a8a96f39deb73dea28084b0e8bf75e"
+      sha256: "0c516bc4ad36a1a75759e54d5047cb9d15cded4459df01aa35a0b5ec7db2c2a0"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
+    version: "10.2.0"
   analyzer_plugin:
     dependency: "direct overridden"
     description:
       name: analyzer_plugin
-      sha256: "6645a029da947ffd823d98118f385d4bd26b54eb069c006b22e0b94e451814b5"
+      sha256: a886aaa94fb128ffe9cf5ee2495d9ef42ef129fe2e265b84b8820987ca15f4cd
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.11"
+    version: "0.14.4"
   ansicolor:
     dependency: transitive
     description:
@@ -357,10 +357,10 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: cad0e811a289ea2a941119dc483c204ec1684cbb9a8fc7351fe4a230b8313160
+      sha256: "25cebb79dfe304022550e0c3c893ae051ded07183d2607f7b88473cb3ade33cb"
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.0"
+    version: "7.3.0"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -485,10 +485,10 @@ packages:
     dependency: "direct dev"
     description:
       name: dart_style
-      sha256: a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b
+      sha256: "29f7ecc274a86d32920b1d9cfc7502fa87220da41ec60b55f329559d5732e2b2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "3.1.7"
   dbus:
     dependency: "direct main"
     description:
@@ -558,10 +558,10 @@ packages:
     dependency: "direct main"
     description:
       name: device_info_plus
-      sha256: "98f28b42168cc509abc92f88518882fd58061ea372d7999aecc424345c7bff6a"
+      sha256: b4fed1b2835da9d670d7bed7db79ae2a94b0f5ad6312268158a9b5479abbacdd
       url: "https://pub.dev"
     source: hosted
-    version: "11.5.0"
+    version: "12.4.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -1194,10 +1194,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_vodozemac
-      sha256: ef4c3580a7f2fe8eebb7602c6cba593a42b4a5e5466c372a022f77ccc14914a5
+      sha256: "4503bc4a33a5126539fe68eecbf736eafe412474874a2ebbfc94aef0b0d2e304"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.6.0"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -1356,10 +1356,10 @@ packages:
     dependency: "direct main"
     description:
       name: health
-      sha256: "320633022fb2423178baa66508001c4ca5aee5806ffa2c913e66488081e9fd47"
+      sha256: "2d9e119f3a1d281139f93149b41032b9f80b759960875bc784c5a25dd3c17524"
       url: "https://pub.dev"
     source: hosted
-    version: "13.1.4"
+    version: "13.3.1"
   hotkey_manager:
     dependency: "direct main"
     description:
@@ -1657,10 +1657,10 @@ packages:
     dependency: "direct main"
     description:
       name: json_annotation
-      sha256: cb09e7dac6210041fad964ed7fbee004f14258b4eca4040f72d1234062ace4c8
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
       url: "https://pub.dev"
     source: hosted
-    version: "4.11.0"
+    version: "4.12.0"
   json_schema_builder:
     dependency: "direct main"
     description:
@@ -1673,10 +1673,10 @@ packages:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: "44729f5c45748e6748f6b9a57ab8f7e4336edc8ae41fc295070e3814e616a6c0"
+      sha256: ffcd10cde35a93b2abbbcc26bd9971f4ca93763e8abe78d855e3c4177797e501
       url: "https://pub.dev"
     source: hosted
-    version: "6.13.0"
+    version: "6.14.0"
   just_audio:
     dependency: transitive
     description:
@@ -1713,10 +1713,10 @@ packages:
     dependency: "direct main"
     description:
       name: latlong2
-      sha256: "98227922caf49e6056f91b6c56945ea1c7b166f28ffcd5fb8e72fc0b453cc8fe"
+      sha256: "84b776b100a84a684a0aaa3fa4dc2c9b1931c658de533701ee4e09bfa991f8dc"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.1"
+    version: "0.10.1"
   leak_tracker:
     dependency: transitive
     description:
@@ -1753,10 +1753,10 @@ packages:
     dependency: "direct main"
     description:
       name: location
-      sha256: b080053c181c7d152c43dd576eec6436c40e25f326933051c330da563ddd5333
+      sha256: d6d8c474b287991de0d397804c22d1f3450deb693f306490db38a147ece312c8
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.1"
+    version: "9.0.0"
   location_platform_interface:
     dependency: transitive
     description:
@@ -1809,10 +1809,10 @@ packages:
     dependency: "direct main"
     description:
       name: matrix
-      sha256: d1d739b18ae6e3dfe1856fb93c85df45c6fef0d66cb8eb07319853ab29d481f4
+      sha256: "25ab47abd6a98c5c1affd1c735b83dcd01844f49c60483d679ffb9463f0a3f61"
       url: "https://pub.dev"
     source: hosted
-    version: "7.5.0"
+    version: "8.1.0"
   media_kit:
     dependency: "direct main"
     description:
@@ -1897,10 +1897,10 @@ packages:
     dependency: "direct main"
     description:
       name: mobile_scanner
-      sha256: c92c26bf2231695b6d3477c8dcf435f51e28f87b1745966b1fe4c47a286171ce
+      sha256: "30f7dc342094eb257ead933572f7e442dfd9d8aa6f3fa5506c3206f7837d1615"
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.0"
+    version: "7.2.1"
   mocktail:
     dependency: "direct dev"
     description:
@@ -3119,10 +3119,10 @@ packages:
     dependency: "direct main"
     description:
       name: uuid
-      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
+      sha256: "9b129329f58692f6e6578329498a8fe9fbe98f090beb764ffbb8ee2eadd01dcd"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.3"
+    version: "4.6.0"
   validators2:
     dependency: transitive
     description:
@@ -3175,10 +3175,10 @@ packages:
     dependency: transitive
     description:
       name: video_player
-      sha256: "0431179e1a7a2234a1148f64dde63c73167ca23829815169b24cc0bc6b9444a3"
+      sha256: "20ef311160e2ced020a62f38e4cc399a1bf289e722fc5fe37c9d7b18e44c9e8d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   video_player_android:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1047+4210
+version: 0.9.1047+4211
 
 msix_config:
   display_name: LottiApp
@@ -35,7 +35,7 @@ dependencies:
     git:
       url: https://github.com/matthiasn/delta_markdown.git
       ref: 131dbc1
-  device_info_plus: ^11.0.0
+  device_info_plus: ^12.1.0
   drift: ^2.21.0
   easy_debounce: ^2.0.2+1
   enum_to_string: ^2.0.1
@@ -67,7 +67,7 @@ dependencies:
   flutter_riverpod: ^3.1.0
   flutter_secure_storage: ^10.0.0
   flutter_svg: ^2.2.4
-  flutter_vodozemac: ^0.5.0
+  flutter_vodozemac: ^0.6.0
   form_builder_validators: ^11.0.0
   formz: ^0.8.0
   freezed_annotation: ^3.1.0
@@ -78,19 +78,19 @@ dependencies:
   google_fonts: ^8.1.0
   gpt_markdown: ^1.0.20
   graphic: ^2.3.0
-  health: ^13.1.0
+  health: ^13.3.1
   hotkey_manager: ^0.2.0
   http: ^1.2.0
   infinite_scroll_pagination: ^5.0.0
   intersperse: ^2.0.0
-  intl: ^0.20.2
+  intl: ^0.20.3
   ionicons: ^0.2.2
-  json_annotation: ^4.9.0
+  json_annotation: ^4.12.0
   json_schema_builder: ^0.1.3
   just_waveform: ^0.0.7
-  latlong2: ^0.9.0
-  location: ^8.0.0
-  matrix: ^7.0.0
+  latlong2: ^0.10.1
+  location: ^9.0.0
+  matrix: ^8.1.0
   media_kit: ^1.0.2
   media_kit_libs_audio: ^1.0.7
   meta: ^1.12.0
@@ -134,13 +134,18 @@ dependencies:
   wolt_modal_sheet: ^0.11.0
 
 dependency_overrides:
-  analyzer_plugin: ^0.13.1
+  # json_serializable >=6.13.2 requires analyzer >=10, while
+  # objectbox_generator 5.x currently caps analyzer below 11.
+  analyzer_plugin: '>=0.14.0 <0.14.5'
+  # health >=13.2.0 requires device_info_plus ^12.1.0, while
+  # super_native_extensions 0.9.1 still caps it below 12.0.0.
+  device_info_plus: ^12.1.0
   # Local fork: runs ONNX inference off the main thread on macOS, which Flutter
   # can't do via platform-channel task queues (flutter/flutter#162613).
   # See third_party/flutter_onnxruntime/LOTTI_PATCHES.md.
   flutter_onnxruntime:
     path: third_party/flutter_onnxruntime
-  intl: ^0.20.2
+  intl: ^0.20.3
   # Downgrade to avoid objective_c.framework malformed bundle issue (ITMS-90291)
   # See: https://github.com/flutter/flutter/issues/178915
   path_provider_foundation: 2.5.1

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -15,6 +15,7 @@
 #include <gal/gal_plugin_c_api.h>
 #include <hotkey_manager_windows/hotkey_manager_windows_plugin_c_api.h>
 #include <irondash_engine_context/irondash_engine_context_plugin_c_api.h>
+#include <location/location_plugin.h>
 #include <media_kit_libs_windows_audio/media_kit_libs_windows_audio_plugin_c_api.h>
 #include <objectbox_flutter_libs/objectbox_flutter_libs_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
@@ -46,6 +47,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("HotkeyManagerWindowsPluginCApi"));
   IrondashEngineContextPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("IrondashEngineContextPluginCApi"));
+  LocationPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("LocationPlugin"));
   MediaKitLibsWindowsAudioPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("MediaKitLibsWindowsAudioPluginCApi"));
   ObjectboxFlutterLibsPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -12,6 +12,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   gal
   hotkey_manager_windows
   irondash_engine_context
+  location
   media_kit_libs_windows_audio
   objectbox_flutter_libs
   permission_handler_windows


### PR DESCRIPTION
## Summary

- upgrade `flutter_vodozemac` to 0.6.0, `matrix` to 8.1.0, and the requested health, localization, JSON, mapping, and location dependencies
- add the compatible `device_info_plus` and analyzer/code-generation constraints required by the new package graph
- register `location 9` on Linux and Windows
- update the Flatpak foreign-dependency mapping and documentation for `flutter_vodozemac 0.6.0`

## Why

The dependency graph had newer compatible releases available, but the health and JSON upgrades expose two upstream constraint gaps:

- `health >=13.2.0` requires `device_info_plus ^12.1.0`, while `super_native_extensions 0.9.1` still caps it below 12
- `json_annotation 4.12.0` requires the analyzer 10 generation stack, while ObjectBox currently caps analyzer below 11

The documented overrides select the narrow compatible ranges until those upstream constraints converge.

## Impact

The app uses the updated Matrix/vodozemac stack and newer health/location APIs. Location 9 also enables its native Linux and Windows plugins. The Flathub submission generator now resolves the vodozemac 0.6 Cargo graph instead of referencing the removed 0.5 package path.

## Validation

- `fvm flutter analyze` — zero issues
- `fvm flutter test test/logic/health_import_test.dart test/services/health_service_test.dart test/features/settings/ui/pages/health_import_page_test.dart test/utils/location_fallback_test.dart` — 90 passed
- `fvm flutter test test/features/sync` — 2,906 passed
- `fvm flutter build linux --release --no-pub` — passed on arm64
- `python3 flatpak/check_foreign_deps.py` — 4 foreign dependency patches validated
- `./flatpak/prepare_flathub_build.sh 0150031559b9e04b6c7ef1f13dcba214d0bc86fd` — emitted 222 Pub sources, 72 Cargo sources, and Rust 1.91.1 manifests
- sandboxed Flatpak 25.08 build — passed on arm64 and exported `com.matthiasn.lotti`, including `libvodozemac_bindings_dart.so` and the Linux location plugin

The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards.