### PR TITLE
fix: prevent bulk checklist suggestion flicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sort controls. Task filters open immediately while project data refreshes in
   place, and active filters remain visible as compact chips on the task page.
 
+### Fixed
+- **Bulk checklist suggestion acceptance no longer flickers.** Confirm all now
+  keeps every proposal row mounted through its staggered exit, even when fast
+  checklist check-offs resolve the underlying suggestions before later rows
+  begin animating. The task page remains anchored throughout the batch.
+
 ## [0.9.1045]
 ### Changed
 - **Date and time pickers are clearer and steadier across the app.** Entry

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -37,6 +37,7 @@
           <p>Hovering a row on the Advanced Settings Maintenance page now fades the dividers above and below it, so the hovered row is never bisected by a hairline — matching the existing Config Flags behaviour. The row layout stays fixed while only the divider colour changes.</p>
           <p>AI agents now respond sooner when several are active. Up to three different agent wake cycles run concurrently by default instead of waiting in one global line, while each individual agent remains single-flight. The device-local limit can be tuned from one through eight in AI Settings.</p>
           <p>Task and project filters now share one coherent, accessible flow. Status, category, label, and project choices stay inside the same smoothly resizing sheet or desktop dialog, with consistent full-width selection states, responsive actions, keyboard focus restoration, and clearer activity and sort controls. Task filters open immediately while project data refreshes in place, and active filters remain visible as compact chips on the task page.</p>
+          <p>Bulk checklist suggestion acceptance no longer flickers. Confirm all keeps every proposal row mounted through its staggered exit even when fast checklist check-offs resolve the underlying suggestions before later rows begin animating, while the task page stays anchored throughout the batch.</p>
       </description>
     </release>
     <release version="0.9.1045" date="2026-07-15">

--- a/lib/features/agents/README.md
+++ b/lib/features/agents/README.md
@@ -1296,8 +1296,15 @@ destructive reject is never flush against accept — a near-miss between adjacen
 zones is the failure users with reduced motor precision fear, and the gap
 removes it. "Confirm all" is an accent pill; pressing it cascades a
 top-to-bottom pop across the rows (per-row 45 ms stagger + a throttled selection
-haptic) so a batch confirm reads as a satisfying sweep. All of this honours the
-system reduce-motion setting.
+haptic) so a batch confirm reads as a satisfying sweep. At gesture time the
+shell synchronously adds every batch fingerprint to `_exitingFingerprints`
+before either persistence or the per-row stagger timers begin. Provider
+re-queries may then resolve those proposals immediately, but
+`_retainExitingSuggestions` keeps each keyed row mounted until its own collapse
+finishes. This matters most for `update_checklist_item`: checking an existing
+item is fast enough to beat a later row's stagger, whereas the slower checklist
+insert path used to hide that race. All of this honours the system reduce-motion
+setting.
 
 ```mermaid
 sequenceDiagram
@@ -1305,6 +1312,7 @@ sequenceDiagram
   participant Builder as ChangeSetBuilder
   participant Store as agent.sqlite
   participant User as User
+  participant Card as AiSummaryCard
   participant Confirm as ChangeSetConfirmationService
   participant Dispatch as TaskToolDispatcher
   participant Journal as Journal DB
@@ -1312,7 +1320,11 @@ sequenceDiagram
 
   Agent->>Builder: queue deferred tool proposals
   Builder->>Store: persist ChangeSetEntity(pending)
-  User->>Confirm: confirm or reject one item
+  User->>Card: confirm, reject, or Confirm all
+  opt Confirm all
+    Card->>Card: retain every batch fingerprint before stagger
+  end
+  Card->>Confirm: confirm or reject pending item(s)
   Confirm->>Store: reload persisted change set
   Confirm->>Store: persist ChangeDecisionEntity first
   Confirm->>Dispatch: dispatch confirmed tool

--- a/lib/features/agents/ui/ai_summary_card.dart
+++ b/lib/features/agents/ui/ai_summary_card.dart
@@ -290,11 +290,19 @@ class _AiSummaryShellState extends ConsumerState<_AiSummaryShell> {
     );
   }
 
+  /// Confirms every visible suggestion while retaining the whole batch until
+  /// each proposal row finishes its staggered exit animation.
   Future<void> _confirmAll(List<PendingSuggestion> pending) async {
     if (_confirmAllBusy || pending.isEmpty) return;
     // Start viewport stabilization before the first persistence call can grow
     // or shrink checklist content above this card.
     widget.onSuggestionResolveStart?.call();
+    // Protect the entire batch synchronously, before either the staggered row
+    // timers or the first persistence call can run. Checklist check-off writes
+    // are fast enough for the provider to resolve every suggestion before a
+    // later row's stagger starts; without this eager retention those rows are
+    // unmounted abruptly instead of completing the confirm-all sweep. Insert
+    // writes are slower, which previously hid this race in that code path.
     // One light haptic for the whole gesture (the rows no longer tick
     // individually — that machine-gunned on a big batch). Bump the pulse so
     // the rows run their resolve → collapse exit as one staggered downward
@@ -311,6 +319,7 @@ class _AiSummaryShellState extends ConsumerState<_AiSummaryShell> {
       ),
     );
     setState(() {
+      _exitingFingerprints.addAll(pending.map((s) => s.fingerprint));
       _confirmAllBusy = true;
       _confirmAllPulse++;
     });

--- a/lib/features/tasks/README.md
+++ b/lib/features/tasks/README.md
@@ -220,12 +220,19 @@ subtle frame in light and dark themes.
   `ChangeSetConfirmationService` applies its items sequentially, so checklist
   additions may reach Riverpod as several refresh waves rather than one atomic
   rebuild. Each wave is corrected independently without an intermediate jump.
+  The AI card also retains every Confirm-all row synchronously, before its
+  staggered exit timers or the first write can run. Fast checklist check-offs
+  can therefore resolve provider state immediately without unmounting later
+  rows mid-sweep; the rows remain keyed and visible until their own collapse
+  completes.
 
   ```mermaid
   flowchart LR
     Tap[Confirm / Confirm all] --> Arm[arm viewport hold]
+    Tap --> Retain[retain all batch proposal rows]
     Tap --> Apply[confirm pending items]
     Apply -->|sequential writes| Refresh[checklist refresh waves]
+    Refresh -. provider may resolve before stagger .-> Retain
     Refresh --> Enter[SizeFadeEntrance per new row/card]
     Enter --> Report[ViewportStableSizeReporter measures delta]
     Report --> Layout[correctForNewDimensions adjusts offset]

--- a/test/features/agents/ui/ai_summary_card/proposals_test.dart
+++ b/test/features/agents/ui/ai_summary_card/proposals_test.dart
@@ -1151,6 +1151,90 @@ void main() {
         expect(find.text('Beta proposal'), findsOneWidget);
       },
     );
+
+    testWidgets(
+      'confirm-all retains later rows when the provider resolves before their '
+      'stagger starts',
+      (tester) async {
+        final csA = makeTestChangeSet(
+          id: 'retain-all-a',
+          items: const [
+            ChangeItem(
+              toolName: 'update_checklist_item',
+              args: {'id': 'item-a', 'isChecked': true},
+              humanSummary: 'Check Alpha',
+            ),
+          ],
+        );
+        final csB = makeTestChangeSet(
+          id: 'retain-all-b',
+          items: const [
+            ChangeItem(
+              toolName: 'update_checklist_item',
+              args: {'id': 'item-b', 'isChecked': true},
+              humanSummary: 'Check Beta',
+            ),
+          ],
+        );
+        final sugA = PendingSuggestion(
+          changeSet: csA,
+          itemIndex: 0,
+          item: csA.items.first,
+          fingerprint: 'fp-retain-all-a',
+        );
+        final sugB = PendingSuggestion(
+          changeSet: csB,
+          itemIndex: 0,
+          item: csB.items.first,
+          fingerprint: 'fp-retain-all-b',
+        );
+        var current = UnifiedSuggestionList(
+          open: [sugA, sugB],
+          activity: const [],
+        );
+
+        final completer = Completer<List<ToolExecutionResult>>();
+        final service = MockChangeSetConfirmationService();
+        when(
+          () => service.confirmAll(any()),
+        ).thenAnswer((_) => completer.future);
+        final bench = AgentTestBench(
+          confirmationService: service,
+          updateNotifications: MockUpdateNotifications(),
+          suggestionListOverride: (ref, taskId) => current,
+        );
+
+        await tester.pumpWidget(bench.build());
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        await tester.tap(find.text('Confirm all'));
+        await tester.pump();
+
+        // Checklist check-off writes can resolve quickly enough for the
+        // provider to drop the whole batch before Beta's stagger timer fires.
+        current = const UnifiedSuggestionList.empty();
+        ProviderScope.containerOf(
+          tester.element(find.byType(AiSummaryCard)),
+        ).invalidate(unifiedSuggestionListProvider(AgentTestBench.taskId));
+        await tester.pump();
+        await tester.pump();
+
+        // Every committed row must remain mounted until its own collapse
+        // completes; otherwise later rows blink out instead of joining the
+        // confirm-all sweep.
+        expect(find.text('Check Alpha'), findsOneWidget);
+        expect(find.text('Check Beta'), findsOneWidget);
+
+        completer.complete(const []);
+        await tester.pump();
+        await tester.pump(ProposalMotion.total);
+        await tester.pump(ProposalMotion.collapse);
+        await tester.pump(ProposalMotion.staggerStep * 8);
+        await tester.pump();
+        expect(find.byType(ProposalRow), findsNothing);
+      },
+    );
   });
 
   group('AiSummaryCard – tap-guard during collapse', () {


### PR DESCRIPTION
## Summary

- keep every Confirm-all proposal row mounted until its staggered exit completes
- preserve the pre-paint checklist viewport stabilization introduced in #3466
- add a regression test for fast checklist check-off provider resolution
- document the batch-retention lifecycle and update release notes

## Root cause

Confirm all begins a staggered top-to-bottom proposal-row sweep while `ChangeSetConfirmationService` persists the batch. Each row previously registered itself in `_exitingFingerprints` only when its own stagger timer fired.

Checklist check-off writes are fast enough for `unifiedSuggestionListProvider` to resolve the whole batch before later timers start. Those unprotected rows were therefore unmounted abruptly, producing the residual flicker. Checklist inserts are slower, which is why the insert flow already looked stable.

## Fix

`AiSummaryCard` now adds every pending batch fingerprint to `_exitingFingerprints` synchronously when Confirm all is pressed, before persistence and before the stagger timers run. Provider refreshes can resolve immediately, but `_retainExitingSuggestions` keeps each keyed row mounted until its own collapse animation finishes.

The existing `ViewportStableScrollController` and checklist size reporter remain unchanged, so the scroll-position stability from #3466 is preserved.

## Verification

- `make analyze` — zero issues
- `fvm flutter test test/features/agents/ui/ai_summary_card/proposals_test.dart` — 31 passed, covering individual and bulk acceptance
- `fvm flutter test test/features/tasks/ui/task_form_test.dart test/features/tasks/ui/widgets/viewport_stable_animated_size_test.dart` — 19 passed, covering the task form wiring and pre-paint viewport anchoring
- `fvm dart format .`
- `git diff --check`

The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards.

## Screenshots

No static pixel appearance changes. The defect is a transient frame-to-frame row-retention race; the regression test forces provider resolution before the later stagger starts and asserts that every committed row remains mounted until its collapse completes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed flickering when accepting all checklist suggestions at once.
  * Checklist suggestion rows now remain visible during staggered exit animations, keeping the task page stable while updates are applied.

* **Documentation**
  * Updated guidance and diagrams to clarify the “Confirm all” behavior and animation flow.

* **Tests**
  * Added coverage to verify checklist rows remain visible until their animations complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->