### PR TITLE
fix: harden manual Pages workflow

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -139,12 +139,15 @@ jobs:
           (github.event_name == 'workflow_dispatch' && inputs.deploy &&
            needs.metadata.outputs.version == 'development')
         working-directory: lotti/docs-site
+        env:
+          PAGES_PREFIX: ${{ github.event.repository.name }}
+          VERSION: ${{ needs.metadata.outputs.version }}
         run: >-
           npm run pages:assemble --
           --build-root build
           --output-root "${RUNNER_TEMP}/lotti-manual-pages"
-          --pages-prefix "${{ github.event.repository.name }}"
-          --version "${{ needs.metadata.outputs.version }}"
+          --pages-prefix "$PAGES_PREFIX"
+          --version "$VERSION"
 
       - name: Upload GitHub Pages artifact
         if: >-


### PR DESCRIPTION
## What changed

- pass the repository Pages prefix and manual version into the shell through step environment variables
- remove inline GitHub expression expansion from the Pages assembly command

## Why

This addresses the remaining security review on #3490 and prevents workflow template-injection warnings while preserving the exact Pages artifact inputs.

## Validation

- assembled the Pages artifact using shell environment variables
- verified `/manual/development/index.html` is present in the generated snapshot
- `git diff --check`

The approximately 27,000-test full suite is intentionally delegated to CI, where it runs in 10 shards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the automated GitHub Pages build workflow by assigning reusable environment variables for the site prefix and version.
  * Preserved the existing versioned snapshot assembly behavior while making command execution more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->