### PR TITLE
fix: enforce Daily OS category scope

### DIFF
--- a/lib/features/daily_os_next/agents/service/day_agent_plan_editor.dart
+++ b/lib/features/daily_os_next/agents/service/day_agent_plan_editor.dart
@@ -459,7 +459,9 @@ class DayAgentPlanEditor {
   /// The block may move, resize, and—when it is standalone—change title or
   /// category in the same sync write. Task-linked title/category fields remain
   /// owned by the task, while imported calendar blocks remain owned by their
-  /// calendar source. All ranges must stay inside the plan's local day.
+  /// calendar source. Category changes must stay inside the agent identity's
+  /// allowed scope and use an active planning category. All ranges must stay
+  /// inside the plan's local day.
   Future<DayPlanEntity> editBlock({
     required String agentId,
     required String dayId,
@@ -469,7 +471,7 @@ class DayAgentPlanEditor {
     String? title,
     String? categoryId,
   }) async {
-    await reads.requireIdentity(agentId);
+    final identity = await reads.requireIdentity(agentId);
     final plan = await reads.draftPlanForDay(agentId: agentId, dayId: dayId);
     if (plan == null) {
       throw DayAgentCaptureException(
@@ -534,7 +536,11 @@ class DayAgentPlanEditor {
     }
     if (categoryChanged) {
       final category = await journalDb.getCategoryById(trimmedCategoryId);
-      if (category == null ||
+      if (!categoryAllowed(
+            trimmedCategoryId,
+            identity.allowedCategoryIds,
+          ) ||
+          category == null ||
           category.deletedAt != null ||
           !category.active ||
           !(category.isAvailableForDayPlan ?? false)) {

--- a/test/features/daily_os_next/agents/service/day_agent_plan_service_test.dart
+++ b/test/features/daily_os_next/agents/service/day_agent_plan_service_test.dart
@@ -3359,46 +3359,68 @@ void main() {
       );
 
       test(
-        'rejects missing, inactive, deleted, and non-planning categories',
+        'rejects unavailable and identity-forbidden categories',
         () async {
           seedPlanEntity();
-          final unavailable = <CategoryDefinition?>[
-            null,
-            CategoryDefinition(
+          final unavailable = <({String id, CategoryDefinition? category})>[
+            (id: 'life', category: null),
+            (
               id: 'life',
-              name: 'Life',
-              createdAt: _now,
-              updatedAt: _now,
-              vectorClock: null,
-              private: false,
-              active: false,
+              category: CategoryDefinition(
+                id: 'life',
+                name: 'Life',
+                createdAt: _now,
+                updatedAt: _now,
+                vectorClock: null,
+                private: false,
+                active: false,
+              ),
             ),
-            CategoryDefinition(
+            (
               id: 'life',
-              name: 'Life',
-              createdAt: _now,
-              updatedAt: _now,
-              deletedAt: _now,
-              vectorClock: null,
-              private: false,
-              active: true,
+              category: CategoryDefinition(
+                id: 'life',
+                name: 'Life',
+                createdAt: _now,
+                updatedAt: _now,
+                deletedAt: _now,
+                vectorClock: null,
+                private: false,
+                active: true,
+              ),
             ),
-            CategoryDefinition(
+            (
               id: 'life',
-              name: 'Life',
-              createdAt: _now,
-              updatedAt: _now,
-              vectorClock: null,
-              private: false,
-              active: true,
-              isAvailableForDayPlan: false,
+              category: CategoryDefinition(
+                id: 'life',
+                name: 'Life',
+                createdAt: _now,
+                updatedAt: _now,
+                vectorClock: null,
+                private: false,
+                active: true,
+                isAvailableForDayPlan: false,
+              ),
+            ),
+            (
+              id: 'forbidden',
+              category: CategoryDefinition(
+                id: 'forbidden',
+                name: 'Forbidden',
+                createdAt: _now,
+                updatedAt: _now,
+                vectorClock: null,
+                private: false,
+                active: true,
+                isAvailableForDayPlan: true,
+              ),
             ),
           ];
 
-          for (final category in unavailable) {
+          for (final value in unavailable) {
             when(
-              () => journalDb.getCategoryById('life'),
-            ).thenAnswer((_) async => category);
+              () => journalDb.getCategoryById(value.id),
+            ).thenAnswer((_) async => value.category);
             await expectLater(
               createService().editBlock(
                 agentId: _agentId,
@@ -3406,7 +3428,7 @@ void main() {
                 blockId: 'block-1',
                 start: DateTime(2026, 5, 25, 9),
                 end: DateTime(2026, 5, 25, 10),
-                categoryId: 'life',
+                categoryId: value.id,
               ),
               throwsA(
                 isA<DayAgentCaptureException>().having(

--- a/test/features/daily_os_next/test_utils.dart
+++ b/test/features/daily_os_next/test_utils.dart
@@ -18,6 +18,7 @@ class RecordingDayAgent implements DayAgentInterface {
     this.proposeGate,
     this.renameError,
     this.editError,
+    this.editErrorOnCall,
     this.submitResult = const CaptureId('cap'),
     this.draftPlanBuilder,
     this.commitGate,
@@ -48,6 +49,12 @@ class RecordingDayAgent implements DayAgentInterface {
   /// When set, [editBlock] throws this error.
   final Error? editError;
 
+  /// Restricts [editError] to this one-based [editBlock] call.
+  ///
+  /// When omitted, [editError] keeps its original behavior and fails every
+  /// edit call.
+  final int? editErrorOnCall;
+
   /// `(blockId, title)` pairs received by [renameBlock].
   final List<(String, String)> renamedBlocks = [];
 
@@ -62,6 +69,9 @@ class RecordingDayAgent implements DayAgentInterface {
     })
   >
   editedBlocks = [];
+
+  /// Number of calls received by [editBlock].
+  int get editCalls => editedBlocks.length;
 
   /// Most recent plan returned by [editBlock].
   DraftPlan? lastEditedPlan;
@@ -203,7 +213,10 @@ class RecordingDayAgent implements DayAgentInterface {
       category: category,
     ));
     final error = editError;
-    if (error != null) throw error;
+    if (error != null &&
+        (editErrorOnCall == null || editCalls == editErrorOnCall)) {
+      throw error;
+    }
     final blocks = [
       for (final block in plan.blocks)
         if (block.id == blockId)

--- a/test/features/daily_os_next/ui/pages/day_page_test.dart
+++ b/test/features/daily_os_next/ui/pages/day_page_test.dart
@@ -42,32 +42,6 @@ const _category = DayAgentCategory(
   colorHex: '0080FF',
 );
 
-class _UndoFailingDayAgent extends RecordingDayAgent {
-  int editCalls = 0;
-
-  @override
-  Future<DraftPlan> editBlock({
-    required DraftPlan plan,
-    required String blockId,
-    required DateTime start,
-    required DateTime end,
-    String? title,
-    DayAgentCategory? category,
-  }) async {
-    editCalls += 1;
-    final edited = await super.editBlock(
-      plan: plan,
-      blockId: blockId,
-      start: start,
-      end: end,
-      title: title,
-      category: category,
-    );
-    if (editCalls == 2) throw StateError('undo persistence failed');
-    return edited;
-  }
-}
-
 DraftPlan _drafted({
   DayState state = DayState.drafted,
   String title = 'Deep work',
@@ -775,7 +749,10 @@ void main() {
         capacityMinutes: 240,
         scheduledMinutes: 60,
       );
-      final agent = _UndoFailingDayAgent();
+      final agent = RecordingDayAgent(
+        editError: StateError('undo persistence failed'),
+        editErrorOnCall: 2,
+      );
       await _pumpDayPage(tester, draft: draft, agent: agent);
 
       final messages = tester.element(find.byType(DayPage)).messages;


### PR DESCRIPTION
## What changed

- Reject manual Daily OS block category changes that fall outside the day agent identity's `allowedCategoryIds`, while preserving the existing empty-set-means-unrestricted behavior.
- Extend the category validation regression test with an active, planning-enabled but identity-forbidden category.
- Move the undo failure behavior into the shared `RecordingDayAgent` test support via a selected-call failure option, removing the page-local fake.

## Why

This is a follow-up to #3480. CodeRabbit completed after that PR had already merged and identified two valid issues: manual block editing did not enforce the same category scope used by plan drafting, and a page test defined a failure-injecting agent inline instead of using shared test support.

The category gap could persist a block assignment that the planner identity is not allowed to use. The test-support change keeps Daily OS tests aligned with the repository's centralized fake/mock conventions.

## Validation

- `make analyze` — zero issues
- `fvm flutter test test/features/daily_os_next/agents/service/day_agent_plan_service_test.dart test/features/daily_os_next/ui/pages/day_page_test.dart` — 181 passed
- `fvm flutter test test/features/daily_os_next` — passed
- The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plan block edits now reject categories outside the agent’s permitted planning scope.
  * Category validation continues to prevent use of missing, deleted, inactive, or day-plan-incompatible categories.
  * Improved validation helps ensure edits remain within the plan day and use eligible categories.

* **Tests**
  * Expanded coverage for invalid and identity-restricted categories.
  * Improved testing of edit failures during undo operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->