### PR TITLE
fix: adapt onboarding to active theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   status text truncates without pushing its actions off-screen, Daily OS time
   anchors wrap at accessibility text sizes, and the What's New footer gives
   translated actions enough room on phones.
+- **Onboarding now follows the active light or dark theme throughout setup.**
+  Panels, text, controls, provider tiles, recording previews, and task handoff
+  states use the matching design-system tokens. The neural and aurora artwork
+  also adapts its palette and compositing so the motion remains visible and
+  balanced on both light and dark surfaces. Provider, category, recording, and
+  task-handoff controls are keyboard operable, and scaled text switches work
+  areas to a readable single-column layout.
 - **The desktop sidebar is navigation-first and keeps important task filters
   visible.** Saved task filters now appear directly under Tasks with live
   counts. The first five follow the order you set, More expands the complete

--- a/docs-site/docs/getting-started/onboarding.mdx
+++ b/docs-site/docs/getting-started/onboarding.mdx
@@ -54,11 +54,23 @@ The provider page identifies the available hosted and local choices:
 - **Ollama** connects to a compatible local endpoint and does not require a
   hosted API key.
 
+<ManualScreenshot
+  caseId="onboarding/api-key"
+  alt="Lotti onboarding provider verification panel showing a verified local Ollama connection"
+  caption="Lotti verifies the chosen provider before enabling Connect. Hosted providers use the same step with an API-key field."
+/>
+
 For a hosted provider, paste the provider API key. Lotti verifies the
 connection before enabling **Connect**. Ollama verifies the configured local
 endpoint and reports reachable models. A successful connection persists the
 provider and seeds the models and inference profile used by the remaining
 steps.
+
+<ManualScreenshot
+  caseId="onboarding/success"
+  alt="Lotti onboarding confirmation that the AI provider is connected and ready"
+  caption="The connection confirmation is intentionally calm; the larger payoff is reserved for the first real task."
+/>
 
 Captured task text is sent to the provider assigned to the selected category
 for structuring. Choose a provider whose deployment and data-handling model
@@ -67,9 +79,21 @@ that structuring request on the machine running it.
 
 ## Pick the recording feel and work areas
 
+<ManualScreenshot
+  caseId="onboarding/recording-style"
+  alt="Lotti onboarding recording-style chooser with Modern energy orb and Analogue VU meter options"
+  caption="Choose the recording visual that feels clearest. Both options use the same capture pipeline."
+/>
+
 After connection succeeds, choose the recording style used by the first-task
 capture and later voice-capture surfaces. You can change it again under
 **Settings → Recording Style**.
+
+<ManualScreenshot
+  caseId="onboarding/categories"
+  alt="Lotti onboarding work-area chooser with Work, Fitness, Family, Friends, and Add your own choices"
+  caption="Choose one or more areas for the new provider. Scaled text and narrow layouts automatically use one full-width choice per row."
+/>
 
 Next, select one or more work areas. Presets cover common categories such as
 Work, Fitness, Family, and Friends; **Add your own** creates a category with a

--- a/docs-site/metadata/features.json
+++ b/docs-site/metadata/features.json
@@ -311,6 +311,10 @@
         "onboarding/settings",
         "onboarding/welcome",
         "onboarding/providers",
+        "onboarding/api-key",
+        "onboarding/success",
+        "onboarding/recording-style",
+        "onboarding/categories",
         "onboarding/first-task",
         "onboarding/task-created"
       ]

--- a/docs-site/metadata/screenshot-cases.json
+++ b/docs-site/metadata/screenshot-cases.json
@@ -1016,6 +1016,50 @@
       }
     },
     {
+      "id": "onboarding/api-key",
+      "title": "Onboarding provider verification",
+      "sourceTest": "test/features/onboarding/ui/onboarding_manual_screenshots_test.dart",
+      "variants": {
+        "mobile-light": "onboarding_api_key_mobile_light.png",
+        "mobile-dark": "onboarding_api_key_mobile_dark.png",
+        "desktop-light": "onboarding_api_key_desktop_light.png",
+        "desktop-dark": "onboarding_api_key_desktop_dark.png"
+      }
+    },
+    {
+      "id": "onboarding/success",
+      "title": "Onboarding provider connected",
+      "sourceTest": "test/features/onboarding/ui/onboarding_manual_screenshots_test.dart",
+      "variants": {
+        "mobile-light": "onboarding_success_mobile_light.png",
+        "mobile-dark": "onboarding_success_mobile_dark.png",
+        "desktop-light": "onboarding_success_desktop_light.png",
+        "desktop-dark": "onboarding_success_desktop_dark.png"
+      }
+    },
+    {
+      "id": "onboarding/recording-style",
+      "title": "Onboarding recording style",
+      "sourceTest": "test/features/onboarding/ui/onboarding_manual_screenshots_test.dart",
+      "variants": {
+        "mobile-light": "onboarding_recording_style_mobile_light.png",
+        "mobile-dark": "onboarding_recording_style_mobile_dark.png",
+        "desktop-light": "onboarding_recording_style_desktop_light.png",
+        "desktop-dark": "onboarding_recording_style_desktop_dark.png"
+      }
+    },
+    {
+      "id": "onboarding/categories",
+      "title": "Onboarding work areas",
+      "sourceTest": "test/features/onboarding/ui/onboarding_manual_screenshots_test.dart",
+      "variants": {
+        "mobile-light": "onboarding_categories_mobile_light.png",
+        "mobile-dark": "onboarding_categories_mobile_dark.png",
+        "desktop-light": "onboarding_categories_desktop_light.png",
+        "desktop-dark": "onboarding_categories_desktop_dark.png"
+      }
+    },
+    {
       "id": "onboarding/first-task",
       "title": "Onboarding first-task voice capture",
       "sourceTest": "test/features/onboarding/ui/onboarding_manual_screenshots_test.dart",

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -37,6 +37,7 @@
       <description>
           <p>The desktop sidebar now opens the Lotti Manual directly. A localized Manual link sits immediately above Settings, remains available when the sidebar is collapsed, and opens the current published manual in the default browser.</p>
           <p>German and large-text layouts stay usable in key setup flows. AI form status text no longer pushes actions off-screen, Daily OS time anchors wrap at accessibility text sizes, and the What's New footer gives translated actions enough room on phones.</p>
+          <p>Onboarding now follows the active light or dark theme throughout setup. Panels, text, controls, provider tiles, recording previews, task handoff states, and the animated neural and aurora artwork all adapt to the matching design-system palette. Critical setup actions support keyboard activation, and scaled text switches work areas to a readable single-column layout.</p>
           <p>The desktop sidebar is navigation-first and keeps important task filters visible. Saved task filters now appear directly under Tasks with live counts. The first five follow the order you set, More expands the complete list without a limit, and the manager handles reordering, renaming, and deleting. Recording, timer, and agent status share one compact expandable activity row, while healthy sync stays quiet until work needs attention.</p>
           <p>Saving a task filter now stays inside the filter flow, with explicit Update filter and Save as new choices instead of a separate popup.</p>
       </description>

--- a/lib/features/daily_os_next/README.md
+++ b/lib/features/daily_os_next/README.md
@@ -429,7 +429,9 @@ sequenceDiagram
   shader subtree for the other phases. The glyph is bound to the state
   machine — mic (idle/error), an inverted stop mark (listening — the filled
   teal disc drops away and the stop square is itself drawn in the orb's teal,
-  sitting in the shader field), dimmed mic (transcribing), outlined mic
+  sitting in the shader field; hosts may supply a themed center surface when
+  the surrounding panel needs extra edge definition), dimmed mic
+  (transcribing), outlined mic
   (captured — demoted so the advance CTA carries the primary weight). Presses
   scale the core down with an overshoot release
   and the ink ripple paints *above* the gradient (via `Ink`), so taps read as

--- a/lib/features/daily_os_next/ui/widgets/voice_button.dart
+++ b/lib/features/daily_os_next/ui/widgets/voice_button.dart
@@ -37,6 +37,7 @@ class VoiceButton extends StatefulWidget {
     this.size = 96,
     this.dbfs = CaptureState.defaultDbfs,
     this.dbfsFloor = CaptureState.defaultDbfs,
+    this.listeningCoreColor,
     super.key,
   });
 
@@ -138,6 +139,13 @@ class VoiceButton extends StatefulWidget {
 
   /// Floor used to normalize [dbfs] inside the shader.
   final double dbfsFloor;
+
+  /// Optional host surface behind the inverted stop mark while listening.
+  ///
+  /// Capture and Refine leave the center transparent so the surrounding page
+  /// shows through. The light onboarding panel supplies its raised surface
+  /// token so the otherwise-white center remains visibly button-shaped.
+  final Color? listeningCoreColor;
 
   @override
   State<VoiceButton> createState() => _VoiceButtonState();
@@ -255,7 +263,10 @@ class _VoiceButtonState extends State<VoiceButton>
             border: Border.all(color: teal.withValues(alpha: 0.55), width: 1.5),
           )
         : listening
-        ? const BoxDecoration(shape: BoxShape.circle)
+        ? BoxDecoration(
+            shape: BoxShape.circle,
+            color: widget.listeningCoreColor,
+          )
         : BoxDecoration(
             shape: BoxShape.circle,
             // Flat brand disc — the one gradient in the system read as a

--- a/lib/features/daily_os_next/ui/widgets/voice_orb_zone.dart
+++ b/lib/features/daily_os_next/ui/widgets/voice_orb_zone.dart
@@ -39,6 +39,7 @@ class VoiceOrbZone extends StatelessWidget {
     required this.onTap,
     this.amplitudes = const [],
     this.dbfs = CaptureState.defaultDbfs,
+    this.listeningCoreColor,
     super.key,
   });
 
@@ -64,6 +65,9 @@ class VoiceOrbZone extends StatelessWidget {
 
   /// Latest recorder amplitude in dBFS, passed through to the orb shader.
   final double dbfs;
+
+  /// Optional themed surface forwarded to the listening button center.
+  final Color? listeningCoreColor;
 
   @override
   Widget build(BuildContext context) {
@@ -101,6 +105,7 @@ class VoiceOrbZone extends StatelessWidget {
           dbfs: dbfs,
           semanticLabel: semanticLabel,
           onTap: onTap,
+          listeningCoreColor: listeningCoreColor,
         ),
         SizedBox(height: tokens.spacing.step5),
         // One shared style across phases keeps the (scaled) line height —

--- a/lib/features/onboarding/README.md
+++ b/lib/features/onboarding/README.md
@@ -290,9 +290,13 @@ provides the active `DsTokens` extension, and every onboarding step consumes
 that same set. `OnboardingBackdrop` also reads the Material brightness to select
 the aurora compositor: additive `BlendMode.plus` keeps blooms luminous on dark
 surfaces, while `BlendMode.srcOver` preserves their colour and contrast on a
-light surface instead of adding them into white. `NeuralConstellation` uses the
-theme's interactive colour for nodes and blends its pulse toward the theme's
-high-emphasis text colour.
+light surface instead of adding them into white. The welcome artwork sits on
+the semantic AI-card background and uses the themed Ollama purple for nodes,
+Anthropic blue for branches, and AI-card accent for travelling activations.
+Its bottom fade uses transparent stops with the panel surface's RGB values;
+this avoids the grey band produced when transparent black is interpolated into
+a light surface. Later-step `OnboardingBackdrop` instances stay on the quieter
+interactive-colour palette.
 
 ```mermaid
 flowchart LR

--- a/lib/features/onboarding/README.md
+++ b/lib/features/onboarding/README.md
@@ -290,16 +290,16 @@ provides the active `DsTokens` extension, and every onboarding step consumes
 that same set. `OnboardingBackdrop` also reads the Material brightness to select
 the aurora compositor: additive `BlendMode.plus` keeps blooms luminous on dark
 surfaces, while `BlendMode.srcOver` preserves their colour and contrast on a
-light surface instead of adding them into white. The welcome constellation has
-an intentionally mode-specific treatment: light mode uses the level-01 white
-surface with fully opaque, high-emphasis monochrome nodes and branches; dark
-mode uses the semantic AI-card background with the themed Ollama purple for
-nodes and Anthropic blue for branches. Both modes use the Task Agent card's
-`proposalKind.update.color` token for travelling activations, keeping the
-signal's role consistent across themes. Its bottom fade uses transparent stops
-with the panel surface's RGB values; this avoids the grey band produced when
-transparent black is interpolated into a light surface. Later-step
-`OnboardingBackdrop` instances stay on the quieter interactive-colour palette.
+light surface instead of adding them into white. The welcome hero has an
+intentionally mode-specific treatment: light mode reuses the AI decoder-bars
+activity language from transcription and image generation, using the active
+interactive and high-emphasis text tokens; dark mode keeps the constellation on
+the semantic AI-card background, with Ollama purple nodes, Anthropic blue
+branches, and the Task Agent `proposalKind.update.color` activation. The hero's
+bottom fade uses transparent stops with the panel surface's RGB values; this
+avoids the grey band produced when transparent black is interpolated into a
+light surface. Later-step `OnboardingBackdrop` instances stay on the quieter
+interactive-colour palette.
 
 ```mermaid
 flowchart LR

--- a/lib/features/onboarding/README.md
+++ b/lib/features/onboarding/README.md
@@ -44,6 +44,12 @@ task lands it is revealed *inside* the panel as a glowing tappable card, and
 only the user's tap on that card leaves the modal — landing on the **real**
 `TaskDetailsPage`.
 
+Every panel follows the active app theme. The route itself stays transparent;
+the step widgets resolve surface, text, alert, interactive, spacing, radius,
+and typography values from `context.designTokens`. The animation palette uses
+the same active token set, so theme changes do not leave a dark island inside a
+light app.
+
 ## Auto-show trigger & re-show cadence
 
 `state/onboarding_trigger_service.dart` decides *when* the welcome auto-shows,
@@ -266,15 +272,40 @@ stateDiagram-v2
   scale-in + glow) acknowledges the connection; the celebration burst is reserved
   for the task payoff alone (one owner of the peak).
 - **Step widgets** (`ui/widgets/`): `OnboardingHeroPanel` + `NeuralConstellation`
-  (the always-dark cinematic welcome and its animated hero), `OnboardingConnectPanel`
-  (provider tiles), `OnboardingApiKeyPanel` (key paste + verify), `OnboardingSuccessView`
-  (connect beat), `OnboardingCategoryView` (the category step's presentational view).
+  (the theme-aware cinematic welcome and its animated hero),
+  `OnboardingConnectPanel` (provider tiles), `OnboardingApiKeyPanel` (key paste
+  + verify), `OnboardingSuccessView` (connect beat), and
+  `OnboardingCategoryView` (the category step's presentational view).
 - **Providers** — Melious.ai first, then Mistral, Gemini, and Qwen, with
   OpenAI / Ollama behind "More options". MLX is excluded from the FTUE
   (multi-GB download); it stays available in Settings. Visuals reuse
   `ai_provider_visual.dart`.
 - **Funnel events** — `welcomeShown`, `providerModalShown`, `providerConnected`,
   `welcomeSkipped`.
+
+### Theme and animation rendering
+
+The route never installs a private light or dark theme. Ambient `ThemeData`
+provides the active `DsTokens` extension, and every onboarding step consumes
+that same set. `OnboardingBackdrop` also reads the Material brightness to select
+the aurora compositor: additive `BlendMode.plus` keeps blooms luminous on dark
+surfaces, while `BlendMode.srcOver` preserves their colour and contrast on a
+light surface instead of adding them into white. `NeuralConstellation` uses the
+theme's interactive colour for nodes and blends its pulse toward the theme's
+high-emphasis text colour.
+
+```mermaid
+flowchart LR
+    TM[App ThemeData<br/>light or dark] --> DS[context.designTokens]
+    DS --> SF[panel surfaces + text + controls]
+    DS --> NP[neural node / line / pulse palette]
+    TM --> BR[Theme brightness]
+    BR -->|dark| ADD[Aurora BlendMode.plus]
+    BR -->|light| SRC[Aurora BlendMode.srcOver]
+    ADD --> BG[OnboardingBackdrop]
+    SRC --> BG
+    NP --> BG
+```
 
 ### The category step
 
@@ -296,11 +327,15 @@ run; Laura is bound only when the row carries no template of its own, and its
 `private` flag is deliberately left untouched. A residual write failure
 surfaces as an error toast instead of a silently dead Continue button.
 
-`OnboardingCategoryView` renders the areas as a uniform two-column grid of chips
-over the shared alive backdrop. Unselected chips are **teal-tinted frosted glass**
+`OnboardingCategoryView` renders the areas as a responsive grid of chips over
+the shared alive backdrop. It uses two equal columns at the standard text scale
+and comfortable widths, then collapses to one column for scaled text or narrow
+panels so labels remain complete instead of ellipsizing. Unselected chips are
+**teal-tinted frosted glass**
 (a translucent brand-teal gradient painted over a `BackdropFilter`, under a crisp
-hairline) so the colour lives in the chip material and the enriched backdrop reads
-through; the selected chip fills solid brand with a trailing check. The shared
+theme-token hairline) so the colour lives in the chip material and the enriched
+backdrop reads through; the selected chip fills solid brand with a trailing check
+using the theme's on-interactive foreground. The shared
 `_FrostedGlass` surface is reused by the quieter "+ Add your own" chip so the grid
 reads as one glass family.
 
@@ -345,10 +380,9 @@ stateDiagram-v2
   **Modern** (the `AiVoiceInputShader` orb + a brand-tinted `LiveWaveform`) and
   **Analogue** (the skeuomorphic `AnalogVuMeter` + a neutral `LiveWaveform`).
   Only the selected card animates; the other rests on a calm static waveform.
-  Its card colors come from an injected `surfaceTokens` (`dsTokensDark` for
-  onboarding, which always sits over its own dark backdrop; the ambient
-  `context.designTokens` for Settings, which has no such backdrop and follows
-  the host theme) — the picker itself never assumes which theme it's on.
+  Its card colours come from the injected ambient `context.designTokens` in
+  both onboarding and Settings; the matching ambient `ColorScheme` drives the
+  analogue meter, so neither surface can drift to a different theme.
 - **`OnboardingRecordingStyleStep`** (`ui/widgets/`, ConsumerStatefulWidget)
   composes `RecordingStyleLivePreview` + the presentational
   **`OnboardingRecordingStyleView`** (title/explanation/Continue chrome around
@@ -391,10 +425,10 @@ then calls the orchestrator **exactly once per capture** (guarded against
 double-fire), passing along the capture's `CaptureState.audioId` so the spoken
 recording is linked under the task. When
 a real task lands the step reveals the **created beat** inside the panel — the
-task title + checklist as a glowing tappable card ("Your first task is
-ready"); tapping the card (or its "Tap your task to open it" hint) hands the
-id to `onTaskCreated`, and the host pops the modal and deep-links to the
-**real `TaskDetailsPage`**.
+task title as a glowing tappable card ("Your first task is ready"); checklist
+proposals remain on the real task page where they can be confirmed. Tapping the
+card (or its "Tap your task to open it" hint) hands the id to `onTaskCreated`,
+and the host pops the modal and deep-links to the **real `TaskDetailsPage`**.
 
 - **The style pick pays off here.** The active band renders the recording
   visual chosen in the style step: `VoiceOrbZone` (the shared Daily OS orb) for
@@ -441,9 +475,11 @@ id to `onTaskCreated`, and the host pops the modal and deep-links to the
   views instead of sitting orphaned and uncategorized in the journal. The
   typed path has no recording and creates no link.
 - **Created beat + real-task payoff** — when the task lands, the panel shows
-  it as a tappable card (title + checklist preview) breathing a soft accent
-  glow, with "Tap your task to open it" underneath. The tap pops the modal and
-  deep-links via the canonical `/tasks/:id` route (`openOnboardingCreatedTask`),
+  its title as a tappable card breathing a soft accent glow, with "Tap your
+  task to open it" underneath. Checklist proposals are deliberately not
+  previewed here; they remain confirmable on the task page. The tap pops the
+  modal and deep-links via the canonical `/tasks/:id` route
+  (`openOnboardingCreatedTask`),
   which also switches to the Tasks destination — necessary because the flow
   may have been launched from another tab (e.g. the Settings → Maintenance
   debug entry). (`CrystallizeHero` lives on only as the hero-gallery
@@ -459,7 +495,18 @@ id to `onTaskCreated`, and the host pops the modal and deep-links to the
   total structuring failure finishes onboarding via `onDone` rather than
   stranding the user on the thinking frame.
 
-## Accessibility — reduced motion
+## Accessibility
+
+Every critical action participates in keyboard focus traversal and activates
+through the platform `ActivateIntent` (Enter/Space): provider tiles, category
+chips, the analogue recorder, destination pills, starter suggestions, recording
+style cards, and the created-task handoff. Focus feedback uses the design
+system's `surface.focusPressed` or active interactive token. Back controls are
+real `IconButton`s with the localized Material Back tooltip and an explicit
+button semantics node. Category choices expose selected state to assistive
+technology, and their responsive grid is covered at 200% and 320% text scale.
+
+### Reduced motion
 
 The shared voice visuals honor the OS "reduce motion" setting. The governing
 principle is **kill the clock-driven looping animation, keep direct voice-level
@@ -475,8 +522,9 @@ feedback** (a volume response is information, not decoration):
   frame under reduced motion — shared by the onboarding step and the
   Settings › Recording Style page.
 
-The welcome hero (`NeuralConstellation`) and `CompletionCelebration` already
-carry their own reduced-motion fallbacks.
+The welcome and backdrop animations (`NeuralConstellation`, `AuroraHero`,
+`CrystallizeHero`, and `WaveformTextHero`) carry their own reduced-motion
+fallbacks.
 
 `NeuralConstellation` paints a seeded, deterministic branching organism rather
 than a proximity graph. The default topology is one root-like soma and spine:

--- a/lib/features/onboarding/README.md
+++ b/lib/features/onboarding/README.md
@@ -290,13 +290,15 @@ provides the active `DsTokens` extension, and every onboarding step consumes
 that same set. `OnboardingBackdrop` also reads the Material brightness to select
 the aurora compositor: additive `BlendMode.plus` keeps blooms luminous on dark
 surfaces, while `BlendMode.srcOver` preserves their colour and contrast on a
-light surface instead of adding them into white. The welcome artwork sits on
-the semantic AI-card background and uses the themed Ollama purple for nodes,
-Anthropic blue for branches, and AI-card accent for travelling activations.
-Its bottom fade uses transparent stops with the panel surface's RGB values;
-this avoids the grey band produced when transparent black is interpolated into
-a light surface. Later-step `OnboardingBackdrop` instances stay on the quieter
-interactive-colour palette.
+light surface instead of adding them into white. The welcome constellation has
+an intentionally mode-specific treatment: light mode uses the level-01 white
+surface with high-emphasis monochrome nodes and branches plus alert-red
+travelling activations; dark mode uses the semantic AI-card background with
+the themed Ollama purple for nodes, Anthropic blue for branches, and AI-card
+accent for activations. Its bottom fade uses transparent stops with the panel
+surface's RGB values; this avoids the grey band produced when transparent black
+is interpolated into a light surface. Later-step `OnboardingBackdrop` instances
+stay on the quieter interactive-colour palette.
 
 ```mermaid
 flowchart LR

--- a/lib/features/onboarding/README.md
+++ b/lib/features/onboarding/README.md
@@ -292,13 +292,14 @@ the aurora compositor: additive `BlendMode.plus` keeps blooms luminous on dark
 surfaces, while `BlendMode.srcOver` preserves their colour and contrast on a
 light surface instead of adding them into white. The welcome constellation has
 an intentionally mode-specific treatment: light mode uses the level-01 white
-surface with high-emphasis monochrome nodes and branches plus alert-red
-travelling activations; dark mode uses the semantic AI-card background with
-the themed Ollama purple for nodes, Anthropic blue for branches, and AI-card
-accent for activations. Its bottom fade uses transparent stops with the panel
-surface's RGB values; this avoids the grey band produced when transparent black
-is interpolated into a light surface. Later-step `OnboardingBackdrop` instances
-stay on the quieter interactive-colour palette.
+surface with fully opaque, high-emphasis monochrome nodes and branches; dark
+mode uses the semantic AI-card background with the themed Ollama purple for
+nodes and Anthropic blue for branches. Both modes use the Task Agent card's
+`proposalKind.update.color` token for travelling activations, keeping the
+signal's role consistent across themes. Its bottom fade uses transparent stops
+with the panel surface's RGB values; this avoids the grey band produced when
+transparent black is interpolated into a light surface. Later-step
+`OnboardingBackdrop` instances stay on the quieter interactive-colour palette.
 
 ```mermaid
 flowchart LR

--- a/lib/features/onboarding/ui/onboarding_animation_gallery_page.dart
+++ b/lib/features/onboarding/ui/onboarding_animation_gallery_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
-import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/onboarding/ui/widgets/onboarding_api_key_panel.dart';
 import 'package:lotti/features/onboarding/ui/widgets/onboarding_connect_panel.dart';
 import 'package:lotti/features/onboarding/ui/widgets/onboarding_hero.dart';
@@ -27,14 +26,11 @@ class _OnboardingAnimationGalleryPageState
 
   @override
   Widget build(BuildContext context) {
-    // Always-dark chrome (debug-only gallery) sourced from the dark token set
-    // so it previews the cinematic dark panels regardless of the app theme.
+    // The debug gallery follows the active app theme, matching the production
+    // panels it previews.
     return Scaffold(
-      backgroundColor: dsTokensDark.colors.background.level01,
       appBar: AppBar(
         title: const Text('Onboarding animations'),
-        backgroundColor: dsTokensDark.colors.background.level02,
-        foregroundColor: dsTokensDark.colors.text.highEmphasis,
       ),
       body: Column(
         children: [

--- a/lib/features/onboarding/ui/onboarding_welcome_modal.dart
+++ b/lib/features/onboarding/ui/onboarding_welcome_modal.dart
@@ -170,7 +170,7 @@ void openOnboardingCreatedTask(String taskId) {
   beamToNamed('/tasks/$taskId');
 }
 
-/// Full-screen dark canvas hosting the flow, centered + scrollable so the
+/// Full-screen transparent canvas hosting the themed flow, centered + scrollable so the
 /// keyboard step fits on small viewports.
 class _OnboardingScaffold extends StatelessWidget {
   const _OnboardingScaffold({
@@ -192,7 +192,7 @@ class _OnboardingScaffold extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // Transparent scaffold so the dim barrier (and the app behind it) shows
-    // around the panel; the panel supplies its own dark surface.
+    // around the panel; the panel supplies its own themed surface.
     final mq = MediaQuery.of(context);
     final wide = mq.size.width >= 600;
     // The panel swallows its own taps (an opaque no-op tap) so tapping it never
@@ -382,7 +382,7 @@ class _OnboardingFlowState extends State<_OnboardingFlow> {
       case _FlowStep.success:
         return OnboardingSuccessView(
           key: const ValueKey('onboarding-success'),
-          accent: dsTokensDark.colors.interactive.enabled,
+          accent: context.designTokens.colors.interactive.enabled,
           title: context.messages.onboardingSuccessTitle,
           subtitle: context.messages.onboardingSuccessSubtitle,
           continueLabel: context.messages.onboardingSuccessContinue,
@@ -625,7 +625,7 @@ class _OnboardingCategoryStepState
     final messages = context.messages;
     final options = _options(messages);
     return OnboardingCategoryView(
-      accent: dsTokensDark.colors.interactive.enabled,
+      accent: context.designTokens.colors.interactive.enabled,
       title: messages.onboardingCategoryTitle,
       explanation: messages.onboardingCategoryExplanation,
       whyLabel: messages.onboardingCategoryWhy,

--- a/lib/features/onboarding/ui/widgets/aurora_hero.dart
+++ b/lib/features/onboarding/ui/widgets/aurora_hero.dart
@@ -4,15 +4,20 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 /// Slow flowing aurora: several large soft colour blooms drift on lissajous
-/// paths and blend additively over a dark surface, producing a calm, premium
-/// "living gradient". Pure [CustomPainter] (additive radial gradients) so it
-/// renders identically in offline goldens — no fragment shader needed.
+/// paths and blend over the host surface, producing a calm, premium "living
+/// gradient". Pure [CustomPainter] (radial gradients) so it renders identically
+/// in offline goldens — no fragment shader needed.
 ///
 /// Used as the ambient backdrop of the connect page (a different motion from
 /// the welcome's neural constellation). Under reduced motion a single static
 /// frame is painted.
 class AuroraHero extends StatefulWidget {
-  const AuroraHero({required this.colors, this.maxAlpha = 0.55, super.key});
+  const AuroraHero({
+    required this.colors,
+    this.maxAlpha = 0.55,
+    this.blendMode = BlendMode.plus,
+    super.key,
+  });
 
   /// Bloom colours (3–4 reads best); each drifts and blends additively.
   final List<Color> colors;
@@ -20,6 +25,11 @@ class AuroraHero extends StatefulWidget {
   /// Peak alpha of each bloom centre — lower it to keep the aurora subtle
   /// behind foreground content.
   final double maxAlpha;
+
+  /// How each bloom is composited onto the host surface. Additive blending
+  /// makes colour glow on dark backgrounds; normal source-over blending keeps
+  /// the same blooms visible on light backgrounds instead of adding into white.
+  final BlendMode blendMode;
 
   @override
   State<AuroraHero> createState() => _AuroraHeroState();
@@ -67,6 +77,7 @@ class _AuroraHeroState extends State<AuroraHero>
               colors: widget.colors,
               t: _controller.value * _loop.inSeconds,
               maxAlpha: widget.maxAlpha,
+              blendMode: widget.blendMode,
             ),
           );
         },
@@ -80,11 +91,13 @@ class _AuroraPainter extends CustomPainter {
     required this.colors,
     required this.t,
     required this.maxAlpha,
+    required this.blendMode,
   });
 
   final List<Color> colors;
   final double t;
   final double maxAlpha;
+  final BlendMode blendMode;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -111,7 +124,7 @@ class _AuroraPainter extends CustomPainter {
         radius,
         Paint()
           ..shader = shader
-          ..blendMode = BlendMode.plus,
+          ..blendMode = blendMode,
       );
     }
   }
@@ -120,5 +133,6 @@ class _AuroraPainter extends CustomPainter {
   bool shouldRepaint(covariant _AuroraPainter oldDelegate) =>
       oldDelegate.t != t ||
       oldDelegate.maxAlpha != maxAlpha ||
+      oldDelegate.blendMode != blendMode ||
       !listEquals(oldDelegate.colors, colors);
 }

--- a/lib/features/onboarding/ui/widgets/onboarding_api_key_panel.dart
+++ b/lib/features/onboarding/ui/widgets/onboarding_api_key_panel.dart
@@ -210,9 +210,12 @@ class _OnboardingApiKeyPanelState extends ConsumerState<OnboardingApiKeyPanel> {
     final tokens = context.designTokens;
     final messages = context.messages;
     final brand = onboardingProviderBrandColor(widget.type);
-    final textHigh = dsTokensDark.colors.text.highEmphasis;
-    final textMed = dsTokensDark.colors.text.mediumEmphasis;
-    final panelBg = dsTokensDark.colors.background.level01;
+    final textHigh = tokens.colors.text.highEmphasis;
+    final textMed = tokens.colors.text.mediumEmphasis;
+    final panelBg = tokens.colors.background.level01;
+    final errorColor = Theme.of(context).brightness == Brightness.dark
+        ? tokens.colors.alert.error.hover
+        : tokens.colors.alert.error.defaultColor;
     final console = aiProviderKeyConsoleUrl(widget.type);
     // Listen (not watch) keeps the verifier alive and feeds the local display
     // state machine, which holds "checking" visible for [_minCheckingVisible].
@@ -292,15 +295,21 @@ class _OnboardingApiKeyPanelState extends ConsumerState<OnboardingApiKeyPanel> {
               children: [
                 Align(
                   alignment: Alignment.centerLeft,
-                  child: InkWell(
+                  child: Semantics(
+                    button: true,
+                    label: MaterialLocalizations.of(
+                      context,
+                    ).backButtonTooltip,
                     onTap: _busy ? null : widget.onBack,
-                    borderRadius: BorderRadius.circular(tokens.radii.s),
-                    child: Padding(
-                      padding: EdgeInsets.all(tokens.spacing.step2),
-                      child: Icon(
-                        Icons.arrow_back_rounded,
+                    child: ExcludeSemantics(
+                      child: IconButton(
+                        tooltip: MaterialLocalizations.of(
+                          context,
+                        ).backButtonTooltip,
+                        onPressed: _busy ? null : widget.onBack,
+                        iconSize: tokens.spacing.step5,
                         color: textHigh,
-                        size: tokens.spacing.step5,
+                        icon: const Icon(Icons.arrow_back_rounded),
                       ),
                     ),
                   ),
@@ -432,7 +441,7 @@ class _OnboardingApiKeyPanelState extends ConsumerState<OnboardingApiKeyPanel> {
                     child: Text(
                       _error!,
                       style: tokens.typography.styles.body.bodySmall.copyWith(
-                        color: dsTokensDark.colors.alert.error.defaultColor,
+                        color: errorColor,
                       ),
                     ),
                   ),
@@ -504,7 +513,7 @@ class _GetKeyHelp extends StatelessWidget {
         Text(
           context.messages.onboardingApiKeyNoKeyHelp,
           style: tokens.typography.styles.body.bodySmall.copyWith(
-            color: dsTokensDark.colors.text.mediumEmphasis,
+            color: tokens.colors.text.mediumEmphasis,
           ),
         ),
       ],
@@ -525,12 +534,12 @@ class _GetKeyLink extends StatelessWidget {
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final messages = context.messages;
-    final textMed = dsTokensDark.colors.text.mediumEmphasis;
+    final textMed = tokens.colors.text.mediumEmphasis;
     final bodySmall = tokens.typography.styles.body.bodySmall;
     // Teal (the app's single structural accent), not the provider brand: a
     // "open this URL" link is an app action, so it matches the Connect CTA and
     // "More options" rather than the provider-identity surfaces.
-    final accent = dsTokensDark.colors.interactive.enabled;
+    final accent = tokens.colors.interactive.enabled;
 
     return InkWell(
       onTap: () => unawaited(handleMarkdownLinkTap('https://$console', '')),
@@ -575,7 +584,7 @@ class _GetKeyLink extends StatelessWidget {
   }
 }
 
-/// Compact, dark-themed live verification line for the key step. Mirrors the
+/// Compact, theme-aware live verification line for the key step. Mirrors the
 /// settings `ConnectionStatusStrip` semantics (checking / verified / failed)
 /// but as a single inline row that fits the cinematic panel. Idle renders
 /// nothing — the caller shows the "get a key" link in that slot instead.
@@ -593,12 +602,14 @@ class _VerifyStatus extends StatelessWidget {
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final messages = context.messages;
-    final textMed = dsTokensDark.colors.text.mediumEmphasis;
-    final success = dsTokensDark.colors.alert.success.defaultColor;
+    final textMed = tokens.colors.text.mediumEmphasis;
+    final success = tokens.colors.alert.success.defaultColor;
     // The lighter error tint (the `hover` ramp step) clears WCAG AA on the dark
     // panel where the base `defaultColor` sits ~3:1; the failure line is the
     // most anxious moment, so it must be the most readable.
-    final danger = dsTokensDark.colors.alert.error.hover;
+    final danger = Theme.of(context).brightness == Brightness.dark
+        ? tokens.colors.alert.error.hover
+        : tokens.colors.alert.error.defaultColor;
 
     switch (state) {
       case ConnectionCheckIdle():

--- a/lib/features/onboarding/ui/widgets/onboarding_category_view.dart
+++ b/lib/features/onboarding/ui/widgets/onboarding_category_view.dart
@@ -29,7 +29,7 @@ const double _kChipTintBottomAlpha = 0.18;
 const double _kAddOwnTintTopAlpha = 0.14;
 const double _kAddOwnTintBottomAlpha = 0.05;
 
-/// Crisp white hairline that defines the glass edge and catches light — bright
+/// Crisp high-emphasis hairline that defines the glass edge and catches light —
 /// enough that the unselected chips' tap-target boundary is unmistakable
 /// against the dark gradient — and against the busy constellation backdrop —
 /// even for low-vision users. The add-own chip uses a quieter hairline to match
@@ -110,16 +110,16 @@ class OnboardingCategoryView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
-    final panelBg = dsTokensDark.colors.background.level01;
-    final textHigh = dsTokensDark.colors.text.highEmphasis;
-    final textMedium = dsTokensDark.colors.text.mediumEmphasis;
+    final panelBg = tokens.colors.background.level01;
+    final textHigh = tokens.colors.text.highEmphasis;
+    final textMedium = tokens.colors.text.mediumEmphasis;
 
     return ClipRRect(
       borderRadius: BorderRadius.circular(tokens.radii.l),
       child: Stack(
         children: [
           const Positioned.fill(child: OnboardingBackdrop()),
-          // Ambient colour wash, painted above the (sparse, near-black)
+          // Ambient colour wash, painted above the sparse themed
           // constellation backdrop but below the scrim + content. The frosted
           // chips blur whatever sits behind them; without this the blur had
           // only near-black to frost, so the glass read milky. These soft
@@ -169,19 +169,25 @@ class OnboardingCategoryView extends StatelessWidget {
                 ),
                 Align(
                   alignment: Alignment.centerLeft,
-                  child: GestureDetector(
-                    onTap: onWhy,
-                    behavior: HitTestBehavior.opaque,
-                    child: Padding(
-                      padding: EdgeInsets.symmetric(
-                        vertical: tokens.spacing.step2,
-                      ),
-                      child: Text(
-                        whyLabel,
-                        style: tokens.typography.styles.body.bodySmall.copyWith(
-                          color: accent,
-                          decoration: TextDecoration.underline,
-                          decorationColor: accent,
+                  child: Material(
+                    type: MaterialType.transparency,
+                    child: InkWell(
+                      onTap: onWhy,
+                      borderRadius: BorderRadius.circular(tokens.radii.s),
+                      focusColor: tokens.colors.surface.focusPressed,
+                      hoverColor: tokens.colors.surface.hover,
+                      child: Padding(
+                        padding: EdgeInsets.symmetric(
+                          vertical: tokens.spacing.step2,
+                        ),
+                        child: Text(
+                          whyLabel,
+                          style: tokens.typography.styles.body.bodySmall
+                              .copyWith(
+                                color: accent,
+                                decoration: TextDecoration.underline,
+                                decorationColor: accent,
+                              ),
                         ),
                       ),
                     ),
@@ -278,11 +284,10 @@ class _AmbientGlow extends StatelessWidget {
   }
 }
 
-/// A tidy uniform grid of selectable area chips: the options laid out in rows
-/// of two equal-width cells (`Expanded`), with the "+ Add your own" chip on its
-/// own full-width row below. Every chip shares the same height + padding so the
-/// grid never looks ragged (the review-panel blocker). An odd final option pairs
-/// with an empty spacer so the column edges stay aligned.
+/// A responsive grid of selectable area chips. At the standard text scale and
+/// comfortable widths it uses two equal columns; scaled text or narrow panels
+/// collapse to one column so labels remain complete instead of ellipsizing.
+/// The "+ Add your own" chip always occupies its own full-width row below.
 class _CategoryGrid extends StatelessWidget {
   const _CategoryGrid({
     required this.tokens,
@@ -305,52 +310,78 @@ class _CategoryGrid extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final gap = tokens.spacing.step3;
-    final rows = <Widget>[];
-    for (var i = 0; i < options.length; i += 2) {
-      if (i > 0) rows.add(SizedBox(height: gap));
-      final left = options[i];
-      final right = i + 1 < options.length ? options[i + 1] : null;
-      rows.add(
-        Row(
-          children: [
-            Expanded(
-              child: _CategoryChip(
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final textIsScaled = MediaQuery.textScalerOf(context).scale(1) > 1;
+        final panelIsNarrow = constraints.maxWidth < tokens.spacing.step13 * 2;
+        final singleColumn = textIsScaled || panelIsNarrow;
+        final rows = <Widget>[];
+
+        if (singleColumn) {
+          for (final option in options) {
+            if (rows.isNotEmpty) rows.add(SizedBox(height: gap));
+            rows.add(
+              _CategoryChip(
                 tokens: tokens,
                 accent: accent,
-                option: left,
-                selected: selected.contains(left.label),
-                onTap: () => onToggle(left.label),
+                option: option,
+                selected: selected.contains(option.label),
+                allowLabelWrap: true,
+                onTap: () => onToggle(option.label),
               ),
-            ),
-            SizedBox(width: gap),
-            Expanded(
-              child: right == null
-                  ? const SizedBox.shrink()
-                  : _CategoryChip(
+            );
+          }
+        } else {
+          for (var i = 0; i < options.length; i += 2) {
+            if (i > 0) rows.add(SizedBox(height: gap));
+            final left = options[i];
+            final right = i + 1 < options.length ? options[i + 1] : null;
+            rows.add(
+              Row(
+                children: [
+                  Expanded(
+                    child: _CategoryChip(
                       tokens: tokens,
                       accent: accent,
-                      option: right,
-                      selected: selected.contains(right.label),
-                      onTap: () => onToggle(right.label),
+                      option: left,
+                      selected: selected.contains(left.label),
+                      allowLabelWrap: false,
+                      onTap: () => onToggle(left.label),
                     ),
-            ),
-          ],
-        ),
-      );
-    }
-    if (rows.isNotEmpty) rows.add(SizedBox(height: gap));
-    rows.add(
-      _AddOwnChip(
-        tokens: tokens,
-        accent: accent,
-        label: addOwnLabel,
-        onTap: onAddOwn,
-      ),
-    );
+                  ),
+                  SizedBox(width: gap),
+                  Expanded(
+                    child: right == null
+                        ? const SizedBox.shrink()
+                        : _CategoryChip(
+                            tokens: tokens,
+                            accent: accent,
+                            option: right,
+                            selected: selected.contains(right.label),
+                            allowLabelWrap: false,
+                            onTap: () => onToggle(right.label),
+                          ),
+                  ),
+                ],
+              ),
+            );
+          }
+        }
+        if (rows.isNotEmpty) rows.add(SizedBox(height: gap));
+        rows.add(
+          _AddOwnChip(
+            tokens: tokens,
+            accent: accent,
+            label: addOwnLabel,
+            onTap: onAddOwn,
+          ),
+        );
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: rows,
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: rows,
+        );
+      },
     );
   }
 }
@@ -359,7 +390,7 @@ class _CategoryGrid extends StatelessWidget {
 /// teal [tint] that lives in the material as a vertical gradient ([topAlpha] →
 /// [bottomAlpha], brighter at the top so the glass reads as catching light) and
 /// a crisp hairline ([borderColor]). The tint is what makes the chip read as
-/// *colour-tinted* glass over the dark backdrop rather than flat neutral grey;
+/// *colour-tinted* glass over the themed backdrop rather than flat neutral grey;
 /// it stays translucent so the blurred ambient glow + constellation still show
 /// through. Shared by the option chips and the "+ Add your own" chip so they
 /// read as one glass family (only the tint strength + content differ).
@@ -417,18 +448,19 @@ class _FrostedGlass extends StatelessWidget {
 }
 
 /// One uniform area chip. Unselected reads as *available* teal-tinted glass — a
-/// backdrop-blurred surface under a translucent teal gradient + crisp white
+/// backdrop-blurred surface under a translucent teal gradient + crisp themed
 /// hairline, so it reads as coloured frosted glass (the brand teal lives in the
 /// material) while the enriched backdrop still shows through. A bright-mint
-/// leading icon and a full-white label sit on top. Selected fills solid brand
-/// (no blur — the chosen state should pop) and gains a trailing check with a
-/// dark icon + label.
+/// leading icon and high-emphasis label sit on top. Selected fills solid brand
+/// (no blur — the chosen state should pop) and gains a trailing check with an
+/// on-interactive icon + label.
 class _CategoryChip extends StatelessWidget {
   const _CategoryChip({
     required this.tokens,
     required this.accent,
     required this.option,
     required this.selected,
+    required this.allowLabelWrap,
     required this.onTap,
   });
 
@@ -436,13 +468,13 @@ class _CategoryChip extends StatelessWidget {
   final Color accent;
   final OnboardingCategoryOption option;
   final bool selected;
+  final bool allowLabelWrap;
   final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
-    final textHigh = dsTokensDark.colors.text.highEmphasis;
-    final panelBg = dsTokensDark.colors.background.level01;
-    final fg = selected ? panelBg : textHigh;
+    final textHigh = tokens.colors.text.highEmphasis;
+    final fg = selected ? tokens.colors.text.onInteractiveAlert : textHigh;
     final radius = BorderRadius.circular(tokens.radii.m);
     final padding = EdgeInsets.symmetric(
       horizontal: tokens.spacing.step4,
@@ -456,15 +488,13 @@ class _CategoryChip extends StatelessWidget {
         Icon(
           option.icon,
           size: tokens.spacing.step5,
-          color: selected
-              ? fg
-              : Color.lerp(accent, const Color(0xFFFFFFFF), 0.5),
+          color: selected ? fg : Color.lerp(accent, textHigh, 0.5),
         ),
         SizedBox(width: tokens.spacing.step3),
         Expanded(
           child: Text(
             option.label,
-            overflow: TextOverflow.ellipsis,
+            overflow: allowLabelWrap ? null : TextOverflow.ellipsis,
             style: tokens.typography.styles.body.bodyLarge.copyWith(color: fg),
           ),
         ),
@@ -481,8 +511,8 @@ class _CategoryChip extends StatelessWidget {
     // (ambient glow + constellation) read through, and the teal tint in the
     // material is what makes it read as *coloured* frosted glass rather than
     // the flat neutral grey an earlier neutral fill produced. The chip sits
-    // dark over the dark backdrop, so the full-white label stays AA-legible
-    // with no extra wash.
+    // themed over the active backdrop, so the high-emphasis label stays
+    // legible with no extra wash.
     final body = selected
         ? DecoratedBox(
             decoration: BoxDecoration(
@@ -506,7 +536,16 @@ class _CategoryChip extends StatelessWidget {
       button: true,
       selected: selected,
       label: option.label,
-      child: GestureDetector(onTap: onTap, child: body),
+      child: Material(
+        type: MaterialType.transparency,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: radius,
+          focusColor: tokens.colors.surface.focusPressed,
+          hoverColor: tokens.colors.surface.hover,
+          child: body,
+        ),
+      ),
     );
   }
 }
@@ -531,46 +570,51 @@ class _AddOwnChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final textHigh = dsTokensDark.colors.text.highEmphasis;
-    final textMedium = dsTokensDark.colors.text.mediumEmphasis;
+    final textHigh = tokens.colors.text.highEmphasis;
+    final textMedium = tokens.colors.text.mediumEmphasis;
     final radius = BorderRadius.circular(tokens.radii.m);
     return Semantics(
       button: true,
       label: label,
-      child: GestureDetector(
-        onTap: onTap,
-        child: _FrostedGlass(
-          tint: accent,
-          topAlpha: _kAddOwnTintTopAlpha,
-          bottomAlpha: _kAddOwnTintBottomAlpha,
-          borderColor: textHigh.withValues(alpha: _kAddOwnBorderAlpha),
-          radius: radius,
-          child: Padding(
-            padding: EdgeInsets.symmetric(
-              horizontal: tokens.spacing.step4,
-              vertical: tokens.spacing.step4,
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Icon(
-                  Icons.add_rounded,
-                  size: tokens.spacing.step5,
-                  color: textMedium,
-                ),
-                SizedBox(width: tokens.spacing.step2),
-                Flexible(
-                  child: Text(
-                    label,
-                    textAlign: TextAlign.center,
-                    overflow: TextOverflow.ellipsis,
-                    style: tokens.typography.styles.body.bodyLarge.copyWith(
-                      color: textMedium,
+      child: Material(
+        type: MaterialType.transparency,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: radius,
+          focusColor: tokens.colors.surface.focusPressed,
+          hoverColor: tokens.colors.surface.hover,
+          child: _FrostedGlass(
+            tint: accent,
+            topAlpha: _kAddOwnTintTopAlpha,
+            bottomAlpha: _kAddOwnTintBottomAlpha,
+            borderColor: textHigh.withValues(alpha: _kAddOwnBorderAlpha),
+            radius: radius,
+            child: Padding(
+              padding: EdgeInsets.symmetric(
+                horizontal: tokens.spacing.step4,
+                vertical: tokens.spacing.step4,
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.add_rounded,
+                    size: tokens.spacing.step5,
+                    color: textMedium,
+                  ),
+                  SizedBox(width: tokens.spacing.step2),
+                  Flexible(
+                    child: Text(
+                      label,
+                      textAlign: TextAlign.center,
+                      style: tokens.typography.styles.body.bodyLarge.copyWith(
+                        color: textMedium,
+                      ),
                     ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/features/onboarding/ui/widgets/onboarding_category_view.dart
+++ b/lib/features/onboarding/ui/widgets/onboarding_category_view.dart
@@ -536,14 +536,32 @@ class _CategoryChip extends StatelessWidget {
       button: true,
       selected: selected,
       label: option.label,
-      child: Material(
-        type: MaterialType.transparency,
-        child: InkWell(
-          onTap: onTap,
-          borderRadius: radius,
-          focusColor: tokens.colors.surface.focusPressed,
-          hoverColor: tokens.colors.surface.hover,
-          child: body,
+      onTap: onTap,
+      child: FocusableActionDetector(
+        actions: <Type, Action<Intent>>{
+          ActivateIntent: CallbackAction<ActivateIntent>(
+            onInvoke: (_) {
+              onTap();
+              return null;
+            },
+          ),
+        },
+        child: Stack(
+          children: [
+            body,
+            Positioned.fill(
+              child: Material(
+                type: MaterialType.transparency,
+                child: InkWell(
+                  onTap: onTap,
+                  excludeFromSemantics: true,
+                  borderRadius: radius,
+                  focusColor: tokens.colors.surface.focusPressed,
+                  hoverColor: tokens.colors.surface.hover,
+                ),
+              ),
+            ),
+          ],
         ),
       ),
     );
@@ -573,50 +591,69 @@ class _AddOwnChip extends StatelessWidget {
     final textHigh = tokens.colors.text.highEmphasis;
     final textMedium = tokens.colors.text.mediumEmphasis;
     final radius = BorderRadius.circular(tokens.radii.m);
+    final body = _FrostedGlass(
+      tint: accent,
+      topAlpha: _kAddOwnTintTopAlpha,
+      bottomAlpha: _kAddOwnTintBottomAlpha,
+      borderColor: textHigh.withValues(alpha: _kAddOwnBorderAlpha),
+      radius: radius,
+      child: Padding(
+        padding: EdgeInsets.symmetric(
+          horizontal: tokens.spacing.step4,
+          vertical: tokens.spacing.step4,
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.add_rounded,
+              size: tokens.spacing.step5,
+              color: textMedium,
+            ),
+            SizedBox(width: tokens.spacing.step2),
+            Flexible(
+              child: Text(
+                label,
+                textAlign: TextAlign.center,
+                style: tokens.typography.styles.body.bodyLarge.copyWith(
+                  color: textMedium,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
     return Semantics(
       button: true,
       label: label,
-      child: Material(
-        type: MaterialType.transparency,
-        child: InkWell(
-          onTap: onTap,
-          borderRadius: radius,
-          focusColor: tokens.colors.surface.focusPressed,
-          hoverColor: tokens.colors.surface.hover,
-          child: _FrostedGlass(
-            tint: accent,
-            topAlpha: _kAddOwnTintTopAlpha,
-            bottomAlpha: _kAddOwnTintBottomAlpha,
-            borderColor: textHigh.withValues(alpha: _kAddOwnBorderAlpha),
-            radius: radius,
-            child: Padding(
-              padding: EdgeInsets.symmetric(
-                horizontal: tokens.spacing.step4,
-                vertical: tokens.spacing.step4,
-              ),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Icon(
-                    Icons.add_rounded,
-                    size: tokens.spacing.step5,
-                    color: textMedium,
-                  ),
-                  SizedBox(width: tokens.spacing.step2),
-                  Flexible(
-                    child: Text(
-                      label,
-                      textAlign: TextAlign.center,
-                      style: tokens.typography.styles.body.bodyLarge.copyWith(
-                        color: textMedium,
-                      ),
-                    ),
-                  ),
-                ],
+      onTap: onTap,
+      child: FocusableActionDetector(
+        actions: <Type, Action<Intent>>{
+          ActivateIntent: CallbackAction<ActivateIntent>(
+            onInvoke: (_) {
+              onTap();
+              return null;
+            },
+          ),
+        },
+        child: Stack(
+          children: [
+            body,
+            Positioned.fill(
+              child: Material(
+                type: MaterialType.transparency,
+                child: InkWell(
+                  onTap: onTap,
+                  excludeFromSemantics: true,
+                  borderRadius: radius,
+                  focusColor: tokens.colors.surface.focusPressed,
+                  hoverColor: tokens.colors.surface.hover,
+                ),
               ),
             ),
-          ),
+          ],
         ),
       ),
     );

--- a/lib/features/onboarding/ui/widgets/onboarding_connect_panel.dart
+++ b/lib/features/onboarding/ui/widgets/onboarding_connect_panel.dart
@@ -324,6 +324,7 @@ class _ProviderTileState extends State<_ProviderTile> {
     return Semantics(
       button: true,
       label: name,
+      onTap: widget.onTap,
       child: FocusableActionDetector(
         mouseCursor: SystemMouseCursors.click,
         onShowFocusHighlight: (focused) {
@@ -338,77 +339,79 @@ class _ProviderTileState extends State<_ProviderTile> {
             },
           ),
         },
-        child: AnimatedModalItem(
-          onTap: widget.onTap,
-          child: Container(
-            padding: EdgeInsets.all(tokens.spacing.step4),
-            decoration: BoxDecoration(
-              gradient: LinearGradient(
-                begin: Alignment.topLeft,
-                end: Alignment.bottomRight,
-                colors: [
-                  Color.lerp(tileBase, accent, 0.18)!,
-                  Color.lerp(tileBase, accent, 0.07)!,
+        child: ExcludeSemantics(
+          child: AnimatedModalItem(
+            onTap: widget.onTap,
+            child: Container(
+              padding: EdgeInsets.all(tokens.spacing.step4),
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                  colors: [
+                    Color.lerp(tileBase, accent, 0.18)!,
+                    Color.lerp(tileBase, accent, 0.07)!,
+                  ],
+                ),
+                borderRadius: BorderRadius.circular(tokens.radii.l),
+                border: Border.all(
+                  color: _focused
+                      ? tokens.colors.interactive.enabled
+                      : accent.withValues(alpha: 0.1),
+                ),
+              ),
+              child: Row(
+                children: [
+                  Container(
+                    width: tokens.spacing.step1,
+                    height: tokens.spacing.step6 * 2,
+                    decoration: BoxDecoration(
+                      color: accent.withValues(alpha: 0.62),
+                      borderRadius: BorderRadius.circular(tokens.radii.s),
+                    ),
+                  ),
+                  SizedBox(width: tokens.spacing.step3),
+                  Container(
+                    padding: EdgeInsets.all(tokens.spacing.step3),
+                    decoration: BoxDecoration(
+                      color: accent.withValues(alpha: 0.16),
+                      borderRadius: BorderRadius.circular(tokens.radii.m),
+                    ),
+                    child: Icon(
+                      aiProviderIcon(widget.type),
+                      color: Color.lerp(accent, textHigh, 0.18),
+                    ),
+                  ),
+                  SizedBox(width: tokens.spacing.step4),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          name,
+                          style: tokens.typography.styles.subtitle.subtitle1
+                              .copyWith(color: textHigh),
+                        ),
+                        if (tagline.isNotEmpty)
+                          Padding(
+                            padding: EdgeInsets.only(
+                              top: tokens.spacing.step1,
+                            ),
+                            child: Text(
+                              tagline,
+                              style: tokens.typography.styles.body.bodySmall
+                                  .copyWith(color: textMed),
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                  Icon(
+                    Icons.chevron_right_rounded,
+                    color: textHigh.withValues(alpha: 0.5),
+                  ),
                 ],
               ),
-              borderRadius: BorderRadius.circular(tokens.radii.l),
-              border: Border.all(
-                color: _focused
-                    ? tokens.colors.interactive.enabled
-                    : accent.withValues(alpha: 0.1),
-              ),
-            ),
-            child: Row(
-              children: [
-                Container(
-                  width: tokens.spacing.step1,
-                  height: tokens.spacing.step6 * 2,
-                  decoration: BoxDecoration(
-                    color: accent.withValues(alpha: 0.62),
-                    borderRadius: BorderRadius.circular(tokens.radii.s),
-                  ),
-                ),
-                SizedBox(width: tokens.spacing.step3),
-                Container(
-                  padding: EdgeInsets.all(tokens.spacing.step3),
-                  decoration: BoxDecoration(
-                    color: accent.withValues(alpha: 0.16),
-                    borderRadius: BorderRadius.circular(tokens.radii.m),
-                  ),
-                  child: Icon(
-                    aiProviderIcon(widget.type),
-                    color: Color.lerp(accent, textHigh, 0.18),
-                  ),
-                ),
-                SizedBox(width: tokens.spacing.step4),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        name,
-                        style: tokens.typography.styles.subtitle.subtitle1
-                            .copyWith(color: textHigh),
-                      ),
-                      if (tagline.isNotEmpty)
-                        Padding(
-                          padding: EdgeInsets.only(
-                            top: tokens.spacing.step1,
-                          ),
-                          child: Text(
-                            tagline,
-                            style: tokens.typography.styles.body.bodySmall
-                                .copyWith(color: textMed),
-                          ),
-                        ),
-                    ],
-                  ),
-                ),
-                Icon(
-                  Icons.chevron_right_rounded,
-                  color: textHigh.withValues(alpha: 0.5),
-                ),
-              ],
             ),
           ),
         ),

--- a/lib/features/onboarding/ui/widgets/onboarding_connect_panel.dart
+++ b/lib/features/onboarding/ui/widgets/onboarding_connect_panel.dart
@@ -69,7 +69,7 @@ Color onboardingProviderBrandColor(InferenceProviderType type) {
   };
 }
 
-/// The cinematic connect page: an always-dark panel matching the welcome, with
+/// The cinematic connect page: a theme-aware panel matching the welcome, with
 /// an ambient **aurora** backdrop (a different motion from the welcome's
 /// constellation) behind a back/title header and clean, Apple-style provider
 /// tiles — soft brand-tinted fills, no outlines.
@@ -93,9 +93,9 @@ class _OnboardingConnectPanelState extends State<OnboardingConnectPanel> {
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
-    final accent = dsTokensDark.colors.interactive.enabled;
-    final panelBg = dsTokensDark.colors.background.level01;
-    final textHigh = dsTokensDark.colors.text.highEmphasis;
+    final accent = tokens.colors.interactive.enabled;
+    final panelBg = tokens.colors.background.level01;
+    final textHigh = tokens.colors.text.highEmphasis;
 
     return ClipRRect(
       borderRadius: BorderRadius.circular(tokens.radii.l),
@@ -159,6 +159,9 @@ class _OnboardingConnectPanelState extends State<OnboardingConnectPanel> {
                   child: _IconBtn(
                     icon: Icons.arrow_back_rounded,
                     color: textHigh,
+                    tooltip: MaterialLocalizations.of(
+                      context,
+                    ).backButtonTooltip,
                     onTap: widget.onBack,
                   ),
                 ),
@@ -175,7 +178,7 @@ class _OnboardingConnectPanelState extends State<OnboardingConnectPanel> {
                 Text(
                   context.messages.onboardingConnectNotSure,
                   style: tokens.typography.styles.body.bodySmall.copyWith(
-                    color: dsTokensDark.colors.text.mediumEmphasis,
+                    color: tokens.colors.text.mediumEmphasis,
                   ),
                 ),
                 SizedBox(height: tokens.spacing.step5),
@@ -262,22 +265,30 @@ class _IconBtn extends StatelessWidget {
   const _IconBtn({
     required this.icon,
     required this.color,
+    required this.tooltip,
     required this.onTap,
   });
 
   final IconData icon;
   final Color color;
+  final String tooltip;
   final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
-    return InkWell(
+    return Semantics(
+      button: true,
+      label: tooltip,
       onTap: onTap,
-      borderRadius: BorderRadius.circular(tokens.radii.s),
-      child: Padding(
-        padding: EdgeInsets.all(tokens.spacing.step2),
-        child: Icon(icon, color: color, size: tokens.spacing.step5),
+      child: ExcludeSemantics(
+        child: IconButton(
+          tooltip: tooltip,
+          onPressed: onTap,
+          iconSize: tokens.spacing.step5,
+          color: color,
+          icon: Icon(icon),
+        ),
       ),
     );
   }
@@ -286,89 +297,120 @@ class _IconBtn extends StatelessWidget {
 /// Clean, Apple-style provider tile: a soft brand-tinted gradient fill with
 /// rounded corners and NO outline/border, a brand icon in a soft chip, name +
 /// tagline, and a quiet chevron.
-class _ProviderTile extends StatelessWidget {
+class _ProviderTile extends StatefulWidget {
   const _ProviderTile({required this.type, required this.onTap});
 
   final InferenceProviderType type;
   final VoidCallback onTap;
 
   @override
+  State<_ProviderTile> createState() => _ProviderTileState();
+}
+
+class _ProviderTileState extends State<_ProviderTile> {
+  bool _focused = false;
+
+  @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
     final messages = context.messages;
-    final accent = onboardingProviderBrandColor(type);
-    final textHigh = dsTokensDark.colors.text.highEmphasis;
-    final textMed = dsTokensDark.colors.text.mediumEmphasis;
-    final tileBase = dsTokensDark.colors.background.level02;
-    final tagline = onboardingProviderTagline(messages, type);
+    final accent = onboardingProviderBrandColor(widget.type);
+    final textHigh = tokens.colors.text.highEmphasis;
+    final textMed = tokens.colors.text.mediumEmphasis;
+    final tileBase = tokens.colors.background.level02;
+    final name = onboardingProviderName(messages, widget.type);
+    final tagline = onboardingProviderTagline(messages, widget.type);
 
-    return AnimatedModalItem(
-      onTap: onTap,
-      child: Container(
-        padding: EdgeInsets.all(tokens.spacing.step4),
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            colors: [
-              Color.lerp(tileBase, accent, 0.18)!,
-              Color.lerp(tileBase, accent, 0.07)!,
-            ],
+    return Semantics(
+      button: true,
+      label: name,
+      child: FocusableActionDetector(
+        mouseCursor: SystemMouseCursors.click,
+        onShowFocusHighlight: (focused) {
+          if (_focused == focused) return;
+          setState(() => _focused = focused);
+        },
+        actions: <Type, Action<Intent>>{
+          ActivateIntent: CallbackAction<ActivateIntent>(
+            onInvoke: (_) {
+              widget.onTap();
+              return null;
+            },
           ),
-          borderRadius: BorderRadius.circular(tokens.radii.l),
-          border: Border.all(color: accent.withValues(alpha: 0.1)),
-        ),
-        child: Row(
-          children: [
-            Container(
-              width: tokens.spacing.step1,
-              height: tokens.spacing.step6 * 2,
-              decoration: BoxDecoration(
-                color: accent.withValues(alpha: 0.62),
-                borderRadius: BorderRadius.circular(tokens.radii.s),
-              ),
-            ),
-            SizedBox(width: tokens.spacing.step3),
-            Container(
-              padding: EdgeInsets.all(tokens.spacing.step3),
-              decoration: BoxDecoration(
-                color: accent.withValues(alpha: 0.16),
-                borderRadius: BorderRadius.circular(tokens.radii.m),
-              ),
-              child: Icon(
-                aiProviderIcon(type),
-                color: Color.lerp(accent, textHigh, 0.18),
-              ),
-            ),
-            SizedBox(width: tokens.spacing.step4),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    onboardingProviderName(messages, type),
-                    style: tokens.typography.styles.subtitle.subtitle1.copyWith(
-                      color: textHigh,
-                    ),
-                  ),
-                  if (tagline.isNotEmpty)
-                    Padding(
-                      padding: EdgeInsets.only(top: tokens.spacing.step1),
-                      child: Text(
-                        tagline,
-                        style: tokens.typography.styles.body.bodySmall.copyWith(
-                          color: textMed,
-                        ),
-                      ),
-                    ),
+        },
+        child: AnimatedModalItem(
+          onTap: widget.onTap,
+          child: Container(
+            padding: EdgeInsets.all(tokens.spacing.step4),
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: [
+                  Color.lerp(tileBase, accent, 0.18)!,
+                  Color.lerp(tileBase, accent, 0.07)!,
                 ],
               ),
+              borderRadius: BorderRadius.circular(tokens.radii.l),
+              border: Border.all(
+                color: _focused
+                    ? tokens.colors.interactive.enabled
+                    : accent.withValues(alpha: 0.1),
+              ),
             ),
-            Icon(
-              Icons.chevron_right_rounded,
-              color: textHigh.withValues(alpha: 0.5),
+            child: Row(
+              children: [
+                Container(
+                  width: tokens.spacing.step1,
+                  height: tokens.spacing.step6 * 2,
+                  decoration: BoxDecoration(
+                    color: accent.withValues(alpha: 0.62),
+                    borderRadius: BorderRadius.circular(tokens.radii.s),
+                  ),
+                ),
+                SizedBox(width: tokens.spacing.step3),
+                Container(
+                  padding: EdgeInsets.all(tokens.spacing.step3),
+                  decoration: BoxDecoration(
+                    color: accent.withValues(alpha: 0.16),
+                    borderRadius: BorderRadius.circular(tokens.radii.m),
+                  ),
+                  child: Icon(
+                    aiProviderIcon(widget.type),
+                    color: Color.lerp(accent, textHigh, 0.18),
+                  ),
+                ),
+                SizedBox(width: tokens.spacing.step4),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        name,
+                        style: tokens.typography.styles.subtitle.subtitle1
+                            .copyWith(color: textHigh),
+                      ),
+                      if (tagline.isNotEmpty)
+                        Padding(
+                          padding: EdgeInsets.only(
+                            top: tokens.spacing.step1,
+                          ),
+                          child: Text(
+                            tagline,
+                            style: tokens.typography.styles.body.bodySmall
+                                .copyWith(color: textMed),
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+                Icon(
+                  Icons.chevron_right_rounded,
+                  color: textHigh.withValues(alpha: 0.5),
+                ),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/features/onboarding/ui/widgets/onboarding_first_task_step.dart
+++ b/lib/features/onboarding/ui/widgets/onboarding_first_task_step.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/features/daily_os_next/state/capture_controller.dart';
-import 'package:lotti/features/design_system/theme/design_system_theme.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/onboarding/model/onboarding_capture_category.dart';
 import 'package:lotti/features/onboarding/model/onboarding_event.dart';
@@ -108,9 +107,6 @@ class _OnboardingFirstTaskStepState
   /// picker until structuring starts.
   late String _selectedCategoryId;
 
-  /// Dark scheme for the analog VU meter on the dark onboarding surface.
-  late final ColorScheme _darkScheme = DesignSystemTheme.dark().colorScheme;
-
   @override
   void initState() {
     super.initState();
@@ -155,8 +151,8 @@ class _OnboardingFirstTaskStepState
     return OnboardingFirstTaskView(
       phase: _viewPhase(captureState.phase),
       style: style,
-      accent: dsTokensDark.colors.interactive.enabled,
-      colorScheme: _darkScheme,
+      accent: context.designTokens.colors.interactive.enabled,
+      colorScheme: Theme.of(context).colorScheme,
       title: messages.onboardingFirstTaskTitle,
       guidance: messages.onboardingFirstTaskGuidance,
       suggestionsLabel: messages.onboardingFirstTaskSuggestionsLabel,

--- a/lib/features/onboarding/ui/widgets/onboarding_first_task_view.dart
+++ b/lib/features/onboarding/ui/widgets/onboarding_first_task_view.dart
@@ -209,7 +209,7 @@ class OnboardingFirstTaskView extends StatelessWidget {
                 Text(
                   _headline,
                   textAlign: TextAlign.center,
-                  style: tokens.typography.styles.heading.heading3.copyWith(
+                  style: tokens.typography.styles.heading.heading2.copyWith(
                     color: textHigh,
                   ),
                 ),
@@ -245,7 +245,7 @@ class OnboardingFirstTaskView extends StatelessWidget {
                   Text(
                     listeningCaption,
                     textAlign: TextAlign.center,
-                    style: tokens.typography.styles.body.bodyLarge.copyWith(
+                    style: tokens.typography.styles.subtitle.subtitle1.copyWith(
                       color: textHigh,
                     ),
                   ),
@@ -277,9 +277,10 @@ class OnboardingFirstTaskView extends StatelessWidget {
                     onPressed: onRatherType,
                     child: Text(
                       ratherTypeLabel,
-                      style: tokens.typography.styles.body.bodyLarge.copyWith(
-                        color: accent,
-                      ),
+                      style: tokens.typography.styles.subtitle.subtitle1
+                          .copyWith(
+                            color: accent,
+                          ),
                     ),
                   ),
                 ],
@@ -414,7 +415,7 @@ class _SuggestionChips extends StatelessWidget {
         Text(
           label,
           textAlign: TextAlign.center,
-          style: tokens.typography.styles.body.bodySmall.copyWith(
+          style: tokens.typography.styles.subtitle.subtitle2.copyWith(
             color: tokens.colors.text.mediumEmphasis,
           ),
         ),
@@ -494,7 +495,7 @@ class _CategoryPicker extends StatelessWidget {
         Text(
           prompt,
           textAlign: TextAlign.center,
-          style: tokens.typography.styles.body.bodySmall.copyWith(
+          style: tokens.typography.styles.subtitle.subtitle2.copyWith(
             color: tokens.colors.text.mediumEmphasis,
           ),
         ),
@@ -572,7 +573,7 @@ class _PickerChip extends StatelessWidget {
               ),
               child: Text(
                 label,
-                style: tokens.typography.styles.body.bodySmall.copyWith(
+                style: tokens.typography.styles.subtitle.subtitle2.copyWith(
                   color: fg,
                 ),
               ),

--- a/lib/features/onboarding/ui/widgets/onboarding_first_task_view.dart
+++ b/lib/features/onboarding/ui/widgets/onboarding_first_task_view.dart
@@ -554,7 +554,7 @@ class _PickerChip extends StatelessWidget {
           borderRadius: radius,
           focusColor: tokens.colors.surface.focusPressed,
           hoverColor: tokens.colors.surface.hover,
-          child: DecoratedBox(
+          child: Ink(
             decoration: BoxDecoration(
               color: selected ? accent : Colors.transparent,
               borderRadius: radius,

--- a/lib/features/onboarding/ui/widgets/onboarding_first_task_view.dart
+++ b/lib/features/onboarding/ui/widgets/onboarding_first_task_view.dart
@@ -23,8 +23,8 @@ enum OnboardingFirstTaskPhase {
   /// thinking shimmer.
   thinking,
 
-  /// The task landed — the created beat: the title + checklist as a glowing
-  /// tappable card that hands off to the real task page.
+  /// The task landed — the created beat: the title as a glowing tappable card
+  /// that hands off to the real task page, where checklist proposals appear.
   created,
 }
 
@@ -39,7 +39,8 @@ enum OnboardingFirstTaskPhase {
 /// listening, and the thinking cluster while structuring. A quiet "Rather
 /// type?" escape hatch stays pinned under the composing frames. The created
 /// frame swaps the band for the landed task itself — a glowing tappable card
-/// (title + checklist) whose tap fires [onOpenTask].
+/// whose tap fires [onOpenTask]. Checklist proposals stay on the real task
+/// page, where they can be reviewed and confirmed.
 ///
 /// It is string- and callback-injected (no `getIt`/Riverpod) so it renders
 /// identically under the real capture flow and in isolation for design review.
@@ -163,9 +164,9 @@ class OnboardingFirstTaskView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
-    final textHigh = dsTokensDark.colors.text.highEmphasis;
-    final textMedium = dsTokensDark.colors.text.mediumEmphasis;
-    final panelBg = dsTokensDark.colors.background.level01;
+    final textHigh = tokens.colors.text.highEmphasis;
+    final textMedium = tokens.colors.text.mediumEmphasis;
+    final panelBg = tokens.colors.background.level01;
     // Minimum height for the band the active element is centred in, so the
     // recording visual and the thinking cluster share one optical anchor across
     // phases. Sized on the token scale to seat the tallest visual (the modern
@@ -314,11 +315,12 @@ class OnboardingFirstTaskView extends StatelessWidget {
         return VoiceOrbZone(
           phase: capturePhase,
           caption: '',
-          captionColor: dsTokensDark.colors.text.mediumEmphasis,
+          captionColor: tokens.colors.text.mediumEmphasis,
           semanticLabel: recordSemanticLabel,
           onTap: onRecordTap,
           amplitudes: amplitudes,
           dbfs: dbfs,
+          listeningCoreColor: tokens.colors.background.level02,
         );
       case RecordingStyle.analogue:
         return _AnalogueRecorder(
@@ -357,25 +359,30 @@ class _AnalogueRecorder extends StatelessWidget {
     return Semantics(
       button: true,
       label: semanticLabel,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: onTap,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            AnalogVuMeter(
-              // 0 VU ≈ -18 dBFS, so VU ≈ dBFS + 18, clamped to the meter range.
-              vu: (dbfs + 18).clamp(-20.0, 3.0),
-              dBFS: dbfs,
-              size: tokens.spacing.step11 * 3,
-              colorScheme: colorScheme,
-            ),
-            SizedBox(height: tokens.spacing.step3),
-            LiveWaveform(
-              amplitudes: amplitudes,
-              color: dsTokensDark.colors.text.highEmphasis,
-            ),
-          ],
+      child: Material(
+        type: MaterialType.transparency,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(tokens.radii.l),
+          focusColor: tokens.colors.surface.focusPressed,
+          hoverColor: tokens.colors.surface.hover,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              AnalogVuMeter(
+                // 0 VU ≈ -18 dBFS, so VU ≈ dBFS + 18, clamped to the meter range.
+                vu: (dbfs + 18).clamp(-20.0, 3.0),
+                dBFS: dbfs,
+                size: tokens.spacing.step11 * 3,
+                colorScheme: colorScheme,
+              ),
+              SizedBox(height: tokens.spacing.step3),
+              LiveWaveform(
+                amplitudes: amplitudes,
+                color: tokens.colors.text.highEmphasis,
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -401,14 +408,14 @@ class _SuggestionChips extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final textHigh = dsTokensDark.colors.text.highEmphasis;
+    final textHigh = tokens.colors.text.highEmphasis;
     return Column(
       children: [
         Text(
           label,
           textAlign: TextAlign.center,
           style: tokens.typography.styles.body.bodySmall.copyWith(
-            color: dsTokensDark.colors.text.mediumEmphasis,
+            color: tokens.colors.text.mediumEmphasis,
           ),
         ),
         SizedBox(height: tokens.spacing.step3),
@@ -428,8 +435,9 @@ class _SuggestionChips extends StatelessWidget {
                     borderRadius: BorderRadius.circular(tokens.radii.l),
                     child: DecoratedBox(
                       decoration: BoxDecoration(
-                        color: dsTokensDark.colors.background.level02
-                            .withValues(alpha: 0.4),
+                        color: tokens.colors.background.level02.withValues(
+                          alpha: 0.4,
+                        ),
                         borderRadius: BorderRadius.circular(tokens.radii.l),
                         border: Border.all(
                           color: textHigh.withValues(alpha: 0.32),
@@ -460,8 +468,8 @@ class _SuggestionChips extends StatelessWidget {
 /// The first-task destination picker: a short prompt over a centred wrap of
 /// pills naming the areas the user created, so they choose which one the
 /// structured task lands in. Selection is colour-led (a solid brand fill for
-/// the chosen area, an outline for the rest) so it stays legible on the dark
-/// panel.
+/// the chosen area, an outline for the rest) so it stays legible on either
+/// themed panel.
 class _CategoryPicker extends StatelessWidget {
   const _CategoryPicker({
     required this.tokens,
@@ -487,7 +495,7 @@ class _CategoryPicker extends StatelessWidget {
           prompt,
           textAlign: TextAlign.center,
           style: tokens.typography.styles.body.bodySmall.copyWith(
-            color: dsTokensDark.colors.text.mediumEmphasis,
+            color: tokens.colors.text.mediumEmphasis,
           ),
         ),
         SizedBox(height: tokens.spacing.step3),
@@ -511,8 +519,8 @@ class _CategoryPicker extends StatelessWidget {
   }
 }
 
-/// One destination pill. Selected fills solid brand with a dark label; the rest
-/// are a quiet outline with a light label.
+/// One destination pill. Selected fills solid brand with an on-interactive
+/// label; the rest use a quiet outline and high-emphasis label.
 class _PickerChip extends StatelessWidget {
   const _PickerChip({
     required this.tokens,
@@ -531,36 +539,42 @@ class _PickerChip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final fg = selected
-        ? dsTokensDark.colors.background.level01
-        : dsTokensDark.colors.text.highEmphasis;
+        ? tokens.colors.text.onInteractiveAlert
+        : tokens.colors.text.highEmphasis;
     final radius = BorderRadius.circular(tokens.radii.l);
     return Semantics(
       button: true,
       selected: selected,
       label: label,
-      child: GestureDetector(
-        onTap: onTap,
-        child: DecoratedBox(
-          decoration: BoxDecoration(
-            color: selected ? accent : Colors.transparent,
-            borderRadius: radius,
-            border: Border.all(
-              color: selected
-                  ? accent
-                  : dsTokensDark.colors.text.mediumEmphasis.withValues(
-                      alpha: 0.5,
-                    ),
+      child: Material(
+        type: MaterialType.transparency,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: radius,
+          focusColor: tokens.colors.surface.focusPressed,
+          hoverColor: tokens.colors.surface.hover,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: selected ? accent : Colors.transparent,
+              borderRadius: radius,
+              border: Border.all(
+                color: selected
+                    ? accent
+                    : tokens.colors.text.mediumEmphasis.withValues(
+                        alpha: 0.5,
+                      ),
+              ),
             ),
-          ),
-          child: Padding(
-            padding: EdgeInsets.symmetric(
-              horizontal: tokens.spacing.step4,
-              vertical: tokens.spacing.step2,
-            ),
-            child: Text(
-              label,
-              style: tokens.typography.styles.body.bodySmall.copyWith(
-                color: fg,
+            child: Padding(
+              padding: EdgeInsets.symmetric(
+                horizontal: tokens.spacing.step4,
+                vertical: tokens.spacing.step2,
+              ),
+              child: Text(
+                label,
+                style: tokens.typography.styles.body.bodySmall.copyWith(
+                  color: fg,
+                ),
               ),
             ),
           ),
@@ -628,7 +642,7 @@ class _CreatedTaskCardState extends State<_CreatedTaskCard>
   @override
   Widget build(BuildContext context) {
     final tokens = widget.tokens;
-    final textHigh = dsTokensDark.colors.text.highEmphasis;
+    final textHigh = tokens.colors.text.highEmphasis;
     final reduceMotion =
         MediaQuery.maybeOf(context)?.disableAnimations ?? false;
 
@@ -642,7 +656,7 @@ class _CreatedTaskCardState extends State<_CreatedTaskCard>
             border: Border.all(
               color: widget.accent.withValues(alpha: 0.35 + 0.35 * t),
             ),
-            color: dsTokensDark.colors.background.level02.withValues(
+            color: tokens.colors.background.level02.withValues(
               alpha: 0.55,
             ),
             boxShadow: [
@@ -672,23 +686,28 @@ class _CreatedTaskCardState extends State<_CreatedTaskCard>
     final content = Semantics(
       button: true,
       label: widget.taskTitle,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: widget.onTap,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            card,
-            SizedBox(height: tokens.spacing.step3),
-            Text(
-              widget.hint,
-              textAlign: TextAlign.center,
-              style: tokens.typography.styles.body.bodySmall.copyWith(
-                color: widget.accent,
+      child: Material(
+        type: MaterialType.transparency,
+        child: InkWell(
+          onTap: widget.onTap,
+          borderRadius: BorderRadius.circular(tokens.radii.l),
+          focusColor: tokens.colors.surface.focusPressed,
+          hoverColor: tokens.colors.surface.hover,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              card,
+              SizedBox(height: tokens.spacing.step3),
+              Text(
+                widget.hint,
+                textAlign: TextAlign.center,
+                style: tokens.typography.styles.body.bodySmall.copyWith(
+                  color: widget.accent,
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );
@@ -749,7 +768,7 @@ class _ThinkingCluster extends StatelessWidget {
               maxLines: 4,
               overflow: TextOverflow.ellipsis,
               style: tokens.typography.styles.body.bodyLarge.copyWith(
-                color: dsTokensDark.colors.text.highEmphasis,
+                color: tokens.colors.text.highEmphasis,
                 fontStyle: FontStyle.italic,
               ),
             ),
@@ -759,7 +778,7 @@ class _ThinkingCluster extends StatelessWidget {
             reassurance,
             textAlign: TextAlign.center,
             style: tokens.typography.styles.body.bodySmall.copyWith(
-              color: dsTokensDark.colors.text.mediumEmphasis,
+              color: tokens.colors.text.mediumEmphasis,
             ),
           ),
         ],

--- a/lib/features/onboarding/ui/widgets/onboarding_hero.dart
+++ b/lib/features/onboarding/ui/widgets/onboarding_hero.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lotti/features/ai/ui/animation/ai_running_animation.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/components/motion/staggered_entrance.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
@@ -142,17 +143,12 @@ Widget buildOnboardingHeroVisual(
   final accent = tokens.colors.interactive.enabled;
   switch (style) {
     case OnboardingHeroStyle.constellation:
-      final monochromeLight = brightness == Brightness.light;
-      final monochrome = tokens.colors.text.highEmphasis.withValues(alpha: 1);
+      if (brightness == Brightness.light) {
+        return const OnboardingThinkingBarsHero();
+      }
       return NeuralConstellation(
-        nodeColor: monochromeLight
-            ? monochrome
-            : tokens.colors.aiProvider.ollama.color,
-        lineColor: monochromeLight
-            ? monochrome
-            : tokens.colors.aiProvider.anthropic.color,
-        // Reuse the Task Agent update signal in both themes instead of
-        // introducing a welcome-only accent.
+        nodeColor: tokens.colors.aiProvider.ollama.color,
+        lineColor: tokens.colors.aiProvider.anthropic.color,
         pulseColor: tokens.colors.proposalKind.update.color,
         nodeCount: 62,
         // The welcome page is the only place where the organism should own the
@@ -188,6 +184,40 @@ Widget buildOnboardingHeroVisual(
         waveColor: accent,
         textColor: tokens.colors.text.highEmphasis,
       );
+  }
+}
+
+/// Welcome-scale presentation of the decoder bars used while AI inference is
+/// running elsewhere in the app.
+///
+/// Light mode deliberately reuses this established activity language instead
+/// of forcing the dark constellation onto a white surface. The shared
+/// [AiThinkingShaderPresence] defaults keep its cadence and line behaviour in
+/// sync with transcription and image-generation progress. Only its footprint
+/// grows to the onboarding hero scale, using design-system spacing.
+class OnboardingThinkingBarsHero extends StatelessWidget {
+  const OnboardingThinkingBarsHero({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.designTokens;
+    final reduceMotion =
+        MediaQuery.maybeOf(context)?.disableAnimations ?? false;
+
+    return TickerMode(
+      enabled: !reduceMotion,
+      child: Padding(
+        padding: EdgeInsets.symmetric(horizontal: tokens.spacing.step6),
+        child: Center(
+          child: AiThinkingShaderPresence(
+            isRunning: true,
+            height: tokens.spacing.step10,
+            primaryColor: tokens.colors.interactive.enabled,
+            secondaryColor: tokens.colors.text.highEmphasis,
+          ),
+        ),
+      ),
+    );
   }
 }
 

--- a/lib/features/onboarding/ui/widgets/onboarding_hero.dart
+++ b/lib/features/onboarding/ui/widgets/onboarding_hero.dart
@@ -142,10 +142,17 @@ Widget buildOnboardingHeroVisual(
   final accent = tokens.colors.interactive.enabled;
   switch (style) {
     case OnboardingHeroStyle.constellation:
+      final monochromeLight = brightness == Brightness.light;
       return NeuralConstellation(
-        nodeColor: tokens.colors.aiProvider.ollama.color,
-        lineColor: tokens.colors.aiProvider.anthropic.color,
-        pulseColor: tokens.colors.aiCard.accent,
+        nodeColor: monochromeLight
+            ? tokens.colors.text.highEmphasis
+            : tokens.colors.aiProvider.ollama.color,
+        lineColor: monochromeLight
+            ? tokens.colors.text.highEmphasis
+            : tokens.colors.aiProvider.anthropic.color,
+        pulseColor: monochromeLight
+            ? tokens.colors.alert.error.defaultColor
+            : tokens.colors.aiCard.accent,
         nodeCount: 62,
         // The welcome page is the only place where the organism should own the
         // opening beat. Later FTUE pages use OnboardingBackdrop's smaller,
@@ -186,8 +193,8 @@ Widget buildOnboardingHeroVisual(
 BlendMode _onboardingAuroraBlendMode(Brightness brightness) =>
     brightness == Brightness.dark ? BlendMode.plus : BlendMode.srcOver;
 
-/// Composes the hero artwork on the semantic AI-card surface, then fades it
-/// into the panel instead of ending as a hard strip above the copy.
+/// Composes the hero artwork on its theme-selected surface, then fades it into
+/// the panel instead of ending as a hard strip above the copy.
 ///
 /// Transparent stops retain [backgroundColor]'s RGB channels. Using
 /// `Colors.transparent` would interpolate transparent black into a light panel
@@ -276,7 +283,9 @@ class OnboardingHeroPanel extends StatelessWidget {
                   width: double.infinity,
                   child: _HeroArtworkFrame(
                     backgroundColor: panelBg,
-                    artworkColor: tokens.colors.aiCard.background,
+                    artworkColor: brightness == Brightness.light
+                        ? panelBg
+                        : tokens.colors.aiCard.background,
                     child: buildOnboardingHeroVisual(
                       heroStyle,
                       tokens: tokens,

--- a/lib/features/onboarding/ui/widgets/onboarding_hero.dart
+++ b/lib/features/onboarding/ui/widgets/onboarding_hero.dart
@@ -46,9 +46,10 @@ List<Color> onboardingAuroraColors(Color accent) {
   ];
 }
 
-/// The shared alive dark backdrop for the connect + API-key pages: a toned-down
-/// aurora wash layered under the neural constellation, on the dark panel
-/// background. Keeps the post-welcome steps as alive as the welcome itself.
+/// The shared alive backdrop for the connect + API-key pages: a toned-down
+/// aurora wash layered under the neural constellation on the active themed
+/// panel background. Keeps the post-welcome steps as alive as the welcome
+/// itself.
 ///
 /// [accent] tints the aurora + constellation; it defaults to the brand teal but
 /// the API-key step passes the chosen provider's brand colour so the backdrop
@@ -61,19 +62,22 @@ class OnboardingBackdrop extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final accentColor = accent ?? dsTokensDark.colors.interactive.enabled;
+    final tokens = context.designTokens;
+    final brightness = Theme.of(context).brightness;
+    final accentColor = accent ?? tokens.colors.interactive.enabled;
     // The motion stays (it carries the welcome's "alive" thread forward) but is
     // toned down behind the working steps so it never competes with the tiles
     // / key field the user is reading and typing into — the review panels'
     // dominant note. Lower aurora wash + dimmer nodes/lines + a calmer pulse.
     return ColoredBox(
-      color: dsTokensDark.colors.background.level01,
+      color: tokens.colors.background.level01,
       child: Stack(
         fit: StackFit.expand,
         children: [
           AuroraHero(
             colors: onboardingAuroraColors(accentColor),
             maxAlpha: 0.09,
+            blendMode: _onboardingAuroraBlendMode(brightness),
           ),
           NeuralConstellation(
             nodeColor: accentColor.withValues(alpha: 0.30),
@@ -83,7 +87,7 @@ class OnboardingBackdrop extends StatelessWidget {
             // fewer travelling activations than the welcome hero.
             pulseColor: Color.lerp(
               accentColor,
-              dsTokensDark.colors.text.highEmphasis,
+              tokens.colors.text.highEmphasis,
               0.42,
             )!.withValues(alpha: 0.36),
             nodeCount: nodeCount,
@@ -93,7 +97,7 @@ class OnboardingBackdrop extends StatelessWidget {
             compositionOffset: const Offset(0, -0.18),
             loop: const Duration(seconds: 14),
           ),
-          const _BackdropContentScrim(),
+          _BackdropContentScrim(tokens: tokens),
         ],
       ),
     );
@@ -103,7 +107,9 @@ class OnboardingBackdrop extends StatelessWidget {
 /// Keeps later onboarding steps quiet enough for form controls: the organism is
 /// still alive, but it fades before it sits under titles, cards, and text fields.
 class _BackdropContentScrim extends StatelessWidget {
-  const _BackdropContentScrim();
+  const _BackdropContentScrim({required this.tokens});
+
+  final DsTokens tokens;
 
   @override
   Widget build(BuildContext context) {
@@ -115,9 +121,9 @@ class _BackdropContentScrim extends StatelessWidget {
             end: Alignment.bottomCenter,
             colors: [
               Colors.transparent,
-              dsTokensDark.colors.background.level01.withValues(alpha: 0.42),
-              dsTokensDark.colors.background.level01.withValues(alpha: 0.86),
-              dsTokensDark.colors.background.level01.withValues(alpha: 0.92),
+              tokens.colors.background.level01.withValues(alpha: 0.42),
+              tokens.colors.background.level01.withValues(alpha: 0.86),
+              tokens.colors.background.level01.withValues(alpha: 0.92),
             ],
             stops: const [0, 0.14, 0.34, 1],
           ),
@@ -127,10 +133,13 @@ class _BackdropContentScrim extends StatelessWidget {
   }
 }
 
-/// Builds the animated visual for [style], coloured from the dark token set so
-/// it reads on the cinematic dark panel regardless of the app's theme.
-Widget buildOnboardingHeroVisual(OnboardingHeroStyle style) {
-  final accent = dsTokensDark.colors.interactive.enabled;
+/// Builds the animated visual for [style] from the active theme tokens.
+Widget buildOnboardingHeroVisual(
+  OnboardingHeroStyle style, {
+  required DsTokens tokens,
+  required Brightness brightness,
+}) {
+  final accent = tokens.colors.interactive.enabled;
   switch (style) {
     case OnboardingHeroStyle.constellation:
       return NeuralConstellation(
@@ -138,7 +147,7 @@ Widget buildOnboardingHeroVisual(OnboardingHeroStyle style) {
         lineColor: accent.withValues(alpha: 0.6),
         pulseColor: Color.lerp(
           accent,
-          dsTokensDark.colors.text.highEmphasis,
+          tokens.colors.text.highEmphasis,
           0.45,
         )!,
         nodeCount: 62,
@@ -154,9 +163,9 @@ Widget buildOnboardingHeroVisual(OnboardingHeroStyle style) {
     case OnboardingHeroStyle.crystallize:
       return CrystallizeHero(
         accent: accent,
-        cardColor: dsTokensLight.colors.background.level01,
-        onCardColor: dsTokensLight.colors.text.highEmphasis,
-        ghostColor: dsTokensDark.colors.text.mediumEmphasis,
+        cardColor: tokens.colors.background.level02,
+        onCardColor: tokens.colors.text.highEmphasis,
+        ghostColor: tokens.colors.text.mediumEmphasis,
         title: 'Car & health errands',
         items: const ['Call the dentist', 'Book the car service'],
         spokenLines: const [
@@ -166,14 +175,20 @@ Widget buildOnboardingHeroVisual(OnboardingHeroStyle style) {
         loop: true,
       );
     case OnboardingHeroStyle.aurora:
-      return AuroraHero(colors: onboardingAuroraColors(accent));
+      return AuroraHero(
+        colors: onboardingAuroraColors(accent),
+        blendMode: _onboardingAuroraBlendMode(brightness),
+      );
     case OnboardingHeroStyle.waveform:
       return WaveformTextHero(
         waveColor: accent,
-        textColor: dsTokensDark.colors.text.highEmphasis,
+        textColor: tokens.colors.text.highEmphasis,
       );
   }
 }
+
+BlendMode _onboardingAuroraBlendMode(Brightness brightness) =>
+    brightness == Brightness.dark ? BlendMode.plus : BlendMode.srcOver;
 
 /// Composes the hero artwork into the modal instead of letting it end as a hard
 /// strip above the copy. The overlays are panel-coloured fades, so the underlying
@@ -238,12 +253,12 @@ class _HeroCloudWash extends StatelessWidget {
   Widget build(BuildContext context) {
     final lifted = Color.lerp(
       backgroundColor,
-      dsTokensDark.colors.background.level02,
+      context.designTokens.colors.background.level02,
       0.78,
     )!;
     final softLifted = Color.lerp(
       backgroundColor,
-      dsTokensDark.colors.background.level02,
+      context.designTokens.colors.background.level02,
       0.38,
     )!;
 
@@ -266,10 +281,10 @@ class _HeroCloudWash extends StatelessWidget {
   }
 }
 
-/// The cinematic welcome content: an always-dark rounded panel with the
+/// The cinematic welcome content: a theme-aware rounded panel with the
 /// animated [heroStyle] hero filling the upper region and the promise + CTA +
-/// skip below. Always dark (uses the dark token set) so the intro feels like a
-/// deliberate, premium takeover in both light and dark app themes.
+/// skip below. Surface, text, controls, and hero palette all resolve from the
+/// active design-system theme.
 class OnboardingHeroPanel extends StatelessWidget {
   const OnboardingHeroPanel({
     required this.onConnect,
@@ -287,9 +302,10 @@ class OnboardingHeroPanel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
-    final panelBg = dsTokensDark.colors.background.level01;
-    final textHigh = dsTokensDark.colors.text.highEmphasis;
-    final textMed = dsTokensDark.colors.text.mediumEmphasis;
+    final panelBg = tokens.colors.background.level01;
+    final textHigh = tokens.colors.text.highEmphasis;
+    final textMed = tokens.colors.text.mediumEmphasis;
+    final brightness = Theme.of(context).brightness;
 
     return ClipRRect(
       borderRadius: BorderRadius.circular(tokens.radii.l),
@@ -309,7 +325,11 @@ class OnboardingHeroPanel extends StatelessWidget {
                   width: double.infinity,
                   child: _HeroArtworkFrame(
                     backgroundColor: panelBg,
-                    child: buildOnboardingHeroVisual(heroStyle),
+                    child: buildOnboardingHeroVisual(
+                      heroStyle,
+                      tokens: tokens,
+                      brightness: brightness,
+                    ),
                   ),
                 ),
               ),

--- a/lib/features/onboarding/ui/widgets/onboarding_hero.dart
+++ b/lib/features/onboarding/ui/widgets/onboarding_hero.dart
@@ -120,7 +120,7 @@ class _BackdropContentScrim extends StatelessWidget {
             begin: Alignment.topCenter,
             end: Alignment.bottomCenter,
             colors: [
-              Colors.transparent,
+              tokens.colors.background.level01.withValues(alpha: 0),
               tokens.colors.background.level01.withValues(alpha: 0.42),
               tokens.colors.background.level01.withValues(alpha: 0.86),
               tokens.colors.background.level01.withValues(alpha: 0.92),
@@ -143,13 +143,9 @@ Widget buildOnboardingHeroVisual(
   switch (style) {
     case OnboardingHeroStyle.constellation:
       return NeuralConstellation(
-        nodeColor: accent,
-        lineColor: accent.withValues(alpha: 0.6),
-        pulseColor: Color.lerp(
-          accent,
-          tokens.colors.text.highEmphasis,
-          0.45,
-        )!,
+        nodeColor: tokens.colors.aiProvider.ollama.color,
+        lineColor: tokens.colors.aiProvider.anthropic.color,
+        pulseColor: tokens.colors.aiCard.accent,
         nodeCount: 62,
         // The welcome page is the only place where the organism should own the
         // opening beat. Later FTUE pages use OnboardingBackdrop's smaller,
@@ -190,14 +186,21 @@ Widget buildOnboardingHeroVisual(
 BlendMode _onboardingAuroraBlendMode(Brightness brightness) =>
     brightness == Brightness.dark ? BlendMode.plus : BlendMode.srcOver;
 
-/// Composes the hero artwork into the modal instead of letting it end as a hard
-/// strip above the copy. The overlays are panel-coloured fades, so the underlying
-/// animation topology stays unchanged while edge clipping and the title boundary
-/// are softened.
+/// Composes the hero artwork on the semantic AI-card surface, then fades it
+/// into the panel instead of ending as a hard strip above the copy.
+///
+/// Transparent stops retain [backgroundColor]'s RGB channels. Using
+/// `Colors.transparent` would interpolate transparent black into a light panel
+/// and produce a visible grey band before the stop becomes opaque.
 class _HeroArtworkFrame extends StatelessWidget {
-  const _HeroArtworkFrame({required this.backgroundColor, required this.child});
+  const _HeroArtworkFrame({
+    required this.backgroundColor,
+    required this.artworkColor,
+    required this.child,
+  });
 
   final Color backgroundColor;
+  final Color artworkColor;
   final Widget child;
 
   @override
@@ -205,23 +208,8 @@ class _HeroArtworkFrame extends StatelessWidget {
     return Stack(
       fit: StackFit.expand,
       children: [
-        _HeroCloudWash(backgroundColor: backgroundColor),
+        ColoredBox(color: artworkColor),
         child,
-        IgnorePointer(
-          child: DecoratedBox(
-            decoration: BoxDecoration(
-              gradient: LinearGradient(
-                colors: [
-                  backgroundColor.withValues(alpha: 0.52),
-                  Colors.transparent,
-                  Colors.transparent,
-                  backgroundColor.withValues(alpha: 0.34),
-                ],
-                stops: const [0, 0.14, 0.84, 1],
-              ),
-            ),
-          ),
-        ),
         IgnorePointer(
           child: DecoratedBox(
             decoration: BoxDecoration(
@@ -229,8 +217,8 @@ class _HeroArtworkFrame extends StatelessWidget {
                 begin: Alignment.topCenter,
                 end: Alignment.bottomCenter,
                 colors: [
-                  Colors.transparent,
-                  Colors.transparent,
+                  backgroundColor.withValues(alpha: 0),
+                  backgroundColor.withValues(alpha: 0),
                   backgroundColor.withValues(alpha: 0.58),
                   backgroundColor,
                 ],
@@ -240,43 +228,6 @@ class _HeroArtworkFrame extends StatelessWidget {
           ),
         ),
       ],
-    );
-  }
-}
-
-class _HeroCloudWash extends StatelessWidget {
-  const _HeroCloudWash({required this.backgroundColor});
-
-  final Color backgroundColor;
-
-  @override
-  Widget build(BuildContext context) {
-    final lifted = Color.lerp(
-      backgroundColor,
-      context.designTokens.colors.background.level02,
-      0.78,
-    )!;
-    final softLifted = Color.lerp(
-      backgroundColor,
-      context.designTokens.colors.background.level02,
-      0.38,
-    )!;
-
-    return IgnorePointer(
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          gradient: RadialGradient(
-            center: const Alignment(-0.24, -0.18),
-            radius: 0.92,
-            colors: [
-              lifted.withValues(alpha: 0.74),
-              softLifted.withValues(alpha: 0.34),
-              backgroundColor.withValues(alpha: 0),
-            ],
-            stops: const [0, 0.48, 1],
-          ),
-        ),
-      ),
     );
   }
 }
@@ -325,6 +276,7 @@ class OnboardingHeroPanel extends StatelessWidget {
                   width: double.infinity,
                   child: _HeroArtworkFrame(
                     backgroundColor: panelBg,
+                    artworkColor: tokens.colors.aiCard.background,
                     child: buildOnboardingHeroVisual(
                       heroStyle,
                       tokens: tokens,
@@ -353,10 +305,9 @@ class OnboardingHeroPanel extends StatelessWidget {
                   Text(
                     context.messages.onboardingWelcomeTitle,
                     textAlign: TextAlign.center,
-                    // heading1 (the display tier of this flow) so the promise
-                    // clearly out-ranks the step titles (heading3) — and the
-                    // larger size wraps earlier, fixing the orphaned "plan.".
-                    style: tokens.typography.styles.heading.heading1.copyWith(
+                    // Heading 2 keeps the promise dominant without letting it
+                    // overpower the visual or CTA on a phone-sized panel.
+                    style: tokens.typography.styles.heading.heading2.copyWith(
                       color: textHigh,
                     ),
                   ),

--- a/lib/features/onboarding/ui/widgets/onboarding_hero.dart
+++ b/lib/features/onboarding/ui/widgets/onboarding_hero.dart
@@ -143,16 +143,17 @@ Widget buildOnboardingHeroVisual(
   switch (style) {
     case OnboardingHeroStyle.constellation:
       final monochromeLight = brightness == Brightness.light;
+      final monochrome = tokens.colors.text.highEmphasis.withValues(alpha: 1);
       return NeuralConstellation(
         nodeColor: monochromeLight
-            ? tokens.colors.text.highEmphasis
+            ? monochrome
             : tokens.colors.aiProvider.ollama.color,
         lineColor: monochromeLight
-            ? tokens.colors.text.highEmphasis
+            ? monochrome
             : tokens.colors.aiProvider.anthropic.color,
-        pulseColor: monochromeLight
-            ? tokens.colors.alert.error.defaultColor
-            : tokens.colors.aiCard.accent,
+        // Reuse the Task Agent update signal in both themes instead of
+        // introducing a welcome-only accent.
+        pulseColor: tokens.colors.proposalKind.update.color,
         nodeCount: 62,
         // The welcome page is the only place where the organism should own the
         // opening beat. Later FTUE pages use OnboardingBackdrop's smaller,

--- a/lib/features/onboarding/ui/widgets/onboarding_recording_style_step.dart
+++ b/lib/features/onboarding/ui/widgets/onboarding_recording_style_step.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:lotti/features/design_system/theme/design_system_theme.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/onboarding/state/recording_style.dart';
 import 'package:lotti/features/onboarding/ui/widgets/onboarding_recording_style_view.dart';
@@ -25,7 +24,6 @@ class OnboardingRecordingStyleStep extends ConsumerStatefulWidget {
 
 class _OnboardingRecordingStyleStepState
     extends ConsumerState<OnboardingRecordingStyleStep> {
-  late final ColorScheme _darkScheme = DesignSystemTheme.dark().colorScheme;
   RecordingStyle _selected = RecordingStyle.modern;
   bool _selectionEdited = false;
 
@@ -58,8 +56,8 @@ class _OnboardingRecordingStyleStepState
     return RecordingStyleLivePreview(
       builder: (context, state) {
         return OnboardingRecordingStyleView(
-          accent: dsTokensDark.colors.interactive.enabled,
-          colorScheme: _darkScheme,
+          accent: context.designTokens.colors.interactive.enabled,
+          colorScheme: Theme.of(context).colorScheme,
           title: messages.onboardingRecordingStyleTitle,
           explanation: messages.onboardingRecordingStyleExplanation,
           analogueLabel: messages.onboardingRecordingStyleAnalogue,

--- a/lib/features/onboarding/ui/widgets/onboarding_recording_style_view.dart
+++ b/lib/features/onboarding/ui/widgets/onboarding_recording_style_view.dart
@@ -35,8 +35,7 @@ class OnboardingRecordingStyleView extends StatelessWidget {
 
   final Color accent;
 
-  /// Colour scheme handed to the analog VU meter (a dark scheme on the dark
-  /// onboarding surface).
+  /// Colour scheme handed to the theme-adaptive analog VU meter.
   final ColorScheme colorScheme;
 
   final String title;
@@ -65,9 +64,9 @@ class OnboardingRecordingStyleView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
-    final textHigh = dsTokensDark.colors.text.highEmphasis;
-    final textMedium = dsTokensDark.colors.text.mediumEmphasis;
-    final panelBg = dsTokensDark.colors.background.level01;
+    final textHigh = tokens.colors.text.highEmphasis;
+    final textMedium = tokens.colors.text.mediumEmphasis;
+    final panelBg = tokens.colors.background.level01;
 
     return ClipRRect(
       borderRadius: BorderRadius.circular(tokens.radii.l),
@@ -116,7 +115,7 @@ class OnboardingRecordingStyleView extends StatelessWidget {
                 RecordingStylePicker(
                   accent: accent,
                   colorScheme: colorScheme,
-                  surfaceTokens: dsTokensDark,
+                  surfaceTokens: tokens,
                   analogueLabel: analogueLabel,
                   modernLabel: modernLabel,
                   tryWithVoiceLabel: tryWithVoiceLabel,

--- a/lib/features/onboarding/ui/widgets/onboarding_success_view.dart
+++ b/lib/features/onboarding/ui/widgets/onboarding_success_view.dart
@@ -67,9 +67,9 @@ class _OnboardingSuccessViewState extends State<OnboardingSuccessView>
   @override
   Widget build(BuildContext context) {
     final tokens = context.designTokens;
-    final panelBg = dsTokensDark.colors.background.level01;
-    final textHigh = dsTokensDark.colors.text.highEmphasis;
-    final textMedium = dsTokensDark.colors.text.mediumEmphasis;
+    final panelBg = tokens.colors.background.level01;
+    final textHigh = tokens.colors.text.highEmphasis;
+    final textMedium = tokens.colors.text.mediumEmphasis;
 
     return ClipRRect(
       borderRadius: BorderRadius.circular(tokens.radii.l),
@@ -120,7 +120,7 @@ class _OnboardingSuccessViewState extends State<OnboardingSuccessView>
                     child: _CheckMark(
                       size: _checkSize,
                       accent: widget.accent,
-                      iconColor: panelBg,
+                      iconColor: tokens.colors.text.onInteractiveAlert,
                     ),
                   ),
                 ),

--- a/lib/features/onboarding/ui/widgets/recording_style_picker.dart
+++ b/lib/features/onboarding/ui/widgets/recording_style_picker.dart
@@ -23,13 +23,10 @@ final List<double> _idleAmplitudes = List<double>.generate(
 /// any surrounding chrome (title/explanation copy, Continue CTA, backdrop) so
 /// onboarding and Settings render an identical picker.
 ///
-/// [surfaceTokens] supplies the card text/fill colors — pass [dsTokensDark]
-/// for a fixed dark card (onboarding, which always sits over its own dark
-/// `OnboardingBackdrop`) or the ambient `context.designTokens` for a card
-/// that follows the host page's light/dark theme (Settings, which has no
-/// such backdrop — a fixed-dark card there would render low-contrast, near
-/// -illegible text on a light background). Layout (spacing/radii/typography)
-/// stays ambient either way, since those scale values don't vary by theme.
+/// [surfaceTokens] supplies the card text/fill colors. Both onboarding and
+/// Settings pass their ambient `context.designTokens`, keeping the picker in
+/// sync with the active light/dark theme. Layout (spacing/radii/typography)
+/// stays ambient too.
 ///
 ///  * **Modern** — the [AiVoiceInputShader] orb + a brand-tinted [LiveWaveform].
 ///  * **Analogue** — the skeuomorphic [AnalogVuMeter] + a neutral [LiveWaveform].
@@ -61,8 +58,7 @@ class RecordingStylePicker extends StatelessWidget {
   /// theme-adaptive; pass a scheme matching [surfaceTokens]'s brightness).
   final ColorScheme colorScheme;
 
-  /// Text/fill colors for the cards and toggle. See the class doc for when
-  /// to pass [dsTokensDark] vs. the ambient `context.designTokens`.
+  /// Text/fill colors for the cards and toggle.
   final DsTokens surfaceTokens;
 
   final String analogueLabel;

--- a/test/features/daily_os_next/ui/widgets/voice_button_test.dart
+++ b/test/features/daily_os_next/ui/widgets/voice_button_test.dart
@@ -15,6 +15,7 @@ void main() {
     double size = 132,
     double dbfs = CaptureState.defaultDbfs,
     double dbfsFloor = CaptureState.defaultDbfs,
+    Color? listeningCoreColor,
     VoidCallback? onTap,
   }) async {
     await tester.pumpWidget(
@@ -26,6 +27,7 @@ void main() {
             dbfsFloor: dbfsFloor,
             size: size,
             semanticLabel: 'Record voice',
+            listeningCoreColor: listeningCoreColor,
             onTap: onTap ?? () {},
           ),
         ),
@@ -118,6 +120,25 @@ void main() {
         buttonSize * VoiceButton.listeningIdleBreath + 0.01,
       ),
     );
+  });
+
+  testWidgets('listening state accepts a host-provided center surface', (
+    tester,
+  ) async {
+    const surface = Color(0xFFF1F4F3);
+    await pumpVoiceButton(
+      tester,
+      phase: CapturePhase.listening,
+      listeningCoreColor: surface,
+    );
+
+    final ink = tester.widget<Ink>(
+      find.ancestor(
+        of: find.byKey(VoiceButton.coreButtonKey),
+        matching: find.byType(Ink),
+      ),
+    );
+    expect((ink.decoration! as BoxDecoration).color, surface);
   });
 
   testWidgets(

--- a/test/features/daily_os_next/ui/widgets/voice_orb_zone_test.dart
+++ b/test/features/daily_os_next/ui/widgets/voice_orb_zone_test.dart
@@ -14,6 +14,7 @@ void main() {
     String caption = 'Tap to talk',
     Color captionColor = Colors.white70,
     List<double> amplitudes = const [],
+    Color? listeningCoreColor,
     VoidCallback? onTap,
   }) async {
     await tester.pumpWidget(
@@ -25,6 +26,7 @@ void main() {
             captionColor: captionColor,
             semanticLabel: 'Record voice',
             amplitudes: amplitudes,
+            listeningCoreColor: listeningCoreColor,
             onTap: onTap ?? () {},
           ),
         ),
@@ -114,6 +116,22 @@ void main() {
     await pumpZone(tester, onTap: () => taps += 1);
     await tester.tap(find.byKey(VoiceButton.coreButtonKey));
     expect(taps, 1);
+  });
+
+  testWidgets('forwards a listening center surface to the voice button', (
+    tester,
+  ) async {
+    const surface = Color(0xFFF1F4F3);
+    await pumpZone(
+      tester,
+      phase: CapturePhase.listening,
+      listeningCoreColor: surface,
+    );
+
+    expect(
+      tester.widget<VoiceButton>(find.byType(VoiceButton)).listeningCoreColor,
+      surface,
+    );
   });
 
   group('LiveTranscriptView', () {

--- a/test/features/onboarding/ui/onboarding_manual_screenshots_test.dart
+++ b/test/features/onboarding/ui/onboarding_manual_screenshots_test.dart
@@ -347,7 +347,6 @@ void main() {
       find.text(_t('Connection verified', 'Verbindung bestätigt')),
       findsOneWidget,
     );
-
   }
 
   Future<void> driveToSuccess(WidgetTester tester) async {

--- a/test/features/onboarding/ui/onboarding_manual_screenshots_test.dart
+++ b/test/features/onboarding/ui/onboarding_manual_screenshots_test.dart
@@ -337,7 +337,7 @@ void main() {
     expect(find.text('Ollama'), findsOneWidget);
   }
 
-  Future<void> driveToFirstTaskPrompt(WidgetTester tester) async {
+  Future<void> driveToApiKey(WidgetTester tester) async {
     await driveToProviders(tester);
     await tapText(tester, 'Ollama');
 
@@ -348,7 +348,16 @@ void main() {
       findsOneWidget,
     );
 
+  }
+
+  Future<void> driveToSuccess(WidgetTester tester) async {
+    await driveToApiKey(tester);
     await tapText(tester, _t('Connect', 'Verbinden'));
+    expect(find.text(_t("You're all set", 'Alles bereit')), findsOneWidget);
+  }
+
+  Future<void> driveToRecordingStyle(WidgetTester tester) async {
+    await driveToSuccess(tester);
     await tapText(tester, _t('Get started', "Los geht's"));
     expect(
       find.text(
@@ -356,14 +365,21 @@ void main() {
       ),
       findsOneWidget,
     );
-    await tapText(tester, _t('Continue', 'Weiter'));
+  }
 
+  Future<void> driveToCategories(WidgetTester tester) async {
+    await driveToRecordingStyle(tester);
+    await tapText(tester, _t('Continue', 'Weiter'));
     expect(
       find.text(
         _t('Where should your AI work?', 'Wo soll deine KI arbeiten?'),
       ),
       findsOneWidget,
     );
+  }
+
+  Future<void> driveToFirstTaskPrompt(WidgetTester tester) async {
+    await driveToCategories(tester);
     await tapText(tester, _t('Add your own', 'Eigene hinzufügen'), frames: 4);
     await tester.enterText(
       find.byType(TextField).last,

--- a/test/features/onboarding/ui/onboarding_welcome_modal_test.dart
+++ b/test/features/onboarding/ui/onboarding_welcome_modal_test.dart
@@ -191,7 +191,9 @@ void main() {
       );
       expect(
         welcomeConstellation.nodeColor,
-        theme.tokens.colors.aiProvider.ollama.color,
+        theme.name == 'light'
+            ? theme.tokens.colors.text.highEmphasis
+            : theme.tokens.colors.aiProvider.ollama.color,
       );
 
       await tester.tap(find.text('Choose your AI brain'));

--- a/test/features/onboarding/ui/onboarding_welcome_modal_test.dart
+++ b/test/features/onboarding/ui/onboarding_welcome_modal_test.dart
@@ -177,10 +177,6 @@ void main() {
           matching: find.byType(ColoredBox),
         ),
       );
-      final welcomeConstellation = tester.widget<NeuralConstellation>(
-        find.byType(NeuralConstellation),
-      );
-
       expect(
         welcomeSurface.color,
         theme.tokens.colors.background.level01,
@@ -189,12 +185,17 @@ void main() {
         welcomeTitle.style?.color,
         theme.tokens.colors.text.highEmphasis,
       );
-      expect(
-        welcomeConstellation.nodeColor,
-        theme.name == 'light'
-            ? theme.tokens.colors.text.highEmphasis.withValues(alpha: 1)
-            : theme.tokens.colors.aiProvider.ollama.color,
-      );
+      if (theme.name == 'light') {
+        expect(find.byType(OnboardingThinkingBarsHero), findsOneWidget);
+      } else {
+        final welcomeConstellation = tester.widget<NeuralConstellation>(
+          find.byType(NeuralConstellation),
+        );
+        expect(
+          welcomeConstellation.nodeColor,
+          theme.tokens.colors.aiProvider.ollama.color,
+        );
+      }
 
       await tester.tap(find.text('Choose your AI brain'));
       await tester.pumpAndSettle();

--- a/test/features/onboarding/ui/onboarding_welcome_modal_test.dart
+++ b/test/features/onboarding/ui/onboarding_welcome_modal_test.dart
@@ -12,10 +12,14 @@ import 'package:lotti/features/ai/util/profile_seeding_service.dart';
 import 'package:lotti/features/categories/repository/categories_repository.dart';
 import 'package:lotti/features/daily_os_next/state/capture_controller.dart';
 import 'package:lotti/features/design_system/components/toasts/design_system_toast.dart';
+import 'package:lotti/features/design_system/theme/design_system_theme.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/onboarding/model/onboarding_event.dart';
 import 'package:lotti/features/onboarding/repository/onboarding_metrics_repository.dart';
 import 'package:lotti/features/onboarding/services/onboarding_capture_to_task_service.dart';
 import 'package:lotti/features/onboarding/ui/onboarding_welcome_modal.dart';
+import 'package:lotti/features/onboarding/ui/widgets/neural_constellation.dart';
+import 'package:lotti/features/onboarding/ui/widgets/onboarding_hero.dart';
 import 'package:lotti/get_it.dart';
 import 'package:lotti/services/logging_service.dart';
 import 'package:lotti/services/nav_service.dart';
@@ -108,7 +112,11 @@ void main() {
     expect(onboardingSeededProfileId(InferenceProviderType.whisper), isNull);
   });
 
-  Future<void> openWelcome(WidgetTester tester, {Widget? child}) async {
+  Future<void> openWelcome(
+    WidgetTester tester, {
+    Widget? child,
+    ThemeData? theme,
+  }) async {
     // The fixed-height modal panel (~680) is taller than the default 800x600
     // render surface; size the surface to the 844-tall MediaQuery so the lower
     // controls are on-screen and hit-testable.
@@ -117,8 +125,15 @@ void main() {
       ..devicePixelRatio = 1;
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
+    final launchHost = child ?? host();
     await tester.pumpWidget(
-      makeTestableWidget(child ?? host(), mediaQueryData: mq),
+      theme == null
+          ? makeTestableWidget(launchHost, mediaQueryData: mq)
+          : makeTestableWidgetNoScroll(
+              launchHost,
+              mediaQueryData: mq,
+              theme: theme,
+            ),
     );
     await tester.tap(find.text('open'));
     await tester.pumpAndSettle();
@@ -135,6 +150,73 @@ void main() {
     final state = await repo.funnelState();
     expect(state.reached(OnboardingEventName.welcomeShown), isTrue);
   });
+
+  for (final theme in [
+    (
+      name: 'light',
+      data: DesignSystemTheme.light(),
+      tokens: dsTokensLight,
+    ),
+    (
+      name: 'dark',
+      data: DesignSystemTheme.dark(),
+      tokens: dsTokensDark,
+    ),
+  ]) {
+    testWidgets('welcome and provider steps follow the ${theme.name} theme', (
+      tester,
+    ) async {
+      await openWelcome(tester, theme: theme.data);
+
+      final welcomeTitle = tester.widget<Text>(
+        find.text('Talk. Lotti turns it into a plan.'),
+      );
+      final welcomeSurface = tester.widget<ColoredBox>(
+        find.ancestor(
+          of: find.text('Talk. Lotti turns it into a plan.'),
+          matching: find.byType(ColoredBox),
+        ),
+      );
+      final welcomeConstellation = tester.widget<NeuralConstellation>(
+        find.byType(NeuralConstellation),
+      );
+
+      expect(
+        welcomeSurface.color,
+        theme.tokens.colors.background.level01,
+      );
+      expect(
+        welcomeTitle.style?.color,
+        theme.tokens.colors.text.highEmphasis,
+      );
+      expect(
+        welcomeConstellation.nodeColor,
+        theme.tokens.colors.interactive.enabled,
+      );
+
+      await tester.tap(find.text('Choose your AI brain'));
+      await tester.pumpAndSettle();
+
+      final providerTitle = tester.widget<Text>(
+        find.text('Choose the AI brain for your tasks'),
+      );
+      final providerBackdrop = tester.widget<ColoredBox>(
+        find.descendant(
+          of: find.byType(OnboardingBackdrop),
+          matching: find.byType(ColoredBox),
+        ),
+      );
+
+      expect(
+        providerTitle.style?.color,
+        theme.tokens.colors.text.highEmphasis,
+      );
+      expect(
+        providerBackdrop.color,
+        theme.tokens.colors.background.level01,
+      );
+    });
+  }
 
   testWidgets('advancing to connect reveals the primary providers and records '
       'providerModalShown', (tester) async {

--- a/test/features/onboarding/ui/onboarding_welcome_modal_test.dart
+++ b/test/features/onboarding/ui/onboarding_welcome_modal_test.dart
@@ -192,7 +192,7 @@ void main() {
       expect(
         welcomeConstellation.nodeColor,
         theme.name == 'light'
-            ? theme.tokens.colors.text.highEmphasis
+            ? theme.tokens.colors.text.highEmphasis.withValues(alpha: 1)
             : theme.tokens.colors.aiProvider.ollama.color,
       );
 

--- a/test/features/onboarding/ui/onboarding_welcome_modal_test.dart
+++ b/test/features/onboarding/ui/onboarding_welcome_modal_test.dart
@@ -191,7 +191,7 @@ void main() {
       );
       expect(
         welcomeConstellation.nodeColor,
-        theme.tokens.colors.interactive.enabled,
+        theme.tokens.colors.aiProvider.ollama.color,
       );
 
       await tester.tap(find.text('Choose your AI brain'));

--- a/test/features/onboarding/ui/widgets/aurora_hero_test.dart
+++ b/test/features/onboarding/ui/widgets/aurora_hero_test.dart
@@ -69,7 +69,7 @@ void main() {
     });
 
     testWidgets(
-      'shouldRepaint: rebuild with different colors and maxAlpha repaints',
+      'shouldRepaint: changed colors, alpha, and blend mode repaint',
       (tester) async {
         await tester.pumpWidget(
           makeTestableWidget(
@@ -95,6 +95,7 @@ void main() {
               const AuroraHero(
                 colors: [Colors.red, Colors.orange],
                 maxAlpha: 0.7,
+                blendMode: BlendMode.srcOver,
               ),
             ),
             mediaQueryData: const MediaQueryData(size: Size(390, 844)),
@@ -117,7 +118,7 @@ void main() {
           makeTestableWidget(
             bounded(
               // Reduced motion so t stays constant: the only way the painter
-              // changes is through colors/maxAlpha, isolating the listEquals
+              // changes is through colors/maxAlpha/blendMode, isolating the listEquals
               // equal-values comparison.
               const AuroraHero(colors: colors, maxAlpha: 0.4),
             ),

--- a/test/features/onboarding/ui/widgets/onboarding_api_key_panel_test.dart
+++ b/test/features/onboarding/ui/widgets/onboarding_api_key_panel_test.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
+import 'dart:ui' show SemanticsAction;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
@@ -464,6 +466,35 @@ void main() {
     );
 
     await tester.tap(find.byIcon(Icons.arrow_back_rounded));
+    await tester.pump();
+
+    expect(backed, isTrue);
+  });
+
+  testWidgets('back control is localized and keyboard operable', (
+    tester,
+  ) async {
+    var backed = false;
+    await pumpPanel(
+      tester,
+      type: InferenceProviderType.gemini,
+      onBack: () => backed = true,
+    );
+
+    final back = find.byTooltip('Back');
+    expect(back, findsOneWidget);
+    final semantics = tester.getSemantics(find.bySemanticsLabel('Back'));
+    expect(semantics.label, 'Back');
+    expect(
+      semantics.getSemanticsData().hasAction(SemanticsAction.tap),
+      isTrue,
+    );
+
+    Focus.of(
+      tester.element(find.byIcon(Icons.arrow_back_rounded)),
+    ).requestFocus();
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
     await tester.pump();
 
     expect(backed, isTrue);

--- a/test/features/onboarding/ui/widgets/onboarding_category_view_test.dart
+++ b/test/features/onboarding/ui/widgets/onboarding_category_view_test.dart
@@ -1,6 +1,7 @@
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/onboarding/ui/widgets/onboarding_category_view.dart';
@@ -22,6 +23,7 @@ void main() {
   Future<void> pumpView(
     WidgetTester tester, {
     required Set<String> selected,
+    TextScaler textScaler = TextScaler.noScaling,
     void Function(String)? onToggle,
     VoidCallback? onWhy,
     VoidCallback? onAddOwn,
@@ -50,7 +52,7 @@ void main() {
         mediaQueryData: const MediaQueryData(
           size: Size(390, 844),
           disableAnimations: true,
-        ),
+        ).copyWith(textScaler: textScaler),
       ),
     );
     await tester.pump();
@@ -269,6 +271,67 @@ void main() {
     await tester.tap(find.text('Work'));
     await tester.tap(find.text('Fitness'));
     expect(toggled, ['Work', 'Fitness']);
+  });
+
+  testWidgets('option and add-own actions activate via keyboard', (
+    tester,
+  ) async {
+    final toggled = <String>[];
+    var added = 0;
+    await pumpView(
+      tester,
+      selected: const {},
+      onToggle: toggled.add,
+      onAddOwn: () => added++,
+    );
+
+    final work = find.text('Work');
+    final workFocus = Focus.of(tester.element(work))..requestFocus();
+    await tester.pump();
+    expect(workFocus.hasPrimaryFocus, isTrue);
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pump();
+    expect(toggled, ['Work']);
+
+    final addOwn = find.text('Add your own');
+    final addFocus = Focus.of(tester.element(addOwn))..requestFocus();
+    await tester.pump();
+    expect(addFocus.hasPrimaryFocus, isTrue);
+    await tester.sendKeyEvent(LogicalKeyboardKey.space);
+    await tester.pump();
+    expect(added, 1);
+
+    for (final finder in [work, addOwn]) {
+      expect(
+        tester
+            .getSemantics(finder)
+            .getSemanticsData()
+            .hasAction(ui.SemanticsAction.tap),
+        isTrue,
+      );
+    }
+  });
+
+  testWidgets('large text collapses category choices to one readable column', (
+    tester,
+  ) async {
+    for (final scale in [2.0, 3.2]) {
+      await pumpView(
+        tester,
+        selected: const {},
+        textScaler: TextScaler.linear(scale),
+      );
+
+      final workRect = tester.getRect(find.text('Work'));
+      final fitnessRect = tester.getRect(find.text('Fitness'));
+      expect(
+        fitnessRect.top,
+        greaterThan(workRect.bottom),
+        reason: 'text scale $scale should use a single-column layout',
+      );
+      expect(tester.widget<Text>(find.text('Work')).overflow, isNull);
+      expect(tester.takeException(), isNull);
+    }
   });
 
   testWidgets('add-your-own reports its tap', (tester) async {

--- a/test/features/onboarding/ui/widgets/onboarding_connect_panel_test.dart
+++ b/test/features/onboarding/ui/widgets/onboarding_connect_panel_test.dart
@@ -176,10 +176,10 @@ void main() {
       final selected = <InferenceProviderType>[];
       await pumpPanel(tester, onSelect: selected.add);
 
-      final provider = find.text(
+      final providerName = find.text(
         onboardingProviderName(m, InferenceProviderType.mistral),
       );
-      final focus = Focus.of(tester.element(provider))..requestFocus();
+      final focus = Focus.of(tester.element(providerName))..requestFocus();
       await tester.pump();
       expect(focus.hasPrimaryFocus, isTrue);
 
@@ -187,6 +187,10 @@ void main() {
       await tester.pump();
 
       expect(selected, [InferenceProviderType.mistral]);
+      final provider = find.bySemanticsLabel(
+        onboardingProviderName(m, InferenceProviderType.mistral),
+      );
+      expect(provider, findsOneWidget);
       final semantics = tester.getSemantics(provider);
       expect(semantics.label, contains('Mistral'));
       expect(

--- a/test/features/onboarding/ui/widgets/onboarding_connect_panel_test.dart
+++ b/test/features/onboarding/ui/widgets/onboarding_connect_panel_test.dart
@@ -1,4 +1,7 @@
+import 'dart:ui' show SemanticsAction;
+
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/onboarding/ui/widgets/onboarding_connect_panel.dart';
@@ -90,6 +93,31 @@ void main() {
       expect(backed, isTrue);
     });
 
+    testWidgets('back control is localized and keyboard operable', (
+      tester,
+    ) async {
+      var backed = false;
+      await pumpPanel(tester, onBack: () => backed = true);
+
+      final back = find.byTooltip('Back');
+      expect(back, findsOneWidget);
+      final semantics = tester.getSemantics(find.bySemanticsLabel('Back'));
+      expect(semantics.label, 'Back');
+      expect(
+        semantics.getSemanticsData().hasAction(SemanticsAction.tap),
+        isTrue,
+      );
+
+      Focus.of(
+        tester.element(find.byIcon(Icons.arrow_back_rounded)),
+      ).requestFocus();
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+
+      expect(backed, isTrue);
+    });
+
     testWidgets('More options reveals the extra providers and toggles back', (
       tester,
     ) async {
@@ -142,6 +170,29 @@ void main() {
       await tester.pump();
 
       expect(selected, [InferenceProviderType.mistral]);
+    });
+
+    testWidgets('a primary provider activates via keyboard', (tester) async {
+      final selected = <InferenceProviderType>[];
+      await pumpPanel(tester, onSelect: selected.add);
+
+      final provider = find.text(
+        onboardingProviderName(m, InferenceProviderType.mistral),
+      );
+      final focus = Focus.of(tester.element(provider))..requestFocus();
+      await tester.pump();
+      expect(focus.hasPrimaryFocus, isTrue);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+
+      expect(selected, [InferenceProviderType.mistral]);
+      final semantics = tester.getSemantics(provider);
+      expect(semantics.label, contains('Mistral'));
+      expect(
+        semantics.getSemanticsData().hasAction(SemanticsAction.tap),
+        isTrue,
+      );
     });
 
     testWidgets('tapping a revealed extra tile fires onSelect with its type', (

--- a/test/features/onboarding/ui/widgets/onboarding_first_task_view_test.dart
+++ b/test/features/onboarding/ui/widgets/onboarding_first_task_view_test.dart
@@ -227,6 +227,52 @@ void main() {
         tester.element(core).designTokens.colors.background.level02,
       );
     });
+
+    testWidgets('uses a clear headline, status, and destination hierarchy', (
+      tester,
+    ) async {
+      await pumpView(
+        tester,
+        OnboardingFirstTaskPhase.listening,
+        categories: twoCategories,
+      );
+
+      final tokens = tester
+          .element(find.text('Create your first task'))
+          .designTokens;
+      final headline = tester.widget<Text>(find.text('Create your first task'));
+      final status = tester.widget<Text>(find.text('Tap when done'));
+      final destination = tester.widget<Text>(
+        find.text('Where should this land?'),
+      );
+      final selectedCategory = tester.widget<Text>(find.text('Work'));
+      final typeInstead = tester.widget<Text>(find.text('Rather type?'));
+
+      expect(
+        headline.style?.fontSize,
+        tokens.typography.styles.heading.heading2.fontSize,
+      );
+      expect(
+        status.style?.fontSize,
+        tokens.typography.styles.subtitle.subtitle1.fontSize,
+      );
+      expect(
+        status.style?.fontWeight,
+        tokens.typography.styles.subtitle.subtitle1.fontWeight,
+      );
+      expect(
+        destination.style?.fontWeight,
+        tokens.typography.styles.subtitle.subtitle2.fontWeight,
+      );
+      expect(
+        selectedCategory.style?.fontWeight,
+        tokens.typography.styles.subtitle.subtitle2.fontWeight,
+      );
+      expect(
+        typeInstead.style?.fontSize,
+        tokens.typography.styles.subtitle.subtitle1.fontSize,
+      );
+    });
   });
 
   group('thinking frame', () {

--- a/test/features/onboarding/ui/widgets/onboarding_first_task_view_test.dart
+++ b/test/features/onboarding/ui/widgets/onboarding_first_task_view_test.dart
@@ -1,7 +1,11 @@
+import 'dart:ui' show SemanticsAction;
+
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/daily_os_next/ui/widgets/voice_button.dart';
 import 'package:lotti/features/daily_os_next/ui/widgets/voice_orb_zone.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/onboarding/model/onboarding_capture_category.dart';
 import 'package:lotti/features/onboarding/state/recording_style.dart';
 import 'package:lotti/features/onboarding/ui/widgets/onboarding_first_task_view.dart';
@@ -152,6 +156,30 @@ void main() {
       expect(recordTaps, 1);
     });
 
+    testWidgets('analogue recorder activates via keyboard', (tester) async {
+      await pumpView(
+        tester,
+        OnboardingFirstTaskPhase.prompt,
+        style: RecordingStyle.analogue,
+      );
+
+      final meter = find.byType(AnalogVuMeter);
+      final focus = Focus.of(tester.element(meter))..requestFocus();
+      await tester.pump();
+      expect(focus.hasPrimaryFocus, isTrue);
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+
+      expect(recordTaps, 1);
+      expect(
+        tester
+            .getSemantics(meter)
+            .getSemanticsData()
+            .hasAction(SemanticsAction.tap),
+        isTrue,
+      );
+    });
+
     testWidgets(
       'the analogue meter also rides the live level while listening',
       (
@@ -182,6 +210,22 @@ void main() {
       expect(find.text('Or start with one of these:'), findsNothing);
       // Still composing, so the escape hatch remains.
       expect(find.text('Rather type?'), findsOneWidget);
+    });
+
+    testWidgets('light themed orb keeps a defined center surface', (
+      tester,
+    ) async {
+      await pumpView(tester, OnboardingFirstTaskPhase.listening);
+
+      final core = find.byKey(VoiceButton.coreButtonKey);
+      final ink = tester.widget<Ink>(
+        find.ancestor(of: core, matching: find.byType(Ink)),
+      );
+      final decoration = ink.decoration! as BoxDecoration;
+      expect(
+        decoration.color,
+        tester.element(core).designTokens.colors.background.level02,
+      );
     });
   });
 
@@ -261,6 +305,23 @@ void main() {
       expect(openTaskTaps, 1);
     });
 
+    testWidgets('created task card activates via keyboard', (tester) async {
+      await pumpView(
+        tester,
+        OnboardingFirstTaskPhase.created,
+        createdTaskTitle: title,
+      );
+
+      final task = find.text(title);
+      final focus = Focus.of(tester.element(task))..requestFocus();
+      await tester.pump();
+      expect(focus.hasPrimaryFocus, isTrue);
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+
+      expect(openTaskTaps, 1);
+    });
+
     testWidgets('the invite glow loops when motion is enabled', (
       tester,
     ) async {
@@ -312,6 +373,23 @@ void main() {
       );
 
       await tester.tap(find.text('Family'), warnIfMissed: false);
+      expect(categoryPicks, ['c2']);
+    });
+
+    testWidgets('an area activates via keyboard', (tester) async {
+      await pumpView(
+        tester,
+        OnboardingFirstTaskPhase.prompt,
+        categories: twoCategories,
+      );
+
+      final family = find.text('Family');
+      final focus = Focus.of(tester.element(family))..requestFocus();
+      await tester.pump();
+      expect(focus.hasPrimaryFocus, isTrue);
+      await tester.sendKeyEvent(LogicalKeyboardKey.space);
+      await tester.pump();
+
       expect(categoryPicks, ['c2']);
     });
 

--- a/test/features/onboarding/ui/widgets/onboarding_hero_test.dart
+++ b/test/features/onboarding/ui/widgets/onboarding_hero_test.dart
@@ -1,8 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
+import 'package:lotti/features/design_system/theme/design_system_theme.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/features/onboarding/ui/widgets/aurora_hero.dart';
+import 'package:lotti/features/onboarding/ui/widgets/crystallize_hero.dart';
 import 'package:lotti/features/onboarding/ui/widgets/neural_constellation.dart';
 import 'package:lotti/features/onboarding/ui/widgets/onboarding_hero.dart';
+import 'package:lotti/features/onboarding/ui/widgets/waveform_text_hero.dart';
 import 'package:lotti/l10n/app_localizations.dart';
 
 import '../../../../widget_test_utils.dart';
@@ -110,6 +115,8 @@ void main() {
     test('constellation welcome uses the entangled multi-vine variant', () {
       final visual = buildOnboardingHeroVisual(
         OnboardingHeroStyle.constellation,
+        tokens: dsTokensLight,
+        brightness: Brightness.light,
       );
 
       final constellation = visual as NeuralConstellation;
@@ -123,7 +130,11 @@ void main() {
       testWidgets('builds a non-null visual for ${style.label}', (
         tester,
       ) async {
-        final visual = buildOnboardingHeroVisual(style);
+        final visual = buildOnboardingHeroVisual(
+          style,
+          tokens: dsTokensLight,
+          brightness: Brightness.light,
+        );
         expect(visual, isNotNull);
         expect(visual, isA<Widget>());
 
@@ -148,9 +159,119 @@ void main() {
         expect(tester.takeException(), isNull);
       });
     }
+
+    test('uses theme-specific visual colours and aurora blending', () {
+      for (final theme in [
+        (
+          tokens: dsTokensLight,
+          brightness: Brightness.light,
+          blendMode: BlendMode.srcOver,
+        ),
+        (
+          tokens: dsTokensDark,
+          brightness: Brightness.dark,
+          blendMode: BlendMode.plus,
+        ),
+      ]) {
+        final constellation =
+            buildOnboardingHeroVisual(
+                  OnboardingHeroStyle.constellation,
+                  tokens: theme.tokens,
+                  brightness: theme.brightness,
+                )
+                as NeuralConstellation;
+        expect(
+          constellation.nodeColor,
+          theme.tokens.colors.interactive.enabled,
+        );
+
+        final crystallize =
+            buildOnboardingHeroVisual(
+                  OnboardingHeroStyle.crystallize,
+                  tokens: theme.tokens,
+                  brightness: theme.brightness,
+                )
+                as CrystallizeHero;
+        expect(
+          crystallize.cardColor,
+          theme.tokens.colors.background.level02,
+        );
+        expect(
+          crystallize.onCardColor,
+          theme.tokens.colors.text.highEmphasis,
+        );
+
+        final aurora =
+            buildOnboardingHeroVisual(
+                  OnboardingHeroStyle.aurora,
+                  tokens: theme.tokens,
+                  brightness: theme.brightness,
+                )
+                as AuroraHero;
+        expect(aurora.blendMode, theme.blendMode);
+
+        final waveform =
+            buildOnboardingHeroVisual(
+                  OnboardingHeroStyle.waveform,
+                  tokens: theme.tokens,
+                  brightness: theme.brightness,
+                )
+                as WaveformTextHero;
+        expect(
+          waveform.textColor,
+          theme.tokens.colors.text.highEmphasis,
+        );
+      }
+    });
   });
 
   group('OnboardingHeroPanel', () {
+    for (final theme in [
+      (
+        name: 'light',
+        data: DesignSystemTheme.light(),
+        tokens: dsTokensLight,
+      ),
+      (
+        name: 'dark',
+        data: DesignSystemTheme.dark(),
+        tokens: dsTokensDark,
+      ),
+    ]) {
+      testWidgets('uses the ${theme.name} surface and text tokens', (
+        tester,
+      ) async {
+        tester.view
+          ..physicalSize = const Size(390, 1000)
+          ..devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+        await tester.pumpWidget(
+          makeTestableWidgetNoScroll(
+            boundedPanel(
+              OnboardingHeroPanel(onConnect: () {}, onSkip: () {}),
+            ),
+            mediaQueryData: reducedMotionMq,
+            theme: theme.data,
+          ),
+        );
+        await tester.pump();
+
+        final panelSurface = tester.widget<ColoredBox>(
+          find.descendant(
+            of: find.byType(OnboardingHeroPanel),
+            matching: find.byType(ColoredBox),
+          ),
+        );
+        final title = tester.widget<Text>(
+          find.text(messages.onboardingWelcomeTitle),
+        );
+
+        expect(panelSurface.color, theme.tokens.colors.background.level01);
+        expect(title.style?.color, theme.tokens.colors.text.highEmphasis);
+      });
+    }
+
     for (final style in OnboardingHeroStyle.values) {
       testWidgets('renders promise text, connect + skip for ${style.label}', (
         tester,

--- a/test/features/onboarding/ui/widgets/onboarding_hero_test.dart
+++ b/test/features/onboarding/ui/widgets/onboarding_hero_test.dart
@@ -180,17 +180,26 @@ void main() {
                   brightness: theme.brightness,
                 )
                 as NeuralConstellation;
+        final expectedNodeColor = theme.brightness == Brightness.light
+            ? theme.tokens.colors.text.highEmphasis
+            : theme.tokens.colors.aiProvider.ollama.color;
+        final expectedLineColor = theme.brightness == Brightness.light
+            ? theme.tokens.colors.text.highEmphasis
+            : theme.tokens.colors.aiProvider.anthropic.color;
+        final expectedPulseColor = theme.brightness == Brightness.light
+            ? theme.tokens.colors.alert.error.defaultColor
+            : theme.tokens.colors.aiCard.accent;
         expect(
           constellation.nodeColor,
-          theme.tokens.colors.aiProvider.ollama.color,
+          expectedNodeColor,
         );
         expect(
           constellation.lineColor,
-          theme.tokens.colors.aiProvider.anthropic.color,
+          expectedLineColor,
         );
         expect(
           constellation.pulseColor,
-          theme.tokens.colors.aiCard.accent,
+          expectedPulseColor,
         );
 
         final crystallize =
@@ -275,12 +284,24 @@ void main() {
           find.text(messages.onboardingWelcomeTitle),
         );
 
+        expect(surfaces.first.color, theme.tokens.colors.background.level01);
+        final heroBox = find
+            .descendant(
+              of: find.byType(OnboardingHeroPanel),
+              matching: find.byType(SizedBox),
+            )
+            .first;
+        final artworkSurface = tester.widget<ColoredBox>(
+          find.descendant(
+            of: heroBox,
+            matching: find.byType(ColoredBox),
+          ),
+        );
         expect(
-          surfaces.map((surface) => surface.color),
-          containsAll([
-            theme.tokens.colors.background.level01,
-            theme.tokens.colors.aiCard.background,
-          ]),
+          artworkSurface.color,
+          theme.name == 'light'
+              ? theme.tokens.colors.background.level01
+              : theme.tokens.colors.aiCard.background,
         );
         expect(title.style?.color, theme.tokens.colors.text.highEmphasis);
         expect(

--- a/test/features/onboarding/ui/widgets/onboarding_hero_test.dart
+++ b/test/features/onboarding/ui/widgets/onboarding_hero_test.dart
@@ -182,7 +182,15 @@ void main() {
                 as NeuralConstellation;
         expect(
           constellation.nodeColor,
-          theme.tokens.colors.interactive.enabled,
+          theme.tokens.colors.aiProvider.ollama.color,
+        );
+        expect(
+          constellation.lineColor,
+          theme.tokens.colors.aiProvider.anthropic.color,
+        );
+        expect(
+          constellation.pulseColor,
+          theme.tokens.colors.aiCard.accent,
         );
 
         final crystallize =
@@ -257,7 +265,7 @@ void main() {
         );
         await tester.pump();
 
-        final panelSurface = tester.widget<ColoredBox>(
+        final surfaces = tester.widgetList<ColoredBox>(
           find.descendant(
             of: find.byType(OnboardingHeroPanel),
             matching: find.byType(ColoredBox),
@@ -267,9 +275,73 @@ void main() {
           find.text(messages.onboardingWelcomeTitle),
         );
 
-        expect(panelSurface.color, theme.tokens.colors.background.level01);
+        expect(
+          surfaces.map((surface) => surface.color),
+          containsAll([
+            theme.tokens.colors.background.level01,
+            theme.tokens.colors.aiCard.background,
+          ]),
+        );
         expect(title.style?.color, theme.tokens.colors.text.highEmphasis);
+        expect(
+          title.style?.fontSize,
+          theme.tokens.typography.styles.heading.heading2.fontSize,
+        );
       });
+
+      testWidgets(
+        'uses the ${theme.name} panel hue for transparent hero fade stops',
+        (tester) async {
+          tester.view
+            ..physicalSize = const Size(390, 1000)
+            ..devicePixelRatio = 1;
+          addTearDown(tester.view.resetPhysicalSize);
+          addTearDown(tester.view.resetDevicePixelRatio);
+          await tester.pumpWidget(
+            makeTestableWidgetNoScroll(
+              boundedPanel(
+                OnboardingHeroPanel(onConnect: () {}, onSkip: () {}),
+              ),
+              mediaQueryData: reducedMotionMq,
+              theme: theme.data,
+            ),
+          );
+          await tester.pump();
+
+          final heroBox = find
+              .descendant(
+                of: find.byType(OnboardingHeroPanel),
+                matching: find.byType(SizedBox),
+              )
+              .first;
+          final gradients = tester
+              .widgetList<DecoratedBox>(
+                find.descendant(
+                  of: heroBox,
+                  matching: find.byType(DecoratedBox),
+                ),
+              )
+              .map((box) => (box.decoration as BoxDecoration).gradient)
+              .whereType<Gradient>();
+          final transparentStops = gradients
+              .expand((gradient) => gradient.colors)
+              .where((color) => color.a == 0);
+          final opaquePanel = theme.tokens.colors.background.level01.withValues(
+            alpha: 1,
+          );
+
+          expect(transparentStops, isNotEmpty);
+          for (final color in transparentStops) {
+            expect(
+              color.withValues(alpha: 1),
+              opaquePanel,
+              reason:
+                  'Transparent black fades darken light surfaces while their '
+                  'alpha is interpolated, creating a visible grey band.',
+            );
+          }
+        },
+      );
     }
 
     for (final style in OnboardingHeroStyle.values) {
@@ -472,5 +544,52 @@ void main() {
       expect(find.byType(CustomPaint), findsWidgets);
       expect(tester.takeException(), isNull);
     });
+
+    for (final theme in [
+      (
+        name: 'light',
+        data: DesignSystemTheme.light(),
+        tokens: dsTokensLight,
+      ),
+      (
+        name: 'dark',
+        data: DesignSystemTheme.dark(),
+        tokens: dsTokensDark,
+      ),
+    ]) {
+      testWidgets(
+        'uses the ${theme.name} surface hue for transparent scrim stops',
+        (tester) async {
+          await tester.pumpWidget(
+            makeTestableWidgetNoScroll(
+              boundedBackdrop(const OnboardingBackdrop()),
+              mediaQueryData: reducedMotionMq,
+              theme: theme.data,
+            ),
+          );
+          await tester.pump();
+
+          final gradients = tester
+              .widgetList<DecoratedBox>(
+                find.descendant(
+                  of: find.byType(OnboardingBackdrop),
+                  matching: find.byType(DecoratedBox),
+                ),
+              )
+              .map((box) => (box.decoration as BoxDecoration).gradient)
+              .whereType<Gradient>();
+          final transparentStops = gradients
+              .expand((gradient) => gradient.colors)
+              .where((color) => color.a == 0);
+          final opaqueSurface = theme.tokens.colors.background.level01
+              .withValues(alpha: 1);
+
+          expect(transparentStops, isNotEmpty);
+          for (final color in transparentStops) {
+            expect(color.withValues(alpha: 1), opaqueSurface);
+          }
+        },
+      );
+    }
   });
 }

--- a/test/features/onboarding/ui/widgets/onboarding_hero_test.dart
+++ b/test/features/onboarding/ui/widgets/onboarding_hero_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lotti/features/ai/ui/animation/ai_running_animation.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_button.dart';
 import 'package:lotti/features/design_system/theme/design_system_theme.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
@@ -112,11 +113,11 @@ void main() {
   });
 
   group('buildOnboardingHeroVisual', () {
-    test('constellation welcome uses the entangled multi-vine variant', () {
+    test('dark constellation uses the entangled multi-vine variant', () {
       final visual = buildOnboardingHeroVisual(
         OnboardingHeroStyle.constellation,
-        tokens: dsTokensLight,
-        brightness: Brightness.light,
+        tokens: dsTokensDark,
+        brightness: Brightness.dark,
       );
 
       final constellation = visual as NeuralConstellation;
@@ -160,6 +161,66 @@ void main() {
       });
     }
 
+    test('uses decoder bars in light mode and the constellation in dark', () {
+      final lightVisual = buildOnboardingHeroVisual(
+        OnboardingHeroStyle.constellation,
+        tokens: dsTokensLight,
+        brightness: Brightness.light,
+      );
+      expect(lightVisual, isA<OnboardingThinkingBarsHero>());
+
+      final darkVisual =
+          buildOnboardingHeroVisual(
+                OnboardingHeroStyle.constellation,
+                tokens: dsTokensDark,
+                brightness: Brightness.dark,
+              )
+              as NeuralConstellation;
+      expect(darkVisual.nodeColor, dsTokensDark.colors.aiProvider.ollama.color);
+      expect(
+        darkVisual.lineColor,
+        dsTokensDark.colors.aiProvider.anthropic.color,
+      );
+      expect(
+        darkVisual.pulseColor,
+        dsTokensDark.colors.proposalKind.update.color,
+      );
+    });
+
+    testWidgets('light welcome reuses the AI decoder-bars treatment', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        makeTestableWidgetNoScroll(
+          const SizedBox(
+            width: 390,
+            height: 276,
+            child: OnboardingThinkingBarsHero(),
+          ),
+          mediaQueryData: reducedMotionMq,
+          theme: DesignSystemTheme.light(),
+        ),
+      );
+      await tester.pump();
+
+      final presence = tester.widget<AiThinkingShaderPresence>(
+        find.byType(AiThinkingShaderPresence),
+      );
+      expect(presence.isRunning, isTrue);
+      expect(presence.height, dsTokensLight.spacing.step10);
+      expect(presence.primaryColor, dsTokensLight.colors.interactive.enabled);
+      expect(
+        presence.secondaryColor,
+        dsTokensLight.colors.text.highEmphasis,
+      );
+      expect(
+        TickerMode.valuesOf(
+          tester.element(find.byType(AiThinkingShaderPresence)),
+        ).enabled,
+        isFalse,
+      );
+    });
+
     test('uses theme-specific visual colours and aurora blending', () {
       for (final theme in [
         (
@@ -173,34 +234,6 @@ void main() {
           blendMode: BlendMode.plus,
         ),
       ]) {
-        final constellation =
-            buildOnboardingHeroVisual(
-                  OnboardingHeroStyle.constellation,
-                  tokens: theme.tokens,
-                  brightness: theme.brightness,
-                )
-                as NeuralConstellation;
-        final expectedNodeColor = theme.brightness == Brightness.light
-            ? theme.tokens.colors.text.highEmphasis.withValues(alpha: 1)
-            : theme.tokens.colors.aiProvider.ollama.color;
-        final expectedLineColor = theme.brightness == Brightness.light
-            ? theme.tokens.colors.text.highEmphasis.withValues(alpha: 1)
-            : theme.tokens.colors.aiProvider.anthropic.color;
-        final expectedPulseColor =
-            theme.tokens.colors.proposalKind.update.color;
-        expect(
-          constellation.nodeColor,
-          expectedNodeColor,
-        );
-        expect(
-          constellation.lineColor,
-          expectedLineColor,
-        );
-        expect(
-          constellation.pulseColor,
-          expectedPulseColor,
-        );
-
         final crystallize =
             buildOnboardingHeroVisual(
                   OnboardingHeroStyle.crystallize,

--- a/test/features/onboarding/ui/widgets/onboarding_hero_test.dart
+++ b/test/features/onboarding/ui/widgets/onboarding_hero_test.dart
@@ -181,14 +181,13 @@ void main() {
                 )
                 as NeuralConstellation;
         final expectedNodeColor = theme.brightness == Brightness.light
-            ? theme.tokens.colors.text.highEmphasis
+            ? theme.tokens.colors.text.highEmphasis.withValues(alpha: 1)
             : theme.tokens.colors.aiProvider.ollama.color;
         final expectedLineColor = theme.brightness == Brightness.light
-            ? theme.tokens.colors.text.highEmphasis
+            ? theme.tokens.colors.text.highEmphasis.withValues(alpha: 1)
             : theme.tokens.colors.aiProvider.anthropic.color;
-        final expectedPulseColor = theme.brightness == Brightness.light
-            ? theme.tokens.colors.alert.error.defaultColor
-            : theme.tokens.colors.aiCard.accent;
+        final expectedPulseColor =
+            theme.tokens.colors.proposalKind.update.color;
         expect(
           constellation.nodeColor,
           expectedNodeColor,


### PR DESCRIPTION
## Summary

- make every AI onboarding step consume the active light or dark design-system tokens instead of installing a dark-only visual island
- adapt the neural constellation, aurora compositing, recording previews, and listening orb so motion remains legible in both themes; light welcome reuses the established AI decoder bars while dark retains the Task Agent-blue constellation signal
- make provider, category, recording, destination, and task-handoff actions keyboard operable with visible focus and localized semantics
- collapse work-area choices to one column for narrow panels and 200%/320% text scaling
- expand the manual screenshot contract from five to nine onboarding states and document the runtime theme/accessibility architecture

## Before / after

| Before: light app with dark-only onboarding | After: active light theme |
| --- | --- |
| <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/01d838e26e01dbc1ac008d5025d6f11a7c0a615a/pr-screenshots/onboarding-light-mode/before-manual.png" width="560" alt="Manual screenshot showing dark onboarding inside a light app" /> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/01d838e26e01dbc1ac008d5025d6f11a7c0a615a/pr-screenshots/onboarding-light-mode/final/onboarding_welcome_desktop_light.png" width="560" alt="Onboarding welcome following the light theme" /> |

| Light first-task recording | Dark first-task recording |
| --- | --- |
| <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/01d838e26e01dbc1ac008d5025d6f11a7c0a615a/pr-screenshots/onboarding-light-mode/final/onboarding_first_task_desktop_light.png" width="560" alt="Light themed onboarding first-task recording" /> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/01d838e26e01dbc1ac008d5025d6f11a7c0a615a/pr-screenshots/onboarding-light-mode/final/onboarding_first_task_desktop_dark.png" width="560" alt="Dark themed onboarding first-task recording" /> |

| Recording style | Work areas |
| --- | --- |
| <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/01d838e26e01dbc1ac008d5025d6f11a7c0a615a/pr-screenshots/onboarding-light-mode/final/onboarding_recording_style_mobile_light.png" width="360" alt="Light themed recording style selection" /> | <img src="https://raw.githubusercontent.com/matthiasn/lotti-docs/01d838e26e01dbc1ac008d5025d6f11a7c0a615a/pr-screenshots/onboarding-light-mode/final/onboarding_categories_mobile_light.png" width="360" alt="Light themed work-area selection" /> |

The immutable review asset commit contains all 36 mobile/desktop × light/dark captures for the nine onboarding states.

## Verification

- `fvm dart format .` — 4,014 files checked and onboarding source/tests normalized
- `fvm flutter analyze --no-pub` — no issues found
- 103 focused Flutter widget/unit tests — all passed
- onboarding manual screenshot harness — 8 refreshed welcome/first-task captures passed
- `npm run check` in `docs-site/` — typecheck, metadata validation, 11 tests, production build, and built-site smoke test passed
- `git diff --check` — clean
- full repository test suite intentionally left to the existing CI shards per repository policy

## Panel review follow-up

- Design: compare the light bloom density and local-provider tile neutrality on a calibrated display.
- Motion: review hero and recording playback at device refresh rate and with Reduce Motion enabled.
- Accessibility: spot-check keyboard traversal plus VoiceOver/TalkBack announcements at 200% and 320% text scaling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Onboarding now follows the active light/dark theme throughout setup (panels, typography, artwork, and previews).
  * Voice controls support an optional themed listening-core color.
  * Added onboarding screenshots for provider verification, connection success, recording style, and work-area selection.
* **Bug Fixes**
  * Removed dark-only styling so setup visuals stay consistent with the current theme.
* **Documentation**
  * Refreshed onboarding guidance for theming/animations and added reduced-motion details.
* **Tests**
  * Expanded theme- and keyboard-accessibility coverage for onboarding and voice widgets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->