### PR TITLE
fix: keep entry date readable next to header actions on narrow phones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.9.1051]
+### Fixed
+- **The entry date stays readable on narrow phones.** When an entry header's
+  action buttons (AI assistant, flag, star, overflow menu) would leave the
+  timestamp squeezed into an ellipsis, the gaps between the buttons now
+  compress so the date and time remain visible. Wider screens keep the
+  original comfortable spacing, and every button keeps its full-size tap
+  target.
+
 ### Added
 - **The desktop sidebar now opens the Lotti Manual directly.** A localized
   Manual link sits immediately above Settings, remains available when the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **The entry date stays readable on narrow phones.** When an entry header's
   action buttons (AI assistant, flag, star, overflow menu) would leave the
-  timestamp squeezed into an ellipsis, the gaps between the buttons now
-  compress so the date and time remain visible. Wider screens keep the
-  original comfortable spacing, and every button keeps its full-size tap
-  target.
+  timestamp squeezed into an ellipsis, the action rail now uses tighter 4px
+  gaps so the date and time remain visible while every button keeps its
+  full-size tap target.
 
 ### Added
 - **The desktop sidebar now opens the Lotti Manual directly.** A localized

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -42,6 +42,7 @@
           <p>Onboarding now follows the active light or dark theme throughout setup. Panels, text, controls, provider tiles, recording previews, task handoff states, and the animated neural and aurora artwork all adapt to the matching design-system palette. Critical setup actions support keyboard activation, and scaled text switches work areas to a readable single-column layout.</p>
           <p>The desktop sidebar is navigation-first and keeps important task filters visible. Saved task filters now appear directly under Tasks with live counts. The first five follow the order you set, More expands the complete list without a limit, and the manager handles reordering, renaming, and deleting. Recording, timer, and agent status share one compact expandable activity row, while healthy sync stays quiet until work needs attention.</p>
           <p>Saving a task filter now stays inside the filter flow, with explicit Update filter and Save as new choices instead of a separate popup.</p>
+          <p>The entry date stays readable on narrow phones. When an entry header's action buttons would leave the timestamp squeezed into an ellipsis, the gaps between the buttons now compress so the date and time remain visible, while every button keeps its full-size tap target.</p>
       </description>
     </release>
     <release version="0.9.1049" date="2026-07-16">

--- a/flatpak/com.matthiasn.lotti.metainfo.xml
+++ b/flatpak/com.matthiasn.lotti.metainfo.xml
@@ -42,7 +42,7 @@
           <p>Onboarding now follows the active light or dark theme throughout setup. Panels, text, controls, provider tiles, recording previews, task handoff states, and the animated neural and aurora artwork all adapt to the matching design-system palette. Critical setup actions support keyboard activation, and scaled text switches work areas to a readable single-column layout.</p>
           <p>The desktop sidebar is navigation-first and keeps important task filters visible. Saved task filters now appear directly under Tasks with live counts. The first five follow the order you set, More expands the complete list without a limit, and the manager handles reordering, renaming, and deleting. Recording, timer, and agent status share one compact expandable activity row, while healthy sync stays quiet until work needs attention.</p>
           <p>Saving a task filter now stays inside the filter flow, with explicit Update filter and Save as new choices instead of a separate popup.</p>
-          <p>The entry date stays readable on narrow phones. When an entry header's action buttons would leave the timestamp squeezed into an ellipsis, the gaps between the buttons now compress so the date and time remain visible, while every button keeps its full-size tap target.</p>
+          <p>The entry date stays readable on narrow phones. Entry-header action buttons now use tighter 4px gaps, so the date and time remain visible while every button keeps its full-size tap target.</p>
       </description>
     </release>
     <release version="0.9.1049" date="2026-07-16">

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,4 +1,7 @@
 PODS:
+  - audio_decoder (0.7.4):
+    - Flutter
+    - FlutterMacOS
   - audio_session (0.0.1):
     - Flutter
   - audioplayers_darwin (0.0.1):
@@ -18,6 +21,8 @@ PODS:
     - SDWebImageWebPCoder
   - flutter_keyboard_visibility_temp_fork (0.0.1):
     - Flutter
+  - flutter_lame (1.0.0):
+    - Flutter
   - flutter_local_notifications (0.0.1):
     - Flutter
   - flutter_onnxruntime (0.0.1):
@@ -34,7 +39,7 @@ PODS:
   - gal (1.0.0):
     - Flutter
     - FlutterMacOS
-  - health (13.1.4):
+  - health (13.3.1):
     - Flutter
   - image_picker_ios (0.0.1):
     - Flutter
@@ -60,8 +65,9 @@ PODS:
   - libwebp/sharpyuv (1.5.0)
   - libwebp/webp (1.5.0):
     - libwebp/sharpyuv
-  - location (0.0.1):
+  - location (8.0.1):
     - Flutter
+    - FlutterMacOS
   - Mantle (2.2.0):
     - Mantle/extobjc (= 2.2.0)
   - Mantle/extobjc (2.2.0)
@@ -142,6 +148,7 @@ PODS:
     - FlutterMacOS
 
 DEPENDENCIES:
+  - audio_decoder (from `.symlinks/plugins/audio_decoder/darwin`)
   - audio_session (from `.symlinks/plugins/audio_session/ios`)
   - audioplayers_darwin (from `.symlinks/plugins/audioplayers_darwin/darwin`)
   - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
@@ -150,6 +157,7 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_image_compress_common (from `.symlinks/plugins/flutter_image_compress_common/ios`)
   - flutter_keyboard_visibility_temp_fork (from `.symlinks/plugins/flutter_keyboard_visibility_temp_fork/ios`)
+  - flutter_lame (from `.symlinks/plugins/flutter_lame/ios`)
   - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - flutter_onnxruntime (from `.symlinks/plugins/flutter_onnxruntime/ios`)
   - flutter_openssl_crypto (from `.symlinks/plugins/flutter_openssl_crypto/ios`)
@@ -162,7 +170,7 @@ DEPENDENCIES:
   - irondash_engine_context (from `.symlinks/plugins/irondash_engine_context/ios`)
   - just_audio (from `.symlinks/plugins/just_audio/darwin`)
   - just_waveform (from `.symlinks/plugins/just_waveform/darwin`)
-  - location (from `.symlinks/plugins/location/ios`)
+  - location (from `.symlinks/plugins/location/darwin`)
   - media_kit_libs_ios_audio (from `.symlinks/plugins/media_kit_libs_ios_audio/ios`)
   - mobile_scanner (from `.symlinks/plugins/mobile_scanner/darwin`)
   - objectbox_flutter_libs (from `.symlinks/plugins/objectbox_flutter_libs/ios`)
@@ -193,6 +201,8 @@ SPEC REPOS:
     - sqlite3
 
 EXTERNAL SOURCES:
+  audio_decoder:
+    :path: ".symlinks/plugins/audio_decoder/darwin"
   audio_session:
     :path: ".symlinks/plugins/audio_session/ios"
   audioplayers_darwin:
@@ -209,6 +219,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_image_compress_common/ios"
   flutter_keyboard_visibility_temp_fork:
     :path: ".symlinks/plugins/flutter_keyboard_visibility_temp_fork/ios"
+  flutter_lame:
+    :path: ".symlinks/plugins/flutter_lame/ios"
   flutter_local_notifications:
     :path: ".symlinks/plugins/flutter_local_notifications/ios"
   flutter_onnxruntime:
@@ -234,7 +246,7 @@ EXTERNAL SOURCES:
   just_waveform:
     :path: ".symlinks/plugins/just_waveform/darwin"
   location:
-    :path: ".symlinks/plugins/location/ios"
+    :path: ".symlinks/plugins/location/darwin"
   media_kit_libs_ios_audio:
     :path: ".symlinks/plugins/media_kit_libs_ios_audio/ios"
   mobile_scanner:
@@ -269,6 +281,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/video_player_avfoundation/darwin"
 
 SPEC CHECKSUMS:
+  audio_decoder: 9d20f77489715b63730ff64bbef05aa68190c2e0
   audio_session: 9bb7f6c970f21241b19f5a3658097ae459681ba0
   audioplayers_darwin: 835ced6edd4c9fc8ebb0a7cc9e294a91d99917d5
   connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
@@ -277,20 +290,21 @@ SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_image_compress_common: 1697a328fd72bfb335507c6bca1a65fa5ad87df1
   flutter_keyboard_visibility_temp_fork: 95b2d534bacf6ac62e7fcbe5c2a9e2c2a17ce06f
+  flutter_lame: bee3d284f5ca264d3ab4c0c898ce219ddfeba03d
   flutter_local_notifications: 643a3eda1ce1c0599413ca31672536d423dee214
   flutter_onnxruntime: 577a012771672fd168079e29be7909a9d0f9c302
   flutter_openssl_crypto: 73dcefff7611c3ac324d82726047d8335d0b6e57
   flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
   flutter_vodozemac: 46015daf07988356d46784d05ab0c7afca00ff36
   gal: baecd024ebfd13c441269ca7404792a7152fde89
-  health: 32d2fbc7f26f9a2388d1a514ce168adbfa5bda65
+  health: 4decf5d74e8f54c58a8c07a385fc72f629a831d9
   image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   irondash_engine_context: 8e58ca8e0212ee9d1c7dc6a42121849986c88486
   just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed
   just_waveform: be2cb6dec86096cb972bf8b73c893fe16bf1cff4
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
-  location: 155caecf9da4f280ab5fe4a55f94ceccfab838f8
+  location: 45c20040d0ccac3cb109821a9e7f2d39c468988c
   Mantle: c5aa8794a29a022dfbbfc9799af95f477a69b62d
   media_kit_libs_ios_audio: 905e6323b72e65c63ab9262b2e473f52c024a3a8
   mobile_scanner: 9157936403f5a0644ca3779a38ff8404c5434a93

--- a/lib/features/journal/README.md
+++ b/lib/features/journal/README.md
@@ -114,6 +114,26 @@ It composes:
 
 That is the real boundary: the journal feature owns the page frame and the switching logic, while other features supply some of the per-type payload UI.
 
+### Detail Header Action Rail
+
+[`EntryDetailHeader`](ui/widgets/entry_details/header/entry_detail_header.dart)
+keeps the editable date/time cluster on the leading edge and assembles the
+right-side controls from the current entry: optional collapse, AI, rating-edit,
+and flagged controls, then the consistently anchored favorite and overflow
+controls. AI is included only when an applicable skill is available, so a
+zero-width AI placeholder cannot consume layout space.
+
+Every action keeps its 48px-wide tap target. The inter-control gap always uses
+the design-system `spacing.step2` (4px), so the timestamp gets the maximum
+available width without hiding or clipping an action.
+
+```mermaid
+flowchart LR
+  Entry["Entry state"] --> Actions["Build available actions"]
+  Actions --> Rail["48px action targets\nstep2 (4px) gaps"]
+  Rail --> Render["Render timestamp + action rail"]
+```
+
 ### Image Viewer
 
 [`EntryImageWidget`](ui/widgets/entry_image_widget.dart) renders a downsampled inline `JournalImage` preview and pushes `HeroPhotoViewRouteWrapper` on tap. The route is non-opaque with a scrim barrier, so the detail page remains visible but darkened behind the viewer. `PhotoView` still owns pinch-zoom and panning; the viewer chrome drives the same `PhotoViewController` and `PhotoViewScaleStateController` for button zoom, reset, and the visible scale readout.

--- a/lib/features/journal/ui/widgets/entry_details/header/entry_detail_header.dart
+++ b/lib/features/journal/ui/widgets/entry_details/header/entry_detail_header.dart
@@ -101,69 +101,28 @@ class _EntryDetailHeaderState extends ConsumerState<EntryDetailHeader> {
         entry is! JournalEvent &&
         !widget.inLinkedEntries;
     final actions = _trailingActions(context, entry, id, notifier, tokens);
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        return Row(
-          children: [
-            // The date/category cluster takes the slack the old Spacer held,
-            // but as an Expanded it also *yields* it: on narrow phones the
-            // trailing action buttons (ending in the overflow `…`) keep their
-            // full width and the timestamp stacks the date over the time (see
-            // EntryDatetimeWidget) instead of the row overflowing and the `…`
-            // being clipped by the card's rounded clip.
-            Expanded(
-              child: Row(
-                children: [
-                  Flexible(child: EntryDatetimeWidget(entryId: widget.entryId)),
-                  if (showCategory) ...[
-                    SizedBox(width: tokens.spacing.step3),
-                    CategorySelectionIconButton(entry: entry),
-                  ],
-                ],
-              ),
-            ),
-            ..._spacedTrailing(
-              context,
-              actions,
-              compact: _useCompactTrailingGaps(
-                maxWidth: constraints.maxWidth,
-                actionCount: actions.length,
-                spacing: tokens.spacing,
-                // The category button sits in the leading cluster, so the
-                // timestamp needs its reserve on top of that button's width.
-                leadingReserve: showCategory
-                    ? tokens.spacing.step3 + AppTheme.headerActionWidth
-                    : 0,
-              ),
-            ),
-          ],
-        );
-      },
+    return Row(
+      children: [
+        // The date/category cluster takes the slack the old Spacer held, but
+        // as an Expanded it also *yields* it: on narrow phones the trailing
+        // action buttons (ending in the overflow `…`) keep their full width
+        // and the timestamp stacks the date over the time (see
+        // EntryDatetimeWidget) instead of the row overflowing and the `…`
+        // being clipped by the card's rounded clip.
+        Expanded(
+          child: Row(
+            children: [
+              Flexible(child: EntryDatetimeWidget(entryId: widget.entryId)),
+              if (showCategory) ...[
+                SizedBox(width: tokens.spacing.step3),
+                CategorySelectionIconButton(entry: entry),
+              ],
+            ],
+          ),
+        ),
+        ..._spacedTrailing(context, actions),
+      ],
     );
-  }
-
-  /// Whether the trailing action gaps should compress to keep the timestamp
-  /// legible.
-  ///
-  /// Compares the width the rail would take with the comfortable (step5) gaps
-  /// against what the row actually has: if the leftover for the leading
-  /// timestamp cluster falls below [AppTheme.headerTimestampMinWidth] (plus
-  /// [leadingReserve] for the category button when present), the gaps switch
-  /// to compact. An unbounded width always fits comfortably.
-  bool _useCompactTrailingGaps({
-    required double maxWidth,
-    required int actionCount,
-    required DsSpacing spacing,
-    required double leadingReserve,
-  }) {
-    if (!maxWidth.isFinite || actionCount == 0) {
-      return false;
-    }
-    final comfortableRail =
-        actionCount * AppTheme.headerActionWidth +
-        (actionCount - 1) * spacing.step5;
-    return maxWidth - comfortableRail <
-        AppTheme.headerTimestampMinWidth + leadingReserve;
   }
 
   /// Whether the AI slot will actually render a control for [entry].
@@ -171,9 +130,8 @@ class _EntryDetailHeaderState extends ConsumerState<EntryDetailHeader> {
   /// [UnifiedAiPopUpMenu] collapses to a zero-width placeholder while no AI
   /// skills are available for the entry, so the header only adds the slot once
   /// skills exist: counting the invisible slot as a full-width action would
-  /// compress the trailing gaps a whole slot too early (see
-  /// [_useCompactTrailingGaps]) and leave a doubled inter-control gap around
-  /// the empty widget.
+  /// reserve a whole slot and leave a doubled inter-control gap around the
+  /// empty widget.
   bool _hasAiSkills(JournalEntity entry) {
     final hasSkills = ref.watch(
       hasAvailableSkillsProvider(
@@ -276,25 +234,22 @@ class _EntryDetailHeaderState extends ConsumerState<EntryDetailHeader> {
   /// Interleaves one uniform inter-control gap between every adjacent header
   /// control.
   ///
-  /// The comfortable gap (step5) sits on top of each control's 48px hit area
-  /// and keeps the crowded 4-control headers from being a mis-tap hazard for
+  /// The compact step2 gap sits on top of each control's 48px hit area, so the
+  /// header uses the available width for the timestamp without shrinking any
+  /// accessible tap targets.
+  ///
+  /// The controls remain separated enough to avoid a mis-tap hazard for
   /// motor-impaired users, keeping the favorite toggle clear of the
-  /// (destructive-capable) overflow menu. When [compact] (narrow phones, see
-  /// [_useCompactTrailingGaps]) the gap drops to step2: the 48px tap targets —
-  /// each with ~10px of visual whitespace around its 28px glyph — already
-  /// provide the tap separation, and the reclaimed width is what keeps the
-  /// timestamp from ellipsizing to `20…` behind the action rail.
+  /// (destructive-capable) overflow menu.
   List<Widget> _spacedTrailing(
     BuildContext context,
-    List<Widget> actions, {
-    required bool compact,
-  }) {
+    List<Widget> actions,
+  ) {
     final spacing = context.designTokens.spacing;
-    final gap = compact ? spacing.step2 : spacing.step5;
     final out = <Widget>[];
     for (var i = 0; i < actions.length; i++) {
       if (i > 0) {
-        out.add(SizedBox(width: gap));
+        out.add(SizedBox(width: spacing.step2));
       }
       out.add(actions[i]);
     }
@@ -355,36 +310,23 @@ class _EntryDetailHeaderState extends ConsumerState<EntryDetailHeader> {
       tokens,
       collapseChevron: chevron,
     );
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        return Row(
-          children: [
-            // Expanded (not a fixed widget + Spacer) so the timestamp yields
-            // space to the trailing rail on narrow phones (stacking date over
-            // time) instead of the row overflowing and clipping the overflow
-            // `…`. The Align keeps the datetime widget's tap target at its
-            // intrinsic text width — without it the Expanded would stretch the
-            // underlying GestureDetector across the empty gap and make that
-            // whitespace open the date/time picker.
-            Expanded(
-              child: Align(
-                alignment: Alignment.centerLeft,
-                child: EntryDatetimeWidget(entryId: widget.entryId),
-              ),
-            ),
-            ..._spacedTrailing(
-              context,
-              actions,
-              compact: _useCompactTrailingGaps(
-                maxWidth: constraints.maxWidth,
-                actionCount: actions.length,
-                spacing: tokens.spacing,
-                leadingReserve: 0,
-              ),
-            ),
-          ],
-        );
-      },
+    return Row(
+      children: [
+        // Expanded (not a fixed widget + Spacer) so the timestamp yields
+        // space to the trailing rail on narrow phones (stacking date over
+        // time) instead of the row overflowing and clipping the overflow
+        // `…`. The Align keeps the datetime widget's tap target at its
+        // intrinsic text width — without it the Expanded would stretch the
+        // underlying GestureDetector across the empty gap and make that
+        // whitespace open the date/time picker.
+        Expanded(
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: EntryDatetimeWidget(entryId: widget.entryId),
+          ),
+        ),
+        ..._spacedTrailing(context, actions),
+      ],
     );
   }
 

--- a/lib/features/journal/ui/widgets/entry_details/header/entry_detail_header.dart
+++ b/lib/features/journal/ui/widgets/entry_details/header/entry_detail_header.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lotti/classes/entry_link.dart';
 import 'package:lotti/classes/journal_entities.dart';
+import 'package:lotti/features/ai/state/skill_trigger_providers.dart';
 import 'package:lotti/features/ai/ui/unified_ai_popup_menu.dart';
 import 'package:lotti/features/categories/ui/widgets/category_selection_icon_button.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
@@ -75,7 +76,10 @@ class _EntryDetailHeaderState extends ConsumerState<EntryDetailHeader> {
     return IconButtonTheme(
       data: IconButtonThemeData(
         style: IconButton.styleFrom(
-          minimumSize: const Size(48, 40),
+          minimumSize: const Size(
+            AppTheme.headerActionWidth,
+            AppTheme.headerActionHeight,
+          ),
           padding: EdgeInsets.zero,
           tapTargetSize: MaterialTapTargetSize.shrinkWrap,
         ),
@@ -96,31 +100,88 @@ class _EntryDetailHeaderState extends ConsumerState<EntryDetailHeader> {
         entry is! Task &&
         entry is! JournalEvent &&
         !widget.inLinkedEntries;
-    return Row(
-      children: [
-        // The date/category cluster takes the slack the old Spacer held, but as
-        // an Expanded it also *yields* it: on narrow phones the trailing action
-        // buttons (ending in the overflow `…`) keep their full width and the
-        // timestamp stacks the date over the time (see EntryDatetimeWidget)
-        // instead of the row overflowing and the `…` being clipped by the
-        // card's rounded clip.
-        Expanded(
-          child: Row(
-            children: [
-              Flexible(child: EntryDatetimeWidget(entryId: widget.entryId)),
-              if (showCategory) ...[
-                SizedBox(width: tokens.spacing.step3),
-                CategorySelectionIconButton(entry: entry),
-              ],
-            ],
-          ),
-        ),
-        ..._spacedTrailing(
-          context,
-          _trailingActions(context, entry, id, notifier, tokens),
-        ),
-      ],
+    final actions = _trailingActions(context, entry, id, notifier, tokens);
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return Row(
+          children: [
+            // The date/category cluster takes the slack the old Spacer held,
+            // but as an Expanded it also *yields* it: on narrow phones the
+            // trailing action buttons (ending in the overflow `…`) keep their
+            // full width and the timestamp stacks the date over the time (see
+            // EntryDatetimeWidget) instead of the row overflowing and the `…`
+            // being clipped by the card's rounded clip.
+            Expanded(
+              child: Row(
+                children: [
+                  Flexible(child: EntryDatetimeWidget(entryId: widget.entryId)),
+                  if (showCategory) ...[
+                    SizedBox(width: tokens.spacing.step3),
+                    CategorySelectionIconButton(entry: entry),
+                  ],
+                ],
+              ),
+            ),
+            ..._spacedTrailing(
+              context,
+              actions,
+              compact: _useCompactTrailingGaps(
+                maxWidth: constraints.maxWidth,
+                actionCount: actions.length,
+                spacing: tokens.spacing,
+                // The category button sits in the leading cluster, so the
+                // timestamp needs its reserve on top of that button's width.
+                leadingReserve: showCategory
+                    ? tokens.spacing.step3 + AppTheme.headerActionWidth
+                    : 0,
+              ),
+            ),
+          ],
+        );
+      },
     );
+  }
+
+  /// Whether the trailing action gaps should compress to keep the timestamp
+  /// legible.
+  ///
+  /// Compares the width the rail would take with the comfortable (step5) gaps
+  /// against what the row actually has: if the leftover for the leading
+  /// timestamp cluster falls below [AppTheme.headerTimestampMinWidth] (plus
+  /// [leadingReserve] for the category button when present), the gaps switch
+  /// to compact. An unbounded width always fits comfortably.
+  bool _useCompactTrailingGaps({
+    required double maxWidth,
+    required int actionCount,
+    required DsSpacing spacing,
+    required double leadingReserve,
+  }) {
+    if (!maxWidth.isFinite || actionCount == 0) {
+      return false;
+    }
+    final comfortableRail =
+        actionCount * AppTheme.headerActionWidth +
+        (actionCount - 1) * spacing.step5;
+    return maxWidth - comfortableRail <
+        AppTheme.headerTimestampMinWidth + leadingReserve;
+  }
+
+  /// Whether the AI slot will actually render a control for [entry].
+  ///
+  /// [UnifiedAiPopUpMenu] collapses to a zero-width placeholder while no AI
+  /// skills are available for the entry, so the header only adds the slot once
+  /// skills exist: counting the invisible slot as a full-width action would
+  /// compress the trailing gaps a whole slot too early (see
+  /// [_useCompactTrailingGaps]) and leave a doubled inter-control gap around
+  /// the empty widget.
+  bool _hasAiSkills(JournalEntity entry) {
+    final hasSkills = ref.watch(
+      hasAvailableSkillsProvider(
+        (entityId: entry.id, linkedFromId: widget.linkedFromId),
+      ),
+    );
+    // hasValue (not isLoading) so the slot survives background refreshes.
+    return hasSkills.hasValue && hasSkills.value!;
   }
 
   /// The trailing action controls shared by both header layouts.
@@ -128,9 +189,10 @@ class _EntryDetailHeaderState extends ConsumerState<EntryDetailHeader> {
   /// The two universal controls — favorite, then overflow — are pinned as the
   /// rightmost two slots so they sit at an identical x on every card type and a
   /// user can build muscle memory for them. The type-specific affordances
-  /// ([collapseChevron], AI, flag) grow *inward* from that fixed anchor, so the
-  /// star/overflow pair never shifts and the collapse chevron is kept well clear
-  /// of the overflow `…` (the near-identical grey pair was a mis-tap hazard).
+  /// ([collapseChevron], AI when skills are available, flag) grow *inward*
+  /// from that fixed anchor, so the star/overflow pair never shifts and the
+  /// collapse chevron is kept well clear of the overflow `…` (the
+  /// near-identical grey pair was a mis-tap hazard).
   List<Widget> _trailingActions(
     BuildContext context,
     JournalEntity? entry,
@@ -146,7 +208,8 @@ class _EntryDetailHeaderState extends ConsumerState<EntryDetailHeader> {
           (entry is Task ||
               entry is JournalImage ||
               entry is JournalAudio ||
-              entry is JournalEntry))
+              entry is JournalEntry) &&
+          _hasAiSkills(entry))
         UnifiedAiPopUpMenu(
           journalEntity: entry,
           linkedFromId: widget.linkedFromId,
@@ -210,18 +273,28 @@ class _EntryDetailHeaderState extends ConsumerState<EntryDetailHeader> {
     ];
   }
 
-  /// Interleaves one wide, uniform inter-control gap (step5) between every
-  /// adjacent header control. The enlarged glyphs left less whitespace inside
-  /// each 48px tap target, so a wider visible gap (on top of the 48px hit area)
-  /// is what keeps the crowded 4-control headers from being a mis-tap hazard for
-  /// motor-impaired users and keeps the favorite toggle clear of the
-  /// (destructive-capable) overflow menu.
-  List<Widget> _spacedTrailing(BuildContext context, List<Widget> actions) {
+  /// Interleaves one uniform inter-control gap between every adjacent header
+  /// control.
+  ///
+  /// The comfortable gap (step5) sits on top of each control's 48px hit area
+  /// and keeps the crowded 4-control headers from being a mis-tap hazard for
+  /// motor-impaired users, keeping the favorite toggle clear of the
+  /// (destructive-capable) overflow menu. When [compact] (narrow phones, see
+  /// [_useCompactTrailingGaps]) the gap drops to step2: the 48px tap targets —
+  /// each with ~10px of visual whitespace around its 28px glyph — already
+  /// provide the tap separation, and the reclaimed width is what keeps the
+  /// timestamp from ellipsizing to `20…` behind the action rail.
+  List<Widget> _spacedTrailing(
+    BuildContext context,
+    List<Widget> actions, {
+    required bool compact,
+  }) {
     final spacing = context.designTokens.spacing;
+    final gap = compact ? spacing.step2 : spacing.step5;
     final out = <Widget>[];
     for (var i = 0; i < actions.length; i++) {
       if (i > 0) {
-        out.add(SizedBox(width: spacing.step5));
+        out.add(SizedBox(width: gap));
       }
       out.add(actions[i]);
     }
@@ -274,33 +347,44 @@ class _EntryDetailHeaderState extends ConsumerState<EntryDetailHeader> {
     // header — favorite + overflow pinned right, the collapse chevron folded
     // into the inward type-specific slot so the star/overflow anchor stays at
     // the same x as every other card type.
-    return Row(
-      children: [
-        // Expanded (not a fixed widget + Spacer) so the timestamp yields space
-        // to the trailing rail on narrow phones (stacking date over time)
-        // instead of the row overflowing and clipping the overflow `…`. The
-        // Align keeps the datetime widget's tap target at its intrinsic text
-        // width — without it the Expanded would stretch the underlying
-        // GestureDetector across the empty gap and make that whitespace open
-        // the date/time picker.
-        Expanded(
-          child: Align(
-            alignment: Alignment.centerLeft,
-            child: EntryDatetimeWidget(entryId: widget.entryId),
-          ),
-        ),
-        ..._spacedTrailing(
-          context,
-          _trailingActions(
-            context,
-            entry,
-            id,
-            notifier,
-            tokens,
-            collapseChevron: chevron,
-          ),
-        ),
-      ],
+    final actions = _trailingActions(
+      context,
+      entry,
+      id,
+      notifier,
+      tokens,
+      collapseChevron: chevron,
+    );
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return Row(
+          children: [
+            // Expanded (not a fixed widget + Spacer) so the timestamp yields
+            // space to the trailing rail on narrow phones (stacking date over
+            // time) instead of the row overflowing and clipping the overflow
+            // `…`. The Align keeps the datetime widget's tap target at its
+            // intrinsic text width — without it the Expanded would stretch the
+            // underlying GestureDetector across the empty gap and make that
+            // whitespace open the date/time picker.
+            Expanded(
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: EntryDatetimeWidget(entryId: widget.entryId),
+              ),
+            ),
+            ..._spacedTrailing(
+              context,
+              actions,
+              compact: _useCompactTrailingGaps(
+                maxWidth: constraints.maxWidth,
+                actionCount: actions.length,
+                spacing: tokens.spacing,
+                leadingReserve: 0,
+              ),
+            ),
+          ],
+        );
+      },
     );
   }
 

--- a/lib/features/journal/ui/widgets/entry_details/header/switch_icon_widget.dart
+++ b/lib/features/journal/ui/widgets/entry_details/header/switch_icon_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
+import 'package:lotti/themes/theme.dart';
 
 class SwitchIconWidget extends StatelessWidget {
   const SwitchIconWidget({
@@ -28,9 +29,9 @@ class SwitchIconWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      // 48px to match the other header controls' tap target so the favorite
-      // toggle is not the one cramped, harder-to-hit control in the cluster.
-      width: 48,
+      // Match the other header controls' tap target so the favorite toggle is
+      // not the one cramped, harder-to-hit control in the cluster.
+      width: AppTheme.headerActionWidth,
       child: IconButton(
         splashColor: Colors.transparent,
         focusColor: Colors.transparent,

--- a/lib/themes/theme_constants.dart
+++ b/lib/themes/theme_constants.dart
@@ -32,12 +32,6 @@ class AppTheme {
   // than its content (see EntryDetailHeader's IconButtonTheme).
   static const double headerActionWidth = 48;
   static const double headerActionHeight = 40;
-  // Minimum width the header keeps clear for the leading timestamp cluster.
-  // When the wide (step5) inter-action gaps would leave less than this, the
-  // gaps compress (step2) so the date stays legible instead of ellipsizing
-  // to `20…` behind the action rail on narrow phones.
-  static const double headerTimestampMinWidth = 96;
-
   // Spacing constants
   static const double spacingXSmall = 4;
   static const double spacingSmall = 8;

--- a/lib/themes/theme_constants.dart
+++ b/lib/themes/theme_constants.dart
@@ -27,6 +27,16 @@ class AppTheme {
   // glyph than the default body icon so the thin outline controls (esp. the
   // unfavorited star) stay perceptible for low-vision users on the dark card.
   static const double headerActionIconSize = 28;
+  // Entry-card header action tap targets: full 48px wide for accessible
+  // horizontal separation, but only 40px tall so the header row is not taller
+  // than its content (see EntryDetailHeader's IconButtonTheme).
+  static const double headerActionWidth = 48;
+  static const double headerActionHeight = 40;
+  // Minimum width the header keeps clear for the leading timestamp cluster.
+  // When the wide (step5) inter-action gaps would leave less than this, the
+  // gaps compress (step2) so the date stays legible instead of ellipsizing
+  // to `20…` behind the action rail on narrow phones.
+  static const double headerTimestampMinWidth = 96;
 
   // Spacing constants
   static const double spacingXSmall = 4;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lotti
 description: Achieve your goals and keep your data private with Lotti.
 publish_to: 'none'
-version: 0.9.1051+4221
+version: 0.9.1051+4222
 
 msix_config:
   display_name: LottiApp

--- a/test/features/journal/ui/widgets/entry_details/header/entry_detail_header_test.dart
+++ b/test/features/journal/ui/widgets/entry_details/header/entry_detail_header_test.dart
@@ -38,7 +38,7 @@ DsSpacing _headerSpacing(WidgetTester tester) =>
     tester.element(find.byType(EntryDetailHeader)).designTokens.spacing;
 
 /// The widths of the spacer boxes between the header's trailing action
-/// controls (step2 when compact, step5 when comfortable).
+/// controls (step2 at every width).
 ///
 /// Inspects only the direct children of the header's outer Row (the one whose
 /// leading child is the Expanded timestamp cluster), so same-width SizedBoxes
@@ -56,9 +56,7 @@ List<double> _trailingGapWidths(WidgetTester tester) {
   return headerRow.children
       .whereType<SizedBox>()
       .where(
-        (s) =>
-            s.child == null &&
-            (s.width == spacing.step2 || s.width == spacing.step5),
+        (s) => s.child == null && s.width == spacing.step2,
       )
       .map((s) => s.width!)
       .toList();
@@ -231,7 +229,7 @@ void main() {
     );
 
     testWidgets(
-      'compresses trailing gaps at narrow widths so the timestamp keeps room',
+      'uses compact trailing gaps so the timestamp keeps room at narrow width',
       (WidgetTester tester) async {
         // Flag + AI skill maximize the trailing rail (AI + flag + star +
         // overflow, four full 48px controls) — the worst case that squeezed
@@ -255,7 +253,7 @@ void main() {
                 )
                 as AiConfigSkill;
 
-        const headerWidth = 330.0;
+        const headerWidth = 300.0;
         await tester.pumpWidget(
           makeTestableWidgetWithScaffold(
             Align(
@@ -282,14 +280,13 @@ void main() {
         expect(find.byIcon(Icons.flag), findsOneWidget);
         expect(find.byIcon(Icons.star_rounded), findsOneWidget);
         expect(find.byIcon(Icons.more_horiz), findsOneWidget);
-        // ...separated by compact step2 gaps, not the wide step5.
+        // ...separated by compact step2 gaps.
         final spacing = _headerSpacing(tester);
         expect(_trailingGapWidths(tester), List.filled(3, spacing.step2));
         // The reclaimed width goes to the timestamp: the rail is
         // 4 × 48 + 3 × step2 = 204px, so the leading cluster keeps
-        // 330 − 204 = 126px (with step5 gaps it got only 90px, ellipsizing
-        // the date). The AI control is the first trailing slot, so its left
-        // edge marks the leading cluster's width.
+        // 300 − 204 = 96px for the leading cluster. The AI control is the
+        // first trailing slot, so its left edge marks that width.
         final compactRail = 4 * AppTheme.headerActionWidth + 3 * spacing.step2;
         final aiButton = find.ancestor(
           of: find.byIcon(Icons.assistant_outlined),
@@ -303,8 +300,8 @@ void main() {
     );
 
     testWidgets(
-      'keeps the comfortable step5 gaps between trailing actions when the '
-      'header is wide',
+      'uses compact step2 gaps between trailing actions when the header is '
+      'wide',
       (WidgetTester tester) async {
         final flaggedTextEntry = testTextEntry.copyWith(
           meta: testTextEntry.meta.copyWith(flag: EntryFlag.import),
@@ -325,8 +322,7 @@ void main() {
                 )
                 as AiConfigSkill;
 
-        // Full test-surface width (800px): plenty of room, so the wide
-        // mis-tap-guard gaps are preserved.
+        // Full test-surface width (800px): the compact gaps remain uniform.
         await tester.pumpWidget(
           makeTestableWidgetWithScaffold(
             EntryDetailHeader(
@@ -344,19 +340,18 @@ void main() {
         expect(find.byIcon(Icons.assistant_outlined), findsOneWidget);
         expect(
           _trailingGapWidths(tester),
-          List.filled(3, _headerSpacing(tester).step5),
+          List.filled(3, _headerSpacing(tester).step2),
         );
       },
     );
 
     testWidgets(
-      'keeps comfortable gaps at narrow width when the AI slot has no skills',
+      'uses compact gaps without an invisible AI slot at narrow width',
       (WidgetTester tester) async {
         // Same flagged entry and 330px width as the compression test above,
         // but with no AI skills the assistant slot must not render — and must
         // not be counted: three real controls (flag + star + overflow) leave
-        // the timestamp 176px even with step5 gaps, so compressing here would
-        // needlessly shrink the mis-tap guard between the controls.
+        // the timestamp 178px with the compact gaps.
         final flaggedTextEntry = testTextEntry.copyWith(
           meta: testTextEntry.meta.copyWith(flag: EntryFlag.import),
         );
@@ -392,13 +387,13 @@ void main() {
         expect(find.byIcon(Icons.more_horiz), findsOneWidget);
         expect(
           _trailingGapWidths(tester),
-          List.filled(2, _headerSpacing(tester).step5),
+          List.filled(2, _headerSpacing(tester).step2),
         );
       },
     );
 
     testWidgets(
-      'collapsible expanded header also compresses its five-control rail at '
+      'collapsible expanded header also uses its five-control compact rail at '
       'phone width',
       (WidgetTester tester) async {
         // Chevron + AI + flag + star + overflow: the five-control rail from

--- a/test/features/journal/ui/widgets/entry_details/header/entry_detail_header_test.dart
+++ b/test/features/journal/ui/widgets/entry_details/header/entry_detail_header_test.dart
@@ -10,6 +10,7 @@ import 'package:lotti/database/editor_db.dart';
 import 'package:lotti/features/ai/model/ai_config.dart';
 import 'package:lotti/features/ai/skills/built_in_skills.dart';
 import 'package:lotti/features/ai/state/consts.dart';
+import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/journal/ui/widgets/entry_details/entry_datetime_widget.dart';
 import 'package:lotti/features/journal/ui/widgets/entry_details/header/entry_detail_header.dart';
 import 'package:lotti/features/journal/util/entry_tools.dart';
@@ -30,6 +31,38 @@ import '../../../../../../helpers/path_provider.dart';
 import '../../../../../../mocks/mocks.dart';
 import '../../../../../../test_data/test_data.dart';
 import '../../../../../../widget_test_utils.dart';
+
+/// The spacing tokens as resolved inside the pumped header, so gap assertions
+/// track the design system instead of duplicating token values.
+DsSpacing _headerSpacing(WidgetTester tester) =>
+    tester.element(find.byType(EntryDetailHeader)).designTokens.spacing;
+
+/// The widths of the spacer boxes between the header's trailing action
+/// controls (step2 when compact, step5 when comfortable).
+///
+/// Inspects only the direct children of the header's outer Row (the one whose
+/// leading child is the Expanded timestamp cluster), so same-width SizedBoxes
+/// nested inside other header widgets can never pollute the result.
+List<double> _trailingGapWidths(WidgetTester tester) {
+  final spacing = _headerSpacing(tester);
+  final headerRow = tester
+      .widgetList<Row>(
+        find.descendant(
+          of: find.byType(EntryDetailHeader),
+          matching: find.byType(Row),
+        ),
+      )
+      .firstWhere((r) => r.children.isNotEmpty && r.children.first is Expanded);
+  return headerRow.children
+      .whereType<SizedBox>()
+      .where(
+        (s) =>
+            s.child == null &&
+            (s.width == spacing.step2 || s.width == spacing.step5),
+      )
+      .map((s) => s.width!)
+      .toList();
+}
 
 void main() {
   group('EntryDetailHeader', () {
@@ -194,6 +227,241 @@ void main() {
         final overflow = find.byIcon(Icons.more_horiz);
         expect(overflow, findsOneWidget);
         expect(tester.getTopRight(overflow).dx, lessThanOrEqualTo(280));
+      },
+    );
+
+    testWidgets(
+      'compresses trailing gaps at narrow widths so the timestamp keeps room',
+      (WidgetTester tester) async {
+        // Flag + AI skill maximize the trailing rail (AI + flag + star +
+        // overflow, four full 48px controls) — the worst case that squeezed
+        // the timestamp to `20…` on phones.
+        final flaggedTextEntry = testTextEntry.copyWith(
+          meta: testTextEntry.meta.copyWith(flag: EntryFlag.import),
+        );
+        when(
+          () => mockJournalDb.journalEntityById(testTextEntry.meta.id),
+        ).thenAnswer((_) async => flaggedTextEntry);
+
+        final textSkill =
+            AiConfig.skill(
+                  id: 'skill-narrow-header',
+                  name: 'Narrow Header Skill',
+                  createdAt: DateTime(2024, 3, 15),
+                  skillType: SkillType.promptGeneration,
+                  requiredInputModalities: const [Modality.text],
+                  systemInstructions: 'sys',
+                  userInstructions: 'usr',
+                )
+                as AiConfigSkill;
+
+        const headerWidth = 330.0;
+        await tester.pumpWidget(
+          makeTestableWidgetWithScaffold(
+            Align(
+              alignment: Alignment.topLeft,
+              child: SizedBox(
+                width: headerWidth,
+                child: EntryDetailHeader(
+                  entryId: testTextEntry.meta.id,
+                  inLinkedEntries: true,
+                ),
+              ),
+            ),
+            overrides: [
+              skillRegistryProvider.overrideWithValue([textSkill]),
+            ],
+          ),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(tester.takeException(), isNull);
+        // All four trailing controls render...
+        expect(find.byIcon(Icons.assistant_outlined), findsOneWidget);
+        expect(find.byIcon(Icons.flag), findsOneWidget);
+        expect(find.byIcon(Icons.star_rounded), findsOneWidget);
+        expect(find.byIcon(Icons.more_horiz), findsOneWidget);
+        // ...separated by compact step2 gaps, not the wide step5.
+        final spacing = _headerSpacing(tester);
+        expect(_trailingGapWidths(tester), List.filled(3, spacing.step2));
+        // The reclaimed width goes to the timestamp: the rail is
+        // 4 × 48 + 3 × step2 = 204px, so the leading cluster keeps
+        // 330 − 204 = 126px (with step5 gaps it got only 90px, ellipsizing
+        // the date). The AI control is the first trailing slot, so its left
+        // edge marks the leading cluster's width.
+        final compactRail = 4 * AppTheme.headerActionWidth + 3 * spacing.step2;
+        final aiButton = find.ancestor(
+          of: find.byIcon(Icons.assistant_outlined),
+          matching: find.byType(IconButton),
+        );
+        expect(
+          tester.getTopLeft(aiButton).dx,
+          moreOrLessEquals(headerWidth - compactRail),
+        );
+      },
+    );
+
+    testWidgets(
+      'keeps the comfortable step5 gaps between trailing actions when the '
+      'header is wide',
+      (WidgetTester tester) async {
+        final flaggedTextEntry = testTextEntry.copyWith(
+          meta: testTextEntry.meta.copyWith(flag: EntryFlag.import),
+        );
+        when(
+          () => mockJournalDb.journalEntityById(testTextEntry.meta.id),
+        ).thenAnswer((_) async => flaggedTextEntry);
+
+        final textSkill =
+            AiConfig.skill(
+                  id: 'skill-wide-header',
+                  name: 'Wide Header Skill',
+                  createdAt: DateTime(2024, 3, 15),
+                  skillType: SkillType.promptGeneration,
+                  requiredInputModalities: const [Modality.text],
+                  systemInstructions: 'sys',
+                  userInstructions: 'usr',
+                )
+                as AiConfigSkill;
+
+        // Full test-surface width (800px): plenty of room, so the wide
+        // mis-tap-guard gaps are preserved.
+        await tester.pumpWidget(
+          makeTestableWidgetWithScaffold(
+            EntryDetailHeader(
+              entryId: testTextEntry.meta.id,
+              inLinkedEntries: true,
+            ),
+            overrides: [
+              skillRegistryProvider.overrideWithValue([textSkill]),
+            ],
+          ),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(find.byIcon(Icons.assistant_outlined), findsOneWidget);
+        expect(
+          _trailingGapWidths(tester),
+          List.filled(3, _headerSpacing(tester).step5),
+        );
+      },
+    );
+
+    testWidgets(
+      'keeps comfortable gaps at narrow width when the AI slot has no skills',
+      (WidgetTester tester) async {
+        // Same flagged entry and 330px width as the compression test above,
+        // but with no AI skills the assistant slot must not render — and must
+        // not be counted: three real controls (flag + star + overflow) leave
+        // the timestamp 176px even with step5 gaps, so compressing here would
+        // needlessly shrink the mis-tap guard between the controls.
+        final flaggedTextEntry = testTextEntry.copyWith(
+          meta: testTextEntry.meta.copyWith(flag: EntryFlag.import),
+        );
+        when(
+          () => mockJournalDb.journalEntityById(testTextEntry.meta.id),
+        ).thenAnswer((_) async => flaggedTextEntry);
+
+        const headerWidth = 330.0;
+        await tester.pumpWidget(
+          makeTestableWidgetWithScaffold(
+            Align(
+              alignment: Alignment.topLeft,
+              child: SizedBox(
+                width: headerWidth,
+                child: EntryDetailHeader(
+                  entryId: testTextEntry.meta.id,
+                  inLinkedEntries: true,
+                ),
+              ),
+            ),
+            overrides: [
+              skillRegistryProvider.overrideWithValue(const <AiConfigSkill>[]),
+            ],
+          ),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(tester.takeException(), isNull);
+        expect(find.byIcon(Icons.assistant_outlined), findsNothing);
+        expect(find.byIcon(Icons.flag), findsOneWidget);
+        expect(find.byIcon(Icons.star_rounded), findsOneWidget);
+        expect(find.byIcon(Icons.more_horiz), findsOneWidget);
+        expect(
+          _trailingGapWidths(tester),
+          List.filled(2, _headerSpacing(tester).step5),
+        );
+      },
+    );
+
+    testWidgets(
+      'collapsible expanded header also compresses its five-control rail at '
+      'phone width',
+      (WidgetTester tester) async {
+        // Chevron + AI + flag + star + overflow: the five-control rail from
+        // the linked-entries screenshot that left the date only `20…`.
+        final flaggedTextEntry = testTextEntry.copyWith(
+          meta: testTextEntry.meta.copyWith(flag: EntryFlag.import),
+        );
+        when(
+          () => mockJournalDb.journalEntityById(testTextEntry.meta.id),
+        ).thenAnswer((_) async => flaggedTextEntry);
+
+        final textSkill =
+            AiConfig.skill(
+                  id: 'skill-collapsible-header',
+                  name: 'Collapsible Header Skill',
+                  createdAt: DateTime(2024, 3, 15),
+                  skillType: SkillType.promptGeneration,
+                  requiredInputModalities: const [Modality.text],
+                  systemInstructions: 'sys',
+                  userInstructions: 'usr',
+                )
+                as AiConfigSkill;
+
+        const headerWidth = 360.0;
+        await tester.pumpWidget(
+          makeTestableWidgetWithScaffold(
+            Align(
+              alignment: Alignment.topLeft,
+              child: SizedBox(
+                width: headerWidth,
+                child: EntryDetailHeader(
+                  entryId: testTextEntry.meta.id,
+                  inLinkedEntries: true,
+                  isCollapsible: true,
+                  onToggleCollapse: () {},
+                ),
+              ),
+            ),
+            overrides: [
+              skillRegistryProvider.overrideWithValue([textSkill]),
+            ],
+          ),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(tester.takeException(), isNull);
+        expect(find.byIcon(Icons.expand_more), findsOneWidget);
+        expect(find.byIcon(Icons.assistant_outlined), findsOneWidget);
+        // Four compact gaps between the five controls.
+        final spacing = _headerSpacing(tester);
+        expect(_trailingGapWidths(tester), List.filled(4, spacing.step2));
+        // Rail: 5 × 48 + 4 × step2 = 256px, leaving the timestamp 104px. The
+        // chevron is the first trailing slot, so its left edge marks it.
+        final compactRail = 5 * AppTheme.headerActionWidth + 4 * spacing.step2;
+        final chevronButton = find.ancestor(
+          of: find.byIcon(Icons.expand_more),
+          matching: find.byType(IconButton),
+        );
+        expect(
+          tester.getTopLeft(chevronButton).dx,
+          moreOrLessEquals(headerWidth - compactRail),
+        );
       },
     );
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved entry header layout on narrow phone screens so the date/time remains fully visible instead of being truncated.
  - Reduced the action rail gap to ~4px (while preserving full-size tap targets) for tighter spacing.
  - Ensured AI-related header controls are only shown when applicable, preventing them from impacting layout.
  - Applied the same compact spacing behavior to both standard and expanded (collapsible) entry headers.
- **Documentation**
  - Updated journal documentation with details on the header action rail layout rules.
- **Tests**
  - Enhanced widget tests to validate responsive spacing and conditional AI control rendering.
- **Chores**
  - Bumped the app version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->