### PR TITLE
fix: fade list dividers on hover across the remaining settings lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.9.1048]
+### Changed
+- **The remaining settings lists fade their dividers on hover.** Hovering a row
+  in Categories, Labels, Habits, Measurables, Dashboards, or the Matrix sync
+  maintenance list now fades the hairlines above and below it, so the hovered
+  row is never bisected — matching Config Flags and Advanced Settings →
+  Maintenance. The row layout stays fixed; only the divider colour changes.
+
 ### Added
 - **Desktop Lotti now has a keyboard-first command layer.** Open the command
   palette with Command/Ctrl+K, jump to the eight main destinations with fixed

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -34,6 +34,7 @@
   <releases>
     <release version="0.9.1048" date="2026-07-16">
       <description>
+          <p>The remaining settings lists now fade their dividers on hover. Hovering a row in Categories, Labels, Habits, Measurables, Dashboards, or the Matrix sync maintenance list fades the hairlines above and below it, so the hovered row is never bisected — matching Config Flags and Advanced Settings Maintenance. The row layout stays fixed while only the divider colour changes.</p>
           <p>Logging a measurable now stays in one clear, accessible sheet. Changing the observed date and time moves to a calendar page in the same capture flow instead of stacking another modal over the editor. Values and comments stay intact when navigating back, the complete time picker scrolls above the sticky action, and Save waits for persistence with visible progress and retry feedback.</p>
           <p>Task agents now use evidence-first processing for everyone. The previously optional behavior is now standard and its Advanced Settings toggle has been removed. If you already had it enabled, nothing changes.</p>
           <p>Synced alerts are now available to everyone. Alerts stay consistent across devices whenever Matrix sync is active, and the former Advanced Settings toggle has been removed.</p>

--- a/lib/features/categories/ui/pages/categories_list_page.dart
+++ b/lib/features/categories/ui/pages/categories_list_page.dart
@@ -5,6 +5,7 @@ import 'package:lotti/features/categories/state/categories_list_controller.dart'
 import 'package:lotti/features/categories/state/category_task_count_provider.dart';
 import 'package:lotti/features/categories/ui/widgets/category_icon_chip.dart';
 import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
+import 'package:lotti/features/design_system/components/lists/hover_divider_index.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/settings/ui/pages/definitions_list_page.dart';
 import 'package:lotti/l10n/app_localizations_context.dart';
@@ -48,10 +49,10 @@ class CategoriesListPage extends ConsumerWidget {
       errorTitle: messages.settingsCategoriesErrorLoading,
       createLabel: messages.settingsCategoriesCreateTitle,
       onCreate: () => beamToNamed('/settings/categories/create'),
-      itemBuilder: (context, category, {required bool showDivider}) =>
+      itemBuilder: (context, category, {required ListRowDivider divider}) =>
           _CategoryListItem(
             category: category,
-            showDivider: showDivider,
+            divider: divider,
             onTap: () => beamToNamed('/settings/categories/${category.id}'),
           ),
     );
@@ -62,12 +63,12 @@ class CategoriesListPage extends ConsumerWidget {
 class _CategoryListItem extends ConsumerWidget {
   const _CategoryListItem({
     required this.category,
-    required this.showDivider,
+    required this.divider,
     required this.onTap,
   });
 
   final CategoryDefinition category;
-  final bool showDivider;
+  final ListRowDivider divider;
   final VoidCallback onTap;
 
   @override
@@ -137,11 +138,13 @@ class _CategoryListItem extends ConsumerWidget {
           ),
         ],
       ),
-      showDivider: showDivider,
+      showDivider: divider.showDivider,
+      dividerColor: divider.color,
       dividerIndent:
           tokens.spacing.step5 +
           DefinitionIconChip.defaultSize +
           tokens.spacing.step3,
+      onHoverChanged: divider.onHoverChanged,
       onTap: onTap,
     );
   }

--- a/lib/features/design_system/components/lists/hover_divider_index.dart
+++ b/lib/features/design_system/components/lists/hover_divider_index.dart
@@ -1,5 +1,38 @@
 import 'package:flutter/material.dart';
 
+/// The divider state a list shell hands to one row.
+///
+/// Bundles the three values that always travel together from a
+/// [HoverDividerIndex] owner to a row's `DesignSystemListItem`. Lists whose
+/// rows are built by a caller-supplied builder (`DefinitionsListPage`) pass
+/// this instead of three separate parameters, so the builder signature stays
+/// stable as the treatment grows and a page cannot declare a parameter it
+/// then forgets to use.
+///
+/// Forwarding is still per-field — `DesignSystemListItem` takes the three
+/// separately, as the lists that own their own row loop (Config Flags,
+/// Maintenance, Matrix sync) pass them. Each page's test covers that its row
+/// forwards all three.
+@immutable
+class ListRowDivider {
+  const ListRowDivider({
+    required this.showDivider,
+    required this.color,
+    required this.onHoverChanged,
+  });
+
+  /// Whether the row draws a hairline beneath it — false for the last row
+  /// of a card. Stays stable across hover; see [HoverDividerIndex].
+  final bool showDivider;
+
+  /// [Colors.transparent] while this hairline brackets the hovered row,
+  /// `null` to keep the row's own design-system default.
+  final Color? color;
+
+  /// The row reports pointer enter/leave here.
+  final ValueChanged<bool> onHoverChanged;
+}
+
 /// Coordinates hover-driven divider fading across a vertical run of
 /// `DesignSystemListItem`s (or any list of rows that expose `onHoverChanged`
 /// and a `dividerColor`).
@@ -12,8 +45,19 @@ import 'package:flutter/material.dart';
 ///
 /// Crucially the caller keeps `showDivider` stable and only swaps the
 /// colour, so hovering never adds/removes a 1&nbsp;px divider and the layout
-/// never shifts. Shared by the Config Flags list (`_FlagsList`) and the
-/// Advanced → Maintenance list (`MaintenanceBody`).
+/// never shifts.
+///
+/// Consumers: the Config Flags list (`_FlagsList`), the Advanced →
+/// Maintenance list (`MaintenanceBody`), the Matrix sync maintenance list
+/// (`MatrixSyncMaintenanceBody`), and `DefinitionsListPage` — which owns
+/// the index on behalf of every settings definition list (categories,
+/// labels, habits, measurables, dashboards) and hands each row a
+/// [ListRowDivider] through `itemBuilder`, built by [dividerFor].
+///
+/// Only rows that report hover can drive this: `DesignSystemListItem`
+/// fires `onHoverChanged` only when it has an `onTap`. A list of
+/// non-tappable rows (the Logging settings switches, say) has no hover
+/// state to bracket in the first place, so it needs no fading.
 mixin HoverDividerIndex<T extends StatefulWidget> on State<T> {
   /// Index of the currently-hovered row, or `null` when no row is hovered.
   int? _hoveredIndex;
@@ -26,6 +70,17 @@ mixin HoverDividerIndex<T extends StatefulWidget> on State<T> {
       (_hoveredIndex == index || _hoveredIndex == index + 1)
       ? Colors.transparent
       : null;
+
+  /// Bundles the divider state for the row at [index] into a single
+  /// [ListRowDivider], for shells that hand rows to a caller-supplied
+  /// builder. [showDivider] is the caller's own last-row decision — the
+  /// mixin only colours the hairline, it never decides whether one exists.
+  ListRowDivider dividerFor(int index, {required bool showDivider}) =>
+      ListRowDivider(
+        showDivider: showDivider,
+        color: hoverDividerColorFor(index),
+        onHoverChanged: (hovered) => onRowHoverChanged(index, hovered: hovered),
+      );
 
   /// Records pointer enter/leave for the row at [index]. Retargets rather
   /// than accumulates: entering a row overrides the previous one, and a

--- a/lib/features/labels/ui/pages/labels_list_page.dart
+++ b/lib/features/labels/ui/pages/labels_list_page.dart
@@ -4,6 +4,7 @@ import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/features/categories/ui/widgets/category_icon_chip.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
+import 'package:lotti/features/design_system/components/lists/hover_divider_index.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/labels/state/labels_list_controller.dart';
 import 'package:lotti/features/settings/ui/pages/definitions_list_page.dart';
@@ -62,11 +63,11 @@ class LabelsListPage extends ConsumerWidget {
       errorTitle: messages.settingsLabelsErrorLoading,
       createLabel: messages.settingsLabelsCreateTitle,
       onCreate: () => beamToNamed('/settings/labels/create'),
-      itemBuilder: (context, label, {required bool showDivider}) =>
+      itemBuilder: (context, label, {required ListRowDivider divider}) =>
           _LabelListItem(
             label: label,
             usageCount: usageCounts[label.id] ?? 0,
-            showDivider: showDivider,
+            divider: divider,
           ),
     );
   }
@@ -77,12 +78,12 @@ class _LabelListItem extends StatelessWidget {
   const _LabelListItem({
     required this.label,
     required this.usageCount,
-    required this.showDivider,
+    required this.divider,
   });
 
   final LabelDefinition label;
   final int usageCount;
-  final bool showDivider;
+  final ListRowDivider divider;
 
   @override
   Widget build(BuildContext context) {
@@ -120,11 +121,13 @@ class _LabelListItem extends StatelessWidget {
           ),
         ],
       ),
-      showDivider: showDivider,
+      showDivider: divider.showDivider,
+      dividerColor: divider.color,
       dividerIndent:
           tokens.spacing.step5 +
           DefinitionIconChip.defaultSize +
           tokens.spacing.step3,
+      onHoverChanged: divider.onHoverChanged,
       onTap: () => beamToNamed('/settings/labels/${label.id}'),
     );
   }

--- a/lib/features/settings/README.md
+++ b/lib/features/settings/README.md
@@ -479,9 +479,8 @@ Each visible flag has:
 
 The Flags entry is reached through Advanced; the `/settings/flags` URL itself is unchanged so existing deep links keep resolving.
 
-The flag rows share a hover-divider treatment with the Maintenance list
-([`ui/pages/advanced/maintenance_page.dart`](ui/pages/advanced/maintenance_page.dart)).
-Both states mix in `HoverDividerIndex`
+The flag rows share a hover-divider treatment with every other hoverable
+settings list. Each mixes in `HoverDividerIndex`
 ([`design_system/components/lists/hover_divider_index.dart`](../../design_system/components/lists/hover_divider_index.dart)),
 which tracks the hovered row index and exposes `onRowHoverChanged` /
 `hoverDividerColorFor`. Rather than toggling `DesignSystemListItem.showDivider`
@@ -490,6 +489,45 @@ and fades the divider to `Colors.transparent` for the hovered row and the row
 above it, so the hovered row is never bisected by a hairline. Maintenance folds
 its final diagnostic repaint-rainbow tile into the same index model so the
 divider between the last action row and the tile fades from either side.
+
+Where the mixin lives depends on who owns the row loop:
+
+| List | Mixed into |
+| --- | --- |
+| Config Flags ([`ui/pages/flags_page.dart`](ui/pages/flags_page.dart)) | `_FlagsListState` |
+| Advanced → Maintenance ([`ui/pages/advanced/maintenance_page.dart`](ui/pages/advanced/maintenance_page.dart)) | `_MaintenanceBodyState` |
+| Matrix sync maintenance ([`sync/ui/matrix_sync_maintenance_page.dart`](../sync/ui/matrix_sync_maintenance_page.dart)) | `_MatrixSyncMaintenanceBodyState` |
+| Categories, Labels, Habits, Measurables, Dashboards | `_DefinitionsListPageState` |
+
+The five definition lists do not each track hover. The shared shell
+([`ui/pages/definitions_list_page.dart`](ui/pages/definitions_list_page.dart))
+already owns the row index, so it owns the hover index too. It bundles each
+row's whole divider treatment — `showDivider`, the hover `color`, and the
+`onHoverChanged` callback — into one `ListRowDivider` via the mixin's
+`dividerFor`, and hands it to `itemBuilder`. A page's only job is to forward the
+three fields to its `DesignSystemListItem`; each page test covers that it does.
+The bundle is what keeps `itemBuilder`'s signature stable as the treatment
+grows, and keeps five pages from each declaring three parameters.
+
+```mermaid
+sequenceDiagram
+    participant P as Pointer
+    participant R as DesignSystemListItem (row i)
+    participant S as State with HoverDividerIndex
+    P->>R: enter
+    R->>S: onHoverChanged(i, hovered: true)
+    Note over S: _hoveredIndex = i
+    S->>R: rebuild — dividerColor for i and i-1 = transparent
+    P->>R: leave
+    R->>S: onHoverChanged(i, hovered: false)
+    Note over S: clears only if _hoveredIndex == i,<br/>so a row-to-row move settles on the new row
+    S->>R: rebuild — dividerColor = null (design-system default)
+```
+
+The Logging settings list ([`ui/pages/advanced/logging_settings_page.dart`](ui/pages/advanced/logging_settings_page.dart))
+is deliberately excluded. Its rows are switch-only with no `onTap`, and
+`DesignSystemListItem` reports hover only for tappable rows — so those rows have
+no hover state (and no hover background) to bracket in the first place.
 
 ### Advanced
 

--- a/lib/features/settings/ui/pages/dashboards/dashboards_page.dart
+++ b/lib/features/settings/ui/pages/dashboards/dashboards_page.dart
@@ -4,6 +4,7 @@ import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/features/categories/ui/widgets/category_icon_chip.dart';
 import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
+import 'package:lotti/features/design_system/components/lists/hover_divider_index.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/settings/ui/pages/definitions_list_page.dart';
 import 'package:lotti/get_it.dart';
@@ -59,8 +60,8 @@ class DashboardSettingsPage extends ConsumerWidget {
       errorTitle: messages.settingsDashboardsErrorLoading,
       createLabel: messages.settingsDashboardsCreateTitle,
       onCreate: () => beamToNamed('/settings/dashboards/create'),
-      itemBuilder: (context, dashboard, {required bool showDivider}) =>
-          _DashboardListItem(dashboard: dashboard, showDivider: showDivider),
+      itemBuilder: (context, dashboard, {required ListRowDivider divider}) =>
+          _DashboardListItem(dashboard: dashboard, divider: divider),
     );
   }
 }
@@ -68,11 +69,11 @@ class DashboardSettingsPage extends ConsumerWidget {
 class _DashboardListItem extends StatelessWidget {
   const _DashboardListItem({
     required this.dashboard,
-    required this.showDivider,
+    required this.divider,
   });
 
   final DashboardDefinition dashboard;
-  final bool showDivider;
+  final ListRowDivider divider;
 
   @override
   Widget build(BuildContext context) {
@@ -107,11 +108,13 @@ class _DashboardListItem extends StatelessWidget {
           ),
         ],
       ),
-      showDivider: showDivider,
+      showDivider: divider.showDivider,
+      dividerColor: divider.color,
       dividerIndent:
           tokens.spacing.step5 +
           DefinitionIconChip.defaultSize +
           tokens.spacing.step3,
+      onHoverChanged: divider.onHoverChanged,
       onTap: () => beamToNamed('/settings/dashboards/${dashboard.id}'),
     );
   }

--- a/lib/features/settings/ui/pages/definitions_list_page.dart
+++ b/lib/features/settings/ui/pages/definitions_list_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_floating_action_button.dart';
 import 'package:lotti/features/design_system/components/lists/design_system_grouped_list.dart';
+import 'package:lotti/features/design_system/components/lists/hover_divider_index.dart';
 import 'package:lotti/features/design_system/components/search/design_system_search.dart';
 import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
@@ -59,11 +60,18 @@ class DefinitionsListPage<T> extends StatefulWidget {
   /// search haystack.
   final String Function(T item) displayName;
 
-  /// Row builder. `showDivider` is false for the last row of the card.
+  /// Row builder.
+  ///
+  /// [ListRowDivider] carries the row's whole divider treatment: whether it
+  /// draws a hairline (false for the last row, and stable across hover so the
+  /// 1 px line never adds/removes vertical space), what colour that hairline
+  /// takes ([Colors.transparent] while it brackets the hovered row), and the
+  /// hover callback that drives the fade. A row forwards all three to its
+  /// `DesignSystemListItem` — see [HoverDividerIndex].
   final Widget Function(
     BuildContext context,
     T item, {
-    required bool showDivider,
+    required ListRowDivider divider,
   })
   itemBuilder;
 
@@ -103,7 +111,8 @@ class DefinitionsListPage<T> extends StatefulWidget {
   State<DefinitionsListPage<T>> createState() => _DefinitionsListPageState<T>();
 }
 
-class _DefinitionsListPageState<T> extends State<DefinitionsListPage<T>> {
+class _DefinitionsListPageState<T> extends State<DefinitionsListPage<T>>
+    with HoverDividerIndex<DefinitionsListPage<T>> {
   late String _queryRaw = widget.initialSearchTerm ?? '';
 
   // Memoize the filtered+sorted list so an unrelated rebuild (a background
@@ -254,7 +263,12 @@ class _DefinitionsListPageState<T> extends State<DefinitionsListPage<T>> {
                   widget.itemBuilder(
                     context,
                     item,
-                    showDivider: index < filtered.length - 1,
+                    // `showDivider` stays a pure function of position, so
+                    // hover only ever changes the colour, never the layout.
+                    divider: dividerFor(
+                      index,
+                      showDivider: index < filtered.length - 1,
+                    ),
                   ),
               ],
             ),

--- a/lib/features/settings/ui/pages/habits/habits_page.dart
+++ b/lib/features/settings/ui/pages/habits/habits_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/features/categories/ui/widgets/category_icon_chip.dart';
 import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
+import 'package:lotti/features/design_system/components/lists/hover_divider_index.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/habits/repository/habits_repository.dart';
 import 'package:lotti/features/settings/ui/pages/definitions_list_page.dart';
@@ -54,8 +55,8 @@ class HabitsPage extends ConsumerWidget {
       errorTitle: messages.settingsHabitsErrorLoading,
       createLabel: messages.settingsHabitsCreateTitle,
       onCreate: () => beamToNamed('/settings/habits/create'),
-      itemBuilder: (context, habit, {required bool showDivider}) =>
-          _HabitListItem(habit: habit, showDivider: showDivider),
+      itemBuilder: (context, habit, {required ListRowDivider divider}) =>
+          _HabitListItem(habit: habit, divider: divider),
     );
   }
 }
@@ -63,11 +64,11 @@ class HabitsPage extends ConsumerWidget {
 class _HabitListItem extends StatelessWidget {
   const _HabitListItem({
     required this.habit,
-    required this.showDivider,
+    required this.divider,
   });
 
   final HabitDefinition habit;
-  final bool showDivider;
+  final ListRowDivider divider;
 
   @override
   Widget build(BuildContext context) {
@@ -132,11 +133,13 @@ class _HabitListItem extends StatelessWidget {
           ),
         ],
       ),
-      showDivider: showDivider,
+      showDivider: divider.showDivider,
+      dividerColor: divider.color,
       dividerIndent:
           tokens.spacing.step5 +
           DefinitionIconChip.defaultSize +
           tokens.spacing.step3,
+      onHoverChanged: divider.onHoverChanged,
       onTap: () => beamToNamed('/settings/habits/by_id/${habit.id}'),
     );
   }

--- a/lib/features/settings/ui/pages/measurables/measurables_page.dart
+++ b/lib/features/settings/ui/pages/measurables/measurables_page.dart
@@ -4,6 +4,7 @@ import 'package:lotti/classes/entity_definitions.dart';
 import 'package:lotti/database/database.dart';
 import 'package:lotti/features/categories/ui/widgets/category_icon_chip.dart';
 import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
+import 'package:lotti/features/design_system/components/lists/hover_divider_index.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/settings/ui/pages/definitions_list_page.dart';
 import 'package:lotti/get_it.dart';
@@ -57,8 +58,8 @@ class MeasurablesPage extends ConsumerWidget {
       errorTitle: messages.settingsMeasurablesErrorLoading,
       createLabel: messages.settingsMeasurablesCreateTitle,
       onCreate: () => beamToNamed('/settings/measurables/create'),
-      itemBuilder: (context, dataType, {required bool showDivider}) =>
-          _MeasurableListItem(item: dataType, showDivider: showDivider),
+      itemBuilder: (context, dataType, {required ListRowDivider divider}) =>
+          _MeasurableListItem(item: dataType, divider: divider),
     );
   }
 }
@@ -66,11 +67,11 @@ class MeasurablesPage extends ConsumerWidget {
 class _MeasurableListItem extends StatelessWidget {
   const _MeasurableListItem({
     required this.item,
-    required this.showDivider,
+    required this.divider,
   });
 
   final MeasurableDataType item;
-  final bool showDivider;
+  final ListRowDivider divider;
 
   @override
   Widget build(BuildContext context) {
@@ -126,11 +127,13 @@ class _MeasurableListItem extends StatelessWidget {
           ),
         ],
       ),
-      showDivider: showDivider,
+      showDivider: divider.showDivider,
+      dividerColor: divider.color,
       dividerIndent:
           tokens.spacing.step5 +
           DefinitionIconChip.defaultSize +
           tokens.spacing.step3,
+      onHoverChanged: divider.onHoverChanged,
       onTap: () => beamToNamed('/settings/measurables/${item.id}'),
     );
   }

--- a/lib/features/sync/ui/matrix_sync_maintenance_page.dart
+++ b/lib/features/sync/ui/matrix_sync_maintenance_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:lotti/database/maintenance.dart';
 import 'package:lotti/features/design_system/components/lists/design_system_grouped_list.dart';
 import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
+import 'package:lotti/features/design_system/components/lists/hover_divider_index.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/settings/ui/pages/sliver_box_adapter_page.dart';
 import 'package:lotti/features/settings/ui/widgets/settings_icon.dart';
@@ -40,9 +41,19 @@ class MatrixSyncMaintenancePage extends StatelessWidget {
 /// definitions, force re-sync, populate sequence log. Extracted so
 /// the V2 detail pane can host the same list without the sliver
 /// chrome.
-class MatrixSyncMaintenanceBody extends StatelessWidget {
+/// Hovering a row fades the hairlines bracketing it, matching the
+/// Advanced → Maintenance list this page mirrors — see
+/// [HoverDividerIndex].
+class MatrixSyncMaintenanceBody extends StatefulWidget {
   const MatrixSyncMaintenanceBody({super.key});
 
+  @override
+  State<MatrixSyncMaintenanceBody> createState() =>
+      _MatrixSyncMaintenanceBodyState();
+}
+
+class _MatrixSyncMaintenanceBodyState extends State<MatrixSyncMaintenanceBody>
+    with HoverDividerIndex<MatrixSyncMaintenanceBody> {
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
@@ -116,8 +127,13 @@ class MatrixSyncMaintenanceBody extends StatelessWidget {
               size: tokens.spacing.step6,
               color: tokens.colors.text.lowEmphasis,
             ),
+            // Keep `showDivider` stable so hover never shifts layout
+            // by 1 px; only the colour changes.
             showDivider: index < items.length - 1,
+            dividerColor: hoverDividerColorFor(index),
             dividerIndent: SettingsIcon.dividerIndent(tokens),
+            onHoverChanged: (hovered) =>
+                onRowHoverChanged(index, hovered: hovered),
             onTap: item.onTap,
           ),
       ],

--- a/test/README.md
+++ b/test/README.md
@@ -41,6 +41,46 @@ It happens when the widget's `await for` is still attached to the controller's s
 
 For broader test conventions — centralized mocks/fallbacks (`test/mocks/mocks.dart`, `test/helpers/fallbacks.dart`), `setUpTestGetIt()` / `makeTestableWidget()`, the "every test must assert something meaningful" rule, and one-test-file-per-source-file — see the **Testing Guidelines** section of `AGENTS.md`.
 
+## Hover-divider tests: `test_utils/hover_divider_harness.dart`
+
+The settings lists that mix in `HoverDividerIndex` fade the hairlines
+bracketing the hovered row. Testing that always needs the same two moves —
+drive a real mouse pointer onto a row, then read the divider state back — so
+both live in `test/test_utils/hover_divider_harness.dart` rather than being
+restated per list.
+
+**Hover needs a real mouse pointer.** `tester.tap` will not fire the row's
+`InkWell.onHover`; use `hoverListRow(tester, finder)`, which creates a
+`PointerDeviceKind.mouse` gesture and removes it on teardown. `hoverRowAt(tester,
+index)` is the same thing addressing the row by render position, for lists whose
+rows carry no distinctive text. Both return the gesture so a test can retarget it
+onto another row or move it off the list — the enter/leave pairing of a
+row-to-row move is exactly what the mixin has to stay robust against, and a fresh
+gesture per row would not reproduce it.
+
+For a page on the `DefinitionsListPage` shell, the page's whole obligation is
+that its row forwards the `ListRowDivider` it is handed, so one call covers it:
+`expectRowFadesDividerOnHover(tester, find.text('Alpha'))`, against a two-row
+list. The fade logic itself belongs to the mixin and the shell, each covered by
+its own test — don't restate it per page.
+
+For lists that own the index directly (Flags, Maintenance, Matrix sync), assert
+against the rows: `listRows(tester)` + `expectFadedRows(rows, {1, 2},
+dividerless: {last})`. `expectFadedRows` also asserts `showDivider` never moved,
+which is the point of fading via colour: hiding the hairline with `showDivider`
+instead would jump the rows below by 1&nbsp;px on hover. `listRowDividerColors(tester)`
+is the lower-level read the shell's own tests use — the `Divider` colours inside
+the grouped-list card, in render order.
+
+Pass `dividerless` for rows that legitimately draw no hairline (normally the
+last one). The mixin still reports a colour for such a row — it is simply
+unobservable, so the harness skips asserting on it rather than pinning down
+dead state.
+
+**Only tappable rows hover at all.** `DesignSystemListItem` fires
+`onHoverChanged` only when it has an `onTap`, so a list of non-tappable rows
+(the Logging settings switches) has no hover state to test.
+
 ## Database test layout
 
 `lib/database/database.dart` and `lib/database/sync_db.dart` are shells (constructor + migration ladder) whose query surfaces live in `part` files holding private mixins (`database_task_queries.dart`, `sync_db_outbox.dart`, …). The tests mirror that layout one test file per part file:

--- a/test/features/categories/ui/pages/categories_list_page_test.dart
+++ b/test/features/categories/ui/pages/categories_list_page_test.dart
@@ -17,6 +17,7 @@ import 'package:mocktail/mocktail.dart';
 
 import '../../../../mocks/mocks.dart';
 import '../../../../test_helper.dart';
+import '../../../../test_utils/hover_divider_harness.dart';
 import '../../../../widget_test_utils.dart';
 import '../../test_utils.dart';
 
@@ -827,6 +828,23 @@ void main() {
         await pumpCategoriesListPage(tester);
 
         expect(find.byType(DesignSystemGroupedList), findsOneWidget);
+      });
+    });
+
+    group('hover dividers', () {
+      testWidgets('the category row forwards its divider treatment', (
+        tester,
+      ) async {
+        when(() => mockRepository.watchCategories()).thenAnswer(
+          (_) => Stream.value([
+            CategoryTestUtils.createTestCategory(id: 'cat-a', name: 'Alpha'),
+            CategoryTestUtils.createTestCategory(id: 'cat-b', name: 'Beta'),
+          ]),
+        );
+
+        await pumpCategoriesListPage(tester);
+
+        await expectRowFadesDividerOnHover(tester, find.text('Alpha'));
       });
     });
   });

--- a/test/features/design_system/components/lists/hover_divider_index_test.dart
+++ b/test/features/design_system/components/lists/hover_divider_index_test.dart
@@ -126,5 +126,57 @@ void main() {
         );
       },
     );
+
+    // `dividerFor` is the entry point for shells that hand rows to a
+    // caller-supplied builder (DefinitionsListPage), so it has to bundle
+    // the same answers the à-la-carte API gives.
+    group('dividerFor', () {
+      testWidgets("carries the caller's showDivider through untouched", (
+        tester,
+      ) async {
+        final state = await pumpHost(tester);
+
+        // The mixin colours hairlines; it never decides whether one
+        // exists. Both answers must survive the round trip.
+        expect(state.dividerFor(0, showDivider: true).showDivider, isTrue);
+        expect(state.dividerFor(1, showDivider: false).showDivider, isFalse);
+      });
+
+      testWidgets('bundles the same colour hoverDividerColorFor reports', (
+        tester,
+      ) async {
+        final state = await pumpHost(tester);
+
+        state.onRowHoverChanged(2, hovered: true);
+        await tester.pump();
+
+        // Rows 1 and 2 bracket the hovered row; row 0 is untouched.
+        expect(
+          state.dividerFor(1, showDivider: true).color,
+          Colors.transparent,
+        );
+        expect(
+          state.dividerFor(2, showDivider: true).color,
+          Colors.transparent,
+        );
+        expect(state.dividerFor(0, showDivider: true).color, isNull);
+      });
+
+      testWidgets('its onHoverChanged reports hover for its own row', (
+        tester,
+      ) async {
+        final state = await pumpHost(tester);
+
+        // The bundled callback must close over the index it was built
+        // for — a row only ever says "hovered", never "hovered: 3".
+        state.dividerFor(3, showDivider: true).onHoverChanged(true);
+        await tester.pump();
+        expect(fadedRows(state, count: 6), {2, 3});
+
+        state.dividerFor(3, showDivider: true).onHoverChanged(false);
+        await tester.pump();
+        expect(fadedRows(state, count: 6), isEmpty);
+      });
+    });
   });
 }

--- a/test/features/labels/ui/pages/labels_list_page_test.dart
+++ b/test/features/labels/ui/pages/labels_list_page_test.dart
@@ -19,6 +19,7 @@ import 'package:mocktail/mocktail.dart';
 import '../../../../mocks/mocks.dart';
 import '../../../../test_data/test_data.dart';
 import '../../../../test_helper.dart';
+import '../../../../test_utils/hover_divider_harness.dart';
 import '../../../../widget_test_utils.dart';
 import '../../test_utils.dart';
 
@@ -726,6 +727,24 @@ void main() {
         expect(find.byType(CustomScrollView), findsOneWidget);
         expect(find.byType(SettingsPageHeader), findsOneWidget);
         expect(find.byType(SliverToBoxAdapter), findsWidgets);
+      });
+    });
+
+    group('hover dividers', () {
+      testWidgets('the label row forwards its divider treatment', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          _buildPage(
+            labels: [
+              testLabelDefinition1.copyWith(id: 'label-a', name: 'Alpha'),
+              testLabelDefinition2.copyWith(id: 'label-b', name: 'Beta'),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await expectRowFadesDividerOnHover(tester, find.text('Alpha'));
       });
     });
   });

--- a/test/features/settings/ui/pages/dashboards/dashboards_page_test.dart
+++ b/test/features/settings/ui/pages/dashboards/dashboards_page_test.dart
@@ -14,6 +14,7 @@ import 'package:mocktail/mocktail.dart';
 
 import '../../../../../mocks/mocks.dart';
 import '../../../../../test_data/test_data.dart';
+import '../../../../../test_utils/hover_divider_harness.dart';
 import '../../../../../widget_test_utils.dart';
 
 void main() {
@@ -380,6 +381,22 @@ void main() {
 
         expect(find.byType(DashboardSettingsPage), findsOneWidget);
         expect(find.text(testDashboardConfig.name), findsOneWidget);
+      });
+    });
+
+    group('hover dividers', () {
+      testWidgets('the dashboard row forwards its divider treatment', (
+        tester,
+      ) async {
+        await pumpDashboardsPage(
+          tester,
+          dashboards: [
+            testDashboardConfig.copyWith(id: 'dash-a', name: 'Alpha'),
+            testDashboardConfig.copyWith(id: 'dash-b', name: 'Beta'),
+          ],
+        );
+
+        await expectRowFadesDividerOnHover(tester, find.text('Alpha'));
       });
     });
   });

--- a/test/features/settings/ui/pages/definitions_list_page_test.dart
+++ b/test/features/settings/ui/pages/definitions_list_page_test.dart
@@ -4,10 +4,14 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_floating_action_button.dart';
 import 'package:lotti/features/design_system/components/lists/design_system_grouped_list.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
+import 'package:lotti/features/design_system/components/lists/hover_divider_index.dart';
 import 'package:lotti/features/design_system/components/search/design_system_search.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/settings/ui/pages/definitions_list_page.dart';
 import 'package:lotti/widgets/app_bar/settings_page_header.dart';
 
+import '../../../../test_utils/hover_divider_harness.dart';
 import '../../../../widget_test_utils.dart';
 
 /// Pumps the generic template directly with plain [String] items — no
@@ -28,10 +32,11 @@ Future<void> _pumpPage(
         itemsAsync: itemsAsync,
         searchHint: 'Search test items',
         displayName: (item) => item,
-        itemBuilder: (context, item, {required bool showDivider}) => ListTile(
-          key: ValueKey('row-$item-divider-$showDivider'),
-          title: Text(item),
-        ),
+        itemBuilder: (context, item, {required ListRowDivider divider}) =>
+            ListTile(
+              key: ValueKey('row-$item-divider-${divider.showDivider}'),
+              title: Text(item),
+            ),
         emptyIcon: Icons.inbox_outlined,
         emptyTitle: 'Nothing here yet',
         emptyHint: 'Tap create to add an item',
@@ -50,6 +55,52 @@ Future<void> _pumpPage(
   // flutter_animate entrance schedules a zero-duration timer that must
   // fire before the test ends, so advance the clock explicitly.
   await tester.pump(const Duration(milliseconds: 100));
+}
+
+/// Pumps the template with real [DesignSystemListItem] rows so the hover
+/// wiring is exercised end-to-end: a real pointer enters a row, the item
+/// fires `onHoverChanged`, and the shell feeds `dividerColor` back on the
+/// next build. Returns the design-system default divider colour so tests
+/// can distinguish "faded" from "untouched".
+///
+/// Rows are titled by [items]; the shell sorts them, so pass names whose
+/// alphabetical order is the intended row order.
+Future<Color> _pumpHoverRows(
+  WidgetTester tester, {
+  required List<String> items,
+}) async {
+  late Color defaultDividerColor;
+  await tester.pumpWidget(
+    makeTestableWidgetNoScroll(
+      DefinitionsListPage<String>(
+        title: 'Test Items',
+        itemsAsync: AsyncValue.data(items),
+        searchHint: 'Search test items',
+        displayName: (item) => item,
+        itemBuilder: (context, item, {required ListRowDivider divider}) {
+          defaultDividerColor = context.designTokens.colors.decorative.level01;
+          return DesignSystemListItem(
+            title: item,
+            showDivider: divider.showDivider,
+            dividerColor: divider.color,
+            onHoverChanged: divider.onHoverChanged,
+            // DesignSystemListItem only reports hover for rows that are
+            // tappable, which every real definition row is.
+            onTap: () {},
+          );
+        },
+        emptyIcon: Icons.inbox_outlined,
+        emptyTitle: 'Nothing here yet',
+        emptyHint: 'Tap create to add an item',
+        noMatchMessage: (query) => 'No items match "$query"',
+        errorTitle: 'Failed to load items',
+        createLabel: 'Create item',
+        onCreate: () {},
+      ),
+    ),
+  );
+  await tester.pump(const Duration(milliseconds: 100));
+  return defaultDividerColor;
 }
 
 /// Row titles in render order (the template builds rows pre-sorted).
@@ -438,7 +489,7 @@ void main() {
               itemsAsync: const AsyncValue.data(['Alpha']),
               searchHint: 'Search test items',
               displayName: (item) => item,
-              itemBuilder: (context, item, {required bool showDivider}) =>
+              itemBuilder: (context, item, {required ListRowDivider divider}) =>
                   ListTile(title: Text(item)),
               emptyIcon: Icons.inbox_outlined,
               emptyTitle: 'Nothing here yet',
@@ -464,4 +515,131 @@ void main() {
       expect(created, isTrue);
     },
   );
+
+  // The shell owns the hover index for every definitions list, so these
+  // cover the wiring once for all five pages: the row-index maths lives in
+  // HoverDividerIndex (tested in isolation), while these prove the shell
+  // feeds it a real pointer and paints the result back onto the rows.
+  //
+  // Three rows -> dividers beneath rows 0 and 1 only; the last row never
+  // draws one.
+  group('hover dividers', () {
+    testWidgets('idle: every divider uses the design-system default', (
+      tester,
+    ) async {
+      final defaultColor = await _pumpHoverRows(
+        tester,
+        items: ['Alpha', 'Beta', 'Gamma'],
+      );
+
+      expect(listRowDividerColors(tester), [defaultColor, defaultColor]);
+    });
+
+    testWidgets('hovering a middle row fades both hairlines bracketing it', (
+      tester,
+    ) async {
+      final defaultColor = await _pumpHoverRows(
+        tester,
+        items: ['Alpha', 'Beta', 'Gamma'],
+      );
+
+      await hoverListRow(tester, find.text('Beta'));
+
+      // Beta is row 1: the divider above it (0) and below it (1) both go.
+      expect(listRowDividerColors(tester), [
+        Colors.transparent,
+        Colors.transparent,
+      ]);
+      expect(defaultColor, isNot(Colors.transparent));
+    });
+
+    testWidgets('hovering the first row fades only its own divider', (
+      tester,
+    ) async {
+      final defaultColor = await _pumpHoverRows(
+        tester,
+        items: ['Alpha', 'Beta', 'Gamma'],
+      );
+
+      await hoverListRow(tester, find.text('Alpha'));
+
+      // No row above row 0, so the second divider is untouched.
+      expect(listRowDividerColors(tester), [Colors.transparent, defaultColor]);
+    });
+
+    testWidgets('hovering the last row fades the divider above it', (
+      tester,
+    ) async {
+      final defaultColor = await _pumpHoverRows(
+        tester,
+        items: ['Alpha', 'Beta', 'Gamma'],
+      );
+
+      await hoverListRow(tester, find.text('Gamma'));
+
+      // Gamma is the last row and draws no divider of its own; only the
+      // hairline separating it from Beta fades.
+      expect(listRowDividerColors(tester), [defaultColor, Colors.transparent]);
+    });
+
+    testWidgets('moving between rows retargets the fade', (tester) async {
+      final defaultColor = await _pumpHoverRows(
+        tester,
+        items: ['Alpha', 'Beta', 'Gamma'],
+      );
+
+      final gesture = await hoverListRow(tester, find.text('Alpha'));
+      expect(listRowDividerColors(tester), [Colors.transparent, defaultColor]);
+
+      await gesture.moveTo(tester.getCenter(find.text('Gamma')));
+      await tester.pump();
+
+      // The enter/leave pair for a row-to-row move must settle on Gamma,
+      // not leave Alpha's divider stuck faded.
+      expect(listRowDividerColors(tester), [defaultColor, Colors.transparent]);
+    });
+
+    testWidgets('moving the pointer off the list restores every divider', (
+      tester,
+    ) async {
+      final defaultColor = await _pumpHoverRows(
+        tester,
+        items: ['Alpha', 'Beta', 'Gamma'],
+      );
+
+      final gesture = await hoverListRow(tester, find.text('Beta'));
+      expect(listRowDividerColors(tester), isNot(contains(defaultColor)));
+
+      await unhoverRows(tester, gesture);
+
+      expect(listRowDividerColors(tester), [defaultColor, defaultColor]);
+    });
+
+    testWidgets('hover changes colour only — it never shifts the layout', (
+      tester,
+    ) async {
+      await _pumpHoverRows(tester, items: ['Alpha', 'Beta', 'Gamma']);
+
+      final dividersBefore = listRowDividerColors(tester).length;
+      final gammaBefore = tester.getTopLeft(find.text('Gamma'));
+
+      await hoverListRow(tester, find.text('Beta'));
+
+      // The regression this guards: fading via `showDivider` instead of
+      // `dividerColor` would remove a 1px divider and jump the rows below.
+      expect(listRowDividerColors(tester), hasLength(dividersBefore));
+      expect(tester.getTopLeft(find.text('Gamma')), gammaBefore);
+    });
+
+    testWidgets('a single-row list renders no divider to fade', (tester) async {
+      await _pumpHoverRows(tester, items: ['Alpha']);
+
+      expect(listRowDividerColors(tester), isEmpty);
+
+      // Hovering the only row must not throw despite there being no
+      // divider for the mixin's index to colour.
+      await hoverListRow(tester, find.text('Alpha'));
+      expect(listRowDividerColors(tester), isEmpty);
+    });
+  });
 }

--- a/test/features/settings/ui/pages/habits/habits_page_test.dart
+++ b/test/features/settings/ui/pages/habits/habits_page_test.dart
@@ -15,6 +15,7 @@ import 'package:mocktail/mocktail.dart';
 
 import '../../../../../mocks/mocks.dart';
 import '../../../../../test_data/test_data.dart';
+import '../../../../../test_utils/hover_divider_harness.dart';
 import '../../../../../widget_test_utils.dart';
 
 void main() {
@@ -409,6 +410,22 @@ void main() {
 
         expect(find.byType(HabitsPage), findsOneWidget);
         expect(find.text(habitFlossing.name), findsOneWidget);
+      });
+    });
+
+    group('hover dividers', () {
+      testWidgets('the habit row forwards its divider treatment', (
+        tester,
+      ) async {
+        await pumpHabitsPage(
+          tester,
+          habits: [
+            habitFlossing.copyWith(id: 'habit-a', name: 'Alpha'),
+            habitFlossing.copyWith(id: 'habit-b', name: 'Beta'),
+          ],
+        );
+
+        await expectRowFadesDividerOnHover(tester, find.text('Alpha'));
       });
     });
   });

--- a/test/features/settings/ui/pages/measurables/measurables_page_test.dart
+++ b/test/features/settings/ui/pages/measurables/measurables_page_test.dart
@@ -10,6 +10,7 @@ import 'package:lotti/features/settings/ui/pages/measurables/measurables_page.da
 import 'package:lotti/services/nav_service.dart';
 
 import '../../../../../test_data/test_data.dart';
+import '../../../../../test_utils/hover_divider_harness.dart';
 import '../../../../../widget_test_utils.dart';
 
 void main() {
@@ -354,6 +355,22 @@ void main() {
 
         expect(find.byType(MeasurablesPage), findsOneWidget);
         expect(find.text(measurableWater.displayName), findsOneWidget);
+      });
+    });
+
+    group('hover dividers', () {
+      testWidgets('the measurable row forwards its divider treatment', (
+        tester,
+      ) async {
+        await pumpMeasurablesPage(
+          tester,
+          measurables: [
+            measurableWater.copyWith(id: 'm-a', displayName: 'Alpha'),
+            measurableWater.copyWith(id: 'm-b', displayName: 'Beta'),
+          ],
+        );
+
+        await expectRowFadesDividerOnHover(tester, find.text('Alpha'));
       });
     });
   });

--- a/test/features/sync/ui/matrix_sync_maintenance_page_test.dart
+++ b/test/features/sync/ui/matrix_sync_maintenance_page_test.dart
@@ -18,6 +18,7 @@ import 'package:mocktail/mocktail.dart';
 
 import '../../../helpers/fallbacks.dart';
 import '../../../mocks/mocks.dart';
+import '../../../test_utils/hover_divider_harness.dart';
 import '../../../widget_test_utils.dart';
 
 class _StubSyncController extends SyncMaintenanceController {
@@ -340,6 +341,120 @@ void main() {
         find.text(scaffoldContext.messages.maintenanceDeleteSyncDb),
         findsNothing,
       );
+    });
+
+    // Mirrors the Advanced -> Maintenance list this page is a twin of:
+    // hovering a row fades the hairlines bracketing it so the hovered row
+    // is never bisected. Five action rows -> dividers beneath rows 0..3;
+    // the last row draws none.
+    group('hover divider fade', () {
+      Future<List<DesignSystemListItem>> pumpBody(WidgetTester tester) async {
+        await tester.pumpWidget(buildPage());
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+        return listRows(tester);
+      }
+
+      /// The final row is the only one that legitimately draws no divider.
+      Set<int> dividerlessOf(List<DesignSystemListItem> rows) => {
+        rows.length - 1,
+      };
+
+      testWidgets('idle: no divider is faded', (tester) async {
+        final rows = await pumpBody(tester);
+
+        expectFadedRows(rows, const {}, dividerless: dividerlessOf(rows));
+      });
+
+      testWidgets('hovering a middle row fades the dividers above AND below', (
+        tester,
+      ) async {
+        final initial = await pumpBody(tester);
+        await hoverRowAt(tester, 2);
+
+        // Row 2 fades its own bottom divider, and row 1 fades the divider
+        // directly above row 2 — the hovered row is bracketed by
+        // invisible hairlines. Nothing else changes.
+        expectFadedRows(
+          listRows(tester),
+          const {1, 2},
+          dividerless: dividerlessOf(initial),
+        );
+      });
+
+      testWidgets('hovering the first row fades only its own divider', (
+        tester,
+      ) async {
+        final initial = await pumpBody(tester);
+        await hoverRowAt(tester, 0);
+
+        // There is no row -1, so only row 0's own divider fades.
+        expectFadedRows(
+          listRows(tester),
+          const {0},
+          dividerless: dividerlessOf(initial),
+        );
+      });
+
+      testWidgets('hovering the last row fades the divider above it', (
+        tester,
+      ) async {
+        final initial = await pumpBody(tester);
+        final last = initial.length - 1;
+        await hoverRowAt(tester, last);
+
+        // The last row draws no divider of its own; only the hairline
+        // separating it from the row above fades.
+        expectFadedRows(
+          listRows(tester),
+          {last - 1},
+          dividerless: dividerlessOf(initial),
+        );
+      });
+
+      testWidgets('moving between rows re-targets the fade', (tester) async {
+        final initial = await pumpBody(tester);
+        final gesture = await hoverRowAt(tester, 1);
+        expectFadedRows(
+          listRows(tester),
+          const {0, 1},
+          dividerless: dividerlessOf(initial),
+        );
+
+        // Move to a non-adjacent row: the exit from row 1 and the enter
+        // onto row 3 must settle on row 3's pair regardless of the order
+        // the two callbacks arrive in.
+        await gesture.moveTo(
+          tester.getCenter(find.byType(DesignSystemListItem).at(3)),
+        );
+        await tester.pump();
+
+        expectFadedRows(
+          listRows(tester),
+          const {2, 3},
+          dividerless: dividerlessOf(initial),
+        );
+      });
+
+      testWidgets('moving the pointer off the list restores every divider', (
+        tester,
+      ) async {
+        final initial = await pumpBody(tester);
+        final gesture = await hoverRowAt(tester, 2);
+        expectFadedRows(
+          listRows(tester),
+          const {1, 2},
+          dividerless: dividerlessOf(initial),
+        );
+
+        await unhoverRows(tester, gesture);
+
+        expectFadedRows(
+          listRows(tester),
+          const {},
+          dividerless: dividerlessOf(initial),
+        );
+      });
     });
   });
 }

--- a/test/test_utils/hover_divider_harness.dart
+++ b/test/test_utils/hover_divider_harness.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_grouped_list.dart';
+import 'package:lotti/features/design_system/components/lists/design_system_list_item.dart';
+
+/// Helpers for the hover-divider treatment shared by the settings lists
+/// (`HoverDividerIndex`): hovering a row fades the hairlines bracketing it
+/// so the hovered row is never bisected.
+///
+/// The contract under test is always the same shape — drive a real mouse
+/// pointer onto a row, then read the divider colours back — so both live
+/// here rather than being restated in each list's test file.
+
+/// Colours of the row dividers inside a grouped-list card, in render
+/// order.
+///
+/// A run of `n` rows renders `n - 1` dividers: the last row never draws
+/// one. A `null` entry means the row passed no explicit colour and the
+/// `DesignSystemListItem` fell back to its own default — which the
+/// production lists never do, since the shell always passes either the
+/// design-system colour or [Colors.transparent].
+///
+/// Scoped to [of] (a [DesignSystemGroupedList] by default) so unrelated
+/// chrome dividers elsewhere on the page cannot leak into the result.
+List<Color?> listRowDividerColors(WidgetTester tester, {Finder? of}) => tester
+    .widgetList<Divider>(
+      find.descendant(
+        of: of ?? find.byType(DesignSystemGroupedList),
+        matching: find.byType(Divider),
+      ),
+    )
+    .map((divider) => divider.color)
+    .toList();
+
+/// Where the pointer rests when it is meant to be hovering nothing.
+///
+/// Deliberately outside the window rather than at [Offset.zero]: the
+/// origin is the top-left *inside* the view, where a back button or header
+/// title usually sits, so parking there would hover a real widget and let
+/// unrelated chrome leak into a test about list rows.
+const _pointerParked = Offset(-1, -1);
+
+/// Moves a mouse pointer onto [row] and settles the resulting rebuild.
+///
+/// The pointer is parked off-screen and then *moved* onto the row. Adding
+/// it directly at the row would also report hover, but entering by motion
+/// is what a real pointer does, and it keeps this identical to the
+/// retarget move a test makes when it continues the same gesture onto the
+/// next row — so the enter path under test is the same one either way.
+///
+/// Returns the gesture so a test can continue the same pointer — moving
+/// it to another row (retargeting) or away from the list (clearing) —
+/// which is the only way to reproduce the enter/leave pairing that
+/// `HoverDividerIndex` has to stay robust against. The pointer is removed
+/// automatically at the end of the test.
+Future<TestGesture> hoverListRow(WidgetTester tester, Finder row) async {
+  final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+  await gesture.addPointer(location: _pointerParked);
+  addTearDown(gesture.removePointer);
+  await gesture.moveTo(tester.getCenter(row));
+  await tester.pump();
+  return gesture;
+}
+
+/// Moves [gesture] off every row, clearing the hover state.
+Future<void> unhoverRows(WidgetTester tester, TestGesture gesture) async {
+  await gesture.moveTo(_pointerParked);
+  await tester.pump();
+}
+
+/// Asserts that a page's row forwards the whole divider treatment it is
+/// handed — hovering [row] must fade the hairline bracketing it.
+///
+/// Expects a list of exactly two rows, which renders exactly one divider
+/// (beneath the first): the smallest arrangement in which a fade is
+/// observable. Fails if the row drops `dividerColor` (the shell's answer
+/// never reaches the divider) or `onHoverChanged` (the shell never learns
+/// about the hover).
+///
+/// This is the per-page half of the contract, identical for every list on
+/// the `DefinitionsListPage` shell. The fade logic itself belongs to
+/// `HoverDividerIndex` and the shell, each covered by its own test.
+Future<void> expectRowFadesDividerOnHover(
+  WidgetTester tester,
+  Finder row,
+) async {
+  expect(
+    listRowDividerColors(tester),
+    [isNot(Colors.transparent)],
+    reason: 'two rows should render one divider, un-faded while idle',
+  );
+
+  await hoverListRow(tester, row);
+
+  expect(listRowDividerColors(tester), [Colors.transparent]);
+}
+
+/// The live [DesignSystemListItem] rows, in render order.
+///
+/// Lists that own the hover index directly (rather than going through a
+/// shell) assert against the rows themselves, so that both halves of the
+/// contract are visible: which dividers faded, and that `showDivider`
+/// never moved.
+List<DesignSystemListItem> listRows(WidgetTester tester) => tester
+    .widgetList<DesignSystemListItem>(
+      find.byType(DesignSystemListItem),
+    )
+    .toList();
+
+/// [hoverListRow] addressing the row by render position rather than by
+/// finder, for lists whose rows carry no distinctive text.
+Future<TestGesture> hoverRowAt(WidgetTester tester, int index) =>
+    hoverListRow(tester, find.byType(DesignSystemListItem).at(index));
+
+/// Asserts that exactly the rows in [expected] have a faded divider, and
+/// — just as importantly — that every row's `showDivider` is untouched.
+///
+/// The layout-stability half is the whole point of fading via colour: had
+/// a list hidden the hairline with `showDivider` instead, rows below the
+/// pointer would jump by 1 px on hover.
+void expectFadedRows(
+  List<DesignSystemListItem> rows,
+  Set<int> expected, {
+
+  /// Rows that legitimately draw no divider (typically the last one).
+  Set<int> dividerless = const {},
+}) {
+  for (final (index, row) in rows.indexed) {
+    expect(
+      row.showDivider,
+      !dividerless.contains(index),
+      reason: 'showDivider must stay stable across hover (row $index)',
+    );
+    // A dividerless row draws no hairline, so whatever colour it was
+    // handed is unobservable — the mixin still reports one for it, and
+    // asserting on it would only pin down dead state.
+    if (dividerless.contains(index)) continue;
+    expect(
+      row.dividerColor == Colors.transparent,
+      expected.contains(index),
+      reason: expected.contains(index)
+          ? 'row $index should be faded'
+          : 'row $index should keep its default divider',
+    );
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated row divider behavior in Categories, Labels, Habits, Measurables, Dashboards, and Matrix maintenance: divider hairlines now fade on hover while the row layout stays fixed.
* **Bug Fixes**
  * Prevented divider lines from visually bisecting the currently hovered row.
* **Documentation**
  * Clarified the hover-divider behavior in settings documentation and release notes.
* **Tests**
  * Added/expanded widget tests to verify hover fade behavior (including edge cases like first/last rows and pointer leave).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->