### PR TITLE
fix(sync): make Matrix catch-up and tests reliable

### DIFF
--- a/.github/workflows/flutter-matrix-test.yml
+++ b/.github/workflows/flutter-matrix-test.yml
@@ -8,6 +8,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  CARGO_HTTP_TIMEOUT: "120"
+  CARGO_NET_RETRY: "10"
+
 jobs:
   test:
     name: Matrix Test on Linux
@@ -24,6 +28,15 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-matrix-cargo-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-matrix-cargo-
       - uses: kuhnroyal/flutter-fvm-config-action@v2
         id: fvm-config-action
       - uses: subosito/flutter-action@v2
@@ -59,6 +72,15 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-matrix-cargo-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-matrix-cargo-
       - uses: kuhnroyal/flutter-fvm-config-action@v2
         id: fvm-config-action
       - uses: subosito/flutter-action@v2
@@ -91,6 +113,15 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-matrix-cargo-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-matrix-cargo-
       - uses: kuhnroyal/flutter-fvm-config-action@v2
         id: fvm-config-action
       - uses: subosito/flutter-action@v2

--- a/.github/workflows/flutter-matrix-test.yml
+++ b/.github/workflows/flutter-matrix-test.yml
@@ -34,7 +34,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: ${{ runner.os }}-matrix-cargo-${{ hashFiles('**/pubspec.lock') }}
+          key: ${{ runner.os }}-matrix-cargo-${{ hashFiles('pubspec.lock') }}
           restore-keys: |
             ${{ runner.os }}-matrix-cargo-
       - uses: kuhnroyal/flutter-fvm-config-action@v2
@@ -78,7 +78,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: ${{ runner.os }}-matrix-cargo-${{ hashFiles('**/pubspec.lock') }}
+          key: ${{ runner.os }}-matrix-cargo-${{ hashFiles('pubspec.lock') }}
           restore-keys: |
             ${{ runner.os }}-matrix-cargo-
       - uses: kuhnroyal/flutter-fvm-config-action@v2
@@ -119,7 +119,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: ${{ runner.os }}-matrix-cargo-${{ hashFiles('**/pubspec.lock') }}
+          key: ${{ runner.os }}-matrix-cargo-${{ hashFiles('pubspec.lock') }}
           restore-keys: |
             ${{ runner.os }}-matrix-cargo-
       - uses: kuhnroyal/flutter-fvm-config-action@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   keep the existing defaults.
 
 ### Fixed
+- **Matrix sync now reliably catches up after a device was offline.** Reopening
+  a device after another device sent a large burst now always walks forward
+  from the last applied Matrix event instead of occasionally treating a cached
+  timeline as complete and leaving newer entries missing.
 - **Command+S saves changed rich text again.** The save command now travels
   with the reusable editor, so it works in journal cards and task forms as well
   as on the standalone entry page without reaching for the Save button.

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -51,6 +51,7 @@
           <p>Checklist cards now collapse cleanly after every item is complete: the completion message stays on one line instead of stacking its letters.</p>
           <p>The editor formatting toolbar renders correctly on macOS again instead of becoming a grey error strip when an editor gains focus.</p>
           <p>Bulk checklist suggestion acceptance no longer flickers. Confirm all keeps every proposal row mounted through its staggered exit even when fast checklist check-offs resolve the underlying suggestions before later rows begin animating, while the task page stays anchored throughout the batch.</p>
+          <p>Matrix sync now reliably catches up after a device was offline. Reopening a device after another device sent a large burst always walks forward from the last applied Matrix event instead of occasionally treating a cached timeline as complete and leaving newer entries missing.</p>
       </description>
     </release>
     <release version="0.9.1045" date="2026-07-15">

--- a/integration_test/docker/docker-compose.yml
+++ b/integration_test/docker/docker-compose.yml
@@ -36,6 +36,15 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget --quiet --output-document=- http://localhost:8008/_matrix/client/versions >/dev/null 2>&1",
+        ]
+      interval: 1s
+      timeout: 2s
+      retries: 60
     networks:
       - internal
     restart: unless-stopped
@@ -44,7 +53,8 @@ services:
     hostname: toxiproxy
     image: ghcr.io/shopify/toxiproxy:2.11.0
     depends_on:
-      - dendrite
+      dendrite:
+        condition: service_healthy
     ports:
       - 18008:18008
       - 8474:8474

--- a/integration_test/run_matrix_actor_isolate_test.sh
+++ b/integration_test/run_matrix_actor_isolate_test.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
+set -euo pipefail
+
 # Go to directory of script
-cd "$(dirname "$0")" || exit
+cd "$(dirname "$0")"
 
 uuid=$(uuidgen)
 TEST_USER="$(tr '[:upper:]' '[:lower:]' <<< "$uuid")"
 TEST_PASSWORD="${TEST_PASSWORD:-?Secret123@}"
 
-cd docker || exit
-docker compose exec dendrite create-account -config dendrite.yaml -username "$TEST_USER" -admin -password "$TEST_PASSWORD"
-cd - > /dev/null || exit
+cd docker
+docker compose up --detach --wait --wait-timeout 60
+docker compose exec -T dendrite create-account -config dendrite.yaml -username "$TEST_USER" -admin -password "$TEST_PASSWORD"
+cd - > /dev/null
 
 cd ..
 

--- a/integration_test/run_matrix_tests.sh
+++ b/integration_test/run_matrix_tests.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
+set -euo pipefail
+
 # Go to directory of script
-cd "$(dirname "$0")" || exit
+cd "$(dirname "$0")"
 
 # Create user name
 uuid1=$(uuidgen)
@@ -8,10 +10,11 @@ uuid2=$(uuidgen)
 TEST_USER1="$(tr '[:upper:]' '[:lower:]' <<< "$uuid1")"
 TEST_USER2="$(tr '[:upper:]' '[:lower:]' <<< "$uuid2")"
 
-cd docker || exit
-docker compose exec dendrite create-account -config dendrite.yaml -username "$TEST_USER1" -admin -password "?Secret123@"
-docker compose exec dendrite create-account -config dendrite.yaml -username "$TEST_USER2" -admin -password "?Secret123@"
-cd - > /dev/null || exit
+cd docker
+docker compose up --detach --wait --wait-timeout 60
+docker compose exec -T dendrite create-account -config dendrite.yaml -username "$TEST_USER1" -admin -password "?Secret123@"
+docker compose exec -T dendrite create-account -config dendrite.yaml -username "$TEST_USER2" -admin -password "?Secret123@"
+cd - > /dev/null
 cd ..
 
 flutter test integration_test/matrix_service_test.dart \

--- a/integration_test/setup_toxiproxy_docker.sh
+++ b/integration_test/setup_toxiproxy_docker.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
-# Go to directory of script
-cd "$(dirname "$0")" || exit
+set -euo pipefail
 
-cd docker || exit
-docker compose exec toxiproxy /toxiproxy-cli create -l toxiproxy:18008 -u dendrite:8008 dendrite-proxy
-docker compose exec toxiproxy /toxiproxy-cli toxic add -t latency -a latency=200 dendrite-proxy
-docker compose exec toxiproxy /toxiproxy-cli toxic add -t bandwidth -a rate=300 dendrite-proxy
+# Go to directory of script
+cd "$(dirname "$0")"
+
+cd docker
+docker compose up --detach --wait --wait-timeout 60
+docker compose exec -T toxiproxy /toxiproxy-cli delete dendrite-proxy \
+  >/dev/null 2>&1 || true
+docker compose exec -T toxiproxy /toxiproxy-cli create -l toxiproxy:18008 -u dendrite:8008 dendrite-proxy
+docker compose exec -T toxiproxy /toxiproxy-cli toxic add -t latency -a latency=200 dendrite-proxy
+docker compose exec -T toxiproxy /toxiproxy-cli toxic add -t bandwidth -a rate=300 dendrite-proxy
 cd ..

--- a/lib/features/sync/README.md
+++ b/lib/features/sync/README.md
@@ -28,7 +28,7 @@ flowchart LR
   Sender --> Room["Encrypted Matrix room"]
 
   Room --> QueueCoord["QueuePipelineCoordinator"]
-  QueueCoord --> Bridge["BridgeCoordinator (catch-up via /messages on limited=true)"]
+  QueueCoord --> Bridge["BridgeCoordinator (anchored catch-up via /context + /messages)"]
   QueueCoord --> Queue["InboundQueue (Drift-backed)"]
   Bridge --> Queue
   Queue --> Worker["InboundWorker (per-room drain, one entry per batch)"]
@@ -789,9 +789,16 @@ The important runtime rules are:
 - live events are routed through `PendingDecryptionPen` so pre-decryption
   ciphertext never lands in `inbound_event_queue.raw_json`, then enqueued via
   `InboundQueue.enqueueLive`
-- on `timeline.limited == true`, `BridgeCoordinator` runs an anchored
+- on coordinator startup, an explicit room save, or `timeline.limited == true`,
+  `BridgeCoordinator` runs an anchored
   **forward** catch-up walk via `CatchUpStrategy.collectForwardForBootstrap`
   (anchored on the per-room `last_applied_event_id` marker in `queue_markers`),
+  forcing a server `/context/{eventId}` request with
+  `room.getTimeline(eventContextId: marker, limit: 0)` before walking
+  `/messages?dir=f`. The zero cache limit is required with Matrix SDK 7.0.0:
+  otherwise an anchor already present in the SDK database suppresses the
+  context request, leaves the timeline without a forward token, and can make a
+  reconnect incorrectly report completion with no bootstrap events,
   falling back to a timestamp-bounded **backward** walk
   (`collectHistoryForBootstrap`) only for fresh clients with no anchor or when
   the anchor is unresolvable, and feeds events through the same enqueue path
@@ -866,14 +873,18 @@ Components (all under `lib/features/sync/queue/`):
   `SyncSequenceLogService.runWithDeferredMissingEntries` so per-slice gap
   detections coalesce into one `onMissingEntriesDetected` emission — the
   F1 concern from the design review. Honours `UserActivityGate`.
-- **`BridgeCoordinator`** — subscribes to `Client.onSync` and, on any
-  joined room's `timeline.limited == true`, runs a catch-up walk anchored on
-  the per-room marker in `queue_markers`: an anchored **forward** walk via
+- **`BridgeCoordinator`** — subscribes to `Client.onSync`; startup, explicit
+  room-save, manual-rescan, and joined-room `timeline.limited == true` signals
+  run a catch-up walk anchored on the per-room marker in `queue_markers`: an
+  anchored **forward** walk via
   `CatchUpStrategy.collectForwardForBootstrap` when `last_applied_event_id` is
-  set (the preferred path), falling back to a timestamp-bounded **backward**
-  walk via `collectHistoryForBootstrap` for fresh clients or an unresolvable
-  anchor. Walked events are appended via `InboundQueue.appendBootstrapPage`,
-  i.e. enqueued with `producer=bootstrap`. Single-flight.
+  set (the preferred path). The forward walk deliberately passes `limit: 0`
+  to `Room.getTimeline` so Matrix SDK cannot satisfy the anchor from its local
+  cache and must return server context with a valid forward-pagination token.
+  It falls back to a timestamp-bounded **backward** walk via
+  `collectHistoryForBootstrap` for fresh clients or an unresolvable anchor.
+  Walked events are appended via `InboundQueue.appendBootstrapPage`, i.e.
+  enqueued with `producer=bootstrap`. Single-flight.
 - **`PendingDecryptionPen`** — LRU holding pen for Megolm-encrypted events
   that arrive before their session key. The worker re-resolves them via
   `room.getEventById` on every drain iteration; only fully-decrypted

--- a/lib/features/sync/matrix/pipeline/bootstrap_forward_strategy.dart
+++ b/lib/features/sync/matrix/pipeline/bootstrap_forward_strategy.dart
@@ -12,13 +12,17 @@ import 'package:matrix/matrix.dart';
 /// does NOT reuse the SDK's cached backward-walking timeline.
 ///
 /// How it works:
-/// - `room.getTimeline(eventContextId: anchorEventId)` asks the
+/// - `room.getTimeline(eventContextId: anchorEventId, limit: 0)` asks the
 ///   server for a fragmented timeline centred on the anchor via
 ///   `/rooms/{roomId}/context/{eventId}`. The returned chunk
 ///   carries `prev_batch` / `next_batch` tokens independent of
 ///   whatever the client has cached from prior sessions — so a
 ///   client whose cached oldest event is months below the gap
 ///   still gets a fresh server-side window here.
+///   The zero database limit is essential: Matrix SDK 7.0.0 skips
+///   the context request when the anchor is already present in its
+///   local event cache, producing a non-fragmented timeline without
+///   the forward token needed to close the reconnect gap.
 /// - `timeline.requestFuture(historyCount: pageSize)` walks
 ///   forward via `/messages?dir=f`, one page at a time, emitting
 ///   each page through the sink until the server reports no more
@@ -55,7 +59,10 @@ Future<BootstrapResult> collectForwardForBootstrapImpl({
   final start = nowFn();
   final Timeline timeline;
   try {
-    timeline = await room.getTimeline(eventContextId: anchorEventId);
+    timeline = await room.getTimeline(
+      eventContextId: anchorEventId,
+      limit: 0,
+    );
   } catch (error, stackTrace) {
     logging.error(
       LogDomain.sync,

--- a/test/features/sync/matrix/pipeline/catch_up_strategy_test.dart
+++ b/test/features/sync/matrix/pipeline/catch_up_strategy_test.dart
@@ -2002,6 +2002,41 @@ void main() {
     );
 
     test(
+      'forces a server context lookup even when the anchor is already in the '
+      'SDK cache',
+      () async {
+        final room = MockRoom();
+        final log = MockDomainLogger();
+        final timeline = MockTimeline();
+        final anchor = buildEvent(r'$anchor', 100);
+        when(
+          () => room.getTimeline(
+            eventContextId: r'$anchor',
+            limit: 0,
+          ),
+        ).thenAnswer((_) async => timeline);
+        when(() => timeline.events).thenReturn([anchor]);
+        when(() => timeline.canRequestFuture).thenReturn(false);
+        when(timeline.cancelSubscriptions).thenAnswer((_) {});
+
+        final result = await CatchUpStrategy.collectForwardForBootstrap(
+          room: room,
+          sink: _CollectingBootstrapSink((_) {}),
+          logging: log,
+          anchorEventId: r'$anchor',
+        );
+
+        expect(result.stopReason, BootstrapStopReason.serverExhausted);
+        verify(
+          () => room.getTimeline(
+            eventContextId: r'$anchor',
+            limit: 0,
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
       'emits events strictly newer than the anchor and stops when the '
       'server runs out of future — this is the load-bearing reconnect '
       'path that backward-walk cannot cover once the cache predates '


### PR DESCRIPTION
## Summary

- force the Matrix bootstrap path to obtain fresh server context before forward pagination
- add regression coverage for an anchor that is already present in the Matrix SDK cache
- wait for Dendrite health before account setup and make Toxiproxy initialization idempotent
- cache Cargo downloads and increase Cargo timeout/retry limits in every Matrix workflow job
- document the corrected catch-up lifecycle and add matching release notes

## Root cause

The primary failure was cache-dependent behavior in Matrix SDK 7.0.0. `Room.getTimeline(eventContextId: anchor)` first checks locally persisted events. When the anchor was already in that cache, the SDK skipped the server `/context/{eventId}` request, produced a non-fragmented timeline without a forward-pagination token, and reported that no future page could be requested.

Our bootstrap bridge interpreted that state as server exhaustion, enqueued zero missing events, and completed even though newer remote entries existed. Cache timing made the behavior intermittent, especially during cold-start convergence after another device sent a large offline burst.

Passing `limit: 0` prevents the database lookup from satisfying the anchor and forces the server context request, restoring the `next_batch` token required for the `/messages?dir=f` walk.

The investigation of the last 100 PRs also separated two infrastructure failure modes from this product bug:

- 37 degraded-convergence job failures matched the catch-up defect
- 8 failures were Dendrite readiness races
- 4 failures were Cargo download errors
- 2 failures were legitimate compile regressions

Overall, 42 of the last 100 PRs had at least one Matrix failure, with 51 failed Matrix jobs.

## Impact

Devices reopening after being offline reliably ingest entries created by another device instead of occasionally treating a cached partial timeline as complete. Matrix CI also waits for a genuinely ready homeserver and is more resilient to transient Cargo network failures.

## Validation

- `fvm flutter analyze` — no issues
- full `catch_up_strategy_test.dart` — 46 tests passed
- bridge and queue coordinator tests — 104 tests passed
- full degraded Docker Matrix integration — all 3 scenarios passed
  - 250-event cold start converged in 8 seconds
  - 150-event mid-burst scenario converged in 67 seconds
- 3 consecutive cold Dendrite startup/account-creation cycles passed
- formatting, shell syntax, workflow YAML, metainfo XML, Compose configuration, and `git diff --check` passed

The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards. CI shards are the authoritative full-suite result, and Codecov is the authoritative patch-coverage result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Matrix synchronization so missed events are reliably recovered after a device has been offline, including after large bursts of activity.
  * Improved reconnect and catch-up handling to prevent newer timeline entries from being skipped.

* **Tests**
  * Improved integration test startup reliability by waiting for services to become healthy before running tests.
  * Added coverage for synchronization when cached timeline data is already present.

* **Documentation**
  * Updated synchronization documentation and release notes to describe the improved catch-up behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->