### PR TITLE
feat(docs): add a complete French manual

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -168,6 +168,7 @@ jobs:
     name: Capture screenshot catalog
     needs: metadata
     if: >-
+      github.event_name == 'push' ||
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && inputs.capture_screenshots)
     runs-on: ubuntu-latest
@@ -232,6 +233,7 @@ jobs:
 
       - name: Commit media to lotti-docs/main
         if: >-
+          github.event_name == 'push' ||
           github.event_name == 'schedule' ||
           (github.event_name == 'workflow_dispatch' && inputs.publish_media)
         working-directory: lotti-docs

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ LOTTI_VERSION := $(shell yq '.version' pubspec.yaml |  tr -d '"')
 THRESH ?= 1000
 LOTTI_DOCS_DIR ?= $(abspath ../lotti-docs)
 MANUAL_VERSION ?= development
-MANUAL_LOCALES ?= en de cs
+MANUAL_LOCALES ?= en de fr cs
 MANUAL_CAPTURE_DIR ?= $(LOTTI_DOCS_DIR)/manual/.staging/$(MANUAL_VERSION)
 MANUAL_MEDIA_DIR ?= $(LOTTI_DOCS_DIR)/manual/screenshots
 

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -89,6 +89,17 @@ mobile/desktop and light/dark PNG inputs into an ignored staging directory,
 converts them to canonical WebP paths, and writes a checksum/dimension manifest under
 `../lotti-docs/manual/screenshots/development/`.
 
+When only a new or changed case needs publishing, pass its IDs to the manifest
+builder so the existing catalog remains untouched. For example:
+
+```bash
+npm run manifest -- --locales en,de --cases onboarding/api-key,onboarding/success
+```
+
+Use `--skip-manifest` only to prepare an incomplete locale catalog before a
+subsequent complete manifest run; it converts the selected cases but deliberately
+does not write a partial manifest.
+
 English media keeps the established
 `development/<case>/<viewport>-<theme>.webp` path. Localized media lives at
 `development/<locale>/<case>/<viewport>-<theme>.webp`. Visible deterministic

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -21,11 +21,12 @@ make manual_check
 make manual_serve
 ```
 
-The local English root is `/manual/development/`; German and Czech are
-available at `/manual/development/de/` and `/manual/development/cs/`. The
-navbar selector preserves the current page, and a German or Czech browser
-visiting the unqualified manual root is redirected to that language unless the
-reader has explicitly chosen a language before.
+The local English root is `/manual/development/`; German, French, and Czech are
+available at `/manual/development/de/`, `/manual/development/fr/`, and
+`/manual/development/cs/`. The navbar selector preserves the current page, and
+a browser using one of those languages that visits the unqualified manual root
+is redirected to that language unless the reader has explicitly chosen a
+language before.
 
 Run the complete manual check with:
 
@@ -83,7 +84,7 @@ registry reuses deterministic feature screenshot harnesses:
 make manual_screenshots
 ```
 
-That command captures all registered English, German, and Czech
+That command captures all registered English, German, French, and Czech
 mobile/desktop and light/dark PNG inputs into an ignored staging directory,
 converts them to canonical WebP paths, and writes a checksum/dimension manifest under
 `../lotti-docs/manual/screenshots/development/`.
@@ -92,7 +93,7 @@ English media keeps the established
 `development/<case>/<viewport>-<theme>.webp` path. Localized media lives at
 `development/<locale>/<case>/<viewport>-<theme>.webp`. Visible deterministic
 demo copy that does not come from the app ARB files must use
-`manualScreenshotText(en: …, de: …, cs: …)` so all three catalogs show the
+`manualScreenshotText(en: …, de: …, fr: …, cs: …)` so all four catalogs show the
 same scenario in the selected language.
 
 Add a screenshot by extending `metadata/screenshot-cases.json`, reusing or

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -89,6 +89,11 @@ mobile/desktop and light/dark PNG inputs into an ignored staging directory,
 converts them to canonical WebP paths, and writes a checksum/dimension manifest under
 `../lotti-docs/manual/screenshots/development/`.
 
+CI runs this same full pipeline on every manual-relevant push to `main`, nightly
+at 02:23 UTC, and on demand. Main-branch captures fast-forward a normal commit
+to `lotti-docs/main`; pull requests only validate the site and never publish
+generated media.
+
 When only a new or changed case needs publishing, pass its IDs to the manifest
 builder so the existing catalog remains untouched. For example:
 
@@ -118,7 +123,8 @@ manual locale.
 
 ## Release model
 
-For app version `1.0.0`, CI checks out the app's `1.0.0` tag and builds with:
+For app version `1.0.0`, a release build must check out the app's `1.0.0` tag and
+build with:
 
 ```bash
 MANUAL_VERSION=1.0.0 \
@@ -128,7 +134,9 @@ MANUAL_BASE_URL=/lotti/manual/1.0.0/ \
 npm run build
 ```
 
-The result is published as an immutable directory. `metadata/releases.json`
-drives cross-version links and records which publicly distributed App Store
-version should receive the `latest` alias. No `versioned_docs` directory is
+`metadata/releases.json` drives cross-version links and records which publicly
+distributed App Store version should receive the `latest` alias. The current
+GitHub Pages workflow publishes the development snapshot; the first App Store
+release needs the companion tagged-release job to assemble the immutable
+versioned Pages snapshot and media catalog. No `versioned_docs` directory is
 allowed.

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -100,6 +100,9 @@ Use `--skip-manifest` only to prepare an incomplete locale catalog before a
 subsequent complete manifest run; it converts the selected cases but deliberately
 does not write a partial manifest.
 
+Use `--manifest-only` after a complete catalog already exists when metadata must
+be refreshed without recompressing any image files.
+
 English media keeps the established
 `development/<case>/<viewport>-<theme>.webp` path. Localized media lives at
 `development/<locale>/<case>/<viewport>-<theme>.webp`. Visible deterministic

--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -45,7 +45,7 @@ const config: Config = {
   },
   i18n: {
     defaultLocale: 'en',
-    locales: ['en', 'de', 'cs'],
+    locales: ['en', 'de', 'fr', 'cs'],
     localeConfigs: {
       en: {
         label: 'English',
@@ -54,6 +54,10 @@ const config: Config = {
       de: {
         label: 'Deutsch',
         htmlLang: 'de-DE',
+      },
+      fr: {
+        label: 'Français',
+        htmlLang: 'fr-FR',
       },
       cs: {
         label: 'Čeština',
@@ -103,7 +107,7 @@ const config: Config = {
         docsRouteBasePath: '/',
         // lunr-languages has no Czech stemmer. Czech pages are still indexed
         // and searchable by exact tokens; supported locales keep stemming.
-        language: ['en', 'de'],
+        language: ['en', 'de', 'fr'],
       },
     ],
   ],

--- a/docs-site/i18n/fr/code.json
+++ b/docs-site/i18n/fr/code.json
@@ -1,0 +1,102 @@
+{
+  "manual.screenshot.allScreenshots": {
+    "message": "Toutes les captures d’écran",
+    "description": "Label for the global screenshot viewport preference"
+  },
+  "manual.screenshot.close": {
+    "message": "Fermer"
+  },
+  "manual.screenshot.desktop": {
+    "message": "Ordinateur"
+  },
+  "manual.screenshot.desktopView": {
+    "message": "Vue ordinateur"
+  },
+  "manual.screenshot.expand": {
+    "message": "Agrandir"
+  },
+  "manual.screenshot.expandedViewer": {
+    "message": "Vue agrandie de la capture"
+  },
+  "manual.screenshot.fullscreen": {
+    "message": "Plein écran"
+  },
+  "manual.screenshot.layoutLabel": {
+    "message": "Présentation des captures pour toutes les images"
+  },
+  "manual.screenshot.mobile": {
+    "message": "Mobile"
+  },
+  "manual.screenshot.mobileView": {
+    "message": "Vue mobile"
+  },
+  "manual.screenshot.openViewer": {
+    "message": "Ouvrir la visionneuse de captures"
+  },
+  "manual.screenshot.screenshot": {
+    "message": "Capture d’écran"
+  },
+  "manual.translationNotice.disclosure": {
+    "message": "Cette traduction a été créée avec GPT 5.6 Sol xHigh et n’a pas encore été relue."
+  },
+  "manual.translationNotice.invitation": {
+    "message": "Les corrections et améliorations sont très bienvenues, sous la forme d’une"
+  },
+  "manual.translationNotice.issue": {
+    "message": "issue GitHub"
+  },
+  "manual.translationNotice.or": {
+    "message": "ou d’une"
+  },
+  "manual.translationNotice.pullRequest": {
+    "message": "pull request"
+  },
+  "manual.translationNotice.title": {
+    "message": "Traduction automatique — vos retours sont les bienvenus"
+  },
+  "manual.version.development": {
+    "message": "Développement"
+  },
+  "theme.colorToggle.ariaLabel.mode.system": {
+    "message": "mode système"
+  },
+  "theme.docs.sidebar.navAriaLabel": {
+    "message": "Navigation latérale de la documentation"
+  },
+  "theme.IconExternalLink.ariaLabel": {
+    "message": "(s’ouvre dans un nouvel onglet)"
+  },
+  "theme.NavBar.navAriaLabel": {
+    "message": "Navigation principale"
+  },
+  "theme.SearchBar.label": {
+    "message": "Rechercher"
+  },
+  "theme.SearchBar.noResultsText": {
+    "message": "Aucun résultat"
+  },
+  "theme.SearchBar.searchInContext": {
+    "message": "Voir tous les résultats dans « {context} »"
+  },
+  "theme.SearchBar.seeAllOutsideContext": {
+    "message": "Voir tous les résultats hors de « {context} »"
+  },
+  "theme.SearchBar.seeAll": {
+    "message": "Voir tous les résultats"
+  },
+  "theme.SearchPage.existingResultsTitle": {
+    "message": "Résultats de recherche pour « {query} »"
+  },
+  "theme.SearchPage.emptyResultsTitle": {
+    "message": "Rechercher dans la documentation"
+  },
+  "theme.SearchPage.documentsFound.plurals": {
+    "message": "Un document trouvé|{count} documents trouvés"
+  },
+  "theme.SearchPage.noResultsText": {
+    "message": "Aucun document trouvé"
+  },
+  "theme.SearchPage.searchContext.everywhere": {
+    "message": "Partout"
+  }
+}

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current.json
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,30 @@
+{
+  "version.label": {
+    "message": "Actuelle",
+    "description": "The label for version current"
+  },
+  "sidebar.manualSidebar.category.Start here": {
+    "message": "Commencer ici",
+    "description": "The label for category 'Start here' in sidebar 'manualSidebar'"
+  },
+  "sidebar.manualSidebar.category.Plan & capture": {
+    "message": "Planifier et capturer",
+    "description": "The label for category 'Plan & capture' in sidebar 'manualSidebar'"
+  },
+  "sidebar.manualSidebar.category.Organize & reflect": {
+    "message": "Organiser et prendre du recul",
+    "description": "The label for category 'Organize & reflect' in sidebar 'manualSidebar'"
+  },
+  "sidebar.manualSidebar.category.AI & automation": {
+    "message": "IA et automatisation",
+    "description": "The label for category 'AI & automation' in sidebar 'manualSidebar'"
+  },
+  "sidebar.manualSidebar.category.Sync & data": {
+    "message": "Synchronisation et données",
+    "description": "The label for category 'Sync & data' in sidebar 'manualSidebar'"
+  },
+  "sidebar.manualSidebar.category.Reference": {
+    "message": "Référence",
+    "description": "The label for category 'Reference' in sidebar 'manualSidebar'"
+  }
+}

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/ai-and-automation/agent-blueprints.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/ai-and-automation/agent-blueprints.mdx
@@ -1,0 +1,127 @@
+---
+title: Concevoir des modèles et des âmes d’agents
+description: Définis des responsabilités d’agent réutilisables, sépare la personnalité des instructions et améliore les deux au fil d’entretiens individuels versionnés.
+---
+
+# Concevoir des modèles et des âmes d’agents
+
+Un **modèle d’agent** définit une responsabilité réutilisable : le type d’agent,
+son profil d’inférence, ses directives de fonctionnement, le format de ses
+rapports et, éventuellement, sa personnalité. Une **âme** rassemble la voix
+réutilisable, les limites de ton, le style d’accompagnement et la politique
+anti-complaisance. Les garder distincts permet d’améliorer une personnalité de
+façon cohérente dans plusieurs modèles, sans recopier les instructions.
+
+## Examiner le catalogue de modèles
+
+Ouvre **Paramètres → Agents → Modèles d’agents**. Le catalogue indique le type de
+modèle, l’identité du modèle d’IA, la version active et si une révision demande
+ton attention.
+
+<ManualScreenshot
+  caseId="agents/templates"
+  alt="Modèles d’agents Lotti pour la sécurité de l’habitat orbital, la planification de la journée du Projet Waddle, le suivi des réserves de sardines et l’accompagnement de la diplomatie des poissons"
+  caption="Chaque modèle du Projet Waddle a une responsabilité précise et une version visible, au lieu d’un unique agent fourre-tout avec un prompt impossible à relire."
+/>
+
+Les types intégrés couvrent des périmètres différents :
+
+- **Agent de tâche** travaille sur une tâche et les éléments qui lui sont liés.
+- **Agent de journée** planifie et révise une journée.
+- **Agent de projet** suit un projet dans le temps.
+- **Agent d’événement** suit l’espace de travail d’un événement.
+- **Améliorateur de modèle** accompagne les 1-on-1 versionnés.
+
+## Modifier un modèle
+
+Sélectionne un modèle pour modifier sa configuration actuelle. Choisis un profil
+d’inférence par défaut doté des outils et modalités dont cette responsabilité a
+besoin, puis associe éventuellement une âme.
+
+<ManualScreenshot
+  caseId="agents/template-editor"
+  alt="Éditeur du modèle Sentinelle de l’habitat orbital utilisant Commandement Projet Waddle et l’amiral Pebble, avec des directives sur la sécurité de l’habitat et les rapports"
+  caption="La directive opérationnelle de la Sentinelle précise quoi inspecter ; l’amiral Pebble apporte le style de communication et de remise en question."
+/>
+
+Utilise volontairement les deux champs de directives :
+
+- **Directive générale** définit la responsabilité, les limites et les règles
+  de décision.
+- **Directive de rapport** définit le contenu d’un rapport enregistré utile.
+
+Enregistrer un modèle modifié crée une nouvelle version. L’historique reste
+disponible pour l’audit et le retour en arrière ; n’enfouis pas des
+responsabilités sans lien dans une longue directive uniquement pour réduire le
+nombre de modèles.
+
+## Faire un 1-on-1 avec un modèle
+
+La page **1-on-1** d’un modèle replace les changements proposés dans le
+contexte de l’activité réelle des réveils, des retours, des
+performances et des séances précédentes. Une séance en attente est une
+proposition, pas une réécriture automatique.
+
+<ManualScreenshot
+  caseId="agents/template-review"
+  alt="1-on-1 de la Sentinelle de l’habitat orbital montrant une proposition pour mettre en avant la décision de lancement et des métriques de performance récentes"
+  caption="La proposition répond à un échec concret : le constat de sécurité était juste, mais la décision de lancer ou non était cachée sous des anecdotes sur les poissons."
+/>
+
+Démarre la conversation, examine les éléments probants et n’approuve que les
+changements qui améliorent la responsabilité. Le résultat approuvé devient un
+nouvel enregistrement de modèle versionné.
+
+## Garder la personnalité réutilisable avec les âmes
+
+Ouvre **Âmes** pour voir les personnalités que les modèles peuvent partager.
+Une âme n’est pas un autre prompt de tâche : elle définit la façon dont un agent
+communique, accompagne et exprime son désaccord.
+
+<ManualScreenshot
+  caseId="agents/souls"
+  alt="Catalogue d’âmes Lotti contenant Admiral Pebble, Dr. Flipper et Captain Sardina"
+  caption="Le Projet Waddle sépare un directeur de vol calme, une scientifique curieuse et un coordinateur de cargaison pragmatique des tâches qui emploient ces personnalités."
+/>
+
+L’éditeur d’âme rend explicites quatre dimensions :
+
+<ManualScreenshot
+  caseId="agents/soul-editor"
+  alt="Éditeur de l’âme de l’amiral Pebble avec la voix, les limites de ton, le style d’accompagnement et la politique anti-complaisance"
+  caption="L’amiral Pebble peut rester chaleureux et décisif tout en contestant les hypothèses optimistes de lancement à l’aide d’éléments probants."
+/>
+
+- **Directive de voix** décrit la voix reconnaissable et les priorités de
+  communication.
+- **Limites de ton** indiquent ce que cette voix doit éviter.
+- **Style d’accompagnement** décrit comment elle aide une personne à prendre
+  une décision.
+- **Politique anti-complaisance** explique quand et comment l’agent doit être
+  en désaccord.
+
+Fixe des limites de comportement concrètes. « Sois utile » est difficile à
+réviser ; « conteste les hypothèses optimistes de lancement et cite
+l’observation qui a changé ta conclusion » peut être vérifié dans la sortie
+réelle.
+
+## Faire évoluer une âme partagée avec prudence
+
+Le **1-on-1** d’une âme rassemble les retours de tous les modèles
+qui utilisent cette personnalité. Le changement a donc de la portée :
+l’approuver peut améliorer plusieurs agents, mais un mauvais changement peut
+aussi tous les affecter.
+
+<ManualScreenshot
+  caseId="agents/soul-review"
+  alt="1-on-1 de l’âme de l’amiral Pebble avec une proposition, un modèle partageant cette âme et l’historique de séances terminées"
+  caption="Le nombre de partages et l’historique des séances rendent l’étendue des effets visible avant l’approbation d’un changement de personnalité."
+/>
+
+Lis le nombre de partages, le résumé des retours proposés et le récapitulatif
+précédent avant de démarrer une révision de personnalité. Si un retour ne vaut
+que pour une responsabilité, modifie ce modèle plutôt que d’enseigner une règle
+spécifique à une tâche à l’âme partagée.
+
+Reviens à [Exécuter et surveiller les agents](./agents.mdx) pour examiner les
+instances et les cycles de réveil issus de ces modèles.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/ai-and-automation/agents.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/ai-and-automation/agents.mdx
@@ -1,0 +1,103 @@
+---
+title: Exécuter et surveiller les agents
+description: Surveille l’activité des agents, examine les instances en cours et contrôle les cycles de réveil planifiés sans perdre la trace d’audit.
+---
+
+# Exécuter et surveiller les agents
+
+Les agents permettent à Lotti d’assurer une responsabilité définie au fil de
+plusieurs cycles de réveil. Chaque instance en cours provient d’un modèle
+d’agent, utilise une configuration d’inférence et conserve son propre état, ses
+rapports, observations et historique d’activité. Ouvre **Paramètres → Agents**
+pour voir l’ensemble du système.
+
+Les rapports, observations et réveils en attente décrivent l’état de travail
+de l’agent ; ils ne réécrivent pas silencieusement ton journal personnel.
+Lorsqu’un agent de tâche souhaite modifier les données d’une tâche, Lotti te
+présente une proposition à examiner. Consulte
+[Examiner les changements proposés](../organize-and-reflect/tasks.mdx#examiner-les-modifications-proposées)
+pour les contrôles d’approbation de chaque tâche et leurs exceptions limitées
+de titre initial et de langue.
+
+## Lire l’activité avant de la modifier
+
+La page **Statistiques** rassemble l’activité des réveils et l’usage des
+jetons. Le premier graphique indique quand les agents se sont activés au cours
+des dernières 24 heures. La section quotidienne compare aujourd’hui au même
+moment des jours récents, puis répartit l’usage par modèle et par source.
+
+<ManualScreenshot
+  caseId="agents/stats"
+  alt="Statistiques d’agents Lotti montrant l’activité du Projet Waddle, l’usage quotidien des jetons et des graphiques par modèle"
+  caption="La flotte d’exemple du Projet Waddle est particulièrement active autour des vérifications de l’habitat et de la planification du lancement ; les sections par modèle et par source permettent d’attribuer cette activité."
+/>
+
+Utilise cette page pour répondre à trois questions distinctes :
+
+- **Quand les agents ont-ils travaillé ?** Lis le graphique des réveils sur 24 heures.
+- **Quelle quantité d’inférence ont-ils utilisée ?** Compare les graphiques quotidiens et par modèle.
+- **Quelle responsabilité l’a provoquée ?** Examine la répartition par modèle ou source.
+
+Un pic n’est pas automatiquement un problème. Une journée de revue de
+lancement devrait être plus chargée qu’une journée ordinaire dans la colonie.
+Pour examiner une activité inattendue, ouvre le modèle ou l’instance source
+avant de modifier une limite globale de concurrence.
+
+## Examiner les instances en cours
+
+Ouvre **Instances** pour voir chaque agent et chaque séance d’évolution. Les
+lignes indiquent le type d’agent, son cycle de vie, le modèle assigné et son
+âme. Le regroupement par âme est utile lorsque plusieurs responsabilités
+partagent une même voix et un même style de décision.
+
+<ManualScreenshot
+  caseId="agents/instances"
+  alt="Instances d’agents Lotti regroupées par l’amiral Pebble, Dr Flipper, Captain Sardina et une séance d’évolution"
+  caption="Inspecteur des joints de l’habitat, Planificateur du Projet Waddle et Coordinateur du fret de sardines restent des instances distinctes, même lorsqu’ils partagent des ressources système."
+/>
+
+Sélectionne une instance pour examiner son fonctionnement interne. L’onglet
+**Statistiques** montre l’usage des modèles, le modèle d’agent, la route
+d’inférence actuelle, les contrôles de cycle de vie, le nombre de réveils et
+l’état de planification.
+
+<ManualScreenshot
+  caseId="agents/instance-detail"
+  alt="Détail de l’instance Inspecteur des joints de l’habitat avec l’usage des jetons, le modèle Sentinelle de l’habitat orbital, la route d’inférence, les contrôles de cycle de vie et l’état des réveils"
+  caption="L’instance conserve assez de provenance pour expliquer quel modèle et quelle route ont produit son travail avant que tu la mettes en pause, la réanalyses ou la détruises."
+/>
+
+Les autres onglets conservent des éléments différents :
+
+- **Rapports** contient les instantanés de rapports enregistrés par l’agent.
+- **Conversations** regroupe les messages par cycle de réveil.
+- **Observations** expose les constats capturés sans les mélanger aux rapports.
+- **Activité** montre la trace chronologique des messages et des outils.
+
+**Mettre en pause** conserve l’instance mais arrête le travail normal.
+**Réanalyser** demande à un agent de tâche de reconsidérer son sujet actuel.
+**Détruire** est irréversible et ne devrait être utilisé que si tu ne veux plus
+de l’instance elle-même ; modifier le modèle pour les futurs agents ne demande
+pas de détruire des instances sans rapport.
+
+## Comprendre les cycles de réveil
+
+Ouvre **Cycles de réveil** pour voir le travail en cours et celui prévu pour
+plus tard. Un réveil **En attente** a été demandé par l’agent. Un réveil
+**Planifié** a été placé par le système ou le planificateur.
+Chaque ligne conserve la tâche, le projet ou la journée liés à côté de l’agent
+responsable et d’un compte à rebours en direct.
+
+<ManualScreenshot
+  caseId="agents/pending-wakes"
+  alt="Cycles de réveil Lotti montrant l’inspection d’habitat en cours ainsi que des réveils du Projet Waddle et de logistique des sardines planifiés"
+  caption="La file distingue un suivi de l’habitat demandé par l’agent des réveils planifiés du jour de lancement et de la cargaison : chaque compte à rebours a ainsi une raison et un responsable."
+/>
+
+Supprimer un réveil en file retire ce minuteur ; cela ne supprime ni
+l’agent ni sa tâche liée. Si un réveil réapparaît immédiatement, examine
+l’état de l’agent ou l’automatisation qui l’a demandée, plutôt que de supprimer
+sans cesse le symptôme.
+
+Poursuis avec [Modèles et âmes d’agents](./agent-blueprints.mdx) pour définir
+ce que font ces instances et leur manière de communiquer.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/ai-and-automation/models-and-profiles.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/ai-and-automation/models-and-profiles.mdx
@@ -1,0 +1,136 @@
+---
+title: Orienter le travail avec des modèles et profils
+description: Décris une fois les capacités des modèles, puis utilise les profils d’inférence pour orienter le raisonnement, la vision, l’audio et la génération d’images.
+---
+
+# Orienter le travail avec des modèles et profils
+
+Un fournisseur indique à Lotti où se connecter. Un modèle enregistre un
+identifiant de modèle chez ce fournisseur et ses capacités. Un profil
+d’inférence assigne ensuite ces modèles aux types de travail que Lotti connaît.
+Tu n’as ainsi pas à décider quel modèle traite l’audio dans chaque tâche ou
+règle d’automatisation.
+
+## Examiner les modèles enregistrés
+
+Ouvre **Paramètres → Paramètres IA → Modèles**. La liste regroupe les modèles par
+fournisseur et propose des filtres de capacité pour le texte, la vision,
+l’audio et le raisonnement.
+
+<ManualScreenshot
+  caseId="ai/models"
+  alt="Liste des modèles IA Lotti avec les modèles du Projet Waddle de texte, réflexion, vision, transcription et génération d’images"
+  caption="L’espace du Projet Waddle mélange des modèles cloud et locaux tout en rendant explicites les capacités de chaque modèle."
+/>
+
+Le contrôle **Réveils d’agents simultanés**, en haut des Paramètres IA,
+limite le nombre d’agents différents qui peuvent lancer une inférence en même
+temps. Une valeur élevée peut améliorer le débit, mais augmente aussi les
+requêtes simultanées au fournisseur et la charge sur l’appareil local. Reste
+prudent lorsqu’un fournisseur a des limites de débit strictes ou qu’un serveur
+de modèles local a peu de mémoire.
+
+## Ajouter ou modifier un modèle
+
+Sélectionne une carte de modèle ou utilise **+** pour en ajouter un. Une
+définition de modèle comprend :
+
+- la connexion au fournisseur ;
+- un nom d’affichage compréhensible et une description facultative ;
+- l’identifiant exact du modèle chez le fournisseur ;
+- la limite maximale de jetons de complétion ;
+- les modalités d’entrée et de sortie ;
+- des indicateurs de capacité, comme le raisonnement ou l’appel de fonctions.
+
+<ManualScreenshot
+  caseId="ai/model-editor"
+  alt="Éditeur de modèle Lotti pour Waddle Command 70B affichant le fournisseur, l’identifiant du modèle fournisseur, la limite de complétion, les modalités et la capacité de raisonnement"
+  caption="Les métadonnées de capacité comptent : Lotti s’en sert pour déterminer les modèles éligibles à chaque emplacement de profil et sélecteur ponctuel."
+/>
+
+Utilise l’identifiant exact attendu par le fournisseur. Le nom d’affichage est
+réservé aux personnes ; le modifier ne change pas le modèle exécuté par le
+fournisseur. N’annonce pas la prise en charge des images, de l’audio, des
+outils ou du raisonnement si le modèle et le point de terminaison ne la
+proposent pas réellement.
+
+## Créer un profil d’inférence
+
+Ouvre **Paramètres → Paramètres IA → Profils d’inférence**. Chaque profil est une
+politique d’orientation réutilisable. La vue d’ensemble indique quel modèle
+occupe chaque emplacement configuré.
+
+<ManualScreenshot
+  caseId="ai/profiles"
+  alt="Profils d’inférence Lotti pour Commandement Projet Waddle, Habitat d’abord local et Diplomatie du poisson avec leurs modèles orientés"
+  caption="Les profils peuvent optimiser des contraintes différentes : un profil cloud généraliste, un profil local réservé au bureau ou un profil de raisonnement spécialisé."
+/>
+
+Modifie un profil pour assigner les modèles aux capacités que tu utilises :
+
+- **Réflexion** est le modèle de texte général obligatoire.
+- **Réflexion (haut de gamme)** peut traiter le travail qui demande
+  explicitement le chemin de raisonnement plus puissant.
+- **Reconnaissance d’images** analyse les images.
+- **Transcription** transforme l’audio en texte.
+- **Génération d’images** crée les illustrations des tâches et d’autres images
+  générées. Le chemin intégré actuel de génération d’images utilise un
+  fournisseur distant configuré : choisis donc ce fournisseur et les
+  références envoyées avec le même soin que pour toute autre inférence cloud.
+
+<ManualScreenshot
+  caseId="ai/profile-editor"
+  alt="Éditeur du profil Commandement Projet Waddle assignant les modèles de réflexion, réflexion haut de gamme, reconnaissance d’images, transcription et génération d’images"
+  caption="Un seul profil oriente chaque modalité du Projet Waddle sans répéter les choix de modèles dans les tâches."
+/>
+
+**Bureau uniquement** masque un profil sur les plateformes mobiles, ce qui est
+utile lorsqu’il dépend d’un modèle accessible uniquement depuis un poste de
+travail. L’épinglage d’appareil concerne le traitement automatique de l’audio
+synchronisé : n’épingle un appareil que s’il annonce les fournisseurs requis
+par le profil. Sans appareil épinglé, l’audio synchronisé n’est pas transcrit
+automatiquement par ce profil.
+
+## Choisir un modèle sans mémoriser les identifiants
+
+Les sélecteurs de modèles commencent par le fournisseur et n’affichent que les
+modèles enregistrés compatibles. Le sélecteur d’un emplacement de profil, par
+exemple, ne proposera pas un modèle audio uniquement pour le raisonnement
+textuel.
+
+<ManualScreenshot
+  caseId="ai/model-picker"
+  alt="Fenêtre Lotti Choisir un modèle listant les fournisseurs OpenRouter, Ollama et Google Gemini au-dessus de l’éditeur de profil du Projet Waddle"
+  caption="Choisis d’abord le fournisseur ; Lotti limite ensuite la page suivante aux modèles éligibles de cette connexion."
+/>
+
+## Définir une valeur par défaut de catégorie
+
+Une catégorie peut choisir un profil d’inférence par défaut dans **Paramètres →
+Définitions → Catégories**. Les nouveaux éléments de cette catégorie peuvent
+alors hériter d’une politique d’orientation cohérente. Choisis le profil dont
+l’équilibre entre confidentialité et capacités convient à la catégorie, plutôt
+que de te baser uniquement sur la vitesse.
+
+<ManualScreenshot
+  caseId="ai/profile-picker"
+  alt="Éditeur de la catégorie Opérations pingouins avec une fenêtre proposant les profils Commandement Projet Waddle, Habitat d’abord local et Diplomatie du poisson"
+  caption="Le badge bureau uniquement rend les limites de plateforme visibles avant de choisir une valeur par défaut de catégorie."
+/>
+
+## Ancien chemin des profils
+
+L’ancien chemin autonome **Profils d’inférence** reste disponible par
+compatibilité et modifie les mêmes enregistrements de profils. Il expose les
+identifiants internes des modèles et donne moins de contexte sur les
+dépendances que les Paramètres IA ; préfère la page actuelle **Paramètres IA →
+Profils d’inférence** pour l’entretien habituel.
+
+<ManualScreenshot
+  caseId="ai/legacy-profiles"
+  alt="Ancienne page Profils d’inférence de Lotti affichant les emplacements du profil Projet Waddle comme identifiants internes de modèles"
+  caption="Utilise cet écran de compatibilité seulement lorsqu’un ancien lien t’y mène ; les cartes de profils des Paramètres IA actuels sont plus faciles à auditer."
+/>
+
+Poursuis avec les [compétences IA](./skills.mdx) pour voir comment le profil
+sélectionné devient une action sur une tâche ou une entrée.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/ai-and-automation/provider-setup.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/ai-and-automation/provider-setup.mdx
@@ -1,0 +1,94 @@
+---
+title: Connecter un fournisseur d’IA
+description: Connecte une inférence cloud ou locale, examine ses modèles et garde le contrôle sur les identifiants et les points de terminaison.
+---
+
+# Connecter un fournisseur d’IA
+
+Lotti sépare une configuration d’IA en trois couches : un **fournisseur** est le
+service auquel elle se connecte, un **modèle** est un modèle exposé par ce
+service et un **profil d’inférence** oriente chaque type de travail vers un
+modèle. Commence par le fournisseur, puis examine les modèles et profils créés
+autour de lui.
+
+<ManualScreenshot
+  caseId="ai/providers"
+  alt="Paramètres IA de Lotti affichant les fournisseurs Routeur Mission Control, Laboratoire local de l’habitat, Vision orbitale et Baie audio des pingouins"
+  caption="Les Paramètres IA regroupent les connexions cloud et locales. Chaque carte indique l’état de la connexion et le nombre de modèles enregistrés qui l’utilisent."
+/>
+
+## Choisir le local ou le distant
+
+- Un fournisseur cloud est généralement le moyen le plus rapide de démarrer et
+  demande souvent une clé API. Le texte, l’audio ou les images que tu lui
+  envoies quittent l’appareil.
+- Un fournisseur local peut conserver l’inférence sur ta machine ou sur un
+  point de terminaison local que tu contrôles, mais son service doit être lancé
+  et accessible depuis l’appareil qui l’invoque dans Lotti. Une adresse LAN peut
+  tout de même faire passer un prompt entre tes appareils ; « local » signifie
+  qu’il n’est pas envoyé à un fournisseur de modèles hébergé, pas qu’il n’y a
+  aucun saut réseau.
+- Une URL de base personnalisée peut diriger un type de fournisseur pris en
+  charge vers un proxy ou une passerelle compatible. Le type de fournisseur
+  contrôle toujours le comportement propre au protocole.
+
+## Connecter un fournisseur
+
+1. Ouvre **Paramètres → Paramètres IA → Fournisseurs**.
+2. Sélectionne le bouton **+**.
+3. Choisis un fournisseur pris en charge.
+4. Saisis son nom d’affichage, son point de terminaison et sa clé API si nécessaire.
+5. Ajoute les modèles suggérés que tu souhaites, puis enregistre.
+
+Pour les fournisseurs de première configuration pris en charge, Lotti prépare
+des modèles utiles et un ou plusieurs profils d’inférence. L’écran de résultat
+résume les éléments créés.
+
+<ManualScreenshot
+  caseId="ai/provider-editor"
+  alt="Éditeur de fournisseur Lotti pour Mission Control Router avec OpenRouter sélectionné, une URL de base, une clé API masquée et des modèles suggérés"
+  caption="Les identifiants restent masqués. Les modèles suggérés sont des raccourcis, pas une obligation : tu peux ajouter plus tard des identifiants de modèle propres au fournisseur."
+/>
+
+## Examiner et entretenir une connexion
+
+Ouvre une carte de fournisseur pour examiner son identifiant masqué, son URL de
+base, ses modèles enregistrés et tout profil actif qui dépend de ces modèles.
+Tu peux modifier la connexion, ajouter un autre modèle ou supprimer le
+fournisseur.
+
+<ManualScreenshot
+  caseId="ai/provider-detail"
+  alt="Détail du fournisseur Routeur Mission Control montrant sa connexion, les modèles Waddle Command et le profil Projet Waddle actif"
+  caption="Le résumé des dépendances rend l’étendue des effets visible avant de modifier ou de supprimer un fournisseur."
+/>
+
+Modifier une URL de base ou une clé API affecte tous les modèles associés à ce
+fournisseur. Après avoir modifié l’une de ces valeurs, vérifie une action IA
+représentative avant de supposer que la connexion fonctionne. Supprimer un
+fournisseur peut aussi affecter les profils qui orientent du travail vers ses
+modèles : examine d’abord les informations de dépendance.
+
+## Examiner l’orientation des profils
+
+Ouvre [Modèles et profils d’inférence](./models-and-profiles.mdx) pour vérifier
+ce que le fournisseur expose et la façon dont Lotti oriente chaque capacité.
+Les catégories peuvent définir un profil par défaut pour leur travail, tandis
+que chaque automatisation peut sélectionner ou remplacer un modèle lorsque le
+flux de travail le permet.
+
+## Frontière de confidentialité
+
+Avant d’envoyer du texte, de l’audio ou des images sensibles, vérifie si le
+point de terminaison configuré est local ou distant. Un nom sympathique comme
+« Habitat Local Lab » n’est pas la frontière de sécurité : ce sont l’URL de
+base, le chemin réseau et la machine qui sert le modèle qui comptent. Dans les
+deux cas, Lotti conserve le journal localement ; ce choix contrôle l’appel
+d’inférence lui-même.
+
+:::warning Clés API
+
+Traite les clés de fournisseur comme des secrets. Ne les colle jamais dans la
+documentation, des tickets ou des captures d’écran.
+
+:::

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/ai-and-automation/skills.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/ai-and-automation/skills.mdx
@@ -1,0 +1,55 @@
+---
+title: Exécuter des compétences IA contextuelles
+description: Utilise le menu Générer pour n’exécuter que les actions IA adaptées à la tâche, à l’enregistrement, à l’image ou à l’entrée en cours.
+---
+
+# Exécuter des compétences IA contextuelles
+
+Les compétences IA sont des actions nommées, avec des instructions et des
+préconditions d’entrée. Lotti filtre le menu **Générer…** selon l’élément
+actuel : une tâche ne propose donc pas une transcription réservée à l’audio, et
+une image ne propose pas une action qui exige un enregistrement.
+
+<ManualScreenshot
+  caseId="ai/skills"
+  alt="Image de l’habitat du Projet Waddle avec la fenêtre Générer proposant Inspecter la photo de l’habitat"
+  caption="Sur une image de l’habitat liée à la tâche, l’action disponible recherche les anomalies du manomètre et les dégâts visibles sur les joints."
+/>
+
+## Exécuter une compétence
+
+1. Ouvre une tâche ou une entrée de journal compatible.
+2. Sélectionne l’action d’assistant encadrée dans l’en-tête de l’entrée. Elle
+   ouvre **Générer…**.
+3. Lis la description de la compétence et sélectionne l’action souhaitée.
+4. Si Lotti propose un sélecteur de modèle ou de mode de raisonnement, confirme
+   la valeur par défaut ou choisis un remplacement ponctuel.
+5. Continue à travailler pendant l’inférence ; le résultat est joint à la
+   tâche ou à l’entrée concernée une fois terminé.
+
+Le menu disponible change selon le contexte :
+
+- les tâches peuvent proposer des actions de texte et de contexte de tâche ;
+- les entrées audio peuvent proposer la transcription et des actions sensibles à l’audio ;
+- les images peuvent proposer une analyse visuelle ;
+- les entrées texte peuvent proposer des prompts ou des actions de génération
+  acceptant du texte.
+
+Certaines compétences nécessitent une tâche liée, car elles lisent un contexte
+de tâche plus large ou écrivent leur résultat dans cette tâche. Si une action
+est absente, vérifie d’abord le type d’entrée et le lien vers la tâche, puis que
+le profil d’inférence actif contient un modèle doté de la capacité requise.
+
+## Les remplacements de modèle sont temporaires
+
+Lorsqu’une compétence propose un sélecteur de modèle, ce choix ne s’applique
+qu’à l’invocation en cours. Il ne réécrit pas silencieusement la valeur par
+défaut de la catégorie ni le profil d’inférence. Pour changer la route normale,
+modifie le profil dans [Modèles et profils d’inférence](./models-and-profiles.mdx).
+
+## Considérer le résultat généré comme un brouillon
+
+Examine les prompts, résumés, transcriptions, analyses d’images et illustrations
+générés avant de t’y fier. Le contexte de la tâche peut être incomplet, un
+fournisseur peut renvoyer une sortie incorrecte, et même un modèle compétent
+peut mal comprendre une urgence très sérieuse de sardines.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/ai-and-automation/usage.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/ai-and-automation/usage.mdx
@@ -1,0 +1,64 @@
+---
+title: Examiner l’utilisation et l’impact de l’IA
+description: Compare les requêtes IA par période, catégorie et modèle, y compris l’estimation du coût, de l’énergie, des émissions et de l’usage des jetons.
+---
+
+# Examiner l’utilisation et l’impact de l’IA
+
+Ouvre **Paramètres → Paramètres IA → Utilisation et impact** pour comprendre
+l’usage des modèles cloud configurés. La même analyse est aussi accessible
+depuis la route du tableau de bord d’impact IA.
+
+<ManualScreenshot
+  caseId="ai/usage"
+  alt="Tableau de bord Impact IA de Lotti pour juillet 2026, affichant le coût, l’énergie, l’équivalent dioxyde de carbone, les jetons, les requêtes et des barres par catégorie"
+  caption="Le mois d’exemple du Projet Waddle sépare Mission Control et Opérations pingouins tout en gardant visible l’empreinte totale des requêtes."
+/>
+
+## Lire les cartes de synthèse
+
+Les cartes du haut résument la période sélectionnée :
+
+- **Coût** estime la dépense auprès du fournisseur.
+- **Énergie** estime l’électricité attribuable à l’inférence cloud mesurée.
+- **CO₂e** exprime l’estimation des émissions associées.
+- **Jetons** compte les jetons traités par les modèles.
+- **Requêtes** compte les appels d’inférence.
+
+L’indicateur de comparaison utilise la période équivalente précédente lorsqu’elle
+existe. Une hausse en pourcentage donne du contexte, sans être automatiquement
+un problème : ne compare pas aveuglément une semaine de revue de lancement à
+une semaine calme dans la colonie.
+
+L’énergie, le CO₂e et le coût ne sont mesurés que pour les modèles cloud.
+L’inférence locale peut consommer beaucoup d’énergie sur l’appareil sans
+apparaître dans ces estimations cloud ; cette page n’est donc pas un compteur
+électrique complet pour tout le système.
+
+## Modifier l’analyse
+
+Utilise le contrôle de période et les boutons fléchés pour naviguer dans le
+temps, ou saute à **Ce mois-ci** et **Cette année**. Choisis ensuite **Les
+deux**, **Par catégorie** ou **Par modèle**. Dans un graphique, passe, lorsque
+l’option existe, entre les valeurs quotidiennes, les totaux cumulés et les
+proportions.
+
+Les vues par catégorie répondent à « quel domaine de travail a entraîné cet
+usage ? ». Les vues par modèle répondent à « quel modèle configuré a entraîné
+cet usage ? ». Consulte les deux avant de modifier un profil : un modèle coûteux
+peut se justifier dans une catégorie spécialisée, mais être gaspillé comme
+valeur par défaut générale.
+
+## Agir face à un résultat surprenant
+
+Si l’usage augmente de façon inattendue :
+
+1. réduis la période au premier jour concerné ;
+2. compare les répartitions par catégorie et par modèle ;
+3. examine les automatisations et la concurrence des agents ;
+4. inspecte le profil d’inférence assigné à la catégorie concernée ;
+5. vérifie la facturation côté fournisseur avant de traiter l’estimation de
+   Lotti comme une facture.
+
+Pour modifier la route responsable des futurs appels, reviens à
+[Modèles et profils d’inférence](./models-and-profiles.mdx).

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/getting-started/first-task.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/getting-started/first-task.mdx
@@ -1,0 +1,85 @@
+---
+title: Crée ta première tâche
+description: Crée une tâche et donne-lui juste assez de structure pour qu’elle soit utile.
+---
+
+# Crée ta première tâche
+
+Une tâche regroupe un résultat, sa liste de contrôle et les notes,
+enregistrements, images ou relevés de temps qui éclairent le travail.
+
+## Commence par le chemin le plus direct
+
+Si tu es encore dans l’intégration, exprime le résultat à voix haute ou choisis
+**Plutôt écrire ?**. Sélectionne le domaine auquel la tâche appartient ; Lotti
+utilise cette catégorie pour la garder visible dans les bonnes vues et choisir
+l’automatisation qui y est configurée.
+
+<ManualScreenshot
+  caseId="onboarding/first-task"
+  alt="Capture vocale de première tâche avec l’orbe de production, forme d’onde en direct et destinations Opérations pingouins et Mission Control"
+  caption="Lorsque le microphone est ouvert, l’orbe de shader et la forme d’onde, vraiment pilotés par le niveau dBFS, réagissent à ta voix. Choisis la destination avant de terminer la capture."
+/>
+
+Après avoir structuré la capture, Lotti affiche le véritable titre de la tâche
+avant de quitter l’intégration. Ouvre la carte pour continuer dans l’espace de
+travail habituel des tâches.
+
+<ManualScreenshot
+  caseId="onboarding/task-created"
+  alt="Création réussie de la première tâche montrant la tâche structurée Inspecter le relais de sardines d’Europe, prête à être ouverte"
+/>
+
+## Crée une tâche depuis la liste
+
+1. Ouvre **Tâches**.
+2. Utilise l’action **+**, puis choisis **Tâche**.
+3. Écris un titre centré sur le résultat.
+4. Choisis une catégorie lorsqu’elle s’applique clairement.
+5. Enregistre la tâche.
+
+Sur ordinateur, l’espace de travail des tâches garde la liste et la tâche
+sélectionnée côte à côte. Sur mobile, sélectionner une tâche ouvre sa vue
+détaillée en plein écran. Dans les deux cas, l’illustration de couverture et le
+contexte de catégorie rendent une liste chargée plus facile à parcourir.
+
+<ManualScreenshot
+  caseId="tasks/workspace"
+  alt="Espace de travail des tâches avec tâches du Projet Waddle, miniatures de couverture distinctes, priorités, catégories et détail de la tâche sélectionnée"
+/>
+
+« Publier le manuel V1 » est plus utile que « Documentation », car le titre te
+dit à quoi ressemble le travail une fois terminé.
+
+## Ajoute du contexte utile
+
+Ouvre la tâche et utilise son action d’ajout pour joindre une note, un
+enregistrement, une image ou une autre entrée. Garde le contenu avec la tâche
+lorsqu’il t’aidera — ou aidera un assistant IA — à comprendre la prochaine
+action plus tard.
+
+<ManualScreenshot
+  caseId="entries/create-menu"
+  alt="Menu Ajouter adapté à la tâche, avec Liste de contrôle, Tâche, Enregistrement audio, Minuteur, Entrée de texte, Importer une image et Capture d’écran"
+/>
+
+<ManualScreenshot
+  caseId="tasks/detail"
+  alt="Détail de tâche pour l’inspection de l’habitat orbital des manchots, avec échéance, catégorie, étiquettes, résumé IA, description, relevés de temps et illustration de couverture"
+/>
+
+## Rends-la concrète
+
+Ajoute une courte liste de contrôle avec des étapes concrètes. Si un fournisseur
+d’IA et les compétences utiles sont configurés, Lotti peut aussi transformer un
+enregistrement ou du contexte écrit en suggestions de liste de contrôle.
+Examine les modifications proposées avant de les appliquer.
+
+## Décide quand elle compte
+
+- Ajoute une échéance lorsqu’il existe une vraie date limite.
+- Définis la priorité pour exprimer l’urgence.
+- Fais apparaître la tâche dans un point d’étape Daily OS lorsqu’elle appartient au plan d’aujourd’hui.
+
+Continue avec la [gestion des tâches](../organize-and-reflect/tasks.mdx) pour
+les priorités, le filtrage et les parcours assistés par la voix.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/getting-started/mental-model.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/getting-started/mental-model.mdx
@@ -1,0 +1,103 @@
+---
+title: Le modèle mental de Lotti
+description: Comprends les quelques éléments qui rendent tout le reste de Lotti plus simple.
+---
+
+# Le modèle mental de Lotti
+
+<div className="manual-hero manual-hero--model">
+  <div className="manual-eyebrow">La friction utile est le cœur du sujet</div>
+  <h1>Ta vie n’est pas un backlog.</h1>
+  <div className="manual-hero-copy">Lotti garde la trace de tes intentions, de tes décisions, de la réalité et de ce que tu en apprends — pas une liste affamée qui écrase tout en « fait » ou « pas fait ». Le plan peut changer. La trace peut dire la vérité.</div>
+</div>
+
+## La boucle : exprimer, choisir, vivre, apprendre
+
+<div className="manual-flow" role="list" aria-label="La boucle de planification et de réflexion de Lotti">
+  <div className="manual-flow-step" role="listitem">
+    <span className="manual-flow-step-number">01</span>
+    <strong>Donne-lui un nom</strong>
+    <p>Une catégorie crée une frontière utile. Une tâche nomme un résultat. Notes, enregistrements, images et listes de contrôle gardent près de toi ce qui l’entoure.</p>
+    <span className="manual-flow-examples">Catégorie · tâche · entrée</span>
+  </div>
+  <div className="manual-flow-step" role="listitem">
+    <span className="manual-flow-step-number">02</span>
+    <strong>Choisis aujourd’hui avec intention</strong>
+    <p>Daily OS transforme ce qui compte en un créneau proposé. C’est une décision pour cette journée, pas une réécriture de la tâche ni une promesse faite à ton futur toi.</p>
+    <span className="manual-flow-examples">Plan · créneau planifié</span>
+  </div>
+  <div className="manual-flow-step" role="listitem">
+    <span className="manual-flow-step-number">03</span>
+    <strong>Laisse la réalité te répondre</strong>
+    <p>Consigne le temps que tu as réellement passé. Ajoute la note, la photo, la mesure ou l’enregistrement vocal qui explique ce qui s’est vraiment produit — imparfait, utile et intact.</p>
+    <span className="manual-flow-examples">Relevé de temps · preuve</span>
+  </div>
+  <div className="manual-flow-step" role="listitem">
+    <span className="manual-flow-step-number">04</span>
+    <strong>Repère les motifs</strong>
+    <p>Habitudes, mesures, tableaux de bord et analyse du temps transforment de nombreuses journées ordinaires en enseignements. Ta prochaine décision gagne alors en justesse.</p>
+    <span className="manual-flow-examples">Habitude · mesure · tableau de bord</span>
+  </div>
+</div>
+
+<ManualScreenshot
+  caseId="daily-os/agenda"
+  alt="Agenda Daily OS de Lotti avec miniatures des tâches du Projet Waddle, créneaux planifiés et contexte de temps"
+  caption="Un créneau Daily OS dit ce que tu as choisi pour aujourd’hui. La tâche liée et le relevé de temps restent, chacun, des éléments honnêtes à part entière."
+/>
+
+## Les éléments de base, sans faire semblant qu’ils sont tous identiques
+
+| Élément | À utiliser pour | Exemple |
+| --- | --- | --- |
+| Catégorie | Un domaine important de ta vie ou de ton travail | Santé, Famille, Recherche |
+| Tâche | Un résultat qui demande d’avancer | Préparer la sortie de la V1 |
+| Liste de contrôle | Des étapes concrètes au sein d’une tâche | Vérifier les notes de version |
+| Entrée | Du contexte ou une preuve | Note, image, enregistrement audio |
+| Créneau planifié | Une place proposée dans la journée | Revue de sortie, 10:00–11:00 |
+| Relevé de temps | Ce qui s’est réellement passé | Revue de sortie, 10:18–11:07 |
+| Habitude | Un comportement récurrent que tu évalues | Prendre un médicament |
+| Mesure | Une observation chiffrée | Fréquence cardiaque au repos |
+| Tableau de bord | Une vue sur des mesures utiles | Vue d’ensemble de l’entraînement |
+
+## Les agents sont des invités, pas des copropriétaires
+
+Un agent peut lire le contexte que tu lui fournis, se faire un avis, résumer une
+tâche confuse et proposer la prochaine modification utile. Son rapport est un
+avis dont l’origine est traçable, pas un nouveau fait dans ton historique. Les
+modifications proposées pour une tâche, une liste de contrôle, un statut ou une
+date attendent que tu les confirmes ou les écartes. Les exceptions étroites sont
+un titre ou une langue initiaux pour une tâche encore vide — ensuite, la même
+règle d’approbation humaine s’applique.
+
+Ce n’est pas une formule de politesse ajoutée à une consigne. Lotti sépare le journal
+personnel et la mémoire de travail de l’agent, afin que celui-ci ne puisse pas
+traiter ton historique comme un brouillon. Tu peux utiliser l’IA, l’ajuster ou
+la laisser entièrement de côté.
+
+## Une première orbite concrète
+
+1. Crée des catégories que tu utilises vraiment pour prendre tes décisions.
+2. Capture ton travail sous forme de tâches et conserve avec elles le contenu qui les éclaire.
+3. Utilise Daily OS pour décider ce qui a sa place dans une journée donnée.
+4. Consigne le temps réel et tes observations sans les forcer à correspondre au plan.
+5. Examine les habitudes et les tableaux de bord pour y voir des motifs plutôt que des journées parfaites isolées.
+
+## Garde les responsabilités bien séparées
+
+- La tâche liée est propriétaire de son titre et de sa catégorie.
+- Un créneau Daily OS est propriétaire de son emplacement et de sa durée.
+- Une entrée de temps est propriétaire de la trace de ce qui s’est passé.
+- L’IA propose ; tu examines et décides.
+
+:::tip Le but n’est pas une chronologie impeccable
+
+Si le plan a changé, laisse-le changer. Si la journée a déraillé, note ce qui
+s’est réellement passé. Un système utile t’aide à voir la forme de ta vie ; il
+ne te demande pas de jouer une version plus productive de toi-même pour la base
+de données.
+
+:::
+
+Ensuite, [crée ta première tâche](./first-task.mdx) ou passe directement à
+[Daily OS](../plan-and-capture/daily-os.mdx).

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/getting-started/onboarding.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/getting-started/onboarding.mdx
@@ -1,0 +1,151 @@
+---
+title: Configure Lotti lors de l’intégration
+description: Connecte un fournisseur d’IA, choisis le style d’enregistrement et les domaines de travail, puis transforme une première pensée en vraie tâche.
+---
+
+# Configure Lotti lors de l’intégration
+
+Le parcours d’intégration rassemble les éléments minimaux nécessaires au parcours de tâches
+assisté par IA de Lotti : un fournisseur, un style d’enregistrement, au moins
+une catégorie et une première vraie tâche. C’est une configuration guidée, pas
+un environnement de démo distinct : les fournisseurs, catégories et tâches
+créés ici restent dans l’application normale.
+
+Ouvre **Paramètres → Intégration** chaque fois que tu veux démarrer ou revoir le
+parcours. La page indique aussi si ce profil a déjà créé sa première tâche
+structurée par IA.
+
+<ManualScreenshot
+  caseId="onboarding/settings"
+  alt="Paramètres d’intégration de Lotti affichant un état activé et l’action Revoir l’intégration"
+  caption="Ce profil du Projet Waddle a déjà créé sa première tâche IA. Revoir l’intégration reste possible après l’activation."
+/>
+
+## Commence par la promesse de bienvenue
+
+<ManualScreenshot
+  caseId="onboarding/welcome"
+  alt="Panneau de bienvenue de l’intégration Lotti invitant à connecter un cerveau IA et à transformer la parole en tâche structurée"
+  caption="Le panneau de bienvenue s’ouvre au-dessus de l’application actuelle. Choisis ton cerveau IA pour continuer, ou quitte le parcours sans modifier ta configuration."
+/>
+
+Choisis **Choisir ton cerveau IA** pour commencer. **Explorer d’abord**, la zone
+assombrie hors du panneau et l’action système de retour quittent tous
+l’intégration sans rien connecter. Tu pourras y revenir plus tard depuis les
+Paramètres.
+
+Lotti peut aussi proposer automatiquement cette bienvenue à un profil éligible.
+L’invite automatique a une cadence de tentatives limitée ; l’entrée dans les
+Paramètres n’en a pas, de sorte que tu gardes toujours un moyen d’y revenir.
+
+## Choisis où structurer les tâches
+
+<ManualScreenshot
+  caseId="onboarding/providers"
+  alt="Sélecteur de fournisseurs de l’intégration Lotti avec Melious.ai, Mistral, Gemini, Qwen, OpenAI et Ollama"
+  caption="Les principaux fournisseurs hébergés apparaissent d’abord. Déplie Plus d’options pour OpenAI et le parcours local Ollama."
+/>
+
+La page des fournisseurs présente les choix hébergés et locaux disponibles :
+
+- **Melious.ai** est le choix par défaut recommandé, hébergé dans l’UE, avec
+  routage dynamique des modèles.
+- **Mistral**, **Gemini** et **Qwen** exposent leurs régions hébergées
+  correspondantes.
+- **OpenAI** est disponible parmi les options supplémentaires.
+- **Ollama** se connecte à un point de terminaison local compatible et ne
+  nécessite pas de clé d’API hébergée.
+
+<ManualScreenshot
+  caseId="onboarding/api-key"
+  alt="Panneau de vérification de fournisseur de l’intégration Lotti montrant une connexion Ollama locale vérifiée"
+  caption="Lotti vérifie le fournisseur choisi avant d’activer Connecter. Les fournisseurs hébergés utilisent la même étape avec un champ de clé API."
+/>
+
+Pour un fournisseur hébergé, colle sa clé API. Lotti vérifie la connexion avant
+d’activer **Connecter**. Ollama vérifie le point de terminaison local configuré
+et indique les modèles joignables. Une connexion réussie conserve le
+fournisseur et prépare les modèles ainsi que le profil d’inférence utilisés
+dans les étapes suivantes.
+
+<ManualScreenshot
+  caseId="onboarding/success"
+  alt="Confirmation de l’intégration Lotti que le fournisseur d’IA est connecté et prêt"
+  caption="La confirmation de connexion est volontairement sobre ; la récompense plus importante est réservée à la première vraie tâche."
+/>
+
+Le texte capturé pour une tâche est envoyé au fournisseur affecté à la catégorie
+sélectionnée afin d’être structuré. Choisis un fournisseur dont le déploiement
+et le traitement des données correspondent au contenu que tu prévois de
+capturer. Un point de terminaison Ollama local joignable garde cette demande de
+structuration sur la machine qui l’exécute.
+
+## Choisis le style d’enregistrement et les domaines de travail
+
+<ManualScreenshot
+  caseId="onboarding/recording-style"
+  alt="Sélecteur de style d’enregistrement de l’intégration Lotti avec les options orbe d’énergie moderne et vumètre analogique"
+  caption="Choisis le visuel d’enregistrement qui te paraît le plus clair. Les deux options utilisent le même pipeline de capture."
+/>
+
+Après avoir établi la connexion, choisis le style d’enregistrement utilisé pour
+la capture de la première tâche et les surfaces de capture vocale suivantes.
+Tu pourras le modifier dans **Paramètres → Style d’enregistrement**.
+
+<ManualScreenshot
+  caseId="onboarding/categories"
+  alt="Sélecteur de domaines de travail de l’intégration Lotti avec Travail, Forme, Famille, Amis et l’option Ajouter la tienne"
+  caption="Choisis un ou plusieurs domaines pour le nouveau fournisseur. Avec un texte agrandi ou une mise en page étroite, chaque choix occupe automatiquement une ligne sur toute sa largeur."
+/>
+
+Choisis ensuite un ou plusieurs domaines de travail. Les préréglages couvrent
+des catégories courantes comme Travail, Forme, Famille et Amis ; **Ajouter la
+tienne** crée une catégorie dont le nom correspond à ton espace de travail.
+L’intégration réutilise une catégorie existante portant le même nom plutôt que
+d’en créer un doublon, la restaure si nécessaire et la relie au profil
+d’inférence nouvellement préparé.
+
+Le jeu de données du manuel crée deux vraies destinations — **Opérations
+pingouins** et **Mission Control** — afin que l’étape suivante montre le
+même choix de catégorie que voit un compte en utilisation.
+
+## Capture la première vraie tâche
+
+<ManualScreenshot
+  caseId="onboarding/first-task"
+  alt="Panneau de première tâche de l’intégration Lotti avec capture vocale, destinations Opérations pingouins et Mission Control, suggestions et Plutôt écrire ?"
+  caption="Choisis où la tâche doit arriver, puis parle naturellement, utilise une suggestion de départ ou choisis Plutôt écrire ?. Opérations pingouins est sélectionnée ici."
+/>
+
+Le panneau de première tâche utilise le pipeline de capture habituel de Lotti.
+Choisis la catégorie cible, puis suis l’un de ces trois chemins :
+
+1. Sélectionne le visuel d’enregistrement et exprime la tâche dans une phrase naturelle.
+2. Choisis une suggestion de départ pour essayer tout de suite le parcours de structuration.
+3. Choisis **Plutôt écrire ?** et saisis la pensée sans utiliser le microphone.
+
+Lotti affiche les mots capturés pendant qu’il les structure. Le résultat est une
+vraie tâche dans la catégorie choisie, pas des données d’exemple réservées à
+l’intégration. Lorsque la structuration produit des suggestions de liste de
+contrôle, elles arrivent sur la tâche sous forme de propositions : tu peux les
+confirmer plutôt que de laisser la tâche changer en silence.
+
+<ManualScreenshot
+  caseId="onboarding/task-created"
+  alt="Panneau de réussite de l’intégration Lotti montrant la tâche créée Inspecter le relais de sardines d’Europe"
+  caption="La pensée saisie du Projet Waddle devient « Inspecter le relais de sardines d’Europe ». La tâche reste dans le panneau jusqu’à ce que tu la choisisses."
+/>
+
+Choisis la carte de la tâche créée pour fermer l’intégration et ouvrir sa page
+normale. Tu peux alors examiner les propositions de liste de contrôle, ajouter
+une illustration de couverture ou une preuve, définir une échéance et une
+priorité, puis intégrer la tâche à Daily OS.
+
+Si tu fermes le parcours après avoir connecté un fournisseur, Lotti conserve
+cette configuration et considère la bienvenue comme terminée. Revoir
+l’intégration plus tard reste sans risque : c’est une action explicite des
+Paramètres, pas une nouvelle invite automatique.
+
+Continue avec [crée ta première tâche](./first-task.mdx),
+[gère les catégories](../organize-and-reflect/categories.mdx) et
+[configure les fournisseurs](../ai-and-automation/provider-setup.mdx).

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/index.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/index.mdx
@@ -1,0 +1,116 @@
+---
+id: index
+title: Manuel Lotti
+slug: /
+sidebar_label: Bienvenue
+description: Découvre comment planifier, capturer, organiser et prendre du recul avec Lotti.
+---
+
+<div className="manual-hero manual-hero--welcome">
+  <div className="manual-eyebrow">Un journal privé, pas un panoptique de la productivité</div>
+  <h1>Garde les faits. Ta journée t’appartient.</h1>
+  <div className="manual-hero-copy">Tâches, temps, notes vocales, habitudes, données de santé et l’idée utile qui surgit parfois méritent mieux que le purgatoire des onglets. Lotti garde la trace ; tu décides de la suite.</div>
+  <div className="manual-hero-principles">
+    <div><strong>Ton histoire reste la tienne.</strong><span>Elle vit dans ton journal local, pas dans un compte cloud Lotti.</span></div>
+    <div><strong>L’IA propose ; tu décides.</strong><span>Les agents peuvent observer, réfléchir et proposer. Ils n’ont pas les clés de ta vie.</span></div>
+    <div><strong>Rends-la mémorable.</strong><span>Utile, sérieuse, délicieusement étrange : ton espace de travail peut te ressembler.</span></div>
+  </div>
+</div>
+
+<ManualScreenshot
+  caseId="tasks/detail"
+  alt="Page de tâche Lotti pour l’habitat orbital des manchots du Projet Waddle, avec contexte, illustration de couverture, liste de contrôle et relevés de temps"
+  caption="Une tâche est une trace vivante : le résultat, son contexte, les prochaines étapes et les preuves du travail avancent ensemble."
+/>
+
+## Pas une nouvelle machine pour faire semblant que tout s’est passé comme prévu
+
+Lotti distingue ce que tu voulais faire de ce qui s’est réellement passé. Une
+tâche peut être importante sans s’approprier toute ta journée. Un plan peut
+être réorganisé sans réécrire l’histoire. Un relevé de temps peut dire,
+honnêtement, que la réunion a débordé et que la bonne idée est arrivée pendant
+le chemin du retour.
+
+Cette séparation est essentielle, pas administrative. Elle te donne une trace
+fiable quand la semaine devient bruyante.
+
+:::note À propos des manchots (et d’autres excellentes absurdités)
+
+Les manchots, l’habitat orbital, les sardines et **Projet Waddle**
+n’apparaissent que dans l’espace de démonstration fictif **Intergalactic
+Penguin Logistics** de ce manuel. Ils donnent aux captures d’écran une histoire
+cohérente, tandis que les commandes, les parcours et le comportement du produit
+montrés sont ceux de la vraie application Lotti. « Opérations pingouins » reste
+le nom fictif d’une catégorie ; pour les animaux, ce manuel emploie le terme
+précis **manchots**. Ton espace peut être aussi ordinaire — ou délicieusement
+étrange — que tu le souhaites. Les illustrations de couverture des tâches sont
+facultatives ; une bonne métaphore visuelle peut rendre une semaine chargée
+bien plus lisible.
+
+Cet univers n’est ni du contenu de démarrage ni ajouté à ton profil. C’est un
+jeu de données de capture déterministe : une opération logistique farfelue, des
+personnages récurrents et des couvertures de tâche distinctes permettent de
+suivre une fonctionnalité de l’agenda à la tâche, au projet, au journal et au
+tableau de bord sans confondre les exemples avec une promesse produit. Les
+illustrations sont tout aussi facultatives dans le vrai travail : crée-les dans
+Lotti lorsqu’une image utile, sérieuse ou glorieusement singulière rend le
+travail plus facile à reconnaître.
+
+:::
+
+## Commence là où ça accroche
+
+<div className="manual-cards">
+  <a className="manual-card" href="getting-started/mental-model/">
+    <strong>Ta vie n’est pas un backlog</strong>
+    Découvre comment l’intention, les plans, le temps réel, les preuves et la réflexion restent distincts — et utiles.
+  </a>
+  <a className="manual-card" href="plan-and-capture/daily-os/">
+    <strong>Construis une journée qui respire</strong>
+    Transforme un point d’étape oral ou écrit en plan de journée modifiable, ancré dans la réalité.
+  </a>
+  <a className="manual-card" href="organize-and-reflect/tasks/">
+    <strong>Donne un foyer au travail</strong>
+    Crée des tâches, ajoute du contexte, fixe les priorités et transforme le flou en prochaines étapes.
+  </a>
+  <a className="manual-card" href="ai-and-automation/provider-setup/">
+    <strong>Choisis un cerveau avec responsabilité</strong>
+    Choisis délibérément une inférence locale ou dans le cloud : confidentialité, conservation, région et énergie font toutes partie de la décision.
+  </a>
+</div>
+
+## L’IA est facultative. Pas ses conséquences.
+
+Lotti n’a ni serveur d’inférence ni copie de ce que tu envoies à un modèle. Le
+stockage local et l’inférence locale sont des choix liés, mais ne constituent
+pas la même promesse : ton journal reste sur tes appareils dans les deux cas.
+Avec un fournisseur local, le contenu sélectionné est traité par la machine ou
+le point de terminaison local que tu configures. Avec un fournisseur cloud, le
+contexte choisi va directement à ce fournisseur sous **ton** compte et ta clé
+d’API. La décision t’appartient — et les vérifications nécessaires aussi.
+
+<div className="manual-responsibility-grid">
+  <div className="manual-responsibility-card">
+    <strong>La confidentialité est un choix de routage.</strong>
+    <p>Pour du contenu sensible, utilise un modèle compétent en local ou choisis un fournisseur seulement après avoir vérifié sa conservation des données, son entraînement, sa juridiction et les paramètres de ton compte. « Cloud » ne veut jamais automatiquement dire « rien n’est conservé ».</p>
+  </div>
+  <div className="manual-responsibility-card">
+    <strong>L’énergie aussi est un choix de routage.</strong>
+    <p>L’IA fonctionne dans des lieux physiques. Préfère une configuration locale ou un fournisseur dont tu peux réellement vérifier l’électricité, la localisation et les affirmations carbone. Une configuration ou un fournisseur alimenté par des énergies renouvelables peut éviter de faire porter à des communautés moins à même de s’y opposer le coût sanitaire et climatique d’un calcul alimenté aux énergies fossiles — notamment par des turbines à gaz.</p>
+  </div>
+  <div className="manual-responsibility-card">
+    <strong>L’approbation humaine est une règle du produit.</strong>
+    <p>Les agents peuvent analyser le contexte et préparer des modifications, mais toute modification de ta trace attend ton accord. Les seules exceptions étroites sont un titre ou une langue initiaux pour une tâche encore vide. Lotti ne transforme pas « utile » en « irresponsable ».</p>
+  </div>
+</div>
+
+La règle pratique : si tu ne trouves pas un chemin de données et d’énergie que
+tu peux assumer, désactive l’IA. Lotti reste utile sans elle.
+
+:::tip Commence petit
+
+Crée quelques catégories qui comptent, une vraie tâche et un point d’étape
+Daily OS. N’ajoute de structure que lorsqu’elle mérite sa place : tu construis
+la trace d’une vie, pas l’alimentation d’une machine à productivité.
+
+:::

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/organize-and-reflect/categories.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/organize-and-reflect/categories.mdx
@@ -1,0 +1,86 @@
+---
+title: Organise avec des catégories
+description: Utilise les catégories comme frontières pertinentes pour filtrer, planifier, protéger la vie privée et automatiser.
+---
+
+# Organise avec des catégories
+
+Une catégorie est le principal foyer structurel d’une entrée. Utilise-en une
+lorsqu’un ensemble de travail a besoin de ses propres règles de planification,
+d’une frontière de confidentialité, d’une identité visuelle ou d’un contexte
+pour l’IA. Dans l’espace de démonstration, **Opérations Pingouins**, **Contrôle
+de mission**, **Diplomatie des poissons** et **Maintenance humaine** séparent des
+domaines réellement distincts de l’expédition.
+
+<ManualScreenshot
+  caseId="categories/list"
+  alt="Réglages des catégories contenant Opérations Pingouins, Contrôle de mission, Diplomatie des poissons et Maintenance humaine, avec nombres de tâches et icônes d’état"
+  caption="La liste est consultable et affiche le nombre de tâches. Les icônes permettent d’identifier d’un coup d’œil les catégories favorites, privées et inactives."
+/>
+
+## Crée une catégorie
+
+1. Ouvre **Réglages → Catégories**.
+2. Sélectionne **Créer une catégorie**.
+3. Saisis un nom, une couleur et une icône distinctifs.
+4. Crée-la, puis ouvre de nouveau la catégorie pour configurer son comportement.
+
+La création commence volontairement par les champs d’identification. Les options
+de planification, de confidentialité, de langue et d’automatisation se trouvent
+dans l’éditeur complet, une fois la catégorie créée.
+
+## Configure le comportement de la catégorie
+
+<ManualScreenshot
+  caseId="categories/detail"
+  alt="Éditeur de catégorie Opérations Pingouins affichant son nom, son identité violette de vol et les options favori, privée, actif et planification du jour"
+/>
+
+L’éditeur contrôle plus que l’apparence :
+
+- **Favori** rend une catégorie importante plus facile à reconnaître et à sélectionner.
+- **Privée** masque son contenu tant que les entrées privées ne sont pas affichées. C’est
+  une frontière de visibilité, pas un chiffrement séparé de la catégorie.
+- **Actif** indique si la catégorie peut être choisie pour de nouvelles entrées.
+  La désactiver préserve les données existantes.
+- **Planification du jour** permet à la catégorie de participer à la planification Daily OS.
+- **Langue** définit la langue par défaut des nouvelles tâches de la catégorie.
+
+Utilise **Planification du jour** avec discernement. L’activer pour chaque
+catégorie élargit le contexte du planificateur et rend le rituel quotidien plus
+bruyant.
+
+## Ajoute un contexte d’automatisation propre à la catégorie
+
+Une catégorie peut fournir des valeurs par défaut pour les nouvelles tâches : un
+profil d’inférence et un modèle d’agent. Ce sont des valeurs par défaut, pas des
+verrous permanents ; les choix au niveau de la tâche peuvent encore changer
+plus tard.
+
+<ManualScreenshot
+  caseId="categories/automation"
+  alt="Réglages avancés d’Opérations Pingouins avec vocabulaire vocal Project Waddle et corrections de liste de contrôle apprises pour Sir Flaps-a-Lot"
+  caption="Les termes vocaux sont séparés par des points-virgules. Les corrections de liste de contrôle sont apprises à partir des modifications ; tu peux les examiner ou les supprimer ici."
+/>
+
+Le dictionnaire de **Reconnaissance vocale** est utile pour les noms, lieux,
+acronymes et le vocabulaire spécialisé que la transcription manque souvent.
+Opérations Pingouins apprend par exemple à Lotti `Project Waddle`,
+`Sir Flaps-a-Lot`, `sardine` et `Europa`.
+
+Lorsque tu corriges manuellement des titres de listes de contrôle générés, Lotti
+peut conserver les exemples avant/après pour de futures suggestions IA. Examine
+les exemples ici et supprime toute correction qui ne devrait pas guider les
+résultats ultérieurs.
+
+## Catégories et étiquettes
+
+Utilise une catégorie pour le foyer principal du travail et une
+[étiquette](./labels.mdx) pour une propriété transversale. **Opérations
+Pingouins** est une catégorie ; **Habitat critique** est une étiquette qui peut
+aussi s’appliquer au travail de Contrôle de mission.
+
+Garde le système de catégories assez petit pour que le choix soit évident.
+Ajoute une catégorie lorsqu’elle change la planification, le filtrage, la
+confidentialité ou l’automatisation — pas simplement parce qu’un nouveau nom
+est apparu.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/organize-and-reflect/dashboards.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/organize-and-reflect/dashboards.mdx
@@ -1,0 +1,119 @@
+---
+title: Crée des tableaux de bord utiles
+description: Combine habitudes, mesures, santé, questionnaires et entraînements dans une vue opérationnelle réutilisable.
+---
+
+# Crée des tableaux de bord utiles
+
+Un tableau de bord rassemble des graphiques qui répondent à une question
+récurrente. **Opérations de la colonie** réunit la pression de l’habitat, la
+demande de sardines et l’effectif de l’expédition ; **État de préparation de la
+mission** isole un examen de lancement privé. Construis-le autour d’une décision
+plutôt que d’accumuler tous les nombres disponibles.
+
+<ManualScreenshot
+  caseId="dashboards/settings-list"
+  alt="Réglages des tableaux de bord contenant Opérations de la colonie et le tableau de bord privé État de préparation de la mission"
+/>
+
+## Crée un tableau de bord
+
+1. Ouvre **Réglages → Gestion des tableaux de bord**.
+2. Sélectionne **Créer un tableau de bord**.
+3. Ajoute un nom clair et une description de la question à laquelle il doit répondre.
+4. Attribue éventuellement une catégorie et un réglage de confidentialité.
+5. Ajoute et ordonne les graphiques, puis enregistre.
+
+<ManualScreenshot
+  caseId="dashboards/settings-detail"
+  alt="Éditeur du tableau de bord Opérations de la colonie, attribué à Opérations Pingouins, avec options de confidentialité et d’activité"
+/>
+
+- **Catégorie** rend le tableau de bord disponible pour le filtrage par catégorie.
+- **Privé** masque le tableau de bord tant que les entrées privées ne sont pas affichées.
+- **Actif** détermine s’il apparaît dans la liste des tableaux de bord sans
+  supprimer sa définition.
+
+## Compose et ordonne les graphiques
+
+<ManualScreenshot
+  caseId="dashboards/charts"
+  alt="Liste de graphiques Opérations de la colonie avec Pression de l’habitat — moyenne quotidienne, Sardines consommées — somme quotidienne et Pingouins recensés — somme quotidienne"
+  caption="Fais glisser la poignée pour réordonner. Sélectionne le contrôle d’ajustement d’un graphique de mesure pour modifier son agrégation, ou retire-le avec ×."
+/>
+
+L’ordre des graphiques est celui du tableau de bord. Place d’abord le signal qui
+donne le cadre aux autres. Pour Opérations de la colonie, la pression de
+l’habitat ouvre la marche, car un habitat dangereux change la façon
+d’interpréter tous les autres nombres.
+
+Les graphiques de mesure conservent leur propre agrégation dans l’élément du
+tableau de bord. Ainsi, une même mesure peut apparaître avec un résumé différent
+dans un autre tableau de bord sans modifier les observations sous-jacentes.
+
+## Ajoute des graphiques depuis les sources prises en charge
+
+<ManualScreenshot
+  caseId="dashboards/sources"
+  alt="Éditeur de tableau de bord proposant Habitudes, Mesures, Santé, Questionnaires et Entraînements comme sources de graphiques, ainsi que l’export JSON"
+/>
+
+L’éditeur peut ajouter :
+
+- **Habitudes** pour l’historique de réalisation.
+- **Mesures** pour les observations numériques définies par l’utilisateur.
+- **Santé** pour les données prises en charge par la plateforme et ses autorisations.
+- **Questionnaires** pour les résultats des questionnaires configurés.
+- **Entraînements** importés depuis les sources de santé prises en charge.
+
+Déplie une source, sélectionne un ou plusieurs graphiques, puis ajoute-les. Leur
+disponibilité dépend des définitions et données de plateforme présentes ; les
+demandes d’autorisation de santé et les types pris en charge varient selon
+l’appareil.
+
+## Ouvre et interprète un tableau de bord
+
+Ouvre **Aperçus** pour voir les tableaux de bord actifs. La liste montre
+l’icône de catégorie, le nom et le rôle de chacun. Utilise le filtre de l’en-tête
+pour te concentrer sur une ou plusieurs catégories.
+
+<ManualScreenshot
+  caseId="dashboards/list"
+  alt="Liste de tableaux de bord Aperçus de Lotti, avec Opérations de la colonie et le tableau de bord privé État de préparation de la mission"
+  caption="Sur ordinateur, le panneau droit est réservé au tableau de bord sélectionné ; sur mobile, le tableau de bord sélectionné s’ouvre sur une page distincte."
+/>
+
+Sélectionne **Opérations de la colonie** pour ouvrir ses graphiques. Sur
+ordinateur, la liste et le tableau de bord sélectionné restent côte à côte. Sur
+mobile, le tableau de bord s’ouvre sur sa propre page, avec un bouton retour.
+
+<ManualScreenshot
+  caseId="dashboards/view"
+  alt="Tableau de bord Opérations de la colonie affichant 90 jours de pression de l’habitat et de sardines consommées, avec la liste des tableaux de bord à côté sur ordinateur"
+  caption="L’en-tête fixe laisse visibles les commandes de période 30, 90, 180 et 365 jours pendant que les graphiques défilent dessous."
+/>
+
+La période sélectionnée s’applique à tous les graphiques de la page. Les cartes
+de graphique conservent leurs propres unités et agrégations : la pression de
+l’habitat utilise une moyenne quotidienne, tandis que la consommation de
+sardines et l’effectif de manchots utilisent des sommes quotidiennes.
+Sélectionne le **+** d’une carte de mesure pour enregistrer une nouvelle
+observation de ce type.
+
+<ManualScreenshot
+  caseId="dashboards/view-crew"
+  alt="Tableau de bord Opérations de la colonie, défilé jusqu’aux graphiques Sardines consommées et Pingouins recensés"
+  caption="Une brève baisse à 36 manchots apparaît dans l’historique de l’équipage sur 90 jours ; les jours alentours reviennent aux 37 attendus."
+/>
+
+Considère un graphique comme une preuve, pas comme un verdict. Vérifie
+l’agrégation, les unités, la plage de dates, les observations manquantes et
+l’état de confidentialité avant d’en tirer des conclusions.
+
+## Exporte la configuration d’un tableau de bord
+
+**Enregistrer et copier le JSON** enregistre le tableau de bord, puis copie sa
+configuration et les définitions de mesures référencées. C’est utile pour
+inspecter ou déplacer une configuration, mais ce n’est pas un lien de
+synchronisation en direct : des modifications ultérieures ne mettent pas à jour
+une charge déjà copiée.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/organize-and-reflect/events.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/organize-and-reflect/events.mdx
@@ -1,0 +1,127 @@
+---
+title: Garde le souvenir des moments importants
+description: Planifie les moments à venir, rassemble leurs photos et leurs notes, et garde les tâches associées près du souvenir.
+---
+
+# Garde le souvenir des moments importants
+
+Les événements donnent une place à part aux moments qui comptent dans Lotti.
+Utilise un événement pour un lancement, un voyage, une célébration, une
+conférence ou tout autre moment que tu souhaites retrouver. Utilise les tâches
+pour le travail de préparation et de suivi qui l’entoure.
+
+Les événements sont pour l’instant une fonctionnalité facultative. Ouvre
+**Réglages → Paramètres avancés → Flags** et active **Activer les événements**. La
+destination **Événements** apparaît alors dans la barre latérale sur ordinateur
+et sous **Plus** sur mobile.
+
+<ManualScreenshot
+  caseId="events/overview"
+  alt="Vue d’ensemble des événements avec le prochain sommet des contrats à terme sur les sardines Europa et des célébrations Project Waddle terminées"
+  caption="La vue d’ensemble met le prochain événement en avant, puis regroupe les archives par année. Chaque exemple montre un moment et une photo de couverture distincts d’Intergalactic Penguin Logistics."
+/>
+
+## Parcours et filtre tes événements
+
+La vue d’ensemble met les photos au premier plan, afin que tu reconnaisses un
+événement avant même de lire son titre. L’événement futur le plus proche occupe
+la section phare **À venir**. Les événements passés sont regroupés par année,
+du plus récent au plus ancien.
+
+Utilise **Rechercher des événements** pour trouver un événement à partir de son
+texte. Sélectionne une puce de catégorie — par exemple **Opérations Pingouins**,
+**Contrôle de mission** ou **Diplomatie des poissons** — pour restreindre
+l’ensemble des archives. Le filtre s’applique à la collection d’événements
+enregistrée, pas seulement aux cartes visibles à l’écran.
+
+Lotti charge les archives volumineuses par pages et n’affiche que les lignes
+proches. Même des centaines d’événements riches en photos restent donc
+pratiques, sans devoir charger toutes les couvertures d’un coup.
+
+## Crée un événement
+
+Sélectionne **Nouvel événement**. Le nouvel événement s’ouvre sur sa page de
+détail, où tu peux ajouter un titre, une catégorie, une date et une heure, un
+statut, une photo de couverture et des entrées associées.
+
+Choisis un titre qui nomme le moment, plutôt que sa préparation. Par exemple,
+**Gala de lancement de Project Waddle** est l’événement ; **Recalibrer le
+distributeur de poissons en apesanteur** est une tâche liée.
+
+## Lis et modifie le détail de l’événement
+
+<ManualScreenshot
+  caseId="events/detail"
+  alt="Événement Gala de lancement de Project Waddle avec photo héro, statut terminé, note de cinq étoiles, résumé, trois photos et deux tâches liées"
+  caption="La même page de détail de production devient une mise en page à deux colonnes sur ordinateur et s’empile dans un seul défilement sur mobile."
+/>
+
+Le bandeau héro réunit l’identité de l’événement et ses commandes principales :
+
+- sélectionne le titre pour le modifier ;
+- sélectionne la puce de catégorie ou de statut pour la modifier ;
+- sélectionne la date et l’heure pour reprogrammer l’événement ;
+- sélectionne une étoile pour modifier la note d’un événement terminé ;
+- ouvre le menu de débordement pour changer la couverture ou supprimer l’événement.
+
+Les changements sont enregistrés depuis la page de détail ; il n’y a pas de
+formulaire distinct à rouvrir. Une note apparaît après qu’un événement est
+terminé, ou dès lors que l’événement possède déjà une note.
+
+Le résumé utilise la réponse IA liée la plus récente lorsqu’il y en a une.
+Sinon, il affiche la note propre à l’événement. Considère-le comme un rappel
+rapide, puis utilise les photos et la chronologie pour retrouver la trace
+sous-jacente.
+
+## Construis une trace photographique
+
+La section **Photos** rassemble toutes les images liées à l’événement dans
+l’ordre chronologique. Sélectionne une miniature pour ouvrir la visionneuse en
+plein écran, puis balaie les photos ou pince pour zoomer. Une collection
+volumineuse est limitée à un aperçu compact ; la dernière tuile indique combien
+d’autres photos sont disponibles.
+
+La couverture est l’une des photos liées à l’événement. Si aucune couverture
+n’a été choisie, Lotti peut utiliser la première photo liée. Utilise
+**Changer la couverture** dans le menu de débordement pour choisir une autre
+image, ou ajoute une nouvelle photo depuis le même sélecteur.
+
+## Suis la chronologie et le travail associé
+
+<ManualScreenshot
+  caseId="events/timeline"
+  alt="Chronologie de l’événement Project Waddle avec photos de contrôle de mission, note sur un joint de pression, images de fret de sardines et deux tâches associées"
+  caption="Photos, notes, enregistrements et tâches de suivi restent liés à l’événement, sans transformer l’événement lui-même en tâche."
+/>
+
+La chronologie trie les entrées liées de la plus ancienne à la plus récente.
+Elle peut contenir :
+
+- des photos et leurs légendes ;
+- des notes ;
+- des entrées audio et des notes vocales ;
+- des enregistrements de temps, indiqués par un début, une fin et une durée écoulée.
+
+Sélectionne un élément de la chronologie pour ouvrir son entrée source.
+Sélectionne **Ajouter** à côté de **Chronologie** pour créer une note, une
+photo, une entrée audio ou une autre entrée prise en charge, automatiquement
+liée à cet événement.
+
+La section **Tâches** sert à la préparation et au suivi. Sélectionne une tâche
+existante pour l’ouvrir, ou **Ajouter** pour créer une tâche déjà liée à
+l’événement. Sur ordinateur, les tâches restent visibles dans une colonne à
+droite pendant que tu lis l’événement ; sur mobile, elles suivent la
+chronologie dans le même défilement.
+
+## Événement ou tâche ?
+
+Utilise cette distinction pour décider où ranger quelque chose :
+
+| Utilise un événement pour… | Utilise une tâche pour… |
+| --- | --- |
+| Un moment avec une date, des photos, un récapitulatif et une valeur de souvenir | Une action avec un statut, une estimation, une liste de contrôle ou une session de travail |
+| Gala de lancement de Project Waddle | Recalibrer le distributeur de poissons en apesanteur |
+| Sommet des contrats à terme sur les sardines Europa | Confirmer les capsules de fret de sardines interplanétaires |
+
+Relie les deux lorsque le travail soutient le moment. Ainsi, l’événement reste
+agréable à retrouver, tandis que son travail opérationnel demeure actionnable.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/organize-and-reflect/habits-and-measurables.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/organize-and-reflect/habits-and-measurables.mdx
@@ -1,0 +1,169 @@
+---
+title: Suis les habitudes et les mesures
+description: Configure des comportements récurrents et des observations chiffrées, puis consigne chacun avec honnêteté.
+---
+
+# Suis les habitudes et les mesures
+
+Une habitude répond à la question **ce comportement récurrent a-t-il eu lieu ?**
+Une mesure répond à **quelle valeur chiffrée ai-je observée ?** Elles peuvent
+servir le même objectif sans être interchangeables : « Appel des manchots
+empereurs » est une habitude, tandis que « Pingouins recensés » est une valeur
+mesurable.
+
+## Travaille avec les habitudes
+
+La page Habitudes organise les définitions actives entre ce qui est dû
+maintenant, prévu plus tard et terminé. Son résumé quotidien, son historique de
+régularité, ses séries et son graphique de taux de réalisation t’aident à
+repérer des tendances sans faire d’un jour manqué toute l’histoire.
+
+<ManualScreenshot
+  caseId="habits/today"
+  alt="Tableau de bord des habitudes Opérations Pingouins montrant vérifications de l’habitat, appel des manchots, inventaire des sardines, état de réalisation, séries et historique récent"
+/>
+
+### Crée et retrouve des définitions d’habitudes
+
+1. Ouvre **Réglages → Habitudes**.
+2. Sélectionne **Créer une habitude**.
+3. Donne au comportement un nom concret et répétable, ainsi qu’une description utile.
+4. Choisis sa catégorie, ses options et son calendrier.
+5. Enregistre.
+
+<ManualScreenshot
+  caseId="habits/settings-list"
+  alt="Réglages des habitudes contenant Appel des manchots empereurs, Examiner les prévisions de sardines et Inspecter les joints de l’habitat, avec états favori, inactif et privé"
+  caption="Cherche les définitions ici. L’étoile, l’œil barré et le cadenas identifient les habitudes favorites, inactives et privées."
+/>
+
+<ManualScreenshot
+  caseId="habits/settings-detail"
+  alt="Éditeur de l’habitude Appel des manchots empereurs, avec description de l’expédition, catégorie Opérations Pingouins et options favori, privée et actif"
+/>
+
+L’éditeur de définition comprend :
+
+- **Catégorie** pour le filtrage et le contexte visuel.
+- **Tableau de bord** lorsque l’habitude doit apparaître comme graphique dans un tableau de bord choisi.
+- **Favori** pour lui donner plus d’importance.
+- **Privée** pour la masquer tant que les entrées privées ne sont pas affichées.
+- **Actif** pour déterminer si elle apparaît sur la page Habitudes sans
+  supprimer son historique.
+
+### Programme une habitude quotidienne
+
+<ManualScreenshot
+  caseId="habits/schedule"
+  alt="Calendrier de l’appel des manchots empereurs commençant le 1er juillet, affiché à partir de 06:00 avec une alerte à 06:30"
+/>
+
+L’éditeur actuel privilégie les habitudes quotidiennes. Définis une **Date de
+début**, retarde si besoin l’heure à laquelle l’habitude est **affichée à
+partir de**, puis choisis éventuellement quand Lotti doit **afficher une
+alerte**. Le modèle de données comprend aussi les calendriers hebdomadaires et
+mensuels, mais l’éditeur expose aujourd’hui les contrôles temporels plus riches
+pour les habitudes quotidiennes.
+
+### Consigne ce qui s’est réellement passé
+
+Ouvre une habitude due ou utilise son action rapide. Le formulaire détaillé de
+réalisation prend en charge trois résultats :
+
+- **Réussi** — le comportement a eu lieu.
+- **Manqué** — il était prévu et possible, mais n’a pas eu lieu.
+- **Ignoré** — il ne s’appliquait raisonnablement pas ce jour-là.
+
+<ManualScreenshot
+  caseId="habits/record"
+  alt="Formulaire de réalisation de l’habitude Inspecter les joints de l’habitat des manchots, avec résultats Réussi, Ignoré et Manqué, ainsi qu’une date et des notes"
+/>
+
+Utilise l’état qui préserve la réalité. Un historique sincère est plus utile
+qu’un graphique parfait. Les enregistrements de réalisation sont des entrées de
+journal ; les vues ultérieures peuvent donc reconstruire le résultat effectif
+pour chaque habitude et chaque jour.
+
+## Travaille avec les mesures
+
+Une définition de mesure décrit le nombre avant que tu ne le consignes : son
+nom, son unité, sa confidentialité et la façon dont plusieurs observations se
+combinent dans les graphiques.
+
+<ManualScreenshot
+  caseId="measurables/settings-list"
+  alt="Réglages des mesures contenant Pression de l’habitat, Pingouins recensés et Sardines consommées"
+/>
+
+### Crée un type de données mesurable
+
+1. Ouvre **Réglages → Types de données mesurables**.
+2. Sélectionne l’action d’ajout.
+3. Ajoute un nom, une description facultative et une abréviation d’unité concise.
+4. Choisis l’agrégation par défaut utilisée par les graphiques.
+5. Décide si elle doit être favorite ou privée, puis enregistre.
+
+<ManualScreenshot
+  caseId="measurables/settings-detail"
+  alt="Éditeur de mesure Pression de l’habitat utilisant kPa et l’agrégation Moyenne quotidienne"
+/>
+
+Choisis l’agrégation selon ce que signifient des relevés répétés :
+
+| Agrégation | À utiliser lorsque |
+| --- | --- |
+| Aucune agrégation | Chaque observation individuelle compte |
+| Somme quotidienne | Les relevés s’accumulent, comme les sardines consommées |
+| Maximum quotidien | Le pic du jour est le signal important |
+| Moyenne quotidienne | Les relevés échantillonnent une valeur changeante, comme la pression de l’habitat |
+| Somme horaire | L’accumulation nécessite des créneaux horaires plus fins |
+
+L’unité donne le contexte d’affichage, ce n’est pas un convertisseur. Si tu
+définis la pression de l’habitat en `kPa`, consigne les valeurs en kPa de
+façon cohérente. Crée une mesure distincte si une autre unité représente une
+série réellement différente.
+
+### Consigne une mesure
+
+Ouvre un tableau de bord qui contient la mesure et sélectionne l’action d’ajout
+sur son graphique. Saisis la valeur observée ; Lotti garde l’unité près du
+nombre afin que ce qui sera enregistré soit clair. Les valeurs distinctes
+récentes apparaissent en actions **Saisie rapide** lorsqu’il est utile
+d’en répéter une.
+
+<ManualScreenshot
+  caseId="measurements/capture"
+  alt="Éditeur de mesure Sardines consommées, ouvert depuis son graphique de tableau de bord rempli, avec 84 sardines, suggestions de saisie rapide, heure d’observation, commentaire et action Enregistrer"
+/>
+
+Utilise **Observé le** pour l’heure à laquelle le relevé a vraiment été pris,
+plutôt que celle à laquelle tu le saisis. La première page sélectionne la date
+du calendrier. **Aujourd’hui** revient directement à la date courante.
+
+<ManualScreenshot
+  caseId="measurements/date"
+  alt="Calendrier Observé le sélectionnant le vendredi 17 juillet 2026 pour la mesure de sardines"
+/>
+
+Fais défiler jusqu’à la section de l’heure pour définir l’heure et les minutes.
+**Maintenant** rétablit l’heure actuelle. Sélectionne **Terminé** pour revenir
+au brouillon de mesure toujours rempli, puis **Enregistrer** pour créer
+l’entrée de journal.
+
+<ManualScreenshot
+  caseId="measurements/time"
+  alt="Molette d’heure Observé le réglée sur 10 h 30 pour la mesure de sardines"
+/>
+
+Le commentaire est facultatif, mais utile lorsqu’un nombre a besoin de contexte
+opérationnel — par exemple une livraison, un changement inhabituel ou une
+méthode de mesure modifiée. Enregistrer une mesure ne change ni sa définition
+ni sa règle d’agrégation.
+
+## Relie les deux sans les confondre
+
+Un appel peut être réalisé avec succès même si seulement 36 manchots ont été
+comptés : l’habitude consigne si la procédure a eu lieu, tandis que la mesure
+consigne le résultat. Place les deux sur un [tableau de
+bord](./dashboards.mdx) lorsque leur relation répond à une question
+opérationnelle récurrente.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/organize-and-reflect/journal.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/organize-and-reflect/journal.mdx
@@ -1,0 +1,130 @@
+---
+title: Tenir un journal utile
+description: Retrouvez notes, photos, enregistrements, événements et résultats IA dans un même flux, puis reliez-les à l’activité qui les documente.
+---
+
+# Tenir un journal utile
+
+Le Journal est le flux d’entrées mixtes de Lotti. Il rassemble notes, photos, enregistrements, événements, listes de contrôle, mesures et réponses IA sans les transformer en tâches. Utilise-le pour mémoriser, examiner ou relier ce qui s’est passé ; utilise **Tâches** lorsque l’entrée représente un travail qu’il reste à faire.
+
+<ManualScreenshot
+  caseId="journal/overview"
+  alt="Flux du Journal avec une photo de lancement de Project Waddle, un journal de mission, un mémo vocal sur les sardines d’Europe, un événement de sommet et un récapitulatif de télémétrie cargo"
+  caption="Les glyphes de type rendent le flux mixte facile à parcourir ; couleurs de catégorie, étiquettes, étoiles, drapeaux, durées et pastilles d’état conservent le contexte utile près de chaque entrée."
+/>
+
+## Lire le flux mixte
+
+Chaque carte commence par son contenu et utilise un glyphe coloré pour identifier le type d’entrée. La couleur vient de la catégorie de l’entrée : **Opérations pingouins**, **Contrôle de mission** et **Diplomatie des poissons** restent ainsi reconnaissables même lorsque plusieurs types se côtoient.
+
+Les cartes ajoutent les métadonnées qui comptent pour leur type. Par exemple :
+
+- un mémo audio affiche sa durée et son drapeau ;
+- un événement affiche son état, sa date, son évaluation et sa note ;
+- une liste de contrôle affiche son avancement ;
+- une mesure affiche sa valeur et son unité ; et
+- une réponse IA est signalée comme générée par IA.
+
+Le flux se charge par pages : un journal conséquent n’a donc pas besoin d’afficher tout son historique d’un coup.
+
+## Chercher par mots ou par sens
+
+Utilise **Texte intégral** pour retrouver les mots enregistrés dans une entrée. Lorsque la recherche vectorielle est activée, passe à **Vectoriel** pour trouver des entrées de sens voisin, même avec des formulations différentes. Les résultats vectoriels forment un classement unique plutôt qu’un flux paginé sans fin.
+
+Si la recherche vectorielle devient indisponible ou est désactivée, Lotti revient à la recherche plein texte au lieu de laisser la recherche dans un état inutilisable.
+
+## Filtrer ce qui apparaît
+
+<ManualScreenshot
+  caseId="journal/filters"
+  alt="Fenêtre de filtres du Journal avec commandes pour les entrées étoilées, signalées, privées, les types d’entrée et les catégories au-dessus du flux de logistique des pingouins"
+  caption="Combine propriétés, types et catégories pour transformer le flux mixte en vue précise dont tu as besoin."
+/>
+
+Ouvre le bouton de filtre près de la recherche. Tu peux limiter le Journal à :
+
+- des entrées étoilées, signalées ou privées ;
+- un ou plusieurs types d’entrée, notamment Texte, Événement, Audio, Photo, Liste de contrôle, À faire et Réponse IA ; et
+- une ou plusieurs catégories.
+
+Ces choix sont conservés pour le Journal. Les filtres des tâches sont enregistrés séparément : modifier la vue du Journal ne réorganise donc pas la page Tâches par surprise.
+
+## Ajouter une entrée
+
+<ManualScreenshot
+  caseId="journal/create"
+  alt="Menu Ajouter proposant Événement, Tâche, Enregistrement audio, Entrée de texte, Importer une image et Capture d’écran au-dessus du Journal de Project Waddle"
+  caption="Le menu ne propose que les actions prises en charge par la plateforme et le contexte actuels."
+/>
+
+Sélectionne **+** pour ouvrir le menu Ajouter. Depuis le Journal principal, tu peux créer une entrée de texte, une tâche, un événement ou un enregistrement audio, importer une photo ou prendre une capture d’écran. Le collage d’une image depuis le presse-papiers peut apparaître lorsqu’une image est disponible. La création d’événement est proposée lorsque la fonctionnalité Événements est activée.
+
+Le même menu s’adapte dans une entrée existante. Il peut alors créer un minuteur déjà relié à l’entrée, et les détails d’une tâche peuvent proposer une liste de contrôle liée. Les images importées, collées, déposées ou capturées peuvent participer à l’analyse d’images automatique lorsque cette automatisation est configurée.
+
+## Lire et modifier une entrée
+
+<ManualScreenshot
+  caseId="journal/detail"
+  alt="Détail du journal de mission de Project Waddle avec catégorie, étiquettes, étoile, durée, texte enrichi, filtres d’activité et photo de lancement liée"
+  caption="L’entrée reste la source de vérité ; les photos, minuteurs, requêtes et liens entrants qui l’accompagnent restent attachés en dessous."
+/>
+
+L’en-tête de détail regroupe date, catégorie, étiquettes, étoile, drapeau, confidentialité et actions supplémentaires. Sélectionne le corps pour modifier le texte enrichi. Enregistre depuis les commandes de l’éditeur, ou utilise **Ctrl+S** sous Windows et Linux et **Command+S** sous macOS. Le texte non enregistré est conservé comme brouillon ; l’abandon rétablit le dernier contenu enregistré.
+
+Le menu d’actions supplémentaires contient les actions qui s’appliquent au type d’entrée actuel, notamment copier, supprimer et les actions de média. Sur ordinateur, les entrées image et audio peuvent aussi révéler leur fichier source dans le gestionnaire de fichiers.
+
+### Modifier la date et la durée d’une entrée
+
+Sélectionne la date ou la durée dans l’en-tête de l’entrée pour ouvrir **Date et heure**. Pour une entrée du même jour, choisis une date et définis séparément l’heure de début et de fin. Le récapitulatif de durée se met à jour au fil des molettes. Active **Choisir une date de fin distincte** pour une entrée nocturne ou sur plusieurs jours, et utilise l’une ou l’autre action **Maintenant** pour placer cette borne à la date et à l’heure actuelles.
+
+<ManualScreenshot
+  caseId="journal/date-time"
+  alt="Éditeur Date et heure du journal de mission de Project Waddle avec le 17 juillet, un début à 8 h 10, une fin à 8 h 40 et une durée de 30 minutes"
+/>
+
+Sélectionne le bouton de date pour ouvrir le calendrier. **Aujourd’hui** revient au jour courant, **Terminé** revient à l’éditeur de plage et **Enregistrer** applique toute la plage début/fin à l’entrée.
+
+<ManualScreenshot
+  caseId="journal/date-picker"
+  alt="Calendrier de date de début sélectionnant le vendredi 17 juillet 2026 pour le journal de mission de Project Waddle"
+/>
+
+La modification de l’horodatage change l’emplacement de l’entrée dans les vues chronologiques. Elle ne réécrit pas son texte et ne détache pas son activité liée.
+
+## Suivre l’activité liée
+
+<ManualScreenshot
+  caseId="journal/activity"
+  alt="Activité liée à Project Waddle avec une requête de programmation IA, une répétition d’appel de 23 minutes et la tâche entrante de revue du lancement"
+  caption="L’activité sortante répond à la question de ce que contient l’entrée ; Lié depuis indique quelles autres entrées pointent vers elle."
+/>
+
+Les entrées peuvent être reliées à des photos, minuteurs, audios, résultats IA, notes et autres éléments de contexte. Les pastilles d’activité permettent d’afficher ou de masquer les entrées **Minuteur**, **Audio**, **Images** et **Code**. Ouvre le contrôle de tri pour choisir l’ordre du plus récent au plus ancien ou l’inverse, inclure les liens masqués ou n’afficher que l’activité signalée.
+
+Les deux directions n’ont pas le même sens :
+
+- l’activité sous l’entrée est liée **depuis cette entrée** ; et
+- **Lié depuis** liste les entrées qui pointent **vers cette entrée**.
+
+Par exemple, le journal de mission de Project Waddle contient sa photo de lancement, sa requête de diagnostic et son minuteur d’appel, tandis que la tâche de revue du lancement apparaît sous **Lié depuis** parce qu’elle référence également le journal.
+
+Ouvre la pastille de tri pour préparer plusieurs changements de visibilité. Choisis l’ordre, l’inclusion des entrées masquées et l’affichage des seules entrées signalées. La liste change lorsque tu sélectionnes la coche pour terminer la feuille ; la fermer autrement annule les choix préparés.
+
+<ManualScreenshot
+  caseId="journal/linked-filter"
+  alt="Feuille Filtrer et trier au-dessus de l’activité liée à Project Waddle avec Du plus ancien au plus récent et Afficher les entrées masquées sélectionnés"
+/>
+
+## Ouvrir et enregistrer une photo
+
+Sélectionne une photo intégrée pour ouvrir la visionneuse plein écran. Pince ou utilise ses commandes pour zoomer et te déplacer, puis réinitialise l’image si nécessaire. L’enregistrement utilise le fichier d’origine plutôt que l’aperçu réduit : sur mobile, l’image est écrite dans la photothèque après autorisation ; sur ordinateur, la boîte de dialogue du système te laisse choisir l’emplacement.
+
+## Journal ou tâche ?
+
+| Utilise le Journal pour… | Utilise les tâches pour… |
+| --- | --- |
+| Un journal de mission, une photo, un mémo vocal, une mesure, le souvenir d’un événement ou un résultat IA | Une action avec un état, une priorité, une estimation, une liste de contrôle ou une session de travail |
+| « Les sardines d’Europe sont plus froides que ne l’exige le protocole diplomatique » | « Recalibrer le distributeur de poissons en apesanteur » |
+| Des preuves et du contexte que tu voudras peut-être consulter à nouveau | Un travail à planifier, exécuter et terminer |
+
+Relie-les lorsqu’une tâche a besoin des preuves du Journal. L’action reste ainsi ciblée tout en conservant l’historique opérationnel plus riche qui l’étaye.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/organize-and-reflect/labels.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/organize-and-reflect/labels.mdx
@@ -1,0 +1,55 @@
+---
+title: Organiser le travail avec des étiquettes
+description: Utilise des étiquettes pour le contexte transversal qui couvre plusieurs catégories et tâches.
+---
+
+# Organiser le travail avec des étiquettes
+
+Les étiquettes ajoutent une seconde couche d’organisation, souple. Une tâche possède une catégorie principale, mais peut porter plusieurs étiquettes pour les initiatives, l’urgence, les attentes ou toute autre propriété qui traverse les frontières entre catégories.
+
+<ManualScreenshot
+  caseId="labels/list"
+  alt="Réglages des étiquettes avec En attente du contrôle de mission, Habitat critique, Project Waddle et Marché des sardines sensible, accompagnés des compteurs d’utilisation dans les tâches"
+  caption="Les compteurs d’utilisation montrent les étiquettes actives dans l’espace de travail ; le cadenas signale une étiquette privée."
+/>
+
+L’espace de travail Intergalactic Penguin Logistics emploie volontairement les étiquettes :
+
+- **Project Waddle** relie le travail de lancement entre Opérations pingouins, Contrôle de mission et Diplomatie des poissons.
+- **Habitat critique** repère le travail à terminer avant l’entrée de l’expédition dans l’habitat orbital.
+- **En attente du contrôle de mission** consigne un véritable état de blocage.
+- **Marché des sardines sensible** rend le travail de négociation privé identifiable.
+
+## Créer et modifier une étiquette
+
+1. Ouvre **Réglages → Étiquettes**.
+2. Sélectionne **Créer une étiquette**.
+3. Ajoute un nom concis et, si besoin, une description.
+4. Choisis une couleur qui reste reconnaissable à côté des autres étiquettes.
+5. Décide si l’étiquette est privée et quelles catégories peuvent l’utiliser.
+6. Enregistre.
+
+<ManualScreenshot
+  caseId="labels/detail"
+  alt="Éditeur de l’étiquette Project Waddle affichant sa description critique pour le lancement, sa couleur bleue, son option de confidentialité et ses trois catégories applicables"
+/>
+
+Une description vaut la peine lorsqu’une étiquette peut être comprise de plusieurs façons. Elle apporte le sens opérationnel sans imposer cette explication dans chaque titre de tâche.
+
+Les **catégories applicables** limitent les endroits où l’étiquette peut être choisie. Project Waddle est disponible dans les trois parties de l’expédition concernées par le lancement, tandis qu’une étiquette spécialisée peut rester limitée à une catégorie. Les sélecteurs restent ainsi pertinents plutôt que de présenter partout toutes les étiquettes.
+
+## Appliquer des étiquettes aux tâches
+
+Ouvre une tâche et utilise son contrôle d’étiquettes pour en ajouter ou en retirer. Les étiquettes fonctionnent avec les filtres d’état, de priorité et de catégorie : tu peux donc poser une question précise comme « afficher le travail P1 critique pour l’habitat encore ouvert » sans créer une catégorie uniquement pour cette vue temporaire.
+
+Retirer une étiquette d’une tâche est traité comme un rejet intentionnel lorsque les suggestions d’étiquettes automatiques sont activées. Lotti enregistre ce choix afin de ne pas réappliquer immédiatement la même suggestion sans nouvelle raison.
+
+## Garder des étiquettes utiles
+
+- Préfère les étiquettes qui modifient une décision, un filtre ou une revue.
+- Réutilise une étiquette stable plutôt que de créer des variantes d’orthographe.
+- Consulte les compteurs d’utilisation avant de supprimer ou de regrouper des étiquettes.
+- Utilise la confidentialité si le nom même de l’étiquette révèle un contexte sensible.
+- Retire les étiquettes qui ne décrivent plus un travail actif.
+
+Si quelque chose est le lieu principal et durable du travail, fais-en plutôt une [catégorie](./categories.mdx).

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/organize-and-reflect/projects.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/organize-and-reflect/projects.mdx
@@ -1,0 +1,106 @@
+---
+title: Mener le travail en projets
+description: Regroupe les tâches liées, suis la santé des projets et garde un rapport opérationnel utile à côté du travail.
+---
+
+# Mener le travail en projets
+
+Les projets se situent entre les catégories et les tâches. Une catégorie comme **Opérations pingouins** définit un domaine de responsabilité large ; **Project Waddle** regroupe les tâches concrètes nécessaires pour préparer l’habitat orbital des manchots.
+
+<ManualScreenshot
+  caseId="projects/list"
+  alt="Projets regroupés sous Opérations pingouins, Contrôle de mission, Diplomatie des poissons et Maintenance humaine, dont Project Waddle et la chaîne du froid des sardines d’Europe"
+  caption="Chaque ligne rassemble l’état, l’avancement des tâches, la date cible et une courte phrase d’objectif. Sur ordinateur, le projet sélectionné reste visible à droite ; sur mobile, la liste utilise toute la largeur."
+/>
+
+## Trouver le projet nécessaire
+
+La recherche parcourt les titres de projet, le texte enregistré dans les projets et les noms de catégories. Le contrôle de filtre limite la liste par état de projet ou catégorie. Un filtre reste inactif jusqu’à la sélection de **Appliquer**.
+
+<ManualScreenshot
+  caseId="projects/filters"
+  alt="Boîte de dialogue de filtre des projets avec contrôles d’état et de catégorie au-dessus de la liste de projets Intergalactic Penguin Logistics"
+/>
+
+Les projets restent regroupés par catégorie après filtrage. Cela permet de distinguer plus facilement les efforts aux noms proches et de garder chaque domaine opérationnel visible.
+
+## Créer un projet
+
+Sélectionne le bouton **+** dans Projets, puis saisis :
+
+- un titre obligatoire ;
+- une catégorie facultative ; et
+- une date cible facultative.
+
+<ManualScreenshot
+  caseId="projects/create"
+  alt="Formulaire Créer un projet pour Établir la réserve lunaire de sardines dans la catégorie Opérations pingouins"
+  caption="Le formulaire de création s’affiche dans une feuille inférieure sur mobile et dans une boîte de dialogue centrée sur ordinateur."
+/>
+
+Un nouveau projet commence à l’état **Ouvert**. Si sa catégorie possède un modèle d’agent de projet, Lotti provisionne aussi cet agent après l’enregistrement du projet. Le projet fonctionne normalement même sans modèle correspondant.
+
+Choisis un titre qui décrit le résultat ou la mission durable. « Établir la réserve lunaire de sardines » est plus parlant que « Sardines ».
+
+## Modifier les réglages d’un projet
+
+La route des réglages de projet fournit l’éditeur de formulaire complet pour l’état, le titre, la date cible, la santé, l’affectation d’agent, les changements d’agent proposés et les tâches liées. Les actions **Annuler** et **Enregistrer** restent également ancrées en bas : les modifications de formulaire en attente sont explicites.
+
+<ManualScreenshot
+  caseId="projects/editor"
+  alt="Éditeur des réglages de Project Waddle affichant son état actif, son titre, sa date cible, sa santé, son affectation d’agent et ses tâches liées"
+  caption="Il s’agit de l’éditeur de réglages de production. Il est distinct de l’espace de travail de projet, conçu d’abord pour la lecture, ci-dessous."
+/>
+
+## Comprendre l’état d’un projet
+
+| État | Utilise-le lorsque |
+| --- | --- |
+| Ouvert | Le projet existe, mais son exécution active n’a pas commencé. |
+| Actif | Le travail avance actuellement et mérite de figurer dans la planification quotidienne. |
+| Surveillance | Aucun travail n’est planifié, mais le résultat doit encore être observé. |
+| En attente | Le travail est en pause pour une raison connue. |
+| Terminé | Le résultat attendu a été atteint. |
+| Archivé | Le projet est conservé pour l’historique, mais n’est plus opérationnel. |
+
+Sélectionne la pastille d’état sur la page de détail du projet pour le modifier. Les changements d’état, de catégorie et de date cible sont enregistrés immédiatement ; cette surface de détail, axée sur la lecture, ne possède pas de bouton d’enregistrement séparé.
+
+## Lire la santé et le rapport du projet
+
+<ManualScreenshot
+  caseId="projects/detail"
+  alt="Détail de Project Waddle affichant un score de santé de 82, cinq tâches terminées sur huit, un blocage et un rapport IA mis à jour il y a deux heures"
+  caption="Sur ordinateur, la liste de projets et le détail restent côte à côte. Sur mobile, le même détail s’ouvre comme une page complète."
+/>
+
+Le panneau de santé résume l’évaluation actuelle de l’agent de projet :
+
+- le score de santé est un signal compact, pas un substitut au travail sous-jacent ;
+- l’avancement des tâches affiche les comptes terminés et bloqués ;
+- le rapport fournit une synthèse actuelle et peut être développé pour son contenu complet ; et
+- les recommandations attirent l’attention sur les prochaines actions concrètes.
+
+Dans Project Waddle, un score de 82 et cinq tâches terminées sont encourageants, mais le distributeur de poissons en apesanteur bloque toujours le lancement. Lis l’explication avant de traiter un score comme un verdict.
+
+Lorsqu’un agent de projet est configuré, le menu de rapport peut demander un rapport actualisé ou annuler un réveil programmé. Sans agent, le projet continue d’afficher ses tâches et tout texte de projet enregistré.
+
+## Garder le travail du projet dans les tâches
+
+<ManualScreenshot
+  caseId="projects/tasks"
+  alt="Panneau de tâches de Project Waddle listant l’inspection de l’habitat, le calibrage du distributeur de poissons en apesanteur et la confirmation des capsules de fret de sardines avec estimations et états"
+/>
+
+Les lignes de tâche d’un projet affichent le titre, un court résumé, l’estimation et l’état actuel de chaque tâche. Sélectionne une ligne pour ouvrir la tâche elle-même. Les détails de tâche restent la source de vérité pour les descriptions, enregistrements, listes de contrôle, images, relevés de temps et illustrations de couverture.
+
+Affecte une tâche à un projet depuis le contrôle de projet dans l’en-tête de la tâche. Les projets sont délimités par catégorie : donne donc une catégorie à la tâche avant de choisir un projet. Une tâche appartient à un seul projet au plus ; affecter un autre projet déplace le lien au lieu de le dupliquer.
+
+## Projets, catégories et tâches
+
+Utilise délibérément les trois niveaux :
+
+- **Catégorie :** un domaine opérationnel durable, tel qu’Opérations pingouins.
+- **Projet :** un résultat nécessitant plusieurs tâches, tel que Project Waddle.
+- **Tâche :** une unité exécutable, telle que recalibrer le distributeur de poissons en apesanteur.
+
+Évite de créer un projet pour une seule action simple. Crée-en un lorsque plusieurs tâches ont besoin d’une date cible, d’un état, d’un avancement agrégé ou d’un rapport opérationnel commun.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/organize-and-reflect/tasks.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/organize-and-reflect/tasks.mdx
@@ -1,0 +1,155 @@
+---
+title: Travailler avec les tâches
+description: Utilise état, priorité, listes de contrôle et contexte joint pour faire avancer les résultats.
+---
+
+# Travailler avec les tâches
+
+Les tâches regroupent un résultat et le contexte ainsi que les étapes nécessaires pour le terminer. Donne aux titres une orientation vers le résultat et place les notes, images, enregistrements et relevés de temps qui les étayent dans la tâche.
+
+<ManualScreenshot
+  caseId="tasks/workspace"
+  alt="Espace de travail de tâches de production affichant de vraies lignes de tâche et des vignettes d’illustration de couverture issues des données de démonstration Interplanetary Penguin Logistics"
+/>
+
+Sur ordinateur, la liste de tâches reste visible à côté de la tâche sélectionnée : tu peux parcourir le travail sans perdre le contexte. Sur mobile, sélectionner une tâche ouvre son détail en plein écran. L’illustration de couverture accompagne la tâche partout où elle apparaît, y compris dans la liste des tâches et les éléments liés de l’agenda Daily OS.
+
+L’illustration de couverture est facultative, mais elle peut rendre un espace de travail dense beaucoup plus facile à parcourir. Utilise-la comme repère visuel utile, référence de produit ou métaphore mémorable du travail. Les illustrations de Project Waddle dans ce manuel ne sont qu’un exemple : une couverture peut être aussi pratique, joueuse ou merveilleusement étrange que tu le souhaites.
+
+<ManualScreenshot
+  caseId="tasks/detail"
+  alt="Page de détail de tâche de production pour inspecter l’habitat orbital des manchots, avec la même illustration de couverture utilisée par les vignettes de tâche"
+/>
+
+Une même tâche peut contenir une description, une catégorie, des étiquettes, une date d’échéance, des relevés de temps, des éléments de liste de contrôle, des images, des liens et des enregistrements audio.
+
+## Affecter un agent de tâche
+
+Une tâche peut avoir un agent de tâche. Lui en affecter un donne à cette tâche un assistant IA persistant, avec sa propre configuration d’inférence, son rapport, son état de réveil et son historique de propositions. L’agent lit la tâche et son contexte lié, distille la situation actuelle dans un bref rapport et peut faire apparaître des modifications proposées de la tâche ou de sa liste de contrôle, que tu confirmes ou refuses.
+
+L’agent affecté apparaît sous les listes de contrôle et les tâches liées. Sa carte repliée garde visible le dernier résumé, le contrôle des mises à jour automatiques, l’action **Réveiller l’agent** et la route de modèle active, sans transformer la page de tâche en console IA.
+
+<ManualScreenshot
+  caseId="tasks/agent-card"
+  alt="Agent de tâche Habitat Watcher affecté à la tâche d’habitat orbital des manchots, avec son résumé actuel, les mises à jour automatiques, l’action de réveil et la route de modèle Projet Waddle"
+  caption="Habitat Watcher est affecté à cette tâche ; l’affectation et les mises à jour automatiques sont deux choix distincts."
+/>
+
+Choisis **Lire la suite** pour développer le rapport complet sur place. La carte développée conserve la tâche visible, ajoute l’évaluation étayant le rapport et l’étape suivante recommandée, et propose **Ouvrir les détails internes de l’agent** lorsque tu as besoin des rapports, conversations, observations ou détails d’exécution.
+
+<ManualScreenshot
+  caseId="tasks/agent-card-expanded"
+  alt="Carte développée de l’agent de tâche Habitat Watcher avec l’évaluation complète de l’habitat de Project Waddle et l’étape suivante recommandée"
+  caption="Le rapport complet se développe dans la tâche plutôt que de t’envoyer sur une page séparée."
+/>
+
+### Examiner les modifications proposées
+
+Un réveil terminé peut mettre à jour le rapport et ajouter des modifications proposées. Les mises à jour automatiques décident *quand l’agent se réveille* ; elles ne lui donnent pas le droit de modifier la tâche. Les propositions restent en attente jusqu’à ton intervention.
+
+<ManualScreenshot
+  caseId="tasks/agent-suggestions"
+  alt="Carte de l’agent Habitat Watcher avec deux propositions de Project Waddle en attente, des actions individuelles Ignorer et Confirmer, et une action Tout confirmer"
+  caption="L’agent propose une étape de liste de contrôle pour tester le distributeur et une estimation révisée ; aucune des deux modifications n’a encore été appliquée."
+/>
+
+Utilise la croix pour **Ignorer** une proposition ou la coche pour **Confirmer** et l’appliquer. Tu peux aussi balayer une proposition vers la gauche pour l’ignorer ou vers la droite pour la confirmer. Lorsque plusieurs propositions sont en attente, **Tout confirmer** applique ensemble les modifications actuellement listées. Examine attentivement les propositions groupées, surtout les modifications d’état, de date et de liste de contrôle.
+
+Ouvre **Historique** pour revoir les résultats récents. Il distingue les modifications confirmées de celles qui ont été ignorées. Une entrée ignorée peut représenter ta décision ou une proposition que l’agent a retirée après qu’un contexte de tâche plus récent l’a rendue obsolète.
+
+Un **Réveiller l’agent** manuel peut produire les mêmes types de rapport et de propositions qu’un réveil automatique. Désactiver les mises à jour automatiques arrête les futurs réveils en arrière-plan ; cela n’applique, ne rejette ni ne résout autrement les propositions qui attendent déjà ta décision.
+
+### Choisir les mises à jour automatiques ou manuelles
+
+Les nouveaux agents de tâche commencent avec les **mises à jour automatiques désactivées**. La seule affectation ne consomme pas de jetons en arrière-plan. Lorsque les mises à jour sont désactivées, Lotti continue de repérer les changements pertinents de la tâche et de ses entrées liées, indique qu’un résumé plus ancien n’est plus à jour et attend que tu choisisses **Réveiller l’agent**. Un réveil manuel reste disponible dès que l’agent possède une configuration IA fonctionnelle.
+
+<ManualScreenshot
+  caseId="tasks/agent-card-manual"
+  alt="Carte de l’agent Habitat Watcher avec mises à jour automatiques désactivées, avertissement de rapport obsolète et action manuelle Réveiller l’agent"
+  caption="Le mode manuel observe les changements et signale l’obsolescence sans lancer d’inférence."
+/>
+
+Lorsque les **mises à jour automatiques** sont activées, Lotti regroupe les changements de tâche correspondants pendant environ deux minutes avant de programmer une actualisation. Ce regroupement évite un réveil d’agent à chaque petite modification. **Réveiller l’agent** reste disponible pour une actualisation immédiate que tu demandes.
+
+Désactiver les mises à jour automatiques efface son compte à rebours en attente et les actualisations automatiques en file, mais n’annule pas un réveil que tu as explicitement demandé. Les réactiver s’applique aux changements futurs ; cela ne rejoue pas les changements arrivés lorsque l’automatisation était désactivée.
+
+## Priorité
+
+Lotti utilise quatre niveaux de priorité concis :
+
+| Priorité | Signification | Utilise-la pour |
+| --- | --- | --- |
+| P0 | Urgente | Le travail qui a réellement besoin d’attention ensuite |
+| P1 | Élevée | Le travail important à faire bientôt |
+| P2 | Moyenne | La valeur normale par défaut |
+| P3 | Faible | Le travail qui peut attendre |
+
+Ouvre une tâche et utilise le contrôle de priorité dans son en-tête pour changer le niveau. Les tâches existantes sans priorité explicite se comportent comme des P2.
+
+## Filtrer et ordonner la liste de tâches
+
+Ouvre les filtres de tâches et sélectionne une ou plusieurs priorités. Efface cette sélection pour revenir à toutes les priorités. La priorité fait partie des filtres qui peuvent être combinés avec les catégories et d’autres propriétés de tâche.
+
+<ManualScreenshot
+  caseId="tasks/filters"
+  alt="Feuille de filtre des tâches avec commandes de tri, état, priorité, catégorie et étiquette"
+/>
+
+L’ordre de priorité par défaut va de P0 à P3. Au sein d’une priorité, les tâches les plus récentes apparaissent d’abord, sauf si une autre vue ou un autre tri actif modifie le résultat.
+
+## Utiliser des listes de contrôle pour l’étape suivante
+
+Un élément de liste de contrôle doit être plus petit et plus concret que sa tâche. « Publier le manuel » est une tâche ; « vérifier chaque lien de navigation » est un élément de liste de contrôle. Les listes de contrôle se modifient directement et peuvent aussi être proposées par des compétences IA configurées à partir du contexte de la tâche.
+
+## Ajouter du contexte à une tâche
+
+Utilise l’action **Ajouter** de la tâche pour joindre une liste de contrôle, une autre tâche, un enregistrement audio, un minuteur, une entrée de texte ou une image sans quitter la tâche. Les actions disponibles dépendent de la plateforme et du contexte actuels.
+
+<ManualScreenshot
+  caseId="entries/create-menu"
+  alt="Menu Ajouter au-dessus de la tâche d’habitat orbital, avec des actions de capture tenant compte de la tâche"
+/>
+
+Consulte [Ajouter des entrées et du contexte](../plan-and-capture/entries.mdx) pour savoir quand employer chaque type d’entrée.
+
+## Générer une illustration de couverture à partir d’images réelles de la tâche
+
+Si une compétence de génération d’images est configurée, ouvre le menu de génération de la tâche et choisis son action d’illustration de couverture. Lotti affiche d’abord les images déjà jointes à la tâche ainsi que les images de couverture disponibles dans les tâches liées. Sélectionne jusqu’à cinq références pour guider le résultat, ou continue sans référence.
+
+La couverture générée est créée dans Lotti à partir du contexte de la tâche et des références que tu sélectionnes. C’est une aide visuelle, pas un champ obligatoire : utilise-la lorsqu’une image distinctive rend le travail plus facile ou plus agréable à reconnaître. La route de génération d’images actuelle utilise le fournisseur configuré ; considère donc l’invite de génération et les références sélectionnées comme des données que tu envoies intentionnellement à ce fournisseur. Une route locale de réflexion ou de transcription ne rend pas la génération de couverture locale.
+
+<ManualScreenshot
+  caseId="tasks/cover-references"
+  alt="Feuille Générer une illustration de couverture présentant cinq images de référence distinctes de Project Waddle tirées du contexte de la tâche"
+  caption="Le sélecteur utilise les mêmes images de tâche visibles dans toute la démonstration de Project Waddle."
+/>
+
+Après avoir continué, la génération d’image s’exécute en arrière-plan. La vue de progression utilise le visualiseur de réflexion de production de Lotti et peut être fermée sans annuler la tâche.
+
+<ManualScreenshot
+  caseId="tasks/cover-generating"
+  alt="Génération d’illustration de couverture de tâche en cours avec le visualiseur de shader de production de Lotti"
+/>
+
+L’image générée devient la couverture de la tâche et suit celle-ci dans les vues liste, détail, projet et Daily OS. Une couverture efficace reste reconnaissable lorsque l’image source large est recadrée en vignette compacte. Elle peut être une preuve littérale, une métaphore sobre ou aussi étrange que le mérite le travail ; le seul test utile est de savoir si tu reconnaîtras la tâche plus vite ensuite.
+
+## Relier des tâches apparentées
+
+Ouvre la section **Lié** de la tâche et choisis de relier une tâche existante. Recherche-la dans le sélecteur, puis sélectionne le résultat associé. Lotti exclut la tâche actuelle et les tâches déjà liées dans cette direction.
+
+<ManualScreenshot
+  caseId="tasks/link-picker"
+  alt="Sélecteur de liens de tâche de production listant des tâches apparentées de Project Waddle avec leur contexte d’état, de priorité, de catégorie et de date d’échéance"
+/>
+
+Les liens de tâche sont directionnels : la tâche actuelle pointe vers celle que tu choisis. Les deux côtés restent accessibles via leurs sections d’entrées liées, tandis que chaque tâche conserve son propre état, calendrier et pièces jointes.
+
+## Utiliser la voix sans perdre le contrôle
+
+Enregistre une note dans la tâche lorsqu’il est plus rapide d’expliquer la situation à voix haute. Avec la transcription et des compétences de tâche configurées, Lotti peut transformer ce contexte en texte et en propositions d’éléments de liste de contrôle. Examine le résultat, en particulier les noms, les dates et les modifications destructrices. Consulte [Enregistrer de l’audio](../plan-and-capture/recordings.mdx) pour les commandes d’enregistrement et les options de traitement.
+
+:::tip
+
+Utilise P0 avec parcimonie. Si tout est urgent, l’étiquette ne transmet plus d’information.
+
+:::

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/organize-and-reflect/time-analysis.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/organize-and-reflect/time-analysis.mdx
@@ -1,0 +1,172 @@
+---
+title: Comprends où est passé ton temps
+description: Ventile le temps suivi par catégorie, suis les domaines de concentration et compare des périodes équivalentes sans quitter Daily OS.
+---
+
+# Comprends où est passé ton temps
+
+L’Analyse du temps transforme tes sessions enregistrées en ventilation par
+catégorie. Utilise-la pour savoir combien de temps tu as suivi, où il est passé
+et si sa répartition a changé par rapport à la période précédente. L’exemple
+Project Waddle sépare **Opérations Pingouins**, **Contrôle de mission**,
+**Diplomatie des poissons**, **Recherche orbitale** et **Maintenance humaine**,
+tout en laissant visible le temps sans catégorie qui demande ton attention.
+
+Sur ordinateur, ouvre **Daily OS** et sélectionne **Analyse du temps** sous le
+calendrier de la barre latérale. Le tableau de bord occupe la zone de contenu
+pour que le graphique et le tableau exact se lisent ensemble. Ses commandes se
+réorganisent aux largeurs étroites sans changer de rôle.
+
+<ManualScreenshot
+  caseId="time-analysis/overview"
+  alt="Tableau de bord Analyse du temps montrant le temps Project Waddle dans cinq catégories opérationnelles et du travail sans catégorie"
+  caption="La vue d’ensemble combine des totaux principaux, un graphique empilé sur sept jours et le tableau exact par catégorie. Passe le manuel en mode mobile ou ordinateur, clair ou sombre, pour examiner chaque mise en page de production."
+/>
+
+## Lis les cartes principales
+
+La première ligne résume la période sélectionnée :
+
+- **TOTAL** est l’ensemble du temps suivi. Sa légende nomme la plus grande
+  catégorie et sa part : la carte indique donc à la fois où est allé
+  l’essentiel du temps et combien a été enregistré.
+- **CONCENTRATION** additionne les catégories que tu as choisi de surveiller.
+  Dans l’exemple, Opérations Pingouins et Contrôle de mission forment cet
+  ensemble.
+- **AUTRE** correspond à tout ce qui est hors de l’ensemble de concentration.
+
+Tant qu’aucun ensemble de concentration n’existe, Lotti affiche **Choisir les
+catégories de concentration** à la place de deux cartes à zéro. Sélectionne-le,
+choisis une ou plusieurs catégories actives, puis termine avec **Terminé**.
+Utilise le bouton de réglage de la carte Concentration quand l’ensemble doit
+changer. Cette préférence est locale à Lotti et ne modifie les catégories
+d’aucune entrée.
+
+## Choisis une période utile
+
+Sélectionne l’unité de période pour passer de **Jour** à **Semaine**, **Mois**,
+**Trimestre** ou **Année**. Utilise les chevrons pour avancer ou reculer d’une
+période complète à la fois. Le chevron avant s’arrête à la période en cours :
+le tableau de bord ne navigue donc jamais dans une plage future vide.
+
+Sélectionne l’étiquette de date pour ouvrir le calendrier et aller directement
+à la période qui contient un autre jour. Les limites de semaine suivent le
+premier jour de semaine configuré dans la région de l’appareil.
+
+Deux raccourcis couvrent les questions les plus courantes :
+
+- **Ce mois-ci** affiche le mois écoulé jusqu’ici ;
+- **Cette année** affiche l’année écoulée jusqu’ici.
+
+Ces plages s’arrêtent aujourd’hui au lieu d’ajouter des jours futurs vides.
+L’étiquette inclut **(jusqu’ici)** et les moyennes n’utilisent que les jours
+déjà écoulés.
+
+## Lis ensemble le graphique et le tableau
+
+Les barres empilées montrent comment chaque catégorie a contribué à chaque
+heure, jour ou semaine de la période. Survole ou appuie sur une barre pour voir
+les valeurs de catégorie de ce créneau.
+
+### Suis le total cumulé
+
+Sélectionne **Total cumulé** lorsque la question passe de « que s’est-il passé
+dans ce créneau ? » à « combien ai-je accumulé depuis le début de cette
+plage ? ». Lotti transforme alors chaque catégorie en aire cumulative :
+
+- l’épaisseur d’une bande colorée à une date correspond au temps suivi dans
+  cette catégorie depuis le début de la plage sélectionnée jusqu’à cette date ;
+- le bord supérieur de l’empilement complet est tout le temps suivi accumulé
+  sur ce même intervalle ;
+- les bandes ne peuvent que rester stables ou monter. Une portion plate signifie
+  qu’aucun temps n’a été ajouté dans cette catégorie durant ces créneaux ; elle
+  ne soustrait jamais le travail antérieur.
+
+<ManualScreenshot
+  caseId="time-analysis/running-total"
+  alt="Graphique de total cumulé de l’Analyse du temps, accumulant les catégories Project Waddle sur le mois sélectionné"
+  caption="Le total cumulé additionne chaque catégorie depuis le début de la plage. Son bord supérieur est le temps suivi total à ce stade ; chaque bande montre la contribution de sa catégorie à ce total."
+/>
+
+La plage sélectionnée détermine le point de départ du compte. Changer de période
+réinitialise le total au premier créneau de cette période. **Jour** utilise des
+créneaux horaires, les plages plus courtes de plusieurs jours des créneaux
+quotidiens et les longues plages des créneaux hebdomadaires ; le sens cumulatif
+reste le même. Dans une période en cours et inachevée, Lotti arrête l’aire au
+dernier créneau écoulé plutôt que de tracer une ligne plate trompeuse à travers
+des dates futures.
+
+Le total cumulé ne change que la projection du graphique. **TOTAL**,
+**CONCENTRATION**, **AUTRE** et le tableau par catégorie continuent de décrire
+l’ensemble de la période sélectionnée. Survole ou appuie sur l’aire pour voir
+la valeur cumulée de chaque catégorie à cet endroit. Sélectionne **Par jour**,
+**Par semaine** ou **Par heure** pour revenir aux valeurs de créneaux
+individuels. Si un seul créneau est écoulé, Lotti conserve les barres : une
+courbe cumulative d’un seul point ne montrerait pas de tendance.
+
+Le tableau est la consultation précise. Il ordonne les catégories selon le
+temps suivi et montre leur total, leur part, leur moyenne par jour et une barre
+de données relative. Une ligne grise **Sans catégorie** est volontaire : elle
+rend visible une attribution manquante au lieu de la cacher silencieusement.
+Ouvre les entrées ou tâches associées et attribue une catégorie lorsque ce temps
+doit appartenir à un domaine opérationnel.
+
+## Compare des périodes équivalentes
+
+<ManualScreenshot
+  caseId="time-analysis/compare"
+  alt="Comparaison de l’Analyse du temps pour Project Waddle montrant le temps actuel, le temps de la période précédente et les variations en pourcentage par catégorie"
+  caption="La comparaison utilise le même nombre de jours écoulés dans chaque période. Une flèche, un signe et une couleur indiquent le sens, tandis que le graphique reste centré sur la période actuelle."
+/>
+
+Sélectionne **Comparer** pour ajouter la période précédente. Pour une semaine,
+un mois, un trimestre ou une année en cours, Lotti compare la portion écoulée
+avec le même nombre de jours immédiatement antérieurs. Ainsi, un résultat de
+mois écoulé jusqu’à un dimanche n’est pas comparé à un mois précédent complet.
+
+Les cartes principales gagnent leur pourcentage de variation et leur valeur
+précédente. Le tableau bascule vers **ACTUEL**, **PRÉCÉDENT** et **Évolution**.
+Aux largeurs étroites, la colonne secondaire Précédent disparaît, tandis que
+Actuel et Évolution restent visibles. Une hausse ou une baisse utilise une
+flèche et un signe explicite en plus de la couleur ; les écarts très faibles
+restent neutres, et un résultat sans base antérieure s’affiche comme nouveau.
+
+Le graphique continue d’afficher uniquement la période actuelle. La note
+**Comparaison affichée dans le tableau ci-dessous** renvoie aux valeurs exactes
+et évite qu’une seconde série de barres masque la répartition des catégories.
+
+## Ce que Lotti compte
+
+L’Analyse du temps compte les entrées de journal chronométrées dont la fin est
+postérieure au début. La durée audio n’est pas comptée séparément, car un
+enregistrement effectué pendant un minuteur en cours serait autrement compté
+deux fois.
+
+L’attribution de catégorie suit le travail :
+
+1. Si l’entrée de temps est liée à une tâche ayant une catégorie, la catégorie de la tâche l’emporte.
+2. Sinon, la catégorie propre à l’entrée de temps est utilisée.
+3. Si aucune n’existe, le temps apparaît comme Sans catégorie.
+
+Les minuteurs qui se chevauchent dans une même catégorie sont fusionnés avant
+le calcul du total. Les chevauchements dans des catégories différentes restent
+dans les deux catégories, car ils représentent des types distincts d’activité
+enregistrée. Les entrées qui traversent minuit sont réparties dans les bons
+jours calendaires locaux. Les entrées privées respectent le réglage global de
+visibilité des données privées, et le tableau de bord s’actualise quand les
+entrées, liens, catégories de tâche ou ce réglage de visibilité changent.
+
+## Garde une image fiable
+
+Utilise les catégories de façon cohérente pour les tâches qui possèdent du
+travail enregistré. Consulte régulièrement la ligne Sans catégorie et choisis
+des catégories de concentration qui répondent à une vraie question, sans
+chercher à tout inclure. Pour Project Waddle, surveiller Opérations Pingouins
+et Contrôle de mission fait de la carte Concentration un signal d’état de
+préparation opérationnelle, tandis que Diplomatie des poissons et Maintenance
+humaine restent visibles dans la ventilation complète.
+
+L’Analyse du temps n’exporte pas encore en CSV, ne regroupe pas les résultats
+par projet et ne trace pas la période précédente comme autre série graphique.
+Les valeurs exactes de comparaison restent dans le tableau, où elles sont plus
+faciles à lire et risquent moins de déformer l’image de la période actuelle.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/organize-and-reflect/time-tracking.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/organize-and-reflect/time-tracking.mdx
@@ -1,0 +1,88 @@
+---
+title: Suis et évalue le travail concentré
+description: Enregistre le temps d’une entrée, termine proprement la session et conserve un jugement rapide sur ta productivité, ton énergie, ta concentration et sa difficulté.
+---
+
+# Suis et évalue le travail concentré
+
+Lotti enregistre le travail concentré sous forme d’entrées de journal
+chronométrées. Démarre un minuteur depuis l’entrée ou la tâche à laquelle ce
+travail appartient, pour que durée et contexte restent liés. À la fin de la
+session, tu peux ajouter une évaluation structurée tant que l’expérience est
+encore fraîche.
+
+L’exemple Project Waddle évalue une répétition de l’appel des manchots empereurs
+de 23 minutes. La feuille d’évaluation présentée ici est l’interface de
+production posée sur cette vraie entrée de temps, pas une maquette pour la
+documentation.
+
+<ManualScreenshot
+  caseId="time-tracking/session-rating"
+  alt="Feuille d’évaluation de session au-dessus d’une entrée de temps Project Waddle, avec productivité, énergie, concentration, difficulté et note de Contrôle de mission"
+  caption="Les trois barres sont des échelles continues. La difficulté utilise des choix explicites et Enregistrer ne devient disponible qu’après une réponse à chaque dimension."
+/>
+
+## Enregistre le temps dans le bon contexte
+
+Ouvre une entrée ou une tâche et utilise son action de minuteur. Un minuteur
+créé depuis une tâche ou une autre entrée de journal est relié à cette source,
+de sorte que le travail qui l’entoure reste visible dans l’activité liée. La
+durée s’actualise pendant l’enregistrement et l’action d’arrêt clôt la session
+sur cette même entrée de temps.
+
+Utilise un minuteur pour une portion de travail cohérente. Si l’objectif
+change — de l’inspection de l’habitat à la diplomatie des sardines, par
+exemple — arrête le minuteur actuel et démarre-en un autre sous la bonne tâche
+ou catégorie. Cela maintient à la fois l’historique des entrées et l’[Analyse
+du temps](./time-analysis.mdx) pertinents.
+
+## Évalue une session terminée
+
+Après la fin d’un enregistrement d’au moins une minute, Lotti affiche une
+invitation étoilée près de la durée. Elle pulse brièvement, puis reste
+disponible jusqu’à ce que tu enregistres une évaluation ou relances
+l’enregistrement. Pour un minuteur affiché dans l’activité liée, le menu
+d’actions de l’entrée propose aussi **Évaluer la session** ou **Voir
+l’évaluation**.
+
+Le catalogue de sessions pose quatre questions :
+
+- **Productivité** est une échelle continue, d’improductive à productivité maximale.
+- **Énergie** va d’épuisée à pleinement énergisée.
+- **Concentration** va de la distraction constante à une concentration ininterrompue.
+- **Ce travail était…** enregistre **Trop facile**, **Juste comme il faut** ou
+  **Trop difficile**. **Juste bien** représente l’équilibre souhaité
+  entre difficulté et compétence.
+
+Fais glisser ou sélectionne n’importe où sur une barre continue ; les valeurs
+ne sont pas limitées aux graduations visibles. Ajoute une note facultative pour
+donner un contexte que les chiffres ne peuvent pas porter. **Enregistrer** reste
+désactivé tant que les quatre réponses ne sont pas présentes. **Passer** ferme
+la feuille sans écrire d’évaluation.
+
+## Examine et corrige une évaluation
+
+Une évaluation enregistrée est conservée comme une entrée de journal à part
+entière et liée à l’entrée de temps qu’elle décrit. Rouvre **Voir l’évaluation**
+pour changer les réponses ou la note. Le résumé enregistré conserve le texte
+des questions et des options utilisé à ce moment-là, afin que les évaluations
+synchronisées restent compréhensibles même si le catalogue change plus tard.
+
+Les évaluations de session sont disponibles lorsque l’option de configuration
+**Évaluations de session** est activée. Un client qui reçoit un catalogue
+d’évaluation qu’il ne reconnaît pas peut toujours afficher les réponses
+enregistrées, mais garde cette évaluation en lecture seule plutôt que de
+deviner comment modifier des données inconnues.
+
+## Utilise les évaluations comme observations, pas comme notes
+
+Ces quatre dimensions décrivent une session, pas ta performance personnelle. Un
+score d’énergie bas peut expliquer pourquoi un travail pourtant utile a semblé
+difficile ; un score de concentration élevé associé à **Trop facile** peut
+suggérer que la prochaine session mérite un périmètre plus ambitieux. Les notes
+sont particulièrement utiles pour les anomalies, comme une sardine en vol, une
+interruption ou un briefing de Contrôle de mission inhabituellement fluide.
+
+Les évaluations complètent la durée sans la modifier. Le minuteur reste la
+source de vérité pour la durée du travail, tandis que l’évaluation consigne la
+façon dont ce temps a été vécu.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/plan-and-capture/daily-os.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/plan-and-capture/daily-os.mdx
@@ -1,0 +1,155 @@
+---
+title: Planifier et clore une journée avec Daily OS
+description: Transforme un point de situation oral ou écrit en plan modifiable, utilise-le à côté du temps enregistré et reporte le bon travail.
+---
+
+# Planifier et clôturer une journée avec Daily OS
+
+Daily OS transforme un point de situation oral ou écrit en plan pour une journée. Il ne remplace ni les tâches ni les relevés de temps : les tâches décrivent le travail, le plan exprime ton intention et les sessions enregistrées racontent ce qui s'est réellement passé.
+
+Les exemples suivent la directrice Aurora lors d'une journée chargée chez Interplanetary Penguin Logistics. Le planificateur protège une revue de lancement Project Waddle, décale les négociations de sardines et garde libre un essai de distributeur de poissons en apesanteur.
+
+## Avant ton premier point de situation
+
+Ouvre **Réglages → Daily OS**. Choisis le profil d'inférence qui doit planifier tes journées et indique le nom que Daily OS doit employer. La notice de confidentialité précise le fournisseur choisi et si le traitement est local ou distant.
+
+<ManualScreenshot
+  alt="Réglages Daily OS configurés pour la directrice Aurora et le profil d'inférence Project Waddle"
+  caseId="daily-os/settings"
+  caption="La directrice Aurora utilise le profil Project Waddle Command, Waddle Command 70B et le fournisseur Mission Control Router."
+/>
+
+Ouvre ensuite **Réglages → Catégories** et active **Planification du jour** seulement pour les catégories que le planificateur peut utiliser. Cette liste d'autorisation garde les tâches sans rapport hors du plan et évite que Daily OS modifie du travail hors de ces catégories.
+
+## 1. Dire ce dont la journée a besoin
+
+Ouvre **Daily OS**, choisis la date et sélectionne **Dicter un point de situation**. Mentionne les engagements fixes, résultats importants, durées approximatives, capacité disponible, pauses, contraintes d'énergie et travail à reporter.
+
+Choisis **Écrire plutôt** quand parler est peu pratique. Après la reconnaissance, relis la transcription complète et corrige sur place les noms, chiffres ou autres erreurs.
+
+<ManualScreenshot
+  alt="Transcription complète du point de situation Daily OS prête à être relue"
+  caseId="daily-os/capture-review"
+  caption="Relis le texte reconnu avant que Daily OS le rapproche des tâches Project Waddle."
+/>
+
+Choisis **Réenregistrer** pour recommencer ou **Vérifier** pour continuer. La construction de la journée reste indisponible jusqu'à la fin du rapprochement.
+
+## 2. Rapprocher la parole du vrai travail
+
+Le rapprochement est le contrôle entre ce que l'assistant a entendu et ce que Lotti va modifier :
+
+- **LIÉ** pointe vers une tâche existante : confirme que c'est bien celle que tu voulais.
+- **NOUVEAU** est une expression qui peut devenir du travail pour aujourd'hui.
+- **MAJ** propose une modification de tâche existante.
+- Les libellés de confiance et de repère temporel indiquent où la relecture est la plus utile.
+
+<ManualScreenshot
+  alt="Daily OS rapprochant un point de situation oral de travail Project Waddle existant et nouveau"
+  caseId="daily-os/reconcile"
+  caption="L'inspection de l'habitat orbital correspond à un vrai travail, tandis que les nouvelles demandes restent des décisions explicites."
+/>
+
+Daily OS fait aussi apparaître le travail en cours, en retard, à échéance aujourd'hui ou récemment manqué. Décide ce qui a sa place aujourd'hui plutôt que d'importer tout l'arriéré.
+
+## 3. Évaluer le brouillon
+
+Choisis **Construire ma journée** lorsque les décisions de rapprochement sont justes. Le résultat s'ouvre sur **Agenda**. La carte de capacité répond à « est-ce que ça tient ? » avant que la liste ne réponde à « qu'est-ce qui compte ? ». Les lignes liées à une tâche conservent catégorie, statut, estimation et miniature de couverture.
+
+<ManualScreenshot
+  alt="Agenda Daily OS Project Waddle avec capacité, miniatures de tâches, priorités et totaux par catégorie"
+  caseId="daily-os/agenda"
+  caption="Chaque tâche de l'agenda conserve sa propre illustration de couverture Project Waddle, y compris le travail terminé."
+/>
+
+Utilise les ajustements rapides lorsque la forme ne convient pas :
+
+- **Trop chargé** demande un plan plus petit.
+- **Déplacer le léger** éloigne le travail exigeant des périodes de faible énergie.
+- **Ajouter du tampon** crée de l'espace pour respirer.
+- **Ajuster** ouvre un ajustement libre, vocal ou écrit.
+
+Choisis **Ça me va** seulement lorsque le brouillon est réellement acceptable.
+
+## 4. Relire chaque ajustement proposé
+
+Ajuster ne réécrit jamais silencieusement le calendrier. Décris le changement, puis examine chaque bloc ajouté, déplacé ou retiré avec ses heures précédente et proposée ainsi que la raison du planificateur. Accepte ou refuse les propositions une par une, choisis **Annuler** pour écarter l'ensemble en attente, ou continue de parler pour demander un nouveau passage.
+
+<ManualScreenshot
+  alt="Daily OS proposant deux changements d'horaires relus pour les négociations de sardines et la démonstration du distributeur de poissons"
+  caseId="daily-os/refine"
+  caption="Les négociations de sardines sont décalées pour protéger la revue de lancement de Mission Control ; la démonstration du distributeur suit la nouvelle marge."
+/>
+
+Seules les propositions acceptées font partie du brouillon. **Ça me va** quitte la relecture une fois que le plan exprime bien ton intention.
+
+## 5. Verrouiller la journée
+
+La page **Verrouiller** donne au brouillon complet une dernière lecture : ordre, durée, résultats et capacité restante. Maintiens la commande de confirmation une seconde pour faire passer le plan de brouillon à engagé. Au clavier, tu peux la focaliser et appuyer sur Entrée ou Espace ; l'activation par technologie d'assistance confirme directement.
+
+<ManualScreenshot
+  alt="Brouillon Project Waddle et action délibérée de maintien pour confirmer sur la page d'engagement Daily OS"
+  caseId="daily-os/commit"
+  caption="Huit éléments de travail utilisent 8 h 45 d'une journée de 9 h, laissant une marge de 15 minutes avant que la directrice Aurora ne verrouille le plan."
+/>
+
+Verrouiller fixe les fondations du plan, pas ta capacité à t'adapter. Tu peux encore utiliser **Ajuster** ensuite, mais les changements proposés restent relisibles.
+
+## 6. Comparer le plan à la réalité
+
+Passe d'**Agenda** à **Journée** pour la projection calendrier. Sur ordinateur, Plan et Réel partagent un axe temporel. Sur téléphone, balaie horizontalement entre les pistes planifiée et enregistrée. Les blocs planifiés sont plus légers et les sessions enregistrées sont pleines : l'écart reste visible sans réécrire l'historique.
+
+<ManualScreenshot
+  alt="Chronologie Daily OS comparant les blocs planifiés Project Waddle au temps enregistré"
+  caseId="daily-os/timeline"
+  caption="Le téléphone passe entre les pistes planifiée et enregistrée ; l'ordinateur montre les deux sur un même axe temporel."
+/>
+
+Démarre et arrête l'enregistrement du temps depuis la tâche liée. Daily OS lit ces relevés comme la réalité ; il ne fabrique pas de travail terminé à partir du plan.
+
+## 7. Déplacer, redimensionner ou modifier un bloc
+
+Choisis l'action **Organiser** à quatre flèches au-dessus de la chronologie. Fais glisser le corps d'un bloc pour le déplacer, ou sa poignée supérieure ou inférieure pour changer son début ou sa fin. Les changements s'alignent sur des incréments de 15 minutes et restent dans la journée choisie. Utilise **Annuler** dans le message de confirmation si l'ancien créneau était meilleur.
+
+<ManualScreenshot
+  alt="Mode Organiser Daily OS avec commandes de déplacement et de redimensionnement sur les blocs Project Waddle"
+  caseId="daily-os/arrange"
+  caption="Le mode Organiser expose les mêmes actions directes de déplacement et de redimensionnement sur téléphone et ordinateur."
+/>
+
+L'action crayon ouvre l'éditeur de bloc. Un bloc lié à une tâche conserve son titre et sa catégorie, qui appartiennent à la tâche, en lecture seule ; choisis **Ouvrir la tâche** pour les modifier à la source. Son début et sa fin prévus restent modifiables depuis Daily OS.
+
+<ManualScreenshot
+  alt="Éditeur de bloc Daily OS pour la tâche du distributeur de poissons en apesanteur"
+  caseId="daily-os/block-editor"
+  caption="La tâche liée possède son titre et la catégorie Penguin Operations ; Daily OS possède le créneau 14 h 30–16 h et la raison de la planification."
+/>
+
+Les blocs de plan autonomes peuvent modifier leur propre titre et leur catégorie, car aucune tâche ne possède ces métadonnées.
+
+## 8. Clore la journée
+
+Après une journée engagée, choisis **Clore**. La fermeture distingue des décisions qui ne doivent pas être confondues :
+
+- **Ce que tu as fait** liste le travail terminé avec la durée réellement suivie.
+- **À reporter** te laisse planifier le travail inachevé pour demain, choisir une date ou l'abandonner.
+- Les métriques résument le temps de concentration, les sessions de flux, les changements de contexte et l'énergie.
+- Une réflexion d'une ligne alimente le prochain brouillon.
+- **Ce que j'ai appris** te laisse confirmer ou oublier les connaissances durables du planificateur.
+- **Pour demain** préserve la note de passage concise.
+
+<ManualScreenshot
+  alt="Fermeture Daily OS avec travail Project Waddle terminé, choix de report, métriques, réflexion et préférences apprises"
+  caseId="daily-os/shutdown"
+  caption="La directrice Aurora a terminé l'inspection de l'habitat, la revue de lancement et l'accord sur les sardines ; la démonstration du distributeur et la question du passager restent des décisions explicites de report."
+/>
+
+Choisis **Enregistrer et fermer** pour quitter la relecture sans déclarer la journée fermée, ou **Clore la journée** lorsque les décisions de report et d'apprentissage sont prêtes.
+
+## La règle de propriété
+
+- Les tâches décrivent le travail et possèdent les métadonnées de tâche.
+- Le plan de journée décrit l'intention et possède les blocs prévus.
+- Les relevés de temps décrivent la réalité.
+- La connaissance du planificateur enregistre les préférences relues pour les jours à venir.
+- L'assistant propose ; tu décides.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/plan-and-capture/entries.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/plan-and-capture/entries.mdx
@@ -1,0 +1,33 @@
+---
+title: Ajouter des entrées et du contexte
+description: Crée des tâches, notes, enregistrements, minuteurs, images et listes de vérification depuis le même menu contextuel.
+---
+
+# Ajouter des entrées et du contexte
+
+Lotti utilise un même menu **Ajouter** pour les éléments que tu captures dans la journée. Ouvre-le depuis le journal pour une entrée autonome, ou depuis une tâche pour garder la nouvelle entrée liée à cette tâche.
+
+<ManualScreenshot
+  caseId="entries/create-menu"
+  alt="Menu Ajouter de production au-dessus de la tâche Inspecter l'habitat orbital des manchots, avec les actions Liste de vérification, Tâche, Enregistrement audio, Minuteur, Entrée texte, Importer une image et Capture d'écran"
+/>
+
+## Choisir l'entrée adaptée au contenu
+
+| Action | À utiliser pour |
+| --- | --- |
+| **Liste de vérification** | Un court ensemble d'étapes concrètes dans la tâche actuelle |
+| **Tâche** | Un résultat distinct qui a besoin de son propre statut et contexte |
+| **Enregistrement audio** | Une note vocale à réécouter ou transcrire |
+| **Minuteur** | Une session de travail chronométrée liée au contexte actuel |
+| **Entrée texte** | Des notes, décisions, observations ou informations collées |
+| **Importer une image** | Une image existante de l'appareil |
+| **Capture d'écran** | Une nouvelle capture d'écran sur ordinateur, jointe comme entrée image |
+
+Le menu est contextuel. **Liste de vérification** est disponible lorsqu'une tâche peut posséder les éléments, alors que les actions propres à un appareil, comme **Capture d'écran**, n'apparaissent que là où la plateforme les prend en charge.
+
+## Garder le contexte avec le travail
+
+Lorsque tu ouvres **Ajouter** depuis une tâche, Lotti relie la nouvelle entrée à cette tâche. Les enregistrements, notes, images et relevés de temps restent ainsi réunis sur la page de détail. Utilise une entrée de journal autonome si le contenu n'appartient pas encore à un résultat précis : tu pourras la lier plus tard.
+
+Consulte [Enregistrer de l'audio](./recordings.mdx) pour la capture et la transcription, ou [Travailler avec les tâches](../organize-and-reflect/tasks.mdx) pour la structure des tâches, les illustrations de couverture et les liens entre tâches.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/plan-and-capture/recordings.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/plan-and-capture/recordings.mdx
@@ -1,0 +1,50 @@
+---
+title: Enregistrer de l'audio
+description: Capture une note vocale et décide du traitement automatisé à effectuer ensuite.
+---
+
+# Enregistrer de l'audio
+
+L'audio est utile lorsque parler est plus rapide qu'écrire ou lorsque le ton et les détails comptent. Un enregistrement peut vivre seul ou dans une tâche.
+
+## Capturer un enregistrement
+
+1. Ouvre le journal ou la tâche qui doit posséder l'enregistrement.
+2. Utilise l'action **+**, puis choisis **Enregistrement audio**.
+3. Examine les options de traitement disponibles.
+4. Démarre l'enregistrement, parle distinctement, puis arrête-le quand tu as terminé.
+
+<ManualScreenshot
+  caseId="recordings/active"
+  alt="Feuille d'enregistrement audio active avec visualiseur en direct, temps écoulé, pause, abandon, arrêt et commandes de reconnaissance vocale"
+/>
+
+Pendant la capture, la feuille garde le temps écoulé et le visualiseur d'entrée en direct visibles. Tu peux mettre en pause et reprendre sans terminer, abandonner la prise ou choisir **Arrêter** pour l'enregistrer. Lorsque la transcription liée à une tâche est disponible, l'option **Reconnaissance vocale** détermine si le traitement doit commencer après l'enregistrement.
+
+Lorsqu'un profil d'inférence et une compétence de transcription sont configurés, Lotti peut transcrire l'enregistrement après la capture. Les enregistrements de tâche peuvent aussi proposer un traitement lié à la tâche, comme des mises à jour de liste de vérification ou de résumé.
+
+## Relire les transcriptions enregistrées
+
+Ouvre une entrée audio, utilise son menu **…**, puis choisis **Reconnaissance vocale**. La feuille de relecture conserve chaque transcription avec l'enregistrement au lieu de remplacer un résultat antérieur. Chaque ligne indique le moment du traitement, sa durée, la langue détectée et le fournisseur ainsi que le modèle qui l'ont produit.
+
+<ManualScreenshot
+  caseId="recordings/transcripts"
+  alt="Feuille de reconnaissance vocale au-dessus d'une entrée audio Project Waddle, avec l'anglais sélectionné et deux transcriptions enregistrées de Mistral et Whisper"
+  caption="L'enregistrement source reste visible derrière la feuille, tandis que chaque résultat de reconnaissance conserve sa propre provenance."
+/>
+
+Le sélecteur de langue propose actuellement **Auto**, **English** et **Deutsch**. Utilise **Auto** lorsque le fournisseur doit détecter la langue, ou sélectionne une langue avant la reconnaissance si tu la connais déjà. Le choix est enregistré sur l'entrée audio.
+
+Sélectionne le double chevron d'un résultat pour afficher le texte complet et sélectionnable. Déplier une ligne révèle aussi son action de suppression. Supprimer une transcription retire ce résultat de reconnaissance, pas l'enregistrement source ni les autres transcriptions.
+
+<ManualScreenshot
+  caseId="recordings/transcript-expanded"
+  alt="Transcription Project Waddle dépliée décrivant la cargaison de sardines Europa, 37 manchots empereurs et le distributeur de poissons en apesanteur"
+  caption="Relis la formulation complète et la provenance du fournisseur avant d'utiliser le texte généré comme contexte de tâche."
+/>
+
+## Choisir l'automatisation délibérément
+
+Les options de traitement sont des demandes adressées aux compétences IA configurées. Le fournisseur choisi peut être local ou distant : vérifie donc le profil d'inférence actif avant d'utiliser du contenu sensible. Relis le texte généré et les changements de tâche proposés au lieu de les traiter comme une source de vérité.
+
+Consulte [Configurer un fournisseur IA](../ai-and-automation/provider-setup.mdx) pour décider où s'exécute l'inférence.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/plan-and-capture/surveys.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/plan-and-capture/surveys.mdx
@@ -1,0 +1,54 @@
+---
+title: Remplir et revoir les questionnaires
+description: Lance les questionnaires inclus depuis un tableau de bord, réponds une question à la fois et conserve les scores dans le Journal.
+---
+
+# Remplir et revoir les questionnaires
+
+Lotti inclut trois questionnaires fixes : **CFQ-11**, **GHQ-12** et **PANAS**. Ajoute celui que tu utilises à un tableau de bord, puis sélectionne l'action **+** de son graphique chaque fois que tu veux enregistrer une nouvelle réponse. Le tableau de bord sert à la fois de point de départ et d'endroit où les scores complétés deviennent une tendance.
+
+Les exemples ci-dessous lancent le vrai questionnaire PANAS depuis le tableau de bord **Opérations de la colonie**. Le questionnaire et sa navigation viennent du même moteur de questionnaires de production que l'app.
+
+<ManualScreenshot
+  caseId="surveys/panas-intro"
+  alt="Instructions du questionnaire PANAS ouvertes au-dessus du tableau de bord Opérations de la colonie"
+  caption="Lis la période concernée par l'instrument et l'échelle de réponse avant de continuer. L'indicateur de progression compte chaque étape d'instruction, de question et de fin."
+/>
+
+## Ajouter un questionnaire à un tableau de bord
+
+Ouvre **Réglages → Définitions → Tableaux de bord**, modifie un tableau de bord et ajoute un graphique depuis **Questionnaires**. Les instruments disponibles sont :
+
+- **CFQ-11**, l'échelle de fatigue de Chalder ;
+- **GHQ-12**, le questionnaire de santé générale ;
+- **PANAS**, l'échelle des affects positifs et négatifs.
+
+Retourne dans **Tableaux de bord** et ouvre le tableau. Le graphique montre les résultats soumis pour son instrument. Sélectionne son action **+** pour commencer une nouvelle réponse. Chaque graphique lance le questionnaire correspondant : il n'existe pas de formulaire générique qui modifie les questions à partir des données de la documentation.
+
+## Répondre à la question en cours
+
+L'étape d'instructions explique la période demandée et le sens de l'échelle de réponse. Sélectionne **Suivant** pour commencer. PANAS présente ensuite 20 mots d'affect, un à la fois, et demande un choix sur une échelle à cinq points. Les instructions, mots d'affect, textes de fin et libellés d'échelle suivent la langue de l'app ; la capture française va de **Pas du tout ou très peu** à **Extrêmement**.
+
+<ManualScreenshot
+  caseId="surveys/panas-question"
+  alt="Question PANAS Intéressé·e avec cinq choix de réponse de Pas du tout ou très peu à Extrêmement"
+  caption="Les questions sont présentées séquentiellement. Choisis une réponse, continue et utilise le compteur de progression pour savoir où tu en es dans le questionnaire."
+/>
+
+Les autres questionnaires inclus utilisent leurs propres définitions fixes de questions et de calcul de score. Choisis la réponse correspondant à la formulation et à la période affichées ; Lotti ne réinterprète ni ne remplit automatiquement les réponses.
+
+## Soumettre ou annuler délibérément
+
+Continue jusqu'à l'étape de fin pour soumettre. Lotti enregistre le résultat brut et ses groupes de scores calculés comme entrée de questionnaire dans le Journal. Le tableau de bord relit ces entrées dans son graphique : chaque questionnaire complété ajoute donc une observation datée.
+
+Fermer le questionnaire demande si tu veux abandonner le résultat en cours. Un questionnaire annulé n'est pas enregistré, y compris le travail partiellement répondu. Si la réponse compte, termine l'étape de fin avant de quitter la feuille.
+
+## Comprendre les scores enregistrés
+
+L'entrée persistée conserve les réponses individuelles et le résumé calculé utilisé par les graphiques :
+
+- **CFQ-11** produit son score de fatigue configuré ;
+- **GHQ-12** produit son score de santé générale configuré ;
+- **PANAS** produit des totaux distincts d'**Affect positif** et d'**Affect négatif**.
+
+Ouvre l'entrée correspondante du Journal pour inspecter le résumé enregistré. Utilise le tableau de bord pour l'évolution dans le temps et le Journal pour la source datée. Les graphiques de questionnaire ne remplacent pas les instructions de l'instrument, et Lotti ne propose pas de système de création de questionnaires permettant de modifier ces définitions incluses.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/reference/advanced-settings.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/reference/advanced-settings.mdx
@@ -1,0 +1,159 @@
+---
+title: Utiliser les paramètres avancés avec précaution
+description: Contrôle les flags et la journalisation, exécute les outils de maintenance, examine les métriques d’intégration et vérifie la version installée de Lotti.
+---
+
+# Utiliser les paramètres avancés avec précaution
+
+Ouvre **Réglages → Paramètres avancés** pour les contrôles avancés, les
+diagnostics et la maintenance. Ces pages modifient le fonctionnement de Lotti
+ou agissent directement sur des données locales ; la personnalisation ordinaire
+a donc sa place ailleurs dans les Réglages.
+
+Sur ordinateur, l’arborescence des réglages reste à côté de la page
+sélectionnée. Sur mobile, une page s’ouvre à la fois avec un bouton retour. Les
+mêmes contrôles et valeurs enregistrées sont utilisés dans les deux présentations.
+
+<ManualScreenshot
+  caseId="advanced-settings/hub"
+  alt="Centre des paramètres avancés Lotti avec Flags, Animations, Journalisation, Maintenance, Métriques d’intégration et À propos de Lotti"
+  caption="Les paramètres avancés séparent les contrôles opérationnels des préférences quotidiennes. Certaines entrées varient selon la plateforme et les capacités activées."
+/>
+
+## Contrôler les fonctionnalités avec les flags
+
+<ManualScreenshot
+  caseId="advanced-settings/flags"
+  alt="Page Flags de Lotti avec des interrupteurs recherchables pour les entrées privées, les notifications, l’enregistrement de la localisation, les info-bulles et le streaming IA"
+  caption="La recherche porte sur le nom et la description des flags. Chaque interrupteur modifie immédiatement le réglage enregistré."
+/>
+
+Les **flags** servent d’interrupteurs pour les fonctionnalités. Ils contrôlent :
+
+- la visibilité des entrées privées, les notifications, la capture de position
+  et les info-bulles ;
+- le streaming des réponses IA et la lecture des résumés ;
+- la journalisation et le comportement de synchronisation Matrix ;
+- des pages comme Habitudes, Tableaux de bord, Événements, Projets et Quoi de
+  neuf ;
+- les embeddings et la recherche vectorielle ;
+- l’activité de synchronisation, les activations d’agents en attente et la
+  réparation de bifurcations.
+
+Utilise **Rechercher des indicateurs** pour limiter la liste par titre ou
+description. Sélectionne une ligne ou son interrupteur pour modifier le flag.
+La nouvelle valeur est enregistrée immédiatement ; il n’y a pas d’action
+Enregistrer séparée.
+
+Les flags peuvent exposer des comportements expérimentaux ou de
+diagnostic. Modifie-en un délibérément, vérifie le flux concerné, puis seulement
+ensuite un autre. **Afficher les entrées privées ?** contrôle l’inclusion du
+contenu sensible dans les listes et sélecteurs ; il ne chiffre, n’exporte, ne
+supprime ni ne modifie le niveau de confidentialité d’une entrée.
+
+## Choisir ce que Lotti journalise
+
+<ManualScreenshot
+  caseId="advanced-settings/logging"
+  alt="Réglages de journalisation Lotti avec un interrupteur maître, des domaines opérationnels individuels et la journalisation des requêtes lentes"
+  caption="L’interrupteur maître contrôle les domaines individuels. Le jeu de données Project Waddle laisse la synchronisation, l’IA et les tâches activées pour des diagnostics ciblés."
+/>
+
+La **journalisation** commence avec **Activer la journalisation**. Lorsqu’il est
+actif, n’active que les domaines nécessaires à ton enquête : synchronisation,
+IA, tâches, étiquettes, santé, habitudes, navigation, notifications ou Daily OS.
+**Requêtes lentes de la base** ajoute des diagnostics de performance de la
+base de données.
+
+Désactiver l’interrupteur maître désactive les contrôles par domaine. Les erreurs
+continuent d’être écrites dans le journal quotidien `error-*.log` ; ces
+interrupteurs gouvernent la journalisation diagnostique supplémentaire, pas le
+minimum d’enregistrement des erreurs. Désactive les domaines bruyants après
+l’enquête pour garder des journaux ciblés et un usage de stockage prévisible.
+
+## Exécuter les actions de maintenance délibérément
+
+<ManualScreenshot
+  caseId="advanced-settings/maintenance"
+  alt="Page Maintenance Lotti avec aperçus d’intégration, actions de réinitialisation, suppression de base de données, purge, index de recherche, embeddings et diagnostic de repeint"
+  caption="La maintenance combine aperçus sûrs, actions destructives et diagnostics. Lis la confirmation et la portée avant de continuer."
+/>
+
+La **maintenance** contient plusieurs types d’actions :
+
+- **Afficher l’accueil d’intégration** et **Galerie d’animations d’intégration**
+  sont des aperçus en direct pour le développement et l’assurance qualité.
+- **Réinitialiser les astuces de l’application** rend les conseils ponctuels
+  de nouveau éligibles à l’affichage.
+- **Réinitialiser le dialogue de configuration Gemini** annule sa
+  fermeture afin de pouvoir tester à nouveau l’invite du fournisseur.
+- **Supprimer la base de données des brouillons** supprime les brouillons de
+  l’éditeur.
+- **Supprimer la base de données des agents** supprime cette base et quitte
+  Lotti, afin que l’app redémarre avec un stockage propre.
+- **Purger les éléments supprimés** efface définitivement les enregistrements
+  supprimés logiquement à travers un flux de confirmation dédié.
+- **Recréer l’index de texte intégral** reconstruit les données de recherche
+  locales sans recréer les entrées du journal.
+- **Générer les embeddings** apparaît lorsque le stockage d’embeddings est
+  disponible et remplit les catégories sélectionnées.
+- **Superposition arc-en-ciel de repeint** fait clignoter les régions repeintes
+  pour les diagnostics d’interface. Elle est conservée en mémoire et revient à
+  désactivée après le redémarrage.
+
+Les aperçus et réinitialisations n’ont pas le même risque qu’une suppression ou
+une purge. Pour les actions destructives, confirme que la cible est bien le
+stockage local voulu et laisse d’abord se terminer toute synchronisation ou
+écriture en cours.
+
+## Examiner le parcours d’intégration
+
+<ManualScreenshot
+  caseId="advanced-settings/onboarding-metrics"
+  alt="Page Métriques d’intégration Lotti affichant l’heure d’installation, quatre jours actifs, l’état d’activation et des nombres d’événements sans contenu"
+  caption="Le jeu de données déterministe du manuel a atteint son véritable déclic en quatre jours actifs après la connexion d’un fournisseur et l’enregistrement de plusieurs captures."
+/>
+
+Les **métriques d’intégration** sont une surface pour le développement et
+l’assurance qualité. Elles dérivent localement un parcours à partir
+d’événements sans contenu et indiquent :
+
+- l’horodatage de première détection en UTC ;
+- le total de jours actifs et ceux des sept premiers jours ;
+- si l’installation appartient à la cohorte de référence pré-FTUE ;
+- si l’étape réelle d’activation a été atteinte ;
+- le nombre de chaque événement d’intégration.
+
+La page enregistre des noms d’événements et des métadonnées à faible
+cardinalité, pas le texte du journal, les titres des tâches, les transcriptions
+ni les détails sensibles aux sardines de Project Waddle.
+
+**Réinitialiser l’état de test d’intégration** efface la cadence des invites
+d’intégration et les métriques locales du parcours après confirmation. Cela ne
+supprime pas les données du journal, les flags ou
+l’historique réel des plans Daily OS. Un profil ayant déjà planifié une journée
+reste donc inéligible au chemin exact du premier plan sur un profil propre.
+
+## Vérifier la version et les totaux locaux
+
+<ManualScreenshot
+  caseId="advanced-settings/about"
+  alt="Page À propos de Lotti affichant la version, la plateforme, le type de build, 2 604 entrées de journal, 11 entrées signalées et le nombre de tâches"
+  caption="À propos de Lotti identifie la version en cours et résume les données locales. Le jeu de données Project Waddle contient 2 604 entrées et 65 tâches réparties sur cinq états."
+/>
+
+**À propos de Lotti** est l’endroit le plus rapide pour vérifier la version qui
+tourne réellement. Il affiche la version et le numéro de build de l’app, la
+plateforme et le type de build. Inclus ces valeurs dans un rapport de
+diagnostic afin qu’un comportement puisse être relié au bon code et à la bonne
+version.
+
+La carte **Tes données** résume les entrées de journal locales, les entrées
+signalées et le nombre de tâches réparties entre Ouvertes, En cours, En pause,
+Bloquées et Terminées. L’espace Project Waddle établi dans le manuel montre un
+compte non vide : 2 604 entrées de journal, 11 entrées signalées et 65 tâches
+plutôt que des zéros de remplacement.
+
+Les effets de fin ont leur propre guide : consulte
+**[Personnaliser les célébrations de fin](./completion-celebrations.mdx)** pour
+la page Animations et son terrain de jeu en direct.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/reference/appearance.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/reference/appearance.mdx
@@ -1,0 +1,47 @@
+---
+title: Choisir l’apparence de Lotti
+description: Définis le mode d’affichage clair, sombre ou automatique et choisis une palette pour chaque apparence.
+---
+
+# Choisir l’apparence de Lotti
+
+Ouvre **Réglages → Thème** pour contrôler l’aspect de Lotti. Le mode
+d’affichage et les deux choix de palette sont indépendants : tu peux associer
+un thème clair de journée à un thème de nuit complètement différent.
+
+<ManualScreenshot
+  caseId="theming/preferences"
+  alt="Réglages Thème de Lotti avec les modes Apparence sombre, Automatique et Apparence claire, ainsi que les sélections de thèmes Sakura et Outer Space"
+  caption="La démonstration associe Sakura au mode clair et Outer Space au mode sombre. Ton choix s’applique immédiatement."
+/>
+
+## Sélectionner un mode d’affichage
+
+Choisis l’un des trois modes :
+
+- **Apparence sombre** utilise toujours le thème sombre sélectionné.
+- **Automatique** suit le réglage clair ou sombre actuel du système
+  d’exploitation.
+- **Apparence claire** utilise toujours le thème clair sélectionné.
+
+Le mode automatique est utile lorsqu’un appareil change d’apparence selon un
+horaire. Lotti suit ce changement tout en conservant la palette que tu as
+choisie pour chaque côté.
+
+## Choisir les palettes claires et sombres
+
+1. Sélectionne **Thème clair** ou **Thème sombre**.
+2. Choisis une palette nommée dans le panneau qui s’ouvre.
+3. Recommence pour l’autre apparence si nécessaire.
+
+<ManualScreenshot
+  caseId="theming/picker"
+  alt="Sélecteur de thèmes Lotti listant les palettes nommées disponibles"
+  caption="Le sélecteur de thèmes utilise la même structure de réglages mobile ou ordinateur que l’application."
+/>
+
+Il n’y a pas de bouton Enregistrer. Le mode d’affichage et les choix de palette
+sont conservés dès que tu les sélectionnes. Le sélecteur clair/sombre du manuel
+est distinct : il modifie la documentation et sélectionne
+automatiquement la variante de capture correspondante, mais ne change pas tes
+réglages Lotti.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/reference/completion-celebrations.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/reference/completion-celebrations.mdx
@@ -1,0 +1,64 @@
+---
+title: Personnaliser les célébrations de fin
+description: Configure les animations de fin, le retour haptique, les styles et leur terrain de jeu en direct.
+---
+
+# Personnaliser les célébrations de fin
+
+Ouvre **Réglages → Paramètres avancés → Animations** pour décider comment Lotti
+réagit lorsque tu termines une tâche, réalises une habitude ou coches un élément
+de liste.
+
+<ManualScreenshot
+  caseId="celebrations/controls"
+  alt="Réglages Animations Lotti avec des interrupteurs de célébration pour les habitudes, les éléments de liste, les tâches et le retour haptique de fin"
+  caption="Les célébrations visuelles ont un interrupteur maître et des interrupteurs par événement. Le retour haptique de fin reste indépendant."
+/>
+
+## Choisir où les célébrations apparaissent
+
+- **Animations de fin** est l’interrupteur maître des effets visuels.
+- **Habitudes**, **Éléments de liste** et **Tâches** contrôlent indépendamment
+  leurs effets visuels de fin.
+- **Retour haptique de fin** contrôle la brève réponse physique et reste
+  disponible même si les animations sont désactivées.
+
+Désactiver une animation n’annule jamais la validation elle-même. Si le système
+d’exploitation demande une réduction des animations, Lotti supprime les effets
+tout en conservant les styles choisis pour plus tard.
+
+## Assigner un style à chaque type de fin
+
+<ManualScreenshot
+  caseId="celebrations/styles"
+  alt="Sélecteur de style de célébration Lotti avec Tâches sélectionné et les choix Étincelles, Feux d’artifice, Confettis, Braises, Bulles, Aléatoire et Combiner deux styles"
+  caption="Les tâches, habitudes et éléments de liste peuvent employer des styles différents. Sélectionne une carte pour l’apercevoir et l’appliquer."
+/>
+
+Pour chaque type de fin, choisis **Étincelles**, **Feux d’artifice**,
+**Confettis**, **Braises** ou **Bulles**. Choisis **Aléatoire** pour un style
+unique renouvelé à chaque fin, ou **Combiner deux styles** pour superposer deux styles
+tirés au hasard.
+
+Utilise **Essayer** pour prévisualiser le choix actuel sans modifier de vraies
+données de tâche ou d’habitude.
+
+## Ajuster un style individuel
+
+Sélectionne l’action de personnalisation d’un style fixe pour ouvrir son
+terrain de jeu plein écran.
+
+<ManualScreenshot
+  caseId="celebrations/playground"
+  alt="Terrain de jeu de célébration Étincelles Lotti avec aperçu de tâche en direct et contrôles groupés Forme, Mouvement et Apparence"
+  caption="Les changements sont enregistrés et appliqués partout immédiatement. Rejoue l’exemple après chaque ajustement."
+/>
+
+Les contrôles disponibles dépendent de l’effet et sont regroupés par **Forme**,
+**Mouvement** et **Apparence**. Ajuste les curseurs, puis utilise l’exemple mis
+en évidence ou **Rejouer** pour voir le résultat. **Réinitialiser** restaure le
+style par défaut ; la confirmation propose **Annuler** si la
+réinitialisation était accidentelle.
+
+La personnalisation est globale pour ce style. Elle n’est attachée ni à la tâche
+d’exemple du terrain de jeu ni à une tâche réelle en particulier.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/reference/keyboard-shortcuts.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/reference/keyboard-shortcuts.mdx
@@ -1,0 +1,66 @@
+---
+title: Travailler avec les raccourcis clavier
+description: Trouve et utilise les commandes de bureau de Lotti.
+---
+
+# Travailler avec les raccourcis clavier
+
+Lotti sur ordinateur propose un catalogue consultable de commandes globales et
+contextuelles. Ouvre **Réglages → Raccourcis clavier** pour voir chaque commande
+avec le raccourci adapté à ta plateforme.
+
+<ManualScreenshot
+  caseId="keyboard-shortcuts/catalog"
+  alt="Réglages Raccourcis clavier Lotti affichant les commandes de bureau regroupées par usage et leurs combinaisons de touches actuelles"
+  caption="La touche principale est Commande sur macOS et Contrôle sur Windows ou Linux ; le catalogue affiche les bons symboles pour la plateforme actuelle."
+/>
+
+## Ouvrir rapidement l’aide des raccourcis
+
+Appuie sur **F1** ou **Touche principale + ?** pour ouvrir la référence des
+raccourcis sans quitter ton travail. La **touche principale** est Commande sur
+macOS et Contrôle sur Windows ou Linux.
+
+Les commandes globales les plus utiles incluent :
+
+| Action | Raccourci |
+| --- | --- |
+| Ouvrir la palette de commandes | Touche principale + K |
+| Créer une entrée texte | Touche principale + N |
+| Créer une tâche | Touche principale + T |
+| Ouvrir Tâches, Daily OS, Projets ou Habitudes | Touche principale + 1 / 2 / 3 / 4 |
+| Ouvrir Tableaux de bord, Journal, Événements ou Réglages | Touche principale + 5 / 6 / 7 / 8 |
+
+Chaque page ajoute des commandes contextuelles, comme enregistrer,
+actualiser, rechercher ou créer. Leur disponibilité peut dépendre de l’élément
+actuellement sélectionné ou de l’existence de modifications non enregistrées.
+
+## Exécuter une commande sans quitter ton travail
+
+Appuie sur **Touche principale + K** pour ouvrir la palette de commandes au-dessus de
+la page actuelle. Elle réunit les actions globales — créer des entrées, ouvrir
+des tâches, naviguer et zoomer — et les commandes fournies par la page active.
+
+<ManualScreenshot
+  caseId="keyboard-shortcuts/palette"
+  alt="Palette de commandes Lotti ouverte au-dessus de Raccourcis clavier, listant les commandes disponibles de création, navigation, affichage et modification"
+  caption="Seules les commandes disponibles dans le contexte actuel apparaissent. La vue mobile montre la même palette de bureau dans une fenêtre étroite ; les commandes clavier sont une fonctionnalité de bureau."
+/>
+
+Commence à taper pour réduire la liste par nom d’action, groupe ou combinaison
+de touches. Utilise les flèches haut et bas pour déplacer la sélection,
+**Entrée** pour l’exécuter et **Échap** pour fermer la palette. Puisqu’elle est
+contextuelle, une commande comme **Enregistrer** n’apparaît que si l’éditeur
+sélectionné peut réellement enregistrer.
+
+## Rechercher par action ou touche
+
+<ManualScreenshot
+  caseId="keyboard-shortcuts/search"
+  alt="Catalogue de raccourcis clavier Lotti filtré par une requête de recherche"
+  caption="Recherche dans le catalogue au lieu de tout mémoriser. Les résultats se mettent à jour pendant la saisie."
+/>
+
+Utilise le champ de recherche lorsque tu connais l’action ou une partie de sa
+combinaison de touches. Le catalogue intégré à l’app fait foi si un raccourci
+change dans une version ultérieure de Lotti.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/reference/manual-maintenance.mdx
@@ -1,0 +1,88 @@
+---
+title: Maintenir ce manuel
+description: Le flux de contribution léger pour le contenu du manuel et les captures d’écran.
+---
+
+# Maintenir ce manuel
+
+La source vit dans le dépôt de l’application afin qu’un changement de
+comportement et sa documentation puissent arriver ensemble. Les captures
+générées vivent dans le dépôt voisin `lotti-docs` et ne sont jamais ajoutées à
+l’arborescence de l’application.
+
+## Modifier le texte
+
+1. Modifie ou ajoute le fichier MDX anglais sous `docs-site/docs`.
+2. Mets à jour le fichier correspondant pour chaque langue publiée sous
+   `docs-site/i18n/<locale>/docusaurus-plugin-content-docs/current`.
+3. Ajoute une nouvelle page à `docs-site/sidebars.ts`.
+4. Mets à jour `docs-site/metadata/features.json` lorsque la couverture change.
+5. Mets à jour les entrées correspondantes de
+   `docs-site/metadata/surface-inventory.json`. Une surface devient **vérifiée**
+   uniquement lorsque son interface de production actuelle, son texte et sa
+   couverture par capture ont tous été examinés.
+6. Exécute `make manual_check`.
+7. Examine localement la version de production avec `make manual_serve`, y compris
+   le sélecteur de langue et chaque route localisée.
+
+La validation exige que chaque arborescence de traduction publiée contienne les
+mêmes chemins de pages que l’arborescence anglaise. Elle rejette aussi les corps
+de pages traduits identiques à l’anglais, afin que de nouvelles pages ne partent
+pas discrètement comme copies non traduites. Les URL publiques anglaises restent
+inchangées ; les autres langues sont publiées sous leur propre préfixe de langue
+versionné.
+
+## Garder l’inventaire de couverture comme référence
+
+L’inventaire définit le périmètre du manuel anglais V1 : chaque page Beamer,
+chaque page ou éditeur Settings V2 et chaque flux majeur qui crée ou modifie
+substantiellement des données ou une configuration transversale. Chaque entrée
+enregistre son fichier source propriétaire et une ancre de texte source. La
+validation échoue si l’un ou l’autre disparaît : une modification de route ou
+d’interface doit alors mettre à jour l’audit du manuel au lieu de laisser une
+ligne obsolète invisible.
+
+Les états de couverture ont volontairement des sens stricts :
+
+- **Planifiée** signifie que la surface est connue mais n’a pas encore une
+  couverture complète.
+- **Documentée** signifie qu’un texte utile existe, mais que les captures de
+  production actuelles ou une revue d’exactitude de bout en bout manquent encore.
+- **Vérifiée** signifie que la page de fonctionnalité concernée est vérifiée et
+  appuyée par des captures de production enregistrées.
+
+Exécute `npm --prefix docs-site run coverage:complete` pour le contrôle de
+publication. Il échoue jusqu’à ce que toute surface inventoriée soit vérifiée ;
+les versions incrémentales ordinaires du manuel continuent d’indiquer le nombre
+restant sans bloquer les commits par sujet.
+
+## Ajouter un cas de capture
+
+1. Ajoute ou réutilise un banc de capture Flutter déterministe.
+2. Enregistre le cas et ses quatre images source dans
+   `docs-site/metadata/screenshot-cases.json`.
+3. Place le texte de démonstration visible derrière `manualScreenshotText(...)`
+   pour chaque langue prise en charge lorsqu’il n’est pas déjà fourni par les
+   fichiers de localisation de l’application.
+4. Capture chaque langue dans `../lotti-docs`, jamais dans ce dépôt.
+5. Génère et valide le manifeste média.
+6. Référence le cas avec `<ManualScreenshot caseId="…" alt="…" />` dans chaque
+   page de langue.
+
+Chaque capture de l’application dans une page rédigée doit utiliser
+`ManualScreenshot`. Les liens directs vers d’anciennes images `lotti-docs`
+échouent à la validation du manuel, car ils ne peuvent pas suivre le choix
+global Mobile/Ordinateur ni le thème clair/sombre du manuel.
+
+Chaque cas automatisé doit fournir les variantes mobile clair, mobile sombre,
+ordinateur clair et ordinateur sombre dans chaque langue publiée. Le composant
+du manuel choisit la langue et le thème correspondants. Changer Mobile/Ordinateur
+sur une image met immédiatement à jour toutes les captures et persiste entre les
+pages et les onglets de manuel ouverts.
+
+## Publier une version
+
+La source du manuel n’est pas copiée pour chaque version de l’application. Le
+tag de version conserve déjà sa source exacte. L’intégration continue récupère
+ce tag, construit avec `MANUAL_VERSION=<version>` et publie un répertoire statique
+immuable. Le menu des versions est un petit manifeste de ces répertoires.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/reference/recording-style.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/reference/recording-style.mdx
@@ -1,0 +1,35 @@
+---
+title: Choisir un style d’enregistrement
+description: Sélectionne et prévisualise la visualisation affichée pendant un enregistrement audio.
+---
+
+# Choisir un style d’enregistrement
+
+Ouvre **Réglages → Style d’enregistrement** pour choisir la visualisation
+affichée pendant que Lotti enregistre de l’audio. Cela ne modifie que la
+présentation : les deux styles représentent le même processus d’enregistrement.
+
+<ManualScreenshot
+  caseId="recording-style/preview"
+  alt="Réglages Style d’enregistrement de Lotti comparant l’orbe d’énergie moderne et le VU-mètre analogique"
+  caption="Sélectionne un style pour le conserver immédiatement, puis prévisualise sa réaction avec des niveaux simulés ou ton microphone."
+/>
+
+## Comparer les deux styles
+
+- **Moderne** affiche une orbe d’énergie animée qui réagit au niveau actuel.
+- **Analogique** affiche un VU-mètre traditionnel avec une aiguille mobile.
+
+Sélectionne l’une ou l’autre carte pour en faire le style actif. Il n’y a pas
+d’action Enregistrer ou Continuer séparée.
+
+## Prévisualiser avec ta voix
+
+Active **Essayer avec ta voix** pour piloter l’aperçu depuis le microphone.
+Parle à la distance à laquelle tu comptes enregistrer et observe la réaction du
+visuel sélectionné. Désactive l’option quand tu as fini de comparer les styles.
+
+L’aperçu t’aide à choisir un langage visuel ; ce n’est pas un outil d’étalonnage
+du gain d’entrée ni de la qualité d’enregistrement. Consulte
+[Enregistrer de l’audio](../plan-and-capture/recordings.mdx) pour le véritable
+flux d’enregistrement.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/reference/settings.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/reference/settings.mdx
@@ -1,0 +1,58 @@
+---
+title: Trouver les réglages
+description: Parcours les réglages de Lotti sur mobile et sur ordinateur.
+---
+
+# Trouver les réglages
+
+Les réglages sont regroupés selon la fonction qu’ils contrôlent. Sur ordinateur,
+une arborescence reste affichée avec la page sélectionnée à côté ; sur mobile,
+une liste dédiée ouvre une page de réglages à la fois.
+
+Sur ordinateur, choisis **Manuel**, juste au-dessus de **Réglages**, pour ouvrir
+ce guide dans ton navigateur par défaut. Le lien reste disponible lorsque la
+barre latérale est repliée.
+
+<ManualScreenshot
+  alt="Accueil des réglages de Lotti présentant les groupes de configuration"
+  caseId="settings/home"
+  caption="Utilise le sélecteur Mobile/ordinateur ci-dessus. L’image suit également le thème clair ou sombre de ce manuel."
+/>
+
+Les destinations courantes comprennent :
+
+- **[Thème](./appearance.mdx)** pour les modes d’affichage clair, sombre et
+  automatique, ainsi que des palettes de thème indépendantes.
+- **[Style d’enregistrement](./recording-style.mdx)** pour l’orbe d’énergie ou le vu-mètre analogique affiché durant l’enregistrement.
+- **[Parole](./speech.mdx)** pour la voix sur l’appareil, le modèle et la vitesse
+  qui lisent les résumés de tâches à voix haute.
+- **[Raccourcis clavier](./keyboard-shortcuts.mdx)** pour le catalogue de
+  commandes pour ordinateur, consultable par recherche.
+- **[Célébrations de fin](./completion-celebrations.mdx)** pour les animations,
+  le retour haptique, les styles et leur espace de test en direct.
+- **[Paramètres avancés](./advanced-settings.mdx)** pour les flags, la
+  journalisation, les actions de maintenance, les diagnostics d’intégration et
+  les informations de build.
+- **Catégories** pour les périmètres de planification et de confidentialité, et
+  **Étiquettes** pour les repères transversaux.
+- **Habitudes** et **Tableaux de bord** pour les structures de réflexion.
+- **Paramètres IA** pour les fournisseurs, modèles, profils et compétences.
+- **Daily OS** pour le profil d’inférence et le message d’accueil du planificateur.
+- **Synchronisation** pour l’état de connexion et d’activité.
+
+L’ensemble exact peut varier selon les capacités de la plateforme et les fonctionnalités activées.
+
+## Gérer les définitions
+
+Ouvre **Réglages → Définitions** pour gérer les structures qui organisent tes
+données. Les catégories définissent les périmètres de planification et de
+confidentialité, les étiquettes relient les tâches entre les catégories, les
+habitudes définissent les routines récurrentes, les tableaux de bord organisent
+les vues de réflexion et les éléments mesurables définissent les nombres que tu
+suis dans le temps.
+
+<ManualScreenshot
+  alt="Centre des réglages Définitions listant les catégories, les étiquettes, les habitudes, les tableaux de bord et les éléments mesurables"
+  caseId="settings/definitions"
+  caption="Sur mobile, la liste Définitions est ciblée ; sur ordinateur, toute l’arborescence des réglages reste visible à côté."
+/>

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/reference/speech.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/reference/speech.mdx
@@ -1,0 +1,48 @@
+---
+title: Choisir la voix de lecture
+description: Configure la voix sur l’appareil, le modèle et la vitesse utilisés pour lire les résumés de tâches à voix haute.
+---
+
+# Choisir la voix de lecture
+
+Lorsque la lecture à voix haute est disponible, ouvre **Réglages → Parole**. Ces
+contrôles s’appliquent aux résumés IA des tâches ; ils ne modifient ni la capture
+par microphone ni le fournisseur IA qui transcrit un enregistrement.
+
+<ManualScreenshot
+  caseId="speech/settings"
+  alt="Réglages Parole de Lotti avec Masculine 3 sélectionné, le modèle Supertonic 3 sur l’appareil et une vitesse de lecture de 1,25×"
+  caption="L’exemple de configuration Contrôle de mission utilise Masculine 3 à 1,25× pour des briefings vifs du projet Waddle."
+/>
+
+## Choisir une voix
+
+Utilise le sélecteur **Féminine / Masculine** pour parcourir les deux groupes, puis
+sélectionne l’une des cinq voix numérotées du groupe. Changer de groupe modifie
+seulement la liste visible ; sélectionne une voix numérotée pour l’activer.
+
+<ManualScreenshot
+  caseId="speech/voice-options"
+  alt="Réglages Parole de Lotti montrant les cinq voix féminines disponibles sur l’appareil"
+  caption="Dix styles de voix intégrés sont disponibles : Féminine 1 à 5 et Masculine 1 à 5."
+/>
+
+La voix sélectionnée est une préférence propre à l’appareil. Ainsi, chacun de
+tes appareils peut utiliser une voix adaptée à ses haut-parleurs et à son
+environnement d’écoute sans modifier le choix des autres appareils.
+
+## Téléchargement du modèle et confidentialité
+
+Lotti utilise actuellement **Supertonic 3** pour la lecture à voix haute. La synthèse s’exécute sur l’appareil, sans envoyer le résumé à un service de synthèse vocale dans le cloud. Le modèle est volumineux et se télécharge lors de sa première utilisation : prévoyez donc du temps, de la bande passante et de l’espace de stockage pour cette configuration initiale.
+
+## Régler la vitesse de lecture
+
+Choisis une vitesse de **0,5×** à **2×**. **1×** correspond au rythme naturel ;
+les valeurs inférieures ralentissent le briefing et les valeurs supérieures le
+raccourcissent. La vitesse choisie est elle aussi enregistrée uniquement sur
+l’appareil actuel.
+
+Le bouton de lecture à voix haute apparaît uniquement lorsque la fonctionnalité est activée, que la plateforme prend en charge le moteur vocal et que la tâche possède un résumé IA non vide.
+
+Pour la saisie vocale et les résultats de reconnaissance enregistrés, consulte
+[Enregistrer de l’audio](../plan-and-capture/recordings.mdx).

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/reference/whats-new.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/reference/whats-new.mdx
@@ -1,0 +1,64 @@
+---
+title: Parcourir « Quoi de neuf »
+description: Consulte la dernière version de Lotti, parcours les notes de versions précédentes et contrôle les mises à jour qui restent non lues.
+---
+
+# Parcourir « Quoi de neuf »
+
+« Quoi de neuf » présente les notes de version dans Lotti, correspondant à la
+version que tu utilises. Cette vue peut s’ouvrir automatiquement après un
+premier lancement éligible ou un changement de version ; elle est aussi
+disponible depuis l’entrée **Quoi de neuf** des Réglages lorsque cette
+fonctionnalité est activée.
+
+Les notes de version sont classées de la plus récente à la plus ancienne. Chaque page associe une image principale propre à la version, son numéro exact et un court récit des changements visibles par les utilisateurs.
+
+<ManualScreenshot
+  caseId="whats-new/latest"
+  alt="Fenêtre modale « Quoi de neuf » de Lotti pour la version 0.9.1049, avec une bannière de contrôle de mission du projet Waddle et les notes de version"
+  caption="La dernière version non lue porte un badge NOUVEAU. Cette capture de démonstration explique les améliorations de Daily OS et de l’espace de travail des tâches derrière le lancement orbital du projet Waddle."
+/>
+
+## Lire la version actuelle
+
+Le badge de version identifie la version dont les notes sont affichées. **NOUVEAU** désigne la version la plus récente de l’ensemble actuel ; cela ne signifie pas que tous les éléments de la page sont inachevés ou expérimentaux.
+
+Le corps défile indépendamment lorsque la version est plus longue que la hauteur disponible. Les liens utilisent le gestionnaire de liens normal de Lotti, et les images sont chargées avant les changements de page lorsque cela est possible, afin que le passage d’une version à l’autre reste fluide.
+
+## Parcourir l’historique des versions
+
+<ManualScreenshot
+  caseId="whats-new/past-release"
+  alt="Fenêtre modale « Quoi de neuf » de Lotti pour la version 0.9.1048, avec une illustration de couverture du marché aux sardines des manchots et la navigation dans les anciennes versions"
+  caption="Utilise les chevrons du pied de page ou les repères de position pour parcourir les versions. La note plus ancienne du projet Waddle présente la comparaison de temps et la télémétrie des sardines prête pour les tableaux de bord."
+/>
+
+Utilise les commandes du pied de page pour naviguer :
+
+- le chevron droit ouvre la version suivante, plus ancienne ;
+- le chevron gauche revient à une version plus récente ;
+- les repères de position indiquent où se trouve la page actuelle dans l’ensemble chargé ;
+- **Ignorer** ferme un ensemble de plusieurs versions avant la dernière page et marque l’ensemble chargé comme lu ; et
+- **Terminé** apparaît sur la page la plus ancienne et marque également l’ensemble entier comme lu.
+
+Fermer la fenêtre en la faisant glisser ou en touchant l’arrière-plan est plus
+prudent : Lotti ne marque comme lues que les versions que tu as réellement
+atteintes, jusqu’à la dernière page consultée. Les versions non atteintes peuvent
+donc réapparaître à la prochaine ouverture de « Quoi de neuf ».
+
+## Revoir des notes déjà ignorées
+
+Lorsqu’il ne reste aucune version non lue, ouvrir « Quoi de neuf » affiche l’état
+**Tu es à jour**. Choisis **Voir les versions précédentes** pour effacer les
+marqueurs locaux de lecture et parcourir de nouveau l’ensemble de versions
+disponible. Cela ne modifie que l’historique local des notes de version ; ni la
+version installée de l’application ni aucun autre build ne sont modifiés ou
+téléchargés.
+
+« Quoi de neuf » n’affiche jamais de notes pour une version plus récente que la
+version installée de Lotti. Si le contenu d’une version ne peut pas être chargé,
+l’application revient à un état vide plutôt que de présenter les notes d’un
+mauvais build.
+
+Pour le numéro de build exact, la plateforme, les totaux d’entrées locales et le
+nombre de tâches, consulte [À propos de Lotti](./advanced-settings.mdx#vérifier-la-version-et-les-totaux-locaux).

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/sync-and-data/conflicts.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/sync-and-data/conflicts.mdx
@@ -1,0 +1,74 @@
+---
+title: Résoudre les conflits de synchronisation
+description: Compare les modifications concurrentes champ par champ et conserve ou combine les bonnes informations.
+---
+
+# Résoudre les conflits de synchronisation
+
+Un conflit apparaît lorsque deux appareils ont modifié la même entrée
+indépendamment et qu’aucune version n’est clairement plus récente. Lotti
+préserve les deux versions au lieu d’en choisir une silencieusement.
+
+Ouvre **Réglages → Synchronisation → Conflits**. La liste sépare les éléments
+non résolus et résolus, et indique le type d’entité ainsi que l’heure de chaque
+conflit.
+
+<ManualScreenshot
+  caseId="sync/conflicts"
+  alt="Liste Conflits de synchronisation de Lotti avec des conflits non résolus sur une tâche Project Waddle et un manifeste de sardines, ainsi qu’une tâche résolue"
+  caption="Résous d’abord les éléments actuels. Les éléments résolus restent visibles comme piste d’audit des décisions précédentes."
+/>
+
+## Comparer les deux versions
+
+Ouvre un conflit pour voir chaque champ différent. Les changements de texte
+comportent une mise en évidence mot par mot ; les champs inchangés sont
+résumés pour que la page ne masque pas la part de l’entrée qui reste identique.
+
+<ManualScreenshot
+  caseId="sync/conflict-detail"
+  alt="Détail de conflit Lotti comparant champ par champ les titres et descriptions locaux et synchronisés d’une tâche Project Waddle"
+  caption="Cet appareil a conservé le dernier empereur et la retenue de cargaison ; la version synchronisée a autorisé les 37 manchots et programmé la libération des sardines. Les deux faits comptent."
+/>
+
+Les trois voies de résolution sont :
+
+- **Utiliser cet appareil** conserve l’intégralité de la version locale.
+- **Utiliser depuis la synchronisation** conserve l’intégralité de la version
+  entrante.
+- **Combiner** te laisse choisir une version de départ, puis le gagnant pour
+  chaque champ pouvant être fusionné indépendamment.
+
+Conserver un côté complet convient lorsque l’autre est simplement obsolète.
+**Combiner** est plus sûr lorsque des champs distincts contiennent du travail
+valide provenant des deux appareils ; Lotti le recommande lorsque plusieurs
+champs fusionnables diffèrent.
+
+## Combiner des champs sans tout retaper
+
+Sélectionne **Combiner**, choisis la version de départ, puis bascule les champs
+individuels vers l’autre côté. Les champs qui ne peuvent pas être fusionnés
+indépendamment suivent la version de départ sélectionnée.
+
+<ManualScreenshot
+  caseId="sync/conflict-combine"
+  alt="Éditeur de conflit Combiner de Lotti avec le contrôle de version de départ et des choix distincts pour le titre et le corps de la tâche"
+  caption="Pars d’une entrée structurellement complète, puis prends le meilleur titre et le meilleur corps depuis cet appareil ou depuis la synchronisation."
+/>
+
+Examine chaque champ listé avant de sélectionner **Appliquer la combinaison**.
+L’entrée résolue reçoit un historique de synchronisation fusionné, pour éviter
+que les deux mêmes modifications ne se heurtent de nouveau immédiatement.
+
+:::caution Une résolution modifie le résultat partagé
+
+Conserver un côté ou appliquer une version combinée écrit le résultat retenu
+localement et lui permet de se synchroniser avec les autres appareils. Lis la
+différence complète avant de confirmer. Si un côté a supprimé l’entrée tandis
+que l’autre l’a modifiée, Lotti propose le choix plus sûr suppression contre
+modification au lieu d’une fusion de champs ordinaire.
+
+:::
+
+Reviens à [Synchroniser les appareils](./sync.mdx) pour examiner la livraison
+et l’état de rattrapage.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/sync-and-data/health-import.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/sync-and-data/health-import.mdx
@@ -1,0 +1,39 @@
+---
+title: Importer des données de santé
+description: Importe une plage de dates choisie depuis le dépôt de données de santé du téléphone.
+---
+
+# Importer des données de santé
+
+L’import de données de santé est disponible sur iOS et Android. Ouvre
+**Réglages → Avancé → Import de données de santé**, choisis une date de début
+et de fin, puis sélectionne la famille de données que tu souhaites faire lire
+à Lotti depuis le dépôt de données de santé du téléphone.
+
+<ManualScreenshot
+  caseId="health-import/overview"
+  alt="Import de données de santé avec une date de début, une date de fin et des actions d’import séparées pour l’activité, le sommeil, la fréquence cardiaque, la pression artérielle, les mensurations et les entraînements"
+  caption="La vue mobile montre l’écran d’import. L’import de données de santé est volontairement absent de l’arborescence Avancé sur ordinateur, comme le montre la vue ordinateur."
+/>
+
+Les imports disponibles sont :
+
+- **Activité** pour les totaux d’activité ;
+- **Sommeil** pour les échantillons de sommeil ;
+- **Fréquence cardiaque** pour les observations de pouls ;
+- **Pression artérielle** pour les mesures de tension ;
+- **Mensuration corporelle** pour les mesures comme les données corporelles ;
+- **Entraînement** pour les entraînements enregistrés.
+
+Chaque bouton n’importe que sa propre famille de données pour la plage de dates
+affichée. Modifier la plage ne lance pas un import à lui seul.
+
+Le système d’exploitation peut demander l’autorisation d’accéder aux données de
+santé. Lotti ne peut lire que les types que tu autorises. Si une famille de
+données attendue manque, vérifie les autorisations de santé de l’app dans les
+réglages système du téléphone, puis réessaie cet import.
+
+L’import de données de santé n’apparaît pas sur ordinateur, car les dépôts de
+santé mobiles sous-jacents n’y sont pas disponibles. Les observations importées
+restent visibles dans les tableaux de bord Lotti pertinents après leur
+synchronisation vers un autre appareil.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/sync-and-data/maintenance.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/sync-and-data/maintenance.mdx
@@ -1,0 +1,45 @@
+---
+title: Maintenance de la synchronisation
+description: Utilise délibérément les actions de réparation et de nettoyage de la synchronisation Matrix, du renvoi d’enregistrements à la reconstruction de l’historique de séquence.
+---
+
+# Maintenance de la synchronisation
+
+Ouvre **Réglages → Synchronisation → Maintenance** pour les réparations et le
+nettoyage au niveau de la base de données. Ces actions ne font pas partie de
+l’appairage habituel ni de la synchronisation quotidienne. Avant de les
+utiliser, laisse les écritures actives se terminer et conserve une sauvegarde
+récente des données que tu ne peux pas recréer.
+
+<ManualScreenshot
+  caseId="sync/maintenance"
+  alt="Maintenance de synchronisation Matrix Lotti avec suppression de la base de données de synchronisation, synchronisation des définitions, resynchronisation des messages, remplissage du journal de séquence et purge de la boîte d’envoi déjà envoyée"
+  caption="La maintenance réunit actions destructives, répétition et nettoyage sur une page. Le texte de confirmation définit la portée de chaque opération."
+/>
+
+## Choisir la réparation la plus limitée
+
+- **Supprimer la base de données de synchronisation** retire la base locale de
+  synchronisation. C’est une récupération locale destructive, pas la méthode
+  normale pour déconnecter un appareil.
+- **Synchroniser les définitions** renvoie les enregistrements de définition
+  actuels, comme les catégories et d’autres configurations partagées.
+- **Resynchroniser les messages** rejoue les messages sélectionnés lorsqu’un
+  état distant manque ou qu’une livraison antérieure doit être répétée.
+- **Remplir le journal de séquence** reconstruit l’historique de séquence local
+  utilisé pour détecter les écarts et piloter le rattrapage.
+- **Purger les anciens éléments envoyés de la boîte d’envoi** supprime
+  l’historique déjà envoyé de la file de diagnostic après sa période de
+  conservation. Cela ne retire pas le travail en attente ou échoué.
+
+Commence par l’opération la plus petite qui correspond au symptôme. Une pièce
+jointe bloquée relève de la [boîte d’envoi](./sync.mdx#examiner-la-boîte-denvoi) ; des
+écarts de séquence persistants relèvent du rattrapage ; deux modifications
+concurrentes valides relèvent des [conflits](./conflicts.mdx). Supprimer la base
+de données de synchronisation doit rester une réinitialisation locale de dernier
+recours, réalisée avec un pair fiable et une sauvegarde disponible.
+
+Après une réparation, reviens aux **Statistiques de synchronisation**, confirme
+que le travail traité progresse sans augmentation du nombre d’échecs, puis
+vérifie que les éléments manquants de la boîte d’envoi et du rattrapage se
+stabilisent.

--- a/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
+++ b/docs-site/i18n/fr/docusaurus-plugin-content-docs/current/sync-and-data/sync.mdx
@@ -1,0 +1,164 @@
+---
+title: Synchroniser des appareils
+description: Appaire tes appareils, vérifie leur identité, surveille la livraison et récupère les données manquantes sans deviner.
+---
+
+# Synchroniser des appareils
+
+Lotti Sync maintient les données prises en charge alignées entre tes appareils.
+Chaque appareil a sa propre base de données locale ; la synchronisation fait
+passer les changements par le compte configuré et rattrape un appareil après
+une période hors ligne. La synchronisation ne déplace pas la source de vérité
+dans un cloud Lotti : le service Matrix configuré relaie des charges utiles
+chiffrées de bout en bout entre tes appareils, tandis que chacun conserve sa
+propre copie locale.
+
+Ouvre **Réglages → Synchronisation** pour accéder aux pages de configuration,
+d’état et de récupération. Le nombre affiché à côté de **Boîte d’envoi**
+correspond au travail qui n’a pas encore atteint le service de synchronisation.
+
+<ManualScreenshot
+  caseId="sync/hub"
+  alt="Réglages Lotti Sync avec synchronisation provisionnée, identité de l’appareil, rattrapage, statistiques, boîte d’envoi, conflits et maintenance"
+  caption="Le centre de synchronisation maintient l’état courant près des outils de diagnostic et de récupération. Project Waddle contient actuellement trois éléments de boîte d’envoi à examiner."
+/>
+
+## Appairer un autre appareil
+
+Commence sur un appareil déjà connecté :
+
+1. Ouvre **Réglages → Synchronisation → Synchronisation provisionnée**.
+2. Sur ordinateur, affiche le code QR de transfert. Garde cet écran privé : le
+   lot donne accès à ton compte et à ton salon de synchronisation.
+3. Sur le nouvel appareil, ouvre la même page et scanne le code QR ou colle le
+   lot de provisionnement complet.
+4. Examine le serveur, l’utilisateur et le salon décodés avant de sélectionner
+   **Importer**.
+5. Laisse la première synchronisation se terminer avant de fermer l’une ou
+   l’autre application.
+
+<ManualScreenshot
+  caseId="sync/status"
+  alt="État de synchronisation provisionnée sur mobile et code QR de transfert sécurisé d’appareil sur ordinateur"
+  caption="L’ordinateur peut présenter le code QR de transfert ; le mobile indique le compte connecté et l’état de vérification. Traite ce code QR comme un mot de passe."
+/>
+
+<ManualScreenshot
+  caseId="sync/provisioned"
+  alt="Revue d’import de provisionnement Lotti affichant le serveur de synchronisation, l’utilisateur et le salon Project Waddle"
+  caption="N’importe que lorsque chaque valeur décodée appartient au compte de synchronisation que tu voulais rejoindre."
+/>
+
+Si l’import signale une erreur, garde l’appareil d’origine connecté, génère un
+nouveau lot de transfert et réessaie avec la valeur complète. Ne modifie pas
+manuellement le lot encodé.
+
+## Vérifier le nouvel appareil
+
+L’appairage connecte l’appareil ; la vérification confirme que les deux
+appareils communiquent sans appareil inconnu entre eux.
+
+<ManualScreenshot
+  caseId="sync/verification"
+  alt="Vérification d’appareil Lotti comparant une séquence d’emoji manchot, poisson, fusée, glace, Terre, lune, étoile et télescope"
+  caption="Compare toute la séquence d’emoji sur les deux appareils. Accepte uniquement si chaque image et son ordre correspondent exactement."
+/>
+
+Compare les emoji en personne ou lors d’un appel de confiance. Sélectionne
+**Accepter** sur les deux appareils seulement lorsque la séquence complète est
+identique. Si un seul emoji diffère, annule la vérification et examine le compte
+et les noms d’appareils avant de recommencer.
+
+## Nommer les appareils et annoncer leurs capacités
+
+Le **profil de nœud de synchronisation** identifie l’appareil actuel auprès du
+reste du groupe de synchronisation. Donne-lui un nom qui distingue la machine
+physique, comme « Mission Control Mac » plutôt que « Ordinateur ».
+
+<ManualScreenshot
+  caseId="sync/node-profile"
+  alt="Profil de nœud Lotti Sync pour Mission Control Mac avec des capacités d’inférence locale et des appareils Project Waddle connus"
+  caption="Des noms d’appareils clairs facilitent beaucoup l’audit de la vérification, des diagnostics et de l’inférence locale épinglée à un appareil."
+/>
+
+La page liste aussi les capacités que l’appareil peut fournir, comme la
+transcription audio locale ou l’inférence locale de modèles de langage. Les
+appareils connus indiquent ce que les autres nœuds ont annoncé le plus
+récemment. La disponibilité de capacité est descriptive : le profil IA concerné
+doit encore être configuré pour l’utiliser.
+
+## Comprendre le rattrapage et le remplissage
+
+La synchronisation normale traite les changements à leur arrivée. Le
+**rattrapage** détecte les écarts dans la séquence reçue des appareils connus et
+redemande les enregistrements manquants.
+
+<ManualScreenshot
+  caseId="sync/backfill"
+  alt="Page Rattrapage Lotti Sync affichant les états entrants, manquants et ignorés, les statistiques de séquence et le rattrapage automatique"
+  caption="Project Waddle a reçu 2 868 enregistrements de séquence et connaît actuellement quatre enregistrements manquants répartis sur deux identifiants d’appareil."
+/>
+
+- **Entrant** est le travail actuellement en attente dans la file entrante.
+- **Manquant** est le nombre d’écarts de séquence connus.
+- **Ignoré** est le travail abandonné par la file entrante après avoir échoué à
+  être traité normalement.
+- **Rattrapage automatique** redemande continuellement les écarts récupérables
+  et est le bon réglage par défaut pour un usage normal.
+- **Récupération avancée** contient des contrôles manuels pour une enquête. Ne
+  l’utilise qu’après avoir laissé le temps à la synchronisation ordinaire et au
+  rattrapage automatique de se stabiliser.
+
+Un nombre non nul d’éléments manquants ne signifie pas automatiquement une
+perte de données : un autre appareil peut encore être hors ligne ou la demande
+être déjà en cours. Enquête lorsque ce nombre reste inchangé alors que tous les
+appareils attendus sont en ligne.
+
+## Lire les statistiques de synchronisation
+
+Les **Statistiques de synchronisation** séparent le volume de messages de la
+santé du traitement. Elles sont utiles lorsque les données semblent obsolètes
+mais que le compte paraît toujours connecté.
+
+<ManualScreenshot
+  caseId="sync/stats"
+  alt="Statistiques Matrix Sync Lotti avec le nombre de messages envoyés, les principaux KPI de traitement, les types de messages, les échecs, les nouvelles tentatives et les totaux d’entités"
+  caption="Les nombres établissent si les messages circulent ; les échecs et nouvelles tentatives planifiées indiquent si le pipeline avance correctement."
+/>
+
+La carte des messages envoyés regroupe les types d’événements Matrix. **Top
+KPI** résume les messages traités, les échecs et les nouvelles tentatives
+planifiées, tandis que les totaux d’entités montrent quelles familles de
+charges utiles Lotti ont contribué à ce travail. Un nombre de messages traités
+qui augmente avec des échecs stables est sain. Des échecs répétés ou des
+nouvelles tentatives qui ne se résorbent jamais demandent de vérifier la boîte
+d’envoi et la connectivité de l’autre appareil.
+
+## Examiner la boîte d’envoi
+
+La **boîte d’envoi** est la file locale des changements qui attendent d’être
+envoyés. Filtre-la par état pour séparer le travail actif des échecs.
+
+<ManualScreenshot
+  caseId="sync/outbox"
+  alt="Boîte d’envoi Lotti Sync filtrée sur une photo échouée du joint de pression de l’habitat Project Waddle, avec des actions de nouvelle tentative et de suppression"
+  caption="Les éléments échoués conservent leur sujet, le détail de leur charge utile, leur historique de tentatives et le chemin local de la pièce jointe afin que la récupération soit précise plutôt qu’aveugle."
+/>
+
+- Les éléments **En attente** attendent leur tour.
+- Les éléments **Envoi** sont en cours de transmission.
+- Les éléments **Échoués** ont épuisé leur tentative actuelle et restent
+  disponibles pour examen.
+- Les éléments **Envoyés** ont été livrés et sont conservés temporairement
+  pour le diagnostic.
+
+Utilise **Réessayer tout** après avoir corrigé le problème de connexion ou de
+compte sous-jacent. Retire un élément échoué seulement lorsque tu ne veux
+intentionnellement pas que ce changement atteigne les autres appareils. Le
+retirer de la boîte d’envoi ne remplace pas la réparation de l’entrée ou de la
+pièce jointe locale correspondante.
+
+Poursuis avec [Résoudre les conflits de synchronisation](./conflicts.mdx)
+lorsque deux appareils ont modifié indépendamment la même entrée, ou avec
+[Maintenance de la synchronisation](./maintenance.mdx) pour les outils de
+récupération au niveau de la base de données.

--- a/docs-site/i18n/fr/docusaurus-theme-classic/footer.json
+++ b/docs-site/i18n/fr/docusaurus-theme-classic/footer.json
@@ -1,0 +1,30 @@
+{
+  "link.title.Manual": {
+    "message": "Manuel",
+    "description": "The title of the footer links column with title=Manual in the footer"
+  },
+  "link.title.Project": {
+    "message": "Projet",
+    "description": "The title of the footer links column with title=Project in the footer"
+  },
+  "link.item.label.Start here": {
+    "message": "Commencer ici",
+    "description": "The label of footer link with label=Start here linking to /"
+  },
+  "link.item.label.Daily OS": {
+    "message": "Daily OS",
+    "description": "The label of footer link with label=Daily OS linking to /plan-and-capture/daily-os/"
+  },
+  "link.item.label.Tasks": {
+    "message": "Tâches",
+    "description": "The label of footer link with label=Tasks linking to /organize-and-reflect/tasks/"
+  },
+  "link.item.label.Source code": {
+    "message": "Code source",
+    "description": "The label of footer link with label=Source code linking to https://github.com/matthiasn/lotti"
+  },
+  "link.item.label.Report a documentation issue": {
+    "message": "Signaler un problème dans la documentation",
+    "description": "The label of footer link with label=Report a documentation issue linking to https://github.com/matthiasn/lotti/issues/new"
+  }
+}

--- a/docs-site/i18n/fr/docusaurus-theme-classic/navbar.json
+++ b/docs-site/i18n/fr/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,14 @@
+{
+  "title": {
+    "message": "Manuel Lotti",
+    "description": "The title in the navbar"
+  },
+  "item.label.Guide": {
+    "message": "Guide",
+    "description": "Navbar item with label Guide"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
+  }
+}

--- a/docs-site/metadata/screenshot-cases.json
+++ b/docs-site/metadata/screenshot-cases.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "defaultLocale": "en",
-  "locales": ["en", "de", "cs"],
+  "locales": ["en", "de", "fr", "cs"],
   "cases": [
     {
       "id": "daily-os/agenda",

--- a/docs-site/scripts/build-screenshot-manifest.mjs
+++ b/docs-site/scripts/build-screenshot-manifest.mjs
@@ -13,6 +13,7 @@ import {
   repositoryDirectory,
   requiredVariants,
   resolveCaptureLocales,
+  resolveScreenshotCases,
   sha256,
   siteDirectory,
   validateManualVersion,
@@ -38,6 +39,12 @@ if (registryErrors.length > 0) {
   throw new Error(registryErrors.join('\n'));
 }
 const captureLocales = resolveCaptureLocales(options.locales, registry.locales);
+const capturedCases = new Set(
+  resolveScreenshotCases(options.cases, registry.cases).map(
+    (screenshotCase) => screenshotCase.id,
+  ),
+);
+const skipManifest = options['skip-manifest'] === true;
 
 if (version !== 'development' && options['allow-release-overwrite'] !== true) {
   try {
@@ -66,9 +73,8 @@ const generatedAt =
 const manifestCases = [];
 
 for (const screenshotCase of registry.cases) {
-  const locales = {};
-  for (const locale of registry.locales) {
-    const variants = {};
+  if (!capturedCases.has(screenshotCase.id)) continue;
+  for (const locale of captureLocales) {
     for (const variant of requiredVariants) {
       const inputPath = resolve(
         captureDirectory,
@@ -82,13 +88,35 @@ for (const screenshotCase of registry.cases) {
         registry.defaultLocale,
       );
       const outputPath = resolve(outputDirectory, relativeOutputPath);
-      if (captureLocales.includes(locale)) {
-        await mkdir(resolve(outputPath, '..'), {recursive: true});
-        const input = await readFile(inputPath);
-        await sharp(input)
-          .webp({quality: 88, effort: 5, smartSubsample: true})
-          .toFile(outputPath);
-      }
+      await mkdir(resolve(outputPath, '..'), {recursive: true});
+      const input = await readFile(inputPath);
+      await sharp(input)
+        .webp({quality: 88, effort: 5, smartSubsample: true})
+        .toFile(outputPath);
+    }
+  }
+}
+
+if (skipManifest) {
+  console.log(
+    `Converted ${capturedCases.size} screenshot case(s) to ${outputDirectory}; ` +
+      `captured locales: ${captureLocales.join(', ')}.`,
+  );
+  process.exit(0);
+}
+
+for (const screenshotCase of registry.cases) {
+  const locales = {};
+  for (const locale of registry.locales) {
+    const variants = {};
+    for (const variant of requiredVariants) {
+      const relativeOutputPath = canonicalVariantPath(
+        screenshotCase.id,
+        variant,
+        locale,
+        registry.defaultLocale,
+      );
+      const outputPath = resolve(outputDirectory, relativeOutputPath);
       const output = await readFile(outputPath);
       const metadata = await sharp(output).metadata();
 
@@ -127,5 +155,6 @@ await writeFile(
 
 console.log(
   `Wrote ${manifestCases.length} screenshot case(s) to ${outputDirectory}; ` +
-    `captured locales: ${captureLocales.join(', ')}.`,
+    `captured locales: ${captureLocales.join(', ')}; ` +
+    `captured cases: ${capturedCases.size}.`,
 );

--- a/docs-site/scripts/build-screenshot-manifest.mjs
+++ b/docs-site/scripts/build-screenshot-manifest.mjs
@@ -45,6 +45,11 @@ const capturedCases = new Set(
   ),
 );
 const skipManifest = options['skip-manifest'] === true;
+const manifestOnly = options['manifest-only'] === true;
+
+if (skipManifest && manifestOnly) {
+  throw new Error('Use either --skip-manifest or --manifest-only, not both.');
+}
 
 if (version !== 'development' && options['allow-release-overwrite'] !== true) {
   try {
@@ -72,27 +77,29 @@ const generatedAt =
       }).trim();
 const manifestCases = [];
 
-for (const screenshotCase of registry.cases) {
-  if (!capturedCases.has(screenshotCase.id)) continue;
-  for (const locale of captureLocales) {
-    for (const variant of requiredVariants) {
-      const inputPath = resolve(
-        captureDirectory,
-        locale,
-        screenshotCase.variants[variant],
-      );
-      const relativeOutputPath = canonicalVariantPath(
-        screenshotCase.id,
-        variant,
-        locale,
-        registry.defaultLocale,
-      );
-      const outputPath = resolve(outputDirectory, relativeOutputPath);
-      await mkdir(resolve(outputPath, '..'), {recursive: true});
-      const input = await readFile(inputPath);
-      await sharp(input)
-        .webp({quality: 88, effort: 5, smartSubsample: true})
-        .toFile(outputPath);
+if (!manifestOnly) {
+  for (const screenshotCase of registry.cases) {
+    if (!capturedCases.has(screenshotCase.id)) continue;
+    for (const locale of captureLocales) {
+      for (const variant of requiredVariants) {
+        const inputPath = resolve(
+          captureDirectory,
+          locale,
+          screenshotCase.variants[variant],
+        );
+        const relativeOutputPath = canonicalVariantPath(
+          screenshotCase.id,
+          variant,
+          locale,
+          registry.defaultLocale,
+        );
+        const outputPath = resolve(outputDirectory, relativeOutputPath);
+        await mkdir(resolve(outputPath, '..'), {recursive: true});
+        const input = await readFile(inputPath);
+        await sharp(input)
+          .webp({quality: 88, effort: 5, smartSubsample: true})
+          .toFile(outputPath);
+      }
     }
   }
 }
@@ -155,6 +162,5 @@ await writeFile(
 
 console.log(
   `Wrote ${manifestCases.length} screenshot case(s) to ${outputDirectory}; ` +
-    `captured locales: ${captureLocales.join(', ')}; ` +
-    `captured cases: ${capturedCases.size}.`,
+    `${manifestOnly ? 'media unchanged' : `captured locales: ${captureLocales.join(', ')}; captured cases: ${capturedCases.size}`}.`,
 );

--- a/docs-site/scripts/manual-lib.mjs
+++ b/docs-site/scripts/manual-lib.mjs
@@ -116,6 +116,31 @@ export function resolveCaptureLocales(value, registryLocales) {
   return requested;
 }
 
+/** Resolve an optional incremental screenshot-case selection. */
+export function resolveScreenshotCases(value, registryCases) {
+  if (!value) return [...registryCases];
+
+  const requestedIds = String(value).split(/[\s,]+/).filter(Boolean);
+  if (requestedIds.length === 0) {
+    throw new Error('At least one manual screenshot case must be selected.');
+  }
+  if (new Set(requestedIds).size !== requestedIds.length) {
+    throw new Error('Manual screenshot case selection contains duplicates.');
+  }
+
+  const casesById = new Map(registryCases.map((screenshotCase) => [
+    screenshotCase.id,
+    screenshotCase,
+  ]));
+  const unsupported = requestedIds.filter((id) => !casesById.has(id));
+  if (unsupported.length > 0) {
+    throw new Error(
+      `Unknown manual screenshot case(s): ${unsupported.join(', ')}.`,
+    );
+  }
+  return requestedIds.map((id) => casesById.get(id));
+}
+
 export function findUnmanagedScreenshotReferences(source) {
   const authoringMarkup = source
     .replace(/```[\s\S]*?```/g, '')

--- a/docs-site/scripts/smoke-built-site.mjs
+++ b/docs-site/scripts/smoke-built-site.mjs
@@ -20,6 +20,14 @@ const localeExpectations = {
     mobile: 'Mobil',
     openViewer: 'Screenshot-Ansicht öffnen',
   },
+  fr: {
+    allScreenshots: 'Toutes les captures d’écran',
+    desktop: 'Ordinateur',
+    firstTaskTitle: 'Crée ta première tâche',
+    layoutLabel: 'Présentation des captures pour toutes les images',
+    mobile: 'Mobile',
+    openViewer: 'Ouvrir la visionneuse de captures',
+  },
   cs: {
     allScreenshots: 'Všechny snímky',
     desktop: 'Počítač',

--- a/docs-site/tests/browser-locale-preference.test.mjs
+++ b/docs-site/tests/browser-locale-preference.test.mjs
@@ -13,14 +13,18 @@ test('browser locale matching uses the first supported language', () => {
   assert.equal(
     preferredSupportedLocale(
       ['fr-FR', 'cs-CZ', 'de-DE', 'en-US'],
-      ['en', 'de', 'cs'],
+      ['en', 'de', 'fr', 'cs'],
       'en',
     ),
-    'cs',
+    'fr',
   );
   assert.equal(
-    preferredSupportedLocale(['fr-FR', 'de-DE', 'en-US'], ['en', 'de', 'cs'], 'en'),
-    'de',
+    preferredSupportedLocale(
+      ['fr-FR', 'de-DE', 'en-US'],
+      ['en', 'de', 'fr', 'cs'],
+      'en',
+    ),
+    'fr',
   );
   assert.equal(
     preferredSupportedLocale(['fr-FR'], ['en', 'de'], 'en'),
@@ -74,6 +78,10 @@ test('locale root URLs preserve the default route and add alternatives', () => {
     localeRootUrl('/lotti/manual/development/', 'cs', 'en'),
     '/lotti/manual/development/cs/',
   );
+  assert.equal(
+    localeRootUrl('/lotti/manual/development/', 'fr', 'en'),
+    '/lotti/manual/development/fr/',
+  );
 });
 
 test('an explicit locale dropdown choice is persisted', () => {
@@ -90,14 +98,15 @@ test('an explicit locale dropdown choice is persisted', () => {
     localeConfigs: {
       en: {htmlLang: 'en-US'},
       de: {htmlLang: 'de-DE'},
+      fr: {htmlLang: 'fr-FR'},
       cs: {htmlLang: 'cs-CZ'},
     },
     storage: {setItem: (key, value) => stored.set(key, value)},
   });
 
   clickListener({
-    target: {closest: () => ({lang: 'de-DE'})},
+    target: {closest: () => ({lang: 'fr-FR'})},
   });
 
-  assert.equal(stored.get(manualLocaleStorageKey), 'de');
+  assert.equal(stored.get(manualLocaleStorageKey), 'fr');
 });

--- a/docs-site/tests/manual-lib.test.mjs
+++ b/docs-site/tests/manual-lib.test.mjs
@@ -104,17 +104,18 @@ test('the screenshot registry requires a valid default and unique locales', () =
 });
 
 test('incremental captures select only registered locales', () => {
-  assert.deepEqual(resolveCaptureLocales(undefined, ['en', 'de', 'cs']), [
+  assert.deepEqual(resolveCaptureLocales(undefined, ['en', 'de', 'fr', 'cs']), [
     'en',
     'de',
+    'fr',
     'cs',
   ]);
-  assert.deepEqual(resolveCaptureLocales('cs, de', ['en', 'de', 'cs']), [
+  assert.deepEqual(resolveCaptureLocales('cs, fr', ['en', 'de', 'fr', 'cs']), [
     'cs',
-    'de',
+    'fr',
   ]);
   assert.throws(
-    () => resolveCaptureLocales('fr', ['en', 'de', 'cs']),
+    () => resolveCaptureLocales('es', ['en', 'de', 'fr', 'cs']),
     /Unsupported manual screenshot locale/,
   );
   assert.throws(

--- a/docs-site/tests/manual-lib.test.mjs
+++ b/docs-site/tests/manual-lib.test.mjs
@@ -7,6 +7,7 @@ import {
   findUnmanagedScreenshotReferences,
   requiredVariants,
   resolveCaptureLocales,
+  resolveScreenshotCases,
   validateCaseId,
   validateManualVersion,
   validateScreenshotRegistry,
@@ -120,6 +121,27 @@ test('incremental captures select only registered locales', () => {
   );
   assert.throws(
     () => resolveCaptureLocales('cs cs', ['en', 'de', 'cs']),
+    /contains duplicates/,
+  );
+});
+
+test('incremental captures select only registered screenshot cases', () => {
+  const cases = [
+    {id: 'onboarding/welcome'},
+    {id: 'onboarding/api-key'},
+    {id: 'onboarding/success'},
+  ];
+  assert.deepEqual(resolveScreenshotCases(undefined, cases), cases);
+  assert.deepEqual(resolveScreenshotCases('onboarding/api-key, onboarding/success', cases), [
+    cases[1],
+    cases[2],
+  ]);
+  assert.throws(
+    () => resolveScreenshotCases('onboarding/unknown', cases),
+    /Unknown manual screenshot case/,
+  );
+  assert.throws(
+    () => resolveScreenshotCases('onboarding/welcome onboarding/welcome', cases),
     /contains duplicates/,
   );
 });

--- a/lib/features/events/ui/widgets/events_overview_view.dart
+++ b/lib/features/events/ui/widgets/events_overview_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lotti/features/design_system/theme/breakpoints.dart';
 import 'package:lotti/features/design_system/theme/design_tokens.dart';
 import 'package:lotti/features/design_system/theme/ds_surface_elevation.dart';
 import 'package:lotti/features/events/ui/model/event_view_data.dart';
@@ -246,7 +247,7 @@ class _Header extends StatelessWidget {
   final ValueChanged<String?>? onSelectCategory;
   final VoidCallback? onSearch;
 
-  /// When non-null (wide layouts), shows a "New event" button in the header.
+  /// When non-null, shows a responsive "New event" action in the header.
   final VoidCallback? onCreateInHeader;
 
   @override
@@ -255,41 +256,28 @@ class _Header extends StatelessWidget {
     final cs = context.colorScheme;
     final styles = tokens.typography.styles;
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.end,
-          children: [
-            Text(
-              context.messages.eventsPageTitle,
-              style: styles.heading.heading1.copyWith(color: cs.onSurface),
+    final title = Text(
+      context.messages.eventsPageTitle,
+      style: styles.heading.heading1.copyWith(color: cs.onSurface),
+    );
+    final subtitleText = subtitle == null
+        ? null
+        : Text(
+            subtitle!,
+            style: styles.body.bodyMedium.copyWith(
+              color: cs.onSurfaceVariant,
             ),
-            if (subtitle != null) ...[
-              SizedBox(width: tokens.spacing.step3),
-              Expanded(
-                child: Text(
-                  subtitle!,
-                  style: styles.body.bodyMedium.copyWith(
-                    color: cs.onSurfaceVariant,
-                  ),
-                ),
-              ),
-            ] else
-              const Spacer(),
-            if (onCreateInHeader != null)
-              FilledButton.icon(
-                onPressed: onCreateInHeader,
-                icon: const Icon(Icons.add),
-                label: Text(context.messages.eventsNewEvent),
-              ),
-          ],
-        ),
-        SizedBox(height: tokens.spacing.step4),
-        _SearchField(onTap: onSearch),
-        if (categories.isNotEmpty) ...[
-          SizedBox(height: tokens.spacing.step3),
-          SingleChildScrollView(
+          );
+    final createButton = onCreateInHeader == null
+        ? null
+        : FilledButton.icon(
+            onPressed: onCreateInHeader,
+            icon: const Icon(Icons.add),
+            label: Text(context.messages.eventsNewEvent),
+          );
+    final categoryChips = categories.isEmpty
+        ? null
+        : SingleChildScrollView(
             scrollDirection: Axis.horizontal,
             child: Row(
               children: [
@@ -305,9 +293,58 @@ class _Header extends StatelessWidget {
                 ],
               ],
             ),
-          ),
-        ],
-      ],
+          );
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        if (constraints.maxWidth < kDesktopBreakpoint) {
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              title,
+              if (subtitleText != null) ...[
+                SizedBox(height: tokens.spacing.step1),
+                subtitleText,
+              ],
+              if (createButton != null) ...[
+                SizedBox(height: tokens.spacing.step3),
+                SizedBox(width: double.infinity, child: createButton),
+              ],
+              SizedBox(height: tokens.spacing.step4),
+              _SearchField(onTap: onSearch),
+              if (categoryChips != null) ...[
+                SizedBox(height: tokens.spacing.step3),
+                categoryChips,
+              ],
+            ],
+          );
+        }
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                title,
+                if (subtitleText != null) ...[
+                  SizedBox(width: tokens.spacing.step3),
+                  Expanded(child: subtitleText),
+                ] else
+                  const Spacer(),
+                if (createButton case final FilledButton createButton)
+                  createButton,
+              ],
+            ),
+            SizedBox(height: tokens.spacing.step4),
+            _SearchField(onTap: onSearch),
+            if (categoryChips != null) ...[
+              SizedBox(height: tokens.spacing.step3),
+              categoryChips,
+            ],
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/features/speech/ui/widgets/recording/audio_recording_modal.dart
+++ b/lib/features/speech/ui/widgets/recording/audio_recording_modal.dart
@@ -634,7 +634,7 @@ class _AudioRecordingModalContentState
           if (visibility.speech)
             LottiAnimatedCheckbox(
               key: const Key('speech_recognition_checkbox'),
-              label: 'Speech Recognition',
+              label: context.messages.speechModalTitle,
               value: state.enableSpeechRecognition ?? true,
               onChanged: (value) {
                 controller.setEnableSpeechRecognition(enable: value);

--- a/lib/features/tasks/ui/widgets/task_action_bar.dart
+++ b/lib/features/tasks/ui/widgets/task_action_bar.dart
@@ -110,7 +110,7 @@ class TaskActionBar extends ConsumerStatefulWidget {
   /// row would otherwise overflow. Both stay reachable via the "..."
   /// (more) menu.
   @visibleForTesting
-  static const double minWidthForImageButton = 400;
+  static const double minWidthForImageButton = 416;
 
   @override
   ConsumerState<TaskActionBar> createState() => _TaskActionBarState();
@@ -304,11 +304,11 @@ class _TaskActionBarState extends ConsumerState<TaskActionBar> {
                 // always fits on a single line. Image goes first, then
                 // checklist; both stay reachable via the "..." (more) menu.
                 //
-                // Thresholds are based on the worst-case rendered widths of
-                // the inner content: the idle pill ("Track time" label,
-                // ~150 px including icon and padding), 48 px round buttons,
-                // and step4 (12 px) gaps. Adding each extra button costs
-                // ~60 px, so 5 items need ≈ 400 px and 4 items need ≈ 340.
+                // Thresholds include the widest translated idle pill
+                // (French "Suivre le temps"), 48 px round buttons, and
+                // step4 (12 px) gaps. Adding each extra button costs ≈60 px,
+                // so the five-control row needs 416 px and the four-control
+                // row needs ≈340 px.
                 final showImage =
                     constraints.maxWidth >=
                     TaskActionBar.minWidthForImageButton;

--- a/test/features/agents/ui/agents_manual_screenshots_test.dart
+++ b/test/features/agents/ui/agents_manual_screenshots_test.dart
@@ -72,6 +72,8 @@ import '../test_utils.dart';
 
 const String _subdir = 'agents';
 String _t(String en, String de) => manualScreenshotText(en: en, de: de);
+AppLocalizations _messages(WidgetTester tester) =>
+    AppLocalizations.of(tester.element(find.byType(Scaffold).first))!;
 const String _habitatTemplateId = 'template-habitat-sentinel';
 const String _dayPlannerTemplateId = 'template-waddle-day-planner';
 const String _cargoTemplateId = 'template-sardine-cargo-watch';
@@ -1125,8 +1127,9 @@ void main() {
               device: device,
               brightness: brightness,
             );
+            final messages = _messages(tester);
             expect(
-              find.textContaining(_t('more tokens today', 'heute mehr Tokens')),
+              find.text(messages.agentStatsUsageAboveAverage('10:30')),
               findsOneWidget,
             );
             expect(find.text('26K'), findsWidgets);
@@ -1379,7 +1382,13 @@ void main() {
           );
           expect(
             find.textContaining(
-              _t('calm flight director', 'ruhiger Flugleiter'),
+              _t(
+                'Speak like a calm flight director who respects both evidence '
+                    'and penguins. Put the operational decision first.',
+                'Sprich wie ein ruhiger Flugleiter, der Belege und Pinguine '
+                    'respektiert. Stelle die betriebliche Entscheidung an den '
+                    'Anfang.',
+              ),
             ),
             findsOneWidget,
           );

--- a/test/features/ai/ui/settings/ai_settings_manual_screenshots_test.dart
+++ b/test/features/ai/ui/settings/ai_settings_manual_screenshots_test.dart
@@ -62,6 +62,8 @@ import '../../../daily_os_next/screenshot_harness.dart';
 
 const String _subdir = 'ai_settings';
 String _t(String en, String de) => manualScreenshotText(en: en, de: de);
+AppLocalizations _messages(WidgetTester tester) =>
+    AppLocalizations.of(tester.element(find.byType(Scaffold).first))!;
 
 enum _AiSurface {
   providers,
@@ -553,11 +555,15 @@ void main() {
             brightness: brightness,
             world: world,
           );
+          final messages = _messages(tester);
           expect(
             find.text(_t('Mission Control Router', 'Missionskontroll-Router')),
             findsWidgets,
           );
-          expect(find.text(_t('Connection', 'Verbindung')), findsOneWidget);
+          expect(
+            find.text(messages.aiProviderDetailConnectionTitle),
+            findsOneWidget,
+          );
           expect(
             find.text(_t('Waddle Command 70B', 'Watschelkommando 70B')),
             findsAtLeastNWidgets(1),
@@ -584,7 +590,9 @@ void main() {
               ),
             );
           } else {
-            await tester.tap(find.text(_t('Edit', 'Bearbeiten')).first);
+            await tester.tap(
+              find.text(messages.aiProviderDetailEditButton).first,
+            );
           }
           await settleFrames(tester, 8);
           expect(
@@ -592,10 +600,10 @@ void main() {
             findsWidgets,
           );
           expect(
-            find.text(_t('Provider Type', 'Anbietertyp')),
+            find.text(messages.apiKeyProviderTypeLabel),
             findsOneWidget,
           );
-          expect(find.text(_t('API Key', 'API-Schlüssel')), findsOneWidget);
+          expect(find.text(messages.apiKeyInputLabel), findsOneWidget);
           await captureScreenshot(
             tester,
             'ai_provider_editor_${viewport}_$theme',
@@ -614,8 +622,9 @@ void main() {
             brightness: brightness,
             world: world,
           );
+          final messages = _messages(tester);
           expect(
-            find.text(_t('Edit Model', 'Modell bearbeiten')),
+            find.text(messages.modelEditPageTitle),
             findsOneWidget,
           );
           expect(
@@ -627,7 +636,7 @@ void main() {
             findsWidgets,
           );
           expect(
-            find.text(_t('Capabilities', 'Fähigkeiten')),
+            find.text(messages.modelEditSectionCapabilities),
             findsOneWidget,
           );
           await captureScreenshot(
@@ -650,8 +659,9 @@ void main() {
             brightness: brightness,
             world: world,
           );
+          final messages = _messages(tester);
           expect(
-            find.text(_t('Edit Profile', 'Profil bearbeiten')),
+            find.text(messages.inferenceProfileEditTitle),
             findsOneWidget,
           );
           expect(
@@ -670,14 +680,16 @@ void main() {
             subdir: _subdir,
           );
 
-          final thinkingField = find.text(_t('Thinking *', 'Denken *'));
+          final thinkingField = find.text(
+            '${messages.inferenceProfileThinking} *',
+          );
           expect(thinkingField, findsOneWidget);
           await tester.tap(
             find.text(_t('Waddle Command 70B', 'Watschelkommando 70B')),
           );
           await settleFrames(tester, 6);
           expect(
-            find.text(_t('Choose a model', 'Modell auswählen')),
+            find.text(messages.inferenceProfileChooseModelTitle),
             findsOneWidget,
           );
           expect(
@@ -705,11 +717,12 @@ void main() {
               brightness: brightness,
               world: world,
             );
-            expect(find.text(_t('AI Impact', 'KI-Impact')), findsOneWidget);
+            final messages = _messages(tester);
+            expect(find.text(messages.aiImpactTitle), findsOneWidget);
             expect(find.text(formatCredits(1.2)), findsOneWidget);
             expect(
-              find.text(_t('Cost by category', 'Kosten nach Kategorie')),
-              findsOneWidget,
+              find.text(messages.aiImpactBreakdownCategory),
+              findsWidgets,
             );
             await captureScreenshot(
               tester,
@@ -732,8 +745,9 @@ void main() {
             brightness: brightness,
             world: world,
           );
+          final messages = _messages(tester);
           expect(
-            find.text(_t('Inference Profiles', 'Inferenz-Profile')),
+            find.text(messages.inferenceProfilesTitle),
             findsOneWidget,
           );
           expect(

--- a/test/features/events/ui/pages/events_manual_screenshots_test.dart
+++ b/test/features/events/ui/pages/events_manual_screenshots_test.dart
@@ -53,6 +53,10 @@ import '../../../daily_os_next/screenshot_harness.dart';
 const _subdir = 'events';
 const _detailEventId = 'event-project-waddle-launch-gala';
 String _t(String en, String de) => manualScreenshotText(en: en, de: de);
+
+AppLocalizations _messages(WidgetTester tester) =>
+    AppLocalizations.of(tester.element(find.byType(EventDetailView)))!;
+
 const ValueKey<String> _precacheKey = ValueKey<String>(
   'events-manual-precache-host',
 );
@@ -521,7 +525,10 @@ void main() {
           find.text(_t('Penguin Operations', 'Pinguinbetrieb')),
           findsOneWidget,
         );
-        expect(find.text(_t('Summary', 'Zusammenfassung')), findsOneWidget);
+        expect(
+          find.text(_messages(tester).eventsSummaryTitle),
+          findsOneWidget,
+        );
         final galleryImages = find.descendant(
           of: find.byType(EventPhotoGrid),
           matching: find.byType(RawImage),
@@ -564,8 +571,14 @@ void main() {
           scrollable: scrollable.first,
         );
         await settleFrames(tester, 4);
-        expect(find.text(_t('Photos', 'Fotos')), findsOneWidget);
-        expect(find.text(_t('Timeline', 'Zeitleiste')), findsOneWidget);
+        expect(
+          find.text(_messages(tester).eventsPhotosSection),
+          findsOneWidget,
+        );
+        expect(
+          find.text(_messages(tester).eventsTimelineSection),
+          findsOneWidget,
+        );
         expect(
           find.text(
             _t(

--- a/test/features/events/ui/widgets/events_overview_view_test.dart
+++ b/test/features/events/ui/widgets/events_overview_view_test.dart
@@ -73,6 +73,21 @@ void main() {
       expect(find.widgetWithText(FilledButton, 'New event'), findsOneWidget);
     });
 
+    testWidgets('keeps the create action available in the compact header', (
+      tester,
+    ) async {
+      await pumpEventScreen(
+        tester,
+        EventsOverviewView(
+          sections: _sections(),
+          onCreate: () {},
+        ),
+      );
+
+      expect(find.text('Events'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, 'New event'), findsOneWidget);
+    });
+
     testWidgets('renders section headers, featured banner and grid cards', (
       tester,
     ) async {

--- a/test/features/habits/ui/habits_manual_screenshots_test.dart
+++ b/test/features/habits/ui/habits_manual_screenshots_test.dart
@@ -32,6 +32,14 @@ import '../test_utils.dart';
 final _today = DateTime(2026, 7, 17);
 String _t(String en, String de) => manualScreenshotText(en: en, de: de);
 
+AppLocalizations _messages(WidgetTester tester) {
+  final habitsPage = find.byType(HabitsTabPage);
+  final context = habitsPage.evaluate().isNotEmpty
+      ? tester.element(habitsPage)
+      : tester.element(find.byType(HabitDialog));
+  return AppLocalizations.of(context)!;
+}
+
 final _penguinOps = CategoryDefinition(
   id: 'penguin-ops',
   name: _t('Penguin Ops', 'Pinguinbetrieb'),
@@ -152,7 +160,10 @@ void main() {
           brightness: brightness,
         );
 
-        expect(find.text(_t('Habits', 'Gewohnheiten')), findsOneWidget);
+        expect(
+          find.text(_messages(tester).settingsHabitsTitle),
+          findsOneWidget,
+        );
         expect(
           find.text(
             _t('Inspect habitat seals', 'Habitatdichtungen inspizieren'),
@@ -183,12 +194,19 @@ void main() {
           ),
           findsOneWidget,
         );
-        expect(find.text(_t('Success', 'Erfolgreich')), findsNWidgets(2));
+        final messages = _messages(tester);
         expect(
-          find.text(_t('Skip', 'Überspringen')),
+          find.text(messages.completeHabitSuccessButton),
           findsNWidgets(2),
         );
-        expect(find.text(_t('Missed', 'Verpasst')), findsNWidgets(2));
+        expect(
+          find.text(messages.completeHabitSkipButton),
+          findsNWidgets(2),
+        );
+        expect(
+          find.text(messages.completeHabitFailButton),
+          findsNWidgets(2),
+        );
         expect(find.byKey(const Key('habit_save')), findsOneWidget);
         await captureScreenshot(
           tester,

--- a/test/features/insights/ui/time_analysis_screenshots_test.dart
+++ b/test/features/insights/ui/time_analysis_screenshots_test.dart
@@ -696,9 +696,10 @@ void main() {
           brightness: brightness,
           size: size,
         );
-        expect(find.text(_t('Time Analysis', 'Zeitanalyse')), findsOneWidget);
-        expect(find.text(_t('TOTAL', 'GESAMT')), findsWidgets);
-        expect(find.text(_t('FOCUS', 'FOKUS')), findsOneWidget);
+        final messages = _messages(tester);
+        expect(find.text(messages.insightsTimeAnalysisTitle), findsOneWidget);
+        expect(find.text(messages.insightsKpiTotal), findsWidgets);
+        expect(find.text(messages.insightsKpiFocus), findsOneWidget);
         expect(
           find.text(_t('Penguin Operations', 'Pinguinbetrieb')),
           findsWidgets,
@@ -718,23 +719,15 @@ void main() {
           brightness: brightness,
           size: size,
         );
+        final messages = _messages(tester);
 
-        final runningTotal = find
-            .text(
-              _t('Running total', 'Laufende Summe'),
-            )
-            .last;
+        final runningTotal = find.text(messages.insightsChartRunningTotal).last;
         await tester.ensureVisible(runningTotal);
         await tester.pump(const Duration(milliseconds: 300));
         await _tap(tester, runningTotal);
 
         expect(
-          find.text(
-            _t(
-              'Running total over the range',
-              'Laufende Summe im Zeitraum',
-            ),
-          ),
+          find.text(messages.insightsChartCumulativeCaption),
           findsOneWidget,
         );
         expect(find.byType(LineChart), findsOneWidget);
@@ -762,10 +755,11 @@ void main() {
           brightness: brightness,
           size: size,
         );
-        await _tap(tester, find.text(_t('Compare', 'Vergleichen')));
+        final messages = _messages(tester);
+        await _tap(tester, find.text(messages.insightsCompare));
         final comparisonHeader = size == _mobileSize
-            ? find.text(_t('Change', 'Änderung'))
-            : find.text(_t('PREVIOUS', 'VORHER'));
+            ? find.text(messages.insightsTableDelta)
+            : find.text(messages.insightsTablePrevious);
         if (size == _mobileSize) {
           final list = find.byType(ListView);
           for (

--- a/test/features/journal/ui/pages/journal_manual_screenshots_test.dart
+++ b/test/features/journal/ui/pages/journal_manual_screenshots_test.dart
@@ -33,6 +33,7 @@ import 'package:lotti/classes/rating_data.dart';
 import 'package:lotti/database/state/config_flag_provider.dart';
 import 'package:lotti/features/ai/state/consts.dart';
 import 'package:lotti/features/design_system/components/buttons/design_system_floating_action_button.dart';
+import 'package:lotti/features/design_system/components/task_filters/design_system_filter_shared.dart';
 import 'package:lotti/features/design_system/theme/design_system_theme.dart';
 import 'package:lotti/features/journal/model/entry_state.dart';
 import 'package:lotti/features/journal/state/journal_page_controller.dart';
@@ -77,6 +78,10 @@ import '../../../daily_os_next/screenshot_harness.dart';
 
 const _subdir = 'journal';
 String _t(String en, String de) => manualScreenshotText(en: en, de: de);
+
+AppLocalizations _messages(WidgetTester tester) =>
+    AppLocalizations.of(tester.element(find.byType(AppCommandHost)))!;
+
 const _briefingId = 'journal-project-waddle-briefing';
 
 class _ManualJournalPageController extends JournalPageController {
@@ -718,15 +723,19 @@ void main() {
           ),
         );
         await settleFrames(tester, 6);
+        final messages = _messages(tester);
         expect(
-          find.text(_t('Filter journal', 'Tagebuch filtern')),
+          find.text(messages.journalFilterTitle),
           findsOneWidget,
         );
         expect(
-          find.text(_t('Entry types', 'Eintragstypen')),
+          find.text(messages.journalFilterEntryTypesTitle),
           findsOneWidget,
         );
-        expect(find.text(_t('Category', 'Kategorie')), findsWidgets);
+        expect(
+          find.text(stripTrailingColon(messages.taskCategoryLabel)),
+          findsWidgets,
+        );
         await captureScreenshot(
           tester,
           'journal_filters_${viewport}_$theme',
@@ -743,14 +752,15 @@ void main() {
         );
         await tester.tap(find.byType(DesignSystemFloatingActionButton));
         await settleFrames(tester, 6);
-        expect(find.text(_t('Add', 'Hinzufügen')), findsOneWidget);
-        expect(find.text(_t('Event', 'Ereignis')), findsOneWidget);
-        expect(find.text(_t('Task', 'Aufgabe')), findsOneWidget);
+        final messages = _messages(tester);
+        expect(find.text(messages.createEntryTitle), findsOneWidget);
+        expect(find.text(messages.addActionAddEvent), findsOneWidget);
+        expect(find.text(messages.addActionAddTask), findsOneWidget);
         expect(
-          find.text(_t('Audio Recording', 'Audioaufnahme')),
+          find.text(messages.addActionAddAudioRecording),
           findsOneWidget,
         );
-        expect(find.text(_t('Text Entry', 'Texteingabe')), findsOneWidget);
+        expect(find.text(messages.addActionAddText), findsOneWidget);
         await captureScreenshot(
           tester,
           'journal_create_${viewport}_$theme',
@@ -809,12 +819,13 @@ void main() {
         await settleFrames(tester, 8);
 
         expect(find.byType(EntryDateTimeEditor), findsOneWidget);
+        final messages = _messages(tester);
         expect(
-          find.text(_t('Date & Time', 'Datum & Uhrzeit')),
+          find.text(messages.journalDateTimeRangeTitle),
           findsOneWidget,
         );
-        expect(find.text(_t('Start time', 'Startzeit')), findsOneWidget);
-        expect(find.text(_t('End time', 'Endzeit')), findsOneWidget);
+        expect(find.text(messages.journalStartTimeLabel), findsOneWidget);
+        expect(find.text(messages.journalEndTimeLabel), findsOneWidget);
         await captureScreenshot(
           tester,
           'journal_date_time_editor_${viewport}_$theme',
@@ -832,7 +843,7 @@ void main() {
               .first,
         );
         await settleFrames(tester, 8);
-        expect(find.text(_t('Start date', 'Startdatum')), findsOneWidget);
+        expect(find.text(messages.journalStartDateLabel), findsOneWidget);
         expect(find.text(_t('July 2026', 'Juli 2026')), findsOneWidget);
         await captureScreenshot(
           tester,
@@ -864,9 +875,19 @@ void main() {
           scrollable: scrollable.first,
         );
         await settleFrames(tester, 4);
-        expect(find.text(_t('Timer', 'Timer')), findsOneWidget);
-        expect(find.text(_t('Images', 'Bilder')), findsOneWidget);
-        expect(find.text(_t('Code', 'Code')), findsOneWidget);
+        final messages = _messages(tester);
+        expect(
+          find.text(messages.journalLinkedEntriesActivityFilterTimer),
+          findsOneWidget,
+        );
+        expect(
+          find.text(messages.journalLinkedEntriesActivityFilterImages),
+          findsOneWidget,
+        );
+        expect(
+          find.text(messages.journalLinkedEntriesActivityFilterCode),
+          findsOneWidget,
+        );
         expect(
           find.textContaining(
             _t(
@@ -907,24 +928,25 @@ void main() {
         expect(find.byType(LinkedEntriesActivityFilterBar), findsOneWidget);
         await tester.tap(filterTrigger);
         await settleFrames(tester, 6);
+        final messages = _messages(tester);
 
         expect(
-          find.text(_t('Filter & Sort', 'Filtern & Sortieren')),
+          find.text(messages.journalLinkedEntriesFilterModalTitle),
           findsOneWidget,
         );
         expect(
-          find.text(_t('Newest first', 'Neueste zuerst')),
+          find.text(messages.journalLinkedEntriesSortNewestFirst),
           findsWidgets,
         );
         expect(
-          find.text(_t('Oldest first', 'Älteste zuerst')),
+          find.text(messages.journalLinkedEntriesSortOldestFirst),
           findsOneWidget,
         );
-        await tester.tap(find.text(_t('Oldest first', 'Älteste zuerst')));
         await tester.tap(
-          find.text(
-            _t('Show hidden entries', 'Versteckte Einträge anzeigen'),
-          ),
+          find.text(messages.journalLinkedEntriesSortOldestFirst),
+        );
+        await tester.tap(
+          find.text(messages.journalLinkedEntriesShowHidden),
         );
         await settleFrames(tester, 3);
         await captureScreenshot(
@@ -1009,41 +1031,27 @@ void main() {
         final pageContext = tester.element(find.byType(EntryDetailsPage));
         unawaited(RatingModal.show(pageContext, rehearsalTimer.id));
         await settleFrames(tester, 8);
+        final messages = _messages(tester);
 
         expect(find.byType(RatingModal), findsOneWidget);
         expect(
-          find.text(_t('Rate this session', 'Sitzung bewerten')),
+          find.text(messages.sessionRatingTitle),
           findsOneWidget,
         );
         expect(
-          find.text(
-            _t(
-              'How productive was this session?',
-              'Wie produktiv war diese Sitzung?',
-            ),
-          ),
+          find.text(messages.sessionRatingProductivityQuestion),
           findsOneWidget,
         );
         expect(
-          find.text(
-            _t(
-              'How energized did you feel?',
-              'Wie energiegeladen hast du dich gefühlt?',
-            ),
-          ),
+          find.text(messages.sessionRatingEnergyQuestion),
           findsOneWidget,
         );
         expect(
-          find.text(
-            _t(
-              'How focused were you?',
-              'Wie fokussiert warst du?',
-            ),
-          ),
+          find.text(messages.sessionRatingFocusQuestion),
           findsOneWidget,
         );
         expect(
-          find.text(_t('Just right', 'Genau richtig')),
+          find.text(messages.sessionRatingChallengeJustRight),
           findsOneWidget,
         );
         expect(
@@ -1057,7 +1065,7 @@ void main() {
           findsOneWidget,
         );
         final saveButton = tester.widget<FilledButton>(
-          find.widgetWithText(FilledButton, _t('Save', 'Speichern')),
+          find.widgetWithText(FilledButton, messages.sessionRatingSaveButton),
         );
         expect(saveButton.onPressed, isNotNull);
 

--- a/test/features/onboarding/ui/onboarding_manual_screenshots_test.dart
+++ b/test/features/onboarding/ui/onboarding_manual_screenshots_test.dart
@@ -52,6 +52,9 @@ import '../../daily_os_next/screenshot_harness.dart';
 
 String _t(String en, String de) => manualScreenshotText(en: en, de: de);
 
+AppLocalizations _messages(WidgetTester tester) =>
+    AppLocalizations.of(tester.element(find.byType(Scaffold).first))!;
+
 final String _typedMission = _t(
   'Inspect the Europa sardine relay before the emperor penguin roll call',
   'Europa-Sardinenrelais vor dem Zählappell der Kaiserpinguine inspizieren',
@@ -332,8 +335,9 @@ void main() {
   }
 
   Future<void> driveToProviders(WidgetTester tester) async {
-    await tapText(tester, _t('Choose your AI brain', 'KI-Gehirn wählen'));
-    await tapText(tester, _t('More options', 'Mehr Optionen'));
+    final messages = _messages(tester);
+    await tapText(tester, messages.onboardingWelcomeConnectButton);
+    await tapText(tester, messages.onboardingConnectMoreOptions);
     expect(find.text('Ollama'), findsOneWidget);
   }
 
@@ -344,42 +348,42 @@ void main() {
     await tester.pump(const Duration(milliseconds: 1100));
     await settleFrames(tester, 4);
     expect(
-      find.text(_t('Connection verified', 'Verbindung bestätigt')),
+      find.text(_messages(tester).aiProviderConnectionVerifiedTitle),
       findsOneWidget,
     );
   }
 
   Future<void> driveToSuccess(WidgetTester tester) async {
     await driveToApiKey(tester);
-    await tapText(tester, _t('Connect', 'Verbinden'));
-    expect(find.text(_t("You're all set", 'Alles bereit')), findsOneWidget);
+    final messages = _messages(tester);
+    await tapText(tester, messages.onboardingApiKeyConnect);
+    expect(find.text(messages.onboardingSuccessTitle), findsOneWidget);
   }
 
   Future<void> driveToRecordingStyle(WidgetTester tester) async {
     await driveToSuccess(tester);
-    await tapText(tester, _t('Get started', "Los geht's"));
+    final messages = _messages(tester);
+    await tapText(tester, messages.onboardingSuccessContinue);
     expect(
-      find.text(
-        _t('How should recording feel?', 'Wie soll die Aufnahme wirken?'),
-      ),
+      find.text(messages.onboardingRecordingStyleTitle),
       findsOneWidget,
     );
   }
 
   Future<void> driveToCategories(WidgetTester tester) async {
     await driveToRecordingStyle(tester);
-    await tapText(tester, _t('Continue', 'Weiter'));
+    final messages = _messages(tester);
+    await tapText(tester, messages.onboardingRecordingStyleContinue);
     expect(
-      find.text(
-        _t('Where should your AI work?', 'Wo soll deine KI arbeiten?'),
-      ),
+      find.text(messages.onboardingCategoryTitle),
       findsOneWidget,
     );
   }
 
   Future<void> driveToFirstTaskPrompt(WidgetTester tester) async {
     await driveToCategories(tester);
-    await tapText(tester, _t('Add your own', 'Eigene hinzufügen'), frames: 4);
+    final messages = _messages(tester);
+    await tapText(tester, messages.onboardingCategoryAddOwn, frames: 4);
     await tester.enterText(
       find.byType(TextField).last,
       _t('Penguin Operations', 'Pinguinbetrieb'),
@@ -390,7 +394,7 @@ void main() {
       findsOneWidget,
     );
 
-    await tapText(tester, _t('Add your own', 'Eigene hinzufügen'), frames: 4);
+    await tapText(tester, messages.onboardingCategoryAddOwn, frames: 4);
     await tester.enterText(
       find.byType(TextField).last,
       _t('Mission Control', 'Missionskontrolle'),
@@ -400,10 +404,10 @@ void main() {
       find.text(_t('Mission Control', 'Missionskontrolle')),
       findsOneWidget,
     );
-    await tapText(tester, _t('Continue', 'Weiter'), frames: 12);
+    await tapText(tester, messages.onboardingCategoryContinue, frames: 12);
 
     expect(
-      find.text(_t('Create your first task', 'Erstelle deine erste Aufgabe')),
+      find.text(messages.onboardingFirstTaskTitle),
       findsOneWidget,
     );
     expect(
@@ -420,17 +424,12 @@ void main() {
     await driveToFirstTaskPrompt(tester);
     await tester.tap(
       find.bySemanticsLabel(
-        _t('Record your thought', 'Deinen Gedanken aufnehmen'),
+        _messages(tester).onboardingCaptureOrbLabel,
       ),
     );
     await settleFrames(tester, 6);
     expect(
-      find.text(
-        _t(
-          "Listening… tap when you're done",
-          'Ich höre zu … tippe, wenn du fertig bist',
-        ),
-      ),
+      find.text(_messages(tester).onboardingCaptureListening),
       findsOneWidget,
     );
     expect(find.byType(AiVoiceInputShader), findsOneWidget);
@@ -438,14 +437,16 @@ void main() {
 
   Future<void> driveToCreatedTask(WidgetTester tester) async {
     await driveToFirstTaskPrompt(tester);
-    await tapText(tester, _t('Rather type?', 'Lieber tippen?'), frames: 4);
+    await tapText(
+      tester,
+      _messages(tester).onboardingCaptureRatherType,
+      frames: 4,
+    );
     await tester.enterText(find.byType(TextField).last, _typedMission);
     await tapText(tester, 'OK', frames: 10);
     await settleFrames(tester, 6);
     expect(
-      find.text(
-        _t('Your first task is ready', 'Deine erste Aufgabe ist fertig'),
-      ),
+      find.text(_messages(tester).onboardingFirstTaskCreatedTitle),
       findsOneWidget,
     );
     expect(find.text(_createdTaskTitle), findsOneWidget);
@@ -489,22 +490,12 @@ void main() {
       switch (scenario) {
         case _OnboardingCase.settings:
           expect(
-            find.text(
-              _t(
-                "You've created your first AI task",
-                'Du hast deine erste KI-Aufgabe erstellt',
-              ),
-            ),
+            find.text(_messages(tester).settingsOnboardingStatusActivated),
             findsOneWidget,
           );
         case _OnboardingCase.welcome:
           expect(
-            find.text(
-              _t(
-                'Talk. Lotti turns it into a plan.',
-                'Sprich. Lotti macht einen Plan daraus.',
-              ),
-            ),
+            find.text(_messages(tester).onboardingWelcomeTitle),
             findsOneWidget,
           );
         case _OnboardingCase.providers:

--- a/test/features/onboarding/ui/onboarding_manual_screenshots_test.dart
+++ b/test/features/onboarding/ui/onboarding_manual_screenshots_test.dart
@@ -140,13 +140,27 @@ Widget _app({
   );
 }
 
-enum _OnboardingCase { settings, welcome, providers, firstTask, taskCreated }
+enum _OnboardingCase {
+  settings,
+  welcome,
+  providers,
+  apiKey,
+  success,
+  recordingStyle,
+  categories,
+  firstTask,
+  taskCreated,
+}
 
 extension on _OnboardingCase {
   String get fileName => switch (this) {
     _OnboardingCase.settings => 'settings',
     _OnboardingCase.welcome => 'welcome',
     _OnboardingCase.providers => 'providers',
+    _OnboardingCase.apiKey => 'api_key',
+    _OnboardingCase.success => 'success',
+    _OnboardingCase.recordingStyle => 'recording_style',
+    _OnboardingCase.categories => 'categories',
     _OnboardingCase.firstTask => 'first_task',
     _OnboardingCase.taskCreated => 'task_created',
   };
@@ -500,6 +514,14 @@ void main() {
           );
         case _OnboardingCase.providers:
           await driveToProviders(tester);
+        case _OnboardingCase.apiKey:
+          await driveToApiKey(tester);
+        case _OnboardingCase.success:
+          await driveToSuccess(tester);
+        case _OnboardingCase.recordingStyle:
+          await driveToRecordingStyle(tester);
+        case _OnboardingCase.categories:
+          await driveToCategories(tester);
         case _OnboardingCase.firstTask:
           await driveToFirstTaskListening(tester);
         case _OnboardingCase.taskCreated:

--- a/test/features/projects/ui/pages/projects_manual_screenshots_test.dart
+++ b/test/features/projects/ui/pages/projects_manual_screenshots_test.dart
@@ -24,6 +24,7 @@ import 'package:lotti/classes/journal_entities.dart';
 import 'package:lotti/classes/project_data.dart';
 import 'package:lotti/features/agents/state/agent_providers.dart';
 import 'package:lotti/features/agents/state/project_agent_providers.dart';
+import 'package:lotti/features/design_system/components/task_filters/design_system_filter_shared.dart';
 import 'package:lotti/features/design_system/theme/design_system_theme.dart';
 import 'package:lotti/features/keyboard/ui/app_command_host.dart';
 import 'package:lotti/features/projects/model/projects_overview_models.dart';
@@ -56,6 +57,9 @@ import '../../test_utils.dart';
 const _subdir = 'projects';
 const _projectWaddleId = 'project-waddle';
 String _t(String en, String de) => manualScreenshotText(en: en, de: de);
+
+AppLocalizations _messages(WidgetTester tester) =>
+    AppLocalizations.of(tester.element(find.byType(AppCommandHost)))!;
 
 class _ManualProjectDetailController extends ProjectDetailController {
   _ManualProjectDetailController(this._record) : super(_record.project.meta.id);
@@ -580,12 +584,19 @@ void main() {
         );
         await tester.tap(find.byIcon(Icons.filter_list_rounded));
         await settleFrames(tester, 6);
+        final messages = _messages(tester);
         expect(
-          find.text(_t('Filter projects', 'Projekte filtern')),
+          find.text(messages.projectsFilterTooltip),
           findsOneWidget,
         );
-        expect(find.text(_t('Status', 'Status')), findsOneWidget);
-        expect(find.text(_t('Category', 'Kategorie')), findsOneWidget);
+        expect(
+          find.text(stripTrailingColon(messages.projectsFilterStatusLabel)),
+          findsOneWidget,
+        );
+        expect(
+          find.text(stripTrailingColon(messages.taskCategoryLabel)),
+          findsOneWidget,
+        );
         await captureScreenshot(
           tester,
           'projects_filters_${viewport}_$theme',
@@ -651,15 +662,13 @@ void main() {
           mobile: const ProjectDetailPage(projectId: _projectWaddleId),
           desktop: const ProjectDetailPage(projectId: _projectWaddleId),
         );
-        expect(
-          find.text(_t('Project Details', 'Projektdetails')),
-          findsOneWidget,
-        );
-        expect(find.text(_t('Change status', 'Status ändern')), findsOneWidget);
+        final messages = _messages(tester);
+        expect(find.text(messages.projectDetailTitle), findsOneWidget);
+        expect(find.text(messages.projectStatusChangeTitle), findsOneWidget);
         expect(find.text('Project Waddle'), findsOneWidget);
-        expect(find.text(_t('Target Date', 'Zieldatum')), findsOneWidget);
+        expect(find.text(messages.projectTargetDateLabel), findsOneWidget);
         expect(
-          find.text(_t('Project health', 'Projektgesundheit')),
+          find.text(messages.projectHealthSectionTitle),
           findsOneWidget,
         );
         await captureScreenshot(

--- a/test/features/settings/ui/settings_advanced_manual_screenshots_test.dart
+++ b/test/features/settings/ui/settings_advanced_manual_screenshots_test.dart
@@ -139,8 +139,8 @@ typedef _AdvancedCase = ({
   String id,
   String route,
   Widget Function() mobilePage,
-  String expectedText,
-  String? desktopExpectedText,
+  String Function(AppLocalizations messages) expectedText,
+  String Function(AppLocalizations messages)? desktopExpectedText,
   String? scrollTo,
 });
 
@@ -149,7 +149,7 @@ final List<_AdvancedCase> _cases = [
     id: 'hub',
     route: '/settings/advanced',
     mobilePage: () => const SettingsMobileBranchPage(branchId: 'advanced'),
-    expectedText: _t('Config Flags', 'Konfigurationsflags'),
+    expectedText: (messages) => messages.settingsFlagsTitle,
     desktopExpectedText: null,
     scrollTo: null,
   ),
@@ -157,10 +157,7 @@ final List<_AdvancedCase> _cases = [
     id: 'flags',
     route: '/settings/flags',
     mobilePage: FlagsPage.new,
-    expectedText: _t(
-      'Show private entries?',
-      'Private Einträge anzeigen?',
-    ),
+    expectedText: (messages) => messages.configFlagPrivate,
     desktopExpectedText: null,
     scrollTo: null,
   ),
@@ -168,7 +165,7 @@ final List<_AdvancedCase> _cases = [
     id: 'logging',
     route: '/settings/advanced/logging_domains',
     mobilePage: LoggingSettingsPage.new,
-    expectedText: _t('Enable Logging', 'Protokollierung aktivieren'),
+    expectedText: (messages) => messages.settingsLoggingGlobalToggle,
     desktopExpectedText: null,
     scrollTo: null,
   ),
@@ -176,21 +173,15 @@ final List<_AdvancedCase> _cases = [
     id: 'health_import',
     route: '/settings/advanced',
     mobilePage: HealthImportPage.new,
-    expectedText: _t(
-      'Import Activity Data',
-      'Aktivitätsdaten importieren',
-    ),
-    desktopExpectedText: _t('Config Flags', 'Konfigurationsflags'),
+    expectedText: (messages) => messages.settingsHealthImportActivity,
+    desktopExpectedText: (messages) => messages.settingsFlagsTitle,
     scrollTo: null,
   ),
   (
     id: 'maintenance',
     route: '/settings/advanced/maintenance',
     mobilePage: MaintenancePage.new,
-    expectedText: _t(
-      'Purge deleted items',
-      'Gelöschte Elemente löschen',
-    ),
+    expectedText: (messages) => messages.maintenancePurgeDeleted,
     desktopExpectedText: null,
     scrollTo: null,
   ),
@@ -198,7 +189,7 @@ final List<_AdvancedCase> _cases = [
     id: 'onboarding_metrics',
     route: '/settings/advanced/onboarding_metrics',
     mobilePage: OnboardingMetricsPage.new,
-    expectedText: 'Reached real aha',
+    expectedText: (messages) => messages.onboardingMetricsReachedRealAha,
     desktopExpectedText: null,
     scrollTo: null,
   ),
@@ -206,7 +197,7 @@ final List<_AdvancedCase> _cases = [
     id: 'about',
     route: '/settings/advanced/about',
     mobilePage: AboutPage.new,
-    expectedText: '2604',
+    expectedText: (_) => '2604',
     desktopExpectedText: null,
     scrollTo: null,
   ),
@@ -379,9 +370,13 @@ void main() {
               brightness: brightness,
             );
 
-            final expectedText = device.isPhone
+            final messages = AppLocalizations.of(
+              tester.element(find.byType(Scaffold).first),
+            )!;
+            final expectedText = (device.isPhone
                 ? scenario.expectedText
-                : scenario.desktopExpectedText ?? scenario.expectedText;
+                : scenario.desktopExpectedText ??
+                      scenario.expectedText)(messages);
             expect(find.text(expectedText), findsWidgets);
             expect(tester.takeException(), isNull);
             await captureScreenshot(

--- a/test/features/settings/ui/settings_definitions_screenshots_test.dart
+++ b/test/features/settings/ui/settings_definitions_screenshots_test.dart
@@ -70,6 +70,9 @@ import '../../labels/test_utils.dart';
 const String _subdir = 'settings_definitions';
 String _t(String en, String de) => manualScreenshotText(en: en, de: de);
 
+AppLocalizations _messages(WidgetTester tester) =>
+    AppLocalizations.of(tester.element(find.byType(Scaffold).first))!;
+
 final DateTime _created = manualDemoNow;
 
 // ---------------------------------------------------------------------------
@@ -723,7 +726,10 @@ void main() {
           find.text(_t('Mission Control', 'Missionskontrolle')),
           findsOneWidget,
         );
-        expect(find.text(_t('37 tasks', '37 Aufgaben')), findsOneWidget);
+        expect(
+          find.text(_messages(tester).settingsCategoriesTaskCount(37)),
+          findsOneWidget,
+        );
         await captureScreenshot(
           tester,
           'categories_list_${viewport}_$theme',
@@ -740,7 +746,7 @@ void main() {
           home: CategoryDetailsPage(categoryId: _penguinOperations.id),
         );
         expect(
-          find.text(_t('Edit category', 'Kategorie bearbeiten')),
+          find.text(_messages(tester).settingsCategoriesDetailsLabel),
           findsOneWidget,
         );
         expect(
@@ -761,18 +767,13 @@ void main() {
         );
 
         await tester.scrollUntilVisible(
-          find.text(
-            _t(
-              'Checklist correction examples',
-              'Checklisten-Korrekturbeispiele',
-            ),
-          ),
+          find.text(_messages(tester).correctionExamplesSectionTitle),
           300,
           scrollable: find.byType(Scrollable).first,
         );
         await settleFrames(tester);
         expect(
-          find.text(_t('Speech recognition', 'Spracherkennung')),
+          find.text(_messages(tester).speechDictionarySectionTitle),
           findsOneWidget,
         );
         expect(find.textContaining('Project Waddle'), findsWidgets);
@@ -811,9 +812,7 @@ void main() {
         await settleFrames(tester, 6);
 
         expect(
-          find.text(
-            _t('Choose an inference profile', 'Inferenzprofil auswählen'),
-          ),
+          find.text(_messages(tester).inferenceProfileChooseTitle),
           findsOneWidget,
         );
         expect(
@@ -847,7 +846,7 @@ void main() {
       home: const CategoryDetailsPage(),
     );
     expect(
-      find.text(_t('Create category', 'Kategorie erstellen')),
+      find.text(_messages(tester).settingsCategoriesCreateTitle),
       findsOneWidget,
     );
     await captureScreenshot(
@@ -868,7 +867,7 @@ void main() {
       home: const CategoriesListPage(),
     );
     expect(
-      find.text(_t('No categories yet', 'Noch keine Kategorien')),
+      find.text(_messages(tester).settingsCategoriesEmptyState),
       findsOneWidget,
     );
     await captureScreenshot(
@@ -924,7 +923,10 @@ void main() {
           find.text(_t('Habitat critical', 'Habitatkritisch')),
           findsOneWidget,
         );
-        expect(find.text(_t('14 tasks', '14 Aufgaben')), findsOneWidget);
+        expect(
+          find.text(_messages(tester).settingsLabelsUsageCount(14)),
+          findsOneWidget,
+        );
         await captureScreenshot(
           tester,
           'labels_list_${viewport}_$theme',
@@ -941,7 +943,7 @@ void main() {
           home: LabelDetailsPage(labelId: _projectWaddle.id),
         );
         expect(
-          find.text(_t('Edit label', 'Label bearbeiten')),
+          find.text(_messages(tester).settingsLabelsEditTitle),
           findsOneWidget,
         );
         expect(find.text('Project Waddle'), findsOneWidget);
@@ -975,7 +977,7 @@ void main() {
       home: LabelDetailsPage(labelId: _projectWaddle.id),
     );
     expect(
-      find.text(_t('Edit label', 'Label bearbeiten')),
+      find.text(_messages(tester).settingsLabelsEditTitle),
       findsOneWidget,
     );
     await captureScreenshot(
@@ -1035,7 +1037,7 @@ void main() {
           home: EditHabitPage(habitId: _rollCall.id),
         );
         expect(
-          find.text(_t('Edit habit', 'Gewohnheit bearbeiten')),
+          find.text(_messages(tester).settingsHabitsDetailsLabel),
           findsOneWidget,
         );
         expect(
@@ -1055,15 +1057,21 @@ void main() {
         );
 
         await tester.scrollUntilVisible(
-          find.text(_t('Schedule', 'Zeitplan')),
+          find.text(_messages(tester).habitSectionScheduleTitle),
           300,
           scrollable: find.byType(Scrollable).first,
         );
         await settleFrames(tester);
-        expect(find.text(_t('Start date', 'Startdatum')), findsOneWidget);
-        expect(find.text(_t('Show from', 'Anzeigen ab')), findsOneWidget);
         expect(
-          find.text(_t('Show alert at', 'Alarm anzeigen um')),
+          find.text(_messages(tester).habitActiveFromLabel),
+          findsOneWidget,
+        );
+        expect(
+          find.text(_messages(tester).habitShowFromLabel),
+          findsOneWidget,
+        );
+        expect(
+          find.text(_messages(tester).habitShowAlertAtLabel),
           findsOneWidget,
         );
         await captureScreenshot(
@@ -1127,7 +1135,7 @@ void main() {
           home: MeasurableDetailsPage(dataType: _habitatPressure),
         );
         expect(
-          find.text(_t('Edit measurable', 'Messgröße bearbeiten')),
+          find.text(_messages(tester).settingsMeasurableDetailsLabel),
           findsOneWidget,
         );
         expect(
@@ -1136,7 +1144,7 @@ void main() {
         );
         expect(find.text('kPa'), findsOneWidget);
         expect(
-          find.text(_t('Daily average', 'Tagesdurchschnitt')),
+          find.text(_messages(tester).dashboardAggregationDailyAverage),
           findsOneWidget,
         );
         await captureScreenshot(
@@ -1221,28 +1229,22 @@ void main() {
         await settleFrames(tester);
         expect(
           find.text(
-            _t(
-              'Habitat pressure — Daily average',
-              'Habitatdruck — Tagesdurchschnitt',
-            ),
+            '${_habitatPressure.displayName} '
+            '— ${messages.dashboardAggregationDailyAverage}',
           ),
           findsOneWidget,
         );
         expect(
           find.text(
-            _t(
-              'Sardines consumed — Daily sum',
-              'Verzehrte Sardinen — Tagessumme',
-            ),
+            '${_sardinesConsumed.displayName} '
+            '— ${messages.aggregationDailySum}',
           ),
           findsOneWidget,
         );
         expect(
           find.text(
-            _t(
-              'Penguins accounted for — Daily sum',
-              'Gezählte Pinguine — Tagessumme',
-            ),
+            '${_penguinsAccountedFor.displayName} '
+            '— ${messages.aggregationDailySum}',
           ),
           findsOneWidget,
         );
@@ -1255,14 +1257,15 @@ void main() {
 
         _alignInOuterScrollView(
           tester,
-          find.text(
-            _t('Add charts by type', 'Diagramme nach Typ hinzufügen'),
-          ),
+          find.text(messages.dashboardAvailableChartsTitle),
         );
         await settleFrames(tester);
-        expect(find.text(_t('Habits', 'Gewohnheiten')), findsOneWidget);
-        expect(find.text(_t('Measurements', 'Messungen')), findsOneWidget);
-        expect(find.text(_t('Health', 'Gesundheit')), findsOneWidget);
+        expect(find.text(messages.dashboardAddHabitButton), findsOneWidget);
+        expect(
+          find.text(messages.dashboardAddMeasurementButton),
+          findsOneWidget,
+        );
+        expect(find.text(messages.dashboardAddHealthButton), findsOneWidget);
         await captureScreenshot(
           tester,
           'dashboards_sources_${viewport}_$theme',

--- a/test/features/settings/ui/settings_home_screenshots_test.dart
+++ b/test/features/settings/ui/settings_home_screenshots_test.dart
@@ -44,7 +44,9 @@ import '../../../widget_test_utils.dart';
 import '../../daily_os_next/screenshot_harness.dart';
 
 const String _subdir = 'settings_home';
-String _t(String en, String de) => manualScreenshotText(en: en, de: de);
+
+AppLocalizations _messages(WidgetTester tester) =>
+    AppLocalizations.of(tester.element(find.byType(Scaffold).first))!;
 
 /// Config-flag values driving the rendered tree/list: a rich-but-quiet
 /// surface (Matrix/Sync, Habits, Dashboards on; What's New off so the
@@ -196,9 +198,10 @@ void main() {
       home: const SettingsRootPage(),
     );
     // Top-level tree leaves prove the V2 tree rendered.
-    expect(find.text(_t('Theming', 'Farbschema')), findsOneWidget);
+    final messages = _messages(tester);
+    expect(find.text(messages.settingsThemingTitle), findsOneWidget);
     expect(
-      find.text(_t('Advanced Settings', 'Erweiterte Einstellungen')),
+      find.text(messages.settingsAdvancedTitle),
       findsOneWidget,
     );
     await captureScreenshot(
@@ -216,9 +219,10 @@ void main() {
       overrides: baseOverrides(),
       home: const SettingsRootPage(),
     );
-    expect(find.text(_t('Theming', 'Farbschema')), findsOneWidget);
+    final messages = _messages(tester);
+    expect(find.text(messages.settingsThemingTitle), findsOneWidget);
     expect(
-      find.text(_t('Advanced Settings', 'Erweiterte Einstellungen')),
+      find.text(messages.settingsAdvancedTitle),
       findsOneWidget,
     );
     await captureScreenshot(
@@ -240,9 +244,10 @@ void main() {
       home: const SettingsRootPage(),
     );
     // Legacy single-page list rows.
-    expect(find.text(_t('Theming', 'Farbschema')), findsOneWidget);
+    final messages = _messages(tester);
+    expect(find.text(messages.settingsThemingTitle), findsOneWidget);
     expect(
-      find.text(_t('Advanced Settings', 'Erweiterte Einstellungen')),
+      find.text(messages.settingsAdvancedTitle),
       findsOneWidget,
     );
     await captureScreenshot(
@@ -260,9 +265,10 @@ void main() {
       overrides: baseOverrides(),
       home: const SettingsRootPage(),
     );
-    expect(find.text(_t('Theming', 'Farbschema')), findsOneWidget);
+    final messages = _messages(tester);
+    expect(find.text(messages.settingsThemingTitle), findsOneWidget);
     expect(
-      find.text(_t('Advanced Settings', 'Erweiterte Einstellungen')),
+      find.text(messages.settingsAdvancedTitle),
       findsOneWidget,
     );
     await captureScreenshot(
@@ -291,12 +297,13 @@ void main() {
       );
       await _openDesktopDefinitions(tester);
 
-      expect(find.text(_t('Definitions', 'Definitionen')), findsWidgets);
-      expect(find.text(_t('Categories', 'Kategorien')), findsOneWidget);
-      expect(find.text(_t('Labels', 'Labels')), findsOneWidget);
-      expect(find.text(_t('Habits', 'Gewohnheiten')), findsOneWidget);
-      expect(find.text(_t('Dashboards', 'Dashboards')), findsOneWidget);
-      expect(find.text(_t('Measurables', 'Messgrößen')), findsOneWidget);
+      final messages = _messages(tester);
+      expect(find.text(messages.settingsDefinitionsTitle), findsWidgets);
+      expect(find.text(messages.settingsCategoriesTitle), findsOneWidget);
+      expect(find.text(messages.settingsLabelsTitle), findsOneWidget);
+      expect(find.text(messages.settingsHabitsTitle), findsOneWidget);
+      expect(find.text(messages.settingsDashboardsTitle), findsOneWidget);
+      expect(find.text(messages.settingsMeasurablesTitle), findsOneWidget);
       await captureScreenshot(
         tester,
         'desktop_settings_definitions_$themeName',
@@ -313,12 +320,13 @@ void main() {
         home: const SettingsMobileBranchPage(branchId: 'definitions'),
       );
 
-      expect(find.text(_t('Definitions', 'Definitionen')), findsOneWidget);
-      expect(find.text(_t('Categories', 'Kategorien')), findsOneWidget);
-      expect(find.text(_t('Labels', 'Labels')), findsOneWidget);
-      expect(find.text(_t('Habits', 'Gewohnheiten')), findsOneWidget);
-      expect(find.text(_t('Dashboards', 'Dashboards')), findsOneWidget);
-      expect(find.text(_t('Measurables', 'Messgrößen')), findsOneWidget);
+      final messages = _messages(tester);
+      expect(find.text(messages.settingsDefinitionsTitle), findsOneWidget);
+      expect(find.text(messages.settingsCategoriesTitle), findsOneWidget);
+      expect(find.text(messages.settingsLabelsTitle), findsOneWidget);
+      expect(find.text(messages.settingsHabitsTitle), findsOneWidget);
+      expect(find.text(messages.settingsDashboardsTitle), findsOneWidget);
+      expect(find.text(messages.settingsMeasurablesTitle), findsOneWidget);
       await captureScreenshot(
         tester,
         'mobile_settings_definitions_$themeName',

--- a/test/features/settings/ui/settings_preferences_screenshots_test.dart
+++ b/test/features/settings/ui/settings_preferences_screenshots_test.dart
@@ -53,6 +53,9 @@ import '../../onboarding/state/recording_style_test_utils.dart';
 const String _subdir = 'settings_preferences';
 String _t(String en, String de) => manualScreenshotText(en: en, de: de);
 
+AppLocalizations _messages(WidgetTester tester) =>
+    AppLocalizations.of(tester.element(find.byType(Scaffold).first))!;
+
 enum _PreferenceSurface {
   theming('/settings/theming'),
   recordingStyle('/settings/recording-style'),
@@ -288,7 +291,8 @@ void main() {
             navService: navService,
             overrides: overrides(),
           );
-          expect(find.text(_t('Theming', 'Farbschema')), findsWidgets);
+          final messages = _messages(tester);
+          expect(find.text(messages.settingsThemingTitle), findsWidgets);
           expect(find.text('Sakura'), findsOneWidget);
           expect(find.text('Outer Space'), findsOneWidget);
           await captureScreenshot(
@@ -330,11 +334,11 @@ void main() {
             findsWidgets,
           );
           expect(
-            find.text(_t('Modern — energy orb', 'Modern — Energie-Orb')),
+            find.text(messages.onboardingRecordingStyleModern),
             findsOneWidget,
           );
           expect(
-            find.text(_t('Analogue — VU meter', 'Analog — VU-Meter')),
+            find.text(messages.onboardingRecordingStyleAnalogue),
             findsOneWidget,
           );
           expect(
@@ -361,20 +365,33 @@ void main() {
             navService: navService,
             overrides: overrides(),
           );
-          expect(find.text(_t('Speech', 'Sprache')), findsWidgets);
-          expect(find.text(_t('Male 3', 'Männlich 3')), findsOneWidget);
-          expect(find.text(_t('Voice', 'Stimme')), findsOneWidget);
+          final messages = _messages(tester);
+          expect(find.text(messages.settingsSpeechTitle), findsWidgets);
+          expect(
+            find.text('${messages.speechVoiceGenderMale} 3'),
+            findsOneWidget,
+          );
+          expect(find.text(messages.speechSettingsVoiceLabel), findsOneWidget);
           await captureScreenshot(
             tester,
             'speech_voice_${viewport}_$theme',
             subdir: _subdir,
           );
 
-          await tester.tap(find.text(_t('Female', 'Weiblich')).last);
+          await tester.tap(find.text(messages.speechVoiceGenderFemale).last);
           await settleFrames(tester, 4);
-          expect(find.text(_t('Female 1', 'Weiblich 1')), findsOneWidget);
-          expect(find.text(_t('Female 5', 'Weiblich 5')), findsOneWidget);
-          expect(find.text(_t('Male 3', 'Männlich 3')), findsNothing);
+          expect(
+            find.text('${messages.speechVoiceGenderFemale} 1'),
+            findsOneWidget,
+          );
+          expect(
+            find.text('${messages.speechVoiceGenderFemale} 5'),
+            findsOneWidget,
+          );
+          expect(
+            find.text('${messages.speechVoiceGenderMale} 3'),
+            findsNothing,
+          );
           await captureScreenshot(
             tester,
             'speech_voice_options_${viewport}_$theme',
@@ -394,17 +411,19 @@ void main() {
             navService: navService,
             overrides: overrides(),
           );
+          final messages = _messages(tester);
           expect(
-            find.text(_t('Keyboard shortcuts', 'Tastaturkurzbefehle')),
+            find.text(messages.keyboardShortcutsTitle),
             findsWidgets,
           );
           expect(
-            find.text(
-              _t('Open command palette', 'Befehlspalette öffnen'),
-            ),
+            find.text(messages.keyboardCommandOpenPalette),
             findsOneWidget,
           );
-          expect(find.text(_t('General', 'Allgemein')), findsOneWidget);
+          expect(
+            find.text(messages.keyboardCommandCategoryGeneral),
+            findsOneWidget,
+          );
           await captureScreenshot(
             tester,
             'keyboard_shortcuts_catalog_${viewport}_$theme',
@@ -416,12 +435,14 @@ void main() {
           await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
           await settleFrames(tester, 4);
           expect(
-            find.text(_t('Command palette', 'Befehlspalette')),
+            find.text(messages.commandPaletteTitle),
             findsOneWidget,
           );
-          expect(find.text(_t('Task', 'Aufgabe')), findsWidgets);
+          expect(find.text(messages.fileMenuNewTask), findsWidgets);
           expect(
-            find.text(_t('Go to Tasks', 'Zu Aufgaben wechseln')),
+            find.text(
+              messages.keyboardCommandNavigate(messages.navTabTitleTasks),
+            ),
             findsWidgets,
           );
           await captureScreenshot(
@@ -431,29 +452,24 @@ void main() {
           );
 
           Navigator.of(
-            tester.element(find.text(_t('Command palette', 'Befehlspalette'))),
+            tester.element(find.text(messages.commandPaletteTitle)),
           ).pop();
           await settleFrames(tester, 4);
           expect(
-            find.text(_t('Command palette', 'Befehlspalette')),
+            find.text(messages.commandPaletteTitle),
             findsNothing,
           );
 
           await tester.enterText(
             find.byType(TextField),
-            _t('rename', 'umbenennen'),
+            messages.keyboardCommandRename,
           );
           await settleFrames(tester, 4);
           expect(
-            find.text(
-              _t(
-                'Rename focused item',
-                'Fokussiertes Element umbenennen',
-              ),
-            ),
+            find.text(messages.keyboardCommandRename).last,
             findsOneWidget,
           );
-          expect(find.text(_t('Task', 'Aufgabe')), findsNothing);
+          expect(find.text(messages.fileMenuNewTask), findsNothing);
           await captureScreenshot(
             tester,
             'keyboard_shortcuts_search_${viewport}_$theme',
@@ -473,15 +489,14 @@ void main() {
             navService: navService,
             overrides: overrides(),
           );
-          expect(find.text(_t('Animations', 'Animationen')), findsWidgets);
+          final messages = _messages(tester);
+          expect(find.text(messages.settingsCelebrationsTitle), findsWidgets);
           expect(
-            find.text(
-              _t('Celebration animations', 'Abschluss-Animationen'),
-            ),
+            find.text(messages.settingsCelebrationsEnabledTitle),
             findsOneWidget,
           );
           expect(
-            find.text(_t('Completion haptics', 'Abschluss-Haptik')),
+            find.text(messages.settingsCelebrationsHapticsTitle),
             findsOneWidget,
           );
           await captureScreenshot(
@@ -490,16 +505,22 @@ void main() {
             subdir: _subdir,
           );
 
-          final style = find.text(_t('Style', 'Stil'));
+          final style = find.text(messages.settingsCelebrationsStyleTitle);
           expect(style, findsOneWidget);
           _alignInOuterScrollView(tester, style);
           await settleFrames(tester, 4);
-          expect(find.text(_t('Sparks', 'Funken')), findsOneWidget);
           expect(
-            find.text(_t('Combine two', 'Zwei kombinieren')),
+            find.text(messages.settingsCelebrationsVariantSparks),
             findsOneWidget,
           );
-          expect(find.text(_t('Try it', 'Ausprobieren')), findsOneWidget);
+          expect(
+            find.text(messages.settingsCelebrationsVariantCombine),
+            findsOneWidget,
+          );
+          expect(
+            find.text(messages.settingsCelebrationsPreviewTitle),
+            findsOneWidget,
+          );
           await captureScreenshot(
             tester,
             'celebrations_styles_${viewport}_$theme',
@@ -528,17 +549,19 @@ void main() {
             ),
           );
           await settleFrames(tester, 6);
-          expect(find.text(_t('Sparks', 'Funken')), findsOneWidget);
+          final messages = _messages(tester);
           expect(
-            find.text(
-              _t(
-                'Changes save and apply everywhere instantly',
-                'Änderungen werden sofort überall gespeichert und angewendet',
-              ),
-            ),
+            find.text(messages.settingsCelebrationsVariantSparks),
             findsOneWidget,
           );
-          expect(find.text(_t('Shape', 'Form')), findsOneWidget);
+          expect(
+            find.text(messages.settingsCelebrationsPlaygroundLiveNote),
+            findsOneWidget,
+          );
+          expect(
+            find.text(messages.settingsCelebrationsGroupShape),
+            findsOneWidget,
+          );
           await captureScreenshot(
             tester,
             'celebrations_playground_${viewport}_$theme',

--- a/test/features/speech/ui/widgets/recording/audio_recording_manual_screenshots_test.dart
+++ b/test/features/speech/ui/widgets/recording/audio_recording_manual_screenshots_test.dart
@@ -24,6 +24,8 @@ import '../../../../daily_os_next/screenshot_harness.dart';
 const _linkedTaskId = 'payment-confirmation';
 const _categoryId = 'focused-work';
 String _t(String en, String de) => manualScreenshotText(en: en, de: de);
+AppLocalizations _messages(WidgetTester tester) =>
+    AppLocalizations.of(tester.element(find.byType(Scaffold).first))!;
 const ValueKey<String> _openRecordingKey = ValueKey<String>(
   'open-audio-recording',
 );
@@ -60,14 +62,15 @@ void main() {
           device: device,
           brightness: brightness,
         );
+        final messages = _messages(tester);
 
         expect(find.byType(AudioRecordingModalContent), findsOneWidget);
         expect(find.text('0:00:42'), findsOneWidget);
-        expect(find.text(_t('STOP', 'STOPP')), findsOneWidget);
+        expect(find.text(messages.audioRecordingStop), findsOneWidget);
         expect(
           find.widgetWithText(
             LottiAnimatedCheckbox,
-            'Speech Recognition',
+            messages.speechModalTitle,
           ),
           findsOneWidget,
         );

--- a/test/features/speech/ui/widgets/recording/audio_recording_modal_test.dart
+++ b/test/features/speech/ui/widgets/recording/audio_recording_modal_test.dart
@@ -155,6 +155,13 @@ AppPrefs _neverResolvingRecordingStylePrefs() => AppPrefs(
   setString: ({required key, required value}) async => true,
 );
 
+Finder _speechRecognitionCheckbox(WidgetTester tester) => find.widgetWithText(
+  LottiAnimatedCheckbox,
+  AppLocalizations.of(
+    tester.element(find.byType(Scaffold).first),
+  )!.speechModalTitle,
+);
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -360,6 +367,8 @@ void main() {
 
           return MaterialApp(
             theme: DesignSystemTheme.light(),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
             home: Scaffold(
               body: AudioRecordingModalContent(
                 categoryId: provideCategory ? 'test-category' : null,
@@ -387,7 +396,7 @@ void main() {
       await tester.pump();
 
       expect(
-        find.widgetWithText(LottiAnimatedCheckbox, 'Speech Recognition'),
+        _speechRecognitionCheckbox(tester),
         findsOneWidget,
       );
     });
@@ -403,7 +412,7 @@ void main() {
       await tester.pump();
 
       expect(
-        find.widgetWithText(LottiAnimatedCheckbox, 'Speech Recognition'),
+        _speechRecognitionCheckbox(tester),
         findsNothing,
       );
     });
@@ -543,6 +552,8 @@ void main() {
           overrides: baseOverrides(),
           child: MaterialApp(
             theme: resolveTestTheme(),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
             home: Builder(
               builder: (context) {
                 return Scaffold(
@@ -1743,6 +1754,8 @@ void main() {
 
             return MaterialApp(
               theme: DesignSystemTheme.light(),
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
               home: Scaffold(
                 body: AudioRecordingModalContent(
                   categoryId: 'test-category',
@@ -1787,7 +1800,7 @@ void main() {
 
       // Speech recognition checkbox should be visible for a Task
       expect(
-        find.widgetWithText(LottiAnimatedCheckbox, 'Speech Recognition'),
+        _speechRecognitionCheckbox(tester),
         findsOneWidget,
       );
     });
@@ -1855,6 +1868,8 @@ void main() {
 
               return MaterialApp(
                 theme: DesignSystemTheme.light(),
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
                 home: const Scaffold(
                   body: AudioRecordingModalContent(
                     categoryId: 'test-category',
@@ -1873,7 +1888,7 @@ void main() {
 
       // Only speech recognition checkbox should be visible, not task-specific ones
       expect(
-        find.widgetWithText(LottiAnimatedCheckbox, 'Speech Recognition'),
+        _speechRecognitionCheckbox(tester),
         findsOneWidget,
       );
     });
@@ -1935,6 +1950,8 @@ void main() {
 
               return MaterialApp(
                 theme: DesignSystemTheme.light(),
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
                 home: const Scaffold(
                   body: AudioRecordingModalContent(
                     categoryId: 'test-category',
@@ -1953,7 +1970,7 @@ void main() {
 
       // Only speech recognition should be visible
       expect(
-        find.widgetWithText(LottiAnimatedCheckbox, 'Speech Recognition'),
+        _speechRecognitionCheckbox(tester),
         findsOneWidget,
       );
     });
@@ -2010,6 +2027,8 @@ void main() {
 
               return MaterialApp(
                 theme: DesignSystemTheme.light(),
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
                 home: const Scaffold(
                   body: AudioRecordingModalContent(
                     categoryId: 'test-category',
@@ -2028,7 +2047,7 @@ void main() {
 
       // Only speech recognition visible, task checkboxes hidden
       expect(
-        find.widgetWithText(LottiAnimatedCheckbox, 'Speech Recognition'),
+        _speechRecognitionCheckbox(tester),
         findsOneWidget,
       );
     });
@@ -2087,6 +2106,9 @@ void main() {
 
                 return MaterialApp(
                   theme: DesignSystemTheme.light(),
+                  localizationsDelegates:
+                      AppLocalizations.localizationsDelegates,
+                  supportedLocales: AppLocalizations.supportedLocales,
                   home: const Scaffold(
                     body: AudioRecordingModalContent(
                       categoryId: 'test-category',
@@ -2105,7 +2127,7 @@ void main() {
 
         // Only speech recognition visible
         expect(
-          find.widgetWithText(LottiAnimatedCheckbox, 'Speech Recognition'),
+          _speechRecognitionCheckbox(tester),
           findsOneWidget,
         );
       },
@@ -2165,6 +2187,8 @@ void main() {
 
               return MaterialApp(
                 theme: DesignSystemTheme.light(),
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
                 home: const Scaffold(
                   body: AudioRecordingModalContent(
                     categoryId: 'test-category',
@@ -2183,7 +2207,7 @@ void main() {
 
       // All checkboxes visible optimistically during loading
       expect(
-        find.widgetWithText(LottiAnimatedCheckbox, 'Speech Recognition'),
+        _speechRecognitionCheckbox(tester),
         findsOneWidget,
       );
     });
@@ -2241,6 +2265,8 @@ void main() {
 
               return MaterialApp(
                 theme: DesignSystemTheme.light(),
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
                 home: const Scaffold(
                   body: AudioRecordingModalContent(
                     categoryId: 'test-category',
@@ -2261,7 +2287,7 @@ void main() {
 
       // Only speech recognition visible on error
       expect(
-        find.widgetWithText(LottiAnimatedCheckbox, 'Speech Recognition'),
+        _speechRecognitionCheckbox(tester),
         findsOneWidget,
       );
     });
@@ -2339,6 +2365,9 @@ void main() {
 
                 return MaterialApp(
                   theme: DesignSystemTheme.light(),
+                  localizationsDelegates:
+                      AppLocalizations.localizationsDelegates,
+                  supportedLocales: AppLocalizations.supportedLocales,
                   home: const Scaffold(
                     body: AudioRecordingModalContent(
                       categoryId: 'test-category',
@@ -2357,7 +2386,7 @@ void main() {
 
         // Speech checkbox visible via profile-driven transcription
         expect(
-          find.widgetWithText(LottiAnimatedCheckbox, 'Speech Recognition'),
+          _speechRecognitionCheckbox(tester),
           findsOneWidget,
         );
       },

--- a/test/features/sync/ui/sync_manual_screenshots_test.dart
+++ b/test/features/sync/ui/sync_manual_screenshots_test.dart
@@ -804,8 +804,6 @@ void main() {
           find.textContaining(messages.settingsMatrixMetrics),
           findsOneWidget,
         );
-        expect(find.text('Top KPIs'), findsOneWidget);
-        expect(find.text('Processed'), findsWidgets);
       case _SyncSurface.outbox:
         expect(
           find.text(
@@ -826,7 +824,7 @@ void main() {
           find.text(messages.syncListCountSummary(label, 2)),
           findsOneWidget,
         );
-        expect(find.text(_t('Task', 'Aufgabe')), findsOneWidget);
+        expect(find.text(messages.entryTypeLabelTask), findsOneWidget);
       case _SyncSurface.conflictDetail:
         expect(find.text(messages.conflictFieldTitle), findsOneWidget);
         expect(find.text(messages.conflictFieldBody), findsOneWidget);

--- a/test/features/tasks/ui/widgets/task_action_bar_test.dart
+++ b/test/features/tasks/ui/widgets/task_action_bar_test.dart
@@ -793,7 +793,7 @@ void main() {
     (tester) async {
       // Outer 420 → inner ~388, which is at-or-above
       // [TaskActionBar.minWidthForChecklistButton] (340) and below
-      // [TaskActionBar.minWidthForImageButton] (400).
+      // [TaskActionBar.minWidthForImageButton] (416).
       await tester.binding.setSurfaceSize(const Size(420, 800));
       addTearDown(() => tester.binding.setSurfaceSize(null));
 
@@ -822,6 +822,29 @@ void main() {
 
       expect(find.byKey(TaskActionBar.imageKey), findsOneWidget);
       expect(find.byKey(TaskActionBar.checklistKey), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'uses the compact affordance set before French Track time text overflows',
+    (tester) async {
+      // Outer 440 → inner ~408. The localized "Suivre le temps" pill is
+      // wider than English, so this must stay below the image threshold.
+      tester.binding.platformDispatcher.localeTestValue = const Locale('fr');
+      addTearDown(tester.binding.platformDispatcher.clearLocaleTestValue);
+      await tester.binding.setSurfaceSize(const Size(440, 800));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await pumpBar(tester);
+
+      expect(find.byKey(TaskActionBar.imageKey), findsNothing);
+      expect(find.byKey(TaskActionBar.checklistKey), findsOneWidget);
+      expectSingleRowWithin(tester, const [
+        TaskActionBar.trackTimeKey,
+        TaskActionBar.audioKey,
+        TaskActionBar.checklistKey,
+        TaskActionBar.moreKey,
+      ]);
     },
   );
 }

--- a/test/features/tasks/ui/widgets/task_manual_screenshots_test.dart
+++ b/test/features/tasks/ui/widgets/task_manual_screenshots_test.dart
@@ -87,8 +87,8 @@ final String _manualTaskAgentTldr = _t(
       'bei 101,3 kPa; als einziges Startrisiko bleibt die Kalibrierung des '
       'Schwerelos-Futterautomaten.',
 );
-final String _manualTaskAgentReport = _t(
-  '''
+final String _manualTaskAgentReport = manualScreenshotText(
+  en: '''
 ## Latest assessment
 
 - Pressure seals A–F stayed stable across the night shift.
@@ -99,7 +99,7 @@ final String _manualTaskAgentReport = _t(
 
 Run the feeder test, attach the telemetry image, then request launch approval.
 ''',
-  '''
+  de: '''
 ## Aktuelle Einschätzung
 
 - Die Druckdichtungen A–F blieben während der Nachtschicht stabil.
@@ -109,6 +109,17 @@ Run the feeder test, attach the telemetry image, then request launch approval.
 ## Empfohlener nächster Schritt
 
 Führe den Automatentest aus, hänge das Telemetriebild an und fordere dann die Startfreigabe an.
+''',
+  fr: '''
+## Dernière évaluation
+
+- Les joints de pression A–F sont restés stables pendant l'équipe de nuit.
+- 840 sardines sont chargées ; le calibrage du distributeur bloque toujours la validation.
+- L'autorisation de Mission Control est attendue avant l'appel de 6 h 30.
+
+## Prochaine étape recommandée
+
+Lance le test du distributeur, joins l'image de télémétrie puis demande l'autorisation de lancement.
 ''',
 );
 
@@ -519,34 +530,28 @@ void main() {
         );
 
         await _focusTaskAgentCard(tester, device: device);
+        final messages = AppLocalizations.of(
+          tester.element(find.byType(TaskDetailsPage)),
+        )!;
         expect(
-          find.text(_t('AI summary', 'KI-Zusammenfassung')),
+          find.text(messages.aiCardTitle),
           findsOneWidget,
         );
         expect(find.text(_manualTaskAgentName), findsOneWidget);
         expect(find.text(_manualTaskAgentTldr), findsOneWidget);
-        final messages = AppLocalizations.of(
-          tester.element(find.byType(TaskDetailsPage)),
-        )!;
         expect(
           find.text(messages.taskAgentAutomaticUpdatesLabel),
           findsOneWidget,
         );
         expect(
-          find.text(
-            _t(
-              'Bundle task changes and update after two minutes.',
-              'Aufgabenänderungen werden gebündelt und nach zwei Minuten '
-                  'aktualisiert.',
-            ),
-          ),
+          find.text(messages.taskAgentAutomaticUpdatesSummary),
           findsOneWidget,
         );
         expect(
           find.textContaining(_t('Waddle Command 70B', 'Watschelkommando 70B')),
           findsOneWidget,
         );
-        expect(find.text(_t('Read more', 'Mehr lesen')), findsOneWidget);
+        expect(find.text(messages.aiCardReadMore), findsOneWidget);
         await captureScreenshot(
           tester,
           'task_agent_collapsed_${viewport}_$theme',
@@ -568,6 +573,9 @@ void main() {
         );
 
         await _focusTaskAgentCard(tester, device: device);
+        final messages = AppLocalizations.of(
+          tester.element(find.byType(TaskDetailsPage)),
+        )!;
         await tester.tap(
           find.byKey(const ValueKey('taskAgentReportDisclosure')),
         );
@@ -584,10 +592,10 @@ void main() {
           findsOneWidget,
         );
         expect(
-          find.text(_t('Open agent internals', 'Agent-Internes öffnen')),
+          find.text(messages.aiCardOpenAgentInternals),
           findsOneWidget,
         );
-        expect(find.text(_t('Show less', 'Weniger anzeigen')), findsOneWidget);
+        expect(find.text(messages.aiCardShowLess), findsOneWidget);
         await captureScreenshot(
           tester,
           'task_agent_expanded_${viewport}_$theme',
@@ -666,28 +674,14 @@ void main() {
           findsOneWidget,
         );
         expect(
-          find.text(
-            _t(
-              'This summary is out of date',
-              'Diese Zusammenfassung ist veraltet',
-            ),
-          ),
+          find.text(messages.taskAgentReportOutdatedTitle),
           findsOneWidget,
         );
         expect(
-          find.text(
-            _t(
-              'The task changed after this summary was generated.',
-              'Die Aufgabe hat sich geändert, nachdem diese Zusammenfassung '
-                  'erstellt wurde.',
-            ),
-          ),
+          find.text(messages.taskAgentReportOutdatedDescription),
           findsOneWidget,
         );
-        expect(
-          find.text(_t('Wake agent', 'Agenten aufwecken')),
-          findsOneWidget,
-        );
+        expect(find.text(messages.taskAgentWakeAgent), findsOneWidget);
         await captureScreenshot(
           tester,
           'task_agent_manual_${viewport}_$theme',
@@ -708,8 +702,11 @@ void main() {
 
         await tester.tap(find.byIcon(Icons.filter_list_rounded).first);
         await settleFrames(tester, 6);
+        final messages = AppLocalizations.of(
+          tester.element(find.byType(TasksRootPage)),
+        )!;
         expect(
-          find.text(_t('Filter tasks', 'Aufgaben filtern')),
+          find.text(messages.tasksFilterTitle),
           findsOneWidget,
         );
         expect(
@@ -750,8 +747,11 @@ void main() {
 
         await tester.tap(find.byIcon(Icons.assistant_outlined));
         await settleFrames(tester, 6);
-        expect(find.text(_t('Generate…', 'Generieren…')), findsOneWidget);
-        expect(find.text(_t('Skills', 'Skills')), findsOneWidget);
+        final messages = AppLocalizations.of(
+          tester.element(find.byType(EntryDetailsWidget)),
+        )!;
+        expect(find.text(messages.aiAssistantTitle), findsOneWidget);
+        expect(find.text(messages.skillsSectionTitle), findsOneWidget);
         expect(
           find.text(_t('Inspect habitat photo', 'Habitatfoto prüfen')),
           findsOneWidget,
@@ -791,13 +791,11 @@ void main() {
           ),
         );
         await settleFrames(tester, 8);
-        expect(find.text(_t('Add', 'Hinzufügen')), findsOneWidget);
-        expect(find.text(_t('Checklist', 'Checkliste')), findsOneWidget);
-        expect(
-          find.text(_t('Audio Recording', 'Audioaufnahme')),
-          findsOneWidget,
-        );
-        expect(find.text(_t('Timer', 'Timer')), findsOneWidget);
+        final messages = AppLocalizations.of(context)!;
+        expect(find.text(messages.createEntryTitle), findsOneWidget);
+        expect(find.text(messages.addActionAddChecklist), findsOneWidget);
+        expect(find.text(messages.addActionAddAudioRecording), findsOneWidget);
+        expect(find.text(messages.addActionAddTimer), findsOneWidget);
         await captureScreenshot(
           tester,
           'create_entry_task_${viewport}_$theme',
@@ -867,11 +865,11 @@ void main() {
           subdir: 'manual',
         );
 
-        await tester.tap(find.text(_t('Continue', 'Weiter')));
+        await tester.tap(find.text(messages.referenceImageContinue));
         await settleFrames(tester, 8);
         await tester.pump(const Duration(milliseconds: 720));
         expect(
-          find.text(_t('Generating image...', 'Bild wird generiert...')),
+          find.text(messages.imageGenerationGenerating),
           findsOneWidget,
         );
         await captureScreenshot(
@@ -903,13 +901,11 @@ void main() {
           ),
         );
         await settleFrames(tester, 30);
+        final messages = AppLocalizations.of(
+          tester.element(find.byType(TaskDetailsPage)),
+        )!;
         expect(
-          find.text(
-            _t(
-              'Link existing task...',
-              'Vorhandene Aufgabe verknüpfen...',
-            ),
-          ),
+          find.text(messages.linkExistingTask),
           findsOneWidget,
         );
         expect(
@@ -1114,7 +1110,10 @@ Future<void> _focusTaskAgentCard(
   WidgetTester tester, {
   required ScreenshotDevice device,
 }) async {
-  final summary = find.text(_t('AI summary', 'KI-Zusammenfassung'));
+  final messages = AppLocalizations.of(
+    tester.element(find.byType(TaskDetailsPage)),
+  )!;
+  final summary = find.text(messages.aiCardTitle);
   final scrollable = find.byType(Scrollable).first;
   await tester.scrollUntilVisible(
     summary,

--- a/test/features/whats_new/ui/whats_new_manual_screenshots_test.dart
+++ b/test/features/whats_new/ui/whats_new_manual_screenshots_test.dart
@@ -44,6 +44,9 @@ const _sardineBannerUrl =
     'https://manual.invalid/project-waddle-sardine-futures.webp';
 String _t(String en, String de) => manualScreenshotText(en: en, de: de);
 
+AppLocalizations _messages(WidgetTester tester) =>
+    AppLocalizations.of(tester.element(find.byType(Scaffold).first))!;
+
 final _manualReleases = <WhatsNewContent>[
   WhatsNewContent(
     release: WhatsNewRelease(
@@ -331,7 +334,7 @@ void main() {
           pastRelease: false,
         );
 
-        expect(find.text('NEW'), findsOneWidget);
+        expect(find.text(_messages(tester).whatsNewBadgeNew), findsOneWidget);
         expect(
           find.textContaining(
             _t(
@@ -358,7 +361,10 @@ void main() {
           pastRelease: true,
         );
 
-        expect(find.text(_t('NEW', 'NEU')), findsNothing);
+        expect(
+          find.text(_messages(tester).whatsNewBadgeNew),
+          findsNothing,
+        );
         expect(
           find.textContaining(
             _t(

--- a/test/helpers/manual_screenshot_french_text.dart
+++ b/test/helpers/manual_screenshot_french_text.dart
@@ -42,6 +42,14 @@ const _copy = <String, String>{
   "This summary is out of date": "Ce résumé n'est plus à jour",
   "The task changed after this summary was generated.":
       "La tâche a changé après la génération de ce résumé.",
+  "Pressure stable · 37 penguins accounted for":
+      "Pression stable · 37 manchots recensés",
+  "Feeder calibration blocks the habitat demo":
+      "Le calibrage du distributeur bloque la démonstration de l'habitat",
+  "Europa cold-chain manifest ready to reconcile":
+      "Le manifeste de la chaîne du froid d'Europe est prêt à être rapproché",
+  "Awaiting an answer from orbital transport counsel":
+      "En attente d'une réponse du conseil juridique du transport orbital",
   "Wake agent": "Réveiller l'agent",
   "Filter tasks": "Filtrer les tâches",
   "Filter projects": "Filtrer les projets",

--- a/test/helpers/manual_screenshot_french_text.dart
+++ b/test/helpers/manual_screenshot_french_text.dart
@@ -477,7 +477,8 @@ const _copy = <String, String>{
       "Les 37 manchots empereurs sont recensés. La pression de l'habitat est restée à 101,3 kPa pendant la nuit ; le risque restant pour le lancement est le calibrage du distributeur de sardines en apesanteur.",
   "Habitat stable; zero-gravity sardine feeder blocks sign-off.":
       "Habitat stable ; le distributeur de sardines en apesanteur bloque la validation.",
-  """## Latest assessment
+  """
+## Latest assessment
 
 - Pressure seals A–F stayed stable across the night shift.
 - 840 sardines are loaded; feeder calibration still blocks sign-off.
@@ -486,7 +487,8 @@ const _copy = <String, String>{
 ## Recommended next step
 
 Run the feeder test, attach the telemetry image, then request launch approval.""":
-      """## Dernière évaluation
+      """
+## Dernière évaluation
 
 - Les joints de pression A–F sont restés stables pendant l'équipe de nuit.
 - 840 sardines sont chargées ; le calibrage du distributeur bloque toujours la validation.

--- a/test/helpers/manual_screenshot_locale.dart
+++ b/test/helpers/manual_screenshot_locale.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 
 import 'manual_screenshot_czech_text.dart';
+import 'manual_screenshot_french_text.dart';
 
 /// Locale requested for the current manual capture process.
 ///
@@ -11,11 +12,14 @@ import 'manual_screenshot_czech_text.dart';
 /// contract without changing screenshot case IDs or filenames.
 Locale manualScreenshotLocaleFromEnvironment(Map<String, String> environment) {
   final languageCode = environment['LOTTI_MANUAL_LOCALE'] ?? 'en';
-  if (languageCode != 'en' && languageCode != 'de' && languageCode != 'cs') {
+  if (languageCode != 'en' &&
+      languageCode != 'de' &&
+      languageCode != 'fr' &&
+      languageCode != 'cs') {
     throw ArgumentError.value(
       languageCode,
       'LOTTI_MANUAL_LOCALE',
-      'Supported manual screenshot locales are en, de, and cs.',
+      'Supported manual screenshot locales are en, de, fr, and cs.',
     );
   }
   return Locale(languageCode);
@@ -28,9 +32,11 @@ Locale get manualScreenshotLocale =>
 String manualScreenshotText({
   required String en,
   required String de,
+  String? fr,
   String? cs,
 }) => switch (manualScreenshotLocale.languageCode) {
   'de' => de,
+  'fr' => fr ?? manualScreenshotFrenchText(en) ?? en,
   'cs' => cs ?? manualScreenshotCzechText(en) ?? en,
   _ => en,
 };

--- a/test/helpers/manual_screenshot_locale_test.dart
+++ b/test/helpers/manual_screenshot_locale_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'manual_screenshot_czech_text.dart';
+import 'manual_screenshot_french_text.dart';
 import 'manual_screenshot_locale.dart';
 
 void main() {
@@ -23,12 +24,18 @@ void main() {
         ),
         const Locale('cs'),
       );
+      expect(
+        manualScreenshotLocaleFromEnvironment(
+          const {'LOTTI_MANUAL_LOCALE': 'fr'},
+        ),
+        const Locale('fr'),
+      );
     });
 
     test('rejects locales without a complete manual media catalog', () {
       expect(
         () => manualScreenshotLocaleFromEnvironment(
-          const {'LOTTI_MANUAL_LOCALE': 'fr'},
+          const {'LOTTI_MANUAL_LOCALE': 'es'},
         ),
         throwsArgumentError,
       );
@@ -41,5 +48,34 @@ void main() {
       );
       expect(manualScreenshotCzechText('Unknown fixture'), isNull);
     });
+
+    test('French fixture catalog localizes representative demo copy', () {
+      expect(
+        manualScreenshotFrenchText('Inspect orbital penguin habitat'),
+        'Inspecter l’habitat orbital des manchots',
+      );
+      expect(manualScreenshotFrenchText('Unknown fixture'), isNull);
+    });
+
+    test(
+      'French fixture catalog localizes multiline agent reports',
+      () {
+        const report = '''
+## Latest assessment
+
+- Pressure seals A–F stayed stable across the night shift.
+- 840 sardines are loaded; feeder calibration still blocks sign-off.
+- Mission Control clearance is due before the 06:30 roll call.
+
+## Recommended next step
+
+Run the feeder test, attach the telemetry image, then request launch approval.''';
+
+        expect(
+          manualScreenshotFrenchText(report),
+          startsWith('## Dernière évaluation'),
+        );
+      },
+    );
   });
 }

--- a/test/pages/create/create_measurement_dialog_screenshots_test.dart
+++ b/test/pages/create/create_measurement_dialog_screenshots_test.dart
@@ -38,6 +38,9 @@ final _rangeEnd = DateTime(2026, 7, 18);
 
 String _t(String en, String de) => manualScreenshotText(en: en, de: de);
 
+AppLocalizations _messages(WidgetTester tester) =>
+    AppLocalizations.of(tester.element(find.byType(MeasurablesBarChart)))!;
+
 final MeasurableDataType _sardinesConsumed = MeasurableDataType(
   id: _measurableId,
   displayName: _t('Sardines consumed', 'Verzehrte Sardinen'),
@@ -240,7 +243,10 @@ void main() {
 
         await tester.tap(find.byKey(const Key('measurement_observed_at')));
         await settleFrames(tester, 10);
-        expect(find.text(_t('Observed at', 'Erfasst um')), findsOneWidget);
+        expect(
+          find.text(_messages(tester).addMeasurementDateLabel),
+          findsOneWidget,
+        );
         await captureScreenshot(
           tester,
           'measurement_capture_date_${viewport}_$theme',


### PR DESCRIPTION
## Summary

- add a complete French manual: 37 reviewed pages, French navigation/search chrome, browser-locale routing, and the unreviewed-translation contribution notice
- publish the complete French screenshot matrix to `lotti-docs` and complete the existing Czech catalog; every one of the 134 cases has mobile/desktop and light/dark variants
- extend onboarding coverage to the actual API-key, connection-success, recording-style, and category steps; make the media builder support safe incremental case conversion
- polish French deterministic task-demo copy and make the smoke build verify every French page and screenshot control
- refresh generated manual media automatically on relevant `main` pushes as well as nightly/on-demand runs

## Representative French production captures

| Tasks workspace | Running total |
| --- | --- |
| ![French task workspace](https://raw.githubusercontent.com/matthiasn/lotti-docs/2dc8dcc26097d2871d17b6a41abe9a318d61465d/manual/screenshots/development/fr/tasks/workspace/desktop-light.webp) | ![French running-total time analysis](https://raw.githubusercontent.com/matthiasn/lotti-docs/2dc8dcc26097d2871d17b6a41abe9a318d61465d/manual/screenshots/development/fr/time-analysis/running-total/desktop-dark.webp) |

## Validation

- `npm --prefix docs-site run check`
- targeted Dart analysis for the updated onboarding/task screenshot harnesses and French fixture catalog
- French onboarding and task screenshot harnesses against the real localized UI
- complete external-media validation: 134 cases × 4 locales × 4 variants (2,144 files), including checksums and dimensions

The approximately 27,000-test Flutter suite is intentionally delegated to CI's sharded test jobs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added French as a supported documentation language, including translated navigation, interface text, and comprehensive manual pages.
  - Expanded manual screenshot coverage to French across mobile/desktop and light/dark variants.
  - Added selective screenshot-case generation and publishing options.

- **Bug Fixes**
  - Improved responsive event and task layouts on compact screens.
  - Localized speech-recognition labels and screenshot verification across supported languages.

- **Documentation**
  - Updated development, screenshot, and release guidance for expanded locale coverage and publishing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->