### PR TITLE
fix: stabilize checklist collapse and editor toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Arrow on a focused row opens the adjacent detail pane instead of resizing
   the divider, and keyboard row focus now uses the same full-width color and
   rounded clipping as pointer hover.
+- **Checklist cards now collapse cleanly after every item is complete.** The
+  completion message stays on one line while the card closes instead of
+  breaking into vertically stacked letters.
+- **The editor formatting toolbar renders correctly on macOS again.** Focusing
+  an editor no longer replaces its formatting controls with a grey error strip.
 - **Bulk checklist suggestion acceptance no longer flickers.** Confirm all now
   keeps every proposal row mounted through its staggered exit, even when fast
   checklist check-offs resolve the underlying suggestions before later rows

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -41,6 +41,8 @@
           <p>Keyboard navigation now enters task and project details directly. Right Arrow on a focused row opens the adjacent detail pane instead of resizing the divider, and keyboard row focus uses the same full-width color and rounded clipping as pointer hover.</p>
           <p>Task and project filters now share one coherent, accessible flow. Status, category, label, and project choices stay inside the same smoothly resizing sheet or desktop dialog, with consistent full-width selection states, responsive actions, keyboard focus restoration, and clearer activity and sort controls. Task filters open immediately while project data refreshes in place, and active filters remain visible as compact chips on the task page.</p>
           <p>New tasks now stay in the filtered list where they are created. A task inherits a single selected category, project, or status together with every selected label, while ambiguous multi-selections keep the existing defaults.</p>
+          <p>Checklist cards now collapse cleanly after every item is complete: the completion message stays on one line instead of stacking its letters.</p>
+          <p>The editor formatting toolbar renders correctly on macOS again instead of becoming a grey error strip when an editor gains focus.</p>
           <p>Bulk checklist suggestion acceptance no longer flickers. Confirm all keeps every proposal row mounted through its staggered exit even when fast checklist check-offs resolve the underlying suggestions before later rows begin animating, while the task page stays anchored throughout the batch.</p>
       </description>
     </release>

--- a/lib/features/keyboard/README.md
+++ b/lib/features/keyboard/README.md
@@ -110,9 +110,10 @@ focus.
 
 On macOS, File, View, Go, and Help menus are adapters over the catalog and
 dispatcher. They do not own duplicate callbacks or shortcut definitions. The
-menu wrapper's nested `Localizations` scope mirrors the app-level delegates,
-including Form Builder and Flutter Quill; otherwise moving the wrapper inside
-`MaterialApp.builder` would shadow editor localizations below it.
+menu wrapper uses `Localizations.override` to inherit the app-level delegates,
+including Form Builder and Flutter Quill. This keeps the nested scope from
+shadowing editor localizations below it and automatically carries future
+delegates added to `MaterialApp.router`.
 
 ## Focus regions and interaction primitives
 

--- a/lib/features/keyboard/README.md
+++ b/lib/features/keyboard/README.md
@@ -109,7 +109,10 @@ and Arrow/Page/Home/End keys scroll the reference while its search field owns
 focus.
 
 On macOS, File, View, Go, and Help menus are adapters over the catalog and
-dispatcher. They do not own duplicate callbacks or shortcut definitions.
+dispatcher. They do not own duplicate callbacks or shortcut definitions. The
+menu wrapper's nested `Localizations` scope mirrors the app-level delegates,
+including Form Builder and Flutter Quill; otherwise moving the wrapper inside
+`MaterialApp.builder` would shadow editor localizations below it.
 
 ## Focus regions and interaction primitives
 

--- a/lib/features/tasks/README.md
+++ b/lib/features/tasks/README.md
@@ -498,6 +498,14 @@ flashed them). Both checklist IDs and linked-item IDs seed their existing set on
 first render; only IDs arriving later play the one-shot size/fade entrance, so
 background refreshes do not replay initial-load motion.
 
+Checklist-card expansion uses width-stable cross-fade endpoints: the hidden
+endpoint keeps the card's full horizontal constraint and collapses only its
+height. This prevents Flutter from relaying out the outgoing body at
+progressively narrower widths. Filter-empty summaries ("all done" / "none
+done") are also explicitly limited to one ellipsized line, so completion and
+collapse animations cannot stack individual letters even under narrow or
+scaled layouts.
+
 ### Checklist runtime model
 
 `ChecklistController`:

--- a/lib/features/tasks/ui/checklists/checklist_card.dart
+++ b/lib/features/tasks/ui/checklists/checklist_card.dart
@@ -298,7 +298,11 @@ class _ChecklistCardState extends ConsumerState<ChecklistCard> {
                   });
                 },
               ),
-              secondChild: const SizedBox.shrink(),
+              // Keep both cross-fade endpoints at the card's full width. A
+              // zero-width target makes AnimatedCrossFade squeeze the outgoing
+              // body horizontally as well as vertically, which relays out text
+              // into stacked fragments during collapse.
+              secondChild: const SizedBox(width: double.infinity),
             ),
           ],
         ),

--- a/lib/features/tasks/ui/checklists/checklist_card_body.dart
+++ b/lib/features/tasks/ui/checklists/checklist_card_body.dart
@@ -65,6 +65,8 @@ class Body extends StatelessWidget {
                 allDone
                     ? context.messages.checklistAllDone
                     : context.messages.checklistNoneDone,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
                 style: tokens.typography.styles.body.bodySmall.copyWith(
                   color: tokens.colors.text.lowEmphasis,
                 ),

--- a/lib/features/tasks/ui/checklists/checklist_card_components.dart
+++ b/lib/features/tasks/ui/checklists/checklist_card_components.dart
@@ -148,7 +148,9 @@ class Header extends StatelessWidget {
             tokens: tokens,
             onFilterChanged: onFilterChanged,
           ),
-          secondChild: const SizedBox.shrink(),
+          // Collapse height only. Targeting SizedBox.shrink would also animate
+          // the header toward zero width and briefly squeeze its text/icons.
+          secondChild: const SizedBox(width: double.infinity),
         ),
       ],
     );

--- a/lib/widgets/misc/desktop_menu.dart
+++ b/lib/widgets/misc/desktop_menu.dart
@@ -4,6 +4,8 @@ import 'dart:ui' as ui;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_quill/flutter_quill.dart';
+import 'package:form_builder_validators/localization/l10n.dart';
 import 'package:lotti/features/keyboard/domain/app_command.dart';
 import 'package:lotti/features/keyboard/domain/app_command_catalog.dart';
 import 'package:lotti/features/keyboard/domain/app_command_text.dart';
@@ -52,9 +54,15 @@ class DesktopMenuWrapper extends StatelessWidget {
       locale: locale,
       delegates: const [
         AppLocalizations.delegate,
+        FormBuilderLocalizations.delegate,
         GlobalMaterialLocalizations.delegate,
         GlobalWidgetsLocalizations.delegate,
         GlobalCupertinoLocalizations.delegate,
+        // DesktopMenuWrapper now lives inside MaterialApp.builder on macOS.
+        // Its nested Localizations scope therefore has to mirror every app
+        // delegate; omitting Quill replaces the formatting toolbar with a grey
+        // release-mode ErrorWidget as soon as an editor gains focus.
+        FlutterQuillLocalizations.delegate,
       ],
       child: Builder(
         builder: (context) {

--- a/lib/widgets/misc/desktop_menu.dart
+++ b/lib/widgets/misc/desktop_menu.dart
@@ -1,16 +1,11 @@
 import 'dart:async';
-import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
-import 'package:flutter_quill/flutter_quill.dart';
-import 'package:form_builder_validators/localization/l10n.dart';
 import 'package:lotti/features/keyboard/domain/app_command.dart';
 import 'package:lotti/features/keyboard/domain/app_command_catalog.dart';
 import 'package:lotti/features/keyboard/domain/app_command_text.dart';
 import 'package:lotti/features/keyboard/ui/app_command_controller.dart';
-import 'package:lotti/l10n/app_localizations.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
 import 'package:lotti/logic/create/create_entry.dart';
 import 'package:lotti/services/nav_service.dart';
@@ -42,28 +37,11 @@ class DesktopMenuWrapper extends StatelessWidget {
       return child;
     }
 
-    // Use Localizations instead of MaterialApp to avoid creating an extra
-    // root Navigator. An outer MaterialApp would shadow the themed
-    // MaterialApp.router below and cause modals opened with
-    // useRootNavigator:true to lose the app's dark/light theme.
-    final locale =
-        Localizations.maybeLocaleOf(context) ??
-        ui.PlatformDispatcher.instance.locale;
-
-    return Localizations(
-      locale: locale,
-      delegates: const [
-        AppLocalizations.delegate,
-        FormBuilderLocalizations.delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-        // DesktopMenuWrapper now lives inside MaterialApp.builder on macOS.
-        // Its nested Localizations scope therefore has to mirror every app
-        // delegate; omitting Quill replaces the formatting toolbar with a grey
-        // release-mode ErrorWidget as soon as an editor gains focus.
-        FlutterQuillLocalizations.delegate,
-      ],
+    // Preserve the app-level delegates while introducing the localization
+    // scope required by PlatformMenuBar. Inheriting them avoids shadowing
+    // editor localizations and automatically includes delegates added later.
+    return Localizations.override(
+      context: context,
       child: Builder(
         builder: (context) {
           final commandController = AppCommandControllerProvider.maybeOf(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1047+4213
+version: 0.9.1047+4214
 
 msix_config:
   display_name: LottiApp

--- a/test/features/tasks/ui/checklists/checklist_card_test.dart
+++ b/test/features/tasks/ui/checklists/checklist_card_test.dart
@@ -734,6 +734,100 @@ void main() {
       expect(find.text('All items completed!'), findsOneWidget);
     });
 
+    testWidgets(
+      'collapse keeps the all-done summary at full width and on one line',
+      (tester) async {
+        await _pump(
+          tester,
+          initiallyExpanded: true,
+          itemIds: const ['x'],
+          completionRate: 1,
+          completedCount: 1,
+          totalCount: 1,
+        );
+        await tester.pump();
+
+        final summaryFinder = find.text('All items completed!');
+        final expandedWidth = tester.getSize(summaryFinder).width;
+        final expandedText = tester.widget<Text>(summaryFinder);
+
+        expect(expandedText.maxLines, 1);
+        expect(expandedText.overflow, TextOverflow.ellipsis);
+
+        await tester.tap(find.byIcon(Icons.expand_more));
+        await tester.pump(checklistCardCollapseAnimationDuration ~/ 2);
+
+        // The outgoing body must collapse vertically only. If the cross-fade
+        // also targets zero width, Flutter relays out this text in a narrowing
+        // column and briefly stacks its letters during the transition.
+        expect(tester.getSize(summaryFinder).width, expandedWidth);
+        expect(tester.widget<Text>(summaryFinder).maxLines, 1);
+      },
+    );
+
+    testWidgets(
+      'collapse preserves horizontal constraints for complete, partial, and '
+      'empty checklists',
+      (tester) async {
+        final cases =
+            <
+              ({
+                String name,
+                List<String> itemIds,
+                double completionRate,
+                int completedCount,
+                int totalCount,
+              })
+            >[
+              (
+                name: 'complete',
+                itemIds: const ['x'],
+                completionRate: 1,
+                completedCount: 1,
+                totalCount: 1,
+              ),
+              (
+                name: 'partial',
+                itemIds: const [],
+                completionRate: 0.5,
+                completedCount: 1,
+                totalCount: 2,
+              ),
+              (
+                name: 'empty',
+                itemIds: const [],
+                completionRate: 0,
+                completedCount: 0,
+                totalCount: 0,
+              ),
+            ];
+
+        for (final testCase in cases) {
+          await _pump(
+            tester,
+            title: 'Checklist ${testCase.name}',
+            initiallyExpanded: true,
+            itemIds: testCase.itemIds,
+            completionRate: testCase.completionRate,
+            completedCount: testCase.completedCount,
+            totalCount: testCase.totalCount,
+          );
+          await tester.pump();
+
+          final cardWidth = tester.getSize(find.byType(ChecklistCard)).width;
+          await tester.tap(find.byIcon(Icons.expand_more));
+          await tester.pump(checklistCardCollapseAnimationDuration ~/ 2);
+
+          expect(
+            tester.getSize(find.byType(ChecklistCard)).width,
+            cardWidth,
+            reason: '${testCase.name} checklist narrowed while collapsing',
+          );
+          expect(tester.takeException(), isNull, reason: testCase.name);
+        }
+      },
+    );
+
     // ── Sorting header with reorderIndex=null ───────────────────────────────
 
     testWidgets('sorting header without reorderIndex shows plain drag handle', (

--- a/test/widgets/misc/desktop_menu_test.dart
+++ b/test/widgets/misc/desktop_menu_test.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/keyboard/domain/app_command.dart';
 import 'package:lotti/features/keyboard/domain/app_command_handler.dart';
 import 'package:lotti/features/keyboard/ui/app_command_host.dart';
+import 'package:lotti/l10n/app_localizations.dart';
 import 'package:lotti/widgets/misc/desktop_menu.dart';
 
 void main() {
@@ -80,6 +83,41 @@ void main() {
 
             expect(find.byType(PlatformMenuBar), findsOneWidget);
             expect(find.text('Menu Child'), findsOneWidget);
+          } finally {
+            debugDefaultTargetPlatformOverride = null;
+          }
+        },
+      );
+
+      testWidgets(
+        'preserves Flutter Quill localization from the app scope on macOS',
+        (tester) async {
+          debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+          try {
+            const childKey = ValueKey('localized-menu-child');
+            await tester.pumpWidget(
+              const MaterialApp(
+                localizationsDelegates: [
+                  AppLocalizations.delegate,
+                  GlobalMaterialLocalizations.delegate,
+                  GlobalWidgetsLocalizations.delegate,
+                  GlobalCupertinoLocalizations.delegate,
+                  FlutterQuillLocalizations.delegate,
+                ],
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: DesktopMenuWrapper(
+                  child: SizedBox(key: childKey),
+                ),
+              ),
+            );
+            await tester.pump();
+
+            final childContext = tester.element(find.byKey(childKey));
+            expect(
+              FlutterQuillLocalizations.of(childContext),
+              isNotNull,
+              reason: 'The desktop menu must not shadow app-level delegates',
+            );
           } finally {
             debugDefaultTargetPlatformOverride = null;
           }

--- a/test/widgets/misc/desktop_menu_test.dart
+++ b/test/widgets/misc/desktop_menu_test.dart
@@ -9,6 +9,8 @@ import 'package:lotti/features/keyboard/ui/app_command_host.dart';
 import 'package:lotti/l10n/app_localizations.dart';
 import 'package:lotti/widgets/misc/desktop_menu.dart';
 
+import '../../widget_test_utils.dart';
+
 void main() {
   group('DesktopMenuWrapper', () {
     // The zoom callbacks the wrapper holds are the closures that get wired
@@ -53,12 +55,11 @@ void main() {
           debugDefaultTargetPlatformOverride = TargetPlatform.android;
           try {
             await tester.pumpWidget(
-              const Directionality(
-                textDirection: TextDirection.ltr,
-                child: DesktopMenuWrapper(child: Text('Direct Child')),
+              makeTestableWidget(
+                const DesktopMenuWrapper(child: Text('Direct Child')),
               ),
             );
-            await tester.pumpAndSettle();
+            await tester.pump();
 
             expect(find.text('Direct Child'), findsOneWidget);
             expect(find.byType(PlatformMenuBar), findsNothing);
@@ -74,12 +75,11 @@ void main() {
           debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
           try {
             await tester.pumpWidget(
-              const Directionality(
-                textDirection: TextDirection.ltr,
-                child: DesktopMenuWrapper(child: Text('Menu Child')),
+              makeTestableWidget(
+                const DesktopMenuWrapper(child: Text('Menu Child')),
               ),
             );
-            await tester.pumpAndSettle();
+            await tester.pump();
 
             expect(find.byType(PlatformMenuBar), findsOneWidget);
             expect(find.text('Menu Child'), findsOneWidget);
@@ -131,9 +131,8 @@ void main() {
         debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
         try {
           await tester.pumpWidget(
-            Directionality(
-              textDirection: TextDirection.ltr,
-              child: AppCommandHost(
+            makeTestableWidget(
+              AppCommandHost(
                 handlers: {
                   AppCommandId.navigateTasks: AppCommandHandler(
                     invoke: (_) => taskNavigations++,
@@ -171,9 +170,8 @@ void main() {
         debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
         try {
           await tester.pumpWidget(
-            Directionality(
-              textDirection: TextDirection.ltr,
-              child: AppCommandHost(
+            makeTestableWidget(
+              AppCommandHost(
                 handlers: {
                   AppCommandId.zoomIn: AppCommandHandler(
                     isEnabled: () => false,

--- a/third_party/flutter_onnxruntime/lib/src/flutter_onnxruntime_method_channel.dart
+++ b/third_party/flutter_onnxruntime/lib/src/flutter_onnxruntime_method_channel.dart
@@ -32,18 +32,23 @@ class MethodChannelFlutterOnnxruntime extends FlutterOnnxruntimePlatform {
   /// which is more memory efficient as it avoids copying the entire model
   /// through the method channel.
   @override
-  Future<Map<String, dynamic>> createSession(String modelPath, {Map<String, dynamic>? sessionOptions}) async {
-    final result = await methodChannel.invokeMethod<Map<Object?, Object?>>('createSession', {
-      'modelPath': modelPath,
-      'sessionOptions': sessionOptions ?? {},
-    });
+  Future<Map<String, dynamic>> createSession(
+    String modelPath, {
+    Map<String, dynamic>? sessionOptions,
+  }) async {
+    final result = await methodChannel.invokeMethod<Map<Object?, Object?>>(
+      'createSession',
+      {'modelPath': modelPath, 'sessionOptions': sessionOptions ?? {}},
+    );
     return _convertMapToStringDynamic(result ?? {});
   }
 
   /// Get the available providers
   @override
   Future<List<String>> getAvailableProviders() async {
-    final result = await methodChannel.invokeMethod<List<Object?>>('getAvailableProviders');
+    final result = await methodChannel.invokeMethod<List<Object?>>(
+      'getAvailableProviders',
+    );
     return result?.map((item) => item.toString()).toList() ?? [];
   }
 
@@ -66,67 +71,104 @@ class MethodChannelFlutterOnnxruntime extends FlutterOnnxruntimePlatform {
       processedInputs[entry.key] = {'valueId': entry.value.id};
     }
 
-    final result = await methodChannel.invokeMethod<Map<Object?, Object?>>('runInference', {
-      'sessionId': sessionId,
-      'inputs': processedInputs,
-      'runOptions': runOptions ?? {},
-    });
+    final result = await methodChannel.invokeMethod<Map<Object?, Object?>>(
+      'runInference',
+      {
+        'sessionId': sessionId,
+        'inputs': processedInputs,
+        'runOptions': runOptions ?? {},
+      },
+    );
     return _convertMapToStringDynamic(result ?? {});
   }
 
   @override
   Future<void> closeSession(String sessionId) async {
-    await methodChannel.invokeMethod<void>('closeSession', {'sessionId': sessionId});
+    await methodChannel.invokeMethod<void>('closeSession', {
+      'sessionId': sessionId,
+    });
   }
 
   @override
   Future<Map<String, dynamic>> getMetadata(String sessionId) async {
-    final result = await methodChannel.invokeMethod<Map<Object?, Object?>>('getMetadata', {'sessionId': sessionId});
+    final result = await methodChannel.invokeMethod<Map<Object?, Object?>>(
+      'getMetadata',
+      {'sessionId': sessionId},
+    );
     return _convertMapToStringDynamic(result ?? {});
   }
 
   @override
   Future<List<Map<String, dynamic>>> getInputInfo(String sessionId) async {
-    final result = await methodChannel.invokeMethod<List<Object?>>('getInputInfo', {'sessionId': sessionId});
-    return result?.map((item) => _convertMapToStringDynamic(item as Map<Object?, Object?>)).toList() ?? [];
+    final result = await methodChannel.invokeMethod<List<Object?>>(
+      'getInputInfo',
+      {'sessionId': sessionId},
+    );
+    return result
+            ?.map(
+              (item) =>
+                  _convertMapToStringDynamic(item as Map<Object?, Object?>),
+            )
+            .toList() ??
+        [];
   }
 
   @override
   Future<List<Map<String, dynamic>>> getOutputInfo(String sessionId) async {
-    final result = await methodChannel.invokeMethod<List<Object?>>('getOutputInfo', {'sessionId': sessionId});
-    return result?.map((item) => _convertMapToStringDynamic(item as Map<Object?, Object?>)).toList() ?? [];
+    final result = await methodChannel.invokeMethod<List<Object?>>(
+      'getOutputInfo',
+      {'sessionId': sessionId},
+    );
+    return result
+            ?.map(
+              (item) =>
+                  _convertMapToStringDynamic(item as Map<Object?, Object?>),
+            )
+            .toList() ??
+        [];
   }
 
   // OrtValue operations
 
   @override
-  Future<Map<String, dynamic>> createOrtValue(String sourceType, dynamic data, List<int> shape) async {
-    final result = await methodChannel.invokeMethod<Map<Object?, Object?>>('createOrtValue', {
-      'sourceType': sourceType,
-      'data': data,
-      'shape': shape,
-    });
+  Future<Map<String, dynamic>> createOrtValue(
+    String sourceType,
+    dynamic data,
+    List<int> shape,
+  ) async {
+    final result = await methodChannel.invokeMethod<Map<Object?, Object?>>(
+      'createOrtValue',
+      {'sourceType': sourceType, 'data': data, 'shape': shape},
+    );
     return _convertMapToStringDynamic(result ?? {});
   }
 
   @override
-  Future<Map<String, dynamic>> convertOrtValue(String valueId, String targetType) async {
-    final result = await methodChannel.invokeMethod<Map<Object?, Object?>>('convertOrtValue', {
-      'valueId': valueId,
-      'targetType': targetType,
-    });
+  Future<Map<String, dynamic>> convertOrtValue(
+    String valueId,
+    String targetType,
+  ) async {
+    final result = await methodChannel.invokeMethod<Map<Object?, Object?>>(
+      'convertOrtValue',
+      {'valueId': valueId, 'targetType': targetType},
+    );
     return _convertMapToStringDynamic(result ?? {});
   }
 
   @override
   Future<Map<String, dynamic>> getOrtValueData(String valueId) async {
-    final result = await methodChannel.invokeMethod<Map<Object?, Object?>>('getOrtValueData', {'valueId': valueId});
+    final result = await methodChannel.invokeMethod<Map<Object?, Object?>>(
+      'getOrtValueData',
+      {'valueId': valueId},
+    );
     return _convertMapToStringDynamic(result ?? {});
   }
 
   @override
   Future<void> releaseOrtValue(String valueId) async {
-    await methodChannel.invokeMethod<void>('releaseOrtValue', {'valueId': valueId});
+    await methodChannel.invokeMethod<void>('releaseOrtValue', {
+      'valueId': valueId,
+    });
   }
 
   Map<String, dynamic> _convertMapToStringDynamic(Map<Object?, Object?> map) {

--- a/third_party/flutter_onnxruntime/lib/src/flutter_onnxruntime_platform_interface.dart
+++ b/third_party/flutter_onnxruntime/lib/src/flutter_onnxruntime_platform_interface.dart
@@ -14,7 +14,8 @@ abstract class FlutterOnnxruntimePlatform extends PlatformInterface {
 
   static final Object _token = Object();
 
-  static FlutterOnnxruntimePlatform _instance = MethodChannelFlutterOnnxruntime();
+  static FlutterOnnxruntimePlatform _instance =
+      MethodChannelFlutterOnnxruntime();
 
   /// The default instance of [FlutterOnnxruntimePlatform] to use.
   ///
@@ -35,13 +36,18 @@ abstract class FlutterOnnxruntimePlatform extends PlatformInterface {
   }
 
   // Core ONNX Runtime operations
-  Future<Map<String, dynamic>> createSession(String modelPath, {Map<String, dynamic>? sessionOptions}) {
+  Future<Map<String, dynamic>> createSession(
+    String modelPath, {
+    Map<String, dynamic>? sessionOptions,
+  }) {
     throw UnimplementedError('createSession() has not been implemented.');
   }
 
   /// Get the available providers
   Future<List<String>> getAvailableProviders() {
-    throw UnimplementedError('getAvailableProviders() has not been implemented.');
+    throw UnimplementedError(
+      'getAvailableProviders() has not been implemented.',
+    );
   }
 
   /// Run inference on a session
@@ -99,7 +105,11 @@ abstract class FlutterOnnxruntimePlatform extends PlatformInterface {
   /// [sourceType] is the source data type (e.g., 'float32', 'int32')
   /// [data] is the data to create the tensor from
   /// [shape] is the shape of the tensor
-  Future<Map<String, dynamic>> createOrtValue(String sourceType, dynamic data, List<int> shape) {
+  Future<Map<String, dynamic>> createOrtValue(
+    String sourceType,
+    dynamic data,
+    List<int> shape,
+  ) {
     throw UnimplementedError('createOrtValue() has not been implemented.');
   }
 
@@ -107,7 +117,10 @@ abstract class FlutterOnnxruntimePlatform extends PlatformInterface {
   ///
   /// [valueId] is the ID of the OrtValue to convert
   /// [targetType] is the target data type (e.g., 'float32', 'float16')
-  Future<Map<String, dynamic>> convertOrtValue(String valueId, String targetType) {
+  Future<Map<String, dynamic>> convertOrtValue(
+    String valueId,
+    String targetType,
+  ) {
     throw UnimplementedError('convertOrtValue() has not been implemented.');
   }
 

--- a/third_party/flutter_onnxruntime/lib/src/onnxruntime.dart
+++ b/third_party/flutter_onnxruntime/lib/src/onnxruntime.dart
@@ -21,7 +21,10 @@ class OnnxRuntime {
   }
 
   /// Create an ONNX Runtime session with the given model path
-  Future<OrtSession> createSession(String modelPath, {OrtSessionOptions? options}) async {
+  Future<OrtSession> createSession(
+    String modelPath, {
+    OrtSessionOptions? options,
+  }) async {
     final result = await FlutterOnnxruntimePlatform.instance.createSession(
       modelPath,
       sessionOptions: options?.toMap() ?? {},
@@ -32,7 +35,10 @@ class OnnxRuntime {
   /// Create an ONNX Runtime session from an asset model file
   ///
   /// This will extract the asset to a temporary file and use that path
-  Future<OrtSession> createSessionFromAsset(String assetKey, {OrtSessionOptions? options}) async {
+  Future<OrtSession> createSessionFromAsset(
+    String assetKey, {
+    OrtSessionOptions? options,
+  }) async {
     if (kIsWeb) {
       // On web, we need to handle differently as path_provider is not available
       // Instead, pass the asset key directly to the web implementation
@@ -66,11 +72,14 @@ class OnnxRuntime {
   ///
   /// Returns a list of the available providers
   Future<List<OrtProvider>> getAvailableProviders() async {
-    final providers = await FlutterOnnxruntimePlatform.instance.getAvailableProviders();
+    final providers =
+        await FlutterOnnxruntimePlatform.instance.getAvailableProviders();
     return providers.map((p) {
       final provider = OrtProvider.values.firstWhere(
         (e) => e.name == p,
-        orElse: () => throw ArgumentError('Provider $p is not a valid OrtProvider.'),
+        orElse:
+            () =>
+                throw ArgumentError('Provider $p is not a valid OrtProvider.'),
       );
       return provider;
     }).toList();

--- a/third_party/flutter_onnxruntime/lib/src/ort_model_metadata.dart
+++ b/third_party/flutter_onnxruntime/lib/src/ort_model_metadata.dart
@@ -28,7 +28,9 @@ class OrtModelMetadata {
       domain: map['domain'] as String? ?? '',
       description: map['description'] as String? ?? '',
       version: map['version'] as int? ?? 0,
-      customMetadataMap: Map<String, String>.from(map['customMetadataMap'] ?? {}),
+      customMetadataMap: Map<String, String>.from(
+        map['customMetadataMap'] ?? {},
+      ),
     );
   }
 

--- a/third_party/flutter_onnxruntime/lib/src/ort_session.dart
+++ b/third_party/flutter_onnxruntime/lib/src/ort_session.dart
@@ -15,7 +15,11 @@ class OrtSession {
   final List<String> outputNames;
 
   // Private constructor
-  OrtSession._({required this.id, required this.inputNames, required this.outputNames});
+  OrtSession._({
+    required this.id,
+    required this.inputNames,
+    required this.outputNames,
+  });
 
   // Public factory constructor to create from map
   factory OrtSession.fromMap(Map<String, dynamic> map) {
@@ -44,7 +48,10 @@ class OrtSession {
   /// };
   /// final outputs = await session.run(inputs);
   /// ```
-  Future<Map<String, OrtValue>> run(Map<String, OrtValue> inputs, {OrtRunOptions? options}) async {
+  Future<Map<String, OrtValue>> run(
+    Map<String, OrtValue> inputs, {
+    OrtRunOptions? options,
+  }) async {
     final result = await FlutterOnnxruntimePlatform.instance.runInference(
       id,
       inputs,
@@ -52,7 +59,11 @@ class OrtSession {
     );
     final outputs = <String, OrtValue>{};
     for (final entry in result.entries) {
-      final tensorMap = {'valueId': entry.value[0], 'dataType': entry.value[1], 'shape': entry.value[2]};
+      final tensorMap = {
+        'valueId': entry.value[0],
+        'dataType': entry.value[1],
+        'shape': entry.value[2],
+      };
       outputs[entry.key] = OrtValue.fromMap(tensorMap);
     }
     return outputs;
@@ -67,7 +78,9 @@ class OrtSession {
   /// Returns information about the model such as producer name, graph name,
   /// domain, description, version, and custom metadata.
   Future<OrtModelMetadata> getMetadata() async {
-    final metadataMap = await FlutterOnnxruntimePlatform.instance.getMetadata(id);
+    final metadataMap = await FlutterOnnxruntimePlatform.instance.getMetadata(
+      id,
+    );
     return OrtModelMetadata.fromMap(metadataMap);
   }
 
@@ -75,7 +88,9 @@ class OrtSession {
   ///
   /// Returns information about the model's inputs such as name, type, and shape.
   Future<List<Map<String, dynamic>>> getInputInfo() async {
-    final inputInfoMap = await FlutterOnnxruntimePlatform.instance.getInputInfo(id);
+    final inputInfoMap = await FlutterOnnxruntimePlatform.instance.getInputInfo(
+      id,
+    );
     return inputInfoMap.map((info) => Map<String, dynamic>.from(info)).toList();
   }
 
@@ -83,8 +98,11 @@ class OrtSession {
   ///
   /// Returns information about the model's outputs such as name, type, and shape.
   Future<List<Map<String, dynamic>>> getOutputInfo() async {
-    final outputInfoMap = await FlutterOnnxruntimePlatform.instance.getOutputInfo(id);
-    return outputInfoMap.map((info) => Map<String, dynamic>.from(info)).toList();
+    final outputInfoMap = await FlutterOnnxruntimePlatform.instance
+        .getOutputInfo(id);
+    return outputInfoMap
+        .map((info) => Map<String, dynamic>.from(info))
+        .toList();
   }
 }
 
@@ -101,13 +119,20 @@ class OrtSessionOptions {
   // set the device id for the session, default is 0
   final int? deviceId;
 
-  OrtSessionOptions({this.intraOpNumThreads, this.interOpNumThreads, this.providers, this.useArena, this.deviceId});
+  OrtSessionOptions({
+    this.intraOpNumThreads,
+    this.interOpNumThreads,
+    this.providers,
+    this.useArena,
+    this.deviceId,
+  });
 
   Map<String, dynamic> toMap() {
     return {
       if (intraOpNumThreads != null) 'intraOpNumThreads': intraOpNumThreads,
       if (interOpNumThreads != null) 'interOpNumThreads': interOpNumThreads,
-      if (providers != null && providers!.isNotEmpty) 'providers': providers!.map((p) => p.name).toList(),
+      if (providers != null && providers!.isNotEmpty)
+        'providers': providers!.map((p) => p.name).toList(),
       if (useArena != null) 'useArena': useArena,
       if (deviceId != null) 'deviceId': deviceId,
     };
@@ -126,7 +151,11 @@ class OrtRunOptions {
   // terminate all incomplete inference using this instance as soon as possible
   final bool? terminate;
 
-  OrtRunOptions({this.logSeverityLevel, this.logVerbosityLevel, this.terminate});
+  OrtRunOptions({
+    this.logSeverityLevel,
+    this.logVerbosityLevel,
+    this.terminate,
+  });
 
   Map<String, dynamic> toMap() {
     return {

--- a/third_party/flutter_onnxruntime/lib/src/ort_value.dart
+++ b/third_party/flutter_onnxruntime/lib/src/ort_value.dart
@@ -59,7 +59,8 @@ class OrtValue {
       dataType: OrtDataType.values.firstWhere(
         (dt) => dt.toString() == 'OrtDataType.${map['dataType']}',
         // throw an exception if the data type is not found
-        orElse: () => throw ArgumentError('Invalid data type: ${map['dataType']}'),
+        orElse:
+            () => throw ArgumentError('Invalid data type: ${map['dataType']}'),
       ),
       shape: List<int>.from(map['shape'] ?? []),
     );
@@ -84,7 +85,11 @@ class OrtValue {
   static Future<OrtValue> fromList(dynamic data, List<int> shape) async {
     // If data is a regular List, convert it to the appropriate TypedData
     if (data is List &&
-        !(data is Float32List || data is Int32List || data is Int64List || data is Uint8List || data is List<String>)) {
+        !(data is Float32List ||
+            data is Int32List ||
+            data is Int64List ||
+            data is Uint8List ||
+            data is List<String>)) {
       data = _convertListToTypedData(data);
     }
 
@@ -117,7 +122,11 @@ class OrtValue {
       throw ArgumentError('Unsupported data type: ${data.runtimeType}');
     }
 
-    final result = await FlutterOnnxruntimePlatform.instance.createOrtValue(sourceType, data, shape);
+    final result = await FlutterOnnxruntimePlatform.instance.createOrtValue(
+      sourceType,
+      data,
+      shape,
+    );
     return OrtValue.fromMap(result);
   }
 
@@ -125,7 +134,10 @@ class OrtValue {
   ///
   /// [targetType] is the target data type to convert to
   Future<OrtValue> to(OrtDataType targetType) async {
-    final result = await FlutterOnnxruntimePlatform.instance.convertOrtValue(id, targetType.toString().split('.').last);
+    final result = await FlutterOnnxruntimePlatform.instance.convertOrtValue(
+      id,
+      targetType.toString().split('.').last,
+    );
     return OrtValue.fromMap(result);
   }
 
@@ -145,7 +157,9 @@ class OrtValue {
     var dataList1d = (rawData is List) ? rawData : List<dynamic>.from(rawData);
     // On iOS/macOS, bool tensors are stored as uint8 internally,
     // so convert 0/1 integers back to false/true
-    if (dataType == OrtDataType.bool && dataList1d.isNotEmpty && dataList1d.first is! bool) {
+    if (dataType == OrtDataType.bool &&
+        dataList1d.isNotEmpty &&
+        dataList1d.first is! bool) {
       dataList1d = dataList1d.map((e) => e != 0).toList();
     }
     return _reshapeList(dataList1d, shape);
@@ -165,7 +179,9 @@ class OrtValue {
     final list = (rawData is List) ? rawData : List<dynamic>.from(rawData);
     // On iOS/macOS, bool tensors are stored as uint8 internally,
     // so convert 0/1 integers back to false/true
-    if (dataType == OrtDataType.bool && list.isNotEmpty && list.first is! bool) {
+    if (dataType == OrtDataType.bool &&
+        list.isNotEmpty &&
+        list.first is! bool) {
       return list.map((e) => e != 0).toList();
     }
     return list;
@@ -205,19 +221,26 @@ class OrtValue {
     // Handle numeric lists
     if (firstElement is num) {
       // Check if it should be Float32List (contains any doubles or decimal values)
-      if (firstElement is double || data.any((e) => e is double || (e is num && e % 1 != 0))) {
-        return Float32List.fromList(data.map((e) => (e as num).toDouble()).toList());
+      if (firstElement is double ||
+          data.any((e) => e is double || (e is num && e % 1 != 0))) {
+        return Float32List.fromList(
+          data.map((e) => (e as num).toDouble()).toList(),
+        );
       }
 
       // Check if Int64List is needed (any value outside Int32 range)
-      bool needsInt64 = data.any((e) => (e as num).toInt() > 2147483647 || (e).toInt() < -2147483648);
+      bool needsInt64 = data.any(
+        (e) => (e as num).toInt() > 2147483647 || (e).toInt() < -2147483648,
+      );
 
       return needsInt64
           ? Int64List.fromList(data.map((e) => (e as num).toInt()).toList())
           : Int32List.fromList(data.map((e) => (e as num).toInt()).toList());
     }
 
-    throw ArgumentError('Unsupported element type: ${firstElement.runtimeType} in list');
+    throw ArgumentError(
+      'Unsupported element type: ${firstElement.runtimeType} in list',
+    );
   }
 
   // Helper method to recursively flatten nested lists
@@ -251,10 +274,16 @@ class OrtValue {
 
   /// Get the number of elements in the data
   static int _getElementCount(dynamic data) {
-    if (data is Float32List || data is Int32List || data is Int64List || data is Uint8List || data is List) {
+    if (data is Float32List ||
+        data is Int32List ||
+        data is Int64List ||
+        data is Uint8List ||
+        data is List) {
       return data.length;
     }
-    throw ArgumentError('Cannot determine element count for type: ${data.runtimeType}');
+    throw ArgumentError(
+      'Cannot determine element count for type: ${data.runtimeType}',
+    );
   }
 
   /// Reshapes a flattened list of data according to the provided shape.
@@ -286,7 +315,11 @@ class OrtValue {
   }
 
   // Recursive function to build nested structure
-  static List _buildNestedList(List<dynamic> flatData, List<int> dimensions, int offset) {
+  static List _buildNestedList(
+    List<dynamic> flatData,
+    List<int> dimensions,
+    int offset,
+  ) {
     // Base case: if we're at the innermost dimension
     if (dimensions.length == 1) {
       return flatData.sublist(offset, offset + dimensions[0]);

--- a/third_party/flutter_onnxruntime/lib/web/flutter_onnxruntime_web_plugin.dart
+++ b/third_party/flutter_onnxruntime/lib/web/flutter_onnxruntime_web_plugin.dart
@@ -88,7 +88,10 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
   }
 
   @override
-  Future<Map<String, dynamic>> createSession(String modelPath, {Map<String, dynamic>? sessionOptions}) async {
+  Future<Map<String, dynamic>> createSession(
+    String modelPath, {
+    Map<String, dynamic>? sessionOptions,
+  }) async {
     try {
       // Initialize session options for onnxruntime-web
       final jsSessionOptions = createJsSessionOptions(sessionOptions);
@@ -107,9 +110,17 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
       _sessions[sessionId] = session;
 
       // Return the required information
-      return {'sessionId': sessionId, 'inputNames': inputNames, 'outputNames': outputNames};
+      return {
+        'sessionId': sessionId,
+        'inputNames': inputNames,
+        'outputNames': outputNames,
+      };
     } catch (e) {
-      throw PlatformException(code: 'PLUGIN_ERROR', message: 'Failed to create ONNX session: $e', details: null);
+      throw PlatformException(
+        code: 'PLUGIN_ERROR',
+        message: 'Failed to create ONNX session: $e',
+        details: null,
+      );
     }
   }
 
@@ -145,21 +156,33 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
             }).toList();
 
         // Set executionProviders property
-        jsOptions.setProperty('executionProviders'.toJS, jsArrayFrom(jsProviders));
+        jsOptions.setProperty(
+          'executionProviders'.toJS,
+          jsArrayFrom(jsProviders),
+        );
       }
 
       // Set other options like intraOpNumThreads, interOpNumThreads if needed
       if (options.containsKey('intraOpNumThreads')) {
-        jsOptions.setProperty('intraOpNumThreads'.toJS, options['intraOpNumThreads']);
+        jsOptions.setProperty(
+          'intraOpNumThreads'.toJS,
+          options['intraOpNumThreads'],
+        );
       }
 
       if (options.containsKey('interOpNumThreads')) {
-        jsOptions.setProperty('interOpNumThreads'.toJS, options['interOpNumThreads']);
+        jsOptions.setProperty(
+          'interOpNumThreads'.toJS,
+          options['interOpNumThreads'],
+        );
       }
 
       // Handle graph optimization level
       if (options.containsKey('graphOptimizationLevel')) {
-        jsOptions.setProperty('graphOptimizationLevel'.toJS, options['graphOptimizationLevel']);
+        jsOptions.setProperty(
+          'graphOptimizationLevel'.toJS,
+          options['graphOptimizationLevel'],
+        );
       }
 
       // Add more options as needed
@@ -169,15 +192,22 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
   }
 
   /// Creates an inference session using onnxruntime-web
-  Future<JSObject> createInferenceSession(String modelPath, JSObject options) async {
+  Future<JSObject> createInferenceSession(
+    String modelPath,
+    JSObject options,
+  ) async {
     final completer = Completer<JSObject>();
 
     try {
       // Get the InferenceSession class from onnxruntime-web
-      final inferenceSession = _ort.getProperty('InferenceSession'.toJS) as JSObject;
+      final inferenceSession =
+          _ort.getProperty('InferenceSession'.toJS) as JSObject;
 
       // Use the create method to create a session - async operation
-      final createPromise = callMethod(inferenceSession, 'create', [modelPath, options]);
+      final createPromise = callMethod(inferenceSession, 'create', [
+        modelPath,
+        options,
+      ]);
 
       // Convert Promise to Future
       final session = await promiseToFuture<JSObject>(createPromise);
@@ -273,7 +303,8 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
     }
     // Check for WebGL support
     final canvas = HTMLCanvasElement();
-    final webgl = canvas.getContext('webgl') ?? canvas.getContext('experimental-webgl');
+    final webgl =
+        canvas.getContext('webgl') ?? canvas.getContext('experimental-webgl');
     if (webgl != null) {
       providers.add('WEB_GL');
     }
@@ -297,7 +328,11 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
     try {
       // Check if the session exists
       if (!_sessions.containsKey(sessionId)) {
-        throw PlatformException(code: "INVALID_SESSION", message: "Session not found", details: null);
+        throw PlatformException(
+          code: "INVALID_SESSION",
+          message: "Session not found",
+          details: null,
+        );
       }
 
       final session = _sessions[sessionId]!;
@@ -314,7 +349,11 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
         final valueId = ortValue.id;
         final tensor = _ortValues[valueId];
         if (tensor == null) {
-          throw PlatformException(code: "INVALID_VALUE", message: "OrtValue with ID $valueId not found", details: null);
+          throw PlatformException(
+            code: "INVALID_VALUE",
+            message: "OrtValue with ID $valueId not found",
+            details: null,
+          );
         }
 
         // Add to inputs object
@@ -328,11 +367,17 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
 
         // Set run options if needed
         if (runOptions.containsKey('logSeverityLevel')) {
-          jsRunOptions.setProperty('logSeverityLevel'.toJS, runOptions['logSeverityLevel']);
+          jsRunOptions.setProperty(
+            'logSeverityLevel'.toJS,
+            runOptions['logSeverityLevel'],
+          );
         }
 
         if (runOptions.containsKey('logVerbosityLevel')) {
-          jsRunOptions.setProperty('logVerbosityLevel'.toJS, runOptions['logVerbosityLevel']);
+          jsRunOptions.setProperty(
+            'logVerbosityLevel'.toJS,
+            runOptions['logVerbosityLevel'],
+          );
         }
 
         if (runOptions.containsKey('terminate')) {
@@ -358,7 +403,8 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
           final tensor = jsOutputs.getProperty(name.toJS) as JSObject;
 
           // Create a new OrtValue and store it
-          final valueId = '${DateTime.now().millisecondsSinceEpoch}_${math.Random().nextInt(10000)}';
+          final valueId =
+              '${DateTime.now().millisecondsSinceEpoch}_${math.Random().nextInt(10000)}';
 
           _ortValues[valueId] = tensor;
 
@@ -367,7 +413,8 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
 
           // Get tensor shape
           final jsShape = tensor.getProperty('dims'.toJS) as JSObject;
-          final shapeLength = (jsShape.getProperty('length'.toJS) as JSNumber).toDartInt;
+          final shapeLength =
+              (jsShape.getProperty('length'.toJS) as JSNumber).toDartInt;
           final shape = <int>[];
 
           for (var i = 0; i < shapeLength; i++) {
@@ -385,7 +432,11 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
       if (e is PlatformException) {
         rethrow;
       }
-      throw PlatformException(code: "INFERENCE_ERROR", message: "Failed to run inference: $e", details: null);
+      throw PlatformException(
+        code: "INFERENCE_ERROR",
+        message: "Failed to run inference: $e",
+        details: null,
+      );
     }
   }
 
@@ -442,7 +493,11 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
     try {
       // Check if the session exists
       if (!_sessions.containsKey(sessionId)) {
-        throw PlatformException(code: "INVALID_SESSION", message: "Session not found", details: null);
+        throw PlatformException(
+          code: "INVALID_SESSION",
+          message: "Session not found",
+          details: null,
+        );
       }
 
       final session = _sessions[sessionId]!;
@@ -463,33 +518,40 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
 
         // Extract metadata properties if they exist
         if (metadata.has('producerName')) {
-          metadataMap['producerName'] = metadata.getProperty('producerName'.toJS).toString();
+          metadataMap['producerName'] =
+              metadata.getProperty('producerName'.toJS).toString();
         }
 
         if (metadata.has('graphName')) {
-          metadataMap['graphName'] = metadata.getProperty('graphName'.toJS).toString();
+          metadataMap['graphName'] =
+              metadata.getProperty('graphName'.toJS).toString();
         }
 
         if (metadata.has('domain')) {
-          metadataMap['domain'] = metadata.getProperty('domain'.toJS).toString();
+          metadataMap['domain'] =
+              metadata.getProperty('domain'.toJS).toString();
         }
 
         if (metadata.has('description')) {
-          metadataMap['description'] = metadata.getProperty('description'.toJS).toString();
+          metadataMap['description'] =
+              metadata.getProperty('description'.toJS).toString();
         }
 
         if (metadata.has('version')) {
-          metadataMap['version'] = metadata.getProperty('version'.toJS).toString();
+          metadataMap['version'] =
+              metadata.getProperty('version'.toJS).toString();
         }
 
         if (metadata.has('customMetadataMap')) {
-          final customMap = metadata.getProperty('customMetadataMap'.toJS) as JSObject;
+          final customMap =
+              metadata.getProperty('customMetadataMap'.toJS) as JSObject;
           final customMetadataMap = <String, String>{};
 
           // Convert JavaScript object to Dart map
           // Use Object.keys() from JavaScript to get the keys of the object
           final keysObj = callMethod(objectGlobal, 'keys', [customMap]);
-          final length = (keysObj.getProperty('length'.toJS) as JSNumber).toDartInt;
+          final length =
+              (keysObj.getProperty('length'.toJS) as JSNumber).toDartInt;
 
           for (var i = 0; i < length; i++) {
             final key = keysObj.getProperty(i.toString().toJS).toString();
@@ -506,7 +568,11 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
       if (e is PlatformException) {
         rethrow;
       }
-      throw PlatformException(code: "PLUGIN_ERROR", message: "Failed to get metadata: $e", details: null);
+      throw PlatformException(
+        code: "PLUGIN_ERROR",
+        message: "Failed to get metadata: $e",
+        details: null,
+      );
     }
   }
 
@@ -515,7 +581,11 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
     try {
       // Check if the session exists
       if (!_sessions.containsKey(sessionId)) {
-        throw PlatformException(code: "INVALID_SESSION", message: "Session not found", details: null);
+        throw PlatformException(
+          code: "INVALID_SESSION",
+          message: "Session not found",
+          details: null,
+        );
       }
 
       final session = _sessions[sessionId]!;
@@ -523,8 +593,10 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
 
       // Get input metadata from session if available
       if (session.has('inputMetadata')) {
-        final inputMetadata = session.getProperty('inputMetadata'.toJS) as JSObject;
-        final length = (inputMetadata.getProperty('length'.toJS) as JSNumber).toDartInt;
+        final inputMetadata =
+            session.getProperty('inputMetadata'.toJS) as JSObject;
+        final length =
+            (inputMetadata.getProperty('length'.toJS) as JSNumber).toDartInt;
 
         for (var i = 0; i < length; i++) {
           final info = inputMetadata.getProperty(i.toJS) as JSObject;
@@ -541,7 +613,8 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
             // Add shape if available
             if (info.has('shape')) {
               final shape = info.getProperty('shape'.toJS) as JSObject;
-              final shapeLength = (shape.getProperty('length'.toJS) as JSNumber).toDartInt;
+              final shapeLength =
+                  (shape.getProperty('length'.toJS) as JSNumber).toDartInt;
               final shapeList = <int>[];
 
               for (var j = 0; j < shapeLength; j++) {
@@ -584,7 +657,11 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
         // Fallback: use input names to create basic info entries
         final inputNames = getInputNames(session);
         for (final name in inputNames) {
-          inputInfoList.add({'name': name, 'shape': <int>[], 'type': 'unknown'});
+          inputInfoList.add({
+            'name': name,
+            'shape': <int>[],
+            'type': 'unknown',
+          });
         }
       }
 
@@ -593,7 +670,11 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
       if (e is PlatformException) {
         rethrow;
       }
-      throw PlatformException(code: "PLUGIN_ERROR", message: "Failed to get input info: $e", details: null);
+      throw PlatformException(
+        code: "PLUGIN_ERROR",
+        message: "Failed to get input info: $e",
+        details: null,
+      );
     }
   }
 
@@ -602,7 +683,11 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
     try {
       // Check if the session exists
       if (!_sessions.containsKey(sessionId)) {
-        throw PlatformException(code: "INVALID_SESSION", message: "Session not found", details: null);
+        throw PlatformException(
+          code: "INVALID_SESSION",
+          message: "Session not found",
+          details: null,
+        );
       }
 
       final session = _sessions[sessionId]!;
@@ -610,11 +695,14 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
 
       // Get output metadata from session if available
       if (session.has('outputMetadata')) {
-        final outputMetadata = session.getProperty('outputMetadata'.toJS) as JSObject;
-        final length = (outputMetadata.getProperty('length'.toJS) as JSNumber).toDartInt;
+        final outputMetadata =
+            session.getProperty('outputMetadata'.toJS) as JSObject;
+        final length =
+            (outputMetadata.getProperty('length'.toJS) as JSNumber).toDartInt;
 
         for (var i = 0; i < length; i++) {
-          final info = outputMetadata.getProperty(i.toString().toJS) as JSObject;
+          final info =
+              outputMetadata.getProperty(i.toString().toJS) as JSObject;
           final infoMap = <String, dynamic>{};
 
           // Add name
@@ -628,7 +716,8 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
             // Add shape if available
             if (info.has('shape')) {
               final shape = info.getProperty('shape'.toJS) as JSObject;
-              final shapeLength = (shape.getProperty('length'.toJS) as JSNumber).toDartInt;
+              final shapeLength =
+                  (shape.getProperty('length'.toJS) as JSNumber).toDartInt;
               final shapeList = <int>[];
 
               for (var j = 0; j < shapeLength; j++) {
@@ -671,7 +760,11 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
         // Fallback: use output names to create basic info entries
         final outputNames = getOutputNames(session);
         for (final name in outputNames) {
-          outputInfoList.add({'name': name, 'shape': <int>[], 'type': 'unknown'});
+          outputInfoList.add({
+            'name': name,
+            'shape': <int>[],
+            'type': 'unknown',
+          });
         }
       }
 
@@ -680,7 +773,11 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
       if (e is PlatformException) {
         rethrow;
       }
-      throw PlatformException(code: "PLUGIN_ERROR", message: "Failed to get output info: $e", details: null);
+      throw PlatformException(
+        code: "PLUGIN_ERROR",
+        message: "Failed to get output info: $e",
+        details: null,
+      );
     }
   }
 
@@ -688,7 +785,11 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
   final Map<String, JSObject> _ortValues = {};
 
   @override
-  Future<Map<String, dynamic>> createOrtValue(String sourceType, dynamic data, List<int> shape) async {
+  Future<Map<String, dynamic>> createOrtValue(
+    String sourceType,
+    dynamic data,
+    List<int> shape,
+  ) async {
     try {
       // Convert shape to JavaScript array
       final jsShape = jsArrayFrom(shape);
@@ -703,26 +804,42 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
         case 'float32':
           // Convert data to Float32Array
           final jsData = _convertToTypedArray(data, 'Float32Array');
-          tensor = tensorConstructor.callAsConstructorVarArgs([dataType.toJS, jsData, jsShape]);
+          tensor = tensorConstructor.callAsConstructorVarArgs([
+            dataType.toJS,
+            jsData,
+            jsShape,
+          ]);
           break;
 
         case 'int32':
           // Convert data to Int32Array
           final jsData = _convertToTypedArray(data, 'Int32Array');
-          tensor = tensorConstructor.callAsConstructorVarArgs([dataType.toJS, jsData, jsShape]);
+          tensor = tensorConstructor.callAsConstructorVarArgs([
+            dataType.toJS,
+            jsData,
+            jsShape,
+          ]);
           break;
 
         case 'int64':
           // Note: JavaScript doesn't have Int64Array, so using BigInt64Array
           // This might require special handling depending on browser support
           final jsData = _convertToTypedArray(data, 'BigInt64Array');
-          tensor = tensorConstructor.callAsConstructorVarArgs([dataType.toJS, jsData, jsShape]);
+          tensor = tensorConstructor.callAsConstructorVarArgs([
+            dataType.toJS,
+            jsData,
+            jsShape,
+          ]);
           break;
 
         case 'uint8':
           // Convert data to Uint8Array
           final jsData = _convertToTypedArray(data, 'Uint8Array');
-          tensor = tensorConstructor.callAsConstructorVarArgs([dataType.toJS, jsData, jsShape]);
+          tensor = tensorConstructor.callAsConstructorVarArgs([
+            dataType.toJS,
+            jsData,
+            jsShape,
+          ]);
           break;
 
         case 'bool':
@@ -739,14 +856,22 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
                 }
               }).toList();
           final jsData = _convertToTypedArray(boolArray, 'Uint8Array');
-          tensor = tensorConstructor.callAsConstructorVarArgs([dataType.toJS, jsData, jsShape]);
+          tensor = tensorConstructor.callAsConstructorVarArgs([
+            dataType.toJS,
+            jsData,
+            jsShape,
+          ]);
           break;
 
         case 'string':
           // For string tensors, we use the standard JavaScript Array
           // ONNX Runtime JS API accepts string arrays for string tensors
           final stringArray = jsArrayFrom((data as List<String>).toList());
-          tensor = tensorConstructor.callAsConstructorVarArgs([dataType.toJS, stringArray, jsShape]);
+          tensor = tensorConstructor.callAsConstructorVarArgs([
+            dataType.toJS,
+            stringArray,
+            jsShape,
+          ]);
           break;
 
         default:
@@ -758,7 +883,8 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
       }
 
       // Generate a unique ID for this tensor
-      final valueId = '${DateTime.now().millisecondsSinceEpoch}_${math.Random().nextInt(10000)}';
+      final valueId =
+          '${DateTime.now().millisecondsSinceEpoch}_${math.Random().nextInt(10000)}';
 
       // Store the tensor
       _ortValues[valueId] = tensor;
@@ -769,7 +895,11 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
       if (e is PlatformException) {
         rethrow;
       }
-      throw PlatformException(code: "TENSOR_CREATION_ERROR", message: "Failed to create OrtValue: $e", details: null);
+      throw PlatformException(
+        code: "TENSOR_CREATION_ERROR",
+        message: "Failed to create OrtValue: $e",
+        details: null,
+      );
     }
   }
 
@@ -816,7 +946,11 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
       case 'string':
         return 'string';
       default:
-        throw PlatformException(code: "UNSUPPORTED_TYPE", message: "Unsupported data type: $sourceType", details: null);
+        throw PlatformException(
+          code: "UNSUPPORTED_TYPE",
+          message: "Unsupported data type: $sourceType",
+          details: null,
+        );
     }
   }
 
@@ -825,7 +959,11 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
     try {
       // Check if the tensor exists
       if (!_ortValues.containsKey(valueId)) {
-        throw PlatformException(code: "INVALID_VALUE", message: "OrtValue not found with ID: $valueId", details: null);
+        throw PlatformException(
+          code: "INVALID_VALUE",
+          message: "OrtValue not found with ID: $valueId",
+          details: null,
+        );
       }
 
       final tensor = _ortValues[valueId]!;
@@ -835,7 +973,8 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
 
       // Get tensor shape
       final jsShape = tensor.getProperty('dims'.toJS) as JSObject;
-      final shapeLength = (jsShape.getProperty('length'.toJS) as JSNumber).toDartInt;
+      final shapeLength =
+          (jsShape.getProperty('length'.toJS) as JSNumber).toDartInt;
       final shape = <int>[];
 
       // Convert shape to Dart list
@@ -846,7 +985,8 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
 
       // Get tensor data
       final jsData = tensor.getProperty('data'.toJS) as JSObject;
-      final dataLength = (jsData.getProperty('length'.toJS) as JSNumber).toDartInt;
+      final dataLength =
+          (jsData.getProperty('length'.toJS) as JSNumber).toDartInt;
 
       // Convert data to Dart TypedData based on type
       final dynamic data;
@@ -931,7 +1071,11 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
       if (e is PlatformException) {
         rethrow;
       }
-      throw PlatformException(code: "DATA_EXTRACTION_ERROR", message: "Failed to get OrtValue data: $e", details: null);
+      throw PlatformException(
+        code: "DATA_EXTRACTION_ERROR",
+        message: "Failed to get OrtValue data: $e",
+        details: null,
+      );
     }
   }
 
@@ -961,11 +1105,18 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
   }
 
   @override
-  Future<Map<String, dynamic>> convertOrtValue(String valueId, String targetType) async {
+  Future<Map<String, dynamic>> convertOrtValue(
+    String valueId,
+    String targetType,
+  ) async {
     try {
       // Check if the tensor exists
       if (!_ortValues.containsKey(valueId)) {
-        throw PlatformException(code: "INVALID_VALUE", message: "OrtValue with ID $valueId not found", details: null);
+        throw PlatformException(
+          code: "INVALID_VALUE",
+          message: "OrtValue with ID $valueId not found",
+          details: null,
+        );
       }
 
       final tensor = _ortValues[valueId]!;
@@ -973,7 +1124,8 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
       // Get tensor type and shape
       final sourceType = tensor.getProperty('type'.toJS).toString();
       final jsShape = tensor.getProperty('dims'.toJS) as JSObject;
-      final shapeLength = (jsShape.getProperty('length'.toJS) as JSNumber).toDartInt;
+      final shapeLength =
+          (jsShape.getProperty('length'.toJS) as JSNumber).toDartInt;
       final shape = <int>[];
 
       for (var i = 0; i < shapeLength; i++) {
@@ -983,7 +1135,8 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
 
       // Get the data from the tensor
       final jsData = tensor.getProperty('data'.toJS) as JSObject;
-      final dataLength = (jsData.getProperty('length'.toJS) as JSNumber).toDartInt;
+      final dataLength =
+          (jsData.getProperty('length'.toJS) as JSNumber).toDartInt;
 
       // Create a new tensor based on the conversion type
       JSObject newTensor;
@@ -999,7 +1152,11 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
           }
 
           final jsIntArray = _convertToTypedArray(intArray, 'Int32Array');
-          newTensor = tensorConstructor.callAsConstructorVarArgs(['int32'.toJS, jsIntArray, jsArrayFrom(shape)]);
+          newTensor = tensorConstructor.callAsConstructorVarArgs([
+            'int32'.toJS,
+            jsIntArray,
+            jsArrayFrom(shape),
+          ]);
           break;
 
         // Float32 to Int64 (BigInt64Array)
@@ -1009,7 +1166,8 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
           // Throw a more user-friendly error
           throw PlatformException(
             code: "CONVERSION_ERROR",
-            message: "Int64 conversions are not fully supported in the web implementation yet",
+            message:
+                "Int64 conversions are not fully supported in the web implementation yet",
             details: null,
           );
 
@@ -1022,7 +1180,11 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
           }
 
           final jsFloatArray = _convertToTypedArray(floatArray, 'Float32Array');
-          newTensor = tensorConstructor.callAsConstructorVarArgs(['float32'.toJS, jsFloatArray, jsArrayFrom(shape)]);
+          newTensor = tensorConstructor.callAsConstructorVarArgs([
+            'float32'.toJS,
+            jsFloatArray,
+            jsArrayFrom(shape),
+          ]);
           break;
 
         // Int64 to Float32
@@ -1042,7 +1204,11 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
           }
 
           final jsFloatArray = _convertToTypedArray(floatArray, 'Float32Array');
-          newTensor = tensorConstructor.callAsConstructorVarArgs(['float32'.toJS, jsFloatArray, jsArrayFrom(shape)]);
+          newTensor = tensorConstructor.callAsConstructorVarArgs([
+            'float32'.toJS,
+            jsFloatArray,
+            jsArrayFrom(shape),
+          ]);
           break;
 
         // Int32 to Int64
@@ -1052,7 +1218,8 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
           // Throw a more user-friendly error
           throw PlatformException(
             code: "CONVERSION_ERROR",
-            message: "Int64 conversions are not fully supported in the web implementation yet",
+            message:
+                "Int64 conversions are not fully supported in the web implementation yet",
             details: null,
           );
 
@@ -1073,7 +1240,11 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
           }
 
           final jsIntArray = _convertToTypedArray(intArray, 'Int32Array');
-          newTensor = tensorConstructor.callAsConstructorVarArgs(['int32'.toJS, jsIntArray, jsArrayFrom(shape)]);
+          newTensor = tensorConstructor.callAsConstructorVarArgs([
+            'int32'.toJS,
+            jsIntArray,
+            jsArrayFrom(shape),
+          ]);
           break;
 
         // Uint8 to Float32
@@ -1085,7 +1256,11 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
           }
 
           final jsFloatArray = _convertToTypedArray(floatArray, 'Float32Array');
-          newTensor = tensorConstructor.callAsConstructorVarArgs(['float32'.toJS, jsFloatArray, jsArrayFrom(shape)]);
+          newTensor = tensorConstructor.callAsConstructorVarArgs([
+            'float32'.toJS,
+            jsFloatArray,
+            jsArrayFrom(shape),
+          ]);
           break;
 
         // Uint8 to Int32
@@ -1097,14 +1272,19 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
           }
 
           final jsIntArray = _convertToTypedArray(intArray, 'Int32Array');
-          newTensor = tensorConstructor.callAsConstructorVarArgs(['int32'.toJS, jsIntArray, jsArrayFrom(shape)]);
+          newTensor = tensorConstructor.callAsConstructorVarArgs([
+            'int32'.toJS,
+            jsIntArray,
+            jsArrayFrom(shape),
+          ]);
           break;
 
         // Uint8 to Int64
         case 'uint8-int64':
           throw PlatformException(
             code: "CONVERSION_ERROR",
-            message: "Int64 conversions are not fully supported in the web implementation yet",
+            message:
+                "Int64 conversions are not fully supported in the web implementation yet",
             details: null,
           );
 
@@ -1118,7 +1298,11 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
           }
 
           final jsUint8Array = _convertToTypedArray(byteArray, 'Uint8Array');
-          newTensor = tensorConstructor.callAsConstructorVarArgs(['uint8'.toJS, jsUint8Array, jsArrayFrom(shape)]);
+          newTensor = tensorConstructor.callAsConstructorVarArgs([
+            'uint8'.toJS,
+            jsUint8Array,
+            jsArrayFrom(shape),
+          ]);
           break;
 
         // Int32 to Uint8
@@ -1130,7 +1314,11 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
           }
 
           final jsUint8Array = _convertToTypedArray(byteArray, 'Uint8Array');
-          newTensor = tensorConstructor.callAsConstructorVarArgs(['uint8'.toJS, jsUint8Array, jsArrayFrom(shape)]);
+          newTensor = tensorConstructor.callAsConstructorVarArgs([
+            'uint8'.toJS,
+            jsUint8Array,
+            jsArrayFrom(shape),
+          ]);
           break;
 
         // Int64 to Uint8
@@ -1148,7 +1336,11 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
           }
 
           final jsUint8Array = _convertToTypedArray(byteArray, 'Uint8Array');
-          newTensor = tensorConstructor.callAsConstructorVarArgs(['uint8'.toJS, jsUint8Array, jsArrayFrom(shape)]);
+          newTensor = tensorConstructor.callAsConstructorVarArgs([
+            'uint8'.toJS,
+            jsUint8Array,
+            jsArrayFrom(shape),
+          ]);
           break;
 
         // Boolean to Float32
@@ -1160,7 +1352,11 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
           }
 
           final jsFloatArray = _convertToTypedArray(floatArray, 'Float32Array');
-          newTensor = tensorConstructor.callAsConstructorVarArgs(['float32'.toJS, jsFloatArray, jsArrayFrom(shape)]);
+          newTensor = tensorConstructor.callAsConstructorVarArgs([
+            'float32'.toJS,
+            jsFloatArray,
+            jsArrayFrom(shape),
+          ]);
           break;
 
         // Boolean to Int32
@@ -1172,14 +1368,19 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
           }
 
           final jsIntArray = _convertToTypedArray(intArray, 'Int32Array');
-          newTensor = tensorConstructor.callAsConstructorVarArgs(['int32'.toJS, jsIntArray, jsArrayFrom(shape)]);
+          newTensor = tensorConstructor.callAsConstructorVarArgs([
+            'int32'.toJS,
+            jsIntArray,
+            jsArrayFrom(shape),
+          ]);
           break;
 
         // Boolean to Int64
         case 'bool-int64':
           throw PlatformException(
             code: "CONVERSION_ERROR",
-            message: "Int64 conversions are not fully supported in the web implementation yet",
+            message:
+                "Int64 conversions are not fully supported in the web implementation yet",
             details: null,
           );
 
@@ -1195,7 +1396,11 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
           }
 
           final jsByteArray = _convertToTypedArray(byteArray, 'Uint8Array');
-          newTensor = tensorConstructor.callAsConstructorVarArgs(['uint8'.toJS, jsByteArray, jsArrayFrom(shape)]);
+          newTensor = tensorConstructor.callAsConstructorVarArgs([
+            'uint8'.toJS,
+            jsByteArray,
+            jsArrayFrom(shape),
+          ]);
           break;
 
         // Int8/Uint8 to Boolean
@@ -1209,7 +1414,11 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
           }
 
           final jsBoolArray = _convertToTypedArray(boolArray, 'Uint8Array');
-          newTensor = tensorConstructor.callAsConstructorVarArgs(['bool'.toJS, jsBoolArray, jsArrayFrom(shape)]);
+          newTensor = tensorConstructor.callAsConstructorVarArgs([
+            'bool'.toJS,
+            jsBoolArray,
+            jsArrayFrom(shape),
+          ]);
           break;
 
         // Same type conversion (no-op)
@@ -1222,19 +1431,25 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
         case 'string-string':
           // Clone the original tensor with the same data
           final newData = tensor.getProperty('data'.toJS);
-          newTensor = tensorConstructor.callAsConstructorVarArgs([sourceType.toJS, newData, jsArrayFrom(shape)]);
+          newTensor = tensorConstructor.callAsConstructorVarArgs([
+            sourceType.toJS,
+            newData,
+            jsArrayFrom(shape),
+          ]);
           break;
 
         default:
           throw PlatformException(
             code: "CONVERSION_ERROR",
-            message: "Conversion from $sourceType to $targetType is not supported",
+            message:
+                "Conversion from $sourceType to $targetType is not supported",
             details: null,
           );
       }
 
       // Generate a unique ID for this tensor
-      final newValueId = '${DateTime.now().millisecondsSinceEpoch}_${math.Random().nextInt(10000)}';
+      final newValueId =
+          '${DateTime.now().millisecondsSinceEpoch}_${math.Random().nextInt(10000)}';
 
       // Store the tensor
       _ortValues[newValueId] = newTensor;
@@ -1245,7 +1460,11 @@ class FlutterOnnxruntimeWebPlugin extends FlutterOnnxruntimePlatform {
       if (e is PlatformException) {
         rethrow;
       }
-      throw PlatformException(code: "CONVERSION_ERROR", message: "Failed to convert OrtValue: $e", details: null);
+      throw PlatformException(
+        code: "CONVERSION_ERROR",
+        message: "Failed to convert OrtValue: $e",
+        details: null,
+      );
     }
   }
 }


### PR DESCRIPTION
## Summary

- keep checklist collapse transitions width-stable and clamp the completed summary to one line
- preserve Flutter Quill and Form Builder localization delegates through the macOS desktop menu wrapper
- cover complete, partial, empty, and macOS toolbar states with focused regression tests
- update release notes, feature documentation, build metadata, and approved third-party formatting

## Root cause

`AnimatedCrossFade` was transitioning checklist content toward a zero-width `SizedBox.shrink()`, so the outgoing text was repeatedly laid out at narrower widths and wrapped during the animation. The macOS menu wrapper also installed a nested `Localizations` scope without Flutter Quill's delegate, shadowing the delegate from the app root and rendering Flutter's grey release-mode error widget in the toolbar.

## Validation

- `fvm flutter analyze`
- `fvm flutter test test/features/tasks/ui/checklists/checklist_card_test.dart test/features/tasks/ui/checklists/checklist_card_body_test.dart test/widgets/misc/desktop_menu_test.dart` (61 tests)
- full suite delegated to CI's 10 shards per repository policy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Checklist cards now collapse without breaking the completion-message layout.
  * “All done / none done” summary text stays on a single truncated line during collapse/animations.
  * The editor formatting toolbar renders correctly on macOS again (no grey error strip).
* **Documentation**
  * Updated release notes and feature docs for checklist collapse behavior and macOS localization/menu handling.
* **Tests**
  * Added UI regression coverage for checklist collapse/ellipsis behavior and desktop menu localization scoping.
* **Maintenance**
  * Bumped the app version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->